### PR TITLE
Add safe local model inquiry host routing

### DIFF
--- a/.codex/skills/start-model-inquiry/SKILL.md
+++ b/.codex/skills/start-model-inquiry/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: start-model-inquiry
-description: "Run a durable pre-ticket Fable and GPT/Codex model inquiry on the configured Mac mini through its subscription-authenticated host launcher when a development question needs independent model review before ticket creation."
+description: "Run a durable pre-ticket Fable and GPT/Codex model inquiry on the configured inquiry host through its subscription-authenticated launcher when a development question needs independent model review before ticket creation."
 ---
 
 # Start Model Inquiry
 
 Use this Builder System skill when the operator asks to investigate one concrete development
-question before issue creation. Run the durable artifact-first workflow on the configured Mac mini;
+question before issue creation. Run the durable artifact-first workflow on the configured inquiry host;
 do not conduct the inquiry in chat history or in the calling workspace.
 
 ## Fixed Boundary
@@ -95,6 +95,8 @@ Run exactly one route as a single-flight operation.
 
    Do not use `rm`, `unlink`, a glob, or a shell cleanup wrapper for this local temporary file. Do
    not register staging or lock release as unconditional cleanup.
+
+   Do not register remote lock release until the launch outcome is known.
 3. Write the question verbatim to a temporary UTF-8 Markdown file with mode `0600`. Treat the
    question as file content; never interpolate it into a shell command.
 4. Stage the question.
@@ -175,7 +177,7 @@ separately: a cleanup failure must not replace or reclassify the captured launch
 allowed staging/lock release fails, report it and do not start another inquiry. Never delete durable
 inquiry artifacts.
 
-The configured Mac mini owns the existing Claude and Codex subscription sessions, BuilderOps
+The configured inquiry host owns the existing Claude and Codex subscription sessions, BuilderOps
 configuration, and durable inquiry artifacts. `Tailscale_macmini` is an operator-configured SSH host
 alias. The launcher and pinned host identity are host-specific operator configuration outside Git.
 
@@ -198,6 +200,7 @@ move its model or adapter configuration into the local workspace.
 - On an ambiguous outcome, delete only the calling process's temporary question file. Do not
   release either route's lock or staged question. A later operator can decide whether the host
   launcher completed; do not make that decision from this skill.
+- Do not release the remote lock after an ambiguous launcher outcome.
 - Do not re-run the inquiry to recover a missing response. It may already have durable artifacts on
   the configured host.
 - Do not overlap invocations that use the fixed question path; both routes use the same exclusive
@@ -207,8 +210,9 @@ move its model or adapter configuration into the local workspace.
 
 ## Boundaries
 
-- Do not run BuilderOps, Python, Codex, Claude, providers, or adapters directly for this inquiry.
-  The proven-local route may invoke only the fixed subscription-authenticated host launcher.
+- Do not run local BuilderOps, Python, Codex, or Claude commands directly for this inquiry, and do
+  not invoke providers or adapters directly. The proven-local route may invoke only the fixed
+  subscription-authenticated host launcher.
 - Do not install dependencies, run vault-init, configure adapters, or use API keys.
 - Do not configure, inspect, copy, or print remote-host proxy credentials, certificates, or endpoints.
 - Do not create a GitHub Issue; use the separate promotion path after a ready receipt exists.

--- a/.codex/skills/start-model-inquiry/SKILL.md
+++ b/.codex/skills/start-model-inquiry/SKILL.md
@@ -1,66 +1,183 @@
 ---
 name: start-model-inquiry
-description: "Run a durable pre-ticket Fable and GPT/Codex model inquiry on the configured remote host through its subscription-authenticated launcher when a development question needs independent model review before ticket creation."
+description: "Run a durable pre-ticket Fable and GPT/Codex model inquiry on the configured Mac mini through its subscription-authenticated host launcher when a development question needs independent model review before ticket creation."
 ---
 
 # Start Model Inquiry
 
 Use this Builder System skill when the operator asks to investigate one concrete development
-question before issue creation. Run the durable artifact-first workflow on the configured remote host;
-do not conduct the inquiry in chat history or in the local workspace.
+question before issue creation. Run the durable artifact-first workflow on the configured Mac mini;
+do not conduct the inquiry in chat history or in the calling workspace.
 
-## Launch
+## Fixed Boundary
 
