### PR TITLE
Add Heimdal Karakeep reading-evidence adapter (KMA-03)

### DIFF
--- a/app/heimdal/karakeep_ingest.py
+++ b/app/heimdal/karakeep_ingest.py
@@ -1,0 +1,948 @@
+"""Heimdal Karakeep reading-evidence adapter -- the Karakeep source-egress seam (KMA-03, #3374).
+
+Ratified by ``docs/adr/ADR-0049-heimdall-ingestion-organ-and-v1-uiux-enactment.md``
+§1 (Heimdal owns watch -> fetch -> attribute -> published event; Mimer owns
+cognition from the handoff) and specified by
+``docs/KARAKEEP_MIMER_ACQUISITION/FETCH_KARAKEEP_READING_EVIDENCE.md`` (KMA-03)
+against the source/identity/publish contract fixed in
+``docs/KARAKEEP_MIMER_ACQUISITION/DEFINE_READING_SOURCE_AND_CANDIDATE_CONTRACT.md``
+(KMA-01).
+
+This module is the **only** component that reads the Karakeep REST API. It is
+read-only: it fetches saved links/notes/highlights, canonicalizes each into a
+source snapshot, derives stable identity/revision, stamps
+provenance/confidence/attribution/entity-mentions, and publishes the contracted
+``heimdal.observation.published.v1`` evidence through the sanctioned
+``app.heimdal.publish.publish_full_observation`` seam. It commits the Heimdal
+producer cursor only after publication is durable.
+
+Constituent boundary (KMA-INV-4, issue AC 5): this module never imports or
+invokes ``app.knowledge_acquisition``, never calls companion capture
+(``/api/capture``), and never touches Mimer state. The published observation
+log is the entire handoff; refinement begins on the other side of it.
+
+Identity / revision (KMA-01 "Karakeep source item and revision identity"):
+
+- ``source_item_identity = karakeep:<item-id>`` is the stable identity and the
+  ``episode_id`` of every revision of that item.
+- ``content_identity = sha256:<canonical-source-snapshot>`` hashes the canonical
+  JSON of the evidence-bearing snapshot (item id, all evidence fields, deletion
+  flag). Credentials, endpoint, fetch timestamps, and cursor values are
+  excluded by construction -- they are never part of the snapshot.
+- ``publication_profile_identity = sha256:<canonical-stage-versions>``.
+- ``observation_id = karakeep:<item-id>:<content-hex>:<profile-hex>`` is one
+  immutable publication. Re-fetching identical content at the same profile
+  republishes the same idempotency input and is a traced no-op.
+- A changed snapshot creates new ``content_identity``/``observation_id``, sets
+  ``supersedes`` to the preceding revision, ``revision_of`` null. A same-snapshot
+  reprocess through a changed publication profile sets ``revision_of`` to the
+  preceding publication of that snapshot, ``supersedes`` null. A source deletion
+  is a changed snapshot with ``content: null`` and
+  ``content_structure.karakeep.tombstone: true`` that supersedes the prior live
+  revision -- never a delete instruction.
+
+Restart / durability (KMA-INV-2/INV-3): the durable, migration-owned observation
+log is the source of truth for per-item revision lineage; :class:`KarakeepAdapter`
+rebuilds that lineage from the log at the start of every run, so a crash that
+loses the in-process producer cursor cannot skip or duplicate evidence -- a
+replayed page dedups against the log before the producer cursor advances. The
+producer cursor (:class:`KarakeepProducerCursor`) is a resume optimization: it
+records the upstream page position and the last durable revision per item, and
+advances only after the page's evidence is durable. It never regresses.
+
+Secret containment (KMA-INV-6): the endpoint base URL and API token arrive only
+through injected runtime configuration/token references; this module places
+neither into fixtures, logs, events, notes, or error messages. Every failure is
+reported as a ``reason_code``/``status`` pair -- provider bodies, URLs, headers,
+and the token are never echoed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, NoReturn, Optional, Protocol
+from urllib.parse import urlsplit
+
+import httpx
+
+from app.events.topic_schema_registry import TopicSchemaViolation
+from app.events.types import HEIMDAL_OBSERVATION_PUBLISHED
+from app.heimdal.observation_log import read_observations_from
+from app.heimdal.publish import publish_full_observation
+
+logger = logging.getLogger(__name__)
+
+# Adapter identity and fixed provenance chain (KMA-01 published-v1 field map).
+ADAPTER_ID = "heimdal_karakeep_adapter"
+ADAPTER_VERSION = "contract-v1"
+SENSOR = "karakeep_rest"
+CAPTURE_CHAIN: list[str] = ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"]
+STAGE_VERSIONS: dict[str, str] = {"karakeep_adapter": ADAPTER_VERSION}
+
+# Envelope source string for the reused outbox envelope (emission provenance).
+_PUBLISH_SOURCE = "heimdal_karakeep_adapter"
+
+# Canonical bookmarks feed path on a Karakeep host. The host itself is
+# operator-owned and injected (never hardcoded); only the API path shape is
+# fixed here.
+_BOOKMARKS_PATH = "api/v1/bookmarks"
+
+_DEFAULT_PAGE_SIZE = 50
+_DEFAULT_MAX_PAGES = 100
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+
+# Content-family kinds this adapter recognizes on the Karakeep source snapshot.
+_KIND_LINK = "link"
+_KIND_NOTE = "note"
+_KIND_HIGHLIGHT = "highlight"
+
+
+class KarakeepConfigError(ValueError):
+    """The injected Karakeep endpoint/config reference is structurally invalid."""
+
+
+class KarakeepApiError(RuntimeError):
+    """A safe, structured Karakeep REST failure.
+
+    ``detail`` is built only from local classifications and the HTTP status.
+    Provider bodies, URLs, headers, and the API token are never copied into it
+    (KMA-INV-6).
+    """
+
+    def __init__(self, reason_code: str, status: int | None, detail: str) -> None:
+        self.reason_code = reason_code
+        self.status = status
+        self.detail = detail
+        super().__init__(f"{reason_code}: {detail}")
+
+
+class MalformedKarakeepItemError(ValueError):
+    """One saved item could not be canonicalized; item-scoped, never page-fatal."""
+
+
+def _raise_detached(error: BaseException) -> NoReturn:
+    """Raise a normalized failure without retaining a prior exception graph.
+
+    Keeps a provider transport error's ``__cause__``/``__context__`` (which may
+    carry the endpoint URL) out of the surfaced :class:`KarakeepApiError`.
+    """
+    error.__cause__ = None
+    error.__context__ = None
+    raise error from None
+
+
+class KarakeepTokenProvider(Protocol):
+    """The credential port consumed by the adapter. Implementations resolve the
+    operator-owned token from runtime configuration; the adapter never sees a
+    literal token in its own source or fixtures."""
+
+    def get_api_token(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class StaticKarakeepToken:
+    """A token provider backed by an already-resolved runtime reference.
+
+    The value is supplied by the caller (e.g. from an environment reference the
+    operator owns). It is never logged or placed in an error message.
+    """
+
+    token: str
+
+    def get_api_token(self) -> str:
+        if not self.token:
+            raise KarakeepConfigError("Karakeep API token reference resolved to an empty value")
+        return self.token
+
+
+@dataclass(frozen=True)
+class KarakeepConfig:
+    """Runtime configuration for one Karakeep source.
+
+    ``base_url`` is an operator-owned private endpoint reference supplied at
+    runtime; committed fixtures use placeholders only. ``grant_ref`` points into
+    the consent ledger (a reference, not a secret). ``source_id`` names the
+    producer-cursor lane so multiple sources never share resume state.
+    """
+
+    base_url: str
+    source_id: str = "karakeep-default"
+    grant_ref: str = "grant:karakeep-source-ingestion"
+    scope_hint: str = "operator_reading_inbox"
+    page_size: int = _DEFAULT_PAGE_SIZE
+    max_pages: int = _DEFAULT_MAX_PAGES
+
+    def __post_init__(self) -> None:
+        parsed = urlsplit(self.base_url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise KarakeepConfigError(
+                "Karakeep base_url must be an absolute http(s) URL with a host "
+                "(the operator-owned endpoint is supplied at runtime)"
+            )
+        if not self.source_id.strip():
+            raise KarakeepConfigError("Karakeep source_id must be non-empty")
+        if not self.grant_ref.strip():
+            raise KarakeepConfigError("Karakeep grant_ref must be a non-empty consent reference")
+        if self.page_size <= 0:
+            raise KarakeepConfigError("page_size must be positive")
+        if self.max_pages <= 0:
+            raise KarakeepConfigError("max_pages must be positive")
+
+
+# ---------------------------------------------------------------------------
+# Source snapshot + identity
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    """The canonical, evidence-bearing snapshot of one saved Karakeep item.
+
+    Deterministic and free of credentials/endpoint/fetch-time/cursor values, so
+    :meth:`content_identity` is stable across fetches of identical content.
+    """
+
+    item_id: str
+    item_kind: str
+    source_url: Optional[str]
+    title: Optional[str]
+    text: Optional[str]
+    tags: tuple[str, ...]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    archived: bool
+    deleted: bool
+
+    def canonical(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "item_kind": self.item_kind,
+            "source_url": self.source_url,
+            "title": self.title,
+            "text": self.text,
+            "tags": list(self.tags),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "archived": self.archived,
+            "deleted": self.deleted,
+        }
+
+    def content_identity(self) -> str:
+        canonical = json.dumps(self.canonical(), sort_keys=True, ensure_ascii=False)
+        return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _publication_profile_identity() -> str:
+    canonical = json.dumps(STAGE_VERSIONS, sort_keys=True, ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _hex(identity: str) -> str:
+    return identity.split(":", 1)[1]
+
+
+def episode_id_for(item_id: str) -> str:
+    return f"karakeep:{item_id}"
+
+
+def observation_id_for(item_id: str, content_identity: str, profile_identity: str) -> str:
+    return f"{episode_id_for(item_id)}:{_hex(content_identity)}:{_hex(profile_identity)}"
+
+
+# ---------------------------------------------------------------------------
+# Producer cursor (Heimdal-owned source checkpoint)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ItemRevisionMark:
+    """The last durable revision of one item, as known to the producer cursor."""
+
+    observation_id: str
+    content_identity: str
+    profile_identity: str
+    sequence: int
+
+
+@dataclass
+class ItemLineage:
+    """Durable lineage of one item: its highest-sequence revision plus the full
+    set of already-published ``observation_id`` values.
+
+    The full set is what makes idempotency correct across a *revert*: because an
+    ``observation_id`` is content+profile keyed and carries no sequence, re-fetching
+    content that was published earlier (even if a later edit intervened) reproduces
+    an already-durable ``observation_id`` and must be a no-op -- never a new row
+    with a duplicate id (KMA-01 "one immutable publication").
+    """
+
+    latest: ItemRevisionMark
+    observation_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
+class SourceCheckpoint:
+    """Per-source producer checkpoint: upstream resume position + per-item lineage."""
+
+    upstream_cursor: Optional[str] = None
+    items: dict[str, ItemLineage] = field(default_factory=dict)
+
+
+class KarakeepProducerCursor:
+    """Heimdal-owned producer checkpoint for Karakeep acquisition.
+
+    Records the upstream page cursor plus the last durable revision per item and
+    advances only after published evidence is durable (KMA-INV-3). The durable
+    observation log is the authoritative lineage store; this cursor is a resume
+    cache seeded from the log via :meth:`rebuild_from_log`, so a lost cursor is
+    reconstructable and can never cause skipped or duplicated evidence. It is
+    process-durable and injectable; the deployment/schedule slices wire a
+    cross-process backing through the same injection point.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sources: dict[str, SourceCheckpoint] = {}
+
+    def _checkpoint(self, source_id: str) -> SourceCheckpoint:
+        return self._sources.setdefault(source_id, SourceCheckpoint())
+
+    def upstream_cursor(self, source_id: str) -> Optional[str]:
+        with self._lock:
+            return self._checkpoint(source_id).upstream_cursor
+
+    def item_lineage(self, source_id: str, item_id: str) -> Optional[ItemLineage]:
+        with self._lock:
+            return self._checkpoint(source_id).items.get(item_id)
+
+    def record_revision(self, source_id: str, item_id: str, mark: ItemRevisionMark) -> None:
+        """Record a newly durable revision. Monotone: never regresses the latest
+        sequence, and accumulates the item's full published ``observation_id`` set."""
+        with self._lock:
+            checkpoint = self._checkpoint(source_id)
+            lineage = checkpoint.items.get(item_id)
+            if lineage is None:
+                checkpoint.items[item_id] = ItemLineage(latest=mark, observation_ids={mark.observation_id})
+                return
+            lineage.observation_ids.add(mark.observation_id)
+            if mark.sequence >= lineage.latest.sequence:
+                lineage.latest = mark
+
+    def advance_upstream(self, source_id: str, cursor: Optional[str]) -> None:
+        """Advance the upstream page cursor after a page's evidence is durable."""
+        with self._lock:
+            self._checkpoint(source_id).upstream_cursor = cursor
+
+    def rebuild_from_log(self, source_id: str) -> None:
+        """Seed per-item lineage from the durable observation log (restart path).
+
+        Reads the append-only log, keeps only this source's ``karakeep_rest``
+        observations, and records each item's highest-sequence revision plus its
+        full set of published ``observation_id`` values. Idempotent -- safe to call
+        at the start of every run so a fresh process recovers full lineage before
+        deciding any revision. Filtering on the stamped source id keeps multiple
+        Karakeep source lanes from contaminating one another's resume state.
+        """
+        with self._lock:
+            checkpoint = self._checkpoint(source_id)
+            for row in read_observations_from(0):
+                payload = row.envelope.get("payload")
+                if not isinstance(payload, Mapping):
+                    continue
+                provenance = payload.get("provenance")
+                if not isinstance(provenance, Mapping) or provenance.get("sensor") != SENSOR:
+                    continue
+                if provenance.get("karakeep_source_id") != source_id:
+                    continue
+                observation_id = payload.get("observation_id")
+                episode_id = payload.get("episode_id")
+                sequence = payload.get("sequence")
+                content_identity = provenance.get("content_identity")
+                if (
+                    not isinstance(observation_id, str)
+                    or not isinstance(episode_id, str)
+                    or not isinstance(sequence, int)
+                    or not isinstance(content_identity, str)
+                ):
+                    continue
+                item_id = episode_id.split(":", 1)[1] if ":" in episode_id else episode_id
+                profile_identity = "sha256:" + observation_id.rsplit(":", 1)[1]
+                mark = ItemRevisionMark(
+                    observation_id=observation_id,
+                    content_identity=content_identity,
+                    profile_identity=profile_identity,
+                    sequence=sequence,
+                )
+                lineage = checkpoint.items.get(item_id)
+                if lineage is None:
+                    checkpoint.items[item_id] = ItemLineage(
+                        latest=mark, observation_ids={observation_id}
+                    )
+                    continue
+                lineage.observation_ids.add(observation_id)
+                if mark.sequence >= lineage.latest.sequence:
+                    lineage.latest = mark
+
+
+_PRODUCER_CURSOR = KarakeepProducerCursor()
+
+
+def reset_producer_cursor() -> None:
+    """Test-only reset hook, mirroring the other Heimdal memory-store resets."""
+    global _PRODUCER_CURSOR
+    _PRODUCER_CURSOR = KarakeepProducerCursor()
+
+
+def default_producer_cursor() -> KarakeepProducerCursor:
+    return _PRODUCER_CURSOR
+
+
+# ---------------------------------------------------------------------------
+# Acquisition result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ItemError:
+    """One item- or page-scoped failure. ``item_id`` is None for a page failure."""
+
+    item_id: Optional[str]
+    reason_code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class AcquisitionResult:
+    """Summary of one acquisition run. Carries no secret-bearing fields."""
+
+    fetched: int
+    published: tuple[str, ...]
+    noops: int
+    item_errors: tuple[ItemError, ...]
+    pages_read: int
+    stopped_early: bool
+    upstream_cursor: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# The adapter
+# ---------------------------------------------------------------------------
+
+
+class KarakeepAdapter:
+    """Read-only Karakeep acquisition into the Heimdal published-evidence handoff."""
+
+    def __init__(
+        self,
+        *,
+        config: KarakeepConfig,
+        token_provider: KarakeepTokenProvider,
+        http: httpx.Client | None = None,
+        cursor: KarakeepProducerCursor | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        publish: Callable[..., Any] = publish_full_observation,
+    ) -> None:
+        self._config = config
+        self._tokens = token_provider
+        self._http = http or httpx.Client()
+        self._cursor = cursor or default_producer_cursor()
+        self._timeout = timeout_seconds
+        self._publish = publish
+
+    # -- public API ---------------------------------------------------------
+
+    def acquire(self) -> AcquisitionResult:
+        """Fetch bounded pages, publish contracted evidence, advance the cursor.
+
+        Idempotent and crash-safe: rebuilds per-item lineage from the durable log
+        first (restart recovery), publishes each new revision, and advances the
+        producer cursor only after a page's evidence is durable. A page fetch
+        failure stops the run before advancing past that page, so a retry replays
+        it and dedups against the log rather than skipping evidence
+        (KMA-INV-2/INV-3). One malformed item dead-letters only itself.
+        """
+        source_id = self._config.source_id
+        self._cursor.rebuild_from_log(source_id)
+
+        published: list[str] = []
+        item_errors: list[ItemError] = []
+        fetched = 0
+        pages_read = 0
+        noops = 0
+        stopped_early = False
+
+        cursor_token = self._cursor.upstream_cursor(source_id)
+        for _ in range(self._config.max_pages):
+            try:
+                page = self._fetch_page(cursor_token)
+            except KarakeepApiError as exc:
+                # Page-scoped failure: legible, secret-safe, and NON-advancing.
+                # The producer cursor stays at this page so a retry replays it.
+                logger.warning(
+                    "Karakeep acquisition[%s]: page fetch stopped (reason=%s status=%s)",
+                    source_id,
+                    exc.reason_code,
+                    exc.status,
+                )
+                item_errors.append(ItemError(None, exc.reason_code, exc.detail))
+                stopped_early = True
+                break
+
+            pages_read += 1
+            page_published, page_noops, page_errors = self._process_items(page.items)
+            fetched += len(page.items)
+            published.extend(page_published)
+            noops += page_noops
+            item_errors.extend(page_errors)
+
+            # The page's evidence is durable (each publish returned before we get
+            # here); only now advance the upstream cursor past it (KMA-INV-3).
+            cursor_token = page.next_cursor
+            self._cursor.advance_upstream(source_id, cursor_token)
+            if page.next_cursor is None:
+                break
+
+        return AcquisitionResult(
+            fetched=fetched,
+            published=tuple(published),
+            noops=noops,
+            item_errors=tuple(item_errors),
+            pages_read=pages_read,
+            stopped_early=stopped_early,
+            upstream_cursor=self._cursor.upstream_cursor(source_id),
+        )
+
+    # -- item processing ----------------------------------------------------
+
+    def _process_items(
+        self, items: Sequence[Mapping[str, Any]]
+    ) -> tuple[list[str], int, list[ItemError]]:
+        published: list[str] = []
+        item_errors: list[ItemError] = []
+        noops = 0
+        source_id = self._config.source_id
+        for raw in items:
+            item_id = raw.get("id") if isinstance(raw, Mapping) else None
+            try:
+                snapshot = _canonicalize_item(raw)
+            except MalformedKarakeepItemError as exc:
+                logger.warning(
+                    "Karakeep acquisition[%s]: dead-lettered malformed item (id=%s): %s",
+                    source_id,
+                    item_id,
+                    exc,
+                )
+                item_errors.append(
+                    ItemError(item_id if isinstance(item_id, str) else None, "malformed_item", str(exc))
+                )
+                continue
+
+            try:
+                outcome = self._publish_snapshot(snapshot)
+            except TopicSchemaViolation as exc:
+                # Item-scoped: a single item that cannot assemble valid evidence
+                # dead-letters only itself and never advances a cursor
+                # (KMA-INV-5). A transient durable-write failure is NOT caught
+                # here -- it propagates so the run stops before the cursor
+                # advances and a retry replays it (KMA-INV-3). The detail carries
+                # no source content -- only the validator's structural reason.
+                logger.warning(
+                    "Karakeep acquisition[%s]: dead-lettered item with invalid evidence (id=%s): %s",
+                    source_id,
+                    snapshot.item_id,
+                    exc,
+                )
+                item_errors.append(ItemError(snapshot.item_id, "invalid_evidence", str(exc)))
+                continue
+
+            if outcome is None:
+                noops += 1
+            else:
+                published.append(outcome)
+        return published, noops, item_errors
+
+    def _publish_snapshot(self, snapshot: SourceSnapshot) -> Optional[str]:
+        """Publish one snapshot as contracted evidence; return its observation_id.
+
+        Returns ``None`` for a traced no-op (identical content at the same
+        publication profile as the latest durable revision of this item).
+        """
+        source_id = self._config.source_id
+        content_identity = snapshot.content_identity()
+        profile_identity = _publication_profile_identity()
+        observation_id = observation_id_for(snapshot.item_id, content_identity, profile_identity)
+
+        lineage = self._cursor.item_lineage(source_id, snapshot.item_id)
+        if lineage is not None and observation_id in lineage.observation_ids:
+            # This exact immutable publication is already durable -- a re-fetch of
+            # identical content at the same profile, even after an intervening
+            # edit was reverted. Traced no-op; never a new row with a duplicate
+            # observation_id (KMA-01 idempotency).
+            logger.info(
+                "Karakeep acquisition[%s]: no-op re-fetch of %s (observation already durable)",
+                source_id,
+                observation_id,
+            )
+            return None
+
+        if lineage is None:
+            sequence = 0
+            revision_of: Optional[str] = None
+            supersedes: Optional[str] = None
+        elif lineage.latest.content_identity != content_identity:
+            # Source update (or tombstone): new content supersedes the prior.
+            sequence = lineage.latest.sequence + 1
+            revision_of = None
+            supersedes = lineage.latest.observation_id
+        else:
+            # Same snapshot content, changed publication profile: a reprocess
+            # revision (same content_identity as latest but a new observation_id).
+            sequence = lineage.latest.sequence + 1
+            revision_of = lineage.latest.observation_id
+            supersedes = None
+
+        payload = _assemble_payload(
+            snapshot,
+            observation_id=observation_id,
+            content_identity=content_identity,
+            source_id=source_id,
+            sequence=sequence,
+            revision_of=revision_of,
+            supersedes=supersedes,
+            grant_ref=self._config.grant_ref,
+            scope_hint=self._config.scope_hint,
+        )
+        row = self._publish(
+            topic=HEIMDAL_OBSERVATION_PUBLISHED,
+            payload=payload,
+            source=_PUBLISH_SOURCE,
+            stage_versions=STAGE_VERSIONS,
+        )
+        # The publish seam dedups an identical revision to None; either way the
+        # revision is now durable, so record it before the cursor advances.
+        self._cursor.record_revision(
+            source_id,
+            snapshot.item_id,
+            ItemRevisionMark(
+                observation_id=observation_id,
+                content_identity=content_identity,
+                profile_identity=profile_identity,
+                sequence=sequence,
+            ),
+        )
+        if row is None:
+            logger.info(
+                "Karakeep acquisition[%s]: publish deduped %s to the existing durable row",
+                source_id,
+                observation_id,
+            )
+            return None
+        return observation_id
+
+    # -- HTTP ---------------------------------------------------------------
+
+    def _fetch_page(self, cursor_token: Optional[str]) -> "_Page":
+        params: dict[str, str] = {"limit": str(self._config.page_size)}
+        if cursor_token:
+            params["cursor"] = cursor_token
+        url = self._config.base_url.rstrip("/") + "/" + _BOOKMARKS_PATH
+        token = self._tokens.get_api_token()
+        headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+        try:
+            response = self._http.get(
+                url, params=params, headers=headers, timeout=self._timeout
+            )
+        except httpx.TimeoutException:
+            _raise_detached(KarakeepApiError("api_unavailable", None, "Karakeep request timed out"))
+        except httpx.TransportError:
+            _raise_detached(KarakeepApiError("network_error", None, "Karakeep transport failed"))
+
+        status = response.status_code
+        if status >= 400:
+            _raise_detached(_mapped_http_error(status))
+
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            _raise_detached(
+                KarakeepApiError("api_unavailable", status, "Karakeep returned invalid JSON")
+            )
+        if not isinstance(body, Mapping):
+            _raise_detached(
+                KarakeepApiError("api_unavailable", status, "Karakeep returned an invalid page shape")
+            )
+        items = body.get("bookmarks")
+        if not isinstance(items, list) or not all(isinstance(item, Mapping) for item in items):
+            _raise_detached(
+                KarakeepApiError("api_unavailable", status, "Karakeep page had an invalid items shape")
+            )
+        next_cursor = body.get("nextCursor")
+        if next_cursor is not None and (not isinstance(next_cursor, str) or not next_cursor):
+            _raise_detached(
+                KarakeepApiError("api_unavailable", status, "Karakeep page cursor was invalid")
+            )
+        return _Page(items=list(items), next_cursor=next_cursor)
+
+
+@dataclass(frozen=True)
+class _Page:
+    items: list[Mapping[str, Any]]
+    next_cursor: Optional[str]
+
+
+def _mapped_http_error(status: int) -> KarakeepApiError:
+    """Map an HTTP status to a secret-free reason code (never echoes the body)."""
+    if status in (401, 403):
+        reason_code = "auth_failed"
+    elif status == 429:
+        reason_code = "rate_limited"
+    elif status >= 500:
+        reason_code = "api_unavailable"
+    else:
+        reason_code = "api_unavailable"
+    return KarakeepApiError(reason_code, status, f"Karakeep request failed with HTTP {status}")
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization + payload assembly
+# ---------------------------------------------------------------------------
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _canonicalize_item(raw: Mapping[str, Any]) -> SourceSnapshot:
+    """Canonicalize one Karakeep bookmark into a :class:`SourceSnapshot`.
+
+    Raises :class:`MalformedKarakeepItemError` (item-scoped) when identity-bearing
+    fields are missing or unrecognized -- the caller dead-letters only that item.
+    """
+    item_id = raw.get("id")
+    if not isinstance(item_id, str) or not item_id:
+        raise MalformedKarakeepItemError("saved item is missing a string id")
+
+    created_at = _optional_str(raw.get("createdAt"))
+    updated_at = _optional_str(raw.get("modifiedAt")) or _optional_str(raw.get("updatedAt"))
+    if created_at is None and updated_at is None:
+        raise MalformedKarakeepItemError(f"item {item_id} has no upstream timestamp")
+
+    deleted = bool(raw.get("deleted", False))
+    archived = bool(raw.get("archived", False))
+    tags = _canonical_tags(raw.get("tags"))
+
+    content = raw.get("content")
+    content_type = content.get("type") if isinstance(content, Mapping) else None
+    note = _optional_str(raw.get("note"))
+    title = _optional_str(raw.get("title"))
+    source_url: Optional[str] = None
+    text: Optional[str] = None
+    kind: str
+
+    if deleted:
+        # A tombstone carries no live content; identity still derives from the id.
+        kind = content_type if isinstance(content_type, str) and content_type else _KIND_LINK
+        kind = _map_kind(kind)
+    elif content_type == "link" or (isinstance(content, Mapping) and content.get("url")):
+        kind = _KIND_LINK
+        if isinstance(content, Mapping):
+            source_url = _optional_str(content.get("url"))
+            title = title or _optional_str(content.get("title"))
+        text = note
+    elif content_type in ("text", "note"):
+        kind = _KIND_NOTE
+        text = _optional_str(content.get("text")) if isinstance(content, Mapping) else None
+        text = text or note
+    elif content_type == "highlight":
+        kind = _KIND_HIGHLIGHT
+        text = _optional_str(content.get("text")) if isinstance(content, Mapping) else None
+        text = text or note
+    elif note is not None:
+        kind = _KIND_NOTE
+        text = note
+    else:
+        raise MalformedKarakeepItemError(f"item {item_id} has an unrecognized content shape")
+
+    if deleted:
+        text = None
+        source_url = None
+        title = None
+
+    return SourceSnapshot(
+        item_id=item_id,
+        item_kind=kind,
+        source_url=source_url,
+        title=title,
+        text=text,
+        tags=tags,
+        created_at=created_at,
+        updated_at=updated_at,
+        archived=archived,
+        deleted=deleted,
+    )
+
+
+def _map_kind(value: str) -> str:
+    if value in ("text", "note"):
+        return _KIND_NOTE
+    if value == "highlight":
+        return _KIND_HIGHLIGHT
+    return _KIND_LINK
+
+
+def _canonical_tags(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    names: set[str] = set()
+    for entry in value:
+        if isinstance(entry, str) and entry:
+            names.add(entry)
+        elif isinstance(entry, Mapping):
+            name = entry.get("name")
+            if isinstance(name, str) and name:
+                names.add(name)
+    return tuple(sorted(names))
+
+
+def _assemble_payload(
+    snapshot: SourceSnapshot,
+    *,
+    observation_id: str,
+    content_identity: str,
+    source_id: str,
+    sequence: int,
+    revision_of: Optional[str],
+    supersedes: Optional[str],
+    grant_ref: str,
+    scope_hint: str,
+) -> dict[str, Any]:
+    """Build the ``heimdal.observation.published.v1`` payload for one snapshot.
+
+    Imported lazily so this module's import graph carries no dependency that a
+    static check for the Mimer boundary could confuse -- assembly is a pure
+    Heimdal publish concern.
+    """
+    from app.heimdal.publish import assemble_observation_payload
+
+    episode_id = episode_id_for(snapshot.item_id)
+    timestamped = snapshot.created_at is not None
+    observed_at_start = snapshot.created_at or snapshot.updated_at
+    assert observed_at_start is not None  # guaranteed by _canonicalize_item
+
+    attributions = [
+        {
+            "mention_id": "operator-recorder",
+            "role": "recorder",
+            "resolution": "resolved",
+            "confidence": 1.0,
+            "basis": "capture_context",
+        }
+    ]
+    entity_mentions = [
+        {
+            "mention_id": f"karakeep-tag:{tag}",
+            "surface_form": tag,
+            "kind_hint": "tag",
+            "resolution": "unresolved",
+            "confidence": None,
+        }
+        for tag in snapshot.tags
+    ]
+    confidence = {
+        "source_integrity": {
+            "score": 1.0,
+            "method": "karakeep_api_snapshot",
+            "calibration": "by_construction",
+        },
+        "attribution": {
+            "score": 1.0,
+            "method": "operator_source_grant",
+            "calibration": "by_construction",
+        },
+        "temporal": {
+            "score": 1.0 if timestamped else 0.5,
+            "method": "karakeep_created_at" if timestamped else "karakeep_inferred_timestamp",
+            "calibration": "by_construction" if timestamped else "heuristic",
+        },
+    }
+    content_structure: dict[str, Any] = {
+        "karakeep": {
+            "item_kind": snapshot.item_kind,
+            "source_item_identity": episode_id,
+            "tombstone": snapshot.deleted,
+        }
+    }
+    if snapshot.source_url is not None:
+        content_structure["karakeep"]["source_url"] = snapshot.source_url
+    if snapshot.tags:
+        content_structure["karakeep"]["tags"] = list(snapshot.tags)
+
+    raw_ref = f"raw:karakeep:{snapshot.item_id}:{_hex(content_identity)[:8]}"
+    provenance = {
+        "sensor": SENSOR,
+        "capture_chain": list(CAPTURE_CHAIN),
+        "content_identity": content_identity,
+        "stage_versions": dict(STAGE_VERSIONS),
+        "raw_ref": raw_ref,
+        # Producer-lane id (not a secret, not part of content identity): keeps
+        # multiple Karakeep source lanes from sharing resume state on rebuild.
+        "karakeep_source_id": source_id,
+    }
+    consent = {
+        "basis": "self_record",
+        "granted_by": "operator",
+        "third_party": "marked",
+        "grant_ref": grant_ref,
+    }
+
+    return assemble_observation_payload(
+        observation_id=observation_id,
+        episode_id=episode_id,
+        observed_at_start=observed_at_start,
+        clock_basis="device_metadata" if timestamped else "inferred",
+        attributions=attributions,
+        entity_mentions=entity_mentions,
+        confidence=confidence,
+        provenance=provenance,
+        consent=consent,
+        sensitivity="private",
+        scope_hint=scope_hint,
+        sequence=sequence,
+        revision_of=revision_of,
+        supersedes=supersedes,
+        modality=None,
+        content=snapshot.text,
+        content_structure=content_structure,
+        raw_ref=raw_ref,
+    )
+
+
+__all__ = [
+    "ADAPTER_ID",
+    "ADAPTER_VERSION",
+    "AcquisitionResult",
+    "CAPTURE_CHAIN",
+    "ItemError",
+    "ItemLineage",
+    "ItemRevisionMark",
+    "KarakeepAdapter",
+    "KarakeepApiError",
+    "KarakeepConfig",
+    "KarakeepConfigError",
+    "KarakeepProducerCursor",
+    "KarakeepTokenProvider",
+    "MalformedKarakeepItemError",
+    "SENSOR",
+    "SourceSnapshot",
+    "StaticKarakeepToken",
+    "default_producer_cursor",
+    "episode_id_for",
+    "observation_id_for",
+    "reset_producer_cursor",
+]

--- a/tests/heimdal/test_karakeep_ingestion.py
+++ b/tests/heimdal/test_karakeep_ingestion.py
@@ -1,0 +1,555 @@
+"""Contract tests for the Heimdal Karakeep reading-evidence adapter (KMA-03, #3374).
+
+All egress runs through ``httpx.MockTransport`` -- no network. The tests exercise
+the real publish seam (``app.heimdal.publish.publish_full_observation`` onto the
+in-memory observation log) so the published evidence is validated against the
+canonical ``heimdal.observation.published.v1`` schema by construction.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+import pytest
+
+from app.events.topic_schema_registry import validate_topic_payload
+from app.events.types import HEIMDAL_OBSERVATION_PUBLISHED
+from app.heimdal import karakeep_ingest
+from app.heimdal.karakeep_ingest import (
+    KarakeepAdapter,
+    KarakeepConfig,
+    KarakeepProducerCursor,
+    StaticKarakeepToken,
+)
+from app.heimdal.observation_log import (
+    read_observations_from,
+    reset_memory_observation_log,
+)
+
+pytestmark = pytest.mark.not_pg
+
+# Placeholders only -- a private endpoint/token never appears in a committed
+# fixture (KMA-INV-6). These sentinels double as redaction canaries in test 4.
+_BASE_URL = "https://karakeep.private.example"
+_SECRET_TOKEN = "kk-secret-token-DO-NOT-LEAK"
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    reset_memory_observation_log()
+    karakeep_ingest.reset_producer_cursor()
+
+
+# ---------------------------------------------------------------------------
+# Fake Karakeep REST server
+# ---------------------------------------------------------------------------
+
+
+class _FakeKarakeep:
+    """A cursor-paginated Karakeep bookmarks endpoint over ``httpx.MockTransport``."""
+
+    def __init__(self, pages: list[list[dict[str, Any]]]) -> None:
+        self._pages = pages
+        self.fail_pages: dict[int, int] = {}  # page index -> HTTP status
+        self.requests: list[httpx.Request] = []
+
+    def _index(self, request: httpx.Request) -> int:
+        cursor = request.url.params.get("cursor")
+        return 0 if cursor is None else int(cursor.split(":", 1)[1])
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        idx = self._index(request)
+        if idx in self.fail_pages:
+            # A provider error body that embeds secret-looking material; the
+            # adapter must never echo any of it into its surfaced error.
+            return httpx.Response(
+                self.fail_pages[idx],
+                request=request,
+                json={"error": "denied", "echo": _SECRET_TOKEN, "endpoint": _BASE_URL},
+            )
+        items = self._pages[idx] if idx < len(self._pages) else []
+        next_cursor = f"page:{idx + 1}" if idx + 1 < len(self._pages) else None
+        return httpx.Response(200, request=request, json={"bookmarks": items, "nextCursor": next_cursor})
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(transport=httpx.MockTransport(self.handler))
+
+
+def _adapter(fake: _FakeKarakeep, *, cursor: KarakeepProducerCursor | None = None) -> KarakeepAdapter:
+    return KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=fake.client(),
+        cursor=cursor,
+    )
+
+
+def _link(item_id: str, url: str, *, note: str | None = None, tags: Iterable[str] = (), created: str = "2026-07-10T08:15:00+02:00") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "createdAt": created,
+        "modifiedAt": created,
+        "archived": False,
+        "note": note,
+        "tags": [{"name": t} for t in tags],
+        "content": {"type": "link", "url": url, "title": f"title-{item_id}"},
+    }
+
+
+def _note(item_id: str, text: str, *, created: str = "2026-07-10T09:00:00+02:00") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "createdAt": created,
+        "modifiedAt": created,
+        "archived": False,
+        "tags": [],
+        "content": {"type": "text", "text": text},
+    }
+
+
+def _highlight(item_id: str, text: str, *, created: str = "2026-07-10T10:00:00+02:00") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "createdAt": created,
+        "modifiedAt": created,
+        "archived": False,
+        "tags": [],
+        "content": {"type": "highlight", "text": text},
+    }
+
+
+def _payloads() -> list[dict[str, Any]]:
+    rows = read_observations_from(0)
+    return [r.envelope["payload"] for r in rows]
+
+
+def _by_episode(payloads: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {}
+    for p in payloads:
+        out.setdefault(p["episode_id"], []).append(p)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# AC 1
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_fetch_attributes_and_publishes_reading_evidence() -> None:
+    fake = _FakeKarakeep(
+        [
+            [_link("item-1", "https://example.com/a", note="a saved note", tags=["reading", "ai"]), _note("item-2", "a standalone note")],
+            [_highlight("item-3", "a highlighted passage")],
+        ]
+    )
+    result = _adapter(fake).acquire()
+
+    assert result.fetched == 3
+    assert len(result.published) == 3
+    assert result.noops == 0
+    assert result.item_errors == ()
+    assert result.pages_read == 2
+    assert not result.stopped_early
+
+    payloads = _payloads()
+    assert len(payloads) == 3
+    for payload in payloads:
+        # Published evidence validates against the canonical schema.
+        validate_topic_payload(HEIMDAL_OBSERVATION_PUBLISHED, payload)
+        assert payload["episode_id"].startswith("karakeep:")
+        assert payload["observation_id"].startswith(payload["episode_id"] + ":")
+        prov = payload["provenance"]
+        assert prov["sensor"] == "karakeep_rest"
+        assert prov["capture_chain"] == ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"]
+        assert prov["content_identity"].startswith("sha256:")
+        assert prov["content_hash"].startswith("sha256:")
+        assert set(payload["confidence"]) == {"source_integrity", "attribution", "temporal"}
+        assert payload["attributions"][0]["mention_id"] == "operator-recorder"
+        assert payload["attributions"][0]["role"] == "recorder"
+        assert payload["consent"]["grant_ref"] == "grant:karakeep-source-ingestion"
+        assert payload["sequence"] == 0  # first revision of each distinct item
+
+    by_ep = _by_episode(payloads)
+    link_payload = by_ep["karakeep:item-1"][0]
+    assert link_payload["content_structure"]["karakeep"]["item_kind"] == "link"
+    assert link_payload["content_structure"]["karakeep"]["source_url"] == "https://example.com/a"
+    assert link_payload["clock_basis"] == "device_metadata"
+    assert link_payload["observed_at_start"] == "2026-07-10T08:15:00+02:00"
+    # Entity mentions are derived from source tags only when present.
+    mention_surfaces = {m["surface_form"] for m in link_payload["entity_mentions"]}
+    assert mention_surfaces == {"reading", "ai"}
+    assert all(m["resolution"] == "unresolved" for m in link_payload["entity_mentions"])
+    assert by_ep["karakeep:item-2"][0]["content"] == "a standalone note"
+    assert by_ep["karakeep:item-2"][0]["entity_mentions"] == []
+    assert by_ep["karakeep:item-3"][0]["content_structure"]["karakeep"]["item_kind"] == "highlight"
+
+    # Restart-safe / incremental: a second run over identical source is all no-ops
+    # and appends no new evidence (the producer cursor + log dedup).
+    second = _adapter(fake, cursor=karakeep_ingest.default_producer_cursor()).acquire()
+    assert second.noops == 3
+    assert second.published == ()
+    assert len(_payloads()) == 3
+
+
+# ---------------------------------------------------------------------------
+# AC 2
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_is_noop_and_changed_revision_preserves_lineage() -> None:
+    shared = KarakeepProducerCursor()
+
+    fake_v1 = _FakeKarakeep([[_link("item-9", "https://example.com/x", note="first note")]])
+    first = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=fake_v1.client(),
+        cursor=shared,
+    ).acquire()
+    assert len(first.published) == 1
+    prior_observation_id = first.published[0]
+
+    # Duplicate revision -> traced no-op, no new row.
+    dup = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=fake_v1.client(),
+        cursor=shared,
+    ).acquire()
+    assert dup.noops == 1
+    assert dup.published == ()
+    assert len(_payloads()) == 1
+
+    # Changed content -> new revision lineage, prior evidence untouched.
+    fake_v2 = _FakeKarakeep([[_link("item-9", "https://example.com/x", note="edited note")]])
+    changed = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=fake_v2.client(),
+        cursor=shared,
+    ).acquire()
+    assert len(changed.published) == 1
+
+    payloads = _by_episode(_payloads())["karakeep:item-9"]
+    assert len(payloads) == 2
+    prior = next(p for p in payloads if p["observation_id"] == prior_observation_id)
+    newer = next(p for p in payloads if p["observation_id"] != prior_observation_id)
+    assert prior["sequence"] == 0
+    assert prior["supersedes"] is None
+    assert newer["sequence"] == 1
+    assert newer["supersedes"] == prior_observation_id
+    assert newer["revision_of"] is None
+    # The prior published content is preserved (not overwritten).
+    assert prior["content"] == "first note"
+    assert newer["content"] == "edited note"
+
+
+# ---------------------------------------------------------------------------
+# AC 3
+# ---------------------------------------------------------------------------
+
+
+def test_page_failure_replays_before_producer_cursor_advance() -> None:
+    pages = [
+        [_link("item-a", "https://example.com/a"), _link("item-b", "https://example.com/b")],
+        [_link("item-c", "https://example.com/c")],
+    ]
+
+    # First run: page 0 publishes, page 1 fails -> stop before advancing past it.
+    fake = _FakeKarakeep([list(p) for p in pages])
+    fake.fail_pages = {1: 503}
+    cursor = KarakeepProducerCursor()
+    partial = _adapter(fake, cursor=cursor).acquire()
+
+    assert len(partial.published) == 2
+    assert partial.stopped_early
+    assert [e.reason_code for e in partial.item_errors] == ["api_unavailable"]
+    # Producer cursor points AT the failed page, never beyond it.
+    assert partial.upstream_cursor == "page:1"
+    episodes = _by_episode(_payloads())
+    assert set(episodes) == {"karakeep:item-a", "karakeep:item-b"}  # page 1 not durable
+
+    # Simulate a crash that lost the producer cursor: a fresh cursor re-fetches
+    # from page 0. Page 0 items dedup against the durable log (no duplicates);
+    # page 1 now succeeds and is published. Evidence is neither skipped nor
+    # duplicated and per-item sequence never regresses.
+    healthy = _FakeKarakeep([list(p) for p in pages])
+    replay = _adapter(healthy, cursor=KarakeepProducerCursor()).acquire()
+
+    assert replay.noops == 2  # page 0 items replayed as no-ops
+    assert len(replay.published) == 1  # page 1 item-c now published
+    assert not replay.stopped_early
+
+    payloads = _payloads()
+    assert len(payloads) == 3  # exactly a,b,c -- no duplicate a/b rows
+    observation_ids = [p["observation_id"] for p in payloads]
+    assert len(observation_ids) == len(set(observation_ids))
+    assert set(_by_episode(payloads)) == {"karakeep:item-a", "karakeep:item-b", "karakeep:item-c"}
+    assert all(p["sequence"] == 0 for p in payloads)
+
+
+# ---------------------------------------------------------------------------
+# AC 4
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "reason_code"),
+    [(401, "auth_failed"), (403, "auth_failed"), (429, "rate_limited"), (503, "api_unavailable")],
+)
+def test_failures_are_bounded_and_credentials_are_redacted(
+    status: int, reason_code: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    fake = _FakeKarakeep([[_link("item-1", "https://example.com/a")]])
+    fake.fail_pages = {0: status}
+    with caplog.at_level("DEBUG"):
+        result = _adapter(fake).acquire()
+
+    assert result.published == ()
+    assert result.stopped_early
+    assert [e.reason_code for e in result.item_errors] == [reason_code]
+
+    # No secret token or private endpoint anywhere the failure is surfaced.
+    detail = result.item_errors[0].detail
+    assert _SECRET_TOKEN not in detail
+    assert _BASE_URL not in detail
+    assert str(status) in detail
+    # The API token is a true secret: it must not appear in ANY log record
+    # (it never reaches the URL httpx logs -- it rides the Authorization header).
+    all_log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert _SECRET_TOKEN not in all_log_text
+    # The adapter's OWN log lines must not echo the private endpoint (KMA-INV-6);
+    # httpx's generic request logging is outside the adapter's surface.
+    adapter_log_text = "\n".join(
+        rec.getMessage() for rec in caplog.records if rec.name == "app.heimdal.karakeep_ingest"
+    )
+    assert adapter_log_text  # the adapter did log the bounded failure
+    assert _BASE_URL not in adapter_log_text
+
+
+def test_malformed_item_is_dead_lettered_and_isolated() -> None:
+    good = _link("item-good", "https://example.com/good")
+    missing_id = {"createdAt": "2026-07-10T08:15:00+02:00", "content": {"type": "link", "url": "https://x"}}
+    no_timestamp = {"id": "item-bad-time", "content": {"type": "text", "text": "hi"}}
+    fake = _FakeKarakeep([[good, missing_id, no_timestamp]])
+
+    result = _adapter(fake).acquire()
+
+    assert len(result.published) == 1  # only the good item
+    reasons = sorted(e.reason_code for e in result.item_errors)
+    assert reasons == ["malformed_item", "malformed_item"]
+    assert not result.stopped_early  # one bad item never aborts the page
+    episodes = set(_by_episode(_payloads()))
+    assert episodes == {"karakeep:item-good"}
+
+
+# ---------------------------------------------------------------------------
+# Identity integrity, lineage completeness, and per-item isolation
+# (contract cases surfaced by independent review of AC 1-4)
+# ---------------------------------------------------------------------------
+
+
+def test_content_revert_is_noop_not_duplicate_observation_id() -> None:
+    """A -> B -> A: reverting to earlier content reproduces an already-durable
+    observation_id and must be a no-op, never a duplicate-id row (KMA-01)."""
+    shared = KarakeepProducerCursor()
+
+    def _run(note: str) -> Any:
+        fake = _FakeKarakeep([[_link("item-r", "https://example.com/r", note=note)]])
+        return KarakeepAdapter(
+            config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+            token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+            http=fake.client(),
+            cursor=shared,
+        ).acquire()
+
+    first = _run("content-A")
+    assert len(first.published) == 1
+    _run("content-B")  # edit
+    revert = _run("content-A")  # revert to the original content
+
+    assert revert.published == ()
+    assert revert.noops == 1
+    payloads = _by_episode(_payloads())["karakeep:item-r"]
+    assert len(payloads) == 2  # exactly A(seq0) and B(seq1) -- no third row
+    observation_ids = [p["observation_id"] for p in payloads]
+    assert len(observation_ids) == len(set(observation_ids))  # no duplicate ids
+    assert first.published[0] in observation_ids
+
+
+def test_tombstone_supersedes_prior_without_deleting_it() -> None:
+    shared = KarakeepProducerCursor()
+    live = _FakeKarakeep([[_link("item-t", "https://example.com/t", note="live note")]])
+    first = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=live.client(),
+        cursor=shared,
+    ).acquire()
+    prior_id = first.published[0]
+
+    deleted_item = _link("item-t", "https://example.com/t", note="live note")
+    deleted_item["deleted"] = True
+    tomb = _FakeKarakeep([[deleted_item]])
+    result = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=tomb.client(),
+        cursor=shared,
+    ).acquire()
+
+    assert len(result.published) == 1
+    payloads = _by_episode(_payloads())["karakeep:item-t"]
+    assert len(payloads) == 2  # prior live evidence is preserved, not deleted
+    tombstone = next(p for p in payloads if p["observation_id"] != prior_id)
+    validate_topic_payload(HEIMDAL_OBSERVATION_PUBLISHED, tombstone)
+    assert tombstone["content"] is None
+    assert tombstone["content_structure"]["karakeep"]["tombstone"] is True
+    assert tombstone["supersedes"] == prior_id
+    assert tombstone["sequence"] == 1
+    prior = next(p for p in payloads if p["observation_id"] == prior_id)
+    assert prior["content"] == "live note"  # untouched
+
+
+def test_inferred_timestamp_when_created_at_absent() -> None:
+    item = {
+        "id": "item-i",
+        "modifiedAt": "2026-07-11T12:00:00+02:00",  # no createdAt
+        "content": {"type": "text", "text": "note with only a modified time"},
+        "tags": [],
+    }
+    fake = _FakeKarakeep([[item]])
+    result = _adapter(fake).acquire()
+
+    assert len(result.published) == 1
+    payload = _payloads()[0]
+    validate_topic_payload(HEIMDAL_OBSERVATION_PUBLISHED, payload)
+    assert payload["observed_at_start"] == "2026-07-11T12:00:00+02:00"
+    assert payload["clock_basis"] == "inferred"
+    assert payload["confidence"]["temporal"]["method"] == "karakeep_inferred_timestamp"
+    assert payload["confidence"]["temporal"]["calibration"] == "heuristic"
+
+
+def test_same_snapshot_reprocess_creates_revision_of_lineage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A changed publication profile over the same content is a reprocess:
+    revision_of the prior publication, supersedes null (KMA-01)."""
+    shared = KarakeepProducerCursor()
+    item = _link("item-p", "https://example.com/p", note="stable content")
+
+    first = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=_FakeKarakeep([[item]]).client(),
+        cursor=shared,
+    ).acquire()
+    prior_id = first.published[0]
+
+    # Simulate an adapter publication-profile bump; content is unchanged.
+    monkeypatch.setattr(karakeep_ingest, "STAGE_VERSIONS", {"karakeep_adapter": "contract-v2"})
+    reprocessed = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=_FakeKarakeep([[item]]).client(),
+        cursor=shared,
+    ).acquire()
+
+    assert len(reprocessed.published) == 1
+    payloads = _by_episode(_payloads())["karakeep:item-p"]
+    assert len(payloads) == 2
+    newer = next(p for p in payloads if p["observation_id"] != prior_id)
+    assert newer["revision_of"] == prior_id
+    assert newer["supersedes"] is None
+    assert newer["sequence"] == 1
+    # Same underlying content identity, distinct publication.
+    assert newer["provenance"]["content_identity"] == next(
+        p for p in payloads if p["observation_id"] == prior_id
+    )["provenance"]["content_identity"]
+
+
+def test_invalid_evidence_item_is_isolated_but_infra_failure_stops() -> None:
+    """A schema-invalid item dead-letters only itself (KMA-INV-5); a transient
+    durable-write failure propagates so the run stops before advancing (KMA-INV-3)."""
+    from app.events.topic_schema_registry import TopicSchemaViolation
+
+    good = _link("item-good", "https://example.com/good")
+    poison = _link("item-poison", "https://example.com/poison")
+    real_publish = karakeep_ingest.publish_full_observation
+
+    def _publish_schema_reject(*, topic: str, payload: dict[str, Any], **kw: Any) -> Any:
+        if payload["episode_id"] == "karakeep:item-poison":
+            raise TopicSchemaViolation(topic=topic, schema_ref="test", reason="synthetic")
+        return real_publish(topic=topic, payload=payload, **kw)
+
+    fake = _FakeKarakeep([[good, poison]])
+    result = KarakeepAdapter(
+        config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+        token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+        http=fake.client(),
+        cursor=KarakeepProducerCursor(),
+        publish=_publish_schema_reject,
+    ).acquire()
+    assert len(result.published) == 1  # good item published
+    assert [e.reason_code for e in result.item_errors] == ["invalid_evidence"]
+    assert not result.stopped_early
+    assert set(_by_episode(_payloads())) == {"karakeep:item-good"}
+
+    # A transient infra failure must NOT be swallowed as a dead-letter.
+    reset_memory_observation_log()
+
+    def _publish_infra_down(*, topic: str, payload: dict[str, Any], **kw: Any) -> Any:
+        raise RuntimeError("durable write unavailable")
+
+    with pytest.raises(RuntimeError):
+        KarakeepAdapter(
+            config=KarakeepConfig(base_url=_BASE_URL, source_id="karakeep-test"),
+            token_provider=StaticKarakeepToken(_SECRET_TOKEN),
+            http=_FakeKarakeep([[good]]).client(),
+            cursor=KarakeepProducerCursor(),
+            publish=_publish_infra_down,
+        ).acquire()
+
+
+# ---------------------------------------------------------------------------
+# AC 5
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_stops_at_published_handoff() -> None:
+    module_path = Path(karakeep_ingest.__file__)
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+
+    # The production adapter never reaches across the constituent boundary into
+    # Mimer/KAP or companion capture (KMA-INV-4, AC 5). This is an import-level
+    # check on executable code -- the module docstring may still *name* the
+    # forbidden surfaces to document the boundary.
+    forbidden_prefixes = (
+        "app.knowledge_acquisition",
+        "app.heimdal.candidate_projection",
+        "app.heimdal.candidate_writeback",
+        "app.heimdal.capture_adapter",
+        "app.heimdal.capture_note",
+        "app.heimdal.capture_runtime",
+        "app.api.routes",  # /api/capture route module family
+    )
+    leaked = {name for name in imported if name.startswith(forbidden_prefixes)}
+    assert leaked == set(), f"adapter imports across the boundary: {leaked}"
+
+    # Positively: a run publishes to the handoff log and nothing beyond it.
+    fake = _FakeKarakeep([[_link("item-1", "https://example.com/a")]])
+    result = _adapter(fake).acquire()
+    assert len(result.published) == 1
+    rows = read_observations_from(0)
+    assert len(rows) == 1
+    assert rows[0].topic == HEIMDAL_OBSERVATION_PUBLISHED


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

