### PR TITLE
Fix selected watcher and outbox test harness isolation

### DIFF
--- a/tests/services/test_outbox_idempotency.py
+++ b/tests/services/test_outbox_idempotency.py
@@ -17,6 +17,7 @@ harness pattern as ``tests/workers/test_outbox_worker_consumes_ingest.py``).
 
 from __future__ import annotations
 
+import inspect
 import uuid
 from typing import Any
 
@@ -384,6 +385,7 @@ def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -
     conn = FakeOutboxConn()
     required_db_values: list[bool] = []
     keys = _capture_worker_keys(monkeypatch, conn, required_db_values=required_db_values)
+    expects_required_db = "required_db" in inspect.signature(write_outbox_event).parameters
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "audit.jsonl"))
 
     payload = {"event_id": "orig-evt-1", "vault_path": "/v/n.md", "trace_id": "t-1"}
@@ -400,9 +402,7 @@ def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -
     assert len(keys) == 2
     assert keys[0] != keys[1]
     assert len(conn.rows) == 2
-    # The base branch retains its pre-#4064 worker call. The spy accepts the
-    # new keyword now so #4064 can be rebased without changing this harness.
-    assert required_db_values == [False, False]
+    assert required_db_values == [expects_required_db, expects_required_db]
 
     # Re-enqueue of the SAME attempt is a duplicate: same key, still 2 rows.
     assert outbox_worker._queue_transient_retry(
@@ -410,7 +410,7 @@ def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -
     )
     assert keys[2] == keys[0]
     assert len(conn.rows) == 2
-    assert required_db_values == [False, False, False]
+    assert required_db_values == [expects_required_db, expects_required_db, expects_required_db]
 
 
 def test_dead_letter_emissions_are_attempt_scoped(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/services/test_outbox_idempotency.py
+++ b/tests/services/test_outbox_idempotency.py
@@ -351,12 +351,28 @@ def test_payload_fingerprint_excludes_trace_id_and_orders_keys() -> None:
 # --- AC: intentional re-emissions (retry/dead-letter) are attempt-scoped -------
 
 
-def _capture_worker_keys(monkeypatch: pytest.MonkeyPatch, conn: FakeOutboxConn) -> list[str]:
+def _capture_worker_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    conn: FakeOutboxConn,
+    *,
+    required_db_values: list[bool] | None = None,
+) -> list[str]:
     keys: list[str] = []
     real = write_outbox_event
 
-    def _spy(event, inner_conn=None, *, idempotency_key: str) -> str:
+    def _spy(
+        event,
+        inner_conn=None,
+        *,
+        idempotency_key: str,
+        required_db: bool = False,
+    ) -> str:
         keys.append(idempotency_key)
+        if required_db_values is not None:
+            required_db_values.append(required_db)
+        # The supplied fake connection owns the test transaction. Keeping it
+        # explicit preserves this harness on the pre-#4064 base while the spy
+        # accepts the newer caller contract when #4064 is rebased.
         return real(event, conn, idempotency_key=idempotency_key)
 
     monkeypatch.setattr(outbox_worker, "write_outbox_event", _spy)
@@ -366,7 +382,8 @@ def _capture_worker_keys(monkeypatch: pytest.MonkeyPatch, conn: FakeOutboxConn) 
 
 def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     conn = FakeOutboxConn()
-    keys = _capture_worker_keys(monkeypatch, conn)
+    required_db_values: list[bool] = []
+    keys = _capture_worker_keys(monkeypatch, conn, required_db_values=required_db_values)
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "audit.jsonl"))
 
     payload = {"event_id": "orig-evt-1", "vault_path": "/v/n.md", "trace_id": "t-1"}
@@ -383,6 +400,9 @@ def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -
     assert len(keys) == 2
     assert keys[0] != keys[1]
     assert len(conn.rows) == 2
+    # The base branch retains its pre-#4064 worker call. The spy accepts the
+    # new keyword now so #4064 can be rebased without changing this harness.
+    assert required_db_values == [False, False]
 
     # Re-enqueue of the SAME attempt is a duplicate: same key, still 2 rows.
     assert outbox_worker._queue_transient_retry(
@@ -390,6 +410,7 @@ def test_retry_events_not_swallowed(tmp_path, monkeypatch: pytest.MonkeyPatch) -
     )
     assert keys[2] == keys[0]
     assert len(conn.rows) == 2
+    assert required_db_values == [False, False, False]
 
 
 def test_dead_letter_emissions_are_attempt_scoped(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/watcher/test_registry_inbox_detection.py
+++ b/tests/watcher/test_registry_inbox_detection.py
@@ -61,6 +61,20 @@ def test_default_scope_glob_from_layout(tmp_path: Path, monkeypatch) -> None:
 
 def test_import_does_not_mutate_env(monkeypatch) -> None:
     monkeypatch.delenv("VAULT_INBOX_DIR_REL", raising=False)
-    sys.modules.pop("app.watcher.registry", None)
-    importlib.import_module("app.watcher.registry")
-    assert os.getenv("VAULT_INBOX_DIR_REL") is None
+    module_name = "app.watcher.registry"
+    watcher_package = importlib.import_module("app.watcher")
+    original_registry = sys.modules[module_name]
+
+    try:
+        sys.modules.pop(module_name, None)
+        importlib.import_module(module_name)
+        assert os.getenv("VAULT_INBOX_DIR_REL") is None
+    finally:
+        # This test deliberately reloads the module to exercise import-time
+        # environment behavior. Restore both Python's module cache and the
+        # package attribute so later tests and string-based monkeypatches keep
+        # referring to the original module identity.
+        sys.modules[module_name] = original_registry
+        setattr(watcher_package, "registry", original_registry)
+
+    assert importlib.import_module(module_name) is original_registry


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4144
Fixes #4144

## Classification

- Lane: governance
- SBS Impact: Builder System / CI test isolation; test-only current-state correction.
- Runtime/product behavior: unchanged.

## Summary

- Restore both `sys.modules` and `app.watcher` package identity after the registry import side-effect test.
- Make the worker retry spy accept and capture the keyword-only `required_db` argument while retaining its explicit fake connection.
- Derive expected retry caller posture from the active writer signature, so the harness proves current main and the later #4064 rebase without a runtime change.

## Validation

- `pytest -q tests/watcher/test_registry_inbox_detection.py::test_import_does_not_mutate_env tests/watcher/test_registry_outbox_enqueue_logging.py::test_registry_logs_db_outbox_enqueue_failures_with_context tests/services/test_outbox_idempotency.py::test_retry_events_not_swallowed` — 3 passed
- `pytest -q -m "not pg" tests/watcher tests/services/test_outbox_idempotency.py` — 163 passed
- `ruff check app tests` — passed
- `git diff --check` — passed

## Review

- Initial independent review rejected the frozen SHA because a fixed `False` expectation would fail once #4064 rebases.
- Repair committed at `e501a41cab16af4c395c29fe8e4241fa50f2d4fd`; fresh independent review accepted that exact SHA with low residual risk.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: This bounded test-harness correction is fully governed by Issue #4144, dispatcher lease `lease-c6491b9e`, PR #4145, and its review/validation receipts.

## Owner-doc writeback

None — no runtime behavior, architecture, or owner-doc truth changed.