### PR TITLE
Add CKM metric observations and retention

### DIFF
--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -21,6 +21,15 @@ METRIC_REGISTRY_VERSION = 1
 RETENTION_POLICY_VERSION = "ckm-metric-sample-retention-v1"
 RETENTION_DAYS = 365
 _VOLATILE_FIELDS = frozenset({"generated_at"})
+_CONTENT_BYTES_SQL = " + ".join(
+    (
+        "COALESCE(length(source_payload), 0)",
+        "COALESCE(length(CAST(observation_json AS BLOB)), 0)",
+        "COALESCE(length(CAST(source_digest AS BLOB)), 0)",
+        "COALESCE(length(CAST(watermarks_json AS BLOB)), 0)",
+        "COALESCE(length(CAST(finding_evaluations_json AS BLOB)), 0)",
+    )
+)
 
 
 def _utc_now() -> str:
@@ -167,7 +176,7 @@ class MetricRetentionStore:
     def storage_usage(self) -> dict[str, int]:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json)), 0) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL").fetchone()
+            count, bytes_ = conn.execute(f"SELECT COUNT(*), COALESCE(SUM({_CONTENT_BYTES_SQL}), 0) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL").fetchone()
         return {"count": int(count), "bytes": int(bytes_)}
 
     def preview_prune(self, *, now: str, earlier_than_365_days: bool = False, max_count: int | None = None, max_bytes: int | None = None) -> list[dict[str, Any]]:
@@ -177,7 +186,7 @@ class MetricRetentionStore:
         if max_bytes is not None and max_bytes < 0:
             raise ValueError("max_bytes must be non-negative")
         with sqlite3.connect(self.path) as conn:
-            rows = conn.execute("SELECT sample_id, retained_at, expires_at, length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL ORDER BY retained_at, sample_id").fetchall()
+            rows = conn.execute(f"SELECT sample_id, retained_at, expires_at, {_CONTENT_BYTES_SQL} FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL ORDER BY retained_at, sample_id").fetchall()
         if earlier_than_365_days:
             return [{"sample_id": row[0], "reason": "explicit_operator_prune_preview"} for row in rows]
         selected: dict[str, str] = {

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -234,13 +234,16 @@ class MetricRetentionStore:
     def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None, metric_id: str | None = None, semantic_version: str | None = None) -> RetainedSample:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            row = conn.execute("SELECT observation_json, typeof(observation_json), source_payload, lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+            row = conn.execute("SELECT observation_json, typeof(observation_json), source_payload, lifecycle, observation_id, source_digest, watermarks_json, finding_evaluations_json, policy_version, retained_at, expires_at, supersedes_sample_id FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
         if row is None:
             raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
         if row[2] is None:
             raise CkmContractError("source_unavailable", "retained source payload is unavailable for correction", {"sample_id": sample_id, "lifecycle": row[3]})
+        if row[3] != "retained":
+            raise CkmContractError("correction_not_allowed", "only an active retained sample may be corrected", {"sample_id": sample_id, "lifecycle": row[3]})
         if row[1] != "text" or not isinstance(row[0], str):
             raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id})
+        source = self.replay(sample_id)
         try:
             observation = json.loads(row[0])
             stored_definition = observation["metric_definition"]
@@ -250,16 +253,63 @@ class MetricRetentionStore:
             if not isinstance(stored_definition, Mapping) or not isinstance(bindings, Mapping):
                 raise TypeError("metric definition and bindings must be objects")
             expected_definition = dict(metric_definition(stored_id, stored_version))
-        except (json.JSONDecodeError, KeyError, TypeError, CkmContractError) as exc:
+            snapshot = source["snapshot"]
+            expected_query = {
+                "digest": source["query_digest"],
+                "resource_type": source["resource_type"],
+            }
+            expected_schema = {
+                "envelope": source["schema_version"],
+                "resource": snapshot["resource_schema_version"],
+                "ckm": snapshot["ckm_schema_version"],
+            }
+            stored_watermarks = json.loads(row[6])
+            stored_evaluations = json.loads(row[7])
+            if not isinstance(stored_evaluations, Mapping):
+                raise TypeError("finding evaluations must be an object")
+            retained_timestamp = datetime.fromisoformat(str(row[9]).replace("Z", "+00:00"))
+            expected_expiry = (retained_timestamp + timedelta(days=RETENTION_DAYS)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError, CkmContractError) as exc:
             raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id}) from exc
         expected_binding_digests = {
             "formula_digest": canonical_digest(expected_definition["formula"]),
             "detector_digest": canonical_digest(expected_definition["detector_bindings"]),
             "configuration_digest": canonical_digest(expected_definition["configuration_bindings"]),
+            "watermark_digest": canonical_digest(snapshot["watermarks"]),
+            "provenance_digest": canonical_digest(snapshot["provenance"]),
         }
-        if stored_definition != expected_definition or any(
-            bindings.get(key) != value for key, value in expected_binding_digests.items()
-        ):
+        semantic_content = {
+            key: value
+            for key, value in observation.items()
+            if key not in {"generated_at", "semantic_digest", "observation_id"}
+        }
+        expected_semantic_digest = canonical_digest(semantic_content)
+        expected_observation_id = f"ckm_observation_{expected_semantic_digest[:24]}"
+        expected_sample_id = f"ckm_sample_{canonical_digest({'observation': expected_observation_id, 'source': row[5], 'finding_evaluations': canonical_digest(stored_evaluations), 'retained_at': row[9], 'supersedes': row[11]})[:24]}"
+        bindings_valid = (
+            bindings.get("schema") == expected_schema
+            and bindings.get("taxonomy_digest") == snapshot["taxonomy_digest"]
+            and all(bindings.get(key) == value for key, value in expected_binding_digests.items())
+        )
+        identity_valid = (
+            observation.get("snapshot") == snapshot
+            and observation.get("query") == expected_query
+            and observation.get("citations") == snapshot["provenance"]
+            and observation.get("freshness") == {
+                "state_revision": snapshot["state_revision"],
+                "watermarks": snapshot["watermarks"],
+            }
+            and isinstance(observation.get("generated_at"), str)
+            and observation.get("semantic_digest") == expected_semantic_digest
+            and observation.get("observation_id") == expected_observation_id
+            and row[4] == expected_observation_id
+            and row[5] == canonical_digest(source)
+            and stored_watermarks == snapshot["watermarks"]
+            and row[8] == RETENTION_POLICY_VERSION
+            and row[10] == expected_expiry
+            and sample_id == expected_sample_id
+        )
+        if stored_definition != expected_definition or not bindings_valid or not identity_valid:
             raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id})
         if (metric_id is not None and metric_id != stored_id) or (
             semantic_version is not None and semantic_version != stored_version

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -167,29 +167,60 @@ class MetricRetentionStore:
     def storage_usage(self) -> dict[str, int]:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(COALESCE(length(source_payload), 0) + length(observation_json)), 0) FROM ckm_metric_sample_v1 WHERE lifecycle = 'retained'").fetchone()
+            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(length(source_payload) + length(observation_json)), 0) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL").fetchone()
         return {"count": int(count), "bytes": int(bytes_)}
 
-    def preview_prune(self, *, now: str, earlier_than_365_days: bool = False) -> list[dict[str, Any]]:
+    def preview_prune(self, *, now: str, earlier_than_365_days: bool = False, max_count: int | None = None, max_bytes: int | None = None) -> list[dict[str, Any]]:
         self.initialize()
+        if max_count is not None and max_count < 0:
+            raise ValueError("max_count must be non-negative")
+        if max_bytes is not None and max_bytes < 0:
+            raise ValueError("max_bytes must be non-negative")
         with sqlite3.connect(self.path) as conn:
-            rows = conn.execute("SELECT sample_id, expires_at FROM ckm_metric_sample_v1 WHERE lifecycle = 'retained' ORDER BY sample_id").fetchall()
+            rows = conn.execute("SELECT sample_id, retained_at, expires_at, length(source_payload) + length(observation_json) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL ORDER BY retained_at, sample_id").fetchall()
         if earlier_than_365_days:
             return [{"sample_id": row[0], "reason": "explicit_operator_prune_preview"} for row in rows]
