### PR TITLE
Filter the CKM capability map honestly

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -435,11 +435,6 @@ def _cockpit_comparison_markup(comparison: Mapping[str, Any] | None) -> str:
     return f'''<section class="cockpit-comparison" aria-labelledby="comparison-heading"><h2 id="comparison-heading">Comparison</h2><p>What differs between the two newest active retained observation records, when O1b says they are compatible?</p><p class="comparison-disclaimer">{disclaimer}</p>{body}<p>Recovery: <code>python -m app.builderops builderops --db-path &lt;db&gt; ckm measure --retain</code> · <code>python -m app.builderops builderops --db-path &lt;db&gt; ckm compare --sample-id &lt;older&gt; --sample-id &lt;newer&gt;</code></p></section>'''
 
 
-def _cockpit_reserved_markup(comparison: Mapping[str, Any] | None) -> str:
-    return _cockpit_comparison_markup(comparison) + """
-    <section class="cockpit-reserved" aria-labelledby="filters-heading"><h2 id="filters-heading">Filters</h2><p>Unavailable in this framing slice. All capability rows are shown.</p></section>"""
-
-
 def _cockpit_proposals_markup() -> str:
     return '<section class="cockpit-reserved" aria-labelledby="proposals-heading"><h2 id="proposals-heading">Proposal drafts</h2><p>Unavailable in this framing slice. No proposal content is generated.</p></section>'
 
@@ -720,6 +715,55 @@ def _honesty_markup(
     )
 
 
