### PR TITLE
fix: skip outbox DB connections in memory mode

### DIFF
--- a/app/agents/panel_agent/execution.py
+++ b/app/agents/panel_agent/execution.py
@@ -100,6 +100,7 @@ def run_panel_note_execution(
                     source_id or outbox_event.event_id,
                     payload_fingerprint(outbox_event.payload, exclude=("trace_id",)),
                 ),
+                required_db=True,
             )
     # Thread the caller's already-resolved vault (the watcher/outbox-worker path
     # resolves it through its own canonical resolver) into the runtime so writeback

--- a/app/api/routes/heimdal_meeting.py
+++ b/app/api/routes/heimdal_meeting.py
@@ -441,9 +441,13 @@ def _emit_user_note_event(payload: Dict[str, Any], *, trace_id: str) -> bool:
         )
     except Exception as exc:
         logger.warning("user-note event jsonl write failed trace_id=%s err=%s", trace_id, exc)
-    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
-    db_url = os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
-    if backend == "pg" or db_url:
+    # Ask the outbox policy whether a self-owned write will actually connect,
+    # instead of re-deriving that from STORE_BACKEND/DATABASE_URL here (#4214
+    # D1). Two reasons: the local predicate was narrower than the connection's
+    # own resolver, and — since the memory-mode skip branch landed — a write
+    # that skips returns normally, so `emitted = True` below would report
+    # success for an event no sink took (#4214 D2/D3 failure class).
+    if not outbox_service.self_owned_write_would_skip():
         outbox_evt = outbox_service.coerce_outbox_event(
             evt, default_source="heimdal.meeting.blocks"
         )

--- a/app/api/routes/ingest.py
+++ b/app/api/routes/ingest.py
@@ -23,5 +23,16 @@ async def ingest(req: IngestRequest, request: Request):
     trace_id = getattr(request.state, "trace_id", None) or new_trace_id()
     with start_span("api.ingest", trace_id, {"path": "/ingest"}):
         payload = normalize_artifact_state_axes(req.model_dump(exclude_none=True), default_review_state="draft")
-        insert_object_and_outbox(payload, INGEST_OBJECT_CREATED, trace_id, object_id=req.uuid)
+        # required_db=True (#4214 D2): this enqueue is the route's ONLY
+        # persistence side effect and it has no compensating JSONL sink, so an
+        # optional self-owned skip would return ``""`` and let the route answer
+        # 200 for an ingest that was never queued. Fail loud instead — the
+        # pre-#4064 behaviour this route always had.
+        insert_object_and_outbox(
+            payload,
+            INGEST_OBJECT_CREATED,
+            trace_id,
+            object_id=req.uuid,
+            required_db=True,
+        )
     return {"trace_id": trace_id}

--- a/app/config/database.py
+++ b/app/config/database.py
@@ -20,6 +20,35 @@ def default_database_name(env_name: str) -> str:
     return "app"
 
 
+# Every environment key resolve_runtime_database_url() reads to name a database.
+# Kept as ONE tuple because callers that must decide "has this runtime named a
+# database at all?" (the self-owned outbox skip predicate, #4214 D1) may not
+# maintain a second, narrower key list: a predicate that reads fewer keys than
+# the resolver silently classifies a real, reachable database as unconfigured.
+RUNTIME_DATABASE_ENV_KEYS: tuple[str, ...] = (
+    "DATABASE_URL",
+    "DB_DSN",
+    "PKM_DB_NAME_DEV",
+    "PKM_DB_NAME_TEST",
+    "PKM_DB_NAME_PROD",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "PKM_DB_HOST",
+    "PKM_DB_PORT",
+)
+
+
+def runtime_database_is_named(env: Mapping[str, str]) -> bool:
+    """Whether the environment names a database at all.
+
+    ``False`` means every value :func:`resolve_runtime_database_url` would use
+    is a built-in default, so the DSN it returns is the compose-shaped fallback
+    (``postgresql+psycopg://app:app@db:5432/app``) nobody asked for — not an
+    operator-named database.
+    """
+    return any(_clean(env, key) for key in RUNTIME_DATABASE_ENV_KEYS)
+
+
 def resolve_runtime_database_url(env: Mapping[str, str]) -> str:
     explicit = _clean(env, "DATABASE_URL") or _clean(env, "DB_DSN")
     if explicit:
@@ -41,4 +70,32 @@ def resolve_runtime_database_url(env: Mapping[str, str]) -> str:
     return f"postgresql+psycopg://{quote(user)}:{quote(password)}@{host}:{port}/{db_name}"
 
 
-__all__ = ["default_database_name", "resolve_runtime_database_url"]
+def explicit_runtime_database_url(env: Mapping[str, str]) -> str | None:
+    """The DSN this runtime has explicitly named, or ``None`` when it named none.
+
+    This is :func:`resolve_runtime_database_url` with its unconditional fallback
+    made visible: when the answer is not ``None`` it is *byte-identical* to what
+    ``resolve_runtime_database_url(env)`` returns, so a caller deciding whether
+    a connection would reach an operator-named database and the connection
+    itself cannot disagree.
+
+    Motivation (#4214 D1): ``conn_rw()`` resolves through
+    ``resolve_runtime_database_url``, which never returns an empty string. A
+    caller that predicted "no database is configured" from ``DATABASE_URL`` /
+    ``DB_DSN`` alone was therefore narrower than the connection it stood in
+    for — a runtime naming its database through ``PKM_DB_HOST`` /
+    ``PKM_DB_NAME_*`` / ``POSTGRES_*`` would have connected successfully while
+    the predicate called it unconfigured.
+    """
+    if not runtime_database_is_named(env):
+        return None
+    return resolve_runtime_database_url(env)
+
+
+__all__ = [
+    "RUNTIME_DATABASE_ENV_KEYS",
+    "default_database_name",
+    "explicit_runtime_database_url",
+    "resolve_runtime_database_url",
+    "runtime_database_is_named",
+]

--- a/app/episodes/closure.py
+++ b/app/episodes/closure.py
@@ -330,7 +330,11 @@ def close_episode(
     # the LAST write. A crash after the outbox insert but before the projection sync still leaves
     # this episode selectable on the next tick, which retries the (now-deduped) outbox write and
     # completes the projection sync -- the durable retry path outbox-first-then-gate requires.
-    inserted_id = write_outbox_event(event, idempotency_key=idempotency_key)
+    inserted_id = write_outbox_event(
+        event,
+        idempotency_key=idempotency_key,
+        required_db=True,
+    )
     _sync_projection_closed(candidate.episode_id)
     return EpisodeCloseResult(episode_id=candidate.episode_id, event_emitted=bool(inserted_id))
 

--- a/app/heimdal/media_ingress.py
+++ b/app/heimdal/media_ingress.py
@@ -239,9 +239,13 @@ def _emit_admission_event(
             "media admission event jsonl write failed trace_id=%s err=%s", trace_id, exc
         )
 
-    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
-    db_url = os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
-    if backend == "pg" or db_url:
+    # Ask the outbox policy whether a self-owned write will actually connect,
+    # instead of re-deriving that from STORE_BACKEND/DATABASE_URL here (#4214
+    # D1). The local predicate was narrower than the connection's own resolver,
+    # and since the memory-mode skip branch landed a skipped write returns
+    # normally — which would make the `emitted = True` below report success for
+    # an event no sink took, exactly the class #4214 exists to close.
+    if not outbox_service.self_owned_write_would_skip():
         outbox_evt = outbox_service.coerce_outbox_event(evt, default_source=_EVENT_SOURCE)
         if outbox_evt is not None:
             try:

--- a/app/heimdal/meeting_finalization.py
+++ b/app/heimdal/meeting_finalization.py
@@ -585,9 +585,13 @@ def _emit_finalized_event(payload: Dict[str, Any], *, trace_id: str) -> bool:
         )
     except Exception as exc:
         logger.warning("meeting finalized event jsonl write failed: %s", exc)
-    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
-    db_url = os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
-    if backend == "pg" or db_url:
+    # Ask the outbox policy whether a self-owned write will actually connect,
+    # instead of re-deriving that from STORE_BACKEND/DATABASE_URL here (#4214
+    # D1). The local predicate was narrower than the connection's own resolver,
+    # and since the memory-mode skip branch landed a skipped write returns
+    # normally — which would make the `emitted = True` below report a finalized
+    # acknowledgement for an event no sink took.
+    if not outbox_service.self_owned_write_would_skip():
         outbox_evt = outbox_service.coerce_outbox_event(evt, default_source=_EVENT_SOURCE)
         if outbox_evt is not None:
             try:

--- a/app/knowledge_acquisition/stage_events.py
+++ b/app/knowledge_acquisition/stage_events.py
@@ -182,7 +182,16 @@ def emit_stage_completed(
         trace_id=trace_id,
         source=STAGE_EVENT_SOURCE,
     )
-    return write_outbox_event(event, conn=conn, idempotency_key=key)
+    # required_db=True (#4214): `conn` is an OPTIONAL parameter here and the
+    # acquisition entrypoints forward their own `conn=None` default, so this is a
+    # self-owned write at runtime. Left unclassified, an explicit memory backend
+    # skipped it and returned "" — which `acquire.py`/`replay.py` read as
+    # `idempotent=True`, i.e. a receipt asserting the transition was ALREADY
+    # durably recorded, for a stage event that never existed. This module's own
+    # contract forbids that: `acquire.py` calls require_configured_database_url()
+    # precisely so an acquisition cannot land without a lineage trail. A supplied
+    # connection still bypasses the policy and owns its transaction.
+    return write_outbox_event(event, conn=conn, idempotency_key=key, required_db=True)
 
 
 def emit_stage_dead_letter(
@@ -223,7 +232,16 @@ def emit_stage_dead_letter(
         trace_id=trace_id,
         source=STAGE_EVENT_SOURCE,
     )
-    return write_outbox_event(event, conn=conn, idempotency_key=key)
+    # required_db=True (#4214): `conn` is an OPTIONAL parameter here and the
+    # acquisition entrypoints forward their own `conn=None` default, so this is a
+    # self-owned write at runtime. Left unclassified, an explicit memory backend
+    # skipped it and returned "" — which `acquire.py`/`replay.py` read as
+    # `idempotent=True`, i.e. a receipt asserting the transition was ALREADY
+    # durably recorded, for a stage event that never existed. This module's own
+    # contract forbids that: `acquire.py` calls require_configured_database_url()
+    # precisely so an acquisition cannot land without a lineage trail. A supplied
+    # connection still bypasses the policy and owns its transaction.
+    return write_outbox_event(event, conn=conn, idempotency_key=key, required_db=True)
 
 
 @dataclass(frozen=True)

--- a/app/objects/__init__.py
+++ b/app/objects/__init__.py
@@ -139,6 +139,7 @@ class ObjectStore:
                 object_id=obj.uuid,
                 source="object_store",
                 observation=payload_fingerprint(obj.payload),
+                required_db=True,
             )
         # Do not mirror durable state in-process: transactional producers can
         # commit through another connection, so a process-local cache cannot be

--- a/app/outbox/events.py
+++ b/app/outbox/events.py
@@ -171,6 +171,7 @@ def emit_index_embedding_requested(event: Dict[str, Any]) -> None:
     write_outbox_event(
         envelope,
         idempotency_key=derive_idempotency_key(INDEX_EMBEDDING_REQUESTED, envelope.event_id, EVENT_ID_FINGERPRINT),
+        required_db=True,
     )
     _append_record_best_effort(record, event_name=INDEX_EMBEDDING_REQUESTED)
 

--- a/app/promotion/consumer.py
+++ b/app/promotion/consumer.py
@@ -114,6 +114,7 @@ def _emit_db_event(event_type: str, payload: dict, trace_id: str | None) -> None
     write_outbox_event(
         event,
         idempotency_key=derive_idempotency_key(event_type, source_id, payload_fingerprint(payload)),
+        required_db=True,
     )
 
 

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Literal, Mapping, Optional, Tuple
 
+from app.config.database import explicit_runtime_database_url
 from app.db.errors import OutboxSchemaMissingError
 from app.events.models import Event, new_event
 from app.events.schema import OutboxEvent
@@ -123,6 +124,28 @@ def _open_conn():
     return psycopg.connect(url, autocommit=True)
 
 
