### PR TITLE
Add compatible CKM observation comparison

### DIFF
--- a/app/builderops/ckm/comparison.py
+++ b/app/builderops/ckm/comparison.py
@@ -1,0 +1,87 @@
+"""Fail-closed comparison of retained CKM metric observations.
+
+This adapter is deliberately descriptive: two compatible snapshots establish a
+bounded delta, never a trend, cadence, cause, forecast, or machine decision.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from app.builderops.ckm.contracts import CkmContractError, canonical_digest
+from app.builderops.ckm.metrics import MetricRetentionStore, RETENTION_POLICY_VERSION
+
+_BINDINGS = {
+    "metric.id": ("metric_definition", "id"),
+    "metric.semantic_version": ("metric_definition", "semantic_version"),
+    "metric.definition_digest": ("metric_definition", "definition_digest"),
+    "formula_digest": ("bindings", "formula_digest"),
+    "detector_digest": ("bindings", "detector_digest"),
+    "configuration_digest": ("bindings", "configuration_digest"),
+    "schema.envelope": ("bindings", "schema", "envelope"),
+    "schema.resource": ("bindings", "schema", "resource"),
+    "schema.ckm": ("bindings", "schema", "ckm"),
+    "taxonomy_digest": ("bindings", "taxonomy_digest"),
+    "canonical_query_digest": ("query", "digest"),
+    "value_state_schema": ("metric_definition", "output_schema", "value_state"),
+    "candidate_confirmed_policy": ("metric_definition", "eligible_population"),
+    "identity_policy_version": ("bindings", "identity_policy_version"),
+    "access_policy_version": ("snapshot", "access_policy_version"),
+    "redaction_policy_version": ("snapshot", "redaction_profile"),
+}
+
+def _at(value: Mapping[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = value
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return "__missing__"
+        current = current[part]
+    return current
+
+def _observation(store: MetricRetentionStore, sample_id: str) -> dict[str, Any]:
+    # replay first: unavailable, expired/pruned, or tampered payloads refuse before
+    # any comparison result is assembled. It performs no retention mutation.
+    if not store.path.exists():
+        raise CkmContractError("source_unavailable", "retained source is unavailable for comparison", {"sample_id": sample_id})
+    store.replay(sample_id)
+    with sqlite3.connect(store.path) as conn:
+        row = conn.execute("SELECT observation_json, policy_version, expires_at, lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+    now = datetime.now(timezone.utc)
+    expired = row is not None and row[2] is not None and datetime.fromisoformat(row[2].replace("Z", "+00:00")) <= now
+    if row is None or row[1] != RETENTION_POLICY_VERSION or row[2] is None or row[3] != "retained" or expired:
+        raise CkmContractError("source_unavailable", "retained source is unavailable for comparison", {"sample_id": sample_id})
+    try:
+        value = json.loads(row[0])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise CkmContractError("corrupt_retained_observation", "retained observation is corrupt", {"sample_id": sample_id}) from exc
+    if not isinstance(value, dict):
+        raise CkmContractError("corrupt_retained_observation", "retained observation is corrupt", {"sample_id": sample_id})
+    return value
+
+def compare_retained_observations(store: MetricRetentionStore, sample_ids: Sequence[str]) -> dict[str, Any]:
+    """Return one all-or-nothing, deterministic descriptive comparison."""
+    if len(sample_ids) < 2 or len(set(sample_ids)) != len(sample_ids):
+        raise CkmContractError("invalid_comparison_inputs", "comparison requires two or more distinct retained samples", {})
+    observations = [_observation(store, sample_id) for sample_id in sample_ids]
+    baseline = observations[0]
+    mismatches: dict[str, list[Any]] = {}
+    for name, path in _BINDINGS.items():
+        values = [_at(item, path) for item in observations]
+        if "__missing__" in values or any(value != values[0] for value in values[1:]):
+            mismatches[name] = values
+    if mismatches:
+        raise CkmContractError("incompatible_observations", "observations have incompatible semantic bindings", {"mismatched_fields": mismatches})
+    components: list[dict[str, Any]] = []
+    keys = sorted(set().union(*(item.get("vector", {}).keys() for item in observations)))
+    for key in keys:
+        states = [item.get("vector", {}).get(key, {"state": "unsupported", "reason": "component absent"}) for item in observations]
+        if all(state.get("state") == "measured" and isinstance(state.get("value"), (int, float)) for state in states):
+            delta: Any = states[-1]["value"] - states[0]["value"]
+        else:
+            delta = None
+        components.append({"component": key, "states": states, "numeric_delta": delta, "state_transition": [state.get("state") for state in states]})
+    limitations = ["Two snapshots prove only a bounded delta, not a trend, cadence, window, minimum evidence count, cause, or forecast.", "No ranking, gating, prioritization, agent score, automated action, or machine authority is exposed."]
+    return {"kind": "ckm_compatible_observation_comparison_v1", "inputs": [{"sample_id": sid, "observation_id": obs.get("observation_id"), "semantic_digest": obs.get("semantic_digest")} for sid, obs in zip(sample_ids, observations)], "compatibility": {"compatible": True, "bindings": {name: _at(baseline, path) for name, path in _BINDINGS.items()}}, "components": components, "provenance": [obs.get("citations", []) for obs in observations], "freshness": [obs.get("freshness", {}) for obs in observations], "aggregate": {"label": "human_advisory_only", "value": None, "sole_input_prohibited": True, "machine_authority_prohibited": True, "co_present_components": True}, "limitations": limitations, "comparison_digest": canonical_digest({"inputs": list(sample_ids), "components": components})}

--- a/app/builderops/ckm/comparison.py
+++ b/app/builderops/ckm/comparison.py
@@ -12,7 +12,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 from app.builderops.ckm.contracts import CkmContractError, canonical_digest
-from app.builderops.ckm.metrics import MetricRetentionStore, RETENTION_POLICY_VERSION
+from app.builderops.ckm.metrics import (
+    MetricRetentionStore,
+    RETENTION_POLICY_VERSION,
+    metric_definition,
+)
 
 _BINDINGS = {
     "metric.id": ("metric_definition", "id"),
@@ -41,24 +45,94 @@ def _at(value: Mapping[str, Any], path: tuple[str, ...]) -> Any:
         current = current[part]
     return current
 
+def _component_delta(states: Sequence[Mapping[str, Any]]) -> int | float | None:
+    if all(
+        state.get("state") == "measured"
+        and isinstance(state.get("value"), (int, float))
+        and not isinstance(state.get("value"), bool)
+        for state in states
+    ):
+        return states[-1]["value"] - states[0]["value"]
+    return None
+
 def _observation(store: MetricRetentionStore, sample_id: str) -> dict[str, Any]:
-    # replay first: unavailable, expired/pruned, or tampered payloads refuse before
-    # any comparison result is assembled. It performs no retention mutation.
     if not store.path.exists():
         raise CkmContractError("source_unavailable", "retained source is unavailable for comparison", {"sample_id": sample_id})
-    store.replay(sample_id)
-    with sqlite3.connect(store.path) as conn:
-        row = conn.execute("SELECT observation_json, policy_version, expires_at, lifecycle FROM ckm_metric_sample_v1 WHERE sample_id = ?", (sample_id,)).fetchone()
+    try:
+        with sqlite3.connect(f"{store.path.resolve().as_uri()}?mode=ro", uri=True) as conn:
+            row = conn.execute(
+                "SELECT observation_json, typeof(observation_json), source_payload, "
+                "typeof(source_payload), source_digest, policy_version, expires_at, "
+                "lifecycle, observation_id FROM ckm_metric_sample_v1 WHERE sample_id = ?",
+                (sample_id,),
+            ).fetchone()
+    except sqlite3.Error as exc:
+        raise CkmContractError("source_unavailable", "retention storage is unavailable or incomplete", {"sample_id": sample_id}) from exc
     now = datetime.now(timezone.utc)
-    expired = row is not None and row[2] is not None and datetime.fromisoformat(row[2].replace("Z", "+00:00")) <= now
-    if row is None or row[1] != RETENTION_POLICY_VERSION or row[2] is None or row[3] != "retained" or expired:
+    try:
+        expired = row is not None and datetime.fromisoformat(row[6].replace("Z", "+00:00")) <= now
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise CkmContractError("source_unavailable", "retained source expiry is invalid", {"sample_id": sample_id}) from exc
+    if row is None or row[5] != RETENTION_POLICY_VERSION or row[7] != "retained" or expired:
         raise CkmContractError("source_unavailable", "retained source is unavailable for comparison", {"sample_id": sample_id})
+    if row[1] != "text" or row[3] != "blob" or not isinstance(row[2], (bytes, bytearray, memoryview)):
+        raise CkmContractError("tampered_retained_source", "retained comparison input has invalid storage types", {"sample_id": sample_id})
     try:
         value = json.loads(row[0])
-    except (TypeError, json.JSONDecodeError) as exc:
+        source = json.loads(bytes(row[2]).decode("utf-8"))
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise CkmContractError("corrupt_retained_observation", "retained observation is corrupt", {"sample_id": sample_id}) from exc
-    if not isinstance(value, dict):
+    if not isinstance(value, dict) or not isinstance(source, dict) or canonical_digest(source) != row[4]:
         raise CkmContractError("corrupt_retained_observation", "retained observation is corrupt", {"sample_id": sample_id})
+    try:
+        definition = dict(metric_definition(value["metric_definition"]["id"], value["metric_definition"]["semantic_version"]))
+        snapshot = source["snapshot"]
+        resources = source["resources"]
+        confirmed = [item for item in resources if not item["candidate"]]
+        candidates = [item for item in resources if item["candidate"]]
+        def distribution(items: list[Mapping[str, Any]]) -> dict[str, int]:
+            counts = {state: 0 for state in ("measured", "missing", "unassessed", "unsupported")}
+            for item in items:
+                for tagged in item["values"].values():
+                    counts[tagged["state"]] += 1
+            return counts
+        expected = {
+            "observation_schema_version": 1,
+            "projection": {"status": "derived_projection", "authoritative": False},
+            "metric_definition": definition,
+            "snapshot": snapshot,
+            "query": {"digest": source["query_digest"], "resource_type": source["resource_type"]},
+            "bindings": {
+                "schema": {"envelope": source["schema_version"], "resource": snapshot["resource_schema_version"], "ckm": snapshot["ckm_schema_version"]},
+                "taxonomy_digest": snapshot["taxonomy_digest"],
+                "formula_digest": canonical_digest(definition["formula"]),
+                "detector_digest": canonical_digest(definition["detector_bindings"]),
+                "configuration_digest": canonical_digest(definition["configuration_bindings"]),
+                "watermark_digest": canonical_digest(snapshot["watermarks"]),
+                "provenance_digest": canonical_digest(snapshot["provenance"]),
+                "identity_policy_version": "ckm-public-id-v1",
+            },
+            "vector": {
+                "confirmed_population": {"state": "measured", "value": len(confirmed)},
+                "candidate_population": {"state": "measured", "value": len(candidates)},
+                "provenance_coverage": {"state": "measured", "value": len([item for item in resources if item["provenance"]])},
+            },
+            "distributions": {"confirmed": distribution(confirmed), "candidate": distribution(candidates)},
+            "composition": {"confirmed_public_ids": [item["public_id"] for item in confirmed], "candidate_public_ids": [item["public_id"] for item in candidates]},
+            "citations": snapshot["provenance"],
+            "freshness": {"state_revision": snapshot["state_revision"], "watermarks": snapshot["watermarks"]},
+            "confidence": {"state": "unassessed", "reason": "metric does not infer confidence from descriptive CKM data"},
+            "limitations": definition["limitations"],
+            "goodhart_warnings": definition["goodhart_warnings"],
+            "aggregate": {"label": "human_advisory_only", "value": None, "sole_input_prohibited": True, "machine_authority_prohibited": True},
+            "generated_at": value["generated_at"],
+        }
+    except (KeyError, TypeError, CkmContractError) as exc:
+        raise CkmContractError("corrupt_retained_observation", "retained observation cannot be reproduced from its source", {"sample_id": sample_id}) from exc
+    expected["semantic_digest"] = canonical_digest({key: item for key, item in expected.items() if key != "generated_at"})
+    expected["observation_id"] = f"ckm_observation_{expected['semantic_digest'][:24]}"
+    if value != expected or row[8] != expected["observation_id"]:
+        raise CkmContractError("observation_source_mismatch", "retained observation does not reproduce from its bound source", {"sample_id": sample_id})
     return value
 
 def compare_retained_observations(store: MetricRetentionStore, sample_ids: Sequence[str]) -> dict[str, Any]:
@@ -78,10 +152,7 @@ def compare_retained_observations(store: MetricRetentionStore, sample_ids: Seque
     keys = sorted(set().union(*(item.get("vector", {}).keys() for item in observations)))
     for key in keys:
         states = [item.get("vector", {}).get(key, {"state": "unsupported", "reason": "component absent"}) for item in observations]
-        if all(state.get("state") == "measured" and isinstance(state.get("value"), (int, float)) for state in states):
-            delta: Any = states[-1]["value"] - states[0]["value"]
-        else:
-            delta = None
+        delta = _component_delta(states)
         components.append({"component": key, "states": states, "numeric_delta": delta, "state_transition": [state.get("state") for state in states]})
     limitations = ["Two snapshots prove only a bounded delta, not a trend, cadence, window, minimum evidence count, cause, or forecast.", "No ranking, gating, prioritization, agent score, automated action, or machine authority is exposed."]
     return {"kind": "ckm_compatible_observation_comparison_v1", "inputs": [{"sample_id": sid, "observation_id": obs.get("observation_id"), "semantic_digest": obs.get("semantic_digest")} for sid, obs in zip(sample_ids, observations)], "compatibility": {"compatible": True, "bindings": {name: _at(baseline, path) for name, path in _BINDINGS.items()}}, "components": components, "provenance": [obs.get("citations", []) for obs in observations], "freshness": [obs.get("freshness", {}) for obs in observations], "aggregate": {"label": "human_advisory_only", "value": None, "sole_input_prohibited": True, "machine_authority_prohibited": True, "co_present_components": True}, "limitations": limitations, "comparison_digest": canonical_digest({"inputs": list(sample_ids), "components": components})}

--- a/app/builderops/ckm/metrics.py
+++ b/app/builderops/ckm/metrics.py
@@ -181,6 +181,7 @@ def build_observation(result: ResultEnvelope, *, metric_id: str = "capability_po
             "configuration_digest": canonical_digest(definition["configuration_bindings"]),
             "watermark_digest": canonical_digest(payload["snapshot"]["watermarks"]),
             "provenance_digest": canonical_digest(payload["snapshot"]["provenance"]),
+            "identity_policy_version": "ckm-public-id-v1",
         },
         "vector": vector,
         "distributions": {"confirmed": _tagged_distribution(confirmed), "candidate": _tagged_distribution(candidates)},

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -47,6 +47,7 @@ from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.ckm.metrics import MetricRetentionStore, build_observation
+from app.builderops.ckm.comparison import compare_retained_observations
 from app.builderops.ckm.contracts import CkmContractError, ResultEnvelope
 from app.builderops.config import BuilderOpsPaths, default_state_dir, load_paths
 from app.builderops.cutover_evidence import (
@@ -646,6 +647,19 @@ def ckm_measure(ctx: click.Context, metric_id: str, retain_sample: bool, limit: 
             sample = MetricRetentionStore(retention_path).retain(result, metric_id=metric_id)
             payload["retained_sample"] = {"sample_id": sample.sample_id, "observation_id": sample.observation_id}
             payload["storage"] = MetricRetentionStore(retention_path).storage_usage()
+    except CkmContractError as exc:
+        payload = {"error": exc.to_dict()}
+    click.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@ckm.command("compare", help="Compare compatible retained CKM observations without inferring a trend.")
+@click.option("--sample-id", "sample_ids", multiple=True, required=True)
+@click.pass_context
+def ckm_compare(ctx: click.Context, sample_ids: tuple[str, ...]) -> None:
+    paths = _effective_paths(ctx)
+    retention_path = paths.db_path.with_name(f"{paths.db_path.stem}-metric-samples.sqlite")
+    try:
+        payload = compare_retained_observations(MetricRetentionStore(retention_path), sample_ids)
     except CkmContractError as exc:
         payload = {"error": exc.to_dict()}
     click.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))

--- a/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
+++ b/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
@@ -129,6 +129,19 @@ count, M2 history, O2 automation, drift detection, federation, rankings, or
 machine decision authority. Those remain unresolved or out of scope until a
 new source-backed contract is accepted.
 
+## O1b delivered comparison semantics
+
+O1b (#3781) compares only two or more replayable retained M1 observations
+whose metric definition, formula/detector/configuration, schema, taxonomy,
+canonical query, tagged value-state, candidate/confirmed, identity, and
+access/redaction bindings all match. It returns deterministic component-wise
+deltas with input identity, provenance, freshness, citations, explicit tagged
+state transitions, and limitations; any mismatch, missing policy binding,
+expiry/pruning/deletion, or tamper refuses without a partial result. An
+aggregate is only `human_advisory_only`, co-present with components and
+limitations, and never sufficient for authority. The gathered observation is
+implementation/test evidence only: it establishes neither trend nor cadence.
+
 ## Observation-gated future work
 
 - **M2 is not filed or Ready.** The accepted question set is limited to compatible sampled changes in evidence coverage/composition, source freshness, citation/confidence coverage, and candidate/finding composition. Filing still requires a costed smallest implementation, source authority, precise semantics, and verifiable refusal behavior. General bitemporality is not the answer.

--- a/tests/builderops/ckm/test_metric_comparison.py
+++ b/tests/builderops/ckm/test_metric_comparison.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import sqlite3
+import json
 from pathlib import Path
 
 import pytest
 
-from app.builderops.ckm.comparison import compare_retained_observations
+from app.builderops.ckm.comparison import _component_delta, compare_retained_observations
 from app.builderops.ckm.contracts import CkmContractError
 from app.builderops.ckm.metrics import MetricRetentionStore
 from tests.builderops.ckm.test_metrics import _result
@@ -27,12 +28,14 @@ def test_compatible_observations_produce_deterministic_bound_delta(tmp_path: Pat
     assert first["inputs"] and first["components"] and first["provenance"] and first["freshness"] and first["limitations"]
 
 def test_semantic_mismatch_refuses_without_partial_comparison(tmp_path: Path) -> None:
-    store, samples = _samples(tmp_path)
-    with sqlite3.connect(store.path) as conn:
-        conn.execute("UPDATE ckm_metric_sample_v1 SET observation_json = replace(observation_json, '\"identity_policy_version\":\"ckm-public-id-v1\"', '\"identity_policy_version\":\"changed\"') WHERE sample_id = ?", (samples[1].sample_id,))
+    store = MetricRetentionStore(tmp_path / "retained.sqlite")
+    samples = [
+        store.retain(_result(tmp_path / "one"), retained_at="2026-07-21T00:00:00Z"),
+        store.retain(_result(tmp_path / "two"), metric_id="provenance_coverage", retained_at="2026-07-22T00:00:00Z"),
+    ]
     with pytest.raises(CkmContractError, match="incompatible") as exc:
         compare_retained_observations(store, [item.sample_id for item in samples])
-    assert "identity_policy_version" in exc.value.details["mismatched_fields"]
+    assert "metric.id" in exc.value.details["mismatched_fields"]
 
 @pytest.mark.parametrize("mutation", ["DELETE FROM ckm_metric_sample_v1 WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET source_payload = NULL WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET source_payload = x'7B7D' WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET policy_version = 'missing' WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET expires_at = '2000-01-01T00:00:00Z' WHERE sample_id = ?"])
 def test_unavailable_or_tampered_retained_source_refuses_comparison(tmp_path: Path, mutation: str) -> None:
@@ -41,10 +44,8 @@ def test_unavailable_or_tampered_retained_source_refuses_comparison(tmp_path: Pa
     with pytest.raises(CkmContractError): compare_retained_observations(store, [item.sample_id for item in samples])
 
 def test_value_state_transitions_are_not_coerced_to_numbers(tmp_path: Path) -> None:
-    store, samples = _samples(tmp_path)
-    with sqlite3.connect(store.path) as conn: conn.execute("UPDATE ckm_metric_sample_v1 SET observation_json = replace(observation_json, '\"value\":1', '\"reason\":\"not measured\"') WHERE sample_id = ?", (samples[1].sample_id,))
-    result = compare_retained_observations(store, [item.sample_id for item in samples])
-    assert any(item["numeric_delta"] is None for item in result["components"])
+    assert _component_delta([{"state": "measured", "value": 0}, {"state": "missing", "reason": "absent"}]) is None
+    assert _component_delta([{"state": "unassessed", "reason": "unknown"}, {"state": "unsupported", "reason": "not supported"}]) is None
 
 def test_comparison_bounds_advisory_aggregate_without_authority(tmp_path: Path) -> None:
     store, samples = _samples(tmp_path); aggregate = compare_retained_observations(store, [item.sample_id for item in samples])["aggregate"]
@@ -53,3 +54,39 @@ def test_comparison_bounds_advisory_aggregate_without_authority(tmp_path: Path) 
 def test_comparison_disclaims_trend_and_cadence_claims(tmp_path: Path) -> None:
     store, samples = _samples(tmp_path); limitations = " ".join(compare_retained_observations(store, [item.sample_id for item in samples])["limitations"])
     assert "trend" in limitations and "cadence" in limitations
+
+def test_comparison_read_path_never_creates_or_mutates_retention_storage(tmp_path: Path) -> None:
+    missing = MetricRetentionStore(tmp_path / "missing" / "retained.sqlite")
+    with pytest.raises(CkmContractError) as exc:
+        compare_retained_observations(missing, ["one", "two"])
+    assert exc.value.code == "source_unavailable"
+    assert not missing.path.parent.exists()
+    incomplete = tmp_path / "incomplete.sqlite"
+    with sqlite3.connect(incomplete) as conn:
+        conn.execute("CREATE TABLE unrelated (id TEXT)")
+    before = incomplete.read_bytes()
+    with pytest.raises(CkmContractError) as exc:
+        compare_retained_observations(MetricRetentionStore(incomplete), ["one", "two"])
+    assert exc.value.code == "source_unavailable"
+    assert incomplete.read_bytes() == before
+    store, samples = _samples(tmp_path / "valid")
+    before_bytes = store.path.read_bytes()
+    before_stat = store.path.stat()
+    before_entries = {item.name for item in store.path.parent.iterdir()}
+    compare_retained_observations(store, [item.sample_id for item in samples])
+    after_stat = store.path.stat()
+    assert store.path.read_bytes() == before_bytes
+    assert after_stat.st_mtime_ns == before_stat.st_mtime_ns
+    assert after_stat.st_size == before_stat.st_size
+    assert {item.name for item in store.path.parent.iterdir()} == before_entries
+
+def test_forged_observation_source_binding_refuses_before_comparison(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path)
+    with sqlite3.connect(store.path) as conn:
+        raw = conn.execute("SELECT observation_json FROM ckm_metric_sample_v1 WHERE sample_id = ?", (samples[1].sample_id,)).fetchone()[0]
+        forged = json.loads(raw)
+        forged["snapshot"]["snapshot_digest"] = "forged"
+        conn.execute("UPDATE ckm_metric_sample_v1 SET observation_json = ? WHERE sample_id = ?", (json.dumps(forged, sort_keys=True, separators=(",", ":")), samples[1].sample_id))
+    with pytest.raises(CkmContractError) as exc:
+        compare_retained_observations(store, [item.sample_id for item in samples])
+    assert exc.value.code == "observation_source_mismatch"

--- a/tests/builderops/ckm/test_metric_comparison.py
+++ b/tests/builderops/ckm/test_metric_comparison.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.builderops.ckm.comparison import compare_retained_observations
+from app.builderops.ckm.contracts import CkmContractError
+from app.builderops.ckm.metrics import MetricRetentionStore
+from tests.builderops.ckm.test_metrics import _result
+
+
+def _samples(path: Path):
+    store = MetricRetentionStore(path / "retained.sqlite")
+    return store, [store.retain(_result(path / str(n), watermark=f"commit:{n}"), retained_at=f"2026-07-2{n}T00:00:00Z") for n in (1, 2)]
+
+def test_compatibility_binds_every_semantics_bearing_field(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path)
+    result = compare_retained_observations(store, [item.sample_id for item in samples])
+    assert {"metric.id", "formula_digest", "detector_digest", "configuration_digest", "schema.envelope", "schema.resource", "taxonomy_digest", "canonical_query_digest", "value_state_schema", "candidate_confirmed_policy", "identity_policy_version", "access_policy_version", "redaction_policy_version"} <= set(result["compatibility"]["bindings"])
+
+def test_compatible_observations_produce_deterministic_bound_delta(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path)
+    first = compare_retained_observations(store, [item.sample_id for item in samples])
+    assert first == compare_retained_observations(store, [item.sample_id for item in samples])
+    assert first["inputs"] and first["components"] and first["provenance"] and first["freshness"] and first["limitations"]
+
+def test_semantic_mismatch_refuses_without_partial_comparison(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path)
+    with sqlite3.connect(store.path) as conn:
+        conn.execute("UPDATE ckm_metric_sample_v1 SET observation_json = replace(observation_json, '\"identity_policy_version\":\"ckm-public-id-v1\"', '\"identity_policy_version\":\"changed\"') WHERE sample_id = ?", (samples[1].sample_id,))
+    with pytest.raises(CkmContractError, match="incompatible") as exc:
+        compare_retained_observations(store, [item.sample_id for item in samples])
+    assert "identity_policy_version" in exc.value.details["mismatched_fields"]
+
+@pytest.mark.parametrize("mutation", ["DELETE FROM ckm_metric_sample_v1 WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET source_payload = NULL WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET source_payload = x'7B7D' WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET policy_version = 'missing' WHERE sample_id = ?", "UPDATE ckm_metric_sample_v1 SET expires_at = '2000-01-01T00:00:00Z' WHERE sample_id = ?"])
+def test_unavailable_or_tampered_retained_source_refuses_comparison(tmp_path: Path, mutation: str) -> None:
+    store, samples = _samples(tmp_path)
+    with sqlite3.connect(store.path) as conn: conn.execute(mutation, (samples[1].sample_id,))
+    with pytest.raises(CkmContractError): compare_retained_observations(store, [item.sample_id for item in samples])
+
+def test_value_state_transitions_are_not_coerced_to_numbers(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path)
+    with sqlite3.connect(store.path) as conn: conn.execute("UPDATE ckm_metric_sample_v1 SET observation_json = replace(observation_json, '\"value\":1', '\"reason\":\"not measured\"') WHERE sample_id = ?", (samples[1].sample_id,))
+    result = compare_retained_observations(store, [item.sample_id for item in samples])
+    assert any(item["numeric_delta"] is None for item in result["components"])
+
+def test_comparison_bounds_advisory_aggregate_without_authority(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path); aggregate = compare_retained_observations(store, [item.sample_id for item in samples])["aggregate"]
+    assert aggregate["label"] == "human_advisory_only" and aggregate["sole_input_prohibited"] and aggregate["co_present_components"]
+
+def test_comparison_disclaims_trend_and_cadence_claims(tmp_path: Path) -> None:
+    store, samples = _samples(tmp_path); limitations = " ".join(compare_retained_observations(store, [item.sample_id for item in samples])["limitations"])
+    assert "trend" in limitations and "cadence" in limitations

--- a/tests/builderops/ckm/test_metrics.py
+++ b/tests/builderops/ckm/test_metrics.py
@@ -47,7 +47,7 @@ def test_metric_definitions_are_versioned_and_warn_against_gating() -> None:
 def test_observation_binds_complete_semantic_bundle(tmp_path: Path) -> None:
     observation = build_observation(_result(tmp_path), generated_at="2026-07-21T00:00:00Z")
     assert observation["snapshot"]["snapshot_digest"] and observation["query"]["digest"]
-    assert observation["bindings"].keys() == {"schema", "taxonomy_digest", "formula_digest", "detector_digest", "configuration_digest", "watermark_digest", "provenance_digest"}
+    assert observation["bindings"].keys() == {"schema", "taxonomy_digest", "formula_digest", "detector_digest", "configuration_digest", "watermark_digest", "provenance_digest", "identity_policy_version"}
     assert observation["metric_definition"]["definition_digest"] and observation["generated_at"]
 
 


### PR DESCRIPTION
Governing-Issue: #3781

Fixes #3781

## Summary
- Add fail-closed retained CKM observation comparison and CLI adapter.
- Bind identity policy and document bounded, advisory-only semantics.
- Inspect retained comparison inputs read-only and reproduce each observation from its digest-verified retained source before compatibility.

## Validation
- python3 -m pytest -q tests/builderops/ckm/test_metric_comparison.py (13 passed)
- python3 -m pytest -q tests/builderops/ckm (209 passed)
- ruff check app tests
- mypy app

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded implementation did not create BuilderOps operational material.

Final-Review-Rounds: 2