+def _filter_value(value: str | None) -> str:
+    """Normalize the closed vocabulary rendered for cockpit filtering."""
+
+    return " ".join((value or "").lower().split())
+
+
+def _capability_filter_attributes(
+    capability: CkmCapability,
+    *,
+    edges: Sequence[CkmEvidenceEdge],
+    findings: Sequence[CkmFinding],
+    projection: CkmAssessmentProjection | None,
+) -> str:
+    assessment = projection.assessment if projection else None
+    assessment_value = (
+        "unavailable"
+        if assessment is None
+        else "available stale"
+        if projection and projection.stale_relative_to_evidence
+        else "available current"
+    )
+    confidence_value = (
+        "unavailable"
+        if assessment is None
+        else "low"
+        if assessment.low_confidence
+        else "standard"
+    )
+    evidence_value = " ".join(
+        lifecycle
+        for lifecycle in ("confirmed", "candidate")
+        if any(edge.lifecycle == lifecycle for edge in edges)
+    ) or "none"
+    values = {
+        "name": capability.name,
+        "definition": capability.definition,
+        "public-id": capability.public_id,
+        "boundary": capability.boundary_ref,
+        "assessment": assessment_value,
+        "confidence": confidence_value,
+        "findings": "present" if findings else "absent",
+        "evidence": evidence_value,
+    }
+    return " ".join(
+        f'data-filter-{name}="{_e(_filter_value(value))}"'
+        for name, value in values.items()
+    )
+
+
 def _capability_markup(
     capability: CkmCapability,
     *,
@@ -759,8 +803,14 @@ def _capability_markup(
         if assessment
         else '<p class="empty">Assessment missing.</p>'
     )
+    filter_attributes = _capability_filter_attributes(
+        capability,
+        edges=edges,
+        findings=findings,
+        projection=projection,
+    )
     return f"""
-    <article id="cap-{_e(capability.id)}" class="capability" data-capability-id="{_e(capability.id)}" style="--depth:{depth}" aria-label="{_e(capability.name)}, depth {depth}">
+    <article id="cap-{_e(capability.id)}" class="capability" data-capability-id="{_e(capability.id)}" {filter_attributes} style="--depth:{depth}" aria-label="{_e(capability.name)}, depth {depth}">
       <details class="capability-details">
         <summary class="capability-summary">
           <span class="tree-name">{_e(capability.name)}</span>
@@ -814,6 +864,96 @@ def _trust_strip(
       <a href="#map-heading">{low} low confidence</a>
       <a href="#gaps-heading">{finding_count} gaps</a>
     </nav>"""
+
+
+def _cockpit_filter_markup(capability_count: int) -> str:
+    """Render the disabled-first controls for the one bounded cockpit enhancement."""
+
+    return f"""<section class="cockpit-filters" aria-labelledby="filters-heading">
+      <h2 id="filters-heading">Filters</h2>
+      <p>Filter capability rows only; trust, hazards, comparison, gaps, proposals, and provenance remain visible.</p>
+      <div class="filter-controls">
+        <label for="filter-search">Search name, definition, public ID, or boundary</label>
+        <input id="filter-search" name="filter-search" type="search" disabled aria-controls="capability-map">
+        <label for="filter-assessment">Assessment freshness</label>
+        <select id="filter-assessment" name="filter-assessment" disabled aria-controls="capability-map">
+          <option value="">Any assessment state</option>
+          <option value="available current">Available and current</option>
+          <option value="available stale">Available and stale</option>
+          <option value="unavailable">Unavailable</option>
+        </select>
+        <label for="filter-confidence">Confidence</label>
+        <select id="filter-confidence" name="filter-confidence" disabled aria-controls="capability-map">
+          <option value="">Any confidence state</option>
+          <option value="low">Low confidence</option>
+          <option value="standard">Standard confidence</option>
+          <option value="unavailable">Confidence unavailable</option>
+        </select>
+        <label for="filter-findings">Findings</label>
+        <select id="filter-findings" name="filter-findings" disabled aria-controls="capability-map">
+          <option value="">Any finding state</option>
+          <option value="present">Findings present</option>
+          <option value="absent">No findings</option>
+        </select>
+        <label for="filter-evidence">Evidence lifecycle</label>
+        <select id="filter-evidence" name="filter-evidence" disabled aria-controls="capability-map">
+          <option value="">Any evidence lifecycle</option>
+          <option value="confirmed">Confirmed evidence present</option>
+          <option value="candidate">Candidate evidence present</option>
+          <option value="none">No linked evidence</option>
+        </select>
+      </div>
+      <p id="filter-count" aria-live="polite" aria-atomic="true">Showing {capability_count} of {capability_count} capabilities.</p>
+      <noscript>Filtering is unavailable; all capability rows are shown.</noscript>
+    </section>"""
+
+
+def _cockpit_filter_script() -> str:
+    """Return the sole cockpit script, constrained to rendered-row filtering."""
+
+    return """<script>(() => {
+  const controls = [
+    document.querySelector('[name="filter-search"]'),
+    document.querySelector('[name="filter-assessment"]'),
+    document.querySelector('[name="filter-confidence"]'),
+    document.querySelector('[name="filter-findings"]'),
+    document.querySelector('[name="filter-evidence"]')
+  ];
+  const [search, assessment, confidence, findings, evidence] = controls;
+  const count = document.querySelector('#filter-count');
+  const rows = document.querySelectorAll('#capability-map > .capability[data-filter-name]');
+  const normalize = (value) => String(value || '').trim().toLowerCase().replace(/\\s+/g, ' ');
+  const update = () => {
+    const searchValue = normalize(search.value);
+    const assessmentValue = normalize(assessment.value);
+    const confidenceValue = normalize(confidence.value);
+    const findingsValue = normalize(findings.value);
+    const evidenceValue = normalize(evidence.value);
+    let visible = 0;
+    rows.forEach((row) => {
+      const matches = (!searchValue || [
+        row.dataset.filterName,
+        row.dataset.filterDefinition,
+        row.dataset.filterPublicId,
+        row.dataset.filterBoundary
+      ].some((value) => normalize(value).includes(searchValue)))
+        && (!assessmentValue || normalize(row.dataset.filterAssessment) === assessmentValue)
+        && (!confidenceValue || normalize(row.dataset.filterConfidence) === confidenceValue)
+        && (!findingsValue || normalize(row.dataset.filterFindings) === findingsValue)
+        && (!evidenceValue || normalize(row.dataset.filterEvidence).split(' ').includes(evidenceValue));
+      row.hidden = !matches;
+      if (matches) visible += 1;
+    });
+    count.textContent = visible || rows.length === 0
+      ? `Showing ${visible} of ${rows.length} capabilities.`
+      : `No capabilities match the selected filters. Showing 0 of ${rows.length} capabilities.`;
+  };
+  controls.forEach((control) => {
+    control.disabled = false;
+    control.addEventListener(control === search ? 'input' : 'change', update);
+  });
+  update();
+})();</script>"""
 
 
 def render_overview_html(
@@ -877,10 +1017,19 @@ def render_overview_html(
     watermark_text = _watermarks(batch.current_watermark_set)
     cockpit_header = _cockpit_trust_markup(batch, timestamp) if cockpit else ""
     cockpit_reserved = (
-        _cockpit_hazards_markup(batch) + _cockpit_reserved_markup(cockpit.comparison) if cockpit else ""
+        _cockpit_hazards_markup(batch) + _cockpit_comparison_markup(cockpit.comparison)
+        if cockpit
+        else ""
     )
     cockpit_proposals = _cockpit_proposals_markup() if cockpit else ""
     cockpit_gap_prompt = "<p>Where is evidence weakest?</p>" if cockpit else ""
+    cockpit_filters = _cockpit_filter_markup(len(forest)) if cockpit else ""
+    cockpit_script = _cockpit_filter_script() if cockpit else ""
+    capability_map_open = (
+        '<div id="capability-map" class="capability-tree">'
+        if cockpit
+        else '<div class="capability-tree">'
+    )
     overview_header = (
         cockpit_header
         if cockpit
@@ -913,6 +1062,7 @@ def render_overview_html(
     .mini-dimensions {{ display:grid; grid-template-columns:repeat(7,1.625rem); gap:0.25rem; }} .mini-dimension {{ position:relative; width:1.625rem; height:0.75rem; border:1px solid var(--border-strong); overflow:hidden; }} .mini-scored {{ background:linear-gradient(to right,var(--agent) var(--score),var(--bg-overlay) var(--score)); }} .mini-starved {{ border:1px dotted var(--amber); background:transparent; }} .mini-unassessed {{ color:var(--fg-3); text-align:center; line-height:0.55rem; }}
     .capability-body {{ border-top:1px solid var(--border); padding:1rem; background:var(--bg-raised); }} .honesty {{ border-left:0.2rem solid var(--amber); padding-left:0.75rem; color:var(--fg-2); }} .honesty p {{ margin:0.2rem 0; }} .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(14rem,1fr)); gap:0.625rem; margin:0.875rem 0; }} .dimension {{ border:1px solid var(--border-strong); padding:0.625rem; }} .dimension-label {{ display:flex; gap:0.5rem; justify-content:space-between; }} .dimension-label span {{ flex:1; }} .dimension-track {{ height:0.5rem; margin:0.4rem 0; background:var(--bg-overlay); overflow:hidden; }} .dimension-starved .dimension-track {{ border:1px dotted var(--amber); background:none; }} .dimension-bar {{ display:block; height:100%; background:var(--agent); }}
     .drilldown,.citations {{ margin-top:0.625rem; }} .evidence-list,.finding-list {{ padding-left:1.25rem; }} .evidence-list li,.finding-list li {{ margin:0.45rem 0; }} .evidence-candidate {{ border-left:0.15rem solid var(--agent); padding-left:0.5rem; }} .basis {{ color:var(--fg-2); margin-left:0.5rem; }} .gaps-panel {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .gap-group {{ margin:0.75rem 0; }}
+    .cockpit-filters {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .filter-controls {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(13rem,1fr)); gap:0.5rem 0.75rem; align-items:end; }} .filter-controls label {{ color:var(--fg-2); }} .filter-controls input,.filter-controls select {{ min-height:2.25rem; border:1px solid var(--border-strong); border-radius:0.1875rem; background:var(--bg-raised); color:var(--fg-1); padding:0.375rem; }} .filter-controls input:focus-visible,.filter-controls select:focus-visible {{ outline:2px solid var(--accent); outline-offset:2px; }} .filter-controls input:disabled,.filter-controls select:disabled {{ opacity:0.65; }}
     footer {{ margin-top:1.75rem; padding:1rem 0 2.25rem; border-top:1px solid var(--border); color:var(--fg-2); overflow-wrap:anywhere; }}
     @media (max-width:680px) {{ main,footer {{ width:min(100% - 1rem,74rem); }} .trust-strip {{ grid-template-columns:1fr 1fr; }} .subsystem-counts-grid {{ grid-template-columns:1fr; }} .capability-count {{ grid-template-columns:1fr; gap:0.15rem; }} .legend {{ grid-template-columns:1fr; }} .dimension-rail {{ display:none; }} .capability {{ margin-left:calc(var(--depth) * 0.5rem); }} .capability-summary {{ flex-wrap:wrap; align-items:flex-start; }} .tree-name {{ min-width:65%; }} .summary-flags {{ flex-wrap:wrap; }} .mini-dimensions {{ order:6; width:100%; grid-template-columns:repeat(7,minmax(1.5rem,1fr)); }} .mini-dimension {{ width:auto; min-height:1.5rem; }} .mini-dimension::before {{ content:attr(data-abbr); display:block; font:0.55rem ui-monospace,monospace; color:var(--fg-2); }} }}
   </style>
@@ -924,11 +1074,12 @@ def render_overview_html(
     {"" if cockpit else _trust_strip(capabilities, assessments, len(all_findings))}
     {cockpit_reserved}
     {subsystem_counts}
+    {cockpit_filters}
     <section aria-labelledby="map-heading">
       <h2 id="map-heading">Capability map</h2>
       {_legend()}
       <div class="dimension-rail" aria-hidden="true">{"".join(f"<span>{abbr}</span>" for abbr, _ in DIMENSION_LABELS.values())}</div>
-      <div class="capability-tree">{cards}</div>
+      {capability_map_open}{cards}</div>
     </section>
     <section class="gaps-panel" aria-labelledby="gaps-heading"><h2 id="gaps-heading">Current gaps</h2>{cockpit_gap_prompt}<ul>{gap_groups}</ul></section>
     {cockpit_proposals}
@@ -940,6 +1091,7 @@ def render_overview_html(
     {footer_identity}
     Candidate and confirmed evidence remain distinct. Regenerate from the CKM store; do not edit this file as authority.
   </footer>
+  {cockpit_script}
 </body>
 </html>
 """

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/DEV_OVERVIEW_DIRECTION_A.md
@@ -78,6 +78,14 @@ The legend spells out every mapping. Verify: CKM11 acceptance criterion 7. Each 
 
 No filters, search, sort, comparison mode, URL state, evolution timeline, print expansion, JavaScript, hosting, Companion UI integration, CLI semantics, store changes, scoring changes, or evidence-model changes. Those are Direction B candidates and require observed owner need plus a separate contract.
 
+## Direction B amendment
+
+The default Direction A output remains byte-deterministic and script-free. Opt-in cockpit output may
+contain exactly one inline script that only enables its disabled-first capability-map filters, reads
+server-rendered filter tokens, toggles capability-row `hidden` state, and updates the filter count.
+It does not change CKM authority, persist state, access a network, or affect trust, hazards,
+comparison/refusal, subsystem counts, gaps, proposals, provenance, or the footer.
+
 ## CKM11-VALIDATION
 
 Run the focused renderer suite, standard lint/type/test baseline, and generate the overview against the live repository-backed CKM store. Capture desktop, expanded-row, 390×844, and 200%-zoom-equivalent views for visual comparison. Post the delivered child receipt and the review artifact on parent #3138; #3138 remains the owner-validation hub and is never a pickup issue.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -32,6 +32,7 @@ Optional / dev-only packages (testing, linting, type-checking, browser automatio
 | Component | Purpose | Installation hint |
 | --- | --- | --- |
 | Python ≥ 3.12 | Primary runtime for CLI/agents. | `pyenv install 3.12.6`, `python -m venv .venv`. |
+| Node.js | Dev/test execution of the CKM generated-HTML JavaScript regression. | `apt-get install nodejs`; `scripts/py312_smoke_test.sh` provisions it in the stock `python:3.12` smoke image. |
 | ffmpeg | Converts audio to 16 kHz wav (`app/media/transcribe.py`). | `brew install ffmpeg` / `apt-get install ffmpeg`. |
 | yt-dlp | Downloads YouTube/audio sources (`app/media/transcribe.py`). | `pip install -r requirements.txt`. |
 | faster-whisper | Local ASR. | Install via pip; GPU builds need a C++ toolchain. |

--- a/scripts/py312_smoke_test.sh
+++ b/scripts/py312_smoke_test.sh
@@ -11,4 +11,4 @@ python3 scripts/run_with_host_lease.py \
   -v "$(pwd):/repo" \
   -w /repo \
   python:3.12 \
-  bash -lc "pip install -r requirements.txt -r dev-requirements.txt && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -q -m 'not pg'"
+  bash -lc "apt-get update && apt-get install -y --no-install-recommends nodejs && rm -rf /var/lib/apt/lists/* && pip install -r requirements.txt -r dev-requirements.txt && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -q -m 'not pg'"

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -667,6 +668,267 @@ def test_cockpit_uses_existing_overview_renderer_call_site(overview_store: CkmSt
     )
     assert "Cockpit trust frame" in rendered
     assert "Capability map" in rendered
+
+
+def _cockpit_filter_script(rendered: str) -> str:
+    match = re.search(r"<script>(.*?)</script>", rendered, re.S)
+    assert match is not None
+    return match.group(1)
+
+
+def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
+    overview_store: CkmStore,
+) -> None:
+    context = CockpitRenderContext(batch=overview_store.load_projection_batch())
+    default = render_overview_html(overview_store)
+    cockpit = render_overview_html(overview_store, cockpit=context)
+
+    assert "<script" not in default
+    assert len(re.findall(r"<script(?:\\s[^>]*)?>", cockpit)) == 1
+    assert '<script src=' not in cockpit
+    assert not re.search(r"\\bon[a-z]+\\s*=", cockpit, re.I)
+    assert not re.search(r"(?:https?:)?//", cockpit, re.I)
+    assert _cockpit_filter_script(cockpit).lstrip().startswith("(() => {")
+    assert cockpit.count('<h2 id="filters-heading">Filters</h2>') == 1
+    assert cockpit.count('id="filters-heading"') == 1
+    assert "Unavailable in this framing slice. All capability rows are shown." not in cockpit
+    assert cockpit.index("Comparison") < cockpit.index("Filters") < cockpit.index("Capability map")
+
+
+def test_cockpit_progressive_enhancement_keeps_full_source_content(
+    overview_store: CkmStore,
+) -> None:
+    batch = overview_store.load_projection_batch()
+    rendered = render_overview_html(overview_store, cockpit=CockpitRenderContext(batch=batch))
+
+    assert rendered.count('class="capability"') == len(batch.capabilities)
+    assert rendered.count('class="capability-body"') == len(batch.capabilities)
+    for name in (
+        "filter-search",
+        "filter-assessment",
+        "filter-confidence",
+        "filter-findings",
+        "filter-evidence",
+    ):
+        assert re.search(rf'name="{name}"[^>]* disabled', rendered)
+    assert f"Showing {len(batch.capabilities)} of {len(batch.capabilities)} capabilities." in rendered
+    assert "Filtering is unavailable; all capability rows are shown." in rendered
+    assert rendered.index("<noscript>") < rendered.index("<script>")
+    assert "Retrieve grounded context." in rendered
+
+
+def test_cockpit_script_has_closed_filter_only_capability(overview_store: CkmStore) -> None:
+    rendered = render_overview_html(
+        overview_store,
+        cockpit=CockpitRenderContext(batch=overview_store.load_projection_batch()),
+    )
+    script = _cockpit_filter_script(rendered)
+    row_openings = re.findall(r'<article[^>]+class="capability"[^>]*>', rendered)
+    expected_attributes = {
+        "data-filter-name",
+        "data-filter-definition",
+        "data-filter-public-id",
+        "data-filter-boundary",
+        "data-filter-assessment",
+        "data-filter-confidence",
+        "data-filter-findings",
+        "data-filter-evidence",
+    }
+
+    assert row_openings
+    assert all(
+        {attribute.split("=", 1)[0] for attribute in re.findall(r"data-filter-[^=]+=", opening)}
+        == expected_attributes
+        for opening in row_openings
+    )
+    assert 'data-filter-assessment="available stale"' in rendered
+    assert 'data-filter-confidence="low"' in rendered
+    assert 'data-filter-findings="present"' in rendered
+    assert 'data-filter-evidence="confirmed candidate"' in rendered
+    for token in (
+        "fetch",
+        "XMLHttpRequest",
+        "WebSocket",
+        "clipboard",
+        "localStorage",
+        "sessionStorage",
+        "cookie",
+        "history",
+        "location",
+        "eval",
+        "setTimeout",
+        "setInterval",
+        "innerHTML",
+        "outerHTML",
+        "insertAdjacentHTML",
+        "createElement",
+    ):
+        assert token not in script
+    for token in (
+        "document.querySelector",
+        "document.querySelectorAll",
+        "row.dataset",
+        "row.hidden",
+        "control.disabled",
+        "control.addEventListener",
+        "count.textContent",
+    ):
+        assert token in script
+
+
+def test_cockpit_filters_rendered_rows_with_deterministic_and_semantics(
+    overview_store: CkmStore,
+) -> None:
+    rendered = render_overview_html(
+        overview_store,
+        cockpit=CockpitRenderContext(batch=overview_store.load_projection_batch()),
+    )
+    script = _cockpit_filter_script(rendered)
+    harness = r'''
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+class Control {
+  constructor() { this.value = ''; this.disabled = true; this.listeners = {}; }
+  addEventListener(type, handler) { this.listeners[type] = handler; }
+  emit(type) { this.listeners[type]({ type }); }
+}
+const search = new Control();
+const assessment = new Control();
+const confidence = new Control();
+const findings = new Control();
+const evidence = new Control();
+const count = { textContent: '' };
+const rows = [
+  { dataset: { filterName: 'Retrieval', filterDefinition: 'Retrieve grounded context', filterPublicId: 'CKM-1', filterBoundary: 'RCA', filterAssessment: 'available current', filterConfidence: 'low', filterFindings: 'present', filterEvidence: 'candidate' }, hidden: false },
+  { dataset: { filterName: 'Context Assembly', filterDefinition: 'Assemble a bounded context bundle', filterPublicId: 'CKM-2', filterBoundary: 'RCA', filterAssessment: 'unavailable', filterConfidence: 'unavailable', filterFindings: 'absent', filterEvidence: 'none' }, hidden: false },
+  { dataset: { filterName: 'Observability', filterDefinition: 'Draft telemetry coverage', filterPublicId: 'CKM-3', filterBoundary: 'OEF', filterAssessment: 'available stale', filterConfidence: 'standard', filterFindings: 'absent', filterEvidence: 'confirmed' }, hidden: false },
+  { dataset: { filterName: 'Mixed Evidence', filterDefinition: 'Confirmed and candidate evidence', filterPublicId: 'CKM-4', filterBoundary: 'OEF', filterAssessment: 'available stale', filterConfidence: 'standard', filterFindings: 'present', filterEvidence: 'confirmed candidate' }, hidden: false }
+];
+const bySelector = {
+  '[name="filter-search"]': search,
+  '[name="filter-assessment"]': assessment,
+  '[name="filter-confidence"]': confidence,
+  '[name="filter-findings"]': findings,
+  '[name="filter-evidence"]': evidence,
+  '#filter-count': count
+};
+const document = {
+  querySelector: (selector) => bySelector[selector],
+  querySelectorAll: (selector) => { assert(selector === '#capability-map > .capability[data-filter-name]', 'row selector'); return rows; }
+};
+''' + script + r'''
+const visible = () => rows.filter((row) => !row.hidden).length;
+const setSearch = (value) => { search.value = value; search.emit('input'); };
+const setFacet = (control, value) => { control.value = value; control.emit('change'); };
+const reset = () => {
+  search.value = ''; assessment.value = ''; confidence.value = ''; findings.value = ''; evidence.value = '';
+  search.emit('input'); assessment.emit('change'); confidence.emit('change'); findings.emit('change'); evidence.emit('change');
+};
+assert([search, assessment, confidence, findings, evidence].every((control) => !control.disabled), 'controls enabled');
+assert(visible() === 4 && count.textContent === 'Showing 4 of 4 capabilities.', 'initial count');
+setSearch('cKm-3'); assert(visible() === 1 && !rows[2].hidden, 'public ID text filter');
+setSearch('draft'); assert(visible() === 1 && !rows[2].hidden, 'definition text filter');
+setFacet(assessment, 'available current'); assert(visible() === 0, 'assessment AND text');
+reset();
+setFacet(assessment, 'available current'); assert(visible() === 1 && !rows[0].hidden, 'current assessment');
+setFacet(assessment, 'available stale'); assert(visible() === 2 && !rows[2].hidden && !rows[3].hidden, 'stale assessment');
+setFacet(assessment, 'unavailable'); assert(visible() === 1 && !rows[1].hidden, 'unavailable assessment');
+reset();
+setFacet(confidence, 'low'); assert(visible() === 1 && !rows[0].hidden, 'low confidence');
+setFacet(confidence, 'standard'); assert(visible() === 2 && !rows[2].hidden && !rows[3].hidden, 'standard confidence');
+setFacet(confidence, 'unavailable'); assert(visible() === 1 && !rows[1].hidden, 'unavailable confidence');
+reset();
+setFacet(findings, 'present'); assert(visible() === 2 && !rows[0].hidden && !rows[3].hidden, 'findings present');
+setFacet(findings, 'absent'); assert(visible() === 2, 'findings absent');
+setFacet(evidence, 'confirmed'); assert(visible() === 1 && !rows[2].hidden, 'combined facets');
+reset();
+setFacet(evidence, 'confirmed'); assert(visible() === 2 && !rows[2].hidden && !rows[3].hidden, 'confirmed evidence');
+setFacet(findings, 'present'); assert(visible() === 1 && !rows[3].hidden, 'mixed evidence AND findings');
+reset();
+setFacet(evidence, 'candidate'); assert(visible() === 2 && !rows[0].hidden && !rows[3].hidden, 'candidate evidence');
+setFacet(evidence, 'none'); assert(visible() === 1 && !rows[1].hidden, 'no evidence');
+setSearch('not-present'); assert(visible() === 0 && count.textContent === 'No capabilities match the selected filters. Showing 0 of 4 capabilities.', 'zero result');
+reset(); assert(visible() === 4 && count.textContent === 'Showing 4 of 4 capabilities.', 'reset count');
+'''
+
+    result = subprocess.run(["node", "-e", harness], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    empty_harness = r'''
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+class Control {
+  constructor() { this.value = ''; this.disabled = true; this.listeners = {}; }
+  addEventListener(type, handler) { this.listeners[type] = handler; }
+}
+const search = new Control();
+const assessment = new Control();
+const confidence = new Control();
+const findings = new Control();
+const evidence = new Control();
+const count = { textContent: '' };
+const document = {
+  querySelector: (selector) => ({
+    '[name="filter-search"]': search,
+    '[name="filter-assessment"]': assessment,
+    '[name="filter-confidence"]': confidence,
+    '[name="filter-findings"]': findings,
+    '[name="filter-evidence"]': evidence,
+    '#filter-count': count
+  })[selector],
+  querySelectorAll: (selector) => {
+    assert(selector === '#capability-map > .capability[data-filter-name]', 'row selector');
+    return [];
+  }
+};
+''' + script + r'''
+assert([search, assessment, confidence, findings, evidence].every((control) => !control.disabled), 'controls enabled');
+assert(count.textContent === 'Showing 0 of 0 capabilities.', 'empty source count');
+'''
+    empty_result = subprocess.run(
+        ["node", "-e", empty_harness], capture_output=True, text=True, check=False
+    )
+    assert empty_result.returncode == 0, empty_result.stderr
+
+
+def test_cockpit_filter_never_hides_trust_or_gap_context(overview_store: CkmStore) -> None:
+    batch = overview_store.load_projection_batch()
+    rendered = render_overview_html(overview_store, cockpit=CockpitRenderContext(batch=batch))
+    script = _cockpit_filter_script(rendered)
+
+    assert script.count("#capability-map > .capability[data-filter-name]") == 1
+    assert script.count("row.hidden") == 1
+    assert f"Showing {len(batch.capabilities)} of {len(batch.capabilities)} capabilities." in rendered
+    for marker in (
+        'class="cockpit-trust"',
+        'class="cockpit-hazards"',
+        'class="cockpit-comparison',
+        'class="subsystem-counts"',
+        'class="gaps-panel"',
+        'id="proposals-heading"',
+    ):
+        section = rendered.split(marker, 1)[1].split("</section>", 1)[0]
+        assert "data-filter-" not in section
+    footer = rendered.split('class="projection-footer"', 1)[1].split("</footer>", 1)[0]
+    assert "data-filter-" not in footer
+
+
+def test_cockpit_filter_controls_are_accessible_and_honest(overview_store: CkmStore) -> None:
+    rendered = render_overview_html(
+        overview_store,
+        cockpit=CockpitRenderContext(batch=overview_store.load_projection_batch()),
+    )
+
+    for control_id, label in (
+        ("filter-search", "Search name, definition, public ID, or boundary"),
+        ("filter-assessment", "Assessment freshness"),
+        ("filter-confidence", "Confidence"),
+        ("filter-findings", "Findings"),
+        ("filter-evidence", "Evidence lifecycle"),
+    ):
+        assert f'<label for="{control_id}">{label}</label>' in rendered
+        assert re.search(rf'id="{control_id}"[^>]* disabled[^>]*aria-controls="capability-map"', rendered)
+    assert '<p id="filter-count" aria-live="polite" aria-atomic="true">' in rendered
+    assert "No capabilities match the selected filters." in _cockpit_filter_script(rendered)
+    assert "Filter capability rows only; trust, hazards, comparison, gaps, proposals, and provenance remain visible." in rendered
 
 
 def test_cockpit_preserves_evidence_profile_count_context(

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import sqlite3
 import subprocess
 from html.parser import HTMLParser
@@ -730,6 +731,14 @@ def _cockpit_filter_script(rendered: str) -> str:
     return parser.script_bodies[0]
 
 
+def _require_node_for_cockpit_script_execution() -> str:
+    node = shutil.which("node")
+    assert node is not None, (
+        "Node.js is a required test dependency for the CKM generated-HTML JavaScript regression."
+    )
+    return node
+
+
 def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
     overview_store: CkmStore,
 ) -> None:
@@ -864,6 +873,7 @@ def test_cockpit_filters_rendered_rows_with_deterministic_and_semantics(
         cockpit=CockpitRenderContext(batch=overview_store.load_projection_batch()),
     )
     script = _cockpit_filter_script(rendered)
+    node = _require_node_for_cockpit_script_execution()
     harness = r'''
 const assert = (condition, message) => { if (!condition) throw new Error(message); };
 class Control {
@@ -930,7 +940,7 @@ setSearch('not-present'); assert(visible() === 0 && count.textContent === 'No ca
 reset(); assert(visible() === 4 && count.textContent === 'Showing 4 of 4 capabilities.', 'reset count');
 '''
 
-    result = subprocess.run(["node", "-e", harness], capture_output=True, text=True, check=False)
+    result = subprocess.run([node, "-e", harness], capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
 
     empty_harness = r'''
@@ -964,7 +974,7 @@ assert([search, assessment, confidence, findings, evidence].every((control) => !
 assert(count.textContent === 'Showing 0 of 0 capabilities.', 'empty source count');
 '''
     empty_result = subprocess.run(
-        ["node", "-e", empty_harness], capture_output=True, text=True, check=False
+        [node, "-e", empty_harness], capture_output=True, text=True, check=False
     )
     assert empty_result.returncode == 0, empty_result.stderr
 

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -676,20 +676,35 @@ class _CockpitHtmlSafetyParser(HTMLParser):
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
+        self.script_count = 0
         self.script_bodies: list[str] = []
         self.script_sources: list[str] = []
         self.inline_handlers: list[str] = []
         self._script_parts: list[str] | None = None
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def _record_start(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+        *,
+        capture_script_body: bool,
+    ) -> None:
         normalized_tag = tag.lower()
         normalized_attrs = [(name.lower(), value) for name, value in attrs]
         self.inline_handlers.extend(name for name, _ in normalized_attrs if name.startswith("on"))
         if normalized_tag == "script":
-            self._script_parts = []
+            self.script_count += 1
             self.script_sources.extend(
                 value or "" for name, value in normalized_attrs if name == "src"
             )
+            if capture_script_body:
+                self._script_parts = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._record_start(tag, attrs, capture_script_body=True)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._record_start(tag, attrs, capture_script_body=False)
 
     def handle_data(self, data: str) -> None:
         if self._script_parts is not None:
@@ -710,6 +725,7 @@ def _parse_cockpit_html_safety(rendered: str) -> _CockpitHtmlSafetyParser:
 
 def _cockpit_filter_script(rendered: str) -> str:
     parser = _parse_cockpit_html_safety(rendered)
+    assert parser.script_count == 1
     assert len(parser.script_bodies) == 1
     return parser.script_bodies[0]
 
@@ -723,7 +739,9 @@ def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
     default_safety = _parse_cockpit_html_safety(default)
     cockpit_safety = _parse_cockpit_html_safety(cockpit)
 
+    assert default_safety.script_count == 0
     assert default_safety.script_bodies == []
+    assert cockpit_safety.script_count == 1
     assert len(cockpit_safety.script_bodies) == 1
     assert cockpit_safety.script_sources == []
     assert cockpit_safety.inline_handlers == []
@@ -736,6 +754,20 @@ def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
     assert synthetic_safety.script_bodies == ["lower", "upper"]
     assert synthetic_safety.script_sources == ["blocked.js"]
     assert synthetic_safety.inline_handlers == ["onload", "onload", "onclick", "onfocus"]
+    unmatched_safety = _parse_cockpit_html_safety(
+        "<script>closed production body</script><SCRIPT>"
+    )
+    assert unmatched_safety.script_count == 2
+    assert unmatched_safety.script_bodies == ["closed production body"]
+    with pytest.raises(AssertionError):
+        _cockpit_filter_script("<script>closed production body</script><SCRIPT>")
+    self_closing_safety = _parse_cockpit_html_safety(
+        '<ScRiPt SRC="blocked.js" OnLoAd="blocked()" />'
+    )
+    assert self_closing_safety.script_count == 1
+    assert self_closing_safety.script_bodies == []
+    assert self_closing_safety.script_sources == ["blocked.js"]
+    assert self_closing_safety.inline_handlers == ["onload"]
     assert _cockpit_filter_script(cockpit).lstrip().startswith("(() => {")
     assert cockpit.count('<h2 id="filters-heading">Filters</h2>') == 1
     assert cockpit.count('id="filters-heading"') == 1

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -682,12 +682,16 @@ def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
     context = CockpitRenderContext(batch=overview_store.load_projection_batch())
     default = render_overview_html(overview_store)
     cockpit = render_overview_html(overview_store, cockpit=context)
+    script_pattern = r"<script\b[^>]*>"
+    handler_pattern = r"\bon[a-z]+\s*="
 
     assert "<script" not in default
-    assert len(re.findall(r"<script(?:\\s[^>]*)?>", cockpit)) == 1
+    assert len(re.findall(script_pattern, cockpit)) == 1
     assert '<script src=' not in cockpit
-    assert not re.search(r"\\bon[a-z]+\\s*=", cockpit, re.I)
+    assert not re.search(handler_pattern, cockpit, re.I)
     assert not re.search(r"(?:https?:)?//", cockpit, re.I)
+    assert len(re.findall(script_pattern, '<script></script><script type="module"></script>')) == 2
+    assert re.search(handler_pattern, '<button onclick="blocked()">', re.I)
     assert _cockpit_filter_script(cockpit).lstrip().startswith("(() => {")
     assert cockpit.count('<h2 id="filters-heading">Filters</h2>') == 1
     assert cockpit.count('id="filters-heading"') == 1

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -4,6 +4,7 @@ import json
 import re
 import sqlite3
 import subprocess
+from html.parser import HTMLParser
 from pathlib import Path
 
 import pytest
@@ -670,10 +671,47 @@ def test_cockpit_uses_existing_overview_renderer_call_site(overview_store: CkmSt
     assert "Capability map" in rendered
 
 
+class _CockpitHtmlSafetyParser(HTMLParser):
+    """Record the parser-normalized script and inline-handler surface of generated HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.script_bodies: list[str] = []
+        self.script_sources: list[str] = []
+        self.inline_handlers: list[str] = []
+        self._script_parts: list[str] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        normalized_tag = tag.lower()
+        normalized_attrs = [(name.lower(), value) for name, value in attrs]
+        self.inline_handlers.extend(name for name, _ in normalized_attrs if name.startswith("on"))
+        if normalized_tag == "script":
+            self._script_parts = []
+            self.script_sources.extend(
+                value or "" for name, value in normalized_attrs if name == "src"
+            )
+
+    def handle_data(self, data: str) -> None:
+        if self._script_parts is not None:
+            self._script_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "script" and self._script_parts is not None:
+            self.script_bodies.append("".join(self._script_parts))
+            self._script_parts = None
+
+
+def _parse_cockpit_html_safety(rendered: str) -> _CockpitHtmlSafetyParser:
+    parser = _CockpitHtmlSafetyParser()
+    parser.feed(rendered)
+    parser.close()
+    return parser
+
+
 def _cockpit_filter_script(rendered: str) -> str:
-    match = re.search(r"<script>(.*?)</script>", rendered, re.S)
-    assert match is not None
-    return match.group(1)
+    parser = _parse_cockpit_html_safety(rendered)
+    assert len(parser.script_bodies) == 1
+    return parser.script_bodies[0]
 
 
 def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
@@ -682,16 +720,22 @@ def test_cockpit_has_exactly_one_filtering_script_and_default_has_none(
     context = CockpitRenderContext(batch=overview_store.load_projection_batch())
     default = render_overview_html(overview_store)
     cockpit = render_overview_html(overview_store, cockpit=context)
-    script_pattern = r"<script\b[^>]*>"
-    handler_pattern = r"\bon[a-z]+\s*="
+    default_safety = _parse_cockpit_html_safety(default)
+    cockpit_safety = _parse_cockpit_html_safety(cockpit)
 
-    assert "<script" not in default
-    assert len(re.findall(script_pattern, cockpit)) == 1
-    assert '<script src=' not in cockpit
-    assert not re.search(handler_pattern, cockpit, re.I)
+    assert default_safety.script_bodies == []
+    assert len(cockpit_safety.script_bodies) == 1
+    assert cockpit_safety.script_sources == []
+    assert cockpit_safety.inline_handlers == []
     assert not re.search(r"(?:https?:)?//", cockpit, re.I)
-    assert len(re.findall(script_pattern, '<script></script><script type="module"></script>')) == 2
-    assert re.search(handler_pattern, '<button onclick="blocked()">', re.I)
+    synthetic_safety = _parse_cockpit_html_safety(
+        '<script TYPE="text/javascript" onload="blocked()">lower</script>'
+        '<SCRIPT SRC="blocked.js" ONLOAD="blocked()">upper</SCRIPT>'
+        '<button ONCLICK="blocked()" onfocus="blocked()">blocked</button>'
+    )
+    assert synthetic_safety.script_bodies == ["lower", "upper"]
+    assert synthetic_safety.script_sources == ["blocked.js"]
+    assert synthetic_safety.inline_handlers == ["onload", "onload", "onclick", "onfocus"]
     assert _cockpit_filter_script(cockpit).lstrip().startswith("(() => {")
     assert cockpit.count('<h2 id="filters-heading">Filters</h2>') == 1
     assert cockpit.count('id="filters-heading"') == 1


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4084

## Linked Issue
Closes #4084

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): CKM generated overview renderer and Python 3.12 validation producer
- Write class: Derived self-contained HTML, tests, narrow current-reality docs, and smoke-producer completion
- Authority impact: None; filters are view state only
- Persistence impact: None; filter state resets on reload
- Derived/rebuildable impact: All source content remains server-rendered and rebuildable
- Human knowledge impact: None
- Memory impact: None
- Retrieval/context impact: None
- Sync/deployment impact: None
- External boundary impact: Dev/test-only Node execution; no runtime network, storage, clipboard, URL, hosted behavior, deploy, prod, or stable effect
- New or changed contract: Exactly one inline filter-only script in opt-in cockpit mode; default output remains script-free; the supported py312 test producer provisions its declared Node test dependency
- Owner-doc impact: Direction A records only the narrow opt-in exception and dependency docs record only the dev/test executor; no Direction B support claim
- Transition debt impact: No new debt; keeps the artifact a local generated file rather than an application
- Fitness rule impact: Exact script count, parser-normalized API denylist, JS-off, accessibility, AND-semantics, zero-state, panel-isolation, and fail-loud test dependency checks
- Boundary risk: An interactive convenience could otherwise acquire action or persistence authority

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add the CKM cockpit one-script progressive-enhancement filter over already-rendered capability rows, with closed server tokens, deterministic AND facets, honest JS-off and zero states, and strict isolation from every non-map panel.
- Close the executable-test producer invariant by declaring Node as dev/test-only, provisioning it in the stock Python 3.12 smoke image, and failing loudly instead of skipping when it is absent.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] Exact head `fc5818d78fed9969f04cfc42baee2814430e7f0e`: six named #4084 AC tests 6 passed; complete `test_overview_html.py` 59 passed within complete `tests/builderops/ckm` 277 passed; `ruff check app tests` passed; `mypy app` passed (808 files); docs guard OK; `bash -n scripts/py312_smoke_test.sh` passed; `git diff --check` passed.
- [x] Security/producer mechanism convergence CLEAN by independent Sol/high on the exact head. Stable patch-id across the final unrelated-base rebase was preserved. Repair accounting: standard repair 2/2 replaced the CodeQL-unsafe case-sensitive HTML regex with `HTMLParser`; strongest-capability auto-repair 1/2 made exact script authority count every normalized start; final-review repair 1/2 declared and provisioned the Node executor without weakening actual production-script execution.
- [x] The exact patch stack was exercised through `scripts/py312_smoke_test.sh`: Debian Node 20.19.2 provisioned successfully and every #4084 test passed inside stock `python:3.12`. The repository-wide command then reported 10,713 passed and 34 unrelated existing environment/infrastructure failures outside this diff (including unmounted worktree git metadata and absent `jq`); this is recorded as a tooling limitation, not presented as a green merge gate. Current-head GitHub CI remains authoritative.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded review findings and repairs remain Issue/PR delivery evidence; no new learning, freshness, roadmap, promotion, projection, or authority-crossing material was produced.

## Notes
Dispatcher task `github-RasmusTho--agentic-pkm-mvp-issue-4084`; holder `codex-implement-4084`; lease `lease-92d7f57c`. Direction B support remains unpromoted until terminal parent #4080 acceptance. D11/D12 preserved. Progressive-enhancement receipts for JS-on, JS-off, zero-result, and gaps-unfiltered will be posted to #4080 before merge and preserved for terminal parent acceptance.