### PR TITLE
Add independent issue fast lane

### DIFF
--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -34,6 +34,12 @@ Load secondary skills only when the work needs them:
 
 ## Modes
 
+### Independent-Issue Fast Lane
+
+An explicit set of strictly ready independent Issues may be dispatched without inventing a synthetic epic. Cap the pilot at a maximum of two workers. Each worker gets exactly one minimal context pack, worktree, branch, PR, `Verify:` ledger, known constraints, and compact terminal receipt. Routine worker-to-worker coordination is prohibited: a dependency, shared mutation surface, migration, contract overlap, or authority ambiguity is a typed coordinator exception that pauses or rejects only the affected wave. The plan and any run-state are evidence-only and rebuildable from live Issue, dispatcher, PR, CI, review, merge, and closure authority; they never authorize effects or parent closure.
+
+Consume, rather than restate, the canonical severity and known-defect routes in `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md` and `.codex/skills/bug-to-issue/SKILL.md`: invalid, malformed, low-confidence, protected, and P0/P1 outcomes block; a valid P2 is deferred through the governed intake without a synchronous repair/re-review loop.
+
 ### Planning / Readiness Mode
 
 Use this mode when the user asks to review, plan, prepare, triage, or make issues ready.

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -78,6 +78,8 @@ from app.builderops.epic_run_state import (
     epic_run_state_path,
     load_epic_run_state,
     new_epic_run_state,
+    new_independent_issue_run_state,
+    save_epic_run_state,
     unresolved_learning_evaluation_candidates,
     update_epic_run_state,
 )
@@ -1549,7 +1551,8 @@ def epic_run_state() -> None:
     "record",
     help="Create or update an epic run-state file from explicit local evidence.",
 )
