### PR TITLE
Ignore the published runtime/settings symlink, not just the directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,11 @@ tmp/index.jsonl
 # the tracked source/test trees app/runtime/ and tests/runtime/ and silently hide
 # any future file added under e.g. tests/runtime/panel/ or app/runtime/settings/.
 # Repo root:
-/runtime/settings/
+# No trailing slash on runtime/settings: the compiler publishes it as a SYMLINK
+# to the winning .settings.staged-* dir, and git treats a symlink as a file, so a
+# directory-only pattern ("/runtime/settings/") does not match it and leaves
+# `?? runtime/settings` in git status. The leading / keeps it anchored.
+/runtime/settings
 /runtime/builderops/
 /runtime/dispatcher/
 /runtime/orientation/
@@ -68,7 +72,7 @@ tmp/index.jsonl
 /runtime/.settings.*
 # companion-ui/companion-app (companion_ui tests run from this cwd and write
 # runtime/panel/panel_confirmation.sqlite3 etc. relative to it):
-/companion-ui/companion-app/runtime/settings/
+/companion-ui/companion-app/runtime/settings
 /companion-ui/companion-app/runtime/builderops/
 /companion-ui/companion-app/runtime/dispatcher/
 /companion-ui/companion-app/runtime/orientation/

--- a/tests/settings/test_runtime_artifacts_gitignored.py
+++ b/tests/settings/test_runtime_artifacts_gitignored.py
@@ -45,14 +45,19 @@ def _compiler_sibling_artifacts() -> list[str]:
     ]
 
 
-def _is_ignored(relpath: str) -> bool:
-    """True when `.gitignore` covers ``relpath`` (path need not exist)."""
+def _is_ignored_in(repo: Path, relpath: str) -> bool:
+    """True when ``repo``'s `.gitignore` covers ``relpath`` (need not exist)."""
     result = subprocess.run(
         ["git", "check-ignore", "-q", "--", relpath],
-        cwd=REPO_ROOT,
+        cwd=repo,
         capture_output=True,
     )
     return result.returncode == 0
+
+
+def _is_ignored(relpath: str) -> bool:
+    """True when this repo's `.gitignore` covers ``relpath``."""
+    return _is_ignored_in(REPO_ROOT, relpath)
 
 
 @pytest.mark.parametrize("producer_root", PRODUCER_ROOTS)
@@ -67,7 +72,7 @@ def test_compiler_runtime_siblings_are_gitignored(producer_root: str) -> None:
 
 
 @pytest.mark.parametrize("producer_root", PRODUCER_ROOTS)
-def test_published_settings_symlink_is_gitignored(producer_root: str, tmp_path: Path) -> None:
+def test_published_settings_symlink_is_gitignored(producer_root: str) -> None:
     """``runtime/settings`` must be ignored even when it is a *symlink*.
 
     ``app/settings/compiler.py`` publishes the winning generation by pointing
@@ -96,15 +101,6 @@ def _pattern_matches_symlink(repo: Path, relpath: str) -> bool:
     link.parent.mkdir(parents=True, exist_ok=True)
     link.symlink_to(target.name)
     return _is_ignored_in(repo, relpath)
-
-
-def _is_ignored_in(repo: Path, relpath: str) -> bool:
-    result = subprocess.run(
-        ["git", "check-ignore", "-q", "--", relpath],
-        cwd=repo,
-        capture_output=True,
-    )
-    return result.returncode == 0
 
 
 def test_settings_pattern_matches_a_real_symlink(tmp_path: Path) -> None:
@@ -142,8 +138,17 @@ def test_ignore_patterns_stay_anchored_to_producer_roots() -> None:
     ``tests/runtime/``. Guard that the fix kept that property.
     """
     for tracked_root in ("app/runtime", "tests/runtime"):
+        # The /runtime/.settings.* pattern.
         probe = f"{tracked_root}/.settings.lock"
         assert not _is_ignored(probe), (
             f"{probe!r} is gitignored — the runtime-artifact pattern lost "
             "its anchoring and now hides tracked source/test trees."
         )
+        # The /runtime/settings pattern. Anchoring here comes from the leading
+        # slash, not the trailing one, so dropping the trailing slash to match
+        # the published symlink must not start swallowing these trees.
+        for probe in (f"{tracked_root}/settings", f"{tracked_root}/settings/loader.py"):
+            assert not _is_ignored(probe), (
+                f"{probe!r} is gitignored — the runtime/settings pattern lost "
+                "its anchoring and now hides tracked source/test trees."
+            )

--- a/tests/settings/test_runtime_artifacts_gitignored.py
+++ b/tests/settings/test_runtime_artifacts_gitignored.py
@@ -66,6 +66,74 @@ def test_compiler_runtime_siblings_are_gitignored(producer_root: str) -> None:
         )
 
 