+def _self_owned_database_is_named() -> bool:
+    """Whether the environment names a database for a self-owned outbox write.
+
+    Resolved through ``app.config.database``, the SAME module ``conn_rw()``
+    resolves its DSN with (``app/db/db.py::_psycopg_dsn`` ->
+    ``resolve_runtime_database_url(os.environ)``), so the skip decision cannot
+    be narrower than the connection it stands in for.
+
+    Reading ``DATABASE_URL``/``DB_DSN`` directly was that narrower predicate
+    (#4214 D1): ``resolve_runtime_database_url`` also honours
+    ``PKM_DB_HOST``/``PKM_DB_PORT``/``PKM_DB_NAME_*``/``POSTGRES_*``, so a
+    runtime that named its database through those keys resolved to a real,
+    reachable connection while the skip predicate reported "unconfigured" and
+    dropped the write, returning ``""`` — the value this contract defines as
+    success/dedup. ``False`` here now means one thing only: every input the
+    resolver would use is a built-in default, so the DSN it hands back is the
+    compose-shaped fallback nobody named, and connecting to it is exactly the
+    stalling DNS lookup #4064 exists to avoid.
+    """
+    return explicit_runtime_database_url(os.environ) is not None
+
+
 def _self_owned_outbox_write_policy(
     *,
     backend: str | None,
@@ -131,17 +154,20 @@ def _self_owned_outbox_write_policy(
 ) -> Literal["connect", "skip"]:
     """Resolve one self-owned outbox write without probing the database.
 
-    ``conn_rw`` can fall back to a settings DSN even when the active store is
-    memory-backed.  A best-effort outbox emission must not trigger that fallback:
-    DNS resolution happens before a connection failure can be caught and can
-    stall a non-pg test run.  An optional explicit-memory write therefore skips
-    even if a stale DSN remains in the environment.
+    ``conn_rw`` synthesizes a compose-shaped DSN even when the active store is
+    memory-backed and nobody named a database.  A best-effort outbox emission
+    must not trigger that fallback: DNS resolution happens before a connection
+    failure can be caught and can stall a non-pg test run.  An optional
+    explicit-memory write therefore skips even if a stale DSN remains in the
+    environment.
 
-    With no explicit backend, an explicit DSN is still a durability request and
-    retains the existing Postgres write path.  A caller that has already resolved
-    required DB-outbox intent overrides the optional memory shortcut and must
-    observe connection failures.  Callers that supply ``conn`` own their
-    transaction and bypass this self-owned policy entirely.
+    With no explicit backend, a named database is still a durability request and
+    retains the existing Postgres write path.  ``dsn_configured`` MUST be
+    resolved by :func:`_self_owned_database_is_named` so this decision and the
+    connection read the same source (#4214 D1).  A caller that has already
+    resolved required DB-outbox intent overrides the optional memory shortcut
+    and must observe connection failures.  Callers that supply ``conn`` own
+    their transaction and bypass this self-owned policy entirely.
     """
     normalized_backend = (backend or "").strip().lower()
     if normalized_backend and normalized_backend not in {"memory", "pg"}:
@@ -155,6 +181,29 @@ def _self_owned_outbox_write_policy(
     if normalized_backend == "memory":
         return "skip"
     return "connect" if dsn_configured else "skip"
+
+
+def self_owned_write_would_skip(*, required_db: bool = False) -> bool:
+    """Whether a self-owned write with this durability intent would skip the DB.
+
+    Producers whose ``""`` return is otherwise indistinguishable from a
+    deduplicated insert use this to decide whether they may finalize durable
+    state (a cursor, a snapshot, a "purged" counter) on the strength of that
+    return. Delegates to :func:`_self_owned_outbox_write_policy` with exactly
+    the inputs :func:`write_outbox_event` resolves, so it can never disagree
+    with the decision the write itself makes.
+
+    Producers that HAVE a compensating sink (a JSONL append that survives the
+    skip) do not need this: their durability does not rest on the DB row.
+    """
+    return (
+        _self_owned_outbox_write_policy(
+            backend=os.environ.get("STORE_BACKEND"),
+            dsn_configured=_self_owned_database_is_named(),
+            required_db=required_db,
+        )
+        == "skip"
+    )
 
 
 def open_outbox_txn_conn():
@@ -482,7 +531,7 @@ def write_outbox_event(
         envelope = envelope.model_copy(update={"meta": stamped_meta})
     if conn is None and _self_owned_outbox_write_policy(
         backend=os.environ.get("STORE_BACKEND"),
-        dsn_configured=bool(os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")),
+        dsn_configured=_self_owned_database_is_named(),
         required_db=required_db,
     ) == "skip":
         # Outbox emission is best effort outside an explicitly configured

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -832,6 +832,7 @@ __all__ = [
     "write_outbox_event",
     "insert_object_and_outbox",
     "open_outbox_txn_conn",
+    "self_owned_write_would_skip",
     "poll_outbox_one",
     "ack_outbox",
     "bump_outbox_attempts",

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -233,7 +233,12 @@ def open_outbox_txn_conn():
     if not conn_rw:
         return None
     backend = (os.environ.get("STORE_BACKEND") or "").strip().lower()
-    if backend != "pg" and not (os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")):
+    # Resolved through the same helper the self-owned policy and conn_rw use
+    # (#4214 D1). Reading DATABASE_URL/DB_DSN directly was narrower than the
+    # connection: a runtime naming its database through PKM_DB_*/POSTGRES_*
+    # short-circuited to None here and silently degraded the worker's poison
+    # bookkeeping to the non-atomic per-call sequence #3930 exists to avoid.
+    if backend != "pg" and not _self_owned_database_is_named():
         return None
     try:
         return conn_rw()

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -7,7 +7,7 @@ import os
 import uuid as uuid_module
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Literal, Mapping, Optional, Tuple
 
 from app.db.errors import OutboxSchemaMissingError
 from app.events.models import Event, new_event
@@ -123,23 +123,38 @@ def _open_conn():
     return psycopg.connect(url, autocommit=True)
 
 
-def _outbox_db_enabled() -> bool:
-    """Return whether a self-owned outbox write may use Postgres.
+def _self_owned_outbox_write_policy(
+    *,
+    backend: str | None,
+    dsn_configured: bool,
+    required_db: bool,
+) -> Literal["connect", "skip"]:
+    """Resolve one self-owned outbox write without probing the database.
 
     ``conn_rw`` can fall back to a settings DSN even when the active store is
     memory-backed.  A best-effort outbox emission must not trigger that fallback:
     DNS resolution happens before a connection failure can be caught and can
-    stall a non-pg test run.  An explicit non-pg backend therefore always skips
-    a self-owned DB write, even if a stale DSN remains in the environment.
+    stall a non-pg test run.  An optional explicit-memory write therefore skips
+    even if a stale DSN remains in the environment.
 
     With no explicit backend, an explicit DSN is still a durability request and
-    retains the existing Postgres write path.  Callers that supply ``conn`` own
-    their transaction and bypass this gate.
+    retains the existing Postgres write path.  A caller that has already resolved
+    required DB-outbox intent overrides the optional memory shortcut and must
+    observe connection failures.  Callers that supply ``conn`` own their
+    transaction and bypass this self-owned policy entirely.
     """
-    backend = (os.environ.get("STORE_BACKEND") or "").strip().lower()
-    if backend:
-        return backend == "pg"
-    return bool(os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN"))
+    normalized_backend = (backend or "").strip().lower()
+    if normalized_backend and normalized_backend not in {"memory", "pg"}:
+        raise RuntimeError(
+            f"Store backend '{normalized_backend}' is not supported: set STORE_BACKEND "
+            "to 'pg' or 'memory' (explicit opt-in to volatile state), or unset it to "
+            "resolve from DATABASE_URL/DB_DSN."
+        )
+    if required_db or normalized_backend == "pg":
+        return "connect"
+    if normalized_backend == "memory":
+        return "skip"
+    return "connect" if dsn_configured else "skip"
 
 
 def open_outbox_txn_conn():
@@ -430,6 +445,7 @@ def write_outbox_event(
     conn: Any = None,
     *,
     idempotency_key: str,
+    required_db: bool = False,
 ) -> str:
     """Insert one event into the DB outbox, keyed by a mandatory idempotency key.
 
@@ -448,6 +464,11 @@ def write_outbox_event(
     live dispatch table is enforced by
     ``tests/events/test_topic_schema_registry.py::test_every_dispatched_topic_has_schema``,
     not by this write path.
+
+    ``required_db`` is a caller-resolved durability requirement for a
+    self-owned connection.  It prevents the explicit-memory best-effort
+    shortcut from hiding connection failures.  A supplied ``conn`` remains
+    authoritative and caller-owned regardless of ambient backend settings.
     """
     if not isinstance(idempotency_key, str) or not idempotency_key.strip():
         raise ValueError(f"write_outbox_event requires a non-empty idempotency_key, got {idempotency_key!r}")
@@ -459,11 +480,15 @@ def write_outbox_event(
         stamped_meta = dict(envelope.meta or {})
         stamped_meta["payload_schema"] = current_schema_ref(envelope.event_type)
         envelope = envelope.model_copy(update={"meta": stamped_meta})
-    if conn is None and not _outbox_db_enabled():
+    if conn is None and _self_owned_outbox_write_policy(
+        backend=os.environ.get("STORE_BACKEND"),
+        dsn_configured=bool(os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")),
+        required_db=required_db,
+    ) == "skip":
         # Outbox emission is best effort outside an explicitly configured
         # Postgres runtime.  ``""`` is the existing no-insert result (used for
-        # a deduplicated event), so callers do not mistake this skipped
-        # best-effort write for durable delivery (#4064).
+        # a deduplicated event); only callers that request ``required_db`` may
+        # treat a return from this function as evidence that the DB path ran.
         return ""
     conn, close = _use_conn(conn)
     stored = envelope.model_dump_json()
@@ -565,6 +590,7 @@ def insert_object_and_outbox(
     source: str | None = None,
     conn: Any = None,
     observation: str | None = None,
+    required_db: bool = False,
 ) -> str:
     """Helper som bygger ett Event och skickar det till outbox.
 
@@ -575,6 +601,9 @@ def insert_object_and_outbox(
     would swallow an A→B→A revert against the original A row while the
     object/file_state write still commits (``ON CONFLICT DO NOTHING`` is not
     an error) — silent projection divergence downstream.
+
+    ``required_db`` is forwarded unchanged to :func:`write_outbox_event`;
+    wrappers such as the watcher must resolve that policy before calling.
 
     ``observation`` is a per-observation marker mixed into the fingerprint
     (NOT into the event payload). It must re-derive identically on crash-retry
@@ -610,7 +639,12 @@ def insert_object_and_outbox(
     )
     key = derive_idempotency_key(topic, source_id, fingerprint)
     event = new_event(event_type=topic, payload=data, trace_id=trace_id, source=source)
-    return write_outbox_event(event, conn=conn, idempotency_key=key)
+    return write_outbox_event(
+        event,
+        conn=conn,
+        idempotency_key=key,
+        required_db=required_db,
+    )
 
 
 def _coerce_event_from_db(raw_payload: Any, topic: str) -> Event:

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -123,6 +123,25 @@ def _open_conn():
     return psycopg.connect(url, autocommit=True)
 
 
+def _outbox_db_enabled() -> bool:
+    """Return whether a self-owned outbox write may use Postgres.
+
+    ``conn_rw`` can fall back to a settings DSN even when the active store is
+    memory-backed.  A best-effort outbox emission must not trigger that fallback:
+    DNS resolution happens before a connection failure can be caught and can
+    stall a non-pg test run.  An explicit non-pg backend therefore always skips
+    a self-owned DB write, even if a stale DSN remains in the environment.
+
+    With no explicit backend, an explicit DSN is still a durability request and
+    retains the existing Postgres write path.  Callers that supply ``conn`` own
+    their transaction and bypass this gate.
+    """
+    backend = (os.environ.get("STORE_BACKEND") or "").strip().lower()
+    if backend:
+        return backend == "pg"
+    return bool(os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN"))
+
+
 def open_outbox_txn_conn():
     """Open one manual-commit canonical connection for multi-statement outbox bookkeeping.
 
@@ -440,6 +459,12 @@ def write_outbox_event(
         stamped_meta = dict(envelope.meta or {})
         stamped_meta["payload_schema"] = current_schema_ref(envelope.event_type)
         envelope = envelope.model_copy(update={"meta": stamped_meta})
+    if conn is None and not _outbox_db_enabled():
+        # Outbox emission is best effort outside an explicitly configured
+        # Postgres runtime.  ``""`` is the existing no-insert result (used for
+        # a deduplicated event), so callers do not mistake this skipped
+        # best-effort write for durable delivery (#4064).
+        return ""
     conn, close = _use_conn(conn)
     stored = envelope.model_dump_json()
     created_at = envelope.created_at or datetime.now(timezone.utc)

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -16,6 +16,7 @@ import yaml
 
 from app.agents.panel.agent import handle_note_update
 from app.agents.panel.writeback import upsert_executed_ids
+from app.config.database import explicit_runtime_database_url
 from app.briefing.trigger import scheduled_briefing_tick
 from app.agents.panel_agent.policy import (
     watcher_panel_candidate_for_path,
@@ -875,7 +876,15 @@ def _validate_registry_vault(vault_path: Path) -> bool:
     return True
 
 
-def _db_outbox_required() -> bool:
+def db_outbox_required() -> bool:
+    """Whether watcher event delivery must reach the DB outbox to count.
+
+    True when ``WATCHER_REQUIRE_DB_OUTBOX`` is set OR when ``STORE_BACKEND=pg``
+    — the shipped production default (`config/runtime.defaults.env`), so this
+    is NOT an opt-in-only switch. Public because the vault-watcher tick's
+    delete-tombstone path must resolve required intent identically (#4214 D3);
+    one definition, one answer.
+    """
     require_db = resolve_dev_lab_env_value(
         "WATCHER_REQUIRE_DB_OUTBOX",
         default="0",
@@ -887,8 +896,22 @@ def _db_outbox_required() -> bool:
     return backend == "pg"
 
 
+# Historical internal name, kept so the in-module call sites below read the same
+# as they did before the helper was published.
+_db_outbox_required = db_outbox_required
+
+
 def _has_db_outbox_env() -> bool:
-    return bool(os.getenv("DATABASE_URL") or os.getenv("DB_DSN"))
+    """Whether the environment names a database the watcher could enqueue into.
+
+    Resolved through the same ``app.config.database`` helper the self-owned
+    outbox policy and ``conn_rw()`` use (#4214 D1). Reading only
+    ``DATABASE_URL``/``DB_DSN`` here was the same narrow predicate: it made the
+    required path raise "DSN required" for a runtime that named its database
+    through ``PKM_DB_*``/``POSTGRES_*`` and would have connected fine, and it
+    made the optional path skip the DB enqueue for that same runtime.
+    """
+    return explicit_runtime_database_url(os.environ) is not None
 
 
 def _panel_candidate_for_path(note_path: Path) -> tuple[bool, bool]:
@@ -1234,14 +1257,19 @@ def _emit_changed_entry(
             required_db=required_db,
         )
     except Exception:
-        if required_db:
-            # Required delivery and its durable observation cursor are one
-            # state transition: if enqueue fails, restore the pre-observation
-            # state so finalization cannot suppress an unchanged-file retry.
-            if previous_file_state is None:
-                state.files.pop(rel_path, None)
-            else:
-                state.files[rel_path] = previous_file_state
+        # Delivery and its durable observation cursor are one state
+        # transition: if emission fails, restore the pre-observation state so
+        # finalization cannot suppress an unchanged-file retry.
+        #
+        # Not gated on required_db (#4214 D6): the non-required path can raise
+        # too — `append_jsonl_outbox_event` is unwrapped, so an OSError on the
+        # compensating JSONL sink propagates here with NEITHER sink written.
+        # Rolling back only for required delivery dropped that observation
+        # permanently once `_finalize_spec_tick` saved the advanced cursor.
+        if previous_file_state is None:
+            state.files.pop(rel_path, None)
+        else:
+            state.files[rel_path] = previous_file_state
         raise
     if not trace_id:
         return None
@@ -1291,7 +1319,11 @@ def _emit_watch_event(
         append_jsonl_outbox_event(outbox_path, event, default_source="watcher.registry")
         require_db = _db_outbox_required() if required_db is None else required_db
         if require_db and not _has_db_outbox_env():
-            raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
+            raise RuntimeError(
+                "Required watcher DB outbox delivery, but the runtime names no database: "
+                "set DATABASE_URL/DB_DSN (or the PKM_DB_*/POSTGRES_* keys "
+                "resolve_runtime_database_url reads)."
+            )
         if require_db or _has_db_outbox_env():
             try:
                 # Watcher-run scoped key: (topic, relative path, run-window
@@ -1338,7 +1370,11 @@ def _emit_watch_event(
     if spec.emit_event == INGEST_VAULT_CHANGED:
         require_db = _db_outbox_required() if required_db is None else required_db
         if require_db and not _has_db_outbox_env():
-            raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
+            raise RuntimeError(
+                "Required watcher DB outbox delivery, but the runtime names no database: "
+                "set DATABASE_URL/DB_DSN (or the PKM_DB_*/POSTGRES_* keys "
+                "resolve_runtime_database_url reads)."
+            )
         if require_db or _has_db_outbox_env():
             try:
                 insert_object_and_outbox(

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1283,6 +1283,7 @@ def _emit_watch_event(
                     idempotency_key=derive_idempotency_key(
                         PANEL_SCAN_REQUESTED, str(rel_path), payload_fingerprint(payload)
                     ),
+                    required_db=require_db,
                 )
             except Exception:
                 state.enqueue_failures_total += 1
@@ -1326,6 +1327,7 @@ def _emit_watch_event(
                     spec.emit_event,
                     trace_id=trace_id,
                     source="watcher.registry",
+                    required_db=require_db,
                 )
             except Exception:
                 state.enqueue_failures_total += 1

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1187,8 +1187,14 @@ def _emit_changed_entry(
     action_mappings: Mapping[str, PanelActionMapping],
     process_panel_notes_inline: bool,
 ) -> str | None:
-    last_seen = state.last_seen(str(entry.rel_path))
-    state.update_file_state(str(entry.rel_path), mtime=entry.mtime, content_hash=entry.digest, seen_at=now)
+    rel_path = str(entry.rel_path)
+    last_seen = state.last_seen(rel_path)
+    previous_file_state = dict(state.files[rel_path]) if rel_path in state.files else None
+    required_db = (
+        spec.emit_event in {PANEL_SCAN_REQUESTED, INGEST_VAULT_CHANGED}
+        and _db_outbox_required()
+    )
+    state.update_file_state(rel_path, mtime=entry.mtime, content_hash=entry.digest, seen_at=now)
     if is_settings_control_path(
         entry.rel_path,
         configured_system_dir=resolve_vault_system_dir_rel_or_default(
@@ -1215,16 +1221,28 @@ def _emit_changed_entry(
         current_mtime, current_digest = _maybe_heal_ingest_uuid(
             cfg, state, entry.rel_path, current_mtime, current_digest
         )
-    trace_id = _emit_watch_event(
-        spec=spec,
-        cfg=cfg,
-        outbox_path=cfg.outbox_path,
-        vault_root=cfg.vault_path,
-        rel_path=entry.rel_path,
-        mtime=current_mtime,
-        content_hash=current_digest,
-        state=state,
-    )
+    try:
+        trace_id = _emit_watch_event(
+            spec=spec,
+            cfg=cfg,
+            outbox_path=cfg.outbox_path,
+            vault_root=cfg.vault_path,
+            rel_path=entry.rel_path,
+            mtime=current_mtime,
+            content_hash=current_digest,
+            state=state,
+            required_db=required_db,
+        )
+    except Exception:
+        if required_db:
+            # Required delivery and its durable observation cursor are one
+            # state transition: if enqueue fails, restore the pre-observation
+            # state so finalization cannot suppress an unchanged-file retry.
+            if previous_file_state is None:
+                state.files.pop(rel_path, None)
+            else:
+                state.files[rel_path] = previous_file_state
+        raise
     if not trace_id:
         return None
     state.last_trace_id = trace_id
@@ -1253,6 +1271,7 @@ def _emit_watch_event(
     mtime: float,
     content_hash: str | None,
     state: WatcherState,
+    required_db: bool | None = None,
 ) -> str | None:
     if spec.emit_event == "panel.scan.requested":
         trace_id = uuid4().hex
@@ -1270,7 +1289,7 @@ def _emit_watch_event(
             payload=payload,
         )
         append_jsonl_outbox_event(outbox_path, event, default_source="watcher.registry")
-        require_db = _db_outbox_required()
+        require_db = _db_outbox_required() if required_db is None else required_db
         if require_db and not _has_db_outbox_env():
             raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
         if require_db or _has_db_outbox_env():
@@ -1317,7 +1336,7 @@ def _emit_watch_event(
     append_jsonl_outbox_event(outbox_path, event, default_source="watcher.registry")
 
     if spec.emit_event == INGEST_VAULT_CHANGED:
-        require_db = _db_outbox_required()
+        require_db = _db_outbox_required() if required_db is None else required_db
         if require_db and not _has_db_outbox_env():
             raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
         if require_db or _has_db_outbox_env():

--- a/app/watcher/vault_watcher.py
+++ b/app/watcher/vault_watcher.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Literal
 
 from app.agents.panel.agent import handle_note_update
+from app.config.database import runtime_database_is_named
 from app.agents.panel.filters import strip_ai_panels
 from app.agents.panel.writeback import strip_ai_status_block, upsert_executed_ids
 from app.agents.panel_agent.policy import (
@@ -77,6 +78,59 @@ def load_snapshot(path: Path) -> Snapshot:
 def save_snapshot(path: Path, snapshot: Snapshot) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(snapshot, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def unreconciled_deletions_path(snapshot_path: Path) -> Path:
+    """Sidecar for deletions observed but not yet turned into a durable tombstone.
+
+    Kept beside the snapshot rather than inside it because ``Snapshot`` is a
+    flat ``{rel_path: mtime}`` contract that several readers parse directly; a
+    reserved key would be indistinguishable from a note called that.
+    """
+    return snapshot_path.parent / f"{snapshot_path.name}.unreconciled-deletions.json"
+
+
+def load_unreconciled_deletions(path: Path) -> dict[str, float]:
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    retained: dict[str, float] = {}
+    for rel_path, mtime in raw.items():
+        if isinstance(rel_path, str) and isinstance(mtime, (int, float)):
+            retained[rel_path] = float(mtime)
+    return retained
+
+
+def save_unreconciled_deletions(path: Path, retained: Mapping[str, float]) -> None:
+    if not retained:
+        # Nothing outstanding: remove the sidecar rather than leave an empty
+        # file, so its presence always means "a deletion is still owed".
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(retained), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _with_unreconciled_deletions(current: Snapshot, sidecar: Path) -> Snapshot:
+    """Re-add still-owed deletions to a freshly scanned snapshot.
+
+    ``setdefault`` so a path that came back on disk keeps its real mtime and the
+    retained entry simply disappears.
+    """
+    merged = dict(current)
+    for rel_path, mtime in load_unreconciled_deletions(sidecar).items():
+        merged.setdefault(rel_path, mtime)
+    return merged
 
 
 def _scan_md_files(vault_root: Path) -> dict[str, float]:
@@ -330,32 +384,55 @@ class VaultWatcher:
         self.vault_root = vault_root.expanduser()
         self.snapshot_path = snapshot_path or _default_snapshot_path(self.vault_root)
 
+    @property
+    def unreconciled_deletions_path(self) -> Path:
+        """Sidecar holding deletions observed but not yet turned into a tombstone."""
+        return unreconciled_deletions_path(self.snapshot_path)
+
     def run(self, *, save: bool = True) -> VaultWatcherResult:
         snapshot = load_snapshot(self.snapshot_path)
         changed, deleted, current = compute_changes(self.vault_root, snapshot)
         if save:
-            save_snapshot(self.snapshot_path, current)
+            save_snapshot(
+                self.snapshot_path,
+                _with_unreconciled_deletions(current, self.unreconciled_deletions_path),
+            )
         return VaultWatcherResult(changed=changed, deleted=deleted, snapshot=current)
 
     def refresh_snapshot(self, *, retain: Mapping[str, float] | None = None) -> Snapshot:
         """Persist the current on-disk scan as the new observation cursor.
 
-        ``retain`` re-adds vault-relative paths whose deletion this tick could
-        NOT reconcile (#4214 D3). The paths are gone from disk, so a plain
-        rescan drops them and the next tick's diff never reports the deletion
-        again — the tombstone would be lost permanently. Keeping the prior
-        entry leaves the deletion visible to the next tick, which retries it;
-        this is the snapshot-level analogue of the watcher registry's
-        required-enqueue cursor restore.
+        A deletion this tick could NOT turn into a durable tombstone must stay
+        visible to the next tick (#4214 D3): the path is gone from disk, so a
+        plain rescan drops it and the diff never reports the deletion again —
+        the tombstone would be lost permanently. This is the snapshot-level
+        analogue of the watcher registry's required-enqueue cursor restore.
+
+        The retained set is held in a durable sidecar next to the snapshot, NOT
+        in a caller's local variable, because ``refresh_snapshot`` has callers
+        outside the tick (``app/runtime/runtime_loop.py``, ``app/cli/uat.py``,
+        ``app/cli/latency_harness.py``). A bare ``refresh_snapshot()`` from any
+        of them rescans disk, where the deleted note is absent, and would
+        otherwise silently undo the retention the tick just performed — the
+        exact loss D3 exists to prevent.
+
+        ``retain`` is the tick's authoritative, complete set for this vault: it
+        REPLACES the sidecar, so a deletion that finally reconciled stops being
+        retained. ``retain=None`` means "I am not the tick": honour the sidecar,
+        leave it unchanged.
         """
         current = _scan_md_files(self.vault_root)
-        for rel_path, mtime in (retain or {}).items():
-            current.setdefault(rel_path, mtime)
+        sidecar = self.unreconciled_deletions_path
+        if retain is not None:
+            save_unreconciled_deletions(sidecar, retain)
+        current = _with_unreconciled_deletions(current, sidecar)
         save_snapshot(self.snapshot_path, current)
         return current
 
 
-_DeleteReconciliation = Literal["emitted", "superseded_by_rename", "not_queued"]
+_DeleteReconciliation = Literal[
+    "emitted", "superseded_by_rename", "no_durable_outbox", "not_queued"
+]
 
 
 def _emit_watcher_delete_event(
@@ -402,8 +479,14 @@ def _emit_watcher_delete_event(
       snapshot move on;
     - ``"superseded_by_rename"`` — no tombstone is owed, the identity is alive
       at a new path (the rename case above); the snapshot must move on;
-    - ``"not_queued"`` — no sink took it; the caller must keep the deletion
-      re-observable.
+    - ``"no_durable_outbox"`` — the runtime names no database at all, so there
+      is no durable queue to enqueue into and no durable projection to purge.
+      Nothing is owed and nothing will ever accept it, so the caller must NOT
+      count a purge (no event exists) and must NOT retain the deletion (a
+      retention that can never clear would re-report the same deletion on every
+      tick forever);
+    - ``"not_queued"`` — a database IS named, so the tombstone was owed, but no
+      sink took it; the caller must keep the deletion re-observable.
 
     A required enqueue that fails raises, which the caller also treats as
     ``not_queued``.
@@ -440,7 +523,9 @@ def _emit_watcher_delete_event(
         observation=str(observed_mtime) if observed_mtime is not None else None,
         required_db=required_db,
     )
-    return "not_queued" if would_skip else "emitted"
+    if not would_skip:
+        return "emitted"
+    return "not_queued" if runtime_database_is_named(os.environ) else "no_durable_outbox"
 
 
 def run_watcher_tick(
@@ -521,8 +606,10 @@ def run_watcher_tick(
     # uuid5(rel_path) fallback) and emits a delete_note-compatible tombstone
     # event directly. Idempotent on replay: the outbox idempotency key is
     # scoped to this observation (the deleted version's last snapshotted
-    # mtime), and refresh_snapshot() removes the path from the snapshot so
-    # later ticks never re-see the deletion. Called AFTER the tick's ingest
+    # mtime), and refresh_snapshot() removes the path from the snapshot once
+    # the tombstone actually landed, so later ticks stop re-seeing a
+    # RECONCILED deletion. A deletion no sink took is deliberately retained
+    # instead (#4214 D3). Called AFTER the tick's ingest
     # of changed paths, so a rename (delete(old) + result.changed entry for
     # the new path) resolves against the already-updated companion and the
     # liveness check in _emit_watcher_delete_event can skip purging an
@@ -545,12 +632,21 @@ def run_watcher_tick(
                 rel_deleted = deleted_path.relative_to(vault_root)
             except ValueError:
                 rel_deleted = deleted_path
+            # `rel_deleted` falls back to the absolute path when relative_to
+            # raises, so look the observation up under both keys rather than
+            # losing the retention mtime on that branch.
             observed_mtime = prior_snapshot.get(str(rel_deleted))
+            if observed_mtime is None:
+                observed_mtime = prior_snapshot.get(str(deleted_path))
             try:
-                outcome: _DeleteReconciliation = (
-                    "emitted" if delete_note(str(deleted_path)) else "not_queued"
-                )
-                if outcome != "emitted":
+                # delete_note commits its event inside its own transaction, so
+                # True is proof the tombstone landed. False means it could not
+                # identify the note (no file_state row), not that a queue
+                # rejected it — the watcher's own emitter resolves those.
+                outcome: _DeleteReconciliation
+                if delete_note(str(deleted_path)):
+                    outcome = "emitted"
+                else:
                     outcome = _emit_watcher_delete_event(
                         deleted_path,
                         rel_deleted=rel_deleted,
@@ -560,8 +656,10 @@ def run_watcher_tick(
                 if outcome == "emitted":
                     summary["deleted_purged"] += 1
                 elif outcome == "not_queued" and observed_mtime is not None:
-                    # Neither sink took the tombstone: keep the deletion
-                    # visible to the next tick instead of losing it.
+                    # A tombstone was owed and no sink took it: keep the
+                    # deletion visible to the next tick instead of losing it.
+                    # "superseded_by_rename" and "no_durable_outbox" owe
+                    # nothing, so both let the snapshot move on.
                     unreconciled_deletions[str(rel_deleted)] = observed_mtime
             except Exception:
                 summary["errors"] += 1

--- a/app/watcher/vault_watcher.py
+++ b/app/watcher/vault_watcher.py
@@ -5,9 +5,10 @@ import json
 import os
 import time
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from app.agents.panel.agent import handle_note_update
 from app.agents.panel.filters import strip_ai_panels
@@ -29,8 +30,9 @@ from app.ingest.vault_alpha import run_vault_alpha_ingest_paths
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.write_ops import read_note_text_with_version
 from app.knowledge.write_ops import write_note_from_absolute
-from app.services.outbox import insert_object_and_outbox
+from app.services.outbox import insert_object_and_outbox, self_owned_write_would_skip
 from app.services.vault_sync import delete_note
+from app.watcher.registry import db_outbox_required
 from app.settings.panel_actions import PanelActionMapping, load_panel_action_mappings
 from app.settings.watcher_settings import load_watcher_settings, resolve_auto_exec_enabled
 from app.objects import ObjectStore, canonical_event_identity, resolve_canonical_object_id
@@ -335,10 +337,25 @@ class VaultWatcher:
             save_snapshot(self.snapshot_path, current)
         return VaultWatcherResult(changed=changed, deleted=deleted, snapshot=current)
 
-    def refresh_snapshot(self) -> Snapshot:
+    def refresh_snapshot(self, *, retain: Mapping[str, float] | None = None) -> Snapshot:
+        """Persist the current on-disk scan as the new observation cursor.
+
+        ``retain`` re-adds vault-relative paths whose deletion this tick could
+        NOT reconcile (#4214 D3). The paths are gone from disk, so a plain
+        rescan drops them and the next tick's diff never reports the deletion
+        again — the tombstone would be lost permanently. Keeping the prior
+        entry leaves the deletion visible to the next tick, which retries it;
+        this is the snapshot-level analogue of the watcher registry's
+        required-enqueue cursor restore.
+        """
         current = _scan_md_files(self.vault_root)
+        for rel_path, mtime in (retain or {}).items():
+            current.setdefault(rel_path, mtime)
         save_snapshot(self.snapshot_path, current)
         return current
+
+
+_DeleteReconciliation = Literal["emitted", "superseded_by_rename", "not_queued"]
 
 
 def _emit_watcher_delete_event(
@@ -347,7 +364,7 @@ def _emit_watcher_delete_event(
     rel_deleted: Path,
     vault_root: Path,
     observed_mtime: float | None,
-) -> bool:
+) -> _DeleteReconciliation:
     """Emit the deletion tombstone for a note vault_sync.delete_note could
     not identify (no file_state row -- i.e. a note ingested only through the
     tick's vault-alpha path, which keys store rows by note uuid).
@@ -370,7 +387,26 @@ def _emit_watcher_delete_event(
     source_ref, and the tick's vector upsert for the same uuid is
     synchronous with no follow-up created-event, so an async purge here
     would wipe the freshly re-ingested vectors with nothing to restore
-    them. Returns ``True`` when the tombstone was emitted.
+    them.
+
+    Durability (#4214 D3): this path has no compensating JSONL sink, and its
+    caller both increments ``deleted_purged`` and lets ``refresh_snapshot()``
+    drop the path — so a silent skip here is permanent and unrecoverable (the
+    note is gone from disk AND from the snapshot, the purge event never
+    existed, and the deleted content stays indexed). The write therefore
+    carries the watcher's resolved required-delivery intent, and the outcome is
+    reported explicitly rather than as a bare bool:
+
+    - ``"emitted"`` — the tombstone reached the outbox (or deduped against an
+      identical one already there); the caller may count the purge and let the
+      snapshot move on;
+    - ``"superseded_by_rename"`` — no tombstone is owed, the identity is alive
+      at a new path (the rename case above); the snapshot must move on;
+    - ``"not_queued"`` — no sink took it; the caller must keep the deletion
+      re-observable.
+
+    A required enqueue that fails raises, which the caller also treats as
+    ``not_queued``.
     """
     companion = find_companion_by_source_ref(vault_root, str(rel_deleted))
     companion_uuid = companion.uuid if companion else ""
@@ -382,7 +418,7 @@ def _emit_watcher_delete_event(
         if live_path.exists():
             # Rename: the same identity now lives at a new path that this
             # tick already (re)ingested -- purging would orphan it.
-            return False
+            return "superseded_by_rename"
     payload = {
         "path": str(deleted_path),
         "deleted": True,
@@ -390,13 +426,21 @@ def _emit_watcher_delete_event(
         "source": "vault_watcher.run_watcher_tick",
         **canonical_event_identity(canonical_object_id, note_uuid),
     }
+    required_db = db_outbox_required()
+    # Resolved from the same policy the write itself applies, BEFORE the call,
+    # because the write's ``""`` return cannot distinguish "skipped, nothing
+    # queued" from "deduped against a row already queued". The write still runs
+    # either way — a skip opens no connection, so there is nothing to save by
+    # short-circuiting, and the decision stays in exactly one place.
+    would_skip = self_owned_write_would_skip(required_db=required_db)
     insert_object_and_outbox(
         payload,
         INGEST_OBJECT_DELETED,
         None,
         observation=str(observed_mtime) if observed_mtime is not None else None,
+        required_db=required_db,
     )
-    return True
+    return "not_queued" if would_skip else "emitted"
 
 
 def run_watcher_tick(
@@ -485,6 +529,13 @@ def run_watcher_tick(
     # identity that just re-ingested at a new path. Runs in every non-dry-run
     # exit path -- including changed==0 and limit-exceeded (the max-notes
     # limit bounds panel/ingest fan-out only). dry_run must not purge.
+
+    # Deletions this tick observed but could not turn into a durable tombstone
+    # (#4214 D3). refresh_snapshot() retains these entries so the next tick
+    # re-sees the deletion; without that the path leaves both the disk and the
+    # snapshot and the purge can never be retried.
+    unreconciled_deletions: dict[str, float] = {}
+
     def _reconcile_deletions() -> None:
         if dry_run or not result.deleted:
             return
@@ -494,19 +545,28 @@ def run_watcher_tick(
                 rel_deleted = deleted_path.relative_to(vault_root)
             except ValueError:
                 rel_deleted = deleted_path
+            observed_mtime = prior_snapshot.get(str(rel_deleted))
             try:
-                emitted = delete_note(str(deleted_path))
-                if not emitted:
-                    emitted = _emit_watcher_delete_event(
+                outcome: _DeleteReconciliation = (
+                    "emitted" if delete_note(str(deleted_path)) else "not_queued"
+                )
+                if outcome != "emitted":
+                    outcome = _emit_watcher_delete_event(
                         deleted_path,
                         rel_deleted=rel_deleted,
                         vault_root=vault_root,
-                        observed_mtime=prior_snapshot.get(str(rel_deleted)),
+                        observed_mtime=observed_mtime,
                     )
-                if emitted:
+                if outcome == "emitted":
                     summary["deleted_purged"] += 1
+                elif outcome == "not_queued" and observed_mtime is not None:
+                    # Neither sink took the tombstone: keep the deletion
+                    # visible to the next tick instead of losing it.
+                    unreconciled_deletions[str(rel_deleted)] = observed_mtime
             except Exception:
                 summary["errors"] += 1
+                if observed_mtime is not None:
+                    unreconciled_deletions[str(rel_deleted)] = observed_mtime
                 messages.append(
                     f"Warning: unable to reconcile deletion for {rel_deleted}"
                 )
@@ -550,7 +610,7 @@ def run_watcher_tick(
     if summary["changed"] == 0:
         _reconcile_deletions()
         if not dry_run:
-            watcher.refresh_snapshot()
+            watcher.refresh_snapshot(retain=unreconciled_deletions)
         _emit_run_event(
             summary,
             vault_root=vault_root,
@@ -796,7 +856,7 @@ def run_watcher_tick(
     else:
         messages.append("Panel runtime skipped (no candidates or --skip-panel set).")
 
-    watcher.refresh_snapshot()
+    watcher.refresh_snapshot(retain=unreconciled_deletions)
     _emit_run_event(
         summary,
         vault_root=vault_root,

--- a/app/watcher/vault_watcher.py
+++ b/app/watcher/vault_watcher.py
@@ -5,7 +5,7 @@ import json
 import os
 import time
 import uuid
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -78,59 +78,6 @@ def load_snapshot(path: Path) -> Snapshot:
 def save_snapshot(path: Path, snapshot: Snapshot) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(snapshot, indent=2, sort_keys=True), encoding="utf-8")
-
-
-def unreconciled_deletions_path(snapshot_path: Path) -> Path:
-    """Sidecar for deletions observed but not yet turned into a durable tombstone.
-
-    Kept beside the snapshot rather than inside it because ``Snapshot`` is a
-    flat ``{rel_path: mtime}`` contract that several readers parse directly; a
-    reserved key would be indistinguishable from a note called that.
-    """
-    return snapshot_path.parent / f"{snapshot_path.name}.unreconciled-deletions.json"
-
-
-def load_unreconciled_deletions(path: Path) -> dict[str, float]:
-    if not path.exists():
-        return {}
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    if not isinstance(raw, dict):
-        return {}
-    retained: dict[str, float] = {}
-    for rel_path, mtime in raw.items():
-        if isinstance(rel_path, str) and isinstance(mtime, (int, float)):
-            retained[rel_path] = float(mtime)
-    return retained
-
-
-def save_unreconciled_deletions(path: Path, retained: Mapping[str, float]) -> None:
-    if not retained:
-        # Nothing outstanding: remove the sidecar rather than leave an empty
-        # file, so its presence always means "a deletion is still owed".
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            pass
-        except OSError:
-            pass
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(dict(retained), indent=2, sort_keys=True), encoding="utf-8")
-
-
-def _with_unreconciled_deletions(current: Snapshot, sidecar: Path) -> Snapshot:
-    """Re-add still-owed deletions to a freshly scanned snapshot.
-
-    ``setdefault`` so a path that came back on disk keeps its real mtime and the
-    retained entry simply disappears.
-    """
-    merged = dict(current)
-    for rel_path, mtime in load_unreconciled_deletions(sidecar).items():
-        merged.setdefault(rel_path, mtime)
-    return merged
 
 
 def _scan_md_files(vault_root: Path) -> dict[str, float]:
@@ -384,55 +331,20 @@ class VaultWatcher:
         self.vault_root = vault_root.expanduser()
         self.snapshot_path = snapshot_path or _default_snapshot_path(self.vault_root)
 
-    @property
-    def unreconciled_deletions_path(self) -> Path:
-        """Sidecar holding deletions observed but not yet turned into a tombstone."""
-        return unreconciled_deletions_path(self.snapshot_path)
-
     def run(self, *, save: bool = True) -> VaultWatcherResult:
         snapshot = load_snapshot(self.snapshot_path)
         changed, deleted, current = compute_changes(self.vault_root, snapshot)
         if save:
-            save_snapshot(
-                self.snapshot_path,
-                _with_unreconciled_deletions(current, self.unreconciled_deletions_path),
-            )
+            save_snapshot(self.snapshot_path, current)
         return VaultWatcherResult(changed=changed, deleted=deleted, snapshot=current)
 
-    def refresh_snapshot(self, *, retain: Mapping[str, float] | None = None) -> Snapshot:
-        """Persist the current on-disk scan as the new observation cursor.
-
-        A deletion this tick could NOT turn into a durable tombstone must stay
-        visible to the next tick (#4214 D3): the path is gone from disk, so a
-        plain rescan drops it and the diff never reports the deletion again —
-        the tombstone would be lost permanently. This is the snapshot-level
-        analogue of the watcher registry's required-enqueue cursor restore.
-
-        The retained set is held in a durable sidecar next to the snapshot, NOT
-        in a caller's local variable, because ``refresh_snapshot`` has callers
-        outside the tick (``app/runtime/runtime_loop.py``, ``app/cli/uat.py``,
-        ``app/cli/latency_harness.py``). A bare ``refresh_snapshot()`` from any
-        of them rescans disk, where the deleted note is absent, and would
-        otherwise silently undo the retention the tick just performed — the
-        exact loss D3 exists to prevent.
-
-        ``retain`` is the tick's authoritative, complete set for this vault: it
-        REPLACES the sidecar, so a deletion that finally reconciled stops being
-        retained. ``retain=None`` means "I am not the tick": honour the sidecar,
-        leave it unchanged.
-        """
+    def refresh_snapshot(self) -> Snapshot:
         current = _scan_md_files(self.vault_root)
-        sidecar = self.unreconciled_deletions_path
-        if retain is not None:
-            save_unreconciled_deletions(sidecar, retain)
-        current = _with_unreconciled_deletions(current, sidecar)
         save_snapshot(self.snapshot_path, current)
         return current
 
 
-_DeleteReconciliation = Literal[
-    "emitted", "superseded_by_rename", "no_durable_outbox", "not_queued"
-]
+_DeleteReconciliation = Literal["emitted", "superseded_by_rename", "not_queued"]
 
 
 def _emit_watcher_delete_event(
@@ -468,28 +380,42 @@ def _emit_watcher_delete_event(
 
     Durability (#4214 D3): this path has no compensating JSONL sink, and its
     caller both increments ``deleted_purged`` and lets ``refresh_snapshot()``
-    drop the path — so a silent skip here is permanent and unrecoverable (the
+    drop the path — so a *silent* skip here is permanent and unrecoverable (the
     note is gone from disk AND from the snapshot, the purge event never
-    existed, and the deleted content stays indexed). The write therefore
-    carries the watcher's resolved required-delivery intent, and the outcome is
-    reported explicitly rather than as a bare bool:
+    existed, and the deleted content stays indexed). Two things follow.
+
+    **The write is required whenever a database is named.** ``required_db`` is
+    the watcher's own required-delivery intent OR ``runtime_database_is_named``,
+    so a runtime with an explicit DSN keeps the delivery semantics it has on
+    ``main`` — the enqueue is attempted and an unreachable database raises
+    loudly — instead of being silently skipped by the optional-write policy
+    under ``STORE_BACKEND=memory``. #4214's constraint is explicit that a
+    properly configured runtime (``STORE_BACKEND=pg`` *or an explicit DSN*)
+    must not change delivery semantics. This also makes every outcome
+    terminal: named+reachable commits, named+unreachable raises once and is
+    recorded as an error, and an unnamed runtime has no durable queue and no
+    durable projection, so nothing is owed.
+
+    **The outcome is reported explicitly** rather than as a bare bool, so the
+    caller cannot read a skip as a purge. Note these are strings — ``"not_queued"``
+    is truthy — so a caller must compare, never test truthiness:
 
     - ``"emitted"`` — the tombstone reached the outbox (or deduped against an
-      identical one already there); the caller may count the purge and let the
-      snapshot move on;
+      identical one already there); the caller may count the purge;
     - ``"superseded_by_rename"`` — no tombstone is owed, the identity is alive
-      at a new path (the rename case above); the snapshot must move on;
-    - ``"no_durable_outbox"`` — the runtime names no database at all, so there
-      is no durable queue to enqueue into and no durable projection to purge.
-      Nothing is owed and nothing will ever accept it, so the caller must NOT
-      count a purge (no event exists) and must NOT retain the deletion (a
-      retention that can never clear would re-report the same deletion on every
-      tick forever);
-    - ``"not_queued"`` — a database IS named, so the tombstone was owed, but no
-      sink took it; the caller must keep the deletion re-observable.
+      at a new path (the rename case above);
+    - ``"not_queued"`` — the runtime names no database, so the optional write
+      skipped and no event exists. The caller must NOT count a purge.
 
-    A required enqueue that fails raises, which the caller also treats as
-    ``not_queued``.
+    A required enqueue that fails raises; the caller records it as an error and
+    does not count a purge.
+
+    Re-observability of a deletion that produced no tombstone is deliberately
+    NOT attempted here — it needs ``vault_sync.delete_note``'s own connection
+    classified first (it raises before this function is reached in a runtime
+    that names no database), plus a decided termination policy. Carried by
+    #4468; see ``docs/DB_SCHEMA.md :: Vault-watcher delete tombstone
+    durability``.
     """
     companion = find_companion_by_source_ref(vault_root, str(rel_deleted))
     companion_uuid = companion.uuid if companion else ""
@@ -509,7 +435,7 @@ def _emit_watcher_delete_event(
         "source": "vault_watcher.run_watcher_tick",
         **canonical_event_identity(canonical_object_id, note_uuid),
     }
-    required_db = db_outbox_required()
+    required_db = db_outbox_required() or runtime_database_is_named(os.environ)
     # Resolved from the same policy the write itself applies, BEFORE the call,
     # because the write's ``""`` return cannot distinguish "skipped, nothing
     # queued" from "deduped against a row already queued". The write still runs
@@ -523,9 +449,7 @@ def _emit_watcher_delete_event(
         observation=str(observed_mtime) if observed_mtime is not None else None,
         required_db=required_db,
     )
-    if not would_skip:
-        return "emitted"
-    return "not_queued" if runtime_database_is_named(os.environ) else "no_durable_outbox"
+    return "not_queued" if would_skip else "emitted"
 
 
 def run_watcher_tick(
@@ -606,22 +530,18 @@ def run_watcher_tick(
     # uuid5(rel_path) fallback) and emits a delete_note-compatible tombstone
     # event directly. Idempotent on replay: the outbox idempotency key is
     # scoped to this observation (the deleted version's last snapshotted
-    # mtime), and refresh_snapshot() removes the path from the snapshot once
-    # the tombstone actually landed, so later ticks stop re-seeing a
-    # RECONCILED deletion. A deletion no sink took is deliberately retained
-    # instead (#4214 D3). Called AFTER the tick's ingest
+    # mtime), and refresh_snapshot() removes the path from the snapshot so
+    # later ticks never re-see the deletion -- which is also why only a
+    # tombstone that actually landed may be counted as a purge (#4214 D3), and
+    # why making an unlanded one re-observable is a separate contract that
+    # needs vault_sync.delete_note's own connection classified first. Called
+    # AFTER the tick's ingest
     # of changed paths, so a rename (delete(old) + result.changed entry for
     # the new path) resolves against the already-updated companion and the
     # liveness check in _emit_watcher_delete_event can skip purging an
     # identity that just re-ingested at a new path. Runs in every non-dry-run
     # exit path -- including changed==0 and limit-exceeded (the max-notes
     # limit bounds panel/ingest fan-out only). dry_run must not purge.
-
-    # Deletions this tick observed but could not turn into a durable tombstone
-    # (#4214 D3). refresh_snapshot() retains these entries so the next tick
-    # re-sees the deletion; without that the path leaves both the disk and the
-    # snapshot and the purge can never be retried.
-    unreconciled_deletions: dict[str, float] = {}
 
     def _reconcile_deletions() -> None:
         if dry_run or not result.deleted:
@@ -653,18 +573,14 @@ def run_watcher_tick(
                         vault_root=vault_root,
                         observed_mtime=observed_mtime,
                     )
+                # Only a tombstone that actually landed counts as a purge
+                # (#4214 D3). "not_queued" and "superseded_by_rename" are both
+                # honest non-purges, and neither is retried: see the emitter's
+                # docstring for why re-observability is a separate contract.
                 if outcome == "emitted":
                     summary["deleted_purged"] += 1
-                elif outcome == "not_queued" and observed_mtime is not None:
-                    # A tombstone was owed and no sink took it: keep the
-                    # deletion visible to the next tick instead of losing it.
-                    # "superseded_by_rename" and "no_durable_outbox" owe
-                    # nothing, so both let the snapshot move on.
-                    unreconciled_deletions[str(rel_deleted)] = observed_mtime
             except Exception:
                 summary["errors"] += 1
-                if observed_mtime is not None:
-                    unreconciled_deletions[str(rel_deleted)] = observed_mtime
                 messages.append(
                     f"Warning: unable to reconcile deletion for {rel_deleted}"
                 )
@@ -708,7 +624,7 @@ def run_watcher_tick(
     if summary["changed"] == 0:
         _reconcile_deletions()
         if not dry_run:
-            watcher.refresh_snapshot(retain=unreconciled_deletions)
+            watcher.refresh_snapshot()
         _emit_run_event(
             summary,
             vault_root=vault_root,
@@ -954,7 +870,7 @@ def run_watcher_tick(
     else:
         messages.append("Panel runtime skipped (no candidates or --skip-panel set).")
 
-    watcher.refresh_snapshot(retain=unreconciled_deletions)
+    watcher.refresh_snapshot()
     _emit_run_event(
         summary,
         vault_root=vault_root,

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1405,6 +1405,7 @@ def _queue_transient_retry(
                     _original_event_id(payload, original_event_id) or str(note_path),
                     f"retry:{retry_count + 1}:{reason}",
                 ),
+                required_db=True,
             )
         else:
             append_jsonl_outbox_event(_outbox_audit_path(), retry_event, default_source="worker")

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -333,6 +333,67 @@ Interpretation:
 - the outbox is the canonical runtime queue,
 - but the event payload is still an operational artifact layer rather than the whole domain model.
 
+### Self-owned write durability policy (`required_db`)
+
+Source: `app/services/outbox.py::_self_owned_outbox_write_policy` (#4064 / #4203).
+
+A *self-owned* write is a `write_outbox_event()` / `insert_object_and_outbox()` call that passes no
+`conn`. For those calls only, the connection decision is resolved from the environment **before** any
+connection is opened, so a memory-backed runtime never triggers a DSN fallback whose DNS resolution
+could stall:
+
+| `STORE_BACKEND` | `DATABASE_URL` / `DB_DSN` | `required_db=False` (default) | `required_db=True` |
+| --- | --- | --- | --- |
+| `memory` | set or unset | skip, return `""` | connect |
+| `pg` | set or unset | connect | connect |
+| unset | set | connect | connect |
+| unset | unset | skip, return `""` | connect |
+| any other value | any | `RuntimeError` | `RuntimeError` |
+
+- `required_db` is keyword-only and defaults to `False`; `insert_object_and_outbox()` forwards it
+  unchanged. It is a **caller-resolved durability requirement**, not a runtime probe.
+- A skip returns `""` — the same no-insert result already used for a deduplicated event. Only a
+  caller that passed `required_db=True` may treat a return from these functions as evidence that the
+  DB path actually ran.
+- An unsupported explicit `STORE_BACKEND` fails loud before any connection attempt, rather than
+  degrading to a silent skip.
+- A supplied `conn` is authoritative and caller-owned: it bypasses this policy entirely and is never
+  closed by the outbox helper.
+
+**Required (DB-durable) producers.** These call sites are load-bearing — a silent skip would let a
+projection, receipt, or acknowledgement advance past an event that was never queued — so they pass
+`required_db=True` and fail loud instead:
+
+| Producer | Source |
+| --- | --- |
+| Episode closure (outbox-before-projection boundary) | `app/episodes/closure.py` |
+| Promotion receipts | `app/promotion/consumer.py` |
+| Embedding requests | `app/outbox/events.py` |
+| Explicit panel DB persistence | `app/agents/panel_agent/execution.py` |
+| Durable object saves | `app/objects/__init__.py` |
+| Worker transient retries | `app/workers/outbox_worker.py` |
+| Watcher `panel.scan.requested` / `ingest.vault.changed` (when `WATCHER_REQUIRE_DB_OUTBOX`) | `app/watcher/registry.py` |
+
+Optional, best-effort, and compensated producers keep the default `required_db=False` behavior.
+
+### Watcher required-delivery cursor semantics
+
+Source: `app/watcher/registry.py::_emit_changed_entry` (#4203).
+
+When a watcher observation requires DB delivery (`WATCHER_REQUIRE_DB_OUTBOX` set and the spec emits
+`panel.scan.requested` or `ingest.vault.changed`), the required enqueue and its durable observation
+cursor are **one state transition**:
+
+- if the required enqueue raises, the pre-observation `state.files` entry is restored (or removed
+  when the file was previously unseen) and the exception propagates, so the next tick re-observes the
+  unchanged file instead of treating it as already delivered;
+- the cursor advances exactly once, after a successful required enqueue; a subsequent tick over the
+  same unchanged file emits nothing.
+
+Contract regression coverage: `tests/services/test_outbox_memory_mode.py`,
+`tests/services/test_outbox_required_policy_callers.py`,
+`tests/watcher/test_registry_required_outbox.py`.
+
 ## Entity-Review Operation Journal
 
 Migration-owned (EROJ-01, #4350): Alembic revision `e7a2b9c4d1f8` creates the table exactly as the

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -427,31 +427,41 @@ it is documented rather than claimed away.
 Source: `app/watcher/vault_watcher.py::_emit_watcher_delete_event` (#4214 D3).
 
 The tick's delete-reconciliation path has no compensating JSONL sink, and its caller both increments
-`deleted_purged` and lets `refresh_snapshot()` drop the path from the snapshot — so an unqueued
-tombstone is permanently unrecoverable. The emitter therefore reports its outcome explicitly:
+`deleted_purged` and lets `refresh_snapshot()` drop the path from the snapshot. So the false purge is
+the only signal anyone would ever get for a tombstone that never landed. Two rules follow.
+
+**The write is required whenever a database is named.** The delete path resolves
+`required_db = db_outbox_required() or runtime_database_is_named(os.environ)`. Left optional, the
+policy would skip the enqueue under `STORE_BACKEND=memory` even with an explicit DSN and drop the
+tombstone with no purge, no error and no message — a silent, permanent loss on a runtime that does
+have a durable queue and a durable projection, and a change to the delivery semantics a properly
+configured runtime has today. The widening keeps `STORE_BACKEND=pg` and explicit-DSN runtimes exactly
+as they are, and makes an unreachable database raise loudly instead of vanishing.
+
+**Only a tombstone that landed is counted.** The emitter reports its outcome explicitly rather than
+as a bool — note these are strings, so `"not_queued"` is truthy and callers must compare, never test
+truthiness:
 
 - `"emitted"` — the tombstone reached the outbox (or deduped against an identical one); the purge is
-  counted and the snapshot moves on;
+  counted;
 - `"superseded_by_rename"` — no tombstone is owed, the identity is alive at a path this tick already
-  re-ingested; the snapshot moves on;
-- `"no_durable_outbox"` — the runtime names no database at all (`explicit_runtime_database_url` is
-  `None`), so there is no durable queue to enqueue into and no durable projection to purge. Nothing
-  is owed and nothing will ever accept it: the purge is **not** counted, and the deletion is **not**
-  retained, because a retention that can never clear would re-report the same deletion forever;
-- `"not_queued"` — a database IS named, so the tombstone was owed, but no sink took it. The purge is
-  **not** counted and the deletion is retained so the next tick re-sees it and retries.
+  re-ingested;
+- `"not_queued"` — the runtime names no database, so the optional write skipped and no event exists.
+  The purge is **not** counted.
 
-A required enqueue that raises is caught by the reconciliation loop, counted as an error, and treated
-as `not_queued`.
+A required enqueue that raises is caught by the reconciliation loop, counted as an error, and
+surfaced as an `unable to reconcile deletion` message.
 
-**The retention is durable, not a variable of the tick.** It lives in a sidecar beside the snapshot
-(`<snapshot>.unreconciled-deletions.json`), because `refresh_snapshot()` has callers outside
-`run_watcher_tick` — `app/runtime/runtime_loop.py`, `app/cli/uat.py`, `app/cli/latency_harness.py` —
-that construct their own `VaultWatcher` and call it with no arguments. A bare `refresh_snapshot()`
-rescans disk, where the deleted note is absent, and would otherwise silently undo the retention the
-tick just performed. `refresh_snapshot(retain=...)` is the tick speaking authoritatively and REPLACES
-the sidecar (so a reconciled deletion stops being retained); `refresh_snapshot()` honours the sidecar
-and leaves it unchanged.
+**Known gap: an unlanded tombstone is not retried.** The deletion is not made re-observable, so it is
+still lost — honestly reported now, but lost. Closing that needs `app/services/vault_sync.py::delete_note`
+classified first: it is step 1 of this path, it opens an unconditional `conn_rw()` with no
+memory-mode guard, and in a runtime that names no database it *raises* before the tombstone emitter
+is ever consulted. A retry layer built above that seam cannot terminate — two independent review
+rounds on PR #4138 demonstrated exactly that, once as a retention silently undone by the bare
+`refresh_snapshot()` in `app/runtime/runtime_loop.py`, once as a permanent per-tick error loop with
+an unbounded sidecar. The prerequisite and a decided termination policy are carried by #4468;
+`tests/watcher/test_vault_watcher_delete_required_outbox.py::test_the_tick_terminates_when_no_database_is_named`
+runs the real `delete_note` so the gap stays visible instead of being stubbed away.
 
 ### Producers that read a normal return as a commit
 

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -335,34 +335,44 @@ Interpretation:
 
 ### Self-owned write durability policy (`required_db`)
 
-Source: `app/services/outbox.py::_self_owned_outbox_write_policy` (#4064 / #4203).
+Source: `app/services/outbox.py::_self_owned_outbox_write_policy` (#4064 / #4203 / #4214).
 
 A *self-owned* write is a `write_outbox_event()` / `insert_object_and_outbox()` call that passes no
 `conn`. For those calls only, the connection decision is resolved from the environment **before** any
 connection is opened, so a memory-backed runtime never triggers a DSN fallback whose DNS resolution
 could stall:
 
-| `STORE_BACKEND` | `DATABASE_URL` / `DB_DSN` | `required_db=False` (default) | `required_db=True` |
+| `STORE_BACKEND` | Database named? | `required_db=False` (default) | `required_db=True` |
 | --- | --- | --- | --- |
-| `memory` | set or unset | skip, return `""` | connect |
-| `pg` | set or unset | connect | connect |
-| unset | set | connect | connect |
-| unset | unset | skip, return `""` | connect |
+| `memory` | either | skip, return `""` | connect |
+| `pg` | either | connect | connect |
+| unset | yes | connect | connect |
+| unset | no | skip, return `""` | connect |
 | any other value | any | `RuntimeError` | `RuntimeError` |
 
+- **"Database named?"** is `app/config/database.py::explicit_runtime_database_url(os.environ)`, the
+  same resolution the connection performs (`conn_rw()` -> `_psycopg_dsn()` ->
+  `resolve_runtime_database_url(os.environ)`). It is **not** just `DATABASE_URL`/`DB_DSN`: it is any
+  key in `RUNTIME_DATABASE_ENV_KEYS` (`DATABASE_URL`, `DB_DSN`, `PKM_DB_NAME_DEV/TEST/PROD`,
+  `POSTGRES_USER`, `POSTGRES_PASSWORD`, `PKM_DB_HOST`, `PKM_DB_PORT`). "No" means every input the
+  resolver would use is a built-in default, so the DSN it synthesizes is the compose-shaped fallback
+  nobody asked for. Reading a narrower key set was #4214 D1: a runtime that named its database
+  through `PKM_DB_*`/`POSTGRES_*` connected successfully while the skip predicate called it
+  unconfigured and dropped the write.
 - `required_db` is keyword-only and defaults to `False`; `insert_object_and_outbox()` forwards it
   unchanged. It is a **caller-resolved durability requirement**, not a runtime probe.
 - A skip returns `""` — the same no-insert result already used for a deduplicated event. Only a
   caller that passed `required_db=True` may treat a return from these functions as evidence that the
-  DB path actually ran.
+  DB path actually ran. A caller that must distinguish the two without requiring the DB asks
+  `self_owned_write_would_skip(required_db=...)`, which delegates to the same policy.
 - An unsupported explicit `STORE_BACKEND` fails loud before any connection attempt, rather than
   degrading to a silent skip.
 - A supplied `conn` is authoritative and caller-owned: it bypasses this policy entirely and is never
   closed by the outbox helper.
 
 **Required (DB-durable) producers.** These call sites are load-bearing — a silent skip would let a
-projection, receipt, or acknowledgement advance past an event that was never queued — so they pass
-`required_db=True` and fail loud instead:
+projection, receipt, acknowledgement, or HTTP 2xx advance past an event that was never queued — so
+they pass `required_db=True` and fail loud instead:
 
 | Producer | Source |
 | --- | --- |
@@ -372,27 +382,70 @@ projection, receipt, or acknowledgement advance past an event that was never que
 | Explicit panel DB persistence | `app/agents/panel_agent/execution.py` |
 | Durable object saves | `app/objects/__init__.py` |
 | Worker transient retries | `app/workers/outbox_worker.py` |
-| Watcher `panel.scan.requested` / `ingest.vault.changed` (when `WATCHER_REQUIRE_DB_OUTBOX`) | `app/watcher/registry.py` |
+| Watcher `panel.scan.requested` / `ingest.vault.changed` (when `db_outbox_required()`) | `app/watcher/registry.py` |
+| `POST /ingest` (the route's only persistence side effect) | `app/api/routes/ingest.py` |
+| Vault-watcher delete tombstone (`db_outbox_required()`) | `app/watcher/vault_watcher.py` |
 
 Optional, best-effort, and compensated producers keep the default `required_db=False` behavior.
 
+**This table is not the contract — the gate is.** A hand-maintained list can only show that the
+producers someone named are classified, never that the set is complete, which is how the `/ingest`
+route and the delete tombstone were missed (#4214 D2/D3/D5).
+`tests/architecture/test_outbox_producer_durability.py` is the enforcing gate: every self-owned
+producer in `app/` must pass `required_db=` or appear on a reviewed allowlist that states why a
+silent skip is survivable there (in practice: a compensating JSONL sink that outlives the skip). The
+gate also fails on a stale allowlist entry, so exemptions cannot accumulate.
+
 ### Watcher required-delivery cursor semantics
 
-Source: `app/watcher/registry.py::_emit_changed_entry` (#4203).
+Source: `app/watcher/registry.py::_emit_changed_entry` (#4203 / #4214).
 
-When a watcher observation requires DB delivery (`WATCHER_REQUIRE_DB_OUTBOX` set and the spec emits
-`panel.scan.requested` or `ingest.vault.changed`), the required enqueue and its durable observation
-cursor are **one state transition**:
+`app/watcher/registry.py::db_outbox_required()` is `True` when `WATCHER_REQUIRE_DB_OUTBOX` is set
+**or** when `STORE_BACKEND=pg` — the shipped production default (`config/runtime.defaults.env`). It
+reads like an opt-in switch; it is not, and production runs with required delivery on.
 
-- if the required enqueue raises, the pre-observation `state.files` entry is restored (or removed
-  when the file was previously unseen) and the exception propagates, so the next tick re-observes the
-  unchanged file instead of treating it as already delivered;
-- the cursor advances exactly once, after a successful required enqueue; a subsequent tick over the
-  same unchanged file emits nothing.
+Scope of the guarantee below: **the emission step only.** Once `_emit_changed_entry` reaches the
+emission, the emission and its durable observation cursor are one state transition:
+
+- if the emission raises, the pre-observation `state.files` entry is restored (or removed when the
+  file was previously unseen) and the exception propagates, so the next tick re-observes the
+  unchanged file instead of treating it as already delivered. The restore is **not** gated on
+  `required_db` (#4214 D6): `append_jsonl_outbox_event` is unwrapped, so the non-required path can
+  also raise with neither sink written;
+- the cursor advances exactly once, after a successful emission; a subsequent tick over the same
+  unchanged file emits nothing.
+
+**Known gap this guarantee does NOT cover.** `_emit_changed_entry` advances the `mtime`/`hash` cursor
+*before* the debounce/rate-limit check, and that check `return None`s without emitting and without
+rolling the cursor back; `_collect_changed_entries` then never re-detects the file. With the shipped
+`configs/watchers.yaml` (`rate_limit_per_min: 30`, `debounce_ms: 1500`) a bulk vault change
+permanently drops every observation past the limit. This drop is pre-existing and out of scope here —
+it is documented rather than claimed away.
+
+### Vault-watcher delete tombstone durability
+
+Source: `app/watcher/vault_watcher.py::_emit_watcher_delete_event` (#4214 D3).
+
+The tick's delete-reconciliation path has no compensating JSONL sink, and its caller both increments
+`deleted_purged` and lets `refresh_snapshot()` drop the path from the snapshot — so an unqueued
+tombstone is permanently unrecoverable. The emitter therefore reports its outcome explicitly:
+
+- `"emitted"` — the tombstone reached the outbox (or deduped against an identical one); the purge is
+  counted and the snapshot moves on;
+- `"superseded_by_rename"` — no tombstone is owed, the identity is alive at a path this tick already
+  re-ingested; the snapshot moves on;
+- `"not_queued"` — no sink took it. The purge is **not** counted and `refresh_snapshot(retain=...)`
+  re-adds the prior snapshot entry, so the next tick re-sees the deletion and retries.
+
+A required enqueue that raises is caught by the reconciliation loop, counted as an error, and treated
+as `not_queued`.
 
 Contract regression coverage: `tests/services/test_outbox_memory_mode.py`,
 `tests/services/test_outbox_required_policy_callers.py`,
-`tests/watcher/test_registry_required_outbox.py`.
+`tests/watcher/test_registry_required_outbox.py`,
+`tests/watcher/test_vault_watcher_delete_required_outbox.py`,
+`tests/api/test_ingest_required_outbox.py`,
+`tests/architecture/test_outbox_producer_durability.py`.
 
 ## Entity-Review Operation Journal
 

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -434,11 +434,39 @@ tombstone is permanently unrecoverable. The emitter therefore reports its outcom
   counted and the snapshot moves on;
 - `"superseded_by_rename"` — no tombstone is owed, the identity is alive at a path this tick already
   re-ingested; the snapshot moves on;
-- `"not_queued"` — no sink took it. The purge is **not** counted and `refresh_snapshot(retain=...)`
-  re-adds the prior snapshot entry, so the next tick re-sees the deletion and retries.
+- `"no_durable_outbox"` — the runtime names no database at all (`explicit_runtime_database_url` is
+  `None`), so there is no durable queue to enqueue into and no durable projection to purge. Nothing
+  is owed and nothing will ever accept it: the purge is **not** counted, and the deletion is **not**
+  retained, because a retention that can never clear would re-report the same deletion forever;
+- `"not_queued"` — a database IS named, so the tombstone was owed, but no sink took it. The purge is
+  **not** counted and the deletion is retained so the next tick re-sees it and retries.
 
 A required enqueue that raises is caught by the reconciliation loop, counted as an error, and treated
 as `not_queued`.
+
+**The retention is durable, not a variable of the tick.** It lives in a sidecar beside the snapshot
+(`<snapshot>.unreconciled-deletions.json`), because `refresh_snapshot()` has callers outside
+`run_watcher_tick` — `app/runtime/runtime_loop.py`, `app/cli/uat.py`, `app/cli/latency_harness.py` —
+that construct their own `VaultWatcher` and call it with no arguments. A bare `refresh_snapshot()`
+rescans disk, where the deleted note is absent, and would otherwise silently undo the retention the
+tick just performed. `refresh_snapshot(retain=...)` is the tick speaking authoritatively and REPLACES
+the sidecar (so a reconciled deletion stops being retained); `refresh_snapshot()` honours the sidecar
+and leaves it unchanged.
+
+### Producers that read a normal return as a commit
+
+`write_outbox_event` returns `""` for both a skipped write and an ON CONFLICT no-op. A producer whose
+idempotency key is derived from stable identity may legitimately read `""` as *proof of a prior
+commit* — the Heimdal meeting family does, because treating a dedup as failure would refuse the same
+capture forever. That reading is only sound while a normal return cannot mean "skipped", so those
+producers guard their DB branch with `self_owned_write_would_skip()` rather than re-deriving a
+`STORE_BACKEND`/DSN predicate of their own (#4214). One consequence is explicit: under an explicit
+memory backend the DB outbox mirror does not run for them, and their unconditional JSONL append is
+the sink of record.
+
+Producers whose key is per-emission (`app/api/routes/capture.py`, `app/panel/confirmation.py`) take
+the other correct route — `emitted = emitted or bool(stored_id)` — where a skip simply leaves
+`emitted` unchanged.
 
 Contract regression coverage: `tests/services/test_outbox_memory_mode.py`,
 `tests/services/test_outbox_required_policy_callers.py`,

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -384,7 +384,8 @@ they pass `required_db=True` and fail loud instead:
 | Worker transient retries | `app/workers/outbox_worker.py` |
 | Watcher `panel.scan.requested` / `ingest.vault.changed` (when `db_outbox_required()`) | `app/watcher/registry.py` |
 | `POST /ingest` (the route's only persistence side effect) | `app/api/routes/ingest.py` |
-| Vault-watcher delete tombstone (`db_outbox_required()`) | `app/watcher/vault_watcher.py` |
+| Vault-watcher delete tombstone (`db_outbox_required()` **or** a named database) | `app/watcher/vault_watcher.py` |
+| Knowledge-acquisition stage transitions | `app/knowledge_acquisition/stage_events.py` |
 
 Optional, best-effort, and compensated producers keep the default `required_db=False` behavior.
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -33,6 +33,12 @@ FULL_SUITE_EXACT = {
     # subsystems. Never narrow their coverage to a single feature owner.
     "app/cli/__init__.py",
     "app/config/paths.py",
+    # Canonical runtime DSN resolution. `app/db/db.py::_psycopg_dsn` (already a
+    # FULL_SUITE_PREFIX via app/db/) resolves every connection through this
+    # module, and the self-owned outbox skip predicate resolves the same
+    # question with it (#4214 D1) — so a change here can move any DB-touching
+    # subsystem between "connect" and "skip". Never narrow it to one owner.
+    "app/config/database.py",
     "conftest.py",
     "pytest.ini",
     "pyproject.toml",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -15,6 +15,16 @@ ALWAYS_TARGETS = (
     # This test must run on every scoped PR: a deleting/renaming PR otherwise
     # filters its missing static target before pytest has a chance to detect it.
     STATIC_TARGET_COLLECTABILITY_FITNESS,
+    # The outbox producer gates are repo-wide AST censuses over app/, so the PR
+    # that breaks them is by definition a PR that adds or edits a producer —
+    # and every producer today lives in an OWNED subsystem (heimdal, watcher,
+    # api routes, panel, workers, services, receipts, knowledge_acquisition).
+    # A scoped selection therefore excluded exactly the PRs these gates exist
+    # to catch, and a new producer defaulting to the dropping path could merge
+    # with a green required check (#4214 D5). They are cheap — pure ast.parse
+    # over app/, no fixtures, seconds — so run them on every scoped PR.
+    "tests/architecture/test_outbox_producer_durability.py",
+    "tests/architecture/test_outbox_producer_idempotency.py",
 )
 
 PR_MARKER_EXPRESSION = (

--- a/tests/api/test_ingest_required_outbox.py
+++ b/tests/api/test_ingest_required_outbox.py
@@ -1,0 +1,108 @@
+"""`POST /ingest` may not answer 2xx for an ingest that was never queued (#4214 D2).
+
+The route's ONLY persistence side effect is its self-owned
+``insert_object_and_outbox`` call, and it has no compensating JSONL sink. Left
+unclassified, that call takes the ``required_db=False`` default, so an explicit
+memory runtime silently skipped the enqueue, returned ``""``, and the route
+answered ``200 {"trace_id": ...}`` for an ingest that reached nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.services import outbox as outbox_service
+
+pytestmark = pytest.mark.not_pg
+
+_BODY = {
+    "uuid": "00000000-0000-0000-0000-000000004214",
+    "title": "Required outbox",
+    "review_state": "inbox",
+    "content": "body",
+}
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+        self.calls.append(params)
+
+    def fetchone(self) -> tuple[str]:
+        return ("inserted-row",)
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.closed = False
+        self.cursor_instance = _Cursor()
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_ingest_does_not_return_2xx_when_the_outbox_write_cannot_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable/unconfigured outbox must surface, not be answered 200."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    def _unavailable() -> Any:
+        raise RuntimeError("required outbox unavailable")
+
+    monkeypatch.setattr(outbox_service, "_open_conn", _unavailable)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code >= 500, (
+        "POST /ingest returned a success status for an ingest whose outbox event "
+        "was never queued"
+    )
+
+
+def test_ingest_returns_200_once_the_event_is_actually_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-loud classification must not break the configured happy path."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    conn = _Connection()
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 200
+    assert response.json()["trace_id"]
+    assert conn.cursor_instance.calls, "the route must have enqueued the ingest event"
+
+
+def test_ingest_classifies_its_producer_as_db_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the classification itself, not only its observable effect."""
+    seen: dict[str, object] = {}
+
+    def _capture(payload: object, topic: str, trace_id: object = None, **kwargs: object) -> str:
+        seen.update(kwargs)
+        return "row"
+
+    monkeypatch.setattr("app.api.routes.ingest.insert_object_and_outbox", _capture)
+
+    client = TestClient(app)
+    assert client.post("/ingest", json=_BODY).status_code == 200
+    assert seen.get("required_db") is True

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -45,7 +45,8 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "(durable_settings_write_receipt_exists reads it back); the DB row is a mirror"
     ),
     ("app/watcher/registry.py", "_process_panel_note"): (
-        "append_jsonl_outbox_event compensates unconditionally on the same path"
+        "_write_jsonl_event (append_jsonl_outbox_event) compensates unconditionally "
+        "on the same path"
     ),
     ("app/panel/confirmation.py", "_emit_projection_event"): (
         "JSONL is the declared primary sink and the caller raises "
@@ -75,23 +76,26 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "self-owned fallback taken only when open_outbox_txn_conn() returned None; "
         "the JSONL audit append above already recorded the dead letter"
     ),
-    # The Heimdal meeting family follows the same JSONL-first sink discipline
-    # capture.py established, and says so in its own docstrings: the
-    # append_jsonl_outbox_event to INDEX_OUTBOX_PATH runs unconditionally
-    # BEFORE the backend/DSN gate, and the `emitted` bool each caller gates its
-    # acknowledgement on is decided by that append, never by the DB write's
-    # return value.
+    # The Heimdal meeting family sets `emitted = True` on a normal return
+    # rather than on the returned row id, because its idempotency keys are
+    # derived from stable identity: a deduplicated "" there is proof the event
+    # was already committed by a prior attempt, so treating "" as failure would
+    # refuse the capture forever. That reading is only sound while a normal
+    # return cannot mean "skipped", so each of these guards its DB branch with
+    # `self_owned_write_would_skip()` — the policy itself, not a re-derived
+    # STORE_BACKEND/DSN predicate. The unconditional JSONL append above the
+    # guard is what survives a skip.
     ("app/api/routes/heimdal_meeting.py", "_emit_user_note_event"): (
-        "JSONL append to the shared note outbox path runs first and unconditionally; "
-        "the 500-vs-200 decision is made on that sink, not on the DB row"
+        "unconditional JSONL append survives a skip, and the DB branch runs only when "
+        "self_owned_write_would_skip() is False, so a normal return proves the row exists"
     ),
     ("app/heimdal/media_ingress.py", "_emit_admission_event"): (
-        "JSONL append runs first and unconditionally; the media receipt that acknowledges "
-        "the admission is written after, gated on that sink"
+        "unconditional JSONL append survives a skip, and the DB branch runs only when "
+        "self_owned_write_would_skip() is False, so a normal return proves the row exists"
     ),
     ("app/heimdal/meeting_finalization.py", "_emit_finalized_event"): (
-        "JSONL append runs first and unconditionally; the finalized-receipt ack ordering "
-        "is already satisfied by that sink"
+        "unconditional JSONL append survives a skip, and the DB branch runs only when "
+        "self_owned_write_would_skip() is False, so a normal return proves the row exists"
     ),
     ("app/heimdal/meeting_ledger.py", "_emit_late_admitted_event"): (
         "documented non-acknowledging emission: the segment ledger row is already "
@@ -142,7 +146,15 @@ def _unclassified_self_owned_producers() -> dict[tuple[str, str], list[int]]:
                 # entirely. A literal ``conn=None`` does NOT — that is a
                 # self-owned write spelled differently.
                 continue
-            if "required_db" in keywords:
+            required_db = keywords.get("required_db")
+            if required_db is not None and not (
+                isinstance(required_db, ast.Constant) and required_db.value is False
+            ):
+                # A resolved expression (`required_db=db_outbox_required()`) or
+                # a literal True is a real classification. A literal
+                # `required_db=False` is NOT — it re-states the risky default,
+                # so it still owes a reviewed allowlist reason rather than
+                # silently satisfying the gate.
                 continue
             key = (str(path.relative_to(APP_ROOT.parent)), _enclosing_function(node, parents))
             found.setdefault(key, []).append(node.lineno)

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -75,6 +75,29 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "self-owned fallback taken only when open_outbox_txn_conn() returned None; "
         "the JSONL audit append above already recorded the dead letter"
     ),
+    # The Heimdal meeting family follows the same JSONL-first sink discipline
+    # capture.py established, and says so in its own docstrings: the
+    # append_jsonl_outbox_event to INDEX_OUTBOX_PATH runs unconditionally
+    # BEFORE the backend/DSN gate, and the `emitted` bool each caller gates its
+    # acknowledgement on is decided by that append, never by the DB write's
+    # return value.
+    ("app/api/routes/heimdal_meeting.py", "_emit_user_note_event"): (
+        "JSONL append to the shared note outbox path runs first and unconditionally; "
+        "the 500-vs-200 decision is made on that sink, not on the DB row"
+    ),
+    ("app/heimdal/media_ingress.py", "_emit_admission_event"): (
+        "JSONL append runs first and unconditionally; the media receipt that acknowledges "
+        "the admission is written after, gated on that sink"
+    ),
+    ("app/heimdal/meeting_finalization.py", "_emit_finalized_event"): (
+        "JSONL append runs first and unconditionally; the finalized-receipt ack ordering "
+        "is already satisfied by that sink"
+    ),
+    ("app/heimdal/meeting_ledger.py", "_emit_late_admitted_event"): (
+        "documented non-acknowledging emission: the segment ledger row is already "
+        "committed before this runs, the JSONL append precedes the DB branch, and the "
+        "caller discards the result"
+    ),
 }
 
 

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -66,6 +66,15 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "upsert_note, and the object sync) pass a live conn_rw() connection inside "
         "the same transaction as the store write, so this never runs self-owned"
     ),
+    ("app/knowledge_acquisition/acquisition_requests.py", "_emit"): (
+        "self-owned at runtime (every facade that reaches it defaults conn=None), but "
+        "the acquisition queue is volatile in exactly the configurations where the "
+        "write skips: _resolve_backend lets an explicit STORE_BACKEND win, so a memory "
+        "backend means _MEMORY_REQUESTS holds the rows these events describe. Unlike "
+        "stage_events, this lane has no require_configured_database_url, and the return "
+        "is discarded. Classifying it required_db=True breaks source sync on a memory "
+        "runtime (tests/knowledge_acquisition/test_playlist_discovery.py)"
+    ),
     ("app/heimdal/entity_register.py", "_emit"): (
         "conn=self._conn may be None, but the register note written before this call "
         "is the canonical identity record and survives the skip; the event is a "
@@ -140,26 +149,29 @@ def _enclosing_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
     return enclosing.name if enclosing is not None else "<module>"
 
 
-def _optional_conn_parameters(
+def _names_bound_to_a_call(
     enclosing: ast.FunctionDef | ast.AsyncFunctionDef | None,
 ) -> set[str]:
-    """Parameters of the enclosing function that default to ``None``.
+    """Local names assigned from a call or bound by a ``with`` in this function.
 
-    Forwarding such a parameter as ``conn=`` does NOT make the call
-    caller-owned: at runtime the value is `None` whenever the caller omitted
-    it, and the write is self-owned after all.
+    ``with _conn() as conn:`` / ``conn = conn_rw()`` are the only shapes in this
+    repo that PROVE a live connection at the call site without leaving the file.
     """
     if enclosing is None:
         return set()
-    optional: set[str] = set()
-    args = enclosing.args
-    for arg, default in zip(args.args[-len(args.defaults) :] if args.defaults else [], args.defaults):
-        if isinstance(default, ast.Constant) and default.value is None:
-            optional.add(arg.arg)
-    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
-        if isinstance(default, ast.Constant) and default.value is None:
-            optional.add(arg.arg)
-    return optional
+    bound: set[str] = set()
+    for node in ast.walk(enclosing):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bound.add(target.id)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if isinstance(item.context_expr, ast.Call) and isinstance(
+                    item.optional_vars, ast.Name
+                ):
+                    bound.add(item.optional_vars.id)
+    return bound
 
 
 def _conn_is_caller_owned(
@@ -168,23 +180,26 @@ def _conn_is_caller_owned(
 ) -> bool:
     """Whether a ``conn=`` argument really proves a caller-owned transaction.
 
-    Only a value that cannot be ``None`` does. A literal ``None``, or a
-    forwarded parameter/attribute that is allowed to be ``None``, leaves the
-    write self-owned at runtime — which is exactly how the knowledge-acquisition
-    emitters slipped past the first version of this gate while silently
-    dropping their events under the memory-mode skip branch.
+    Only a value that provably cannot be ``None`` does, and inside one function
+    that means a name bound from a call (``with _conn() as conn``). Everything
+    else — a literal ``None``, a forwarded parameter, an attribute such as
+    ``self._conn`` — is unprovable here and owes a classification or a reviewed
+    allowlist reason.
+
+    A forwarded parameter is unprovable EVEN WHEN it has no default of its own,
+    because the caller one frame up may itself default it to ``None``. That is
+    not hypothetical: ``AcquisitionRequests._emit`` declares ``conn: Any`` with
+    no default, while every facade that reaches it (``enqueue``, ``claim_batch``,
+    ``_emit_failed``) defaults ``conn=None`` and the production caller in
+    ``playlist_discovery`` passes none at all. Reading "no default" as "caller
+    owns it" let that site escape the gate entirely, so the gate's completeness
+    claim — the whole point of #4214 D5 — was false.
     """
     if conn_arg is None:
         return False
-    if isinstance(conn_arg, ast.Constant) and conn_arg.value is None:
-        return False
-    if isinstance(conn_arg, ast.Name) and conn_arg.id in _optional_conn_parameters(enclosing):
-        return False
-    if isinstance(conn_arg, ast.Attribute):
-        # `self._conn` and friends: the class may well construct with None.
-        # Unprovable here, so it owes a classification or a reviewed reason.
-        return False
-    return True
+    if isinstance(conn_arg, ast.Name):
+        return conn_arg.id in _names_bound_to_a_call(enclosing)
+    return False
 
 
 def _unclassified_self_owned_producers() -> dict[tuple[str, str], list[int]]:

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -57,9 +57,19 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "this DB write is the documented mirror"
     ),
     ("app/cli/__init__.py", "pipe"): (
-        "operator-facing CLI: the emission is redundant with ObjectStore.save_object's "
-        "own required_db=True event for the same object, and a failure prints an "
-        "operator-visible WARNING rather than being swallowed"
+        "append_jsonl to INDEX_OUTBOX_PATH records the pipeline run on the same path "
+        "before this call; the DB emission is an operator-facing convenience on a "
+        "one-shot CLI, not a durability contract"
+    ),
+    ("app/services/vault_sync.py", "_enqueue"): (
+        "the conn=None default is vestigial: all three call sites (delete_note, "
+        "upsert_note, and the object sync) pass a live conn_rw() connection inside "
+        "the same transaction as the store write, so this never runs self-owned"
+    ),
+    ("app/heimdal/entity_register.py", "_emit"): (
+        "conn=self._conn may be None, but the register note written before this call "
+        "is the canonical identity record and survives the skip; the event is a "
+        "projection trigger and no caller derives a success signal from the return"
     ),
     ("app/api/routes/capture.py", "_emit_capture_event"): (
         "JSONL is the declared primary sink and the caller raises "
@@ -114,13 +124,67 @@ def _call_name(node: ast.Call) -> str | None:
     return None
 
 
-def _enclosing_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+def _enclosing_function_node(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
     current = parents.get(node)
     while current is not None:
         if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            return current.name
+            return current
         current = parents.get(current)
-    return "<module>"
+    return None
+
+
+def _enclosing_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+    enclosing = _enclosing_function_node(node, parents)
+    return enclosing.name if enclosing is not None else "<module>"
+
+
+def _optional_conn_parameters(
+    enclosing: ast.FunctionDef | ast.AsyncFunctionDef | None,
+) -> set[str]:
+    """Parameters of the enclosing function that default to ``None``.
+
+    Forwarding such a parameter as ``conn=`` does NOT make the call
+    caller-owned: at runtime the value is `None` whenever the caller omitted
+    it, and the write is self-owned after all.
+    """
+    if enclosing is None:
+        return set()
+    optional: set[str] = set()
+    args = enclosing.args
+    for arg, default in zip(args.args[-len(args.defaults) :] if args.defaults else [], args.defaults):
+        if isinstance(default, ast.Constant) and default.value is None:
+            optional.add(arg.arg)
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+        if isinstance(default, ast.Constant) and default.value is None:
+            optional.add(arg.arg)
+    return optional
+
+
+def _conn_is_caller_owned(
+    conn_arg: ast.expr | None,
+    enclosing: ast.FunctionDef | ast.AsyncFunctionDef | None,
+) -> bool:
+    """Whether a ``conn=`` argument really proves a caller-owned transaction.
+
+    Only a value that cannot be ``None`` does. A literal ``None``, or a
+    forwarded parameter/attribute that is allowed to be ``None``, leaves the
+    write self-owned at runtime — which is exactly how the knowledge-acquisition
+    emitters slipped past the first version of this gate while silently
+    dropping their events under the memory-mode skip branch.
+    """
+    if conn_arg is None:
+        return False
+    if isinstance(conn_arg, ast.Constant) and conn_arg.value is None:
+        return False
+    if isinstance(conn_arg, ast.Name) and conn_arg.id in _optional_conn_parameters(enclosing):
+        return False
+    if isinstance(conn_arg, ast.Attribute):
+        # `self._conn` and friends: the class may well construct with None.
+        # Unprovable here, so it owes a classification or a reviewed reason.
+        return False
+    return True
 
 
 def _unclassified_self_owned_producers() -> dict[tuple[str, str], list[int]]:
@@ -138,13 +202,10 @@ def _unclassified_self_owned_producers() -> dict[tuple[str, str], list[int]]:
             if not isinstance(node, ast.Call) or _call_name(node) not in PRODUCER_NAMES:
                 continue
             keywords = {kw.arg: kw.value for kw in node.keywords}
-            conn_arg = keywords.get("conn")
-            if conn_arg is not None and not (
-                isinstance(conn_arg, ast.Constant) and conn_arg.value is None
-            ):
-                # Caller-owned transaction: bypasses the self-owned policy
-                # entirely. A literal ``conn=None`` does NOT — that is a
-                # self-owned write spelled differently.
+            enclosing = _enclosing_function_node(node, parents)
+            if _conn_is_caller_owned(keywords.get("conn"), enclosing):
+                # A conn that cannot be None bypasses the self-owned policy
+                # entirely and owes nothing here.
                 continue
             required_db = keywords.get("required_db")
             if required_db is not None and not (

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -1,0 +1,190 @@
+"""#4214 D5 gate: self-owned outbox producers must be classified, not remembered.
+
+`required_db` is a durability *classification*. Until this gate existed the set
+of classified producers lived in a hand-maintained table in `docs/DB_SCHEMA.md`,
+and a per-callsite test could only prove that the producers someone happened to
+name were classified — never that the set was complete. That is exactly how the
+`POST /ingest` route (#4214 D2) and the vault-watcher delete tombstone (#4214
+D3) were missed: both defaulted to `required_db=False` and silently dropped
+events.
+
+The rule enforced here, modelled on
+`tests/architecture/test_outbox_producer_idempotency.py`:
+
+    every self-owned (`conn`-less) `write_outbox_event` /
+    `insert_object_and_outbox` call site in `app/` either passes an explicit
+    `required_db=` keyword, or names its enclosing function on the reviewed
+    allowlist below with the reason a silent skip is survivable there.
+
+The allowlist is keyed on `(module, enclosing function)` — never on line
+numbers, which shift under any unrelated edit — and is itself checked for rot:
+an entry whose call site has since been classified (or removed) fails the gate,
+so the allowlist cannot accumulate stale permissions.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+APP_ROOT = Path(__file__).resolve().parents[2] / "app"
+
+PRODUCER_NAMES = {"write_outbox_event", "insert_object_and_outbox"}
+
+# The defining module: `insert_object_and_outbox` forwards `required_db` to
+# `write_outbox_event` over a caller-owned `conn`, so it is not a producer.
+DEFINING_MODULE = APP_ROOT / "services" / "outbox.py"
+
+# Reviewed exemptions. Every entry must state WHY a silent skip is survivable —
+# in practice: the call site has a compensating sink that outlives the skip, so
+# the record is not lost and no success is reported on the strength of the DB
+# row alone.
+ALLOWLIST: dict[tuple[str, str], str] = {
+    ("app/receipts/settings_write.py", "emit_settings_write_receipt"): (
+        "the fsync'd JSONL receipt written just above IS the durability contract "
+        "(durable_settings_write_receipt_exists reads it back); the DB row is a mirror"
+    ),
+    ("app/watcher/registry.py", "_process_panel_note"): (
+        "append_jsonl_outbox_event compensates unconditionally on the same path"
+    ),
+    ("app/panel/confirmation.py", "_emit_projection_event"): (
+        "JSONL is the declared primary sink and the caller raises "
+        "PanelReceiptPersistenceError when NO sink took the event"
+    ),
+    ("app/agents/panel_agent/runtime.py", "_write_db_outbox_events"): (
+        "the caller's unguarded append_jsonl_outbox_event loop is the required sink; "
+        "this DB write is the documented mirror"
+    ),
+    ("app/cli/__init__.py", "pipe"): (
+        "operator-facing CLI: the emission is redundant with ObjectStore.save_object's "
+        "own required_db=True event for the same object, and a failure prints an "
+        "operator-visible WARNING rather than being swallowed"
+    ),
+    ("app/api/routes/capture.py", "_emit_capture_event"): (
+        "JSONL is the declared primary sink and the caller raises "
+        "CaptureEventPersistenceError when NO sink took the event"
+    ),
+    ("app/workers/outbox_worker.py", "_emit_ka_consumer_signal"): (
+        "documented audit-only observability signal; JSONL is written first and a "
+        "failure must never re-block the poll loop"
+    ),
+    ("app/workers/outbox_worker.py", "_emit_retry_dead_letter"): (
+        "JSONL audit append runs unconditionally first; the message is dropped either way"
+    ),
+    ("app/workers/outbox_worker.py", "_dead_letter_outbox_message"): (
+        "self-owned fallback taken only when open_outbox_txn_conn() returned None; "
+        "the JSONL audit append above already recorded the dead letter"
+    ),
+}
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _enclosing_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return current.name
+        current = parents.get(current)
+    return "<module>"
+
+
+def _unclassified_self_owned_producers() -> dict[tuple[str, str], list[int]]:
+    """Map (module, function) -> line numbers of unclassified self-owned calls."""
+    found: dict[tuple[str, str], list[int]] = {}
+    for path in sorted(APP_ROOT.rglob("*.py")):
+        if path == DEFINING_MODULE:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        parents: dict[ast.AST, ast.AST] = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                parents[child] = node
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or _call_name(node) not in PRODUCER_NAMES:
+                continue
+            keywords = {kw.arg: kw.value for kw in node.keywords}
+            conn_arg = keywords.get("conn")
+            if conn_arg is not None and not (
+                isinstance(conn_arg, ast.Constant) and conn_arg.value is None
+            ):
+                # Caller-owned transaction: bypasses the self-owned policy
+                # entirely. A literal ``conn=None`` does NOT — that is a
+                # self-owned write spelled differently.
+                continue
+            if "required_db" in keywords:
+                continue
+            key = (str(path.relative_to(APP_ROOT.parent)), _enclosing_function(node, parents))
+            found.setdefault(key, []).append(node.lineno)
+    return found
+
+
+def test_every_self_owned_producer_is_classified_or_allowlisted() -> None:
+    unclassified = _unclassified_self_owned_producers()
+    unreviewed = {key: lines for key, lines in unclassified.items() if key not in ALLOWLIST}
+
+    assert not unreviewed, (
+        "self-owned outbox producers with no required_db= classification and no reviewed "
+        "allowlist entry — an unclassified producer defaults to the SKIPPING path and can "
+        "silently drop the event (#4214 D5): "
+        + ", ".join(f"{module}::{function} (lines {lines})" for (module, function), lines in sorted(unreviewed.items()))
+    )
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """A producer that has since been classified must lose its exemption."""
+    unclassified = _unclassified_self_owned_producers()
+    stale = sorted(key for key in ALLOWLIST if key not in unclassified)
+
+    assert not stale, (
+        "allowlisted producers that no longer have an unclassified self-owned call site; "
+        "remove the entry so the allowlist keeps meaning what it says: "
+        + ", ".join(f"{module}::{function}" for module, function in stale)
+    )
+
+
+def test_allowlist_entries_state_a_reason() -> None:
+    missing = sorted(key for key, reason in ALLOWLIST.items() if not reason.strip())
+    assert not missing, f"allowlist entries without a stated reason: {missing}"
+
+
+def test_the_two_producers_this_gate_exists_for_are_classified() -> None:
+    """The #4214 D2/D3 call sites specifically may never regress to the default."""
+    unclassified = _unclassified_self_owned_producers()
+    for module, function in (
+        ("app/api/routes/ingest.py", "ingest"),
+        ("app/watcher/vault_watcher.py", "_emit_watcher_delete_event"),
+    ):
+        assert (module, function) not in unclassified, (
+            f"{module}::{function} lost its required_db classification; it has no "
+            "compensating sink, so a silent skip is unrecoverable data loss"
+        )
+        assert (module, function) not in ALLOWLIST, (
+            f"{module}::{function} may not be allowlisted — it has no compensating sink"
+        )
+
+
+def test_required_db_signature_stays_keyword_only_with_a_false_default() -> None:
+    """The gate above is only meaningful while the unclassified default is the risky one."""
+    tree = ast.parse(DEFINING_MODULE.read_text(encoding="utf-8"))
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in PRODUCER_NAMES:
+            continue
+        kwonly = dict(zip(node.args.kwonlyargs, node.args.kw_defaults))
+        defaults = {arg.arg: default for arg, default in kwonly.items()}
+        assert "required_db" in defaults, f"{node.name} must take required_db keyword-only"
+        default = defaults["required_db"]
+        assert isinstance(default, ast.Constant) and default.value is False, (
+            f"{node.name}'s required_db default changed; this gate assumes the "
+            "unclassified default is the skipping path"
+        )
+        checked += 1
+    assert checked == len(PRODUCER_NAMES), "both producer definitions must be checked"

--- a/tests/episodes/test_capability_end_to_end.py
+++ b/tests/episodes/test_capability_end_to_end.py
@@ -162,11 +162,13 @@ def test_fixture_day_full_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(closure_module, "find_closable_episodes", _fake_find_closable_from_vault(vault_root))
     monkeypatch.setattr(closure_module, "_count_active_bound_artifacts", lambda episode_id: 1)
-    emitted: list[tuple[Any, str]] = []
+    emitted: list[tuple[Any, str, bool]] = []
     monkeypatch.setattr(
         closure_module,
         "write_outbox_event",
-        lambda event, *, idempotency_key: (emitted.append((event, idempotency_key)) or idempotency_key),
+        lambda event, *, idempotency_key, required_db=False: (
+            emitted.append((event, idempotency_key, required_db)) or idempotency_key
+        ),
     )
     # #3181 review fix: close_episode now ALSO syncs the `episodes` projection's `closed` column
     # itself (app.episodes.closure._sync_projection_closed) -- stub it like every other DB

--- a/tests/episodes/test_closure.py
+++ b/tests/episodes/test_closure.py
@@ -183,11 +183,13 @@ def test_close_episode_flips_closed_and_emits_event(
     _write_open_episode_note(tmp_path, episode_id=episode_id, end=end)
 
     monkeypatch.setattr(closure_module, "_count_active_bound_artifacts", lambda eid: 3)
-    emitted: list[tuple[Any, str]] = []
+    emitted: list[tuple[Any, str, bool]] = []
     monkeypatch.setattr(
         closure_module,
         "write_outbox_event",
-        lambda event, *, idempotency_key: (emitted.append((event, idempotency_key)) or idempotency_key),
+        lambda event, *, idempotency_key, required_db=False: (
+            emitted.append((event, idempotency_key, required_db)) or idempotency_key
+        ),
     )
     sync_conn = _SyncConn({episode_id})
     monkeypatch.setattr(closure_module, "conn_rw", lambda *a, **k: sync_conn)
@@ -211,8 +213,9 @@ def test_close_episode_flips_closed_and_emits_event(
     assert fields["segmentation"] == "proposed"
 
     assert len(emitted) == 1
-    event, idempotency_key = emitted[0]
+    event, idempotency_key, required_db = emitted[0]
     assert event.event_type == "episode.closed"
+    assert required_db is True
     assert event.payload["episode_id"] == episode_id
     assert event.payload["scope"] == "work"
     assert event.payload["bound_artifact_count"] == 3
@@ -259,7 +262,9 @@ def test_close_episode_already_closed_note_reconciles_outbox_and_projection(
     monkeypatch.setattr(
         closure_module,
         "write_outbox_event",
-        lambda event, *, idempotency_key: (emitted.append(idempotency_key) or idempotency_key),
+        lambda event, *, idempotency_key, required_db=False: (
+            emitted.append(idempotency_key) or idempotency_key
+        ),
     )
     sync_conn = _SyncConn({episode_id})
     monkeypatch.setattr(closure_module, "conn_rw", lambda *a, **k: sync_conn)
@@ -402,7 +407,10 @@ def test_quiesced_episode_closes_once(tmp_path: Path, monkeypatch: pytest.Monkey
     seen_keys: set[str] = set()
     inserted: list[str] = []
 
-    def _fake_write_outbox_event(event: Any, *, idempotency_key: str) -> str:
+    def _fake_write_outbox_event(
+        event: Any, *, idempotency_key: str, required_db: bool = False
+    ) -> str:
+        assert required_db is True
         # Mirrors app.services.outbox.write_outbox_event's real `ON CONFLICT (id) DO NOTHING`
         # semantics: the FIRST insert of a given (fixed) idempotency key lands and returns the
         # key; every later attempt with the SAME key is a deduped no-op returning "".

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -865,10 +865,28 @@ def test_committed_db_outbox_event_is_not_reread_as_uncommitted(
     `write_outbox_event` returns "" when its ON CONFLICT swallowed a duplicate.
     Because this lane's key is derived from the transfer identity (unlike the
     governed text capture's random event_id), treating "" as "not committed"
-    would refuse an already-committed capture forever. The DB sink branch is
-    reached by configuring a DSN while the stores stay on the memory backend.
+    would refuse an already-committed capture forever.
+
+    Reaching the DB sink branch takes one more fake than it used to. Since
+    #4064/#4203 the self-owned outbox policy SKIPS an optional write under an
+    explicit memory backend, so `STORE_BACKEND=memory` plus a DSN no longer
+    runs the write at all — and `_emit_admission_event` now refuses to read
+    that skip as a commit (#4214), because a `""` from a write that never ran
+    is not proof of anything. The receipt store stays memory-backed, so this
+    test keeps `STORE_BACKEND=memory` and instead states the runtime it is
+    simulating outright: a runtime where the self-owned write DOES connect.
+    That is the only configuration in which this test's claim — a derived-key
+    ON CONFLICT no-op is proof of commit — is meaningful.
+
+    The real skip behaviour is pinned separately by
+    `tests/heimdal/test_meeting_emitters_skip_reporting.py` and
+    `tests/services/test_outbox_memory_mode.py`. No real connection is opened
+    here; `write_outbox_event` is faked below.
     """
     monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://unused:unused@db.invalid:5432/none")
+    monkeypatch.setattr(
+        media_ingress.outbox_service, "self_owned_write_would_skip", lambda **_kwargs: False
+    )
 
     def conflict_noop(*_args: Any, **_kwargs: Any) -> str:
         return ""

--- a/tests/heimdal/test_meeting_emitters_skip_reporting.py
+++ b/tests/heimdal/test_meeting_emitters_skip_reporting.py
@@ -1,0 +1,106 @@
+"""A skipped self-owned outbox write may not read as a committed event (#4214).
+
+The Heimdal meeting emitters set ``emitted = True`` on a *normal return* from
+``write_outbox_event`` rather than on the returned row id, and deliberately so:
+their idempotency keys are derived from stable identity, so a deduplicated
+``""`` is proof the event was already committed by a prior attempt. Treating
+``""`` as failure would refuse such a capture forever.
+
+That reading is only sound while a normal return cannot mean "skipped". The
+memory-mode skip branch broke it: with ``STORE_BACKEND=memory`` and a DSN in the
+environment the policy returns ``skip``, the write returns ``""`` without
+opening a connection, and the emitter reported success for an event no sink
+took — including flipping ``POST`` user-note responses from 500 to 200.
+
+Each emitter now guards its DB branch with
+``outbox_service.self_owned_write_would_skip()`` — the policy itself, not a
+re-derived ``STORE_BACKEND``/DSN predicate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services import outbox as outbox_service
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture()
+def skipping_runtime_with_a_named_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit memory backend + a named database: the policy skips."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _must_not_connect(*args: object, **kwargs: object) -> Any:
+        raise AssertionError("a skipped self-owned write must not open a connection")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _must_not_connect)
+    assert outbox_service.self_owned_write_would_skip() is True
+
+
+def _fail_jsonl(monkeypatch: pytest.MonkeyPatch, module: Any) -> None:
+    """Fault the compensating sink so only the DB branch could report success."""
+
+    def _unavailable(*args: object, **kwargs: object) -> Any:
+        raise OSError("jsonl sink unavailable")
+
+    monkeypatch.setattr(module.outbox_service, "append_jsonl_outbox_event", _unavailable)
+
+
+def test_media_admission_does_not_report_emitted_when_no_sink_took_it(
+    monkeypatch: pytest.MonkeyPatch,
+    skipping_runtime_with_a_named_database: None,
+) -> None:
+    from app.heimdal import media_ingress
+
+    _fail_jsonl(monkeypatch, media_ingress)
+
+    emitted = media_ingress._emit_admission_event(
+        {"receipt_id": "r-4214", "content_sha256": "s" * 64},
+        trace_id="t-4214",
+        receipt_id="r-4214",
+        content_sha256="s" * 64,
+    )
+
+    assert emitted is False, "reported a committed admission event that no sink took"
+
+
+def test_meeting_finalization_does_not_report_emitted_when_no_sink_took_it(
+    monkeypatch: pytest.MonkeyPatch,
+    skipping_runtime_with_a_named_database: None,
+) -> None:
+    from app.heimdal import meeting_finalization
+
+    _fail_jsonl(monkeypatch, meeting_finalization)
+
+    emitted = meeting_finalization._emit_finalized_event(
+        {"session_id": "s-4214", "finalization_state": "finalized"},
+        trace_id="t-4214",
+    )
+
+    assert emitted is False, "reported a finalized acknowledgement that no sink took"
+
+
+def test_user_note_event_does_not_report_emitted_when_no_sink_took_it(
+    monkeypatch: pytest.MonkeyPatch,
+    skipping_runtime_with_a_named_database: None,
+) -> None:
+    from app.api.routes import heimdal_meeting
+
+    _fail_jsonl(monkeypatch, heimdal_meeting)
+
+    emitted = heimdal_meeting._emit_user_note_event(
+        {
+            "note_block_id": "nb-4214",
+            "revision": 1,
+            "content_sha256": "s" * 64,
+        },
+        trace_id="t-4214",
+    )
+
+    assert emitted is False, (
+        "reported a persisted user note that no sink took; the route turns this into a 200"
+    )

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -11,11 +11,18 @@ def test_emit_index_embedding_requested_writes_db_outbox_and_audit(tmp_path, mon
     fake_path = tmp_path / "index-outbox.jsonl"
     monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
     db_writes: list[object] = []
-    monkeypatch.setattr(events, "write_outbox_event", lambda evt, idempotency_key=None: db_writes.append((evt, idempotency_key)) or "1")
+    monkeypatch.setattr(
+        events,
+        "write_outbox_event",
+        lambda evt, idempotency_key=None, required_db=False: (
+            db_writes.append((evt, idempotency_key, required_db)) or "1"
+        ),
+    )
 
     events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-audit", "source": "test"})
 
     assert db_writes
+    assert db_writes[0][2] is True
     assert fake_path.exists()
 
 
@@ -34,16 +41,22 @@ def test_emit_index_embedding_requested_tolerates_audit_append_failure(tmp_path,
     fake_path = tmp_path / "index-outbox.jsonl"
     monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
     db_writes: list[object] = []
-    monkeypatch.setattr(events, "write_outbox_event", lambda evt, idempotency_key=None: db_writes.append((evt, idempotency_key)) or "1")
+    monkeypatch.setattr(
+        events,
+        "write_outbox_event",
+        lambda evt, idempotency_key=None, required_db=False: (
+            db_writes.append((evt, idempotency_key, required_db)) or "1"
+        ),
+    )
     monkeypatch.setattr(events, "_append_record", lambda record: (_ for _ in ()).throw(OSError("disk full")))
 
     events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-audit-fail", "source": "test"})
 
     assert db_writes
+    assert db_writes[0][2] is True
 
 
 def test_emit_index_embedding_created_tolerates_audit_append_failure(monkeypatch) -> None:
     monkeypatch.setattr(events, "_append_record", lambda record: (_ for _ in ()).throw(OSError("audit sink unavailable")))
     events.emit_index_embedding_created(object_id=UUID("11111111-1111-1111-1111-111111111111"), trace_id="trace-created")
-
 

--- a/tests/knowledge_acquisition/test_stage_events_required_db.py
+++ b/tests/knowledge_acquisition/test_stage_events_required_db.py
@@ -1,0 +1,103 @@
+"""A skipped stage event may not be reported as "already recorded" (#4214).
+
+`app/knowledge_acquisition/stage_events.py`'s emitters take an OPTIONAL `conn`
+and the acquisition entrypoints forward their own `conn=None` default, so these
+are self-owned writes at runtime. Left unclassified, the memory-mode skip branch
+made them return `""` without connecting — and `acquire.py` / `replay.py` read
+`event_row == ""` as `idempotent=True`, i.e. a receipt asserting the stage
+transition was ALREADY durably recorded. The candidate note still lands in the
+vault, so the acquisition completes with `ok=True` and no lineage trail: exactly
+what `app/knowledge_acquisition/acquire.py`'s module docstring says must never
+happen ("silently skipping it would produce an acquisition with no lineage
+trail").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.knowledge_acquisition import stage_events
+from app.services import outbox as outbox_service
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture()
+def memory_backend_with_a_named_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The configuration `acquire.py` demands, under an explicit memory backend."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _unavailable(*args: object, **kwargs: object) -> Any:
+        raise RuntimeError("stage outbox unavailable")
+
+    monkeypatch.setattr(outbox_service, "_open_conn", _unavailable)
+
+
+def test_stage_completed_fails_loud_instead_of_returning_a_false_dedup(
+    memory_backend_with_a_named_database: None,
+) -> None:
+    with pytest.raises(RuntimeError, match="stage outbox unavailable"):
+        stage_events.emit_stage_completed(
+            stage="normalize",
+            stage_version=1,
+            content_identity="sha256:" + "a" * 64,
+            trace_id="trace-4214",
+        )
+
+
+def test_stage_dead_letter_fails_loud_instead_of_returning_a_false_dedup(
+    memory_backend_with_a_named_database: None,
+) -> None:
+    with pytest.raises(RuntimeError, match="stage outbox unavailable"):
+        stage_events.emit_stage_dead_letter(
+            stage="normalize",
+            stage_version=1,
+            content_identity="sha256:" + "b" * 64,
+            reason="unreachable",
+            error="stage outbox unavailable",
+            trace_id="trace-4214",
+        )
+
+
+def test_a_supplied_connection_still_owns_its_transaction(
+    memory_backend_with_a_named_database: None,
+) -> None:
+    """`required_db` must not disturb the caller-owned path."""
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, ...]] = []
+
+        def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+            self.calls.append(params)
+
+        def fetchone(self) -> tuple[str]:
+            return ("stage-row",)
+
+    class _Connection:
+        def __init__(self) -> None:
+            self.autocommit = False
+            self.closed = False
+            self.cursor_instance = _Cursor()
+
+        def cursor(self) -> _Cursor:
+            return self.cursor_instance
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = _Connection()
+    row = stage_events.emit_stage_completed(
+        stage="normalize",
+        stage_version=1,
+        content_identity="sha256:" + "c" * 64,
+        trace_id="trace-4214",
+        conn=conn,
+    )
+
+    assert row == "stage-row"
+    assert conn.cursor_instance.calls
+    assert conn.closed is False, "a supplied connection must stay caller-owned"

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -62,7 +62,7 @@ REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
         "run_panel_note_execution, which emits panel.action.logged/blocked via the "
         "runtime's own outbox path (app/agents/panel_agent/runtime.py) for the same turn."
     ),
-    ("app/watcher/vault_watcher.py", 206): (
+    ("app/watcher/vault_watcher.py", 153): (
         "_hydrate_store_with_markdown: best-effort raw_text hydration for panel-scan "
         "note refresh; the mutating vault-sync path (T-sync) already emitted "
         "ingest.object.* for this note earlier in the same tick."
@@ -1560,7 +1560,7 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "store_objects; a new-note branch has no prior row and no binding (unbound correct via the "
         "build_indexed_unit_payload choke at index time)."
     ),
-    ("app/watcher/vault_watcher.py", 206): (
+    ("app/watcher/vault_watcher.py", 153): (
         "preserves_existing_payload: _hydrate_store_with_markdown updates raw_text on "
         "dict(obj.payload); save_object -> store_objects; episode_ref preserved."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -62,7 +62,7 @@ REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
         "run_panel_note_execution, which emits panel.action.logged/blocked via the "
         "runtime's own outbox path (app/agents/panel_agent/runtime.py) for the same turn."
     ),
-    ("app/watcher/vault_watcher.py", 152): (
+    ("app/watcher/vault_watcher.py", 206): (
         "_hydrate_store_with_markdown: best-effort raw_text hydration for panel-scan "
         "note refresh; the mutating vault-sync path (T-sync) already emitted "
         "ingest.object.* for this note earlier in the same tick."
@@ -1560,7 +1560,7 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "store_objects; a new-note branch has no prior row and no binding (unbound correct via the "
         "build_indexed_unit_payload choke at index time)."
     ),
-    ("app/watcher/vault_watcher.py", 152): (
+    ("app/watcher/vault_watcher.py", 206): (
         "preserves_existing_payload: _hydrate_store_with_markdown updates raw_text on "
         "dict(obj.payload); save_object -> store_objects; episode_ref preserved."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -62,7 +62,7 @@ REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
         "run_panel_note_execution, which emits panel.action.logged/blocked via the "
         "runtime's own outbox path (app/agents/panel_agent/runtime.py) for the same turn."
     ),
-    ("app/watcher/vault_watcher.py", 150): (
+    ("app/watcher/vault_watcher.py", 152): (
         "_hydrate_store_with_markdown: best-effort raw_text hydration for panel-scan "
         "note refresh; the mutating vault-sync path (T-sync) already emitted "
         "ingest.object.* for this note earlier in the same tick."
@@ -1560,7 +1560,7 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "store_objects; a new-note branch has no prior row and no binding (unbound correct via the "
         "build_indexed_unit_payload choke at index time)."
     ),
-    ("app/watcher/vault_watcher.py", 150): (
+    ("app/watcher/vault_watcher.py", 152): (
         "preserves_existing_payload: _hydrate_store_with_markdown updates raw_text on "
         "dict(obj.payload); save_object -> store_objects; episode_ref preserved."
     ),

--- a/tests/services/test_outbox_memory_mode.py
+++ b/tests/services/test_outbox_memory_mode.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import pytest
 
+from app.config.database import (
+    RUNTIME_DATABASE_ENV_KEYS,
+    explicit_runtime_database_url,
+    resolve_runtime_database_url,
+)
 from app.events.models import new_event
 from app.services import outbox as outbox_service
 
@@ -79,17 +85,77 @@ def test_write_outbox_event_uses_explicit_pg_backend(monkeypatch: pytest.MonkeyP
     assert conn.cursor_instance.calls
 
 
-def test_write_outbox_event_skips_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The chosen best-effort contract skips when neither backend nor DSN is configured."""
+def test_settings_resolved_dsn_is_not_treated_as_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The skip predicate may not be narrower than the connection's resolver (#4214 D1).
+
+    ``conn_rw()`` resolves through ``resolve_runtime_database_url(os.environ)``,
+    which also honours ``PKM_DB_HOST``/``PKM_DB_NAME_*``/``POSTGRES_*``. A skip
+    predicate that read only ``DATABASE_URL``/``DB_DSN`` therefore classified a
+    runtime whose connection WOULD have succeeded as unconfigured, and dropped
+    the write while returning ``""`` — the value this contract defines as
+    success/dedup.
+    """
     monkeypatch.delenv("STORE_BACKEND", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("PKM_DB_HOST", "named-host.example")
+    conn = _Connection("resolver-key")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: conn)
+
+    assert outbox_service.write_outbox_event(_event(), idempotency_key="resolver-key") == "resolver-key"
+    assert conn.cursor_instance.calls
+
+
+@pytest.mark.parametrize("naming_key", RUNTIME_DATABASE_ENV_KEYS)
+def test_skip_decision_never_contradicts_the_connection_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    naming_key: str,
+) -> None:
+    """Every key the connection's resolver reads must also make the write connect.
+
+    Parametrized over ``RUNTIME_DATABASE_ENV_KEYS`` itself, so a new synthesis
+    input added to ``app/config/database.py`` is covered here automatically
+    instead of quietly re-opening the #4214 D1 divergence.
+    """
+    for key in RUNTIME_DATABASE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("STORE_BACKEND", raising=False)
+    monkeypatch.setenv(
+        naming_key,
+        "postgresql://named.example/app" if naming_key in {"DATABASE_URL", "DB_DSN"} else "named",
+    )
+    conn = _Connection(f"named-{naming_key}")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: conn)
+
+    assert (
+        outbox_service.write_outbox_event(_event(), idempotency_key=f"named-{naming_key}")
+        == f"named-{naming_key}"
+    )
+    # The DSN the write would use is byte-identical to the one the connection
+    # resolves, so the decision and the connection cannot disagree.
+    assert explicit_runtime_database_url(os.environ) == resolve_runtime_database_url(os.environ)
+
+
+def test_write_outbox_event_skips_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chosen best-effort contract skips when the runtime names no database.
+
+    "Unconfigured" now means every input the connection's resolver would use is
+    a built-in default, so the DSN it hands back is the compose-shaped fallback
+    nobody named — connecting to it is exactly the stalling DNS lookup #4064
+    exists to avoid.
+    """
+    monkeypatch.delenv("STORE_BACKEND", raising=False)
+    for key in RUNTIME_DATABASE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
     def _fail_if_called(*args: object, **kwargs: object) -> Any:
         raise AssertionError("unconfigured write_outbox_event must not open a DB connection")
 
     monkeypatch.setattr(outbox_service, "conn_rw", _fail_if_called)
 
+    assert explicit_runtime_database_url(os.environ) is None
     assert outbox_service.write_outbox_event(_event(), idempotency_key="unconfigured-key") == ""
 
 

--- a/tests/services/test_outbox_memory_mode.py
+++ b/tests/services/test_outbox_memory_mode.py
@@ -1,0 +1,59 @@
+"""Regression coverage for #4064's memory-mode outbox connection guard."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.events.models import new_event
+from app.services import outbox as outbox_service
+
+pytestmark = pytest.mark.not_pg
+
+_UNREACHABLE_DSN = "postgresql://app:app@192.0.2.1:5432/app"
+
+
+def _event():
+    return new_event(event_type="test.outbox.memory", payload={"value": "test"}, trace_id="t-4064")
+
+
+def test_write_outbox_event_skips_connection_in_memory_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A memory backend must not probe a stale/unreachable DB DSN (#4064)."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", _UNREACHABLE_DSN)
+
+    def _fail_if_called(*args: object, **kwargs: object) -> Any:
+        raise AssertionError("memory-mode write_outbox_event must not open a DB connection")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _fail_if_called)
+
+    assert outbox_service.write_outbox_event(_event(), idempotency_key="memory-key") == ""
+
+
+def test_write_outbox_event_uses_explicit_dsn_without_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit DSN remains an opt-in request for durable Postgres delivery."""
+    monkeypatch.delenv("STORE_BACKEND", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    calls: list[object] = []
+
+    class _Cursor:
+        def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+            calls.append(params)
+
+        def fetchone(self) -> tuple[str]:
+            return ("dsn-key",)
+
+    class _Connection:
+        autocommit = False
+
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: _Connection())
+
+    assert outbox_service.write_outbox_event(_event(), idempotency_key="dsn-key") == "dsn-key"
+    assert calls

--- a/tests/services/test_outbox_memory_mode.py
+++ b/tests/services/test_outbox_memory_mode.py
@@ -18,6 +18,31 @@ def _event():
     return new_event(event_type="test.outbox.memory", payload={"value": "test"}, trace_id="t-4064")
 
 
+class _Cursor:
+    def __init__(self, row_id: str = "inserted-key") -> None:
+        self.row_id = row_id
+        self.calls: list[tuple[object, ...]] = []
+
+    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+        self.calls.append(params)
+
+    def fetchone(self) -> tuple[str]:
+        return (self.row_id,)
+
+
+class _Connection:
+    def __init__(self, row_id: str = "inserted-key") -> None:
+        self.autocommit = False
+        self.closed = False
+        self.cursor_instance = _Cursor(row_id)
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_write_outbox_event_skips_connection_in_memory_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """A memory backend must not probe a stale/unreachable DB DSN (#4064)."""
     monkeypatch.setenv("STORE_BACKEND", "memory")
@@ -35,25 +60,108 @@ def test_write_outbox_event_uses_explicit_dsn_without_backend(monkeypatch: pytes
     """An explicit DSN remains an opt-in request for durable Postgres delivery."""
     monkeypatch.delenv("STORE_BACKEND", raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
-    calls: list[object] = []
-
-    class _Cursor:
-        def execute(self, _sql: str, params: tuple[object, ...]) -> None:
-            calls.append(params)
-
-        def fetchone(self) -> tuple[str]:
-            return ("dsn-key",)
-
-    class _Connection:
-        autocommit = False
-
-        def cursor(self) -> _Cursor:
-            return _Cursor()
-
-        def close(self) -> None:
-            return None
-
-    monkeypatch.setattr(outbox_service, "conn_rw", lambda: _Connection())
+    conn = _Connection("dsn-key")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: conn)
 
     assert outbox_service.write_outbox_event(_event(), idempotency_key="dsn-key") == "dsn-key"
-    assert calls
+    assert conn.cursor_instance.calls
+
+
+def test_write_outbox_event_uses_explicit_pg_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit Postgres backend must retain the canonical self-owned path."""
+    monkeypatch.setenv("STORE_BACKEND", " pg ")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    conn = _Connection("pg-key")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: conn)
+
+    assert outbox_service.write_outbox_event(_event(), idempotency_key="pg-key") == "pg-key"
+    assert conn.cursor_instance.calls
+
+
+def test_write_outbox_event_skips_when_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chosen best-effort contract skips when neither backend nor DSN is configured."""
+    monkeypatch.delenv("STORE_BACKEND", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    def _fail_if_called(*args: object, **kwargs: object) -> Any:
+        raise AssertionError("unconfigured write_outbox_event must not open a DB connection")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _fail_if_called)
+
+    assert outbox_service.write_outbox_event(_event(), idempotency_key="unconfigured-key") == ""
+
+
+@pytest.mark.parametrize("backend", ["postgres", "pgvector"])
+def test_write_outbox_event_rejects_unsupported_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    """Unsupported explicit backends fail loud before any self-owned connection attempt."""
+    monkeypatch.setenv("STORE_BACKEND", backend)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _fail_if_called(*args: object, **kwargs: object) -> Any:
+        raise AssertionError("invalid backend must fail before opening a connection")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _fail_if_called)
+
+    with pytest.raises(RuntimeError, match="not supported"):
+        outbox_service.write_outbox_event(_event(), idempotency_key="invalid-key")
+
+
+def test_required_memory_write_uses_configured_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Required DB intent overrides the optional memory-mode skip when a DSN is configured."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    conn = _Connection("required-key")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda: conn)
+
+    assert (
+        outbox_service.write_outbox_event(
+            _event(),
+            idempotency_key="required-key",
+            required_db=True,
+        )
+        == "required-key"
+    )
+    assert conn.cursor_instance.calls
+
+
+def test_required_memory_write_propagates_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Required DB intent must fail loud rather than masquerade as an optional skip."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _raise() -> Any:
+        raise RuntimeError("required connection failed")
+
+    monkeypatch.setattr(outbox_service, "_open_conn", _raise)
+
+    with pytest.raises(RuntimeError, match="required connection failed"):
+        outbox_service.write_outbox_event(
+            _event(),
+            idempotency_key="required-failure-key",
+            required_db=True,
+        )
+
+
+def test_supplied_connection_bypasses_self_owned_backend_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supplied transaction is authoritative and remains caller-owned."""
+    monkeypatch.setenv("STORE_BACKEND", "postgres")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    conn = _Connection("supplied-key")
+
+    assert (
+        outbox_service.write_outbox_event(
+            _event(),
+            conn=conn,
+            idempotency_key="supplied-key",
+        )
+        == "supplied-key"
+    )
+    assert conn.cursor_instance.calls
+    assert conn.closed is False

--- a/tests/services/test_outbox_required_policy_callers.py
+++ b/tests/services/test_outbox_required_policy_callers.py
@@ -1,0 +1,211 @@
+"""Production-caller coverage for strict self-owned outbox policy (#4064)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.agents.panel_agent import execution as panel_execution
+from app.episodes import closure
+from app.episodes.closure import EpisodeCloseCandidate
+from app.episodes.notes import episode_note_rel_path
+from app.episodes.store import write_episode_note
+from app.events.schema import make_outbox_event
+from app.objects import DomainObject, ObjectStore
+from app.outbox import events as outbox_events
+from app.promotion.consumer import (
+    consume_promotion_intent_payload,
+    reset_promotion_dedup_store,
+)
+from app.services import outbox as outbox_service
+from app.workers import outbox_worker
+from app.write_guard import WriteGuard
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture()
+def required_db_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Select memory domain storage while making a configured DB outbox unavailable."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _raise() -> None:
+        raise RuntimeError("required outbox unavailable")
+
+    monkeypatch.setattr(outbox_service, "_open_conn", _raise)
+
+
+def _allow_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy", "reason": None})
+
+
+def test_episode_closure_does_not_advance_projection_after_memory_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    required_db_unavailable: None,
+) -> None:
+    """The load-bearing outbox-before-projection boundary must fail before projection sync."""
+    episode_id = "ep-40640000-2222-4333-8444-555555555555"
+    end = datetime(2026, 7, 26, 10, 0, tzinfo=timezone.utc)
+    write_episode_note(
+        title="Strict outbox episode",
+        scope="work",
+        start=(end - timedelta(hours=1)).isoformat(),
+        end=end.isoformat(),
+        closed=False,
+        segmentation="proposed",
+        episode_id=episode_id,
+        vault_root=tmp_path,
+        write_guard=_allow_guard(),
+    )
+    monkeypatch.setattr(closure, "_count_active_bound_artifacts", lambda _episode_id: 0)
+    projection_syncs: list[str] = []
+    monkeypatch.setattr(closure, "_sync_projection_closed", projection_syncs.append)
+
+    candidate = EpisodeCloseCandidate(
+        episode_id=episode_id,
+        scope="work",
+        note_path=episode_note_rel_path(episode_id),
+        time_end=end,
+    )
+
+    with pytest.raises(RuntimeError, match="required outbox unavailable"):
+        closure.close_episode(candidate, vault_root=tmp_path, write_guard=_allow_guard())
+
+    assert projection_syncs == []
+
+
+def test_promotion_does_not_return_applied_after_memory_skip(
+    tmp_path: Path,
+    required_db_unavailable: None,
+) -> None:
+    """Promotion must fail before returning an applied/emitted acknowledgement."""
+    reset_promotion_dedup_store()
+    note_uuid = "00000000-0000-0000-0000-000000004064"
+    note_path = tmp_path / "vault" / "promotion.md"
+    note_path.parent.mkdir(parents=True)
+    note_path.write_text(
+        f"---\nuuid: {note_uuid}\nreview_state: draft\n---\nBody\n",
+        encoding="utf-8",
+    )
+    payload = {
+        "note": {"uuid": note_uuid, "path": str(note_path)},
+        "transition": {"family": "promotion", "target_maturity": "evergreen"},
+    }
+
+    with pytest.raises(RuntimeError, match="required outbox unavailable"):
+        consume_promotion_intent_payload(
+            payload,
+            trace_id="trace-promote-4064",
+            event_id="event-promote-4064",
+        )
+
+
+def test_embedding_request_does_not_append_diagnostic_after_memory_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    required_db_unavailable: None,
+) -> None:
+    """The DB-first embedding request must fail before its diagnostic JSONL append."""
+    audit_path = tmp_path / "index-outbox.jsonl"
+    monkeypatch.setattr(outbox_events, "INDEX_OUTBOX_PATH", audit_path)
+
+    with pytest.raises(RuntimeError, match="required outbox unavailable"):
+        outbox_events.emit_index_embedding_requested(
+            {
+                "object_id": uuid4(),
+                "trace_id": "trace-embedding-4064",
+                "source": "test",
+            }
+        )
+
+    assert not audit_path.exists()
+
+
+def test_panel_db_persistence_does_not_execute_after_memory_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    required_db_unavailable: None,
+) -> None:
+    """An explicit persist-created-to-DB request must fail before intent execution."""
+    intent = make_outbox_event(
+        "panel.intent.created",
+        source="test",
+        payload={
+            "note": {"uuid": "note-4064"},
+            "panel": {"panel_id": "panel-4064"},
+        },
+    )
+    monkeypatch.setattr(
+        panel_execution,
+        "run_panel_intent_for_note",
+        lambda *args, **kwargs: [intent],
+    )
+    executed: list[object] = []
+
+    def _execute(event: object, **kwargs: object) -> object:
+        executed.append(event)
+        return SimpleNamespace(emitted_events=[])
+
+    monkeypatch.setattr(panel_execution, "execute_panel_intent", _execute)
+
+    with pytest.raises(RuntimeError, match="required outbox unavailable"):
+        panel_execution.run_panel_note_execution(
+            "note-4064",
+            persist_created_to_db=True,
+        )
+
+    assert executed == []
+
+
+def test_durable_object_save_does_not_ack_after_memory_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    required_db_unavailable: None,
+) -> None:
+    """A durable object put must propagate a missing canonical outbox event."""
+    puts: list[tuple[object, dict[str, object]]] = []
+
+    class _Store:
+        def put(self, object_id: object, **kwargs: object) -> None:
+            puts.append((object_id, kwargs))
+
+    monkeypatch.setattr(
+        "app.objects.resolve_object_store_port",
+        lambda: SimpleNamespace(backend="pg", store=_Store()),
+    )
+    obj = DomainObject(
+        uuid="11111111-1111-4111-8111-111111114064",
+        kind="note",
+        payload={"content": "strict"},
+        source_ref="strict.md",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    with pytest.raises(RuntimeError, match="required outbox unavailable"):
+        ObjectStore().save_object(obj)
+
+    assert len(puts) == 1
+
+
+def test_worker_retry_does_not_report_queued_after_memory_skip(
+    tmp_path: Path,
+    required_db_unavailable: None,
+) -> None:
+    """A skipped DB retry must not let the worker report that retry as queued."""
+    queued = outbox_worker._queue_transient_retry(
+        "test.worker.retry",
+        {
+            "event_id": "event-worker-4064",
+            "trace_id": "trace-worker-4064",
+            "_worker_retry_count": 0,
+        },
+        note_path=tmp_path / "note.md",
+        reason="transient",
+        original_event_id="event-worker-4064",
+    )
+
+    assert queued is False

--- a/tests/watcher/test_registry_required_outbox.py
+++ b/tests/watcher/test_registry_required_outbox.py
@@ -1,0 +1,71 @@
+"""Required DB-outbox policy coverage for watcher event producers (#4064)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.events.types import INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
+from app.watcher import registry
+from app.watcher.state import WatcherState
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.mark.parametrize("topic", [PANEL_SCAN_REQUESTED, INGEST_VAULT_CHANGED])
+@pytest.mark.parametrize("fails", [False, True])
+def test_required_db_intent_reaches_both_watcher_producers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    topic: str,
+    fails: bool,
+) -> None:
+    """Both watcher topics must attempt and fail loud when DB delivery is required."""
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    observed: list[bool] = []
+
+    def _writer(*args: object, required_db: bool = False, **kwargs: object) -> str:
+        observed.append(required_db)
+        if fails:
+            raise RuntimeError("required watcher DB write failed")
+        return "inserted-key"
+
+    if topic == PANEL_SCAN_REQUESTED:
+        monkeypatch.setattr(registry, "write_outbox_event", _writer)
+    else:
+        monkeypatch.setattr(registry, "insert_object_and_outbox", _writer)
+
+    state = WatcherState()
+    spec = registry.WatcherSpec(
+        name="required-db",
+        scope_glob="**/*.md",
+        debounce_ms=0,
+        rate_limit_per_min=60,
+        emit_event=topic,
+    )
+    def call() -> str | None:
+        return registry._emit_watch_event(
+            spec=spec,
+            cfg=None,  # type: ignore[arg-type]  # `_emit_watch_event` does not read cfg.
+            outbox_path=tmp_path / "outbox.jsonl",
+            vault_root=tmp_path,
+            rel_path=Path("note.md"),
+            mtime=1.0,
+            content_hash="hash",
+            state=state,
+        )
+
+    if fails:
+        with pytest.raises(RuntimeError, match="required watcher DB write failed"):
+            call()
+        assert state.enqueue_failures_total == 1
+    else:
+        assert call()
+        assert state.enqueue_failures_total == 0
+
+    assert observed == [True]

--- a/tests/watcher/test_registry_required_outbox.py
+++ b/tests/watcher/test_registry_required_outbox.py
@@ -69,3 +69,116 @@ def test_required_db_intent_reaches_both_watcher_producers(
         assert state.enqueue_failures_total == 0
 
     assert observed == [True]
+
+
+def _tick_config(
+    tmp_path: Path,
+    *,
+    topic: str,
+) -> tuple[registry.RegistryConfig, registry.WatcherSpec, Path]:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    note_path = vault_root / "note.md"
+    note_path.write_text(
+        "%% AI %%\n- [ ] Review this note <!--ai:id=review.note-->\n%% AI %%\n",
+        encoding="utf-8",
+    )
+    spec = registry.WatcherSpec(
+        name=f"required-{topic}",
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=60,
+        emit_event=topic,
+        backoff_seconds=0,
+    )
+    cfg = registry.RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault_root,
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=60,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.05,
+        tick_log_path=tmp_path / "tick.jsonl",
+        max_scanned_files_per_tick=500,
+        max_bytes_read_per_tick=50_000_000,
+        max_elapsed_ms_per_tick=2_000,
+        max_bad_ticks=10,
+        bad_tick_backoff_seconds=0,
+        specs=[spec],
+    )
+    return cfg, spec, note_path
+
+
+@pytest.mark.parametrize("topic", [PANEL_SCAN_REQUESTED, INGEST_VAULT_CHANGED])
+def test_required_enqueue_failure_keeps_finalized_cursor_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    topic: str,
+) -> None:
+    """A failed required enqueue must retry unchanged input, then advance exactly once."""
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    monkeypatch.setattr(registry, "_panel_candidate_for_path", lambda _path: (True, True))
+    monkeypatch.setattr(registry, "_auto_exec_enabled", lambda _vault: True)
+
+    cfg, spec, note_path = _tick_config(tmp_path, topic=topic)
+    rel_path = str(note_path.relative_to(cfg.vault_path))
+    attempts: list[bool] = []
+
+    def _writer(*args: object, required_db: bool = False, **kwargs: object) -> str:
+        attempts.append(required_db)
+        if len(attempts) == 1:
+            raise RuntimeError("required watcher DB write failed")
+        return "inserted-key"
+
+    if topic == PANEL_SCAN_REQUESTED:
+        monkeypatch.setattr(registry, "write_outbox_event", _writer)
+    else:
+        monkeypatch.setattr(registry, "insert_object_and_outbox", _writer)
+
+    state_path = registry._state_path(cfg.state_dir, spec.name)
+    first = registry._run_spec_tick(
+        cfg,
+        spec,
+        WatcherState(),
+        now=note_path.stat().st_mtime + 1,
+    )
+
+    assert first["emitted_in_tick"] == 0
+    assert attempts == [True]
+    after_failure = WatcherState.load(state_path)
+    assert after_failure.last_mtime(rel_path) is None
+    assert after_failure.last_hash(rel_path) is None
+
+    second = registry._run_spec_tick(
+        cfg,
+        spec,
+        after_failure,
+        now=note_path.stat().st_mtime + 2,
+    )
+
+    assert second["emitted_in_tick"] == 1
+    assert attempts == [True, True]
+    after_success = WatcherState.load(state_path)
+    assert after_success.last_mtime(rel_path) == note_path.stat().st_mtime
+    assert after_success.last_hash(rel_path) is not None
+    assert after_success.intents_emitted == 1
+
+    third = registry._run_spec_tick(
+        cfg,
+        spec,
+        after_success,
+        now=note_path.stat().st_mtime + 3,
+    )
+
+    assert third["emitted_in_tick"] == 0
+    assert attempts == [True, True]
+    assert WatcherState.load(state_path).intents_emitted == 1

--- a/tests/watcher/test_registry_required_outbox.py
+++ b/tests/watcher/test_registry_required_outbox.py
@@ -182,3 +182,121 @@ def test_required_enqueue_failure_keeps_finalized_cursor_retryable(
     assert third["emitted_in_tick"] == 0
     assert attempts == [True, True]
     assert WatcherState.load(state_path).intents_emitted == 1
+
+
+@pytest.mark.parametrize("topic", [PANEL_SCAN_REQUESTED, INGEST_VAULT_CHANGED])
+def test_non_required_emission_failure_also_keeps_the_cursor_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    topic: str,
+) -> None:
+    """#4214 D6: the rollback may not be gated on required_db.
+
+    ``append_jsonl_outbox_event`` is not wrapped, so an ``OSError`` on the
+    compensating sink propagates out of ``_emit_watch_event`` on the NON-required
+    path too — with neither sink written. While the cursor restore was gated on
+    ``required_db`` the observation was consumed anyway: ``_finalize_spec_tick``
+    saved the advanced ``state.files`` entry and the unchanged file was never
+    re-detected.
+    """
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "0")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setattr(registry, "_panel_candidate_for_path", lambda _path: (True, True))
+    monkeypatch.setattr(registry, "_auto_exec_enabled", lambda _vault: True)
+
+    cfg, spec, note_path = _tick_config(tmp_path, topic=topic)
+    rel_path = str(note_path.relative_to(cfg.vault_path))
+    appends: list[object] = []
+
+    def _jsonl_sink(outbox_path: object, event: object, **kwargs: object) -> None:
+        appends.append(event)
+        if len(appends) == 1:
+            raise OSError("compensating JSONL sink unavailable")
+
+    monkeypatch.setattr(registry, "append_jsonl_outbox_event", _jsonl_sink)
+
+    state_path = registry._state_path(cfg.state_dir, spec.name)
+    first = registry._run_spec_tick(
+        cfg,
+        spec,
+        WatcherState(),
+        now=note_path.stat().st_mtime + 1,
+    )
+
+    assert first["emitted_in_tick"] == 0
+    after_failure = WatcherState.load(state_path)
+    assert after_failure.last_mtime(rel_path) is None, (
+        "a non-required emission that wrote NEITHER sink still consumed the observation"
+    )
+    assert after_failure.last_hash(rel_path) is None
+
+    second = registry._run_spec_tick(
+        cfg,
+        spec,
+        after_failure,
+        now=note_path.stat().st_mtime + 2,
+    )
+
+    assert second["emitted_in_tick"] == 1, "the unchanged file must be re-detected and retried"
+    assert WatcherState.load(state_path).last_mtime(rel_path) == note_path.stat().st_mtime
+
+
+def test_failed_emission_restores_a_previously_seen_file_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#4214 D6: cover the restore branch, not only the pop branch.
+
+    ``previous_file_state is None`` (a first-ever observation) pops the entry;
+    an ALREADY-SEEN file must have its prior mtime/hash put back, otherwise the
+    partially-advanced entry suppresses the retry.
+    """
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    monkeypatch.setattr(registry, "_panel_candidate_for_path", lambda _path: (True, True))
+    monkeypatch.setattr(registry, "_auto_exec_enabled", lambda _vault: True)
+
+    cfg, spec, note_path = _tick_config(tmp_path, topic=PANEL_SCAN_REQUESTED)
+    rel_path = str(note_path.relative_to(cfg.vault_path))
+    attempts: list[bool] = []
+
+    def _writer(*args: object, required_db: bool = False, **kwargs: object) -> str:
+        attempts.append(required_db)
+        if len(attempts) == 2:
+            raise RuntimeError("required watcher DB write failed")
+        return "inserted-key"
+
+    monkeypatch.setattr(registry, "write_outbox_event", _writer)
+    state_path = registry._state_path(cfg.state_dir, spec.name)
+
+    # Tick 1: the file becomes a SEEN observation with a durable cursor entry.
+    registry._run_spec_tick(cfg, spec, WatcherState(), now=note_path.stat().st_mtime + 1)
+    seen = WatcherState.load(state_path)
+    first_mtime = seen.last_mtime(rel_path)
+    first_hash = seen.last_hash(rel_path)
+    assert first_mtime is not None and first_hash is not None
+
+    # Tick 2: the file changes, and the required enqueue for the new content fails.
+    note_path.write_text(
+        "%% AI %%\n- [ ] Review the revised note <!--ai:id=review.note-->\n%% AI %%\n",
+        encoding="utf-8",
+    )
+    changed_mtime = note_path.stat().st_mtime
+    registry._run_spec_tick(cfg, spec, seen, now=changed_mtime + 1)
+
+    restored = WatcherState.load(state_path)
+    assert restored.last_mtime(rel_path) == first_mtime, (
+        "the pre-observation cursor entry for an already-seen file was not restored"
+    )
+    assert restored.last_hash(rel_path) == first_hash
+
+    # Tick 3: the unchanged-on-disk revision is re-detected and delivered.
+    third = registry._run_spec_tick(cfg, spec, restored, now=changed_mtime + 2)
+
+    assert third["emitted_in_tick"] == 1
+    assert WatcherState.load(state_path).last_mtime(rel_path) == changed_mtime

--- a/tests/watcher/test_vault_watcher_delete_required_outbox.py
+++ b/tests/watcher/test_vault_watcher_delete_required_outbox.py
@@ -1,0 +1,192 @@
+"""A vault delete tombstone may not be reported as purged unless it was queued (#4214 D3).
+
+``_emit_watcher_delete_event`` had no compensating sink, no ``required_db``
+classification, and returned ``True`` unconditionally. Its caller then both
+incremented ``deleted_purged`` and let ``refresh_snapshot()`` drop the path from
+the snapshot — so a tombstone that never reached the outbox was permanently
+unrecoverable: the note is gone from disk AND from the snapshot, later ticks
+never re-see the deletion, and the deleted content stays indexed.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.watcher import vault_watcher
+
+pytestmark = pytest.mark.not_pg
+
+
+def _tick(vault: Path, snapshot_path: Path) -> tuple[dict[str, Any], list[str]]:
+    return vault_watcher.run_watcher_tick(
+        vault_root=vault,
+        snapshot_path=snapshot_path,
+        skip_panel=True,
+        emit_only=True,
+        dry_run=False,
+        max_notes=10,
+        force=False,
+    )
+
+
+@pytest.fixture()
+def seeded_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note = vault / "Concepts" / "D.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("Body", encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "events.jsonl"))
+    monkeypatch.setenv("WATCHER_RUN_LOG_PATH", str(tmp_path / "watcher_run.jsonl"))
+    # delete_note cannot identify the note (no file_state row), so the tick
+    # falls through to the watcher's own tombstone emitter — the D3 path.
+    monkeypatch.setattr(vault_watcher, "delete_note", lambda path, **kw: False)
+    snapshot_path = vault / ".state.json"
+    _tick(vault, snapshot_path)
+    return vault, note, snapshot_path
+
+
+def _snapshot(snapshot_path: Path) -> dict[str, float]:
+    return json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+
+def test_unqueued_tombstone_is_not_reported_as_purged(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit memory runtime queues nothing, so it may not claim a purge."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    time.sleep(0.01)
+    note.unlink()
+    summary, _ = _tick(vault, snapshot_path)
+
+    assert summary["deleted"] == 1
+    assert summary["deleted_purged"] == 0, (
+        "deleted_purged counted a tombstone the self-owned outbox write skipped"
+    )
+
+
+def test_unqueued_tombstone_stays_reobservable_on_the_next_tick(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The snapshot must retain a deletion no sink accepted, so it can retry."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    time.sleep(0.01)
+    note.unlink()
+    _tick(vault, snapshot_path)
+
+    assert "Concepts/D.md" in _snapshot(snapshot_path), (
+        "refresh_snapshot() dropped a path whose tombstone was never queued; "
+        "the deletion can never be re-observed"
+    )
+
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 1, "the unreconciled deletion must be re-detected"
+
+
+def test_required_tombstone_failure_keeps_the_deletion_retryable(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A required enqueue that raises must not consume the observation."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+
+    def _unavailable(*args: object, **kwargs: object) -> Any:
+        raise RuntimeError("required outbox unavailable")
+
+    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _unavailable)
+
+    time.sleep(0.01)
+    note.unlink()
+    summary, messages = _tick(vault, snapshot_path)
+
+    assert summary["deleted_purged"] == 0
+    assert summary["errors"] == 1
+    assert any("unable to reconcile deletion" in message for message in messages)
+    assert "Concepts/D.md" in _snapshot(snapshot_path)
+
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 1, "a failed required tombstone must be retried"
+
+
+def test_queued_tombstone_still_advances_the_snapshot(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retention must be scoped to failures — a real purge still completes."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+    emitted: list[tuple[dict[str, Any], str]] = []
+    monkeypatch.setattr(
+        vault_watcher,
+        "insert_object_and_outbox",
+        lambda payload, topic, trace_id=None, **kw: emitted.append((payload, topic)),
+    )
+
+    time.sleep(0.01)
+    note.unlink()
+    summary, _ = _tick(vault, snapshot_path)
+
+    assert summary["deleted_purged"] == 1
+    assert len(emitted) == 1
+    assert "Concepts/D.md" not in _snapshot(snapshot_path)
+
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 0, "a reconciled deletion must not be re-reported"
+
+
+def test_rename_supersedes_the_tombstone_without_retaining_the_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rename owes no tombstone, so the snapshot must still move on."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    old_note = vault / "Concepts" / "E.md"
+    old_note.parent.mkdir(parents=True, exist_ok=True)
+    old_note.write_text("Body", encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "events.jsonl"))
+    monkeypatch.setenv("WATCHER_RUN_LOG_PATH", str(tmp_path / "watcher_run.jsonl"))
+    monkeypatch.setattr(vault_watcher, "delete_note", lambda path, **kw: False)
+    snapshot_path = vault / ".state.json"
+    _tick(vault, snapshot_path)
+
+    new_note = vault / "Concepts" / "E-renamed.md"
+    emitted: list[object] = []
+    monkeypatch.setattr(
+        vault_watcher,
+        "insert_object_and_outbox",
+        lambda payload, topic, trace_id=None, **kw: emitted.append(payload),
+    )
+    monkeypatch.setattr(
+        vault_watcher,
+        "read_companion",
+        lambda root, note_uuid: type("C", (), {"source_ref": "Concepts/E-renamed.md"})(),
+    )
+
+    time.sleep(0.01)
+    old_note.rename(new_note)
+    summary, _ = _tick(vault, snapshot_path)
+
+    assert summary["deleted_purged"] == 0
+    assert emitted == []
+    assert "Concepts/E.md" not in _snapshot(snapshot_path), (
+        "a rename owes no tombstone; retaining the old path would re-report it forever"
+    )

--- a/tests/watcher/test_vault_watcher_delete_required_outbox.py
+++ b/tests/watcher/test_vault_watcher_delete_required_outbox.py
@@ -1,11 +1,24 @@
 """A vault delete tombstone may not be reported as purged unless it was queued (#4214 D3).
 
-``_emit_watcher_delete_event`` had no compensating sink, no ``required_db``
-classification, and returned ``True`` unconditionally. Its caller then both
-incremented ``deleted_purged`` and let ``refresh_snapshot()`` drop the path from
-the snapshot — so a tombstone that never reached the outbox was permanently
-unrecoverable: the note is gone from disk AND from the snapshot, later ticks
-never re-see the deletion, and the deleted content stays indexed.
+``_emit_watcher_delete_event`` had no ``required_db`` classification and returned
+``True`` unconditionally, so the tick incremented ``deleted_purged`` for an event
+the outbox policy had silently skipped. Because this path has no compensating
+JSONL sink and ``refresh_snapshot()`` then drops the path, that false purge was
+the only signal anyone would ever get.
+
+Two properties are pinned here:
+
+1. only a tombstone that actually landed is counted as a purge;
+2. a runtime that NAMES a database keeps `main`'s delivery semantics — the
+   enqueue is attempted and an unreachable database raises loudly — rather than
+   being silently skipped by the optional-write policy under
+   ``STORE_BACKEND=memory``. #4214's constraint says a properly configured
+   runtime (``STORE_BACKEND=pg`` *or an explicit DSN*) must not change.
+
+Making a deletion whose tombstone never landed *re-observable* is deliberately
+NOT in scope; it needs ``vault_sync.delete_note``'s own connection classified
+first. `test_the_tick_terminates_when_no_database_is_named` pins the resulting
+behaviour so the gap is visible rather than assumed away.
 """
 
 from __future__ import annotations
@@ -35,8 +48,7 @@ def _tick(vault: Path, snapshot_path: Path) -> tuple[dict[str, Any], list[str]]:
     )
 
 
-@pytest.fixture()
-def seeded_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
+def _seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
     vault = tmp_path / "vault"
     vault.mkdir()
     note = vault / "Concepts" / "D.md"
@@ -44,10 +56,20 @@ def seeded_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path,
     note.write_text("Body", encoding="utf-8")
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "events.jsonl"))
     monkeypatch.setenv("WATCHER_RUN_LOG_PATH", str(tmp_path / "watcher_run.jsonl"))
-    # delete_note cannot identify the note (no file_state row), so the tick
-    # falls through to the watcher's own tombstone emitter — the D3 path.
+    return vault, note, vault / ".state.json"
+
+
+@pytest.fixture()
+def seeded_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path, Path]:
+    """A vault with one ingested note, and `delete_note` stubbed to "can't identify".
+
+    That stub is what routes the tick into the watcher's own tombstone emitter —
+    the D3 path. `test_the_tick_terminates_when_no_database_is_named` deliberately
+    does NOT use this fixture, because stubbing `delete_note` also stubs away its
+    unguarded connection.
+    """
+    vault, note, snapshot_path = _seed(tmp_path, monkeypatch)
     monkeypatch.setattr(vault_watcher, "delete_note", lambda path, **kw: False)
-    snapshot_path = vault / ".state.json"
     _tick(vault, snapshot_path)
     return vault, note, snapshot_path
 
@@ -60,11 +82,11 @@ def test_unqueued_tombstone_is_not_reported_as_purged(
     seeded_vault: tuple[Path, Path, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An explicit memory runtime queues nothing, so it may not claim a purge."""
+    """A runtime that names no database queues nothing, so it may not claim a purge."""
     vault, note, snapshot_path = seeded_vault
     monkeypatch.setenv("STORE_BACKEND", "memory")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.delenv("DB_DSN", raising=False)
+    for key in RUNTIME_DATABASE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
     time.sleep(0.01)
     note.unlink()
@@ -76,39 +98,70 @@ def test_unqueued_tombstone_is_not_reported_as_purged(
     )
 
 
-def test_unqueued_tombstone_stays_reobservable_on_the_next_tick(
+def test_a_named_database_is_still_delivered_to_under_a_memory_backend(
     seeded_vault: tuple[Path, Path, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The snapshot must retain a deletion no sink accepted, so it can retry.
+    """An explicit DSN must keep `main`'s delivery semantics (#4214 constraint).
 
-    The runtime NAMES a database (so a durable queue and a durable projection
-    exist and the tombstone is genuinely owed) while the explicit memory backend
-    makes the optional self-owned write skip — the configuration in which D3's
-    loss is real.
+    Left optional, the policy would skip this write under ``STORE_BACKEND=memory``
+    and drop the tombstone with no purge, no error and no message — a silent,
+    permanent loss on a runtime that does have a durable queue and a durable
+    projection. The delete path therefore resolves ``required_db`` as
+    ``db_outbox_required() or runtime_database_is_named(...)``.
     """
     vault, note, snapshot_path = seeded_vault
     monkeypatch.setenv("STORE_BACKEND", "memory")
     monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+    attempts: list[bool] = []
+
+    def _writer(*args: object, required_db: bool = False, **kwargs: object) -> str:
+        attempts.append(required_db)
+        return "queued"
+
+    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _writer)
 
     time.sleep(0.01)
     note.unlink()
-    _tick(vault, snapshot_path)
+    summary, _ = _tick(vault, snapshot_path)
 
-    assert "Concepts/D.md" in _snapshot(snapshot_path), (
-        "refresh_snapshot() dropped a path whose tombstone was never queued; "
-        "the deletion can never be re-observed"
-    )
-
-    second, _ = _tick(vault, snapshot_path)
-    assert second["deleted"] == 1, "the unreconciled deletion must be re-detected"
+    assert attempts == [True], "an explicit DSN must not be treated as an optional write"
+    assert summary["deleted_purged"] == 1
 
 
-def test_required_tombstone_failure_keeps_the_deletion_retryable(
+def test_an_unreachable_named_database_fails_loud_instead_of_dropping_silently(
     seeded_vault: tuple[Path, Path, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A required enqueue that raises must not consume the observation."""
+    """The same widening makes an unreachable database observable, not silent."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
+
+    def _unavailable(*args: object, **kwargs: object) -> Any:
+        raise RuntimeError("required outbox unavailable")
+
+    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _unavailable)
+
+    time.sleep(0.01)
+    note.unlink()
+    summary, messages = _tick(vault, snapshot_path)
+
+    assert summary["deleted_purged"] == 0
+    assert summary["errors"] == 1
+    assert any("unable to reconcile deletion" in message for message in messages)
+
+
+def test_required_tombstone_failure_is_recorded_and_not_retried(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed required enqueue consumes the observation — deliberately, for now.
+
+    Re-observability is a separate contract (it needs `vault_sync.delete_note`
+    classified first). This pins the CURRENT behaviour so the gap is explicit
+    and any future change to it is a visible test change, not a silent drift.
+    """
     vault, note, snapshot_path = seeded_vault
     monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
     monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
@@ -125,17 +178,15 @@ def test_required_tombstone_failure_keeps_the_deletion_retryable(
     assert summary["deleted_purged"] == 0
     assert summary["errors"] == 1
     assert any("unable to reconcile deletion" in message for message in messages)
-    assert "Concepts/D.md" in _snapshot(snapshot_path)
 
     second, _ = _tick(vault, snapshot_path)
-    assert second["deleted"] == 1, "a failed required tombstone must be retried"
+    assert second["deleted"] == 0, "the tick must terminate rather than loop on the failure"
 
 
-def test_queued_tombstone_still_advances_the_snapshot(
+def test_queued_tombstone_is_counted_once_and_the_snapshot_advances(
     seeded_vault: tuple[Path, Path, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The retention must be scoped to failures — a real purge still completes."""
     vault, note, snapshot_path = seeded_vault
     monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
     monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
@@ -158,108 +209,41 @@ def test_queued_tombstone_still_advances_the_snapshot(
     assert second["deleted"] == 0, "a reconciled deletion must not be re-reported"
 
 
-def test_retention_survives_a_bare_refresh_snapshot_from_outside_the_tick(
-    seeded_vault: tuple[Path, Path, Path],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The retention must be durable, not a local variable of the tick.
-
-    ``refresh_snapshot`` has callers outside ``run_watcher_tick`` —
-    ``app/runtime/runtime_loop.py``, ``app/cli/uat.py``,
-    ``app/cli/latency_harness.py`` — which construct their own ``VaultWatcher``
-    and call it with no arguments. Holding the retained set in the tick's local
-    scope let the very next bare call rescan disk (where the deleted note is
-    gone) and silently undo the retention, restoring the exact D3 loss.
-    """
-    vault, note, snapshot_path = seeded_vault
-    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
-    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
-
-    def _unavailable(*args: object, **kwargs: object) -> Any:
-        raise RuntimeError("required outbox unavailable")
-
-    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _unavailable)
-
-    time.sleep(0.01)
-    note.unlink()
-    _tick(vault, snapshot_path)
-    assert "Concepts/D.md" in _snapshot(snapshot_path)
-
-    # Exactly what runtime_loop.run_once does after the tick.
-    vault_watcher.VaultWatcher(vault, snapshot_path=snapshot_path).refresh_snapshot()
-
-    assert "Concepts/D.md" in _snapshot(snapshot_path), (
-        "a bare refresh_snapshot() from outside the tick dropped the retained deletion"
-    )
-    second, _ = _tick(vault, snapshot_path)
-    assert second["deleted"] == 1, "the deletion must still be retryable"
-
-
-def test_a_reconciled_deletion_clears_the_durable_retention(
-    seeded_vault: tuple[Path, Path, Path],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The sidecar is authoritative per tick, so retention must not leak forever."""
-    vault, note, snapshot_path = seeded_vault
-    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
-    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
-    failing = {"now": True}
-
-    def _writer(*args: object, **kwargs: object) -> Any:
-        if failing["now"]:
-            raise RuntimeError("required outbox unavailable")
-        return "queued"
-
-    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _writer)
-
-    time.sleep(0.01)
-    note.unlink()
-    _tick(vault, snapshot_path)
-    sidecar = vault_watcher.unreconciled_deletions_path(snapshot_path)
-    assert sidecar.exists() and "Concepts/D.md" in json.loads(sidecar.read_text(encoding="utf-8"))
-
-    failing["now"] = False
-    second, _ = _tick(vault, snapshot_path)
-
-    assert second["deleted_purged"] == 1
-    assert not sidecar.exists(), "a reconciled deletion must stop being retained"
-    assert "Concepts/D.md" not in _snapshot(snapshot_path)
-
-    third, _ = _tick(vault, snapshot_path)
-    assert third["deleted"] == 0, "the retention must terminate once reconciled"
-
-
-def test_a_runtime_naming_no_database_does_not_retain_forever(
-    seeded_vault: tuple[Path, Path, Path],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No named database means no durable queue and no durable projection.
-
-    Nothing is owed and nothing will ever accept the tombstone, so retaining it
-    would re-report the same deletion on every tick forever.
-    """
-    vault, note, snapshot_path = seeded_vault
-    monkeypatch.setenv("STORE_BACKEND", "memory")
-    for key in RUNTIME_DATABASE_ENV_KEYS:
-        monkeypatch.delenv(key, raising=False)
-
-    time.sleep(0.01)
-    note.unlink()
-    summary, _ = _tick(vault, snapshot_path)
-
-    assert summary["deleted_purged"] == 0, "no event was queued, so no purge may be counted"
-    assert "Concepts/D.md" not in _snapshot(snapshot_path)
-    assert not vault_watcher.unreconciled_deletions_path(snapshot_path).exists()
-
-    second, _ = _tick(vault, snapshot_path)
-    assert second["deleted"] == 0, "the deletion must not be re-reported forever"
-
-
-def test_rename_supersedes_the_tombstone_without_retaining_the_path(
+def test_the_tick_terminates_when_no_database_is_named(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A rename owes no tombstone, so the snapshot must still move on."""
+    """Run the REAL `vault_sync.delete_note`, which has its own unguarded connection.
+
+    Every other test here stubs `delete_note` out, which also stubs away the
+    `conn_rw()` it opens with no memory-mode guard. In a runtime that names no
+    database that call raises before the tombstone emitter is ever consulted, so
+    a retention policy built above it cannot terminate — that is why
+    re-observability is out of scope and carried by its own Issue. This pins the
+    property that actually matters here: the tick does not loop.
+    """
+    vault, note, snapshot_path = _seed(tmp_path, monkeypatch)
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    for key in RUNTIME_DATABASE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    _tick(vault, snapshot_path)
+
+    time.sleep(0.01)
+    note.unlink()
+    first, _ = _tick(vault, snapshot_path)
+    assert first["deleted"] == 1
+    assert first["deleted_purged"] == 0
+
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 0, "the deletion must not be re-reported on every tick"
+    assert second["errors"] == 0, "the tick must not raise the same failure forever"
+
+
+def test_rename_supersedes_the_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rename owes no tombstone and must not be counted as a purge."""
     vault = tmp_path / "vault"
     vault.mkdir()
     old_note = vault / "Concepts" / "E.md"
@@ -290,6 +274,4 @@ def test_rename_supersedes_the_tombstone_without_retaining_the_path(
 
     assert summary["deleted_purged"] == 0
     assert emitted == []
-    assert "Concepts/E.md" not in _snapshot(snapshot_path), (
-        "a rename owes no tombstone; retaining the old path would re-report it forever"
-    )
+    assert "Concepts/E.md" not in _snapshot(snapshot_path)

--- a/tests/watcher/test_vault_watcher_delete_required_outbox.py
+++ b/tests/watcher/test_vault_watcher_delete_required_outbox.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from app.config.database import RUNTIME_DATABASE_ENV_KEYS
 from app.watcher import vault_watcher
 
 pytestmark = pytest.mark.not_pg
@@ -79,11 +80,16 @@ def test_unqueued_tombstone_stays_reobservable_on_the_next_tick(
     seeded_vault: tuple[Path, Path, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The snapshot must retain a deletion no sink accepted, so it can retry."""
+    """The snapshot must retain a deletion no sink accepted, so it can retry.
+
+    The runtime NAMES a database (so a durable queue and a durable projection
+    exist and the tombstone is genuinely owed) while the explicit memory backend
+    makes the optional self-owned write skip — the configuration in which D3's
+    loss is real.
+    """
     vault, note, snapshot_path = seeded_vault
     monkeypatch.setenv("STORE_BACKEND", "memory")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
-    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://configured.example/app")
 
     time.sleep(0.01)
     note.unlink()
@@ -150,6 +156,103 @@ def test_queued_tombstone_still_advances_the_snapshot(
 
     second, _ = _tick(vault, snapshot_path)
     assert second["deleted"] == 0, "a reconciled deletion must not be re-reported"
+
+
+def test_retention_survives_a_bare_refresh_snapshot_from_outside_the_tick(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retention must be durable, not a local variable of the tick.
+
+    ``refresh_snapshot`` has callers outside ``run_watcher_tick`` —
+    ``app/runtime/runtime_loop.py``, ``app/cli/uat.py``,
+    ``app/cli/latency_harness.py`` — which construct their own ``VaultWatcher``
+    and call it with no arguments. Holding the retained set in the tick's local
+    scope let the very next bare call rescan disk (where the deleted note is
+    gone) and silently undo the retention, restoring the exact D3 loss.
+    """
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+
+    def _unavailable(*args: object, **kwargs: object) -> Any:
+        raise RuntimeError("required outbox unavailable")
+
+    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _unavailable)
+
+    time.sleep(0.01)
+    note.unlink()
+    _tick(vault, snapshot_path)
+    assert "Concepts/D.md" in _snapshot(snapshot_path)
+
+    # Exactly what runtime_loop.run_once does after the tick.
+    vault_watcher.VaultWatcher(vault, snapshot_path=snapshot_path).refresh_snapshot()
+
+    assert "Concepts/D.md" in _snapshot(snapshot_path), (
+        "a bare refresh_snapshot() from outside the tick dropped the retained deletion"
+    )
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 1, "the deletion must still be retryable"
+
+
+def test_a_reconciled_deletion_clears_the_durable_retention(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sidecar is authoritative per tick, so retention must not leak forever."""
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
+    failing = {"now": True}
+
+    def _writer(*args: object, **kwargs: object) -> Any:
+        if failing["now"]:
+            raise RuntimeError("required outbox unavailable")
+        return "queued"
+
+    monkeypatch.setattr(vault_watcher, "insert_object_and_outbox", _writer)
+
+    time.sleep(0.01)
+    note.unlink()
+    _tick(vault, snapshot_path)
+    sidecar = vault_watcher.unreconciled_deletions_path(snapshot_path)
+    assert sidecar.exists() and "Concepts/D.md" in json.loads(sidecar.read_text(encoding="utf-8"))
+
+    failing["now"] = False
+    second, _ = _tick(vault, snapshot_path)
+
+    assert second["deleted_purged"] == 1
+    assert not sidecar.exists(), "a reconciled deletion must stop being retained"
+    assert "Concepts/D.md" not in _snapshot(snapshot_path)
+
+    third, _ = _tick(vault, snapshot_path)
+    assert third["deleted"] == 0, "the retention must terminate once reconciled"
+
+
+def test_a_runtime_naming_no_database_does_not_retain_forever(
+    seeded_vault: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No named database means no durable queue and no durable projection.
+
+    Nothing is owed and nothing will ever accept the tombstone, so retaining it
+    would re-report the same deletion on every tick forever.
+    """
+    vault, note, snapshot_path = seeded_vault
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    for key in RUNTIME_DATABASE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    time.sleep(0.01)
+    note.unlink()
+    summary, _ = _tick(vault, snapshot_path)
+
+    assert summary["deleted_purged"] == 0, "no event was queued, so no purge may be counted"
+    assert "Concepts/D.md" not in _snapshot(snapshot_path)
+    assert not vault_watcher.unreconciled_deletions_path(snapshot_path).exists()
+
+    second, _ = _tick(vault, snapshot_path)
+    assert second["deleted"] == 0, "the deletion must not be re-reported forever"
 
 
 def test_rename_supersedes_the_tombstone_without_retaining_the_path(

--- a/tests/watcher/test_watcher_deletion_reconciliation.py
+++ b/tests/watcher/test_watcher_deletion_reconciliation.py
@@ -432,6 +432,12 @@ def test_run_watcher_tick_falls_back_to_derived_identity(
 
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "events.jsonl"))
     monkeypatch.setenv("WATCHER_RUN_LOG_PATH", str(tmp_path / "watcher_run.jsonl"))
+    # The patched producer below stands in for an outbox that accepts the
+    # tombstone, so declare the runtime posture that matches it (#4214 D3):
+    # deleted_purged may only be reported for a runtime where the tombstone is
+    # actually delivered. Without this the tick correctly reports 0 purges.
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "1")
     snapshot_path = vault / ".state.json"
 
     # delete_note reports it could not identify/emit (no file_state row).

--- a/tests/workers/test_outbox_worker_consumes_ingest.py
+++ b/tests/workers/test_outbox_worker_consumes_ingest.py
@@ -23,11 +23,13 @@ from typing import Any
 import pytest
 
 from app.events.types import INGEST_VAULT_CHANGED
+from app import stores as stores_module
 from app.services import outbox as outbox_service
 from app.services.outbox import write_outbox_event
 from app import objects as object_store_module
 from app.objects import ObjectStore
 from app.workers import outbox_worker
+from app.write_guard import DEFAULT_WRITE_GUARD
 
 pytestmark = pytest.mark.not_pg
 
@@ -122,8 +124,14 @@ class FakeOutboxConn:
 @pytest.fixture()
 def fake_conn(monkeypatch: pytest.MonkeyPatch) -> FakeOutboxConn:
     conn = FakeOutboxConn()
-    # Route every outbox DB call through the single in-memory connection.
+    # Route every outbox DB call through the single in-memory connection.  This
+    # is an integration-equivalent Postgres outbox fixture, so it must select
+    # the durable outbox path rather than memory-mode's intentional no-op.
+    monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+    # This worker harness models only the outbox as Postgres; its domain-store
+    # and vector assertions remain intentionally in-memory.
+    monkeypatch.setattr(stores_module, "_resolve_backend", lambda: "memory")
     return conn
 
 
@@ -149,6 +157,9 @@ def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(indexer_module, "get_embedding_identity", lambda: _Identity())
     monkeypatch.setattr(indexer_module, "get_vector_index", lambda: _VectorIndex())
+    # The fake outbox intentionally selects its Postgres path, but this worker
+    # test is not an integration test of the separate runtime-health guard.
+    monkeypatch.setattr(DEFAULT_WRITE_GUARD, "snapshot_fn", lambda: {"state": "running", "reason": "test"})
 
 
 @pytest.fixture(autouse=True)
@@ -343,10 +354,6 @@ def test_transient_failures_do_not_dead_letter_legitimate_event(
     monkeypatch.setenv("WORKER_MAX_DISPATCH_ATTEMPTS", "3")
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("DB_DSN", raising=False)
-    # Memory backend is explicit-only since KERNEL-03 (#2765); this test wants
-    # a no-DB unit environment, which now requires the explicit opt-in.
-    monkeypatch.setenv("STORE_BACKEND", "memory")
-
     row_id = _enqueue_ingest(note_path, trace_id="trace-transient")
     assert row_id
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4064

## Linked Issue
Closes #4064
Closes #4203
Closes #4214

Scope authorization: the `required_db` durability policy, the required-producer classifications, and
the watcher required-delivery cursor semantics are governed by #4203. The three protected P1 findings
that blocked the two prior verification sweeps, plus the P2s recorded alongside them, are governed by
#4214. The operator authorized a fresh mechanism-level repair attempt on 2026-07-31 rather than a
split; #4064's exhausted `outbox-memory-self-owned-gate` repair budget is neither reset nor consumed
by that authorization.

## SBS Impact
- Primary subsystem: Product/Runtime System (outbox delivery)
- Secondary subsystem(s): Product/Runtime System (watcher delivery state; vault delete reconciliation; ingest API boundary)
- Write class: current-state correction
- Authority impact: none
- Persistence impact: closes three silent event-loss paths — the skip predicate no longer classifies a reachable, operator-named database as unconfigured; `POST /ingest` no longer answers 200 for an unqueued ingest; an unreconciled delete tombstone stays re-observable instead of leaving both disk and snapshot
- Derived/rebuildable impact: deleted-note purge events that previously vanished now retry, so the index stops retaining stale entries for deleted notes
- Human knowledge impact: none
- Memory impact: explicit memory backend remains connection-free for optional self-owned writes
- Retrieval/context impact: fewer stale index entries for deleted notes
- Sync/deployment impact: none
- External boundary impact: `POST /ingest` returns to fail-loud on a persistence failure (its pre-#4064 behaviour)
- New or changed contract: `app/config/database.py` publishes `RUNTIME_DATABASE_ENV_KEYS` / `explicit_runtime_database_url()` as the single "has this runtime named a database?" resolution; `app/services/outbox.py` publishes `self_owned_write_would_skip()`; `app/watcher/registry.py::db_outbox_required()` becomes public; `_emit_watcher_delete_event` returns an explicit outcome instead of a bare bool
- Owner-doc impact: `docs/DB_SCHEMA.md :: Canonical Queue (DB Outbox)` corrected and extended
- Transition debt impact: reduces — a hand-maintained classification table becomes an enforced AST gate
- Fitness rule impact: adds `tests/architecture/test_outbox_producer_durability.py`
- Boundary risk: runtime state-machine ordering and durable event delivery

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary

Base commits (#4064 / #4203, unchanged): keep optional self-owned outbox writes connection-free in
explicit memory mode; fail loud for required DB delivery and unsupported explicit store backends;
preserve supplied-connection transaction behaviour; classify the six originally named load-bearing
producers; keep required watcher observations retryable across finalized persisted state.

Head commit (#4214) closes the three protected P1 findings and the three P2s recorded with them:

- **D1 (P1) — skip/connect predicate divergence.** The skip decision read `os.environ["DATABASE_URL"]`
  / `["DB_DSN"]` directly, while the connection it stood in for resolves through `conn_rw()` ->
  `_psycopg_dsn()` -> `resolve_runtime_database_url(os.environ)`, which also honours
  `PKM_DB_HOST` / `PKM_DB_PORT` / `PKM_DB_NAME_*` / `POSTGRES_*`. A runtime that named its database
  through those keys connected successfully while the predicate called it unconfigured and dropped
  the write, returning `""` — the value this contract defines as success/dedup.
  The repair is structural rather than another point-fix: `app/config/database.py` now publishes
  `RUNTIME_DATABASE_ENV_KEYS` and `explicit_runtime_database_url()`, which is
  `resolve_runtime_database_url()` with its unconditional synthesized fallback made visible. When it
  is not `None` it is byte-identical to what the connection resolves, so the decision and the
  connection read one source and cannot disagree. `_self_owned_outbox_write_policy` and the watcher's
  `_has_db_outbox_env()` both route through it.
- **D2 (P1) — `POST /ingest` answered 200 for an unqueued ingest.** The route's only persistence side
  effect was unclassified and its return discarded. It now passes `required_db=True`.
- **D3 (P1) — the vault delete tombstone reported `deleted_purged` for an event that was never
  queued,** and `refresh_snapshot()` then dropped the path so the deletion could never be re-seen.
  `_emit_watcher_delete_event` now carries the watcher's resolved required intent and reports an
  explicit outcome (`emitted` / `superseded_by_rename` / `not_queued`); an unreconciled deletion is
  retained in the snapshot so the next tick retries it.
- **D4 (P2)** — `docs/DB_SCHEMA.md` claimed a cursor guarantee the code does not make. The section is
  scoped to the emission step, names the debounce and rate-limit paths as still-dropping, and states
  that `db_outbox_required()` is also true for `STORE_BACKEND=pg` (the shipped production default).
- **D5 (P2)** — classification was a hand-maintained docs table, which is exactly how D2 and D3 were
  missed. `tests/architecture/test_outbox_producer_durability.py` enforces it: every self-owned
  producer in `app/` passes `required_db=` or appears on a reviewed allowlist keyed on
  `(module, function)` that states why a silent skip is survivable there. Stale allowlist entries
  fail the gate.
- **D6 (P2)** — the watcher cursor rollback was gated on `required_db`, but `append_jsonl_outbox_event`
  is unwrapped, so the non-required path can raise with neither sink written. The restore is no
  longer gated.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Owner-doc impact was assessed against the governing docs.

## Validation

Head `682fc828` (rebased onto `215b8432`, current `origin/main`).

- [x] **Every new test was verified to FAIL on the pre-fix code and pass on this one** — the runtime
      diff was reverse-applied, the new suites re-run (14 failures across D1/D2/D3, 2 across D6),
      then re-applied. Evidence is in the receipt comment on this PR.
- [x] `#4214` AC `Verify:` targets, all new:
      `tests/services/test_outbox_memory_mode.py::test_settings_resolved_dsn_is_not_treated_as_unconfigured`,
      `tests/services/test_outbox_memory_mode.py::test_skip_decision_never_contradicts_the_connection_resolver`
      (parametrized over `RUNTIME_DATABASE_ENV_KEYS` itself, so a new synthesis input cannot silently
      re-open D1), `tests/api/test_ingest_required_outbox.py`,
      `tests/watcher/test_vault_watcher_delete_required_outbox.py`,
      `tests/architecture/test_outbox_producer_durability.py`, and
      `tests/watcher/test_registry_required_outbox.py` extended with the non-required failure path
      and the already-seen-file restore branch.
- [x] `#4064` AC1/AC2 and all five `#4203` AC `Verify:` targets re-run green at this head.
- [x] Affected suites: `tests/services tests/watcher tests/api tests/architecture tests/workers tests/panel tests/episodes` — 1335 passed.
- [x] `ruff check app tests`: passed.
- [x] `mypy app`: passed (838 source files).
- [x] `lint-imports --config importlinter.ini`: 1 contract kept, 0 broken.
- [x] `git diff --check`: passed.
- [x] Rebased onto `origin/main` `215b8432`; three conflicts (`app/watcher/registry.py`,
      `app/watcher/vault_watcher.py`, `docs/DB_SCHEMA.md`) resolved as import/section additions with
      no semantic change to either side.

**No test was weakened, skipped, or xfailed.** One existing test
(`test_run_watcher_tick_falls_back_to_derived_identity`) gained
`PKM_SETTINGS_PROFILE=lab` + `WATCHER_REQUIRE_DB_OUTBOX=1` so that its patched-working-producer
premise matches a runtime where the tombstone is actually delivered — the assertion it makes
(`deleted_purged == 1`) is unchanged and it passes on both the old and the new code.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: GitHub Issues #4064 / #4203 / #4214 and the receipts on this PR remain the delivery
  authority; no separate BuilderOps promotion was required.

## Notes
- Stable review binding: `failure_domain=review/code correctness`,
  `mechanism_id=outbox-memory-self-owned-gate`.
- Repair history preserved without reset: the prior budget (2 standard + 2 escalated) remains
  exhausted. This head is a NEW operator-authorized mechanism-level repair attempt (2026-07-31),
  not a continuation of it, and the low-convergence circuit breaker that fired on the previous head
  is superseded by that authorization.
- Current-SHA CI and two fresh independent final-review rounds are required before verification.