-@click.option("--epic-issue-number", required=True, type=int)
+@click.option("--epic-issue-number", type=int)
+@click.option("--independent-issue", "independent_issues", multiple=True, type=int)
 @click.option("--run-id", required=True)
 @click.option(
     "--root",
@@ -1567,7 +1570,8 @@ def epic_run_state() -> None:
 @click.option("--dry-run", is_flag=True, help="Preview the state without writing a file.")
 @click.option("--json", "as_json", is_flag=True)
 def record_epic_run_state(
-    epic_issue_number: int,
+    epic_issue_number: int | None,
+    independent_issues: tuple[int, ...],
     run_id: str,
     root: Path | None,
     update_json: str,
@@ -1575,6 +1579,8 @@ def record_epic_run_state(
     dry_run: bool,
     as_json: bool,
 ) -> None:
+    if (epic_issue_number is None) == (not independent_issues):
+        raise click.UsageError("provide exactly one of --epic-issue-number or --independent-issue")
     updates = _merge_json_objects(
         _load_json_object_file(update_file, field="update-file"),
         _parse_json_object(update_json, field="update-json"),
@@ -1585,17 +1591,17 @@ def record_epic_run_state(
         if dry_run:
             if state_exists:
                 base_state = load_epic_run_state(run_id, root=root)
-                if base_state["epic_issue_number"] != epic_issue_number:
+                if base_state["epic_issue_number"] != epic_issue_number or base_state.get("independent_issue_numbers", []) != sorted(independent_issues):
                     raise EpicRunStateError(
                         f"run_id {run_id!r} already belongs to epic "
                         f"{base_state['epic_issue_number']}"
                     )
             else:
-                base_state = new_epic_run_state(epic_issue_number, run_id)
+                base_state = new_epic_run_state(epic_issue_number, run_id) if epic_issue_number is not None else new_independent_issue_run_state(list(independent_issues), run_id)
             state = apply_epic_run_update(base_state, **updates)
         elif state_exists:
             existing_state = load_epic_run_state(run_id, root=root)
-            if existing_state["epic_issue_number"] != epic_issue_number:
+            if existing_state["epic_issue_number"] != epic_issue_number or existing_state.get("independent_issue_numbers", []) != sorted(independent_issues):
                 raise EpicRunStateError(
                     f"run_id {run_id!r} already belongs to epic "
                     f"{existing_state['epic_issue_number']}"
@@ -1606,12 +1612,9 @@ def record_epic_run_state(
                 else existing_state
             )
         else:
-            state = create_epic_run_state(
-                epic_issue_number,
-                run_id,
-                root=root,
-                **updates,
-            )
+            state = create_epic_run_state(epic_issue_number, run_id, root=root, **updates) if epic_issue_number is not None else new_independent_issue_run_state(list(independent_issues), run_id, **updates)
+            if epic_issue_number is None:
+                save_epic_run_state(state, root=root)
     except EpicRunStateError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -1646,7 +1649,8 @@ def show_epic_run_state(run_id: str, root: Path | None, as_json: bool) -> None:
     "dispatch-plan",
     help="Dry-run runtime-neutral worker context packs for an epic run.",
 )
-@click.option("--epic-issue-number", required=True, type=int)
+@click.option("--epic-issue-number", type=int)
+@click.option("--independent-issue", "independent_issues", multiple=True, type=int)
 @click.option("--run-id", required=True)
 @click.option(
     "--root",
@@ -1669,7 +1673,8 @@ def show_epic_run_state(run_id: str, root: Path | None, as_json: bool) -> None:
 )
 @click.option("--json", "as_json", is_flag=True)
 def dispatch_plan(
-    epic_issue_number: int,
+    epic_issue_number: int | None,
+    independent_issues: tuple[int, ...],
     run_id: str,
     root: Path | None,
     candidates_file: Path,
@@ -1677,6 +1682,8 @@ def dispatch_plan(
     runtime_targets: tuple[str, ...],
     as_json: bool,
 ) -> None:
+    if (epic_issue_number is None) == (not independent_issues):
+        raise click.UsageError("provide exactly one of --epic-issue-number or --independent-issue")
     payload = _load_json_object_file(candidates_file, field="candidates-file")
     candidates = payload.get("candidates", [])
     active_leases = payload.get("active_leases", [])
@@ -1686,6 +1693,7 @@ def dispatch_plan(
             state = load_epic_run_state(run_id, root=root)
         plan = build_dispatch_plan(
             epic_issue_number=epic_issue_number,
+            independent_issue_numbers=independent_issues,
             run_id=run_id,
             candidates=candidates,
             max_parallel=max_parallel,

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -75,11 +75,11 @@ from app.builderops.epic_run_state import (
     EpicRunStateError,
     apply_epic_run_update,
     create_epic_run_state,
+    create_independent_issue_run_state,
     epic_run_state_path,
     load_epic_run_state,
     new_epic_run_state,
     new_independent_issue_run_state,
-    save_epic_run_state,
     unresolved_learning_evaluation_candidates,
     update_epic_run_state,
 )
@@ -1612,9 +1612,13 @@ def record_epic_run_state(
                 else existing_state
             )
         else:
-            state = create_epic_run_state(epic_issue_number, run_id, root=root, **updates) if epic_issue_number is not None else new_independent_issue_run_state(list(independent_issues), run_id, **updates)
-            if epic_issue_number is None:
-                save_epic_run_state(state, root=root)
+            state = (
+                create_epic_run_state(epic_issue_number, run_id, root=root, **updates)
+                if epic_issue_number is not None
+                else create_independent_issue_run_state(
+                    list(independent_issues), run_id, root=root, **updates
+                )
+            )
     except EpicRunStateError as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/app/builderops/epic_dispatch.py
+++ b/app/builderops/epic_dispatch.py
@@ -381,9 +381,21 @@ def _normalize_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
             for value in candidate.get("dependencies", candidate.get("depends_on", []))
         ],
         "dependencies_satisfied": bool(candidate.get("dependencies_satisfied", False)),
-        "strict_ready": bool(candidate.get("strict_ready", True)),
-        "authority_ambiguous": bool(candidate.get("authority_ambiguous", False)),
-        "has_migration": bool(candidate.get("has_migration", False)),
+        "strict_ready": _normalize_optional_bool(candidate.get("strict_ready"), "strict_ready"),
+        "dependencies_known": _normalize_optional_bool(
+            candidate.get("dependencies_known"), "dependencies_known"
+        ),
+        "authority_ambiguous": _normalize_optional_bool(
+            candidate.get("authority_ambiguous"), "authority_ambiguous"
+        ),
+        "has_migration": _normalize_optional_bool(
+            candidate.get("has_migration"), "has_migration"
+        ),
+        "contract_surfaces": set(
+            _normalize_string_list(
+                candidate.get("contract_surfaces", []), "contract_surfaces"
+            )
+        ),
         "likely_touched_files": set(
             _normalize_string_list(
                 candidate.get("likely_touched_files", []),
@@ -468,20 +480,25 @@ def _validate_independent_fast_lane_admission(
     candidates: list[dict[str, Any]], *, independent_issue_numbers: list[int]
 ) -> None:
     by_number = {candidate["issue_number"]: candidate for candidate in candidates}
-    if set(by_number) != set(independent_issue_numbers):
+    if (
+        len(candidates) != len(independent_issue_numbers)
+        or len(by_number) != len(candidates)
+        or set(by_number) != set(independent_issue_numbers)
+    ):
         raise EpicDispatchError(
             "independent issue set must match candidates exactly"
         )
     for candidate in candidates:
-        if not candidate["strict_ready"] or candidate["state"] != "OPEN" or "agent:ready" not in candidate["labels"]:
+        if candidate["strict_ready"] is not True or candidate["state"] != "OPEN" or "agent:ready" not in candidate["labels"]:
             raise EpicDispatchError(f"issue {candidate['issue_number']} is not strictly ready")
-        if candidate["dependencies"]:
+        if candidate["dependencies_known"] is not True or candidate["dependencies"]:
             raise EpicDispatchError(f"issue {candidate['issue_number']} has dependencies")
-        if candidate["authority_ambiguous"]:
+        if candidate["authority_ambiguous"] is not False:
             raise EpicDispatchError(f"issue {candidate['issue_number']} has authority ambiguity")
-        if candidate["has_migration"]:
+        if candidate["has_migration"] is not False:
             raise EpicDispatchError(f"issue {candidate['issue_number']} includes a migration")
     touched: set[str] = set()
+    contracts: set[str] = set()
     for candidate in candidates:
         overlap = touched.intersection(candidate["likely_touched_files"])
         if overlap:
@@ -489,6 +506,12 @@ def _validate_independent_fast_lane_admission(
                 f"independent issue set has likely shared mutation surface: {sorted(overlap)}"
             )
         touched.update(candidate["likely_touched_files"])
+        contract_overlap = contracts.intersection(candidate["contract_surfaces"])
+        if contract_overlap:
+            raise EpicDispatchError(
+                f"independent issue set has contract overlap: {sorted(contract_overlap)}"
+            )
+        contracts.update(candidate["contract_surfaces"])
 
 
 def _normalize_runtime_targets(values: Iterable[str]) -> list[str]:
@@ -510,6 +533,14 @@ def _normalize_string(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise EpicDispatchError(f"{field} must be a non-empty string")
     return value.strip()
+
+
+def _normalize_optional_bool(value: Any, field: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise EpicDispatchError(f"{field} must be a boolean when supplied")
+    return value
 
 
 def _normalize_optional_string(value: Any) -> str | None:

--- a/app/builderops/epic_dispatch.py
+++ b/app/builderops/epic_dispatch.py
@@ -9,6 +9,7 @@ from app.builderops.epic_run_state import validate_run_id
 
 SCHEMA_VERSION = 1
 DEFAULT_MAX_PARALLEL = 2
+FAST_LANE_MAX_PARALLEL = 2
 VALID_PATHS = {"inline", "script", "subagent", "skip"}
 
 HANDOFF_RECEIPT_SCHEMA: dict[str, Any] = {
@@ -37,7 +38,8 @@ class EpicDispatchError(ValueError):
 
 def build_dispatch_plan(
     *,
-    epic_issue_number: int,
+    epic_issue_number: int | None = None,
+    independent_issue_numbers: Iterable[int] = (),
     run_id: str,
     candidates: Iterable[Mapping[str, Any]],
     max_parallel: int = DEFAULT_MAX_PARALLEL,
@@ -54,8 +56,24 @@ def build_dispatch_plan(
     """
 
     normalized_run_id = validate_run_id(run_id)
-    normalized_epic = _normalize_positive_int(epic_issue_number, "epic_issue_number")
+    independent_scope = _normalize_independent_issue_numbers(independent_issue_numbers)
+    if epic_issue_number is None:
+        if not independent_scope:
+            raise EpicDispatchError(
+                "dispatch scope requires epic_issue_number or independent_issue_numbers"
+            )
+        normalized_epic = None
+    else:
+        normalized_epic = _normalize_positive_int(epic_issue_number, "epic_issue_number")
+        if independent_scope:
+            raise EpicDispatchError(
+                "independent_issue_numbers cannot be combined with epic_issue_number"
+            )
     normalized_max = _normalize_positive_int(max_parallel, "max_parallel")
+    if independent_scope and normalized_max > FAST_LANE_MAX_PARALLEL:
+        raise EpicDispatchError(
+            f"independent fast lane max_parallel must not exceed {FAST_LANE_MAX_PARALLEL}"
+        )
     runtimes = _normalize_runtime_targets(runtime_targets)
     lease_issues = _normalize_active_leases(active_leases)
     normalized_candidates = [_normalize_candidate(item) for item in candidates]
@@ -64,12 +82,18 @@ def build_dispatch_plan(
         _validate_run_state_owner(
             run_state,
             epic_issue_number=normalized_epic,
+            independent_issue_numbers=independent_scope,
             run_id=normalized_run_id,
         )
     run_state_constraints = _normalize_json_list(
         run_state.get("reusable_constraints", []) if run_state is not None else [],
         "run_state.reusable_constraints",
     )
+    if independent_scope:
+        _validate_independent_fast_lane_admission(
+            normalized_candidates,
+            independent_issue_numbers=independent_scope,
+        )
 
     decisions: list[dict[str, Any]] = []
     context_packs: list[dict[str, Any]] = []
@@ -125,9 +149,8 @@ def build_dispatch_plan(
         )
         decisions.append(decision)
 
-    return {
+    result = {
         "schema_version": SCHEMA_VERSION,
-        "epic_issue_number": normalized_epic,
         "run_id": normalized_run_id,
         "max_parallel": normalized_max,
         "runtime_targets": runtimes,
@@ -144,6 +167,15 @@ def build_dispatch_plan(
         "source": "builderops.epic_dispatch.dry_run",
         "run_state_seen": run_state_seen,
     }
+    if independent_scope:
+        result["scope"] = {
+            "kind": "independent_issue_set",
+            "issue_numbers": independent_scope,
+            "parent_closure": "prohibited-without-real-governed-parent",
+        }
+    else:
+        result["epic_issue_number"] = normalized_epic
+    return result
 
 
 def _build_tcd_decision(
@@ -219,6 +251,10 @@ def _build_context_pack(
             "builderops_routing_required": True,
             "github_lifecycle_truth": "Issues/PRs/CI",
             "no_project_or_label_mutation_by_dispatch_planner": True,
+        },
+        "coordination": {
+            "routine_worker_to_worker": "prohibited",
+            "discovered_overlap": "typed-coordinator-exception",
         },
         "return_schema": HANDOFF_RECEIPT_SCHEMA,
     }
@@ -345,6 +381,9 @@ def _normalize_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
             for value in candidate.get("dependencies", candidate.get("depends_on", []))
         ],
         "dependencies_satisfied": bool(candidate.get("dependencies_satisfied", False)),
+        "strict_ready": bool(candidate.get("strict_ready", True)),
+        "authority_ambiguous": bool(candidate.get("authority_ambiguous", False)),
+        "has_migration": bool(candidate.get("has_migration", False)),
         "likely_touched_files": set(
             _normalize_string_list(
                 candidate.get("likely_touched_files", []),
@@ -382,17 +421,22 @@ def _normalize_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
 def _validate_run_state_owner(
     run_state: Mapping[str, Any],
     *,
-    epic_issue_number: int,
+    epic_issue_number: int | None,
+    independent_issue_numbers: list[int],
     run_id: str,
 ) -> None:
-    state_epic = _normalize_positive_int(
-        run_state.get("epic_issue_number"),
-        "run_state.epic_issue_number",
+    state_epic = run_state.get("epic_issue_number")
+    state_independent = _normalize_independent_issue_numbers(
+        run_state.get("independent_issue_numbers", [])
     )
     state_run_id = _normalize_string(run_state.get("run_id"), "run_state.run_id")
-    if state_epic != epic_issue_number:
+    if state_epic != epic_issue_number or state_independent != independent_issue_numbers:
+        if state_epic is not None:
+            raise EpicDispatchError(
+                f"run_id {run_id!r} already belongs to epic {state_epic}"
+            )
         raise EpicDispatchError(
-            f"run_id {run_id!r} already belongs to epic {state_epic}"
+            f"run_id {run_id!r} belongs to a different dispatch scope"
         )
     if state_run_id != run_id:
         raise EpicDispatchError(
@@ -411,6 +455,40 @@ def _normalize_active_leases(
             value = lease
         lease_issues.add(_normalize_positive_int(value, "active_leases"))
     return lease_issues
+
+
+def _normalize_independent_issue_numbers(values: Iterable[int]) -> list[int]:
+    normalized = [_normalize_positive_int(value, "independent_issue_numbers") for value in values]
+    if len(set(normalized)) != len(normalized):
+        raise EpicDispatchError("independent_issue_numbers must be unique")
+    return sorted(normalized)
+
+
+def _validate_independent_fast_lane_admission(
+    candidates: list[dict[str, Any]], *, independent_issue_numbers: list[int]
+) -> None:
+    by_number = {candidate["issue_number"]: candidate for candidate in candidates}
+    if set(by_number) != set(independent_issue_numbers):
+        raise EpicDispatchError(
+            "independent issue set must match candidates exactly"
+        )
+    for candidate in candidates:
+        if not candidate["strict_ready"] or candidate["state"] != "OPEN" or "agent:ready" not in candidate["labels"]:
+            raise EpicDispatchError(f"issue {candidate['issue_number']} is not strictly ready")
+        if candidate["dependencies"]:
+            raise EpicDispatchError(f"issue {candidate['issue_number']} has dependencies")
+        if candidate["authority_ambiguous"]:
+            raise EpicDispatchError(f"issue {candidate['issue_number']} has authority ambiguity")
+        if candidate["has_migration"]:
+            raise EpicDispatchError(f"issue {candidate['issue_number']} includes a migration")
+    touched: set[str] = set()
+    for candidate in candidates:
+        overlap = touched.intersection(candidate["likely_touched_files"])
+        if overlap:
+            raise EpicDispatchError(
+                f"independent issue set has likely shared mutation surface: {sorted(overlap)}"
+            )
+        touched.update(candidate["likely_touched_files"])
 
 
 def _normalize_runtime_targets(values: Iterable[str]) -> list[str]:

--- a/app/builderops/epic_dispatch.py
+++ b/app/builderops/epic_dispatch.py
@@ -396,6 +396,8 @@ def _normalize_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
                 candidate.get("contract_surfaces", []), "contract_surfaces"
             )
         ),
+        "file_surfaces_known": "likely_touched_files" in candidate,
+        "contract_surfaces_known": "contract_surfaces" in candidate,
         "likely_touched_files": set(
             _normalize_string_list(
                 candidate.get("likely_touched_files", []),
@@ -497,6 +499,14 @@ def _validate_independent_fast_lane_admission(
             raise EpicDispatchError(f"issue {candidate['issue_number']} has authority ambiguity")
         if candidate["has_migration"] is not False:
             raise EpicDispatchError(f"issue {candidate['issue_number']} includes a migration")
+        if not candidate["file_surfaces_known"]:
+            raise EpicDispatchError(
+                f"issue {candidate['issue_number']} lacks likely mutation surface evidence"
+            )
+        if not candidate["contract_surfaces_known"]:
+            raise EpicDispatchError(
+                f"issue {candidate['issue_number']} lacks contract surface evidence"
+            )
     touched: set[str] = set()
     contracts: set[str] = set()
     for candidate in candidates:

--- a/app/builderops/epic_run_state.py
+++ b/app/builderops/epic_run_state.py
@@ -175,6 +175,47 @@ def create_epic_run_state(
         return state
 
 
+def create_independent_issue_run_state(
+    issue_numbers: list[int],
+    run_id: str,
+    *,
+    root: Path | str | None = None,
+    **updates: Any,
+) -> dict[str, Any]:
+    """Create or idempotently load a local independent-issue run-state file.
+
+    Mirrors `create_epic_run_state`: the existence check, the run-owner check,
+    and the write all happen under `_locked_run_state`, so two concurrent
+    creates for the same absent `run_id` cannot both take the create branch and
+    silently discard the loser's scope or updates.
+
+    Deliberately has no `overwrite` escape hatch: an unguarded ownership
+    transfer would reopen the multi-writer hole this function exists to close.
+    """
+
+    path = epic_run_state_path(run_id, root=root)
+    expected_numbers = _normalize_independent_issue_numbers(list(issue_numbers))
+    with _locked_run_state(path):
+        if path.exists():
+            existing = deserialize_epic_run_state(path.read_text(encoding="utf-8"))
+            if (
+                existing["epic_issue_number"] is not None
+                or existing.get("independent_issue_numbers", []) != expected_numbers
+            ):
+                raise EpicRunStateError(
+                    f"run_id {run_id!r} already belongs to epic "
+                    f"{existing['epic_issue_number']}"
+                )
+            if updates:
+                existing = apply_epic_run_update(existing, **updates)
+                save_epic_run_state(existing, root=root)
+            return existing
+
+        state = new_independent_issue_run_state(issue_numbers, run_id, **updates)
+        save_epic_run_state(state, root=root)
+        return state
+
+
 def load_epic_run_state(
     run_id: str,
     *,
@@ -724,6 +765,7 @@ __all__ = [
     "apply_epic_run_update",
     "assert_learning_evaluation_candidates_terminal",
     "create_epic_run_state",
+    "create_independent_issue_run_state",
     "deserialize_epic_run_state",
     "epic_run_state_path",
     "load_epic_run_state",

--- a/app/builderops/epic_run_state.py
+++ b/app/builderops/epic_run_state.py
@@ -48,6 +48,7 @@ _REPLACE_MAPPING_FIELDS = ("dispatcher_status",)
 _STATE_FIELDS = (
     "schema_version",
     "epic_issue_number",
+    "independent_issue_numbers",
     "run_id",
     *_LIST_FIELDS,
     *_MERGE_MAPPING_FIELDS,
@@ -105,6 +106,7 @@ def new_epic_run_state(
     state: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "epic_issue_number": _normalize_epic_issue_number(epic_issue_number),
+        "independent_issue_numbers": [],
         "run_id": validate_run_id(run_id),
         "child_queue": [],
         "learning_evaluation_candidates": [],
@@ -121,6 +123,23 @@ def new_epic_run_state(
         "context_budget_receipts": [],
         "last_verified_head_sha": None,
     }
+    if updates:
+        return apply_epic_run_update(state, **updates)
+    return normalize_epic_run_state(state)
+
+
+def new_independent_issue_run_state(
+    issue_numbers: list[int],
+    run_id: str,
+    **updates: Any,
+) -> dict[str, Any]:
+    """Build evidence-only state for an explicit set with no synthetic parent."""
+
+    state = new_epic_run_state(1, run_id)
+    state["epic_issue_number"] = None
+    state["independent_issue_numbers"] = _normalize_independent_issue_numbers(
+        issue_numbers
+    )
     if updates:
         return apply_epic_run_update(state, **updates)
     return normalize_epic_run_state(state)
@@ -340,11 +359,27 @@ def normalize_epic_run_state(state: Mapping[str, Any]) -> dict[str, Any]:
             f"unsupported epic run-state schema_version: {schema_version!r}"
         )
 
+    epic_issue_number = raw.get("epic_issue_number")
+    independent_issue_numbers = _normalize_independent_issue_numbers(
+        raw.get("independent_issue_numbers", [])
+    )
+    if epic_issue_number is None:
+        if not independent_issue_numbers:
+            raise EpicRunStateError(
+                "independent run-state requires independent_issue_numbers"
+            )
+        normalized_epic_issue_number: int | None = None
+    else:
+        normalized_epic_issue_number = _normalize_epic_issue_number(epic_issue_number)
+        if independent_issue_numbers:
+            raise EpicRunStateError(
+                "epic run-state must not include independent_issue_numbers"
+            )
+
     normalized: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
-        "epic_issue_number": _normalize_epic_issue_number(
-            raw.get("epic_issue_number")
-        ),
+        "epic_issue_number": normalized_epic_issue_number,
+        "independent_issue_numbers": independent_issue_numbers,
         "run_id": validate_run_id(raw.get("run_id")),
         "last_verified_head_sha": _normalize_optional_string(
             raw.get("last_verified_head_sha"),
@@ -375,6 +410,15 @@ def _normalize_epic_issue_number(value: Any) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise EpicRunStateError("epic_issue_number must be a positive integer")
     return value
+
+
+def _normalize_independent_issue_numbers(value: Any) -> list[int]:
+    if not isinstance(value, list):
+        raise EpicRunStateError("independent_issue_numbers must be a list")
+    normalized = [_normalize_epic_issue_number(item) for item in value]
+    if len(set(normalized)) != len(normalized):
+        raise EpicRunStateError("independent_issue_numbers must be unique")
+    return sorted(normalized)
 
 
 def _normalize_optional_string(value: Any, field: str) -> str | None:
@@ -684,6 +728,7 @@ __all__ = [
     "epic_run_state_path",
     "load_epic_run_state",
     "new_epic_run_state",
+    "new_independent_issue_run_state",
     "normalize_epic_run_state",
     "record_dispatcher_status",
     "save_epic_run_state",

--- a/companion-ui/prompts/codex/deliver-epic-autonomous-runner.md
+++ b/companion-ui/prompts/codex/deliver-epic-autonomous-runner.md
@@ -207,6 +207,10 @@ mutation. Do not mark work Ready merely to fill worker slots.
 
 ### Phase 2 — Select the next delivery wave
 
+#### Independent-Issue Fast Lane
+
+For an explicit independent issue set, do not manufacture an epic or parent-closure plan. Admit only strictly ready Issues with no dependency, likely shared mutation surface, migration, contract overlap, or authority ambiguity, and never start more than two workers during the pilot. Give each worker one minimal pack (one Issue, one worktree/branch plan, exact `Verify:` targets, known constraints, and compact terminal-receipt schema). Workers do not message one another routinely; discovered overlap becomes a typed coordinator exception and pauses or rejects the affected wave. Dry-run and persisted run-state are reconstructable evidence only, never delivery authority. Follow `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md` and the existing structured severity and known-defect contracts: invalid/P0/P1/protected/low-confidence outcomes block; only a valid P2 may defer through governed intake without synchronous repair or re-review.
+
 Rank executable work by:
 
 1. explicit priority;

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -93,6 +93,15 @@ def test_subagent_role_governance_is_discoverable() -> None:
     assert "skills remain" in agents_text.lower()
 
 
+def test_independent_fast_lane_has_no_routine_worker_coordination() -> None:
+    skill = _read(".codex/skills/deliver-issue-set/SKILL.md")
+    runner = _read("companion-ui/prompts/codex/deliver-epic-autonomous-runner.md")
+    for surface in (skill, runner):
+        assert "Routine worker-to-worker coordination is prohibited" in surface or "Workers do not message one another routinely" in surface
+        assert "typed coordinator exception" in surface
+        assert "two workers" in surface
+
+
 def test_model_inquiry_local_host_route_is_identity_gated_and_fail_closed() -> None:
     skill = _read(".codex/skills/start-model-inquiry/SKILL.md")
     normalized_skill = " ".join(skill.split())

--- a/tests/builderops/test_epic_dispatch.py
+++ b/tests/builderops/test_epic_dispatch.py
@@ -345,6 +345,8 @@ def test_fast_lane_rejects_non_independent_or_over_budget_sets() -> None:
 
     missing_fact = _candidate(5203, risk="high")
     missing_fact.pop("strict_ready")
+    missing_surfaces = _candidate(5207, risk="high")
+    missing_surfaces.pop("likely_touched_files")
     duplicate = [_candidate(5204, risk="high"), _candidate(5204, risk="high")]
     contract_overlap = [
         dict(_candidate(5205, risk="high"), contract_surfaces=["contract/a"]),
@@ -352,6 +354,7 @@ def test_fast_lane_rejects_non_independent_or_over_budget_sets() -> None:
     ]
     for candidates, scope, expected in (
         ([missing_fact], [5203], "strictly ready"),
+        ([missing_surfaces], [5207], "mutation surface evidence"),
         (duplicate, [5204], "match candidates exactly"),
         (contract_overlap, [5205, 5206], "contract overlap"),
     ):

--- a/tests/builderops/test_epic_dispatch.py
+++ b/tests/builderops/test_epic_dispatch.py
@@ -286,3 +286,74 @@ def test_cli_dispatch_plan_is_dry_run_and_does_not_write_state(tmp_path: Path) -
     assert payload["context_packs"][0]["issue_contract"]["number"] == 5001
     assert payload["epic_run_state_update"]["dispatch_decisions"][0]["id"] == "dispatch-5001"
     assert not epic_run_state_path("run-cli-dispatch", root=tmp_path).exists()
+
+
+def test_explicit_independent_issue_set_needs_no_synthetic_epic() -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5101, 5102],
+        run_id="independent-fast-lane",
+        candidates=[
+            _candidate(5101, risk="high", files=["app/a.py"]),
+            _candidate(5102, risk="high", files=["app/b.py"]),
+        ],
+    )
+
+    assert "epic_issue_number" not in plan
+    assert plan["scope"] == {
+        "kind": "independent_issue_set",
+        "issue_numbers": [5101, 5102],
+        "parent_closure": "prohibited-without-real-governed-parent",
+    }
+    assert plan["selected_count"] == 2
+
+
+def test_fast_lane_rejects_non_independent_or_over_budget_sets() -> None:
+    base = [_candidate(5201, risk="high", files=["app/a.py"])]
+    for candidate_overrides, expected in (
+        ([ _candidate(5201, risk="high", dependencies=[1])], "dependencies"),
+        ([ _candidate(5201, risk="high", files=["app/a.py"]), _candidate(5202, risk="high", files=["app/a.py"])], "shared mutation"),
+        ([dict(_candidate(5201, risk="high"), has_migration=True)], "migration"),
+        ([dict(_candidate(5201, risk="high"), authority_ambiguous=True)], "authority ambiguity"),
+    ):
+        try:
+            build_dispatch_plan(
+                independent_issue_numbers=[item["issue_number"] for item in candidate_overrides],
+                run_id="independent-reject",
+                candidates=candidate_overrides,
+            )
+        except ValueError as exc:
+            assert expected in str(exc)
+        else:  # pragma: no cover - assertion keeps each admission rule fail-closed.
+            raise AssertionError(f"expected {expected} rejection")
+
+    try:
+        build_dispatch_plan(
+            independent_issue_numbers=[5201],
+            run_id="independent-cap",
+            max_parallel=3,
+            candidates=base,
+        )
+    except ValueError as exc:
+        assert "must not exceed 2" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected pilot cap rejection")
+
+
+def test_fast_lane_context_pack_is_minimal_and_receipted() -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5301],
+        run_id="independent-pack",
+        candidates=[_candidate(5301, risk="high", files=["app/a.py"])],
+    )
+    pack = plan["context_packs"][0]
+
+    assert pack["issue_contract"]["number"] == 5301
+    assert pack["branch_worktree_plan"]["worker_self_claim"] is True
+    assert pack["validation_ledger"]
+    assert pack["known_constraints"]
+    assert pack["return_schema"]["schema_name"] == "subagent_handoff_receipt"
+    assert pack["coordination"] == {
+        "routine_worker_to_worker": "prohibited",
+        "discovered_overlap": "typed-coordinator-exception",
+    }
+    assert "epic_history" not in json.dumps(pack)

--- a/tests/builderops/test_epic_dispatch.py
+++ b/tests/builderops/test_epic_dispatch.py
@@ -47,6 +47,11 @@ def _candidate(
         "owner_doc_writeback_required": owner_doc_writeback_required,
         "dependencies": dependencies or [],
         "dependencies_satisfied": dependencies_satisfied,
+        "dependencies_known": True,
+        "strict_ready": True,
+        "authority_ambiguous": False,
+        "has_migration": False,
+        "contract_surfaces": [],
         "source_anchors": ["#3229"],
         "known_constraints": ["worker self-claims through issue-to-code"],
         "validation": ["pytest -q tests/builderops/test_epic_dispatch.py"],
@@ -337,6 +342,29 @@ def test_fast_lane_rejects_non_independent_or_over_budget_sets() -> None:
         assert "must not exceed 2" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected pilot cap rejection")
+
+    missing_fact = _candidate(5203, risk="high")
+    missing_fact.pop("strict_ready")
+    duplicate = [_candidate(5204, risk="high"), _candidate(5204, risk="high")]
+    contract_overlap = [
+        dict(_candidate(5205, risk="high"), contract_surfaces=["contract/a"]),
+        dict(_candidate(5206, risk="high"), contract_surfaces=["contract/a"]),
+    ]
+    for candidates, scope, expected in (
+        ([missing_fact], [5203], "strictly ready"),
+        (duplicate, [5204], "match candidates exactly"),
+        (contract_overlap, [5205, 5206], "contract overlap"),
+    ):
+        try:
+            build_dispatch_plan(
+                independent_issue_numbers=scope,
+                run_id="independent-fail-closed",
+                candidates=candidates,
+            )
+        except ValueError as exc:
+            assert expected in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError(f"expected {expected} rejection")
 
 
 def test_fast_lane_context_pack_is_minimal_and_receipted() -> None:

--- a/tests/builderops/test_epic_run_state.py
+++ b/tests/builderops/test_epic_run_state.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +11,15 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+try:  # pragma: no cover - POSIX-only, mirrors app.builderops.epic_run_state
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX host
+    fcntl = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+from app.builderops import cli as builderops_cli
+from app.builderops import epic_run_state as epic_run_state_module
 from app.builderops.__main__ import _root as builderops_standalone_root
 from app.builderops.epic_run_state import (
     DEFAULT_EPIC_RUNS_DIR,
@@ -17,8 +28,10 @@ from app.builderops.epic_run_state import (
     assert_learning_evaluation_candidates_terminal,
     apply_epic_run_update,
     create_epic_run_state,
+    create_independent_issue_run_state,
     new_independent_issue_run_state,
     deserialize_epic_run_state,
+    save_epic_run_state,
     epic_run_state_path,
     load_epic_run_state,
     new_epic_run_state,
@@ -748,3 +761,254 @@ def test_fast_lane_state_never_becomes_delivery_authority(tmp_path: Path) -> Non
 
     create_epic_run_state(3229, "separate-epic", root=tmp_path)
     assert epic_run_state_path("separate-epic", root=tmp_path).exists()
+
+
+def _record_run_state(
+    *,
+    run_id: str,
+    issue_numbers: tuple[int, ...],
+    root: Path,
+    updates: dict[str, object],
+) -> None:
+    """Invoke the `epic-run-state record` implementation without Click's runner.
+
+    Two concurrent `CliRunner.invoke` calls would race on the globally patched
+    stdout, so the concurrency tests drive the command callback directly.
+    """
+
+    builderops_cli.record_epic_run_state.callback(
+        epic_issue_number=None,
+        independent_issues=issue_numbers,
+        run_id=run_id,
+        root=root,
+        update_json=json.dumps(updates),
+        update_file=None,
+        dry_run=False,
+        as_json=True,
+    )
+
+
+def _install_create_race(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    run_id: str,
+    first_call_started: threading.Event,
+    second_call_dispatched: threading.Event,
+) -> None:
+    """Hold the first independent create open until a second create is in flight.
+
+    The delay is injected into `new_independent_issue_run_state`, which both the
+    unlocked and the locked create paths call, so the window between the
+    existence check and the write is observable from a second writer.
+    """
+
+    original_new = epic_run_state_module.new_independent_issue_run_state
+    first_call_seen = threading.Event()
+
+    def delayed_new(
+        issue_numbers: list[int], state_run_id: str, **updates: object
+    ) -> dict[str, object]:
+        state = original_new(issue_numbers, state_run_id, **updates)
+        if state_run_id == run_id and not first_call_seen.is_set():
+            first_call_seen.set()
+            first_call_started.set()
+            assert second_call_dispatched.wait(timeout=5)
+            time.sleep(0.3)
+        return state
+
+    monkeypatch.setattr(
+        epic_run_state_module, "new_independent_issue_run_state", delayed_new
+    )
+    monkeypatch.setattr(
+        builderops_cli, "new_independent_issue_run_state", delayed_new
+    )
+
+
+def test_independent_run_state_creation_is_locked_and_rechecked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run-independent-concurrent"
+    issue_numbers = (4164, 4165)
+    first_call_started = threading.Event()
+    second_call_dispatched = threading.Event()
+    _install_create_race(
+        monkeypatch,
+        run_id=run_id,
+        first_call_started=first_call_started,
+        second_call_dispatched=second_call_dispatched,
+    )
+
+    errors: list[BaseException] = []
+
+    def record(child_issue: int, ready: threading.Event | None = None) -> None:
+        if ready is not None:
+            ready.set()
+        try:
+            _record_run_state(
+                run_id=run_id,
+                issue_numbers=issue_numbers,
+                root=tmp_path,
+                updates={
+                    "child_queue": [
+                        {"issue_number": child_issue, "state": "queued"}
+                    ]
+                },
+            )
+        except BaseException as exc:  # noqa: BLE001 - reported by the assertions
+            errors.append(exc)
+
+    first = threading.Thread(target=record, args=(4164,))
+    first.start()
+    assert first_call_started.wait(timeout=5)
+    second = threading.Thread(target=record, args=(4165, second_call_dispatched))
+    second.start()
+    first.join(timeout=15)
+    second.join(timeout=15)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+
+    final_state = load_epic_run_state(run_id, root=tmp_path)
+    assert final_state["epic_issue_number"] is None
+    assert final_state["independent_issue_numbers"] == [4164, 4165]
+    assert sorted(
+        entry["issue_number"] for entry in final_state["child_queue"]
+    ) == [4164, 4165]
+
+
+def test_independent_record_rejects_conflicting_run_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run-independent-owner"
+    first_call_started = threading.Event()
+    second_call_dispatched = threading.Event()
+    _install_create_race(
+        monkeypatch,
+        run_id=run_id,
+        first_call_started=first_call_started,
+        second_call_dispatched=second_call_dispatched,
+    )
+
+    results: dict[str, BaseException | None] = {}
+
+    def record(
+        name: str,
+        issue_numbers: tuple[int, ...],
+        child_issue: int,
+        ready: threading.Event | None = None,
+    ) -> None:
+        if ready is not None:
+            ready.set()
+        try:
+            _record_run_state(
+                run_id=run_id,
+                issue_numbers=issue_numbers,
+                root=tmp_path,
+                updates={
+                    "child_queue": [
+                        {"issue_number": child_issue, "state": "queued"}
+                    ]
+                },
+            )
+        except BaseException as exc:  # noqa: BLE001 - reported by the assertions
+            results[name] = exc
+        else:
+            results[name] = None
+
+    owner = threading.Thread(target=record, args=("owner", (4164, 4165), 4164))
+    owner.start()
+    assert first_call_started.wait(timeout=5)
+    intruder = threading.Thread(
+        target=record, args=("intruder", (4200,), 4200, second_call_dispatched)
+    )
+    intruder.start()
+    owner.join(timeout=15)
+    intruder.join(timeout=15)
+
+    assert not owner.is_alive()
+    assert not intruder.is_alive()
+    assert results["owner"] is None
+    intruder_error = results["intruder"]
+    assert intruder_error is not None, (
+        "a conflicting independent scope must not silently replace the run-state file"
+    )
+    assert "already belongs to" in str(intruder_error)
+
+    final_state = load_epic_run_state(run_id, root=tmp_path)
+    assert final_state["epic_issue_number"] is None
+    assert final_state["independent_issue_numbers"] == [4164, 4165]
+    assert final_state["child_queue"] == [
+        {"issue_number": 4164, "state": "queued"}
+    ]
+
+    # The same in-lock owner check must also reject an epic-owned run id.
+    create_epic_run_state(3229, "run-epic-owned", root=tmp_path)
+    with pytest.raises(EpicRunStateError, match="already belongs to epic 3229"):
+        create_independent_issue_run_state([4164], "run-epic-owned", root=tmp_path)
+
+
+@pytest.mark.skipif(
+    epic_run_state_module.fcntl is None,
+    reason="cross-process run-state locking requires fcntl",
+)
+def test_independent_run_state_creation_serializes_across_processes(
+    tmp_path: Path,
+) -> None:
+    """Prove the `fcntl.flock` arm, not just the in-process thread lock.
+
+    `epic-run-state record` runs as separate OS processes, so the real race is
+    cross-process. A second process that observes the run-state file as absent
+    must block on the file lock and then honour the winner's file.
+    """
+
+    run_id = "run-independent-cross-process"
+    path = epic_run_state_path(run_id, root=tmp_path)
+    lock_path = path.with_name(f".{path.name}.lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "app.builderops",
+                "builderops",
+                "epic-run-state",
+                "record",
+                "--independent-issue",
+                "4200",
+                "--run-id",
+                run_id,
+                "--root",
+                str(tmp_path),
+                "--json",
+            ],
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            # The lock is held, so the create must not complete or write.
+            with pytest.raises(subprocess.TimeoutExpired):
+                process.wait(timeout=5)
+            assert not path.exists()
+
+            # The winner writes a different independent scope under the lock.
+            save_epic_run_state(
+                new_independent_issue_run_state([4164, 4165], run_id),
+                root=tmp_path,
+            )
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+        output, _ = process.communicate(timeout=60)
+
+    assert process.returncode != 0
+    assert "already belongs to" in output
+
+    final_state = load_epic_run_state(run_id, root=tmp_path)
+    assert final_state["epic_issue_number"] is None
+    assert final_state["independent_issue_numbers"] == [4164, 4165]

--- a/tests/builderops/test_epic_run_state.py
+++ b/tests/builderops/test_epic_run_state.py
@@ -17,6 +17,7 @@ from app.builderops.epic_run_state import (
     assert_learning_evaluation_candidates_terminal,
     apply_epic_run_update,
     create_epic_run_state,
+    new_independent_issue_run_state,
     deserialize_epic_run_state,
     epic_run_state_path,
     load_epic_run_state,
@@ -736,3 +737,14 @@ def test_cli_rejects_epic_mismatch_before_writing(tmp_path: Path) -> None:
     assert "already belongs to epic 3229" in result.output
     state = load_epic_run_state("run-owned-by-3229", root=tmp_path)
     assert state["child_queue"] == [{"issue_number": 3247, "state": "queued"}]
+
+
+def test_fast_lane_state_never_becomes_delivery_authority(tmp_path: Path) -> None:
+    state = new_independent_issue_run_state([4164, 4165], "fast-lane-state")
+    assert state["epic_issue_number"] is None
+    assert state["independent_issue_numbers"] == [4164, 4165]
+    assert "parent_closure" not in state
+    assert "github_mutations" not in state
+
+    create_epic_run_state(3229, "separate-epic", root=tmp_path)
+    assert epic_run_state_path("separate-epic", root=tmp_path).exists()

--- a/tests/ops/test_review_before_ci_gate.py
+++ b/tests/ops/test_review_before_ci_gate.py
@@ -442,6 +442,16 @@ def test_review_severity_routing_blocks_only_p0_and_p1() -> None:
         assert "P3" in surface and "informational" in normalized_lower
 
 
+def test_fast_lane_consumes_structured_severity_without_weakening_gates() -> None:
+    skill = (REPO_ROOT / ".codex/skills/deliver-issue-set/SKILL.md").read_text(encoding="utf-8")
+    runner = (REPO_ROOT / "companion-ui/prompts/codex/deliver-epic-autonomous-runner.md").read_text(encoding="utf-8")
+    for surface in (skill, runner):
+        assert "AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md" in surface
+        assert ".codex/skills/bug-to-issue/SKILL.md" in surface or "known-defect contracts" in surface
+        assert "P2" in surface
+        assert "P0/P1" in surface
+
+
 def test_protected_review_invariants_cannot_be_downgraded_to_p2() -> None:
     contract = " ".join(REVIEW_REPAIR_CONTRACT.read_text(encoding="utf-8").split())
     closure_skill = " ".join(VERIFICATION_SKILL.read_text(encoding="utf-8").split())


### PR DESCRIPTION
Governing-Issue: #4164

Fixes #4164
Fixes #4205

Final-Review-Rounds: 1

## Summary

Adds an explicit independent-issue dispatch scope with a two-worker cap, fail-closed admission, minimal worker packs, evidence-only run-state support, and no routine worker coordination. It also closes the independent run-state creation race discovered during review.

## Multi-Issue Scope

#4205 is the bounded concurrency repair found while verifying #4164. It changes the same Builder System run-state seam, lands on this exact PR head, and shares the validation and rollback surface; both issues are fully delivered here. Parent #4163 remains open.

## Validation

- #4164: all six governing Verify tests passed
- #4205: both governing Verify tests plus a cross-process lock regression passed
- Focused affected suite: 775 passed
- Current-head GitHub CI: all required/relevant checks green
- `python3 scripts/lint_skills_consistency.py`, `python3 scripts/docs_guard.py`, `ruff check app tests`, and `git diff --check`: passed
- P2 AC6 verification-coverage gap deferred as `KD-76FD624A5781` through registry #4172

## BuilderOps Routing

- Records/projections/receipts: known-defect receipt `KD-76FD624A5781`; otherwise none
- Reason: the confirmed P2 is deferred under the governed registry; this PR changes Builder System helpers and has no additional operational record.

## Claim Receipt

`task_id=github-RasmusTho--agentic-pkm-mvp-issue-4164`; `lease_id=lease-651ff974`; `holder=codex-root`; `evidence=verified-dispatcher-lease`.
