### PR TITLE
Recover immutable pr-contract validation on current main

### DIFF
--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -298,6 +298,15 @@ the LF-less form when the authenticated comment `created_at` and `updated_at` bo
 remain valid; the legacy fallback rejects any CR/CRLF, spaces, interior drift, post-cutoff receipt,
 or other receipt/live-state mismatch. Preserve receipt identity, phase continuity, and repair budget.
 
+For the singular pre-#4010 immutable PR #4052 compatibility deadlock, current-main/base-side
+recovery may attach an additional auditable `pr-contract` result only after re-reading repository,
+PR, fixed head, title, canonical neutralized body, empty closing links, issue sets, unique trusted
+authority receipt, continuous `prepared` phase, and unchanged repair budget. It uses the current-main
+validator and fails closed for mutable/foreign/unprepared, stale/forged/conflicting, noncanonical, or
+drifted contexts. It is not a branch-protection waiver: it neither replaces unrelated checks nor
+merges, restores closers, posts phases, closes issues, or changes dispatcher accounting. Hand the
+same exact head back to the ordinary verified-merge sequence below.
+
 1. freeze the authenticated v2 context (`run_id`, repository, PR, exact head, governing issue,
    `closing_issues`, durable `supporting_issues`, attempts, and 2+2 repair-budget projection); re-read
    the live PR title/body/head and GitHub `closingIssuesReferences`, and reject any mismatch or title

--- a/.github/workflows/base-side-pr-contract-recovery.yml
+++ b/.github/workflows/base-side-pr-contract-recovery.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'RasmusTho/agentic-pkm-mvp'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Authenticate and attach exact-head pr-contract recovery result
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/base-side-pr-contract-recovery.yml
+++ b/.github/workflows/base-side-pr-contract-recovery.yml
@@ -1,0 +1,24 @@
+name: Base-side pr-contract recovery
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Immutable legacy PR number (only 4052 is authorized)
+        required: true
+        type: string
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  checks: write
+jobs:
+  recover:
+    if: github.repository == 'RasmusTho/agentic-pkm-mvp'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate and attach exact-head pr-contract recovery result
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RECOVERY_PR_NUMBER: ${{ inputs.pull_number }}
+        run: node scripts/base_side_pr_contract_recovery.js

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -344,6 +344,15 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   PR is merged but incomplete, recovery re-authenticates the exact merge commit, authority receipt,
   checks, repair-budget policy, and highest continuous phase, then resumes at the first missing
   phase. Neither path resets attempts, durable supporting authority, or the 2+2 budget.
+- A narrow current-main/base-side recovery exists only for the pre-#4010 immutable PR #4052 head
+  after a live-neutralized PR independently re-reads one unique trusted exact-head authority receipt
+  and one continuous `prepared` phase. It uses the current-main `pr-contract` semantics and attaches
+  an additional auditable `pr-contract` result only to that exact head after binding repository, PR,
+  title, canonical body, empty closing links, governing/closing/supporting sets, authority/phase
+  identity, and unchanged repair budget. It is not a waiver or generic status API: mutable, foreign,
+  unprepared, stale/forged/conflicting, drifted, live-closer, and noncanonical contexts fail closed
+  without a result. Handoff remains the ordinary verified-merge flow; recovery does not merge, close,
+  restore closers, rewrite receipts, or change dispatcher accounting.
 - Post-merge reconciliation explicitly closes every and only the authenticated closing set, restores
   the authenticated original body, and proves exact closure attribution before terminal delivery.
   Candidate enumeration reads the bounded repository issue-event feed through REST, proves its

--- a/scripts/base_side_pr_contract_recovery.js
+++ b/scripts/base_side_pr_contract_recovery.js
@@ -1,23 +1,50 @@
 "use strict";
+
 // Deliberately not a generic check/status publisher: one immutable legacy head only.
 const crypto = require("crypto");
 const fs = require("fs");
-const TARGET = Object.freeze({repository: "RasmusTho/agentic-pkm-mvp", prNumber: 4052, head: "a159571da2ce9068131810aedc1ea05107d7bfaf", title: "Fix CKM metric schema bundle refusal"});
+
+const TARGET = Object.freeze({
+  repository: "RasmusTho/agentic-pkm-mvp",
+  defaultBranch: "main",
+  prNumber: 4052,
+  head: "a159571da2ce9068131810aedc1ea05107d7bfaf",
+  title: "Fix CKM metric schema bundle refusal",
+});
 const TRUSTED = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const AUTHORITY_MARKER = "verified issue-set merge authority:";
 const PHASE_MARKER = "verified issue-set merge phase:";