-Run this fixed-path protocol as a single-flight operation. Before staging a question, acquire the
-exclusive remote lock exactly once:
+The host bridge has four fixed identities:
+
+- SSH alias: `Tailscale_macmini`
+- exclusive lock: `/tmp/yggdrasil-model-inquiry.lock`
+- staged question: `/tmp/model-inquiry-question.md`
+- subscription-authenticated launcher:
+  `$HOME/.local/bin/yggdrasil-model-inquiry`
+
+Do not accept an environment variable, caller argument, inferred checkout path, or fallback command
+for any of these identities. In particular, do not invoke a checkout-local launcher, provider
+command, adapter, Codex, Claude, or BuilderOps directly.
+
+## Route Selection
+
+Select the route before acquiring the lock and before attempting any SSH connection:
+
+1. Expand the fixed alias without connecting:
+
+   ```bash
+   /usr/bin/ssh -G Tailscale_macmini
+   ```
+
+   Read the first effective `hostname`, `hostkeyalias`, `port`, and `user` values. The expansion
+   must succeed, `hostname` and `user` must be non-empty, and `hostname` must not equal the literal
+   alias after ASCII case-folding.
+2. Bind the local account and home directory to the SSH principal:
+
+   ```bash
+   /usr/bin/id -un
+   /usr/bin/dscl . -read "/Users/$(/usr/bin/id -un)" NFSHomeDirectory
+   ```
+
+   The effective SSH `user` must exactly equal `/usr/bin/id -un`. Parse exactly one non-empty,
+   absolute `NFSHomeDirectory` value from the directory-service record, and require the current
+   `$HOME` to equal it byte-for-byte. Do not rewrite `$HOME`, accept a different home, or read
+   `known_hosts` or a launcher below an unverified home.
+3. Prove that the fixed alias identifies this host without attempting a connection. Use the
+   effective `hostkeyalias` when it is non-empty and not `none`; otherwise use the effective
+   `hostname`. For a non-default port, use the OpenSSH `[host]:port` lookup form. Use
+   `/usr/bin/ssh-keygen -F` to inspect only `$HOME/.ssh/known_hosts` and
+   `$HOME/.ssh/known_hosts2`. The proof matches only when one pinned public key's algorithm and
+   base64 key blob exactly equal one public key in `/etc/ssh/ssh_host_*_key.pub`. Never read a
+   private host-key file, and never print public-key material while checking.
+4. Use the **proven-local route** only when alias expansion, principal binding, home binding, and
+   the pinned host-key proof all succeed. Otherwise use the **remote route**. An unavailable,
+   failed, malformed, incomplete, or non-matching check is not permission to weaken another check.
+
+This is an evidence check, not a connectivity fallback. Never infer that the caller is local because
+SSH, `scp`, DNS, or the `Tailscale_macmini` alias failed to connect or resolve. Once selected, do not
+switch routes during the invocation.
+
+## Single-Flight Launch
+
+Run exactly one route as a single-flight operation.
+
+1. Acquire the exclusive lock exactly once.
+
+   Remote route:
 
    ```bash
    ssh -T Tailscale_macmini 'mkdir /tmp/yggdrasil-model-inquiry.lock'
    ```
 
-   If the lock command fails, report its error and stop. Do not remove an existing lock, reuse the
-   fixed question path, or substitute a different remote path.
+   Proven-local route:
 
-   Immediately register deletion of the local temporary file as an unconditional `finally` action.
-   Do not register remote lock release until the launch outcome is known.
+   ```bash
+   /bin/mkdir /tmp/yggdrasil-model-inquiry.lock
+   ```
 
-1. Write the question verbatim to a local, temporary UTF-8 Markdown file with mode `0600`. Treat
-   the question as file content; never interpolate it into a shell command.
-2. Copy that file to the configured host:
+   If lock acquisition fails, report the error and stop. Do not remove an existing lock or staged
+   question, retry acquisition, or reuse the fixed question path.
+2. Immediately register deletion of the calling process's temporary question file as an
+   unconditional `finally` action. Record its resolved absolute path. The action must perform a
+   read-only exact-path existence check and, when present, delete that one recorded path with the
+   `apply_patch` tool:
+
+   ```text
+   *** Begin Patch
+   *** Delete File: <absolute QUESTION_FILE>
+   *** End Patch
+   ```
+
+   Do not use `rm`, `unlink`, a glob, or a shell cleanup wrapper for this local temporary file. Do
+   not register staging or lock release as unconditional cleanup.
+3. Write the question verbatim to a temporary UTF-8 Markdown file with mode `0600`. Treat the
+   question as file content; never interpolate it into a shell command.
+4. Stage the question.
+
+   Remote route:
 
    ```bash
    scp "$QUESTION_FILE" Tailscale_macmini:/tmp/model-inquiry-question.md
    ```
 
-3. Run exactly:
+   Proven-local route:
+
+   ```bash
+   /usr/bin/install -m 0600 "$QUESTION_FILE" /tmp/model-inquiry-question.md
+   ```
+
+5. Start the fixed host launcher exactly once.
+
+   Remote route:
 
    ```bash
    ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'
    ```
 
-4. Interpret the outcome before releasing the remote staging path:
+   Proven-local route:
 
-   - If the local question write or `scp` fails before the launcher starts, run this remote cleanup,
-     then report the original failure:
+   ```bash
+   "$HOME/.local/bin/yggdrasil-model-inquiry" --question-file /tmp/model-inquiry-question.md
+   ```
 
-     ```bash
-     ssh -T Tailscale_macmini 'rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock'
-     ```
+   Capture the launcher's exit status and stdout separately. Do not pipe the launcher through
+   another command or let a formatter replace its exit status.
+6. Validate the response before releasing staging. A valid terminal response requires exit status
+   zero and non-empty stdout whose entire contents parse as exactly one JSON object. The object must
+   contain non-empty string values for `inquiry_id`, `final_state`, `terminal_receipt_id`, and
+   `human_readable_report`. Non-JSON prefixes or suffixes, an array or scalar, an empty required
+   value, or a missing required field is invalid.
 
-   - Release the remote staging path with that same command only after the launcher returns one
-     non-empty, valid JSON response containing `inquiry_id`, `final_state`,
-     `terminal_receipt_id`, and `human_readable_report`.
-   - If the launcher returns a nonzero status, empty stdout, malformed JSON, or a missing response
-     field, delete only the local temporary file. Do not release the remote lock or staged question,
-     because the remote launcher may still be running.
+## Cleanup Matrix
 
-5. Always delete the local temporary question file through the registered `finally` action. Do not
-   delete durable inquiry artifacts. If an allowed remote release fails, report the error and do not
-   start another inquiry.
+The launcher attempt begins at step 5. Apply exactly one row:
 
