### PR TITLE
Fix CKM metric schema bundle refusal

### DIFF
--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -14,7 +14,15 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
-from app.builderops.ckm.contracts import CkmContractError, ENVELOPE_SCHEMA_VERSION, ResultEnvelope, canonical_digest, canonical_json
+from app.builderops.ckm.contracts import (
+    ACCESS_POLICY_VERSION,
+    ENVELOPE_SCHEMA_VERSION,
+    RESOURCE_SCHEMA_VERSION,
+    CkmContractError,
+    ResultEnvelope,
+    canonical_digest,
+    canonical_json,
+)
 from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
 
 METRIC_REGISTRY_VERSION = 1
@@ -83,14 +91,72 @@ def _tagged_distribution(resources: list[Mapping[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def _validate_metric_schema_bundle(payload: Mapping[str, Any]) -> None:
+    snapshot = payload["snapshot"]
+    expected_versions = {
+        "result.schema_version": (payload["schema_version"], ENVELOPE_SCHEMA_VERSION),
+        "snapshot.envelope_schema_version": (
+            snapshot["envelope_schema_version"],
+            ENVELOPE_SCHEMA_VERSION,
+        ),
+        "snapshot.resource_schema_version": (
+            snapshot["resource_schema_version"],
+            RESOURCE_SCHEMA_VERSION,
+        ),
+        "snapshot.ckm_schema_version": (
+            snapshot["ckm_schema_version"],
+            CKM_SCHEMA_VERSION,
+        ),
+        "snapshot.access_policy_version": (
+            snapshot["access_policy_version"],
+            ACCESS_POLICY_VERSION,
+        ),
+    }
+    expected_versions.update(
+        {
+            f"resources[{index}].schema_version": (
+                resource["schema_version"],
+                RESOURCE_SCHEMA_VERSION,
+            )
+            for index, resource in enumerate(payload["resources"])
+        }
+    )
+    mismatches = {
+        key: {"requested": requested, "supported": supported}
+        for key, (requested, supported) in expected_versions.items()
+        if requested != supported
+    }
+    inconsistencies: dict[str, dict[str, Any]] = {}
+    if payload["schema_version"] != snapshot["envelope_schema_version"]:
+        inconsistencies["result.snapshot.envelope_schema_version"] = {
+            "result": payload["schema_version"],
+            "snapshot": snapshot["envelope_schema_version"],
+        }
+    resource_version_mismatches = {
+        str(index): resource["schema_version"]
+        for index, resource in enumerate(payload["resources"])
+        if resource["schema_version"] != snapshot["resource_schema_version"]
+    }
+    if resource_version_mismatches:
+        inconsistencies["snapshot.resources.schema_version"] = {
+            "snapshot": snapshot["resource_schema_version"],
+            "resources": resource_version_mismatches,
+        }
+    if mismatches or inconsistencies:
+        raise CkmContractError(
+            "unsupported_metric_schema",
+            "metric cannot coerce an unknown or inconsistent query schema bundle",
+            {"mismatches": mismatches, "inconsistencies": inconsistencies},
+        )
+
+
 def build_observation(result: ResultEnvelope, *, metric_id: str = "capability_population", generated_at: str | None = None) -> dict[str, Any]:
     """Build deterministic semantic observation content from one Q1 result."""
     if not isinstance(result, ResultEnvelope):
         raise CkmContractError("unsupported_metric_semantics", "metric requires a supported complete query result", {})
-    definition = dict(metric_definition(metric_id))
     payload = result.to_dict()
-    if payload["schema_version"] != ENVELOPE_SCHEMA_VERSION or payload["snapshot"]["ckm_schema_version"] != CKM_SCHEMA_VERSION:
-        raise CkmContractError("unsupported_metric_schema", "metric cannot coerce an unknown query schema bundle", {})
+    _validate_metric_schema_bundle(payload)
+    definition = dict(metric_definition(metric_id))
     if payload["resource_type"] != "capability" or not payload["snapshot"]["completeness"]["complete"]:
         raise CkmContractError("unsupported_metric_semantics", "metric requires a complete capability snapshot", {})
     resources = payload["resources"]
@@ -158,8 +224,8 @@ class MetricRetentionStore:
 
     def retain(self, result: ResultEnvelope, *, metric_id: str = "capability_population", finding_evaluations: Mapping[str, Any] | None = None, retained_at: str | None = None, supersedes_sample_id: str | None = None) -> RetainedSample:
         """Persist only an already-returned result; this method never invokes Q1."""
-        self.initialize()
         observation = build_observation(result, metric_id=metric_id, generated_at=retained_at)
+        self.initialize()
         source = result.to_dict()
         source_bytes = canonical_json(source).encode("utf-8")
         source_digest = canonical_digest(source)

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -2,15 +2,24 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
-from app.builderops.ckm.contracts import CkmContractError, ErrorEnvelope, canonical_digest
+from app.builderops.ckm.contracts import (
+    ACCESS_POLICY_VERSION,
+    ENVELOPE_SCHEMA_VERSION,
+    RESOURCE_SCHEMA_VERSION,
+    CkmContractError,
+    ErrorEnvelope,
+    canonical_digest,
+)
 from app.builderops.ckm.metrics import METRIC_REGISTRY, MetricRetentionStore, build_observation, metric_definition
 from app.builderops.ckm.query_service import CkmQueryService
+from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
 from app.builderops.ckm.store import CkmStore
 
 
@@ -462,6 +471,102 @@ def test_metric_version_and_semantics_mismatch_refuse(tmp_path: Path) -> None:
     with pytest.raises(CkmContractError) as semantics:
         build_observation(result)  # type: ignore[arg-type]
     assert semantics.value.code == "unsupported_metric_semantics"
+
+
+@pytest.mark.parametrize(
+    ("snapshot_field", "detail_key", "requested", "supported"),
+    (
+        (
+            "envelope_schema_version",
+            "snapshot.envelope_schema_version",
+            999,
+            ENVELOPE_SCHEMA_VERSION,
+        ),
+        (
+            "resource_schema_version",
+            "snapshot.resource_schema_version",
+            999,
+            RESOURCE_SCHEMA_VERSION,
+        ),
+        (
+            "ckm_schema_version",
+            "snapshot.ckm_schema_version",
+            999,
+            CKM_SCHEMA_VERSION,
+        ),
+        (
+            "access_policy_version",
+            "snapshot.access_policy_version",
+            "unknown-policy",
+            ACCESS_POLICY_VERSION,
+        ),
+    ),
+)
+def test_metric_snapshot_schema_bundle_refuses_unknown_versions(
+    tmp_path: Path,
+    snapshot_field: str,
+    detail_key: str,
+    requested: object,
+    supported: object,
+) -> None:
+    result = _result(tmp_path)
+    unsupported = replace(
+        result,
+        snapshot=replace(result.snapshot, **{snapshot_field: requested}),
+    )
+
+    with pytest.raises(CkmContractError) as refusal:
+        build_observation(unsupported)
+
+    assert refusal.value.code == "unsupported_metric_schema"
+    assert refusal.value.details["mismatches"][detail_key] == {
+        "requested": requested,
+        "supported": supported,
+    }
+
+
+def test_metric_schema_bundle_refuses_resource_dto_version_atomically(
+    tmp_path: Path,
+) -> None:
+    result = _result(tmp_path)
+    unsupported_resource = replace(result.resources[0], schema_version=999)
+    unsupported = replace(
+        result,
+        resources=(unsupported_resource, *result.resources[1:]),
+    )
+    retained = MetricRetentionStore(tmp_path / "unsupported-schema.sqlite")
+
+    with pytest.raises(CkmContractError) as refusal:
+        retained.retain(unsupported, retained_at="2026-07-21T00:00:00Z")
+
+    assert refusal.value.code == "unsupported_metric_schema"
+    assert refusal.value.details["mismatches"]["resources[0].schema_version"] == {
+        "requested": 999,
+        "supported": RESOURCE_SCHEMA_VERSION,
+    }
+    assert not retained.path.exists()
+
+
+def test_metric_schema_bundle_refuses_result_snapshot_envelope_inconsistency(
+    tmp_path: Path,
+) -> None:
+    result = _result(tmp_path)
+    inconsistent = replace(
+        result,
+        schema_version=998,
+        snapshot=replace(result.snapshot, envelope_schema_version=999),
+    )
+
+    with pytest.raises(CkmContractError) as refusal:
+        build_observation(inconsistent)
+
+    assert refusal.value.code == "unsupported_metric_schema"
+    assert refusal.value.details["inconsistencies"] == {
+        "result.snapshot.envelope_schema_version": {
+            "result": 998,
+            "snapshot": 999,
+        }
+    }
 
 
 def test_cli_measure_retains_only_after_public_query_result(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #3779

Fixes #3779

## Summary
Validate the complete version-bearing CKM snapshot bundle before metric observation construction or explicit retention. Unknown result-envelope, snapshot-envelope, snapshot-resource, CKM, access-policy, or resource DTO versions—and result/snapshot version inconsistencies—now fail with the typed `unsupported_metric_schema` refusal without creating retention state.

## Historic Repair Binding
- Prior merged evidence only: PR #4044, head `53a648727211fb0f37ccb415b6d534f7d2a0a6e7`, merge `6b1c2938d67d8dae3cbbd0608a9b96bfdba019ef`.
- Exact-head reject evidence: issue comment #5036113880.
- Governing contract reopen/repair receipt: issue comment #5036182955.
- Parent repair receipt: issue comment #5036183080.
- Repair mechanism: `correction-silently-resets-metric-definition`.
- Repair budget: `standard_used=2`, `escalated_remaining=2`.

## TCD
Terra/high is justified because this repair closes a contract-version and SQLite-retention boundary where silent coercion has high hidden-defect risk. The implementation is otherwise the smallest bounded two-file correction.

## Validation
- `python3 -m pytest -q tests/builderops/ckm/test_metrics.py` — 38 passed
- `python3 -m pytest -q tests/builderops/ckm` — 196 passed
- `ruff check app tests` — passed
- `mypy app` — passed (803 source files)
- `git diff --check origin/main...HEAD` — passed
- `scripts/agent_workspace_preflight.sh --expected-branch codex/issue-3779-ac11-schema-bundle --expected-worktree /Users/rasmus/worktrees/issue-3779-ac11-schema-bundle --allow-dirty` — passed pre-commit and pre-push

## BuilderOps Routing
- Records/projections/receipts: none newly created; GitHub comments #5036182955 and #5036183080 are the existing authoritative repair receipts.
- Reason: this bounded source repair produced no new BuilderOps Vault operational material.

Final-Review-Rounds: 1