### PR TITLE
Add 3 CKM observation adapters to the audited vault-store allowlist

### DIFF
--- a/tests/architecture/test_builderops_store_boundary.py
+++ b/tests/architecture/test_builderops_store_boundary.py
@@ -67,6 +67,9 @@ VAULT_STORE_ALLOWLIST: frozenset[str] = frozenset(
         "app/builderops/cutover_evidence.py",  # #3686 audited one-time receipt producer/validator
         "app/builderops/ckm/store.py",  # CKM receipt store built on the Vault store
         "app/builderops/ckm/query_service.py",  # CKM projection-only read path: I-MA11 requires direct SQLite mode=ro
+        "app/builderops/ckm/metrics.py",  # outer adapter over query_service; own small versioned SQLite receipt store, non-authoritative
+        "app/builderops/ckm/comparison.py",  # fail-closed, descriptive-only comparison of retained metrics observations
+        "app/builderops/ckm/observation_capture.py",  # privacy-safe observations over already-returned CKM outcomes; own adjacent SQLite store, no policy/promotion authority
     }
 )
 


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: PR #4060 landed three new CKM observation-adapter files (metrics.py, comparison.py, observation_capture.py) that touch a store outside app/builderops/control_plane/, but never updated VAULT_STORE_ALLOWLIST in tests/architecture/test_builderops_store_boundary.py — breaking that architecture fitness guard for every subsequent PR's CI (discovered while trying to get an unrelated PR's CI green). All three are non-authoritative, bounded evidence adapters over already-returned CKM outcomes with their own small versioned SQLite receipt stores and no policy/promotion authority — the same legitimate category as the existing query_service.py allowlist entry.
Validation: `pytest -q -m "not pg" tests/architecture/test_builderops_store_boundary.py` (5 passed, was 1 failed before); `ruff check tests/architecture/test_builderops_store_boundary.py` clean.
Issue required: no — bounded immediate repair

Final-Review-Rounds: 1

## Summary
Adds `app/builderops/ckm/metrics.py`, `comparison.py`, and `observation_capture.py` to `VAULT_STORE_ALLOWLIST`.

## Validation
- `pytest -q -m "not pg" tests/architecture/test_builderops_store_boundary.py` — 5 passed (was failing before this change).
- `ruff check tests/architecture/test_builderops_store_boundary.py` — clean.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded direct repair, fully captured in this PR body's Direct Repair block.

---