### PR TITLE
Fix durable Model Inquiry host entrypoints

### DIFF
--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -53,6 +53,13 @@ empty stdout, malformed JSON, or missing field is ambiguous: the launcher may st
 so the package leaves the remote lock and staged question in place, reports the error, and does not
 retry or infer completion.
 
+The SSH host must expose both durable role entrypoints before its launcher is considered ready.
+They are installed and checked with the repository-owned
+`scripts/install_model_inquiry_host.py` routine documented in the Mac mini agent playbook. This
+stabilizes the versioned command boundary across shell and reboot changes without moving provider
+credentials or subscription configuration into Git. The routine deliberately does not create a
+GUI-session proxy or alter authentication; those remain explicit host-operator setup when needed.
+
 ## Concretely
 
 ```text

--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -55,7 +55,7 @@ retry or infer completion.
 
 The SSH host must expose both durable role entrypoints before its launcher is considered ready.
 They are installed and checked with the repository-owned
-`scripts/install_model_inquiry_host.py` routine documented in the Mac mini agent playbook. This
+`scripts/install_model_inquiry_host.py` routine documented in the host agent playbook. This
 stabilizes the versioned command boundary across shell and reboot changes without moving provider
 credentials or subscription configuration into Git. The routine deliberately does not create a
 GUI-session proxy or alter authentication; those remain explicit host-operator setup when needed.

--- a/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
@@ -61,6 +61,25 @@ inner command deadline, and a 600-second host adapter deadline. Credentials, sub
 and host-specific executable paths remain outside Git. It never substitutes Codex, Claude,
 Anthropic, OpenAI, mock, or the deterministic dry-run planner for a missing Fable role.
 
+## Host role-entrypoint lifecycle
+
+The repository owns the two stable command names consumed by that profile:
+`fable-subscription-cli` and `codex-subscription-cli`. Run
+`scripts/install_model_inquiry_host.py install` to create owner-only executable wrappers in an
+explicit host bin directory. Each wrapper binds exactly one role to the versioned
+`scripts/model_inquiry_subscription_adapter.py`; an exact reinstall is a no-op, while a symlink,
+unsafe directory, or unrelated existing command fails closed without overwriting it.
+
+The companion `check` operation is read-only. It reports only whether both installed entrypoints
+match the adapter digest committed into the installer in its own operator-authoritative checkout
+and Python interpreter, whether the launch `PATH` resolves both names to those exact files, and
+whether the underlying `claude`, `codex`, and host launcher commands are discoverable. Host-time
+validation does not invoke Git; an adapter change and its installer digest update are one repo
+change. The recognized
+subscription profile runs the same lineage check during desktop preflight; arbitrary same-name
+executables cannot make it healthy. The check does not run either provider, inspect subscription
+state, reveal paths, or create inquiry artifacts.
+
 ## Concretely
 
 ```bash

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -201,3 +201,9 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Diverged:** Chat reservations and process polling did not prevent another worktree from starting a host-global non-PG full suite, wasting one exact-SHA proof and forcing quiet-period recovery.
 **Upstream artifact:** `AGENTS.md :: Parallel-agent execution`, `docs/development/DEV_WORKFLOW.md`, and `scripts/run_with_host_lease.py` — replace advisory chat coordination with an atomic repo-common kernel lease held for the complete host-global child process.
 **Compatibility fallback:** BuilderOps LearningSignal write unavailable: implicit host-stable store selection was refused because the required same-user/same-host cutover acknowledgement is absent.
+
+## 2026-07-24 — #3958 (descriptor-bound Git authority)
+**Source:** Sol/xhigh mechanism convergence review
+**Diverged:** The plan treated before/after pathname identity checks around `git -C` as checkout-lineage proof, but an ABA replacement can source HEAD/index from a foreign checkout while restoring the trusted path before every check.
+**Upstream artifact:** `docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md :: Host role-entrypoint lifecycle` — require immutable in-process digest/object authority rather than treating Git evidence obtained through a mutable pathname as lineage proof.
+**Compatibility fallback:** BuilderOps LearningSignal write unavailable: implicit host-stable store selection was refused because the required same-user/same-host cutover acknowledgement or explicit BuilderOps state path is absent.

--- a/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
+++ b/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
@@ -46,6 +46,62 @@ Work top to bottom; stop and report if a step fails.
 7. **Report** to the operator: gateway `/healthz`, the env you set, and the
    routed-vs-local check result.
 
