### PR TITLE
Retire CKM cross-dimension scalar render

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -66,16 +66,6 @@ def _forest(capabilities: Sequence[CkmCapability]) -> list[tuple[int, CkmCapabil
     return result
 
 
-def _band(aggregate: float | None) -> str:
-    if aggregate is None:
-        return "unknown"
-    if aggregate < 0.4:
-        return "critical"
-    if aggregate < 0.7:
-        return "watch"
-    return "healthy"
-
-
 def _edge_counts(edges: Sequence[CkmEvidenceEdge]) -> tuple[int, int]:
     return (
         sum(edge.lifecycle == "confirmed" for edge in edges),
@@ -211,8 +201,6 @@ def _capability_markup(
 ) -> str:
     confirmed, candidate = _edge_counts(edges)
     assessment = projection.assessment if projection else None
-    aggregate = float(assessment.aggregate) if assessment else None
-    band = _band(aggregate)
     summary_flags: list[str] = []
     if projection and projection.stale_relative_to_evidence:
         summary_flags.append(
@@ -243,16 +231,13 @@ def _capability_markup(
         if assessment
         else '<p class="empty">Assessment missing.</p>'
     )
-    aggregate_text = f"{aggregate:.2f}" if aggregate is not None else "—"
     return f"""
-    <article id="cap-{_e(capability.id)}" class="capability band-{band}" data-capability-id="{_e(capability.id)}" data-aggregate-band="{band}" style="--depth:{depth}" aria-label="{_e(capability.name)}, depth {depth}">
+    <article id="cap-{_e(capability.id)}" class="capability" data-capability-id="{_e(capability.id)}" style="--depth:{depth}" aria-label="{_e(capability.name)}, depth {depth}">
       <details class="capability-details">
         <summary class="capability-summary">
           <span class="tree-name">{_e(capability.name)}</span>
           <span class="summary-flags">{"".join(summary_flags)}</span>
           {_mini_dimensions_markup(assessment)}
-          <span class="aggregate" title="Minimum of seven maturity dimensions">min {_e(aggregate_text)}</span>
-          <span class="band-label"><span class="band-dot" aria-hidden="true"></span>{band}</span>
           <span class="lifecycle">node: {_e(capability.lifecycle)}</span>
         </summary>
         <div class="capability-body">
@@ -357,11 +342,10 @@ def render_overview_html(
     .trust-strip {{ display:grid; grid-template-columns:repeat(5,1fr); border:1px solid var(--border-strong); background:var(--bg-surface); }} .trust-strip a {{ padding:0.625rem; text-decoration:none; border-right:1px solid var(--border); }}
     .legend {{ display:grid; grid-template-columns:2fr 1fr; gap:1rem; margin:1rem 0; padding:0.75rem; border:1px solid var(--border); background:var(--bg-surface); }} .legend ul {{ display:flex; gap:0.5rem 1rem; flex-wrap:wrap; list-style:none; padding:0; margin:0.35rem 0 0; }} .legend-cell {{ display:inline-block; width:1.5rem; height:0.5rem; margin-right:0.3rem; background:var(--agent); }} .legend-cell.starved {{ border:1px dotted var(--amber); background:transparent; }} .legend-cell.unassessed {{ height:auto; background:none; color:var(--fg-3); }}
     .dimension-rail {{ position:sticky; top:0; z-index:2; display:grid; grid-template-columns:repeat(7,1fr); gap:0.25rem; margin-left:auto; width:13rem; padding:0.25rem; background:var(--bg-base); color:var(--fg-2); font:0.7rem ui-monospace,monospace; text-align:center; }}
-    .capability {{ margin:0.5rem 0 0.5rem calc(var(--depth) * 1.375rem); border:1px solid var(--border); border-left:0.25rem solid var(--unknown); border-radius:0.25rem; background:var(--bg-surface); }} .band-critical {{ border-left-color:var(--destructive); }} .band-watch {{ border-left-color:var(--amber); }} .band-healthy {{ border-left-color:var(--healthy); }}
+    .capability {{ margin:0.5rem 0 0.5rem calc(var(--depth) * 1.375rem); border:1px solid var(--border); border-left:0.25rem solid var(--unknown); border-radius:0.25rem; background:var(--bg-surface); }}
     summary {{ cursor:pointer; }} summary::before {{ content:"+"; color:var(--fg-2); font-family:ui-monospace,monospace; }} details[open] > summary::before {{ content:"−"; }} .capability-summary {{ min-height:2.75rem; display:flex; gap:0.5rem; align-items:center; padding:0.625rem 0.75rem; }} .capability-summary:hover {{ background:var(--bg-overlay); }} .tree-name {{ flex:1; font-weight:600; }}
-    .summary-flags {{ display:flex; gap:0.25rem; }} .flag,.badge,.lifecycle,.aggregate,.band-label {{ border:1px solid var(--border-strong); border-radius:0.1875rem; padding:0.125rem 0.375rem; font:0.7rem ui-monospace,monospace; white-space:nowrap; }} .flag-stale {{ background:var(--amber); color:var(--bg-base); }} .flag-low {{ border-color:var(--amber); color:var(--amber); }} .flag-candidate {{ border-color:var(--agent); color:var(--agent); }} .gap-link {{ color:var(--accent); text-decoration:none; }}
+    .summary-flags {{ display:flex; gap:0.25rem; }} .flag,.badge,.lifecycle {{ border:1px solid var(--border-strong); border-radius:0.1875rem; padding:0.125rem 0.375rem; font:0.7rem ui-monospace,monospace; white-space:nowrap; }} .flag-stale {{ background:var(--amber); color:var(--bg-base); }} .flag-low {{ border-color:var(--amber); color:var(--amber); }} .flag-candidate {{ border-color:var(--agent); color:var(--agent); }} .gap-link {{ color:var(--accent); text-decoration:none; }}
     .mini-dimensions {{ display:grid; grid-template-columns:repeat(7,1.625rem); gap:0.25rem; }} .mini-dimension {{ position:relative; width:1.625rem; height:0.75rem; border:1px solid var(--border-strong); overflow:hidden; }} .mini-scored {{ background:linear-gradient(to right,var(--agent) var(--score),var(--bg-overlay) var(--score)); }} .mini-starved {{ border:1px dotted var(--amber); background:transparent; }} .mini-unassessed {{ color:var(--fg-3); text-align:center; line-height:0.55rem; }}
-    .aggregate {{ color:var(--fg-2); }} .band-dot {{ display:inline-block; width:0.45rem; height:0.45rem; border-radius:50%; margin-right:0.3rem; background:var(--unknown); }} .band-critical .band-dot {{ background:var(--destructive); }} .band-watch .band-dot {{ background:var(--amber); }} .band-healthy .band-dot {{ background:var(--healthy); }}
     .capability-body {{ border-top:1px solid var(--border); padding:1rem; background:var(--bg-raised); }} .honesty {{ border-left:0.2rem solid var(--amber); padding-left:0.75rem; color:var(--fg-2); }} .honesty p {{ margin:0.2rem 0; }} .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(14rem,1fr)); gap:0.625rem; margin:0.875rem 0; }} .dimension {{ border:1px solid var(--border-strong); padding:0.625rem; }} .dimension-label {{ display:flex; gap:0.5rem; justify-content:space-between; }} .dimension-label span {{ flex:1; }} .dimension-track {{ height:0.5rem; margin:0.4rem 0; background:var(--bg-overlay); overflow:hidden; }} .dimension-starved .dimension-track {{ border:1px dotted var(--amber); background:none; }} .dimension-bar {{ display:block; height:100%; background:var(--agent); }}
     .drilldown,.citations {{ margin-top:0.625rem; }} .evidence-list,.finding-list {{ padding-left:1.25rem; }} .evidence-list li,.finding-list li {{ margin:0.45rem 0; }} .evidence-candidate {{ border-left:0.15rem solid var(--agent); padding-left:0.5rem; }} .basis {{ color:var(--fg-2); margin-left:0.5rem; }} .gaps-panel {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .gap-group {{ margin:0.75rem 0; }}
     footer {{ margin-top:1.75rem; padding:1rem 0 2.25rem; border-top:1px solid var(--border); color:var(--fg-2); overflow-wrap:anywhere; }}

--- a/app/builderops/ckm/projections.py
+++ b/app/builderops/ckm/projections.py
@@ -198,9 +198,7 @@ def _render_maturity(batch: CkmProjectionBatch) -> list[str]:
         freshness = "STALE relative to evidence" if projection.stale_relative_to_evidence else "current"
         confidence = "LOW CONFIDENCE" if assessment.low_confidence else "normal confidence"
         lines.extend([
-            f"Assessment: **{freshness}**; **{confidence}**; "
-            f"aggregate convenience score **{assessment.aggregate:.3f}** "
-            f"(`{assessment.aggregate_formula_id}`).",
+            f"Assessment: **{freshness}**; **{confidence}**.",
             "",
             "| Dimension | Score | Citations | Candidate share | Formula |",
             "| --- | ---: | ---: | ---: | --- |",
@@ -411,7 +409,7 @@ def render_capability_show(
         assessment = projection.assessment
         freshness = "STALE relative to evidence" if projection.stale_relative_to_evidence else "current"
         lines.extend([
-            f"Assessment: **{freshness}**; aggregate convenience score **{assessment.aggregate:.3f}**.",
+            f"Assessment: **{freshness}**.",
             "",
             "| Dimension | Score | Citations | Candidate share |",
             "| --- | ---: | ---: | ---: |",

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/CKM_PROJECTIONS_AND_QUERY.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/CKM_PROJECTIONS_AND_QUERY.md
@@ -19,7 +19,7 @@ Make the model consumable — for the owner, for builder agents, and for reports
 
 - Extends `app/builderops/ckm/projections.py` with four projection types, following the `app/builderops/projections.py` metadata contract (every output opens with the generated-projection header):
   - `ckm-capability-map` — the capability forest with lifecycle, boundary refs, evidence counts (confirmed vs candidate), unlinked-artifact count.
-  - `ckm-maturity` — per capability: the seven-dimension vector with per-dimension citations count, candidate share, aggregate (labeled convenience), low-confidence and **staleness** flags (INV-CKM-5: assessment older than evidence watermark ⇒ `STALE` marker).
+  - `ckm-maturity` — per capability: the seven-dimension vector with per-dimension citations count, candidate share, low-confidence and **staleness** flags (INV-CKM-5: assessment older than evidence watermark ⇒ `STALE` marker). The stored aggregate remains a compatibility field but is not rendered in Markdown projections.
   - `ckm-gaps` — current findings grouped by kind, each with its statement + citations.
   - `ckm-traceability-matrix` — a generated matrix in the same column shape as `docs/architecture/traceability-matrix.md`, emitted for **side-by-side comparison** with the hand-authored one; divergence is a signal, never an auto-edit (ADR-0057 §Consequences).
 - CLI query surface: `python -m app.builderops ckm show <capability-slug>` (assessment + evidence listing with basis strings) and `python -m app.builderops ckm project --type <type> --out <dir>`.

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md
@@ -19,7 +19,7 @@ Refine `app/builderops/ckm/overview_html.py` so a reader can judge trust and mat
 - a complete seven-dimension legend and aligned column rail;
 - collapsed-row stale, low-confidence, candidate-share, and gap markers;
 - scored, evidence-starved, and unassessed dimension-cell states;
-- a subordinate aggregate labeled `min`, plus text-and-shape maturity-band encoding;
+- no cross-dimension aggregate or maturity-band presentation; the per-dimension vector is the collapsed-row display;
 - explicit `node: confirmed` lifecycle wording;
 - explicit explanatory prose in expanded details that names assessment availability, stale-relative-to-evidence state, and candidate-evidence share without presenting absence as zero;
 - capability↔gap fragment links and grouped gap presentation;
@@ -29,9 +29,9 @@ The renderer signature remains `render_overview_html(store) -> str`. Store reads
 
 ## CKM11-STATIC-CONTRACT
 
-The output remains one self-contained HTML file with inline CSS, native semantic HTML, and no JavaScript, remote fonts, images, stylesheets, or other network references. Verify: CKM11 acceptance criterion 8. Missing-database behavior is unchanged and rendering is deterministic. Verify: CKM11 acceptance criterion 11. Missing assessment is rendered as unavailable (`—` / `min —`), never as `0.00` or `0.0%`. Candidate and confirmed evidence remain visibly distinct. Verify: CKM11 acceptance criteria 2, 3, and 12.
+The output remains one self-contained HTML file with inline CSS, native semantic HTML, and no JavaScript, remote fonts, images, stylesheets, or other network references. Verify: CKM11 acceptance criterion 8. Missing-database behavior is unchanged and rendering is deterministic. Verify: CKM11 acceptance criterion 11. Missing assessment is rendered as unavailable (`—`), never as `0.00` or `0.0%`. Candidate and confirmed evidence remain visibly distinct. Verify: CKM11 acceptance criteria 2, 3, and 12.
 
-Every color signal has a text or shape twin: maturity band uses dot plus word; trust states use named chips; candidate share uses a named percentage; unassessed uses a dash plus accessible text; evidence-starved uses a dotted treatment plus citation count. Verify: CKM11 acceptance criteria 1, 2, 3, 5, and 10.
+Every color signal has a text or shape twin: trust states use named chips; candidate share uses a named percentage; unassessed uses a dash plus accessible text; evidence-starved uses a dotted treatment plus citation count. Verify: CKM11 acceptance criteria 1, 2, 3, and 10.
 
 ## CKM11-DIMENSIONS
 
@@ -55,7 +55,7 @@ The legend spells out every mapping. Verify: CKM11 acceptance criterion 7. Each 
 2. Every collapsed capability renders exactly seven dimension cells: scored cells expose proportional fill values, evidence-starved zeroes use the dotted state, and unavailable cells render `—` without a score/fill value. Verify: `tests/builderops/ckm/test_overview_html.py::test_dimension_cells_render_three_states_and_proportional_fill`
 3. Candidate-share summary markup is absent at zero and present with a percentage above zero. Verify: `tests/builderops/ckm/test_overview_html.py::test_candidate_chip_conditional`
 4. Findings for known capabilities link to their capability fragments, and capabilities with findings link back to grouped gap fragments. Verify: `tests/builderops/ckm/test_overview_html.py::test_gap_capability_crosslinks`
-5. The aggregate is labeled `min {value}` or `min —` and is never an anonymous summary numeral. Verify: `tests/builderops/ckm/test_overview_html.py::test_aggregate_demoted_label`
+5. The collapsed capability summary renders no cross-dimension aggregate or maturity band: no `min` aggregate chip, `band-*` class, `data-aggregate-band` attribute, or band label. Verify: `tests/builderops/ckm/test_overview_html.py::test_aggregate_demoted_label`
 6. The generated-projection provenance banner precedes the capability map and the projection footer contract remains present. Verify: `tests/builderops/ckm/test_overview_html.py::test_provenance_banner_precedes_map_and_footer_remains`
 7. The legend contains all seven full dimension names and explains scored, evidence-starved, and unassessed cells. Verify: `tests/builderops/ckm/test_overview_html.py::test_legend_dimension_mapping`
 8. Output remains self-contained with no script elements, executable inline handlers, or external/network references. Verify: `tests/builderops/ckm/test_overview_html.py::test_no_scripts_or_external_references`
@@ -71,7 +71,7 @@ The legend spells out every mapping. Verify: CKM11 acceptance criterion 7. Each 
 - Preserve visible `:focus-visible` outlines on summaries and links. Verify: CKM11 acceptance criterion 10.
 - Provide a visible plus/minus disclosure affordance without motion. Verify: CKM11 acceptance criterion 10.
 - Use system font stacks and relative units; avoid horizontal scrolling at 390 px and at 200% zoom-equivalent widths. Verify: CKM11 acceptance criterion 10 plus parent #3138 visual-review receipt.
-- Give every collapsed trust signal a non-color label and every maturity band a dot plus text. Verify: CKM11 acceptance criteria 1, 5, and 10.
+- Give every collapsed trust signal a non-color label. Verify: CKM11 acceptance criteria 1 and 10.
 - Use unique expanded disclosure labels such as `Citations — test completeness (0)`. Verify: CKM11 acceptance criterion 10.
 
 ## CKM11-OUT-OF-SCOPE

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md
@@ -1,6 +1,6 @@
 ---
 name: Dev Overview HTML Projection
-description: Static-HTML Development Overview — capability map + maturity heatmap + gap list — rendered from the store, plus the parent-closure handoff
+description: Static-HTML Development Overview — capability map + per-dimension evidence vector + gap list — rendered from the store, plus the parent-closure handoff
 task_id: CKM-10
 source_anchor: docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md :: 5.15 Interfaces (Development Overview UI)
 parent_capability: Capability Knowledge Model
@@ -13,12 +13,12 @@ can_parallelize_with: []
 
 ## Purpose
 
-Give the owner the one-glance surface: a static HTML Development Overview rendering the capability map as a maturity heatmap with drill-down to evidence. One consumer of the model, not the product (SRS §System Context).
+Give the owner the one-glance surface: a static HTML Development Overview rendering the capability map with a per-dimension evidence vector and drill-down to evidence. One consumer of the model, not the product (SRS §System Context).
 
 ## What This Task Does
 
 - Implements `app/builderops/ckm/overview_html.py`: a pure `render_overview_html(store) -> str` function (mirroring the companion-UI `render_index_html` pure-render pattern) producing one self-contained HTML file — no server, no build step, no external assets:
-  - capability forest as an indented tree, each node colored by aggregate band with the seven-dimension mini-bars;
+  - capability forest as an indented tree, each node carrying the seven-dimension mini-bars without a cross-dimension aggregate band or heatmap;
   - low-confidence, staleness, and candidate-share markers rendered per node (inheriting CKM-09's flags);
   - per-capability expandable detail: dimension citations, evidence list with basis strings, findings;
   - gaps panel listing current findings;
@@ -30,7 +30,7 @@ Give the owner the one-glance surface: a static HTML Development Overview render
 
 ```bash
 python -m app.builderops ckm overview --out ~/Desktop/ckm-overview.html
-open ~/Desktop/ckm-overview.html   # heatmap over real repo state, no server needed
+open ~/Desktop/ckm-overview.html   # per-dimension view over real repo state, no server needed
 ```
 
 ## Why This Matters
@@ -39,8 +39,8 @@ The Development Overview is the owner-facing payoff and the surface most likely 
 
 ## Acceptance Criteria
 
-- [ ] `render_overview_html` is pure (store in, string out) and renders the fixture graph with tree, heatmap bands, and dimension bars present.
-  - Verify: `tests/builderops/ckm/test_overview_html.py::test_pure_render_over_fixture_graph`
+- [ ] `render_overview_html` is pure (store in, string out) and renders the fixture graph with tree and dimension bars present, without a rendered cross-dimension aggregate or maturity band; aggregate persistence remains a compatibility concern outside the render.
+  - Verify: `tests/builderops/ckm/test_overview_html.py::test_pure_render_over_fixture_graph`; `tests/builderops/ckm/test_overview_html.py::test_aggregate_demoted_label`
 - [ ] Staleness, low-confidence, and candidate-share markers from the store render in the HTML (enforcement of INV-CKM-3/5 at the final egress).
   - Verify: `tests/builderops/ckm/test_overview_html.py::test_honesty_markers_render`
 - [ ] The projection footer (self-identification + watermarks) is present in every rendered document.

--- a/docs/CKM_EVIDENCE_PROFILE/SCALAR_RETIREMENT.md
+++ b/docs/CKM_EVIDENCE_PROFILE/SCALAR_RETIREMENT.md
@@ -38,7 +38,10 @@ view or the tri-state work — is the mechanism that removes the false picture.
 - Bundle the presentation-contract writeback: update the acceptance rows in
   `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md` that require the subordinate `min`
   aggregate and the text-and-shape maturity band (its rows 5 and 22, the band-encoding language, and
-  the CKM11 criteria that reference `min`/band) in the same PR as the render change.
+  the CKM11 criteria that reference `min`/band), plus the active Markdown and HTML projection
+  contracts at `docs/CAPABILITY_KNOWLEDGE_MODEL/CKM_PROJECTIONS_AND_QUERY.md` and
+  `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md`, in the same PR as the render
+  change.
 
 ## Concretely
 
@@ -79,9 +82,9 @@ schema epoch, which Phase 1 explicitly forbids (INV-EP-1).
   Verify: `tests/builderops/ckm/test_assessment_engine.py::test_aggregate_transparent_and_min_capped` still passes; `tests/builderops/ckm/test_store.py` assessment round-trip still asserts the column is populated.
 - [ ] Render stays pure, deterministic, read-only, and self-contained after the removal.
   Verify: `tests/builderops/ckm/test_overview_html.py::test_pure_render_over_fixture_graph`; `::test_cli_rejects_missing_database_without_creating_it`; `::test_no_scripts_or_external_references`.
-- [ ] The Direction A acceptance rows that require the `min` aggregate / maturity band are updated in
-  this PR.
-  Verify: doc writeback at `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md :: Acceptance criteria` present in the CKM-EP-01 PR diff.
+- [ ] The Direction A acceptance rows and the active Markdown and HTML projection contracts no longer
+  require a rendered `min` aggregate / maturity band in this PR.
+  Verify: doc writeback at `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md :: Acceptance criteria`, `docs/CAPABILITY_KNOWLEDGE_MODEL/CKM_PROJECTIONS_AND_QUERY.md :: What This Task Does`, and `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md :: What This Task Does` present in the CKM-EP-01 PR diff.
 - [ ] Shared real-store validation gate (INV-EP-6): replaying `seed → ingest → link → assess →
   overview` on the operator's real 31-capability store shows Retrieval no longer rendering falsely red
   / `critical`.
@@ -117,6 +120,8 @@ state is introduced; a process restart changes nothing about what the next rende
 
 - `docs/CKM_EVIDENCE_PROFILE/README.md`
 - `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md`
+- `docs/CAPABILITY_KNOWLEDGE_MODEL/CKM_PROJECTIONS_AND_QUERY.md`
+- `docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md`
 - `docs/CAPABILITY_KNOWLEDGE_MODEL/README.md`
 - `app/builderops/ckm/overview_html.py`, `app/builderops/ckm/projections.py`, `app/builderops/ckm/assess.py`
 

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -133,7 +133,10 @@ def test_pure_render_over_fixture_graph(overview_store: CkmStore) -> None:
     assert '<div class="capability-tree">' in first
     assert "Retrieval" in first and "Context Assembly" in first
     assert 'style="--depth:1"' in first
-    assert 'data-aggregate-band="healthy"' in first
+    assert "data-aggregate-band" not in first
+    assert "band-critical" not in first
+    assert "band-watch" not in first
+    assert "band-healthy" not in first
     assert first.count('class="dimension-bar"') == len(MATURITY_DIMENSIONS)
     summary = first.split("</summary>", maxsplit=1)[0]
     assert summary.count('class="mini-dimension ') == len(MATURITY_DIMENSIONS)
@@ -198,8 +201,11 @@ def test_gap_capability_crosslinks(overview_store: CkmStore) -> None:
 def test_aggregate_demoted_label(overview_store: CkmStore) -> None:
     rendered = render_overview_html(overview_store)
 
-    assert '<span class="aggregate" title="Minimum of seven maturity dimensions">min 0.80</span>' in rendered
-    assert '<span class="aggregate" title="Minimum of seven maturity dimensions">min —</span>' in rendered
+    assert 'class="aggregate"' not in rendered
+    assert "Minimum of seven maturity dimensions" not in rendered
+    assert "data-aggregate-band" not in rendered
+    assert 'class="band-label"' not in rendered
+    assert 'class="band-dot"' not in rendered
 
 
 def test_legend_dimension_mapping(overview_store: CkmStore) -> None:
@@ -243,7 +249,7 @@ def test_accessibility_and_responsive_contract(overview_store: CkmStore) -> None
     assert 'font-size:1rem' in rendered
     assert 'role="img"' in rendered
     assert "Citations — operational readiness (0)" in rendered
-    assert '<span class="band-dot" aria-hidden="true"></span>' in rendered
+    assert 'class="band-dot"' not in rendered
 
 
 def test_node_lifecycle_and_evidence_confirmation_are_distinct(

--- a/tests/builderops/ckm/test_projections.py
+++ b/tests/builderops/ckm/test_projections.py
@@ -169,6 +169,16 @@ def test_candidate_confirmed_distinction_rendered(populated_store: CkmStore) -> 
     assert "basis: semantic:retrieval-doc" in shown
 
 
+def test_assessment_projections_do_not_render_aggregate_convenience_scores(
+    populated_store: CkmStore,
+) -> None:
+    maturity = render_projection(populated_store, "ckm-maturity")
+    shown = render_capability_show(populated_store, "retrieval")
+
+    assert "aggregate convenience score" not in maturity
+    assert "aggregate convenience score" not in shown
+
+
 def test_generated_matrix_shape_and_never_overwrites_canonical(
     populated_store: CkmStore,
     tmp_path: Path,


### PR DESCRIPTION
Final-Review-Rounds: 1

Governing-Issue: #4090

Fixes #4090

## Summary
- Removes the aggregate chip and maturity-band markup/CSS from the generated CKM HTML overview.
- Removes aggregate convenience-score lines from CKM Markdown projections while preserving aggregate storage and computation.
- Updates Direction A and both active CKM projection contracts so the per-dimension vector is the rendered contract.

## Validation
- `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py tests/builderops/ckm/test_projections.py tests/builderops/ckm/test_assessment_engine.py tests/builderops/ckm/test_store.py` — 57 passed after the owner-doc repair
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — passed; the existing app diff is non-temporal and the guard otherwise requires an explicit override
- `ruff check app tests` — passed
- `mypy app` — passed
- `pytest -q -m 'not pg' tests/builderops/ckm` — started; focused run emitted passing progress but the host runner did not return a terminal summary.
- `pytest -q -m 'not pg'` — started and reached ~10%; stalled in an unrelated asynchronous path for over five minutes without further output, so its isolated runner was terminated. This PR does not claim a full-suite pass.
- Disposable real-source replay: `seed` produced 31 capabilities, but `ingest --source all` did not terminate after more than ten minutes (8,813 temporary artifacts; no edges); it was stopped without touching an existing store. No INV-EP-6 success is claimed.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260724135439_e2a4d4d0` — applied by this PR
- Reason: `docs/CKM_EVIDENCE_PROFILE/SCALAR_RETIREMENT.md` now names the Direction A plus active Markdown/HTML projection-contract writebacks; both stale contracts are aligned with the retired scalar.

---