-The configured remote host owns the existing Claude and Codex subscription sessions, BuilderOps configuration,
-and durable inquiry artifacts. `Tailscale_macmini` is an operator-configured SSH host alias, and
-the remote launcher is host-specific operator configuration outside Git.
+| Outcome | Remote route | Proven-local route |
+| --- | --- | --- |
+| Failure after lock acquisition but before step 5 starts | Run the fixed remote release command below; report the original failure and any cleanup failure. | Run the fixed proven-local release procedure below; report the original failure and any cleanup failure. |
+| Valid terminal response | Preserve the response, then run the fixed remote release command. | Preserve the response, then run the fixed proven-local release procedure. |
+| Ambiguous launcher outcome after step 5 starts | Preserve the remote staging file and lock. | Preserve the local staging file and lock. |
+
+Fixed remote release:
+
+```bash
+ssh -T Tailscale_macmini 'rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock'
+```
+
+Fixed proven-local release procedure:
+
+1. Perform a read-only exact-path check for `/tmp/model-inquiry-question.md`.
+2. If it exists, delete exactly that file with:
+
+```text
+*** Begin Patch
+*** Delete File: /tmp/model-inquiry-question.md
+*** End Patch
+```
+
+3. Only when the staged path was absent or that exact deletion succeeded, run:
+
+```bash
+/bin/rmdir /tmp/yggdrasil-model-inquiry.lock
+```
+
+If exact staging deletion fails, do not remove the lock. Report the cleanup failure and do not start
+another inquiry.
+
+Always delete only the calling process's temporary question file through the registered `finally`
+action. Capture and validate the launcher result before any cleanup, and report cleanup outcomes
+separately: a cleanup failure must not replace or reclassify the captured launcher outcome. If an
+allowed staging/lock release fails, report it and do not start another inquiry. Never delete durable
+inquiry artifacts.
+
+The configured Mac mini owns the existing Claude and Codex subscription sessions, BuilderOps
+configuration, and durable inquiry artifacts. `Tailscale_macmini` is an operator-configured SSH host
+alias. The launcher and pinned host identity are host-specific operator configuration outside Git.
 
 On the configured host, the Fable command may be mediated by a host-local, GUI-session proxy so a
 non-interactive SSH launch does not need direct login-keychain access. This is an internal remote-host
@@ -68,31 +185,30 @@ authentication path, not a desktop-skill capability: do not configure it, read o
 or certificates, invoke it directly, or substitute a different provider path. If that host path is
 unavailable, preserve the established ambiguous-launcher failure handling below.
 
-The configured remote launcher owns the high-reasoning profile and extended per-role deadline for
+The configured host launcher owns the high-reasoning profile and extended per-role deadline for
 both independent roles. Do not lower or override that profile from the desktop skill, and do not
 move its model or adapter configuration into the local workspace.
 
 ## Failure Handling
 
-- If `scp` fails after acquiring the lock, run the pre-launch remote cleanup first, then report the
-  original failure. Include any cleanup failure without masking the original error.
-- Treat every launcher SSH failure as ambiguous. Delete only the local temporary file, report the
-  error, and stop.
-- Treat exit code zero with empty stdout, malformed JSON, or any missing required response field as
-  an ambiguous launcher failure. Delete only the local temporary file, report the observed output,
-  and stop.
-- Do not release the remote lock after an ambiguous launcher outcome. A later operator can decide
-  whether the remote launcher completed; do not make that decision from this skill.
+- Treat every launcher SSH failure and every proven-local launcher failure after step 5 starts as
+  ambiguous.
+- Treat a nonzero launcher status, empty stdout, malformed JSON, non-object JSON, or an invalid
+  required response field as an ambiguous launcher failure.
+- On an ambiguous outcome, delete only the calling process's temporary question file. Do not
+  release either route's lock or staged question. A later operator can decide whether the host
+  launcher completed; do not make that decision from this skill.
 - Do not re-run the inquiry to recover a missing response. It may already have durable artifacts on
-  the configured remote host.
-- Do not overlap invocations that use the fixed remote question path; acquire and release its
-  exclusive remote lock around each launch.
+  the configured host.
+- Do not overlap invocations that use the fixed question path; both routes use the same exclusive
+  lock.
 - Do not inspect or recover an inquiry from the vault as a substitute for the launcher's response.
 - Do not substitute an in-chat Fable/GPT exchange or silently use one model for both roles.
 
 ## Boundaries
 
-- Do not run local BuilderOps, Python, Codex, or Claude commands for this inquiry.
+- Do not run BuilderOps, Python, Codex, Claude, providers, or adapters directly for this inquiry.
+  The proven-local route may invoke only the fixed subscription-authenticated host launcher.
 - Do not install dependencies, run vault-init, configure adapters, or use API keys.
 - Do not configure, inspect, copy, or print remote-host proxy credentials, certificates, or endpoints.
 - Do not create a GitHub Issue; use the separate promotion path after a ready receipt exists.

--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -1,6 +1,6 @@
 ---
 name: Desktop Skill Launchers
-description: Package thin Codex and Claude desktop launchers that delegate inquiries to the configured remote-host runner.
+description: Package thin Codex and Claude desktop launchers that delegate inquiries to the configured host runner.
 task_id: BMI-04
 source_anchor: docs/BUILDEROPS_MODEL_INQUIRY/README.md :: Scope
 parent_capability: BuilderOps Model Inquiry
@@ -19,39 +19,63 @@ orchestrator inside either chat history or configuring providers in the local wo
 ## What This Task Does
 
 Create a repo-local `start-model-inquiry` skill and a portable Claude custom-skill package. Both
-write the question verbatim to a mode-`0600` local Markdown file, copy it to
+write the question verbatim to a mode-`0600` local Markdown file. Remote callers copy it to
 `Tailscale_macmini:/tmp/model-inquiry-question.md`, then run exactly:
 
 ```bash
 ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'
 ```
 
-The configured remote host owns the BuilderOps vault, adapters, durable artifacts, and the existing
+The configured Mac mini owns the BuilderOps vault, adapters, durable artifacts, and the existing
 Claude and Codex subscription sessions. Its launcher settings, credentials, and executable paths
 are host-specific operator configuration and stay outside Git; the portable subscription adapter
 profile is versioned with the BuilderOps command. That profile gives both roles `xhigh` reasoning
 effort and a bounded extended deadline. Neither skill rebuilds that environment, configures
 providers, or reimplements orchestration in prompt prose.
 
