### PR TITLE
Optimize bounded CKM query plans

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -202,16 +202,15 @@ def _honesty_markup(
 
 
 def _capability_markup(
-    store: CkmStore,
     capability: CkmCapability,
     *,
     depth: int,
+    edges: Sequence[CkmEvidenceEdge],
+    findings: Sequence[CkmFinding],
+    projection: CkmAssessmentProjection | None,
 ) -> str:
-    edges = store.list_evidence_edges_for_capability(capability.id)
-    findings = store.list_findings_for_capability(capability.id)
     confirmed, candidate = _edge_counts(edges)
-    assessment = store.latest_assessment_for_capability(capability.id)
-    projection = store.assessment_for_projection(capability.id) if assessment else None
+    assessment = projection.assessment if projection else None
     aggregate = float(assessment.aggregate) if assessment else None
     band = _band(aggregate)
     summary_flags: list[str] = []
@@ -308,18 +307,29 @@ def render_overview_html(
     """Render one self-contained CKM projection without mutating the store."""
 
     timestamp = generated_at or utc_now()
-    capabilities = store.list_capabilities()
+    batch = store.load_projection_batch()
+    capabilities = batch.capabilities
     capability_by_id = {item.id: item for item in capabilities}
-    all_findings = store.list_findings()
+    all_findings = tuple(
+        finding
+        for findings in batch.findings_by_capability.values()
+        for finding in findings
+    )
     assessments = {
         capability.id: (
-            assessment := store.latest_assessment_for_capability(capability.id),
-            store.assessment_for_projection(capability.id) if assessment else None,
+            projection.assessment if (projection := batch.assessments_by_capability.get(capability.id)) else None,
+            projection,
         )
         for capability in capabilities
     }
     cards = "".join(
-        _capability_markup(store, capability, depth=depth)
+        _capability_markup(
+            capability,
+            depth=depth,
+            edges=batch.edges_by_capability.get(capability.id, ()),
+            findings=batch.findings_by_capability.get(capability.id, ()),
+            projection=batch.assessments_by_capability.get(capability.id),
+        )
         for depth, capability in _forest(capabilities)
     ) or '<p class="empty">No capabilities in the CKM store.</p>'
     grouped: dict[str, list[CkmFinding]] = defaultdict(list)
@@ -332,7 +342,7 @@ def render_overview_html(
         for capability_id, findings in sorted(grouped.items())
         if capability_id in capability_by_id
     ) or "<li>No current findings.</li>"
-    watermark_text = _watermarks(store.current_watermark_set())
+    watermark_text = _watermarks(batch.current_watermark_set)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -388,6 +398,7 @@ def write_overview_html(
     *,
     generated_at: str | None = None,
 ) -> Path:
+    store.ensure_schema()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
         render_overview_html(store, generated_at=generated_at),

--- a/app/builderops/ckm/projections.py
+++ b/app/builderops/ckm/projections.py
@@ -9,7 +9,6 @@ from typing import Iterable, Mapping, Sequence
 
 from app.builderops.ckm.models import (
     MATURITY_DIMENSIONS,
-    CkmAssessmentProjection,
     CkmArtifact,
     CkmCapability,
     CkmEvidenceEdge,
@@ -18,7 +17,7 @@ from app.builderops.ckm.models import (
     utc_now,
 )
 from app.builderops.ckm.seed import SeedManifestError, load_manifest
-from app.builderops.ckm.store import CkmStore
+from app.builderops.ckm.store import CkmProjectionBatch, CkmStore
 
 
 TRACEABILITY_COLUMNS = (
@@ -93,7 +92,7 @@ def _slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
 
 
-def _capability_by_slug(store: CkmStore, slug: str) -> CkmCapability:
+def _capability_by_slug(capabilities: Sequence[CkmCapability], slug: str) -> CkmCapability:
     normalized = _slug(slug)
     try:
         manifest = load_manifest()
@@ -102,7 +101,9 @@ def _capability_by_slug(store: CkmStore, slug: str) -> CkmCapability:
     manifest_by_slug = {_slug(entry.slug): entry for entry in manifest}
     manifest_entry = manifest_by_slug.get(normalized)
     if manifest_entry is not None:
-        capability = store.get_capability_by_name(manifest_entry.name)
+        capability = next(
+            (item for item in capabilities if item.name == manifest_entry.name), None
+        )
         if capability is None:
             raise CkmValidationError(
                 f"seeded capability is missing for manifest slug: {slug}"
@@ -115,7 +116,7 @@ def _capability_by_slug(store: CkmStore, slug: str) -> CkmCapability:
     seeded_names = {entry.name for entry in manifest}
     matches = [
         item
-        for item in store.list_capabilities()
+        for item in capabilities
         if item.name not in seeded_names and _slug(item.name) == normalized
     ]
     if not matches:
@@ -154,15 +155,13 @@ def _forest_order(capabilities: Sequence[CkmCapability]) -> list[tuple[int, CkmC
     return ordered
 
 
-def _render_capability_map(store: CkmStore) -> list[str]:
-    capabilities = store.list_capabilities()
-    all_edges = store.list_evidence_edges()
-    edges_by_capability: dict[str, list[CkmEvidenceEdge]] = {}
+def _render_capability_map(batch: CkmProjectionBatch) -> list[str]:
+    capabilities = batch.capabilities
+    edges_by_capability = batch.edges_by_capability
     linked_artifacts: set[str] = set()
-    for edge in all_edges:
-        edges_by_capability.setdefault(edge.capability_id, []).append(edge)
-        linked_artifacts.add(edge.artifact_id)
-    unlinked = sum(artifact.id not in linked_artifacts for artifact in store.list_artifacts())
+    for edges in edges_by_capability.values():
+        linked_artifacts.update(edge.artifact_id for edge in edges)
+    unlinked = sum(artifact.id not in linked_artifacts for artifact in batch.artifacts)
     lines = [
         "# CKM Capability Map",
         "",
@@ -181,18 +180,12 @@ def _render_capability_map(store: CkmStore) -> list[str]:
     return lines
 
 
-def _assessment_or_none(store: CkmStore, capability_id: str) -> CkmAssessmentProjection | None:
-    if store.latest_assessment_for_capability(capability_id) is None:
-        return None
-    return store.assessment_for_projection(capability_id)
-
-
-def _render_maturity(store: CkmStore) -> list[str]:
+def _render_maturity(batch: CkmProjectionBatch) -> list[str]:
     lines = ["# CKM Maturity", ""]
-    for capability in store.list_capabilities():
-        edges = store.list_evidence_edges_for_capability(capability.id)
+    for capability in batch.capabilities:
+        edges = batch.edges_by_capability.get(capability.id, ())
         confirmed, candidate = _edge_counts(edges)
-        projection = _assessment_or_none(store, capability.id)
+        projection = batch.assessments_by_capability.get(capability.id)
         lines.extend([f"## {_markdown(capability.name)}", ""])
         lines.append(
             f"Evidence: **{confirmed} confirmed / {candidate} candidate**. "
@@ -241,11 +234,12 @@ def _citation_text(citation: Mapping[str, object]) -> str:
     return " — ".join(parts)
 
 
-def _render_gaps(store: CkmStore) -> list[str]:
-    capabilities = {item.id: item for item in store.list_capabilities()}
+def _render_gaps(batch: CkmProjectionBatch) -> list[str]:
+    capabilities = {item.id: item for item in batch.capabilities}
     grouped: dict[str, list[CkmFinding]] = {"gap": [], "missing_evidence": []}
-    for finding in store.list_findings():
-        grouped.setdefault(finding.kind, []).append(finding)
+    for batch_findings in batch.findings_by_capability.values():
+        for finding in batch_findings:
+            grouped.setdefault(finding.kind, []).append(finding)
     lines = ["# CKM Gaps and Missing Evidence", ""]
     for kind in ("gap", "missing_evidence"):
         lines.extend([f"## {kind.replace('_', ' ').title()}", ""])
@@ -285,8 +279,8 @@ def _refs_for_kind(
     return ", ".join(sorted(set(values))) or "—"
 
 
-def _render_traceability_matrix(store: CkmStore) -> list[str]:
-    artifacts = {item.id: item for item in store.list_artifacts()}
+def _render_traceability_matrix(batch: CkmProjectionBatch) -> list[str]:
+    artifacts = {item.id: item for item in batch.artifacts}
     lines = [
         "# Generated CKM Traceability Matrix",
         "",
@@ -296,8 +290,8 @@ def _render_traceability_matrix(store: CkmStore) -> list[str]:
         "| " + " | ".join(TRACEABILITY_COLUMNS) + " |",
         "| " + " | ".join("---" for _ in TRACEABILITY_COLUMNS) + " |",
     ]
-    for index, capability in enumerate(store.list_capabilities(), start=1):
-        edges = store.list_evidence_edges_for_capability(capability.id)
+    for index, capability in enumerate(batch.capabilities, start=1):
+        edges = batch.edges_by_capability.get(capability.id, ())
         row = (
             str(index),
             f"{capability.name} ({capability.lifecycle})",
@@ -345,16 +339,20 @@ def render_projection(
     if normalized not in PROJECTION_FILENAMES:
         allowed = ", ".join(sorted(PROJECTION_FILENAMES))
         raise CkmValidationError(f"unsupported CKM projection type: {projection_type}; allowed: {allowed}")
-    store.ensure_schema()
     timestamp = generated_at or utc_now()
+    batch = store.load_projection_batch()
     body = {
         "ckm-capability-map": _render_capability_map,
         "ckm-maturity": _render_maturity,
         "ckm-gaps": _render_gaps,
         "ckm-traceability-matrix": _render_traceability_matrix,
-    }[normalized](store)
+    }[normalized](batch)
     return "\n".join(
-        _header(normalized, generated_at=timestamp, watermarks=store.current_watermark_set())
+        _header(
+            normalized,
+            generated_at=timestamp,
+            watermarks=batch.current_watermark_set,
+        )
         + body
         + [""]
     )
@@ -372,6 +370,7 @@ def write_projection(
     if filename is None:
         allowed = ", ".join(sorted(PROJECTION_FILENAMES))
         raise CkmValidationError(f"unsupported CKM projection type: {projection_type}; allowed: {allowed}")
+    store.ensure_schema()
     timestamp = generated_at or utc_now()
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / filename
@@ -388,15 +387,15 @@ def render_capability_show(
     *,
     generated_at: str | None = None,
 ) -> str:
-    store.ensure_schema()
-    capability = _capability_by_slug(store, capability_slug)
+    batch = store.load_projection_batch()
+    capability = _capability_by_slug(batch.capabilities, capability_slug)
     timestamp = generated_at or utc_now()
-    edges = store.list_evidence_edges_for_capability(capability.id)
+    edges = batch.edges_by_capability.get(capability.id, ())
     confirmed, candidate = _edge_counts(edges)
     lines = _header(
         "ckm-show",
         generated_at=timestamp,
-        watermarks=store.current_watermark_set(),
+        watermarks=batch.current_watermark_set,
     )
     lines.extend([
         f"# {_markdown(capability.name)}",
@@ -405,7 +404,7 @@ def render_capability_show(
         f"Evidence: **{confirmed} confirmed / {candidate} candidate**.",
         "",
     ])
-    projection = _assessment_or_none(store, capability.id)
+    projection = batch.assessments_by_capability.get(capability.id)
     if projection is None:
         lines.extend(["Assessment: **missing**.", ""])
     else:

--- a/app/builderops/ckm/query_service.py
+++ b/app/builderops/ckm/query_service.py
@@ -27,10 +27,22 @@ from app.builderops.ckm.contracts import (
     canonical_query_digest,
     validate_contract_request,
 )
-from app.builderops.ckm.schema import CKM_REQUIRED_COLUMNS, CKM_SCHEMA_VERSION, CKM_TABLE_NAMES
+from app.builderops.ckm.schema import (
+    CKM_REQUIRED_COLUMNS,
+    CKM_REQUIRED_QUERY_INDEXES,
+    CKM_SCHEMA_VERSION,
+    CKM_TABLE_NAMES,
+)
 
 
 DEFAULT_CAPTURE_LIMIT = 500
+_SUPPORTED_FILTERS = {
+    "capability": frozenset({"public_ids", "subtree_root_public_id"}),
+    "artifact": frozenset({"unlinked"}),
+    "evidence_edge": frozenset({"capability_public_id"}),
+    "assessment": frozenset({"capability_public_id"}),
+    "finding": frozenset({"capability_public_id"}),
+}
 _SQLITE_RECOVERY_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _SQLITE_WAL_SIDECAR_SUFFIXES = ("-wal", "-shm")
 _SQLITE_HEADER_MAGIC = b"SQLite format 3\x00"
@@ -57,16 +69,35 @@ class CkmQueryService:
         )
 
     def list_capabilities(self, **request: Any) -> ResultEnvelope | ErrorEnvelope:
-        return self._query(public_id=None, **request)
+        return self._query(resource_type="capability", public_id=None, **request)
 
     def get_capability(self, public_id: str, **request: Any) -> ResultEnvelope | ErrorEnvelope:
-        return self._query(public_id=public_id, **request)
+        return self._query(resource_type="capability", public_id=public_id, **request)
 
-    def _query(self, *, public_id: str | None, **request: Any) -> ResultEnvelope | ErrorEnvelope:
-        query = {"operation": "get_capability" if public_id else "list_capabilities", "public_id": public_id}
-        query.update({key: value for key, value in request.items() if value is not None})
+    def list_resources(self, resource_type: str, **request: Any) -> ResultEnvelope | ErrorEnvelope:
+        return self._query(resource_type=resource_type, public_id=None, **request)
+
+    def _query(self, *, resource_type: str, public_id: str | None, **request: Any) -> ResultEnvelope | ErrorEnvelope:
         try:
-            validate_contract_request(resource_type="capability", **request)
+            raw_filters = request.get("filters")
+            filters = self._canonical_filters(resource_type, raw_filters)
+            if raw_filters is not None:
+                request["filters"] = filters
+            operation = (
+                "get_capability"
+                if public_id
+                else "list_capabilities"
+                if resource_type == "capability" and raw_filters is None
+                else "list_resources"
+            )
+            query = {
+                "operation": operation,
+                "public_id": public_id,
+            }
+            if operation == "list_resources":
+                query["resource_type"] = resource_type
+            query.update({key: value for key, value in request.items() if value is not None})
+            validate_contract_request(resource_type=resource_type, supported_filters=_SUPPORTED_FILTERS.get(resource_type, frozenset()), **request)
             if not self._db_path.is_file():
                 raise CkmContractError("missing_store", "CKM database does not exist", {"path": str(self._db_path)})
             snapshot_identity = self._snapshot_identity()
@@ -90,7 +121,7 @@ class CkmQueryService:
                 conn.execute("PRAGMA query_only = ON")
                 conn.execute("BEGIN")  # exactly one explicit read transaction
                 self._validate_schema(conn)
-                result = self._read_capabilities(conn, public_id=public_id, query=query)
+                result = self._read_resources(conn, resource_type=resource_type, public_id=public_id, filters=filters, query=query)
                 self._refuse_recovery_sidecars(include_rollback_journal=False)
                 if self._snapshot_identity() != snapshot_identity:
                     raise CkmContractError(
@@ -110,6 +141,33 @@ class CkmQueryService:
                 conn.close()
         except CkmContractError as exc:
             return ErrorEnvelope(exc)
+
+    def _canonical_filters(self, resource_type: str, raw: Any) -> dict[str, Any]:
+        if raw is None:
+            return {}
+        if not isinstance(raw, Mapping):
+            raise CkmContractError("unsupported_filter", "filters must be an object", {})
+        unknown = sorted(set(raw) - set(_SUPPORTED_FILTERS.get(resource_type, frozenset())))
+        if unknown:
+            raise CkmContractError("unsupported_filter", "unsupported CKM filter", {"filters": unknown})
+        filters: dict[str, Any] = {}
+        for key in sorted(raw):
+            value = raw[key]
+            if key == "public_ids":
+                if not isinstance(value, (list, tuple)) or not value or len(value) > self._capture_limit or any(not isinstance(item, str) or not item for item in value):
+                    raise CkmContractError("unsupported_filter", "public_ids must be a non-empty bounded string list", {"limit": self._capture_limit})
+                filters[key] = sorted(set(value))
+            elif key in {"subtree_root_public_id", "capability_public_id"}:
+                if not isinstance(value, str) or not value:
+                    raise CkmContractError("unsupported_filter", f"{key} must be a public ID", {})
+                filters[key] = value
+            elif key == "unlinked":
+                if value is not True:
+                    raise CkmContractError("unsupported_filter", "unlinked only supports true", {})
+                filters[key] = True
+        if "public_ids" in filters and "subtree_root_public_id" in filters:
+            raise CkmContractError("unsupported_filter", "capability filters cannot combine public_ids and subtree", {})
+        return filters
 
     def _snapshot_identity(self) -> tuple[int, int, int, int]:
         try:
@@ -177,22 +235,65 @@ class CkmQueryService:
             columns = {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
             if not required.issubset(columns):
                 raise CkmContractError("unsupported_store", "CKM schema is unsupported", {"table": table})
+        indexes = {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'index'")}
+        missing_indexes = sorted(CKM_REQUIRED_QUERY_INDEXES - indexes)
+        if missing_indexes:
+            raise CkmContractError("unsupported_store", "CKM query indexes are incomplete", {"missing_indexes": missing_indexes})
         state_rows = conn.execute("SELECT epoch, state_revision, schema_version FROM ckm_state WHERE singleton = 1").fetchall()
         if len(state_rows) != 1 or int(state_rows[0]["schema_version"]) != CKM_SCHEMA_VERSION:
             raise CkmContractError("unsupported_version", "CKM state schema version is unsupported", {})
 
-    def _read_capabilities(self, conn: sqlite3.Connection, *, public_id: str | None, query: Mapping[str, Any]) -> ResultEnvelope:
+    def _read_resources(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        resource_type: str,
+        public_id: str | None,
+        filters: Mapping[str, Any],
+        query: Mapping[str, Any],
+    ) -> ResultEnvelope:
+        if resource_type == "capability":
+            return self._read_capabilities(conn, public_id=public_id, filters=filters, query=query)
+        if public_id is not None:
+            raise CkmContractError("unsupported_filter", "exact lookup is supported only for capability", {})
+        return self._read_related_resources(conn, resource_type=resource_type, filters=filters, query=query)
+
+    def _read_capabilities(self, conn: sqlite3.Connection, *, public_id: str | None, filters: Mapping[str, Any], query: Mapping[str, Any]) -> ResultEnvelope:
         state_row = conn.execute("SELECT epoch, state_revision, schema_version FROM ckm_state WHERE singleton = 1").fetchone()
         assert state_row is not None
         state = CkmStateIdentity(str(state_row["epoch"]), int(state_row["state_revision"]), int(state_row["schema_version"]))
         total = int(conn.execute("SELECT COUNT(*) FROM ckm_capability").fetchone()[0])
-        if public_id is None and total > self._capture_limit:
+        if public_id is None and not filters and total > self._capture_limit:
             raise CkmContractError("snapshot_too_large", "complete capability snapshot exceeds configured bound", {"limit": self._capture_limit, "total": total})
         if public_id is None:
-            rows = conn.execute(
-                "SELECT capability.*, EXISTS(SELECT 1 FROM ckm_assessment AS assessment WHERE assessment.capability_id = capability.id) AS has_assessment FROM ckm_capability AS capability ORDER BY capability.public_id"
-            ).fetchall()
-            if len(rows) != total:
+            if "public_ids" in filters:
+                values = filters["public_ids"]
+                placeholders = ",".join("?" for _ in values)
+                rows = conn.execute(
+                    f"SELECT capability.*, EXISTS(SELECT 1 FROM ckm_assessment AS assessment WHERE assessment.capability_id = capability.id) AS has_assessment FROM ckm_capability AS capability WHERE capability.public_id IN ({placeholders}) ORDER BY capability.public_id",
+                    tuple(values),
+                ).fetchall()
+            elif "subtree_root_public_id" in filters:
+                rows = conn.execute(
+                    """
+                    WITH RECURSIVE subtree(id) AS (
+                        SELECT id FROM ckm_capability WHERE public_id = ?
+                        UNION
+                        SELECT child.id FROM ckm_capability AS child JOIN subtree ON child.parent_id = subtree.id
+                    )
+                    SELECT capability.*, EXISTS(SELECT 1 FROM ckm_assessment AS assessment WHERE assessment.capability_id = capability.id) AS has_assessment
+                    FROM ckm_capability AS capability JOIN subtree ON subtree.id = capability.id
+                    ORDER BY capability.public_id
+                    """,
+                    (filters["subtree_root_public_id"],),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT capability.*, EXISTS(SELECT 1 FROM ckm_assessment AS assessment WHERE assessment.capability_id = capability.id) AS has_assessment FROM ckm_capability AS capability ORDER BY capability.public_id"
+                ).fetchall()
+            if len(rows) > self._capture_limit:
+                raise CkmContractError("snapshot_too_large", "filtered capability snapshot exceeds configured bound", {"limit": self._capture_limit, "total": len(rows)})
+            if not filters and len(rows) != total:
                 raise CkmContractError(
                     "incomplete_snapshot",
                     "complete capability snapshot could not be captured",
@@ -227,7 +328,7 @@ class CkmQueryService:
             raise CkmContractError("mixed_epoch", "CKM state changed during snapshot capture", {})
         resources = tuple(self._dto(row, has_assessment=bool(row["has_assessment"])) for row in rows)
         read_set = {"capability": tuple(item.public_id for item in resources)}
-        completeness = CompletenessManifest((ObjectClassCompleteness("capability", included=len(resources), filtered=(total - len(resources)) if public_id else 0),), complete=True)
+        completeness = CompletenessManifest((ObjectClassCompleteness("capability", included=len(resources), filtered=total - len(resources)),), complete=True)
         watermarks = {str(row["source"]): str(row["value"]) for row in conn.execute("SELECT source, value FROM ckm_watermark ORDER BY source")}
         provenance = tuple({"source_ref": item.provenance[0]["source_ref"]} for item in resources)
         # Taxonomy identity belongs to the state, not to one query subset.
@@ -250,6 +351,56 @@ class CkmQueryService:
         ]
         snapshot = SnapshotManifest.build(state=state, taxonomy_digest=canonical_digest(taxonomy), watermarks=watermarks, provenance=provenance, completeness=completeness, read_set=read_set)
         return ResultEnvelope(resource_type="capability", query_digest=canonical_query_digest(query), snapshot=snapshot, resources=resources)
+
+    def _read_related_resources(self, conn: sqlite3.Connection, *, resource_type: str, filters: Mapping[str, Any], query: Mapping[str, Any]) -> ResultEnvelope:
+        table = {
+            "artifact": "ckm_artifact",
+            "evidence_edge": "ckm_evidence_edge",
+            "assessment": "ckm_assessment",
+            "finding": "ckm_finding",
+        }.get(resource_type)
+        if table is None:
+            raise CkmContractError("unsupported_resource", "unsupported CKM resource type", {"resource_type": resource_type})
+        state_row = conn.execute("SELECT epoch, state_revision, schema_version FROM ckm_state WHERE singleton = 1").fetchone()
+        assert state_row is not None
+        state = CkmStateIdentity(str(state_row["epoch"]), int(state_row["state_revision"]), int(state_row["schema_version"]))
+        total = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        parameters: tuple[Any, ...] = ()
+        if resource_type == "artifact" and filters.get("unlinked") is True:
+            sql = "SELECT artifact.* FROM ckm_artifact AS artifact WHERE NOT EXISTS (SELECT 1 FROM ckm_evidence_edge AS edge WHERE edge.artifact_id = artifact.id) ORDER BY artifact.public_id"
+        elif "capability_public_id" in filters:
+            sql = f"SELECT resource.* FROM {table} AS resource JOIN ckm_capability AS capability ON capability.id = resource.capability_id WHERE capability.public_id = ? ORDER BY resource.public_id"
+            parameters = (filters["capability_public_id"],)
+        else:
+            sql = f"SELECT resource.* FROM {table} AS resource ORDER BY resource.public_id"
+        rows = conn.execute(sql, parameters).fetchall()
+        if len(rows) > self._capture_limit:
+            raise CkmContractError("snapshot_too_large", "complete filtered snapshot exceeds configured bound", {"limit": self._capture_limit, "total": len(rows), "resource_type": resource_type})
+        end_state = conn.execute("SELECT epoch, state_revision FROM ckm_state WHERE singleton = 1").fetchone()
+        if end_state is None or (str(end_state["epoch"]), int(end_state["state_revision"])) != (state.epoch, state.state_revision):
+            raise CkmContractError("mixed_epoch", "CKM state changed during snapshot capture", {})
+        resources = tuple(self._related_dto(resource_type, row) for row in rows)
+        read_set = {resource_type: tuple(item.public_id for item in resources)}
+        completeness = CompletenessManifest((ObjectClassCompleteness(resource_type, included=len(resources), filtered=total - len(resources)),), complete=True)
+        watermarks = {str(row["source"]): str(row["value"]) for row in conn.execute("SELECT source, value FROM ckm_watermark ORDER BY source")}
+        provenance = tuple({"source_ref": item.provenance[0]["source_ref"]} for item in resources)
+        taxonomy = [
+            {"public_id": str(row["public_id"]), "parent_public_id": str(row["parent_public_id"] or ""), "lifecycle": str(row["lifecycle"])}
+            for row in conn.execute("SELECT child.public_id, parent.public_id AS parent_public_id, child.lifecycle FROM ckm_capability AS child LEFT JOIN ckm_capability AS parent ON parent.id = child.parent_id ORDER BY child.public_id")
+        ]
+        snapshot = SnapshotManifest.build(state=state, taxonomy_digest=canonical_digest(taxonomy), watermarks=watermarks, provenance=provenance, completeness=completeness, read_set=read_set)
+        return ResultEnvelope(resource_type=resource_type, query_digest=canonical_query_digest(query), snapshot=snapshot, resources=resources)
+
+    @staticmethod
+    def _related_dto(resource_type: str, row: sqlite3.Row) -> ResourceDto:
+        if resource_type == "artifact":
+            return ResourceDto(public_id=str(row["public_id"]), resource_type=resource_type, display_name=str(row["source_ref"]), lifecycle="confirmed", candidate=False, provenance=({"source_ref": str(row["source_ref"])},), values={"artifact_kind": TaggedValue.measured(str(row["artifact_kind"])), "source": TaggedValue.measured(str(row["source"])), "watermark": TaggedValue.measured(str(row["watermark"]))})
+        if resource_type == "evidence_edge":
+            lifecycle = str(row["lifecycle"])
+            return ResourceDto(public_id=str(row["public_id"]), resource_type=resource_type, display_name=str(row["evidence_kind"]), lifecycle=lifecycle, candidate=lifecycle == "candidate", provenance=({"source_ref": str(row["source_ref"])},), values={"polarity": TaggedValue.measured(str(row["polarity"])), "maturity_dimension": TaggedValue.measured(str(row["maturity_dimension"])), "confidence": TaggedValue.measured(float(row["confidence"]))})
+        if resource_type == "assessment":
+            return ResourceDto(public_id=str(row["public_id"]), resource_type=resource_type, display_name=str(row["aggregate_formula_id"]), lifecycle="confirmed", candidate=False, provenance=({"source_ref": f"assessment:{row['asserted_at']}"},), values={"aggregate": TaggedValue.measured(float(row["aggregate"])), "low_confidence": TaggedValue.measured(bool(row["low_confidence"]))})
+        return ResourceDto(public_id=str(row["public_id"]), resource_type=resource_type, display_name=str(row["kind"]), lifecycle="confirmed", candidate=False, provenance=({"source_ref": f"finding:{row['public_id']}"},), values={"dimension": TaggedValue.measured(str(row["dimension"])), "statement": TaggedValue.measured(str(row["statement"]))})
 
     @staticmethod
     def _dto(row: sqlite3.Row, *, has_assessment: bool) -> ResourceDto:

--- a/app/builderops/ckm/schema.py
+++ b/app/builderops/ckm/schema.py
@@ -28,6 +28,16 @@ CKM_TABLE_NAMES = (
     "ckm_watermark",
 )
 
+CKM_REQUIRED_QUERY_INDEXES = frozenset(
+    {
+        "idx_ckm_capability_parent_public",
+        "idx_ckm_evidence_edge_capability_public",
+        "idx_ckm_evidence_edge_artifact_public",
+        "idx_ckm_assessment_capability_asserted_public",
+        "idx_ckm_finding_capability_public",
+    }
+)
+
 CKM_REQUIRED_COLUMNS = {
     "ckm_state": frozenset(
         {"singleton", "epoch", "state_revision", "schema_version", "created_at", "updated_at"}
@@ -166,6 +176,10 @@ CKM_DDL_STATEMENTS = [
     ON ckm_capability(parent_id)
     """,
     """
+    CREATE INDEX IF NOT EXISTS idx_ckm_capability_parent_public
+    ON ckm_capability(parent_id, public_id)
+    """,
+    """
     CREATE TABLE IF NOT EXISTS ckm_artifact (
         id TEXT PRIMARY KEY,
         public_id TEXT NOT NULL,
@@ -218,6 +232,14 @@ CKM_DDL_STATEMENTS = [
     """
     CREATE INDEX IF NOT EXISTS idx_ckm_evidence_edge_artifact
     ON ckm_evidence_edge(artifact_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_ckm_evidence_edge_capability_public
+    ON ckm_evidence_edge(capability_id, public_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_ckm_evidence_edge_artifact_public
+    ON ckm_evidence_edge(artifact_id, public_id)
     """,
     """
     CREATE TABLE IF NOT EXISTS ckm_evidence_edge_history (
@@ -284,6 +306,10 @@ CKM_DDL_STATEMENTS = [
     ON ckm_assessment(capability_id, asserted_at)
     """,
     """
+    CREATE INDEX IF NOT EXISTS idx_ckm_assessment_capability_asserted_public
+    ON ckm_assessment(capability_id, asserted_at, public_id)
+    """,
+    """
     CREATE TABLE IF NOT EXISTS ckm_finding (
         id TEXT PRIMARY KEY,
         public_id TEXT NOT NULL,
@@ -304,6 +330,10 @@ CKM_DDL_STATEMENTS = [
     """
     CREATE INDEX IF NOT EXISTS idx_ckm_finding_capability
     ON ckm_finding(capability_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_ckm_finding_capability_public
+    ON ckm_finding(capability_id, public_id)
     """,
     """
     CREATE TABLE IF NOT EXISTS ckm_watermark (

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import secrets
 import sqlite3
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -52,9 +53,22 @@ from app.builderops.ckm.schema import (
 
 JsonDict = dict[str, Any]
 
+CKM_PROJECTION_CLASS_CAPTURE_LIMIT = 500
+CKM_PROJECTION_AGGREGATE_CAPTURE_LIMIT = 3_000
+
+
+class CkmProjectionCaptureError(CkmValidationError):
+    """Typed all-or-nothing refusal from the projection snapshot reader."""
+
+    def __init__(self, code: str, message: str, details: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = dict(details)
+
 
 @dataclass(frozen=True)
 class CkmProjectionBatch:
+    state_identity: CkmStateIdentity
     capabilities: tuple[CkmCapability, ...]
     artifacts: tuple[CkmArtifact, ...]
     edges_by_capability: Mapping[str, tuple[CkmEvidenceEdge, ...]]
@@ -112,6 +126,29 @@ class CkmStore:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA query_only = ON")
         return conn
+
+    def _db_file_identity(self) -> tuple[int, int, int, int]:
+        try:
+            value = self._db_path.lstat()
+        except FileNotFoundError as exc:
+            raise CkmProjectionCaptureError(
+                "missing_store",
+                f"CKM database does not exist: {self._db_path}",
+                {},
+            ) from exc
+        except OSError as exc:
+            raise CkmProjectionCaptureError(
+                "unsupported_store",
+                f"CKM database identity could not be verified: {self._db_path}",
+                {"reason": str(exc)},
+            ) from exc
+        if not stat.S_ISREG(value.st_mode):
+            raise CkmProjectionCaptureError(
+                "unsupported_store",
+                f"CKM database path is not a regular file: {self._db_path}",
+                {},
+            )
+        return (value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns)
 
     @staticmethod
     def _preflight_read_schema(conn: sqlite3.Connection) -> None:
@@ -1317,16 +1354,101 @@ class CkmStore:
             rows = conn.execute("SELECT * FROM ckm_capability ORDER BY name").fetchall()
         return [CkmCapability.from_row(row) for row in rows]
 
-    def load_projection_batch(self) -> CkmProjectionBatch:
-        """Load all projection inputs read-only with a constant bounded plan."""
+    def load_projection_batch(
+        self,
+        *,
+        class_capture_limit: int = CKM_PROJECTION_CLASS_CAPTURE_LIMIT,
+        aggregate_capture_limit: int = CKM_PROJECTION_AGGREGATE_CAPTURE_LIMIT,
+    ) -> CkmProjectionBatch:
+        """Capture all bounded projection inputs in one read-only snapshot."""
+        if class_capture_limit < 1 or aggregate_capture_limit < 1:
+            raise ValueError("projection capture limits must be positive")
+        file_identity = self._db_file_identity()
         with self._readonly_connect() as conn:
+            conn.execute("BEGIN")
             self._preflight_read_schema(conn)
+            start_state_row = conn.execute(
+                "SELECT epoch, state_revision, schema_version "
+                "FROM ckm_state WHERE singleton = 1"
+            ).fetchone()
+            assert start_state_row is not None
+            state_identity = CkmStateIdentity(
+                str(start_state_row["epoch"]),
+                int(start_state_row["state_revision"]),
+                int(start_state_row["schema_version"]),
+            )
+            count_row = conn.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM ckm_capability) AS capability,
+                    (SELECT COUNT(*) FROM ckm_artifact) AS artifact,
+                    (SELECT COUNT(*) FROM ckm_evidence_edge) AS evidence_edge,
+                    (SELECT COUNT(*) FROM ckm_assessment) AS assessment,
+                    (SELECT COUNT(*) FROM ckm_finding) AS finding,
+                    (SELECT COUNT(*) FROM ckm_watermark) AS watermark
+                """
+            ).fetchone()
+            assert count_row is not None
+            object_counts = {
+                key: int(count_row[key])
+                for key in (
+                    "capability",
+                    "artifact",
+                    "evidence_edge",
+                    "assessment",
+                    "finding",
+                    "watermark",
+                )
+            }
+            over_bound = {
+                key: count
+                for key, count in object_counts.items()
+                if count > class_capture_limit
+            }
+            aggregate_count = sum(object_counts.values())
+            if over_bound or aggregate_count > aggregate_capture_limit:
+                raise CkmProjectionCaptureError(
+                    "snapshot_too_large",
+                    "complete CKM projection snapshot exceeds configured bounds",
+                    {
+                        "class_limit": class_capture_limit,
+                        "aggregate_limit": aggregate_capture_limit,
+                        "object_counts": object_counts,
+                        "over_bound_classes": over_bound,
+                        "aggregate_count": aggregate_count,
+                    },
+                )
             capability_rows = conn.execute("SELECT * FROM ckm_capability ORDER BY name, id").fetchall()
             artifact_rows = conn.execute("SELECT * FROM ckm_artifact ORDER BY source_ref, id").fetchall()
             edge_rows = conn.execute("SELECT * FROM ckm_evidence_edge ORDER BY capability_id, public_id").fetchall()
             assessment_rows = conn.execute("SELECT * FROM ckm_assessment ORDER BY capability_id, asserted_at, rowid").fetchall()
             finding_rows = conn.execute("SELECT * FROM ckm_finding ORDER BY capability_id, kind, dimension").fetchall()
             watermark_rows = conn.execute("SELECT source, value FROM ckm_watermark ORDER BY source").fetchall()
+            end_state_row = conn.execute(
+                "SELECT epoch, state_revision, schema_version "
+                "FROM ckm_state WHERE singleton = 1"
+            ).fetchone()
+            if end_state_row is None or (
+                str(end_state_row["epoch"]),
+                int(end_state_row["state_revision"]),
+                int(end_state_row["schema_version"]),
+            ) != (
+                state_identity.epoch,
+                state_identity.state_revision,
+                state_identity.schema_version,
+            ):
+                raise CkmProjectionCaptureError(
+                    "mixed_epoch",
+                    "CKM state changed during projection snapshot capture",
+                    {},
+                )
+            if self._db_file_identity() != file_identity:
+                raise CkmProjectionCaptureError(
+                    "mixed_epoch",
+                    "CKM database identity changed during projection snapshot capture",
+                    {},
+                )
+            conn.commit()
         edges: dict[str, list[CkmEvidenceEdge]] = {}
         for row in edge_rows:
             edges.setdefault(str(row["capability_id"]), []).append(CkmEvidenceEdge.from_row(row))
@@ -1345,6 +1467,7 @@ class CkmStore:
                 CkmFinding.from_row(row, citations=_loads(row["citations"]))
             )
         return CkmProjectionBatch(
+            state_identity=state_identity,
             capabilities=tuple(CkmCapability.from_row(row) for row in capability_rows),
             artifacts=tuple(CkmArtifact.from_row(row) for row in artifact_rows),
             edges_by_capability={key: tuple(value) for key, value in edges.items()},

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import secrets
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 from uuid import uuid4
@@ -44,11 +45,22 @@ from app.builderops.ckm.schema import (
     CKM_DDL_STATEMENTS,
     CKM_LEGACY_ADDED_COLUMNS,
     CKM_REQUIRED_COLUMNS,
+    CKM_REQUIRED_QUERY_INDEXES,
     CKM_SCHEMA_VERSION,
     CKM_TABLE_NAMES,
 )
 
 JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CkmProjectionBatch:
+    capabilities: tuple[CkmCapability, ...]
+    artifacts: tuple[CkmArtifact, ...]
+    edges_by_capability: Mapping[str, tuple[CkmEvidenceEdge, ...]]
+    assessments_by_capability: Mapping[str, CkmAssessmentProjection]
+    findings_by_capability: Mapping[str, tuple[CkmFinding, ...]]
+    current_watermark_set: Mapping[str, str]
 
 
 def _dumps(value: Any) -> str:
@@ -89,6 +101,51 @@ class CkmStore:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
+
+    def _readonly_connect(self) -> sqlite3.Connection:
+        """Open the existing CKM store without creating or mutating filesystem state."""
+        validate_db_path_outside_vault(self._db_path)
+        if not self._db_path.is_file():
+            raise CkmValidationError(f"CKM database does not exist: {self._db_path}")
+        uri = f"{self._db_path.resolve().as_uri()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only = ON")
+        return conn
+
+    @staticmethod
+    def _preflight_read_schema(conn: sqlite3.Connection) -> None:
+        """Fail loudly on missing/outdated read schema with a constant query plan."""
+        objects = {
+            (str(row["type"]), str(row["name"]))
+            for row in conn.execute(
+                "SELECT type, name FROM sqlite_master "
+                "WHERE (type = 'table' AND name LIKE 'ckm_%') OR type = 'index'"
+            ).fetchall()
+        }
+        missing_tables = sorted(
+            table for table in CKM_TABLE_NAMES if ("table", table) not in objects
+        )
+        missing_indexes = sorted(
+            name for name in CKM_REQUIRED_QUERY_INDEXES if ("index", name) not in objects
+        )
+        if missing_tables or missing_indexes:
+            details = []
+            if missing_tables:
+                details.append(f"tables: {', '.join(missing_tables)}")
+            if missing_indexes:
+                details.append(f"indexes: {', '.join(missing_indexes)}")
+            raise CkmValidationError(
+                f"CKM read preflight failed; missing {'; '.join(details)}"
+            )
+        CkmStore._validate_required_columns(conn, legacy=False)
+        state_rows = conn.execute(
+            "SELECT schema_version FROM ckm_state WHERE singleton = 1"
+        ).fetchall()
+        if len(state_rows) != 1 or int(state_rows[0]["schema_version"]) != CKM_SCHEMA_VERSION:
+            raise CkmValidationError(
+                "CKM read preflight failed: missing or unsupported state row"
+            )
 
     # --- Schema lifecycle ----------------------------------------------------
 
@@ -1259,6 +1316,42 @@ class CkmStore:
         with self._connect() as conn:
             rows = conn.execute("SELECT * FROM ckm_capability ORDER BY name").fetchall()
         return [CkmCapability.from_row(row) for row in rows]
+
+    def load_projection_batch(self) -> CkmProjectionBatch:
+        """Load all projection inputs read-only with a constant bounded plan."""
+        with self._readonly_connect() as conn:
+            self._preflight_read_schema(conn)
+            capability_rows = conn.execute("SELECT * FROM ckm_capability ORDER BY name, id").fetchall()
+            artifact_rows = conn.execute("SELECT * FROM ckm_artifact ORDER BY source_ref, id").fetchall()
+            edge_rows = conn.execute("SELECT * FROM ckm_evidence_edge ORDER BY capability_id, public_id").fetchall()
+            assessment_rows = conn.execute("SELECT * FROM ckm_assessment ORDER BY capability_id, asserted_at, rowid").fetchall()
+            finding_rows = conn.execute("SELECT * FROM ckm_finding ORDER BY capability_id, kind, dimension").fetchall()
+            watermark_rows = conn.execute("SELECT source, value FROM ckm_watermark ORDER BY source").fetchall()
+        edges: dict[str, list[CkmEvidenceEdge]] = {}
+        for row in edge_rows:
+            edges.setdefault(str(row["capability_id"]), []).append(CkmEvidenceEdge.from_row(row))
+        current_watermarks = {str(row["source"]): str(row["value"]) for row in watermark_rows}
+        latest: dict[str, CkmAssessmentProjection] = {}
+        for row in assessment_rows:
+            assessment = self._assessment_from_row(row)
+            latest[assessment.capability_id] = CkmAssessmentProjection(
+                assessment=assessment,
+                current_watermark_set=current_watermarks,
+                stale_relative_to_evidence=dict(assessment.watermark_set) != current_watermarks,
+            )
+        findings: dict[str, list[CkmFinding]] = {}
+        for row in finding_rows:
+            findings.setdefault(str(row["capability_id"]), []).append(
+                CkmFinding.from_row(row, citations=_loads(row["citations"]))
+            )
+        return CkmProjectionBatch(
+            capabilities=tuple(CkmCapability.from_row(row) for row in capability_rows),
+            artifacts=tuple(CkmArtifact.from_row(row) for row in artifact_rows),
+            edges_by_capability={key: tuple(value) for key, value in edges.items()},
+            assessments_by_capability=latest,
+            findings_by_capability={key: tuple(value) for key, value in findings.items()},
+            current_watermark_set=current_watermarks,
+        )
 
     # --- Artifact --------------------------------------------------------------
 

--- a/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
+++ b/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
@@ -124,12 +124,14 @@ a typed refusal without a partial semantic result.
 
 Composite indexes support the live predicates and are installed by both new-
 store bootstrap and existing-store `ensure_schema()` migration. Projection and
-overview rendering use one read-only batch with a constant statement plan;
-rendering performs a bounded fail-loud schema preflight and cannot initialize or
-migrate a missing or outdated store. Write/CLI producers remain responsible for
-explicit schema setup before producing generated files. This delivery does not
-add pagination, arbitrary filters or sorting, ranking, HTTP/UI, metrics, or
-observation semantics.
+overview rendering use one explicit read-only SQLite snapshot transaction with
+a constant statement plan. The batch binds and rechecks CKM epoch/revision/schema
+identity plus database-file identity, and it refuses before materialization when
+any declared object-class or aggregate capture bound is exceeded. Rendering also
+performs a fail-loud schema preflight and cannot initialize or migrate a missing
+or outdated store. Write/CLI producers remain responsible for explicit schema
+setup before producing generated files. This delivery does not add pagination,
+arbitrary filters or sorting, ranking, HTTP/UI, metrics, or observation semantics.
 
 ## M1 delivered semantics
 

--- a/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
+++ b/docs/CKM_MEASUREMENT_AND_ACCESS/README.md
@@ -112,6 +112,25 @@ Dependency graph:
 
 `accepted observation evidence → future O2 proposal`
 
+## Q2 delivered bounded-query semantics
+
+Q2 (#3778) extends the Q1 read service with a deliberately small allowlist:
+bounded capability public-ID and subtree filters, capability-scoped evidence,
+assessment, and finding filters, and unlinked-artifact selection. Filters are
+canonicalized, deterministically ordered, completeness-accounted, and subject
+to the same hard capture bound, access policy, one-transaction snapshot, and
+mixed-epoch refusal rules as Q1. Unknown, invalid, or over-bound requests return
+a typed refusal without a partial semantic result.
+
+Composite indexes support the live predicates and are installed by both new-
+store bootstrap and existing-store `ensure_schema()` migration. Projection and
+overview rendering use one read-only batch with a constant statement plan;
+rendering performs a bounded fail-loud schema preflight and cannot initialize or
+migrate a missing or outdated store. Write/CLI producers remain responsible for
+explicit schema setup before producing generated files. This delivery does not
+add pagination, arbitrary filters or sorting, ranking, HTTP/UI, metrics, or
+observation semantics.
+
 ## M1 delivered semantics
 
 M1 (#3779) supplies a small versioned registry of descriptive, snapshot-bound
@@ -158,7 +177,7 @@ implementation/test evidence only: it establishes neither trend nor cadence.
   Verify: Q1a and Q1b child delivery receipts plus `tests/builderops/ckm/test_query_service.py`
 - [ ] Query execution is read-only/side-effect free; incomplete/oversized capture and all unknown schema/version/policy/semantics states fail explicitly.
   Verify: `tests/builderops/ckm/test_query_service.py::test_query_path_is_read_only_and_side_effect_free`; `tests/builderops/ckm/test_query_service.py::test_incomplete_or_oversized_snapshot_refuses`
-- [ ] Q2 proves bounded indexed plans, constant query counts per complete capture, and no N+1 regression without weakening Q1 ordering/completeness guarantees.
+- [x] Q2 proves bounded indexed plans, constant query counts per complete capture, and no N+1 regression without weakening Q1 ordering/completeness guarantees.
   Verify: `tests/builderops/ckm/test_query_plans.py`
 - [ ] M1 emits deterministic fully bound descriptive observations with machine-readable Goodhart warnings; any aggregate is `human_advisory_only`, accompanied by its evidence-rich components, and cannot drive machine authority.
   Verify: `tests/builderops/ckm/test_metrics.py`

--- a/tests/builderops/ckm/test_measurement_contract.py
+++ b/tests/builderops/ckm/test_measurement_contract.py
@@ -108,6 +108,11 @@ def _downgrade_identity_schema_to_v4(db_path: Path) -> None:
             "idx_ckm_evidence_edge_public_id",
             "idx_ckm_assessment_public_id",
             "idx_ckm_finding_public_id",
+            "idx_ckm_capability_parent_public",
+            "idx_ckm_evidence_edge_capability_public",
+            "idx_ckm_evidence_edge_artifact_public",
+            "idx_ckm_assessment_capability_asserted_public",
+            "idx_ckm_finding_capability_public",
         ):
             conn.execute(f"DROP INDEX {index_name}")
         conn.execute("DROP TABLE ckm_identity_successor")

--- a/tests/builderops/ckm/test_query_plans.py
+++ b/tests/builderops/ckm/test_query_plans.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.builderops.ckm.contracts import ACCESS_POLICY_VERSION
+from app.builderops.ckm.models import CkmValidationError, MATURITY_DIMENSIONS
+from app.builderops.ckm.overview_html import render_overview_html
+from app.builderops.ckm.projections import render_projection
+from app.builderops.ckm.query_service import CkmQueryService
+from app.builderops.ckm.schema import CKM_REQUIRED_QUERY_INDEXES
+from app.builderops.ckm.store import CkmStore
+from tests.builderops.ckm.test_query_service import _mixed_epoch_payload
+
+
+def _populated(tmp_path: Path, *, count: int = 3) -> tuple[CkmStore, list, object, object]:
+    store = CkmStore(tmp_path / "ckm.sqlite")
+    store.ensure_schema()
+    root = store.upsert_capability(identity_key="root", name="root", definition="root", lifecycle="confirmed", existence_provenance="fixture")
+    capabilities = [root]
+    for index in range(1, count):
+        capabilities.append(store.upsert_capability(identity_key=f"child:{index}", name=f"child-{index:03d}", definition="child", parent_id=root.id if index == 1 else None, lifecycle="confirmed", existence_provenance="fixture"))
+    linked = store.upsert_artifact(source_ref="repo:linked", artifact_kind="source_file", source="repo", watermark="one", provenance="fixture")
+    unlinked = store.upsert_artifact(source_ref="repo:unlinked", artifact_kind="source_file", source="repo", watermark="one", provenance="fixture")
+    store.upsert_evidence_edge(artifact_id=linked.id, capability_id=root.id, evidence_kind="source", polarity="supports", maturity_dimension="functional_completeness", confidence=1.0, extraction_method="deterministic", lifecycle="confirmed", source_ref="repo:linked")
+    store.set_watermark("repo", "one")
+    store.append_assessment(capability_id=root.id, scores={key: 0.5 for key in MATURITY_DIMENSIONS}, citations={key: [] for key in MATURITY_DIMENSIONS}, aggregate=0.5, watermark_set={"repo": "one"})
+    store.upsert_finding(kind="gap", capability_id=root.id, dimension="functional_completeness", statement="fixture gap", citations=[{"artifact_id": linked.id, "artifact": linked.to_dict()}])
+    return store, capabilities, linked, unlinked
+
+
+def test_bounded_filters_preserve_q1_completeness_contract(tmp_path: Path) -> None:
+    store, capabilities, linked, unlinked = _populated(tmp_path)
+    service = CkmQueryService(store.db_path)
+    ids = [capabilities[1].public_id, capabilities[0].public_id]
+    selected = service.list_resources("capability", filters={"public_ids": ids}).to_dict()
+    assert [item["public_id"] for item in selected["resources"]] == sorted(ids)
+    assert selected["snapshot"]["completeness"]["object_classes"] == [{"object_class": "capability", "included": 2, "filtered": 1, "omitted": 0, "truncated": 0}]
+    assert selected == service.list_resources("capability", filters={"public_ids": list(reversed(ids))}).to_dict()
+    subtree = service.list_resources("capability", filters={"subtree_root_public_id": capabilities[0].public_id}).to_dict()
+    assert [item["display_name"] for item in subtree["resources"]] == ["child-001", "root"]
+    for resource_type in ("evidence_edge", "assessment", "finding"):
+        payload = service.list_resources(resource_type, filters={"capability_public_id": capabilities[0].public_id}).to_dict()
+        assert len(payload["resources"]) == 1 and payload["snapshot"]["completeness"]["complete"] is True
+    artifacts = service.list_resources("artifact", filters={"unlinked": True}).to_dict()
+    assert [item["public_id"] for item in artifacts["resources"]] == [unlinked.public_id]
+    assert linked.public_id != unlinked.public_id
+
+
+def _statement_count(store: CkmStore, public_ids: list[str]) -> tuple[int, dict]:
+    statements: list[str] = []
+    original = sqlite3.connect
+    def connect(uri: str) -> sqlite3.Connection:
+        conn = original(uri, uri=True)
+        conn.set_trace_callback(statements.append)
+        return conn
+    result = CkmQueryService(store.db_path, capture_limit=1000, _connection_factory=connect).list_resources("capability", filters={"public_ids": public_ids}).to_dict()
+    selects = [statement for statement in statements if statement.lstrip().upper().startswith(("SELECT", "WITH"))]
+    return len(selects), result
+
+
+def test_batch_read_plan_has_constant_query_count(tmp_path: Path) -> None:
+    small, small_caps, _, _ = _populated(tmp_path / "small", count=3)
+    large, large_caps, _, _ = _populated(tmp_path / "large", count=500)
+    small_count, small_result = _statement_count(small, [item.public_id for item in small_caps])
+    large_count, large_result = _statement_count(large, [item.public_id for item in large_caps])
+    assert small_count == large_count
+    assert small_result["resources"] == CkmQueryService(small.db_path).list_capabilities().to_dict()["resources"]
+    assert len(large_result["resources"]) == 500
+
+
+def test_supported_filters_use_required_indexes(tmp_path: Path) -> None:
+    store, capabilities, linked, _ = _populated(tmp_path)
+    with sqlite3.connect(store.db_path) as conn:
+        for index in CKM_REQUIRED_QUERY_INDEXES:
+            conn.execute(f"DROP INDEX {index}")
+    store.ensure_schema()
+    with sqlite3.connect(store.db_path) as conn:
+        indexes = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+        assert CKM_REQUIRED_QUERY_INDEXES <= indexes
+        plans = " ".join(
+            row[3]
+            for statement, params in (
+                ("SELECT * FROM ckm_capability WHERE parent_id = ? ORDER BY public_id", (capabilities[0].id,)),
+                ("SELECT * FROM ckm_evidence_edge WHERE capability_id = ? ORDER BY public_id", (capabilities[0].id,)),
+                ("SELECT * FROM ckm_evidence_edge WHERE artifact_id = ? ORDER BY public_id", (linked.id,)),
+                ("SELECT * FROM ckm_assessment WHERE capability_id = ? ORDER BY asserted_at, public_id", (capabilities[0].id,)),
+                ("SELECT * FROM ckm_finding WHERE capability_id = ? ORDER BY public_id", (capabilities[0].id,)),
+            )
+            for row in conn.execute(f"EXPLAIN QUERY PLAN {statement}", params)
+        )
+    assert CKM_REQUIRED_QUERY_INDEXES <= {name for name in CKM_REQUIRED_QUERY_INDEXES if name in plans}
+
+
+def _projection_select_count(store: CkmStore) -> int:
+    statements: list[str] = []
+    original = store._readonly_connect
+    def traced() -> sqlite3.Connection:
+        conn = original()
+        conn.set_trace_callback(statements.append)
+        return conn
+    store._readonly_connect = traced  # type: ignore[method-assign]
+    render_projection(store, "ckm-maturity")
+    render_overview_html(store, generated_at="2026-07-21T00:00:00Z")
+    return len([item for item in statements if item.lstrip().upper().startswith("SELECT")])
+
+
+def test_projection_consumers_do_not_regress_to_n_plus_one(tmp_path: Path) -> None:
+    small, _, _, _ = _populated(tmp_path / "small", count=3)
+    large, _, _, _ = _populated(tmp_path / "large", count=30)
+    assert _projection_select_count(small) == _projection_select_count(large)
+
+    missing_path = tmp_path / "missing" / "ckm.sqlite"
+    with pytest.raises(CkmValidationError, match="does not exist"):
+        render_projection(CkmStore(missing_path), "ckm-maturity")
+    assert not missing_path.parent.exists()
+
+    outdated, _, _, _ = _populated(tmp_path / "outdated")
+    with sqlite3.connect(outdated.db_path) as conn:
+        conn.execute("UPDATE ckm_state SET schema_version = 0")
+    before = outdated.db_path.read_bytes()
+    with pytest.raises(CkmValidationError, match="unsupported state row"):
+        render_overview_html(outdated)
+    assert outdated.db_path.read_bytes() == before
+
+
+def test_query_optimization_cannot_weaken_q1_bounds(tmp_path: Path) -> None:
+    store, capabilities, _, _ = _populated(tmp_path)
+    service = CkmQueryService(store.db_path, capture_limit=2)
+    for filters in ({"unknown": True}, {"public_ids": [item.public_id for item in capabilities]}, {"unlinked": False}):
+        resource_type = "artifact" if "unlinked" in filters else "capability"
+        refusal = service.list_resources(resource_type, filters=filters).to_dict()
+        assert refusal["error"]["code"] in {"unsupported_filter", "snapshot_too_large"} and "resources" not in refusal
+    complete = CkmQueryService(store.db_path).list_capabilities().to_dict()
+    assert [item["public_id"] for item in complete["resources"]] == sorted(item.public_id for item in capabilities)
+    assert complete["snapshot"]["completeness"]["complete"] is True
+    assert complete["snapshot"]["access_policy_version"] == ACCESS_POLICY_VERSION
+    mixed = _mixed_epoch_payload(store.db_path)
+    assert mixed["error"]["code"] == "mixed_epoch" and "resources" not in mixed

--- a/tests/builderops/ckm/test_query_plans.py
+++ b/tests/builderops/ckm/test_query_plans.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,7 @@ from app.builderops.ckm.overview_html import render_overview_html
 from app.builderops.ckm.projections import render_projection
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.ckm.schema import CKM_REQUIRED_QUERY_INDEXES
-from app.builderops.ckm.store import CkmStore
+from app.builderops.ckm.store import CkmProjectionCaptureError, CkmStore
 from tests.builderops.ckm.test_query_service import _mixed_epoch_payload
 
 
@@ -124,6 +125,114 @@ def test_projection_consumers_do_not_regress_to_n_plus_one(tmp_path: Path) -> No
     with pytest.raises(CkmValidationError, match="unsupported state row"):
         render_overview_html(outdated)
     assert outdated.db_path.read_bytes() == before
+
+
+def test_projection_batch_snapshot_prevents_concurrent_revision_mix(
+    tmp_path: Path,
+) -> None:
+    store, capabilities, _, _ = _populated(tmp_path)
+    wal_keeper = sqlite3.connect(store.db_path)
+    assert wal_keeper.execute("PRAGMA journal_mode = WAL").fetchone()[0] == "wal"
+    wal_keeper.execute("UPDATE ckm_state SET updated_at = updated_at WHERE singleton = 1")
+    wal_keeper.commit()
+    original = store._readonly_connect
+    writer_done = threading.Event()
+    writer_errors: list[Exception] = []
+    writer_started = False
+
+    def write_revision() -> None:
+        try:
+            with sqlite3.connect(store.db_path, timeout=5) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute(
+                    "UPDATE ckm_state SET state_revision = state_revision + 1 "
+                    "WHERE singleton = 1"
+                )
+                conn.commit()
+        except Exception as exc:  # pragma: no cover - asserted below
+            writer_errors.append(exc)
+        finally:
+            writer_done.set()
+
+    def traced() -> sqlite3.Connection:
+        conn = original()
+
+        def on_statement(statement: str) -> None:
+            nonlocal writer_started
+            if writer_started or not statement.startswith("SELECT * FROM ckm_capability"):
+                return
+            writer_started = True
+            threading.Thread(target=write_revision, daemon=True).start()
+            assert writer_done.wait(timeout=2)
+
+        conn.set_trace_callback(on_statement)
+        return conn
+
+    store._readonly_connect = traced  # type: ignore[method-assign]
+    batch = store.load_projection_batch()
+    assert not writer_errors
+    assert batch.capabilities == tuple(
+        sorted(capabilities, key=lambda item: (item.name, item.id))
+    )
+    assert store.load_projection_batch().state_identity.state_revision == (
+        batch.state_identity.state_revision + 1
+    )
+    wal_keeper.close()
+
+
+def test_projection_batch_refuses_mixed_database_identity(tmp_path: Path) -> None:
+    store, _, _, _ = _populated(tmp_path / "original")
+    replacement, _, _, _ = _populated(tmp_path / "replacement")
+    original = store._readonly_connect
+    replaced = False
+
+    def traced() -> sqlite3.Connection:
+        conn = original()
+
+        def on_statement(statement: str) -> None:
+            nonlocal replaced
+            if replaced or not statement.startswith("SELECT * FROM ckm_capability"):
+                return
+            replaced = True
+            replacement.db_path.replace(store.db_path)
+
+        conn.set_trace_callback(on_statement)
+        return conn
+
+    store._readonly_connect = traced  # type: ignore[method-assign]
+    with pytest.raises(CkmProjectionCaptureError) as refusal:
+        store.load_projection_batch()
+    assert refusal.value.code == "mixed_epoch"
+    assert "identity changed" in str(refusal.value)
+
+
+def test_projection_batch_refuses_over_bound_before_materialization(
+    tmp_path: Path,
+) -> None:
+    store, _, _, _ = _populated(tmp_path, count=4)
+    statements: list[str] = []
+    original = store._readonly_connect
+
+    def traced() -> sqlite3.Connection:
+        conn = original()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    store._readonly_connect = traced  # type: ignore[method-assign]
+    before = store.db_path.read_bytes()
+    with pytest.raises(CkmProjectionCaptureError) as class_refusal:
+        store.load_projection_batch(class_capture_limit=3)
+    assert class_refusal.value.code == "snapshot_too_large"
+    assert class_refusal.value.details["over_bound_classes"] == {"capability": 4}
+    with pytest.raises(CkmProjectionCaptureError) as aggregate_refusal:
+        store.load_projection_batch(
+            class_capture_limit=100,
+            aggregate_capture_limit=3,
+        )
+    assert aggregate_refusal.value.code == "snapshot_too_large"
+    assert aggregate_refusal.value.details["aggregate_count"] > 3
+    assert not any(statement.startswith("SELECT * FROM") for statement in statements)
+    assert store.db_path.read_bytes() == before
 
 
 def test_query_optimization_cannot_weaken_q1_bounds(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add canonical bounded capability, subtree, capability-scoped evidence/assessment/finding, and unlinked-artifact filters without weakening Q1 completeness or refusal behavior
- add composite query indexes plus new-store, existing-store migration, and downgrade-fixture producer coverage
- replace projection/overview N+1 reads with one bounded read-only SQLite snapshot transaction
- record delivered Q2 semantics in the CKM Measurement & Access owner document

## Review finding and repair
- blocking finding at reviewed head `3f59972f545a73758e0bcaa8fc1838e565af1f3f`: `ckm-projection-batch-snapshot-bound` lacked an explicit snapshot transaction, revision/file fence, and capture bounds
- repaired at `0a1599a42c7455dbf0c4c14e4fb539e0c6627f4c`: explicit `BEGIN` on `mode=ro`/`query_only`, start/end CKM state binding, database-file identity fence, and typed class/aggregate over-bound refusal before materialization
- regression coverage commits a concurrent WAL revision between batch SELECTs and proves one coherent old snapshot followed by exactly revision +1; atomic file replacement refuses `mixed_epoch`; class and aggregate overflow refuse `snapshot_too_large` without materialization or mutation

## Verification
- initial exact Q2/Q1 suite — 13 passed
- initial full CKM run — 6 failed, 208 passed because the v4 downgrade producer retained the five new indexes
- producer repair focused rerun — 6 passed, 10 deselected
- pre-review full CKM run — 214 passed
- repair round focused Q2/Q1/projection/overview — 38 passed, RC=0
- repair round full `python -m pytest -q tests/builderops/ckm` — 217 passed in 41.69s, RC=0
- capture-limit receipt: bounded query SELECTs remain 9 at 3 and 500 capabilities; combined maturity/overview projection SELECTs increase from 16 to 22 for constant count/state/state fencing and remain 22 at both 3 and 500
- `ruff check app tests companion-ui/companion-app` — passed, RC=0
- `mypy app` — passed, 804 source files, RC=0
- `git diff --check` — passed, RC=0

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded Issue/PR implementation and review-repair evidence remains in GitHub and Git; no separate BuilderOps operational material was produced

Governing-Issue: #3778
Fixes #3778

Final-Review-Rounds: 2