### PR TITLE
Fix vault layout fitness test selection

### DIFF
--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -5,7 +5,7 @@ Owner: Builder-agent governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: code, workflow files, and repo-local skill docs
-Last reviewed: 2026-07-23
+Last reviewed: 2026-07-26
 Last verified against: `.github/workflows/ci-smoke.yaml`, `.github/workflows/issue-pr-governance.yml`, `tests/architecture/test_agent_skill_entrypoints.py`, `tests/architecture/test_dispatcher_skill_integration.py`, `docs/development/PR_HOT_PATH.md`, `docs/development/PR_ESCALATION_PATHS.md`, `docs/development/PARENT_ISSUE_CLOSURE.md`, `.codex/skills/issue-to-code/SKILL.md`, `.codex/skills/pr-integration/SKILL.md`, `.codex/skills/verification-and-closure/SKILL.md`, `scripts/select_pr_tests.py`, `scripts/docs_guard_logic.py`
 
 # Test Strategy for the Hot Path
@@ -22,6 +22,7 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - The hot-path and direct-repair invariants are covered by `tests/architecture/test_pr_hot_path_governance.py`.
 - PR unit CI uses `scripts/select_pr_tests.py` to map changed files to subsystem-scoped pytest targets. Shared CI/test configuration, migrations, dependencies, and shared fixtures run the deterministic broad suite; E2E coverage is deferred to post-merge and nightly validation. This document is `scripts/select_pr_tests.py`'s `docs/development/` contract for the `scripts/docs_guard_logic.py :: GOVERNANCE_TEMPORAL_ENFORCEMENT` temporal-owner-doc exemption, and the check enforces that pairing specifically: update this doc, not `docs/STATUS.md`/`docs/ROADMAP.md`/etc., when the selection script's behavior changes.
 - Every `builder_system` match includes `tests/architecture/test_builderops_store_boundary.py` as an exact run target, not only as an ownership prefix. Ordinary `app/builderops/**` changes must execute the audited store-access guard so new direct-store sites cannot bypass it while their own subsystem tests remain green.
+- Every `vault` match includes `tests/architecture/test_no_hardcoded_vault_layout.py` as an exact run target, not only as an ownership prefix. Ordinary `app/vault/**` changes must execute the vault-layout guard without widening the subsystem to all architecture tests.
 - Runtime-start harness tests that exercise `scripts/start_full_system.sh` and its process-cleanup behavior are owned by the `ops_deploy` selector, even when the touched files live under `tests/helpers/` or `tests/runtime/`.
 - Store and vault-ingest changes are owned by the `store_ingest` selection and run its focused
   `tests/stores`, `tests/ingest`, and architecture contracts in the ordinary `not pg` job. That job

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -152,7 +152,13 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # file owned without widening vault to all architecture tests.
             "tests/architecture/test_no_hardcoded_vault_layout.py",
         ),
-        ("tests/instance", "tests/vault", "tests/knowledge", "tests/ports"),
+        (
+            "tests/instance",
+            "tests/vault",
+            "tests/knowledge",
+            "tests/ports",
+            "tests/architecture/test_no_hardcoded_vault_layout.py",
+        ),
     ),
     (
         "companion_ui",

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -39,6 +39,7 @@ def test_instance_registry_change_selects_vault_coverage() -> None:
     selection = select_tests(
         ["app/instance/vault_registry.py", "tests/instance/test_vault_registry.py"]
     )
+    vault_module_selection = select_tests(["app/vault/some_new_file.py"])
 
     assert selection.full_suite is False
     assert selection.subsystems == ("vault",)
@@ -46,6 +47,10 @@ def test_instance_registry_change_selects_vault_coverage() -> None:
     assert "tests/instance" in selection.targets
     assert "tests/vault" in selection.targets
     assert "tests/instance/test_vault_registry.py" in selection.targets
+    assert (
+        "tests/architecture/test_no_hardcoded_vault_layout.py"
+        in vault_module_selection.targets
+    )
 
 
 def test_ci_workflow_change_selects_governance_contract_tests() -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4068

## Linked Issue
Closes #4068

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: mechanical CI test-selection correction plus paired owner-doc writeback
- Authority impact: unaffected
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: no; strengthens execution of the existing vault-layout fitness guard
- Owner-doc impact: updated in this PR: docs/development/TEST_STRATEGY_HOT_PATH.md
- Transition debt impact: reduces the observed selector/run-target enforcement gap
- Fitness rule impact: strengthens the existing vault-layout guard on vault-owned changes
- Boundary risk: low; test selection and its owner documentation only, with no Product/Runtime behavior change

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Run the existing vault-layout architecture fitness guard whenever ordinary vault-owned changes select the vault subsystem.
- Lock the run-target behavior with a regression assertion for an app/vault/** change without widening vault ownership to all architecture tests.
- Document the selector behavior in its paired temporal owner doc so code, fitness enforcement, and hot-path test strategy remain synchronized.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] pytest -q -m "not pg" tests/scripts/test_select_pr_tests.py::test_instance_registry_change_selects_vault_coverage (1 passed; captured red before implementation)
- [x] pytest -q -m "not pg" tests/scripts/test_select_pr_tests.py tests/governance/test_select_pr_tests.py tests/architecture/test_no_hardcoded_vault_layout.py (80 passed on repaired exact SHA)
- [x] python3 scripts/select_pr_tests.py --changed-file app/vault/some_new_file.py (vault subsystem and exact architecture guard selected)
- [x] python3 scripts/docs_guard.py (Docs guard: OK on repaired exact SHA)
- [x] ruff check app tests companion-ui/companion-app (All checks passed)
- [x] mypy app (Success: no issues found in 808 source files)
- [x] independent exact-SHA review on 78c2ea570812018ebd7cc9851d7cc836c5666221 against a45c8662f21b9992ef016d811e67fefdebf00e50 (CLEAN; no findings)

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260723201044_cc8478bc (existing selector owner-doc routing lesson)
- Reason: The verifier finding is a recurrence of the already-recorded selector owner-doc divergence; the paired authoritative writeback applies that existing learning without creating a duplicate record.

## Notes
Repairs blocker comment 5085504850 and inline thread 3653458684 under failure_domain=documentation-governance-temporal-guard-consistency / mechanism_id=selector-owner-documentation-synchronization. Focused validation is proportionate to the isolated selector and owner-doc change; current-SHA CI remains the closure gate.