### PR TITLE
Fix legacy outbox schema authority

### DIFF
--- a/app/db/migrations_obsidian.sql
+++ b/app/db/migrations_obsidian.sql
@@ -47,16 +47,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS objects_uuid_idx ON public.objects(uuid);
 CREATE INDEX IF NOT EXISTS objects_created_at_idx ON public.objects (created_at DESC);
 CREATE INDEX IF NOT EXISTS objects_source_ref_idx ON public.objects (source_ref);
 
-CREATE TABLE IF NOT EXISTS public.outbox(
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  topic text NOT NULL,
-  payload jsonb NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  delivered_at timestamptz NULL,
-  attempts int NOT NULL DEFAULT 0
-);
-CREATE INDEX IF NOT EXISTS outbox_created_at_idx ON public.outbox (created_at DESC);
-CREATE INDEX IF NOT EXISTS outbox_delivered_null_idx ON public.outbox ((delivered_at IS NULL));
+-- Outbox DDL is intentionally absent here. Alembic revision f3a1c9d2e4b7 is
+-- the sole production owner of the canonical outbox table and its indexes.
+-- This legacy bootstrap may create other compatibility schema, but it must
+-- never create or mutate outbox before assert-only runtime startup.
 
 DROP VIEW IF EXISTS public.view_objects_ready_for_projection;
 DROP VIEW IF EXISTS public.view_objects_missing_review;

--- a/tests/migrations/test_outbox_schema_parity.py
+++ b/tests/migrations/test_outbox_schema_parity.py
@@ -104,6 +104,35 @@ def _run_bootstrap(dsn: str, monkeypatch: pytest.MonkeyPatch) -> None:
     outbox_module.bootstrap()
 
 