-        return [{"sample_id": row[0], "reason": "retention_expired"} for row in rows if row[1] <= now]
+        selected: dict[str, str] = {
+            str(row[0]): "retention_expired" for row in rows if row[2] <= now
+        }
+        remaining = [row for row in rows if str(row[0]) not in selected]
+        remaining_count = len(remaining)
+        remaining_bytes = sum(int(row[3]) for row in remaining)
+        for row in remaining:
+            over_count = max_count is not None and remaining_count > max_count
+            over_bytes = max_bytes is not None and remaining_bytes > max_bytes
+            if not over_count and not over_bytes:
+                break
+            selected[str(row[0])] = (
+                "storage_count_and_byte_cap"
+                if over_count and over_bytes
+                else "storage_count_cap"
+                if over_count
+                else "storage_byte_cap"
+            )
+            remaining_count -= 1
+            remaining_bytes -= int(row[3])
+        return [
+            {"sample_id": str(row[0]), "reason": selected[str(row[0])]}
+            for row in rows
+            if str(row[0]) in selected
+        ]
 
     def prune(self, sample_ids: list[str], *, reason: str, at: str, previewed_sample_ids: list[str] | None = None) -> None:
         self.initialize()
         previewed = set(previewed_sample_ids or [])
         with sqlite3.connect(self.path) as conn:
             for sample_id in sample_ids:
