### PR TITLE
Add honest CKM subsystem evidence counts

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -73,6 +73,110 @@ def _edge_counts(edges: Sequence[CkmEvidenceEdge]) -> tuple[int, int]:
     )
 
 
+def _shared_evidence_pairs(
+    edges_by_capability: Mapping[str, Sequence[CkmEvidenceEdge]],
+) -> frozenset[tuple[str, str]]:
+    capability_ids_by_pair: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for edges in edges_by_capability.values():
+        for edge in edges:
+            capability_ids_by_pair[(edge.artifact_id, edge.basis)].add(
+                edge.capability_id
+            )
+    return frozenset(
+        pair
+        for pair, capability_ids in capability_ids_by_pair.items()
+        if len(capability_ids) >= 2
+    )
+
+
+def _evidence_count_values(
+    edges: Sequence[CkmEvidenceEdge],
+    shared_pairs: frozenset[tuple[str, str]],
+) -> tuple[int, int, int, str]:
+    distinct_artifacts = len({edge.artifact_id for edge in edges})
+    edge_count = len(edges)
+    shared_edge_count = sum(
+        (edge.artifact_id, edge.basis) in shared_pairs for edge in edges
+    )
+    shared_percentage = (
+        f"{shared_edge_count / edge_count:.1%}" if edge_count else "0.0%"
+    )
+    return distinct_artifacts, edge_count, shared_edge_count, shared_percentage
+
+
+def _subsystem_counts_markup(
+    forest: Sequence[tuple[int, CkmCapability]],
+    edges_by_capability: Mapping[str, Sequence[CkmEvidenceEdge]],
+) -> str:
+    shared_pairs = _shared_evidence_pairs(edges_by_capability)
+    all_edges = tuple(
+        edge
+        for _, capability in forest
+        for edge in edges_by_capability.get(capability.id, ())
+    )
+    (
+        global_artifacts,
+        global_edges,
+        global_shared_edges,
+        global_shared_percentage,
+    ) = _evidence_count_values(all_edges, shared_pairs)
+
+    groups: list[list[tuple[int, CkmCapability]]] = []
+    current: list[tuple[int, CkmCapability]] = []
+    for depth, capability in forest:
+        if depth == 0:
+            if current:
+                groups.append(current)
+            current = [(depth, capability)]
+        else:
+            current.append((depth, capability))
+    if current:
+        groups.append(current)
+
+    cards: list[str] = []
+    for group in groups:
+        root = group[0][1]
+        group_edges = tuple(
+            edge
+            for _, capability in group
+            for edge in edges_by_capability.get(capability.id, ())
+        )
+        distinct_artifacts, edge_count, shared_edge_count, shared_percentage = (
+            _evidence_count_values(group_edges, shared_pairs)
+        )
+        capability_rows: list[str] = []
+        for depth, capability in group:
+            capability_edges = edges_by_capability.get(capability.id, ())
+            (
+                capability_artifacts,
+                capability_edge_count,
+                capability_shared_edges,
+                capability_shared_percentage,
+            ) = _evidence_count_values(capability_edges, shared_pairs)
+            capability_rows.append(
+                f"""<li class="capability-count" data-capability-name="{_e(capability.name)}" data-distinct-artifacts="{capability_artifacts}" data-shared-edge-count="{capability_shared_edges}" data-edge-count="{capability_edge_count}" data-shared-evidence="{capability_shared_percentage}" style="--count-depth:{depth}">
+              <span class="count-name">{_e(capability.name)}</span>
+              <span>distinct artifacts: <strong>{capability_artifacts}</strong></span>
+              <span class="secondary">edges: {capability_edge_count}</span>
+              <span>shared evidence: <strong>{capability_shared_percentage}</strong> ({capability_shared_edges} of {capability_edge_count} edges)</span>
+            </li>"""
+            )
+        cards.append(
+            f"""<section class="subsystem-counts-card" data-subsystem-name="{_e(root.name)}" data-capability-count="{len(group)}" data-distinct-artifacts="{distinct_artifacts}" data-shared-edge-count="{shared_edge_count}" data-edge-count="{edge_count}" data-shared-evidence="{shared_percentage}">
+          <h3>{_e(root.name)} subsystem</h3>
+          <p>capabilities: <strong>{len(group)}</strong> · distinct artifacts: <strong>{distinct_artifacts}</strong> · shared evidence: <strong>{shared_percentage}</strong> ({shared_edge_count} of {edge_count} edges)</p>
+          <ul>{"".join(capability_rows)}</ul>
+        </section>"""
+        )
+
+    cards_markup = "".join(cards) or '<p class="empty">No subsystems in the CKM store.</p>'
+    return f"""<section class="subsystem-counts" aria-labelledby="subsystem-counts-heading">
+      <h2 id="subsystem-counts-heading">Evidence counts by subsystem</h2>
+      <p class="linkage-masthead" data-denominator="global" data-distinct-artifacts="{global_artifacts}" data-capability-count="{len(forest)}" data-shared-edge-count="{global_shared_edges}" data-edge-count="{global_edges}" data-shared-evidence="{global_shared_percentage}"><strong>Linkage masthead:</strong> {global_artifacts} distinct artifacts across {len(forest)} capabilities · shared evidence: <strong>{global_shared_percentage}</strong> of all {global_edges} edges (global).</p>
+      <div class="subsystem-counts-grid">{cards_markup}</div>
+    </section>"""
+
+
 def _citation_source(citation: Mapping[str, object]) -> str:
     source_ref = citation.get("source_ref")
     artifact = citation.get("artifact")
