### PR TITLE
Add opt-in CKM cockpit framing

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from html import escape
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -16,7 +17,8 @@ from app.builderops.ckm.models import (
     CkmAssessmentProjection,
     utc_now,
 )
-from app.builderops.ckm.store import CkmStore
+from app.builderops.ckm.contracts import canonical_digest
+from app.builderops.ckm.store import CkmProjectionBatch, CkmStore
 
 
 DIMENSION_LABELS = {
@@ -28,6 +30,76 @@ DIMENSION_LABELS = {
     "architectural_stability": ("ARC", "architectural stability"),
     "requirement_coverage": ("REQ", "requirement coverage"),
 }
+
+
+@dataclass(frozen=True)
+class CockpitRenderContext:
+    """Immutable, data-only input captured before cockpit rendering begins."""
+
+    batch: CkmProjectionBatch
+
+
+def _cockpit_digest(batch: CkmProjectionBatch) -> str:
+    """Bind cockpit provenance to every captured projection input deterministically."""
+
+    return canonical_digest(
+        {
+            "state_identity": batch.state_identity.to_dict(),
+            "object_counts": dict(sorted(batch.object_counts.items())),
+            "capabilities": [item.to_dict() for item in batch.capabilities],
+            "artifacts": [item.to_dict() for item in batch.artifacts],
+            "edges": [
+                edge.to_dict()
+                for capability_id in sorted(batch.edges_by_capability)
+                for edge in batch.edges_by_capability[capability_id]
+            ],
+            "assessments": [
+                batch.assessments_by_capability[capability_id].assessment.to_dict()
+                for capability_id in sorted(batch.assessments_by_capability)
+            ],
+            "findings": [
+                finding.to_dict()
+                for capability_id in sorted(batch.findings_by_capability)
+                for finding in batch.findings_by_capability[capability_id]
+            ],
+            "watermarks": dict(sorted(batch.current_watermark_set.items())),
+        }
+    )
+
+
+def _cockpit_trust_markup(batch: CkmProjectionBatch, timestamp: str) -> str:
+    identity = batch.state_identity
+    counts = batch.object_counts
+    count_text = " · ".join(
+        f"{_e(label)}: {counts.get(key, 0)}"
+        for key, label in (
+            ("capability", "capabilities"),
+            ("artifact", "artifacts"),
+            ("evidence_edge", "evidence edges"),
+            ("assessment", "assessments"),
+            ("finding", "findings"),
+            ("watermark", "watermarks"),
+        )
+    )
+    return f"""<header class="cockpit-header"><h1>CKM Cockpit</h1><p class="subtitle">Portfolio-first, generated, non-authoritative inspection surface.</p></header>
+    <section class="cockpit-trust" aria-labelledby="cockpit-trust-heading">
+      <h2 id="cockpit-trust-heading">Cockpit trust frame</h2>
+      <p>Is this projection fresh and complete enough to inspect?</p>
+      <p>Generated: {_e(timestamp)} · epoch: {_e(identity.epoch)} · state revision: {identity.state_revision} · schema version: {identity.schema_version}</p>
+      <p>Watermarks: {_watermarks(batch.current_watermark_set)}</p>
+      <p>Bounded counts: {count_text}</p>
+      <p>projection-input digest: <code>{_cockpit_digest(batch)}</code></p>
+    </section>"""
+
+
+def _cockpit_reserved_markup() -> str:
+    return """<section class="cockpit-reserved" aria-labelledby="hazards-heading"><h2 id="hazards-heading">Interpretation hazards</h2><p>What should not be taken at face value?</p><p>Unavailable in this framing slice. No interpretation is generated here.</p></section>
+    <section class="cockpit-reserved" aria-labelledby="comparison-heading"><h2 id="comparison-heading">Comparison</h2><p>What differs between the two newest active retained observation records, when O1b says they are compatible?</p><p>Unavailable in this framing slice. No retained-observation comparison was read.</p></section>
+    <section class="cockpit-reserved" aria-labelledby="filters-heading"><h2 id="filters-heading">Filters</h2><p>Unavailable in this framing slice. All capability rows are shown.</p></section>"""
+
+
+def _cockpit_proposals_markup() -> str:
+    return '<section class="cockpit-reserved" aria-labelledby="proposals-heading"><h2 id="proposals-heading">Proposal drafts</h2><p>Unavailable in this framing slice. No proposal content is generated.</p></section>'
 
 
 def _e(value: object) -> str:
@@ -415,6 +487,7 @@ def render_overview_html(
     generated_at: str | None = None,
     class_capture_limit: int | None = None,
     aggregate_capture_limit: int | None = None,
+    cockpit: CockpitRenderContext | None = None,
 ) -> str:
     """Render one self-contained CKM projection without mutating the store."""
 
@@ -424,7 +497,7 @@ def render_overview_html(
         capture_limits["class_capture_limit"] = class_capture_limit
     if aggregate_capture_limit is not None:
         capture_limits["aggregate_capture_limit"] = aggregate_capture_limit
-    batch = store.load_projection_batch(**capture_limits)
+    batch = cockpit.batch if cockpit is not None else store.load_projection_batch(**capture_limits)
     capabilities = batch.capabilities
     capability_by_id = {item.id: item for item in capabilities}
     all_findings = tuple(
@@ -461,6 +534,21 @@ def render_overview_html(
         if capability_id in capability_by_id
     ) or "<li>No current findings.</li>"
     watermark_text = _watermarks(batch.current_watermark_set)
+    cockpit_header = _cockpit_trust_markup(batch, timestamp) if cockpit else ""
+    cockpit_reserved = _cockpit_reserved_markup() if cockpit else ""
+    cockpit_proposals = _cockpit_proposals_markup() if cockpit else ""
+    cockpit_gap_prompt = "<p>Where is evidence weakest?</p>" if cockpit else ""
+    overview_header = (
+        cockpit_header
+        if cockpit
+        else '<header><h1>Development Overview</h1><p class="subtitle">Capability Knowledge Model maturity, trust, and cited drill-down.</p></header>'
+    )
+    subsystem_counts = "" if cockpit else _subsystem_counts_markup(forest, batch.edges_by_capability)
+    footer_identity = (
+        f'<br>State identity: epoch {_e(batch.state_identity.epoch)} · revision {batch.state_identity.state_revision} · schema {batch.state_identity.schema_version}<br>projection-input digest: <code>{_cockpit_digest(batch)}</code>'
+        if cockpit
+        else ""
+    )
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -489,21 +577,24 @@ def render_overview_html(
 <body>
   <div class="projection-banner"><strong>Generated projection — not source of truth.</strong> Read watermarks and trust states before maturity values.</div>
   <main>
-    <header><h1>Development Overview</h1><p class="subtitle">Capability Knowledge Model maturity, trust, and cited drill-down.</p></header>
-    {_trust_strip(capabilities, assessments, len(all_findings))}
-    {_subsystem_counts_markup(forest, batch.edges_by_capability)}
+    {overview_header}
+    {"" if cockpit else _trust_strip(capabilities, assessments, len(all_findings))}
+    {cockpit_reserved}
+    {subsystem_counts}
     <section aria-labelledby="map-heading">
       <h2 id="map-heading">Capability map</h2>
       {_legend()}
       <div class="dimension-rail" aria-hidden="true">{"".join(f"<span>{abbr}</span>" for abbr, _ in DIMENSION_LABELS.values())}</div>
       <div class="capability-tree">{cards}</div>
     </section>
-    <section class="gaps-panel" aria-labelledby="gaps-heading"><h2 id="gaps-heading">Current gaps</h2><ul>{gap_groups}</ul></section>
+    <section class="gaps-panel" aria-labelledby="gaps-heading"><h2 id="gaps-heading">Current gaps</h2>{cockpit_gap_prompt}<ul>{gap_groups}</ul></section>
+    {cockpit_proposals}
   </main>
   <footer class="projection-footer">
     <strong>Generated projection (BuilderOps CKM). Not source of truth.</strong><br>
     Generated: {_e(timestamp)}<br>
     Watermarks: {watermark_text}<br>
+    {footer_identity}
     Candidate and confirmed evidence remain distinct. Regenerate from the CKM store; do not edit this file as authority.
   </footer>
 </body>
@@ -518,16 +609,17 @@ def write_overview_html(
     generated_at: str | None = None,
     class_capture_limit: int | None = None,
     aggregate_capture_limit: int | None = None,
+    cockpit: CockpitRenderContext | None = None,
 ) -> Path:
-    store.ensure_schema()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        render_overview_html(
+    if cockpit is None:
+        store.ensure_schema()
+    rendered = render_overview_html(
             store,
             generated_at=generated_at,
             class_capture_limit=class_capture_limit,
             aggregate_capture_limit=aggregate_capture_limit,
-        ),
-        encoding="utf-8",
+            cockpit=cockpit,
     )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
     return output_path

--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -543,7 +543,7 @@ def render_overview_html(
         if cockpit
         else '<header><h1>Development Overview</h1><p class="subtitle">Capability Knowledge Model maturity, trust, and cited drill-down.</p></header>'
     )
-    subsystem_counts = "" if cockpit else _subsystem_counts_markup(forest, batch.edges_by_capability)
+    subsystem_counts = _subsystem_counts_markup(forest, batch.edges_by_capability)
     footer_identity = (
         f'<br>State identity: epoch {_e(batch.state_identity.epoch)} · revision {batch.state_identity.state_revision} · schema {batch.state_identity.schema_version}<br>projection-input digest: <code>{_cockpit_digest(batch)}</code>'
         if cockpit

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -70,6 +70,7 @@ class CkmProjectionCaptureError(CkmValidationError):
 @dataclass(frozen=True)
 class CkmProjectionBatch:
     state_identity: CkmStateIdentity
+    object_counts: Mapping[str, int]
     capabilities: tuple[CkmCapability, ...]
     artifacts: tuple[CkmArtifact, ...]
     edges_by_capability: Mapping[str, tuple[CkmEvidenceEdge, ...]]
@@ -1474,6 +1475,7 @@ class CkmStore:
             )
         return CkmProjectionBatch(
             state_identity=state_identity,
+            object_counts=object_counts,
             capabilities=tuple(CkmCapability.from_row(row) for row in capability_rows),
             artifacts=tuple(CkmArtifact.from_row(row) for row in artifact_rows),
             edges_by_capability={key: tuple(value) for key, value in edges.items()},

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -31,7 +31,7 @@ from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
-from app.builderops.ckm.overview_html import write_overview_html
+from app.builderops.ckm.overview_html import CockpitRenderContext, write_overview_html
 from app.builderops.ckm.projections import (
     PROJECTION_FILENAMES as CKM_PROJECTION_FILENAMES,
     render_capability_show,
@@ -689,6 +689,11 @@ def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> N
 
 @ckm.command("overview", help="Write the self-contained CKM Development Overview HTML.")
 @click.option(
+    "--cockpit",
+    is_flag=True,
+    help="Render the opt-in non-authoritative CKM cockpit framing.",
+)
+@click.option(
     "--out",
     "output_path",
     type=click.Path(dir_okay=False, path_type=Path),
@@ -712,16 +717,28 @@ def ckm_overview(
     output_path: Path,
     class_capture_limit: int | None,
     aggregate_capture_limit: int | None,
+    cockpit: bool,
 ) -> None:
     try:
         store = _ckm_store(ctx)
         if not store.db_path.is_file():
             raise CkmValidationError(f"CKM database does not exist: {store.db_path}")
+        cockpit_context = None
+        if cockpit:
+            capture_limits = {}
+            if class_capture_limit is not None:
+                capture_limits["class_capture_limit"] = class_capture_limit
+            if aggregate_capture_limit is not None:
+                capture_limits["aggregate_capture_limit"] = aggregate_capture_limit
+            cockpit_context = CockpitRenderContext(
+                batch=store.load_projection_batch(**capture_limits)
+            )
         result = write_overview_html(
             store,
             output_path,
             class_capture_limit=class_capture_limit,
             aggregate_capture_limit=aggregate_capture_limit,
+            cockpit=cockpit_context,
         )
     except (CkmValidationError, OSError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm overview failed: {exc}") from exc

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -634,6 +634,28 @@ def test_cockpit_uses_existing_overview_renderer_call_site(overview_store: CkmSt
     assert "Capability map" in rendered
 
 
+def test_cockpit_preserves_evidence_profile_count_context(
+    fanout_overview_store: CkmStore,
+) -> None:
+    context = CockpitRenderContext(batch=fanout_overview_store.load_projection_batch())
+    cockpit = render_overview_html(
+        fanout_overview_store,
+        generated_at="2026-07-25T10:00:00Z",
+        cockpit=context,
+    )
+    default = render_overview_html(
+        fanout_overview_store,
+        generated_at="2026-07-25T10:00:00Z",
+    )
+
+    for rendered in (cockpit, default):
+        assert 'data-subsystem-name="Retrieval subsystem"' in rendered
+        assert 'data-distinct-artifacts="3"' in rendered
+        assert 'data-shared-evidence="40.0%"' in rendered
+    assert "Cockpit trust frame" in cockpit
+    assert "Cockpit trust frame" not in default
+
+
 def test_cockpit_uses_one_projection_batch_without_mutation(
     overview_store: CkmStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,7 @@ from click.testing import CliRunner
 
 from app.builderops.cli import builderops
 from app.builderops.ckm.models import MATURITY_DIMENSIONS
-from app.builderops.ckm.overview_html import render_overview_html
+from app.builderops.ckm.overview_html import CockpitRenderContext, render_overview_html
 from app.builderops.ckm.store import CkmStore
 
 
@@ -604,3 +605,131 @@ def test_cli_rejects_missing_database_without_creating_it(tmp_path: Path) -> Non
     assert "CKM database does not exist" in result.output
     assert not database.exists()
     assert not output.exists()
+
+
+def test_cli_cockpit_is_opt_in_and_default_remains_direction_a(
+    overview_store: CkmStore, tmp_path: Path
+) -> None:
+    default_output = tmp_path / "default.html"
+    cockpit_output = tmp_path / "cockpit.html"
+    default = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(overview_store.db_path), "ckm", "overview", "--out", str(default_output)],
+    )
+    cockpit = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(overview_store.db_path), "ckm", "overview", "--cockpit", "--out", str(cockpit_output)],
+    )
+    assert default.exit_code == cockpit.exit_code == 0
+    assert "Cockpit trust frame" not in default_output.read_text(encoding="utf-8")
+    assert "Cockpit trust frame" in cockpit_output.read_text(encoding="utf-8")
+
+
+def test_cockpit_uses_existing_overview_renderer_call_site(overview_store: CkmStore) -> None:
+    context = CockpitRenderContext(batch=overview_store.load_projection_batch())
+    rendered = render_overview_html(
+        overview_store, generated_at="2026-07-25T10:00:00Z", cockpit=context
+    )
+    assert "Cockpit trust frame" in rendered
+    assert "Capability map" in rendered
+
+
+def test_cockpit_uses_one_projection_batch_without_mutation(
+    overview_store: CkmStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    batch = overview_store.load_projection_batch()
+    calls = 0
+
+    def load_once(**_: int) -> object:
+        nonlocal calls
+        calls += 1
+        return batch
+
+    monkeypatch.setattr(overview_store, "load_projection_batch", load_once)
+    before = overview_store.state_identity()
+    render_overview_html(overview_store, cockpit=CockpitRenderContext(batch=batch))
+    assert calls == 0
+    assert overview_store.state_identity() == before
+
+
+def test_cockpit_trust_frame_binds_complete_projection_identity(overview_store: CkmStore) -> None:
+    batch = overview_store.load_projection_batch()
+    rendered = render_overview_html(
+        overview_store,
+        generated_at="2026-07-25T10:00:00Z",
+        cockpit=CockpitRenderContext(batch=batch),
+    )
+    for value in (batch.state_identity.epoch, str(batch.state_identity.state_revision), str(batch.state_identity.schema_version), "fixture=two"):
+        assert value in rendered
+    for label in ("capabilities", "artifacts", "evidence edges", "assessments", "findings", "projection-input digest"):
+        assert label in rendered
+
+
+def test_cockpit_empty_store_keeps_fixed_information_architecture(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "empty-cockpit.sqlite3")
+    store.ensure_schema()
+    rendered = render_overview_html(
+        store,
+        generated_at="2026-07-25T10:00:00Z",
+        cockpit=CockpitRenderContext(batch=store.load_projection_batch()),
+    )
+    headings = ("Cockpit trust frame", "Interpretation hazards", "Comparison", "Filters", "Capability map", "Current gaps", "Proposal drafts")
+    assert all(heading in rendered for heading in headings)
+    assert rendered.index("Cockpit trust frame") < rendered.index("Interpretation hazards") < rendered.index("Comparison") < rendered.index("Filters") < rendered.index("Capability map") < rendered.index("Current gaps") < rendered.index("Proposal drafts")
+    assert "Is this projection fresh and complete enough to inspect?" in rendered
+    assert "What differs between the two newest active retained observation records" in rendered
+    assert "Where is evidence weakest?" in rendered
+    assert "What should not be taken at face value?" in rendered
+
+
+def test_cockpit_cli_fails_closed_before_writing_partial_output(
+    overview_store: CkmStore, tmp_path: Path
+) -> None:
+    database = tmp_path / "missing" / "ckm.sqlite3"
+    output = tmp_path / "cockpit.html"
+    result = CliRunner().invoke(builderops, ["--db-path", str(database), "ckm", "overview", "--cockpit", "--out", str(output)])
+    assert result.exit_code != 0
+    assert not database.exists()
+    assert not output.exists()
+
+    _make_snapshot_exceed_default(overview_store)
+    oversized_output = tmp_path / "oversized.html"
+    oversized = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--cockpit",
+            "--out",
+            str(oversized_output),
+        ],
+    )
+    assert oversized.exit_code != 0
+    assert "snapshot" in oversized.output
+    assert not oversized_output.exists()
+
+    with sqlite3.connect(overview_store.db_path) as conn:
+        conn.execute("UPDATE ckm_state SET schema_version = 999 WHERE singleton = 1")
+    unsupported_output = tmp_path / "unsupported.html"
+    unsupported = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--cockpit",
+            "--out",
+            str(unsupported_output),
+        ],
+    )
+    assert unsupported.exit_code != 0
+    assert not unsupported_output.exists()
+
+
+def test_cockpit_render_is_byte_deterministic(overview_store: CkmStore) -> None:
+    batch = overview_store.load_projection_batch()
+    context = CockpitRenderContext(batch=batch)
+    assert render_overview_html(overview_store, generated_at="2026-07-25T10:00:00Z", cockpit=context) == render_overview_html(overview_store, generated_at="2026-07-25T10:00:00Z", cockpit=context)


### PR DESCRIPTION
Governing-Issue: #4081

Fixes #4081

Refs #4080

## Summary

Adds the opt-in `ckm overview --cockpit` path through the existing overview renderer and writer. Cockpit output is bound to one immutable, bounded projection batch with deterministic identity metadata; the Direction A default remains unchanged. The cockpit also preserves the delivered distinct-artifact and shared-evidence count context.

## Validation

- `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py` — 30 passed
- `python3 -m pytest -q tests/builderops/ckm` — passed
- `ruff check app tests` — passed
- `mypy app` — passed (808 source files)
- `python3 scripts/review_before_ci_gate.py ...` — not required; empty declared risk-surface set

## Owner-doc posture

Target-state remains linked; no supported Direction B claim.

## Transition debt

D11/D12 preserved. This establishes one extension seam in the existing overview renderer and adds no parallel dashboard or new debt row.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: No delivery divergence or BuilderOps operational material was produced; the stale target-doc lifecycle wording is resolved by the live terminal prerequisite receipt and does not alter the bounded implementation contract.

## Pickup receipt

- Mode: github-label-only-fallback
- Evidence: issue comment 5078123205
- Reason: dispatcher exact task `github-RasmusTho--agentic-pkm-mvp-issue-4081` was unavailable despite the live strictly ready issue.

Final-Review-Rounds: 1