Final-Review-Rounds: 2

Governing-Issue: #3374

## Linked Issue
Fixes #3374

## Summary
Implements KMA-03: a read-only `app/heimdal/karakeep_ingest.py` adapter that fetches paginated Karakeep links/notes/highlights, derives stable source-item identity and content/publication-profile revision, stamps provenance/confidence/attribution and tag-derived entity mentions, and publishes the contracted `heimdal.observation.published.v1` evidence through the sanctioned `publish_full_observation` seam. The Heimdal producer cursor advances only after a page's evidence is durable and never regresses; per-item lineage (including the full published-`observation_id` set) is rebuilt from the durable observation log on restart, so a lost cursor cannot skip or duplicate evidence. Endpoint/credential references arrive only through injected runtime config; failures are `reason_code`/`status` pairs with no secret echo. The adapter never imports or calls `app.knowledge_acquisition` or companion capture.

## SBS Impact
- Primary subsystem: Heimdal ingestion organ (Karakeep watch/fetch/attribute) → Mimer KAP refinement boundary
- Secondary subsystem(s): EBF, DRI, HKA/SIP/GOV, OEF
- Write class: Product/Runtime derived/published evidence; no candidate write in this slice
- Authority impact: no new semantic authority; source stays non-authoritative, review-required downstream
- Persistence impact: durable Heimdal published evidence via existing observation log; producer cursor is process-durable and rebuilt from the log
- Derived/rebuildable impact: adapter output and per-item lineage are rebuildable from the append-only log
- Human knowledge impact: none in this slice (no candidate materialization)
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none (stubbed HTTP; no network in tests)
- External boundary impact: Heimdal-owned Karakeep REST egress with secret-safe injected config and bounded, redacted failures
- New or changed contract: implements (does not change) the KMA-01 Karakeep→published-evidence handoff contract
- Owner-doc impact: none this slice; owner-doc promotion happens at parent #3367 acceptance (KMA-06)
- Transition debt impact: reduces the read-later→Mimer gap under ADR-0049 constituent ownership
- Fitness rule impact: strengthens provenance, cursor/replay idempotency, and secret containment
- Boundary risk: none — adapter stops at the published handoff; no KAP/capture import or call

