### PR TITLE
Correct the HSP-02 delivery state carried into ADR-0064

### DIFF
--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -1,4 +1,4 @@
-State: Specification directory (design + bounded slices). Advisory until child issues are delivered. Defines the shared host/deploy secret boundary for the local-first posture; it does not claim a new runtime subsystem or a shipped secret manager.
+State: Specification directory (design + bounded slices). Both child tasks are delivered (HSP-01 via #3845/PR #3888; HSP-02 via #3846/PR #4008, merged 2026-07-20); parent #3843 remains open only for the redacted dev-deploy validation receipt and the `docs/SECURITY.md` promotion described under `Validation and acceptance`. Defines the shared host/deploy secret boundary for the local-first posture; it does not claim a new runtime subsystem or a shipped secret manager.
 Doc role: Capability specification (feature-breakdown lane)
 Authority: Owns the proposed local secret-provisioning design. Subordinate to `docs/SECURITY.md` for the security baseline, `docs/ENVIRONMENTS.md` for channel isolation, and the product owner documents of consumers it provisions.
 Owner: Architecture / operations
@@ -62,7 +62,7 @@ environment variable.
 | Order | Task | ID | Prerequisite | Outcome |
 | --- | --- | --- | --- | --- |
 | 1 | [Define host secret contract](DEFINE_HOST_SECRET_CONTRACT.md) | HSP-01 | — | delivered by [#3845](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3845) / PR #3888: names, consumer allowlist, Keychain access and redaction contract |
-| 2 | [Deliver runtime secret bootstrap](DELIVER_RUNTIME_SECRET_BOOTSTRAP.md) | HSP-02 | HSP-01 | bootstrap, channel integration and fail-closed/redaction tests |
+| 2 | [Deliver runtime secret bootstrap](DELIVER_RUNTIME_SECRET_BOOTSTRAP.md) | HSP-02 | HSP-01 | delivered by [#3846](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3846) / PR #4008 (merged 2026-07-20): bootstrap, channel integration and fail-closed/redaction tests |
 | Evidence | Delivered [#3830](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3830) | — | completed 2026-07-16 | redacted dev Keychain provisioning and healthy capture-watch receipt; it is not a child or dependency |
 
 ## Cross-task invariants

--- a/docs/adr/ADR-0064-model-access-substrate.md
+++ b/docs/adr/ADR-0064-model-access-substrate.md
@@ -170,15 +170,21 @@ needed.
 - Current Product routing and Builder Model Inquiry behavior are unchanged until their own migration
   steps. Steps 1-3 of the migration are purely additive.
 - `docs/LOCAL_SECRET_PROVISIONING/` is extended, not superseded: model-provider identifiers join the
-  contract, and its hardcoded consumer allowlist becomes data. This unblocks parent issue #3843.
+  contract, and its hardcoded consumer allowlist becomes data. Both HSP children are already
+  delivered (#3845/PR #3888 and #3846/PR #4008), so this extends a shipped mechanism rather than
+  waiting on one. It neither depends on nor closes parent issue #3843, which remains open for a
+  redacted dev-deploy receipt and the `docs/SECURITY.md` promotion; the model-provider identifiers
+  do, however, change what that promotion must say.
 - `docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md` becomes a delivery target. Its R4-1
   census is the first step. Its `capability-first` egress stage is unchanged and remains the owner's
   ruling.
 - Metered spend becomes an observable rather than a bet: the egress ledger and budget circuit breaker
   specified at `RUNTIME_MODEL_POSTURE.md:131,138` are prerequisites for volume growth, not follow-ups.
-- Two CI workflows that currently report green when their provider secret is absent
-  (`.github/workflows/ci-smoke.yaml:518-528`, `.github/workflows/architecture-ci.yaml:110-118`)
-  become contract violations under §6 and must be repaired as part of the census/credential work.
+- Two CI provider paths become contract violations under §6 and must be repaired as part of the
+  credential work. `.github/workflows/ci-smoke.yaml:518-528` reports green when its provider secret
+  is absent. `.github/workflows/architecture-ci.yaml:108-117` is worse: that workflow is
+  `workflow_dispatch`-only, so its gate never runs automatically at all, and the step writes a
+  credential into `$GITHUB_ENV`. "Repaired" means fail-closed or removed — never green-on-absent.
 - Consolidating the six Product-side abstractions is explicitly **not** authorized as a program. The
   census test blocks new drift; existing sites migrate opportunistically.
 - Architecture tests must eventually enforce: census equality across every allowlist, credential

--- a/docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md
+++ b/docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md
@@ -1,4 +1,4 @@
-State: Advisory design position, 2026-07-27. Evidence baseline: worktree `claude/reverent-kilby-ffb5fb` off `origin/main` at `ae37a7a49`, plus read-only inspection of the configured inquiry host. No implementation, no Issue, no PR is authorized by this document. It requests exactly one owner ruling (§7).
+State: Advisory design position, 2026-07-27. Evidence baseline: worktree `claude/reverent-kilby-ffb5fb` off `origin/main` at `ae37a7a49`, plus read-only inspection of the configured inquiry host. No implementation, no Issue, no PR is authorized by this document. It requests exactly one owner ruling (§7). Corrected 2026-07-27 after ratification: this document originally stated that HSP-02 was open. It was delivered on 2026-07-20 (#3846 / PR #4008); the error was inherited from a stale task-order row in `docs/LOCAL_SECRET_PROVISIONING/README.md`, corrected in the same change. Migration step 2 therefore extends a shipped mechanism and is independent of open parent #3843.
 Doc role: Reference (architecture design position — pre-ADR)
 Authority: Evidence-based analysis and a recommendation only. `docs/adr/ADR-0063-shared-llm-contract-kernel.md` remains authoritative for the Product/Builder contract seam; `docs/LLM_ROUTING.md` for current Product routing; ADR-0062 for Builder credential/process separation; `docs/LOCAL_SECRET_PROVISIONING/` for the host secret boundary. Owner docs win on disagreement.
 Owner: Architecture spine / LLM boundary
@@ -69,7 +69,7 @@ explicitly **out of scope**.
 | Spec | Owns | Explicitly excludes |
 |---|---|---|
 | ADR-0063 (Accepted) | contract kernel, fallback vocabulary, mappers | credentials, provider sessions, host processes (`:87-89`) |
-| LOCAL_SECRET_PROVISIONING (HSP-01 delivered, HSP-02 open, parent `agent:blocked`) | Keychain substrate, channel isolation, fail-closed | runtime model-provider enablement (`:105`) |
+| LOCAL_SECRET_PROVISIONING (both children delivered; parent #3843 open for a receipt only) | Keychain substrate, channel isolation, fail-closed | runtime model-provider enablement (`:105`) |
 | RUNTIME_MODEL_POSTURE (0 % delivered) | provider census, Anthropic provider, graduated egress posture | — but was never decomposed into Issues |
 
 Model credentials fall between all three. Nobody owns the seam. That is the actual defect.
@@ -225,7 +225,7 @@ One contract, four bindings, no new machinery:
 
 | Surface | Binding | Notes |
 |---|---|---|
-| Laptop (dev) | Keychain via `host_secret_contract.json`, channel `dev` | Mechanism already delivered (HSP-01). Needs the model-provider identifiers added and `host_secret_contract.py:17-19`'s hardcoded allowlist made data |
+| Laptop (dev) | Keychain via `host_secret_contract.json`, channel `dev` | Mechanism already delivered end to end (HSP-01 contract + HSP-02 bootstrap). Needs the model-provider identifiers added and `host_secret_contract.py:17-19`'s hardcoded allowlist made data |
 | Inquiry host | Same contract, channels `test`/`prod`, plus the **brokered session** backend for subscription paths | The proxy generalized: one local service, N providers, in Git, values still host-only |
 | dev/test/prod channels | The contract's `channel` dimension — already isolated and tested (INV-HSP-2) | No new isolation model |
 | CI | Declared secret backend only, via GitHub Actions secrets, resolved through the same contract | Subscription sessions are **structurally impossible** in CI. This is not a limitation to engineer around; it is the reason §7 exists |
@@ -366,7 +366,7 @@ mergeable.
 | # | Step | Touches | Exit |
 |---|---|---|---|
 | 1 | **Provider census** — `docs/settings/models/providers.yaml` + the static equality test across every allowlist site | new file, one test | `tests/settings/test_provider_census.py` green; `router.py:42`, `legacy.py:21`, `PROVIDER_REGISTRY`, health probes and docs all equal the census. R4-1, already specified |
-| 2 | **Credential contract extension** — model-provider identifiers in `host_secret_contract.json`; `host_secret_contract.py:17-19`'s hardcoded allowlist becomes data; HSP-02 bootstrap lands | `app/ops/**`, `config/secrets/` | Existing INV-HSP-1/2/3 tests extended to a model secret. Unblocks #3843 |
+| 2 | **Credential contract extension** — model-provider identifiers in `host_secret_contract.json`; `host_secret_contract.py:17-19`'s hardcoded allowlist becomes data | `app/ops/**`, `config/secrets/` | Existing INV-HSP-1/2/3 tests extended to a model secret. Extends the delivered HSP-01/HSP-02 mechanism; independent of open parent #3843 |
 | 3 | **Adapter contract promotion** — `ModelTurnAdapter` moves into the neutral kernel; auth-specific failure classes added | `app/builderops/model_inquiry_adapters.py` and kernel | Existing `tests/builderops/test_model_inquiry_adapters.py` green through the new location |
 | 4 | **First beneficiary: model inquiry** — `BUILDEROPS_INQUIRY_ADAPTERS_JSON` resolves through the credential contract | host config + launcher | A model inquiry completes over a fresh non-interactive SSH. This is the reported failure, fixed as a consequence rather than a patch |
 | 5 | **CKM** — replace `FabricSemanticAssociator` with a Builder-side adapter | `app/builderops/ckm/semantic.py` | `tests/builderops/ckm/test_semantic.py` green plus a negative test that Product fallback cannot execute the Builder task. ADR-0063 M4 |
@@ -439,7 +439,7 @@ recurring incident classes.
 the authority boundary.
 
 **The thing that makes this cheaper than it looks:** almost none of it is new design. The census is
-specified (R4-1). The credential mechanism is delivered (HSP-01). The adapter protocol is
+specified (R4-1). The credential mechanism is delivered end to end (HSP-01 and HSP-02). The adapter protocol is
 implemented and proven on two transports. The fallback vocabulary is ratified (ADR-0063). What is
 missing is that no Issue was ever created for any of it.
 
@@ -482,7 +482,7 @@ Not in scope; recorded so they are not rediscovered.
 | D1 | `read_only_cognition.plan()` fallback is **always** taken — it calls `run_reasoning(PLANNING, …)`, which has no PLANNING branch and always hits "mode planning not implemented". That surface has only ever emitted a canned 3-step plan | `app/chat/read_only_cognition.py:86-98`; `app/reasoning/provider.py:186-476` |
 | D2 | Ingest stamps `openai/text-embedding-3-large` on every `index.embedding.requested` event — a model no adapter can serve | `app/ingest/api.py:14,140` |
 | D3 | The OpenAI chat path silently discards the JSON Schema, downgrading to `{"type":"json_object"}`; the Ollama path honors it. Constrained decoding is provider-asymmetric at a seam that presents as uniform | `app/services/llm.py:282-290` |
-| D4 | Two workflows report green when their provider secret is absent | `ci-smoke.yaml:518-528`; `architecture-ci.yaml:110-118` |
+| D4 | `panel-llm-e2e` reports green when its provider secret is absent (`ci-smoke.yaml:518-528`). The `architecture-ci.yaml:110-118` Codex gate is worse than a silent skip: that whole workflow is `workflow_dispatch`-only by its own header note, so the gate never runs automatically at all — and the step writes a credential into `$GITHUB_ENV` | `ci-smoke.yaml:518-528`; `.github/workflows/architecture-ci.yaml:1-12,108-117` |
 | D5 | `config/agents.yaml` declares `merge.model: gpt-5.4` / `hygiene.model: gpt-5.4`. **No code reads it**; the name is a false friend for builder model config | `config/agents.yaml:6,15` |
 | D6 | `_SUPPORTED_EMBED_PROVIDERS` accepts `openai`/`deepseek`, but `PROVIDER_REGISTRY` has no adapter for either → runtime `ValueError` | `app/components/embeddings/legacy.py:21`; `app/llm/embeddings.py:377,394` |
 | D7 | `app/components/embeddings/base.py:11-24` documents OpenAI/Anthropic/Local implementations that do not exist and is unused by the runtime path | `app/components/embeddings/base.py` |
@@ -499,7 +499,7 @@ Not in scope; recorded so they are not rediscovered.
 | ADR-0062 | **Conforms.** Host-local model/subscription sessions remain the privileged Builder executor's (`:164-168`); the broker does not distribute credentials to laptops or Product Runtime. |
 | ADR-0057 (CKM projection-only) | **Unchanged here.** CKM-as-orchestrator needs a separate amendment; this document treats CKM only as a consumer. |
 | ADR-0023 / ADR-0052 (embedding egress) | **Untouched.** Embedding identity and reconciliation stay Product-owned; embeddings map to `fallback_compatible_identity`. |
-| `docs/LOCAL_SECRET_PROVISIONING/` | **Extended.** Same mechanism, model-provider identifiers added; unblocks #3843. |
+| `docs/LOCAL_SECRET_PROVISIONING/` | **Extended.** Same mechanism, model-provider identifiers added. Both children are delivered, so this extends shipped code; it neither depends on nor closes open parent #3843. |
 | `docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md` | **Delivery target.** R4-1 census becomes step 1. Its `capability-first` stage is the owner's egress ruling, unchanged. |
 | `AGENTS.md :: Total Cost of Development` | **Unchanged as policy.** The census makes it resolvable instead of only readable. |
 


### PR DESCRIPTION
## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

## Linked Issue


## SBS Impact
- Primary subsystem: Docs/governance truth for the host credential boundary and the ADR-0064 decision record
- Secondary subsystem(s): LOCAL_SECRET_PROVISIONING capability spec; model-access design position
- Write class: factual correction to merged authoritative docs; no code, no runtime behavior
- Authority impact: none — corrects a consequence statement and a dependency claim; the ADR-0064 decision and its owner receipt are unchanged
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: none; corrects statements about existing contracts
- Owner-doc impact: docs/LOCAL_SECRET_PROVISIONING/README.md corrected at source (State line and task-order row 2)
- Transition debt impact: removes a false dependency between the model-credential work and open parent #3843, preventing a duplicate HSP-02 filing during feature-breakdown
- Fitness rule impact: none
- Boundary risk: low; docs-only

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Correct the HSP-02 delivery state that a stale task-order row carried into the model-access audit and ADR-0064.
- Migration step 2 extends a shipped mechanism and is independent of open parent #3843, so it must not be filed as an HSP child. The ruling itself is unchanged.
- Verification: #3845 closed 2026-07-17, #3846 closed 2026-07-20, PR #4008 merged 2026-07-20, #3843 still open — all read directly from the GitHub API. The architecture-ci.yaml workflow_dispatch-only claim was verified against that workflow's own header at :1-12. docs_guard, public_seam_lint --mode gate (0 uncovered hits), and adr_index all pass.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Correction to repo-governed docs; the ADR authority path is the correct surface

## Notes
Root cause: the LOCAL_SECRET_PROVISIONING task-order row never recorded HSP-02's delivery, so a downstream design pass inherited the error into an ADR. Corrected at source, not only downstream.
