### PR TITLE
Bound the neutralized PR body to its merge attempt

### DIFF
--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -497,8 +497,11 @@ python3 scripts/resolve_neutralized_body_restoration.py \
   --pr-json <pr.json> --comments-json <comments.json> --repository <owner/repo>
 ```
 
-It is read-only and exits `2` when the live body is neutralized while no authority receipt covers the
-current head, naming the durable receipt's `restore_body_sha256` as the only accepted restore target.
+It is read-only and separates a positively safe state from an indeterminate one: `0` means no
+restoration is required, `2` means the body is neutralized with no receipt for the current head and
+names the durable receipt's `restore_body_sha256` as the only accepted restore target, and `3` means
+the body is neutralized on an open PR but the evidence is missing, untrusted, or conflicting. Treat
+`3` as a hard stop and recover the evidence; never read it as "nothing to do".
 
 Rules for the restore:
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -390,7 +390,15 @@ same exact head back to the ordinary verified-merge sequence below.
 2. run `scripts/prepare_verified_issue_set_merge.py` against those snapshots; require its
    `verified_issue_set_merge_authority.v1` receipt and neutralized body, then post that exact
    machine-readable authority receipt on the PR from an authenticated repository collaborator before
-   changing the body so the original authority remains durable and auditable
+   changing the body so the original authority remains durable and auditable.
+   **Neutralization precondition — this exact head must be the final head.** A neutralized body is
+   only valid while the attempt it was prepared for is in flight, so the planner requires a
+   head-bound `verified_issue_set_merge_readiness.v1` statement through `--merge-readiness-json`
+   whose `head_sha` equals this exact head, with `required_checks_green: true`,
+   `review_gate_resolved: true`, and `further_commits_anticipated: false`. Do not neutralize while
+   any repair, rebase, base-branch update, review-feedback fix, or other commit is still expected;
+   finish those commits first and restart at step 1 on the new head. A readiness statement is never
+   reusable across heads, and the planner refuses neutralization when the precondition is unmet
 3. replace the live PR body with the plan's neutralized body, which converts every authenticated
    closer to evidence-only `Refs`; immediately re-read the PR and fail closed unless the head and
    neutralized body matches the plan under the terminal-LF-only canonical digest contract above, the
@@ -412,7 +420,8 @@ same exact head back to the ordinary verified-merge sequence below.
 5. merge through the exact-head REST endpoint using the verified SHA and only the plan's fixed
    non-closing commit title/message. Never use GitHub-synthesized or caller-supplied free-form merge
    text. A body/head/closing-link change before this request is a hard stop; never restore closers and
-   retry around a failed gate
+   retry around a failed gate. A hard stop ends this merge attempt, so apply
+   `Restoring a neutralized body after a head change` below before any further repair work
 6. verify merge success and re-fetch the merge commit to prove its title/message contains no
    canonical or malformed closing attempt, then post the authority-bound `merged` phase receipt
 7. on resume, recover either authenticated interruption window without restarting accounting. If the
@@ -468,6 +477,40 @@ same exact head back to the ordinary verified-merge sequence below.
 17. assert each required `post-merge owner-doc check: PR #<PR>;` receipt exists before emitting a delivery
     receipt; watchdog or pending reminders are not closure receipts. [owner-doc-receipt-gate]
 18. if direct repair, write a direct repair delivery receipt instead of issue-closure state changes
+
+### Restoring a neutralized body after a head change
+
+A neutralized body's lifetime is bounded by the one merge attempt that justified it. It is never a
+durable PR state, so it must not outlive its exact head.
+
+Whenever a new head is observed on a PR whose body is still neutralized — a repair commit, a rebase,
+a base-branch update, an abandoned attempt, or a resumed session — restore the canonical body before
+any further repair, verification, or re-merge work. Leaving it neutralized fails `pr-contract`
+deterministically on that head and on every head after it, because the exact-head authority receipt
+no longer covers the live head. That happened on PR #4021, where one neutralized body survived six
+later heads for about seven hours.
+
+Detect the state instead of relying on noticing it per head:
+
+```bash
+python3 scripts/resolve_neutralized_body_restoration.py \
+  --pr-json <pr.json> --comments-json <comments.json> --repository <owner/repo>
+```
+
+It is read-only and exits `2` when the live body is neutralized while no authority receipt covers the
+current head, naming the durable receipt's `restore_body_sha256` as the only accepted restore target.
+
+Rules for the restore:
+
+- restore the exact authenticated pre-neutralization body; prove it with
+  `restored_body_matches_authority` against that receipt digest and its governing/closing identities
+  before writing, and fail closed rather than hand-editing a body the receipt cannot authenticate
+- never rewrite, delete, or re-post the durable authority and phase receipt trail; it is historical
+  evidence of the abandoned attempt, and restoration repairs only the mutable body
+- never restore while a merge request for that head may still be in flight — resolve the attempt
+  through step 7 first, so a restore cannot race a merge or grant authority
+- resume normally afterwards: once the new head is final again, step 2 re-derives a fresh head-bound
+  readiness statement, authority receipt, and neutralized body on that head
 
 ## When Not to Merge
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -500,14 +500,24 @@ python3 scripts/resolve_neutralized_body_restoration.py \
 It is read-only and separates a positively safe state from an indeterminate one: `0` means no
 restoration is required, `2` means the body is neutralized with no receipt for the current head and
 names the durable receipt's `restore_body_sha256` as the only accepted restore target, and `3` means
-the body is neutralized on an open PR but the evidence is missing, untrusted, or conflicting. Treat
-`3` as a hard stop and recover the evidence; never read it as "nothing to do".
+the body still carries a `Verified-Closing-Issues` marker but no restore target can be proven —
+because the evidence is missing, untrusted, or conflicting, because the snapshot is incomplete, or
+because the marker survived while the body's grammar no longer parses. Treat `3` as a hard stop and
+recover the evidence; never read it as "nothing to do". Only exit `0` means the body is positively
+canonical or the attempt is still in flight.
 
 Rules for the restore:
 
-- restore the exact authenticated pre-neutralization body; prove it with
-  `restored_body_matches_authority` against that receipt digest and its governing/closing identities
-  before writing, and fail closed rather than hand-editing a body the receipt cannot authenticate
+- restore the exact authenticated pre-neutralization body, and prove the candidate before writing it:
+
+  ```bash
+  python3 scripts/verify_restored_pr_body.py \
+    --restoration-json <restoration.json> --restored-body-file <candidate-body.md>
+  ```
+
+  It exits `0` only when the candidate reproduces the receipt's original-body digest and its
+  governing/closing identities. Never hand-edit a body the receipt cannot authenticate — a
+  hand-edited body is what strands a neutralization in the first place
 - never rewrite, delete, or re-post the durable authority and phase receipt trail; it is historical
   evidence of the abandoned attempt, and restoration repairs only the mutable body
 - never restore while a merge request for that head may still be in flight — resolve the attempt

