### PR TITLE
Add Karakeep reading-source-note projection in Mimer (KMA-04)

### DIFF
--- a/app/heimdal/candidate_projection.py
+++ b/app/heimdal/candidate_projection.py
@@ -88,6 +88,18 @@ REVIEW_STATE_DRAFT = "draft"
 DEFAULT_CANDIDATES_DIR = "Sources/Heimdal"
 CANDIDATE_WRITE_ACTION = "heimdal.candidate_projection.write"
 
+# Karakeep reading-source-note extension (KMA-04, #3375). The Karakeep source
+# is discriminated by ``provenance.sensor == karakeep_rest``; its published
+# evidence maps to a distinct ``reading_source_note`` candidate that preserves
+# one candidate per immutable ``observation_id`` (not the generic episode fold),
+# under its own deterministic path. It reuses this module's governed
+# WriteGuard/write call site and the one ``mimer.candidate_projector`` cursor --
+# no second consumer, projector, or read path.
+KARAKEEP_SENSOR = "karakeep_rest"
+READING_ARTIFACT_CLASS = "reading_source_note"
+DEFAULT_READING_CANDIDATES_DIR = "Sources/Reading/Karakeep"
+READING_CANDIDATE_WRITE_ACTION = "heimdal.candidate_projection.write_reading"
+
 
 class CandidateProjectionError(RuntimeError):
     """Raised when an observation cannot be projected into a candidate."""
@@ -396,46 +408,456 @@ def write_candidate_note(
     )
 
 
