### PR TITLE
Add managed Karakeep service deployment contract (KMA-02)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 *.pyc
 .env
 .env.*.local
+# Operator-owned Karakeep managed-service config (KMA-02); the .example template
+# stays tracked. Never commit the filled-in secrets/endpoint file.
+config/karakeep.env
 env/
 .venv*
 .idea/

--- a/app/heimdal/karakeep_service.py
+++ b/app/heimdal/karakeep_service.py
@@ -1,0 +1,153 @@
+"""Managed Karakeep service preconditions for Heimdal fetch (KMA-02, #3373).
+
+Ratified by ``docs/adr/ADR-0049-heimdall-ingestion-organ-and-v1-uiux-enactment.md``
+§1 and specified by
+``docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md`` (KMA-02).
+
+The managed Karakeep service (``docker-compose.karakeep.yml``) is Heimdal's
+external source dependency. This module is the fail-loud gate the Heimdal
+acquisition worker calls *before* any source egress: acquisition must not run
+when required configuration references are absent or the service health is red
+(KMA-INV-5). It is deliberately narrow and side-effect-free -- it validates
+config presence and probes health; it does not fetch, publish, or read the
+observation log.
+
+Secret containment (KMA-INV-6): configuration arrives only through the injected
+environment mapping (default ``os.environ``); this module reads reference
+*names* and never emits their values. A missing-config error names only the
+absent variable names, and a health failure reports a status class, never the
+endpoint URL or token.
+
+Boundary (KMA-INV-4): this gate governs Heimdal *fetch* only. Mimer replay of
+already-published evidence reads the durable observation log through its own
+consumer seam and never calls this gate, so an unhealthy or absent Karakeep
+service cannot stop Mimer from replaying evidence that is already durable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Runtime configuration references the operator owns. Values live in the
+# gitignored config/karakeep.env (template: config/karakeep.env.example); this
+# module only checks that the references resolve to a non-empty value.
+REQUIRED_CONFIG_ENV: tuple[str, ...] = ("KARAKEEP_BASE_URL", "KARAKEEP_API_TOKEN")
+
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+class KarakeepServiceConfigError(RuntimeError):
+    """Required Karakeep configuration references are absent (names only, no values)."""
+
+
+class KarakeepServiceUnhealthyError(RuntimeError):
+    """The managed Karakeep service is not healthy; Heimdal fetch is refused."""
+
+
+@dataclass(frozen=True)
+class HealthStatus:
+    """Outcome of a Karakeep health probe. Carries no secret-bearing fields."""
+
+    healthy: bool
+    status: Optional[int]
+    reason: str
+
+
+def missing_config(env: Mapping[str, str] | None = None) -> list[str]:
+    """Return the names (only) of required config references that are unset/empty."""
+    resolved = env if env is not None else os.environ
+    return [name for name in REQUIRED_CONFIG_ENV if not (resolved.get(name) or "").strip()]
+
+
+def assert_required_config(env: Mapping[str, str] | None = None) -> None:
+    """Fail loud if any required config reference is absent. Reports names only."""
+    missing = missing_config(env)
+    if missing:
+        raise KarakeepServiceConfigError(
+            "Karakeep acquisition config is incomplete; set the missing operator-owned "
+            f"reference(s): {', '.join(sorted(missing))}"
+        )
+
+
+def check_service_health(
+    base_url: str,
+    *,
+    http: httpx.Client | None = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> HealthStatus:
+    """Probe the managed service's liveness without raising on an unhealthy result.
+
+    A non-error 2xx/3xx from the web root is healthy. Any error status, timeout,
+    or transport failure is reported as unhealthy with a secret-free reason (the
+    endpoint URL and token are never included).
+    """
+    client = http or httpx.Client()
+    owns_client = http is None
+    try:
+        response = client.get(base_url, timeout=timeout_seconds)
+    except httpx.TimeoutException:
+        return HealthStatus(False, None, "timeout")
+    except httpx.InvalidURL:
+        # A malformed operator-set endpoint. Report a status class only -- never
+        # surface the URL (its exception text would embed base_url), KMA-INV-6.
+        return HealthStatus(False, None, "invalid_endpoint")
+    except httpx.HTTPError:
+        # Any other transport/protocol failure (connect, read, protocol, ...).
+        return HealthStatus(False, None, "transport_error")
+    finally:
+        if owns_client:
+            client.close()
+
+    status = response.status_code
+    if status < 400:
+        return HealthStatus(True, status, "ok")
+    return HealthStatus(False, status, "unhealthy_status")
+
+
+def assert_fetch_ready(
+    env: Mapping[str, str] | None = None,
+    *,
+    http: httpx.Client | None = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> None:
+    """Fail loud before Heimdal fetch when config is absent or health is red.
+
+    This is the one gate the acquisition worker calls before source egress. It
+    intentionally does not touch the observation log: Mimer replay of already
+    published evidence stays available regardless of service health.
+    """
+    assert_required_config(env)
+    resolved = env if env is not None else os.environ
+    base_url = (resolved.get("KARAKEEP_BASE_URL") or "").strip()
+    health = check_service_health(base_url, http=http, timeout_seconds=timeout_seconds)
+    if not health.healthy:
+        # Secret-safe: log the status class and reason only, never base_url/token.
+        logger.warning(
+            "Karakeep service health is red (reason=%s status=%s); refusing Heimdal fetch",
+            health.reason,
+            health.status,
+        )
+        raise KarakeepServiceUnhealthyError(
+            f"Karakeep service is not healthy (reason={health.reason}, "
+            f"status={health.status}); refusing Heimdal fetch"
+        )
+
+
+__all__ = [
+    "HealthStatus",
+    "KarakeepServiceConfigError",
+    "KarakeepServiceUnhealthyError",
+    "REQUIRED_CONFIG_ENV",
+    "assert_fetch_ready",
+    "assert_required_config",
+    "check_service_health",
+    "missing_config",
+]

--- a/config/karakeep.env.example
+++ b/config/karakeep.env.example
@@ -1,0 +1,19 @@
+# Karakeep managed-service configuration TEMPLATE (KMA-02, #3373).
+#
+# Copy to `config/karakeep.env` (gitignored) on the deployment host and replace every
+# REPLACE_ME_* placeholder with an operator-owned value. This template contains
+# NO real credential or private-endpoint value -- committed truth stays
+# secret-free (KMA-INV-6). Never commit the filled-in config/karakeep.env.
+
+# --- Karakeep service secrets (consumed by the container) ---
+# Auth secret for Karakeep sessions. Generate with `openssl rand -base64 36`.
+NEXTAUTH_SECRET=REPLACE_ME_WITH_GENERATED_SECRET
+# Meilisearch master key. Generate with `openssl rand -base64 36`.
+MEILI_MASTER_KEY=REPLACE_ME_WITH_GENERATED_KEY
+
+# --- Heimdal adapter references (consumed by the KMA-03 acquisition worker) ---
+# Operator-owned private endpoint for the Heimdal Karakeep adapter. The default
+# loopback bind is fine when the worker runs on the same host as the service.
+KARAKEEP_BASE_URL=http://127.0.0.1:3000
+# Karakeep API key minted in the Karakeep UI (Settings -> API Keys).
+KARAKEEP_API_TOKEN=REPLACE_ME_WITH_KARAKEEP_API_KEY

--- a/docker-compose.karakeep.yml
+++ b/docker-compose.karakeep.yml
@@ -1,0 +1,64 @@
+# Managed Karakeep reading source (KMA-02, #3373).
+#
+# Karakeep is Heimdal's external read-later source dependency on the deployment host
+# (docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md,
+# ADR-0049 §1). This manifest is repo-owned deployment truth: a pinned image,
+# durable volumes, a healthcheck, and restart supervision. It contains NO
+# credential or private-endpoint value -- every secret/endpoint rides the
+# operator-owned env_file (config/karakeep.env, gitignored; see
+# config/karakeep.env.example for the placeholder template).
+#
+# The service is bound to loopback only (127.0.0.1); there is no public ingress
+# (parent constraint: never expose Karakeep publicly). Mimer never connects to
+# Karakeep -- only Heimdal does, through the KMA-03 adapter.
+services:
+  karakeep:
+    image: ghcr.io/karakeep-app/karakeep:0.28.0
+    restart: unless-stopped
+    # Loopback bind only -- reachable by the Heimdal adapter on the host, never
+    # published to a public interface.
+    ports:
+      - "127.0.0.1:3000:3000"
+    env_file:
+      # Operator-owned; gitignored. Populated from config/karakeep.env.example.
+      - ./config/karakeep.env
+    environment:
+      # Non-secret wiring only. Secrets/endpoints stay in the env_file above.
+      MEILI_ADDR: http://karakeep-meilisearch:7700
+      DATA_DIR: /data
+    depends_on:
+      karakeep-meilisearch:
+        condition: service_healthy
+    volumes:
+      - karakeep-data:/data
+    healthcheck:
+      # Liveness against the app web root (deliberately NOT /api/health, which
+      # the repo reserves for the expensive operator diagnostic route).
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+
+  karakeep-meilisearch:
+    image: getmeili/meilisearch:v1.13.3
+    restart: unless-stopped
+    env_file:
+      - ./config/karakeep.env
+    environment:
+      MEILI_NO_ANALYTICS: "true"
+    volumes:
+      - karakeep-meilisearch-data:/meili_data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7700/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  # Durable named volumes survive `docker compose down` / restart / image update
+  # (only `down -v` removes them). Karakeep bookmarks/assets and the search
+  # index are the durable data referenced by the backup/rollback runbook.
+  karakeep-data:
+  karakeep-meilisearch-data:

--- a/docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md
+++ b/docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md
@@ -45,6 +45,37 @@ Service restart preserves database/assets volumes. A failed migration/update lea
 version recoverable under the runbook. Worker cursor state is separate and is not stored in the
 container lifecycle.
 
+The repo-owned manifest is [`docker-compose.karakeep.yml`](../../docker-compose.karakeep.yml): a
+pinned image (`ghcr.io/karakeep-app/karakeep:<version>`), the durable named volumes `karakeep-data`
+(bookmarks/assets) and `karakeep-meilisearch-data` (search index), a web-root healthcheck, and
+`restart: unless-stopped`. Every secret and the private endpoint ride the operator-owned, gitignored
+`config/karakeep.env` (template: [`config/karakeep.env.example`](../../config/karakeep.env.example));
+the committed manifest and template carry no credential or endpoint value. The service binds to
+loopback only — there is no public ingress. The fail-loud gate
+`app.heimdal.karakeep_service.assert_fetch_ready` refuses Heimdal acquisition when a required config
+reference is absent or health is red, while Mimer replay of already-published evidence is unaffected.
+
+### Backup / update / rollback runbook
+
+All commands run from the repo root on the mac mini with
+`docker compose -f docker-compose.karakeep.yml` (abbreviated `compose` below).
+
+- **Backup (durable data):** the durable data is the named volumes `karakeep-data` and
+  `karakeep-meilisearch-data`. Snapshot them while the service is stopped or quiescent:
+  `compose stop` then, for each volume,
+  `docker run --rm -v karakeep-data:/data -v "$PWD/backup":/backup alpine tar czf /backup/karakeep-data.tgz -C /data .`
+  (repeat for `karakeep-meilisearch-data`). **Verification check:** confirm each archive is non-empty
+  and lists entries — `tar tzf backup/karakeep-data.tgz | head` — before treating the backup as good.
+- **Update:** bump the pinned image tag in `docker-compose.karakeep.yml`, take a fresh backup (above),
+  then `compose pull && compose up -d`. **Verification check:** `compose ps` shows the service
+  `healthy` and `docker inspect --format '{{.Config.Image}}' <container>` reports the new pinned tag.
+  A half-upgraded or unhealthy service is caught here (and by `assert_fetch_ready`) before any fetch.
+- **Rollback:** restore the previous pinned tag in the manifest and `compose up -d`; if data must be
+  reverted, `compose down` (never `-v`, which would delete the durable volumes), restore the volume
+  archives with the inverse `tar x` into each named volume, then `compose up -d`. **Verification
+  check:** `compose ps` reports `healthy` and a spot read in the Karakeep UI shows the expected
+  bookmarks. The durable volumes survive `compose down`/restart; only `down -v` destroys them.
+
 ## Acceptance Criteria
 
 - [ ] Deployment pins an explicit image/version and declares durable volumes, healthcheck, and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -252,6 +252,23 @@ Companion docs:
   Markdown read-back, mixed-language segments may route to different voices, and production
   deployment still depends on the Mac mini/local model health path.
 
+### Karakeep managed source service (KMA-02)
+- `docker-compose.karakeep.yml` is the repo-owned deployment for the self-hosted Karakeep
+  read-later source on the mac mini (Heimdal's external source dependency; ADR-0049 §1). It pins the
+  `karakeep`/`meilisearch` images, declares the durable `karakeep-data` / `karakeep-meilisearch-data`
+  volumes, health-checks both services, and binds to loopback only — there is no public ingress.
+- Secrets and the private endpoint ride the operator-owned, gitignored `config/karakeep.env`
+  (template: `config/karakeep.env.example`); the committed manifest and template carry no credential
+  or endpoint value.
+- Backup / update / rollback steps (and their verification checks) live in
+  `docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md :: Restart / Durability Posture`.
+- `app.heimdal.karakeep_service.assert_fetch_ready` is the fail-loud gate: Heimdal acquisition is
+  refused when a required config reference is absent or service health is red, while Mimer replay of
+  already-published evidence is unaffected.
+- Scope note: this ships the deployment manifest/runbook and the fetch-readiness gate only. The live
+  acquisition pipeline (Heimdal fetch → published evidence → Mimer candidates) is not accepted as
+  shipped until the parent Karakeep acquisition feature (#3367) completes its acceptance slice.
+
 Detailed startup, local topology, and recovery procedures live in `docs/INFRASTRUCTURE.md`.
 Task-specific operator walkthroughs live in `docs/runbooks/`.
 

--- a/tests/ops/test_karakeep_service_contract.py
+++ b/tests/ops/test_karakeep_service_contract.py
@@ -1,0 +1,191 @@
+"""Managed Karakeep service deployment contract (KMA-02, #3373).
+
+Asserts the repo-owned deployment manifest is pinned, durable, health-checked,
+and secret-free, and that the fail-loud fetch gate blocks Heimdal acquisition on
+absent config or red health while leaving Mimer replay of already-published
+evidence available.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.heimdal.karakeep_service import (
+    KarakeepServiceConfigError,
+    KarakeepServiceUnhealthyError,
+    assert_fetch_ready,
+)
+from app.release_channels.channel_isolation_preflight import _load_compose
+
+pytestmark = pytest.mark.not_pg
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MANIFEST = _REPO_ROOT / "docker-compose.karakeep.yml"
+_ENV_EXAMPLE = _REPO_ROOT / "config" / "karakeep.env.example"
+_KARAKEEP_SERVICE = "karakeep"
+
+
+def _services() -> dict:
+    return _load_compose(_MANIFEST)["services"]
+
+
+def test_service_manifest_is_pinned_persistent_and_health_checked() -> None:
+    compose = _load_compose(_MANIFEST)
+    services = compose["services"]
+    karakeep = services[_KARAKEEP_SERVICE]
+
+    # Pinned image/version -- never a floating tag.
+    image = karakeep["image"]
+    assert ":" in image, "image must carry an explicit version/digest, not a bare repository"
+    assert not image.endswith(":latest"), "image must be pinned, not :latest"
+    tag = image.rsplit(":", 1)[1]
+    assert tag and tag != "latest"
+
+    # Restart supervision.
+    assert karakeep["restart"] == "unless-stopped"
+
+    # Healthcheck present with an executable test.
+    healthcheck = karakeep.get("healthcheck") or {}
+    assert healthcheck.get("test"), "karakeep service must declare a healthcheck test"
+
+    # Durable named volume for the service data, declared at the top level so it
+    # survives restart/update (only `down -v` removes it).
+    service_volumes = karakeep.get("volumes") or []
+    named_mounts = [v for v in service_volumes if isinstance(v, str) and not v.startswith("/") and not v.startswith(".")]
+    assert named_mounts, "karakeep service must mount a durable named volume"
+    top_level_volumes = compose.get("volumes") or {}
+    for mount in named_mounts:
+        volume_name = mount.split(":", 1)[0]
+        assert volume_name in top_level_volumes, f"named volume {volume_name} must be declared"
+
+    # The search dependency is likewise pinned and durably backed.
+    meili = services["karakeep-meilisearch"]
+    assert not meili["image"].endswith(":latest")
+    assert any(
+        isinstance(v, str) and v.split(":", 1)[0] in top_level_volumes
+        for v in (meili.get("volumes") or [])
+    )
+
+
+def test_unhealthy_service_blocks_heimdal_fetch_not_mimer_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    from app.heimdal.observation_log import reset_memory_observation_log
+    from app.heimdal.publish import publish_full_observation, read_observations_for_consumer
+
+    reset_memory_observation_log()
+
+    ready_env = {
+        "KARAKEEP_BASE_URL": "http://127.0.0.1:3000",
+        "KARAKEEP_API_TOKEN": "placeholder-token",
+    }
+
+    # 1. Absent required config -> Heimdal fetch is refused before any egress.
+    with pytest.raises(KarakeepServiceConfigError) as config_exc:
+        assert_fetch_ready(env={"KARAKEEP_BASE_URL": "http://127.0.0.1:3000"})
+    assert "KARAKEEP_API_TOKEN" in str(config_exc.value)
+
+    # 2. Config present but service health red -> fetch refused.
+    def _unhealthy(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request, text="unavailable")
+
+    with pytest.raises(KarakeepServiceUnhealthyError):
+        assert_fetch_ready(env=ready_env, http=httpx.Client(transport=httpx.MockTransport(_unhealthy)))
+
+    # 3. Healthy service -> gate passes.
+    def _healthy(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request, text="ok")
+
+    assert_fetch_ready(env=ready_env, http=httpx.Client(transport=httpx.MockTransport(_healthy)))
+
+    # 4. Mimer replay is independent of the service gate: already-published
+    #    evidence remains readable through the consumer seam while the service
+    #    is down (KMA-INV-4).
+    published = publish_full_observation(
+        topic="heimdal.observation.published",
+        payload={
+            "observation_id": "karakeep:svc-1:aa:bb",
+            "episode_id": "karakeep:svc-1",
+            "observed_at_start": "2026-07-10T08:15:00+02:00",
+            "attributions": [
+                {"mention_id": "operator-recorder", "role": "recorder", "resolution": "resolved", "basis": "capture_context"}
+            ],
+            "content": "already durable",
+            "confidence": {"source_integrity": {"score": 1.0, "calibration": "by_construction"}},
+            "provenance": {
+                "sensor": "karakeep_rest",
+                "capture_chain": ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"],
+                "content_identity": "sha256:aa",
+            },
+            "sensitivity": "private",
+            "consent": {"basis": "self_record", "grant_ref": "grant:karakeep-source-ingestion"},
+        },
+        source="heimdal_karakeep_adapter",
+    )
+    assert published is not None
+
+    # Service is "down": the gate refuses fetch...
+    with pytest.raises(KarakeepServiceUnhealthyError):
+        assert_fetch_ready(env=ready_env, http=httpx.Client(transport=httpx.MockTransport(_unhealthy)))
+    # ...but Mimer replay of the durable evidence still works.
+    replayed = read_observations_for_consumer("mimer.candidate_projector")
+    assert [r.envelope["payload"]["observation_id"] for r in replayed] == ["karakeep:svc-1:aa:bb"]
+
+
+def test_service_manifest_is_health_checked_and_secret_free() -> None:
+    manifest_text = _MANIFEST.read_text(encoding="utf-8")
+    example_text = _ENV_EXAMPLE.read_text(encoding="utf-8")
+
+    # Health-checked: every service in the manifest declares a healthcheck test.
+    for name, service in _services().items():
+        assert (service.get("healthcheck") or {}).get("test"), f"{name} must declare a healthcheck"
+
+    # Secret-free committed manifest: secrets/endpoints ride the env_file, never
+    # a literal value in the compose file.
+    assert "./config/karakeep.env" in manifest_text
+    lowered = manifest_text.lower()
+    for secret_marker in ("nextauth_secret:", "meili_master_key:", "karakeep_api_token:"):
+        assert secret_marker not in lowered, f"{secret_marker} must not carry a literal value in the manifest"
+
+    # The committed template uses placeholders only -- no real credential values.
+    assert "KARAKEEP_API_TOKEN=REPLACE_ME" in example_text
+    assert "NEXTAUTH_SECRET=REPLACE_ME" in example_text
+    assert "MEILI_MASTER_KEY=REPLACE_ME" in example_text
+
+    # The filled-in operator config is never committed; only the template is.
+    tracked = subprocess.run(
+        ["git", "ls-files", "config/karakeep.env", "config/karakeep.env.example"],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    assert "config/karakeep.env.example" in tracked
+    assert "config/karakeep.env" not in tracked
+
+    # A malformed operator endpoint is handled secret-safely: an httpx.InvalidURL
+    # (whose message would embed the endpoint) is caught and reported as a status
+    # class only, never surfaced.
+    from app.heimdal.karakeep_service import check_service_health
+
+    def _raise_invalid(request: httpx.Request) -> httpx.Response:
+        raise httpx.InvalidURL("No host in URL 'http://karakeep.private.example'")
+
+    health = check_service_health(
+        "http://placeholder", http=httpx.Client(transport=httpx.MockTransport(_raise_invalid))
+    )
+    assert not health.healthy
+    assert health.reason == "invalid_endpoint"
+
+    # Logs/errors from the gate are secret-safe: a missing-config error names the
+    # variable but never a value; a health error names a status class, not the URL.
+    try:
+        assert_fetch_ready(env={"KARAKEEP_BASE_URL": "https://karakeep.private.example"})
+    except KarakeepServiceConfigError as exc:
+        assert "https://karakeep.private.example" not in str(exc)
+        assert "KARAKEEP_API_TOKEN" in str(exc)
+    else:  # pragma: no cover - the token is absent, so the gate must raise
+        raise AssertionError("expected a config error for the absent token reference")


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

Final-Review-Rounds: 2

Governing-Issue: #3373

## Linked Issue
Fixes #3373

## Summary
Implements KMA-02: the repo-owned managed Karakeep service deployment. Adds `docker-compose.karakeep.yml` (pinned images, durable named volumes, web-root healthchecks, `restart: unless-stopped`, loopback-only binding), a placeholder-only `config/karakeep.env.example` template (the filled-in `config/karakeep.env` is gitignored), and `app/heimdal/karakeep_service.py` — a fail-loud gate that refuses Heimdal fetch when required config references are absent or service health is red, while leaving Mimer replay of already-published evidence available. Every committed artifact and the gate's error/log surfaces are secret-free. Expands the DEPLOY task doc's Restart/Durability Posture with a backup/update/rollback runbook (durable data + a verification check per step) and records the operational current-state in `docs/OPERATIONS.md`.

## SBS Impact
- Primary subsystem: OEF (managed service/schedule substrate); Heimdal/EBF secondary (the service is Heimdal's external source dependency)
- Secondary subsystem(s): Heimdal/EBF
- Write class: Product/Runtime deployment/config; a thin runtime readiness gate
- Authority impact: none — no semantic authority; the gate only permits/refuses fetch
- Persistence impact: durable Karakeep data via named volumes `karakeep-data` / `karakeep-meilisearch-data`; worker cursor state is separate and not in the container lifecycle
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: adds a managed mac-mini service manifest + runbook; loopback-only, no public ingress
- External boundary impact: Heimdal-owned Karakeep REST/service boundary with secret-safe injected config and a secret-safe health probe
- New or changed contract: implements the KMA-02 deployment/runbook contract; no product-contract change
- Owner-doc impact: owner-doc updated in this PR (OPERATIONS.md + DEPLOY task doc)
- Transition debt impact: reduces the read-later ingestion-service gap under ADR-0049 constituent ownership
- Fitness rule impact: strengthens secret containment, fail-loud service health, and durable-data/rollback posture
- Boundary risk: none — Mimer has no Karakeep connection; only Heimdal does

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR.

`docs/OPERATIONS.md` (Runtime Compose Stack → Karakeep managed source service) records the shipped deployment manifest + fetch-readiness gate as current operational state, explicitly scoping that the live acquisition pipeline is not accepted until parent #3367. `docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md :: Restart / Durability Posture` carries the backup/update/rollback runbook.

## Acceptance Criteria → Verify targets (all green)
- AC1 pinned + durable + health-checked + restart → `tests/ops/test_karakeep_service_contract.py::test_service_manifest_is_pinned_persistent_and_health_checked`
- AC2 startup fails before acquisition on absent config / red health; Mimer replay unaffected → `::test_unhealthy_service_blocks_heimdal_fetch_not_mimer_replay`
- AC3 manifest/config/logs secret-free → `::test_service_manifest_is_health_checked_and_secret_free`
- AC4 backup/update/rollback name durable data + a verification check → doc writeback at `docs/KARAKEEP_MIMER_ACQUISITION/DEPLOY_KARAKEEP_AS_A_MANAGED_SERVICE.md :: Restart / Durability Posture`

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated (OPERATIONS.md + DEPLOY doc; live pipeline explicitly not claimed shipped).

## Validation
- [x] `ruff check app tests` — clean
- [x] `mypy app` — clean (807 files)
- [x] `pytest -q tests/ops/test_karakeep_service_contract.py` — 3 passed
- [x] `python3 scripts/docs_guard.py` — OK
- [x] Global compose-scanning ops guards re-run green (healthcheck-target `/api/health` guard, volume/isolation contracts): the new manifest healthchecks the web root, not `/api/health`.
- Independent adversarial review: initial round found a blocking `docs_guard` temporal-owner failure and an `httpx.InvalidURL` secret-leak edge; both fixed (OPERATIONS.md writeback; `InvalidURL` caught → `invalid_endpoint`, with a regression test); confirmation round clean.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Product/Runtime deployment slice (OEF/Heimdal boundary); no plan divergence and no Builder-System artifact produced.

## Notes
- Out of scope (per issue): private endpoint/credential values, DNS/firewall, public ingress, Karakeep product customization, interactive MCP. Operator smoke-checks (image `wget` availability, real health) belong to the live acceptance slice (KMA-06).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
