### PR TITLE
Fix BCP-04 control-plane CLI review residuals

### DIFF
--- a/app/builderops/control_plane/client_cli.py
+++ b/app/builderops/control_plane/client_cli.py
@@ -118,7 +118,8 @@ def build_parser() -> argparse.ArgumentParser:
             "(see app.builderops.control_plane.routing). Required for every "
             "mutating command: the addressed repository's manifest is loaded "
             "and routed by (RepoRef, stack, task-class) before dispatch; a "
-            "missing, ambiguous, stale, or cross-repository route fails closed. "
+            "missing, ambiguous, stale cached/prior, or cross-repository route "
+            "fails closed. "
             "Routing is advisory request shaping only, never privileged authority."
         ),
     )
@@ -305,9 +306,11 @@ def _resolve_route(args: argparse.Namespace) -> RoutePolicy | None:
 
     Read commands return ``None`` because they cannot mutate authority. Every
     mutating command is a full commitment to fail-closed routing: a missing
-    manifest directory/task class, or a missing, ambiguous, stale, or
-    cross-repo-reused manifest/route raises before a client is constructed or a
-    request is dispatched. The resolved policy is advisory request-shaping only
+    manifest directory/task class, or a missing, ambiguous, stale cached/prior,
+    or cross-repo-reused manifest/route raises before a client is constructed
+    or a request is dispatched. The manifest is reloaded for every invocation;
+    no previous route can authorize a later mutation. The resolved policy is
+    advisory request-shaping only
     — never privileged authority; BCP-05 independently re-resolves
     protected-base policy before any privileged effect.
     """

--- a/app/builderops/control_plane/client_cli.py
+++ b/app/builderops/control_plane/client_cli.py
@@ -38,11 +38,10 @@ ClientFactory = Callable[[ClientConfig], BuilderOpsControlPlaneClient]
 _FAIL_CLOSED_EXIT = 3
 _CONFIG_EXIT = 2
 
-# Subcommands whose envelope this CLI can resolve a delivery-manifest route
-# for: they carry --repository/--stack (the RepoRef/stack half of the routing
-# key) and a --task-class-scoped mutation. Read-only commands (status, receipt)
-# are not envelope-routed.
-_ROUTABLE_COMMANDS = frozenset(
+# Every authority-bearing CLI command carries an envelope and must resolve the
+# addressed repository's delivery-manifest route before it can dispatch.  Read
+# commands (status, receipt) intentionally stay outside this mutation gate.
+_MUTATING_COMMANDS = frozenset(
     {
         "record",
         "inquiry",
@@ -115,19 +114,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--delivery-manifest-dir",
         help=(
-            "Optional directory of per-repository delivery-manifest JSON "
-            "documents (see app.builderops.control_plane.routing). When given, "
-            "the addressed repository's manifest is loaded and routed by "
-            "(RepoRef, stack, task-class) before dispatch; a missing/ambiguous "
-            "manifest or route fails closed. Omit to skip routing entirely — "
-            "no manifest is required by default. This is advisory request "
-            "shaping only, never privileged authority."
+            "Directory of per-repository delivery-manifest JSON documents "
+            "(see app.builderops.control_plane.routing). Required for every "
+            "mutating command: the addressed repository's manifest is loaded "
+            "and routed by (RepoRef, stack, task-class) before dispatch; a "
+            "missing, ambiguous, stale, or cross-repository route fails closed. "
+            "Routing is advisory request shaping only, never privileged authority."
         ),
     )
     parser.add_argument(
         "--task-class",
         help="Task-class half of the (RepoRef, stack, task-class) routing key. "
-        "Required when --delivery-manifest-dir is given for a routable command.",
+        "Required for every mutating command.",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -204,6 +202,13 @@ def build_parser() -> argparse.ArgumentParser:
     promotion.add_argument("--status", required=True)
     promotion.add_argument("--payload", help="JSON object payload.")
     promotion.add_argument("--idempotency-key", required=True)
+    promotion.add_argument(
+        "--lease",
+        help=(
+            "JSON fenced lease object. Required by the service when updating an "
+            "existing promotion; stale or missing evidence fails closed."
+        ),
+    )
 
     receipt = sub.add_parser("receipt", help="Read a committed authority-object receipt.")
     receipt.add_argument("--repository", required=True)
@@ -283,6 +288,7 @@ def _dispatch(
             status=args.status,
             payload=_json_payload(args.payload),
             idempotency_key=args.idempotency_key,
+            lease=_json_payload(args.lease) if args.lease else None,
         )
     if command == "receipt":
         return client.get_receipt(
@@ -297,23 +303,22 @@ def _dispatch(
 def _resolve_route(args: argparse.Namespace) -> RoutePolicy | None:
     """Resolve the addressed repo's (RepoRef, stack, task-class) route.
 
