### PR TITLE
docs: state receipt bootstrap prerequisite and store-posture criterion

### DIFF
--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -207,9 +207,9 @@ they start from. The value must be absolute (`~` expansion is applied, but a rel
 resolved against any stable base): a relative `BUILDEROPS_STATE_DIR` or `BUILDEROPS_DB_PATH` is
 interpreted against each process working directory and silently produces a separate database per
 worktree, which is the exact failure this posture exists to prevent. Record the choice in a
-host-local operator note; that note is host state, not repo authority. Worked example: the primary development laptop was consolidated onto the explicit
-`BUILDEROPS_STATE_DIR` posture on 2026-07-27, with the reasoning kept host-locally in
-`~/.local/state/builderops/HOST_POSTURE.md` on that machine.
+host-local operator note; that note is host state, not repo authority. Worked example: the primary
+development laptop was consolidated onto the explicit `BUILDEROPS_STATE_DIR` posture on 2026-07-27,
+with the reasoning kept host-locally in `~/.local/state/builderops/HOST_POSTURE.md` on that machine.
 
 Either posture yields the same host-stable store. The override does not weaken the SQLite
 separation check or the vault-confinement guard; it only bypasses the receipt gate during store

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -84,7 +84,9 @@ Override mechanisms:
 
 - `BUILDEROPS_STATE_DIR` sets the BuilderOps state directory. The default database name remains
   `builderops.sqlite3`.
-- `BUILDEROPS_DB_PATH` sets the exact SQLite database path.
+- `BUILDEROPS_DB_PATH` sets the exact SQLite database path. When both are set, `BUILDEROPS_DB_PATH`
+  selects the database and `BUILDEROPS_STATE_DIR` only sets the state directory; the state directory
+  does not redirect an explicit database path.
 - CLI commands generally accept `--db-path` for an explicit one-command override, which is the
   preferred test path. The `cutover-evidence generate` producer is the exception: it rejects this
   override because it can produce evidence only for the implicit host-stable store.
@@ -201,8 +203,11 @@ following holds on the host:
 
 Set the override where every shell inherits it (for example `~/.zshenv`), so interactive shells,
 agent tool shells, and CLI sessions resolve the same store regardless of which checkout or worktree
-they start from. Record the choice in a host-local operator note; that note is host state, not repo
-authority. Worked example: the primary development laptop was consolidated onto the explicit
+they start from. The value must be absolute (`~` expansion is applied, but a relative value is not
+resolved against any stable base): a relative `BUILDEROPS_STATE_DIR` or `BUILDEROPS_DB_PATH` is
+interpreted against each process working directory and silently produces a separate database per
+worktree, which is the exact failure this posture exists to prevent. Record the choice in a
+host-local operator note; that note is host state, not repo authority. Worked example: the primary development laptop was consolidated onto the explicit
 `BUILDEROPS_STATE_DIR` posture on 2026-07-27, with the reasoning kept host-locally in
 `~/.local/state/builderops/HOST_POSTURE.md` on that machine.
 