-const PHASE_FIELDS = ["authority_sha256", "body_sha256", "closed_issues", "contract", "head_sha", "merge_commit_sha", "phase", "pr_number", "reopened_unauthorized_issues", "repository", "run_id"].sort();
-const canonicalJson = value => Array.isArray(value) ? `[${value.map(canonicalJson).join(",")}]` : value !== null && typeof value === "object" ? `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}` : JSON.stringify(value);
+const PHASE_FIELDS = [
+  "authority_sha256", "body_sha256", "closed_issues", "contract", "head_sha",
+  "merge_commit_sha", "phase", "pr_number", "reopened_unauthorized_issues",
+  "repository", "run_id",
+].sort();
+const canonicalJson = value => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key =>
+      `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+    ).join(",")}}`;
+  }
+  return JSON.stringify(value);
+};
 const sha256 = value => crypto.createHash("sha256").update(value, "utf8").digest("hex");
-const hasExactFields = (value, fields) => value !== null && typeof value === "object" && !Array.isArray(value) && JSON.stringify(Object.keys(value).sort()) === JSON.stringify(fields);
+const hasExactFields = (value, fields) => value !== null && typeof value === "object" &&
+  !Array.isArray(value) && canonicalJson(Object.keys(value).sort()) === canonicalJson(fields);
+const canonicalTimestamp = value => {
+  if (typeof value !== "string" || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/.test(value)) return null;
+  const instant = Date.parse(value);
+  return Number.isFinite(instant) && new Date(instant).toISOString() === `${value.slice(0, -1)}.000Z` ? instant : null;
+};
 
 function currentMainValidator() {
   const workflow = fs.readFileSync(".github/workflows/issue-pr-governance.yml", "utf8");
   const between = (start, end) => workflow.split(start, 2)[1].split(end, 2)[0];
-  const source = between("// authority-classifier:start", "// authority-classifier:end") + between("// neutralized-authority-validator:start", "// neutralized-authority-validator:end");
-  // Reuse the current-main production parser, never a weaker recovery parser.
+  const source = between("// authority-classifier:start", "// authority-classifier:end") +
+    between("// neutralized-authority-validator:start", "// neutralized-authority-validator:end");
   return new Function("crypto", `${source}\nreturn { classifyIssueAuthority, resolveNeutralizedMergeAuthority };`)(crypto);
 }
+
 function trustedRecords(comments, marker) {
   const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(`${escaped}\\s*\\x60\\x60\\x60json\\s*([\\s\\S]*?)\\s*\\x60\\x60\\x60`, "gm");
@@ -25,28 +52,72 @@ function trustedRecords(comments, marker) {
     if (!TRUSTED.has(comment.author_association) || typeof comment.body !== "string") return [];
     const matches = [...comment.body.matchAll(pattern)];
     if (matches.length !== 1) return [];
-    try { return [{comment, receipt: JSON.parse(matches[0][1])}]; } catch (_) { return []; }
+    try {
+      const created = canonicalTimestamp(comment.created_at);
+      const updated = canonicalTimestamp(comment.updated_at);
+      return [{
+        comment: {
+          id: comment.id, actor: comment.user?.login,
+          association: comment.author_association,
+          created_at: comment.created_at, updated_at: comment.updated_at,
+        },
+        metadata_valid: Number.isInteger(comment.id) &&
+          typeof comment.user?.login === "string" && created !== null &&
+          updated !== null && created <= updated,
+        receipt: JSON.parse(matches[0][1]),
+      }];
+    } catch (_) { return []; }
   });
 }
-function targetRecords(records) { return records.filter(({receipt}) => receipt && typeof receipt === "object" && receipt.repository === TARGET.repository && receipt.pr_number === TARGET.prNumber && receipt.head_sha === TARGET.head); }
+
+function targetRecords(records) {
+  return records.filter(({receipt}) => receipt && typeof receipt === "object" &&
+    receipt.repository === TARGET.repository && receipt.pr_number === TARGET.prNumber &&
+    receipt.head_sha === TARGET.head);
+}
+
 function requireUniquePreparedPhase(comments, authority) {
   const records = targetRecords(trustedRecords(comments, PHASE_MARKER));
   const authoritySha = sha256(canonicalJson(authority));
-  const valid = records.filter(({receipt}) => hasExactFields(receipt, PHASE_FIELDS) && receipt.contract === "verified_issue_set_merge_phase.v1" && receipt.run_id === authority.run_id && receipt.phase === "prepared" && receipt.authority_sha256 === authoritySha && receipt.body_sha256 === authority.neutralized_body_sha256 && receipt.merge_commit_sha === null && Array.isArray(receipt.closed_issues) && receipt.closed_issues.length === 0 && Array.isArray(receipt.reopened_unauthorized_issues) && receipt.reopened_unauthorized_issues.length === 0);
-  if (!valid.length || valid.length !== records.length || new Set(valid.map(({receipt}) => canonicalJson(receipt))).size !== 1) throw new Error("prepared phase is missing, stale, forged, conflicting, or non-continuous");
+  const valid = records.filter(({receipt, metadata_valid: metadataValid}) => metadataValid &&
+    hasExactFields(receipt, PHASE_FIELDS) &&
+    receipt.contract === "verified_issue_set_merge_phase.v1" &&
+    receipt.run_id === authority.run_id && receipt.phase === "prepared" &&
+    receipt.authority_sha256 === authoritySha &&
+    receipt.body_sha256 === authority.neutralized_body_sha256 &&
+    receipt.merge_commit_sha === null && Array.isArray(receipt.closed_issues) &&
+    receipt.closed_issues.length === 0 && Array.isArray(receipt.reopened_unauthorized_issues) &&
+    receipt.reopened_unauthorized_issues.length === 0);
+  if (records.length !== 1 || valid.length !== 1) {
+    throw new Error("prepared phase is missing, stale, forged, conflicting, or non-continuous");
+  }
   return valid[0];
 }