+## BuilderOps Model Inquiry host entrypoints
+
+The Model Inquiry launcher expects two stable host commands:
+`fable-subscription-cli` and `codex-subscription-cli`. Install them as durable,
+owner-only wrappers bound to the current repository checkout:
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+python3 "$repo_root/scripts/install_model_inquiry_host.py" install \
+  --repo-root "$repo_root" \
+  --bin-dir "$HOME/.local/bin" \
+  --python "$repo_root/.venv/bin/python3"
+```
+
+The operation is idempotent. An exact rerun reports both entrypoints as
+`unchanged`; an unrelated existing file, symlinked bin directory, or unsafe
+permissions fail closed and must be inspected rather than overwritten.
+If an I/O failure interrupts the two-role install, an exact first wrapper may
+remain while the second is absent. Do not delete it as rollback: rerun the same
+command, which validates the retained wrapper and converges the missing role.
+Any reported temporary-file cleanup failure remains an install failure and
+requires inspection of owner-only `.<entrypoint>.*.tmp` files in the bin
+directory.
+
+Before advertising the launcher as healthy, run the sanitized, read-only check:
+
+```bash
+python3 "$repo_root/scripts/install_model_inquiry_host.py" check \
+  --repo-root "$repo_root" \
+  --bin-dir "$HOME/.local/bin" \
+  --python "$repo_root/.venv/bin/python3"
+```
+
+The check succeeds only when both wrappers match the selected checkout and
+interpreter, the current `PATH` resolves both role names to those exact wrapper
+files, and the underlying `claude`, `codex`, and `yggdrasil-model-inquiry`
+commands are discoverable. It does not invoke either provider or inspect
+authentication. If the host needs a GUI-session proxy for subscription access,
+configure that separately outside Git and rerun the check afterward.
+
+After a reboot or checkout promotion, run the same `check` command through the
+actual non-interactive transport:
+
+```bash
+ssh -T Tailscale_macmini \
+  'PATH="$HOME/.local/bin:$PATH"; python3 /path/to/repo/scripts/install_model_inquiry_host.py check --repo-root /path/to/repo --bin-dir "$HOME/.local/bin" --python /path/to/repo/.venv/bin/python3'
+```
+
+If `check` reports a stale wrapper after an intentional checkout or interpreter
+move, inspect both wrapper files first. Only when they are confirmed as products
+of this installer, move them to an owner-only backup directory and rerun
+`install`. The installer intentionally does not overwrite or delete a stale,
+symlinked, or unrelated command. Uninstall uses the same rule: verify lineage,
+back up or remove exactly those two wrapper files, then rerun `check` to confirm
+they are unavailable.
+
 ## Notes
 - Embeddings must never route to the gaming PC (identity drift would force a full
   index rebuild — see `docs/LLM_ROUTING.md`). The gateway enforces this; don't

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -51,15 +51,16 @@ class Checkout:
 
 
 def _resolve_file(path: Path, *, label: str, executable: bool = False) -> Path:
+    candidate = Path(os.path.abspath(path.expanduser()))
     try:
-        resolved = path.expanduser().resolve(strict=True)
+        details = os.stat(candidate)
     except OSError as exc:
         raise HostInstallError(f"{label} is unavailable") from exc
-    if not resolved.is_file():
+    if not stat.S_ISREG(details.st_mode):
         raise HostInstallError(f"{label} must be a regular file")
-    if executable and not os.access(resolved, os.X_OK):
+    if executable and not os.access(candidate, os.X_OK):
         raise HostInstallError(f"{label} must be executable")
-    return resolved
+    return candidate
 
 
 def _absolute_parts(path: Path, *, label: str) -> tuple[str, ...]:

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Install and verify durable BuilderOps Model Inquiry role entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import stat
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+SCHEMA_INSTALL = "builderops.model-inquiry-host-install.v1"
+SCHEMA_CHECK = "builderops.model-inquiry-host-check.v1"
+TRUSTED_REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSIONED_ADAPTER_SHA256 = "59bd9ec13f96ac990b0ba3f5ee1e08df760201e54255bbd5033b10df174a8e59"
+
+
+@dataclass(frozen=True)
+class RoleSpec:
+    role: str
+    entrypoint: str
+    provider_command: str
+
+
+ROLE_SPECS = (
+    RoleSpec("fable", "fable-subscription-cli", "claude"),
+    RoleSpec("gpt_codex", "codex-subscription-cli", "codex"),
+)
+
+
+class HostInstallError(RuntimeError):
+    """Safe operator-facing installation error."""
+
+
+@dataclass(frozen=True)
+class Checkout:
+    root: Path
+    adapter: Path
+    adapter_sha256: str
+    root_identity: tuple[int, int]
+    adapter_identity: tuple[int, int]
+
+
+def _resolve_file(path: Path, *, label: str, executable: bool = False) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise HostInstallError(f"{label} is unavailable") from exc
+    if not resolved.is_file():
+        raise HostInstallError(f"{label} must be a regular file")
+    if executable and not os.access(resolved, os.X_OK):
+        raise HostInstallError(f"{label} must be executable")
+    return resolved
+
+
+def _absolute_parts(path: Path, *, label: str) -> tuple[str, ...]:
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        raise HostInstallError(f"{label} must be absolute")
+    parts = expanded.parts[1:]
+    if not parts or any(part in ("", ".", "..") for part in parts):
+        raise HostInstallError(f"{label} is invalid")
+    return parts
+
+
+def _open_directory_chain(path: Path, *, label: str, create_final: bool = False) -> int:
+    parts = _absolute_parts(path, label=label)
+    flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    current_fd = os.open("/", flags)
+    try:
+        for index, part in enumerate(parts):
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create_final or index != len(parts) - 1:
+                    raise HostInstallError(f"{label} is unavailable") from None
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=current_fd)
+                    os.fsync(current_fd)
+                    next_fd = os.open(part, flags, dir_fd=current_fd)
+                except OSError as exc:
+                    raise HostInstallError(f"unable to create {label}") from exc
+            except OSError as exc:
+                raise HostInstallError(f"{label} must not contain symlinks") from exc
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _directory_identity(directory_fd: int) -> tuple[int, int]:
+    details = os.fstat(directory_fd)
+    return (details.st_dev, details.st_ino)
+
+
+def _assert_directory_identity(
+    path: Path,
+    expected: tuple[int, int],
+    *,
+    label: str,
+) -> None:
+    verification_fd = _open_directory_chain(path, label=label)
+    try:
+        if _directory_identity(verification_fd) != expected:
+            raise HostInstallError(f"{label} identity changed during validation")
+    finally:
+        os.close(verification_fd)
+
+
+def _read_regular_file_at(
+    directory_fd: int,
+    name: str,
+    *,
+    label: str,
+    executable: bool = False,
+) -> tuple[bytes, os.stat_result]:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(name, flags, dir_fd=directory_fd)
+    except OSError as exc:
+        raise HostInstallError(f"{label} is unavailable or unsafe") from exc
+    try:
+        details = os.fstat(fd)
+        if not stat.S_ISREG(details.st_mode):
+            raise HostInstallError(f"{label} must be a regular file")
+        if executable and not details.st_mode & stat.S_IXUSR:
+            raise HostInstallError(f"{label} must be executable")
+        chunks: list[bytes] = []
+        while chunk := os.read(fd, 65536):
+            chunks.append(chunk)
+        return b"".join(chunks), details
+    finally:
+        os.close(fd)
+
+
+def _resolve_repo_root(path: Path) -> Checkout:
+    root_fd = _open_directory_chain(path, label="repo root")
+    try:
+        root_identity = _directory_identity(root_fd)
+        resolved = Path(os.path.realpath(path.expanduser()))
+        if resolved != TRUSTED_REPO_ROOT:
+            raise HostInstallError("repo root must match the trusted installer checkout")
+        _assert_directory_identity(resolved, root_identity, label="repo root")
+        scripts_flags = os.O_RDONLY | os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            scripts_flags |= os.O_NOFOLLOW
+        try:
+            scripts_fd = os.open("scripts", scripts_flags, dir_fd=root_fd)
+        except OSError as exc:
+            raise HostInstallError("versioned adapter directory is unavailable or unsafe") from exc
+        try:
+            adapter_bytes, adapter_details = _read_regular_file_at(
+                scripts_fd,
+                "model_inquiry_subscription_adapter.py",
+                label="versioned subscription adapter",
+            )
+        finally:
+            os.close(scripts_fd)
+        adapter_sha256 = hashlib.sha256(adapter_bytes).hexdigest()
+        if adapter_sha256 != VERSIONED_ADAPTER_SHA256:
+            raise HostInstallError(
+                "versioned subscription adapter must match the installer digest"
+            )
+        _assert_directory_identity(resolved, root_identity, label="repo root")
+        adapter = resolved / "scripts" / "model_inquiry_subscription_adapter.py"
+        return Checkout(
+            resolved,
+            adapter,
+            adapter_sha256,
+            root_identity,
+            (adapter_details.st_dev, adapter_details.st_ino),
+        )
+    finally:
+        os.close(root_fd)
+
+
+def _open_bin_dir(path: Path, *, create: bool) -> tuple[Path, int, tuple[int, int]]:
+    try:
+        directory_fd = _open_directory_chain(
+            path,
+            label="bin directory",
+            create_final=create,
+        )
+    except HostInstallError:
+        if not create and not path.expanduser().exists():
+            raise
+        raise
+    details = os.fstat(directory_fd)
+    if details.st_uid != os.getuid():
+        os.close(directory_fd)
+        raise HostInstallError("bin directory must be owned by the current user")
+    if details.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        os.close(directory_fd)
+        raise HostInstallError("bin directory must not be group/world writable")
+    return (
+        Path(os.path.realpath(path.expanduser())),
+        directory_fd,
+        _directory_identity(directory_fd),
+    )
+
+
+def _wrapper_content(
+    *,
+    role: str,
+    python: Path,
+    adapter: Path,
+    adapter_sha256: str,
+) -> str:
+    return (
+        "#!/bin/sh\n"
+        f"# adapter-sha256={adapter_sha256}\n"
+        "set -eu\n"
+        f"INQUIRY_ROLE={shlex.quote(role)} "
+        f"exec {shlex.quote(str(python))} {shlex.quote(str(adapter))}\n"
+    )
+
+
+def _assert_adapter_identity(checkout: Checkout) -> None:
+    root_fd = _open_directory_chain(checkout.root, label="repo root")
+    try:
+        if _directory_identity(root_fd) != checkout.root_identity:
+            raise HostInstallError("repo root identity changed during validation")
+        scripts_flags = os.O_RDONLY | os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            scripts_flags |= os.O_NOFOLLOW
+        try:
+            scripts_fd = os.open("scripts", scripts_flags, dir_fd=root_fd)
+        except OSError as exc:
+            raise HostInstallError(
+                "versioned adapter directory is unavailable or unsafe"
+            ) from exc
+        try:
+            adapter_bytes, adapter_details = _read_regular_file_at(
+                scripts_fd,
+                "model_inquiry_subscription_adapter.py",
+                label="versioned subscription adapter",
+            )
+        finally:
+            os.close(scripts_fd)
+    finally:
+        os.close(root_fd)
+    if (
+        (adapter_details.st_dev, adapter_details.st_ino) != checkout.adapter_identity
+        or hashlib.sha256(adapter_bytes).hexdigest() != checkout.adapter_sha256
+    ):
+        raise HostInstallError("versioned subscription adapter identity changed")
+
+
+def _assert_checkout_authority(checkout: Checkout) -> None:
+    _assert_directory_identity(
+        checkout.root,
+        checkout.root_identity,
+        label="repo root",
+    )
+    _assert_adapter_identity(checkout)
+
+
+def _expected_wrappers(*, checkout: Checkout, python: Path) -> dict[RoleSpec, str]:
+    _assert_checkout_authority(checkout)
+    wrappers = {
+        spec: _wrapper_content(
+            role=spec.role,
+            python=python,
+            adapter=checkout.adapter,
+            adapter_sha256=checkout.adapter_sha256,
+        )
+        for spec in ROLE_SPECS
+    }
+    _assert_checkout_authority(checkout)
+    return wrappers
+
+
+def _entrypoint_matches(directory_fd: int, name: str, expected: str) -> bool:
+    try:
+        payload, details = _read_regular_file_at(
+            directory_fd,
+            name,
+            label=f"entrypoint {name}",
+            executable=True,
+        )
+    except HostInstallError:
+        return False
+    try:
+        return (
+            payload.decode("utf-8") == expected
+            and details.st_uid == os.getuid()
+            and stat.S_IMODE(details.st_mode) == 0o700
+        )
+    except UnicodeError:
+        return False
+
+
+def _install_no_overwrite(
+    directory_fd: int,
+    name: str,
+    content: str,
+) -> bool:
+    temp = f".{name}.{uuid.uuid4().hex}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd: int | None = None
+    temp_created = False
+    cleanup_error: OSError | None = None
+    installed: bool | None = None
+    try:
+        fd = os.open(temp, flags, 0o700, dir_fd=directory_fd)
+        temp_created = True
+        payload = content.encode("utf-8")
+        with os.fdopen(fd, "wb", closefd=False) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.fchmod(fd, 0o700)
+        os.fsync(fd)
+        try:
+            os.link(
+                temp,
+                name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            os.fsync(directory_fd)
+            installed = True
+        except FileExistsError:
+            if not _entrypoint_matches(directory_fd, name, content):
+                raise HostInstallError(f"conflicting entrypoint: {name}") from None
+            installed = False
+    except OSError as exc:
+        if exc.errno == errno.EXDEV:
+            raise HostInstallError("bin directory does not support atomic installation") from exc
+        raise HostInstallError(f"unable to install entrypoint: {name}") from exc
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if temp_created:
+            try:
+                os.unlink(temp, dir_fd=directory_fd)
+                os.fsync(directory_fd)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                cleanup_error = exc
+    if cleanup_error is not None:
+        raise HostInstallError(f"temporary entrypoint cleanup failed: {name}") from cleanup_error
+    if installed is None:
+        raise HostInstallError(f"unable to install entrypoint: {name}")
+    return installed
+
+
+def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object]:
+    checkout = _resolve_repo_root(repo_root)
+    interpreter = _resolve_file(python, label="host Python", executable=True)
+    wrappers = _expected_wrappers(checkout=checkout, python=interpreter)
+    destination, directory_fd, destination_identity = _open_bin_dir(
+        bin_dir,
+        create=True,
+    )
+    try:
+        _assert_checkout_authority(checkout)
+        _assert_directory_identity(
+            destination,
+            destination_identity,
+            label="bin directory",
+        )
+        states: dict[RoleSpec, str] = {}
+        for spec, content in wrappers.items():
+            try:
+                os.stat(spec.entrypoint, dir_fd=directory_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                states[spec] = "installed"
+            else:
+                if not _entrypoint_matches(directory_fd, spec.entrypoint, content):
+                    raise HostInstallError(f"conflicting entrypoint: {spec.entrypoint}")
+                states[spec] = "unchanged"
+
+        for spec, content in wrappers.items():
+            if states[spec] == "installed":
+                installed = _install_no_overwrite(
+                    directory_fd,
+                    spec.entrypoint,
+                    content,
+                )
+                if not installed:
+                    states[spec] = "unchanged"
+        _assert_directory_identity(
+            destination,
+            destination_identity,
+            label="bin directory",
+        )
+        for spec, content in wrappers.items():
+            if not _entrypoint_matches(directory_fd, spec.entrypoint, content):
+                raise HostInstallError(
+                    f"entrypoint changed during installation: {spec.entrypoint}"
+                )
+        _assert_directory_identity(
+            destination,
+            destination_identity,
+            label="bin directory",
+        )
+        _assert_checkout_authority(checkout)
+    finally:
+        os.close(directory_fd)
+
+    return {
+        "schema": SCHEMA_INSTALL,
+        "ok": True,
+        "roles": {
+            spec.role: {"entrypoint": spec.entrypoint, "status": states[spec]}
+            for spec in ROLE_SPECS
+        },
+    }
+
+
+def check(
+    *,
+    repo_root: Path,
+    bin_dir: Path,
+    python: Path,
+    path: str | None = None,
+) -> dict[str, object]:
+    checkout = _resolve_repo_root(repo_root)
+    interpreter = _resolve_file(python, label="host Python", executable=True)
+    wrappers = _expected_wrappers(checkout=checkout, python=interpreter)
+    try:
+        destination, directory_fd, destination_identity = _open_bin_dir(
+            bin_dir,
+            create=False,
+        )
+    except HostInstallError:
+        destination = Path(os.path.abspath(bin_dir.expanduser()))
+        directory_fd = None
+        destination_identity = None
+    command_path = path if path is not None else os.environ.get("PATH", os.defpath)
+    roles: dict[str, object] = {}
+    ok = directory_fd is not None
+    launcher_available = False
+    try:
+        _assert_checkout_authority(checkout)
+        if destination_identity is not None:
+            _assert_directory_identity(
+                destination,
+                destination_identity,
+                label="bin directory",
+            )
+        for spec, content in wrappers.items():
+            discovered = shutil.which(spec.entrypoint, path=command_path)
+            expected_path = destination / spec.entrypoint
+            path_matches = (
+                discovered is not None
+                and Path(os.path.abspath(discovered)) == expected_path
+            )
+            entrypoint_available = (
+                directory_fd is not None
+                and path_matches
+                and _entrypoint_matches(directory_fd, spec.entrypoint, content)
+            )
+            provider_available = (
+                shutil.which(spec.provider_command, path=command_path) is not None
+            )
+            role_ok = entrypoint_available and provider_available
+            ok = ok and role_ok
+            roles[spec.role] = {
+                "entrypoint": spec.entrypoint,
+                "entrypoint_status": "available" if entrypoint_available else "unavailable",
+                "provider_command": spec.provider_command,
+                "provider_status": "available" if provider_available else "unavailable",
+            }
+        launcher_available = (
+            shutil.which("yggdrasil-model-inquiry", path=command_path) is not None
+        )
+        ok = ok and launcher_available
+        if directory_fd is not None and destination_identity is not None:
+            _assert_directory_identity(
+                destination,
+                destination_identity,
+                label="bin directory",
+            )
+            for spec, content in wrappers.items():
+                discovered = shutil.which(spec.entrypoint, path=command_path)
+                expected_path = destination / spec.entrypoint
+                final_available = (
+                    discovered is not None
+                    and Path(os.path.abspath(discovered)) == expected_path
+                    and _entrypoint_matches(directory_fd, spec.entrypoint, content)
+                )
+                if not final_available:
+                    ok = False
+                    role_status = roles[spec.role]
+                    if isinstance(role_status, dict):
+                        role_status["entrypoint_status"] = "unavailable"
+            _assert_directory_identity(
+                destination,
+                destination_identity,
+                label="bin directory",
+            )
+        _assert_checkout_authority(checkout)
+    finally:
+        if directory_fd is not None:
+            os.close(directory_fd)
+    return {
+        "schema": SCHEMA_CHECK,
+        "ok": ok,
+        "launcher": {
+            "command": "yggdrasil-model-inquiry",
+            "status": "available" if launcher_available else "unavailable",
+        },
+        "roles": roles,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("install", "check"))
+    parser.add_argument("--repo-root", required=True, type=Path)
+    parser.add_argument("--bin-dir", required=True, type=Path)
+    parser.add_argument(
+        "--python",
+        type=Path,
+        help="Python executable for installed role entrypoints; defaults to <repo>/.venv/bin/python3",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    python = args.python or args.repo_root / ".venv" / "bin" / "python3"
+    try:
+        if args.operation == "install":
+            payload = install(
+                repo_root=args.repo_root,
+                bin_dir=args.bin_dir,
+                python=python,
+            )
+        else:
+            payload = check(
+                repo_root=args.repo_root,
+                bin_dir=args.bin_dir,
+                python=python,
+            )
+    except HostInstallError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(payload, sort_keys=True), flush=True)
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start_model_inquiry.py
+++ b/scripts/start_model_inquiry.py
@@ -78,10 +78,11 @@ def preflight_dependencies(
                 "subscription role entrypoints do not share one validated host bin directory"
             )
         try:
+            selected_python = Path(env.get("BUILDEROPS_PYTHON", sys.executable))
             host_status = check_host_entrypoints(
                 repo_root=command_cwd,
                 bin_dir=Path(bin_dirs.pop()),
-                python=Path(sys.executable),
+                python=selected_python,
                 path=path,
             )
         except HostInstallError as exc:

--- a/scripts/start_model_inquiry.py
+++ b/scripts/start_model_inquiry.py
@@ -26,6 +26,10 @@ from app.builderops.model_inquiry_adapters import (
     sanitized_adapter_identity,
 )
 from app.builderops.models import BuilderOpsValidationError
+from scripts.install_model_inquiry_host import (
+    HostInstallError,
+    check as check_host_entrypoints,
+)
 
 WORKFLOW = "fable-gpt-architecture"
 SOURCE_REF = "desktop_skill:start-model-inquiry"
@@ -43,6 +47,51 @@ def preflight_dependencies(
     """Validate the durable store and explicit adapters without mutation."""
     ModelInquiryService.from_env(env)
     adapters = load_adapters(env)
+    subscription_entrypoints = {
+        "fable": "fable-subscription-cli",
+        "gpt_codex": "codex-subscription-cli",
+    }
+    if all(
+        isinstance(adapters.get(role), LocalCommandAdapter)
+        and adapters[role].adapter_id == entrypoint
+        and adapters[role].argv == (entrypoint,)
+        for role, entrypoint in subscription_entrypoints.items()
+    ):
+        path = env.get("PATH", os.defpath)
+        discovered = {
+            role: shutil.which(entrypoint, path=path)
+            for role, entrypoint in subscription_entrypoints.items()
+        }
+        if not all(discovered.values()):
+            missing_role = next(role for role, value in discovered.items() if value is None)
+            adapter = adapters[missing_role]
+            raise AdapterUnavailableError(
+                f"{missing_role}: local command unavailable: {adapter.adapter_id}"
+            )
+        bin_dirs = {
+            str(Path(value).absolute().parent)
+            for value in discovered.values()
+            if value is not None
+        }
+        if len(bin_dirs) != 1:
+            raise AdapterUnavailableError(
+                "subscription role entrypoints do not share one validated host bin directory"
+            )
+        try:
+            host_status = check_host_entrypoints(
+                repo_root=command_cwd,
+                bin_dir=Path(bin_dirs.pop()),
+                python=Path(sys.executable),
+                path=path,
+            )
+        except HostInstallError as exc:
+            raise AdapterUnavailableError(
+                "subscription role entrypoints failed installed-lineage preflight"
+            ) from exc
+        if not host_status["ok"]:
+            raise AdapterUnavailableError(
+                "subscription role entrypoints failed installed-lineage preflight"
+            )
     for role, adapter in adapters.items():
         if not isinstance(adapter, LocalCommandAdapter):
             continue

--- a/scripts/start_model_inquiry.sh
+++ b/scripts/start_model_inquiry.sh
@@ -16,4 +16,5 @@ if [ -z "$PYTHON" ]; then
 fi
 
 cd "$APP_ROOT"
+export BUILDEROPS_PYTHON="$PYTHON"
 exec "$PYTHON" "$SCRIPT_DIR/start_model_inquiry.py" "$@"

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -412,7 +413,13 @@ def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
 def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     selected_python = tmp_path / "selected-python"
-    selected_python.symlink_to(Path(sys.executable))
+    interpreter_target = tmp_path / "interpreter-target"
+    interpreter_target.write_text(
+        f"#!/bin/sh\\n[ \"$0\" = {shlex.quote(str(selected_python))} ]\\n",
+        encoding="utf-8",
+    )
+    interpreter_target.chmod(0o700)
+    selected_python.symlink_to(interpreter_target)
 
     result = _run_installer(
         "install",
@@ -428,7 +435,8 @@ def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) 
     for entrypoint in ("fable-subscription-cli", "codex-subscription-cli"):
         content = (bin_dir / entrypoint).read_text(encoding="utf-8")
         assert str(selected_python) in content
-        assert str(Path(sys.executable).resolve()) not in content
+        executed = subprocess.run([str(bin_dir / entrypoint)], check=False)
+        assert executed.returncode == 0
 
 
 def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -397,7 +397,7 @@ def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
     adapter = str((REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py").resolve())
     adapter_sha256 = hashlib.sha256(Path(adapter).read_bytes()).hexdigest()
     assert host_installer.VERSIONED_ADAPTER_SHA256 == adapter_sha256
-    python = str(Path(sys.executable).resolve())
+    python = str(Path(sys.executable))
     for name, role in expected.items():
         content = (bin_dir / name).read_text(encoding="utf-8")
         assert f"INQUIRY_ROLE={role}" in content
@@ -407,6 +407,28 @@ def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
         assert "BUILDEROPS_INQUIRY_ADAPTERS_JSON" not in content
         assert "TOKEN" not in content
         assert "KEY" not in content
+
+
+def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    selected_python = tmp_path / "selected-python"
+    selected_python.symlink_to(Path(sys.executable))
+
+    result = _run_installer(
+        "install",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        str(selected_python),
+    )
+
+    assert result.returncode == 0, result.stderr
+    for entrypoint in ("fable-subscription-cli", "codex-subscription-cli"):
+        content = (bin_dir / entrypoint).read_text(encoding="utf-8")
+        assert str(selected_python) in content
+        assert str(Path(sys.executable).resolve()) not in content
 
 
 def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -415,7 +415,7 @@ def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) 
     selected_python = tmp_path / "selected-python"
     interpreter_target = tmp_path / "interpreter-target"
     interpreter_target.write_text(
-        f"#!/bin/sh\\n[ \"$0\" = {shlex.quote(str(selected_python))} ]\\n",
+        f"#!/bin/sh\n[ \"$0\" = {shlex.quote(str(selected_python))} ]\n",
         encoding="utf-8",
     )
     interpreter_target.chmod(0o700)

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -1,0 +1,895 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import scripts.install_model_inquiry_host as host_installer
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install_model_inquiry_host.py"
+
+
+def _run_installer(
+    *arguments: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(INSTALLER), *arguments],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _install(bin_dir: Path) -> subprocess.CompletedProcess[str]:
+    return _run_installer(
+        "install",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        sys.executable,
+    )
+
+
+def _init_adapter_checkout(root: Path) -> Path:
+    adapter = root / "scripts" / "model_inquiry_subscription_adapter.py"
+    adapter.parent.mkdir(parents=True)
+    adapter.write_bytes(
+        (REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py").read_bytes()
+    )
+    return adapter
+
+
+def test_installer_creates_both_role_entrypoints_and_exact_retry_is_noop(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    first = _install(bin_dir)
+    second = _install(bin_dir)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    first_payload = json.loads(first.stdout)
+    second_payload = json.loads(second.stdout)
+    assert first_payload["roles"] == {
+        "fable": {"entrypoint": "fable-subscription-cli", "status": "installed"},
+        "gpt_codex": {
+            "entrypoint": "codex-subscription-cli",
+            "status": "installed",
+        },
+    }
+    assert second_payload["roles"] == {
+        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "gpt_codex": {
+            "entrypoint": "codex-subscription-cli",
+            "status": "unchanged",
+        },
+    }
+    for name in ("fable-subscription-cli", "codex-subscription-cli"):
+        path = bin_dir / name
+        assert path.is_file()
+        assert path.stat().st_mode & 0o777 == 0o700
+
+
+def test_installer_rejects_conflicting_or_unsafe_destinations(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    conflicting = bin_dir / "fable-subscription-cli"
+    conflicting.write_text("unrelated host command\n", encoding="utf-8")
+    conflicting.chmod(0o700)
+
+    conflict = _install(bin_dir)
+
+    assert conflict.returncode == 2
+    assert "conflicting entrypoint" in conflict.stderr
+    assert conflicting.read_text(encoding="utf-8") == "unrelated host command\n"
+    assert not (bin_dir / "codex-subscription-cli").exists()
+
+    real_bin = tmp_path / "real-bin"
+    real_bin.mkdir()
+    symlinked_bin = tmp_path / "symlinked-bin"
+    symlinked_bin.symlink_to(real_bin, target_is_directory=True)
+    unsafe = _install(symlinked_bin)
+
+    assert unsafe.returncode == 2
+    assert "bin directory must not contain symlinks" in unsafe.stderr
+    assert not list(real_bin.iterdir())
+
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    symlinked_parent = tmp_path / "symlinked-parent"
+    symlinked_parent.symlink_to(real_parent, target_is_directory=True)
+    unsafe_ancestor = _install(symlinked_parent / "bin")
+
+    assert unsafe_ancestor.returncode == 2
+    assert "bin directory must not contain symlinks" in unsafe_ancestor.stderr
+    assert not (real_parent / "bin").exists()
+
+    symlink_target_bin = tmp_path / "symlink-target-bin"
+    symlink_target_bin.mkdir()
+    unrelated = tmp_path / "unrelated-command"
+    unrelated.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (symlink_target_bin / "fable-subscription-cli").symlink_to(unrelated)
+    symlink_target = _install(symlink_target_bin)
+
+    assert symlink_target.returncode == 2
+    assert "conflicting entrypoint" in symlink_target.stderr
+    assert (symlink_target_bin / "fable-subscription-cli").is_symlink()
+    assert not (symlink_target_bin / "codex-subscription-cli").exists()
+
+    missing_checkout = _run_installer(
+        "install",
+        "--repo-root",
+        str(tmp_path / "not-a-checkout"),
+        "--bin-dir",
+        str(tmp_path / "missing-checkout-bin"),
+        "--python",
+        sys.executable,
+    )
+
+    assert missing_checkout.returncode == 2
+    assert "repo root is unavailable" in missing_checkout.stderr
+    assert not (tmp_path / "missing-checkout-bin").exists()
+
+    fake_checkout = tmp_path / "fake-checkout"
+    _init_adapter_checkout(fake_checkout)
+    foreign_checkout = _run_installer(
+        "install",
+        "--repo-root",
+        str(fake_checkout),
+        "--bin-dir",
+        str(tmp_path / "fake-checkout-bin"),
+        "--python",
+        sys.executable,
+    )
+
+    assert foreign_checkout.returncode == 2
+    assert "trusted installer checkout" in foreign_checkout.stderr
+    assert not (tmp_path / "fake-checkout-bin").exists()
+
+
+def test_installer_rejects_dirty_tracked_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    adapter = _init_adapter_checkout(checkout)
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+
+    clean = host_installer._resolve_repo_root(checkout)
+    assert clean.adapter_sha256 == hashlib.sha256(adapter.read_bytes()).hexdigest()
+
+    adapter.write_text("raise SystemExit('modified')\n", encoding="utf-8")
+    with pytest.raises(
+        host_installer.HostInstallError,
+        match="must match the installer digest",
+    ):
+        host_installer._resolve_repo_root(checkout)
+
+def test_installer_does_not_require_git_on_host(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    result = _run_installer(
+        "install",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        sys.executable,
+        env={**os.environ, "PATH": ""},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (bin_dir / "fable-subscription-cli").is_file()
+
+
+def test_new_bin_directory_is_durably_linked_from_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    parent_identity = (tmp_path.stat().st_dev, tmp_path.stat().st_ino)
+    real_fsync = host_installer.os.fsync
+    parent_fsynced = False
+
+    def record_fsync(fd: int) -> None:
+        nonlocal parent_fsynced
+        details = os.fstat(fd)
+        if (details.st_dev, details.st_ino) == parent_identity:
+            parent_fsynced = True
+        real_fsync(fd)
+
+    monkeypatch.setattr(host_installer.os, "fsync", record_fsync)
+    directory_fd = host_installer._open_directory_chain(
+        bin_dir,
+        label="bin directory",
+        create_final=True,
+    )
+    os.close(directory_fd)
+
+    assert parent_fsynced
+    assert bin_dir.is_dir()
+
+
+def test_new_bin_parent_fsync_failure_fails_install_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    parent_identity = (tmp_path.stat().st_dev, tmp_path.stat().st_ino)
+    real_fsync = host_installer.os.fsync
+
+    def fail_parent_fsync(fd: int) -> None:
+        details = os.fstat(fd)
+        if (details.st_dev, details.st_ino) == parent_identity:
+            raise OSError("injected parent fsync failure")
+        real_fsync(fd)
+
+    monkeypatch.setattr(host_installer.os, "fsync", fail_parent_fsync)
+    with pytest.raises(host_installer.HostInstallError, match="unable to create bin directory"):
+        host_installer.install(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert bin_dir.is_dir()
+    assert not list(bin_dir.iterdir())
+
+
+def test_installer_rejects_checkout_replacement_during_wrapper_construction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    _init_adapter_checkout(checkout)
+    original_checkout = tmp_path / "original-checkout"
+    bin_dir = tmp_path / "bin"
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+    real_wrapper_content = host_installer._wrapper_content
+    replaced = False
+
+    def replace_during_wrapper(
+        *,
+        role: str,
+        python: Path,
+        adapter: Path,
+        adapter_sha256: str,
+    ) -> str:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            checkout.rename(original_checkout)
+            _init_adapter_checkout(checkout)
+        return real_wrapper_content(
+            role=role,
+            python=python,
+            adapter=adapter,
+            adapter_sha256=adapter_sha256,
+        )
+
+    monkeypatch.setattr(host_installer, "_wrapper_content", replace_during_wrapper)
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.install(
+            repo_root=checkout,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert replaced
+    assert original_checkout.is_dir()
+    assert checkout.is_dir()
+    assert not bin_dir.exists()
+
+
+def test_install_rejects_checkout_replacement_after_bin_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    _init_adapter_checkout(checkout)
+    original_checkout = tmp_path / "original-checkout"
+    bin_dir = tmp_path / "bin"
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+    real_open_bin_dir = host_installer._open_bin_dir
+
+    def replace_checkout_after_bin_open(
+        path: Path,
+        *,
+        create: bool,
+    ) -> tuple[Path, int, tuple[int, int]]:
+        opened = real_open_bin_dir(path, create=create)
+        checkout.rename(original_checkout)
+        replacement = _init_adapter_checkout(checkout)
+        replacement.write_text("raise SystemExit('foreign')\n", encoding="utf-8")
+        return opened
+
+    monkeypatch.setattr(
+        host_installer,
+        "_open_bin_dir",
+        replace_checkout_after_bin_open,
+    )
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.install(
+            repo_root=checkout,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert original_checkout.is_dir()
+    assert checkout.is_dir()
+    assert bin_dir.is_dir()
+    assert not list(bin_dir.iterdir())
+
+
+def test_installer_rejects_adapter_replacement_during_wrapper_construction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    adapter = _init_adapter_checkout(checkout)
+    original_adapter = checkout / "scripts" / "original-adapter.py"
+    bin_dir = tmp_path / "bin"
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+    real_wrapper_content = host_installer._wrapper_content
+    replaced = False
+
+    def replace_adapter_during_wrapper(
+        *,
+        role: str,
+        python: Path,
+        adapter: Path,
+        adapter_sha256: str,
+    ) -> str:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            payload = adapter.read_bytes()
+            adapter.rename(original_adapter)
+            adapter.write_bytes(payload)
+        return real_wrapper_content(
+            role=role,
+            python=python,
+            adapter=adapter,
+            adapter_sha256=adapter_sha256,
+        )
+
+    monkeypatch.setattr(
+        host_installer,
+        "_wrapper_content",
+        replace_adapter_during_wrapper,
+    )
+    with pytest.raises(host_installer.HostInstallError, match="adapter identity changed"):
+        host_installer.install(
+            repo_root=checkout,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert replaced
+    assert original_adapter.is_file()
+    assert adapter.is_file()
+    assert not bin_dir.exists()
+
+
+def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    result = _install(bin_dir)
+    assert result.returncode == 0, result.stderr
+
+    expected = {
+        "fable-subscription-cli": "fable",
+        "codex-subscription-cli": "gpt_codex",
+    }
+    adapter = str((REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py").resolve())
+    adapter_sha256 = hashlib.sha256(Path(adapter).read_bytes()).hexdigest()
+    assert host_installer.VERSIONED_ADAPTER_SHA256 == adapter_sha256
+    python = str(Path(sys.executable).resolve())
+    for name, role in expected.items():
+        content = (bin_dir / name).read_text(encoding="utf-8")
+        assert f"INQUIRY_ROLE={role}" in content
+        assert adapter in content
+        assert f"adapter-sha256={adapter_sha256}" in content
+        assert python in content
+        assert "BUILDEROPS_INQUIRY_ADAPTERS_JSON" not in content
+        assert "TOKEN" not in content
+        assert "KEY" not in content
+
+
+def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    assert _install(bin_dir).returncode == 0
+    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+        executable = bin_dir / command
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+    env = {**os.environ, "PATH": str(bin_dir)}
+    before = {
+        path.relative_to(tmp_path): (path.stat().st_mode, path.read_bytes())
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    result = _run_installer(
+        "check",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        sys.executable,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "schema": "builderops.model-inquiry-host-check.v1",
+        "ok": True,
+        "launcher": {
+            "command": "yggdrasil-model-inquiry",
+            "status": "available",
+        },
+        "roles": {
+            "fable": {
+                "entrypoint": "fable-subscription-cli",
+                "entrypoint_status": "available",
+                "provider_command": "claude",
+                "provider_status": "available",
+            },
+            "gpt_codex": {
+                "entrypoint": "codex-subscription-cli",
+                "entrypoint_status": "available",
+                "provider_command": "codex",
+                "provider_status": "available",
+            },
+        },
+    }
+    assert str(tmp_path) not in result.stdout
+    assert "BUILDEROPS_" not in result.stdout
+    assert not any("model-inquir" in path.name for path in tmp_path.rglob("*") if path.is_dir())
+    after = {
+        path.relative_to(tmp_path): (path.stat().st_mode, path.read_bytes())
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+
+    provider_bin = tmp_path / "provider-bin"
+    provider_bin.mkdir()
+    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+        executable = provider_bin / command
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+    missing_from_path = _run_installer(
+        "check",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        sys.executable,
+        env={**os.environ, "PATH": str(provider_bin)},
+    )
+
+    assert missing_from_path.returncode == 1
+    missing_payload = json.loads(missing_from_path.stdout)
+    assert missing_payload["roles"]["fable"] == {
+        "entrypoint": "fable-subscription-cli",
+        "entrypoint_status": "unavailable",
+        "provider_command": "claude",
+        "provider_status": "available",
+    }
+    assert missing_payload["roles"]["gpt_codex"]["entrypoint_status"] == "unavailable"
+
+
+def test_partial_install_is_retained_for_exact_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    real_install = host_installer._install_no_overwrite
+
+    def fail_second_role(directory_fd: int, name: str, content: str) -> bool:
+        if name == "codex-subscription-cli":
+            raise host_installer.HostInstallError("injected second-role failure")
+        return real_install(directory_fd, name, content)
+
+    monkeypatch.setattr(host_installer, "_install_no_overwrite", fail_second_role)
+    with pytest.raises(host_installer.HostInstallError, match="second-role failure"):
+        host_installer.install(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert (bin_dir / "fable-subscription-cli").is_file()
+    assert not (bin_dir / "codex-subscription-cli").exists()
+    monkeypatch.undo()
+
+    retry = _install(bin_dir)
+    assert retry.returncode == 0, retry.stderr
+    assert json.loads(retry.stdout)["roles"] == {
+        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "gpt_codex": {
+            "entrypoint": "codex-subscription-cli",
+            "status": "installed",
+        },
+    }
+
+
+def test_temporary_cleanup_failure_cannot_return_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    directory_fd = os.open(bin_dir, os.O_RDONLY | os.O_DIRECTORY)
+    real_unlink = os.unlink
+
+    def fail_temp_cleanup(
+        path: str | bytes,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        if isinstance(path, str) and path.startswith(".test-entrypoint."):
+            raise OSError("injected cleanup failure")
+        real_unlink(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(host_installer.os, "unlink", fail_temp_cleanup)
+    try:
+        with pytest.raises(
+            host_installer.HostInstallError,
+            match="temporary entrypoint cleanup failed",
+        ):
+            host_installer._install_no_overwrite(
+                directory_fd,
+                "test-entrypoint",
+                "#!/bin/sh\nexit 0\n",
+            )
+    finally:
+        os.close(directory_fd)
+        monkeypatch.undo()
+
+    assert (bin_dir / "test-entrypoint").is_file()
+    assert len(list(bin_dir.glob(".test-entrypoint.*.tmp"))) == 1
+
+
+def test_concurrent_exact_writer_produces_truthful_unchanged_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    real_install = host_installer._install_no_overwrite
+    raced: set[str] = set()
+
+    def exact_writer_wins(directory_fd: int, name: str, content: str) -> bool:
+        if name not in raced:
+            raced.add(name)
+            assert real_install(directory_fd, name, content) is True
+        return real_install(directory_fd, name, content)
+
+    monkeypatch.setattr(host_installer, "_install_no_overwrite", exact_writer_wins)
+    receipt = host_installer.install(
+        repo_root=REPO_ROOT,
+        bin_dir=bin_dir,
+        python=Path(sys.executable),
+    )
+
+    assert receipt["roles"] == {
+        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "gpt_codex": {
+            "entrypoint": "codex-subscription-cli",
+            "status": "unchanged",
+        },
+    }
+
+
+def test_concurrent_conflicting_writer_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    real_install = host_installer._install_no_overwrite
+
+    def conflicting_writer_wins(directory_fd: int, name: str, content: str) -> bool:
+        if name == "fable-subscription-cli":
+            fd = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o700,
+                dir_fd=directory_fd,
+            )
+            try:
+                os.write(fd, b"unrelated concurrent command\n")
+            finally:
+                os.close(fd)
+        return real_install(directory_fd, name, content)
+
+    monkeypatch.setattr(
+        host_installer,
+        "_install_no_overwrite",
+        conflicting_writer_wins,
+    )
+    with pytest.raises(host_installer.HostInstallError, match="conflicting entrypoint"):
+        host_installer.install(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+        "unrelated concurrent command\n"
+    )
+    assert not (bin_dir / "codex-subscription-cli").exists()
+
+
+def test_install_rejects_bin_directory_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    detached_bin = tmp_path / "detached-bin"
+    real_install = host_installer._install_no_overwrite
+    replaced = False
+
+    def replace_bin_before_write(directory_fd: int, name: str, content: str) -> bool:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            bin_dir.rename(detached_bin)
+            bin_dir.mkdir()
+        return real_install(directory_fd, name, content)
+
+    monkeypatch.setattr(
+        host_installer,
+        "_install_no_overwrite",
+        replace_bin_before_write,
+    )
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.install(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert replaced
+    assert not list(bin_dir.iterdir())
+    assert (detached_bin / "fable-subscription-cli").is_file()
+    assert (detached_bin / "codex-subscription-cli").is_file()
+
+
+def test_check_rejects_bin_directory_replacement_during_path_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    detached_bin = tmp_path / "detached-bin"
+    assert _install(bin_dir).returncode == 0
+    real_which = host_installer.shutil.which
+    replaced = False
+
+    def replace_bin_before_discovery(command: str, *, path: str | None = None) -> str | None:
+        nonlocal replaced
+        if command != "git" and not replaced:
+            replaced = True
+            bin_dir.rename(detached_bin)
+            bin_dir.mkdir()
+            for name in (
+                "fable-subscription-cli",
+                "codex-subscription-cli",
+                "claude",
+                "codex",
+                "yggdrasil-model-inquiry",
+            ):
+                executable = bin_dir / name
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o700)
+        return real_which(command, path=path)
+
+    monkeypatch.setattr(host_installer.shutil, "which", replace_bin_before_discovery)
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.check(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+            path=str(bin_dir),
+        )
+
+    assert replaced
+    assert (detached_bin / "fable-subscription-cli").is_file()
+    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+        "#!/bin/sh\nexit 0\n"
+    )
+
+
+def test_check_rejects_checkout_replacement_after_bin_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    _init_adapter_checkout(checkout)
+    original_checkout = tmp_path / "original-checkout"
+    bin_dir = tmp_path / "bin"
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+    host_installer.install(
+        repo_root=checkout,
+        bin_dir=bin_dir,
+        python=Path(sys.executable),
+    )
+    _add_fake_host_dependencies(bin_dir)
+    real_open_bin_dir = host_installer._open_bin_dir
+
+    def replace_checkout_after_bin_open(
+        path: Path,
+        *,
+        create: bool,
+    ) -> tuple[Path, int, tuple[int, int]]:
+        opened = real_open_bin_dir(path, create=create)
+        checkout.rename(original_checkout)
+        replacement = _init_adapter_checkout(checkout)
+        replacement.write_text("raise SystemExit('foreign')\n", encoding="utf-8")
+        return opened
+
+    monkeypatch.setattr(
+        host_installer,
+        "_open_bin_dir",
+        replace_checkout_after_bin_open,
+    )
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.check(
+            repo_root=checkout,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+            path=str(bin_dir),
+        )
+
+    assert original_checkout.is_dir()
+    assert checkout.is_dir()
+
+
+def test_install_revalidates_all_wrappers_before_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    real_install = host_installer._install_no_overwrite
+
+    def replace_first_during_second(
+        directory_fd: int,
+        name: str,
+        content: str,
+    ) -> bool:
+        if name == "codex-subscription-cli":
+            os.unlink("fable-subscription-cli", dir_fd=directory_fd)
+            fd = os.open(
+                "fable-subscription-cli",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o700,
+                dir_fd=directory_fd,
+            )
+            try:
+                os.write(fd, b"unrelated replacement\n")
+            finally:
+                os.close(fd)
+        return real_install(directory_fd, name, content)
+
+    monkeypatch.setattr(
+        host_installer,
+        "_install_no_overwrite",
+        replace_first_during_second,
+    )
+    with pytest.raises(
+        host_installer.HostInstallError,
+        match="entrypoint changed during installation",
+    ):
+        host_installer.install(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+        )
+
+    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+        "unrelated replacement\n"
+    )
+
+
+def _add_fake_host_dependencies(bin_dir: Path) -> None:
+    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+        executable = bin_dir / command
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+
+
+def test_check_revalidates_earlier_wrapper_after_later_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    assert _install(bin_dir).returncode == 0
+    _add_fake_host_dependencies(bin_dir)
+    real_which = host_installer.shutil.which
+    replaced = False
+
+    def replace_fable_during_codex_discovery(
+        command: str,
+        *,
+        path: str | None = None,
+    ) -> str | None:
+        nonlocal replaced
+        if command == "codex-subscription-cli" and not replaced:
+            replaced = True
+            fable = bin_dir / "fable-subscription-cli"
+            fable.unlink()
+            fable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fable.chmod(0o700)
+        return real_which(command, path=path)
+
+    monkeypatch.setattr(
+        host_installer.shutil,
+        "which",
+        replace_fable_during_codex_discovery,
+    )
+    payload = host_installer.check(
+        repo_root=REPO_ROOT,
+        bin_dir=bin_dir,
+        python=Path(sys.executable),
+        path=str(bin_dir),
+    )
+
+    assert replaced
+    assert payload["ok"] is False
+    roles = payload["roles"]
+    assert isinstance(roles, dict)
+    fable = roles["fable"]
+    assert isinstance(fable, dict)
+    assert fable["entrypoint_status"] == "unavailable"
+
+
+def test_check_rejects_bin_replacement_during_launcher_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    detached_bin = tmp_path / "detached-bin"
+    assert _install(bin_dir).returncode == 0
+    _add_fake_host_dependencies(bin_dir)
+    real_which = host_installer.shutil.which
+    replaced = False
+
+    def replace_bin_for_launcher(
+        command: str,
+        *,
+        path: str | None = None,
+    ) -> str | None:
+        nonlocal replaced
+        if command == "yggdrasil-model-inquiry" and not replaced:
+            replaced = True
+            bin_dir.rename(detached_bin)
+            bin_dir.mkdir()
+        return real_which(command, path=path)
+
+    monkeypatch.setattr(host_installer.shutil, "which", replace_bin_for_launcher)
+    with pytest.raises(host_installer.HostInstallError, match="identity changed"):
+        host_installer.check(
+            repo_root=REPO_ROOT,
+            bin_dir=bin_dir,
+            python=Path(sys.executable),
+            path=str(bin_dir),
+        )
+
+    assert replaced
+    assert not list(bin_dir.iterdir())

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import pytest
 
 from app.builderops.model_inquiry import ModelInquiryService
+from app.builderops.model_inquiry_adapters import AdapterUnavailableError
+from scripts.start_model_inquiry import preflight_dependencies
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LAUNCHER = REPO_ROOT / "scripts" / "start_model_inquiry.sh"
@@ -333,6 +335,119 @@ def test_skill_preflight_reports_missing_dependencies(tmp_path: Path) -> None:
     )
     assert missing_executable.returncode == 2
     assert "local command unavailable" in missing_executable.stderr
+    assert not (vault / "model-inquiries").exists()
+
+
+def test_host_role_entrypoints_gate_desktop_preflight(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    adapter_config = {
+        "fable": {
+            "kind": "command",
+            "role_identity": "fable",
+            "adapter_id": "fable-subscription-cli",
+            "provider": "anthropic-subscription",
+            "model": "configured-fable",
+            "argv": ["fable-subscription-cli"],
+            "environment_allowlist": ["PATH"],
+        },
+        "gpt_codex": {
+            "kind": "command",
+            "role_identity": "gpt_codex",
+            "adapter_id": "codex-subscription-cli",
+            "provider": "openai-subscription",
+            "model": "configured-codex",
+            "argv": ["codex-subscription-cli"],
+            "environment_allowlist": ["PATH"],
+        },
+    }
+    env = {
+        **os.environ,
+        "PATH": str(bin_dir),
+        "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
+        "BUILDEROPS_VAULT_ROOT": str(tmp_path / "vault"),
+        "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(adapter_config),
+    }
+    (tmp_path / "vault").mkdir()
+    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+        executable = bin_dir / command
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+
+    with pytest.raises(AdapterUnavailableError, match="fable-subscription-cli"):
+        preflight_dependencies(env, command_cwd=REPO_ROOT)
+
+    for command in ("fable-subscription-cli", "codex-subscription-cli"):
+        executable = bin_dir / command
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o700)
+    with pytest.raises(AdapterUnavailableError, match="installed-lineage preflight"):
+        preflight_dependencies(env, command_cwd=REPO_ROOT)
+    for command in ("fable-subscription-cli", "codex-subscription-cli"):
+        (bin_dir / command).unlink()
+
+    installed = _run_host_installer(tmp_path, bin_dir)
+    assert installed.returncode == 0, installed.stderr
+    result = preflight_dependencies(env, command_cwd=REPO_ROOT)
+
+    assert set(result["adapters"]) == {"fable", "gpt_codex"}
+    assert not (tmp_path / "vault" / "model-inquiries").exists()
+
+
+def _run_host_installer(
+    tmp_path: Path,
+    bin_dir: Path,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "install_model_inquiry_host.py"),
+            "install",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--bin-dir",
+            str(bin_dir),
+            "--python",
+            sys.executable,
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "BUILDEROPS_DB_PATH": str(tmp_path / "unused.sqlite3")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_generic_command_adapters_do_not_require_host_entrypoint_lineage(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    config: dict[str, dict[str, object]] = {}
+    for role in ("fable", "gpt_codex"):
+        command = bin_dir / f"generic-{role}"
+        command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        command.chmod(0o700)
+        config[role] = {
+            "kind": "command",
+            "role_identity": role,
+            "adapter_id": f"generic-{role}",
+            "provider": f"provider-{role}",
+            "model": f"model-{role}",
+            "argv": [str(command)],
+        }
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    env = {
+        **os.environ,
+        "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
+        "BUILDEROPS_VAULT_ROOT": str(vault),
+        "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(config),
+    }
+
+    result = preflight_dependencies(env, command_cwd=REPO_ROOT)
+
+    assert set(result["adapters"]) == {"fable", "gpt_codex"}
     assert not (vault / "model-inquiries").exists()
 
 

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -386,17 +386,25 @@ def test_host_role_entrypoints_gate_desktop_preflight(tmp_path: Path) -> None:
     for command in ("fable-subscription-cli", "codex-subscription-cli"):
         (bin_dir / command).unlink()
 
-    installed = _run_host_installer(tmp_path, bin_dir)
+    selected_python = tmp_path / "selected-python"
+    selected_python.symlink_to(Path(sys.executable))
+    env["BUILDEROPS_PYTHON"] = str(selected_python)
+    installed = _run_host_installer(tmp_path, bin_dir, python=selected_python)
     assert installed.returncode == 0, installed.stderr
     result = preflight_dependencies(env, command_cwd=REPO_ROOT)
 
     assert set(result["adapters"]) == {"fable", "gpt_codex"}
     assert not (tmp_path / "vault" / "model-inquiries").exists()
+    mismatched_env = {key: value for key, value in env.items() if key != "BUILDEROPS_PYTHON"}
+    with pytest.raises(AdapterUnavailableError, match="installed-lineage preflight"):
+        preflight_dependencies(mismatched_env, command_cwd=REPO_ROOT)
 
 
 def _run_host_installer(
     tmp_path: Path,
     bin_dir: Path,
+    *,
+    python: Path = Path(sys.executable),
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
@@ -408,7 +416,7 @@ def _run_host_installer(
             "--bin-dir",
             str(bin_dir),
             "--python",
-            sys.executable,
+            str(python),
         ],
         cwd=REPO_ROOT,
         env={**os.environ, "BUILDEROPS_DB_PATH": str(tmp_path / "unused.sqlite3")},


### PR DESCRIPTION
Governing-Issue: #3958

Fixes #3958

## Summary
- Add an idempotent, owner-only host installer and sanitized check for the Fable and GPT/Codex subscription role entrypoints.
- Bind wrappers to the operator-authoritative checkout and committed adapter digest, with fail-closed race, symlink, conflict, cleanup, and crash-order handling.
- Route the desktop subscription preflight through the same checker and document install, restart recovery, repair, and uninstall.

## Validation
- pytest -q tests/governance/test_model_inquiry_host_install.py (22 passed)
- pytest -q tests/governance/test_start_model_inquiry_skill.py (11 passed)
- ruff check app tests
- python3 scripts/lint_skills_consistency.py
- git diff --check
- CI repair: real newlines in the fake interpreter shebang preserve the selected-symlink `$0` proof.

## BuilderOps Routing
- Records/projections/receipts: issue #3958 recovery/convergence receipts; compatibility LearningSignal entry in docs/learning-log.md.
- Reason: BuilderOps LearningSignal creation was attempted but the live store lacked the required explicit store/cutover receipt, so capture-learning routed the signal to the compatibility log.

## Risk and activation
- Risk surface: credential durability. No credentials, provider invocations, inquiry artifacts, locks, or vault writes are created by install/check validation.
- Host activation is intentionally deferred until this repo-owned installer is merged into the canonical checkout; the existing stale host wrappers are not overwritten.

---

Final-Review-Rounds: 2