### PR TITLE
Export runner identity for CI docker smokes (MVR-01B launcher contract 3/3)

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -294,6 +294,13 @@ jobs:
               environment:
                 WORKER_LOG_HEARTBEAT_SECONDS: "${WORKER_LOG_HEARTBEAT_SECONDS}"
           YAML
+          # MVR-01B launcher contract part 3/3: every compose invocation in this
+          # step (including raw `up` and its instance-state-init dependency)
+          # must chown/run as the runner identity, or the init service's
+          # compose default LOCAL_UID:-0 root-owns the host bind and the next
+          # step's chmod fails EPERM.
+          export LOCAL_UID="$(id -u)"
+          export LOCAL_GID="$(id -g)"
           source scripts/lib/instance_ownership_host_state.sh
           prepare_instance_ownership_host_state_dir
           compose_files="-f docker-compose.yaml -f /tmp/docker-compose.worker-ci.yaml"
@@ -442,6 +449,13 @@ jobs:
           cache/
           EOF
 
+          # MVR-01B launcher contract part 3/3: every compose invocation in this
+          # step (including raw `up` and its instance-state-init dependency)
+          # must chown/run as the runner identity, or the init service's
+          # compose default LOCAL_UID:-0 root-owns the host bind and the next
+          # step's chmod fails EPERM.
+          export LOCAL_UID="$(id -u)"
+          export LOCAL_GID="$(id -g)"
           source scripts/lib/instance_ownership_host_state.sh
           prepare_instance_ownership_host_state_dir
           compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"


### PR DESCRIPTION
## Summary

- Final mechanism of the main-only `smoke-docker` gate. On `656a1dd9` the worker smoke step itself **passed** (mechanisms 1-2 — host-state export #4037, layout producer #4038 — are proven fixed); the job now fails in the next step, `CI gate: vaultwide panel verifier`, at `chmod: .../instance-ownership: Operation not permitted`.
- Mechanism 3: the worker step's raw `docker compose up` re-runs the `instance-state-init` dependency with compose-interpolated defaults `LOCAL_UID:-0`/`LOCAL_GID:-0` (the lib's prefixed export applies only to its own `compose run`), so the init service chowns the host-global bind to root. The panel step then starts with `prepare_instance_ownership_host_state_dir`, whose `chmod 0700` fails EPERM as the runner user.
- Repair: `export LOCAL_UID="$(id -u)"`/`LOCAL_GID="$(id -g)"` at the top of both docker steps, so every compose invocation — including raw `up` and its init dependency — chowns/runs as the runner identity, matching the `start_full_system.sh` launcher shape.
- This completes the three-part MVR-01B launcher contract in CI (host-state export, layout producer, runtime identity). The mechanism analysis across the three layers is the convergence packet for this domain; if any further failure appears here, no additional repair will be attempted without an owner decision.
- PR-context CI cannot prove the fix (docker steps skipped on pull_request); proof is the next main push run.

## Direct Repair
Type: code
Reason: main push gate still red after #4038 in a different step and mechanism (root-owned host bind from compose uid defaults); worker smoke itself green on 656a1dd9.
Validation: mechanism verified from run 29823348259 step outcomes (worker step success, panel step EPERM at first chmod); YAML parse check; both steps patched identically; matches the local launcher's LOCAL_UID export behavior.
Issue required: no

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: mechanical CI-launcher repair, final identity part; learning consolidated on #4036

Final-Review-Rounds: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)