### PR TITLE
Add coordinated Karakeep producer/consumer scheduling (KMA-05)

### DIFF
--- a/app/heimdal/karakeep_schedule.py
+++ b/app/heimdal/karakeep_schedule.py
@@ -1,0 +1,422 @@
+"""Coordinated Karakeep producer/consumer scheduling (KMA-05, #3377).
+
+Turns the two proven one-shot halves -- the Heimdal producer
+(``app.heimdal.karakeep_ingest.KarakeepAdapter`` gated by
+``app.heimdal.karakeep_service.assert_fetch_ready``) and the Mimer consumer
+(``app.heimdal.candidate_projection.project_pending_candidates``) -- into
+bounded, unattended acquisition WITHOUT merging their ownership.
+
+Coordination happens only through the durable published-evidence handoff
+(KMA-INV-4): this module never makes an in-process cross-constituent call or a
+shared transaction, and it holds no shared execution lock. Each constituent has:
+
+- its own bounded run entrypoint (:func:`run_producer` / :func:`run_consumer`);
+- its own independent lease (:data:`PRODUCER_LEASE` / :data:`CONSUMER_LEASE`),
+  so a run only excludes another run of the *same* side, never the other side;
+- its own durable cursor (Heimdal's producer cursor; Mimer's consumer cursor),
+  which schedule state can never substitute for;
+- a truthful, secret-safe receipt.
+
+Karakeep health gates ONLY the Heimdal fetch; the Mimer consumer may drain the
+durable handoff while Karakeep is down (KMA-INV-5). Either half may fail, lag, or
+overlap without falsifying the other half's durable success -- the combined
+:class:`BoundaryReceipt` reports each side independently.
+
+Secret containment (KMA-INV-6): receipts carry counts, a status class, and a
+secret-free gate reason code only -- never an endpoint, token, or raw provider
+output.
+
+Bounding (timeout/backoff): each run is a single bounded pass -- the producer's
+page budget and the consumer's read batch bound the work per run, and the lease
+TTL bounds how long a crashed holder can hold its side before the lease expires
+and the next run may proceed. Inter-run backoff and the poll interval belong to
+the driving loop (shaped like ``app.heimdal.capture_runtime.run_forever``), not
+to these bounded one-shot entrypoints; wiring a live driver is deferred to the
+acceptance slice (KMA-06).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from app.heimdal.karakeep_service import (
+    KarakeepServiceConfigError,
+    KarakeepServiceUnhealthyError,
+    assert_fetch_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+PRODUCER_LEASE = "karakeep.producer"
+CONSUMER_LEASE = "karakeep.consumer"
+
+DEFAULT_LEASE_TTL_SECONDS = 900.0
+
+# A monotonic clock is the default; tests inject a deterministic one.
+_MONOTONIC = time.monotonic
+
+
+# ---------------------------------------------------------------------------
+# Independent per-constituent leases (no shared execution lock)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Lease:
+    key: str
+    holder: str
+    expires_at: float
+
+
+class LeaseStore:
+    """In-process leases keyed per constituent. Acquiring one key never blocks a
+    different key, so the producer and consumer sides are independent; a second
+    acquire of the *same* live key by a different holder is refused, preventing
+    same-side overlap without a cross-side lock. Process-durable and injectable;
+    a real deployment wires a cross-process backing through the same surface."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._leases: dict[str, Lease] = {}
+
+    def acquire(self, key: str, holder: str, *, ttl_seconds: float, now: float) -> Optional[Lease]:
+        with self._lock:
+            existing = self._leases.get(key)
+            if existing is not None and existing.expires_at > now and existing.holder != holder:
+                return None
+            lease = Lease(key=key, holder=holder, expires_at=now + ttl_seconds)
+            self._leases[key] = lease
+            return lease
+
+    def release(self, key: str, holder: str) -> None:
+        with self._lock:
+            existing = self._leases.get(key)
+            if existing is not None and existing.holder == holder:
+                del self._leases[key]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._leases.clear()
+
+
+_DEFAULT_LEASE_STORE = LeaseStore()
+
+
+def default_lease_store() -> LeaseStore:
+    return _DEFAULT_LEASE_STORE
+
+
+def reset_lease_store() -> None:
+    """Test-only reset hook, mirroring the other Heimdal memory-store resets."""
+    _DEFAULT_LEASE_STORE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Receipts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProducerReceipt:
+    """Heimdal producer outcome. Secret-free (counts + status class + reason code)."""
+
+    ran: bool
+    lease_conflict: bool
+    gated: bool
+    gate_reason: Optional[str]
+    fetched: int
+    published: int
+    noops: int
+    item_errors: int
+    stopped_early: bool
+    failed: bool
+    producer_cursor: Optional[str]
+    constituent: str = "heimdal"
+
+
+@dataclass(frozen=True)
+class ConsumerReceipt:
+    """Mimer consumer outcome. Independent of the producer's success."""
+
+    ran: bool
+    lease_conflict: bool
+    consumed: int
+    written: int
+    already_exists: int
+    blocked: int
+    failed: bool
+    consumer_cursor: Optional[int]
+    constituent: str = "mimer"
+
+
+@dataclass(frozen=True)
+class BoundaryReceipt:
+    """The combined operator receipt: each constituent reported truthfully and
+    independently. A failed/gated producer never falsifies the consumer half."""
+
+    producer: ProducerReceipt
+    consumer: ConsumerReceipt
+
+
+# ---------------------------------------------------------------------------
+# Health gate (wraps the KMA-02 fetch-readiness gate into the scheduler contract)
+# ---------------------------------------------------------------------------
+
+
+def source_health_gate(
+    env: Optional[Any] = None, *, http: Optional[Any] = None
+) -> Optional[str]:
+    """The real Heimdal-fetch health gate: ``None`` when fetch-ready, else a
+    secret-safe reason code. Delegates to
+    ``app.heimdal.karakeep_service.assert_fetch_ready`` -- config absence and red
+    health both refuse the fetch, and neither the endpoint nor the token appears
+    in the returned code (KMA-INV-6)."""
+    try:
+        assert_fetch_ready(env=env, http=http)
+        return None
+    except KarakeepServiceConfigError:
+        return "config_absent"
+    except KarakeepServiceUnhealthyError:
+        return "source_unhealthy"
+
+
+# ---------------------------------------------------------------------------
+# Bounded runs
+# ---------------------------------------------------------------------------
+
+
+def run_producer(
+    *,
+    holder: str,
+    health_gate: Callable[[], Optional[str]],
+    acquire: Callable[[], Any],
+    read_producer_cursor: Callable[[], Optional[str]],
+    lease_store: Optional[LeaseStore] = None,
+    ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+    clock: Callable[[], float] = _MONOTONIC,
+) -> ProducerReceipt:
+    """One bounded Heimdal producer run under the producer lease.
+
+    ``health_gate`` returns ``None`` when the source is fetch-ready, else a
+    secret-safe reason code (e.g. ``"config_absent"`` / ``"source_unhealthy"``);
+    when gated, no fetch runs and the producer cursor is untouched. ``acquire``
+    is a bounded fetch/publish pass returning an
+    ``app.heimdal.karakeep_ingest.AcquisitionResult``; its failure is isolated so
+    the schedule survives, and because Heimdal's cursor only advances on durable
+    publication (KMA-INV-3), a failed or gated run cannot regress it.
+    """
+    store = lease_store or default_lease_store()
+    now = clock()
+    lease = store.acquire(PRODUCER_LEASE, holder, ttl_seconds=ttl_seconds, now=now)
+    if lease is None:
+        logger.info("Karakeep producer run skipped: producer lease held by another runner")
+        return _producer_conflict(read_producer_cursor)
+
+    try:
+        reason = health_gate()
+        if reason is not None:
+            logger.info("Karakeep producer fetch gated (reason=%s); Mimer replay is unaffected", reason)
+            return ProducerReceipt(
+                ran=True,
+                lease_conflict=False,
+                gated=True,
+                gate_reason=reason,
+                fetched=0,
+                published=0,
+                noops=0,
+                item_errors=0,
+                stopped_early=False,
+                failed=False,
+                producer_cursor=_safe_cursor(read_producer_cursor),
+            )
+        try:
+            result = acquire()
+        except Exception as exc:  # noqa: BLE001 -- one bad run must not kill the schedule
+            logger.error("Karakeep producer run failed: %s", type(exc).__name__)
+            return ProducerReceipt(
+                ran=True,
+                lease_conflict=False,
+                gated=False,
+                gate_reason=None,
+                fetched=0,
+                published=0,
+                noops=0,
+                item_errors=0,
+                stopped_early=True,
+                failed=True,
+                producer_cursor=_safe_cursor(read_producer_cursor),
+            )
+        return ProducerReceipt(
+            ran=True,
+            lease_conflict=False,
+            gated=False,
+            gate_reason=None,
+            fetched=int(getattr(result, "fetched", 0)),
+            published=len(getattr(result, "published", ()) or ()),
+            noops=int(getattr(result, "noops", 0)),
+            item_errors=len(getattr(result, "item_errors", ()) or ()),
+            stopped_early=bool(getattr(result, "stopped_early", False)),
+            failed=False,
+            producer_cursor=_safe_cursor(read_producer_cursor),
+        )
+    finally:
+        store.release(PRODUCER_LEASE, holder)
+
+
+def run_consumer(
+    *,
+    holder: str,
+    project: Callable[[], list[Any]],
+    read_consumer_cursor: Callable[[], int],
+    lease_store: Optional[LeaseStore] = None,
+    ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+    clock: Callable[[], float] = _MONOTONIC,
+) -> ConsumerReceipt:
+    """One bounded Mimer consumer run under the consumer lease.
+
+    No health gate: the consumer drains the durable handoff regardless of
+    Karakeep availability (KMA-INV-4). ``project`` is a bounded materialization
+    pass returning ``app.heimdal.candidate_projection.CandidateWriteResult``
+    rows; its failure is isolated and Mimer's consumer cursor only advances
+    across a contiguous durable prefix, so a failure preserves it (KMA-INV-3).
+    """
+    store = lease_store or default_lease_store()
+    now = clock()
+    lease = store.acquire(CONSUMER_LEASE, holder, ttl_seconds=ttl_seconds, now=now)
+    if lease is None:
+        logger.info("Karakeep consumer run skipped: consumer lease held by another runner")
+        return _consumer_conflict(read_consumer_cursor)
+
+    try:
+        try:
+            results = project()
+        except Exception as exc:  # noqa: BLE001 -- one bad run must not kill the schedule
+            logger.error("Karakeep consumer run failed: %s", type(exc).__name__)
+            return ConsumerReceipt(
+                ran=True,
+                lease_conflict=False,
+                consumed=0,
+                written=0,
+                already_exists=0,
+                blocked=0,
+                failed=True,
+                consumer_cursor=_safe_int_cursor(read_consumer_cursor),
+            )
+        statuses = [getattr(r, "status", "") for r in results]
+        return ConsumerReceipt(
+            ran=True,
+            lease_conflict=False,
+            consumed=len(results),
+            written=statuses.count("written"),
+            already_exists=statuses.count("already_exists"),
+            blocked=statuses.count("blocked"),
+            failed=False,
+            consumer_cursor=_safe_int_cursor(read_consumer_cursor),
+        )
+    finally:
+        store.release(CONSUMER_LEASE, holder)
+
+
+def run_boundary_cycle(
+    *,
+    holder: str,
+    health_gate: Callable[[], Optional[str]],
+    acquire: Callable[[], Any],
+    read_producer_cursor: Callable[[], Optional[str]],
+    project: Callable[[], list[Any]],
+    read_consumer_cursor: Callable[[], int],
+    lease_store: Optional[LeaseStore] = None,
+    ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+    clock: Callable[[], float] = _MONOTONIC,
+) -> BoundaryReceipt:
+    """Run one bounded producer pass and one bounded consumer pass.
+
+    The consumer runs regardless of the producer's outcome (gated, failed, or
+    overlapping), because it consumes only the already-durable handoff. The two
+    sides never share a lock and never call each other in process.
+    """
+    store = lease_store or default_lease_store()
+    producer = run_producer(
+        holder=holder,
+        health_gate=health_gate,
+        acquire=acquire,
+        read_producer_cursor=read_producer_cursor,
+        lease_store=store,
+        ttl_seconds=ttl_seconds,
+        clock=clock,
+    )
+    consumer = run_consumer(
+        holder=holder,
+        project=project,
+        read_consumer_cursor=read_consumer_cursor,
+        lease_store=store,
+        ttl_seconds=ttl_seconds,
+        clock=clock,
+    )
+    return BoundaryReceipt(producer=producer, consumer=consumer)
+
+
+def _producer_conflict(read_producer_cursor: Callable[[], Optional[str]]) -> ProducerReceipt:
+    return ProducerReceipt(
+        ran=False,
+        lease_conflict=True,
+        gated=False,
+        gate_reason=None,
+        fetched=0,
+        published=0,
+        noops=0,
+        item_errors=0,
+        stopped_early=False,
+        failed=False,
+        producer_cursor=_safe_cursor(read_producer_cursor),
+    )
+
+
+def _consumer_conflict(read_consumer_cursor: Callable[[], int]) -> ConsumerReceipt:
+    return ConsumerReceipt(
+        ran=False,
+        lease_conflict=True,
+        consumed=0,
+        written=0,
+        already_exists=0,
+        blocked=0,
+        failed=False,
+        consumer_cursor=_safe_int_cursor(read_consumer_cursor),
+    )
+
+
+def _safe_cursor(read: Callable[[], Optional[str]]) -> Optional[str]:
+    try:
+        return read()
+    except Exception:  # noqa: BLE001 -- a cursor read failure must not break the receipt
+        return None
+
+
+def _safe_int_cursor(read: Callable[[], int]) -> Optional[int]:
+    try:
+        return read()
+    except Exception:  # noqa: BLE001 -- a cursor read failure must not break the receipt
+        return None
+
+
+__all__ = [
+    "CONSUMER_LEASE",
+    "DEFAULT_LEASE_TTL_SECONDS",
+    "PRODUCER_LEASE",
+    "BoundaryReceipt",
+    "ConsumerReceipt",
+    "Lease",
+    "LeaseStore",
+    "ProducerReceipt",
+    "default_lease_store",
+    "reset_lease_store",
+    "run_boundary_cycle",
+    "run_consumer",
+    "run_producer",
+    "source_health_gate",
+]