-async function main() {
-  const token = process.env.GITHUB_TOKEN, repository = process.env.GITHUB_REPOSITORY, requestedPr = Number(process.env.RECOVERY_PR_NUMBER || 0);
-  if (!token || repository !== TARGET.repository || requestedPr !== TARGET.prNumber) throw new Error("recovery target is not the one authorized immutable legacy PR");
-  const request = async (method, path, body) => { const response = await fetch(`https://api.github.com${path}`, {method, headers: {Accept: "application/vnd.github+json", Authorization: `Bearer ${token}`, "X-GitHub-Api-Version": "2022-11-28"}, body: body === undefined ? undefined : JSON.stringify(body)}); if (!response.ok) throw new Error(`${method} ${path} failed: ${response.status}`); return response.status === 204 ? null : response.json(); };
+
+function requireExactBaseIdentity(repo, branch, pullRequest, env) {
+  if (repo.default_branch !== TARGET.defaultBranch) throw new Error("repository default branch drifted from main");
+  if (env.GITHUB_REF !== "refs/heads/main" || env.GITHUB_SHA !== branch.commit.sha) {
+    throw new Error("recovery must execute from the current default-branch head");
+  }
+  if (pullRequest.state !== "open" || pullRequest.draft !== false ||
+      pullRequest.number !== TARGET.prNumber || pullRequest.head?.sha !== TARGET.head ||
+      pullRequest.head?.repo?.full_name !== TARGET.repository ||
+      pullRequest.base?.repo?.full_name !== TARGET.repository ||
+      pullRequest.base?.ref !== TARGET.defaultBranch || pullRequest.title !== TARGET.title) {
+    throw new Error("PR identity/base is mutable, retargeted, foreign, or not the authorized legacy target");
+  }
+}
+
+async function captureValidatedSnapshot(request, env) {
   const repo = await request("GET", "/repos/RasmusTho/agentic-pkm-mvp");
-  const branch = await request("GET", `/repos/RasmusTho/agentic-pkm-mvp/branches/${repo.default_branch}`);
-  if (process.env.GITHUB_REF !== `refs/heads/${repo.default_branch}` || process.env.GITHUB_SHA !== branch.commit.sha) throw new Error("recovery must execute from the current default-branch head");
+  const branch = await request("GET", "/repos/RasmusTho/agentic-pkm-mvp/branches/main");
   const pullRequest = await request("GET", "/repos/RasmusTho/agentic-pkm-mvp/pulls/4052");
-  if (pullRequest.state !== "open" || pullRequest.number !== TARGET.prNumber || pullRequest.head?.sha !== TARGET.head || pullRequest.head?.repo?.full_name !== TARGET.repository || pullRequest.title !== TARGET.title) throw new Error("PR identity is current, mutable, foreign, or otherwise not the authorized legacy target");
-  const closing = await request("POST", "/graphql", {query: "query { repository(owner:\"RasmusTho\", name:\"agentic-pkm-mvp\") { pullRequest(number:4052) { closingIssuesReferences(first:20) { nodes { number } } } } }"});
-  if (closing.data?.repository?.pullRequest?.closingIssuesReferences?.nodes?.length !== 0) throw new Error("live closing references are not empty");
+  requireExactBaseIdentity(repo, branch, pullRequest, env);
+  const closing = await request("POST", "/graphql", {
+    query: "query { repository(owner:\"RasmusTho\", name:\"agentic-pkm-mvp\") { pullRequest(number:4052) { closingIssuesReferences(first:20) { nodes { number } } } } }",
+  });
+  const closingNodes = closing.data?.repository?.pullRequest?.closingIssuesReferences?.nodes;
+  if (!Array.isArray(closingNodes) || closingNodes.length !== 0) throw new Error("live closing references are not empty");
   const comments = [];
   for (let page = 1; page <= 10; page += 1) {
     const batch = await request("GET", `/repos/RasmusTho/agentic-pkm-mvp/issues/4052/comments?per_page=100&page=${page}`);
@@ -57,10 +128,65 @@ async function main() {
   }
   const {classifyIssueAuthority, resolveNeutralizedMergeAuthority} = currentMainValidator();
   const issueAuthority = classifyIssueAuthority(pullRequest.body || "");
-  const authority = resolveNeutralizedMergeAuthority({ comments, issueAuthority, pullRequest, repository });
+  const authority = resolveNeutralizedMergeAuthority({comments, issueAuthority, pullRequest, repository: TARGET.repository});
   const authorityRecords = targetRecords(trustedRecords(comments, AUTHORITY_MARKER));
-  if (authority === null || !authorityRecords.length || authorityRecords.some(({receipt}) => canonicalJson(receipt) !== canonicalJson(authority))) throw new Error("authority receipt is missing, forged, stale, or conflicting");
+  if (authority === null || authorityRecords.length !== 1 || !authorityRecords[0].metadata_valid ||
+      canonicalJson(authorityRecords[0].receipt) !== canonicalJson(authority)) {
+    throw new Error("authority receipt is missing, forged, stale, or conflicting");
+  }
   const phase = requireUniquePreparedPhase(comments, authority);
-  await request("POST", "/repos/RasmusTho/agentic-pkm-mvp/check-runs", {name: "pr-contract", head_sha: TARGET.head, status: "completed", conclusion: "success", external_id: `base-side-pr-contract-recovery:${authority.run_id}:${TARGET.head}`, details_url: `${process.env.GITHUB_SERVER_URL}/${TARGET.repository}/actions/runs/${process.env.GITHUB_RUN_ID}`, output: {title: "Current-main pr-contract recovery authenticated", summary: `authority_run=${authority.run_id}; prepared_phase=${phase.receipt.run_id}. Additional exact-head result only; no check is replaced, suppressed, or waived.`}});
+  return {
+    default_branch: repo.default_branch,
+    default_branch_sha: branch.commit.sha,
+    pull_request: {
+      number: pullRequest.number, state: pullRequest.state, draft: pullRequest.draft,
+      title: pullRequest.title, body: pullRequest.body,
+      head: {sha: pullRequest.head.sha, ref: pullRequest.head.ref, repository: pullRequest.head.repo.full_name},
+      base: {sha: pullRequest.base.sha, ref: pullRequest.base.ref, repository: pullRequest.base.repo.full_name},
+    },
+    closing_issues: closingNodes.map(node => node.number),
+    authority: authorityRecords[0],
+    phase,
+  };
 }
-main().catch(error => { console.error(error.stack || error.message); process.exitCode = 1; });
+
+async function publishStableSnapshot({request, env, capture = captureValidatedSnapshot}) {
+  const validated = await capture(request, env);
+  // This second complete read is the publication fence. Any main, PR, closer,
+  // authority-comment, phase-comment, identity, timestamp, or budget drift posts nothing.
+  const reread = await capture(request, env);
+  if (canonicalJson(validated) !== canonicalJson(reread)) throw new Error("recovery snapshot drifted before publication");
+  const authority = reread.authority.receipt;
+  const phase = reread.phase.receipt;
+  await request("POST", "/repos/RasmusTho/agentic-pkm-mvp/check-runs", {
+    name: "pr-contract", head_sha: reread.pull_request.head.sha,
+    status: "completed", conclusion: "success",
+    external_id: `base-side-pr-contract-recovery:${authority.run_id}:${reread.pull_request.head.sha}`,
+    details_url: `${env.GITHUB_SERVER_URL}/${TARGET.repository}/actions/runs/${env.GITHUB_RUN_ID}`,
+    output: {title: "Current-main pr-contract recovery authenticated", summary: `authority_run=${authority.run_id}; prepared_phase=${phase.run_id}. Additional exact-head result only; no check is replaced, suppressed, or waived.`},
+  });
+}
+
+async function main() {
+  const env = process.env;
+  if (!env.GITHUB_TOKEN || env.GITHUB_REPOSITORY !== TARGET.repository ||
+      Number(env.RECOVERY_PR_NUMBER || 0) !== TARGET.prNumber) {
+    throw new Error("recovery target is not the one authorized immutable legacy PR");
+  }
+  const request = async (method, path, body) => {
+    const response = await fetch(`https://api.github.com${path}`, {
+      method,
+      headers: {Accept: "application/vnd.github+json", Authorization: `Bearer ${env.GITHUB_TOKEN}`, "X-GitHub-Api-Version": "2022-11-28"},
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`${method} ${path} failed: ${response.status}`);
+    return response.status === 204 ? null : response.json();
+  };
+  await publishStableSnapshot({request, env});
+}
+
+module.exports = {publishStableSnapshot, requireExactBaseIdentity};
+if (require.main === module) main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});

--- a/scripts/base_side_pr_contract_recovery.js
+++ b/scripts/base_side_pr_contract_recovery.js
@@ -1,0 +1,66 @@
+"use strict";
+// Deliberately not a generic check/status publisher: one immutable legacy head only.
+const crypto = require("crypto");
+const fs = require("fs");
+const TARGET = Object.freeze({repository: "RasmusTho/agentic-pkm-mvp", prNumber: 4052, head: "a159571da2ce9068131810aedc1ea05107d7bfaf", title: "Fix CKM metric schema bundle refusal"});
+const TRUSTED = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const AUTHORITY_MARKER = "verified issue-set merge authority:";
+const PHASE_MARKER = "verified issue-set merge phase:";
+const PHASE_FIELDS = ["authority_sha256", "body_sha256", "closed_issues", "contract", "head_sha", "merge_commit_sha", "phase", "pr_number", "reopened_unauthorized_issues", "repository", "run_id"].sort();
+const canonicalJson = value => Array.isArray(value) ? `[${value.map(canonicalJson).join(",")}]` : value !== null && typeof value === "object" ? `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}` : JSON.stringify(value);
+const sha256 = value => crypto.createHash("sha256").update(value, "utf8").digest("hex");
+const hasExactFields = (value, fields) => value !== null && typeof value === "object" && !Array.isArray(value) && JSON.stringify(Object.keys(value).sort()) === JSON.stringify(fields);
+
+function currentMainValidator() {
+  const workflow = fs.readFileSync(".github/workflows/issue-pr-governance.yml", "utf8");
+  const between = (start, end) => workflow.split(start, 2)[1].split(end, 2)[0];
+  const source = between("// authority-classifier:start", "// authority-classifier:end") + between("// neutralized-authority-validator:start", "// neutralized-authority-validator:end");
+  // Reuse the current-main production parser, never a weaker recovery parser.
+  return new Function("crypto", `${source}\nreturn { classifyIssueAuthority, resolveNeutralizedMergeAuthority };`)(crypto);
+}
+function trustedRecords(comments, marker) {
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`${escaped}\\s*\\x60\\x60\\x60json\\s*([\\s\\S]*?)\\s*\\x60\\x60\\x60`, "gm");
+  return comments.flatMap(comment => {
+    if (!TRUSTED.has(comment.author_association) || typeof comment.body !== "string") return [];
+    const matches = [...comment.body.matchAll(pattern)];
+    if (matches.length !== 1) return [];
+    try { return [{comment, receipt: JSON.parse(matches[0][1])}]; } catch (_) { return []; }
+  });
+}
+function targetRecords(records) { return records.filter(({receipt}) => receipt && typeof receipt === "object" && receipt.repository === TARGET.repository && receipt.pr_number === TARGET.prNumber && receipt.head_sha === TARGET.head); }
+function requireUniquePreparedPhase(comments, authority) {
+  const records = targetRecords(trustedRecords(comments, PHASE_MARKER));
+  const authoritySha = sha256(canonicalJson(authority));
+  const valid = records.filter(({receipt}) => hasExactFields(receipt, PHASE_FIELDS) && receipt.contract === "verified_issue_set_merge_phase.v1" && receipt.run_id === authority.run_id && receipt.phase === "prepared" && receipt.authority_sha256 === authoritySha && receipt.body_sha256 === authority.neutralized_body_sha256 && receipt.merge_commit_sha === null && Array.isArray(receipt.closed_issues) && receipt.closed_issues.length === 0 && Array.isArray(receipt.reopened_unauthorized_issues) && receipt.reopened_unauthorized_issues.length === 0);
+  if (!valid.length || valid.length !== records.length || new Set(valid.map(({receipt}) => canonicalJson(receipt))).size !== 1) throw new Error("prepared phase is missing, stale, forged, conflicting, or non-continuous");
+  return valid[0];
+}
+async function main() {
+  const token = process.env.GITHUB_TOKEN, repository = process.env.GITHUB_REPOSITORY, requestedPr = Number(process.env.RECOVERY_PR_NUMBER || 0);
+  if (!token || repository !== TARGET.repository || requestedPr !== TARGET.prNumber) throw new Error("recovery target is not the one authorized immutable legacy PR");
+  const request = async (method, path, body) => { const response = await fetch(`https://api.github.com${path}`, {method, headers: {Accept: "application/vnd.github+json", Authorization: `Bearer ${token}`, "X-GitHub-Api-Version": "2022-11-28"}, body: body === undefined ? undefined : JSON.stringify(body)}); if (!response.ok) throw new Error(`${method} ${path} failed: ${response.status}`); return response.status === 204 ? null : response.json(); };
+  const repo = await request("GET", "/repos/RasmusTho/agentic-pkm-mvp");
+  const branch = await request("GET", `/repos/RasmusTho/agentic-pkm-mvp/branches/${repo.default_branch}`);
+  if (process.env.GITHUB_REF !== `refs/heads/${repo.default_branch}` || process.env.GITHUB_SHA !== branch.commit.sha) throw new Error("recovery must execute from the current default-branch head");
+  const pullRequest = await request("GET", "/repos/RasmusTho/agentic-pkm-mvp/pulls/4052");
+  if (pullRequest.state !== "open" || pullRequest.number !== TARGET.prNumber || pullRequest.head?.sha !== TARGET.head || pullRequest.head?.repo?.full_name !== TARGET.repository || pullRequest.title !== TARGET.title) throw new Error("PR identity is current, mutable, foreign, or otherwise not the authorized legacy target");
+  const closing = await request("POST", "/graphql", {query: "query { repository(owner:\"RasmusTho\", name:\"agentic-pkm-mvp\") { pullRequest(number:4052) { closingIssuesReferences(first:20) { nodes { number } } } } }"});
+  if (closing.data?.repository?.pullRequest?.closingIssuesReferences?.nodes?.length !== 0) throw new Error("live closing references are not empty");
+  const comments = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const batch = await request("GET", `/repos/RasmusTho/agentic-pkm-mvp/issues/4052/comments?per_page=100&page=${page}`);
+    if (!Array.isArray(batch)) throw new Error("comment enumeration is malformed");
+    comments.push(...batch);
+    if (batch.length < 100) break;
+    if (page === 10) throw new Error("comment enumeration exceeded bounded recovery limit");
+  }
+  const {classifyIssueAuthority, resolveNeutralizedMergeAuthority} = currentMainValidator();
+  const issueAuthority = classifyIssueAuthority(pullRequest.body || "");
+  const authority = resolveNeutralizedMergeAuthority({ comments, issueAuthority, pullRequest, repository });
+  const authorityRecords = targetRecords(trustedRecords(comments, AUTHORITY_MARKER));
+  if (authority === null || !authorityRecords.length || authorityRecords.some(({receipt}) => canonicalJson(receipt) !== canonicalJson(authority))) throw new Error("authority receipt is missing, forged, stale, or conflicting");
+  const phase = requireUniquePreparedPhase(comments, authority);
+  await request("POST", "/repos/RasmusTho/agentic-pkm-mvp/check-runs", {name: "pr-contract", head_sha: TARGET.head, status: "completed", conclusion: "success", external_id: `base-side-pr-contract-recovery:${authority.run_id}:${TARGET.head}`, details_url: `${process.env.GITHUB_SERVER_URL}/${TARGET.repository}/actions/runs/${process.env.GITHUB_RUN_ID}`, output: {title: "Current-main pr-contract recovery authenticated", summary: `authority_run=${authority.run_id}; prepared_phase=${phase.receipt.run_id}. Additional exact-head result only; no check is replaced, suppressed, or waived.`}});
+}
+main().catch(error => { console.error(error.stack || error.message); process.exitCode = 1; });

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -512,13 +512,13 @@ def test_base_side_pr_contract_recovery_accepts_only_legacy_prepared_immutable_c
 
 def test_base_side_pr_contract_recovery_binds_live_exact_head_and_receipts() -> None:
     recovery = _read_base_side_recovery()