-The operator machine needs the `Tailscale_macmini` SSH alias. The remote host may internally mediate
-the Fable command through a GUI-session proxy so the SSH child does not directly depend on login-keychain
-access. That authentication path is host-specific operator configuration outside Git; desktop skill
-packages neither configure it nor access its credentials, certificates, or endpoint. A failed copy or SSH command, empty
-stdout, malformed JSON, or absent response field fails loudly: report the error and stop. Do not
-retry, inspect the vault for a substitute response, or fall back to an in-chat inquiry.
+The repo-local Codex skill also supports a caller already running on the configured Mac mini. Before
+any connection attempt or lock mutation, it expands the fixed `Tailscale_macmini` alias with
+the fixed system `ssh -G`. The effective SSH user must equal the current fixed-system `id -un`, and
+the process `$HOME` must byte-match that account's `NFSHomeDirectory` from macOS directory service.
+The local route then requires a public key pinned for the effective SSH host identity in one of the
+two fixed user `known_hosts` files to exactly match a local public SSH host key under `/etc/ssh/`.
+The proof uses fixed system tools, reads no private key, and prints no key material. Missing,
+invalid, or non-matching alias, principal, home, or host-key evidence selects the remote route. A
+failed SSH, copy, DNS, or alias-resolution attempt never proves local identity. The proven-local
+route copies to the same fixed staging file and directly invokes only:
 
-The established remote command has one fixed `/tmp/model-inquiry-question.md` input path. Before
-copying the question, both packages acquire the atomic remote lock with
-`mkdir /tmp/yggdrasil-model-inquiry.lock`. A failed lock acquisition stops the launch without
-removing the existing lock. This prevents one desktop session from overwriting another inquiry's
-question while retaining the required fixed copy and launcher commands.
+```bash
+"$HOME/.local/bin/yggdrasil-model-inquiry" --question-file /tmp/model-inquiry-question.md
+```
+
+The operator machine needs the `Tailscale_macmini` SSH alias. The remote host may internally mediate
+the Fable command through a GUI-session proxy so the SSH child does not directly depend on
+login-keychain access. That authentication path is host-specific operator configuration outside Git;
+desktop skill packages neither configure it nor access its credentials, certificates, or endpoint.
+A failed copy or launcher command, empty stdout, malformed/non-object JSON, or absent/empty response
+field fails loudly: report the error and stop. Do not retry, inspect the vault for a substitute
+response, or fall back to an in-chat inquiry.
+
+The established host command has one fixed `/tmp/model-inquiry-question.md` input path. Before
+copying the question, both packages acquire `/tmp/yggdrasil-model-inquiry.lock` atomically: through
+SSH for remote callers and directly only for a proven-local Codex caller. A failed lock acquisition
+stops the launch without removing the existing lock. Both routes therefore share one single-flight
+boundary and cannot overwrite another inquiry's question.
 
 After lock acquisition, local temporary-file cleanup is a registered `finally` action. The remote
-question and lock are released only when the copy failed before the launcher began, or when the
-launcher returned a valid non-empty JSON receipt with every required field. A transport failure,
-empty stdout, malformed JSON, or missing field is ambiguous: the launcher may still run remotely,
-so the package leaves the remote lock and staged question in place, reports the error, and does not
-retry or infer completion.
+or proven-local staged question and lock are released only when staging failed before the launcher
+attempt began, or when the launcher returned exit zero and exactly one non-empty JSON object with
+non-empty string values for `inquiry_id`, `final_state`, `terminal_receipt_id`, and
+`human_readable_report`. A transport or launcher failure, empty stdout, malformed/non-object JSON,
+or invalid required field after launch begins is ambiguous: the launcher may have created durable
+artifacts, so both routes leave the shared lock and staged question in place, report the error, and
+do not retry or infer completion. A valid terminal response and a pre-launch failure use the same
+route by which the lock was acquired for cleanup; cleanup failure is reported without masking the
+original outcome. Codex deletes its dynamic caller-temp file and any allowed proven-local fixed
+staging file through exact-target `apply_patch` deletion, never a shell `rm -f`; it removes the
+empty fixed lock directory only after staging deletion succeeded or the staged path was absent.
+Launcher status and JSON are captured and validated before cleanup, so a cleanup failure is reported
+separately and cannot erase or reclassify the launcher outcome.
 
 The SSH host must expose both durable role entrypoints before its launcher is considered ready.
 They are installed and checked with the repository-owned
@@ -73,21 +97,29 @@ other.
 
 ## Acceptance Criteria
 
-- [x] Both desktop skill packages use the exact remote-host bridge command and report its inquiry
-  receipt fields. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
+- [x] Both desktop skill packages preserve the exact remote-host bridge command and report its
+  inquiry receipt fields. Verify:
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
 - [x] Both packages reject local BuilderOps setup, provider configuration, API keys, and
   desktop-control automation. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
 - [x] Both packages fail loudly for a copy/SSH failure, empty stdout, malformed JSON, or an absent
   receipt field. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
-- [x] Both packages atomically lock the fixed remote question path rather than silently overwriting
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+- [x] Both packages atomically lock the fixed host question path rather than silently overwriting
   a concurrent inquiry. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