+# ---------------------------------------------------------------------------
+# Karakeep reading-source-note extension (KMA-04, #3375)
+# ---------------------------------------------------------------------------
+
+
+def _payload_of(row: ObservationRow) -> Mapping[str, Any]:
+    payload = row.envelope.get("payload")
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _is_karakeep(payload: Mapping[str, Any]) -> bool:
+    return _provenance_block(payload).get("sensor") == KARAKEEP_SENSOR
+
+
+def _karakeep_block(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    structure = payload.get("content_structure")
+    if isinstance(structure, Mapping):
+        block = structure.get("karakeep")
+        if isinstance(block, Mapping):
+            return block
+    return {}
+
+
+@dataclass(frozen=True)
+class ReadingSourceCandidate:
+    """A ``reading_source_note`` candidate materialized from one Karakeep observation.
+
+    Preserves one candidate per immutable ``observation_id`` (a Karakeep item
+    shares ``episode_id`` across source updates, reprocesses, and tombstones, so
+    the generic episode fold would collapse distinct revisions). Posture is
+    structurally fixed non-authoritative/review-required (KMA-INV-1); it can
+    never self-promote or overwrite a human artifact.
+    """
+
+    observation_id: str
+    episode_id: str
+    item_id: str
+    item_kind: str
+    source_url: Optional[str]
+    tags: tuple[str, ...]
+    content_identity: str
+    raw_ref: Optional[str]
+    scope_hint: Optional[str]
+    sequence: Optional[int]
+    supersedes: Optional[str]
+    revision_of: Optional[str]
+    tombstone: bool
+    evidence_text: str
+    requires_review: bool = True
+    source_authoritative: bool = False
+    review_state: str = REVIEW_STATE_DRAFT
+    triage_state: str = TRIAGE_STATE_CAPTURED
+
+    def __post_init__(self) -> None:
+        if self.requires_review is not True:
+            raise CandidateProjectionError(
+                "reading candidate must be requires_review=True (KMA-INV-1) -- cannot self-promote"
+            )
+        if self.source_authoritative is not False:
+            raise CandidateProjectionError("reading candidate is never source_authoritative (KMA-INV-1)")
+        if not self.content_identity:
+            raise CandidateProjectionError("reading candidate.content_identity is required (provenance survival)")
+        if not self.item_id:
+            raise CandidateProjectionError("reading candidate.item_id is required")
+
+    @property
+    def revision_prefix(self) -> str:
+        """The revision discriminator, derived from the immutable observation_id.
+
+        ``observation_id`` is ``karakeep:<item-id>:<content-hex>:<profile-hex>``;
+        the content-hex uniquely identifies this revision of the item.
+        """
+        parts = self.observation_id.rsplit(":", 2)
+        content_hex = parts[1] if len(parts) == 3 else self.content_identity.split(":", 1)[-1]
+        return content_hex[:16] or "rev"
+
+    @property
+    def prior_revision(self) -> Optional[str]:
+        """The prior published revision this one links to (supersede or reprocess)."""
+        return self.supersedes or self.revision_of
+
+
+def build_reading_candidate(row: ObservationRow) -> ReadingSourceCandidate:
+    """Build one reading candidate from a Karakeep published observation row.
+
+    Consumes only the published evidence -- no Karakeep egress, no re-attribution
+    (KMA-INV-4). Observed note/highlight text is quarantined before it becomes
+    candidate content (HEIM-9); a tombstone carries no live content.
+    """
+    payload = row.envelope.get("payload")
+    if not isinstance(payload, Mapping):
+        payload = {}
+    observation_id = _observation_id_of(row)
+    episode_id = payload.get("episode_id")
+    episode = str(episode_id) if isinstance(episode_id, str) and episode_id.strip() else observation_id
+    item_id = episode.split(":", 1)[1] if episode.startswith("karakeep:") else episode
+    provenance = _provenance_block(payload)
+    karakeep = _karakeep_block(payload)
+    tombstone = bool(karakeep.get("tombstone"))
+    tags_raw = karakeep.get("tags")
+    tags = tuple(str(t) for t in tags_raw) if isinstance(tags_raw, (list, tuple)) else ()
+    text = _content_text(payload)
+    evidence = "" if tombstone or not text else quarantine_observed_content(text).fenced_text
+
+    sequence = payload.get("sequence")
+    return ReadingSourceCandidate(
+        observation_id=observation_id,
+        episode_id=episode,
+        item_id=item_id,
+        item_kind=str(karakeep.get("item_kind") or "link"),
+        source_url=karakeep.get("source_url") if isinstance(karakeep.get("source_url"), str) else None,
+        tags=tags,
+        content_identity=str(provenance.get("content_identity") or ""),
+        raw_ref=payload.get("raw_ref") if isinstance(payload.get("raw_ref"), str) else provenance.get("raw_ref"),
+        scope_hint=payload.get("scope_hint") if isinstance(payload.get("scope_hint"), str) else None,
+        sequence=sequence if isinstance(sequence, int) else None,
+        supersedes=payload.get("supersedes") if isinstance(payload.get("supersedes"), str) else None,
+        revision_of=payload.get("revision_of") if isinstance(payload.get("revision_of"), str) else None,
+        tombstone=tombstone,
+        evidence_text=evidence,
+    )
+
+
+def reading_candidate_note_path(
+    candidate: ReadingSourceCandidate, *, candidates_dir: str = DEFAULT_READING_CANDIDATES_DIR
+) -> str:
+    """Deterministic first-write-wins path: ``Sources/Reading/Karakeep/<item-id>-<revision-prefix>.md``.
+
+    Keyed by the immutable ``observation_id`` (via item-id + revision-prefix), so
+    each revision targets a distinct path and replay of the same revision always
+    targets the same path (idempotent). A source update, reprocess, or tombstone
+    lands at a new path and never overwrites a prior or human-reviewed note.
+    """
+    safe_dir = _safe_rel_path(candidates_dir)
+    return (PurePosixPath(safe_dir) / f"{_slug(candidate.item_id)}-{candidate.revision_prefix}.md").as_posix()
+
+
+def render_reading_candidate_note(candidate: ReadingSourceCandidate) -> str:
+    """Render the reading candidate: source link + Heimdal/Karakeep provenance +
+    quarantined notes/highlights + non-authoritative summary + empty human space."""
+    now = _iso(datetime.now(timezone.utc))
+    frontmatter: Dict[str, Any] = {
+        "artifact_class": READING_ARTIFACT_CLASS,
+        "lifecycle": "active",
+        "work_relation": "learn",
+        "source": {
+            "provider": "karakeep",
+            "item_kind": candidate.item_kind,
+            "url": candidate.source_url,
+            "tags": list(candidate.tags),
+        },
+        "provenance": {
+            "sensor": KARAKEEP_SENSOR,
+            "observation_id": candidate.observation_id,
+            "episode_id": candidate.episode_id,
+            "derived_from": candidate.observation_id,
+            "content_identity": candidate.content_identity,
+            "raw_ref": candidate.raw_ref,
+            "sequence": candidate.sequence,
+            "supersedes": candidate.supersedes,
+            "revision_of": candidate.revision_of,
+        },
+        "scope_hint": candidate.scope_hint,
+        "tombstone": candidate.tombstone,
+        "prior_revision": candidate.prior_revision,
+        "authority": {
+            "source_authoritative": False,
+            "ai_generated": True,
+            "requires_review": True,
+        },
+        "review_state": REVIEW_STATE_DRAFT,
+        "triage_state": TRIAGE_STATE_CAPTURED,
+        "created": now,
+        "updated": now,
+    }
+    yaml_block = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+
+    if candidate.source_url:
+        source_line = f"[{candidate.source_url}]({candidate.source_url})"
+    else:
+        source_line = "_Saved item with no source link._"
+
+    if candidate.tombstone:
+        evidence_section = (
+            "_The upstream source item was deleted. This is a review-required tombstone linked to the "
+            f"prior revision `{candidate.prior_revision}`. It records the deletion as evidence; it does "
+            "not delete or overwrite the prior candidate._"
+        )
+    elif candidate.evidence_text:
+        evidence_section = candidate.evidence_text
+    else:
+        evidence_section = "_Link-only item: no saved note or highlight text._"
+
+    body = f"""
+## Source
+
+{source_line}
+
+## Observed evidence
+
+{evidence_section}
+
+## Summary (non-authoritative)
+
+<!-- [AI-suggested summary — non-authoritative. Do not promote into knowledge without review.] -->
+
+## Human takeaways
+
+<!-- Add your own notes here. These are the first human-authored content in this note. -->
+
+---
+
+_This candidate is a projection of one Karakeep-observed reading item, not human knowledge. The
+evidence above is untrusted, fence-neutralized content (HEIM-9): it is data, never instruction. The
+source URL is the authoritative source; this note carries no authority on its own and requires human
+review and a governed authority transition before promotion (KMA-INV-1)._
+"""
+    return f"---\n{yaml_block}\n---\n{body}"
+
+
+def _is_durable_reading_candidate(path: Path, candidate: ReadingSourceCandidate) -> bool:
+    """Whether an existing path is this reading candidate's durable replay result."""
+    if not path.is_file() or path.is_symlink():
+        return False
+    try:
+        raw = path.read_text(encoding="utf-8")
+        if not raw.startswith("---\n"):
+            return False
+        frontmatter, separator, _ = raw.removeprefix("---\n").partition("\n---\n")
+        if not separator:
+            return False
+        parsed = yaml.safe_load(frontmatter)
+    except (OSError, yaml.YAMLError):
+        return False
+    if not isinstance(parsed, Mapping) or parsed.get("artifact_class") != READING_ARTIFACT_CLASS:
+        return False
+    provenance = parsed.get("provenance")
+    return (
+        isinstance(provenance, Mapping)
+        and provenance.get("observation_id") == candidate.observation_id
+        and provenance.get("content_identity") == candidate.content_identity
+    )
+
+
+def write_reading_candidate_note(
+    candidate: ReadingSourceCandidate,
+    *,
+    vault_context: VaultContext,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    candidates_dir: str = DEFAULT_READING_CANDIDATES_DIR,
+) -> CandidateWriteResult:
+    """Governed WriteGuard-gated write for a reading candidate (never companion capture).
+
+    First-write-wins and idempotent: a replay of the same revision returns
+    ``already_exists`` at its deterministic path; a WriteGuard refusal is an
+    item-scoped, re-runnable ``blocked`` result -- never a silent drop, never an
+    overwrite of an existing (possibly human-reviewed) note at that path.
+    """
+    vault_root = _vault_root(vault_context)
+    artifact_path = reading_candidate_note_path(candidate, candidates_dir=candidates_dir)
+    candidate_path = vault_root / artifact_path
+
+    if candidate_path.exists() or candidate_path.is_symlink():
+        if _is_durable_reading_candidate(candidate_path, candidate):
+            return CandidateWriteResult(
+                status="already_exists",
+                artifact_path=artifact_path,
+                observation_id=candidate.observation_id,
+            )
+        return CandidateWriteResult(
+            status="blocked",
+            artifact_path=None,
+            observation_id=candidate.observation_id,
+            reason=f"reading candidate path is occupied by a non-matching artifact: {artifact_path}",
+        )
+
+    try:
+        write_guard.assert_writes_allowed(READING_CANDIDATE_WRITE_ACTION)
+    except WritesBlockedError as exc:
+        return CandidateWriteResult(
+            status="blocked",
+            artifact_path=None,
+            observation_id=candidate.observation_id,
+            reason=str(exc),
+        )
+
+    content = render_reading_candidate_note(candidate)
+    write_note_relative(artifact_path, content, vault_root=vault_root, action=READING_CANDIDATE_WRITE_ACTION)
+    return CandidateWriteResult(
+        status="written",
+        artifact_path=artifact_path,
+        observation_id=candidate.observation_id,
+    )
+
+
+@dataclass(frozen=True)
+class _PlannedWrite:
+    """One materialization unit and the log rows it durably acknowledges."""
+
+    rows: tuple[ObservationRow, ...]
+    kind: str  # "heimdal" | "karakeep"
+    candidate: Any
+
+
+def _plan_writes(rows: List[ObservationRow]) -> List[_PlannedWrite]:
+    """Plan materialization units in earliest-row order.
+
+    Karakeep rows (``sensor == karakeep_rest``) each become one reading
+    candidate keyed by their immutable ``observation_id`` -- never folded onto a
+    shared ``episode_id``. Non-Karakeep rows keep the existing episode fold
+    (last-correction-wins). Units are ordered by their earliest covered log
+    sequence so results and cursor advancement follow publication order.
+    """
+    karakeep_rows: List[ObservationRow] = []
+    heimdal_rows: List[ObservationRow] = []
+    for row in rows:
+        (karakeep_rows if _is_karakeep(_payload_of(row)) else heimdal_rows).append(row)
+
+    planned: List[_PlannedWrite] = []
+    # Non-Karakeep rows keep the existing episode fold (last-correction-wins),
+    # grouped here so each unit records the exact rows it acknowledges.
+    groups: "dict[str, List[ObservationRow]]" = {}
+    order: List[str] = []
+    for row in heimdal_rows:
+        key = _fold_key(_payload_of(row), _observation_id_of(row))
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(row)
+    for key in order:
+        group = sorted(groups[key], key=lambda r: r.sequence)
+        planned.append(_PlannedWrite(rows=tuple(group), kind="heimdal", candidate=_build_candidate(group)))
+    for row in karakeep_rows:
+        planned.append(_PlannedWrite(rows=(row,), kind="karakeep", candidate=build_reading_candidate(row)))
+
+    planned.sort(key=lambda unit: min(r.sequence for r in unit.rows))
+    return planned
+
+
+def _durable_prefix(
+    rows: List[ObservationRow], planned: List[_PlannedWrite], durable: Dict[int, bool]
+) -> List[ObservationRow]:
+    """The contiguous prefix of rows (by log sequence) that is safe to acknowledge.
+
+    The acknowledgement boundary starts at the first non-durable row and is then
+    lowered by any durable materialization unit that *straddles* it (a folded
+    chain with rows on both sides). Every row below the final boundary belongs to
+    a fully-durable, non-straddling unit, so acknowledging up to it never
+    half-commits a folded chain and never consumes a row that sits beneath a
+    blocked one. Because ``advance_cursor_for_consumer`` advances to
+    ``max(sequence)+1`` and the batch is a contiguous read from the cursor, the
+    returned prefix advances exactly to that boundary; a later successful row
+    above the boundary stays unread and replays rather than being skipped
+    (KMA-INV-3).
+    """
+    if not rows:
+        return []
+
+    unit_of: Dict[int, int] = {}
+    unit_min: Dict[int, int] = {}
+    unit_max: Dict[int, int] = {}
+    unit_durable: Dict[int, bool] = {}
+    for index, unit in enumerate(planned):
+        seqs = [row.sequence for row in unit.rows]
+        unit_min[index] = min(seqs)
+        unit_max[index] = max(seqs)
+        unit_durable[index] = all(durable.get(seq, False) for seq in seqs)
+        for seq in seqs:
+            unit_of[seq] = index
+
+    ordered = sorted(rows, key=lambda r: r.sequence)
+    boundary: Optional[int] = None
+    for row in ordered:
+        if not unit_durable[unit_of[row.sequence]]:
+            boundary = row.sequence
+            break
+    if boundary is None:
+        return ordered  # every unit durable -- acknowledge the whole batch
+
+    changed = True
+    while changed:
+        changed = False
+        for index, is_durable in unit_durable.items():
+            if is_durable and unit_min[index] < boundary <= unit_max[index]:
+                boundary = unit_min[index]
+                changed = True
+    return [row for row in ordered if row.sequence < boundary]
+
+
 def project_pending_candidates(
     *,
     vault_context: VaultContext,
     consumer_id: str = CANDIDATE_CONSUMER_ID,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
     candidates_dir: str = DEFAULT_CANDIDATES_DIR,
+    reading_candidates_dir: str = DEFAULT_READING_CANDIDATES_DIR,
     limit: Optional[int] = None,
     advance: bool = True,
 ) -> List[CandidateWriteResult]:
-    """THE production call site: cursor-consume, fold, and write noncanonical candidates.
+    """THE production call site: cursor-consume, materialize, and advance a durable prefix.
 
     Reads the next unread batch for ``consumer_id`` through the A2 cursor
-    contract (``read_observations_for_consumer`` -- no store/table import),
-    folds supersede/revision chains (:func:`fold_observations`), and writes
-    each resulting candidate through the governed path
-    (:func:`write_candidate_note`). Advances the consumer's own cursor past
-    the processed batch (unless ``advance=False``, e.g. dry-run/replay) --
-    this consumer's cursor is independent of A3's quarantine-proving
-    consumer, so replay/rewind here never affects the other.
+    contract (``read_observations_for_consumer`` -- no store/table import).
+    Non-Karakeep observations fold supersede/revision chains
+    (:func:`fold_observations`) and write through :func:`write_candidate_note`;
+    Karakeep observations write one ``reading_source_note`` per immutable
+    ``observation_id`` through :func:`write_reading_candidate_note`. Both use the
+    governed WriteGuard call site and this one consumer's cursor -- no second
+    consumer, projector, read path, or companion capture.
+
+    Cursor advancement (KMA-INV-3): the consumer's own cursor advances only
+    across the contiguous durable prefix of rows whose materialization returned
+    ``written``/``already_exists``. A WriteGuard refusal or item-scoped failure
+    stops the prefix at that row, so a later successful row is never skipped --
+    it replays on the next run. Replays are safe because a prior successful write
+    is ``already_exists`` at its deterministic path.
     """
-    # The cursor is a durability acknowledgement: do not begin a batch unless
-    # a selected, existing vault can hold its candidates. This happens before
+    # The cursor is a durability acknowledgement: do not begin a batch unless a
+    # selected, existing vault can hold its candidates. This happens before
     # writes so a restart can replay the complete unread batch safely.
     _vault_root(vault_context)
     rows = read_observations_for_consumer(consumer_id, limit=limit)
-    candidates = fold_observations(rows)
-    results = [
-        write_candidate_note(
-            candidate,
-            vault_context=vault_context,
-            write_guard=write_guard,
-            candidates_dir=candidates_dir,
-        )
-        for candidate in candidates
-    ]
-    # A cursor may acknowledge a batch only after every candidate is durable.
-    # Replays are safe because a prior successful write is ``already_exists``
-    # at its deterministic path.
-    if advance and rows and all(result.status in {"written", "already_exists"} for result in results):
-        advance_cursor_for_consumer(consumer_id, rows)
+    planned = _plan_writes(rows)
+
+    results: List[CandidateWriteResult] = []
+    durable: Dict[int, bool] = {}
+    for unit in planned:
+        if unit.kind == "karakeep":
+            result = write_reading_candidate_note(
+                unit.candidate,
+                vault_context=vault_context,
+                write_guard=write_guard,
+                candidates_dir=reading_candidates_dir,
+            )
+        else:
+            result = write_candidate_note(
+                unit.candidate,
+                vault_context=vault_context,
+                write_guard=write_guard,
+                candidates_dir=candidates_dir,
+            )
+        results.append(result)
+        is_durable = result.status in {"written", "already_exists"}
+        for row in unit.rows:
+            durable[row.sequence] = is_durable
+
+    if advance and rows:
+        prefix = _durable_prefix(rows, planned, durable)
+        if prefix:
+            advance_cursor_for_consumer(consumer_id, prefix)
     return results
 
 
@@ -513,14 +935,23 @@ __all__ = [
     "ARTIFACT_CLASS",
     "CANDIDATE_CONSUMER_ID",
     "CANDIDATE_WRITE_ACTION",
+    "DEFAULT_READING_CANDIDATES_DIR",
+    "KARAKEEP_SENSOR",
+    "READING_ARTIFACT_CLASS",
+    "READING_CANDIDATE_WRITE_ACTION",
     "REVIEW_STATE_DRAFT",
     "TRIAGE_STATE_CAPTURED",
     "CandidateProjectionError",
     "CandidateWriteResult",
     "HeimdalCandidate",
+    "ReadingSourceCandidate",
+    "build_reading_candidate",
     "candidate_note_path",
     "fold_observations",
     "project_pending_candidates",
+    "reading_candidate_note_path",
     "render_candidate_note",
+    "render_reading_candidate_note",
     "write_candidate_note",
+    "write_reading_candidate_note",
 ]

--- a/tests/heimdal/test_projector.py
+++ b/tests/heimdal/test_projector.py
@@ -431,6 +431,42 @@ def test_projector_replay_is_idempotent_after_partial_write(tmp_path: Path, monk
     assert get_cursor(CANDIDATE_CONSUMER_ID) == 2
 
 
+def test_interleaved_fold_straddling_a_blocked_unit_does_not_skip(tmp_path: Path, monkeypatch) -> None:
+    """A folded episode whose rows straddle a blocked unit must not be
+    half-acknowledged, and its earliest revision must never be silently skipped
+    by a watermark advance (KMA-04 durable-prefix regression)."""
+    # ep-A spans seq 0 and seq 3 (a revision); ep-B seq 1; ep-C seq 2 is blocked.
+    _publish("obs-a0", episode_id="ep-A", content="a original")
+    _publish("obs-b1", episode_id="ep-B", content="b only")
+    _publish("obs-c2", episode_id="ep-C", content="c blocked")
+    _publish("obs-a3", episode_id="ep-A", content="a corrected", revision_of="obs-a0")
+    vault = _vault(tmp_path / "vault")
+
+    original = candidate_projection.write_candidate_note
+
+    def block_ep_c(candidate, **kwargs):
+        if candidate.episode_id == "ep-C":
+            return CandidateWriteResult(
+                status="blocked", artifact_path=None, observation_id=candidate.observation_id, reason="test block"
+            )
+        return original(candidate, **kwargs)
+
+    monkeypatch.setattr(candidate_projection, "write_candidate_note", block_ep_c)
+    project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    # ep-A straddles the blocked ep-C (seq 0 < 2 <= 3), so the boundary drops to
+    # ep-A's earliest row: nothing is acknowledged, no revision is dropped.
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 0
+
+    monkeypatch.setattr(candidate_projection, "write_candidate_note", original)
+    replay = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 4
+    ep_a = next(r for r in replay if r.observation_id == "obs-a3")
+    front, _, _ = (Path(vault.active_vault_path) / ep_a.artifact_path).read_text(encoding="utf-8").removeprefix("---\n").partition("\n---\n")
+    frontmatter = yaml.safe_load(front)
+    # The earlier revision survives in the fold lineage -- never dropped.
+    assert frontmatter["superseded_observation_ids"] == ["obs-a0"]
+
+
 def test_projector_restart_resumes_unpersisted_observation(tmp_path: Path) -> None:
     _publish("obs-retry-a", episode_id="ep-retry-a")
     _publish("obs-retry-b", episode_id="ep-retry-b")

--- a/tests/knowledge_acquisition/test_karakeep_candidate_writeback.py
+++ b/tests/knowledge_acquisition/test_karakeep_candidate_writeback.py
@@ -1,0 +1,351 @@
+"""Mimer reading-candidate writeback for the Karakeep handoff (KMA-04, #3375).
+
+Exercises the real production call site
+``app.heimdal.candidate_projection.project_pending_candidates`` end to end
+against the in-memory observation log: published Karakeep evidence becomes a
+governed, review-required ``reading_source_note`` per immutable
+``observation_id``, written behind WriteGuard, with a contiguous-durable-prefix
+consumer cursor. No Karakeep egress, no companion capture.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.events.types import HEIMDAL_OBSERVATION_PUBLISHED
+from app.heimdal import candidate_projection
+from app.heimdal.candidate_projection import (
+    CANDIDATE_CONSUMER_ID,
+    READING_ARTIFACT_CLASS,
+    project_pending_candidates,
+)
+from app.heimdal.cursor_store import get_cursor, reset_memory_cursor_store
+from app.heimdal.observation_log import read_observations_from, reset_memory_observation_log
+from app.heimdal.publish import publish_observation
+from app.heimdal.quarantine import FENCE_CLOSE, FENCE_OPEN
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+
+pytestmark = pytest.mark.not_pg
+
+_HEX = "0123456789abcdef"
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores():
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    yield
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_name="Vault Test",
+        active_vault_path=str(root),
+    )
+
+
+def _allowing_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _blocking_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "safe_mode", "reason": "test-induced block"})
+
+
+def _content_hex(seed: str) -> str:
+    return (seed * 64)[:64]
+
+
+def _karakeep_payload(
+    item_id: str,
+    content_seed: str,
+    *,
+    item_kind: str = "link",
+    source_url: str | None = "https://example.com/read",
+    content: str | None = "a saved note",
+    tags: tuple[str, ...] = (),
+    tombstone: bool = False,
+    sequence: int = 0,
+    supersedes: str | None = None,
+    revision_of: str | None = None,
+) -> tuple[str, dict]:
+    episode_id = f"karakeep:{item_id}"
+    content_hex = _content_hex(content_seed)
+    profile_hex = _content_hex("c")
+    observation_id = f"{episode_id}:{content_hex}:{profile_hex}"
+    karakeep_block: dict = {
+        "item_kind": item_kind,
+        "source_item_identity": episode_id,
+        "tombstone": tombstone,
+    }
+    if source_url and not tombstone:
+        karakeep_block["source_url"] = source_url
+    if tags:
+        karakeep_block["tags"] = list(tags)
+    payload = {
+        "observation_id": observation_id,
+        "episode_id": episode_id,
+        "sequence": sequence,
+        "supersedes": supersedes,
+        "revision_of": revision_of,
+        "content": None if tombstone else content,
+        "raw_ref": f"raw:karakeep:{item_id}:{content_hex[:8]}",
+        "scope_hint": "operator_reading_inbox",
+        "content_structure": {"karakeep": karakeep_block},
+        "provenance": {
+            "sensor": "karakeep_rest",
+            "capture_chain": ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"],
+            "content_identity": f"sha256:{content_hex}",
+            "raw_ref": f"raw:karakeep:{item_id}:{content_hex[:8]}",
+        },
+    }
+    return observation_id, payload
+
+
+def _publish(observation_id: str, payload: dict) -> None:
+    publish_observation(
+        topic=HEIMDAL_OBSERVATION_PUBLISHED,
+        observation_id=observation_id,
+        payload=payload,
+        source="heimdal_karakeep_adapter",
+        stage_versions={"karakeep_adapter": "contract-v1"},
+    )
+
+
+def _frontmatter(vault: VaultContext, artifact_path: str) -> tuple[dict, str]:
+    raw = (Path(vault.active_vault_path) / artifact_path).read_text(encoding="utf-8")
+    front, _, body = raw.removeprefix("---\n").partition("\n---\n")
+    return yaml.safe_load(front), body
+
+
+# ---------------------------------------------------------------------------
+# AC1
+# ---------------------------------------------------------------------------
+
+
+def test_link_note_highlight_mapping_preserves_evidence_and_provenance(tmp_path: Path) -> None:
+    oid_link, p_link = _karakeep_payload("item-link", "a", item_kind="link", source_url="https://example.com/a", content="my saved thought", tags=("ai", "reading"))
+    oid_note, p_note = _karakeep_payload("item-note", "b", item_kind="note", source_url=None, content="a standalone note body")
+    oid_hl, p_hl = _karakeep_payload("item-hl", "d", item_kind="highlight", source_url="https://example.com/h", content="a highlighted passage")
+    _publish(oid_link, p_link)
+    _publish(oid_note, p_note)
+    _publish(oid_hl, p_hl)
+
+    vault = _vault(tmp_path / "vault")
+    results = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+
+    assert [r.status for r in results] == ["written", "written", "written"]
+    by_oid = {r.observation_id: r for r in results}
+
+    fm_link, body_link = _frontmatter(vault, by_oid[oid_link].artifact_path)
+    assert fm_link["artifact_class"] == READING_ARTIFACT_CLASS
+    assert fm_link["provenance"]["sensor"] == "karakeep_rest"
+    assert fm_link["provenance"]["observation_id"] == oid_link
+    assert fm_link["provenance"]["content_identity"] == p_link["provenance"]["content_identity"]
+    assert fm_link["source"]["url"] == "https://example.com/a"
+    assert fm_link["source"]["item_kind"] == "link"
+    assert fm_link["source"]["tags"] == ["ai", "reading"]
+    assert fm_link["authority"] == {"source_authoritative": False, "ai_generated": True, "requires_review": True}
+    assert fm_link["review_state"] == "draft"
+    assert fm_link["triage_state"] == "captured"
+    # Observed text is present only as fenced, quarantined evidence (no fabricated fields).
+    assert FENCE_OPEN in body_link and FENCE_CLOSE in body_link
+    assert "my saved thought" in body_link
+    assert "## Human takeaways" in body_link
+
+    fm_note, body_note = _frontmatter(vault, by_oid[oid_note].artifact_path)
+    assert fm_note["source"]["item_kind"] == "note"
+    assert "a standalone note body" in body_note
+
+    fm_hl, body_hl = _frontmatter(vault, by_oid[oid_hl].artifact_path)
+    assert fm_hl["source"]["item_kind"] == "highlight"
+    assert "a highlighted passage" in body_hl
+
+    # Deterministic, distinct per-item paths under the reading directory.
+    for result in results:
+        assert result.artifact_path.startswith("Sources/Reading/Karakeep/")
+    assert len({r.artifact_path for r in results}) == 3
+
+
+# ---------------------------------------------------------------------------
+# AC2
+# ---------------------------------------------------------------------------
+
+
+def test_reading_candidate_is_review_required_and_first_write_wins(tmp_path: Path) -> None:
+    oid, payload = _karakeep_payload("item-fw", "a", content="original evidence")
+    _publish(oid, payload)
+    vault = _vault(tmp_path / "vault")
+
+    # advance=False keeps the same rows readable so we can assert idempotent
+    # replay of the SAME revision (cursor-advance semantics are covered elsewhere).
+    first = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard(), advance=False)
+    assert first[0].status == "written"
+    note_path = Path(vault.active_vault_path) / first[0].artifact_path
+
+    fm, _ = _frontmatter(vault, first[0].artifact_path)
+    assert fm["authority"]["requires_review"] is True
+    assert fm["authority"]["source_authoritative"] is False
+
+    # A human reviews the note in place (frontmatter provenance preserved).
+    human_edited = note_path.read_text(encoding="utf-8") + "\nMy own human takeaway.\n"
+    note_path.write_text(human_edited, encoding="utf-8")
+
+    # Replaying the same revision is already_exists and never overwrites the
+    # human edit (first-write-wins).
+    second = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard(), advance=False)
+    assert second[0].status == "already_exists"
+    assert "My own human takeaway." in note_path.read_text(encoding="utf-8")
+
+    # A path occupied by a foreign (non-matching) artifact is never overwritten.
+    oid2, payload2 = _karakeep_payload("item-occupied", "b", content="evidence")
+    _publish(oid2, payload2)
+    row2 = next(r for r in read_observations_from(0) if r.envelope["payload"]["observation_id"] == oid2)
+    reading_path = candidate_projection.reading_candidate_note_path(
+        candidate_projection.build_reading_candidate(row2)
+    )
+    occupied = Path(vault.active_vault_path) / reading_path
+    occupied.parent.mkdir(parents=True, exist_ok=True)
+    occupied.write_text("a pre-existing human note, not a candidate", encoding="utf-8")
+    blocked = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard(), advance=False)
+    occupied_result = next(r for r in blocked if r.observation_id == oid2)
+    assert occupied_result.status == "blocked"
+    assert "a pre-existing human note, not a candidate" in occupied.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC3
+# ---------------------------------------------------------------------------
+
+
+def test_reading_candidate_uses_kap_writeback_not_capture(tmp_path: Path) -> None:
+    module_path = Path(candidate_projection.__file__)
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    # The governed write path is WriteGuard + write_note_relative -- never
+    # companion capture or the /api/capture route family (KMA-INV boundary).
+    forbidden = ("app.heimdal.capture_adapter", "app.heimdal.capture_note", "app.heimdal.capture_runtime", "app.api.routes")
+    assert not any(name.startswith(forbidden) for name in imported)
+    assert "app.write_guard" in imported
+    assert "app.knowledge.write_ops" in imported
+    source = module_path.read_text(encoding="utf-8")
+    assert "/api/capture" not in source
+
+    # WriteGuard actually gates the write: a blocked guard yields a blocked,
+    # re-runnable result rather than a silent write.
+    oid, payload = _karakeep_payload("item-guard", "a")
+    _publish(oid, payload)
+    vault = _vault(tmp_path / "vault")
+    blocked = project_pending_candidates(vault_context=vault, write_guard=_blocking_guard())
+    assert blocked[0].status == "blocked"
+    assert not list((Path(vault.active_vault_path) / "Sources/Reading/Karakeep").glob("*.md")) if (Path(vault.active_vault_path) / "Sources/Reading/Karakeep").exists() else True
+
+
+# ---------------------------------------------------------------------------
+# AC5 (blocked/idempotent) + KMA-01 batch (two revisions + tombstone) + prefix
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_write_retries_idempotently(tmp_path: Path) -> None:
+    oid, payload = _karakeep_payload("item-retry", "a")
+    _publish(oid, payload)
+    vault = _vault(tmp_path / "vault")
+
+    blocked = project_pending_candidates(vault_context=vault, write_guard=_blocking_guard())
+    assert blocked[0].status == "blocked"
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 0
+
+    retried = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    assert retried[0].status == "written"
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 1
+
+    again = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    assert again == []  # nothing new; cursor already past it
+    notes = list((Path(vault.active_vault_path) / "Sources/Reading/Karakeep").glob("*.md"))
+    assert len(notes) == 1  # no duplicate note
+
+
+def test_two_revisions_and_tombstone_in_one_batch(tmp_path: Path) -> None:
+    oid0, p0 = _karakeep_payload("item-9", "a", content="first version", sequence=0)
+    oid1, p1 = _karakeep_payload("item-9", "d", content="edited version", sequence=1, supersedes=oid0)
+    oid_tomb, p_tomb = _karakeep_payload("item-9", "e", tombstone=True, sequence=2, supersedes=oid1)
+    _publish(oid0, p0)
+    _publish(oid1, p1)
+    _publish(oid_tomb, p_tomb)
+
+    vault = _vault(tmp_path / "vault")
+    results = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+
+    # One candidate per immutable observation_id -- NOT folded onto the shared
+    # episode. Three distinct notes at three distinct paths.
+    assert [r.status for r in results] == ["written", "written", "written"]
+    assert len({r.artifact_path for r in results}) == 3
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 3
+
+    by_oid = {r.observation_id: r for r in results}
+    fm0, body0 = _frontmatter(vault, by_oid[oid0].artifact_path)
+    fm1, body1 = _frontmatter(vault, by_oid[oid1].artifact_path)
+    fm_t, body_t = _frontmatter(vault, by_oid[oid_tomb].artifact_path)
+
+    assert "first version" in body0
+    assert "edited version" in body1
+    assert fm1["provenance"]["supersedes"] == oid0
+    # Tombstone: review-required, links the prior revision, deletes nothing.
+    assert fm_t["tombstone"] is True
+    assert fm_t["prior_revision"] == oid1
+    assert fm_t["authority"]["requires_review"] is True
+    assert "tombstone" in body_t.lower()
+    # Prior revisions untouched by the tombstone.
+    assert "first version" in (Path(vault.active_vault_path) / by_oid[oid0].artifact_path).read_text(encoding="utf-8")
+    assert "edited version" in (Path(vault.active_vault_path) / by_oid[oid1].artifact_path).read_text(encoding="utf-8")
+
+
+def test_blocked_middle_row_advances_only_durable_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    published = []
+    for idx, item in enumerate(("a", "b", "c", "d")):
+        oid, payload = _karakeep_payload(f"item-{item}", item, sequence=0)
+        _publish(oid, payload)
+        published.append(oid)
+    vault = _vault(tmp_path / "vault")
+
+    original = candidate_projection.write_reading_candidate_note
+
+    def block_c(candidate, **kwargs):
+        if candidate.item_id == "item-c":
+            return candidate_projection.CandidateWriteResult(
+                status="blocked", artifact_path=None, observation_id=candidate.observation_id, reason="test block"
+            )
+        return original(candidate, **kwargs)
+
+    monkeypatch.setattr(candidate_projection, "write_reading_candidate_note", block_c)
+    partial = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    assert [r.status for r in partial] == ["written", "written", "blocked", "written"]
+    # Contiguous durable prefix stops at the blocked row: only a, b acknowledged.
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 2
+
+    monkeypatch.setattr(candidate_projection, "write_reading_candidate_note", original)
+    replay = project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+    # c and d replay (never skipped); a and b already advanced, not re-read.
+    # d was durably WRITTEN in the partial run (only c was blocked) but not
+    # acknowledged past the blocked prefix, so its replay is already_exists --
+    # proving the later success was neither skipped nor duplicated (KMA-INV-3).
+    assert [r.observation_id for r in replay] == [published[2], published[3]]
+    assert [r.status for r in replay] == ["written", "already_exists"]
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 4
+    notes = list((Path(vault.active_vault_path) / "Sources/Reading/Karakeep").glob("*.md"))
+    assert len(notes) == 4  # a, b, c, d -- no duplicates