@@ -223,8 +228,11 @@ the implicit path. On a host with no host-stable store yet, the receipt route is
 override-first — the override is a prerequisite of the receipt, not an alternative to it:
 
 ```bash
-# 1. Pin the store explicitly. The value must equal the default state directory, because that is
-#    the only target the producer will inspect.
+# 1. Pin the store explicitly at the default state directory, because that is the only target the
+#    producer will inspect. Clear any inherited BUILDEROPS_DB_PATH first: an exact database path
+#    takes precedence over the state directory when both are set, so leaving it in place would
+#    write step 2 into the old database while the producer inspects the still-empty target.
+unset BUILDEROPS_DB_PATH
 export BUILDEROPS_STATE_DIR="$HOME/.local/state/builderops"
 
 # 2. Initialize the target and give it at least one record. An initialized but record-free

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -5,8 +5,8 @@ Owner: BuilderOps governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: app/builderops, app/cli/builderops.py, ADR-0010, BuilderOps object model
-Last reviewed: 2026-07-14
-Last verified against: issues #1501/#1502/#1507/#1508/#3686
+Last reviewed: 2026-07-27
+Last verified against: issues #1501/#1502/#1507/#1508/#3686; store-posture and receipt-bootstrap mechanics verified against app/builderops/config.py, app/builderops/cutover_evidence.py, and app/builderops/cli.py at c25f86949
 
 # BuilderOps Vault Store and CLI
 
@@ -170,6 +170,86 @@ or reconcile records, or perform the live cutover.
 
 Default home-directory resolution is lazy. An absolute explicit DB/state/CLI override therefore
 continues to work in hostless automation where no user home can be resolved.
+
+### Choosing a store posture for a host
+
+The receipt route and the explicit override are not interchangeable defaults. `validate_receipt`
+re-derives its bindings on every implicit store load, so the receipt posture only holds on a host
+where those bindings are stable:
+
+- the current working directory must sit inside exactly one declared participant root;
+- `_participants` resolves each declared root with `strict=True`, so a root that no longer exists
+  fails the gate closed;
+- the legacy-store inventory beneath the declared roots is re-walked and compared on each load, and
+  any legacy-store write after the reconciliation epoch is rejected.
+
+Prefer the receipt when the host's BuilderOps working directories all live under a small set of
+long-lived roots that can be declared once, and the legacy stores beneath those roots are frozen.
+Implicit selection is then self-verifying, with no environment state to lose.
+
+Prefer the explicit override (`BUILDEROPS_STATE_DIR`, or `BUILDEROPS_DB_PATH`) when any of the
+following holds on the host:
+
+- BuilderOps commands run from worktrees under several unrelated parent directories — for example
+  `<repo>/.claude/worktrees/`, `~/.codex/worktrees/`, and `~/code/pkm-worktrees/`. Every parent has
+  to be declared, and adding a new worktree parent silently re-breaks the gate until the receipt is
+  regenerated.
+- Those parent directories are created and reaped routinely. A reaped root fails strict resolution
+  and takes store selection down with it.
+- The recursive legacy-store discovery walk over the declared roots is expensive enough that paying
+  it on every store load is unattractive.
+
+Set the override where every shell inherits it (for example `~/.zshenv`), so interactive shells,
+agent tool shells, and CLI sessions resolve the same store regardless of which checkout or worktree
+they start from. Record the choice in a host-local operator note; that note is host state, not repo
+authority. Worked example: the primary development laptop was consolidated onto the explicit
+`BUILDEROPS_STATE_DIR` posture on 2026-07-27, with the reasoning kept host-locally in
+`~/.local/state/builderops/HOST_POSTURE.md` on that machine.
+
+Either posture yields the same host-stable store. The override does not weaken the SQLite
+separation check or the vault-confinement guard; it only bypasses the receipt gate during store
+selection.
+
+### Bootstrapping the receipt on a host with no host-stable store
+
+`cutover-evidence generate` verifies an existing target; it never creates one. `build_receipt`
+inspects the implicit target with `inspect_target` and fails closed with `target store is empty`
+unless that database already exists, is an initialized BuilderOps database, and holds at least one
+record. The producer always resolves the target from the default state directory:
+`BUILDEROPS_STATE_DIR` does not redirect it, and the CLI rejects `--db-path` before inspection.
+
+Because implicit selection is exactly what the guard blocks, the target cannot be created through
+the implicit path. On a host with no host-stable store yet, the receipt route is therefore
+override-first — the override is a prerequisite of the receipt, not an alternative to it:
+
+```bash
+# 1. Pin the store explicitly. The value must equal the default state directory, because that is
+#    the only target the producer will inspect.
+export BUILDEROPS_STATE_DIR="$HOME/.local/state/builderops"
+
+# 2. Initialize the target and give it at least one record. An initialized but record-free
+#    database still fails with "target store is empty".
+scripts/builderops_cli.sh builderops create-worklog \
+  --summary "Host store bootstrap" \
+  --body "Initialized the host-stable target store." \
+  --source-ref repo_doc:docs/builderops/BUILDEROPS_VAULT_STORE.md \
+  --idempotency-key create:host_store_bootstrap
+
+# 3. Stop BuilderOps writers and reconcile every legacy store beneath the participant roots into
+#    that target, then generate the receipt from a working directory inside exactly one declared
+#    participant root.
+python -m app.builderops builderops cutover-evidence generate \
+  --participants-file participants.json --reconciliation-file reconciliation.json \
+  --actor <operator> --json
+
+# 4. Drop the override and confirm that implicit selection now passes.
+unset BUILDEROPS_STATE_DIR
+scripts/builderops_cli.sh builderops list --json
+```
+
+Stopping after step 2 leaves a working host-stable store under the explicit-override posture. The
+receipt only adds self-verifying implicit selection on top of it, and is worth producing only when
+the bindings in `Choosing a store posture for a host` hold.
 
 ### Shared artifact vault and advisory claim signals
 


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): none
- Write class: docs
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: operator-facing store-posture guidance
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: none
- Owner-doc impact: BUILDEROPS_VAULT_STORE.md is the owner doc and is updated here
- Transition debt impact: none
- Fitness rule impact: none
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Document that the host-store-cutover receipt requires an already non-empty target store, add the override-first bootstrap sequence for a fresh host, and add a criterion for choosing between the receipt posture and the explicit BUILDEROPS_STATE_DIR override.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Docs authoring lane:
- [x] python3 scripts/docs_guard.py (OK); claims verified directly against app/builderops/config.py, app/builderops/cutover_evidence.py, app/builderops/cli.py at c25f86949; the empty-target failure mode reproduced locally against a throwaway store dir (inspect_target raised 'target store is empty' on an initialized but record-free database). Docs-only; no code changed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Docs-only clarification; no BuilderOps material routed.

## Notes
Receipt-posture bindings are described from validate_receipt as it exists at c25f86949; the worked example (laptop consolidated 2026-07-27) is host-local operator state and is labelled as such, not repo authority.