-- [x] Both packages release the remote lock only after a pre-launch failure or a verified receipt,
-  preserving it after an ambiguous launcher result. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+- [x] Both packages release staging and the lock through the selected route only after a pre-launch
+  failure or a verified receipt, preserving both after an ambiguous launcher result. Verify:
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+- [x] Codex local cleanup uses policy-compatible exact-target deletion for the caller temp and fixed
+  staging file, never a blocked shell `rm -f`, and cannot mask the captured launcher result. Verify:
+  `tests/governance/test_start_model_inquiry_skill.py::test_codex_skill_local_route_is_identity_gated_and_fail_closed`.
+- [x] The Codex skill selects its local-host route only after fixed-alias, OS principal/home, and
+  pinned-host-key proofs all match, invokes only the fixed host launcher, shares the fixed
+  single-flight lock, strictly validates the terminal response, and preserves staging after
+  ambiguous outcomes. Verify:
+  `tests/governance/test_start_model_inquiry_skill.py::test_codex_skill_local_route_is_identity_gated_and_fail_closed`.
 - [x] A terminal `provider_error` returns one JSON response carrying the established receipt fields
   and only an optional allowlisted diagnostic object. Verify:
   `tests/governance/test_start_model_inquiry_skill.py::test_local_launcher_emits_terminal_provider_error_json`.

--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -26,14 +26,14 @@ write the question verbatim to a mode-`0600` local Markdown file. Remote callers
 ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'
 ```
 
-The configured Mac mini owns the BuilderOps vault, adapters, durable artifacts, and the existing
+The configured inquiry host owns the BuilderOps vault, adapters, durable artifacts, and the existing
 Claude and Codex subscription sessions. Its launcher settings, credentials, and executable paths
 are host-specific operator configuration and stay outside Git; the portable subscription adapter
 profile is versioned with the BuilderOps command. That profile gives both roles `xhigh` reasoning
 effort and a bounded extended deadline. Neither skill rebuilds that environment, configures
 providers, or reimplements orchestration in prompt prose.
 
-The repo-local Codex skill also supports a caller already running on the configured Mac mini. Before
+The repo-local Codex skill also supports a caller already running on the configured inquiry host. Before
 any connection attempt or lock mutation, it expands the fixed `Tailscale_macmini` alias with
 the fixed system `ssh -G`. The effective SSH user must equal the current fixed-system `id -un`, and
 the process `$HOME` must byte-match that account's `NFSHomeDirectory` from macOS directory service.
@@ -99,34 +99,34 @@ other.
 
 - [x] Both desktop skill packages preserve the exact remote-host bridge command and report its
   inquiry receipt fields. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
 - [x] Both packages reject local BuilderOps setup, provider configuration, API keys, and
   desktop-control automation. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
 - [x] Both packages fail loudly for a copy/SSH failure, empty stdout, malformed JSON, or an absent
   receipt field. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
 - [x] Both packages atomically lock the fixed host question path rather than silently overwriting
   a concurrent inquiry. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
 - [x] Both packages release staging and the lock through the selected route only after a pre-launch
   failure or a verified receipt, preserving both after an ambiguous launcher result. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_preserve_remote_macmini_launcher_contract`.