--- a/tests/knowledge_acquisition/test_karakeep_handoff_consumer.py
+++ b/tests/knowledge_acquisition/test_karakeep_handoff_consumer.py
@@ -1,13 +1,21 @@
-"""Executable design check for the Mimer side of the Karakeep handoff (#3372)."""
+"""Executable design check for the Mimer side of the Karakeep handoff (#3372, #3375)."""
 
 from __future__ import annotations
 
+import ast
 import inspect
 from pathlib import Path
 
 import pytest
 
+from app.events.types import HEIMDAL_OBSERVATION_PUBLISHED
 from app.heimdal import candidate_projection
+from app.heimdal.candidate_projection import CANDIDATE_CONSUMER_ID, project_pending_candidates
+from app.heimdal.cursor_store import get_cursor, reset_memory_cursor_store
+from app.heimdal.observation_log import reset_memory_observation_log
+from app.heimdal.publish import publish_observation
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
 
 pytestmark = pytest.mark.not_pg
 
@@ -38,7 +46,10 @@ def test_contract_extends_existing_mimer_projector_without_parallel_consumer() -
     assert candidate_projection.CANDIDATE_CONSUMER_ID == "mimer.candidate_projector"
     assert "read_observations_for_consumer(consumer_id" in projector_source
     assert "write_candidate_note(" in projector_source