@@ -328,6 +432,7 @@ def render_overview_html(
         )
         for capability in capabilities
     }
+    forest = _forest(capabilities)
     cards = "".join(
         _capability_markup(
             capability,
@@ -336,7 +441,7 @@ def render_overview_html(
             findings=batch.findings_by_capability.get(capability.id, ()),
             projection=batch.assessments_by_capability.get(capability.id),
         )
-        for depth, capability in _forest(capabilities)
+        for depth, capability in forest
     ) or '<p class="empty">No capabilities in the CKM store.</p>'
     grouped: dict[str, list[CkmFinding]] = defaultdict(list)
     for finding in all_findings:
@@ -361,6 +466,7 @@ def render_overview_html(
     main,footer {{ width:min(74rem,calc(100% - 2rem)); margin:0 auto; }} a {{ color:inherit; }} summary:focus-visible,a:focus-visible {{ outline:2px solid var(--accent); outline-offset:2px; }}
     .projection-banner {{ border-left:0.25rem solid var(--amber); background:var(--bg-raised); padding:0.75rem 1rem; color:var(--fg-2); }} header {{ padding:1.75rem 0 0.75rem; }} h1 {{ font:400 1.75rem/1.2 ui-serif,Georgia,serif; }} h2 {{ margin-top:1.5rem; }} .subtitle,.empty,small,.meta {{ color:var(--fg-2); }}
     .trust-strip {{ display:grid; grid-template-columns:repeat(5,1fr); border:1px solid var(--border-strong); background:var(--bg-surface); }} .trust-strip a {{ padding:0.625rem; text-decoration:none; border-right:1px solid var(--border); }}
+    .linkage-masthead {{ padding:0.75rem; border-left:0.25rem solid var(--agent); background:var(--bg-raised); }} .subsystem-counts-grid {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(22rem,1fr)); gap:0.75rem; }} .subsystem-counts-card {{ border:1px solid var(--border); background:var(--bg-surface); padding:0.75rem; }} .subsystem-counts-card h3 {{ margin:0; }} .subsystem-counts-card ul {{ list-style:none; margin:0.75rem 0 0; padding:0; }} .capability-count {{ display:grid; grid-template-columns:minmax(10rem,1fr) repeat(3,auto); gap:0.5rem 1rem; margin-left:calc(var(--count-depth) * 0.75rem); padding:0.45rem 0; border-top:1px solid var(--border); }} .count-name {{ font-weight:600; }} .secondary {{ color:var(--fg-2); }}
     .legend {{ display:grid; grid-template-columns:2fr 1fr; gap:1rem; margin:1rem 0; padding:0.75rem; border:1px solid var(--border); background:var(--bg-surface); }} .legend ul {{ display:flex; gap:0.5rem 1rem; flex-wrap:wrap; list-style:none; padding:0; margin:0.35rem 0 0; }} .legend-cell {{ display:inline-block; width:1.5rem; height:0.5rem; margin-right:0.3rem; background:var(--agent); }} .legend-cell.starved {{ border:1px dotted var(--amber); background:transparent; }} .legend-cell.unassessed {{ height:auto; background:none; color:var(--fg-3); }}
     .dimension-rail {{ position:sticky; top:0; z-index:2; display:grid; grid-template-columns:repeat(7,1fr); gap:0.25rem; margin-left:auto; width:13rem; padding:0.25rem; background:var(--bg-base); color:var(--fg-2); font:0.7rem ui-monospace,monospace; text-align:center; }}
     .capability {{ margin:0.5rem 0 0.5rem calc(var(--depth) * 1.375rem); border:1px solid var(--border); border-left:0.25rem solid var(--unknown); border-radius:0.25rem; background:var(--bg-surface); }}