+  `tests/governance/test_start_model_inquiry_skill.py::test_desktop_skills_route_to_macmini_launcher`.
 - [x] Codex local cleanup uses policy-compatible exact-target deletion for the caller temp and fixed
   staging file, never a blocked shell `rm -f`, and cannot mask the captured launcher result. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_codex_skill_local_route_is_identity_gated_and_fail_closed`.
+  `tests/architecture/test_agent_skill_entrypoints.py::test_model_inquiry_local_host_route_is_identity_gated_and_fail_closed`.
 - [x] The Codex skill selects its local-host route only after fixed-alias, OS principal/home, and
   pinned-host-key proofs all match, invokes only the fixed host launcher, shares the fixed
   single-flight lock, strictly validates the terminal response, and preserves staging after
   ambiguous outcomes. Verify:
-  `tests/governance/test_start_model_inquiry_skill.py::test_codex_skill_local_route_is_identity_gated_and_fail_closed`.
+  `tests/architecture/test_agent_skill_entrypoints.py::test_model_inquiry_local_host_route_is_identity_gated_and_fail_closed`.
 - [x] A terminal `provider_error` returns one JSON response carrying the established receipt fields
   and only an optional allowlisted diagnostic object. Verify:
   `tests/governance/test_start_model_inquiry_skill.py::test_local_launcher_emits_terminal_provider_error_json`.
 
 ## How to Verify (Pre-Merge)
 
-- `pytest -q tests/governance/test_start_model_inquiry_skill.py`
+- `pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/governance/test_start_model_inquiry_skill.py`
 - `python3 scripts/lint_skills_consistency.py`
 - `python3 scripts/package_claude_skill.py --output /tmp/start-model-inquiry.zip`
 

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -91,3 +91,78 @@ def test_subagent_role_governance_is_discoverable() -> None:
     assert role_doc in claude_text
     assert ".codex/agents" in agents_text
     assert "skills remain" in agents_text.lower()
+
+
+def test_model_inquiry_local_host_route_is_identity_gated_and_fail_closed() -> None:
+    skill = _read(".codex/skills/start-model-inquiry/SKILL.md")
+    normalized_skill = " ".join(skill.split())
+
+    assert skill.index("## Route Selection") < skill.index("## Single-Flight Launch")
+    for identity_contract in (
+        "/usr/bin/ssh -G Tailscale_macmini",
+        "/usr/bin/id -un",
+        "NFSHomeDirectory",
+        "require the current `$HOME` to equal it byte-for-byte",
+        "`$HOME/.ssh/known_hosts` and `$HOME/.ssh/known_hosts2`",
+        "`/usr/bin/ssh-keygen -F`",
+        "`/etc/ssh/ssh_host_*_key.pub`",
+        "Never read a private host-key file",
+        "Use the **proven-local route** only when alias expansion, principal binding, home binding, and the pinned host-key proof all succeed.",
+        "Never infer that the caller is local because",
+        "Once selected, do not switch routes during the invocation.",
+    ):
+        assert identity_contract in normalized_skill
+
+    launcher_invocations = [
+        line.strip()
+        for line in skill.splitlines()
+        if "yggdrasil-model-inquiry" in line and "--question-file" in line
+    ]
+    assert launcher_invocations == [
+        "ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'",
+        '"$HOME/.local/bin/yggdrasil-model-inquiry" --question-file /tmp/model-inquiry-question.md',
+    ]
+
+    lock_invocations = [
+        line.strip()
+        for line in skill.splitlines()
+        if "mkdir /tmp/yggdrasil-model-inquiry.lock" in line
+    ]
+    assert lock_invocations == [
+        "ssh -T Tailscale_macmini 'mkdir /tmp/yggdrasil-model-inquiry.lock'",
+        "/bin/mkdir /tmp/yggdrasil-model-inquiry.lock",
+    ]
+
+    local_release = _section_between(
+        skill,
+        "Fixed proven-local release procedure:",
+        "The configured inquiry host owns",
+    )
+    assert "*** Delete File: /tmp/model-inquiry-question.md" in local_release
+    assert "/bin/rmdir /tmp/yggdrasil-model-inquiry.lock" in local_release
+    assert "rm -f" not in local_release
+
+    for local_contract in (
+        '/usr/bin/install -m 0600 "$QUESTION_FILE" /tmp/model-inquiry-question.md',
+        "*** Delete File: <absolute QUESTION_FILE>",
+        "Do not use `rm`, `unlink`, a glob, or a shell cleanup wrapper for this local temporary file.",
+        "non-empty stdout whose entire contents parse as exactly one JSON object",
+        "contain non-empty string values for `inquiry_id`, `final_state`, `terminal_receipt_id`, and",
+        "| Failure after lock acquisition but before step 5 starts | Run the fixed remote release command below; report the original failure and any cleanup failure. | Run the fixed proven-local release procedure below; report the original failure and any cleanup failure. |",
+        "| Valid terminal response | Preserve the response, then run the fixed remote release command. | Preserve the response, then run the fixed proven-local release procedure. |",
+        "| Ambiguous launcher outcome after step 5 starts | Preserve the remote staging file and lock. | Preserve the local staging file and lock. |",
+        "a cleanup failure must not replace or reclassify the captured launcher outcome.",
+        "The proven-local route may invoke only the fixed subscription-authenticated host launcher.",
+    ):
+        assert local_contract in normalized_skill
+
+    for forbidden_bypass in (
+        "BUILDEROPS_VAULT_ROOT",
+        "BUILDEROPS_INQUIRY_ADAPTERS_JSON",
+        "scripts/start_model_inquiry.sh",
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_rsa_key",
+        "tailscale status --json",
+        "/bin/rm -f /tmp/model-inquiry-question.md",
+    ):
+        assert forbidden_bypass not in skill

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -221,7 +221,7 @@ def test_subscription_adapter_preserves_invalid_provider_fields_for_runner_valid
     assert module._response_from_text(json.dumps(response)) == response
 
 
-def test_desktop_skills_route_to_macmini_launcher(tmp_path: Path) -> None:
+def test_desktop_skills_preserve_remote_macmini_launcher_contract(tmp_path: Path) -> None:
     codex = (REPO_ROOT / ".codex/skills/start-model-inquiry/SKILL.md").read_text()
     claude = (REPO_ROOT / "claude-skills/start-model-inquiry/SKILL.md").read_text()
     for skill in (codex, claude):
@@ -240,16 +240,13 @@ def test_desktop_skills_route_to_macmini_launcher(tmp_path: Path) -> None:
             "mkdir /tmp/yggdrasil-model-inquiry.lock",
             "rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock",
             "Do not remove an existing lock",
-            "Do not register remote lock release until the launch outcome is known",
-            "Do not release the remote lock after an ambiguous launcher outcome",
             "high-reasoning profile",
         ):
             assert contract_field in skill
-        for required_boundary in (
-            "Do not run local BuilderOps, Python, Codex, or Claude commands",
-            "Do not install dependencies, run vault-init, configure adapters, or use API keys.",
-        ):
-            assert required_boundary in skill
+        assert (
+            "Do not install dependencies, run vault-init, configure adapters, or use API keys."
+            in skill
+        )
         for forbidden in (
             "scripts/start_model_inquiry.sh",
             "BUILDEROPS_VAULT_ROOT",
@@ -277,6 +274,90 @@ def test_desktop_skills_route_to_macmini_launcher(tmp_path: Path) -> None:
     with zipfile.ZipFile(archive) as bundle:
         assert bundle.namelist() == ["start-model-inquiry/SKILL.md"]
         assert bundle.read(bundle.namelist()[0]).decode() == claude
+
+
+def test_codex_skill_local_route_is_identity_gated_and_fail_closed() -> None:
+    skill = (
+        REPO_ROOT / ".codex/skills/start-model-inquiry/SKILL.md"
+    ).read_text(encoding="utf-8")
+    normalized_skill = " ".join(skill.split())
+
+    route_selection = skill.index("## Route Selection")
+    lock_acquisition = skill.index("## Single-Flight Launch")
+    assert route_selection < lock_acquisition
+    for identity_contract in (
+        "/usr/bin/ssh -G Tailscale_macmini",
+        "/usr/bin/id -un",
+        'NFSHomeDirectory',
+        "require the current `$HOME` to equal it byte-for-byte",
+        "`$HOME/.ssh/known_hosts` and `$HOME/.ssh/known_hosts2`",
+        "`/usr/bin/ssh-keygen -F`",
+        "`/etc/ssh/ssh_host_*_key.pub`",
+        "Never read a private host-key file",
+        "Use the **proven-local route** only when alias expansion, principal binding, home binding, and the pinned host-key proof all succeed.",
+        "Never infer that the caller is local because",
+        "Once selected, do not switch routes during the invocation.",
+    ):
+        assert identity_contract in normalized_skill
+
+    launcher_invocations = [
+        line.strip()
+        for line in skill.splitlines()
+        if "yggdrasil-model-inquiry" in line and "--question-file" in line
+    ]
+    assert launcher_invocations == [
+        "ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'",
+        '"$HOME/.local/bin/yggdrasil-model-inquiry" --question-file /tmp/model-inquiry-question.md',
+    ]
+    lock_invocations = [
+        line.strip()
+        for line in skill.splitlines()
+        if "mkdir /tmp/yggdrasil-model-inquiry.lock" in line
+    ]
+    assert lock_invocations == [
+        "ssh -T Tailscale_macmini 'mkdir /tmp/yggdrasil-model-inquiry.lock'",
+        "/bin/mkdir /tmp/yggdrasil-model-inquiry.lock",
+    ]
+    release_invocations = [
+        line.strip()
+        for line in skill.splitlines()
+        if "rm -f /tmp/model-inquiry-question.md" in line
+        and "rmdir /tmp/yggdrasil-model-inquiry.lock" in line
+    ]
+    assert release_invocations == [
+        "ssh -T Tailscale_macmini 'rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock'",
+    ]
+    local_release = skill.split("Fixed proven-local release procedure:", 1)[1].split(
+        "The configured Mac mini owns", 1
+    )[0]
+    assert "*** Delete File: /tmp/model-inquiry-question.md" in local_release
+    assert "/bin/rmdir /tmp/yggdrasil-model-inquiry.lock" in local_release
+    assert "rm -f" not in local_release
+    for local_contract in (
+        "/bin/mkdir /tmp/yggdrasil-model-inquiry.lock",
+        '/usr/bin/install -m 0600 "$QUESTION_FILE" /tmp/model-inquiry-question.md',
+        "*** Delete File: <absolute QUESTION_FILE>",
+        "Do not use `rm`, `unlink`, a glob, or a shell cleanup wrapper for this local temporary file.",
+        "non-empty stdout whose entire contents parse as exactly one JSON object",
+        "contain non-empty string values for `inquiry_id`, `final_state`, `terminal_receipt_id`, and",
+        "| Failure after lock acquisition but before step 5 starts | Run the fixed remote release command below; report the original failure and any cleanup failure. | Run the fixed proven-local release procedure below; report the original failure and any cleanup failure. |",
+        "| Valid terminal response | Preserve the response, then run the fixed remote release command. | Preserve the response, then run the fixed proven-local release procedure. |",
+        "| Ambiguous launcher outcome after step 5 starts | Preserve the remote staging file and lock. | Preserve the local staging file and lock. |",
+        "a cleanup failure must not replace or reclassify the captured launcher outcome.",
+        "The proven-local route may invoke only the fixed subscription-authenticated host launcher.",
+    ):
+        assert local_contract in normalized_skill
+
+    for forbidden_bypass in (
+        "BUILDEROPS_VAULT_ROOT",
+        "BUILDEROPS_INQUIRY_ADAPTERS_JSON",
+        "scripts/start_model_inquiry.sh",
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_rsa_key",
+        "tailscale status --json",
+        "/bin/rm -f /tmp/model-inquiry-question.md",
+    ):
+        assert forbidden_bypass not in skill
 
 
 def test_skill_preflight_reports_missing_dependencies(tmp_path: Path) -> None:

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -221,7 +221,7 @@ def test_subscription_adapter_preserves_invalid_provider_fields_for_runner_valid
     assert module._response_from_text(json.dumps(response)) == response
 
 
-def test_desktop_skills_preserve_remote_macmini_launcher_contract(tmp_path: Path) -> None:
+def test_desktop_skills_route_to_macmini_launcher(tmp_path: Path) -> None:
     codex = (REPO_ROOT / ".codex/skills/start-model-inquiry/SKILL.md").read_text()
     claude = (REPO_ROOT / "claude-skills/start-model-inquiry/SKILL.md").read_text()
     for skill in (codex, claude):
@@ -240,13 +240,16 @@ def test_desktop_skills_preserve_remote_macmini_launcher_contract(tmp_path: Path
             "mkdir /tmp/yggdrasil-model-inquiry.lock",
             "rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock",
             "Do not remove an existing lock",
+            "Do not register remote lock release until the launch outcome is known",
+            "Do not release the remote lock after an ambiguous launcher outcome",
             "high-reasoning profile",
         ):
             assert contract_field in skill
-        assert (
-            "Do not install dependencies, run vault-init, configure adapters, or use API keys."
-            in skill
-        )
+        for required_boundary in (
+            "Do not run local BuilderOps, Python, Codex, or Claude commands",
+            "Do not install dependencies, run vault-init, configure adapters, or use API keys.",
+        ):
+            assert required_boundary in skill
         for forbidden in (
             "scripts/start_model_inquiry.sh",
             "BUILDEROPS_VAULT_ROOT",
@@ -274,90 +277,6 @@ def test_desktop_skills_preserve_remote_macmini_launcher_contract(tmp_path: Path
     with zipfile.ZipFile(archive) as bundle:
         assert bundle.namelist() == ["start-model-inquiry/SKILL.md"]
         assert bundle.read(bundle.namelist()[0]).decode() == claude
-
-
-def test_codex_skill_local_route_is_identity_gated_and_fail_closed() -> None:
-    skill = (
-        REPO_ROOT / ".codex/skills/start-model-inquiry/SKILL.md"
-    ).read_text(encoding="utf-8")
-    normalized_skill = " ".join(skill.split())
-
-    route_selection = skill.index("## Route Selection")
-    lock_acquisition = skill.index("## Single-Flight Launch")
-    assert route_selection < lock_acquisition
-    for identity_contract in (
-        "/usr/bin/ssh -G Tailscale_macmini",
-        "/usr/bin/id -un",
-        'NFSHomeDirectory',
-        "require the current `$HOME` to equal it byte-for-byte",
-        "`$HOME/.ssh/known_hosts` and `$HOME/.ssh/known_hosts2`",
-        "`/usr/bin/ssh-keygen -F`",
-        "`/etc/ssh/ssh_host_*_key.pub`",
-        "Never read a private host-key file",
-        "Use the **proven-local route** only when alias expansion, principal binding, home binding, and the pinned host-key proof all succeed.",
-        "Never infer that the caller is local because",
-        "Once selected, do not switch routes during the invocation.",
-    ):
-        assert identity_contract in normalized_skill
-
-    launcher_invocations = [
-        line.strip()
-        for line in skill.splitlines()
-        if "yggdrasil-model-inquiry" in line and "--question-file" in line
-    ]
-    assert launcher_invocations == [
-        "ssh -T Tailscale_macmini '$HOME/.local/bin/yggdrasil-model-inquiry --question-file /tmp/model-inquiry-question.md'",
-        '"$HOME/.local/bin/yggdrasil-model-inquiry" --question-file /tmp/model-inquiry-question.md',
-    ]
-    lock_invocations = [
-        line.strip()
-        for line in skill.splitlines()
-        if "mkdir /tmp/yggdrasil-model-inquiry.lock" in line
-    ]
-    assert lock_invocations == [
-        "ssh -T Tailscale_macmini 'mkdir /tmp/yggdrasil-model-inquiry.lock'",
-        "/bin/mkdir /tmp/yggdrasil-model-inquiry.lock",
-    ]
-    release_invocations = [
-        line.strip()
-        for line in skill.splitlines()
-        if "rm -f /tmp/model-inquiry-question.md" in line
-        and "rmdir /tmp/yggdrasil-model-inquiry.lock" in line
-    ]
-    assert release_invocations == [
-        "ssh -T Tailscale_macmini 'rm -f /tmp/model-inquiry-question.md; rmdir /tmp/yggdrasil-model-inquiry.lock'",
-    ]
-    local_release = skill.split("Fixed proven-local release procedure:", 1)[1].split(
-        "The configured Mac mini owns", 1
-    )[0]
-    assert "*** Delete File: /tmp/model-inquiry-question.md" in local_release
-    assert "/bin/rmdir /tmp/yggdrasil-model-inquiry.lock" in local_release
-    assert "rm -f" not in local_release
-    for local_contract in (
-        "/bin/mkdir /tmp/yggdrasil-model-inquiry.lock",
-        '/usr/bin/install -m 0600 "$QUESTION_FILE" /tmp/model-inquiry-question.md',
-        "*** Delete File: <absolute QUESTION_FILE>",
-        "Do not use `rm`, `unlink`, a glob, or a shell cleanup wrapper for this local temporary file.",
-        "non-empty stdout whose entire contents parse as exactly one JSON object",
-        "contain non-empty string values for `inquiry_id`, `final_state`, `terminal_receipt_id`, and",
-        "| Failure after lock acquisition but before step 5 starts | Run the fixed remote release command below; report the original failure and any cleanup failure. | Run the fixed proven-local release procedure below; report the original failure and any cleanup failure. |",
-        "| Valid terminal response | Preserve the response, then run the fixed remote release command. | Preserve the response, then run the fixed proven-local release procedure. |",
-        "| Ambiguous launcher outcome after step 5 starts | Preserve the remote staging file and lock. | Preserve the local staging file and lock. |",
-        "a cleanup failure must not replace or reclassify the captured launcher outcome.",
-        "The proven-local route may invoke only the fixed subscription-authenticated host launcher.",
-    ):
-        assert local_contract in normalized_skill
-
-    for forbidden_bypass in (
-        "BUILDEROPS_VAULT_ROOT",
-        "BUILDEROPS_INQUIRY_ADAPTERS_JSON",
-        "scripts/start_model_inquiry.sh",
-        "/etc/ssh/ssh_host_ed25519_key",
-        "/etc/ssh/ssh_host_rsa_key",
-        "tailscale status --json",
-        "/bin/rm -f /tmp/model-inquiry-question.md",
-    ):
-        assert forbidden_bypass not in skill
 
 
 def test_skill_preflight_reports_missing_dependencies(tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: durable repo-governed workflow instruction, owner doc, and focused governance test
- Authority impact: Builder System workflow authority only; no Product/Runtime authority
- Persistence impact: Git-tracked governance artifacts only
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: Host launcher routing is clarified; launcher, adapters, and credentials remain host-owned and unchanged
- New or changed contract: start-model-inquiry local/remote routing, cleanup, and response-validation workflow contract updated; Product contracts unaffected
- Owner-doc impact: docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md updated in this PR
- Transition debt impact: no effect
- Fitness rule impact: focused governance regression test strengthened; Product SBS fitness rules unaffected
- Boundary risk: fail-closed host identity and credential-durability boundary; no runtime mutation

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a deterministic proven-local route for Codex callers already on the configured inquiry host while preserving the fixed SSH path for remote callers.
- Bind local execution to the alias principal, directory-service home, and pinned SSH host key; keep the shared lock and fail-closed cleanup matrix.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Governance lane:
- [x] pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/governance/test_start_model_inquiry_skill.py (17 passed)
- [x] python3 scripts/lint_skills_consistency.py (clean)
- [x] python3 scripts/docs_guard.py (Docs guard: OK)
- [x] python3 scripts/public_seam_lint.py --mode gate (0 secret/uncovered/stale/pending hits)
- [x] python3 scripts/package_claude_skill.py --output /tmp/start-model-inquiry-local-host-check.zip (package created; Claude source unchanged)
- [x] ruff check app tests (All checks passed)
- [x] Live read-only identity proof: alias principal, OS home, and pinned host key all match; no launcher or lock mutation
- [x] Fresh gpt-5.6-sol/high independent review of 0b79dfb97: clean

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The concrete delivery divergence is fully repaired in this governance change; no separate operational record or authority crossing is needed.

## Notes
The earlier local attempt remains ambiguous. Its fixed staging file and lock are intentionally retained, and this PR does not authorize retry or cleanup of that state.