+@pytest.mark.parametrize("producer_root", PRODUCER_ROOTS)
+def test_published_settings_symlink_is_gitignored(producer_root: str, tmp_path: Path) -> None:
+    """``runtime/settings`` must be ignored even when it is a *symlink*.
+
+    ``app/settings/compiler.py`` publishes the winning generation by pointing
+    ``runtime/settings`` at a ``.settings.staged-*`` sibling, so the path is a
+    symlink rather than a real directory. Git treats a symlink as a file, so a
+    directory-only pattern (``/runtime/settings/``, with the trailing slash)
+    does not match it and leaves ``?? runtime/settings`` in
+    ``git status --porcelain`` after any compile.
+    """
+    parent = compiler.RUNTIME.parent.as_posix()
+    name = compiler.RUNTIME.name
+    relpath = f"{producer_root}{parent}/{name}"
+
+    assert _is_ignored(relpath), (
+        f"{relpath!r} is not covered by .gitignore. The settings compiler "
+        "publishes it as a symlink to a .settings.staged-* dir; drop the "
+        "trailing slash from the pattern so it matches a symlink too."
+    )
+
+
+def _pattern_matches_symlink(repo: Path, relpath: str) -> bool:
+    """Materialize ``relpath`` as a real symlink and ask git if it is ignored."""
+    target = repo / f"{relpath}-target"
+    target.mkdir(parents=True, exist_ok=True)
+    link = repo / relpath
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target.name)
+    return _is_ignored_in(repo, relpath)
+
+
+def _is_ignored_in(repo: Path, relpath: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", relpath],
+        cwd=repo,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def test_settings_pattern_matches_a_real_symlink(tmp_path: Path) -> None:
+    """Prove the pattern against an actual on-disk symlink, not just a path string.
+
+    ``git check-ignore`` can answer from the pattern alone, so this builds a
+    throwaway repo, copies the real ``.gitignore`` into it, materializes
+    ``runtime/settings`` as a genuine symlink, and asserts git ignores it. This
+    is the check that fails when the trailing slash comes back.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / ".gitignore").write_text(
+        (REPO_ROOT / ".gitignore").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    assert _pattern_matches_symlink(tmp_path, "runtime/settings")
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "runtime/settings" not in status, (
+        f"a published settings symlink still dirties git status:\n{status}"
+    )
+
+
 def test_ignore_patterns_stay_anchored_to_producer_roots() -> None:
     """Tracked source/test `runtime/` trees must NOT be swallowed.
 


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: The settings compiler publishes runtime/settings as a symlink to the winning .settings.staged-* dir. Git treats a symlink as a file, so the directory-only .gitignore pattern (/runtime/settings/) never matched it and every compile left '?? runtime/settings' in git status --porcelain. This is the same hygiene failure #3891/#3892 fixed for the dot-prefixed siblings; the existing guard test covered those siblings but never the published symlink itself. Bounded one-character fix on two anchored lines plus regression guards.
Validation: python3 -m pytest tests/settings/test_runtime_artifacts_gitignored.py -q => 6 passed. Load-bearing check: restoring the trailing slash makes all 3 new tests fail (test_published_settings_symlink_is_gitignored[] , [companion-ui/companion-app/], test_settings_pattern_matches_a_real_symlink); restoring the fix returns 6 passed. git status --porcelain in this worktree went from '?? runtime/' to clean. git check-ignore -v runtime/settings now resolves to .gitignore:58:/runtime/settings. ruff check tests => All checks passed.
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System - repo hygiene
- Secondary subsystem(s): Product/Runtime System - settings compiler artifacts (observed only, not modified)
- Write class: mechanical
- Authority impact: none
- Persistence impact: none; no runtime artifact changes location or lifetime
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: unaffected
- Retrieval/context impact: unaffected
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: none
- Owner-doc impact: none; the .gitignore comment block is updated in place to explain the symlink case
- Transition debt impact: reduces; removes a recurring dirty-tree source that the branch-truth gate and publication preflight both trip over
- Fitness rule impact: strengthens; the existing guard suite now covers the published symlink, not just its dot-prefixed siblings
- Boundary risk: low; the leading slash keeps both patterns anchored, so tracked app/runtime/ and tests/runtime/ trees stay tracked (asserted by the pre-existing test_ignore_patterns_stay_anchored_to_producer_roots)

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- drop the trailing slash from the runtime/settings .gitignore entry on both producer roots so the pattern matches the published symlink, not only a real directory
- add two regression guards: per-producer-root ignore assertions, and one that builds a throwaway repo, materializes runtime/settings as a genuine symlink, and asserts git status stays clean

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded mechanical repo-hygiene repair with its own regression guards; no divergence, freshness, roadmap, or promotion material beyond the fix itself.

## Notes
None.