@@ -370,7 +476,7 @@ def render_overview_html(
     .capability-body {{ border-top:1px solid var(--border); padding:1rem; background:var(--bg-raised); }} .honesty {{ border-left:0.2rem solid var(--amber); padding-left:0.75rem; color:var(--fg-2); }} .honesty p {{ margin:0.2rem 0; }} .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(14rem,1fr)); gap:0.625rem; margin:0.875rem 0; }} .dimension {{ border:1px solid var(--border-strong); padding:0.625rem; }} .dimension-label {{ display:flex; gap:0.5rem; justify-content:space-between; }} .dimension-label span {{ flex:1; }} .dimension-track {{ height:0.5rem; margin:0.4rem 0; background:var(--bg-overlay); overflow:hidden; }} .dimension-starved .dimension-track {{ border:1px dotted var(--amber); background:none; }} .dimension-bar {{ display:block; height:100%; background:var(--agent); }}
     .drilldown,.citations {{ margin-top:0.625rem; }} .evidence-list,.finding-list {{ padding-left:1.25rem; }} .evidence-list li,.finding-list li {{ margin:0.45rem 0; }} .evidence-candidate {{ border-left:0.15rem solid var(--agent); padding-left:0.5rem; }} .basis {{ color:var(--fg-2); margin-left:0.5rem; }} .gaps-panel {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .gap-group {{ margin:0.75rem 0; }}
     footer {{ margin-top:1.75rem; padding:1rem 0 2.25rem; border-top:1px solid var(--border); color:var(--fg-2); overflow-wrap:anywhere; }}
-    @media (max-width:680px) {{ main,footer {{ width:min(100% - 1rem,74rem); }} .trust-strip {{ grid-template-columns:1fr 1fr; }} .legend {{ grid-template-columns:1fr; }} .dimension-rail {{ display:none; }} .capability {{ margin-left:calc(var(--depth) * 0.5rem); }} .capability-summary {{ flex-wrap:wrap; align-items:flex-start; }} .tree-name {{ min-width:65%; }} .summary-flags {{ flex-wrap:wrap; }} .mini-dimensions {{ order:6; width:100%; grid-template-columns:repeat(7,minmax(1.5rem,1fr)); }} .mini-dimension {{ width:auto; min-height:1.5rem; }} .mini-dimension::before {{ content:attr(data-abbr); display:block; font:0.55rem ui-monospace,monospace; color:var(--fg-2); }} }}
+    @media (max-width:680px) {{ main,footer {{ width:min(100% - 1rem,74rem); }} .trust-strip {{ grid-template-columns:1fr 1fr; }} .subsystem-counts-grid {{ grid-template-columns:1fr; }} .capability-count {{ grid-template-columns:1fr; gap:0.15rem; }} .legend {{ grid-template-columns:1fr; }} .dimension-rail {{ display:none; }} .capability {{ margin-left:calc(var(--depth) * 0.5rem); }} .capability-summary {{ flex-wrap:wrap; align-items:flex-start; }} .tree-name {{ min-width:65%; }} .summary-flags {{ flex-wrap:wrap; }} .mini-dimensions {{ order:6; width:100%; grid-template-columns:repeat(7,minmax(1.5rem,1fr)); }} .mini-dimension {{ width:auto; min-height:1.5rem; }} .mini-dimension::before {{ content:attr(data-abbr); display:block; font:0.55rem ui-monospace,monospace; color:var(--fg-2); }} }}
   </style>
 </head>
 <body>
@@ -378,6 +484,7 @@ def render_overview_html(
   <main>
     <header><h1>Development Overview</h1><p class="subtitle">Capability Knowledge Model maturity, trust, and cited drill-down.</p></header>
     {_trust_strip(capabilities, assessments, len(all_findings))}
+    {_subsystem_counts_markup(forest, batch.edges_by_capability)}
     <section aria-labelledby="map-heading">
       <h2 id="map-heading">Capability map</h2>
       {_legend()}

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -115,6 +115,84 @@ def overview_store(tmp_path: Path) -> CkmStore:
     return store
 
 
+@pytest.fixture()
+def fanout_overview_store(tmp_path: Path) -> CkmStore:
+    store = CkmStore(tmp_path / "fanout-overview.sqlite3")
+    store.ensure_schema()
+    subsystem = store.upsert_capability(
+        identity_key="fixture:counts:subsystem",
+        name="Retrieval subsystem",
+        definition="Fixture subsystem.",
+        existence_provenance="seeded:fixture",
+        lifecycle="confirmed",
+        boundary_ref="RCA",
+    )
+    child = store.upsert_capability(
+        identity_key="fixture:counts:child",
+        name="Retrieval",
+        definition="Fixture child capability.",
+        existence_provenance="seeded:fixture-child",
+        lifecycle="confirmed",
+        parent_id=subsystem.id,
+        boundary_ref="RCA",
+    )
+    other = store.upsert_capability(
+        identity_key="fixture:counts:other",
+        name="Observability subsystem",
+        definition="Fixture second subsystem.",
+        existence_provenance="seeded:fixture-other",
+        lifecycle="confirmed",
+        boundary_ref="OEF",
+    )
+    shared = store.upsert_artifact(
+        source_ref="docs/shared.md",
+        artifact_kind="document",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"docs/shared.md"}',
+    )
+    subsystem_only = store.upsert_artifact(
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"app/retrieval.py"}',
+    )
+    child_only = store.upsert_artifact(
+        source_ref="tests/test_retrieval.py",
+        artifact_kind="test",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"tests/test_retrieval.py"}',
+    )
+
+    def edge(*, artifact_id: str, capability_id: str, basis: str) -> None:
+        store.upsert_evidence_edge(
+            artifact_id=artifact_id,
+            capability_id=capability_id,
+            evidence_kind="source",
+            polarity="supports",
+            maturity_dimension="functional_completeness",
+            confidence=1.0,
+            extraction_method="deterministic",
+            lifecycle="confirmed",
+            source_ref=f"fixture:{artifact_id}",
+            basis=basis,
+        )
+
+    edge(artifact_id=shared.id, capability_id=subsystem.id, basis="fixture:fanout")
+    edge(artifact_id=shared.id, capability_id=subsystem.id, basis="fixture:second-edge")
+    edge(
+        artifact_id=subsystem_only.id,
+        capability_id=subsystem.id,
+        basis="fixture:subsystem-only",
+    )
+    edge(artifact_id=shared.id, capability_id=child.id, basis="fixture:fanout")
+    edge(artifact_id=child_only.id, capability_id=child.id, basis="fixture:child-only")
+    edge(artifact_id=shared.id, capability_id=other.id, basis="fixture:fanout")
+    return store
+
+
 def test_pure_render_over_fixture_graph(overview_store: CkmStore) -> None:
     before = (
         overview_store.list_capabilities(),
@@ -308,6 +386,74 @@ def test_provenance_banner_precedes_map_and_footer_remains(
         assert rendered.index("Generated projection — not source of truth") < rendered.index(
             'id="map-heading"'
         )
+
+
+def test_subsystem_counts_distinct_artifacts(
+    fanout_overview_store: CkmStore,
+) -> None:
+    rendered = render_overview_html(fanout_overview_store)
+
+    subsystem = re.search(
+        r'<section class="subsystem-counts-card"[^>]*data-subsystem-name="Retrieval subsystem"'
+        r'[^>]*data-capability-count="2"[^>]*data-distinct-artifacts="3"',
+        rendered,
+    )
+    assert subsystem is not None
+    root = re.search(
+        r'<li class="capability-count"[^>]*data-capability-name="Retrieval subsystem"'
+        r'[^>]*data-distinct-artifacts="2"[^>]*data-edge-count="3"',
+        rendered,
+    )
+    child = re.search(
+        r'<li class="capability-count"[^>]*data-capability-name="Retrieval"'
+        r'[^>]*data-distinct-artifacts="2"[^>]*data-edge-count="2"',
+        rendered,
+    )
+    assert root is not None
+    assert child is not None
+    assert "distinct artifacts: <strong>3</strong>" in subsystem.group(0) + rendered[
+        subsystem.end() : subsystem.end() + 300
+    ]
+
+
+def test_subsystem_counts_shared_evidence_indicator(
+    fanout_overview_store: CkmStore,
+) -> None:
+    rendered = render_overview_html(fanout_overview_store)
+
+    assert re.search(
+        r'data-subsystem-name="Retrieval subsystem"[^>]*data-shared-edge-count="2"'
+        r'[^>]*data-edge-count="5"[^>]*data-shared-evidence="40.0%"',
+        rendered,
+    )
+    assert re.search(
+        r'data-capability-name="Retrieval subsystem"[^>]*data-shared-edge-count="1"'
+        r'[^>]*data-edge-count="3"[^>]*data-shared-evidence="33.3%"',
+        rendered,
+    )
+    assert re.search(
+        r'data-capability-name="Retrieval"[^>]*data-shared-edge-count="1"'
+        r'[^>]*data-edge-count="2"[^>]*data-shared-evidence="50.0%"',
+        rendered,
+    )
+    assert rendered.count("shared evidence:") == 6
+
+
+def test_subsystem_counts_global_masthead(
+    fanout_overview_store: CkmStore,
+) -> None:
+    rendered = render_overview_html(fanout_overview_store)
+
+    assert re.search(
+        r'class="linkage-masthead" data-denominator="global" '
+        r'data-distinct-artifacts="3" data-capability-count="3" '
+        r'data-shared-edge-count="3" data-edge-count="6" '
+        r'data-shared-evidence="50.0%"',
+        rendered,
+    )
+    assert "3 distinct artifacts across 3 capabilities" in rendered
+    assert "50.0%</strong> of all 6 edges (global)" in rendered
+
 
 def test_no_external_references(overview_store: CkmStore) -> None:
     rendered = render_overview_html(overview_store)


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4092

## Linked Issue
Fixes #4092

## SBS Impact
- Primary subsystem: Builder System / CES boundary — BuilderOps CKM generated projection
- Secondary subsystem(s): none; Product/Runtime System is read-only and unaffected
- Write class: deterministic derived counts view and tests
- Authority impact: none; counts remain descriptive projection evidence
- Persistence impact: none
- Derived/rebuildable impact: counts and HTML are rebuilt from the captured CKM capability/evidence snapshot
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none; no release promotion or runtime mutation
- External boundary impact: none
- New or changed contract: distinct-artifact counts, shared-evidence indicators, and a global linkage masthead
- Owner-doc impact: none; the CKM Evidence Profile already owns this bounded presentation contract
- Transition debt impact: preserves visibility of linker fan-out without claiming linker precision is fixed
- Fitness rule impact: strengthens union-counting, cross-capability fan-out disclosure, global-denominator, purity, and self-containment checks
- Boundary risk: low; pure deterministic render over one read-only snapshot with no schema/linker/ingest change

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a per-subsystem overview section that reuses the unchanged `_forest` ordering and reports capability counts plus distinct-artifact unions rather than raw-edge coverage.
- Compute shared-evidence indicators from globally cross-capability `(artifact_id, basis)` pairs for every capability/subsystem, with the masthead denominator fixed to the whole graph.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed: `_forest`, schema, linker, and ingestion behavior are unchanged.
- [x] Acceptance Criteria from the linked Issue are satisfied by code and automated verification; the authorized real-store replay remains the parent terminal gate described below.
- [x] Existing owner/spec docs already state the changed presentation contract, so no duplicate docs writeback is required.
- [x] No roadmap/plan wording becomes false before delivery; parent #4089 retains terminal acceptance.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py` — `19 passed in 0.59s`
- [x] `python3 -m pytest -q -m "not pg" tests/builderops/ckm` — `234 passed in 40.88s`
- [x] `ruff check app tests` — `All checks passed!`
- [x] `mypy app` — `Success: no issues found in 808 source files`
- [x] Named fan-out fixture independently proves root `3 edges / 2 artifacts`, subsystem union `3` rather than child sum `4`, and capability/subsystem/global shared ratios `33.3% / 40.0% / 50.0%`.
- [x] The governing `Verify:` targets, render purity, missing-DB refusal, and self-containment tests passed.
- [x] Host-leased repository-wide non-PG run completed: `10693 passed, 46 skipped, 273 deselected, 18 xfailed`; one unrelated current-main failure remains in `tests/properties/test_guard_at_seam.py::test_every_write_note_relative_seam_has_port_coverage` because the Heimdal reading-candidate call site is absent from the census. Neither failing surface is changed here; bug #4096 tracks it.

The documented broad command first aborted before collection because this host auto-loads AnyIO while the command explicitly loaded it a second time. The successful leased retry used pytest auto-discovery and is the result above.

## BuilderOps Routing
- Records/projections/receipts: pickup receipt [issue comment 5071626002](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4092#issuecomment-5071626002); bug #4096 for the unrelated broad-suite fitness failure; attempted LearningSignal write produced no record
- Reason: the exact dispatcher task was absent, so pickup used the governed GitHub-label fallback. LearningSignal creation for the documented pytest-command divergence failed closed because no explicit host-stable BuilderOps store/cutover receipt was available; this PR does not guess a store or add unrelated fallback docs.

## Notes
- Real-store replay was not attempted: parent #4089 identifies the authorized host but no exact authorized 31-capability CKM database path, and the #4091 receipt confirms no CKM tables in known BuilderOps paths. No existing/prod store was opened or mutated and no terminal acceptance is fabricated. The parent needs an exact authorized DB path and the post-merge EP-03 candidate before replaying `seed → ingest → link → assess → overview`.
- Sharedness is global by pair identity: a pair is shared only when it appears on at least two distinct capability IDs. Capability and subsystem percentages retain their own edge denominators; the linkage masthead uses all graph edges.
- Refs #4089.