+def _run_legacy_sql_runner(dsn: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute the production legacy SQL entrypoint against a scratch database."""
+    from scripts import run_migration
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.chdir(REPO_ROOT)
+    run_migration.main()
+
+
+def _create_authoritative_outbox(dsn: str) -> None:
+    """Install only the outbox shape owned by Alembic revision f3a1c9d2e4b7."""
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute(
+            """
+            CREATE TABLE outbox (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                topic TEXT NOT NULL,
+                payload JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                delivered_at TIMESTAMPTZ,
+                attempts INT NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute("CREATE INDEX outbox_created_idx ON outbox (created_at)")
+        conn.execute("CREATE INDEX outbox_delivered_idx ON outbox (delivered_at)")
+
+
 def _schema_snapshot(dsn: str) -> dict:
     """Column/PK/index shape of the outbox table, normalized for comparison."""
     with psycopg.connect(dsn) as conn:
@@ -161,6 +190,25 @@ def test_fresh_db_parity(scratch_db_factory, monkeypatch: pytest.MonkeyPatch) ->
         f"bootstrap: {json.dumps(bootstrapped_shape, indent=2, default=str)}"
     )
     assert migrated_shape["columns"], "outbox table missing after alembic upgrade"
+
+
+def test_legacy_sql_runner_cannot_create_or_mutate_outbox_schema(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The legacy SQL runner has no outbox DDL authority on fresh or existing schema."""
+    dsn = scratch_db_factory()
+
+    _run_legacy_sql_runner(dsn, monkeypatch)
+    with psycopg.connect(dsn) as conn:
+        outbox_oid = conn.execute("SELECT to_regclass('public.outbox')").fetchone()
+    assert outbox_oid == (None,), "legacy SQL runner created the migration-owned outbox table"
+
+    _create_authoritative_outbox(dsn)
+    before = _schema_snapshot(dsn)
+    _run_legacy_sql_runner(dsn, monkeypatch)
+    after = _schema_snapshot(dsn)
+
+    assert after == before, "legacy SQL runner mutated the migration-owned outbox schema"
 
 
 def test_upgrade_idempotent_on_existing(scratch_db_factory, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/services/test_outbox_bootstrap_assert_only.py
+++ b/tests/services/test_outbox_bootstrap_assert_only.py
@@ -25,8 +25,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
-def scratch_db(monkeypatch: pytest.MonkeyPatch):
-    """A throwaway database at `alembic upgrade head`, wired into DATABASE_URL."""
+def scratch_db_factory(monkeypatch: pytest.MonkeyPatch):
+    """Create throwaway databases, wiring each one into DATABASE_URL."""
     from app.db.dsn import resolve_dsn
 
     admin_dsn = resolve_dsn()
@@ -38,32 +38,74 @@ def scratch_db(monkeypatch: pytest.MonkeyPatch):
         pytest.skip(f"Postgres unavailable: {exc}")
     probe.close()
 
-    name = f"scratch_outbox_assertonly_{uuid.uuid4().hex[:12]}"
-    with psycopg.connect(admin_dsn, autocommit=True) as conn:
-        conn.execute(f'CREATE DATABASE "{name}"')
     base, _, _ = admin_dsn.rpartition("/")
-    dsn = f"{base}/{name}"
+    created: list[str] = []
 
+    def _create() -> str:
+        name = f"scratch_outbox_assertonly_{uuid.uuid4().hex[:12]}"
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'CREATE DATABASE "{name}"')
+        created.append(name)
+        dsn = f"{base}/{name}"
+        monkeypatch.setenv("DATABASE_URL", dsn)
+        monkeypatch.delenv("DB_DSN", raising=False)
+        # See tests/migrations/test_outbox_schema_parity.py: an earlier migration
+        # declares `embedding VECTOR`, so pgvector must exist in the scratch DB.
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        return dsn
+
+    yield _create
+
+    for name in created:
+        try:
+            with psycopg.connect(admin_dsn, autocommit=True) as conn:
+                conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def scratch_db(scratch_db_factory, monkeypatch: pytest.MonkeyPatch):
+    """A throwaway database at `alembic upgrade head`, wired into DATABASE_URL."""
     from alembic import command
     from alembic.config import Config
 
-    monkeypatch.setenv("DATABASE_URL", dsn)
-    monkeypatch.delenv("DB_DSN", raising=False)
-    # See tests/migrations/test_outbox_schema_parity.py: an earlier migration
-    # declares `embedding VECTOR`, so pgvector must exist in the scratch DB.
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    dsn = scratch_db_factory()
     cfg = Config(str(REPO_ROOT / "alembic.ini"))
     cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
     command.upgrade(cfg, "head")
+    return dsn
 
-    yield dsn
 
-    try:
-        with psycopg.connect(admin_dsn, autocommit=True) as conn:
-            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
-    except Exception:
-        pass
+def _run_legacy_sql_runner(dsn: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import run_migration
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.chdir(REPO_ROOT)
+    run_migration.main()
+
+
+def _outbox_snapshot(dsn: str) -> tuple[list[tuple], list[tuple]]:
+    with psycopg.connect(dsn) as conn:
+        columns = conn.execute(
+            """
+            SELECT column_name, data_type, is_nullable, COALESCE(column_default, '')
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'outbox'
+            ORDER BY column_name
+            """
+        ).fetchall()
+        indexes = conn.execute(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public' AND tablename = 'outbox'
+            ORDER BY indexname
+            """
+        ).fetchall()
+    return list(columns), list(indexes)
 
 
 def test_missing_table_raises(scratch_db, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,6 +155,33 @@ def test_migrated_schema_passes_assert_only(scratch_db, monkeypatch: pytest.Monk
     monkeypatch.delenv("DB_DSN", raising=False)
 
     outbox_module.bootstrap()  # must not raise
+
+
+def test_legacy_sql_runner_cannot_create_or_mutate_outbox_before_assert_only_startup(
+    scratch_db_factory, scratch_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production startup path fails loud after legacy SQL and never repairs schema."""
+    from app.services import outbox as outbox_module
+
+    legacy_dsn = scratch_db_factory()
+    _run_legacy_sql_runner(legacy_dsn, monkeypatch)
+    monkeypatch.delenv("STORE_SCHEMA_AUTOCREATE", raising=False)
+
+    with pytest.raises(OutboxSchemaMissingError, match="alembic upgrade head"):
+        outbox_module.bootstrap()
+    assert _outbox_snapshot(legacy_dsn) == ([], [])
+
+    with psycopg.connect(legacy_dsn, autocommit=True) as conn:
+        conn.execute("CREATE TABLE outbox (id UUID PRIMARY KEY)")
+    incompatible_before = _outbox_snapshot(legacy_dsn)
+
+    with pytest.raises(OutboxSchemaMissingError, match="missing column"):
+        outbox_module.bootstrap()
+    assert _outbox_snapshot(legacy_dsn) == incompatible_before
+
+    monkeypatch.setenv("DATABASE_URL", scratch_db)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    outbox_module.bootstrap()
 
 
 def test_is_transient_marker_classifies_boot_ordering() -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #3988

## Linked Issue

Fixes #3988

## SBS Impact
- Primary subsystem: PDM
- Secondary subsystem(s): EXE, OEF
- Write class: mechanical durable schema write
- Authority impact: none; Alembic remains the sole mechanical schema authority and the outbox remains the canonical runtime queue
- Persistence impact: removes the retained legacy SQL path's ability to create or mutate the durable outbox schema
- Derived/rebuildable impact: schema parity evidence is rebuildable from Alembic and the explicit test-fixture bootstrap
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: deployment migration runs continue to use Alembic; the legacy SQL runner no longer alters outbox before startup
- External boundary impact: none
- New or changed contract: no new contract; enforces the already-owned single-producer and assert-only startup contract
- Owner-doc impact: none; `docs/DB_SCHEMA.md :: Canonical Queue (DB Outbox)` already states the intended Alembic-owned/assert-only posture
- Transition debt impact: reduces inherited dual-producer schema drift; no new debt
- Fitness rule impact: strengthens fresh-schema parity and production startup fail-loud coverage
- Boundary risk: data and migration; no live database, release channel, deployment, restart, or promotion action was performed

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Removes only the outbox table/index DDL from `app/db/migrations_obsidian.sql`, leaving Alembic revision `f3a1c9d2e4b7` as the sole production schema producer.
- Adds production-path PostgreSQL coverage proving `scripts/run_migration.py` cannot create or mutate outbox and assert-only startup fails without mutation on absent/incompatible schema while migrated schema passes.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No doc change was needed because the owner doc already states this contract.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Not applicable; this is a current-state defect correction, not roadmap delivery.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app`
- [x] Governing `Verify:` targets and affected-subsystem tests passed
- [x] If the contract or cross-system blast radius requires the repo-wide non-PG suite, it ran through `scripts/run_with_host_lease.py`; otherwise the focused-scope rationale is recorded below

Evidence on exact SHA `200ab6f28b906fe749ad44d31b896ee61c475c48`:

- Test-first red:
  - `test_fresh_db_parity` failed because legacy bootstrap added `outbox_created_at_idx` and `outbox_delivered_null_idx` beyond Alembic's canonical indexes.
  - Both new production-path Verify tests failed because `scripts/run_migration.py` created `outbox`, allowing startup to pass.
- Exact PR-head post-review Suggested Validation: `3 passed in 5.97s`.
- Affected subsystem on the byte-identical pre-amend tree: full `tests/migrations/test_outbox_schema_parity.py`, `tests/services/test_outbox_bootstrap_assert_only.py`, and `tests/db/test_ensure_schema.py`: `10 passed in 10.06s`; the metadata-only amend preserved tree `faf1e7b8b5b9eb819c7f5ffbab11c6ed15113e2e`.
- `ruff check app tests`: `All checks passed!`
- `mypy app`: `Success: no issues found in 808 source files`
- Static producer census: executable outbox DDL remains only in Alembic and the explicit `STORE_SCHEMA_AUTOCREATE=1` fixture branch; none remains in the legacy SQL/runner paths.
- Settings validation: not applicable; no settings or runtime configuration changed.
- Repo-wide non-PG suite: not required by the Issue and not run; the change is isolated to one legacy SQL DDL block and PostgreSQL schema/startup regression tests, with no cross-system code path change.

## Mechanism Convergence

- Mechanism key: `outbox-schema-authority`
- Risk surfaces: `data`, `migration`
- Packet: `.codex-tmp/issue-3988-mechanism-convergence.md` (local evidence packet; summarized here rather than committed)
- Independent review: CLEAN exact-SHA rebind by `gpt-5.6-sol` / high reasoning on `200ab6f28b906fe749ad44d31b896ee61c475c48`; tree `faf1e7b8b5b9eb819c7f5ffbab11c6ed15113e2e` is byte-identical to the previously CLEAN-reviewed tree.
- Review-before-CI gate: satisfied; matched `risk:data` and `risk:migration`, `may_handoff_to_ci=true`.
- Expensive cycles avoided/repeated: no CI or broad suite ran before convergence; the three named targets were rerun once after the clean review.

## Lifecycle / Claim Receipt

- Branch: `codex/fix-outbox-bootstrap-parity-3988`
- Worktree: `/Users/rasmus/worktrees/issue-3988-outbox-parity`
- Coordination mode: `dispatcher-backed`
- Task: `github-RasmusTho--agentic-pkm-mvp-issue-3988`
- Lease: `lease-39a6a47d`
- Holder: `codex-implement-3988`
- Evidence: `verified-dispatcher-lease`
- Live `agent:ready` was removed after the verified claim.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the repaired GitHub Issue, this PR, and the convergence/validation receipts fully represent the bounded work; no new divergence, freshness observation, roadmap movement, or cross-authority proposal needs a BuilderOps record.

## Notes
- Existing databases are not mutated by this PR. Any absent or incompatible outbox schema now continues to fail loud until the governed Alembic migration path is run.
- No live database migration, deploy, image publication, release-channel change, promotion, restart, merge, or Issue closure was performed.