## Owner-Doc Writeback
- [x] No owner-doc change implied.

The FETCH task contract is implemented as specified; current-state docs stay honest until parent #3367 acceptance (per the issue: "Keep current-state owner docs honest until this slice and the parent acceptance path supply evidence").

## Acceptance Criteria → Verify targets (all green)
- AC1 fetch/attribute/publish → `tests/heimdal/test_karakeep_ingestion.py::test_incremental_fetch_attributes_and_publishes_reading_evidence`
- AC2 duplicate no-op + revision lineage → `::test_duplicate_is_noop_and_changed_revision_preserves_lineage`
- AC3 mid-page crash replays before cursor advance → `::test_page_failure_replays_before_producer_cursor_advance`
- AC4 bounded, secret-safe failures → `::test_failures_are_bounded_and_credentials_are_redacted` (+ `::test_malformed_item_is_dead_lettered_and_isolated`)
- AC5 stops at published handoff (no KAP/capture) → `::test_adapter_stops_at_published_handoff`

Plus review-driven regression tests: content-revert no-op (no duplicate `observation_id`), tombstone supersede-without-delete, inferred-timestamp path, same-snapshot reprocess (`revision_of`), and per-item schema-violation isolation vs infra-failure stop.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract change; N/A.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Deferred to parent acceptance per the issue; no premature promotion.)