-                row = conn.execute("SELECT expires_at FROM ckm_metric_sample_v1 WHERE sample_id = ? AND lifecycle = 'retained'", (sample_id,)).fetchone()
+                row = conn.execute("SELECT expires_at, lifecycle, lifecycle_marker_json, source_payload, observation_id FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
                 if row is None:
                     raise CkmContractError("missing_retained_sample", "retained metric sample is unavailable for pruning", {"sample_id": sample_id})
+                if row[3] is None:
+                    raise CkmContractError("source_unavailable", "retained source payload is already unavailable", {"sample_id": sample_id, "lifecycle": row[1]})
                 if row[0] > at and sample_id not in previewed:
                     raise CkmContractError("prune_preview_required", "early payload pruning requires an explicit operator preview", {"sample_id": sample_id})
-                marker = {"event": reason, "payload_removed": True, "at": at}
-                conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND lifecycle = 'retained'", (reason, canonical_json(marker), at, sample_id))
+                marker = {"event": reason, "payload_removed": True, "at": at, "prior_marker": json.loads(row[2])}
+                observation_marker = {"observation_id": row[4], "payload_removed": True}
+                conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, observation_json = ?, lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND source_payload IS NOT NULL", (canonical_json(observation_marker), reason, canonical_json(marker), at, sample_id))
 
     def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None) -> RetainedSample:
         self.initialize()

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -205,11 +205,13 @@ class MetricRetentionStore:
     def replay(self, sample_id: str) -> dict[str, Any]:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            row = conn.execute("SELECT source_payload, source_digest, lifecycle, lifecycle_marker_json FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+            row = conn.execute("SELECT source_payload, source_digest, lifecycle, lifecycle_marker_json, typeof(source_payload) FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
         if row is None:
             raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
         if row[0] is None:
-            raise CkmContractError("source_unavailable", "retained source payload is unavailable", {"sample_id": sample_id, "lifecycle": row[2], "marker": json.loads(row[3])})
+            raise CkmContractError("source_unavailable", "retained source payload is unavailable", {"sample_id": sample_id, "lifecycle": row[2]})
+        if row[4] != "blob" or not isinstance(row[0], (bytes, bytearray, memoryview)):
+            raise CkmContractError("tampered_retained_source", "retained source payload failed integrity verification", {"sample_id": sample_id, "storage_type": row[4]})
         try:
             payload = json.loads(bytes(row[0]).decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -153,12 +153,15 @@ class MetricRetentionStore:
         observation = build_observation(result, metric_id=metric_id, generated_at=retained_at)
         source = result.to_dict()
         source_bytes = canonical_json(source).encode("utf-8")
+        source_digest = canonical_digest(source)
+        evaluations_json = canonical_json(dict(finding_evaluations or {}))
+        evaluations_digest = canonical_digest(dict(finding_evaluations or {}))
         retained = retained_at or _utc_now()
         expires = (datetime.fromisoformat(retained.replace("Z", "+00:00")) + timedelta(days=RETENTION_DAYS)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-        sample_id = f"ckm_sample_{canonical_digest({'observation': observation['observation_id'], 'source': source['snapshot']['snapshot_digest'], 'retained_at': retained, 'supersedes': supersedes_sample_id})[:24]}"
+        sample_id = f"ckm_sample_{canonical_digest({'observation': observation['observation_id'], 'source': source_digest, 'finding_evaluations': evaluations_digest, 'retained_at': retained, 'supersedes': supersedes_sample_id})[:24]}"
         marker = {"event": "retained", "payload_removed": False, "policy_version": RETENTION_POLICY_VERSION}
         with sqlite3.connect(self.path) as conn:
-            conn.execute("INSERT OR IGNORE INTO ckm_metric_sample_v1 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (sample_id, observation["observation_id"], canonical_json(observation), source_bytes, source["snapshot"]["snapshot_digest"], canonical_json(source["snapshot"]["watermarks"]), canonical_json(dict(finding_evaluations or {})), RETENTION_POLICY_VERSION, retained, expires, "retained", canonical_json(marker), supersedes_sample_id, None))
+            conn.execute("INSERT OR IGNORE INTO ckm_metric_sample_v1 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (sample_id, observation["observation_id"], canonical_json(observation), source_bytes, source_digest, canonical_json(source["snapshot"]["watermarks"]), evaluations_json, RETENTION_POLICY_VERSION, retained, expires, "retained", canonical_json(marker), supersedes_sample_id, None))
         return RetainedSample(sample_id, observation["observation_id"], "retained", True)
 
     def storage_usage(self) -> dict[str, int]:
@@ -202,9 +205,15 @@ class MetricRetentionStore:
     def replay(self, sample_id: str) -> dict[str, Any]:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            row = conn.execute("SELECT source_payload, lifecycle, lifecycle_marker_json FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+            row = conn.execute("SELECT source_payload, source_digest, lifecycle, lifecycle_marker_json FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
         if row is None:
             raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
         if row[0] is None:
-            raise CkmContractError("source_unavailable", "retained source payload is unavailable", {"sample_id": sample_id, "lifecycle": row[1], "marker": json.loads(row[2])})
-        return json.loads(bytes(row[0]).decode("utf-8"))
+            raise CkmContractError("source_unavailable", "retained source payload is unavailable", {"sample_id": sample_id, "lifecycle": row[2], "marker": json.loads(row[3])})
+        try:
+            payload = json.loads(bytes(row[0]).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CkmContractError("tampered_retained_source", "retained source payload failed integrity verification", {"sample_id": sample_id}) from exc
+        if canonical_digest(payload) != row[1]:
+            raise CkmContractError("tampered_retained_source", "retained source payload failed integrity verification", {"sample_id": sample_id})
+        return payload

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -231,13 +231,41 @@ class MetricRetentionStore:
                 observation_marker = {"observation_id": row[4], "payload_removed": True}
                 conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, source_digest = '', observation_json = ?, watermarks_json = '{}', finding_evaluations_json = '{}', lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND source_payload IS NOT NULL", (canonical_json(observation_marker), reason, canonical_json(marker), at, sample_id))
 
-    def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None) -> RetainedSample:
+    def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None, metric_id: str | None = None, semantic_version: str | None = None) -> RetainedSample:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            exists = conn.execute("SELECT 1 FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
-        if exists is None:
+            row = conn.execute("SELECT observation_json, typeof(observation_json), source_payload, lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+        if row is None:
             raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
-        replacement = self.retain(result, finding_evaluations=finding_evaluations, retained_at=retained_at, supersedes_sample_id=sample_id)
+        if row[2] is None:
+            raise CkmContractError("source_unavailable", "retained source payload is unavailable for correction", {"sample_id": sample_id, "lifecycle": row[3]})
+        if row[1] != "text" or not isinstance(row[0], str):
+            raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id})
+        try:
+            observation = json.loads(row[0])
+            stored_definition = observation["metric_definition"]
+            stored_id = stored_definition["id"]
+            stored_version = stored_definition["semantic_version"]
+            bindings = observation["bindings"]
+            if not isinstance(stored_definition, Mapping) or not isinstance(bindings, Mapping):
+                raise TypeError("metric definition and bindings must be objects")
+            expected_definition = dict(metric_definition(stored_id, stored_version))
+        except (json.JSONDecodeError, KeyError, TypeError, CkmContractError) as exc:
+            raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id}) from exc
+        expected_binding_digests = {
+            "formula_digest": canonical_digest(expected_definition["formula"]),
+            "detector_digest": canonical_digest(expected_definition["detector_bindings"]),
+            "configuration_digest": canonical_digest(expected_definition["configuration_bindings"]),
+        }
+        if stored_definition != expected_definition or any(
+            bindings.get(key) != value for key, value in expected_binding_digests.items()
+        ):
+            raise CkmContractError("corrupt_retained_observation", "retained metric definition binding is corrupt", {"sample_id": sample_id})
+        if (metric_id is not None and metric_id != stored_id) or (
+            semantic_version is not None and semantic_version != stored_version
+        ):
+            raise CkmContractError("metric_definition_mismatch", "correction metric definition must exactly match the retained sample", {"sample_id": sample_id, "stored_metric_id": stored_id, "stored_semantic_version": stored_version})
+        replacement = self.retain(result, metric_id=stored_id, finding_evaluations=finding_evaluations, retained_at=retained_at, supersedes_sample_id=sample_id)
         with sqlite3.connect(self.path) as conn:
             conn.execute("UPDATE ckm_metric_sample_v1 SET lifecycle = 'superseded', lifecycle_marker_json = ? WHERE sample_id = ?", (canonical_json({"event": "superseded", "successor": replacement.sample_id, "payload_removed": False}), sample_id))
         return replacement

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -1,0 +1,210 @@
+"""Snapshot-bound, non-authoritative CKM metric observations.
+
+This is deliberately an outer adapter over :mod:`query_service`: it accepts an
+already-returned complete query envelope and never opens the CKM source store.
+Retained payloads live in a small, separately versioned SQLite receipt store;
+they are derived BuilderOps evidence, never Product or policy authority.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from app.builderops.ckm.contracts import CkmContractError, ENVELOPE_SCHEMA_VERSION, ResultEnvelope, canonical_digest, canonical_json
+from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
+
+METRIC_REGISTRY_VERSION = 1
+RETENTION_POLICY_VERSION = "ckm-metric-sample-retention-v1"
+RETENTION_DAYS = 365
+_VOLATILE_FIELDS = frozenset({"generated_at"})
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _definition(metric_id: str, purpose: str, formula: str) -> dict[str, Any]:
+    value = {
+        "id": metric_id,
+        "semantic_version": "1.0.0",
+        "purpose": purpose,
+        "intended_uses": ["single-operator descriptive CKM review"],
+        "prohibited_uses": ["ranking", "gating", "prioritization", "agent_scoring", "prediction", "automation", "action"],
+        "approval_owner": "BuilderOps governance / Capability Knowledge Model",
+        "output_schema": {"value_state": ["measured", "missing", "unassessed", "unsupported"], "shape": "tagged_vector"},
+        "eligible_population": {"resource_type": "capability", "cohort": "complete_snapshot", "denominator": "resources_by_lifecycle"},
+        "formula": formula,
+        "detector_bindings": {"query_service": "ckm-q1b-v1"},
+        "configuration_bindings": {"registry_version": METRIC_REGISTRY_VERSION},
+        "limitations": ["descriptive projection only", "not causal", "candidate material remains separate"],
+        "not_for_gating": True,
+        "goodhart_warnings": ["Do not optimize this proxy", "Not a machine decision input", "Never use as a sole human decision input"],
+    }
+    value["definition_digest"] = canonical_digest(value)
+    return value
+
+
+METRIC_REGISTRY = {
+    item["id"]: item for item in (
+        _definition("capability_population", "Describe confirmed and candidate CKM population composition.", "count resources by lifecycle"),
+        _definition("provenance_coverage", "Describe presence of provenance records in the snapshot.", "resources with non-empty provenance / lifecycle cohort"),
+        _definition("value_state_distribution", "Describe tagged field-state distribution without coercing absence to zero.", "count tagged states by lifecycle cohort"),
+    )
+}
+
+
+def metric_definition(metric_id: str, semantic_version: str = "1.0.0") -> Mapping[str, Any]:
+    definition = METRIC_REGISTRY.get(metric_id)
+    if definition is None:
+        raise CkmContractError("unknown_metric_definition", "unknown CKM metric definition", {"metric_id": metric_id})
+    if semantic_version != definition["semantic_version"]:
+        raise CkmContractError("unsupported_metric_version", "unsupported CKM metric version", {"metric_id": metric_id, "requested": semantic_version, "supported": [definition["semantic_version"]]})
+    return definition
+
+
+def _tagged_distribution(resources: list[Mapping[str, Any]]) -> dict[str, int]:
+    counts = {state: 0 for state in ("measured", "missing", "unassessed", "unsupported")}
+    for resource in resources:
+        for value in resource["values"].values():
+            counts[value["state"]] += 1
+    return counts
+
+
+def build_observation(result: ResultEnvelope, *, metric_id: str = "capability_population", generated_at: str | None = None) -> dict[str, Any]:
+    """Build deterministic semantic observation content from one Q1 result."""
+    if not isinstance(result, ResultEnvelope):
+        raise CkmContractError("unsupported_metric_semantics", "metric requires a supported complete query result", {})
+    definition = dict(metric_definition(metric_id))
+    payload = result.to_dict()
+    if payload["schema_version"] != ENVELOPE_SCHEMA_VERSION or payload["snapshot"]["ckm_schema_version"] != CKM_SCHEMA_VERSION:
+        raise CkmContractError("unsupported_metric_schema", "metric cannot coerce an unknown query schema bundle", {})
+    if payload["resource_type"] != "capability" or not payload["snapshot"]["completeness"]["complete"]:
+        raise CkmContractError("unsupported_metric_semantics", "metric requires a complete capability snapshot", {})
+    resources = payload["resources"]
+    confirmed = [item for item in resources if not item["candidate"]]
+    candidates = [item for item in resources if item["candidate"]]
+    vector = {
+        "confirmed_population": {"state": "measured", "value": len(confirmed)},
+        "candidate_population": {"state": "measured", "value": len(candidates)},
+        "provenance_coverage": {"state": "measured", "value": len([item for item in resources if item["provenance"]])},
+    }
+    observation = {
+        "observation_schema_version": 1,
+        "projection": {"status": "derived_projection", "authoritative": False},
+        "metric_definition": definition,
+        "snapshot": payload["snapshot"],
+        "query": {"digest": payload["query_digest"], "resource_type": payload["resource_type"]},
+        "bindings": {
+            "schema": {"envelope": payload["schema_version"], "resource": payload["snapshot"]["resource_schema_version"], "ckm": payload["snapshot"]["ckm_schema_version"]},
+            "taxonomy_digest": payload["snapshot"]["taxonomy_digest"],
+            "formula_digest": canonical_digest(definition["formula"]),
+            "detector_digest": canonical_digest(definition["detector_bindings"]),
+            "configuration_digest": canonical_digest(definition["configuration_bindings"]),
+            "watermark_digest": canonical_digest(payload["snapshot"]["watermarks"]),
+            "provenance_digest": canonical_digest(payload["snapshot"]["provenance"]),
+        },
+        "vector": vector,
+        "distributions": {"confirmed": _tagged_distribution(confirmed), "candidate": _tagged_distribution(candidates)},
+        "composition": {"confirmed_public_ids": [item["public_id"] for item in confirmed], "candidate_public_ids": [item["public_id"] for item in candidates]},
+        "citations": payload["snapshot"]["provenance"],
+        "freshness": {"state_revision": payload["snapshot"]["state_revision"], "watermarks": payload["snapshot"]["watermarks"]},
+        "confidence": {"state": "unassessed", "reason": "metric does not infer confidence from descriptive CKM data"},
+        "limitations": definition["limitations"],
+        "goodhart_warnings": definition["goodhart_warnings"],
+        "aggregate": {"label": "human_advisory_only", "value": None, "sole_input_prohibited": True, "machine_authority_prohibited": True},
+        "generated_at": generated_at or _utc_now(),
+    }
+    semantic = {key: value for key, value in observation.items() if key not in _VOLATILE_FIELDS}
+    observation["semantic_digest"] = canonical_digest(semantic)
+    observation["observation_id"] = f"ckm_observation_{observation['semantic_digest'][:24]}"
+    return observation
+
+
+@dataclass(frozen=True)
+class RetainedSample:
+    sample_id: str
+    observation_id: str
+    lifecycle: str
+    source_available: bool
+
+
+class MetricRetentionStore:
+    """Explicit post-read persistence with non-content lifecycle markers."""
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def initialize(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("""CREATE TABLE IF NOT EXISTS ckm_metric_sample_v1 (
+                sample_id TEXT PRIMARY KEY, observation_id TEXT NOT NULL, observation_json TEXT NOT NULL,
+                source_payload BLOB, source_digest TEXT NOT NULL, watermarks_json TEXT NOT NULL,
+                finding_evaluations_json TEXT NOT NULL, policy_version TEXT NOT NULL, retained_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL, lifecycle TEXT NOT NULL, lifecycle_marker_json TEXT NOT NULL,
+                supersedes_sample_id TEXT, deleted_at TEXT)""")
+
+    def retain(self, result: ResultEnvelope, *, metric_id: str = "capability_population", finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None, supersedes_sample_id: str | None = None) -> RetainedSample:
+        """Persist only an already-returned result; this method never invokes Q1."""
+        self.initialize()
+        observation = build_observation(result, metric_id=metric_id, generated_at=retained_at)
+        source = result.to_dict()
+        source_bytes = canonical_json(source).encode("utf-8")
+        retained = retained_at or _utc_now()
+        expires = (datetime.fromisoformat(retained.replace("Z", "+00:00")) + timedelta(days=RETENTION_DAYS)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        sample_id = f"ckm_sample_{canonical_digest({'observation': observation['observation_id'], 'source': source['snapshot']['snapshot_digest'], 'retained_at': retained, 'supersedes': supersedes_sample_id})[:24]}"
+        marker = {"event": "retained", "payload_removed": False, "policy_version": RETENTION_POLICY_VERSION}
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("INSERT OR IGNORE INTO ckm_metric_sample_v1 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (sample_id, observation["observation_id"], canonical_json(observation), source_bytes, source["snapshot"]["snapshot_digest"], canonical_json(source["snapshot"]["watermarks"]), canonical_json(dict(finding_evaluations or {})), RETENTION_POLICY_VERSION, retained, expires, "retained", canonical_json(marker), supersedes_sample_id, None))
+        return RetainedSample(sample_id, observation["observation_id"], "retained", True)
+
+    def storage_usage(self) -> dict[str, int]:
+        self.initialize()
+        with sqlite3.connect(self.path) as conn:
+            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(COALESCE(length(source_payload), 0) + length(observation_json)), 0) FROM ckm_metric_sample_v1 WHERE lifecycle = 'retained'").fetchone()
+        return {"count": int(count), "bytes": int(bytes_)}
+
+    def preview_prune(self, *, now: str, earlier_than_365_days: bool = False) -> list[dict[str, Any]]:
+        self.initialize()
+        with sqlite3.connect(self.path) as conn:
+            rows = conn.execute("SELECT sample_id, expires_at FROM ckm_metric_sample_v1 WHERE lifecycle = 'retained' ORDER BY sample_id").fetchall()
+        if earlier_than_365_days:
+            return [{"sample_id": row[0], "reason": "explicit_operator_prune_preview"} for row in rows]
+        return [{"sample_id": row[0], "reason": "retention_expired"} for row in rows if row[1] <= now]
+
+    def prune(self, sample_ids: list[str], *, reason: str, at: str, previewed_sample_ids: list[str] | None = None) -> None:
+        self.initialize()
+        previewed = set(previewed_sample_ids or [])
+        with sqlite3.connect(self.path) as conn:
+            for sample_id in sample_ids:
+                row = conn.execute("SELECT expires_at FROM ckm_metric_sample_v1 WHERE sample_id = ? AND lifecycle = 'retained'", (sample_id,)).fetchone()
+                if row is None:
+                    raise CkmContractError("missing_retained_sample", "retained metric sample is unavailable for pruning", {"sample_id": sample_id})
+                if row[0] > at and sample_id not in previewed:
+                    raise CkmContractError("prune_preview_required", "early payload pruning requires an explicit operator preview", {"sample_id": sample_id})
+                marker = {"event": reason, "payload_removed": True, "at": at}
+                conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND lifecycle = 'retained'", (reason, canonical_json(marker), at, sample_id))
+
+    def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None) -> RetainedSample:
+        self.initialize()
+        with sqlite3.connect(self.path) as conn:
+            exists = conn.execute("SELECT 1 FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+        if exists is None:
+            raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
+        replacement = self.retain(result, finding_evaluations=finding_evaluations, retained_at=retained_at, supersedes_sample_id=sample_id)
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("UPDATE ckm_metric_sample_v1 SET lifecycle = 'superseded', lifecycle_marker_json = ? WHERE sample_id = ?", (canonical_json({"event": "superseded", "successor": replacement.sample_id, "payload_removed": False}), sample_id))
+        return replacement
+
+    def replay(self, sample_id: str) -> dict[str, Any]:
+        self.initialize()
+        with sqlite3.connect(self.path) as conn:
+            row = conn.execute("SELECT source_payload, lifecycle, lifecycle_marker_json FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+        if row is None:
+            raise CkmContractError("missing_retained_sample", "retained metric sample is unknown", {"sample_id": sample_id})
+        if row[0] is None:
+            raise CkmContractError("source_unavailable", "retained source payload is unavailable", {"sample_id": sample_id, "lifecycle": row[1], "marker": json.loads(row[2])})
+        return json.loads(bytes(row[0]).decode("utf-8"))

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -167,7 +167,7 @@ class MetricRetentionStore:
     def storage_usage(self) -> dict[str, int]:
         self.initialize()
         with sqlite3.connect(self.path) as conn:
-            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(length(source_payload) + length(observation_json)), 0) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL").fetchone()
+            count, bytes_ = conn.execute("SELECT COUNT(*), COALESCE(SUM(length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json)), 0) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL").fetchone()
         return {"count": int(count), "bytes": int(bytes_)}
 
     def preview_prune(self, *, now: str, earlier_than_365_days: bool = False, max_count: int | None = None, max_bytes: int | None = None) -> list[dict[str, Any]]:
@@ -177,7 +177,7 @@ class MetricRetentionStore:
         if max_bytes is not None and max_bytes < 0:
             raise ValueError("max_bytes must be non-negative")
         with sqlite3.connect(self.path) as conn:
-            rows = conn.execute("SELECT sample_id, retained_at, expires_at, length(source_payload) + length(observation_json) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL ORDER BY retained_at, sample_id").fetchall()
+            rows = conn.execute("SELECT sample_id, retained_at, expires_at, length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL ORDER BY retained_at, sample_id").fetchall()
         if earlier_than_365_days:
             return [{"sample_id": row[0], "reason": "explicit_operator_prune_preview"} for row in rows]
         selected: dict[str, str] = {
@@ -220,7 +220,7 @@ class MetricRetentionStore:
                     raise CkmContractError("prune_preview_required", "early payload pruning requires an explicit operator preview", {"sample_id": sample_id})
                 marker = {"event": reason, "payload_removed": True, "at": at, "prior_marker": json.loads(row[2])}
                 observation_marker = {"observation_id": row[4], "payload_removed": True}
-                conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, observation_json = ?, lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND source_payload IS NOT NULL", (canonical_json(observation_marker), reason, canonical_json(marker), at, sample_id))
+                conn.execute("UPDATE ckm_metric_sample_v1 SET source_payload = NULL, source_digest = '', observation_json = ?, watermarks_json = '{}', finding_evaluations_json = '{}', lifecycle = ?, lifecycle_marker_json = ?, deleted_at = ? WHERE sample_id = ? AND source_payload IS NOT NULL", (canonical_json(observation_marker), reason, canonical_json(marker), at, sample_id))
 
     def correct(self, sample_id: str, result: ResultEnvelope, *, finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None) -> RetainedSample:
         self.initialize()

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -46,6 +46,8 @@ from app.builderops.ckm.semantic import (
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
 from app.builderops.ckm.query_service import CkmQueryService
+from app.builderops.ckm.metrics import MetricRetentionStore, build_observation
+from app.builderops.ckm.contracts import CkmContractError, ResultEnvelope
 from app.builderops.config import BuilderOpsPaths, default_state_dir, load_paths
 from app.builderops.cutover_evidence import (
     CutoverEvidenceError,
@@ -622,6 +624,31 @@ def ckm_query(ctx: click.Context, public_id: str | None, limit: int) -> None:
     service = CkmQueryService(paths.db_path, capture_limit=limit)
     result = service.get_capability(public_id) if public_id else service.list_capabilities()
     click.echo(json.dumps(result.to_dict(), ensure_ascii=False, sort_keys=True))
+
+
+@ckm.command("measure", help="Build a snapshot-bound descriptive CKM metric observation.")
+@click.option("--metric-id", default="capability_population", show_default=True)
+@click.option("--retain", "retain_sample", is_flag=True, help="Explicitly retain the returned snapshot and observation after the read completes.")
+@click.option("--limit", type=click.IntRange(1, 100000), default=500, show_default=True)
+@click.pass_context
+def ckm_measure(ctx: click.Context, metric_id: str, retain_sample: bool, limit: int) -> None:
+    """The optional retention write is deliberately after the Q1 result exists."""
+    paths = _effective_paths(ctx)
+    result = CkmQueryService(paths.db_path, capture_limit=limit).list_capabilities()
+    if not isinstance(result, ResultEnvelope):
+        click.echo(json.dumps(result.to_dict(), ensure_ascii=False, sort_keys=True))
+        return
+    try:
+        observation = build_observation(result, metric_id=metric_id)
+        payload: dict[str, Any] = {"observation": observation}
+        if retain_sample:
+            retention_path = paths.db_path.with_name(f"{paths.db_path.stem}-metric-samples.sqlite")
+            sample = MetricRetentionStore(retention_path).retain(result, metric_id=metric_id)
+            payload["retained_sample"] = {"sample_id": sample.sample_id, "observation_id": sample.observation_id}
+            payload["storage"] = MetricRetentionStore(retention_path).storage_usage()
+    except CkmContractError as exc:
+        payload = {"error": exc.to_dict()}
+    click.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 
 
 @ckm.command("project", help="Write one non-authoritative CKM Markdown projection.")

--- a/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
+++ b/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
@@ -112,6 +112,23 @@ Dependency graph:
 
 `accepted observation evidence → future O2 proposal`
 
+## M1 delivered semantics
+
+M1 (#3779) supplies a small versioned registry of descriptive, snapshot-bound
+metric observations. Its outer measurement adapter retains a source payload
+only after the Q1 read result exists, together with bound watermarks,
+finding-evaluation material, and the observation receipt. Retention is a
+versioned 365-day policy with visible storage use, previewed early pruning,
+superseding correction, and non-content deletion markers. The public result
+keeps confirmed and candidate material separate and carries the vector,
+distribution, composition, citations, freshness, confidence, limitations,
+and Goodhart warnings beside an optional `human_advisory_only` aggregate.
+
+This does not establish a cadence, observation window, minimum snapshot
+count, M2 history, O2 automation, drift detection, federation, rankings, or
+machine decision authority. Those remain unresolved or out of scope until a
+new source-backed contract is accepted.
+
 ## Observation-gated future work
 
 - **M2 is not filed or Ready.** The accepted question set is limited to compatible sampled changes in evidence coverage/composition, source freshness, citation/confidence coverage, and candidate/finding composition. Filing still requires a costed smallest implementation, source authority, precise semantics, and verifiable refusal behavior. General bitemporality is not the answer.

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -8,7 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
-from app.builderops.ckm.contracts import CkmContractError, ErrorEnvelope
+from app.builderops.ckm.contracts import CkmContractError, ErrorEnvelope, canonical_digest
 from app.builderops.ckm.metrics import METRIC_REGISTRY, MetricRetentionStore, build_observation, metric_definition
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.ckm.store import CkmStore
@@ -229,6 +229,118 @@ def test_correction_refuses_corrupt_persisted_metric_definition(tmp_path: Path) 
         )
     assert exc.value.code == "corrupt_retained_observation"
     assert retained.storage_usage()["count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "tampered_value"),
+    (
+        (("bindings", "watermark_digest"), "tampered"),
+        (("bindings", "taxonomy_digest"), "tampered"),
+        (("bindings", "provenance_digest"), "tampered"),
+        (("bindings", "schema"), {"ckm": 999}),
+        (("snapshot", "snapshot_digest"), "tampered"),
+        (("query", "digest"), "tampered"),
+        (("semantic_digest",), "tampered"),
+        (("observation_id",), "ckm_observation_tampered"),
+    ),
+)
+def test_correction_refuses_corrupt_semantic_identity_before_mutation(
+    tmp_path: Path, path: tuple[str, ...], tampered_value: object
+) -> None:
+    retained = MetricRetentionStore(
+        tmp_path / f"corrupt-semantic-{'-'.join(path)}.sqlite"
+    )
+    result = _result(tmp_path)
+    original = retained.retain(
+        result,
+        metric_id="provenance_coverage",
+        finding_evaluations={"finding": "bound"},
+        retained_at="2026-01-01T00:00:00Z",
+    )
+    with sqlite3.connect(retained.path) as conn:
+        payload = json.loads(
+            conn.execute(
+                "SELECT observation_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+                (original.sample_id,),
+            ).fetchone()[0]
+        )
+        target = payload
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = tampered_value
+        conn.execute(
+            "UPDATE ckm_metric_sample_v1 SET observation_json = ? WHERE sample_id = ?",
+            (json.dumps(payload), original.sample_id),
+        )
+    usage_before = retained.storage_usage()
+    with pytest.raises(CkmContractError) as exc:
+        retained.correct(
+            original.sample_id, result, retained_at="2026-01-02T00:00:00Z"
+        )
+    assert exc.value.code == "corrupt_retained_observation"
+    assert retained.storage_usage() == usage_before
+    with sqlite3.connect(retained.path) as conn:
+        assert conn.execute(
+            "SELECT lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+            (original.sample_id,),
+        ).fetchone()[0] == "retained"
+
+
+@pytest.mark.parametrize(
+    ("update_sql", "value", "expected_code"),
+    (
+        (
+            "UPDATE ckm_metric_sample_v1 SET observation_id = ? WHERE sample_id = ?",
+            "ckm_observation_tampered",
+            "corrupt_retained_observation",
+        ),
+        (
+            "UPDATE ckm_metric_sample_v1 SET watermarks_json = ? WHERE sample_id = ?",
+            '{"repo":"tampered"}',
+            "corrupt_retained_observation",
+        ),
+        (
+            "UPDATE ckm_metric_sample_v1 SET finding_evaluations_json = ? WHERE sample_id = ?",
+            '{"finding":"tampered"}',
+            "corrupt_retained_observation",
+        ),
+        (
+            "UPDATE ckm_metric_sample_v1 SET policy_version = ? WHERE sample_id = ?",
+            "tampered-policy",
+            "corrupt_retained_observation",
+        ),
+        (
+            "UPDATE ckm_metric_sample_v1 SET source_digest = ? WHERE sample_id = ?",
+            "tampered-source-digest",
+            "tampered_retained_source",
+        ),
+    ),
+)
+def test_correction_refuses_corrupt_identity_columns_before_mutation(
+    tmp_path: Path, update_sql: str, value: str, expected_code: str
+) -> None:
+    retained = MetricRetentionStore(
+        tmp_path / f"corrupt-column-{expected_code}-{canonical_digest(update_sql)[:8]}.sqlite"
+    )
+    result = _result(tmp_path)
+    original = retained.retain(
+        result,
+        metric_id="provenance_coverage",
+        finding_evaluations={"finding": "bound"},
+        retained_at="2026-01-01T00:00:00Z",
+    )
+    with sqlite3.connect(retained.path) as conn:
+        conn.execute(update_sql, (value, original.sample_id))
+    with pytest.raises(CkmContractError) as exc:
+        retained.correct(
+            original.sample_id, result, retained_at="2026-01-02T00:00:00Z"
+        )
+    assert exc.value.code == expected_code
+    with sqlite3.connect(retained.path) as conn:
+        assert conn.execute(
+            "SELECT lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+            (original.sample_id,),
+        ).fetchone()[0] == "retained"
 
 
 def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -19,6 +19,7 @@ def _result(tmp_path: Path):
     store.ensure_schema()
     store.upsert_capability(identity_key="confirmed", name="Confirmed", definition="x", lifecycle="confirmed", existence_provenance="fixture")
     store.upsert_capability(identity_key="candidate", name="Candidate", definition="x", lifecycle="candidate", existence_provenance="fixture")
+    store.set_watermark("repo", "commit:fixture")
     payload = CkmQueryService(store.db_path).list_capabilities()
     assert not isinstance(payload, ErrorEnvelope)
     return payload
@@ -128,12 +129,24 @@ def test_retained_sample_correction_and_deletion_preserve_lifecycle_truth(tmp_pa
 def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path) -> None:
     retained = MetricRetentionStore(tmp_path / "correction-accounting.sqlite")
     result = _result(tmp_path)
-    original = retained.retain(result, retained_at="2025-01-01T00:00:00Z")
+    original = retained.retain(
+        result,
+        finding_evaluations={"finding": "original-bound-content"},
+        retained_at="2025-01-01T00:00:00Z",
+    )
     corrected = retained.correct(
-        original.sample_id, result, retained_at="2025-01-02T00:00:00Z"
+        original.sample_id,
+        result,
+        finding_evaluations={"finding": "corrected-bound-content"},
+        retained_at="2025-01-02T00:00:00Z",
     )
     usage = retained.storage_usage()
     assert usage["count"] == 2 and usage["bytes"] > 0
+    with sqlite3.connect(retained.path) as conn:
+        expected_bytes = conn.execute(
+            "SELECT SUM(length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json)) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL"
+        ).fetchone()[0]
+    assert usage["bytes"] == expected_bytes
 
     cap_preview = retained.preview_prune(
         now="2025-01-03T00:00:00Z",
@@ -161,8 +174,8 @@ def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path
             retained.replay(sample_id)
         assert exc.value.code == "source_unavailable"
     with sqlite3.connect(retained.path) as conn:
-        lifecycle_json, observation_json = conn.execute(
-            "SELECT lifecycle_marker_json, observation_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+        lifecycle_json, observation_json, source_payload, source_digest, watermarks_json, evaluations_json = conn.execute(
+            "SELECT lifecycle_marker_json, observation_json, source_payload, source_digest, watermarks_json, finding_evaluations_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
             (original.sample_id,),
         ).fetchone()
     marker = json.loads(lifecycle_json)
@@ -172,6 +185,26 @@ def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path
         "observation_id": original.observation_id,
         "payload_removed": True,
     }
+    assert source_payload is None
+    assert source_digest == ""
+    assert json.loads(watermarks_json) == {}
+    assert json.loads(evaluations_json) == {}
+    with sqlite3.connect(retained.path) as conn:
+        pruned_content = conn.execute(
+            "SELECT sample_id, source_payload, source_digest, observation_json, watermarks_json, finding_evaluations_json FROM ckm_metric_sample_v1 ORDER BY sample_id"
+        ).fetchall()
+    expected_observations = {
+        original.sample_id: original.observation_id,
+        corrected.sample_id: corrected.observation_id,
+    }
+    for sample_id, payload, digest, observation, watermarks, evaluations in pruned_content:
+        assert payload is None and digest == ""
+        assert json.loads(observation) == {
+            "observation_id": expected_observations[sample_id],
+            "payload_removed": True,
+        }
+        assert json.loads(watermarks) == {}
+        assert json.loads(evaluations) == {}
 
 
 def test_observation_is_deterministic_for_same_snapshot_and_definition(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -14,12 +14,12 @@ from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.ckm.store import CkmStore
 
 
-def _result(tmp_path: Path):
+def _result(tmp_path: Path, *, watermark: str = "commit:fixture"):
     store = CkmStore(tmp_path / "ckm.sqlite")
     store.ensure_schema()
     store.upsert_capability(identity_key="confirmed", name="Confirmed", definition="x", lifecycle="confirmed", existence_provenance="fixture")
     store.upsert_capability(identity_key="candidate", name="Candidate", definition="x", lifecycle="candidate", existence_provenance="fixture")
-    store.set_watermark("repo", "commit:fixture")
+    store.set_watermark("repo", watermark)
     payload = CkmQueryService(store.db_path).list_capabilities()
     assert not isinstance(payload, ErrorEnvelope)
     return payload
@@ -113,6 +113,31 @@ def test_retained_samples_apply_storage_accounting_and_pruning_policy(tmp_path: 
     assert retained.preview_prune(now="2026-01-02T00:00:00Z", earlier_than_365_days=True) == [{"sample_id": sample.sample_id, "reason": "explicit_operator_prune_preview"}]
 
 
+def test_storage_usage_and_byte_cap_use_exact_utf8_bytes(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "utf8-accounting.sqlite")
+    sample = retained.retain(
+        _result(tmp_path, watermark="commit:åäö🚀"),
+        finding_evaluations={"finding": "åäö🚀"},
+        retained_at="2026-01-01T00:00:00Z",
+    )
+    with sqlite3.connect(retained.path) as conn:
+        source, observation, digest, watermarks, evaluations = conn.execute(
+            "SELECT source_payload, observation_json, source_digest, watermarks_json, finding_evaluations_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+            (sample.sample_id,),
+        ).fetchone()
+    expected_bytes = len(source) + sum(
+        len(value.encode("utf-8"))
+        for value in (observation, digest, watermarks, evaluations)
+    )
+    assert retained.storage_usage() == {"count": 1, "bytes": expected_bytes}
+    assert retained.preview_prune(
+        now="2026-01-02T00:00:00Z", max_bytes=expected_bytes
+    ) == []
+    assert retained.preview_prune(
+        now="2026-01-02T00:00:00Z", max_bytes=expected_bytes - 1
+    ) == [{"sample_id": sample.sample_id, "reason": "storage_byte_cap"}]
+
+
 def test_retained_sample_correction_and_deletion_preserve_lifecycle_truth(tmp_path: Path) -> None:
     retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
     first = retained.retain(_result(tmp_path), retained_at="2026-07-21T00:00:00Z")
@@ -144,7 +169,7 @@ def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path
     assert usage["count"] == 2 and usage["bytes"] > 0
     with sqlite3.connect(retained.path) as conn:
         expected_bytes = conn.execute(
-            "SELECT SUM(length(source_payload) + length(observation_json) + length(source_digest) + length(watermarks_json) + length(finding_evaluations_json)) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL"
+            "SELECT SUM(length(source_payload) + length(CAST(observation_json AS BLOB)) + length(CAST(source_digest AS BLOB)) + length(CAST(watermarks_json AS BLOB)) + length(CAST(finding_evaluations_json AS BLOB))) FROM ckm_metric_sample_v1 WHERE source_payload IS NOT NULL"
         ).fetchone()[0]
     assert usage["bytes"] == expected_bytes
 

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sqlite3
 
 import pytest
 from click.testing import CliRunner
@@ -46,6 +47,38 @@ def test_explicit_retention_runs_outside_read_path_and_binds_source_sample(tmp_p
     sample = retained.retain(result, finding_evaluations={"finding": "bound"}, retained_at="2026-07-21T00:00:00Z")
     replay = retained.replay(sample.sample_id)
     assert replay["snapshot"]["watermarks"] == result.to_dict()["snapshot"]["watermarks"]
+
+
+def test_retention_identity_binds_finding_evaluations_and_is_idempotent(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
+    result = _result(tmp_path)
+    first = retained.retain(result, finding_evaluations={"finding": "first"}, retained_at="2026-07-21T00:00:00Z")
+    identical = retained.retain(result, finding_evaluations={"finding": "first"}, retained_at="2026-07-21T00:00:00Z")
+    changed = retained.retain(result, finding_evaluations={"finding": "changed"}, retained_at="2026-07-21T00:00:00Z")
+    assert identical.sample_id == first.sample_id
+    assert changed.sample_id != first.sample_id
+    assert retained.storage_usage()["count"] == 2
+    with sqlite3.connect(retained.path) as conn:
+        evaluations = dict(
+            conn.execute(
+                "SELECT sample_id, finding_evaluations_json FROM ckm_metric_sample_v1"
+            ).fetchall()
+        )
+    assert evaluations[first.sample_id] == '{"finding":"first"}'
+    assert evaluations[changed.sample_id] == '{"finding":"changed"}'
+
+
+def test_replay_refuses_tampered_retained_source(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
+    sample = retained.retain(_result(tmp_path), retained_at="2026-07-21T00:00:00Z")
+    with sqlite3.connect(retained.path) as conn:
+        conn.execute(
+            "UPDATE ckm_metric_sample_v1 SET source_payload = ? WHERE sample_id = ?",
+            (b'{"tampered":true}', sample.sample_id),
+        )
+    with pytest.raises(CkmContractError) as exc:
+        retained.replay(sample.sample_id)
+    assert exc.value.code == "tampered_retained_source"
 
 
 def test_retained_samples_apply_storage_accounting_and_pruning_policy(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.contracts import CkmContractError, ErrorEnvelope
+from app.builderops.ckm.metrics import METRIC_REGISTRY, MetricRetentionStore, build_observation, metric_definition
+from app.builderops.ckm.query_service import CkmQueryService
+from app.builderops.ckm.store import CkmStore
+
+
+def _result(tmp_path: Path):
+    store = CkmStore(tmp_path / "ckm.sqlite")
+    store.ensure_schema()
+    store.upsert_capability(identity_key="confirmed", name="Confirmed", definition="x", lifecycle="confirmed", existence_provenance="fixture")
+    store.upsert_capability(identity_key="candidate", name="Candidate", definition="x", lifecycle="candidate", existence_provenance="fixture")
+    payload = CkmQueryService(store.db_path).list_capabilities()
+    assert not isinstance(payload, ErrorEnvelope)
+    return payload
+
+
+def test_metric_definitions_are_versioned_and_warn_against_gating() -> None:
+    assert len(METRIC_REGISTRY) <= 6
+    for definition in METRIC_REGISTRY.values():
+        assert definition["id"] and definition["semantic_version"] and definition["definition_digest"]
+        assert definition["purpose"] and definition["approval_owner"] and definition["formula"]
+        assert definition["intended_uses"] and definition["prohibited_uses"] and definition["limitations"]
+        assert definition["eligible_population"]["denominator"] and definition["output_schema"]["value_state"]
+        assert definition["not_for_gating"] is True and definition["goodhart_warnings"]
+
+
+def test_observation_binds_complete_semantic_bundle(tmp_path: Path) -> None:
+    observation = build_observation(_result(tmp_path), generated_at="2026-07-21T00:00:00Z")
+    assert observation["snapshot"]["snapshot_digest"] and observation["query"]["digest"]
+    assert observation["bindings"].keys() == {"schema", "taxonomy_digest", "formula_digest", "detector_digest", "configuration_digest", "watermark_digest", "provenance_digest"}
+    assert observation["metric_definition"]["definition_digest"] and observation["generated_at"]
+
+
+def test_explicit_retention_runs_outside_read_path_and_binds_source_sample(tmp_path: Path, monkeypatch) -> None:
+    result = _result(tmp_path)
+    retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
+    monkeypatch.setattr(CkmQueryService, "list_capabilities", lambda *_: (_ for _ in ()).throw(AssertionError("retain must not query")))
+    sample = retained.retain(result, finding_evaluations={"finding": "bound"}, retained_at="2026-07-21T00:00:00Z")
+    replay = retained.replay(sample.sample_id)
+    assert replay["snapshot"]["watermarks"] == result.to_dict()["snapshot"]["watermarks"]
+
+
+def test_retained_samples_apply_storage_accounting_and_pruning_policy(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
+    sample = retained.retain(_result(tmp_path), retained_at="2026-01-01T00:00:00Z")
+    assert retained.retain(_result(tmp_path), retained_at="2026-01-01T00:00:00Z").sample_id == sample.sample_id
+    assert retained.storage_usage()["count"] == 1 and retained.storage_usage()["bytes"] > 0
+    assert retained.preview_prune(now="2026-12-31T23:59:59Z") == []
+    assert retained.preview_prune(now="2027-01-01T00:00:00Z") == [{"sample_id": sample.sample_id, "reason": "retention_expired"}]
+    assert retained.preview_prune(now="2026-01-02T00:00:00Z", earlier_than_365_days=True) == [{"sample_id": sample.sample_id, "reason": "explicit_operator_prune_preview"}]
+
+
+def test_retained_sample_correction_and_deletion_preserve_lifecycle_truth(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
+    first = retained.retain(_result(tmp_path), retained_at="2026-07-21T00:00:00Z")
+    corrected = retained.correct(first.sample_id, _result(tmp_path), retained_at="2026-07-22T00:00:00Z")
+    assert corrected.observation_id == first.observation_id
+    with pytest.raises(CkmContractError, match="preview"):
+        retained.prune([corrected.sample_id], reason="operator_deleted", at="2026-07-23T00:00:00Z")
+    retained.prune([corrected.sample_id], reason="operator_deleted", at="2026-07-23T00:00:00Z", previewed_sample_ids=[corrected.sample_id])
+    with pytest.raises(CkmContractError, match="unavailable") as exc:
+        retained.replay(corrected.sample_id)
+    assert exc.value.code == "source_unavailable"
+
+
+def test_observation_is_deterministic_for_same_snapshot_and_definition(tmp_path: Path) -> None:
+    result = _result(tmp_path)
+    first = build_observation(result, generated_at="2026-07-21T00:00:00Z")
+    second = build_observation(result, generated_at="2026-07-22T00:00:00Z")
+    assert first["semantic_digest"] == second["semantic_digest"]
+    assert first["observation_id"] == second["observation_id"]
+
+
+def test_metric_value_states_and_candidate_separation(tmp_path: Path) -> None:
+    observation = build_observation(_result(tmp_path))
+    assert observation["vector"]["confirmed_population"] == {"state": "measured", "value": 1}
+    assert observation["vector"]["candidate_population"] == {"state": "measured", "value": 1}
+    assert set(observation["distributions"]["confirmed"]) == {"measured", "missing", "unassessed", "unsupported"}
+    assert observation["composition"]["confirmed_public_ids"] != observation["composition"]["candidate_public_ids"]
+
+
+def test_metric_registry_bounds_advisory_aggregate_without_scalar_authority(tmp_path: Path) -> None:
+    observation = build_observation(_result(tmp_path))
+    assert observation["aggregate"] == {"label": "human_advisory_only", "value": None, "sole_input_prohibited": True, "machine_authority_prohibited": True}
+    for field in ("vector", "distributions", "composition", "citations", "freshness", "confidence", "limitations", "goodhart_warnings"):
+        assert observation[field]
+    assert "ranking" in observation["metric_definition"]["prohibited_uses"]
+
+
+def test_metric_version_and_semantics_mismatch_refuse(tmp_path: Path) -> None:
+    with pytest.raises(CkmContractError) as unknown:
+        metric_definition("unknown")
+    assert unknown.value.code == "unknown_metric_definition"
+    with pytest.raises(CkmContractError) as version:
+        metric_definition("capability_population", "2.0.0")
+    assert version.value.code == "unsupported_metric_version"
+    store = CkmStore(tmp_path / "empty.sqlite")
+    store.ensure_schema()
+    result = CkmQueryService(store.db_path).get_capability("missing")
+    assert isinstance(result, ErrorEnvelope)
+    with pytest.raises(CkmContractError) as semantics:
+        build_observation(result)  # type: ignore[arg-type]
+    assert semantics.value.code == "unsupported_metric_semantics"
+
+
+def test_cli_measure_retains_only_after_public_query_result(tmp_path: Path) -> None:
+    _result(tmp_path)
+    runner = CliRunner()
+    invocation = runner.invoke(builderops, ["--db-path", str(tmp_path / "ckm.sqlite"), "ckm", "measure", "--retain"])
+    assert invocation.exit_code == 0, invocation.output
+    assert "human_advisory_only" in invocation.output
+    assert (tmp_path / "ckm-metric-samples.sqlite").exists()

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -81,6 +81,26 @@ def test_replay_refuses_tampered_retained_source(tmp_path: Path) -> None:
     assert exc.value.code == "tampered_retained_source"
 
 
+@pytest.mark.parametrize(
+    ("tampered_payload", "storage_type"),
+    (("tampered-text", "text"), (42, "integer"), (3.14, "real")),
+)
+def test_replay_refuses_unsupported_sqlite_payload_storage_classes(
+    tmp_path: Path, tampered_payload: object, storage_type: str
+) -> None:
+    retained = MetricRetentionStore(tmp_path / f"metrics-{storage_type}.sqlite")
+    sample = retained.retain(_result(tmp_path), retained_at="2026-07-21T00:00:00Z")
+    with sqlite3.connect(retained.path) as conn:
+        conn.execute(
+            "UPDATE ckm_metric_sample_v1 SET source_payload = ? WHERE sample_id = ?",
+            (tampered_payload, sample.sample_id),
+        )
+    with pytest.raises(CkmContractError) as exc:
+        retained.replay(sample.sample_id)
+    assert exc.value.code == "tampered_retained_source"
+    assert exc.value.details["storage_type"] == storage_type
+
+
 def test_retained_samples_apply_storage_accounting_and_pruning_policy(tmp_path: Path) -> None:
     retained = MetricRetentionStore(tmp_path / "metrics.sqlite")
     sample = retained.retain(_result(tmp_path), retained_at="2026-01-01T00:00:00Z")

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
+import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -122,6 +123,55 @@ def test_retained_sample_correction_and_deletion_preserve_lifecycle_truth(tmp_pa
     with pytest.raises(CkmContractError, match="unavailable") as exc:
         retained.replay(corrected.sample_id)
     assert exc.value.code == "source_unavailable"
+
+
+def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "correction-accounting.sqlite")
+    result = _result(tmp_path)
+    original = retained.retain(result, retained_at="2025-01-01T00:00:00Z")
+    corrected = retained.correct(
+        original.sample_id, result, retained_at="2025-01-02T00:00:00Z"
+    )
+    usage = retained.storage_usage()
+    assert usage["count"] == 2 and usage["bytes"] > 0
+
+    cap_preview = retained.preview_prune(
+        now="2025-01-03T00:00:00Z",
+        max_count=1,
+        max_bytes=usage["bytes"] - 1,
+    )
+    assert cap_preview == [
+        {"sample_id": original.sample_id, "reason": "storage_count_and_byte_cap"}
+    ]
+
+    age_preview = retained.preview_prune(now="2026-01-02T00:00:00Z")
+    assert age_preview == [
+        {"sample_id": original.sample_id, "reason": "retention_expired"},
+        {"sample_id": corrected.sample_id, "reason": "retention_expired"},
+    ]
+    retained.prune(
+        [item["sample_id"] for item in age_preview],
+        reason="retention_expired",
+        at="2026-01-02T00:00:00Z",
+    )
+    assert retained.storage_usage() == {"count": 0, "bytes": 0}
+    assert retained.preview_prune(now="2027-01-01T00:00:00Z") == []
+    for sample_id in (original.sample_id, corrected.sample_id):
+        with pytest.raises(CkmContractError) as exc:
+            retained.replay(sample_id)
+        assert exc.value.code == "source_unavailable"
+    with sqlite3.connect(retained.path) as conn:
+        lifecycle_json, observation_json = conn.execute(
+            "SELECT lifecycle_marker_json, observation_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+            (original.sample_id,),
+        ).fetchone()
+    marker = json.loads(lifecycle_json)
+    assert marker["prior_marker"]["event"] == "superseded"
+    assert marker["prior_marker"]["successor"] == corrected.sample_id
+    assert json.loads(observation_json) == {
+        "observation_id": original.observation_id,
+        "payload_removed": True,
+    }
 
 
 def test_observation_is_deterministic_for_same_snapshot_and_definition(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -151,6 +151,86 @@ def test_retained_sample_correction_and_deletion_preserve_lifecycle_truth(tmp_pa
     assert exc.value.code == "source_unavailable"
 
 
+def test_correction_preserves_non_default_metric_definition_and_refuses_mismatch(
+    tmp_path: Path,
+) -> None:
+    retained = MetricRetentionStore(tmp_path / "metric-correction.sqlite")
+    result = _result(tmp_path)
+    original = retained.retain(
+        result,
+        metric_id="provenance_coverage",
+        retained_at="2026-01-01T00:00:00Z",
+    )
+    corrected = retained.correct(
+        original.sample_id,
+        result,
+        metric_id="provenance_coverage",
+        semantic_version="1.0.0",
+        retained_at="2026-01-02T00:00:00Z",
+    )
+    with sqlite3.connect(retained.path) as conn:
+        rows = conn.execute(
+            "SELECT sample_id, lifecycle, observation_json FROM ckm_metric_sample_v1 WHERE sample_id IN (?, ?) ORDER BY sample_id",
+            (original.sample_id, corrected.sample_id),
+        ).fetchall()
+    observations = {sample_id: json.loads(payload) for sample_id, _, payload in rows}
+    lifecycles = {sample_id: lifecycle for sample_id, lifecycle, _ in rows}
+    assert lifecycles[original.sample_id] == "superseded"
+    assert observations[original.sample_id]["metric_definition"] == observations[corrected.sample_id]["metric_definition"]
+    for digest in ("formula_digest", "detector_digest", "configuration_digest"):
+        assert observations[original.sample_id]["bindings"][digest] == observations[corrected.sample_id]["bindings"][digest]
+    assert observations[corrected.sample_id]["metric_definition"]["id"] == "provenance_coverage"
+
+    mismatch = retained.retain(
+        result,
+        metric_id="provenance_coverage",
+        retained_at="2026-02-01T00:00:00Z",
+    )
+    usage_before_mismatch = retained.storage_usage()
+    with pytest.raises(CkmContractError) as exc:
+        retained.correct(
+            mismatch.sample_id,
+            result,
+            metric_id="capability_population",
+            retained_at="2026-02-02T00:00:00Z",
+        )
+    assert exc.value.code == "metric_definition_mismatch"
+    assert retained.storage_usage() == usage_before_mismatch
+    with sqlite3.connect(retained.path) as conn:
+        assert conn.execute(
+            "SELECT lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+            (mismatch.sample_id,),
+        ).fetchone()[0] == "retained"
+
+
+def test_correction_refuses_corrupt_persisted_metric_definition(tmp_path: Path) -> None:
+    retained = MetricRetentionStore(tmp_path / "corrupt-metric-correction.sqlite")
+    result = _result(tmp_path)
+    original = retained.retain(
+        result,
+        metric_id="provenance_coverage",
+        retained_at="2026-01-01T00:00:00Z",
+    )
+    with sqlite3.connect(retained.path) as conn:
+        payload = json.loads(
+            conn.execute(
+                "SELECT observation_json FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+                (original.sample_id,),
+            ).fetchone()[0]
+        )
+        payload["metric_definition"]["definition_digest"] = "tampered"
+        conn.execute(
+            "UPDATE ckm_metric_sample_v1 SET observation_json = ? WHERE sample_id = ?",
+            (json.dumps(payload), original.sample_id),
+        )
+    with pytest.raises(CkmContractError) as exc:
+        retained.correct(
+            original.sample_id, result, retained_at="2026-01-02T00:00:00Z"
+        )
+    assert exc.value.code == "corrupt_retained_observation"
+    assert retained.storage_usage()["count"] == 1
+
+
 def test_correction_payloads_remain_accounted_and_policy_prunable(tmp_path: Path) -> None:
     retained = MetricRetentionStore(tmp_path / "correction-accounting.sqlite")
     result = _result(tmp_path)


### PR DESCRIPTION
Governing-Issue: #3779

Fixes #3779

## Summary
- Adds a versioned, descriptive CKM metric registry and deterministic snapshot-bound observations.
- Adds explicit post-read SQLite retention with 365-day policy, UTF-8 byte-accurate storage accounting, deterministic preview-gated pruning, correction, deletion markers, and honest replay refusal.
- Updates the CKM owner specification with delivered M1 semantics and explicit unresolved boundaries.

## TCD scope receipt
Three bounded descriptive metric families were selected because they provide decision-context coverage without adding runtime scoring, history, cadence, or automation machinery. The surface is advisory-only and rejects unknown metric/schema semantics rather than coercing them.

## Validation
- `python3 -m pytest -q tests/builderops/ckm/test_metrics.py` — 32 passed
- Full CKM suite — 190 passed in bounded groups (57 + linker 2+4+6 + 56 + 65)
- `ruff check app tests` — passed
- `mypy app` — passed
- `git diff --check` — passed
- SQLite/data review — correction validates the complete source/sample/observation identity chain before mutation: source digest, sample ID inputs, observation column/JSON, snapshot/query/schema/taxonomy/watermark/provenance bindings, semantic digest, observation ID, policy and expiry.

## BuilderOps Routing
- Records/projections/receipts: none.
- Reason: this PR changes the CKM BuilderOps projection implementation and its authoritative repository specification; it creates no operational worklog, learning signal, or promotion record.

Final-Review-Rounds: 1