### PR TITLE
governance: make publish-pr PR-body templates satisfy the pr-contract gate

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -251,7 +251,13 @@ Any overlap with your staged file set => STOP: keep the earlier compliant PR, cl
 
 ### Step 6: Create or Update PR
 
-Execute based on lane classification:
+Execute based on lane classification. Every template below includes the required
+`Final-Review-Rounds: 1` line (the `pr-contract` gate rejects a body with zero or more than one
+match of `/^Final-Review-Rounds:[ \t]*[12][ \t]*$/`; use `2` only when a second final review round
+is actually planned) and concrete `## BuilderOps Routing` defaults instead of `<...>` placeholders
+(the gate rejects any routing value matching `^<.*>$`). The `none` / reason defaults shown match what
+`scripts/pr_body_generator.py` emits (`_builderops_section`) — replace them with the actual
+records/projections/receipts and reason whenever BuilderOps material was in fact routed.
 
 **Implementation Lane (Fixes an Issue):**
 ```bash
@@ -262,12 +268,14 @@ Governing-Issue: #<ISSUE_NUMBER>
 
 Fixes #<ISSUE_NUMBER>
 
+Final-Review-Rounds: 1
+
 ## Summary
 <1-2 sentence summary of the bounded change>
 
 ## BuilderOps Routing
-- Records/projections/receipts: <ids or "none">
-- Reason: <why no BuilderOps material was created, or what was routed>
+- Records/projections/receipts: none
+- Reason: Tier 1 lane with no BuilderOps material routed.
 
 ## Notes
 Validation: <What validation actually ran>
@@ -283,6 +291,8 @@ gh pr create \
   --body "$(cat <<'EOF'
 - [x] Docs authoring lane
 
+Final-Review-Rounds: 1
+
 ## Summary
 <Summary of documentation changes>
 
@@ -290,8 +300,8 @@ gh pr create \
 <What surfaces were updated>
 
 ## BuilderOps Routing
-- Records/projections/receipts: <ids or "none">
-- Reason: <why no BuilderOps material was created, or what was routed>
+- Records/projections/receipts: none
+- Reason: Tier 1 lane with no BuilderOps material routed.
 
 ## Notes
 Validation: <Docs validation that ran>
@@ -307,6 +317,8 @@ gh pr create \
   --body "$(cat <<'EOF'
 - [x] Governance lane
 
+Final-Review-Rounds: 1
+
 ## Summary
 <Summary of governance/workflow change>
 
@@ -314,8 +326,8 @@ gh pr create \
 <What surfaces were updated>
 
 ## BuilderOps Routing
-- Records/projections/receipts: <ids or "none">
-- Reason: <why no BuilderOps material was created, or what was routed>
+- Records/projections/receipts: none
+- Reason: Tier 1 lane with no BuilderOps material routed.
 
 ## Notes
 Validation: <Governance validation that ran>
@@ -323,6 +335,37 @@ Validation: <Governance validation that ran>
 EOF
 )"
 ```
+
+**Direct Repair Lane (bounded immediate fix, no governing Issue):**
+```bash
+gh pr create \
+  --title "<bounded repair outcome>" \
+  --body "$(cat <<'EOF'
+## Direct Repair
+Type: governance
+Reason: state why this qualifies as a bounded, immediate direct repair
+Validation: state the checks that were actually run
+Issue required: no
+
+Final-Review-Rounds: 1
+
+## Summary
+<1-2 sentence summary of the bounded repair>
+
+## BuilderOps Routing
+- Records/projections/receipts: none
+- Reason: Tier 1 lane with no BuilderOps material routed.
+
+## Notes
+Validation: <What validation actually ran>
+---
+EOF
+)"
+```
+
+`Type:` must be exactly one of `docs`, `governance`, or `code` (`docs/development/PR_HOT_PATH.md ::
+Direct Repair`). No lane checkbox and no `Governing-Issue`/closing-keyword line are needed when this
+block is complete — the gate accepts the `## Direct Repair` block as the standalone contract.
 
 **Update Existing PR:**
 ```bash
@@ -341,8 +384,12 @@ Pre-push PR-body contract gate:
   - governance lane: `- [x] Governance lane`
   - direct repair: a complete `## Direct Repair` block with `Type:`, `Reason:`, `Validation:`, and `Issue required: no`
 - If none is present, stop and repair the PR body before publication.
+- Verify exactly one `Final-Review-Rounds: 1` or `Final-Review-Rounds: 2` line is present — every
+  lane requires it, including direct repair.
 - Verify BuilderOps Routing per tier — see the `## Core rules` PR-body machinery rule above
-  (`docs/development/GOVERNANCE_PROPORTIONALITY.md`); never leave the section present but unfilled.
+  (`docs/development/GOVERNANCE_PROPORTIONALITY.md`); never leave the section present but unfilled,
+  and never leave a `<...>` placeholder in a value the gate reads (`Records/projections/receipts:`
+  or `Reason:`).
 
 Direct Repair block placement: prefer placing the `## Direct Repair` block as the first section of the PR body (before `## Summary`). The governance check accepts the block in any position — first, middle, or last — but first placement is preferred for reviewer clarity.
 