-    Returns ``None`` when routing was not engaged (no ``--delivery-manifest-dir``
-    given, or the command has no envelope to route). Engaging routing on a
-    routable command is a full commitment to fail-closed behavior: a missing,
-    ambiguous, or cross-repo-reused manifest raises ``RoutingError`` rather than
-    silently skipping. The resolved policy is advisory request-shaping only —
-    never privileged authority; BCP-05 independently re-resolves protected-base
-    policy before any privileged effect.
+    Read commands return ``None`` because they cannot mutate authority. Every
+    mutating command is a full commitment to fail-closed routing: a missing
+    manifest directory/task class, or a missing, ambiguous, stale, or
+    cross-repo-reused manifest/route raises before a client is constructed or a
+    request is dispatched. The resolved policy is advisory request-shaping only
+    — never privileged authority; BCP-05 independently re-resolves
+    protected-base policy before any privileged effect.
     """
     manifest_dir = getattr(args, "delivery_manifest_dir", None)
-    if manifest_dir is None:
+    if args.command not in _MUTATING_COMMANDS:
         return None
-    if args.command not in _ROUTABLE_COMMANDS:
-        return None
+    if not manifest_dir:
+        raise ValueError("--delivery-manifest-dir is required for mutating commands")
     if not getattr(args, "task_class", None):
         raise ValueError(
-            "--task-class is required when --delivery-manifest-dir is given "
-            "for a routable command"
+            "--task-class is required for mutating commands"
         )
     repo = RepoRef.parse(args.repository)
     registry = DeliveryManifestRegistry.from_directory(manifest_dir)

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -143,8 +143,11 @@ create no local SQLite/JSONL/JSON authority and no fabricated GitHub lease.
 Every mutating CLI command requires `--delivery-manifest-dir` and
 `--task-class` and resolves delivery-manifest `(RepoRef, stack, task-class)`
 routing (`app.builderops.control_plane.routing`) before dispatch. Missing,
-ambiguous, stale, or cross-repository manifests/routes fail closed before a
-client is constructed. The resolved policy remains advisory request shaping
+ambiguous, stale cached/prior-route, or cross-repository manifests/routes fail
+closed before a client is constructed; every invocation reloads the addressed
+repository's manifest rather than reusing a prior route. Temporal
+base-SHA/manifest-hash freshness remains BCP-05 protected-base authority. The
+resolved policy remains advisory request shaping
 (for example, a `ttl_seconds` default), never privileged authority; BCP-05
 still independently re-resolves protected-base policy and credential binding.
 Promotion updates pass the caller-supplied fenced `--lease` object through the

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -140,14 +140,16 @@ opt-in and the only `outbox:write` scope. With the service unavailable or the
 credential rejected, the client and wrapper fail closed with a non-zero exit and
 create no local SQLite/JSONL/JSON authority and no fabricated GitHub lease.
 
-The CLI's optional `--delivery-manifest-dir`/`--task-class` flags engage
-delivery-manifest `(RepoRef, stack, task-class)` routing
-(`app.builderops.control_plane.routing`) for a mutating command: when given,
-the addressed repository's manifest is loaded and its route resolved before
-dispatch (advisory request-shaping only, e.g. a `ttl_seconds` default — never
-privileged authority), and a missing/ambiguous manifest or route fails closed.
-Routing is opt-in; omitting both flags skips it entirely and uses the
-historical hardcoded defaults, matching this slice's non-authoritative scope.
+Every mutating CLI command requires `--delivery-manifest-dir` and
+`--task-class` and resolves delivery-manifest `(RepoRef, stack, task-class)`
+routing (`app.builderops.control_plane.routing`) before dispatch. Missing,
+ambiguous, stale, or cross-repository manifests/routes fail closed before a
+client is constructed. The resolved policy remains advisory request shaping
+(for example, a `ttl_seconds` default), never privileged authority; BCP-05
+still independently re-resolves protected-base policy and credential binding.
+Promotion updates pass the caller-supplied fenced `--lease` object through the
+same API boundary; the store rejects missing or stale lease evidence without a
+local or fabricated fallback.
 
 ## How to Verify (Pre-Merge)
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -154,6 +154,10 @@ Promotion updates pass the caller-supplied fenced `--lease` object through the
 same API boundary; the store rejects missing or stale lease evidence without a
 local or fabricated fallback.
 
+The canonical `scripts/builderops_api_client.sh` wrapper supplies the required
+global route flags from host/worktree-owned `BUILDEROPS_DELIVERY_MANIFEST_DIR`
+and `BUILDEROPS_TASK_CLASS`; missing values fail closed before dispatch.
+
 ## How to Verify (Pre-Merge)
 
 - run client contract tests against a disposable BCP-02 service;

--- a/docs/BUILDEROPS_CONTROL_PLANE/README.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/README.md
@@ -55,10 +55,11 @@ whatever service/store backend is configured and ships non-authoritative; the
 legacy direct-SQLite `app.dispatcher`/`app.builderops` CLIs remain in place, and
 BCP-06 owns activating production authority and freezing those legacy writers.
 Issue #3968 closes the BCP-04 review residuals: all mutation paths now require
-delivery-manifest routing before dispatch, and promotion updates can carry the
-store-required fenced lease through the client CLI. This remains client-side
-request formation only; it does not alter BCP-05 verification or BCP-06
-cutover authority.
+delivery-manifest routing before dispatch, reject stale cached/prior-route
+reuse by reloading the addressed manifest per invocation, and promotion updates
+can carry the store-required fenced lease through the client CLI. This remains
+client-side request formation only; temporal protected-base manifest freshness
+stays with BCP-05, and BCP-06 cutover authority is unchanged.
 
 ## Target boundary
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/README.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/README.md
@@ -54,6 +54,11 @@ and governance gates. This is not a production cutover either: the client target
 whatever service/store backend is configured and ships non-authoritative; the
 legacy direct-SQLite `app.dispatcher`/`app.builderops` CLIs remain in place, and
 BCP-06 owns activating production authority and freezing those legacy writers.
+Issue #3968 closes the BCP-04 review residuals: all mutation paths now require
+delivery-manifest routing before dispatch, and promotion updates can carry the
+store-required fenced lease through the client CLI. This remains client-side
+request formation only; it does not alter BCP-05 verification or BCP-06
+cutover authority.
 
 ## Target boundary
 

--- a/scripts/builderops_api_client.sh
+++ b/scripts/builderops_api_client.sh
@@ -23,6 +23,12 @@
 #     --record-id learning-3791 --record-type LearningSignal --state active \
 #     --idempotency-key record-learning-3791
 #
+# Mutations additionally require host/worktree-owned route configuration; the
+# wrapper injects it before the subcommand so callers cannot accidentally skip
+# the CLI's fail-closed manifest gate:
+#   BUILDEROPS_DELIVERY_MANIFEST_DIR — directory containing addressed-repo manifests
+#   BUILDEROPS_TASK_CLASS            — route task class (for example implementation)
+#
 # Credentials are host-owned and never inlined here or committed to the repo:
 #   BUILDEROPS_API_URL         — control-plane base URL (required), e.g.
 #                                https://<builderops-host>.<tailnet>.ts.net:<port>
@@ -55,4 +61,20 @@ if [ -z "${BUILDEROPS_API_URL:-}" ]; then
 fi
 
 cd "$APP_ROOT"
-exec "$PYTHON" -m app.builderops.control_plane "$@"
+case "${1:-}" in
+    status|receipt)
+        exec "$PYTHON" -m app.builderops.control_plane "$@"
+        ;;
+    "")
+        exec "$PYTHON" -m app.builderops.control_plane "$@"
+        ;;
+    *)
+        if [ -z "${BUILDEROPS_DELIVERY_MANIFEST_DIR:-}" ] || [ -z "${BUILDEROPS_TASK_CLASS:-}" ]; then
+            echo "ERROR: BuilderOps mutations require BUILDEROPS_DELIVERY_MANIFEST_DIR and BUILDEROPS_TASK_CLASS." >&2
+            exit 2
+        fi
+        exec "$PYTHON" -m app.builderops.control_plane \
+            --delivery-manifest-dir "$BUILDEROPS_DELIVERY_MANIFEST_DIR" \
+            --task-class "$BUILDEROPS_TASK_CLASS" "$@"
+        ;;
+esac

--- a/scripts/builderops_api_client.sh
+++ b/scripts/builderops_api_client.sh
@@ -62,7 +62,7 @@ fi
 
 cd "$APP_ROOT"
 case "${1:-}" in
-    status|receipt)
+    status|receipt|-h|--help)
         exec "$PYTHON" -m app.builderops.control_plane "$@"
         ;;
     "")

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -11,6 +11,9 @@ test" requested by the issue #3791 review (finding S1).
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -433,7 +436,7 @@ def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
         "promotion", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3968",
         "--stack", "builderops-control-plane", "--source-ref", "github:issue:3968",
         "--promotion-id", "promotion-1", "--status", "approved", "--idempotency-key", "update-1",
-        "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"promotion-1","holder":"client","fencing_token":2,"expires_at":"2026-07-17T00:00:00+00:00","lease_kind":"promotion"}',
+        "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"promotion:promotion-1","holder":"client","fencing_token":2,"expires_at":"2026-07-17T00:00:00+00:00","lease_kind":"generic"}',
     ]
     assert main(args, client_factory=factory) == 0
     [client] = factory.created
@@ -475,6 +478,31 @@ def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
     assert main(missing_lease_args, client_factory=missing_factory) == 3
     assert missing_clients[0].calls[0][1]["lease"] is None
     assert missing_clients[0].closed is True
+
+
+def test_wrapper_mutation_injects_required_delivery_route(tmp_path: Path) -> None:
+    """The documented wrapper path carries the mandatory global route flags."""
+    manifest_dir = _manifest_dir(tmp_path)
+    root = Path(__file__).resolve().parents[3]
+    env = os.environ | {
+        "BUILDEROPS_PYTHON": sys.executable,
+        "BUILDEROPS_API_URL": "http://127.0.0.1:1",
+        "BUILDEROPS_API_TOKEN": "test-token",
+        "BUILDEROPS_DELIVERY_MANIFEST_DIR": str(manifest_dir),
+        "BUILDEROPS_TASK_CLASS": "implementation",
+    }
+    result = subprocess.run(
+        [
+            str(root / "scripts/builderops_api_client.sh"), "record",
+            "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3968",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3968",
+            "--record-id", "record-1", "--record-type", "LearningSignal", "--state", "active",
+            "--idempotency-key", "record-1",
+        ],
+        cwd=root, env=env, text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 3
+    assert "ControlPlaneUnavailableError" in result.stderr
 
 
 def test_routing_not_engaged_for_read_only_commands(tmp_path: Path, factory) -> None:

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -488,7 +488,7 @@ def test_promotion_update_real_cli_client_service_store_path(tmp_path: Path) -> 
     """Real CLI -> authenticated client -> service -> store fencing regression."""
     class Store:
         epoch = 1
-        calls: list[str] = []
+        def __init__(self): self.calls: list[str] = []
         def readiness(self): return {"authority_epoch": 1, "schema_version": 1}
         def commit_promotion(self, **kw):
             self.calls.append(kw["status"])
@@ -544,6 +544,14 @@ def test_wrapper_mutation_injects_required_delivery_route(tmp_path: Path) -> Non
     )
     assert result.returncode == 3
     assert "ControlPlaneUnavailableError" in result.stderr
+
+
+def test_wrapper_help_does_not_require_delivery_route() -> None:
+    root = Path(__file__).resolve().parents[3]
+    env = os.environ | {"BUILDEROPS_PYTHON": sys.executable, "BUILDEROPS_API_URL": "http://127.0.0.1:1"}
+    result = subprocess.run([str(root / "scripts/builderops_api_client.sh"), "--help"], cwd=root, env=env, text=True, capture_output=True, check=False)
+    assert result.returncode == 0
+    assert "BUILDEROPS_DELIVERY_MANIFEST_DIR" not in result.stderr
 
 
 def test_routing_not_engaged_for_read_only_commands(tmp_path: Path, factory) -> None:

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -18,9 +18,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from fastapi.testclient import TestClient
 
-from app.builderops.control_plane.client import ClientConfig, StaleLeaseError
+from app.builderops.control_plane.auth import CredentialRegistry
+from app.builderops.control_plane.client import BuilderOpsControlPlaneClient, ClientConfig, StaleLeaseError
 from app.builderops.control_plane.client_cli import main
+from app.builderops.control_plane.models import AuthorityObjectResult, Lease, LeaseRequired, StaleFencingToken
+from app.builderops.control_plane.service import create_app
 
 
 class _RecordingClient:
@@ -478,6 +482,43 @@ def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
     assert main(missing_lease_args, client_factory=missing_factory) == 3
     assert missing_clients[0].calls[0][1]["lease"] is None
     assert missing_clients[0].closed is True
+
+
+def test_promotion_update_real_cli_client_service_store_path(tmp_path: Path) -> None:
+    """Real CLI -> authenticated client -> service -> store fencing regression."""
+    class Store:
+        epoch = 1
+        calls: list[str] = []
+        def readiness(self): return {"authority_epoch": 1, "schema_version": 1}
+        def commit_promotion(self, **kw):
+            self.calls.append(kw["status"])
+            lease = kw["lease"]
+            if kw["status"] == "prepared":
+                return AuthorityObjectResult(kw["envelope"].repository, "promotion", "p1", "prepared", 1, "0/1")
+            if lease is None: raise LeaseRequired("promotion update requires a fenced lease")
+            if lease.lease_kind != "generic" or lease.resource_id != "promotion:p1": raise StaleFencingToken("wrong promotion lease")
+            if lease.fencing_token != 2: raise StaleFencingToken("stale promotion lease")
+            return AuthorityObjectResult(kw["envelope"].repository, "promotion", "p1", "approved", 2, "0/2")
+    secret = tmp_path / "token"; secret.write_text("client-token\n")
+    manifest = tmp_path / "credentials.json"; manifest.write_text(json.dumps({"credentials":[{"id":"c","principal":"client","secret_ref":"host-secret:client","secret_file":str(secret),"scopes":["status:read","promotions:write"],"repositories":["RasmusTho/agentic-pkm-mvp"],"rotation_generation":1}]}))
+    store = Store()
+    transport = TestClient(create_app(store=store, credentials=CredentialRegistry(manifest)))
+    route_dir = _manifest_dir(tmp_path)
+    def factory(config: ClientConfig):
+        client = BuilderOpsControlPlaneClient(ClientConfig(config.base_url, "client-token"), http_client=transport, max_retries=0)
+        # The focused store implements the promotion port only; pin the epoch as
+        # a preceding authenticated status read would, so the regression drives
+        # the real CLI/client/service/store promotion path.
+        client._pinned_epoch = 1
+        return client
+    base = ["--delivery-manifest-dir",str(route_dir),"--task-class","implementation","promotion","--repository","RasmusTho/agentic-pkm-mvp","--scope","issue:3968","--stack","builderops-control-plane","--source-ref","github:issue:3968","--promotion-id","p1","--idempotency-key","p"]
+    assert main(base + ["--status","prepared"], client_factory=factory) == 0
+    lease = '{"resource_id":"promotion:p1","holder":"client","fencing_token":2,"expires_at":"2026-07-21T12:00:00+00:00","lease_kind":"generic"}'
+    assert main(base + ["--status","approved","--lease",lease], client_factory=factory) == 0
+    assert main(base + ["--status","approved"], client_factory=factory) == 3
+    stale = lease.replace('"fencing_token":2', '"fencing_token":1')
+    assert main(base + ["--status","approved","--lease",stale], client_factory=factory) == 3
+    assert store.calls == ["prepared", "approved", "approved", "approved"]
 
 
 def test_wrapper_mutation_injects_required_delivery_route(tmp_path: Path) -> None:

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pytest
 
-from app.builderops.control_plane.client import ClientConfig
+from app.builderops.control_plane.client import ClientConfig, StaleLeaseError
 from app.builderops.control_plane.client_cli import main
 
 
@@ -53,6 +53,26 @@ class _RecordingClient:
     def commit_record(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(("commit_record", kwargs))
         return {"object_id": kwargs["record_id"], "state": kwargs["state"]}
+
+    def create_inquiry(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("create_inquiry", kwargs))
+        return {"object_id": kwargs["inquiry_id"], "state": kwargs["state"]}
+
+    def heartbeat_task(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("heartbeat_task", kwargs))
+        return {"result": {"state": "claimed"}}
+
+    def complete_task(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("complete_task", kwargs))
+        return {"result": {"state": "completed"}}
+
+    def commit_attempt(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("commit_attempt", kwargs))
+        return {"object_id": kwargs["attempt_id"], "state": kwargs["state"]}
+
+    def commit_promotion(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("commit_promotion", kwargs))
+        return {"object_id": kwargs["promotion_id"], "state": kwargs["status"]}
 
     def close(self) -> None:
         self.closed = True
@@ -170,10 +190,45 @@ def test_explicit_ttl_flag_wins_over_manifest_policy(tmp_path: Path, factory) ->
     assert client.calls[0][1]["ttl_seconds"] == 60
 
 
-def test_no_manifest_dir_skips_routing_and_uses_hardcoded_default(factory) -> None:
-    """Routing is opt-in: omitting --delivery-manifest-dir must not require a
-    manifest to exist anywhere, and the historical hardcoded default applies."""
-    exit_code = main(
+@pytest.mark.parametrize(
+    "command_args",
+    [
+        [
+            "record",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:3791",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "github:issue:3791",
+            "--record-id",
+            "record-1",
+            "--record-type",
+            "LearningSignal",
+            "--state",
+            "active",
+            "--idempotency-key",
+            "record-1",
+        ],
+        [
+            "inquiry",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:3791",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "github:issue:3791",
+            "--inquiry-id",
+            "inquiry-1",
+            "--state",
+            "active",
+            "--idempotency-key",
+            "inquiry-1",
+        ],
         [
             "task-claim",
             "--repository",
@@ -189,11 +244,41 @@ def test_no_manifest_dir_skips_routing_and_uses_hardcoded_default(factory) -> No
             "--idempotency-key",
             "claim-1",
         ],
-        client_factory=factory,
-    )
-    assert exit_code == 0
-    [client] = factory.created
-    assert client.calls[0][1]["ttl_seconds"] == 5400
+        [
+            "task-heartbeat", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3791",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3791",
+            "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"issue-3791","holder":"client","fencing_token":1,"expires_at":"2026-07-17T00:00:00+00:00"}',
+            "--idempotency-key", "heartbeat-1",
+        ],
+        [
+            "task-complete", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3791",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3791",
+            "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"issue-3791","holder":"client","fencing_token":1,"expires_at":"2026-07-17T00:00:00+00:00"}',
+            "--idempotency-key", "complete-1",
+        ],
+        [
+            "lease-claim", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3791",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3791",
+            "--resource-id", "promotion-1", "--idempotency-key", "lease-1",
+        ],
+        [
+            "attempt", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3791",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3791",
+            "--task-id", "issue-3791", "--attempt-id", "attempt-1", "--state", "started",
+            "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"issue-3791","holder":"client","fencing_token":1,"expires_at":"2026-07-17T00:00:00+00:00"}',
+            "--idempotency-key", "attempt-1",
+        ],
+        [
+            "promotion", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3791",
+            "--stack", "builderops-control-plane", "--source-ref", "github:issue:3791",
+            "--promotion-id", "promotion-1", "--status", "prepared", "--idempotency-key", "promotion-1",
+        ],
+    ],
+)
+def test_mutating_commands_require_delivery_manifest_route(command_args: list[str], factory) -> None:
+    """Every real mutating CLI dispatch fails before client construction without a route."""
+    assert main(command_args, client_factory=factory) == 2
+    assert factory.created == []
 
 
 def test_missing_manifest_for_addressed_repo_fails_closed(tmp_path: Path, factory) -> None:
@@ -281,8 +366,15 @@ def test_manifest_dir_without_task_class_is_a_usage_error(tmp_path: Path, factor
 def test_malformed_repository_fails_closed_not_uncaught(factory) -> None:
     """H1 regression test: RepoRefError from _envelope()'s RepoRef.parse() must
     be caught as a fail-closed CLI error (exit 3), never an uncaught traceback."""
+    # Route configuration is supplied so the malformed RepoRef is the gate
+    # under test rather than the required manifest-dir check.
+    # A missing directory is not reached because RepoRef.parse happens first.
     exit_code = main(
         [
+            "--delivery-manifest-dir",
+            "/does-not-matter",
+            "--task-class",
+            "implementation",
             "record",
             "--repository",
             "not-a-valid-repo",
@@ -304,9 +396,60 @@ def test_malformed_repository_fails_closed_not_uncaught(factory) -> None:
         client_factory=factory,
     )
     assert exit_code == 3
+    assert factory.created == []
+
+
+def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
+    tmp_path: Path, factory
+) -> None:
+    manifest_dir = _manifest_dir(tmp_path)
+    args = [
+        "--delivery-manifest-dir", str(manifest_dir), "--task-class", "implementation",
+        "promotion", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3968",
+        "--stack", "builderops-control-plane", "--source-ref", "github:issue:3968",
+        "--promotion-id", "promotion-1", "--status", "approved", "--idempotency-key", "update-1",
+        "--lease", '{"repository":"rasmustho/agentic-pkm-mvp","resource_id":"promotion-1","holder":"client","fencing_token":2,"expires_at":"2026-07-17T00:00:00+00:00","lease_kind":"promotion"}',
+    ]
+    assert main(args, client_factory=factory) == 0
     [client] = factory.created
-    assert client.calls == []
-    assert client.closed is True
+    assert client.calls[0][0] == "commit_promotion"
+    assert client.calls[0][1]["lease"]["fencing_token"] == 2
+
+    class _StalePromotionClient(_RecordingClient):
+        def commit_promotion(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(("commit_promotion", kwargs))
+            raise StaleLeaseError("StaleFencingToken")
+
+    stale_clients: list[_StalePromotionClient] = []
+
+    def stale_factory(config: ClientConfig) -> _StalePromotionClient:
+        client = _StalePromotionClient(config)
+        stale_clients.append(client)
+        return client
+
+    assert main(args, client_factory=stale_factory) == 3
+    assert stale_clients[0].calls[0][1]["lease"]["fencing_token"] == 2
+    assert stale_clients[0].closed is True
+
+    class _MissingLeaseClient(_RecordingClient):
+        def commit_promotion(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(("commit_promotion", kwargs))
+            if kwargs["lease"] is None:
+                raise StaleLeaseError("LeaseRequired")
+            return super().commit_promotion(**kwargs)
+
+    missing_clients: list[_MissingLeaseClient] = []
+
+    def missing_factory(config: ClientConfig) -> _MissingLeaseClient:
+        client = _MissingLeaseClient(config)
+        missing_clients.append(client)
+        return client
+
+    missing_lease_args = [arg for arg in args if arg != "--lease"]
+    missing_lease_args.remove(args[-1])
+    assert main(missing_lease_args, client_factory=missing_factory) == 3
+    assert missing_clients[0].calls[0][1]["lease"] is None
+    assert missing_clients[0].closed is True
 
 
 def test_routing_not_engaged_for_read_only_commands(tmp_path: Path, factory) -> None:

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -431,7 +431,7 @@ def test_malformed_repository_fails_closed_not_uncaught(factory) -> None:
     assert factory.created == []
 
 
-def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
+def test_promotion_cli_forwards_fenced_lease_and_typed_errors(
     tmp_path: Path, factory
 ) -> None:
     manifest_dir = _manifest_dir(tmp_path)
@@ -484,7 +484,7 @@ def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(
     assert missing_clients[0].closed is True
 
 
-def test_promotion_update_real_cli_client_service_store_path(tmp_path: Path) -> None:
+def test_promotion_update_accepts_fenced_lease_and_rejects_stale_lease(tmp_path: Path) -> None:
     """Real CLI -> authenticated client -> service -> store fencing regression."""
     class Store:
         epoch = 1

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -23,7 +23,7 @@ from fastapi.testclient import TestClient
 from app.builderops.control_plane.auth import CredentialRegistry
 from app.builderops.control_plane.client import BuilderOpsControlPlaneClient, ClientConfig, StaleLeaseError
 from app.builderops.control_plane.client_cli import main
-from app.builderops.control_plane.models import AuthorityObjectResult, Lease, LeaseRequired, StaleFencingToken
+from app.builderops.control_plane.models import AuthorityObjectResult, LeaseRequired, StaleFencingToken
 from app.builderops.control_plane.service import create_app
 
 

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -159,6 +159,31 @@ def test_delivery_manifest_routing_is_engaged_through_real_cli_dispatch(
     assert "rasmustho/agentic-pkm-mvp" in stderr
 
 
+def test_mutating_cli_reloads_manifest_and_rejects_stale_prior_route(
+    tmp_path: Path, factory
+) -> None:
+    """A prior invocation's route cannot authorize a later mutation.
+
+    This drives ``main()`` twice rather than only exercising the registry: after
+    the first dispatch, removing the addressed repository manifest makes the
+    second invocation fail before it constructs another client.
+    """
+    manifest_dir = _manifest_dir(tmp_path)
+    args = [
+        "--delivery-manifest-dir", str(manifest_dir), "--task-class", "implementation",
+        "task-claim", "--repository", "RasmusTho/agentic-pkm-mvp", "--scope", "issue:3968",
+        "--stack", "builderops-control-plane", "--source-ref", "github:issue:3968",
+        "--task-id", "issue-3968", "--idempotency-key", "claim-1",
+    ]
+    assert main(args, client_factory=factory) == 0
+    assert len(factory.created) == 1
+
+    (manifest_dir / "agentic-pkm-mvp.json").unlink()
+
+    assert main(args, client_factory=factory) == 3
+    assert len(factory.created) == 1
+
+
 def test_explicit_ttl_flag_wins_over_manifest_policy(tmp_path: Path, factory) -> None:
     manifest_dir = _manifest_dir(tmp_path, ttl_seconds=1800)
     exit_code = main(

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -549,6 +549,8 @@ def test_wrapper_mutation_injects_required_delivery_route(tmp_path: Path) -> Non
 def test_wrapper_help_does_not_require_delivery_route() -> None:
     root = Path(__file__).resolve().parents[3]
     env = os.environ | {"BUILDEROPS_PYTHON": sys.executable, "BUILDEROPS_API_URL": "http://127.0.0.1:1"}
+    env.pop("BUILDEROPS_DELIVERY_MANIFEST_DIR", None)
+    env.pop("BUILDEROPS_TASK_CLASS", None)
     result = subprocess.run([str(root / "scripts/builderops_api_client.sh"), "--help"], cwd=root, env=env, text=True, capture_output=True, check=False)
     assert result.returncode == 0
     assert "BUILDEROPS_DELIVERY_MANIFEST_DIR" not in result.stderr


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

Final-Review-Rounds: 2

Governing-Issue: #3968

Fixes #3968

## Summary

- Require an addressed-repository delivery-manifest route before every BuilderOps control-plane CLI mutation dispatches, including the canonical wrapper path.
- Forward and validate generic fenced promotion leases through the real CLI → client → service → store path.

## Validation

- `pytest -q tests/builderops/control_plane/test_client_cli.py tests/builderops/control_plane/test_delivery_manifest_routing.py tests/builderops/control_plane/test_api_clients.py tests/governance/test_builderops_api_only_clients.py tests/architecture/test_builderops_store_boundary.py` — 39 passed
- `ruff check app tests` — passed
- `mypy app` — Success: no issues found in 797 source files
- Two independent final review rounds passed on the reconciled merge SHA.

## Owner-Doc Writeback

- Updated `docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md` and `docs/BUILDEROPS_CONTROL_PLANE/README.md`.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded Issue-governed code/doc slice; no BuilderOps Vault record was produced.

## Notes

- Temporal protected-base manifest freshness remains BCP-05 authority; BCP-06 remains unchanged.