### PR TITLE
Implement PLANNING reasoning mode and stop masking its absence in Chat

### DIFF
--- a/app/chat/read_only_cognition.py
+++ b/app/chat/read_only_cognition.py
@@ -37,6 +37,7 @@ class ReadOnlyChatResponse:
     denied_requests: list[str] = field(default_factory=list)
     side_effects_emitted: bool = False
     trace_id: str | None = None
+    degraded: bool = False
 
 
 class ReadOnlyChatCognition:
@@ -58,6 +59,8 @@ class ReadOnlyChatCognition:
         denied = self._detect_denied_requests(text)
         planning = self._plan_read_only(text, trace_id=trace_id)
 
+        degraded = bool(planning.get("degraded"))
+
         if denied:
             answer = (
                 "Read-only Chat cognition denied mutation/execution requests. "
@@ -66,6 +69,13 @@ class ReadOnlyChatCognition:
         else:
             answer = "Read-only Chat cognition generated a planning-only response."
 
+        if degraded:
+            # Surface the degradation instead of presenting a canned plan as real.
+            answer = (
+                f"{answer} A plan could not be produced: "
+                f"{planning.get('provider_error') or 'planning is unavailable'}."
+            )
+
         return ReadOnlyChatResponse(
             read_only=True,
             answer=answer,
@@ -73,6 +83,7 @@ class ReadOnlyChatCognition:
             denied_requests=denied,
             side_effects_emitted=False,
             trace_id=trace_id,
+            degraded=degraded,
         )
 
     @staticmethod
@@ -81,18 +92,23 @@ class ReadOnlyChatCognition:
         return sorted({match.group(1) for match in _DENY_PATTERN.finditer(lowered)})
 
     def _plan_read_only(self, prompt: str, *, trace_id: str | None) -> dict[str, Any]:
+        """Plan via the reasoning facade, or return a self-identifying degraded payload.
+
+        When the underlying PLANNING run fails, this surface must not substitute
+        generic steps that are indistinguishable from a model-produced plan.
+        The degraded payload carries the marker and the provider error instead.
+        """
         facade = self._facade_factory()
         run = facade.plan([], goal=prompt, trace_id=trace_id)
         if run.status == "ok" and isinstance(run.result, dict) and run.result:
             return run.result
         return {
-            "mode": "read_only_fallback",
+            "mode": "read_only_degraded",
+            "degraded": True,
+            "degraded_reason": "planning_unavailable",
+            "provider_error": run.error or "planning run returned no result",
             "goal": prompt,
-            "steps": [
-                "Clarify the request and constraints.",
-                "Identify relevant context and assumptions.",
-                "Propose a non-mutating response strategy.",
-            ],
+            "steps": [],
             "execution_allowed": False,
             "trace_id": trace_id,
         }

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -451,6 +451,13 @@ def run_reasoning(
                 trace_id=trace_id,
             )
             data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise ValueError("planning output was not a JSON object")
+            plan_text = str(data.get("plan") or "").strip()
+            raw_steps = data.get("steps") or []
+            # Keep the documented {"plan": str, "steps": list[str]} contract even
+            # when the model returns a scalar or a list of non-strings.
+            steps = [str(step) for step in raw_steps] if isinstance(raw_steps, list) else []
         except Exception as exc:
             return ReasoningRun(
                 mode=mode,
@@ -460,8 +467,6 @@ def run_reasoning(
                 error=str(exc),
                 result={"plan": "", "steps": []},
             )
-        plan_text = str(data.get("plan") or "").strip()
-        steps = data.get("steps") or []
         ok = bool(plan_text or steps)
         return ReasoningRun(
             mode=mode,

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -399,6 +399,78 @@ def run_reasoning(
             status="ok" if ok else "failed",
             error=None if ok else "ranking has no reasons" if ranking else "no ranking produced",
         )
+    if mode == ReasoningMode.PLANNING:
+        goal = (question or "").strip()
+        if not goal:
+            return ReasoningRun(
+                mode=mode,
+                trace_id=trace_id,
+                object_uuids=list(object_ids),
+                status="failed",
+                error="goal is required for planning mode",
+                result={"plan": "", "steps": []},
+            )
+        context_lines: List[str] = []
+        for oid in object_ids:
+            text, _ = _load_object_text(oid)
+            if text:
+                context_lines.append(f"- {oid}: {_simple_preview(text, 180)}")
+        backend = _reasoning_backend()
+        provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()
+        provider = "mock" if provider in {"", "fake"} else provider
+        if backend == "mock" or provider == "mock":
+            result = {
+                "plan": f"MOCK_PLAN: {goal}",
+                "steps": [
+                    "Clarify the goal and its constraints.",
+                    "Identify the relevant context and assumptions.",
+                    "Outline the concrete steps that reach the goal.",
+                ],
+            }
+            return ReasoningRun(
+                mode=mode,
+                trace_id=trace_id,
+                object_uuids=list(object_ids),
+                result=result,
+                status="ok",
+            )
+        user_lines = [f"Goal: {goal}"]
+        if context_lines:
+            user_lines.append("")
+            user_lines.append("Context:")
+            user_lines.extend(context_lines)
+        sys_prompt = system_prompt or (
+            "You are a planning assistant. Return JSON with plan (str) and steps (list of str)."
+        )
+        try:
+            raw = _call_chat(
+                task_kind="plan",
+                pack={"system": sys_prompt, "user": "\n".join(user_lines)},
+                agent=agent_name,
+                kind=kind_name,
+                trace_id=trace_id,
+            )
+            data = json.loads(raw)
+        except Exception as exc:
+            return ReasoningRun(
+                mode=mode,
+                trace_id=trace_id,
+                object_uuids=list(object_ids),
+                status="failed",
+                error=str(exc),
+                result={"plan": "", "steps": []},
+            )
+        plan_text = str(data.get("plan") or "").strip()
+        steps = data.get("steps") or []
+        ok = bool(plan_text or steps)
+        return ReasoningRun(
+            mode=mode,
+            trace_id=trace_id,
+            object_uuids=list(object_ids),
+            result={"plan": plan_text, "steps": steps},
+            status="ok" if ok else "failed",
+            error=None if ok else "empty planning result",
+        )
     if mode == ReasoningMode.ASK_ANSWER:
         backend = _reasoning_backend()
         provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()

--- a/tests/chat/test_read_only_chat_cognition.py
+++ b/tests/chat/test_read_only_chat_cognition.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.chat.read_only_cognition import ReadOnlyChatCognition
 from app.reasoning.models import ReasoningMode, ReasoningRun
 
@@ -84,12 +86,41 @@ def test_chat_cognition_has_no_note_or_outbox_side_effects() -> None:
     assert outbox_writer.calls == 0
 
 
-def test_chat_cognition_uses_fallback_planning_when_reasoning_plan_fails() -> None:
+def test_chat_cognition_marks_planning_degraded_when_reasoning_plan_fails() -> None:
     cognition = ReadOnlyChatCognition(facade_factory=lambda: _FailingFacade())
     result = cognition.respond("Plan how to summarize this thread", trace_id="trace-chat-fallback")
-    assert result.planning["mode"] == "read_only_fallback"
+
+    # The degraded payload must be self-identifying, not a canned plan that
+    # reads like a real one.
+    assert result.planning["mode"] == "read_only_degraded"
+    assert result.planning["degraded"] is True
+    assert result.planning["degraded_reason"] == "planning_unavailable"
+    assert result.planning["provider_error"] == "mode planning not implemented"
     assert result.planning["execution_allowed"] is False
-    assert "steps" in result.planning and result.planning["steps"]
+    assert result.planning["goal"] == "Plan how to summarize this thread"
+    assert result.planning["trace_id"] == "trace-chat-fallback"
+    # No fabricated plan steps.
+    assert result.planning.get("steps") == []
+    assert result.degraded is True
+    assert "could not be produced" in result.answer.lower()
+
+
+def test_chat_cognition_reaches_real_planning_path_on_mock_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The default (non-injected) facade must now reach a real PLANNING result
+    # instead of always falling back.
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("REASONING_PROVIDER", "mock")
+    monkeypatch.delenv("CI", raising=False)
+
+    result = ReadOnlyChatCognition().respond("Help me think about X", trace_id="trace-real")
+
+    assert result.degraded is False
+    assert result.planning.get("mode") not in {"read_only_fallback", "read_only_degraded"}
+    assert result.planning.get("plan")
+    assert result.planning.get("steps")
 
 
 def test_chat_cognition_denied_detection_uses_word_boundaries() -> None:

--- a/tests/reasoning/test_provider_planning.py
+++ b/tests/reasoning/test_provider_planning.py
@@ -1,0 +1,171 @@
+"""PLANNING-mode dispatch in ``run_reasoning``.
+
+Regression coverage for the defect where ``ReasoningMode.PLANNING`` was a
+first-class enum member with no branch in ``run_reasoning``, so every
+``ReasoningFacade.plan()`` call fell through to the terminal
+``"mode planning not implemented"`` return.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from app.reasoning.models import ReasoningMode
+from app.reasoning import provider as provider_module
+from app.reasoning.provider import run_reasoning
+from app.stores import get_object_store, reset_store_backends
+
+
+def _mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("REASONING_PROVIDER", "mock")
+    monkeypatch.delenv("CI", raising=False)
+
+
+def _llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.delenv("CI", raising=False)
+
+
+def test_planning_mode_returns_structured_plan_on_mock_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_env(monkeypatch)
+    reset_store_backends()
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Summarize this thread")
+
+    assert run.status == "ok"
+    assert run.error is None
+    assert run.mode == ReasoningMode.PLANNING
+    assert isinstance(run.result, dict)
+    assert run.result.get("plan")
+    assert run.result.get("steps")
+    # The old terminal fallthrough must no longer be reachable for PLANNING.
+    assert "not implemented" not in (run.error or "")
+
+
+def test_planning_mode_includes_object_context_on_mock_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_env(monkeypatch)
+    reset_store_backends()
+    store = get_object_store()
+    object_id = uuid4()
+    store.put(object_id, kind="note", source_ref="p.md", payload={"text": "Planning source note"})
+
+    run = run_reasoning(ReasoningMode.PLANNING, [str(object_id)], question="Plan the rollout")
+
+    assert run.status == "ok"
+    assert run.object_uuids == [str(object_id)]
+
+
+def test_planning_mode_does_not_call_backend_when_provider_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With no LLM_PROVIDER the route resolves to the mock client, which returns
+    # a decide-shaped blob unrelated to planning. Match ASK_ANSWER and short-
+    # circuit instead of parsing that as a failed plan.
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.delenv("CI", raising=False)
+    reset_store_backends()
+
+    def _must_not_be_called(**_kwargs: object) -> str:  # pragma: no cover - guard
+        raise AssertionError("planning must not call the backend on a mock route")
+
+    monkeypatch.setattr(provider_module, "_call_chat", _must_not_be_called)
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "ok"
+    assert run.result["plan"]
+    assert run.result["steps"]
+
+
+def test_planning_mode_calls_chat_backend_and_parses_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_call_chat(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return json.dumps(
+            {"plan": "Ship it in two passes.", "steps": ["Draft the change", "Validate and ship"]}
+        )
+
+    monkeypatch.setattr(provider_module, "_call_chat", _fake_call_chat)
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "ok"
+    assert run.result == {
+        "plan": "Ship it in two passes.",
+        "steps": ["Draft the change", "Validate and ship"],
+    }
+    assert len(calls) == 1
+    # PLANNING routes on the router's dedicated "plan" task kind
+    # (app/components/llm/router.py routes "plan" to default_reasoning).
+    assert calls[0]["task_kind"] == "plan"
+    pack = calls[0]["pack"]
+    assert isinstance(pack, dict)
+    assert "Ship the thing" in pack["user"]
+
+
+def test_planning_mode_reports_provider_failure_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    def _boom(**_kwargs: object) -> str:
+        raise RuntimeError("backend exploded")
+
+    monkeypatch.setattr(provider_module, "_call_chat", _boom)
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "failed"
+    assert "backend exploded" in (run.error or "")
+    assert run.result == {"plan": "", "steps": []}
+
+
+def test_planning_mode_reports_non_json_response_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    monkeypatch.setattr(provider_module, "_call_chat", lambda **_kwargs: "not json at all")
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "failed"
+    assert run.error
+    assert run.result == {"plan": "", "steps": []}
+
+
+def test_planning_mode_requires_a_goal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    def _must_not_be_called(**_kwargs: object) -> str:  # pragma: no cover - guard
+        raise AssertionError("planning must not call the chat backend without a goal")
+
+    monkeypatch.setattr(provider_module, "_call_chat", _must_not_be_called)
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="   ")
+
+    assert run.status == "failed"
+    assert run.error
+    assert run.result == {"plan": "", "steps": []}

--- a/tests/reasoning/test_provider_planning.py
+++ b/tests/reasoning/test_provider_planning.py
@@ -51,9 +51,12 @@ def test_planning_mode_returns_structured_plan_on_mock_backend(
     assert "not implemented" not in (run.error or "")
 
 
-def test_planning_mode_includes_object_context_on_mock_backend(
+def test_planning_mode_carries_object_uuids_on_mock_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # The mock branch does not consume object text; it must still report the
+    # object identities it was given. Prompt-level context is asserted on the
+    # real backend path in test_planning_mode_sends_object_context_to_backend.
     _mock_env(monkeypatch)
     reset_store_backends()
     store = get_object_store()
@@ -64,6 +67,92 @@ def test_planning_mode_includes_object_context_on_mock_backend(
 
     assert run.status == "ok"
     assert run.object_uuids == [str(object_id)]
+
+
+def test_planning_mode_sends_object_context_to_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+    store = get_object_store()
+    object_id = uuid4()
+    store.put(
+        object_id,
+        kind="note",
+        source_ref="p.md",
+        payload={"text": "Rollout depends on the migration landing first"},
+    )
+
+    captured: list[dict[str, object]] = []
+
+    def _fake_call_chat(**kwargs: object) -> str:
+        captured.append(kwargs)
+        return json.dumps({"plan": "p", "steps": ["s"]})
+
+    monkeypatch.setattr(provider_module, "_call_chat", _fake_call_chat)
+
+    run = run_reasoning(ReasoningMode.PLANNING, [str(object_id)], question="Plan the rollout")
+
+    assert run.status == "ok"
+    pack = captured[0]["pack"]
+    assert isinstance(pack, dict)
+    user_prompt = pack["user"]
+    assert "Context:" in user_prompt
+    assert str(object_id) in user_prompt
+    assert "migration landing first" in user_prompt
+
+
+def test_planning_mode_rejects_non_object_json_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Valid JSON that is not an object must fail closed, not raise
+    # AttributeError out of run_reasoning.
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    for payload in ('["a", "b"]', '"just a string"', "42"):
+
+        def _fake_call_chat(_payload: str = payload, **_kwargs: object) -> str:
+            return _payload
+
+        monkeypatch.setattr(provider_module, "_call_chat", _fake_call_chat)
+
+        run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+        assert run.status == "failed", payload
+        assert run.error
+        assert run.result == {"plan": "", "steps": []}
+
+
+def test_planning_mode_normalizes_steps_to_a_list_of_strings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+
+    monkeypatch.setattr(
+        provider_module,
+        "_call_chat",
+        lambda **_k: json.dumps({"plan": "do it", "steps": [1, {"a": 2}]}),
+    )
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "ok"
+    assert run.result["steps"] == ["1", "{'a': 2}"]
+
+    # A scalar `steps` must not leak through as a non-list.
+    monkeypatch.setattr(
+        provider_module,
+        "_call_chat",
+        lambda **_k: json.dumps({"plan": "do it", "steps": "not a list"}),
+    )
+
+    run = run_reasoning(ReasoningMode.PLANNING, [], question="Ship the thing")
+
+    assert run.status == "ok"
+    assert run.result["steps"] == []
+    assert run.result["plan"] == "do it"
 
 
 def test_planning_mode_does_not_call_backend_when_provider_is_unconfigured(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4177

## Linked Issue
Closes #4177

## SBS Impact
- Primary subsystem: Product/Runtime System - Reasoning / cognition
- Secondary subsystem(s): Chat surface (read-only cognition scaffold)
- Write class: derived
- Authority impact: none; the read-only Chat cognition stays execution-denied and gains no write or tool capability
- Persistence impact: none; ReasoningRun is not persisted on this path
- Derived/rebuildable impact: the planning result becomes model-derived instead of hardcoded
- Human knowledge impact: none
- Memory impact: unaffected
- Retrieval/context impact: unaffected; the call site passes no object context
- Sync/deployment impact: none
- External boundary impact: adds one LLM egress path through the existing app/components/llm/fabric chat client on router task kind 'plan'; no new provider, endpoint, or credential, and the path short-circuits before egress whenever the route is mock
- New or changed contract: PLANNING result shape {"plan": str, "steps": list[str]} on ReasoningRun.result, aligned with PlanningResult in app/components/reasoning/facade.py
- Owner-doc impact: none; no doc describes the fallback payload shape and the scaffold's documented execution-denied posture is preserved
- Transition debt impact: reduces; removes an enum member with no implementation and a silent fallback that masked it
- Fitness rule impact: strengthens; a degraded reasoning path is now observable instead of presenting as a normal result
- Boundary risk: low; no channel, migration, vault, or prod surface touched

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- ReasoningMode.PLANNING was a first-class enum member with no branch in run_reasoning, so every ReasoningFacade.plan() call fell through to the terminal "mode planning not implemented" return; the only caller, ReadOnlyChatCognition, swallowed that behind a status guard and substituted a hardcoded three-step plan, so that surface had never made a model call (D1 in docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md)
- adds the PLANNING branch in the same shape as its sibling modes and replaces the canned chat fallback with a self-identifying degraded payload that carries the provider error and emits no fabricated steps

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260727192442_dfe5bff6; dispatcher claim lease-2df02ecf (task github-RasmusTho--agentic-pkm-mvp-issue-4177, evidence=verified-dispatcher-lease)
- Reason: Issue-backed Product/Runtime slice. The LearningSignal records a validation-substrate divergence found while delivering it: this host's kern.maxfilesperproc (10240) makes the repo-wide local suite fabricate hundreds of phantom Errno 24 errors on consecutive runs.

## Notes
Validation on the pushed SHA: focused/affected-subsystem set derived from reverse imports of the two changed modules (tests/reasoning, tests/chat, tests/agents, tests/agent_memory, tests/components/reasoning, tests/architecture, tests/e2e, tests/deploy/test_cutover_readiness.py, tests/scripts/test_select_pr_tests.py) => 986 passed, 8 skipped, 0 failed. ruff check app tests companion-ui/companion-app => All checks passed. Behaviour receipt: run_reasoning(PLANNING, [], question='ship the thing') went from status=failed error='mode planning not implemented' result=None to status=ok result={'plan': 'MOCK_PLAN: ship the thing', 'steps': [...]}, and ReadOnlyChatCognition().respond(...) now reaches a real planning result instead of the canned fallback. Repo-wide non-PG suite was attempted through scripts/run_with_host_lease.py but is not trustworthy evidence on this host: kern.maxfilesperproc is 10240 and whichever full run executes second returns ~464 'OSError: [Errno 24] Too many open files' errors regardless of which tree it is; proven by running clean origin/main and this branch in both orders. That exhaustion also surfaces as 'OSError: could not get source code' from inspect.getsource, which made the unrelated execution-denial guard test look like a regression. CI is the authoritative repo-wide gate for this PR. Residual/follow-ups: (1) REVIEW and RANKING still lack the mock-provider guard this branch adds to PLANNING, so with LLM_PROVIDER unset they parse the mock client's decide-shaped blob; not fixed here. (2) D8 in the same audit (two distinct ReasoningFacade classes sharing a name and factory name) is untouched and remains a separate architectural decision. (3) runtime/ is untracked in this worktree although AGENTS.md states the dispatcher state dir is gitignored; it was deliberately not staged.