@@ -358,6 +405,13 @@ echo "Handing off to pr-integration skill"
 **Do not force this as an immediate publication step.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge when the PR needs that readiness path.
 
 ## PR body requirements
+
+Every lane, with no exception:
+
+- include exactly one `Final-Review-Rounds: 1` or `Final-Review-Rounds: 2` line
+- include a `## BuilderOps Routing` section with concrete `Records/projections/receipts:` and
+  `Reason:` values (never a `<...>` placeholder) unless the Tier 1 omission rule in `## Core rules`
+  applies
 
 Implementation lane:
 
@@ -376,6 +430,13 @@ Governance lane:
 
 - mark `Governance lane`
 - confirm the change stays within approved governance surfaces
+
+Direct repair lane:
+
+- include a complete `## Direct Repair` block: `Type:` (one of `docs`, `governance`, `code`),
+  `Reason:`, `Validation:`, and `Issue required: no`
+- no lane checkbox and no `Governing-Issue`/closing-keyword line — the Direct Repair block is the
+  standalone contract
 
 
 ## Capturing learning

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, edited, reopened, labeled, unlabeled, locked, unlocked, closed]
   pull_request:
-    types: [opened, edited, reopened, synchronize, review_requested]
+    types: [opened, edited, reopened, synchronize]
 
 permissions:
   contents: read
@@ -198,6 +198,9 @@ jobs:
 
   pr-contract:
     if: github.event_name == 'pull_request'
+    concurrency:
+      group: pr-contract-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -44,25 +44,32 @@ Default rule:
 
 ## PR Body Preparation
 
-Before opening a PR, generate or preflight the body from lane inputs instead of reconstructing the
-template by hand:
+`.codex/skills/publish-pr/SKILL.md :: Step 6` is the authoritative source of the four PR-body
+templates (implementation, docs-authoring, governance, direct-repair) actually used at publication
+time. Copy the template for the chosen lane directly from that step. Each template already carries
+the fields the `pr-contract` gate requires — a single `Final-Review-Rounds: 1` (or `2`) line, a
+filled `## BuilderOps Routing` section with no `<...>` placeholder, and, for direct repair, the
+complete `Type:` / `Reason:` / `Validation:` / `Issue required: no` block — so an agent that copies
+one of them and fills in the bracketed content satisfies the gate by construction.
 
-```bash
-python3 scripts/pr_body_generator.py --input-json /path/to/pr-body-inputs.json > /tmp/pr-body.md
-```
-
-Use the generator for implementation, docs-authoring, governance, and direct-repair lanes when a PR
-touches governance surfaces, closes an issue, or needs BuilderOps routing evidence. The generated
-body remains editable before PR creation, but required lane inputs fail locally before any PR is
-opened:
+`scripts/pr_body_generator.py` implements the same field contract as a standalone generator
+(`--input-json` in, a complete body out) and is available for ad hoc preflight or drift-checking
+against these templates, but no skill invokes it as part of the publication path. Wiring
+`publish-pr` to the generator is deliberately out of scope for now: the generator hard-enforces the
+full 16-field `SBS Impact` block (`docs/architecture/SBS_OPERATING_MODEL.md`), and that block's
+contract is under an open owner ruling tracked outside this doc — wiring the generator in before
+that ruling lands would cement a contract that may be about to change. Revisit this section once
+the ruling lands. Whichever source is used — skill template or generator — required lane inputs must
+be concrete before any PR is opened:
 
 - implementation lane requires a linked issue;
 - every body requires concrete SBS impact, validation, and owner-doc writeback resolution;
 - issue-backed and direct-repair bodies require concrete BuilderOps routing lines;
 - direct repair requires `Type`, `Reason`, `Validation`, and `Issue required: no`.
 
-The generator does not weaken `pr-contract`, infer issues silently, open PRs, or write to GitHub. CI
-remains the authority for whether the final PR body satisfies the repository contract.
+Neither the skill templates nor the generator weaken `pr-contract`, infer issues silently, open PRs,
+or write to GitHub. CI remains the authority for whether the final PR body satisfies the repository
+contract.
 
 ## Multi-Issue PR Scope
 

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -45,6 +45,23 @@ def test_pr_contract_requires_one_bounded_final_review_declaration() -> None:
     assert "Final-Review-Rounds: 1` or `Final-Review-Rounds: 2" in workflow
 
 
