### PR TITLE
Fix bounded capture options for CKM overview

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -413,11 +413,18 @@ def render_overview_html(
     store: CkmStore,
     *,
     generated_at: str | None = None,
+    class_capture_limit: int | None = None,
+    aggregate_capture_limit: int | None = None,
 ) -> str:
     """Render one self-contained CKM projection without mutating the store."""
 
     timestamp = generated_at or utc_now()
-    batch = store.load_projection_batch()
+    capture_limits: dict[str, int] = {}
+    if class_capture_limit is not None:
+        capture_limits["class_capture_limit"] = class_capture_limit
+    if aggregate_capture_limit is not None:
+        capture_limits["aggregate_capture_limit"] = aggregate_capture_limit
+    batch = store.load_projection_batch(**capture_limits)
     capabilities = batch.capabilities
     capability_by_id = {item.id: item for item in capabilities}
     all_findings = tuple(
@@ -509,11 +516,18 @@ def write_overview_html(
     output_path: Path,
     *,
     generated_at: str | None = None,
+    class_capture_limit: int | None = None,
+    aggregate_capture_limit: int | None = None,
 ) -> Path:
     store.ensure_schema()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(
-        render_overview_html(store, generated_at=generated_at),
+        render_overview_html(
+            store,
+            generated_at=generated_at,
+            class_capture_limit=class_capture_limit,
+            aggregate_capture_limit=aggregate_capture_limit,
+        ),
         encoding="utf-8",
     )
     return output_path

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -694,13 +694,35 @@ def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> N
     type=click.Path(dir_okay=False, path_type=Path),
     required=True,
 )
+@click.option(
+    "--class-capture-limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Finite per-class projection capture bound (defaults to the store policy).",
+)
+@click.option(
+    "--aggregate-capture-limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Finite aggregate projection capture bound (defaults to the store policy).",
+)
 @click.pass_context
-def ckm_overview(ctx: click.Context, output_path: Path) -> None:
+def ckm_overview(
+    ctx: click.Context,
+    output_path: Path,
+    class_capture_limit: int | None,
+    aggregate_capture_limit: int | None,
+) -> None:
     try:
         store = _ckm_store(ctx)
         if not store.db_path.is_file():
             raise CkmValidationError(f"CKM database does not exist: {store.db_path}")
-        result = write_overview_html(store, output_path)
+        result = write_overview_html(
+            store,
+            output_path,
+            class_capture_limit=class_capture_limit,
+            aggregate_capture_limit=aggregate_capture_limit,
+        )
     except (CkmValidationError, OSError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm overview failed: {exc}") from exc
     click.echo(result)

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_HTML_PROJECTION.md
@@ -24,6 +24,10 @@ Give the owner the one-glance surface: a static HTML Development Overview render
   - gaps panel listing current findings;
   - footer: generated-projection self-identification + watermark set (INV-CKM-2).
 - CLI: `python -m app.builderops ckm overview --out /path/overview.html`.
+- For real stores whose finite projection exceeds the conservative defaults, operators may pass
+  explicit positive finite bounds: `--class-capture-limit N` and
+  `--aggregate-capture-limit N`. Defaults and typed refusal remain unchanged; there is no
+  unbounded or auto-sizing mode.
 - **Parent-closure handoff:** this final child updates `docs/CAPABILITY_KNOWLEDGE_MODEL/README.md` acceptance checklist to reflect delivered state, posts the capability-level validation receipt (live-run outputs + overview screenshot/file) to the parent feature issue, and either closes the parent (if all capability ACs verify) or files the explicit parent-closure issue naming what remains.
 
 ## Concretely

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from app.builderops.cli import builderops
 from app.builderops.ckm.models import MATURITY_DIMENSIONS
 from app.builderops.ckm.overview_html import render_overview_html
-from app.builderops.ckm.store import CkmProjectionCaptureError, CkmStore
+from app.builderops.ckm.store import CkmStore
 
 
 @pytest.fixture()
@@ -113,6 +113,19 @@ def overview_store(tmp_path: Path) -> CkmStore:
     )
     store.set_watermark("fixture", "two")
     return store
+
+
+def _make_snapshot_exceed_default(store: CkmStore) -> None:
+    """Add enough real fixture artifacts to exceed the default class bound."""
+    existing = len(store.list_artifacts())
+    for index in range(existing, 501):
+        store.upsert_artifact(
+            source_ref=f"fixture/oversized-{index}.md",
+            artifact_kind="document",
+            source="fixture",
+            watermark="one",
+            provenance=f'{{"source_ref":"fixture/oversized-{index}.md"}}',
+        )
 
 
 @pytest.fixture()