-    assert "advance_cursor_for_consumer(consumer_id, rows)" in projector_source
+    # KMA-04 delivered the contiguous-durable-prefix advance the contract below
+    # requires: the projector still advances only through the one sanctioned
+    # cursor seam, now across the durable prefix instead of the whole batch.
+    assert "advance_cursor_for_consumer(consumer_id, prefix)" in projector_source
     # KMA-01 names the necessary KMA-04 repair rather than claiming the
     # current whole-batch advance is already safe for blocked writes.
     assert "KMA-04 must change that\nbehavior before enabling Karakeep projection" in contract
@@ -53,3 +64,63 @@ def test_contract_extends_existing_mimer_projector_without_parallel_consumer() -
         "Karakeep MCP",
     ):
         assert f"forbids `{forbidden}`" in contract
+
+
+def test_consumer_starts_at_handoff_and_owns_only_consumer_cursor(tmp_path: Path) -> None:
+    """The Mimer consumer reads only published evidence (zero Karakeep egress /
+    re-attribution) and advances only its own cursor after a durable outcome."""
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    try:
+        # Zero egress: the consumer module never imports the Karakeep source
+        # adapter or any network/re-attribution path.
+        tree = ast.parse(Path(candidate_projection.__file__).read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(a.name for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        assert "app.heimdal.karakeep_ingest" not in imported
+        assert not any(name in {"httpx", "requests"} for name in imported)
+
+        content_hex = ("a" * 64)
+        observation_id = f"karakeep:item-c:{content_hex}:{'c' * 64}"
+        publish_observation(
+            topic=HEIMDAL_OBSERVATION_PUBLISHED,
+            observation_id=observation_id,
+            payload={
+                "observation_id": observation_id,
+                "episode_id": "karakeep:item-c",
+                "sequence": 0,
+                "content": "saved reading evidence",
+                "raw_ref": "raw:karakeep:item-c:aaaa",
+                "content_structure": {"karakeep": {"item_kind": "link", "source_item_identity": "karakeep:item-c", "tombstone": False, "source_url": "https://example.com/c"}},
+                "provenance": {
+                    "sensor": "karakeep_rest",
+                    "capture_chain": ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"],
+                    "content_identity": f"sha256:{content_hex}",
+                },
+            },
+            source="heimdal_karakeep_adapter",
+            stage_versions={"karakeep_adapter": "contract-v1"},
+        )
+
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir(parents=True, exist_ok=True)
+        vault = VaultContext(status="selected", active_vault_id="v", active_vault_name="V", active_vault_path=str(vault_root))
+
+        results = project_pending_candidates(vault_context=vault, write_guard=WriteGuard(lambda: {"state": "healthy"}))
+        assert [r.status for r in results] == ["written"]
+
+        # Provenance is reused from the published evidence, not re-derived.
+        note = (vault_root / results[0].artifact_path).read_text(encoding="utf-8")
+        assert "sensor: karakeep_rest" in note
+        assert observation_id in note
+
+        # Advances ONLY its own consumer cursor; a different consumer is untouched.
+        assert get_cursor(CANDIDATE_CONSUMER_ID) == 1
+        assert get_cursor("some.other.consumer") == 0
+    finally:
+        reset_memory_observation_log()
+        reset_memory_cursor_store()


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

Final-Review-Rounds: 2

Governing-Issue: #3375

## Linked Issue
Fixes #3375

## Summary
Implements KMA-04: extends `app.heimdal.candidate_projection.project_pending_candidates` to consume the durable published Karakeep evidence and materialize governed, review-required `reading_source_note` candidates. Karakeep observations (`provenance.sensor == karakeep_rest`) produce one candidate per immutable `observation_id` (never the generic episode fold), at the deterministic first-write-wins path `Sources/Reading/Karakeep/<item-id>-<revision-prefix>.md`, written behind the same WriteGuard/`write_note_relative` call site — never companion capture or `/api/capture`. A source update, reprocess, or tombstone lands at a new path and never overwrites a prior or human-reviewed note; a tombstone is a review-required candidate linked to the prior revision, not a delete. The consumer performs zero Karakeep egress or re-attribution and advances its own cursor only across the contiguous durable prefix of rows. Non-Karakeep observations keep the existing episode fold unchanged.

## SBS Impact
- Primary subsystem: Mimer/DRI at the Heimdal published-evidence handoff
- Secondary subsystem(s): HKA, SIP, GOV (governed candidate write, review-required)
- Write class: derived assembly + governed draft-note write (no promotion)
- Authority impact: none — reading candidates are structurally `requires_review: true` / `source_authoritative: false`; no governed-promotion path
- Persistence impact: durable review-required candidate notes at deterministic paths; Mimer consumer cursor advances only a contiguous durable prefix
- Derived/rebuildable impact: candidate assembly is replayable from published evidence with zero Karakeep egress
- Human knowledge impact: creates draft/review-required reading candidates only; no auto-promotion; never overwrites a human-reviewed note
- Memory impact: none
- Retrieval/context impact: none (no index change)
- Sync/deployment impact: none
- External boundary impact: none — consumer never contacts Karakeep (KMA-INV-4)
- New or changed contract: implements the KMA-01 additive `reading_source_note` mapping; no contract change
- Owner-doc impact: no owner-doc change implied (implements, does not change, the named contract; current-state promotion deferred to parent #3367 acceptance)
- Transition debt impact: reduces the read-later→Mimer gap under ADR-0049
- Fitness rule impact: strengthens governed-write, cursor/replay idempotency, and Heimdal→Mimer boundary integrity
- Boundary risk: none — one consumer cursor, no second consumer/projector/read path

## Owner-Doc Writeback
- [x] No owner-doc change implied.

The KMA-01 contract already fixes the `reading_source_note` mapping, tombstone no-delete behaviour, deterministic path, and WriteGuard materialization; this PR implements it. Current-state owner docs stay honest until parent #3367 acceptance (KMA-06).

## Acceptance Criteria → Verify targets (all green)
- AC1 link/note/highlight mapping preserves evidence + provenance → `tests/knowledge_acquisition/test_karakeep_candidate_writeback.py::test_link_note_highlight_mapping_preserves_evidence_and_provenance`
- AC2 review-required + first-write-wins (no promote/overwrite) → `::test_reading_candidate_is_review_required_and_first_write_wins`
- AC3 KAP WriteGuard/writeback, never capture → `::test_reading_candidate_uses_kap_writeback_not_capture`
- AC4 zero egress/re-attribution, own-cursor-only → `tests/knowledge_acquisition/test_karakeep_handoff_consumer.py::test_consumer_starts_at_handoff_and_owns_only_consumer_cursor`
- AC5 blocked/failed writes retry idempotently → `tests/knowledge_acquisition/test_karakeep_candidate_writeback.py::test_blocked_write_retries_idempotently`

Plus KMA-01 batch requirements: `::test_two_revisions_and_tombstone_in_one_batch` (one candidate per observation_id, tombstone links prior) and `::test_blocked_middle_row_advances_only_durable_prefix` (contiguous-prefix advance), and a fold-straddle cursor-safety regression `tests/heimdal/test_projector.py::test_interleaved_fold_straddling_a_blocked_unit_does_not_skip`.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract change; N/A.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Deferred to parent acceptance; no premature promotion.)

## Validation
- [x] `ruff check app tests` — clean
- [x] `mypy app` — clean (807 files)
- [x] `pytest tests/knowledge_acquisition/test_karakeep_candidate_writeback.py tests/knowledge_acquisition/test_karakeep_handoff_consumer.py` — green
- [x] Regression: `pytest tests/heimdal/test_projector.py tests/knowledge_acquisition/test_candidate_writeback.py tests/knowledge_acquisition/test_replay.py` — green (non-Karakeep fold path unchanged)
- Independent adversarial review found a real cursor-safety defect (durable-prefix watermark could skip a straddling fold unit's earlier row on an interleaved heimdal batch); fixed with a boundary-lowering algorithm + regression test; re-review clean. Two independent clean rounds total.

## Claim receipt
`pickup-claim-complete issue=3375 coordination_mode=github-label-only-fallback fallback_reason=dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-3375 absent (issue was agent:blocked until #3374 merged; not synced into dispatcher queue) agent=claude-opus-kma04 evidence=github-comment:5063421814`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Product/Runtime implementation slice (Mimer/DRI refinement at the Heimdal handoff). One plan divergence noted (dispatcher-queue-absent → sanctioned GitHub-label-only fallback per AGENTS.md); no Builder-System artifact produced.

## Notes
- Residual risk: low. The generalized durable-prefix advance was hardened against fold-straddle interleaving; the pure-Karakeep path is single-row (exact advance).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
