### PR TITLE
docs: record #4111 atomic-create dependency learning

### DIFF
--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -219,3 +219,9 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Diverged:** The plan covered Markdown and HTML structural spoofing, but accepted authority rendering also required an explicit Unicode default-ignorable and bidi-output policy plus contracted owner-authority phrase forms.
 **Upstream artifact:** `docs/YOUTUBE_SOURCE_NOTE_V2/COMPOSE_REVIEW_REQUIRED_PROPOSAL_NOTE.md :: Acceptance Criteria` — add Unicode/bidi and contracted-language cases to the visible-authority convergence matrix before implementation reaches expensive verification.
 **Compatibility fallback:** BuilderOps LearningSignal write unavailable: implicit host-stable store selection was refused because the required same-user/same-host cutover acknowledgement or explicit BuilderOps state path is absent.
+
+## 2026-07-27 — #4111 (atomic HKA creation prerequisite)
+**Source:** issue-to-code pre-implementation reassessment
+**Diverged:** The dependency plan treated #4111 as executable after #4110, but D5 requires the canonical atomic KnowledgePort create-if-absent boundary still blocked in #4132.
+**Upstream artifact:** `docs/YOUTUBE_SOURCE_NOTE_V2/PERSIST_ANCHORED_TRANSCRIPT_AND_EXTRACTIONS.md` and `docs/YOUTUBE_SOURCE_NOTE_V2/ISSUE_DRAFTS.md` — make the atomic HKA creation prerequisite explicit before the persistence slice becomes pickup-eligible.
+**Compatibility fallback:** BuilderOps LearningSignal write unavailable: implicit host-stable store selection was refused because the required same-user/same-host cutover acknowledgement or explicit BuilderOps state path is absent.


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 1

## Summary
Record the dependency-plan divergence discovered during #4111 pickup: D5 cannot be implemented safely until the canonical atomic KnowledgePort create-if-absent seam in #4132 is delivered.

## Changes
- Append one compatibility learning entry to `docs/learning-log.md`.
- Name the two YouTube Source Note v2 spec artifacts that should absorb the prerequisite during a future governed repair.
- Make no shipped-state, implementation, owner-doc, or ProfileAgent claim.

## Validation
- `python3 scripts/docs_guard.py` — passed
- `git diff --check` — passed
- Branch/worktree publication preflight — passed

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: `create-learning-signal` was attempted with an idempotency key, but the mandatory host-store cutover gate refused implicit store selection; `capture-learning` therefore requires this append-only compatibility fallback.

---
