### PR TITLE
Fix unpinned-local-venv drift: Click mix_stderr, Starlette route internals, mypy

### DIFF
--- a/app/dispatcher/control_plane.py
+++ b/app/dispatcher/control_plane.py
@@ -272,11 +272,13 @@ def transition(store: SqliteStore, paths: DispatcherPaths, mode: str, *, activat
     with store._connect() as conn:
         conn.execute("BEGIN IMMEDIATE")
         row = conn.execute("SELECT value FROM dispatcher_meta WHERE key = ?", (STATE_KEY,)).fetchone()
-        current = {"mode": "normal", "revision": 0} if row is None else json.loads(row["value"])
+        current: dict[str, Any] = (
+            {"mode": "normal", "revision": 0} if row is None else json.loads(row["value"])
+        )
         if current.get("revision") != expected_revision:
             conn.rollback()
             raise ValueError("Control-plane state changed concurrently; re-read status before retrying")
-        if mode not in _ALLOWED.get(current.get("mode"), set()):
+        if mode not in _ALLOWED.get(current.get("mode", ""), set()):
             conn.rollback()
             raise ValueError(f"Invalid control-plane transition: {current.get('mode')} -> {mode}")
         if mode == "degraded" and proof["ok"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     # CLI / media / retrieval
-    "click>=8.1,<9",
+    # Upper bound is load-bearing: Click 8.2 removed CliRunner's mix_stderr
+    # kwarg (tests/_click_compat.py shims around it, but stay in the
+    # validated range so `pip install -e .` matches requirements.txt).
+    "click>=8.1,<8.2",
     "faster-whisper>=1.0.0",
     "yt-dlp>=2024.7.2",
     "bgutil-ytdlp-pot-provider>=1.3.1",
@@ -28,7 +31,10 @@ dependencies = [
     "fastapi>=0.115,<1",
     "python-multipart>=0.0.20",
     "uvicorn>=0.30",
-    "starlette>=1.0",
+    # Upper bound is load-bearing: Starlette 1.3 wraps include_router()
+    # sub-routers in an internal representation that breaks naive
+    # app.routes walks (see tests/_route_introspection.py).
+    "starlette>=1.0,<1.3",
     "slowapi>=0.1.9",
     "prometheus-fastapi-instrumentator>=6.0",
     "prometheus-client>=0.20",
@@ -68,7 +74,11 @@ dev = [
     "pytest-asyncio>=1.4,<2",
     "pytest-xdist>=3.6",
     "ruff>=0.5",
-    "mypy>=1.9",
+    "mypy>=1.9,<2",
+    # dev-requirements.txt (CI's pinned mypy install) carries this stub
+    # package; without it here too, a fresh `pip install -e .[dev]` gets
+    # 29 spurious "Library stubs not installed for yaml" mypy errors.
+    "types-PyYAML>=6.0.12",
     "deepeval>=0.20.60",
     "ragas>=0.1.11",
     "datasets>=2.21.0",

--- a/tests/_click_compat.py
+++ b/tests/_click_compat.py
@@ -1,0 +1,21 @@
+"""Click-version-tolerant CliRunner construction.
+
+Click 8.2 removed ``CliRunner``'s ``mix_stderr`` parameter: ``Result`` now
+always exposes both ``.output`` (stdout+stderr merged, in write order) and
+``.stderr`` (isolated) regardless of capture mode, so the flag became a
+no-op and was dropped. ``cli_runner()`` requests the old explicit behavior
+when the installed Click still accepts it and falls back to the
+(equivalent) default otherwise, so call sites work unchanged across the
+CI-pinned Click 8.1.x and Click 8.2+.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+
+def cli_runner(*, mix_stderr: bool = True) -> CliRunner:
+    try:
+        return CliRunner(mix_stderr=mix_stderr)
+    except TypeError:
+        return CliRunner()

--- a/tests/_route_introspection.py
+++ b/tests/_route_introspection.py
@@ -1,0 +1,26 @@
+"""Starlette-version-stable route introspection for tests.
+
+Starlette wraps ``include_router``-registered sub-routers in an internal
+representation that changes across versions (for example a private
+``_IncludedRouter`` on Starlette >=1.3, replacing the flattened ``Route`` /
+``APIRoute`` objects ``app.routes`` held on Starlette 1.2.x). Tests that
+walked ``app.routes`` and read ``.path`` / ``.methods`` directly broke on
+that change -- and one of them (the P-3 read-purity property) silently
+enumerated only a handful of routes out of dozens, rather than failing
+loudly.
+
+``app.openapi()`` is FastAPI's own stable, public view of every registered
+path and its declared HTTP operations, independent of how Starlette stores
+included sub-routers internally. Use it instead of walking ``app.routes``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+
+
+def openapi_paths(app: FastAPI) -> dict[str, dict[str, Any]]:
+    """Every path in ``app``'s OpenAPI schema, mapped to its operations."""
+    return app.openapi()["paths"]

--- a/tests/api/test_context_bundle_route.py
+++ b/tests/api/test_context_bundle_route.py
@@ -121,8 +121,8 @@ def test_route_registered_via_seam():
     # The route is registered through the seam in app/api/app.py without an
     # import-time failure (the seam variable resolves to a real router).
     from app.api import app as app_module
+    from tests._route_introspection import openapi_paths
 
     assert app_module.context_bundles_router is not None
 
-    paths = {route.path for route in app.routes}
-    assert "/api/context-bundles/{bundle_id}" in paths
+    assert "/api/context-bundles/{bundle_id}" in openapi_paths(app)

--- a/tests/cli/test_vault_alpha_ingest.py
+++ b/tests/cli/test_vault_alpha_ingest.py
@@ -18,6 +18,7 @@ from app.cli import cli
 from app.ingest import vault_alpha as vault_alpha
 from app.ingest.vault_alpha import _compute_ingest_fingerprint, run_vault_alpha_ingest
 from app.retrieval.hybrid import get_store, rebuild_from_durable_index, reset_durable_rebuild_state
+from tests._click_compat import cli_runner
 from app.services.companion_note import companion_path, read_companion, write_companion, CompanionNote
 from app.stores import get_object_store, reset_store_backends
 from scripts.yaml_roundtrip import load_frontmatter
@@ -842,7 +843,7 @@ def test_vault_alpha_ingest_json_summary(tmp_path: Path) -> None:
     reset_store_backends()
     get_store().set_documents([])
     vault = _prepare_vault(tmp_path)
-    runner = CliRunner(mix_stderr=False)
+    runner = cli_runner(mix_stderr=False)
     env = _base_env(tmp_path)
 
     with patch.dict(os.environ, env, clear=False):

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -467,11 +467,10 @@ def test_acquire_youtube_cli_exits_nonzero_on_blocked_write(
     receipt-handling/exit logic without a real Postgres connection (the real DB path is covered
     by `test_acquire_youtube_writeguard_blocked_is_not_ok_no_note`, which drives the actual
     `acquire_youtube` core with a denying guard and a fake conn)."""
-    from click.testing import CliRunner
-
     from app.cli import cli
     from app.knowledge_acquisition.acquire import AcquireStageReceipt, AcquisitionReceipt
     import app.knowledge_acquisition.acquire as acquire_mod
+    from tests._click_compat import cli_runner
 
     blocked_receipt = AcquisitionReceipt(
         source_kind="youtube_url",
@@ -503,7 +502,7 @@ def test_acquire_youtube_cli_exits_nonzero_on_blocked_write(
     vault_root = tmp_path / "vault"
     vault_root.mkdir(parents=True, exist_ok=True)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = cli_runner(mix_stderr=False)
     result = runner.invoke(
         cli,
         ["acquire-youtube", FAKE_URL, "--vault-root", str(vault_root)],

--- a/tests/llm/test_gemini_embeddings.py
+++ b/tests/llm/test_gemini_embeddings.py
@@ -503,13 +503,13 @@ def test_embed_probe_provider_override_reaches_gemini(monkeypatch: pytest.Monkey
     """`embed-probe --provider gemini` selects the Gemini adapter (not the forced mock
     default) — with no key it reports unavailable and exits non-zero rather than silently
     validating mock or crashing with a traceback (Codex P2, #2302)."""
-    from click.testing import CliRunner
     from app.cli.embed_probe import embed_probe
+    from tests._click_compat import cli_runner
 
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     _unset_keys(monkeypatch)
     monkeypatch.setenv("EMBED_DIM", "768")
-    result = CliRunner(mix_stderr=True).invoke(embed_probe, ["--provider", "gemini"])
+    result = cli_runner(mix_stderr=True).invoke(embed_probe, ["--provider", "gemini"])
     assert result.exit_code != 0, result.output
     assert "provider=gemini" in result.output  # reached the gemini adapter, not mock
     assert "unavailable" in result.output.lower()
@@ -519,13 +519,13 @@ def test_cli_group_embed_probe_forwards_provider(monkeypatch: pytest.MonkeyPatch
     """The canonical `python -m app.cli embed-probe --provider gemini` wrapper forwards
     --provider to the probe (Codex P2, #2302) — without it the documented path 500s on
     an unknown option."""
-    from click.testing import CliRunner
     from app.cli import cli
+    from tests._click_compat import cli_runner
 
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
     _unset_keys(monkeypatch)
     monkeypatch.setenv("EMBED_DIM", "768")
-    result = CliRunner(mix_stderr=True).invoke(cli, ["embed-probe", "--provider", "gemini"])
+    result = cli_runner(mix_stderr=True).invoke(cli, ["embed-probe", "--provider", "gemini"])
     # The option is accepted (not a usage error) and reaches the gemini adapter:
     assert "no such option" not in result.output.lower()
     assert "provider=gemini" in result.output

--- a/tests/properties/test_read_purity.py
+++ b/tests/properties/test_read_purity.py
@@ -6,9 +6,14 @@ REGISTERED_HEAL_TRANSITIONS``) -- heal-on-read is legal only when declared,
 per ``docs/architecture/formal-model.md`` §3 invariant Q4 and
 ``docs/testing/invariant-synthesis-2026-07.md :: P-3``.
 
-Method: enumerate every GET route DYNAMICALLY from the real FastAPI route
-table (``app.api.app.app.routes`` -- not a static list, so a new route cannot
-silently escape classification, mirroring the #2773 no-silent-cap precedent),
+Method: enumerate every GET route DYNAMICALLY from the real FastAPI app's
+OpenAPI schema (``app.api.app.app.openapi()`` -- not a static list, so a new
+route cannot silently escape classification, mirroring the #2773
+no-silent-cap precedent; walking ``app.routes`` directly is deliberately
+avoided here because Starlette wraps ``include_router``-registered
+sub-routers in an internal representation that varies across versions,
+which silently drops most routes from a naive ``isinstance(route, Route)``
+walk on newer Starlette -- exactly the silent cap this property forbids),
 call each route through a real ``TestClient`` with spy wrappers on the two
 durable-write primitives P-3's registered heals actually reach
 (``WriteSpy`` / ``spy_on_durable_writes`` in ``_machinery.py``), across fixture
@@ -35,12 +40,12 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
-from starlette.routing import Route
 
 from app.api.app import app
 from app.health_contract import WRITE_BLOCKED_STATES
 from app.write_guard import DEFAULT_WRITE_GUARD
 
+from tests._route_introspection import openapi_paths
 from tests.api._vault_test_helpers import bind_initialized_vault
 from tests.properties._machinery import (
     REGISTERED_HEAL_TRANSITIONS,
@@ -53,20 +58,16 @@ from tests.properties._machinery import (
 # ---------------------------------------------------------------------------
 
 
-def _enumerate_get_routes() -> list[Route]:
-    """Every GET route on the real, fully-configured production app.
+def _enumerate_get_routes() -> list[str]:
+    """Every GET path on the real, fully-configured production app.
 
-    Reads ``app.routes`` fresh at call time (not a module-level constant)
+    Reads the OpenAPI schema fresh at call time (not a module-level constant)
     so a route registered after import is still picked up by any caller that
     re-invokes this function -- the route table itself is the generator, per
     the property spec ("enumerated from the FastAPI app's route table --
     dynamic, so a new route cannot silently escape").
     """
-    return [
-        route
-        for route in app.routes
-        if isinstance(route, Route) and route.methods and "GET" in route.methods
-    ]
+    return [path for path, operations in openapi_paths(app).items() if "get" in operations]
 
 
 # A small per-route argument map for the handful of GET routes that require a
@@ -85,10 +86,9 @@ _ROUTE_PARAMS: dict[str, dict[str, Any]] = {
 }
 
 
-def _call_route(client: TestClient, route: Route) -> Any:
+def _call_route(client: TestClient, path: str) -> Any:
     """Invoke one GET route with sensible placeholder args, tolerating any
     response status -- the property is about writes, not response shape."""
-    path = route.path
     kwargs = dict(_ROUTE_PARAMS.get(path, {}))
     path_params = {k: v for k, v in kwargs.items() if k != "params"}
     query_params = kwargs.get("params", {})
@@ -185,17 +185,17 @@ def test_get_routes_do_not_write_durably(
         )
 
     client = TestClient(app)
-    routes = _enumerate_get_routes()
-    assert routes, "expected at least one GET route on the real app"
+    paths = _enumerate_get_routes()
+    assert paths, "expected at least one GET route on the real app"
 
     spy = WriteSpy()
     with spy_on_durable_writes(monkeypatch, spy):
-        for route in routes:
+        for path in paths:
             # Response status is deliberately not asserted -- a 404/422/200
             # must all show the same write-purity property. Network/setup
             # errors surfacing as 5xx still must not have produced an
             # unregistered write, so no status filtering happens here.
-            _call_route(client, route)
+            _call_route(client, path)
 
     unregistered = spy.seams_hit() - set(REGISTERED_HEAL_TRANSITIONS)
     assert not unregistered, (

--- a/tests/relevance/test_arch_cre_pull_path.py
+++ b/tests/relevance/test_arch_cre_pull_path.py
@@ -60,10 +60,9 @@ def test_moment_materialization_is_governed() -> None:
 
 def test_glance_now_surface_is_read_only_pull() -> None:
     """Arrow 2 is pull-only: ``/api/companion/now`` exposes GET, never a write verb."""
+    from tests._route_introspection import openapi_paths
 
-    methods: set[str] = set()
-    for route in fastapi_app.routes:
-        if getattr(route, "path", None) == "/api/companion/now":
-            methods |= set(getattr(route, "methods", set()) or set())
+    operations = openapi_paths(fastapi_app).get("/api/companion/now", {})
+    methods = {method.upper() for method in operations}
     assert methods, "the glance /now route must be registered"
     assert methods <= {"GET", "HEAD", "OPTIONS"}, f"glance must be read-only, got {methods}"


### PR DESCRIPTION
Governing-Issue: #4046

Fixes #4046

Final-Review-Rounds: 1

## Summary
`pyproject.toml`'s dependency bounds were far looser than the exact versions `requirements.txt`/`dev-requirements.txt` actually validate for CI. A fresh `pip install -e ".[dev]"` (the natural way to bootstrap a local dev env) silently resolves newer Click/Starlette/mypy that CI never tests against, which is why a clean local venv failed 6 tests + 1 mypy check while CI stayed green.

- **Click 8.2** removed `CliRunner`'s `mix_stderr` kwarg. Added `tests/_click_compat.py::cli_runner()` (tries the kwarg, falls back for 8.2+) and used it at the 4 affected call sites.
- **Starlette 1.3** wraps `include_router()`-registered sub-routers in a private `_IncludedRouter` object instead of flattening them into the `app.routes` list, breaking any code that walks `app.routes` and reads `.path`/`.methods` directly. Fixed the 2 originally-reported tests, **and found a third, more serious instance while verifying**: `tests/properties/test_read_purity.py` (the P-3 read-purity property, #2911) used the same pattern to dynamically enumerate every GET route — under Starlette 1.3 this silently dropped from 38 real routes to 6, so the property would have kept passing green while checking almost nothing. All three now use `app.openapi()` (`tests/_route_introspection.py`), FastAPI's own stable, version-independent view of every registered path/method, instead of walking Starlette's internal route representation. Note: the pre-fix `isinstance(route, Route)` walk actually counted 42 (not 38) under the *unaffected* Starlette 1.2.1 — the 4-route difference is FastAPI's own `/openapi.json`, `/docs`, `/docs/oauth2-redirect`, `/redoc`, which FastAPI itself excludes from the OpenAPI schema and which never do durable writes, so the property's real coverage intent is unaffected either way.
- **mypy** flagged `app/dispatcher/control_plane.py:279` (`dict.get()` on an ambiguously-typed dict). Fixed with an explicit `dict[str, Any]` annotation and a default value on the inner `.get()` call — a genuine (if minor) type-narrowing gap, not just version noise; verified clean under both mypy 1.11.2 (CI-pinned) and 2.1.0, and confirmed behavior-neutral (`_ALLOWED` has no `None`/`""` key, so the added default is a no-op at runtime).
- Tightened `pyproject.toml`: `click>=8.1,<8.2`, `starlette>=1.0,<1.3`, `mypy>=1.9,<2`, and added `types-PyYAML` (present in `dev-requirements.txt` but missing from `pyproject.toml`'s `dev` extras, which was causing 29 more spurious "stub not installed" mypy errors on a fresh install).

`fastapi`'s own bound was deliberately left unchanged: its dist metadata only requires `starlette>=0.46.0`, so pinning our own direct `starlette` dependency is what actually constrains the resolved version regardless of which `fastapi` gets installed (verified: a fresh install now resolves `fastapi==0.139.2` + `starlette==1.2.1` together, no conflict).

**Found but out of scope** (verified independent of this diff via a clean, unmodified `origin/main` checkout): the full local `not pg` suite had pre-existing failures from other already-merged PRs that didn't satisfy existing architecture fitness guards — a `VAULT_STORE_ALLOWLIST` gap (#4047, resolved via #4051 and #4065), a `NameError` inside `scripts/export_runtime_env.sh` (#4048), a hardcoded-literal guard false-positive (#4050, fixed via #4051), an intermittent DB-DNS-timeout flake in `write_outbox_event` (#4064), and a CI test-selection gap that let the allowlist regress repeatedly (#4066). All filed separately; none touched here.

## Validation
- `ruff check app tests companion-ui/companion-app` — clean.
- `mypy app` — clean under both mypy 1.11.2 (CI-pinned, via a `.venv` built from `requirements.txt`+`dev-requirements.txt`) and mypy 2.1.0 (newer, reproducing the original drift).
- All 7 originally-affected tests (the 6 reported + the read-purity property) pass under: the CI-pinned dependency set, the originally-drifted newer dependency set, and a from-scratch `pip install -e ".[dev]"` using this PR's tightened bounds.
- Full `pytest -q -m "not pg"` under the CI-pinned venv, locally: 10500+ passed, with only the separately-filed pre-existing issues above failing — none caused by this diff.
- **CI on the current head SHA**: all required checks green, including `Unit tests (not pg)`, after rebasing onto main with #4051/#4065 merged.
- A from-scratch `pip install -e ".[dev]"` now resolves `click==8.1.8`, `starlette==1.2.1`, `mypy<2` and reports zero mypy errors with no manual follow-up install step.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded dependency/test-hygiene fix fully captured in Issue #4046 and this PR body; the adjacent discoveries were promoted directly to their own Issues (#4047, #4048, #4050, #4064, #4066) rather than left as informal notes, so no separate BuilderOps record is needed.

---