-    for fragment in ("pullRequest.head?.sha !== TARGET.head", "pullRequest.title !== TARGET.title", "closingIssuesReferences(first:20)", "resolveNeutralizedMergeAuthority({ comments, issueAuthority, pullRequest, repository })", "receipt.authority_sha256 === authoritySha", "receipt.body_sha256 === authority.neutralized_body_sha256", "canonicalJson(receipt) !== canonicalJson(authority)"):
+    for fragment in ("pullRequest.head?.sha !== TARGET.head", "pullRequest.title !== TARGET.title", "closingIssuesReferences(first:20)", "resolveNeutralizedMergeAuthority({comments, issueAuthority, pullRequest, repository: TARGET.repository})", "receipt.authority_sha256 === authoritySha", "receipt.body_sha256 === authority.neutralized_body_sha256", "canonicalJson(authorityRecords[0].receipt) !== canonicalJson(authority)"):
         assert fragment in recovery
 
 
 def test_base_side_pr_contract_recovery_rejects_noneligible_or_drifted_contexts() -> None:
     recovery = _read_base_side_recovery()
-    for fragment in ("recovery must execute from the current default-branch head", "live closing references are not empty", "authority receipt is missing, forged, stale, or conflicting", "prepared phase is missing, stale, forged, conflicting, or non-continuous", 'pullRequest.state !== "open"', "pullRequest.head?.repo?.full_name !== TARGET.repository"):
+    for fragment in ("repository default branch drifted from main", "recovery must execute from the current default-branch head", "live closing references are not empty", "authority receipt is missing, forged, stale, or conflicting", "prepared phase is missing, stale, forged, conflicting, or non-continuous", 'pullRequest.state !== "open"', "pullRequest.head?.repo?.full_name !== TARGET.repository", "pullRequest.base?.repo?.full_name !== TARGET.repository", "pullRequest.base?.ref !== TARGET.defaultBranch"):
         assert fragment in recovery
 
 
