### PR TITLE
fix(karakeep): probe 127.0.0.1 in compose healthchecks to avoid BusyBox IPv6 false-unhealthy

### DIFF
--- a/docker-compose.karakeep.yml
+++ b/docker-compose.karakeep.yml
@@ -34,7 +34,9 @@ services:
     healthcheck:
       # Liveness against the app web root (deliberately NOT /api/health, which
       # the repo reserves for the expensive operator diagnostic route).
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null 2>&1 || exit 1"]
+      # Use 127.0.0.1, not localhost: the image's BusyBox wget resolves
+      # localhost to IPv6 ::1 first, but the app binds IPv4 -> false "unhealthy".
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -50,7 +52,9 @@ services:
     volumes:
       - karakeep-meilisearch-data:/meili_data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:7700/health >/dev/null 2>&1 || exit 1"]
+      # 127.0.0.1, not localhost: BusyBox wget prefers IPv6 ::1 but Meilisearch
+      # binds IPv4 0.0.0.0 -> localhost probe gets connection-refused.
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:7700/health >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4077

## Linked Issue
Closes #4077

## SBS Impact
Classified per `docs/architecture/SBS_OPERATING_MODEL.md`.
- Primary subsystem: Product/Runtime System — deployment (managed Karakeep service)
- Secondary subsystem(s): none
- Write class: none (deployment manifest only)
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: container healthchecks correctly report health on the deploy host
- External boundary impact: none
- New or changed contract: none
- Owner-doc impact: none
- Transition debt impact: none
- Fitness rule impact: none
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Both `docker-compose.karakeep.yml` healthchecks probed `http://localhost:...`. The images' BusyBox `wget` resolves `localhost` to IPv6 `::1` first, but the services bind IPv4, so the probes were connection-refused and the containers reported a false `unhealthy`.
- Switches both healthchecks (Karakeep app `:3000/`, Meilisearch `:7700/health`) to `http://127.0.0.1:...` with an explanatory comment. Behaviour-preserving for a healthy service; it only removes the false negative.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.

## Validation
Implementation lane:
- `ruff check app tests` — N/A: no files under `app/` or `tests/` changed (deployment-manifest-only change).
- `mypy app` — N/A: no Python changed.
- Governing `Verify:` target — verified in the branch: `grep 127.0.0.1 docker-compose.karakeep.yml` shows both `healthcheck.test` lines and no `localhost:` remains in a healthcheck.
- Repo-wide non-PG suite — N/A: single deploy-manifest line-level change, no cross-system blast radius.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: deployment-manifest healthcheck correction; no BuilderOps objects, projections, or receipts were created or routed.

## Notes
- Deploy-manifest-only change; no application code touched. The identical fix is already validated on the deploy host (currently uncommitted there); this PR lands it in the shipped manifest on `main`.
- Residual risk: none beyond the healthcheck probe target.
