### PR TITLE
Fix hardcoded-vault-literal guard false positive on 'Inbox' domain term

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -143,6 +143,9 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/knowledge/",
             "docs/VAULT",
             "docs/builderops/BUILDEROPS_VAULT",
+            # Vault-layout hardcoded-literal fitness guard. Keep this exact
+            # file owned without widening vault to all architecture tests.
+            "tests/architecture/test_no_hardcoded_vault_layout.py",
         ),
         ("tests/instance", "tests/vault", "tests/knowledge", "tests/ports"),
     ),

--- a/tests/architecture/test_no_hardcoded_vault_layout.py
+++ b/tests/architecture/test_no_hardcoded_vault_layout.py
@@ -9,8 +9,14 @@ pytestmark = pytest.mark.not_pg
 
 
 _FORBIDDEN_LITERALS = [
+    # The bare word "Inbox" (without the vault folder's emoji prefix) is not
+    # included here: it collides with unrelated domain vocabulary (e.g. a
+    # source platform's own "Inbox playlist" concept in
+    # app/knowledge_acquisition/playlist_discovery.py) and, per the repo's
+    # actual default vault layout (app/settings/default-vault-layout.yaml),
+    # the real vault literal is always emoji-prefixed -- the bare form adds
+    # no additional protection.
     "📥 Inbox",
-    "Inbox",
     "⚙️ System",
     "System-changes.md",
 ]


### PR DESCRIPTION
Governing-Issue: #4050

Fixes #4050

Final-Review-Rounds: 1

## Summary
`tests/architecture/test_no_hardcoded_vault_layout.py`'s `_FORBIDDEN_LITERALS` included a bare `"Inbox"` entry that collided with an unrelated domain term (a source platform's own "Inbox playlist" concept) in `app/knowledge_acquisition/playlist_discovery.py`, added by an earlier merged PR. The repo's actual vault folder literal is always emoji-prefixed (`"📥 Inbox"` per `app/settings/default-vault-layout.yaml`), and there is no other bare `"Inbox"` usage anywhere in `app/` — so the bare entry added zero protection beyond what `"📥 Inbox"` already catches. Removed it.

## Validation
- `pytest -q -m "not pg" tests/architecture/test_no_hardcoded_vault_layout.py` — passes (was failing before this change).
- `ruff check tests/architecture/test_no_hardcoded_vault_layout.py` — clean.
- Confirmed via `grep` that no other file in `app/` contains the bare word "Inbox", so this change cannot silently let a real hardcoded vault-path literal through.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded direct test-guard fix fully captured in Issue #4050 and this PR body.

---