### PR TITLE
fix: include selector contract tests for shared outbox producers

### DIFF
--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -31,8 +31,9 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
   the selected CI result as database-path evidence.
 - The exact shared producer `app/objects/__init__.py` uses the same `store_ingest` selection: its
   canonical object-store facade writes through the store provider seam and emits ingest lifecycle
-  events. The exact `app/outbox/events.py` producer belongs to both `outbox_worker` and
-  `memory_retrieval`, so its selection unions delivery-worker/event and indexer coverage. Other
+  events, and its selection includes the exact ObjectStore outbox-emission regression. The exact
+  `app/outbox/events.py` producer belongs to both `outbox_worker` and `memory_retrieval`, so its
+  selection unions delivery-worker/event, indexer, and event-envelope contract coverage. Other
   `app/objects/**` and `app/outbox/**` paths remain unowned unless explicitly mapped.
 - E2E tests under `tests/e2e/` run after merge and in the nightly suite, not on ordinary PRs. Opt-in classes (live LLM, browser, human UAT, eval) remain in their dedicated post-merge or nightly lanes.
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -281,7 +281,12 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "docs/DB_SCHEMA.md",
             "docs/RUNTIME_CORRECTNESS_KERNEL/",
         ),
-        ("tests/stores", "tests/ingest", "tests/architecture"),
+        (
+            "tests/stores",
+            "tests/ingest",
+            "tests/architecture",
+            "tests/services/test_outbox_idempotency.py::test_save_object_content_change_emits_new_event",
+        ),
     ),
     (
         "relevance",
@@ -377,6 +382,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/services/test_indexer_worker.py",
             "tests/cli/test_index_rebuild_resilience.py",
             "tests/cli/test_index_doctor_mixed_identity.py",
+            "tests/architecture/test_events_outbox_contracts.py",
             *E2E_TARGETS["memory_retrieval"],
         ),
     ),

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -462,6 +462,10 @@ def test_store_ingest_change_selects_its_owned_contract_tests() -> None:
     assert "tests/stores" in selection.targets
     assert "tests/ingest" in selection.targets
     assert "tests/architecture" in selection.targets
+    assert (
+        "tests/services/test_outbox_idempotency.py::test_save_object_content_change_emits_new_event"
+        in selection.targets
+    )
 
 
 def test_object_store_module_selects_store_ingest_regressions() -> None:
@@ -474,6 +478,10 @@ def test_object_store_module_selects_store_ingest_regressions() -> None:
     assert "tests/stores" in selection.targets
     assert "tests/ingest" in selection.targets
     assert "tests/architecture" in selection.targets
+    assert (
+        "tests/services/test_outbox_idempotency.py::test_save_object_content_change_emits_new_event"
+        in selection.targets
+    )
 
 
 def test_outbox_worker_change_selects_worker_regressions() -> None:
@@ -504,6 +512,7 @@ def test_outbox_embedding_events_select_shared_regressions() -> None:
     assert "tests/indexer" in selection.targets
     assert "tests/index" in selection.targets
     assert "tests/services/test_indexer_worker.py" in selection.targets
+    assert "tests/architecture/test_events_outbox_contracts.py" in selection.targets
 
 
 def test_worker_metrics_module_change_has_a_ci_owner() -> None:


### PR DESCRIPTION
Final-Review-Rounds: 1

Governing-Issue: #4156

Fixes #4156

## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Summary
- Add the exact ObjectStore outbox-emission regression target to the `app/objects/__init__.py` selector path.
- Add the event-envelope contract suite to the `app/outbox/events.py` shared producer selector path and document the owner-doc contract.

## Validation
- `python3 scripts/validate_issue_readiness.py --body-file /var/folders/df/cmsr6vf5175313kjjbgqyhb00000gn/T/tmp.CrqrGLvhxR --label agent:ready` — ready_candidate
- `pytest -q tests/scripts/test_select_pr_tests.py::test_object_store_module_selects_store_ingest_regressions tests/scripts/test_select_pr_tests.py::test_outbox_embedding_events_select_shared_regressions` — 2 passed
- `python3 scripts/docs_guard.py` — Docs guard: OK
- `ruff check app tests` — All checks passed
- `git diff --check` — passed
- `python3 scripts/review_before_ci_gate.py --lane governance --review-gate-complete --risk-assessment-complete --changed-file docs/development/TEST_STRATEGY_HOT_PATH.md --changed-file scripts/select_pr_tests.py --changed-file tests/scripts/test_select_pr_tests.py` — satisfied

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260727063457_f70207c2`
- Reason: Daily review-comment closure audit found that issue #4140 reached terminal state via PR #4141 while two actionable selector review comments remained unreplied and not fully satisfied.

## Review Thread Follow-Up
- Replied to #4141 `discussion_r3654213920` with #4156/#4158 repair evidence: `discussion_r3654898290`; GraphQL thread `PRRT_kwDOQEip6s6T7RKN` remains unresolved until this PR lands.
- Replied to #4141 `discussion_r3654213921` with #4156/#4158 repair evidence: `discussion_r3654898286`; GraphQL thread `PRRT_kwDOQEip6s6T7RKO` remains unresolved until this PR lands.

