### PR TITLE
fix(builderops): verify governed host-store cutover evidence

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -318,6 +318,11 @@ def cutover_evidence_generate(
     actor: str, as_json: bool,
 ) -> None:
     """Install evidence only after an existing non-empty target is verified."""
+    if (ctx.obj or {}).get("db_path") is not None:
+        raise click.ClickException(
+            "cutover-evidence generate only supports the implicit host-stable store; "
+            "--db-path is not allowed"
+        )
     try:
         participants = _load_json_value_file(participants_file, field="participants-file")
         reconciliation_payload = _load_json_value_file(reconciliation_file, field="reconciliation-file")

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -45,7 +45,12 @@ from app.builderops.ckm.semantic import (
 )
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
-from app.builderops.config import BuilderOpsPaths, load_paths
+from app.builderops.config import BuilderOpsPaths, default_state_dir, load_paths
+from app.builderops.cutover_evidence import (
+    CutoverEvidenceError,
+    build_receipt as build_cutover_receipt,
+    write_receipt as write_cutover_receipt,
+)
 from app.builderops.evidence_bridge import (
     EvidenceBridgeError,
     build_evidence_bridge_report,
@@ -295,6 +300,36 @@ def _effective_paths(ctx: click.Context) -> BuilderOpsPaths:
         return load_paths(db_path_override=obj.get("db_path"))
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+@builderops.group("cutover-evidence", help="Produce fail-closed host-store cutover evidence.")
+def cutover_evidence() -> None:
+    """Evidence production only; it does not migrate data or stop writers."""
+
+
+@cutover_evidence.command("generate", help="Inventory declared roots and install a bound receipt.")
+@click.option("--participants-file", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+@click.option("--reconciliation-file", type=click.Path(exists=True, dir_okay=False, path_type=Path), required=True)
+@click.option("--actor", required=True, help="Operator identity recorded in the receipt.")
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def cutover_evidence_generate(
+    ctx: click.Context, participants_file: Path, reconciliation_file: Path,
+    actor: str, as_json: bool,
+) -> None:
+    """Install evidence only after an existing non-empty target is verified."""
+    try:
+        participants = _load_json_value_file(participants_file, field="participants-file")
+        reconciliation_payload = _load_json_value_file(reconciliation_file, field="reconciliation-file")
+        reconciliation = reconciliation_payload.get("stores") if isinstance(reconciliation_payload, dict) else reconciliation_payload
+        receipt = build_cutover_receipt(
+            state_dir=default_state_dir(), participants=participants, reconciliation=reconciliation,
+            actor=actor,
+        )
+        path = write_cutover_receipt(default_state_dir(), receipt)
+    except (CutoverEvidenceError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit({"receipt_path": str(path), "receipt": receipt}, as_json)
 
 
 def _model_inquiry_service(ctx: click.Context) -> ModelInquiryService:

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -7,14 +7,11 @@ import os
 import platform
 import stat
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
-from uuid import UUID
 
 DEFAULT_DB_NAME = "builderops.sqlite3"
 CUTOVER_ACK_NAME = "host-store-cutover-v1.json"
-CUTOVER_ACK_SCHEMA = "builderops.host-store-cutover.v1"
+CUTOVER_ACK_SCHEMA = "builderops.host-store-cutover.v2"
 
 
 def default_state_dir() -> Path:
@@ -99,38 +96,8 @@ def current_user_id() -> str:
     return str(os.getuid())
 
 
-def _legacy_store_mtimes(root: Path) -> tuple[float, ...]:
-    """Inventory legacy stores recursively without following symlinked trees."""
-
-    def fail_on_walk_error(error: OSError) -> None:
-        raise error
-
-    mtimes: list[float] = []
-    for directory, child_dirs, files in os.walk(
-        root, followlinks=False, onerror=fail_on_walk_error
-    ):
-        directory_path = Path(directory)
-        child_dirs[:] = [
-            name for name in child_dirs if not (directory_path / name).is_symlink()
-        ]
-        if (
-            directory_path.name == "builderops"
-            and directory_path.parent.name == "runtime"
-            and DEFAULT_DB_NAME in files
-        ):
-            candidate = directory_path / DEFAULT_DB_NAME
-            candidate_stat = candidate.lstat()
-            if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISREG(
-                candidate_stat.st_mode
-            ):
-                raise ValueError
-            mtimes.append(candidate_stat.st_mtime)
-    return tuple(mtimes)
-
-
 def _validate_host_cutover_ack(state_dir: Path) -> None:
     """Require bounded host-global evidence before implicit store selection."""
-
     path = host_cutover_ack_path(state_dir)
     try:
         path_stat = path.lstat()
@@ -141,66 +108,21 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
             or path_stat.st_uid != os.getuid()
         ):
             raise ValueError
-        payload: Any = json.loads(path.read_text(encoding="utf-8"))
-        acknowledged_at = datetime.fromisoformat(
-            str(payload["acknowledged_at"]).replace("Z", "+00:00")
+        from app.builderops.cutover_evidence import validate_receipt
+        validate_receipt(
+            state_dir,
+            json.loads(path.read_text(encoding="utf-8")),
+            host_id=current_host_id(),
+            user_id=current_user_id(),
         )
-        participating_repos = payload["participating_repos"]
-        participating_roots = payload["participating_roots"]
-        roots = tuple(Path(root).resolve(strict=True) for root in participating_roots)
-        cwd = Path.cwd().resolve()
-        cwd_is_in_inventory = cwd in roots
-        latest_legacy_write = max(
-            (
-                datetime.fromtimestamp(mtime, tz=timezone.utc)
-                for root in roots
-                for mtime in _legacy_store_mtimes(root)
-            ),
-            default=None,
-        )
-        now = datetime.now(timezone.utc)
-        valid = (
-            isinstance(payload, dict)
-            and payload.get("schema_version") == CUTOVER_ACK_SCHEMA
-            and payload.get("scope") == "same-user-same-host"
-            and payload.get("host_id") == current_host_id()
-            and payload.get("user_id") == current_user_id()
-            and payload.get("legacy_stores_reconciled") is True
-            and isinstance(payload.get("actor"), str)
-            and bool(payload["actor"].strip())
-            and acknowledged_at.tzinfo is not None
-            and acknowledged_at <= now + timedelta(minutes=5)
-            and (
-                latest_legacy_write is None
-                or latest_legacy_write <= acknowledged_at
-            )
-            and isinstance(payload.get("inventory_epoch"), str)
-            and bool(UUID(payload["inventory_epoch"]))
-            and isinstance(participating_repos, list)
-            and all(isinstance(repo, str) and repo.strip() for repo in participating_repos)
-            and len(set(participating_repos)) == len(participating_repos)
-            and isinstance(participating_roots, list)
-            and bool(participating_roots)
-            and all(
-                isinstance(root, str) and Path(root).is_absolute()
-                for root in participating_roots
-            )
-            and len(set(participating_roots)) == len(participating_roots)
-            and len(set(roots)) == len(roots)
-            and all(root.is_dir() for root in roots)
-            and len(participating_repos) == len(roots)
-            and cwd_is_in_inventory
-        )
-    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
-        valid = False
-    if valid:
         return
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        pass
     raise ValueError(
         "Refusing implicit host-stable BuilderOps store selection: a valid "
-        "same-user/same-host cutover acknowledgement is required. Stop BuilderOps "
-        "writers, reconcile legacy stores across every participating repository, "
-        "bind a fresh inventory epoch to this host, user, and every participating "
-        "root, then install the documented host-store-cutover-v1 acknowledgement or set "
+        "same-user/same-host cutover acknowledgement is required (a generated cutover receipt with a fresh inventory epoch). Stop BuilderOps "
+        "writers, reconcile every discovered legacy store beneath the declared participant roots, "
+        "then install the documented host-store-cutover-v1 receipt or set "
         "BUILDEROPS_DB_PATH / BUILDEROPS_STATE_DIR explicitly."
     )
 

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -50,6 +50,8 @@ def load_paths(
     configured_db_path = (
         raw_db_path if raw_db_path is not None and raw_db_path.strip() else None
     )
+    vault_value = src.get("BUILDEROPS_VAULT_ROOT", "").strip()
+    vault_root = Path(vault_value).expanduser() if vault_value else None
     exact_db_path = (
         db_path_override if db_path_override is not None else configured_db_path
     )
@@ -59,6 +61,10 @@ def load_paths(
         state_dir = Path(exact_db_path).expanduser().parent
     else:
         state_dir = default_state_dir()
+        validate_db_path_outside_vault(
+            state_dir / DEFAULT_DB_NAME,
+            vault_root=vault_root,
+        )
         _validate_host_cutover_ack(state_dir)
     db_path = (
         db_path_override.expanduser()
@@ -69,8 +75,6 @@ def load_paths(
             else state_dir / DEFAULT_DB_NAME
         ).expanduser()
     )
-    vault_value = src.get("BUILDEROPS_VAULT_ROOT", "").strip()
-    vault_root = Path(vault_value).expanduser() if vault_value else None
     paths = BuilderOpsPaths(
         state_dir=state_dir,
         db_path=db_path,

--- a/app/builderops/cutover_evidence.py
+++ b/app/builderops/cutover_evidence.py
@@ -1,0 +1,269 @@
+"""Fail-closed evidence for the one-time BuilderOps SQLite store cutover.
+
+The operator declares the participating repository roots.  This module does
+not claim to discover arbitrary filesystems; it deterministically inventories
+every legacy store below those declared roots and binds that result to a
+non-empty, already-reconciled target database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import NAMESPACE_OID, UUID, uuid5
+
+
+RECEIPT_SCHEMA = "builderops.host-store-cutover.v2"
+_LEGACY_DB = "builderops.sqlite3"
+
+
+class CutoverEvidenceError(ValueError):
+    """Raised when cutover evidence cannot safely activate the implicit store."""
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def _derived_epoch(host: str, user: str, participants: Any, inventory: Any, report: Any, target_identity: str) -> str:
+    seed = {"host": host, "user": user, "participants": participants, "inventory": inventory, "reconciliation": report, "target_identity": target_identity}
+    return str(uuid5(NAMESPACE_OID, hashlib.sha256(_canonical(seed)).hexdigest()))
+
+
+def _evidence_projection(payload: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(payload)
+    result.pop("receipt_sha256", None)
+    target = result.get("target_store")
+    if isinstance(target, Mapping):
+        result["target_store"] = {"path": target.get("path"), "identity": target.get("identity")}
+    return result
+
+
+def _sha256_path(path: Path) -> str:
+    before = _regular(path)
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    after = _regular(path)
+    if (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+        raise CutoverEvidenceError("store changed while being inventoried")
+    return digest.hexdigest()
+
+
+def _utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise CutoverEvidenceError("cutover epoch must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _regular(path: Path) -> os.stat_result:
+    entry = path.lstat()
+    if stat.S_ISLNK(entry.st_mode) or not stat.S_ISREG(entry.st_mode):
+        raise CutoverEvidenceError("cutover evidence contains a non-regular path")
+    return entry
+
+
+def _participants(raw: Any) -> list[dict[str, str]]:
+    if not isinstance(raw, list) or not raw:
+        raise CutoverEvidenceError("participant inventory must be a non-empty ordered list")
+    result: list[dict[str, str]] = []
+    roots: set[Path] = set()
+    repos: set[str] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise CutoverEvidenceError("participant inventory entry is invalid")
+        repo, root = item.get("repository"), item.get("root")
+        if not isinstance(repo, str) or not repo.strip() or not isinstance(root, str):
+            raise CutoverEvidenceError("participant repository/root is invalid")
+        resolved = Path(root).resolve(strict=True)
+        if not resolved.is_dir() or resolved in roots or repo in repos:
+            raise CutoverEvidenceError("participant roots and repositories must be unique directories")
+        roots.add(resolved)
+        repos.add(repo)
+        result.append({"repository": repo, "root": str(resolved)})
+    return result
+
+
+def discover_legacy_stores(participants: Any) -> list[dict[str, Any]]:
+    """Return a deterministic complete inventory beneath declared roots."""
+    stores: list[dict[str, Any]] = []
+    for participant in _participants(participants):
+        root = Path(participant["root"])
+        def fail_walk(error: OSError) -> None:
+            raise CutoverEvidenceError("participant inventory traversal failed") from error
+        for directory, child_dirs, filenames in os.walk(root, followlinks=False, onerror=fail_walk):
+            base = Path(directory)
+            child_dirs[:] = sorted(name for name in child_dirs if not (base / name).is_symlink())
+            if base.name != "builderops" or base.parent.name != "runtime" or _LEGACY_DB not in filenames:
+                continue
+            path = base / _LEGACY_DB
+            entry = _regular(path)
+            stores.append({
+                "repository": participant["repository"], "path": str(path.resolve()),
+                "sha256": _sha256_path(path), "size": entry.st_size, "mtime_ns": entry.st_mtime_ns,
+            })
+    return sorted(stores, key=lambda item: (item["repository"], item["path"]))
+
+
+def _records(path: Path) -> list[dict[str, str]]:
+    try:
+        uri = f"{path.resolve().as_uri()}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute("SELECT id, payload FROM builderops_records ORDER BY id").fetchall()
+    except sqlite3.Error as exc:
+        raise CutoverEvidenceError("BuilderOps store is malformed or unreadable") from exc
+    return [{"id": str(row[0]), "payload_sha256": hashlib.sha256(str(row[1]).encode()).hexdigest()} for row in rows]
+
+
+def inspect_target(db_path: Path) -> dict[str, Any]:
+    """Inspect an existing target without creating or initializing it."""
+    entry = _regular(db_path)
+    if entry.st_size == 0:
+        raise CutoverEvidenceError("target store is empty")
+    try:
+        uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as connection:
+            count = connection.execute("SELECT COUNT(*) FROM builderops_records").fetchone()[0]
+            marker = connection.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone()
+    except sqlite3.Error as exc:
+        raise CutoverEvidenceError("target store is not an initialized BuilderOps database") from exc
+    if not isinstance(count, int) or count <= 0:
+        raise CutoverEvidenceError("target store is empty")
+    # The target necessarily changes after cutover as normal BuilderOps records
+    # are appended.  Bind its identity and prove it was non-empty at receipt
+    # production; validation then proves the same target remains non-empty,
+    # rather than treating legitimate post-cutover writes as tampering.
+    identity = hashlib.sha256(f"{entry.st_dev}:{entry.st_ino}:{db_path.resolve()}".encode()).hexdigest()
+    records = _records(db_path)
+    return {"path": str(db_path.resolve()), "record_count": count, "records_sha256": hashlib.sha256(_canonical(records)).hexdigest(), "identity": identity, "marker": marker[0] if marker else None}
+
+
+def _stamp_target(db_path: Path, marker: Mapping[str, str]) -> None:
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("INSERT OR REPLACE INTO builderops_meta(key, value) VALUES (?, ?)", ("host_store_cutover_v2", _canonical(dict(marker)).decode()))
+        connection.commit()
+
+
+def _reconciliation(raw: Any, inventory: list[dict[str, Any]], target_path: Path) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise CutoverEvidenceError("reconciliation report must contain a store list")
+    reported: dict[str, dict[str, Any]] = {}
+    target_records = {(item["id"], item["payload_sha256"]) for item in _records(target_path)}
+    for item in raw:
+        if not isinstance(item, Mapping) or not isinstance(item.get("path"), str) or not isinstance(item.get("disposition"), str):
+            raise CutoverEvidenceError("reconciliation report entry is invalid")
+        path, disposition = str(Path(item["path"]).resolve()), item["disposition"]
+        if disposition not in {"migrated", "retained"} or path in reported:
+            raise CutoverEvidenceError("reconciliation disposition is invalid")
+        source = _records(Path(path))
+        source_digest = hashlib.sha256(_canonical(source)).hexdigest()
+        if item.get("source_records_sha256") not in {None, source_digest}:
+            raise CutoverEvidenceError("reconciliation source evidence does not match legacy store")
+        if disposition == "migrated" and not {(row["id"], row["payload_sha256"]) for row in source}.issubset(target_records):
+            raise CutoverEvidenceError("migrated legacy records are not accounted for in target")
+        reported[path] = {"path": path, "disposition": disposition, "source_records_sha256": source_digest, "source_record_count": len(source)}
+    expected = {item["path"] for item in inventory}
+    if set(reported) != expected:
+        raise CutoverEvidenceError("reconciliation report does not account for every discovered legacy store")
+    return [reported[path] for path in sorted(reported)]
+
+
+def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, actor: str) -> dict[str, Any]:
+    """Build a receipt only after a real, non-empty target has been reconciled."""
+    if not isinstance(actor, str) or not actor.strip():
+        raise CutoverEvidenceError("cutover actor is required")
+    cutoff = datetime.now(timezone.utc)
+    participant_list = _participants(participants)
+    inventory = discover_legacy_stores(participant_list)
+    if any(item["mtime_ns"] > int(cutoff.timestamp() * 1_000_000_000) for item in inventory):
+        raise CutoverEvidenceError("legacy store changed during reconciliation inventory")
+    report = _reconciliation(reconciliation, inventory, state_dir / _LEGACY_DB)
+    target = inspect_target(state_dir / _LEGACY_DB)
+    host, user = __import__("platform").node().strip(), str(os.getuid())
+    derived_epoch = _derived_epoch(host, user, participant_list, inventory, report, target["identity"])
+    payload: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA, "scope": "same-user-same-host",
+        "host_id": host, "user_id": user,
+        "actor": actor.strip(), "reconciliation_epoch": derived_epoch,
+        "reconciled_at": cutoff.isoformat(),
+        "participants": participant_list, "legacy_store_inventory": inventory,
+        "reconciliation": report, "target_store": target,
+    }
+    payload["inventory_sha256"] = hashlib.sha256(_canonical(inventory)).hexdigest()
+    payload["reconciliation_sha256"] = hashlib.sha256(_canonical(report)).hexdigest()
+    # A producer must not stamp evidence from a snapshot that has already
+    # drifted while source records were being inspected.  Re-run both source
+    # discovery and reconciliation immediately before the sole write.
+    final_inventory = discover_legacy_stores(participant_list)
+    final_report = _reconciliation(reconciliation, final_inventory, state_dir / _LEGACY_DB)
+    if final_inventory != inventory or final_report != report:
+        raise CutoverEvidenceError("legacy store inventory drifted during reconciliation")
+    evidence_digest = hashlib.sha256(_canonical(_evidence_projection(payload))).hexdigest()
+    _stamp_target(state_dir / _LEGACY_DB, {"identity": target["identity"], "epoch": derived_epoch, "evidence_sha256": evidence_digest})
+    payload["target_store"] = inspect_target(state_dir / _LEGACY_DB)
+    payload["receipt_sha256"] = hashlib.sha256(_canonical(payload)).hexdigest()
+    return payload
+
+
+def write_receipt(state_dir: Path, receipt: Mapping[str, Any]) -> Path:
+    path = state_dir / "host-store-cutover-v1.json"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_bytes(_canonical(dict(receipt)))
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+    return path
+
+
+def validate_receipt(state_dir: Path, payload: Any, *, host_id: str, user_id: str) -> None:
+    """Recompute all producer bindings before a SQLite connection can be opened."""
+    if not isinstance(payload, Mapping):
+        raise CutoverEvidenceError("cutover receipt is not an object")
+    try:
+        receipt = dict(payload)
+        signature = receipt.pop("receipt_sha256")
+        if not isinstance(signature, str) or hashlib.sha256(_canonical(receipt)).hexdigest() != signature:
+            raise CutoverEvidenceError("cutover receipt integrity binding is invalid")
+        if receipt.get("schema_version") != RECEIPT_SCHEMA or receipt.get("scope") != "same-user-same-host":
+            raise CutoverEvidenceError("cutover receipt schema is invalid")
+        if receipt.get("host_id") != host_id or receipt.get("user_id") != user_id:
+            raise CutoverEvidenceError("cutover receipt host/user binding is invalid")
+        epoch = receipt.get("reconciliation_epoch")
+        UUID(epoch)
+        reconciled_at = _utc(str(receipt["reconciled_at"]))
+        if reconciled_at > datetime.now(timezone.utc):
+            raise CutoverEvidenceError("cutover receipt is stale or future-dated")
+        participants = _participants(receipt.get("participants"))
+        cwd = Path.cwd().resolve()
+        roots = [Path(item["root"]) for item in participants]
+        if sum(cwd == root or root in cwd.parents for root in roots) != 1:
+            raise CutoverEvidenceError("current working directory is outside the participant inventory")
+        inventory = discover_legacy_stores(participants)
+        if inventory != receipt.get("legacy_store_inventory") or hashlib.sha256(_canonical(inventory)).hexdigest() != receipt.get("inventory_sha256"):
+            raise CutoverEvidenceError("cutover receipt inventory is incomplete or stale")
+        report = _reconciliation(receipt.get("reconciliation"), inventory, state_dir / _LEGACY_DB)
+        if report != receipt.get("reconciliation") or hashlib.sha256(_canonical(report)).hexdigest() != receipt.get("reconciliation_sha256"):
+            raise CutoverEvidenceError("cutover receipt reconciliation binding is invalid")
+        target = inspect_target(state_dir / _LEGACY_DB)
+        recorded_target = receipt.get("target_store")
+        if not isinstance(recorded_target, Mapping) or recorded_target.get("path") != target["path"] or target["identity"] != recorded_target.get("identity") or target.get("marker") != recorded_target.get("marker") or target["record_count"] < int(recorded_target.get("record_count", 1)):
+            raise CutoverEvidenceError("cutover target store is empty, changed, or unaccounted")
+        marker = json.loads(str(target["marker"]))
+        expected_epoch = _derived_epoch(host_id, user_id, participants, inventory, report, target["identity"])
+        expected_digest = hashlib.sha256(_canonical(_evidence_projection(receipt))).hexdigest()
+        if marker.get("identity") != target["identity"] or marker.get("epoch") != epoch or epoch != expected_epoch or marker.get("evidence_sha256") != expected_digest:
+            raise CutoverEvidenceError("cutover target marker does not bind this receipt epoch")
+        if any(item["mtime_ns"] > int(reconciled_at.timestamp() * 1_000_000_000) for item in inventory):
+            raise CutoverEvidenceError("legacy store was written after reconciliation epoch")
+    except (KeyError, TypeError, ValueError, OSError) as exc:
+        if isinstance(exc, CutoverEvidenceError):
+            raise
+        raise CutoverEvidenceError("cutover receipt is malformed") from exc

--- a/app/builderops/cutover_evidence.py
+++ b/app/builderops/cutover_evidence.py
@@ -163,18 +163,30 @@ def _reconciliation(
 ) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         raise CutoverEvidenceError("reconciliation report must contain a store list")
-    reported: dict[str, dict[str, Any]] = {}
+    expected = {item["path"] for item in inventory}
+    normalized: dict[str, tuple[Mapping[str, Any], str]] = {}
+    for item in raw:
+        if not isinstance(item, Mapping) or not isinstance(item.get("path"), str) or not isinstance(item.get("disposition"), str):
+            raise CutoverEvidenceError("reconciliation report entry is invalid")
+        path, disposition = str(Path(item["path"]).resolve()), item["disposition"]
+        if path not in expected:
+            raise CutoverEvidenceError(
+                "reconciliation report path is outside the discovered legacy inventory"
+            )
+        if disposition not in {"migrated", "retained"} or path in normalized:
+            raise CutoverEvidenceError("reconciliation disposition is invalid")
+        normalized[path] = (item, disposition)
+    if set(normalized) != expected:
+        raise CutoverEvidenceError("reconciliation report does not account for every discovered legacy store")
+
     target_records = (
         {(item["id"], item["payload_sha256"]) for item in _records(target_path)}
         if verify_migrated_target
         else set()
     )
-    for item in raw:
-        if not isinstance(item, Mapping) or not isinstance(item.get("path"), str) or not isinstance(item.get("disposition"), str):
-            raise CutoverEvidenceError("reconciliation report entry is invalid")
-        path, disposition = str(Path(item["path"]).resolve()), item["disposition"]
-        if disposition not in {"migrated", "retained"} or path in reported:
-            raise CutoverEvidenceError("reconciliation disposition is invalid")
+    reported: dict[str, dict[str, Any]] = {}
+    for path in sorted(normalized):
+        item, disposition = normalized[path]
         source = _records(Path(path))
         source_digest = hashlib.sha256(_canonical(source)).hexdigest()
         if item.get("source_records_sha256") not in {None, source_digest}:
@@ -182,9 +194,6 @@ def _reconciliation(
         if disposition == "migrated" and verify_migrated_target and not {(row["id"], row["payload_sha256"]) for row in source}.issubset(target_records):
             raise CutoverEvidenceError("migrated legacy records are not accounted for in target")
         reported[path] = {"path": path, "disposition": disposition, "source_records_sha256": source_digest, "source_record_count": len(source)}
-    expected = {item["path"] for item in inventory}
-    if set(reported) != expected:
-        raise CutoverEvidenceError("reconciliation report does not account for every discovered legacy store")
     return [reported[path] for path in sorted(reported)]
 
 

--- a/app/builderops/cutover_evidence.py
+++ b/app/builderops/cutover_evidence.py
@@ -152,11 +152,21 @@ def _stamp_target(db_path: Path, marker: Mapping[str, str]) -> None:
         connection.commit()
 
 
-def _reconciliation(raw: Any, inventory: list[dict[str, Any]], target_path: Path) -> list[dict[str, Any]]:
+def _reconciliation(
+    raw: Any,
+    inventory: list[dict[str, Any]],
+    target_path: Path,
+    *,
+    verify_migrated_target: bool,
+) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         raise CutoverEvidenceError("reconciliation report must contain a store list")
     reported: dict[str, dict[str, Any]] = {}
-    target_records = {(item["id"], item["payload_sha256"]) for item in _records(target_path)}
+    target_records = (
+        {(item["id"], item["payload_sha256"]) for item in _records(target_path)}
+        if verify_migrated_target
+        else set()
+    )
     for item in raw:
         if not isinstance(item, Mapping) or not isinstance(item.get("path"), str) or not isinstance(item.get("disposition"), str):
             raise CutoverEvidenceError("reconciliation report entry is invalid")
@@ -167,7 +177,7 @@ def _reconciliation(raw: Any, inventory: list[dict[str, Any]], target_path: Path
         source_digest = hashlib.sha256(_canonical(source)).hexdigest()
         if item.get("source_records_sha256") not in {None, source_digest}:
             raise CutoverEvidenceError("reconciliation source evidence does not match legacy store")
-        if disposition == "migrated" and not {(row["id"], row["payload_sha256"]) for row in source}.issubset(target_records):
+        if disposition == "migrated" and verify_migrated_target and not {(row["id"], row["payload_sha256"]) for row in source}.issubset(target_records):
             raise CutoverEvidenceError("migrated legacy records are not accounted for in target")
         reported[path] = {"path": path, "disposition": disposition, "source_records_sha256": source_digest, "source_record_count": len(source)}
     expected = {item["path"] for item in inventory}
@@ -185,7 +195,7 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     inventory = discover_legacy_stores(participant_list)
     if any(item["mtime_ns"] > int(cutoff.timestamp() * 1_000_000_000) for item in inventory):
         raise CutoverEvidenceError("legacy store changed during reconciliation inventory")
-    report = _reconciliation(reconciliation, inventory, state_dir / _LEGACY_DB)
+    report = _reconciliation(reconciliation, inventory, state_dir / _LEGACY_DB, verify_migrated_target=True)
     target = inspect_target(state_dir / _LEGACY_DB)
     host, user = __import__("platform").node().strip(), str(os.getuid())
     derived_epoch = _derived_epoch(host, user, participant_list, inventory, report, target["identity"])
@@ -203,7 +213,7 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     # drifted while source records were being inspected.  Re-run both source
     # discovery and reconciliation immediately before the sole write.
     final_inventory = discover_legacy_stores(participant_list)
-    final_report = _reconciliation(reconciliation, final_inventory, state_dir / _LEGACY_DB)
+    final_report = _reconciliation(reconciliation, final_inventory, state_dir / _LEGACY_DB, verify_migrated_target=True)
     if final_inventory != inventory or final_report != report:
         raise CutoverEvidenceError("legacy store inventory drifted during reconciliation")
     evidence_digest = hashlib.sha256(_canonical(_evidence_projection(payload))).hexdigest()
@@ -249,7 +259,7 @@ def validate_receipt(state_dir: Path, payload: Any, *, host_id: str, user_id: st
         inventory = discover_legacy_stores(participants)
         if inventory != receipt.get("legacy_store_inventory") or hashlib.sha256(_canonical(inventory)).hexdigest() != receipt.get("inventory_sha256"):
             raise CutoverEvidenceError("cutover receipt inventory is incomplete or stale")
-        report = _reconciliation(receipt.get("reconciliation"), inventory, state_dir / _LEGACY_DB)
+        report = _reconciliation(receipt.get("reconciliation"), inventory, state_dir / _LEGACY_DB, verify_migrated_target=False)
         if report != receipt.get("reconciliation") or hashlib.sha256(_canonical(report)).hexdigest() != receipt.get("reconciliation_sha256"):
             raise CutoverEvidenceError("cutover receipt reconciliation binding is invalid")
         target = inspect_target(state_dir / _LEGACY_DB)

--- a/app/builderops/cutover_evidence.py
+++ b/app/builderops/cutover_evidence.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Any, Mapping
 from uuid import NAMESPACE_OID, UUID, uuid5
 
+from app.builderops.config import validate_db_path_outside_vault
+
 
 RECEIPT_SCHEMA = "builderops.host-store-cutover.v2"
 _LEGACY_DB = "builderops.sqlite3"
@@ -188,6 +190,8 @@ def _reconciliation(
 
 def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, actor: str) -> dict[str, Any]:
     """Build a receipt only after a real, non-empty target has been reconciled."""
+    target_path = state_dir / _LEGACY_DB
+    validate_db_path_outside_vault(target_path)
     if not isinstance(actor, str) or not actor.strip():
         raise CutoverEvidenceError("cutover actor is required")
     cutoff = datetime.now(timezone.utc)
@@ -195,8 +199,8 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     inventory = discover_legacy_stores(participant_list)
     if any(item["mtime_ns"] > int(cutoff.timestamp() * 1_000_000_000) for item in inventory):
         raise CutoverEvidenceError("legacy store changed during reconciliation inventory")
-    report = _reconciliation(reconciliation, inventory, state_dir / _LEGACY_DB, verify_migrated_target=True)
-    target = inspect_target(state_dir / _LEGACY_DB)
+    report = _reconciliation(reconciliation, inventory, target_path, verify_migrated_target=True)
+    target = inspect_target(target_path)
     host, user = __import__("platform").node().strip(), str(os.getuid())
     derived_epoch = _derived_epoch(host, user, participant_list, inventory, report, target["identity"])
     payload: dict[str, Any] = {
@@ -213,12 +217,12 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     # drifted while source records were being inspected.  Re-run both source
     # discovery and reconciliation immediately before the sole write.
     final_inventory = discover_legacy_stores(participant_list)
-    final_report = _reconciliation(reconciliation, final_inventory, state_dir / _LEGACY_DB, verify_migrated_target=True)
+    final_report = _reconciliation(reconciliation, final_inventory, target_path, verify_migrated_target=True)
     if final_inventory != inventory or final_report != report:
         raise CutoverEvidenceError("legacy store inventory drifted during reconciliation")
     evidence_digest = hashlib.sha256(_canonical(_evidence_projection(payload))).hexdigest()
-    _stamp_target(state_dir / _LEGACY_DB, {"identity": target["identity"], "epoch": derived_epoch, "evidence_sha256": evidence_digest})
-    payload["target_store"] = inspect_target(state_dir / _LEGACY_DB)
+    _stamp_target(target_path, {"identity": target["identity"], "epoch": derived_epoch, "evidence_sha256": evidence_digest})
+    payload["target_store"] = inspect_target(target_path)
     payload["receipt_sha256"] = hashlib.sha256(_canonical(payload)).hexdigest()
     return payload
 

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -108,6 +108,8 @@ python -m app.builderops builderops cutover-evidence generate \
 The ordered participant/repository/root list is the explicit inventory boundary. The producer
 recursively discovers every legacy store beneath those roots, binds its identity and disposition,
 the actual host and numeric user, one reconciliation epoch, and an already-existing non-empty target.
+Because this producer governs the implicit host-stable store, the group-level CLI `--db-path`
+override is rejected before inspection or mutation.
 The validator recomputes those bindings before SQLite initialization; copied, stale, incomplete,
 post-epoch-mutated, or empty-target receipts fail closed.
 The payload schema is `builderops.host-store-cutover.v2`; the `host-store-cutover-v1.json`

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -111,6 +111,9 @@ recursively discovers every legacy store beneath those roots, binds its identity
 the actual host and numeric user, one reconciliation epoch, and an already-existing non-empty target.
 Because this producer governs the implicit host-stable store, the group-level CLI `--db-path`
 override is rejected before inspection or mutation.
+The producer also applies the shared vault-confinement guard to the implicit target path before
+legacy-store inventory, target inspection, marker stamping, or receipt creation. A target beneath
+`BUILDEROPS_VAULT_ROOT` therefore fails without mutating the database or receipt location.
 The validator recomputes those bindings before SQLite initialization; copied, stale, incomplete,
 post-epoch-mutated, or empty-target receipts fail closed.
 The payload schema is `builderops.host-store-cutover.v2`; the `host-store-cutover-v1.json`

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -85,8 +85,9 @@ Override mechanisms:
 - `BUILDEROPS_STATE_DIR` sets the BuilderOps state directory. The default database name remains
   `builderops.sqlite3`.
 - `BUILDEROPS_DB_PATH` sets the exact SQLite database path.
-- CLI commands also accept `--db-path` for explicit one-command override, which is the preferred
-  test path.
+- CLI commands generally accept `--db-path` for an explicit one-command override, which is the
+  preferred test path. The `cutover-evidence generate` producer is the exception: it rejects this
+  override because it can produce evidence only for the implicit host-stable store.
 - API/tool callers may set `builderops_db_path` through tool settings or `BUILDEROPS_DB_PATH`
   through the environment; see `docs/builderops/BUILDEROPS_VAULT_BOUNDARY.md`.
 
@@ -135,26 +136,31 @@ filename is intentionally retained as the compatibility location for the prior m
 }
 ```
 
-The operator creates this owner-only `0600`, non-symlink marker only after stopping BuilderOps writers, inventorying
-every participating repository on the host, and reconciling or explicitly retaining its legacy
-stores. The marker is bound to the actual hostname and numeric UID. `participating_repos` names
-the bounded logical inventory; `participating_roots` lists the same number of unique, resolved,
-absolute local roots in matching inventory order, and the current working directory must equal one
-of those exact roots. Every listed root is recursively inventoried for nested
-`runtime/builderops/builderops.sqlite3` stores without following symlinks, so a broad secondary
-root cannot hide a newer nested legacy store. The UUID
-`inventory_epoch` and timezone-aware timestamp identify the
-reconciliation pass. A future timestamp, a legacy DB written after that pass, a copied host/user
-identity, an unlisted current root, wrong ownership/mode, or a missing/malformed field fails before
-the consolidated DB is opened. Error text remains privacy-safe; host paths and contents are not
-printed.
+After the operator has stopped BuilderOps writers and reconciled every discovered legacy store, the
+producer recursively inventories the ordered `participants` roots without following symlinks,
+verifies the supplied reconciliation report against that inventory and the existing non-empty
+target, stamps the target, and creates the owner-only `0600`, non-symlink receipt. Each participant
+contains its repository identity and one unique, resolved absolute root. Receipt validation accepts
+a current working directory equal to or descended from exactly one declared root; an unrelated or
+ambiguously nested participant location fails closed.
 
-`BUILDEROPS_DB_PATH`, `BUILDEROPS_STATE_DIR`, and CLI `--db-path` bypass the acknowledgement gate.
-Environment overrides must be non-blank after trimming; blank values are treated as absent and
-therefore follow the acknowledged implicit host-store path.
-They remain the operator path for keeping the current store pinned before cutover and selecting the
-reconciled store during cutover. This PR does not create the acknowledgement, inventory repos,
-reconcile records, migrate data, stop writers, or perform the live cutover.
+The deterministic `reconciliation_epoch` is derived from the actual host and numeric user, ordered
+participants, complete legacy-store inventory, reconciliation report, and target identity. The
+receipt binds the inventory and report with `inventory_sha256` and `reconciliation_sha256`, binds
+the target path and identity, and carries a whole-receipt digest. The target marker binds that same
+identity and epoch to an evidence digest of the receipt. Validation recomputes these bindings and
+the inventory before the implicit database can be initialized; a future cutoff, post-cutoff legacy
+write, copied host/user identity, incomplete report, changed target marker, invalid ownership or
+mode, or malformed field fails closed. Error text remains privacy-safe; host paths and contents are
+not printed.
+
+Non-blank `BUILDEROPS_DB_PATH` and `BUILDEROPS_STATE_DIR` values bypass the receipt gate during
+normal store selection, as does CLI `--db-path` for commands that support it. Blank environment
+values are treated as absent and therefore follow the receipt-gated implicit host-store path. The
+`cutover-evidence generate` command rejects CLI `--db-path` before inspection or mutation. These
+overrides remain the operator path for pinning the current store before cutover and selecting the
+reconciled store during cutover. The producer is evidence-only: it does not stop writers, migrate
+or reconcile records, or perform the live cutover.
 
 Default home-directory resolution is lazy. An absolute explicit DB/state/CLI override therefore
 continues to work in hostless automation where no user home can be resolved.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -114,6 +114,8 @@ override is rejected before inspection or mutation.
 The producer also applies the shared vault-confinement guard to the implicit target path before
 legacy-store inventory, target inspection, marker stamping, or receipt creation. A target beneath
 `BUILDEROPS_VAULT_ROOT` therefore fails without mutating the database or receipt location.
+Implicit path loading applies that same guard before reading the receipt or opening the target, so
+a previously valid target later confined beneath the vault is rejected without inspection.
 The validator recomputes those bindings before SQLite initialization; copied, stale, incomplete,
 post-epoch-mutated, or empty-target receipts fail closed.
 The payload schema is `builderops.host-store-cutover.v2`; the `host-store-cutover-v1.json`
@@ -142,7 +144,8 @@ filename is intentionally retained as the compatibility location for the prior m
 After the operator has stopped BuilderOps writers and reconciled every discovered legacy store, the
 producer recursively inventories the ordered `participants` roots without following symlinks,
 verifies the supplied reconciliation report against that inventory and the existing non-empty
-target, stamps the target, and creates the owner-only `0600`, non-symlink receipt. Each participant
+target, stamps the target, and creates the owner-only `0600`, non-symlink receipt. A report path
+outside the discovered inventory is rejected before its records are opened. Each participant
 contains its repository identity and one unique, resolved absolute root. Receipt validation accepts
 a current working directory equal to or descended from exactly one declared root; an unrelated or
 ambiguously nested participant location fails closed.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -96,7 +96,22 @@ Existing legacy stores under `<checkout>/runtime/builderops/` are not migrated, 
 silently treated as the consolidated store by this code change. Absence of a legacy store in the
 current repository is not evidence that other participating repositories have no legacy state.
 With neither store override set, path loading therefore fails before opening or initializing the
-host-stable database unless the operator has installed this host-level acknowledgement:
+host-stable database unless the operator has installed the supported producer-generated receipt.
+The receipt is created (without running live cutover) with:
+
+```text
+python -m app.builderops builderops cutover-evidence generate \
+  --participants-file participants.json --reconciliation-file reconciliation.json \
+  --actor <operator> --json
+```
+
+The ordered participant/repository/root list is the explicit inventory boundary. The producer
+recursively discovers every legacy store beneath those roots, binds its identity and disposition,
+the actual host and numeric user, one reconciliation epoch, and an already-existing non-empty target.
+The validator recomputes those bindings before SQLite initialization; copied, stale, incomplete,
+post-epoch-mutated, or empty-target receipts fail closed.
+The payload schema is `builderops.host-store-cutover.v2`; the `host-store-cutover-v1.json`
+filename is intentionally retained as the compatibility location for the prior marker.
 
 ```text
 ~/.local/state/builderops/host-store-cutover-v1.json
@@ -104,16 +119,17 @@ host-stable database unless the operator has installed this host-level acknowled
 
 ```json
 {
-  "schema_version": "builderops.host-store-cutover.v1",
+  "schema_version": "builderops.host-store-cutover.v2",
   "scope": "same-user-same-host",
   "host_id": "actual local hostname",
   "user_id": "actual local numeric uid",
-  "legacy_stores_reconciled": true,
-  "participating_repos": ["owner/repo-a", "owner/repo-b"],
-  "participating_roots": ["/absolute/repo-a", "/absolute/repo-b"],
-  "inventory_epoch": "7afaf9af-b94f-4b5e-8242-c3cb45fc70fb",
+  "participants": [{"repository": "owner/repo-a", "root": "/absolute/repo-a"}],
+  "reconciliation_epoch": "7afaf9af-b94f-4b5e-8242-c3cb45fc70fb",
   "actor": "operator identity",
-  "acknowledged_at": "2026-07-15T00:00:00Z"
+  "reconciled_at": "2026-07-15T00:00:00Z",
+  "legacy_store_inventory": [],
+  "reconciliation": [],
+  "target_store": {"path": "/absolute/state/builderops.sqlite3", "record_count": 1}
 }
 ```
 

--- a/tests/architecture/test_builderops_store_boundary.py
+++ b/tests/architecture/test_builderops_store_boundary.py
@@ -64,6 +64,7 @@ VAULT_STORE_ALLOWLIST: frozenset[str] = frozenset(
         "app/builderops/cli.py",  # legacy Vault CLI (this session's own coordination path)
         "app/builderops/boundary.py",  # local Vault HTTP/tool boundary (#1503), Product-adjacent
         "app/builderops/completeness_report.py",  # read-only Vault inventory report
+        "app/builderops/cutover_evidence.py",  # #3686 audited one-time receipt producer/validator
         "app/builderops/ckm/store.py",  # CKM receipt store built on the Vault store
     }
 )

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 import app.builderops.config as builderops_config
+import app.builderops.cutover_evidence as cutover_evidence
 from app.builderops.store import SqliteBuilderOpsStore
 from app.builderops.cutover_evidence import CutoverEvidenceError, build_receipt, discover_legacy_stores, write_receipt
 
@@ -112,9 +113,32 @@ def test_host_stable_default_still_confined_outside_vault(
         lambda: state_dir,
     )
     _write_cutover_ack(state_dir, roots=[Path.cwd()])
+    db_path = state_dir / "builderops.sqlite3"
+    receipt_path = builderops_config.host_cutover_ack_path(state_dir)
+    before_db, before_receipt = db_path.read_bytes(), receipt_path.read_bytes()
+    receipt_reads: list[Path] = []
+    target_opens: list[object] = []
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == receipt_path:
+            receipt_reads.append(path)
+            pytest.fail("vault-confined receipt was read before path preflight")
+        return original_read_text(path, *args, **kwargs)
+
+    def guarded_connect(*args: object, **kwargs: object) -> object:
+        target_opens.append((args, kwargs))
+        pytest.fail("vault-confined target was opened before path preflight")
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    monkeypatch.setattr(cutover_evidence.sqlite3, "connect", guarded_connect)
 
     with pytest.raises(ValueError, match="outside BUILDEROPS_VAULT_ROOT"):
         builderops_config.load_paths({"BUILDEROPS_VAULT_ROOT": str(vault)})
+
+    assert not receipt_reads and not target_opens
+    assert db_path.read_bytes() == before_db
+    assert receipt_path.read_bytes() == before_receipt
 
 
 def test_explicit_overrides_unchanged(tmp_path: Path) -> None:

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -12,6 +12,7 @@ import pytest
 
 import app.builderops.config as builderops_config
 from app.builderops.store import SqliteBuilderOpsStore
+from app.builderops.cutover_evidence import CutoverEvidenceError, build_receipt, discover_legacy_stores, write_receipt
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -27,31 +28,34 @@ def _write_cutover_ack(
     user_id: str | None = None,
 ) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
-    path = builderops_config.host_cutover_ack_path(state_dir)
-    path.write_text(
-        json.dumps(
-            {
-                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
-                "scope": "same-user-same-host",
-                "host_id": host_id or builderops_config.current_host_id(),
-                "user_id": user_id or builderops_config.current_user_id(),
-                "legacy_stores_reconciled": True,
-                "participating_repos": repos
-                if repos is not None
-                else [f"local/repo-{index}" for index, _root in enumerate(roots or [Path.cwd()])],
-                "participating_roots": [
-                    str(root.resolve()) for root in (roots or [Path.cwd()])
-                ],
-                "inventory_epoch": str(uuid4()),
-                "actor": "operator-test",
-                "acknowledged_at": (
-                    acknowledged_at or datetime.now(timezone.utc)
-                ).isoformat(),
-            }
-        ),
-        encoding="utf-8",
+    target = SqliteBuilderOpsStore(state_dir / "builderops.sqlite3")
+    target.initialize()
+    target.create_agent_worklog(
+        id=f"awl_cutover_{uuid4().hex}", summary="cutover fixture", body="fixture",
+        task_context={}, source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "test"},
     )
-    path.chmod(0o600)
+    root_values = roots or [Path.cwd()]
+    participants = [
+        {"repository": (repos or [f"local/repo-{i}" for i in range(len(root_values))])[i], "root": str(root.resolve())}
+        for i, root in enumerate(root_values)
+    ]
+    reconciliation = [{"path": item["path"], "disposition": "retained"} for item in discover_legacy_stores(participants)]
+    receipt = build_receipt(
+        state_dir=state_dir, participants=participants, reconciliation=reconciliation, actor="operator-test"
+    )
+    if host_id:
+        receipt["host_id"] = host_id
+    if user_id:
+        receipt["user_id"] = user_id
+    if acknowledged_at:
+        receipt["reconciled_at"] = acknowledged_at.isoformat()
+    if host_id or user_id or acknowledged_at:
+        body = dict(receipt)
+        body.pop("receipt_sha256")
+        import hashlib
+        receipt["receipt_sha256"] = hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    write_receipt(state_dir, receipt)
 
 
 def _run_implicit_cli(*, cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
@@ -279,7 +283,7 @@ def test_host_ack_is_bound_to_host_user_inventory_and_reconciliation_epoch(
     state_dir = tmp_path / "host-state" / "builderops"
     legacy_db = repo / "runtime" / "builderops" / "builderops.sqlite3"
     legacy_db.parent.mkdir(parents=True)
-    legacy_db.write_bytes(b"SQLite format 3\x00")
+    SqliteBuilderOpsStore(legacy_db).initialize()
     stale = datetime.now(timezone.utc) - timedelta(days=1)
     monkeypatch.chdir(repo)
 
@@ -312,7 +316,7 @@ def test_host_ack_rejects_broad_parent_that_hides_newer_nested_legacy_store(
     repo.mkdir(parents=True)
     legacy_db = repo / "runtime" / "builderops" / "builderops.sqlite3"
     legacy_db.parent.mkdir(parents=True)
-    legacy_db.write_bytes(b"SQLite format 3\x00")
+    SqliteBuilderOpsStore(legacy_db).initialize()
     acknowledged_at = datetime.now(timezone.utc) - timedelta(minutes=1)
     newer = acknowledged_at + timedelta(seconds=30)
     os.utime(legacy_db, (newer.timestamp(), newer.timestamp()))
@@ -341,7 +345,7 @@ def test_host_ack_rejects_broad_secondary_root_with_newer_nested_store(
     nested_repo.mkdir(parents=True)
     legacy_db = nested_repo / "runtime" / "builderops" / "builderops.sqlite3"
     legacy_db.parent.mkdir(parents=True)
-    legacy_db.write_bytes(b"SQLite format 3\x00")
+    SqliteBuilderOpsStore(legacy_db).initialize()
     acknowledged_at = datetime.now(timezone.utc) - timedelta(minutes=1)
     newer = acknowledged_at + timedelta(seconds=30)
     os.utime(legacy_db, (newer.timestamp(), newer.timestamp()))
@@ -369,14 +373,12 @@ def test_host_ack_rejects_non_directory_secondary_root(
     non_directory.write_text("not a directory", encoding="utf-8")
     state_dir = tmp_path / "host-state" / "builderops"
     monkeypatch.chdir(current_repo)
-    _write_cutover_ack(
-        state_dir,
-        ["owner/repo-a", "owner/not-a-root"],
-        roots=[current_repo, non_directory],
-    )
-
-    with pytest.raises(ValueError, match="fresh inventory epoch"):
-        builderops_config._validate_host_cutover_ack(state_dir)
+    with pytest.raises(CutoverEvidenceError, match="unique directories"):
+        _write_cutover_ack(
+            state_dir,
+            ["owner/repo-a", "owner/not-a-root"],
+            roots=[current_repo, non_directory],
+        )
 
 
 def test_host_ack_fails_closed_on_inventory_traversal_error(

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -173,6 +173,82 @@ def test_cutover_producer_rejects_post_cutoff_inventory_without_stamping(tmp_pat
         assert conn.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone() is None
 
 
+def test_cutover_producer_rejects_target_inside_vault_before_inspection_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root, state_dir, root = tmp_path / "vault", tmp_path / "vault" / "state", tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.delenv("BUILDEROPS_VAULT_ROOT", raising=False)
+    _target(state_dir)
+    db_path = state_dir / "builderops.sqlite3"
+    before = db_path.read_bytes()
+    inventory_calls: list[object] = []
+    monkeypatch.setenv("BUILDEROPS_VAULT_ROOT", str(vault_root))
+    monkeypatch.setattr(
+        evidence,
+        "discover_legacy_stores",
+        lambda participants: inventory_calls.append(participants),
+    )
+
+    with pytest.raises(ValueError, match="must be outside BUILDEROPS_VAULT_ROOT"):
+        build_receipt(
+            state_dir=state_dir,
+            participants=[{"repository": "owner/repo", "root": str(root)}],
+            reconciliation=[],
+            actor="operator",
+        )
+
+    assert not inventory_calls
+    assert db_path.read_bytes() == before
+    assert not config.host_cutover_ack_path(state_dir).exists()
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+        marker = conn.execute(
+            "SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'"
+        ).fetchone()
+        assert marker is None
+
+
+def test_cutover_evidence_cli_rejects_target_inside_vault_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root, state_dir, root = tmp_path / "vault", tmp_path / "vault" / "state", tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.delenv("BUILDEROPS_VAULT_ROOT", raising=False)
+    _target(state_dir)
+    db_path = state_dir / "builderops.sqlite3"
+    before = db_path.read_bytes()
+    participants = tmp_path / "participants.json"
+    reconciliation = tmp_path / "reconciliation.json"
+    participants.write_text(json.dumps([{"repository": "owner/repo", "root": str(root)}]), encoding="utf-8")
+    reconciliation.write_text(json.dumps([]), encoding="utf-8")
+    monkeypatch.setenv("BUILDEROPS_VAULT_ROOT", str(vault_root))
+    monkeypatch.setattr("app.builderops.cli.default_state_dir", lambda: state_dir)
+
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "cutover-evidence",
+            "generate",
+            "--participants-file",
+            str(participants),
+            "--reconciliation-file",
+            str(reconciliation),
+            "--actor",
+            "operator",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "must be outside BUILDEROPS_VAULT_ROOT" in result.output
+    assert db_path.read_bytes() == before
+    assert not config.host_cutover_ack_path(state_dir).exists()
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+        marker = conn.execute(
+            "SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'"
+        ).fetchone()
+        assert marker is None
+
+
 def test_cutover_evidence_cli_rejects_db_override_before_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -173,6 +173,31 @@ def test_cutover_producer_rejects_post_cutoff_inventory_without_stamping(tmp_pat
         assert conn.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone() is None
 
 
+def test_reconciliation_rejects_external_report_path_before_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    participant_root = tmp_path / "repo"
+    participant_root.mkdir()
+    expected_path = participant_root / "runtime" / "builderops" / "builderops.sqlite3"
+    external_path = tmp_path / "external.sqlite3"
+    external_path.write_bytes(b"external")
+    opened: list[Path] = []
+    monkeypatch.setattr(evidence, "_records", lambda path: opened.append(path))
+
+    with pytest.raises(
+        CutoverEvidenceError,
+        match="outside the discovered legacy inventory",
+    ):
+        evidence._reconciliation(
+            [{"path": str(external_path), "disposition": "retained"}],
+            [{"path": str(expected_path.resolve())}],
+            tmp_path / "target.sqlite3",
+            verify_migrated_target=True,
+        )
+
+    assert not opened
+
+
 def test_cutover_producer_rejects_target_inside_vault_before_inspection_or_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -64,6 +64,14 @@ def test_generated_receipt_binds_host_user_inventory_and_reconciliation_epoch(tm
     monkeypatch.setattr(config, "default_state_dir", lambda: state_dir)
     monkeypatch.chdir(nested)
     assert config.load_paths({}).db_path == state_dir / "builderops.sqlite3"
+    target = SqliteBuilderOpsStore(state_dir / "builderops.sqlite3")
+    lease = target.acquire_lease("awl_migrated", actor={"actor_type": "agent", "id": "transition"})
+    target.transition_record_state(
+        "awl_migrated", actor={"actor_type": "agent", "id": "transition"}, lease_id=lease["lease_id"],
+        idempotency_key="transition:awl_migrated:accepted", source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        summary="authorized target transition", action="archive", receipt_body="normal post-cutover transition", lifecycle_state="archived",
+    )
+    assert config.load_paths({}).db_path == state_dir / "builderops.sqlite3"
     assert receipt["participants"] == [{"repository": "owner/repo", "root": str(root.resolve())}]
     assert receipt["host_id"] == config.current_host_id() and receipt["user_id"] == config.current_user_id()
     assert receipt["legacy_store_inventory"][0]["path"] == str(legacy.resolve())

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import hashlib
+import sqlite3
+import copy
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+import app.builderops.config as config
+import app.builderops.cutover_evidence as evidence
+from app.builderops.cutover_evidence import CutoverEvidenceError, build_receipt, discover_legacy_stores, write_receipt
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+def _target(state_dir: Path) -> None:
+    store = SqliteBuilderOpsStore(state_dir / "builderops.sqlite3")
+    store.initialize()
+    store.create_agent_worklog(
+        id=f"awl_{uuid4().hex}", summary="reconciled", body="reconciled", task_context={},
+        source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "test"},
+    )
+
+
+def _receipt(state_dir: Path, root: Path) -> dict[str, object]:
+    participants = [{"repository": "owner/repo", "root": str(root)}]
+    report = [{"path": item["path"], "disposition": "retained"} for item in discover_legacy_stores(participants)]
+    return build_receipt(state_dir=state_dir, participants=participants, reconciliation=report, actor="operator")
+
+
+def _resign(receipt: dict[str, object]) -> None:
+    receipt.pop("receipt_sha256", None)
+    receipt["receipt_sha256"] = hashlib.sha256(json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def test_declarative_marker_cannot_activate_empty_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.setattr(config, "default_state_dir", lambda: state_dir)
+    marker = {"schema_version": config.CUTOVER_ACK_SCHEMA, "legacy_stores_reconciled": True}
+    state_dir.mkdir()
+    config.host_cutover_ack_path(state_dir).write_text(json.dumps(marker), encoding="utf-8")
+    config.host_cutover_ack_path(state_dir).chmod(0o600)
+    with pytest.raises(ValueError, match="generated cutover receipt"):
+        config.load_paths({})
+    assert not (state_dir / "builderops.sqlite3").exists()
+
+
+def test_generated_receipt_binds_host_user_inventory_and_reconciliation_epoch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    nested = root / "subdir"; nested.mkdir(parents=True); _target(state_dir)
+    legacy = root / "runtime" / "builderops" / "builderops.sqlite3"; legacy.parent.mkdir(parents=True)
+    source = SqliteBuilderOpsStore(legacy); source.initialize()
+    source.create_agent_worklog(id="awl_migrated", summary="source", body="source", task_context={}, source_refs=[{"ref_type":"github_issue","ref":"#3686"}], created_by={"actor_type":"agent","id":"source"})
+    with sqlite3.connect(legacy) as conn:
+        payload = json.loads(conn.execute("SELECT payload FROM builderops_records WHERE id='awl_migrated'").fetchone()[0])
+    SqliteBuilderOpsStore(state_dir / "builderops.sqlite3").create_record(payload)
+    participants = [{"repository":"owner/repo", "root":str(root)}]
+    receipt = build_receipt(state_dir=state_dir, participants=participants, reconciliation=[{"path":str(legacy), "disposition":"migrated"}], actor="operator")
+    write_receipt(state_dir, receipt)
+    monkeypatch.setattr(config, "default_state_dir", lambda: state_dir)
+    monkeypatch.chdir(nested)
+    assert config.load_paths({}).db_path == state_dir / "builderops.sqlite3"
+    assert receipt["participants"] == [{"repository": "owner/repo", "root": str(root.resolve())}]
+    assert receipt["host_id"] == config.current_host_id() and receipt["user_id"] == config.current_user_id()
+    assert receipt["legacy_store_inventory"][0]["path"] == str(legacy.resolve())
+    assert receipt["reconciliation"][0]["disposition"] == "migrated"
+    assert receipt["reconciliation"][0]["source_record_count"] == 1
+    assert receipt["target_store"]["identity"] and receipt["target_store"]["marker"]
+    marker = json.loads(receipt["target_store"]["marker"])
+    assert marker["epoch"] == receipt["reconciliation_epoch"] and marker["evidence_sha256"]
+    changed = build_receipt(state_dir=state_dir, participants=participants, reconciliation=[{"path":str(legacy), "disposition":"retained"}], actor="operator")
+    assert receipt["reconciliation_epoch"] != changed["reconciliation_epoch"]
+
+
+def test_stale_copied_or_incomplete_receipts_fail_before_store_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    root.mkdir(); _target(state_dir)
+    legacy = root / "nested" / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy.parent.mkdir(parents=True); SqliteBuilderOpsStore(legacy).initialize()
+    monkeypatch.setattr(config, "default_state_dir", lambda: state_dir)
+    monkeypatch.chdir(root)
+    original = _receipt(state_dir, root)
+    pristine = copy.deepcopy(original)
+    clean_root, clean_state = tmp_path / "clean-root", tmp_path / "clean-state"
+    clean_root.mkdir(); _target(clean_state)
+    clean_receipt = _receipt(clean_state, clean_root)
+    initialize_calls: list[object] = []
+    monkeypatch.setattr(SqliteBuilderOpsStore, "initialize", lambda self: initialize_calls.append(self))
+    def reject(mutator) -> None:
+        receipt = copy.deepcopy(original); mutator(receipt); _resign(receipt); write_receipt(state_dir, receipt)
+        with pytest.raises(ValueError, match="generated cutover receipt"): config.load_paths({})
+        assert original == pristine
+    reject(lambda r: r.__setitem__("host_id", "copied-host"))
+    reject(lambda r: r.__setitem__("user_id", "999999"))
+    reject(lambda r: r.__setitem__("reconciliation_epoch", str(uuid4())))
+    reject(lambda r: r["reconciliation"][0].__setitem__("source_record_count", 99))
+    reject(lambda r: r.__setitem__("legacy_store_inventory", []))
+    reject(lambda r: r.__setitem__("target_store", {"path":"/copied/target", "identity":"copied", "marker":"copied", "record_count":1}))
+    write_receipt(state_dir, original)
+    SqliteBuilderOpsStore(legacy).create_agent_worklog(id="awl_post_epoch", summary="post", body="post", task_context={}, source_refs=[{"ref_type":"github_issue","ref":"#3686"}], created_by={"actor_type":"agent","id":"post"})
+    with pytest.raises(ValueError): config.load_paths({})
+    with pytest.raises(CutoverEvidenceError, match="not accounted"):
+        build_receipt(state_dir=state_dir, participants=[{"repository":"owner/repo", "root":str(root)}], reconciliation=[{"path":str(legacy),"disposition":"migrated"}], actor="operator")
+    # Traversal errors must be surfaced through the supplied os.walk onerror
+    # callback; they must not silently produce an incomplete inventory.
+    write_receipt(state_dir, original)
+    def denied_walk(_root, *, followlinks, onerror):
+        assert followlinks is False
+        onerror(PermissionError("denied"))
+        return iter(())
+    with monkeypatch.context() as walk_patch:
+        walk_patch.setattr(evidence.os, "walk", denied_walk)
+        with pytest.raises(ValueError, match="generated cutover receipt"): config.load_paths({})
+    # A malformed legacy DB fails validation before an implicit consumer can initialize.
+    legacy.write_bytes(b"not sqlite")
+    with pytest.raises(ValueError, match="generated cutover receipt"): config.load_paths({})
+    # Empty and uninitialized targets cannot be activated by a declarative marker.
+    for name, make_target in (("empty", lambda path: path.write_bytes(b"")), ("uninitialized", lambda path: sqlite3.connect(path).close())):
+        isolated = tmp_path / name; isolated.mkdir()
+        marker = isolated / config.CUTOVER_ACK_NAME
+        copied = copy.deepcopy(clean_receipt)
+        marker.write_text(json.dumps(copied), encoding="utf-8"); marker.chmod(0o600)
+        make_target(isolated / "builderops.sqlite3")
+        monkeypatch.setattr(config, "default_state_dir", lambda value=isolated: value)
+        monkeypatch.chdir(clean_root)
+        with pytest.raises(ValueError, match="generated cutover receipt"): config.load_paths({})
+        assert not initialize_calls
+    assert not initialize_calls
+
+
+def test_cutover_producer_rejects_post_cutoff_inventory_without_stamping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    root.mkdir(); _target(state_dir)
+    participants = [{"repository": "owner/repo", "root": str(root)}]
+    real_discover = evidence.discover_legacy_stores
+    monkeypatch.setattr(evidence, "discover_legacy_stores", lambda _participants: [{"repository":"owner/repo", "path":str(root / "runtime/builderops/builderops.sqlite3"), "sha256":"x", "size":1, "mtime_ns": 9_999_999_999_999_999_999}])
+    with pytest.raises(CutoverEvidenceError, match="changed during reconciliation"):
+        build_receipt(state_dir=state_dir, participants=participants, reconciliation=[{"path":str(root / "runtime/builderops/builderops.sqlite3"), "disposition":"retained"}], actor="operator")
+    assert not config.host_cutover_ack_path(state_dir).exists()
+    with sqlite3.connect(f"file:{state_dir / 'builderops.sqlite3'}?mode=ro", uri=True) as conn:
+        assert conn.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone() is None
+    monkeypatch.setattr(evidence, "discover_legacy_stores", real_discover)
+    legacy = root / "runtime" / "builderops" / "builderops.sqlite3"; legacy.parent.mkdir(parents=True)
+    SqliteBuilderOpsStore(legacy).initialize()
+    inventory = real_discover(participants)
+    calls = 0
+    def drifting(_participants):
+        nonlocal calls
+        calls += 1
+        result = copy.deepcopy(inventory)
+        if calls > 1:
+            result[0]["mtime_ns"] += 1
+        return result
+    monkeypatch.setattr(evidence, "discover_legacy_stores", drifting)
+    with pytest.raises(CutoverEvidenceError, match="inventory drifted"):
+        build_receipt(state_dir=state_dir, participants=participants, reconciliation=[{"path":str(legacy), "disposition":"retained"}], actor="operator")
+    assert not config.host_cutover_ack_path(state_dir).exists()
+    with sqlite3.connect(f"file:{state_dir / 'builderops.sqlite3'}?mode=ro", uri=True) as conn:
+        assert conn.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone() is None

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from click.testing import CliRunner
 
 import app.builderops.config as config
 import app.builderops.cutover_evidence as evidence
 from app.builderops.cutover_evidence import CutoverEvidenceError, build_receipt, discover_legacy_stores, write_receipt
 from app.builderops.store import SqliteBuilderOpsStore
+from app.builderops.cli import builderops
 
 
 def _target(state_dir: Path) -> None:
@@ -169,3 +171,44 @@ def test_cutover_producer_rejects_post_cutoff_inventory_without_stamping(tmp_pat
     assert not config.host_cutover_ack_path(state_dir).exists()
     with sqlite3.connect(f"file:{state_dir / 'builderops.sqlite3'}?mode=ro", uri=True) as conn:
         assert conn.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone() is None
+
+
+def test_cutover_evidence_cli_rejects_db_override_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_state, override_state, root = tmp_path / "default", tmp_path / "override", tmp_path / "repo"
+    root.mkdir()
+    _target(default_state)
+    _target(override_state)
+    default_db, override_db = default_state / "builderops.sqlite3", override_state / "builderops.sqlite3"
+    before_default, before_override = default_db.read_bytes(), override_db.read_bytes()
+    participants = tmp_path / "participants.json"
+    reconciliation = tmp_path / "reconciliation.json"
+    participants.write_text(json.dumps([{"repository": "owner/repo", "root": str(root)}]), encoding="utf-8")
+    reconciliation.write_text(json.dumps([]), encoding="utf-8")
+    monkeypatch.setattr("app.builderops.cli.default_state_dir", lambda: default_state)
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(override_db),
+            "cutover-evidence",
+            "generate",
+            "--participants-file",
+            str(participants),
+            "--reconciliation-file",
+            str(reconciliation),
+            "--actor",
+            "operator",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--db-path is not allowed" in result.output
+    assert default_db.read_bytes() == before_default and override_db.read_bytes() == before_override
+    assert not config.host_cutover_ack_path(default_state).exists()
+    for db_path in (default_db, override_db):
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            marker = conn.execute(
+                "SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'"
+            ).fetchone()
+            assert marker is None

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import json
-from datetime import datetime, timezone
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
 import app.builderops.config as builderops_config
 from app.builderops.models import BuilderOpsLeaseError
 from app.builderops.store import SqliteBuilderOpsStore
+from app.builderops.cutover_evidence import build_receipt, write_receipt
 
 
 def test_default_store_leases_coordinate_across_cwd(
@@ -27,25 +25,19 @@ def test_default_store_leases_coordinate_across_cwd(
     first_cwd.mkdir()
     second_cwd.mkdir()
     state_dir.mkdir(parents=True)
-    ack_path = builderops_config.host_cutover_ack_path(state_dir)
-    ack_path.write_text(
-        json.dumps(
-            {
-                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
-                "scope": "same-user-same-host",
-                "host_id": builderops_config.current_host_id(),
-                "user_id": builderops_config.current_user_id(),
-                "legacy_stores_reconciled": True,
-                "participating_repos": ["repo-a", "repo-b"],
-                "participating_roots": [str(first_cwd), str(second_cwd)],
-                "inventory_epoch": str(uuid4()),
-                "actor": "operator-test",
-                "acknowledged_at": datetime.now(timezone.utc).isoformat(),
-            }
-        ),
-        encoding="utf-8",
+    seeded = SqliteBuilderOpsStore(state_dir / "builderops.sqlite3")
+    seeded.initialize()
+    seeded.create_agent_worklog(
+        id="awl_seed", summary="seed", body="seed", task_context={},
+        source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "seed"},
     )
-    ack_path.chmod(0o600)
+    receipt = build_receipt(
+        state_dir=state_dir,
+        participants=[{"repository": "repo-a", "root": str(first_cwd)}, {"repository": "repo-b", "root": str(second_cwd)}],
+        reconciliation=[], actor="operator-test",
+    )
+    write_receipt(state_dir, receipt)
 
     monkeypatch.chdir(first_cwd)
     first_store = SqliteBuilderOpsStore(builderops_config.load_paths({}).db_path)

--- a/tests/ops/test_builderops_startup_bootstrap.py
+++ b/tests/ops/test_builderops_startup_bootstrap.py
@@ -4,9 +4,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
@@ -15,28 +13,26 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _write_cutover_ack(state_dir: Path) -> None:
-    from app.builderops import config as builderops_config
+    from app.builderops.cutover_evidence import build_receipt, write_receipt
+    from app.builderops.store import SqliteBuilderOpsStore
 
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = builderops_config.host_cutover_ack_path(state_dir)
-    path.write_text(
-        json.dumps(
-            {
-                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
-                "scope": "same-user-same-host",
-                "host_id": builderops_config.current_host_id(),
-                "user_id": builderops_config.current_user_id(),
-                "legacy_stores_reconciled": True,
-                "participating_repos": ["local/repo"],
-                "participating_roots": [str(Path.cwd().resolve())],
-                "inventory_epoch": str(uuid4()),
-                "actor": "operator-test",
-                "acknowledged_at": datetime.now(timezone.utc).isoformat(),
-            }
-        ),
-        encoding="utf-8",
+    target = SqliteBuilderOpsStore(state_dir / "builderops.sqlite3")
+    target.initialize()
+    target.create_agent_worklog(
+        id="awl_startup_fixture_cutover",
+        summary="Startup fixture cutover evidence",
+        body="Non-empty fixture target for implicit readiness validation.",
+        task_context={"issue": "#3686"},
+        source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "startup-fixture"},
     )
-    path.chmod(0o600)
+    receipt = build_receipt(
+        state_dir=state_dir,
+        participants=[{"repository": "local/repo", "root": str(Path.cwd().resolve())}],
+        reconciliation=[],
+        actor="operator-test",
+    )
+    write_receipt(state_dir, receipt)
 
 
 def test_default_repos_include_agentic_and_bifrost() -> None:


### PR DESCRIPTION
Governing-Issue: #3686

Fixes #3686

## Summary

- Replace declarative host-store acknowledgement with a generated, host/user/inventory-bound receipt.
- Require evidence-bearing reconciliation and a target-bound BuilderOps metadata marker before implicit SQLite selection.
- Fail closed on source drift, copied/tampered receipts, traversal failures, malformed sources, empty targets, unsupported cutover `--db-path` overrides, implicit targets beneath `BUILDEROPS_VAULT_ROOT`, and reconciliation report paths outside the discovered inventory.
- Apply vault confinement before producer or implicit-validator receipt/target inspection, and validate complete report membership before opening any report or target records.
- Align the owner runbook with the v2 producer/validator contract and explicitly audit the one-time SQLite receipt producer at the store boundary.

## Validation

- exact fail-before-inspection/mutation regressions — 5 passed
- `pytest -q tests/builderops/test_cutover_evidence.py tests/builderops/test_config_paths.py tests/builderops/test_store.py tests/ops/test_builderops_startup_bootstrap.py tests/architecture/test_builderops_store_boundary.py` — 40 passed
- `pytest -q -m "not pg" tests/builderops --junitxml=/tmp/issue3686-final-integrated.xml` — 562 passed, 137 deselected
- `pytest -q tests/architecture/test_builderops_store_boundary.py` — 5 passed
- `ruff check app/builderops tests/builderops tests/architecture/test_builderops_store_boundary.py tests/ops/test_builderops_startup_bootstrap.py scripts/select_pr_tests.py tests/scripts/test_select_pr_tests.py`
- `mypy app/builderops`
- `git diff --check`
- branch-truth prepush gate against `origin/main` `6918655ec9226dc1e256c871bae63902b9fa1193`

## Upstream Integration

- #4043 / PR #4045 merged to main as `6918655ec9226dc1e256c871bae63902b9fa1193`.
- This branch integrated that exact main non-force at `7416f5c874712ab12166d27217a312eeda69b550`.
- The audited allowlist now preserves both the #3686 cutover receipt producer and the upstream CKM read path; the architecture boundary is green.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: this implementation delivers the governing BuilderOps persistence contract; no separate operational record was created.

## TCD Review

```yaml
tcd_review:
  verdict: accept
  risk_level: high
  model_used: gpt-5.6-sol
  reasoning_effort_used: high
  under_modeling_detected: false
  over_modeling_detected: false
  blocking_issues: []
  non_blocking_issues: []
  missing_tests: []
  hidden_defect_risks: []
  recommended_fixes: []
  recommended_model_for_fix: null
  recommended_reasoning_for_fix: null
  residual_risk: operator-managed live cutover remains out of scope
```

Final-Review-Rounds: 2