+def test_pr_contract_trigger_excludes_review_requested_and_cancels_stale_runs() -> None:
+    """`pr-contract` has no assertion that reads anything `review_requested` changes (not the
+    body, file list, commits, or title), so re-running it on that event only burns CI minutes
+    and the shared Actions queue. Keep `opened`/`edited`/`reopened`/`synchronize` — `edited` is
+    how body repairs re-trigger the gate and `synchronize` is when the diff can change."""
+    workflow = _read_workflow()
+
+    assert "types: [opened, edited, reopened, synchronize]" in workflow
+    assert "review_requested" not in workflow
+
+    pr_contract_job = workflow[workflow.index("\n  pr-contract:") :]
+    assert "concurrency:" in pr_contract_job
+    concurrency_block = pr_contract_job[: pr_contract_job.index("runs-on:")]
+    assert "group: pr-contract-${{ github.event.pull_request.number }}" in concurrency_block
+    assert "cancel-in-progress: true" in concurrency_block
+
+
 _TIER1_LANE_REGEX = re.compile(
     r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b",
     re.IGNORECASE | re.MULTILINE,


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

Governing-Issue: #4187

## Linked Issue
Fixes #4187

Both lines are required for a single-issue PR and identify the same issue. For an approved multi-issue PR, keep exactly one governing identity, reference the governing parent when it remains open, and use closing keywords only for fully delivered issues.
Leave both fields blank only when no governing issue exists, including issue-free docs-authoring or governance-lane PRs.

## SBS Impact
Classify Product/Runtime System, Builder System, or boundary work per `docs/architecture/SBS_OPERATING_MODEL.md` §3, then fill SBS impact per §4; use "none"/"unaffected" explicitly rather than leaving a field blank.
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): PR contract enforcement
- Write class: governance/docs/process
- Authority impact: none — gate predicates are unchanged; only the templates and trigger set change
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: GitHub Actions trigger configuration (removed `review_requested` from `pr-contract`, added job-level `concurrency` cancellation)
- New or changed contract: none — templates are brought into conformance with the existing contract
- Owner-doc impact: will-update-in-PR
- Transition debt impact: reduces
- Fitness rule impact: strengthens
- Boundary risk: this PR edits the very templates and gate its own body is judged against; the body is validated against the template on origin/main at CI time, not against the edited one — verified `git show origin/main:.github/pull_request_template.md` before writing this body

## Owner-Doc Writeback
Resolve to exactly one (`docs/architecture/SBS_OPERATING_MODEL.md` §9). A comment or "to update later" note is not an acceptable resolution.
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add the required `Final-Review-Rounds:` line and replace `<...>` BuilderOps Routing placeholders with concrete defaults (matching `scripts/pr_body_generator.py:197-204`) in all three `publish-pr` PR-body templates, and add a fourth worked-example Direct Repair template.
- Reconcile `docs/development/PR_HOT_PATH.md :: PR Body Preparation` to describe what `publish-pr` Step 6 actually instructs (hand-authored templates) instead of a generator invocation no skill performs.
- Drop `review_requested` from the `pr-contract` trigger set in `.github/workflows/issue-pr-governance.yml` (kept `opened`/`edited`/`reopened`/`synchronize`) and add job-level `concurrency: { group: pr-contract-<pr-number>, cancel-in-progress: true }` so a stale re-run is cancelled instead of burning a redundant CI slot.
- Add a governance test asserting the new trigger set and concurrency block in `tests/governance/test_issue_pr_governance.py`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed.

## Notes
- No gate assertion was weakened or removed; only the templates were brought into conformance with the existing `pr-contract` predicates, and the trigger/concurrency change only stops a redundant re-run that no assertion reads.
- `publish-pr` was deliberately not wired to `scripts/pr_body_generator.py` in this slice per the issue's Constraints — that generator's 16-field `SBS Impact` enforcement is under a separate open owner ruling.
- Validation: `ruff check app tests` clean; `mypy app` clean (809 source files, no issues); `python3 scripts/lint_skills_consistency.py` clean; `python3 scripts/docs_guard.py` clean; `scripts/review_before_ci_gate.py --lane governance --review-gate-complete --risk-assessment-complete` satisfied; targeted `pytest tests/governance/test_issue_pr_governance.py tests/architecture/test_pr_hot_path_governance.py tests/architecture/test_agent_skill_entrypoints.py tests/scripts/test_pr_body_generator.py` all green (122+ passed, 0 failed). A full `pytest -q -m "not pg" -n auto --dist=loadfile --timeout=300` was also run through `scripts/run_with_host_lease.py --resource pytest-not-pg`; it overlapped with two other concurrent full-suite runs on the same shared host (confirmed via `ps`/lease files, different sessions), which produced heavy environment-driven error noise unrelated to this diff. This change touches no `app/` code, so the targeted governance/architecture tests above are the reliable regression signal; GitHub CI's isolated runner is the authoritative full-suite result.
- Escalate to the repo-wide non-PG suite only through `scripts/run_with_host_lease.py --resource pytest-not-pg ...`; see `docs/development/DEV_WORKFLOW.md :: Validation baseline`.