@@ -489,22 +502,17 @@ def test_cli_writes_overview(overview_store: CkmStore, tmp_path: Path) -> None:
 def test_cli_overview_accepts_explicit_capture_bounds(
     overview_store: CkmStore,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    observed: dict[str, int] = {}
-    original = CkmStore.load_projection_batch
+    _make_snapshot_exceed_default(overview_store)
+    default_output = tmp_path / "default-refused" / "ckm-overview.html"
+    default_result = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(overview_store.db_path), "ckm", "overview", "--out", str(default_output)],
+    )
+    assert default_result.exit_code != 0
+    assert "snapshot" in default_result.output
+    assert not default_output.exists()
 
-    def traced(self: CkmStore, **kwargs: int):
-        observed.update(kwargs)
-        if not kwargs:
-            raise CkmProjectionCaptureError(
-                "snapshot_too_large",
-                "complete CKM projection snapshot exceeds configured bounds",
-                {"class_limit": 500, "aggregate_limit": 3_000},
-            )
-        return original(self, **kwargs)
-
-    monkeypatch.setattr(CkmStore, "load_projection_batch", traced)
     output = tmp_path / "bounded" / "ckm-overview.html"
     result = CliRunner().invoke(
         builderops,
@@ -523,29 +531,14 @@ def test_cli_overview_accepts_explicit_capture_bounds(
     )
 
     assert result.exit_code == 0, result.output
-    assert observed == {"class_capture_limit": 501, "aggregate_capture_limit": 3001}
     assert output.is_file()
 
 
 def test_cli_overview_preserves_default_and_insufficient_bound_refusal(
     overview_store: CkmStore,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    observed: dict[str, int] = {}
-
-    def refuse(self: CkmStore, **kwargs: int):
-        observed.update(kwargs)
-        raise CkmProjectionCaptureError(
-            "snapshot_too_large",
-            "complete CKM projection snapshot exceeds configured bounds",
-            {
-                "class_limit": kwargs.get("class_capture_limit", 500),
-                "aggregate_limit": kwargs.get("aggregate_capture_limit", 3_000),
-            },
-        )
-
-    monkeypatch.setattr(CkmStore, "load_projection_batch", refuse)
+    _make_snapshot_exceed_default(overview_store)
     output = tmp_path / "refused" / "ckm-overview.html"
     result = CliRunner().invoke(
         builderops,
@@ -565,32 +558,37 @@ def test_cli_overview_preserves_default_and_insufficient_bound_refusal(
 
     assert result.exit_code != 0
     assert "snapshot" in result.output
-    assert observed == {"class_capture_limit": 1, "aggregate_capture_limit": 1}
     assert not output.exists()
+
+    insufficient = tmp_path / "insufficient" / "ckm-overview.html"
+    insufficient_result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path", str(overview_store.db_path), "ckm", "overview", "--out", str(insufficient),
+            "--class-capture-limit", "1", "--aggregate-capture-limit", "1",
+        ],
+    )
+    assert insufficient_result.exit_code != 0
+    assert "snapshot" in insufficient_result.output
+    assert not insufficient.exists()
 
 
 def test_cli_overview_rejects_non_positive_capture_bounds(
     overview_store: CkmStore,
     tmp_path: Path,
 ) -> None:
-    output = tmp_path / "invalid" / "ckm-overview.html"
-    result = CliRunner().invoke(
-        builderops,
-        [
-            "--db-path",
-            str(overview_store.db_path),
-            "ckm",
-            "overview",
-            "--out",
-            str(output),
-            "--class-capture-limit",
-            "0",
-        ],
-    )
-
-    assert result.exit_code != 0
-    assert "Invalid value" in result.output
-    assert not output.exists()
+    for value in ("0", "-1"):
+        output = tmp_path / f"invalid-{value.replace('-', 'negative-')}" / "ckm-overview.html"
+        result = CliRunner().invoke(
+            builderops,
+            [
+                "--db-path", str(overview_store.db_path), "ckm", "overview", "--out", str(output),
+                "--class-capture-limit", value,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output
+        assert not output.exists()
 
 
 def test_cli_rejects_missing_database_without_creating_it(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from app.builderops.cli import builderops
 from app.builderops.ckm.models import MATURITY_DIMENSIONS
 from app.builderops.ckm.overview_html import render_overview_html
-from app.builderops.ckm.store import CkmStore
+from app.builderops.ckm.store import CkmProjectionCaptureError, CkmStore
 
 
 @pytest.fixture()
@@ -484,6 +484,105 @@ def test_cli_writes_overview(overview_store: CkmStore, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert output.is_file()
     assert "Development Overview" in output.read_text(encoding="utf-8")
+
+
+def test_cli_overview_accepts_explicit_capture_bounds(
+    overview_store: CkmStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, int] = {}
+    original = CkmStore.load_projection_batch
+
+    def traced(self: CkmStore, **kwargs: int):
+        observed.update(kwargs)
+        if kwargs.get("class_capture_limit") == 500:
+            raise CkmProjectionCaptureError(
+                "snapshot_too_large",
+                "complete CKM projection snapshot exceeds configured bounds",
+                {"class_limit": 500, "aggregate_limit": 3_000},
+            )
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(CkmStore, "load_projection_batch", traced)
+    output = tmp_path / "bounded" / "ckm-overview.html"
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--out",
+            str(output),
+            "--class-capture-limit",
+            "501",
+            "--aggregate-capture-limit",
+            "3001",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed == {"class_capture_limit": 501, "aggregate_capture_limit": 3001}
+    assert output.is_file()
+
+
+def test_cli_overview_preserves_default_and_insufficient_bound_refusal(
+    overview_store: CkmStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def refuse(self: CkmStore, **kwargs: int):
+        raise CkmProjectionCaptureError(
+            "snapshot_too_large",
+            "complete CKM projection snapshot exceeds configured bounds",
+            {
+                "class_limit": kwargs.get("class_capture_limit", 500),
+                "aggregate_limit": kwargs.get("aggregate_capture_limit", 3_000),
+            },
+        )
+
+    monkeypatch.setattr(CkmStore, "load_projection_batch", refuse)
+    output = tmp_path / "refused" / "ckm-overview.html"
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--out",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "snapshot" in result.output
+    assert not output.exists()
+
+
+def test_cli_overview_rejects_non_positive_capture_bounds(
+    overview_store: CkmStore,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "invalid" / "ckm-overview.html"
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--out",
+            str(output),
+            "--class-capture-limit",
+            "0",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output
+    assert not output.exists()
 
 
 def test_cli_rejects_missing_database_without_creating_it(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -496,7 +496,7 @@ def test_cli_overview_accepts_explicit_capture_bounds(
 
     def traced(self: CkmStore, **kwargs: int):
         observed.update(kwargs)
-        if kwargs.get("class_capture_limit") == 500:
+        if not kwargs:
             raise CkmProjectionCaptureError(
                 "snapshot_too_large",
                 "complete CKM projection snapshot exceeds configured bounds",
@@ -532,7 +532,10 @@ def test_cli_overview_preserves_default_and_insufficient_bound_refusal(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    observed: dict[str, int] = {}
+
     def refuse(self: CkmStore, **kwargs: int):
+        observed.update(kwargs)
         raise CkmProjectionCaptureError(
             "snapshot_too_large",
             "complete CKM projection snapshot exceeds configured bounds",
@@ -553,11 +556,16 @@ def test_cli_overview_preserves_default_and_insufficient_bound_refusal(
             "overview",
             "--out",
             str(output),
+            "--class-capture-limit",
+            "1",
+            "--aggregate-capture-limit",
+            "1",
         ],
     )
 
     assert result.exit_code != 0
     assert "snapshot" in result.output
+    assert observed == {"class_capture_limit": 1, "aggregate_capture_limit": 1}
     assert not output.exists()
 
 


### PR DESCRIPTION
Governing-Issue: #4098
Final-Review-Rounds: 2

Fixes #4098

## Summary
Add explicit positive finite capture-bound options to `ckm overview` and thread them through HTML rendering to the projection store. Existing default bounds and typed refusal behavior remain unchanged.

## Validation
- `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py -k 'capture_bounds or capture_limit'` (2 passed)
- `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py tests/builderops/ckm/test_query_plans.py` (31 passed)
- `python3 -m pytest -q tests/builderops/ckm --ignore=tests/builderops/ckm/test_postgres_integration.py` (237 passed)
- `ruff check app tests` (passed)
- `mypy app` (passed)
- Exact-head canonical Demerzel replay passed against `8f7f1e696`; overview artifact SHA-256 `af3eeca11de323aab262d45d54f301934ce9fe1d1f2946a6be15982e98dbfd28`; terminal receipt on #4089 comment 5072782036.

## BuilderOps Routing
- Records/projections/receipts: Parent #4089 terminal replay receipt (issue comment 5072782036); no new BuilderOps record created.
- Reason: This bounded repair completed the already-authorized real-store replay; the parent receipt now records canonical success and independent output checks.

---