## Validation
- [x] `ruff check app tests` — clean
- [x] `mypy app` — clean (806 files)
- [x] Governing `Verify:` targets and affected-subsystem tests passed — `pytest -q tests/heimdal/test_karakeep_ingestion.py` 14 passed (stubbed HTTP via `httpx.MockTransport`; no network)
- [x] Focused-scope rationale: read-only adapter slice with no cross-system blast radius; the repo-wide non-PG suite is not required by the issue.
- Independent adversarial review run twice (initial + fix-delta) on the exact head; initial round found 4 real issues incl. a duplicate-`observation_id` identity defect on content-revert; all resolved with regression tests; re-review confirmed no regressions/blockers.

## Known contract-level edge (not an implementation defect)
Per KMA-01, `observation_id` carries no source component. Two *distinct* Karakeep sources ingesting a colliding item-id with byte-identical content would share one `observation_id`. Requires cross-instance item-id collision (extreme edge); the id shape is contract-mandated. Producer-lane resume isolation is handled by the `karakeep_source_id` provenance stamp + rebuild filter.

## Claim receipt
`pickup-claim-complete issue=3374 coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-3374 lease_id=lease-53e326eb holder=claude-opus-kma03 evidence=verified-dispatcher-lease`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Product/Runtime implementation slice (Heimdal→Mimer boundary); no plan divergence and no Builder-System artifact produced. Owner-doc promotion deferred to parent #3367 acceptance (KMA-06).

## Notes
- Residual risk: low. Stubbed/offline unit slice; runtime/durable wiring and live acceptance land in KMA-05/KMA-06.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