@@ -528,10 +528,90 @@ def test_base_side_pr_contract_recovery_publishes_only_scoped_auditable_equivale
     assert "checks: write" in workflow
     assert "workflow_dispatch:" in workflow
     assert 'name: "pr-contract"' in recovery
-    assert "head_sha: TARGET.head" in recovery
-    assert "base-side-pr-contract-recovery:${authority.run_id}:${TARGET.head}" in recovery
+    assert "head_sha: reread.pull_request.head.sha" in recovery
+    assert "base-side-pr-contract-recovery:${authority.run_id}:${reread.pull_request.head.sha}" in recovery
     assert "/statuses" not in recovery
     assert 'method: "PATCH"' not in recovery
+    action_refs = re.findall(r"^\s*- uses:\s*([^\s#]+)", workflow, re.MULTILINE)
+    assert action_refs
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", ref) for ref in action_refs)
+
+
+def test_base_side_pr_contract_recovery_posts_nothing_when_snapshot_mutates() -> None:
+    recovery_path = REPO_ROOT / "scripts/base_side_pr_contract_recovery.js"
+    script = r"""
+const {publishStableSnapshot} = require(process.argv[1]);
+const base = {
+  default_branch: "main", default_branch_sha: "a".repeat(40),
+  pull_request: {number: 4052, state: "open", draft: false, title: "title", body: "body",
+    head: {sha: "b".repeat(40), ref: "head", repository: "RasmusTho/agentic-pkm-mvp"},
+    base: {sha: "c".repeat(40), ref: "main", repository: "RasmusTho/agentic-pkm-mvp"}},
+  closing_issues: [],
+  authority: {comment: {id: 1, actor: "owner", association: "OWNER", created_at: "2026-07-21T00:00:00Z", updated_at: "2026-07-21T00:00:00Z"}, receipt: {run_id: "run", repair_budget: {policy_version: "v2"}}},
+  phase: {comment: {id: 2, actor: "owner", association: "OWNER", created_at: "2026-07-21T00:00:01Z", updated_at: "2026-07-21T00:00:01Z"}, receipt: {run_id: "run", phase: "prepared"}}
+};
+const paths = JSON.parse(process.argv[2]);
+(async () => {
+  const results = [];
+  for (const path of paths) {
+    const second = JSON.parse(JSON.stringify(base));
+    let cursor = second;
+    for (const key of path.slice(0, -1)) cursor = cursor[key];
+    cursor[path.at(-1)] = typeof cursor[path.at(-1)] === "string" ? `${cursor[path.at(-1)]}-drift` : [4056];
+    let reads = 0, posts = 0, failed = false;
+    const capture = async () => (++reads === 1 ? base : second);
+    const request = async (method, url) => { if (method === "POST" && url.endsWith("/check-runs")) posts += 1; };
+    try { await publishStableSnapshot({request, env: {}, capture}); } catch (_) { failed = true; }
+    results.push({path, posts, failed});
+  }
+  process.stdout.write(JSON.stringify(results));
+})();
+"""
+    mutation_paths = [
+        ["default_branch_sha"], ["pull_request", "title"],
+        ["closing_issues"], ["pull_request", "body"],
+        ["pull_request", "head", "sha"], ["pull_request", "base", "ref"],
+        ["authority", "comment", "updated_at"],
+        ["authority", "receipt", "repair_budget"],
+        ["phase", "comment", "actor"], ["phase", "receipt", "phase"],
+    ]
+    completed = subprocess.run(
+        ["node", "-e", script, str(recovery_path), json.dumps(mutation_paths)],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    results = json.loads(completed.stdout)
+    assert all(result["failed"] and result["posts"] == 0 for result in results)
+
+
+def test_base_side_pr_contract_recovery_rejects_default_or_pr_base_retarget() -> None:
+    recovery_path = REPO_ROOT / "scripts/base_side_pr_contract_recovery.js"
+    script = r"""
+const {requireExactBaseIdentity} = require(process.argv[1]);
+const repo = {default_branch: "main"};
+const branch = {commit: {sha: "c".repeat(40)}};
+const pr = {number: 4052, state: "open", draft: false,
+  title: "Fix CKM metric schema bundle refusal",
+  head: {sha: "a159571da2ce9068131810aedc1ea05107d7bfaf", repo: {full_name: "RasmusTho/agentic-pkm-mvp"}},
+  base: {ref: "main", repo: {full_name: "RasmusTho/agentic-pkm-mvp"}}};
+const env = {GITHUB_REF: "refs/heads/main", GITHUB_SHA: "c".repeat(40)};
+const candidates = [
+  [{...repo, default_branch: "trunk"}, pr],
+  [repo, {...pr, base: {...pr.base, ref: "stable"}}],
+  [repo, {...pr, base: {...pr.base, repo: {full_name: "foreign/repo"}}}],
+];
+const rejected = candidates.map(([candidateRepo, candidatePr]) => {
+  try { requireExactBaseIdentity(candidateRepo, branch, candidatePr, env); return false; }
+  catch (_) { return true; }
+});
+process.stdout.write(JSON.stringify(rejected));
+"""
+    completed = subprocess.run(
+        ["node", "-e", script, str(recovery_path)],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == [True, True, True]
 
 
 @pytest.mark.parametrize("separator", [",", ", ", ",\t", ", \t\t"])

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -498,6 +498,42 @@ def test_production_pr_contract_authenticates_neutralized_merge_authority() -> N
         assert fragment in workflow
 
 
+def _read_base_side_recovery() -> str:
+    return (REPO_ROOT / "scripts/base_side_pr_contract_recovery.js").read_text(encoding="utf-8")
+
+
+def test_base_side_pr_contract_recovery_accepts_only_legacy_prepared_immutable_context() -> None:
+    recovery = _read_base_side_recovery()
+    assert 'prNumber: 4052' in recovery
+    assert 'head: "a159571da2ce9068131810aedc1ea05107d7bfaf"' in recovery
+    assert 'receipt.phase === "prepared"' in recovery
+    assert "requireUniquePreparedPhase(comments, authority)" in recovery
+
+
+def test_base_side_pr_contract_recovery_binds_live_exact_head_and_receipts() -> None:
+    recovery = _read_base_side_recovery()
+    for fragment in ("pullRequest.head?.sha !== TARGET.head", "pullRequest.title !== TARGET.title", "closingIssuesReferences(first:20)", "resolveNeutralizedMergeAuthority({ comments, issueAuthority, pullRequest, repository })", "receipt.authority_sha256 === authoritySha", "receipt.body_sha256 === authority.neutralized_body_sha256", "canonicalJson(receipt) !== canonicalJson(authority)"):
+        assert fragment in recovery
+
+
+def test_base_side_pr_contract_recovery_rejects_noneligible_or_drifted_contexts() -> None:
+    recovery = _read_base_side_recovery()
+    for fragment in ("recovery must execute from the current default-branch head", "live closing references are not empty", "authority receipt is missing, forged, stale, or conflicting", "prepared phase is missing, stale, forged, conflicting, or non-continuous", 'pullRequest.state !== "open"', "pullRequest.head?.repo?.full_name !== TARGET.repository"):
+        assert fragment in recovery
+
+
+def test_base_side_pr_contract_recovery_publishes_only_scoped_auditable_equivalent_check() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/base-side-pr-contract-recovery.yml").read_text(encoding="utf-8")
+    recovery = _read_base_side_recovery()
+    assert "checks: write" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert 'name: "pr-contract"' in recovery
+    assert "head_sha: TARGET.head" in recovery
+    assert "base-side-pr-contract-recovery:${authority.run_id}:${TARGET.head}" in recovery
+    assert "/statuses" not in recovery
+    assert 'method: "PATCH"' not in recovery
+
+
 @pytest.mark.parametrize("separator", [",", ", ", ",\t", ", \t\t"])
 def test_verified_merge_neutralized_separator_grammar_matches_javascript_and_python(
     separator: str,


### PR DESCRIPTION
Governing-Issue: #4056

Fixes #4056

## Summary
Adds the one current-main recovery seam for the already-neutralized immutable PR #4052 head. It independently authenticates live identity, current validator authority, and continuous prepared phase before creating an additional exact-head `pr-contract` check run.

## Repair Bindings
- `failure_domain=lease/concurrency`, `mechanism_id=recovery-validation-publication-toctou`, `standard_attempt=1/2`: repaired at `b10c96c7` with a complete second live snapshot fence immediately before append-only check publication; any default-main, PR head/base/title/body/state/draft, closer, authority/comment/repair-budget, or prepared-phase/comment drift posts nothing.
- `failure_domain=static-quality`, `mechanism_id=mutable-action-reference`, `standard_attempt=1/2`: repaired at `b10c96c7` by pinning every action in the checks-write workflow to a full immutable commit SHA and enforcing that invariant in governance tests.
- Related verifier base-identity finding is covered by the TOCTOU/base family above: the repository default branch must remain literal `main`, workflow ref/SHA must be current main, and PR #4052 must target `main` in the same repository.

## Validation
- Four governing #4056 AC tests — 4 passed
- Recovery-focused governance tests, including mutation and base-retarget negatives — 6 passed
- Proportional governance, verification-dispatch, verified-merge, and dispatcher suites — 498 passed
- `ruff check app tests` — passed
- `mypy app` — passed (803 source files)
- `node --check scripts/base_side_pr_contract_recovery.js` — passed
- `actionlint .github/workflows/base-side-pr-contract-recovery.yml` — passed
- workflow YAML parse, skills consistency lint, diff check, and branch-truth gates — passed

## BuilderOps Routing
- Records/projections/receipts: none.
- Reason: this bounded Builder System code/docs change creates no BuilderOps Vault operational record; GitHub issue claim receipt #5037770023 and the repair receipts on this PR are durable lifecycle evidence.

Final-Review-Rounds: 1