--- a/tests/heimdal/test_karakeep_schedule.py
+++ b/tests/heimdal/test_karakeep_schedule.py
@@ -1,0 +1,266 @@
+"""Coordinated Karakeep producer/consumer scheduling (KMA-05, #3377).
+
+Exercises the scheduler's lease independence, health gating, cursor preservation,
+and truthful secret-safe receipts. The Mimer consumer runs against the real
+``project_pending_candidates`` over a temp vault and real published evidence, so
+"health gates the producer, not the consumer" is proven end to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.events.types import HEIMDAL_OBSERVATION_PUBLISHED
+from app.heimdal import karakeep_schedule
+from app.heimdal.candidate_projection import CANDIDATE_CONSUMER_ID, project_pending_candidates
+from app.heimdal.cursor_store import get_cursor, reset_memory_cursor_store
+from app.heimdal.karakeep_schedule import (
+    CONSUMER_LEASE,
+    PRODUCER_LEASE,
+    LeaseStore,
+    run_boundary_cycle,
+    run_consumer,
+    run_producer,
+    source_health_gate,
+)
+from app.heimdal.observation_log import reset_memory_observation_log
+from app.heimdal.publish import publish_observation
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+
+pytestmark = pytest.mark.not_pg
+
+_SECRET_BASE_URL = "https://karakeep.secret.example"
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores():
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    karakeep_schedule.reset_lease_store()
+    yield
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    karakeep_schedule.reset_lease_store()
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext(status="selected", active_vault_id="v", active_vault_name="V", active_vault_path=str(root))
+
+
+def _allowing_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _publish_karakeep(item_id: str, seed: str) -> str:
+    content_hex = (seed * 64)[:64]
+    observation_id = f"karakeep:{item_id}:{content_hex}:{'c' * 64}"
+    publish_observation(
+        topic=HEIMDAL_OBSERVATION_PUBLISHED,
+        observation_id=observation_id,
+        payload={
+            "observation_id": observation_id,
+            "episode_id": f"karakeep:{item_id}",
+            "sequence": 0,
+            "content": "saved reading evidence",
+            "content_structure": {"karakeep": {"item_kind": "link", "source_item_identity": f"karakeep:{item_id}", "tombstone": False, "source_url": "https://example.com/x"}},
+            "provenance": {"sensor": "karakeep_rest", "capture_chain": ["karakeep", "karakeep_rest", "heimdal_karakeep_adapter"], "content_identity": f"sha256:{content_hex}"},
+        },
+        source="heimdal_karakeep_adapter",
+        stage_versions={"karakeep_adapter": "contract-v1"},
+    )
+    return observation_id
+
+
+def _real_consumer(vault: VaultContext):
+    def _project():
+        return project_pending_candidates(vault_context=vault, write_guard=_allowing_guard())
+
+    return _project
+
+
+def _read_consumer_cursor() -> int:
+    return get_cursor(CANDIDATE_CONSUMER_ID)
+
+
+# ---------------------------------------------------------------------------
+# AC1
+# ---------------------------------------------------------------------------
+
+
+def test_source_health_gates_producer_not_consumer(tmp_path: Path) -> None:
+    _publish_karakeep("item-1", "a")
+    vault = _vault(tmp_path / "vault")
+
+    fetch_calls: list[int] = []
+
+    def _should_not_fetch():
+        fetch_calls.append(1)
+        raise AssertionError("producer must not fetch while the source is unhealthy")
+
+    # Real health gate against an unhealthy (503) source with a secret endpoint.
+    def _unhealthy(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    env = {"KARAKEEP_BASE_URL": _SECRET_BASE_URL, "KARAKEEP_API_TOKEN": "tok"}
+    http = httpx.Client(transport=httpx.MockTransport(_unhealthy))
+
+    receipt = run_boundary_cycle(
+        holder="runner-1",
+        health_gate=lambda: source_health_gate(env, http=http),
+        acquire=_should_not_fetch,
+        read_producer_cursor=lambda: None,
+        project=_real_consumer(vault),
+        read_consumer_cursor=_read_consumer_cursor,
+    )
+
+    # Producer is gated: no fetch, no publish.
+    assert receipt.producer.gated is True
+    assert receipt.producer.gate_reason == "source_unhealthy"
+    assert receipt.producer.published == 0
+    assert fetch_calls == []
+    # Consumer drains the durable handoff regardless of source health.
+    assert receipt.consumer.written == 1
+    assert receipt.consumer.consumer_cursor == 1
+
+
+# ---------------------------------------------------------------------------
+# AC2
+# ---------------------------------------------------------------------------
+
+
+def test_constituent_leases_are_independent() -> None:
+    store = LeaseStore()
+    now = 100.0
+
+    # Producer and consumer leases are independent -- one never blocks the other.
+    assert store.acquire(PRODUCER_LEASE, "A", ttl_seconds=90, now=now) is not None
+    assert store.acquire(CONSUMER_LEASE, "B", ttl_seconds=90, now=now) is not None
+
+    # Same-side overlap is refused (no double producer run) ...
+    assert store.acquire(PRODUCER_LEASE, "C", ttl_seconds=90, now=now) is None
+    # ... but there is no shared cross-side lock.
+    store.release(PRODUCER_LEASE, "A")
+    assert store.acquire(PRODUCER_LEASE, "C", ttl_seconds=90, now=now) is not None
+
+    # At the run level: a producer lease held elsewhere blocks a producer run but
+    # never the consumer run (independent sides).
+    run_store = LeaseStore()
+    run_store.acquire(PRODUCER_LEASE, "other-runner", ttl_seconds=90, now=now)
+    producer = run_producer(
+        holder="me",
+        health_gate=lambda: None,
+        acquire=lambda: pytest.fail("must not fetch under a lease conflict"),
+        read_producer_cursor=lambda: "cursor-x",
+        lease_store=run_store,
+        clock=lambda: now,
+    )
+    assert producer.lease_conflict is True and producer.ran is False
+    consumer = run_consumer(
+        holder="me",
+        project=lambda: [],
+        read_consumer_cursor=lambda: 0,
+        lease_store=run_store,
+        clock=lambda: now,
+    )
+    assert consumer.lease_conflict is False and consumer.ran is True
+
+
+# ---------------------------------------------------------------------------
+# AC3
+# ---------------------------------------------------------------------------
+
+
+def test_failed_or_overlapping_run_preserves_constituent_cursors(tmp_path: Path) -> None:
+    _publish_karakeep("item-a", "a")
+    vault = _vault(tmp_path / "vault")
+
+    # First consumer run drains one item and advances the consumer cursor.
+    first = run_consumer(holder="c1", project=_real_consumer(vault), read_consumer_cursor=_read_consumer_cursor)
+    assert first.written == 1
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 1
+
+    # A failed producer run does not regress the producer cursor.
+    producer_cursor = {"value": "page:2"}
+    failed = run_producer(
+        holder="p1",
+        health_gate=lambda: None,
+        acquire=lambda: (_ for _ in ()).throw(RuntimeError("transient fetch failure")),
+        read_producer_cursor=lambda: producer_cursor["value"],
+    )
+    assert failed.failed is True
+    assert failed.producer_cursor == "page:2"  # unchanged by the failure
+
+    # An overlapping consumer run (lease held elsewhere) does not advance/regress
+    # the consumer cursor.
+    karakeep_schedule.default_lease_store().acquire(CONSUMER_LEASE, "other", ttl_seconds=90, now=0.0)
+    overlapped = run_consumer(holder="c2", project=_real_consumer(vault), read_consumer_cursor=_read_consumer_cursor, clock=lambda: 0.0)
+    assert overlapped.lease_conflict is True
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 1  # untouched
+    karakeep_schedule.default_lease_store().release(CONSUMER_LEASE, "other")
+
+    # Restart / replay is idempotent: nothing new, no duplicate, cursor stable.
+    resumed = run_consumer(holder="c3", project=_real_consumer(vault), read_consumer_cursor=_read_consumer_cursor)
+    assert resumed.consumed == 0
+    assert get_cursor(CANDIDATE_CONSUMER_ID) == 1
+    notes = list((tmp_path / "vault" / "Sources/Reading/Karakeep").glob("*.md"))
+    assert len(notes) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC4
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_receipt_reports_each_constituent_truthfully(tmp_path: Path) -> None:
+    _publish_karakeep("item-x", "a")
+    vault = _vault(tmp_path / "vault")
+
+    class _Result:
+        fetched = 3
+        published = ("karakeep:item-x:aa:cc", "karakeep:item-y:bb:cc")
+        noops = 1
+        item_errors = ("err",)
+        stopped_early = False
+
+    receipt = run_boundary_cycle(
+        holder="runner",
+        health_gate=lambda: None,
+        acquire=lambda: _Result(),
+        read_producer_cursor=lambda: "page:5",
+        project=_real_consumer(vault),
+        read_consumer_cursor=_read_consumer_cursor,
+    )
+
+    # Producer's published is reported separately from the consumer's write outcome.
+    assert receipt.producer.published == 2
+    assert receipt.producer.fetched == 3
+    assert receipt.producer.item_errors == 1
+    assert receipt.producer.producer_cursor == "page:5"
+    assert receipt.consumer.written == 1
+    assert receipt.consumer.blocked == 0
+    assert receipt.consumer.consumer_cursor == 1
+    # The two halves are independent truths.
+    assert receipt.producer.constituent == "heimdal"
+    assert receipt.consumer.constituent == "mimer"
+
+    # Secret-safe: a gated run reports a code, never the endpoint/token.
+    def _unhealthy(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, request=request)
+
+    env = {"KARAKEEP_BASE_URL": _SECRET_BASE_URL, "KARAKEEP_API_TOKEN": "super-secret-token"}
+    http = httpx.Client(transport=httpx.MockTransport(_unhealthy))
+    gated = run_producer(
+        holder="runner",
+        health_gate=lambda: source_health_gate(env, http=http),
+        acquire=lambda: pytest.fail("gated run must not fetch"),
+        read_producer_cursor=lambda: None,
+    )
+    assert gated.gate_reason == "source_unhealthy"
+    text = repr(gated)
+    assert _SECRET_BASE_URL not in text
+    assert "super-secret-token" not in text


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

Final-Review-Rounds: 2

Governing-Issue: #3377

## Linked Issue
Fixes #3377

## Summary
Implements KMA-05: `app.heimdal.karakeep_schedule` coordinates bounded, unattended runs of the Heimdal producer (KMA-03 adapter gated by the KMA-02 fetch-readiness gate) and the Mimer consumer (KMA-04 `project_pending_candidates`) without merging their ownership. Each side has its own bounded run entrypoint, its own independent lease (producer/consumer keys never share an execution lock, so one side never blocks the other, while same-side overlap is refused), its own durable cursor, and a truthful, secret-safe receipt. Karakeep health gates only the Heimdal fetch; the Mimer consumer drains the durable handoff regardless of source availability. A failed, gated, or overlapping run preserves both independent cursors and resumes idempotently. Coordination happens only through the durable handoff — no in-process cross-constituent call or shared transaction.

## SBS Impact
- Primary subsystem: OEF/EXE coordination around Heimdal/EBF producer and Mimer/DRI consumer
- Secondary subsystem(s): EBF, DRI (runtime control-loop + observability)
- Write class: Product/Runtime coordination; no new authority, no candidate-content change
- Authority impact: none — existing KAP/WriteGuard governance remains controlling
- Persistence impact: reads the two durable constituent cursors for receipts; never writes/advances them
- Derived/rebuildable impact: each side's durable state is authoritative; schedule state cannot substitute for it
- Human knowledge impact: none (composition only)
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: adds a bounded coordination surface; a live driver loop is deferred to acceptance (KMA-06)
- External boundary impact: health gate only refuses the Heimdal fetch; no new egress
- New or changed contract: implements the KMA-05 scheduling contract; no product-contract change
- Owner-doc impact: no owner-doc change implied (implements the named contract; no current-state promotion until parent #3367 acceptance)
- Transition debt impact: reduces the unattended-acquisition gap under ADR-0049 constituent ownership
- Fitness rule impact: strengthens overlap exclusion, cursor/replay isolation, and secret-safe receipts
- Boundary risk: none — no cross-constituent in-process call, no shared lock, one cursor per side

## Owner-Doc Writeback
- [x] No owner-doc change implied.

Implements the KMA-05 SCHEDULE contract; a live cron/worker driver and its operational documentation are deferred to the acceptance slice (KMA-06). Current-state owner docs stay honest until parent #3367 acceptance.

## Acceptance Criteria → Verify targets (all green)
- AC1 health gates producer, not consumer → `tests/heimdal/test_karakeep_schedule.py::test_source_health_gates_producer_not_consumer`
- AC2 per-constituent leases independent, no shared lock → `::test_constituent_leases_are_independent`
- AC3 failure/timeout/restart preserves both cursors, idempotent resume → `::test_failed_or_overlapping_run_preserves_constituent_cursors`
- AC4 receipt distinguishes published vs consumed/written/blocked, secret-safe → `::test_boundary_receipt_reports_each_constituent_truthfully`

AC1 and AC3 drive the real `project_pending_candidates` over real published evidence and a temp vault (not a stub); AC1 uses the real `source_health_gate` against a 503 source.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract change; N/A.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Deferred to parent acceptance; no premature promotion.)

## Validation
- [x] `ruff check app tests` — clean
- [x] `mypy app` — clean (808 files)
- [x] `pytest tests/heimdal/test_karakeep_schedule.py` — 4 passed
- [x] `pytest tests/heimdal/test_karakeep_ingestion.py tests/knowledge_acquisition/test_karakeep_handoff_consumer.py` — green
- Two independent clean review rounds (`Final-Review-Rounds: 2`) confirmed lease independence, no lease-leak/wedge, cursor non-advance on gate/failure/overlap, consumer-drains-regardless, and receipt secret-safety. Two accepted non-blocking notes: (1) `run_producer` isolates the `acquire()` failure but relies on the documented total contract of the injected `health_gate` (the shipped `source_health_gate` never raises); (2) the in-process `LeaseStore` uses `time.monotonic`, correct for this scope (a cross-process backing is deferred to KMA-06).

## Claim receipt
`pickup-claim-complete issue=3377 coordination_mode=github-label-only-fallback fallback_reason=dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-3377 absent (was agent:blocked until #3373+#3375 merged; not synced into dispatcher queue) agent=claude-opus-kma05 evidence=github-comment:5063766740`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Product/Runtime coordination slice. One plan divergence (dispatcher-queue-absent → sanctioned GitHub-label-only fallback per AGENTS.md); no Builder-System artifact produced.

## Notes
- Residual risk: low. Bounded one-shot entrypoints; the driving loop and live acceptance are deferred to KMA-06.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
