### PR TITLE
Fix write_frontmatter seam census line drift

### DIFF
--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -476,11 +476,13 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 1373): (
+    ("app/instance/vault_registry.py", 1394): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
-        "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact."
+        "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
+        "Line drifted 1373 -> 1394 (site unchanged); re-pinned after directly "
+        "related insertions earlier in vault_registry.py."
     ),
 }
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4127

## Linked Issue
Fixes #4127

## SBS Impact
- Primary subsystem: Builder System test enforcement
- Secondary subsystem(s): WSP app-local settings boundary
- Write class: repository test census only
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: restores the mandatory non-PG delivery gate
- External boundary impact: none
- New or changed contract: none; restores the existing closed-census projection
- Owner-doc impact: none
- Transition debt impact: none
- Fitness rule impact: repairs the guard-at-seam property target after line drift
- Boundary risk: low; no runtime code change

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Re-pin the unchanged `AppLocalSettingsStore.save` `write_frontmatter` census coordinate from line 1373 to its live line 1394.
- Preserve the existing `out_of_scope` classification and record the directly related line drift in its justification.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] No runtime behavior, WriteGuard policy, or other census entry changed.
- [x] No owner-doc or roadmap writeback is implied because the seam classification and contract are unchanged.

## Validation
- [x] Pre-fix: `pytest -q tests/properties/test_guard_at_seam.py::test_every_write_seam_asserts_writeguard` (failed exactly on unregistered `app/instance/vault_registry.py:1394`)
- [x] Post-fix: `pytest -q tests/properties/test_guard_at_seam.py::test_every_write_seam_asserts_writeguard` (1 passed)
- [x] `ruff check app tests companion-ui/companion-app` (All checks passed)
- [x] `git diff --check` (clean)
- [x] Diff inspection confirms only `tests/properties/_machinery.py :: WRITE_FRONTMATTER_SITE_CLASSIFICATION` changed

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded, known line-drift repair is fully represented by Issue #4127 and its PR; no new divergence, learning, freshness, roadmap, or promotion material was produced.

## Pickup Receipt
- coordination_mode: dispatcher-backed
- task_id: `github-RasmusTho--agentic-pkm-mvp-issue-4127`
- lease_id: `lease-6da8d0ab`
- holder: `codex-implement-4127`
- evidence: verified-dispatcher-lease