--- a/app/dispatcher/verification_contract.py
+++ b/app/dispatcher/verification_contract.py
@@ -208,6 +208,24 @@ def neutralize_closing_issue_references(
     return result
 
 
+def has_neutralized_closing_marker(pr_body: object) -> bool:
+    """Return whether a body still advertises a neutralized closing marker.
+
+    This is the deliberately loose companion to
+    :func:`resolve_neutralized_issue_authority`, and the same predicate
+    :func:`neutralize_closing_issue_references` uses to refuse re-neutralizing an
+    already-neutralized body. The strict resolver returns ``None`` both for a
+    canonical body and for a body whose marker survives but whose grammar no
+    longer parses; only this predicate separates those, so a stranded
+    neutralization is never mistaken for a clean body.
+    """
+
+    return (
+        isinstance(pr_body, str)
+        and _NEUTRALIZED_CLOSING_LINE_PATTERN.search(pr_body) is not None
+    )
+
+
 def resolve_neutralized_issue_authority(pr_body: object) -> IssueAuthority | None:
     """Resolve the bounded non-closing authority used only during exact-head merge."""
     if not isinstance(pr_body, str) or re.search(r"\r(?!\n)|[\u2028\u2029]", pr_body):

--- a/app/dispatcher/verified_merge.py
+++ b/app/dispatcher/verified_merge.py
@@ -30,6 +30,10 @@ VERIFIED_MERGE_AUTHORITY_CONTRACT = "verified_issue_set_merge_authority.v1"
 VERIFIED_MERGE_AUTHORITY_MARKER = "verified issue-set merge authority:"
 VERIFIED_MERGE_PHASE_CONTRACT = "verified_issue_set_merge_phase.v1"
 VERIFIED_MERGE_PHASE_MARKER = "verified issue-set merge phase:"
+VERIFIED_MERGE_READINESS_CONTRACT = "verified_issue_set_merge_readiness.v1"
+NEUTRALIZED_BODY_RESTORATION_CONTRACT = (
+    "verified_issue_set_neutralized_body_restoration.v1"
+)
 _CONTEXT_CONTRACT = "verification_closer_dispatch_context.v2"
 _SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 _DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
@@ -58,6 +62,20 @@ _AUTHORITY_RECEIPT_FIELDS: Final = frozenset(
         "repository",
         "run_id",
     }
+)
+_MERGE_READINESS_FIELDS: Final = frozenset(
+    {
+        "contract",
+        "further_commits_anticipated",
+        "head_sha",
+        "required_checks_green",
+        "review_gate_resolved",
+    }
+)
+_MERGE_READINESS_ASSERTIONS: Final = (
+    ("required_checks_green", True),
+    ("review_gate_resolved", True),
+    ("further_commits_anticipated", False),
 )
 _PHASE_RECEIPT_FIELDS: Final = frozenset(
     {
@@ -273,6 +291,38 @@ def _complete_merged_identity(pr: Mapping[str, object]) -> bool:
     )
 
 
+def _assert_neutralization_precondition(
+    merge_readiness: object,
+    *,
+    head_sha: str,
+) -> None:
+    """Refuse neutralization unless this exact head is the final head.
+
+    Neutralizing a PR body converts durable closing authority into a state that
+    is only valid while one exact-head merge attempt is in flight. A neutralized
+    body that outlives its attempt deadlocks ``pr-contract`` on every later head,
+    so the caller must state, bound to this head, that CI and review are green
+    and that no further commits are anticipated.
+    """
+
+    if (
+        not isinstance(merge_readiness, Mapping)
+        or set(merge_readiness) != _MERGE_READINESS_FIELDS
+        or merge_readiness.get("contract") != VERIFIED_MERGE_READINESS_CONTRACT
+        or merge_readiness.get("head_sha") != head_sha
+        or any(
+            not isinstance(merge_readiness.get(field), bool)
+            for field, _ in _MERGE_READINESS_ASSERTIONS
+        )
+    ):
+        raise ValueError("verified merge readiness is malformed")
+    if any(
+        merge_readiness[field] is not expected
+        for field, expected in _MERGE_READINESS_ASSERTIONS
+    ):
+        raise ValueError("verified merge neutralization precondition is unmet")
+
+
 def _valid_authority_receipt(
     receipt: Mapping[str, object],
     *,
@@ -460,6 +510,140 @@ def resolve_verified_merge_authority_receipt(
         ) is None:
             return None
     return authority_receipt
+
+
+def resolve_neutralized_body_restoration(
+    comments: Sequence[Mapping[str, object]],
+    *,
+    pr: Mapping[str, object],
+    repository: str,
+    expected_run_id: str | None = None,
+) -> dict[str, object] | None:
+    """Surface a neutralized PR body that outlived its own merge attempt.
+
+    A neutralized body is only valid while the exact head it was prepared for is
+    still the head being merged. When a further commit lands, the exact-head
+    authority receipt no longer resolves, yet the body keeps advertising
+    ``Verified-Closing-Issues``; ``pr-contract`` then fails deterministically on
+    every later head until the canonical body is restored.
+
+    Return the bounded restoration state for that condition, or ``None`` when it
+    does not hold or the evidence is not unambiguous. This is detection only: it
+    performs no writes, does not grant merge authority, never relaxes the
+    exact-head binding, and deliberately does not accept the pre-#4010 legacy
+    terminal-LF digest form, so an ambiguous case fails closed instead of naming
+    a restore target it cannot prove.
+    """
+
+    body = pr.get("body")
+    head = pr.get("head")
+    pr_number = pr.get("number")
+    if (
+        not isinstance(body, str)
+        or not isinstance(head, Mapping)
+        or not _positive_int(pr_number)
+    ):
+        return None
+    head_sha = head.get("sha")
+    if not isinstance(head_sha, str) or _SHA_PATTERN.fullmatch(head_sha) is None:
+        return None
+    if (
+        pr.get("state") != "open"
+        or pr.get("merged") is True
+        or pr.get("merged_at") is not None
+    ):
+        # A merged PR is still inside its own attempt; the ``restored`` phase of
+        # the merge sequence owns that body, not this recovery path.
+        return None
+    neutralized = resolve_neutralized_issue_authority(body)
+    if neutralized is None:
+        return None
+    if (
+        resolve_verified_merge_authority_receipt(
+            comments,
+            pr=pr,
+            repository=repository,
+            expected_run_id=expected_run_id,
+        )
+        is not None
+    ):
+        return None
+    stale: list[Mapping[str, object]] = []
+    for receipt, _ in _comment_receipt_entries(
+        comments, VERIFIED_MERGE_AUTHORITY_MARKER
+    ):
+        stored_head = receipt.get("head_sha")
+        body_digest = receipt.get("body_sha256")
+        if (
+            set(receipt) != _AUTHORITY_RECEIPT_FIELDS
+            or receipt.get("contract") != VERIFIED_MERGE_AUTHORITY_CONTRACT
+            or receipt.get("repository") != repository
+            or receipt.get("pr_number") != pr_number
+            or receipt.get("governing_issue") != neutralized.governing_issue
+            or receipt.get("closing_issues") != list(neutralized.closing_issues)
+            or not isinstance(stored_head, str)
+            or _SHA_PATTERN.fullmatch(stored_head) is None
+            or stored_head == head_sha
+            or not isinstance(receipt.get("run_id"), str)
+            or not receipt.get("run_id")
+            or (
+                expected_run_id is not None
+                and receipt.get("run_id") != expected_run_id
+            )
+            or not isinstance(body_digest, str)
+            or _DIGEST_PATTERN.fullmatch(body_digest) is None
+            or body_digest == receipt.get("neutralized_body_sha256")
+            or not _matches_stored_body_digest(
+                body, receipt.get("neutralized_body_sha256")
+            )
+        ):
+            continue
+        stale.append(receipt)
+    if not stale or len({receipt["body_sha256"] for receipt in stale}) != 1:
+        return None
+    authority_receipt = stale[-1]
+    return {
+        "closing_issues": list(neutralized.closing_issues),
+        "contract": NEUTRALIZED_BODY_RESTORATION_CONTRACT,
+        "governing_issue": neutralized.governing_issue,
+        "head_sha": head_sha,
+        "neutralized_body_sha256": authority_receipt["neutralized_body_sha256"],
+        "neutralized_head_sha": authority_receipt["head_sha"],
+        "pr_number": pr_number,
+        "reason": "neutralized-body-outlived-merge-attempt",
+        "repository": repository,
+        "restore_body_sha256": authority_receipt["body_sha256"],
+        "run_id": authority_receipt["run_id"],
+    }
+
+
+def restored_body_matches_authority(
+    body: object,
+    *,
+    restoration: Mapping[str, object],
+) -> bool:
+    """Prove a candidate body is exactly the authenticated pre-neutralization body.
+
+    Restoration is a repair of the mutable body only. It never rewrites the
+    durable authority or phase receipt trail, and it is accepted only when the
+    candidate reproduces the receipt's original body digest and its governing and
+    closing identities.
+    """
+
+    if (
+        not isinstance(body, str)
+        or restoration.get("contract") != NEUTRALIZED_BODY_RESTORATION_CONTRACT
+        or not _matches_stored_body_digest(
+            body, restoration.get("restore_body_sha256")
+        )
+    ):
+        return False
+    authority = resolve_issue_authority(body)
+    return bool(
+        authority is not None
+        and authority.governing_issue == restoration.get("governing_issue")
+        and list(authority.closing_issues) == restoration.get("closing_issues")
+    )
 
 
 def resolve_post_merge_governing_issue(
@@ -740,8 +924,15 @@ def prepare_verified_merge(
     context: Mapping[str, object],
     pr: Mapping[str, object],
     live_closing_issues: object,
+    merge_readiness: Mapping[str, object],
 ) -> dict[str, object]:
-    """Build the exact, reversible merge plan for one verified PR head."""
+    """Build the exact, reversible merge plan for one verified PR head.
+
+    ``merge_readiness`` is the caller's head-bound statement that this is the
+    final head: CI and review are green and no further commits are anticipated.
+    It is required and has no default, so neutralization cannot be reached by
+    forgetting the precondition.
+    """
     repository = context.get("repository")
     pr_number = context.get("pr_number")
     governing_issue = context.get("governing_issue")
@@ -807,6 +998,11 @@ def prepare_verified_merge(
     )
     if observed_closing != closing:
         raise ValueError("verified merge GitHub closing links changed")
+
+    # Last gate before the body stops carrying its own closing authority: this
+    # exact head must be the final head. Everything above only proves the
+    # snapshot is internally consistent.
+    _assert_neutralization_precondition(merge_readiness, head_sha=head_sha)
 
     neutralized_body = neutralize_closing_issue_references(body, authority)
     if resolve_neutralized_issue_authority(neutralized_body) != authority:

--- a/app/dispatcher/verified_merge.py
+++ b/app/dispatcher/verified_merge.py
@@ -512,6 +512,30 @@ def resolve_verified_merge_authority_receipt(
     return authority_receipt
 
 
+def _resolve_merge_state(pr: Mapping[str, object]) -> str:
+    """Classify a live PR snapshot as ``open``, ``merged``, or ``unknown``.
+
+    Never guess from a partial or self-contradictory snapshot. A missing or
+    unknown ``state``, or a combination such as ``state="open"`` with
+    ``merged=True``, resolves to ``unknown`` so callers fail closed instead of
+    reading an unestablished snapshot as a safe one.
+    """
+
+    state = pr.get("state")
+    merged = pr.get("merged")
+    merged_at = pr.get("merged_at")
+    if state == "open" and merged is not True and merged_at is None:
+        return "open"
+    if (
+        state == "closed"
+        and merged is True
+        and isinstance(merged_at, str)
+        and merged_at
+    ):
+        return "merged"
+    return "unknown"
+
+
 def resolve_neutralized_body_restoration(
     comments: Sequence[Mapping[str, object]],
     *,
@@ -547,13 +571,10 @@ def resolve_neutralized_body_restoration(
     head_sha = head.get("sha")
     if not isinstance(head_sha, str) or _SHA_PATTERN.fullmatch(head_sha) is None:
         return None
-    if (
-        pr.get("state") != "open"
-        or pr.get("merged") is True
-        or pr.get("merged_at") is not None
-    ):
+    if _resolve_merge_state(pr) != "open":
         # A merged PR is still inside its own attempt; the ``restored`` phase of
-        # the merge sequence owns that body, not this recovery path.
+        # the merge sequence owns that body, not this recovery path. A snapshot
+        # that cannot be positively established never names a restore target.
         return None
     neutralized = resolve_neutralized_issue_authority(body)
     if neutralized is None:
@@ -579,11 +600,19 @@ def resolve_neutralized_body_restoration(
             or receipt.get("contract") != VERIFIED_MERGE_AUTHORITY_CONTRACT
             or receipt.get("repository") != repository
             or receipt.get("pr_number") != pr_number
-            or receipt.get("governing_issue") != neutralized.governing_issue
+        ):
+            continue
+        if stored_head == head_sha:
+            # Trusted evidence for the live head exists, yet the resolver above
+            # could not resolve it to one identity. A merge for this attempt may
+            # still be in flight, so never fall back to an older head and name a
+            # restore target that could race it.
+            return None
+        if (
+            receipt.get("governing_issue") != neutralized.governing_issue
             or receipt.get("closing_issues") != list(neutralized.closing_issues)
             or not isinstance(stored_head, str)
             or _SHA_PATTERN.fullmatch(stored_head) is None
-            or stored_head == head_sha
             or not isinstance(receipt.get("run_id"), str)
             or not receipt.get("run_id")
             or (
@@ -626,13 +655,10 @@ def carries_live_neutralized_body(pr: Mapping[str, object]) -> bool:
     must stop repair work rather than read as "nothing to do".
     """
 
-    if (
-        pr.get("state") != "open"
-        or pr.get("merged") is True
-        or pr.get("merged_at") is not None
-    ):
-        return False
-    return resolve_neutralized_issue_authority(pr.get("body")) is not None
+    return (
+        _resolve_merge_state(pr) == "open"
+        and resolve_neutralized_issue_authority(pr.get("body")) is not None
+    )
 
 
 def classify_neutralized_body_state(
@@ -649,14 +675,15 @@ def classify_neutralized_body_state(
     be proven. Those must not collapse into one "all clear" answer, so classify
     the live body into exactly one of:
 
-    * ``no_restoration_required`` -- the body is canonical or already merged, or a
-      trusted authority receipt still covers the current head, so the merge
-      attempt that neutralized it is in flight.
+    * ``no_restoration_required`` -- the body is canonical, or it is neutralized
+      on a positively merged PR, or a trusted authority receipt still covers the
+      current head, so the merge attempt that neutralized it is in flight.
     * ``restoration_required`` -- the body outlived its attempt and the durable
       receipt names the restore target.
-    * ``ambiguous_neutralized_body`` -- the body is neutralized on an open PR with
-      no receipt for the current head and no provable restore target. Stop and
-      recover evidence; never continue repair work on this answer.
+    * ``ambiguous_neutralized_body`` -- the body is neutralized but no restore
+      target can be proven, including when the live snapshot is incomplete or
+      self-contradictory. Stop and recover evidence; never continue repair work
+      on this answer.
     """
 
     restoration = resolve_neutralized_body_restoration(
@@ -665,10 +692,16 @@ def classify_neutralized_body_state(
         repository=repository,
         expected_run_id=expected_run_id,
     )
+    merge_state = _resolve_merge_state(pr)
     if restoration is not None:
         status = "restoration_required"
-    elif not carries_live_neutralized_body(pr) or (
-        resolve_verified_merge_authority_receipt(
+    elif resolve_neutralized_issue_authority(pr.get("body")) is None:
+        # A canonical body cannot be a stranded neutralization, whatever the
+        # rest of the snapshot says.
+        status = "no_restoration_required"
+    elif merge_state == "merged" or (
+        merge_state == "open"
+        and resolve_verified_merge_authority_receipt(
             comments,
             pr=pr,
             repository=repository,

--- a/app/dispatcher/verified_merge.py
+++ b/app/dispatcher/verified_merge.py
@@ -617,6 +617,75 @@ def resolve_neutralized_body_restoration(
     }
 
 
+def carries_live_neutralized_body(pr: Mapping[str, object]) -> bool:
+    """Whether an open, unmerged PR currently advertises a neutralized body.
+
+    Callers pair this with :func:`resolve_neutralized_body_restoration` to tell
+    the two ``None`` outcomes apart: a canonical body is a positively safe state,
+    while a neutralized body with no provable restore target is indeterminate and
+    must stop repair work rather than read as "nothing to do".
+    """
+
+    if (
+        pr.get("state") != "open"
+        or pr.get("merged") is True
+        or pr.get("merged_at") is not None
+    ):
+        return False
+    return resolve_neutralized_issue_authority(pr.get("body")) is not None
+
+
+def classify_neutralized_body_state(
+    comments: Sequence[Mapping[str, object]],
+    *,
+    pr: Mapping[str, object],
+    repository: str,
+    expected_run_id: str | None = None,
+) -> dict[str, object]:
+    """Separate a positively safe body state from an indeterminate one.
+
+    ``resolve_neutralized_body_restoration`` returns ``None`` both when there is
+    nothing to restore and when the body is neutralized but no restore target can
+    be proven. Those must not collapse into one "all clear" answer, so classify
+    the live body into exactly one of:
+
+    * ``no_restoration_required`` -- the body is canonical or already merged, or a
+      trusted authority receipt still covers the current head, so the merge
+      attempt that neutralized it is in flight.
+    * ``restoration_required`` -- the body outlived its attempt and the durable
+      receipt names the restore target.
+    * ``ambiguous_neutralized_body`` -- the body is neutralized on an open PR with
+      no receipt for the current head and no provable restore target. Stop and
+      recover evidence; never continue repair work on this answer.
+    """
+
+    restoration = resolve_neutralized_body_restoration(
+        comments,
+        pr=pr,
+        repository=repository,
+        expected_run_id=expected_run_id,
+    )
+    if restoration is not None:
+        status = "restoration_required"
+    elif not carries_live_neutralized_body(pr) or (
+        resolve_verified_merge_authority_receipt(
+            comments,
+            pr=pr,
+            repository=repository,
+            expected_run_id=expected_run_id,
+        )
+        is not None
+    ):
+        status = "no_restoration_required"
+    else:
+        status = "ambiguous_neutralized_body"
+    return {
+        "restoration": restoration,
+        "restoration_required": restoration is not None,
+        "status": status,
+    }
+
+
 def restored_body_matches_authority(
     body: object,
     *,

--- a/app/dispatcher/verified_merge.py
+++ b/app/dispatcher/verified_merge.py
@@ -20,6 +20,7 @@ from app.dispatcher.verification_contract import (
     IssueAuthority,
     MAX_CLOSING_ISSUES,
     has_closing_issue_attempt,
+    has_neutralized_closing_marker,
     neutralize_closing_issue_references,
     resolve_issue_authority,
     resolve_neutralized_issue_authority,
@@ -589,27 +590,34 @@ def resolve_neutralized_body_restoration(
         is not None
     ):
         return None
+    # Any trusted authority evidence naming the live head means a merge for this
+    # attempt may still be in flight, so an older head must never name a restore
+    # target that could race it. Scan the raw comment text rather than only
+    # well-formed receipts: a receipt with an extra key, a missing field, or two
+    # fenced blocks in one comment is exactly the evidence a structural filter
+    # would silently drop, and dropping it is what re-enables the race.
+    if any(
+        comment.get("author_association") in _TRUSTED_AUTHOR_ASSOCIATIONS
+        and isinstance(comment.get("body"), str)
+        and VERIFIED_MERGE_AUTHORITY_MARKER in str(comment["body"])
+        and head_sha in str(comment["body"])
+        for comment in comments
+    ):
+        return None
     stale: list[Mapping[str, object]] = []
     for receipt, _ in _comment_receipt_entries(
         comments, VERIFIED_MERGE_AUTHORITY_MARKER
     ):
         stored_head = receipt.get("head_sha")
+        if stored_head == head_sha:
+            return None
         body_digest = receipt.get("body_sha256")
         if (
             set(receipt) != _AUTHORITY_RECEIPT_FIELDS
             or receipt.get("contract") != VERIFIED_MERGE_AUTHORITY_CONTRACT
             or receipt.get("repository") != repository
             or receipt.get("pr_number") != pr_number
-        ):
-            continue
-        if stored_head == head_sha:
-            # Trusted evidence for the live head exists, yet the resolver above
-            # could not resolve it to one identity. A merge for this attempt may
-            # still be in flight, so never fall back to an older head and name a
-            # restore target that could race it.
-            return None
-        if (
-            receipt.get("governing_issue") != neutralized.governing_issue
+            or receipt.get("governing_issue") != neutralized.governing_issue
             or receipt.get("closing_issues") != list(neutralized.closing_issues)
             or not isinstance(stored_head, str)
             or _SHA_PATTERN.fullmatch(stored_head) is None
@@ -630,12 +638,19 @@ def resolve_neutralized_body_restoration(
         stale.append(receipt)
     if not stale or len({receipt["body_sha256"] for receipt in stale}) != 1:
         return None
+    # The restore target is load-bearing and is proven unique above. The
+    # provenance fields below describe the last matching attempt in the supplied
+    # comment order, which for the GitHub comments API is the most recent one.
+    # A restore-then-re-neutralize loop legitimately leaves several attempts
+    # matching the same target, so report the count rather than implying the
+    # named attempt is the only one.
     authority_receipt = stale[-1]
     return {
         "closing_issues": list(neutralized.closing_issues),
         "contract": NEUTRALIZED_BODY_RESTORATION_CONTRACT,
         "governing_issue": neutralized.governing_issue,
         "head_sha": head_sha,
+        "matching_attempts": len(stale),
         "neutralized_body_sha256": authority_receipt["neutralized_body_sha256"],
         "neutralized_head_sha": authority_receipt["head_sha"],
         "pr_number": pr_number,
@@ -644,21 +659,6 @@ def resolve_neutralized_body_restoration(
         "restore_body_sha256": authority_receipt["body_sha256"],
         "run_id": authority_receipt["run_id"],
     }
-
-
-def carries_live_neutralized_body(pr: Mapping[str, object]) -> bool:
-    """Whether an open, unmerged PR currently advertises a neutralized body.
-
-    Callers pair this with :func:`resolve_neutralized_body_restoration` to tell
-    the two ``None`` outcomes apart: a canonical body is a positively safe state,
-    while a neutralized body with no provable restore target is indeterminate and
-    must stop repair work rather than read as "nothing to do".
-    """
-
-    return (
-        _resolve_merge_state(pr) == "open"
-        and resolve_neutralized_issue_authority(pr.get("body")) is not None
-    )
 
 
 def classify_neutralized_body_state(
@@ -684,8 +684,17 @@ def classify_neutralized_body_state(
       target can be proven, including when the live snapshot is incomplete or
       self-contradictory. Stop and recover evidence; never continue repair work
       on this answer.
+
+    "Canonical" is decided by :func:`has_neutralized_closing_marker`, never by
+    the strict resolver. The strict resolver also returns ``None`` for a body
+    whose marker survives but whose grammar no longer parses -- a second
+    ``Governing-Issue`` line, a duplicated marker, a deleted ``Refs`` line, a
+    lone CR -- and that body is a live stranded neutralization, not a clean one.
+    Reading it as safe would reproduce the very deadlock this module exists to
+    stop.
     """
 
+    body = pr.get("body")
     restoration = resolve_neutralized_body_restoration(
         comments,
         pr=pr,
@@ -695,9 +704,10 @@ def classify_neutralized_body_state(
     merge_state = _resolve_merge_state(pr)
     if restoration is not None:
         status = "restoration_required"
-    elif resolve_neutralized_issue_authority(pr.get("body")) is None:
-        # A canonical body cannot be a stranded neutralization, whatever the
-        # rest of the snapshot says.
+    elif not isinstance(body, str):
+        # No body to establish anything from.
+        status = "ambiguous_neutralized_body"
+    elif not has_neutralized_closing_marker(body):
         status = "no_restoration_required"
     elif merge_state == "merged" or (
         merge_state == "open"

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -336,6 +336,17 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   non-closing title/message from the plan. The fetched merge commit must match the exact repository
   and SHA, remain within its response/message caps, and contain no canonical or malformed closing
   attempt; a merge commit message can never become closer authority.
+- A neutralized body's lifetime is bounded by the merge attempt that justified it. Neutralization
+  requires a head-bound `verified_issue_set_merge_readiness.v1` statement asserting that CI and the
+  review gate are green and that no further commits are anticipated on that exact head; the statement
+  is not reusable across heads, and `prepare_verified_merge` refuses to neutralize without it. When a
+  further commit changes the head while the body is still neutralized, the exact-head authority
+  receipt correctly stops resolving and `pr-contract` fails on that head, so the canonical body must
+  be restored before further repair work. `resolve_neutralized_body_restoration` detects that state
+  from the live PR plus its trusted receipts and names the durable receipt's original-body digest as
+  the only accepted restore target; it is read-only detection that grants no merge authority, does
+  not weaken the exact-head binding, never rewrites the durable receipt trail, and fails closed on
+  merged, foreign, untrusted, or conflicting evidence.
 - The authority-bound phase ledger is continuous and idempotent:
   `prepared -> merged -> reconciled -> restored`. Duplicate identical phase receipts are harmless;
   missing, stale, forged, skipped, or conflicting phases fail closed. If a crash leaves the exact

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -292,6 +292,10 @@ Low-risk wording or reference-only skill edits may stay on the hot path if safet
   truth, and resumes a crashed post-merge sequence idempotently without resetting attempts or the
   2+2 repair budget. Explicit expected-issue closes require a null closer plus the delivery actor/time
   fence; automatic closes require the exact target PR/repository/merge SHA
+- a neutralized PR body may not outlive its merge attempt: neutralization requires a head-bound
+  readiness statement that CI and review are green and no further commits are anticipated, and a head
+  change while the body is still neutralized requires restoring the canonical body before further
+  repair work
 - branch/worktree sanity before commit, push, or merge
 - required and relevant repo-standard checks must be known and non-stale
 - blocking review feedback must be addressed or explicitly classified

--- a/scripts/prepare_verified_issue_set_merge.py
+++ b/scripts/prepare_verified_issue_set_merge.py
@@ -27,6 +27,15 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--context-json", type=Path, required=True)
     parser.add_argument("--pr-json", type=Path, required=True)
     parser.add_argument("--live-closing-json", type=Path, required=True)
+    parser.add_argument(
+        "--merge-readiness-json",
+        type=Path,
+        required=True,
+        help=(
+            "head-bound verified_issue_set_merge_readiness.v1 statement that CI "
+            "and review are green and no further commits are anticipated"
+        ),
+    )
     parser.add_argument("--output-json", type=Path, required=True)
     return parser
 
@@ -37,6 +46,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         context=_mapping(args.context_json),
         pr=_mapping(args.pr_json),
         live_closing_issues=_json(args.live_closing_json),
+        merge_readiness=_mapping(args.merge_readiness_json),
     )
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(

--- a/scripts/resolve_neutralized_body_restoration.py
+++ b/scripts/resolve_neutralized_body_restoration.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Detect a neutralized PR body that outlived its own verified-merge attempt.
+
+Read-only detection. It performs no GitHub writes, grants no merge authority,
+and never relaxes the exact-head authority binding. Exit ``0`` when no
+restoration is needed, ``2`` when the live PR body is neutralized while no
+authority receipt covers the current head, so the caller can restore the
+canonical body before continuing repair work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from app.dispatcher.verified_merge import resolve_neutralized_body_restoration
+
+
+def _mapping(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _comments(path: Path) -> list[dict[str, object]]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, list) or any(
+        not isinstance(item, dict) for item in value
+    ):
+        raise ValueError(f"{path} must contain a JSON array of objects")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-json", type=Path, required=True)
+    parser.add_argument("--comments-json", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--expected-run-id")
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    restoration = resolve_neutralized_body_restoration(
+        _comments(args.comments_json),
+        pr=_mapping(args.pr_json),
+        repository=args.repository,
+        expected_run_id=args.expected_run_id,
+    )
+    payload: dict[str, object] = {
+        "restoration_required": restoration is not None,
+        "restoration": restoration,
+    }
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 2 if restoration is not None else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_neutralized_body_restoration.py
+++ b/scripts/resolve_neutralized_body_restoration.py
@@ -2,10 +2,18 @@
 """Detect a neutralized PR body that outlived its own verified-merge attempt.
 
 Read-only detection. It performs no GitHub writes, grants no merge authority,
-and never relaxes the exact-head authority binding. Exit ``0`` when no
-restoration is needed, ``2`` when the live PR body is neutralized while no
-authority receipt covers the current head, so the caller can restore the
-canonical body before continuing repair work.
+and never relaxes the exact-head authority binding.
+
+Exit codes distinguish a positively safe state from an indeterminate one, so
+exit ``0`` never stands in for "cannot tell":
+
+* ``0`` -- no restoration required: the live body is canonical, or a trusted
+  authority receipt still covers the current head.
+* ``2`` -- restoration required: the body is neutralized, no receipt covers the
+  current head, and the durable receipt names the restore target.
+* ``3`` -- ambiguous: the body is neutralized on an open PR but the evidence is
+  missing, untrusted, or conflicting, so no restore target can be proven. Stop
+  and recover evidence; do not continue repair work.
 """
 
 from __future__ import annotations
@@ -15,7 +23,14 @@ import json
 from pathlib import Path
 from typing import Sequence
 
-from app.dispatcher.verified_merge import resolve_neutralized_body_restoration
+from app.dispatcher.verified_merge import classify_neutralized_body_state
+
+
+_EXIT_CODES = {
+    "no_restoration_required": 0,
+    "restoration_required": 2,
+    "ambiguous_neutralized_body": 3,
+}
 
 
 def _mapping(path: Path) -> dict[str, object]:
@@ -46,16 +61,13 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
-    restoration = resolve_neutralized_body_restoration(
+    payload = classify_neutralized_body_state(
         _comments(args.comments_json),
         pr=_mapping(args.pr_json),
         repository=args.repository,
         expected_run_id=args.expected_run_id,
     )
-    payload: dict[str, object] = {
-        "restoration_required": restoration is not None,
-        "restoration": restoration,
-    }
+    exit_code = _EXIT_CODES[str(payload["status"])]
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
         args.output_json.write_text(
@@ -63,7 +75,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             encoding="utf-8",
         )
     print(json.dumps(payload, indent=2, sort_keys=True))
-    return 2 if restoration is not None else 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/verify_restored_pr_body.py
+++ b/scripts/verify_restored_pr_body.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Prove a candidate PR body restores exactly the authenticated pre-merge body.
+
+Read-only. Consume the restoration payload written by
+``scripts/resolve_neutralized_body_restoration.py --output-json`` and a candidate
+body file, and exit ``0`` only when the candidate reproduces the durable
+receipt's original-body digest and its governing and closing identities.
+
+This exists so restoring a stranded neutralization is an executable proof rather
+than a hand-edit. A hand-edited body is exactly what strands a neutralization in
+the first place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from app.dispatcher.verified_merge import restored_body_matches_authority
+
+
+def _restoration(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    # Accept either the resolver payload or the bare restoration it wraps.
+    nested = value.get("restoration")
+    if isinstance(nested, dict):
+        return nested
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--restoration-json", type=Path, required=True)
+    parser.add_argument("--restored-body-file", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    restoration = _restoration(args.restoration_json)
+    body = args.restored_body_file.read_text(encoding="utf-8")
+    matches = restored_body_matches_authority(body, restoration=restoration)
+    print(
+        json.dumps(
+            {
+                "restore_body_sha256": restoration.get("restore_body_sha256"),
+                "restored_body_matches_authority": matches,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -1632,6 +1632,13 @@ def _merge_plan(
         context=context,
         pr=eligible_pr(body=body, head={"ref": "branch", "sha": head_sha}),
         live_closing_issues=[3603],
+        merge_readiness={
+            "contract": "verified_issue_set_merge_readiness.v1",
+            "further_commits_anticipated": False,
+            "head_sha": head_sha,
+            "required_checks_green": True,
+            "review_gate_resolved": True,
+        },
     )
 
 

--- a/tests/dispatcher/test_verified_merge.py
+++ b/tests/dispatcher/test_verified_merge.py
@@ -14,6 +14,8 @@ from app.dispatcher.verified_merge import (
     NEUTRALIZED_BODY_RESTORATION_CONTRACT,
     VERIFIED_MERGE_AUTHORITY_CONTRACT,
     build_verified_merge_phase,
+    carries_live_neutralized_body,
+    classify_neutralized_body_state,
     plan_post_merge_reconciliation,
     prepare_verified_merge,
     resolve_neutralized_body_restoration,
@@ -1295,7 +1297,17 @@ def test_neutralized_body_restoration_cli_uses_production_resolver(
     assert json.loads(output_path.read_text(encoding="utf-8")) == {
         "restoration": None,
         "restoration_required": False,
+        "status": "no_restoration_required",
     }
+
+    pr_path.write_text(json.dumps(_pr()), encoding="utf-8")
+    canonical = _run()
+
+    assert canonical.returncode == 0, canonical.stderr
+    assert (
+        json.loads(output_path.read_text(encoding="utf-8"))["status"]
+        == "no_restoration_required"
+    )
 
     pr_path.write_text(
         json.dumps(
@@ -1310,9 +1322,22 @@ def test_neutralized_body_restoration_cli_uses_production_resolver(
 
     assert outlived.returncode == 2, outlived.stderr
     payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "restoration_required"
     assert payload["restoration_required"] is True
     assert payload["restoration"]["neutralized_head_sha"] == HEAD
     assert payload["restoration"]["head_sha"] == NEXT_HEAD
+
+    # A neutralized body whose evidence cannot prove a restore target is
+    # indeterminate, never a safe exit 0.
+    comments_path.write_text(json.dumps([]), encoding="utf-8")
+    ambiguous = _run()
+
+    assert ambiguous.returncode == 3, ambiguous.stderr
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "restoration": None,
+        "restoration_required": False,
+        "status": "ambiguous_neutralized_body",
+    }
 
 
 def test_neutralized_body_restoration_fails_closed_without_unambiguous_evidence() -> None:
@@ -1393,3 +1418,72 @@ def test_neutralized_body_restoration_fails_closed_without_unambiguous_evidence(
         )
         is None
     )
+
+    # Every one of those `None` outcomes is still an indeterminate live
+    # neutralized body, distinct from a canonical or already-merged body.
+    assert carries_live_neutralized_body(head_b_pr)
+    assert not carries_live_neutralized_body({**head_b_pr, "body": _body()})
+    assert not carries_live_neutralized_body(
+        {
+            **head_b_pr,
+            "state": "closed",
+            "merged": True,
+            "merged_at": "2026-07-27T08:18:08Z",
+        }
+    )
+
+
+def test_neutralized_body_state_never_reports_ambiguity_as_safe() -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    neutralized_body = str(plan["neutralized_body"])
+    head_a_pr = _pr(neutralized_body)
+    head_b_pr = {**head_a_pr, "head": {"sha": NEXT_HEAD}}
+
+    def _status(
+        candidate_comments: list[dict[str, object]],
+        pr: dict[str, object],
+    ) -> object:
+        return classify_neutralized_body_state(
+            candidate_comments, pr=pr, repository=REPOSITORY
+        )["status"]
+
+    # In flight on the head the receipt covers, and a canonical body, are both
+    # positively safe.
+    assert _status(comments, head_a_pr) == "no_restoration_required"
+    assert _status(comments, _pr()) == "no_restoration_required"
+    assert _status([], _pr()) == "no_restoration_required"
+
+    # Outlived its attempt with a provable restore target.
+    assert _status(comments, head_b_pr) == "restoration_required"
+
+    # Neutralized with unusable evidence is indeterminate, not safe.
+    assert _status([], head_b_pr) == "ambiguous_neutralized_body"
+    assert (
+        _status(
+            [{**comments[0], "author_association": "NONE"}],
+            head_b_pr,
+        )
+        == "ambiguous_neutralized_body"
+    )
+    assert (
+        classify_neutralized_body_state(
+            comments,
+            pr=head_b_pr,
+            repository=REPOSITORY,
+            expected_run_id="vrun-other",
+        )["status"]
+        == "ambiguous_neutralized_body"
+    )
+    assert classify_neutralized_body_state(
+        comments, pr=head_a_pr, repository=REPOSITORY
+    ) == {
+        "restoration": None,
+        "restoration_required": False,
+        "status": "no_restoration_required",
+    }

--- a/tests/dispatcher/test_verified_merge.py
+++ b/tests/dispatcher/test_verified_merge.py
@@ -11,14 +11,17 @@ import pytest
 
 from app.dispatcher.verification_contract import IssueAuthority, MAX_CLOSING_ISSUES
 from app.dispatcher.verified_merge import (
+    NEUTRALIZED_BODY_RESTORATION_CONTRACT,
     VERIFIED_MERGE_AUTHORITY_CONTRACT,
     build_verified_merge_phase,
     plan_post_merge_reconciliation,
     prepare_verified_merge,
+    resolve_neutralized_body_restoration,
     resolve_post_merge_governing_issue,
     resolve_post_merge_issue_authority,
     resolve_verified_merge_authority_receipt,
     resolve_verified_merge_phase,
+    restored_body_matches_authority,
 )
 
 
@@ -47,6 +50,16 @@ def _context() -> dict[str, object]:
                 }
             ],
         },
+    }
+
+
+def _readiness(head_sha: str = HEAD) -> dict[str, object]:
+    return {
+        "contract": "verified_issue_set_merge_readiness.v1",
+        "further_commits_anticipated": False,
+        "head_sha": head_sha,
+        "required_checks_green": True,
+        "review_gate_resolved": True,
     }
 
 
@@ -93,6 +106,7 @@ def test_prepare_verified_merge_neutralizes_closers_and_preserves_authority() ->
             {"number": 3823, "repository": REPOSITORY},
             {"number": 3820, "repository": REPOSITORY},
         ],
+        merge_readiness=_readiness(),
     )
 
     assert "Fixes #3820" not in plan["neutralized_body"]
@@ -123,10 +137,16 @@ def test_verified_merge_body_digest_canonicalizes_terminal_newline() -> None:
     without_terminal_lf = with_terminal_lf[:-1]
 
     with_lf_plan = prepare_verified_merge(
-        context=_context(), pr=_pr(with_terminal_lf), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(with_terminal_lf),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     without_lf_plan = prepare_verified_merge(
-        context=_context(), pr=_pr(without_terminal_lf), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(without_terminal_lf),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
 
     assert (
@@ -141,7 +161,10 @@ def test_verified_merge_body_digest_canonicalizes_terminal_newline() -> None:
 
 def test_prepared_phase_accepts_github_terminal_newline_canonicalization() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -161,7 +184,10 @@ def test_prepared_phase_accepts_github_terminal_newline_canonicalization() -> No
 
 def test_prepared_phase_rejects_substantive_body_drift_after_canonicalization() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -176,7 +202,10 @@ def test_prepared_phase_rejects_substantive_body_drift_after_canonicalization() 
 
 def _legacy_authority_fixture() -> tuple[dict[str, object], dict[str, object], str, str]:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = copy.deepcopy(plan["authority_receipt"])
     assert isinstance(authority, dict)
@@ -377,7 +406,10 @@ def test_legacy_authority_receipt_preserves_continuous_phase_recovery() -> None:
 def test_canonical_authority_receipt_preserves_unchanged_double_terminal_lf() -> None:
     original = _body() + "\n"
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(original), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(original),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -436,6 +468,7 @@ def test_prepare_verified_merge_fails_closed_on_mutable_authority_races(
             context=context,
             pr=pr,
             live_closing_issues=closing,
+            merge_readiness=_readiness(),
         )
 
 
@@ -457,6 +490,7 @@ def test_prepare_verified_merge_rejects_noncanonical_closure_attempts(
             context=_context(),
             pr=_pr(_body() + suffix),
             live_closing_issues=[3820, 3823],
+            merge_readiness=_readiness(),
         )
 
 
@@ -472,6 +506,7 @@ def test_prepare_verified_merge_keeps_ten_issue_limit() -> None:
         context=context,
         pr=_pr(body),
         live_closing_issues=closing,
+        merge_readiness=_readiness(),
     )
     assert plan["authority_receipt"]["closing_issues"] == closing
 
@@ -483,6 +518,7 @@ def test_prepare_verified_merge_keeps_ten_issue_limit() -> None:
             context=over_limit,
             pr=_pr(body + "\nFixes #5000"),
             live_closing_issues=[*closing, 5000],
+            merge_readiness=_readiness(),
         )
 
 
@@ -490,35 +526,52 @@ def test_prepare_verified_merge_cli_uses_production_planner(tmp_path: Path) -> N
     context_path = tmp_path / "context.json"
     pr_path = tmp_path / "pr.json"
     closing_path = tmp_path / "closing.json"
+    readiness_path = tmp_path / "readiness.json"
     output_path = tmp_path / "plan.json"
     context_path.write_text(json.dumps(_context()), encoding="utf-8")
     pr_path.write_text(json.dumps(_pr()), encoding="utf-8")
     closing_path.write_text(json.dumps([3820, 3823]), encoding="utf-8")
+    readiness_path.write_text(json.dumps(_readiness()), encoding="utf-8")
 
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "scripts.prepare_verified_issue_set_merge",
-            "--context-json",
-            str(context_path),
-            "--pr-json",
-            str(pr_path),
-            "--live-closing-json",
-            str(closing_path),
-            "--output-json",
-            str(output_path),
-        ],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    def _run(readiness: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.prepare_verified_issue_set_merge",
+                "--context-json",
+                str(context_path),
+                "--pr-json",
+                str(pr_path),
+                "--live-closing-json",
+                str(closing_path),
+                "--merge-readiness-json",
+                str(readiness),
+                "--output-json",
+                str(output_path),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    completed = _run(readiness_path)
 
     assert completed.returncode == 0, completed.stderr
     plan = json.loads(output_path.read_text(encoding="utf-8"))
     assert plan["authority_receipt"]["closing_issues"] == [3820, 3823]
     assert "Refs #3820" in plan["neutralized_body"]
+
+    unmet_path = tmp_path / "unmet-readiness.json"
+    unmet = _readiness()
+    unmet["further_commits_anticipated"] = True
+    unmet_path.write_text(json.dumps(unmet), encoding="utf-8")
+
+    refused = _run(unmet_path)
+
+    assert refused.returncode != 0
+    assert "neutralization precondition is unmet" in refused.stderr
 
 
 def test_authority_receipt_resolver_rejects_forged_stale_and_conflicting_comments() -> None:
@@ -526,6 +579,7 @@ def test_authority_receipt_resolver_rejects_forged_stale_and_conflicting_comment
         context=_context(),
         pr=_pr(),
         live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     original_comment = _trusted_comment(str(plan["authority_receipt_comment"]))
     neutral_pr = _pr(str(plan["neutralized_body"]))
@@ -629,6 +683,7 @@ def test_authority_receipt_requires_exact_live_supporting_body_authority(
         context=_context(),
         pr=_pr(),
         live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     receipt = copy.deepcopy(plan["authority_receipt"])
     assert isinstance(receipt, dict)
@@ -651,7 +706,10 @@ def test_authority_receipt_requires_exact_live_supporting_body_authority(
 
 def test_merge_phase_receipts_form_continuous_idempotent_recovery_chain() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -722,7 +780,10 @@ def test_merge_phase_receipts_form_continuous_idempotent_recovery_chain() -> Non
 
 def test_merge_phase_resolver_stops_at_premerge_phase_after_merge_crash() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -751,7 +812,10 @@ def test_merge_phase_resolver_stops_at_premerge_phase_after_merge_crash() -> Non
 
 def test_merged_body_race_recovers_only_from_trusted_authority_bound_phase() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -799,7 +863,10 @@ def test_merged_body_race_recovers_only_from_trusted_authority_bound_phase() -> 
 
 def test_merged_body_race_rejects_forged_stale_and_conflicting_evidence() -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)
@@ -873,6 +940,7 @@ def test_merged_body_race_rejects_forged_stale_and_conflicting_evidence() -> Non
         context=raced_context,
         pr=_pr(str(raced_pr["body"])),
         live_closing_issues=[4999],
+        merge_readiness=_readiness(),
     )
     body_matching_conflict_comment = _trusted_comment(
         str(body_matching_conflict["authority_receipt_comment"])
@@ -917,7 +985,10 @@ def test_merged_body_race_rejects_forged_stale_and_conflicting_evidence() -> Non
 
 def test_merge_phase_cli_uses_production_phase_builder(tmp_path: Path) -> None:
     plan = prepare_verified_merge(
-        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
     )
     merged_pr = {
         **_pr(str(plan["original_body"])),
@@ -996,3 +1067,329 @@ def test_post_merge_reconciliation_requires_complete_issue_evidence() -> None:
                 {"number": 3820, "state": "closed", "closed_by_pull_requests": [3822]}
             ],
         )
+
+
+NEXT_HEAD = "b" * 40
+
+
+def _authority_comment(receipt: dict[str, object]) -> dict[str, object]:
+    payload = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
+    return _trusted_comment(
+        "verified issue-set merge authority:\n```json\n" + payload + "\n```"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "unmet"),
+    [
+        ("further_commits_anticipated", True),
+        ("required_checks_green", False),
+        ("review_gate_resolved", False),
+    ],
+)
+def test_neutralization_is_refused_until_the_head_is_final(
+    field: str, unmet: bool
+) -> None:
+    readiness = _readiness()
+    readiness[field] = unmet
+
+    with pytest.raises(ValueError, match="neutralization precondition is unmet"):
+        prepare_verified_merge(
+            context=_context(),
+            pr=_pr(),
+            live_closing_issues=[3820, 3823],
+            merge_readiness=readiness,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(
+            lambda readiness: readiness.update(head_sha=NEXT_HEAD),
+            id="readiness-bound-to-another-head",
+        ),
+        pytest.param(
+            lambda readiness: readiness.update(contract="unknown.v1"),
+            id="unknown-contract",
+        ),
+        pytest.param(
+            lambda readiness: readiness.update(further_commits_anticipated="false"),
+            id="non-boolean-assertion",
+        ),
+        pytest.param(
+            lambda readiness: readiness.pop("review_gate_resolved"),
+            id="missing-assertion",
+        ),
+        pytest.param(
+            lambda readiness: readiness.update(merged_by="agent"),
+            id="unknown-field",
+        ),
+    ],
+)
+def test_neutralization_readiness_fails_closed_on_malformed_statements(
+    mutate,
+) -> None:
+    readiness = _readiness()
+    mutate(readiness)
+
+    with pytest.raises(ValueError, match="readiness is malformed"):
+        prepare_verified_merge(
+            context=_context(),
+            pr=_pr(),
+            live_closing_issues=[3820, 3823],
+            merge_readiness=readiness,
+        )
+
+
+def test_neutralized_body_outliving_its_head_is_surfaced_as_restorable() -> None:
+    """Reproduce PR #4021: neutralize at head A, then push head B.
+
+    There, the body stayed neutralized across six later heads for about seven
+    hours because nothing detected that it had outlived the merge attempt that
+    justified it, so `pr-contract` failed deterministically on every head.
+    """
+
+    original_body = _body()
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(original_body),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    authority_receipt = plan["authority_receipt"]
+    assert isinstance(authority_receipt, dict)
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    neutralized_body = str(plan["neutralized_body"])
+    head_a_pr = _pr(neutralized_body)
+
+    # Inside the merge attempt the receipt covers the live head; nothing to restore.
+    assert (
+        resolve_verified_merge_authority_receipt(
+            comments, pr=head_a_pr, repository=REPOSITORY
+        )
+        == authority_receipt
+    )
+    assert (
+        resolve_neutralized_body_restoration(
+            comments, pr=head_a_pr, repository=REPOSITORY
+        )
+        is None
+    )
+
+    # A further commit lands. The exact-head binding is unchanged, so the
+    # receipt stops resolving while the body still advertises neutralization.
+    head_b_pr = {**head_a_pr, "head": {"sha": NEXT_HEAD}}
+    assert (
+        resolve_verified_merge_authority_receipt(
+            comments, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+
+    restoration = resolve_neutralized_body_restoration(
+        comments, pr=head_b_pr, repository=REPOSITORY
+    )
+    assert restoration == {
+        "closing_issues": [3820, 3823],
+        "contract": NEUTRALIZED_BODY_RESTORATION_CONTRACT,
+        "governing_issue": 3821,
+        "head_sha": NEXT_HEAD,
+        "neutralized_body_sha256": authority_receipt["neutralized_body_sha256"],
+        "neutralized_head_sha": HEAD,
+        "pr_number": 3822,
+        "reason": "neutralized-body-outlived-merge-attempt",
+        "repository": REPOSITORY,
+        "restore_body_sha256": authority_receipt["body_sha256"],
+        "run_id": "vrun-authority",
+    }
+
+    # Only the authenticated original body is an accepted restoration, and the
+    # durable authority trail stays untouched evidence.
+    assert restored_body_matches_authority(original_body, restoration=restoration)
+    assert not restored_body_matches_authority(
+        neutralized_body, restoration=restoration
+    )
+    assert not restored_body_matches_authority(
+        original_body.replace("Refs #3900", "Refs #3901"), restoration=restoration
+    )
+    assert comments == [_trusted_comment(str(plan["authority_receipt_comment"]))]
+
+    # A restored-then-reneutralized body still resumes normally on the new head.
+    restored_pr = {**head_b_pr, "body": original_body}
+    assert (
+        resolve_neutralized_body_restoration(
+            comments, pr=restored_pr, repository=REPOSITORY
+        )
+        is None
+    )
+    next_plan = prepare_verified_merge(
+        context={**_context(), "head_sha": NEXT_HEAD},
+        pr=restored_pr,
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(NEXT_HEAD),
+    )
+    next_comments = [
+        *comments,
+        _trusted_comment(str(next_plan["authority_receipt_comment"])),
+    ]
+    reneutralized_pr = {**restored_pr, "body": str(next_plan["neutralized_body"])}
+    assert (
+        resolve_verified_merge_authority_receipt(
+            next_comments, pr=reneutralized_pr, repository=REPOSITORY
+        )
+        == next_plan["authority_receipt"]
+    )
+    assert (
+        resolve_neutralized_body_restoration(
+            next_comments, pr=reneutralized_pr, repository=REPOSITORY
+        )
+        is None
+    )
+
+
+def test_neutralized_body_restoration_cli_uses_production_resolver(
+    tmp_path: Path,
+) -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    pr_path = tmp_path / "pr.json"
+    comments_path = tmp_path / "comments.json"
+    output_path = tmp_path / "restoration.json"
+    comments_path.write_text(
+        json.dumps([_trusted_comment(str(plan["authority_receipt_comment"]))]),
+        encoding="utf-8",
+    )
+
+    def _run() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.resolve_neutralized_body_restoration",
+                "--pr-json",
+                str(pr_path),
+                "--comments-json",
+                str(comments_path),
+                "--repository",
+                REPOSITORY,
+                "--output-json",
+                str(output_path),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    pr_path.write_text(
+        json.dumps(_pr(str(plan["neutralized_body"]))), encoding="utf-8"
+    )
+    inside_attempt = _run()
+
+    assert inside_attempt.returncode == 0, inside_attempt.stderr
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "restoration": None,
+        "restoration_required": False,
+    }
+
+    pr_path.write_text(
+        json.dumps(
+            {
+                **_pr(str(plan["neutralized_body"])),
+                "head": {"sha": NEXT_HEAD},
+            }
+        ),
+        encoding="utf-8",
+    )
+    outlived = _run()
+
+    assert outlived.returncode == 2, outlived.stderr
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["restoration_required"] is True
+    assert payload["restoration"]["neutralized_head_sha"] == HEAD
+    assert payload["restoration"]["head_sha"] == NEXT_HEAD
+
+
+def test_neutralized_body_restoration_fails_closed_without_unambiguous_evidence() -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    authority_receipt = plan["authority_receipt"]
+    assert isinstance(authority_receipt, dict)
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    head_b_pr = {**_pr(str(plan["neutralized_body"])), "head": {"sha": NEXT_HEAD}}
+
+    # No receipt at all: the restore target cannot be proven.
+    assert (
+        resolve_neutralized_body_restoration([], pr=head_b_pr, repository=REPOSITORY)
+        is None
+    )
+
+    # Untrusted authorship never names a restore target.
+    untrusted = [{**comments[0], "author_association": "NONE"}]
+    assert (
+        resolve_neutralized_body_restoration(
+            untrusted, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+
+    # A canonical body is not a restorable state.
+    assert (
+        resolve_neutralized_body_restoration(
+            comments,
+            pr={**head_b_pr, "body": _body()},
+            repository=REPOSITORY,
+        )
+        is None
+    )
+
+    # A merged PR stays owned by the `restored` phase of its own attempt.
+    assert (
+        resolve_neutralized_body_restoration(
+            comments,
+            pr={
+                **head_b_pr,
+                "state": "closed",
+                "merged": True,
+                "merged_at": "2026-07-27T08:18:08Z",
+            },
+            repository=REPOSITORY,
+        )
+        is None
+    )
+
+    # Foreign repository, foreign run, and conflicting restore targets fail closed.
+    assert (
+        resolve_neutralized_body_restoration(
+            comments, pr=head_b_pr, repository="RasmusTho/other"
+        )
+        is None
+    )
+    assert (
+        resolve_neutralized_body_restoration(
+            comments,
+            pr=head_b_pr,
+            repository=REPOSITORY,
+            expected_run_id="vrun-other",
+        )
+        is None
+    )
+    conflicting = dict(authority_receipt)
+    conflicting["body_sha256"] = "c" * 64
+    assert (
+        resolve_neutralized_body_restoration(
+            [*comments, _authority_comment(conflicting)],
+            pr=head_b_pr,
+            repository=REPOSITORY,
+        )
+        is None
+    )

--- a/tests/dispatcher/test_verified_merge.py
+++ b/tests/dispatcher/test_verified_merge.py
@@ -1487,3 +1487,122 @@ def test_neutralized_body_state_never_reports_ambiguity_as_safe() -> None:
         "restoration_required": False,
         "status": "no_restoration_required",
     }
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        pytest.param({}, "restoration_required", id="positively-open"),
+        pytest.param(
+            {
+                "state": "closed",
+                "merged": True,
+                "merged_at": "2026-07-27T08:18:08Z",
+            },
+            "no_restoration_required",
+            id="positively-merged",
+        ),
+        pytest.param({"state": None}, "ambiguous_neutralized_body", id="no-state"),
+        pytest.param(
+            {"state": "unknown"}, "ambiguous_neutralized_body", id="unknown-state"
+        ),
+        pytest.param(
+            {"state": "open", "merged": True},
+            "ambiguous_neutralized_body",
+            id="open-but-merged",
+        ),
+        pytest.param(
+            {"state": "closed", "merged": True, "merged_at": None},
+            "ambiguous_neutralized_body",
+            id="merged-without-timestamp",
+        ),
+        pytest.param(
+            {"state": "closed"}, "ambiguous_neutralized_body", id="closed-unmerged"
+        ),
+    ],
+)
+def test_incomplete_or_contradictory_snapshots_are_never_reported_safe(
+    overrides: dict[str, object], expected: str
+) -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    pr = {
+        **_pr(str(plan["neutralized_body"])),
+        "head": {"sha": NEXT_HEAD},
+        **overrides,
+    }
+    if overrides.get("state") is None and "state" in overrides:
+        del pr["state"]
+
+    result = classify_neutralized_body_state(
+        comments, pr=pr, repository=REPOSITORY
+    )
+
+    assert result["status"] == expected
+    if expected != "restoration_required":
+        assert result["restoration"] is None
+        assert (
+            resolve_neutralized_body_restoration(
+                comments, pr=pr, repository=REPOSITORY
+            )
+            is None
+        )
+
+
+def test_conflicting_current_head_authority_never_falls_back_to_a_stale_head() -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    stale_receipt = plan["authority_receipt"]
+    assert isinstance(stale_receipt, dict)
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    head_b_pr = {
+        **_pr(str(plan["neutralized_body"])),
+        "head": {"sha": NEXT_HEAD},
+    }
+
+    # Baseline: the stale head alone names a restore target.
+    assert (
+        resolve_neutralized_body_restoration(
+            comments, pr=head_b_pr, repository=REPOSITORY
+        )
+        is not None
+    )
+
+    # Two conflicting trusted receipts for the live head. The exact-head resolver
+    # correctly refuses to pick one, so a merge for this attempt may still be in
+    # flight and restoration must not race it.
+    current_a = {**stale_receipt, "head_sha": NEXT_HEAD}
+    current_b = {**current_a, "run_id": "vrun-other"}
+    conflicted = [
+        *comments,
+        _authority_comment(current_a),
+        _authority_comment(current_b),
+    ]
+
+    assert (
+        resolve_verified_merge_authority_receipt(
+            conflicted, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+    assert (
+        resolve_neutralized_body_restoration(
+            conflicted, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+    assert (
+        classify_neutralized_body_state(
+            conflicted, pr=head_b_pr, repository=REPOSITORY
+        )["status"]
+        == "ambiguous_neutralized_body"
+    )

--- a/tests/dispatcher/test_verified_merge.py
+++ b/tests/dispatcher/test_verified_merge.py
@@ -9,12 +9,16 @@ from pathlib import Path
 
 import pytest
 
-from app.dispatcher.verification_contract import IssueAuthority, MAX_CLOSING_ISSUES
+from app.dispatcher.verification_contract import (
+    IssueAuthority,
+    MAX_CLOSING_ISSUES,
+    has_neutralized_closing_marker,
+    resolve_neutralized_issue_authority,
+)
 from app.dispatcher.verified_merge import (
     NEUTRALIZED_BODY_RESTORATION_CONTRACT,
     VERIFIED_MERGE_AUTHORITY_CONTRACT,
     build_verified_merge_phase,
-    carries_live_neutralized_body,
     classify_neutralized_body_state,
     plan_post_merge_reconciliation,
     prepare_verified_merge,
@@ -1197,6 +1201,7 @@ def test_neutralized_body_outliving_its_head_is_surfaced_as_restorable() -> None
         "contract": NEUTRALIZED_BODY_RESTORATION_CONTRACT,
         "governing_issue": 3821,
         "head_sha": NEXT_HEAD,
+        "matching_attempts": 1,
         "neutralized_body_sha256": authority_receipt["neutralized_body_sha256"],
         "neutralized_head_sha": HEAD,
         "pr_number": 3822,
@@ -1421,15 +1426,23 @@ def test_neutralized_body_restoration_fails_closed_without_unambiguous_evidence(
 
     # Every one of those `None` outcomes is still an indeterminate live
     # neutralized body, distinct from a canonical or already-merged body.
-    assert carries_live_neutralized_body(head_b_pr)
-    assert not carries_live_neutralized_body({**head_b_pr, "body": _body()})
-    assert not carries_live_neutralized_body(
-        {
-            **head_b_pr,
-            "state": "closed",
-            "merged": True,
-            "merged_at": "2026-07-27T08:18:08Z",
-        }
+    def _status(pr: dict[str, object]) -> object:
+        return classify_neutralized_body_state(
+            comments, pr=pr, repository=REPOSITORY
+        )["status"]
+
+    assert _status(head_b_pr) == "restoration_required"
+    assert _status({**head_b_pr, "body": _body()}) == "no_restoration_required"
+    assert (
+        _status(
+            {
+                **head_b_pr,
+                "state": "closed",
+                "merged": True,
+                "merged_at": "2026-07-27T08:18:08Z",
+            }
+        )
+        == "no_restoration_required"
     )
 
 
@@ -1554,6 +1567,125 @@ def test_incomplete_or_contradictory_snapshots_are_never_reported_safe(
         )
 
 
+@pytest.mark.parametrize(
+    "damage",
+    [
+        pytest.param(
+            lambda body: body + "Governing-Issue: #3821\n",
+            id="second-governing-issue-line",
+        ),
+        pytest.param(
+            # Drops the evidence line for a closing issue, so the marker's
+            # closing set is no longer a subset of governing + supporting.
+            lambda body: body.replace("Refs #3820\n", ""),
+            id="deleted-closing-evidence-line",
+        ),
+        pytest.param(
+            lambda body: body + "Verified-Closing-Issues: #3820, #3823\n",
+            id="duplicated-marker-line",
+        ),
+        pytest.param(lambda body: body + "\ra\n", id="lone-carriage-return"),
+        pytest.param(
+            lambda body: body.replace("Governing-Issue: #3821", "Governing-Issue: x"),
+            id="unparseable-governing-issue",
+        ),
+    ],
+)
+def test_a_marker_that_no_longer_parses_is_stranded_not_canonical(damage) -> None:
+    """A body can keep its marker while its grammar stops resolving.
+
+    `resolve_neutralized_issue_authority` answers `None` for a canonical body and
+    for a damaged one alike. Treating that shared `None` as "canonical" strands a
+    neutralization that carries no closing authority at all, so `pr-contract`
+    fails on every head — issue #4185 reproduced by its own fix. The realistic
+    source is an agent re-pasting the PR template after a merge hard stop.
+    """
+
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    damaged = damage(str(plan["neutralized_body"]))
+    pr = {**_pr(damaged), "head": {"sha": NEXT_HEAD}}
+
+    # Precondition: the damage really did break the strict grammar, so this test
+    # exercises the conflation rather than an intact body.
+    assert resolve_neutralized_issue_authority(damaged) is None
+    assert has_neutralized_closing_marker(damaged)
+
+    assert (
+        classify_neutralized_body_state(comments, pr=pr, repository=REPOSITORY)[
+            "status"
+        ]
+        == "ambiguous_neutralized_body"
+    )
+
+
+def test_a_snapshot_without_a_body_is_never_reported_safe() -> None:
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    pr = {**_pr(), "head": {"sha": NEXT_HEAD}}
+    del pr["body"]
+
+    assert (
+        classify_neutralized_body_state(comments, pr=pr, repository=REPOSITORY)[
+            "status"
+        ]
+        == "ambiguous_neutralized_body"
+    )
+
+
+def test_restored_body_proof_binds_contract_identities_and_lf_equivalence() -> None:
+    original_body = _body()
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(original_body),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    restoration = resolve_neutralized_body_restoration(
+        comments,
+        pr={**_pr(str(plan["neutralized_body"])), "head": {"sha": NEXT_HEAD}},
+        repository=REPOSITORY,
+    )
+    assert restoration is not None
+
+    assert restored_body_matches_authority(original_body, restoration=restoration)
+    # GitHub may return the same body without its single terminal LF.
+    assert original_body.endswith("\n")
+    assert restored_body_matches_authority(
+        original_body[:-1], restoration=restoration
+    )
+
+    # A payload that is not this contract proves nothing, even with a digest hit.
+    assert not restored_body_matches_authority(
+        original_body,
+        restoration={**restoration, "contract": "some_other_contract.v1"},
+    )
+    # Digest and identities must agree; neither alone is sufficient.
+    assert not restored_body_matches_authority(
+        original_body,
+        restoration={**restoration, "governing_issue": 4185},
+    )
+    assert not restored_body_matches_authority(
+        original_body,
+        restoration={**restoration, "closing_issues": [3820]},
+    )
+    assert not restored_body_matches_authority(
+        original_body + "trailing drift\n", restoration=restoration
+    )
+    assert not restored_body_matches_authority(None, restoration=restoration)
+
+
 def test_conflicting_current_head_authority_never_falls_back_to_a_stale_head() -> None:
     plan = prepare_verified_merge(
         context=_context(),
@@ -1606,3 +1738,162 @@ def test_conflicting_current_head_authority_never_falls_back_to_a_stale_head() -
         )["status"]
         == "ambiguous_neutralized_body"
     )
+
+
+@pytest.mark.parametrize(
+    "live_head_evidence",
+    [
+        pytest.param(
+            lambda receipt: [_authority_comment({**receipt, "surprise": True})],
+            id="extra-key",
+        ),
+        pytest.param(
+            lambda receipt: [
+                _authority_comment(
+                    {
+                        field: value
+                        for field, value in receipt.items()
+                        if field != "repair_budget"
+                    }
+                )
+            ],
+            id="missing-repair-budget",
+        ),
+        pytest.param(
+            lambda receipt: [
+                _trusted_comment(
+                    2
+                    * (
+                        "verified issue-set merge authority:\n```json\n"
+                        + json.dumps(
+                            receipt, sort_keys=True, separators=(",", ":")
+                        )
+                        + "\n```\n"
+                    )
+                )
+            ],
+            id="two-receipt-blocks-in-one-comment",
+        ),
+    ],
+)
+def test_malformed_live_head_evidence_still_blocks_a_stale_fallback(
+    live_head_evidence,
+) -> None:
+    """A structural filter must not be able to discard the race guard.
+
+    Each of these receipts is invalid as authority, so the exact-head resolver
+    ignores it. But it is still trusted evidence that a merge attempt exists on
+    the live head, and answering from an older head there is the merge race the
+    restore contract forbids.
+    """
+
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    stale_receipt = plan["authority_receipt"]
+    assert isinstance(stale_receipt, dict)
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    head_b_pr = {**_pr(str(plan["neutralized_body"])), "head": {"sha": NEXT_HEAD}}
+
+    assert (
+        resolve_neutralized_body_restoration(
+            comments, pr=head_b_pr, repository=REPOSITORY
+        )
+        is not None
+    )
+
+    guarded = [
+        *comments,
+        *live_head_evidence({**stale_receipt, "head_sha": NEXT_HEAD}),
+    ]
+
+    assert (
+        resolve_verified_merge_authority_receipt(
+            guarded, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+    assert (
+        resolve_neutralized_body_restoration(
+            guarded, pr=head_b_pr, repository=REPOSITORY
+        )
+        is None
+    )
+    assert (
+        classify_neutralized_body_state(
+            guarded, pr=head_b_pr, repository=REPOSITORY
+        )["status"]
+        == "ambiguous_neutralized_body"
+    )
+
+    # Untrusted authorship is not evidence and must not block a real restore.
+    untrusted = [
+        *comments,
+        *[
+            {**comment, "author_association": "NONE"}
+            for comment in live_head_evidence(
+                {**stale_receipt, "head_sha": NEXT_HEAD}
+            )
+        ],
+    ]
+    assert (
+        resolve_neutralized_body_restoration(
+            untrusted, pr=head_b_pr, repository=REPOSITORY
+        )
+        is not None
+    )
+
+
+def test_restored_body_proof_cli_uses_production_verifier(tmp_path: Path) -> None:
+    original_body = _body()
+    plan = prepare_verified_merge(
+        context=_context(),
+        pr=_pr(original_body),
+        live_closing_issues=[3820, 3823],
+        merge_readiness=_readiness(),
+    )
+    comments = [_trusted_comment(str(plan["authority_receipt_comment"]))]
+    restoration = resolve_neutralized_body_restoration(
+        comments,
+        pr={**_pr(str(plan["neutralized_body"])), "head": {"sha": NEXT_HEAD}},
+        repository=REPOSITORY,
+    )
+    restoration_path = tmp_path / "restoration.json"
+    body_path = tmp_path / "candidate.md"
+    # The resolver CLI's wrapper shape must be accepted directly.
+    restoration_path.write_text(
+        json.dumps({"restoration": restoration, "restoration_required": True}),
+        encoding="utf-8",
+    )
+
+    def _run() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.verify_restored_pr_body",
+                "--restoration-json",
+                str(restoration_path),
+                "--restored-body-file",
+                str(body_path),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    body_path.write_text(original_body, encoding="utf-8")
+    accepted = _run()
+
+    assert accepted.returncode == 0, accepted.stderr
+    assert json.loads(accepted.stdout)["restored_body_matches_authority"] is True
+
+    body_path.write_text(str(plan["neutralized_body"]), encoding="utf-8")
+    refused = _run()
+
+    assert refused.returncode == 1
+    assert json.loads(refused.stdout)["restored_body_matches_authority"] is False

--- a/tests/scripts/test_post_merge_docs_classifier.py
+++ b/tests/scripts/test_post_merge_docs_classifier.py
@@ -126,6 +126,13 @@ def _neutralized_multi_issue_evidence() -> tuple[dict[str, object], list[dict[st
         },
         pr=pr,
         live_closing_issues=[3820, 3823],
+        merge_readiness={
+            "contract": "verified_issue_set_merge_readiness.v1",
+            "further_commits_anticipated": False,
+            "head_sha": head,
+            "required_checks_green": True,
+            "review_gate_resolved": True,
+        },
     )
     neutralized_pr = {**pr, "body": plan["neutralized_body"]}
     comments = [


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4185

## Linked Issue

Fixes #4185

Implementation lane, so neither Tier 1 lane box applies — see Notes.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): verified issue-set merge authority
- Write class: authority-bearing
- Authority impact: constrains when merge-authority neutralization may be applied and adds a read-only restorable-state detector; the exact-head receipt binding is unchanged
- Persistence impact: durable — GitHub PR body state and the durable authority/phase receipt trail
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: GitHub PR body and comment writes remain the closure agent's; this change adds no new external writes and the new detector is read-only
- New or changed contract: `verified_issue_set_merge_readiness.v1` (new, now required by `prepare_verified_merge` and by `scripts/prepare_verified_issue_set_merge.py --merge-readiness-json`) and `verified_issue_set_neutralized_body_restoration.v1` (new detection payload); the neutralized-body lifetime is now bounded by the merge attempt that justified it
- Owner-doc impact: updated in this PR (`docs/AGENT_ISSUE_DISPATCHER.md`, `docs/development/PR_HOT_PATH.md`)
- Transition debt impact: reduces
- Fitness rule impact: strengthens
- Boundary risk: a restore must not mutate the durable receipt trail and must not race an in-flight merge — detection is read-only, refuses merged PRs, never rewrites receipts, and fails closed on foreign, untrusted, ambiguous, or conflicting evidence

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- The verified-merge flow neutralized a PR body (authenticated closing keywords rewritten to evidence-only `Refs` plus a `Verified-Closing-Issues` marker) as soon as it believed the merge prerequisites were met, with no precondition against further commits and no rule restoring the canonical body when more commits arrived. Because the authority receipt is bound to the exact head, every later head then failed `pr-contract` deterministically while the body still advertised neutralization — observed on PR #4021 across six heads over about seven hours.
- Precondition: `prepare_verified_merge` now takes a required, head-bound `verified_issue_set_merge_readiness.v1` statement and refuses to neutralize unless CI is green, the review gate is resolved, and no further commits are anticipated on that exact head. The parameter has no default, so the precondition cannot be reached by omission, and the statement is bound to the head so it is not reusable across a rebase or repair commit.
- Restore rule: `.codex/skills/verification-and-closure/SKILL.md` gains the stated precondition on merge step 2 and a new `Restoring a neutralized body after a head change` subsection requiring the canonical body to be restored before any further repair, verification, or re-merge work.
- Detection: `resolve_neutralized_body_restoration` surfaces "neutralized body with no authority receipt for the current head" as a bounded restorable state, naming the durable receipt's original-body digest as the only accepted restore target; `restored_body_matches_authority` validates a candidate restoration. `classify_neutralized_body_state` keeps "nothing to restore" and "cannot prove a restore target" apart, and `scripts/resolve_neutralized_body_restoration.py` exposes the whole thing read-only with distinct exit codes (`0` no restoration required, `2` restoration required, `3` ambiguous — a hard stop). Detection requires a positively established snapshot and refuses to answer from a stale head whenever the live head carries any trusted receipt, so it can neither race an in-flight merge nor report an unestablished state as safe.
- The exact-head binding is untouched. The existing `_valid_authority_receipt` assertions, including the stale-head rejection in `test_authority_receipt_resolver_rejects_forged_stale_and_conflicting_comments`, pass unmodified, and the detector defers to the live receipt whenever one covers the current head.
- Owner docs: `docs/AGENT_ISSUE_DISPATCHER.md` gains the neutralized-body lifetime invariant; `docs/development/PR_HOT_PATH.md` gains the matching safety invariant.

## BuilderOps Routing
- Records/projections/receipts: `LearningSignal lrn_20260727233108_61badf4a`
- Reason: a builder-workflow divergence occurred during delivery — the review returned only P2/P3 findings, and both the implementing agent and the coordinator treated each P2 as a merge blocker and fixed it, against `verification-and-closure :: Severity routing` ("there is no valid `blocking P2` category") and `:: Re-triggering after a fix` ("P2/P3 disposition leaves the code unchanged for that finding and does not re-trigger review"). That turned one merge into four review rounds. The signal names the two skill sections and the coordinator hand-back prompting as upstream artifacts. No deferred-defect Issue accompanies it: the findings were fixed and verified green, so no live defect remains to defer.

## Notes
- Tests: a new `#4021` regression test neutralizes at head A, moves the head to B, asserts the authority receipt correctly stops resolving, asserts the restorable state is surfaced with the durable receipt's restore digest, asserts only the authenticated original body is accepted as the restoration, asserts the receipt trail is unchanged, and asserts a restored-then-reneutralized body still resumes normally on the new head. A companion test covers fail-closed cases (no receipt, untrusted authorship, canonical body, merged PR, foreign repository, foreign run id, conflicting restore targets), plus precondition-refused and readiness-malformed cases and a CLI test for the new script.
- Review: four rounds, every one of which found a real defect in the new code. All fixed rather than deferred, because each was in the fail-closed property this change exists to provide.
  1. An ambiguous neutralized body (no provable restore target) reported `restoration_required: false` and exit 0, so a caller using the command as the pre-repair gate would continue past exactly the indeterminate state the detector exists to stop. `classify_neutralized_body_state` now returns one of three states and the CLI maps them to exit `0` / `2` / `3`.
  2. A snapshot that omitted `state`, reported an unknown state, or contradicted itself (`state: "open"` with `merged: true`) was read as "not live" and answered safe. `_resolve_merge_state` now resolves `open` / `merged` / `unknown` and never guesses; `unknown` is ambiguous.
  3. When the live head carried conflicting trusted receipts, the detector fell back to an older head and reported `restoration_required` — the merge-race the governing issue explicitly forbids. Trusted evidence naming the live head now stops the fallback, and it is detected from raw comment text so a receipt with an extra key, a missing field, or two receipt blocks in one comment cannot be discarded by a structural filter.
  4. The sharpest one, and the reason this PR went four rounds: the classifier decided "canonical" with the strict resolver, which returns `None` both for a clean body and for one whose `Verified-Closing-Issues` marker survives while its grammar no longer parses. The second is a live stranded neutralization with no closing authority at all — issue #4185 reproduced by its own fix, most plausibly when an agent re-pastes the PR template after a merge hard stop. Five bodies that previously answered exit 0 (second `Governing-Issue:` line, deleted closing `Refs` line, duplicated marker, lone CR, and a snapshot with no `body` key) now answer exit 3. `has_neutralized_closing_marker` — the same loose predicate `neutralize_closing_issue_references` uses to refuse double neutralization — now decides canonical. `carries_live_neutralized_body` held an identical copy of the defect with no production caller, so it is deleted rather than fixed twice.
- Also from round four: the restoration payload reports `matching_attempts` so a restore-then-re-neutralize loop that legitimately leaves several attempts matching the same proven target is visible rather than silently reported as one; and `scripts/verify_restored_pr_body.py` makes the skill's mandated restore proof executable, since it previously named a function with no CLI and left a hand-edit as the operator's only route — a hand-edited body being exactly what strands a neutralization.
- Validation: `ruff check app tests scripts` clean, `mypy app` clean (809 files), `pytest -q tests/architecture tests/governance tests/dispatcher tests/scripts` 1902 passed. The full `not pg` sweep under `scripts/run_with_host_lease.py --resource pytest-not-pg` reports 32 failed / 11064 passed on this host. Every failure is in `tests/deploy/` or `tests/ops/`, which shell out to docker and to the system `python3` (for example `ModuleNotFoundError: No module named 'pydantic_settings'` from `scripts/export_runtime_env.sh`). None of them import `app.dispatcher.verified_merge` or `app.dispatcher.verification_contract`, and the failing set drifts run to run on this host (33, 35, and 32 with different members), so they are environmental rather than attributable to this diff. `Unit tests (not pg)` on the PR head is the authority. `scripts/review_before_ci_gate.py --lane implementation ... --review-gate-complete` is satisfied.
- Test-quality note from round four: the earlier suites passed 49/49 on a head that carried a P2, because the snapshot tests varied only `state`/`merged`/`merged_at` and the safety assertion used a well-formed canonical body — which passes identically whether the check means "canonical" or "unparseable". The damaged-body table is now parametrized directly, each case asserting first that the damage really did break the strict grammar while the marker survived, so the test cannot silently stop exercising the conflation.
- Lane checkboxes are intentionally left unchecked: this is an issue-backed implementation-lane PR, and the canonical implementation template in `.codex/skills/publish-pr/SKILL.md :: Step 6` carries no lane box. The Tier 1 lane boxes classify docs-authoring and governance-lane PRs, whose surface allowlists do not cover `app/`, `scripts/`, or `tests/dispatcher/`. The `## BuilderOps Routing` section is filled concretely rather than relying on the Tier 1 omission allowance.
- `scripts/docs_guard.py` reports its temporal-docs advisory for the `app/`+`scripts/` change. Knowingly skipped: this is Builder System merge orchestration and changes no shipped product status, roadmap, operations, or flow surface. It is a local advisory tool and not a CI gate.
- Callers of `prepare_verified_merge` and `scripts/prepare_verified_issue_set_merge.py` must now supply the readiness statement; this is a deliberate fail-closed break rather than a defaulted flag, and every in-repo caller and test is updated.
- The new detector deliberately does not accept the pre-#4010 legacy terminal-LF digest form. That path exists only for historical receipts; declining it here means an ambiguous case returns "nothing to restore" rather than naming a restore target it cannot prove.
- Residual risk: the readiness statement is an attestation by the closure agent, so it constrains the orchestration rather than proving CI state independently. It is bound to the exact head, which is the property that actually failed on PR #4021; independent check-state verification stays with the existing CI gates.
