### PR TITLE
Add CKM per-dimension evidence status (CKM-EP-02)

### DIFF
--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -32,7 +32,7 @@ class Formula:
 _DIMENSION_FORMULA_IDS = {
     "functional_completeness": "functional-evidence-balance-v1",
     "test_completeness": "test-evidence-balance-v1",
-    "documentation_quality": "current-doc-evidence-v1",
+    "documentation_quality": "current-doc-evidence-v2",
     "integration_completeness": "source-and-surface-span-v1",
     "operational_readiness": "operational-evidence-balance-v1",
     "architectural_stability": "architecture-vs-churn-v1",
@@ -55,6 +55,11 @@ FORMULAS: dict[str, Formula] = {
         "current-doc-evidence-v1",
         "documentation_quality",
         "Current State:-bearing supporting documentation divided by all cited documentation evidence.",
+    ),
+    "current-doc-evidence-v2": Formula(
+        "current-doc-evidence-v2",
+        "documentation_quality",
+        "Current State:-bearing supporting documentation divided by all cited documentation evidence; an empty selected set is unassessed.",
     ),
     "source-and-surface-span-v1": Formula(
         "source-and-surface-span-v1",
@@ -93,6 +98,7 @@ FORMULAS: dict[str, Formula] = {
 class DimensionResult:
     score: float
     edges: tuple[CkmEvidenceEdge, ...]
+    status: str | None = None
 
 
 @dataclass(frozen=True)
@@ -191,7 +197,7 @@ def _documentation(
         and artifacts[edge.artifact_id].artifact_kind == "document"
     )
     if not selected:
-        return DimensionResult(0.0, ())
+        return DimensionResult(0.0, (), "unassessed")
     current = 0.0
     total = 0.0
     for edge in selected:
@@ -470,6 +476,7 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
         scores: dict[str, float] = {}
         citations: dict[str, list[dict[str, object]]] = {}
         candidate_shares: dict[str, float] = {}
+        dimension_status: dict[str, str] = {}
         formula_ids: dict[str, str] = {}
         for dimension in MATURITY_DIMENSIONS:
             result = _SCORERS[dimension](edges, artifacts)
@@ -482,12 +489,16 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
             candidate_shares[dimension] = (
                 len(candidates) / len(supporting) if supporting else 0.0
             )
+            dimension_status[dimension] = result.status or (
+                "measured" if result.edges else "missing"
+            )
             formula_ids[dimension] = _DIMENSION_FORMULA_IDS[dimension]
         assessment = store.append_assessment(
             capability_id=capability.id,
             scores=scores,
             citations=citations,
             candidate_shares=candidate_shares,
+            dimension_status=dimension_status,
             formula_ids=formula_ids,
             aggregate=compute_aggregate(scores),
             aggregate_formula_id=AGGREGATE_FORMULA_ID,

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -24,6 +24,8 @@ from datetime import datetime, timezone
 from typing import Any, Mapping
 from uuid import uuid4
 
+from app.builderops.ckm.contracts import SUPPORTED_VALUE_STATES
+
 JsonDict = dict[str, Any]
 
 # --- Capability -------------------------------------------------------------
@@ -337,6 +339,7 @@ class CkmAssessment:
     scores: Mapping[str, float]
     citations: Mapping[str, list[JsonDict]]
     candidate_shares: Mapping[str, float]
+    dimension_status: Mapping[str, str]
     formula_ids: Mapping[str, str]
     aggregate: float
     aggregate_formula_id: str
@@ -353,6 +356,27 @@ class CkmAssessment:
         missing_dims = set(MATURITY_DIMENSIONS) - set(self.scores)
         if missing_dims:
             raise CkmValidationError(f"assessment missing dimension score(s): {sorted(missing_dims)}")
+        unknown_status_dims = set(self.dimension_status) - set(MATURITY_DIMENSIONS)
+        if unknown_status_dims:
+            raise CkmValidationError(
+                f"assessment has unknown dimension status key(s): {sorted(unknown_status_dims)}"
+            )
+        if self.dimension_status:
+            missing_status_dims = set(MATURITY_DIMENSIONS) - set(self.dimension_status)
+            if missing_status_dims:
+                raise CkmValidationError(
+                    "assessment missing dimension status(es): "
+                    f"{sorted(missing_status_dims)}"
+                )
+        unsupported_statuses = {
+            status
+            for status in self.dimension_status.values()
+            if status not in SUPPORTED_VALUE_STATES
+        }
+        if unsupported_statuses:
+            raise CkmValidationError(
+                f"assessment has unsupported dimension status(es): {sorted(unsupported_statuses)}"
+            )
         for dimension in MATURITY_DIMENSIONS:
             score = self.scores[dimension]
             if not isinstance(score, (int, float)) or not (0.0 <= float(score) <= 1.0):
@@ -383,6 +407,7 @@ class CkmAssessment:
         scores: Mapping[str, float],
         citations: Mapping[str, list[JsonDict]],
         candidate_shares: Mapping[str, float],
+        dimension_status: Mapping[str, str],
         formula_ids: Mapping[str, str],
         watermark_set: Mapping[str, str],
     ) -> "CkmAssessment":
@@ -393,6 +418,7 @@ class CkmAssessment:
             scores=scores,
             citations=citations,
             candidate_shares=candidate_shares,
+            dimension_status=dimension_status,
             formula_ids=formula_ids,
             aggregate=row["aggregate"],
             aggregate_formula_id=row["aggregate_formula_id"],
@@ -401,7 +427,7 @@ class CkmAssessment:
             watermark_set=watermark_set,
             valid_from=row["valid_from"],
             asserted_at=row["asserted_at"],
-        )
+        ).validate()
 
     def to_dict(self) -> JsonDict:
         return {
@@ -411,6 +437,7 @@ class CkmAssessment:
             "scores": dict(self.scores),
             "citations": {k: list(v) for k, v in self.citations.items()},
             "candidate_shares": dict(self.candidate_shares),
+            "dimension_status": dict(self.dimension_status),
             "formula_ids": dict(self.formula_ids),
             "aggregate": self.aggregate,
             "aggregate_formula_id": self.aggregate_formula_id,

--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -91,9 +91,21 @@ def _dimension_markup(
     score: float,
     citations: Sequence[Mapping[str, object]],
     candidate_share: float,
+    status: str | None,
 ) -> str:
-    percent = max(0.0, min(100.0, score * 100.0))
     _, label = DIMENSION_LABELS[dimension]
+    if status in {"unassessed", "unsupported"}:
+        state_label = (
+            "unassessed — no selected evidence"
+            if status == "unassessed"
+            else "unsupported by this assessment formula"
+        )
+        return f"""
+      <section class="dimension dimension-unassessed" data-dimension="{_e(dimension)}" data-cell-state="unassessed">
+        <div class="dimension-label"><span>{_e(label)}</span><strong>—</strong></div>
+        <small>{_e(state_label)}</small>
+      </section>"""
+    percent = max(0.0, min(100.0, score * 100.0))
     starved = score == 0 and not citations
     citation_items = "".join(
         f"<li>{_e(_citation_source(citation))}</li>" for citation in citations
@@ -125,8 +137,16 @@ def _mini_dimensions_markup(assessment: CkmAssessment | None) -> str:
             continue
         score = float(assessment.scores[dimension])
         citations = assessment.citations[dimension]
+        status = assessment.dimension_status.get(dimension)
+        if status in {"unassessed", "unsupported"}:
+            aria_parts.append(f"{label} {status}")
+            cells.append(
+                f'<span class="mini-dimension mini-unassessed" data-cell-state="unassessed" '
+                f'data-abbr="{abbreviation}" title="{_e(label)}: {_e(status)}">—</span>'
+            )
+            continue
         percent = max(0.0, min(100.0, score * 100.0))
-        starved = score == 0 and not citations
+        starved = status == "missing" or (status is None and score == 0 and not citations)
         state = "starved" if starved else "scored"
         state_label = "evidence-starved" if starved else "scored"
         aria_parts.append(f"{label} {score:.2f}, {len(citations)} citations")
@@ -225,6 +245,7 @@ def _capability_markup(
                 float(assessment.scores[dimension]),
                 assessment.citations[dimension],
                 float(assessment.candidate_shares[dimension]),
+                assessment.dimension_status.get(dimension),
             )
             for dimension in MATURITY_DIMENSIONS
         )

--- a/app/builderops/ckm/schema.py
+++ b/app/builderops/ckm/schema.py
@@ -85,7 +85,7 @@ CKM_REQUIRED_COLUMNS = {
             "operational_readiness", "operational_readiness_citations",
             "architectural_stability", "architectural_stability_citations",
             "requirement_coverage", "requirement_coverage_citations", "candidate_shares",
-            "formula_ids", "aggregate", "aggregate_formula_id", "low_confidence",
+            "dimension_status", "formula_ids", "aggregate", "aggregate_formula_id", "low_confidence",
             "edge_fingerprint", "watermark_set", "valid_from", "asserted_at",
         }
     ),
@@ -112,7 +112,7 @@ CKM_LEGACY_ADDED_COLUMNS = {
     "ckm_assessment": frozenset(
         {
             "public_id", "candidate_shares", "formula_ids", "aggregate_formula_id",
-            "low_confidence", "edge_fingerprint",
+            "dimension_status", "low_confidence", "edge_fingerprint",
         }
     ),
     "ckm_finding": frozenset({"public_id"}),
@@ -287,6 +287,7 @@ CKM_DDL_STATEMENTS = [
         requirement_coverage REAL NOT NULL,
         requirement_coverage_citations TEXT NOT NULL,
         candidate_shares TEXT NOT NULL,
+        dimension_status TEXT NOT NULL DEFAULT '{}',
         formula_ids TEXT NOT NULL,
         aggregate REAL NOT NULL,
         aggregate_formula_id TEXT NOT NULL,

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -25,6 +25,7 @@ from app.builderops.config import BuilderOpsPaths, load_paths, validate_db_path_
 from app.builderops.store import SqliteBuilderOpsStore
 
 from app.builderops.ckm.contracts import (
+    SUPPORTED_VALUE_STATES,
     CkmStateIdentity,
     canonical_digest,
     canonical_json,
@@ -212,12 +213,15 @@ class CkmStore:
                 )
             legacy = bool(existing_tables) and "ckm_state" not in existing_tables
             if existing_tables:
+                # Additive current-version columns must land before strict
+                # validation; otherwise a valid pre-column v5 store refuses
+                # before it can migrate.
+                self._migrate_assessment_explainability(conn)
                 self._validate_required_columns(conn, legacy=legacy)
                 if not legacy:
                     self._validate_persisted_identity_values(conn)
             self._add_public_identity_columns(conn)
             self._migrate_evidence_edge_basis(conn)
-            self._migrate_assessment_explainability(conn)
             for statement in CKM_DDL_STATEMENTS:
                 if "CREATE UNIQUE INDEX" in statement and (
                     "public_id" in statement or "identity_key" in statement
@@ -889,6 +893,7 @@ class CkmStore:
             "scores": {dimension: row[dimension] for dimension in MATURITY_DIMENSIONS},
             "candidate_shares": row["candidate_shares"],
             "formula_ids": row["formula_ids"],
+            "dimension_status": row["dimension_status"],
             "aggregate": row["aggregate"],
             "aggregate_formula_id": row["aggregate_formula_id"],
             "low_confidence": row["low_confidence"],
@@ -1012,6 +1017,7 @@ class CkmStore:
         additions = (
             ("candidate_shares", "TEXT NOT NULL DEFAULT '{}'"),
             ("formula_ids", "TEXT NOT NULL DEFAULT '{}'"),
+            ("dimension_status", "TEXT NOT NULL DEFAULT '{}'"),
             (
                 "aggregate_formula_id",
                 "TEXT NOT NULL DEFAULT 'legacy-pre-ckm07'",
@@ -2020,6 +2026,7 @@ class CkmStore:
         scores: Mapping[str, float],
         citations: Mapping[str, list[JsonDict]],
         candidate_shares: Mapping[str, float] | None = None,
+        dimension_status: Mapping[str, str] | None = None,
         formula_ids: Mapping[str, str] | None = None,
         aggregate: float,
         aggregate_formula_id: str = "legacy-pre-ckm07",
@@ -2040,6 +2047,37 @@ class CkmStore:
         resolved_candidate_shares = candidate_shares or {
             dimension: 0.0 for dimension in MATURITY_DIMENSIONS
         }
+        resolved_dimension_status = (
+            dict(dimension_status)
+            if dimension_status is not None
+            else {
+                dimension: (
+                    "missing"
+                    if float(scores[dimension]) == 0.0 and not citations[dimension]
+                    else "measured"
+                )
+                for dimension in MATURITY_DIMENSIONS
+            }
+        )
+        missing_statuses = set(MATURITY_DIMENSIONS) - set(resolved_dimension_status)
+        if missing_statuses:
+            raise CkmValidationError(
+                f"assessment missing dimension status(es): {sorted(missing_statuses)}"
+            )
+        unknown_statuses = set(resolved_dimension_status) - set(MATURITY_DIMENSIONS)
+        if unknown_statuses:
+            raise CkmValidationError(
+                f"assessment has unknown dimension status key(s): {sorted(unknown_statuses)}"
+            )
+        unsupported_statuses = {
+            status
+            for status in resolved_dimension_status.values()
+            if status not in SUPPORTED_VALUE_STATES
+        }
+        if unsupported_statuses:
+            raise CkmValidationError(
+                f"assessment has unsupported dimension status(es): {sorted(unsupported_statuses)}"
+            )
         resolved_formula_ids = formula_ids or {
             dimension: "legacy-pre-ckm07" for dimension in MATURITY_DIMENSIONS
         }
@@ -2060,6 +2098,7 @@ class CkmStore:
             values.append(_dumps(citations[dimension]))
         columns += [
             "candidate_shares",
+            "dimension_status",
             "formula_ids",
             "aggregate",
             "aggregate_formula_id",
@@ -2071,6 +2110,7 @@ class CkmStore:
         ]
         values += [
             _dumps(resolved_candidate_shares),
+            _dumps(resolved_dimension_status),
             _dumps(resolved_formula_ids),
             aggregate,
             aggregate_formula_id,
@@ -2093,6 +2133,7 @@ class CkmStore:
                     for dimension in MATURITY_DIMENSIONS
                 },
                 "candidate_shares": _dumps(resolved_candidate_shares),
+                "dimension_status": _dumps(resolved_dimension_status),
                 "formula_ids": _dumps(resolved_formula_ids),
                 "aggregate": aggregate,
                 "aggregate_formula_id": aggregate_formula_id,
@@ -2165,6 +2206,7 @@ class CkmStore:
             dimension: _loads(row[f"{dimension}_citations"]) for dimension in MATURITY_DIMENSIONS
         }
         candidate_shares = _loads(row["candidate_shares"])
+        dimension_status = _loads(row["dimension_status"])
         formula_ids = _loads(row["formula_ids"])
         watermark_set = _loads(row["watermark_set"])
         return CkmAssessment.from_row(
@@ -2172,6 +2214,7 @@ class CkmStore:
             scores=scores,
             citations=citations,
             candidate_shares=candidate_shares,
+            dimension_status=dimension_status,
             formula_ids=formula_ids,
             watermark_set=watermark_set,
         )

--- a/tests/builderops/ckm/test_assessment_engine.py
+++ b/tests/builderops/ckm/test_assessment_engine.py
@@ -120,6 +120,7 @@ def test_every_dimension_cites_evidence(store: CkmStore) -> None:
     assert assessment is not None
     assert set(assessment.scores) == set(MATURITY_DIMENSIONS)
     assert set(assessment.citations) == set(MATURITY_DIMENSIONS)
+    assert set(assessment.dimension_status) == set(MATURITY_DIMENSIONS)
     assert set(assessment.formula_ids) == set(MATURITY_DIMENSIONS)
     assert all(formula_id in FORMULAS for formula_id in assessment.formula_ids.values())
     edge_ids = {edge.id for edge in store.list_evidence_edges()}
@@ -129,6 +130,48 @@ def test_every_dimension_cites_evidence(store: CkmStore) -> None:
         for citation in assessment.citations[dimension]:
             assert CkmEvidenceEdge.from_row(citation["edge"]).validate().id == citation["edge_id"]
             assert CkmArtifact.from_row(citation["artifact"]).validate().id == citation["artifact_id"]
+
+
+def test_documentation_empty_set_is_unassessed_with_formula_v2(store: CkmStore) -> None:
+    capability = _capability(store)
+
+    assert assess_capabilities(store).assessed == 1
+    assessment = store.latest_assessment_for_capability(capability.id)
+
+    assert assessment is not None
+    assert assessment.scores["documentation_quality"] == 0.0
+    assert assessment.citations["documentation_quality"] == []
+    assert assessment.dimension_status["documentation_quality"] == "unassessed"
+    assert assessment.formula_ids["documentation_quality"] == "current-doc-evidence-v2"
+
+
+def test_documentation_formula_v1_assessment_is_reminted(
+    store: CkmStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capability = _capability(store)
+    monkeypatch.setitem(
+        assess_module._DIMENSION_FORMULA_IDS,
+        "documentation_quality",
+        "current-doc-evidence-v1",
+    )
+    assert assess_capabilities(store).assessed == 1
+    first = store.latest_assessment_for_capability(capability.id)
+    assert first is not None
+    assert first.formula_ids["documentation_quality"] == "current-doc-evidence-v1"
+
+    monkeypatch.setitem(
+        assess_module._DIMENSION_FORMULA_IDS,
+        "documentation_quality",
+        "current-doc-evidence-v2",
+    )
+    assert assess_capabilities(store).assessed == 1
+    history = store.list_assessments_for_capability(capability.id)
+
+    assert len(history) == 2
+    assert history[0].id == first.id
+    assert history[1].id != first.id
+    assert history[1].formula_ids["documentation_quality"] == "current-doc-evidence-v2"
+    assert history[0].edge_fingerprint != history[1].edge_fingerprint
 
 
 def test_assessment_public_id_survives_real_rebuild_producer(
@@ -704,6 +747,7 @@ def test_schema_v2_assessment_migrates_with_legacy_formula_provenance(tmp_path: 
     assert all(migrated.citations[dimension] == [] for dimension in MATURITY_DIMENSIONS)
     assert migrated.aggregate == 0.25
     assert set(migrated.formula_ids.values()) == {"legacy-pre-ckm07"}
+    assert dict(migrated.dimension_status) == {}
     assert migrated.aggregate_formula_id == "legacy-pre-ckm07"
     assert set(migrated.candidate_shares.values()) == {0.0}
     assert migrated.low_confidence is False

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -84,12 +84,18 @@ def overview_store(tmp_path: Path) -> CkmStore:
     }
     scores = {dimension: 0.8 for dimension in MATURITY_DIMENSIONS}
     citations = {dimension: [citation] for dimension in MATURITY_DIMENSIONS}
+    dimension_status = {dimension: "measured" for dimension in MATURITY_DIMENSIONS}
     scores["operational_readiness"] = 0.0
     citations["operational_readiness"] = []
+    dimension_status["operational_readiness"] = "missing"
+    scores["documentation_quality"] = 0.0
+    citations["documentation_quality"] = []
+    dimension_status["documentation_quality"] = "unassessed"
     store.append_assessment(
         capability_id=parent.id,
         scores=scores,
         citations=citations,
+        dimension_status=dimension_status,
         candidate_shares={dimension: 0.75 for dimension in MATURITY_DIMENSIONS},
         formula_ids={dimension: "fixture-formula" for dimension in MATURITY_DIMENSIONS},
         aggregate=0.8,
@@ -137,7 +143,7 @@ def test_pure_render_over_fixture_graph(overview_store: CkmStore) -> None:
     assert "band-critical" not in first
     assert "band-watch" not in first
     assert "band-healthy" not in first
-    assert first.count('class="dimension-bar"') == len(MATURITY_DIMENSIONS)
+    assert first.count('class="dimension-bar"') == len(MATURITY_DIMENSIONS) - 1
     summary = first.split("</summary>", maxsplit=1)[0]
     assert summary.count('class="mini-dimension ') == len(MATURITY_DIMENSIONS)
     assert '<details class="drilldown"><summary>Evidence and basis</summary>' in first
@@ -151,7 +157,7 @@ def test_honesty_markers_render(overview_store: CkmStore) -> None:
     assert "LOW CONFIDENCE" in rendered
     assert "candidate share 75.0%" in rendered
     assert "candidate share unavailable" in rendered
-    assert rendered.count('mini-dimension mini-unassessed') == len(MATURITY_DIMENSIONS)
+    assert rendered.count('mini-dimension mini-unassessed') == len(MATURITY_DIMENSIONS) + 1
     assert "2 confirmed / 1 candidate" not in rendered
     assert "1 confirmed / 1 candidate" in rendered
     assert '<span class="badge evidence-status">candidate</span>' in rendered
@@ -173,10 +179,22 @@ def test_dimension_cells_render_three_states_and_proportional_fill(
     assert 'class="mini-dimension mini-scored"' in rendered
     assert 'style="--score:80.0%"' in rendered
     assert 'class="mini-dimension mini-starved"' in rendered
+    assert (
+        '<section class="dimension dimension-unassessed" '
+        'data-dimension="documentation_quality" data-cell-state="unassessed">'
+        in rendered
+    )
+    unassessed_section = rendered.split(
+        'data-dimension="documentation_quality" data-cell-state="unassessed">',
+        maxsplit=1,
+    )[1].split("</section>", maxsplit=1)[0]
+    assert "<strong>—</strong>" in unassessed_section
+    assert "dimension-track" not in unassessed_section
+    assert "dimension-bar" not in unassessed_section
     unknown_cells = re.findall(
         r'<span class="mini-dimension mini-unassessed"[^>]*>—</span>', rendered
     )
-    assert len(unknown_cells) == len(MATURITY_DIMENSIONS)
+    assert len(unknown_cells) == len(MATURITY_DIMENSIONS) + 1
     assert all("--score" not in cell for cell in unknown_cells)
 
 

--- a/tests/builderops/ckm/test_store.py
+++ b/tests/builderops/ckm/test_store.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 import pytest
 
+from app.builderops.ckm.contracts import SUPPORTED_VALUE_STATES
 from app.builderops.ckm.models import MATURITY_DIMENSIONS, CkmValidationError
-from app.builderops.ckm.schema import CKM_TABLE_NAMES
+from app.builderops.ckm.schema import CKM_SCHEMA_VERSION, CKM_TABLE_NAMES
 from app.builderops.ckm.store import CkmStore
 from app.builderops.store import SqliteBuilderOpsStore
 
@@ -284,6 +285,73 @@ def test_assessment_append_only_bitemporal(store: CkmStore) -> None:
 
     latest = store.latest_assessment_for_capability(capability.id)
     assert latest.id == second.id
+
+
+def test_dimension_status_round_trips_supported_vocabulary(store: CkmStore) -> None:
+    capability = _upsert_capability(store)
+    scores, citations = _assessment_scores_and_citations()
+    statuses = {dimension: "measured" for dimension in MATURITY_DIMENSIONS}
+    statuses["documentation_quality"] = "unassessed"
+
+    assessment = store.append_assessment(
+        capability_id=capability.id,
+        scores=scores,
+        citations=citations,
+        dimension_status=statuses,
+        aggregate=0.5,
+        watermark_set={"repo_artifact_ingestion": "commit:abc123"},
+    )
+
+    assert dict(assessment.dimension_status) == statuses
+    assert set(assessment.dimension_status.values()) <= SUPPORTED_VALUE_STATES
+    assert store.get_assessment(assessment.id) == assessment
+
+    invalid = dict(statuses)
+    invalid["documentation_quality"] = "unknown"
+    with pytest.raises(CkmValidationError, match="unsupported dimension status"):
+        store.append_assessment(
+            capability_id=capability.id,
+            scores=scores,
+            citations=citations,
+            dimension_status=invalid,
+            aggregate=0.5,
+            watermark_set={"repo_artifact_ingestion": "commit:abc123"},
+        )
+
+
+def test_current_v5_store_idempotently_backfills_dimension_status(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "current-v5.sqlite3")
+    store.ensure_schema()
+    capability = _upsert_capability(store)
+    scores, citations = _assessment_scores_and_citations()
+    assessment = store.append_assessment(
+        capability_id=capability.id,
+        scores=scores,
+        citations=citations,
+        dimension_status={dimension: "measured" for dimension in MATURITY_DIMENSIONS},
+        aggregate=0.5,
+        watermark_set={"repo_artifact_ingestion": "commit:abc123"},
+    )
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute("ALTER TABLE ckm_assessment DROP COLUMN dimension_status")
+        before = conn.execute(
+            "SELECT epoch, schema_version FROM ckm_state WHERE singleton = 1"
+        ).fetchone()
+
+    store.ensure_schema()
+    store.ensure_schema()
+
+    with sqlite3.connect(store.db_path) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(ckm_assessment)")
+        }
+        after = conn.execute(
+            "SELECT epoch, schema_version FROM ckm_state WHERE singleton = 1"
+        ).fetchone()
+    assert "dimension_status" in columns
+    assert before == after
+    assert after[1] == CKM_SCHEMA_VERSION == 5
+    assert dict(store.get_assessment(assessment.id).dimension_status) == {}
 
 
 def test_append_assessment_requires_all_dimension_citations(store: CkmStore) -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4091

## Linked Issue
Fixes #4091

## SBS Impact
- Primary subsystem: Builder System / CES boundary — BuilderOps CKM store and generated projection
- Secondary subsystem(s): none; Product/Runtime System is read-only and unaffected
- Write class: additive mechanical persistence, scoring-semantics correction, derived render change, and tests
- Authority impact: none; CKM remains projection-only
- Persistence impact: durable additive `dimension_status` JSON column and newly minted bitemporal assessment rows
- Derived/rebuildable impact: HTML projection remains rebuildable from CKM state
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none; no release promotion
- External boundary impact: none
- New or changed contract: per-dimension evidence status plus documentation formula `current-doc-evidence-v2`
- Owner-doc impact: none; Direction A and the CKM Evidence Profile already define the intended three states
- Transition debt impact: reduces unavailable-versus-zero ambiguity; no new SBS transition debt
- Fitness rule impact: strengthens additive migration, vocabulary, formula-id/fingerprint, render-purity, and replay checks
- Boundary risk: low and additive; persisted-vocabulary and bitemporal remint tests cover the hidden data-correctness boundary

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Persist per-dimension CKM evidence status through the schema-v5 four-place compatibility path without changing schema version or epoch.
- Mark documentation with no selected evidence as `unassessed`, remint formula-v1 assessments under `current-doc-evidence-v2`, and render the unavailable state without a score bar.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied by code and automated verification; authorized real-store replay remains the parent-governed delivery gate described below.
- [x] Existing owner docs already state the changed contract, so no duplicate docs writeback is required.
- [x] No roadmap/plan wording becomes false before delivery; parent #4089 retains the terminal replay and next-child handoff.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests` — `All checks passed!`
- [x] `mypy app` — `Success: no issues found in 808 source files`
- [x] `python3 -m pytest -q tests/builderops/ckm/test_store.py tests/builderops/ckm/test_assessment_engine.py tests/builderops/ckm/test_overview_html.py` — `54 passed in 8.57s`
- [x] `python3 -m pytest -q -m "not pg" tests/builderops/ckm` — `231 passed in 40.07s`
- [x] Current-v5 migration fixture opens twice, backfills `{}`, and proves schema `5` plus unchanged epoch; legacy-v0/schema-v2 coverage remains green.
- [x] The governing `Verify:` targets and affected CKM subsystem tests passed.
- [x] Focused-scope rationale: the issue is confined to BuilderOps CKM schema, assessment, and pure HTML projection; its complete CKM suite is the proportionate gate.

Additional evidence: the voluntarily-run repository-wide non-PG suite reached `10690 passed, 46 skipped, 273 deselected, 18 xfailed` with one unrelated existing failure in `tests/properties/test_guard_at_seam.py::test_every_write_note_relative_seam_has_port_coverage`: `app/heimdal/candidate_projection.py::write_reading_candidate_note` is absent from the write-note census in `tests/properties/_machinery.py`. Neither surface is changed here.

## BuilderOps Routing
- Records/projections/receipts: pickup receipt [issue comment 5071005843](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4091#issuecomment-5071005843); LearningSignal `lrn_20260724145920_730922a6`
- Reason: the dispatcher had no exact #4091 task, so pickup used the governed GitHub-label fallback; the unrelated broad-suite seam divergence was captured for upstream repair rather than expanding this Issue.

## Notes
- Real-store preflight on `Demerzel.cyberdyne.lan` found no CKM tables in the known BuilderOps SQLite paths and no parent-authorized 31-capability CKM database path. No store was mutated and no named-absence success is claimed. The parent #4089 terminal replay remains pending at its authorized post-EP-03 gate.
- Historical rows are not patched: pre-column stores backfill `{}` for compatibility, while the v2 formula id changes the assessment fingerprint and appends a new bitemporal row on reassessment.
- Refs #4089. Issue #4092 remains untouched and blocked on this delivery.