### PR TITLE
fix: stop test subprocesses shadowing the interpreter's sitecustomize

### DIFF
--- a/scripts/ci/harness_gate_fault_injection.sh
+++ b/scripts/ci/harness_gate_fault_injection.sh
@@ -46,7 +46,7 @@ _run_preflight() {
   env -i \
     HOME="${HOME:-/root}" \
     PATH="${PATH}" \
-    PYTHONPATH="${PYTHONPATH:-$PYLIB_DIR}" \
+    PYTHONPATH="$PYLIB_DIR" \
     "$@" \
     "${PYTHON}" -m app.cli ops channel-preflight --channel test --context host 2>&1
 }

--- a/scripts/ci/harness_gate_fault_injection.sh
+++ b/scripts/ci/harness_gate_fault_injection.sh
@@ -15,6 +15,19 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 PYTHON="${PYTHON:-python}"
 
+# Private, sitecustomize-free PYTHONPATH default exposing only app/ (issue
+# #4186). $ROOT carries its own root sitecustomize.py (decision-receipt
+# hook); putting $ROOT itself on PYTHONPATH makes Python's site machinery
+# import THAT file instead of the interpreter's real sitecustomize.py (e.g.
+# Homebrew's, which wires up the actual third-party site-packages
+# directory) -- site init imports only the FIRST module literally named
+# `sitecustomize` on sys.path, so the repo's file wins and every
+# third-party import in `-m app.cli` below fails. Symlinking only `app/`
+# into a private directory sidesteps this entirely.
+PYLIB_DIR="$(mktemp -d)"
+trap 'rm -rf "$PYLIB_DIR"' EXIT
+ln -s "$ROOT/app" "$PYLIB_DIR/app"
+
 fail=0
 
 # The marker the preflight emits ONLY for a real channel-env violation. A bare
@@ -33,7 +46,7 @@ _run_preflight() {
   env -i \
     HOME="${HOME:-/root}" \
     PATH="${PATH}" \
-    PYTHONPATH="${PYTHONPATH:-$ROOT}" \
+    PYTHONPATH="${PYTHONPATH:-$PYLIB_DIR}" \
     "$@" \
     "${PYTHON}" -m app.cli ops channel-preflight --channel test --context host 2>&1
 }

--- a/tests/activation/test_journal_panel_import_order.py
+++ b/tests/activation/test_journal_panel_import_order.py
@@ -5,13 +5,15 @@ from pathlib import Path
 import subprocess
 import sys
 
+from tests.helpers.subprocess_pythonpath import isolated_app_pythonpath
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
+def _run_isolated(script: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["PYTHONPATH"] = isolated_app_pythonpath(tmp_path / "pylib", REPO_ROOT)
     return subprocess.run(
         [sys.executable, "-c", script],
         cwd=REPO_ROOT,
@@ -22,7 +24,7 @@ def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_journal_import_preserves_panel_agent_submodule_attribute() -> None:
+def test_journal_import_preserves_panel_agent_submodule_attribute(tmp_path: Path) -> None:
     result = _run_isolated(
         """
 import sys
@@ -32,13 +34,14 @@ import app.agents.panel_agent as panel_package
 
 panel_module = sys.modules["app.agents.panel_agent.agent"]
 assert panel_package.agent is panel_module
-"""
+""",
+        tmp_path,
     )
 
     assert result.returncode == 0, result.stderr
 
 
-def test_journal_first_import_supports_panel_monkeypatch_resolution() -> None:
+def test_journal_first_import_supports_panel_monkeypatch_resolution(tmp_path: Path) -> None:
     result = _run_isolated(
         """
 from pathlib import Path
@@ -53,7 +56,8 @@ patch.setattr(
     raising=False,
 )
 patch.undo()
-"""
+""",
+        tmp_path,
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -14,6 +14,7 @@ import app.builderops.config as builderops_config
 import app.builderops.cutover_evidence as cutover_evidence
 from app.builderops.store import SqliteBuilderOpsStore
 from app.builderops.cutover_evidence import CutoverEvidenceError, build_receipt, discover_legacy_stores, write_receipt
+from tests.helpers.subprocess_pythonpath import isolated_app_pythonpath
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -62,7 +63,7 @@ def _write_cutover_ack(
 def _run_implicit_cli(*, cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["HOME"] = str(home)
-    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["PYTHONPATH"] = isolated_app_pythonpath(cwd.parent / "_pythonpath", REPO_ROOT)
     for key in ("BUILDEROPS_DB_PATH", "BUILDEROPS_STATE_DIR", "BUILDEROPS_VAULT_ROOT"):
         env.pop(key, None)
     return subprocess.run(
@@ -219,7 +220,7 @@ with patch.object(Path, "home", side_effect=RuntimeError("home unavailable")):
     assert paths.db_path == Path({str(explicit_db)!r})
 """
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["PYTHONPATH"] = isolated_app_pythonpath(tmp_path / "_pythonpath", REPO_ROOT)
 
     result = subprocess.run(
         [sys.executable, "-c", code],

--- a/tests/helpers/subprocess_pythonpath.py
+++ b/tests/helpers/subprocess_pythonpath.py
@@ -1,0 +1,50 @@
+"""Shared helper for giving a test subprocess ``app.*``/``scripts.*``
+importability without shadowing the interpreter's own ``sitecustomize.py``
+(issue #4186).
+
+Putting the repository root itself on a subprocess ``PYTHONPATH`` makes
+Python's site machinery import the repo's own root-level ``sitecustomize.py``
+(kept for the decision-receipt hook) instead of the *real* one the
+interpreter would otherwise load -- e.g. Homebrew's, whose only load-bearing
+line wires up the actual third-party site-packages directory via
+``site.addsitedir(...)``. Python's site initialization imports only the FIRST
+module literally named ``sitecustomize`` found on ``sys.path``, and
+``PYTHONPATH`` entries land ahead of the stdlib, so the repo's file wins and
+the real one never runs. Every third-party import in that subprocess then
+fails with ``ModuleNotFoundError`` -- reproducible outside CI on any
+Homebrew Python, unrelated to product code correctness.
+
+The fix is to never put ``REPO_ROOT`` itself on a subprocess ``PYTHONPATH``.
+Instead, symlink only the packages a subprocess actually needs (``app/`` and,
+since ``app`` genuinely cross-imports helpers such as
+``scripts.yaml_roundtrip`` and ``scripts.validate_issue_readiness``,
+``scripts/`` too) into a private directory containing no ``sitecustomize.py``
+of its own, and put THAT private directory on PYTHONPATH. First proven at
+``tests/deploy/test_deploy_channel.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def isolated_app_pythonpath(private_dir: Path, repo_root: Path) -> str:
+    """Return a ``PYTHONPATH`` value exposing only ``app/`` and ``scripts/``
+    from *repo_root*.
+
+    Creates *private_dir* if needed and symlinks ``app`` and ``scripts`` into
+    it (idempotent across repeated calls with the same directory), then
+    returns *private_dir* as a string suitable for a subprocess
+    ``PYTHONPATH``. ``scripts/`` is included because ``app`` modules import
+    from it directly (e.g. ``app.builderops.model_inquiry_promotion`` imports
+    ``scripts.validate_issue_readiness``); omitting it would trade one
+    ``ModuleNotFoundError`` for another.
+
+    Never pass *repo_root* itself as (or on) a subprocess ``PYTHONPATH`` --
+    see the module docstring for why.
+    """
+    private_dir.mkdir(parents=True, exist_ok=True)
+    for package in ("app", "scripts"):
+        link = private_dir / package
+        if not link.exists():
+            link.symlink_to(repo_root / package)
+    return str(private_dir)

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -272,9 +272,10 @@ import sys
 # Re-delegate to the real sitecustomize this interpreter would otherwise
 # load (issue #4186): search sys.path with this hook's own directory
 # excluded, and if a real `sitecustomize` module is found elsewhere, execute
-# its source in this module's namespace so its site-packages wiring still
-# happens. A venv interpreter that ships no sitecustomize.py of its own
-# leaves this as a no-op.
+# it through its own spec/loader in a temporary module. The temporary module
+# keeps the real hook's __spec__, __loader__, and __file__ metadata intact;
+# source-reading into this replacement module's globals does not. A venv
+# interpreter that ships no sitecustomize.py of its own leaves this as a no-op.
 _this_dir = os.path.dirname(os.path.abspath(__file__))
 _search_path = [p for p in sys.path if os.path.abspath(p) != _this_dir]
 _real_spec = importlib.machinery.PathFinder().find_spec(
@@ -282,11 +283,17 @@ _real_spec = importlib.machinery.PathFinder().find_spec(
 )
 if (
     _real_spec is not None
-    and _real_spec.origin
-    and os.path.abspath(_real_spec.origin) != os.path.abspath(__file__)
+    and _real_spec.loader is not None
+    and hasattr(_real_spec.loader, "exec_module")
+    and (_real_spec.origin is None or os.path.abspath(_real_spec.origin) != os.path.abspath(__file__))
 ):
-    _real_source = Path(_real_spec.origin).read_text(encoding="utf-8")
-    exec(compile(_real_source, _real_spec.origin, "exec"), globals())
+    _real_module = importlib.util.module_from_spec(_real_spec)
+    _injected_module = sys.modules[__name__]
+    sys.modules[_real_spec.name] = _real_module
+    try:
+        _real_spec.loader.exec_module(_real_module)
+    finally:
+        sys.modules[_real_spec.name] = _injected_module
 
 _counter = Path(os.environ["PKM_SETTINGS_LOCATION_IMPORT_COUNTER"])
 _fail_on = int(os.environ["PKM_SETTINGS_LOCATION_IMPORT_FAIL_ON"])
@@ -349,6 +356,59 @@ def test_export_runtime_env_fails_loudly_when_settings_location_import_fails(
     assert "injected settings-location import failure" in result.stderr
     assert "NameError: name 'resolve_settings_file' is not defined" not in result.stderr
     assert "NameError: name 'LEGACY_COMPILED_DIR' is not defined" not in result.stderr
+
+
+def test_export_runtime_env_delegated_sitecustomize_preserves_loader_metadata(
+    tmp_path: Path,
+) -> None:
+    """A delegated hook executes with its own import-spec metadata.
+
+    A source-file hook is enough to expose the original bug: executing its
+    source in the injection module gives it the injection module's ``__file__``
+    and ``__spec__``. Running the export path also proves the controlled import
+    failure still fires after delegation.
+    """
+    repo_root, _, env = _runtime_env_with_db(tmp_path)
+    real_hook_dir = tmp_path / "real-python-hook"
+    real_hook_dir.mkdir()
+    metadata_path = tmp_path / "delegated-sitecustomize-metadata"
+    (real_hook_dir / "sitecustomize.py").write_text(
+        """\
+import os
+from pathlib import Path
+
+if __spec__ is None or __spec__.name != "sitecustomize":
+    raise RuntimeError("delegated sitecustomize lost its spec")
+if __loader__ is not __spec__.loader:
+    raise RuntimeError("delegated sitecustomize lost its loader")
+if Path(__file__).resolve() != Path(__spec__.origin).resolve():
+    raise RuntimeError("delegated sitecustomize lost its file metadata")
+Path(os.environ["PKM_DELEGATED_SITECUSTOMIZE_METADATA"]).write_text(
+    f"{__spec__.name}|{Path(__file__).resolve()}|{type(__loader__).__name__}",
+    encoding="utf-8",
+)
+""",
+        encoding="utf-8",
+    )
+    env["PYTHONPATH"] = str(real_hook_dir)
+    env["PKM_DELEGATED_SITECUSTOMIZE_METADATA"] = str(metadata_path)
+    _install_settings_location_import_failure(tmp_path, env, fail_on_import=1)
+
+    result = subprocess.run(
+        ["bash", "scripts/export_runtime_env.sh"],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "injected settings-location import failure" in result.stderr
+    name, origin, loader_name = metadata_path.read_text(encoding="utf-8").split("|")
+    assert name == "sitecustomize"
+    assert Path(origin) == (real_hook_dir / "sitecustomize.py").resolve()
+    assert loader_name == "SourceFileLoader"
 
 
 def test_export_runtime_env_import_failure_paths_do_not_leave_unbound_location_helpers() -> None:

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -239,6 +239,23 @@ def _install_settings_location_import_failure(
     the checked-out ``app`` package is not reliable. ``sitecustomize`` instead
     adds a narrow import hook for the exact required module while leaving every
     installed package and the successful path untouched.
+
+    This injection hook's own directory is placed first on the child's
+    ``PYTHONPATH``, which means Python's site machinery finds THIS
+    ``sitecustomize.py`` before any other -- including whichever real one the
+    interpreter would otherwise load (e.g. Homebrew's, whose only
+    load-bearing line wires up the actual third-party site-packages
+    directory via ``site.addsitedir(...)``). Left unhandled, that would
+    shadow the real hook and break every third-party import (e.g.
+    ``pydantic_settings``) in the child process -- the same class of defect
+    as putting ``REPO_ROOT`` on ``PYTHONPATH`` (issue #4186), just
+    self-inflicted by this test's own fixture instead. Since this hook is a
+    deliberate, necessary replacement of ``sitecustomize`` (there is no
+    private-directory-symlink alternative here), it must instead
+    RE-DELEGATE: locate and execute whatever real ``sitecustomize`` module
+    this interpreter would have loaded absent the injected hook directory,
+    before installing the controlled ``app.settings.locations`` import
+    failure below.
     """
     hook_dir = tmp_path / "python-hook"
     hook_dir.mkdir()
@@ -246,10 +263,30 @@ def _install_settings_location_import_failure(
     (hook_dir / "sitecustomize.py").write_text(
         """\
 import importlib.abc
+import importlib.machinery
 import importlib.util
 import os
 from pathlib import Path
 import sys
+
+# Re-delegate to the real sitecustomize this interpreter would otherwise
+# load (issue #4186): search sys.path with this hook's own directory
+# excluded, and if a real `sitecustomize` module is found elsewhere, execute
+# its source in this module's namespace so its site-packages wiring still
+# happens. A venv interpreter that ships no sitecustomize.py of its own
+# leaves this as a no-op.
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+_search_path = [p for p in sys.path if os.path.abspath(p) != _this_dir]
+_real_spec = importlib.machinery.PathFinder().find_spec(
+    "sitecustomize", path=_search_path
+)
+if (
+    _real_spec is not None
+    and _real_spec.origin
+    and os.path.abspath(_real_spec.origin) != os.path.abspath(__file__)
+):
+    _real_source = Path(_real_spec.origin).read_text(encoding="utf-8")
+    exec(compile(_real_source, _real_spec.origin, "exec"), globals())
 
 _counter = Path(os.environ["PKM_SETTINGS_LOCATION_IMPORT_COUNTER"])
 _fail_on = int(os.environ["PKM_SETTINGS_LOCATION_IMPORT_FAIL_ON"])

--- a/tests/release_channels/test_harness_fidelity.py
+++ b/tests/release_channels/test_harness_fidelity.py
@@ -272,7 +272,7 @@ def test_fault_injection_fails_when_preflight_crashes(tmp_path: Path) -> None:
     assert "BASELINE FAILED" in combined or "CRASHED" in combined
 
 
-def test_fault_injection_ignores_ambient_repo_root_pythonpath() -> None:
+def test_fault_injection_isolates_env_per_case() -> None:
     """The private import path wins even if a caller exports the repo root.
 
     This executes the actual gate with precisely the environment that used to

--- a/tests/release_channels/test_harness_fidelity.py
+++ b/tests/release_channels/test_harness_fidelity.py
@@ -220,7 +220,11 @@ def test_harness_selfverify_paths_include_release_channels() -> None:
 def _run_fault_injection(python: str) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ)
     env["PYTHON"] = python
-    env.setdefault("PYTHONPATH", str(REPO_ROOT))
+    # Deliberately do NOT default PYTHONPATH to REPO_ROOT here: the script
+    # itself builds a private, sitecustomize-free PYTHONPATH default when the
+    # caller does not supply one (issue #4186). REPO_ROOT carries its own
+    # root sitecustomize.py (decision-receipt hook) that would shadow the
+    # interpreter's real one and break every third-party import.
     return subprocess.run(
         ["bash", str(FAULT_INJECTION)],
         cwd=REPO_ROOT,

--- a/tests/release_channels/test_harness_fidelity.py
+++ b/tests/release_channels/test_harness_fidelity.py
@@ -217,9 +217,13 @@ def test_harness_selfverify_paths_include_release_channels() -> None:
 # isolates the env per case (so the unset case is genuinely unset).
 # ---------------------------------------------------------------------------
 
-def _run_fault_injection(python: str) -> subprocess.CompletedProcess[str]:
+def _run_fault_injection(
+    python: str, *, ambient_pythonpath: str | None = None
+) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ)
     env["PYTHON"] = python
+    if ambient_pythonpath is not None:
+        env["PYTHONPATH"] = ambient_pythonpath
     # Deliberately do NOT default PYTHONPATH to REPO_ROOT here: the script
     # itself builds a private, sitecustomize-free PYTHONPATH default when the
     # caller does not supply one (issue #4186). REPO_ROOT carries its own
@@ -268,16 +272,20 @@ def test_fault_injection_fails_when_preflight_crashes(tmp_path: Path) -> None:
     assert "BASELINE FAILED" in combined or "CRASHED" in combined
 
 
-def test_fault_injection_isolates_env_per_case() -> None:
-    """The gate must run each case under a hermetic `env -i` shell.
+def test_fault_injection_ignores_ambient_repo_root_pythonpath() -> None:
+    """The private import path wins even if a caller exports the repo root.
 
-    Without isolation a caller-exported INDEX_OUTBOX_PATH would mask the
-    'unset' case and the gate would silently stop testing it.
+    This executes the actual gate with precisely the environment that used to
+    shadow an affected interpreter's real ``sitecustomize``. A text assertion
+    that merely notices ``env -i`` would not prove the hermetic guarantee.
     """
-    text = FAULT_INJECTION.read_text(encoding="utf-8")
-    assert "env -i" in text
-    # The discriminator asserts the specific marker, not a bare non-zero exit.
-    assert "channel-env preflight" in text
+    proc = _run_fault_injection(sys.executable, ambient_pythonpath=str(REPO_ROOT))
+    assert proc.returncode == 0, (
+        "an ambient repository-root PYTHONPATH must not affect the hermetic gate\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert "baseline known-good test env accepted" in proc.stdout
+    assert "the gate is real" in proc.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4186

## Linked Issue
Fixes #4186

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): test harness
- Write class: mechanical
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: subprocess `PYTHONPATH` construction convention for tests, via a shared helper
- Owner-doc impact: none
- Transition debt impact: reduces
- Fitness rule impact: strengthens
- Boundary risk: a skip or xfail marker here could hide a genuine regression in an environment whose quirk merely resembles this one; none is used, and the fix is to the `PYTHONPATH` construction itself so the tests keep executing everywhere

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Tests that spawn a subprocess with `PYTHONPATH` set to the repository root put this repo's committed `sitecustomize.py` ahead of the standard library on `sys.path`. Python imports only the first `sitecustomize` it finds, so on a Homebrew interpreter the repo's file wins and Homebrew's never runs — and Homebrew's is what adds the external site-packages directory. Every third-party import in that subprocess then fails with `ModuleNotFoundError` for `click`, `pydantic`, `pydantic_settings`, or `regex`.
- Applies the pattern already proven at `tests/deploy/test_deploy_channel.py:833-847`, which documents this exact mechanism: expose only the needed package through a private directory carrying no `sitecustomize.py`, rather than putting the repository root on `PYTHONPATH`. Extracted into `tests/helpers/subprocess_pythonpath.py` so the next caller inherits the fix instead of rediscovering the bug.
- `tests/ops/test_export_runtime_env.py` is the special case: it writes its *own* `sitecustomize.py` to inject a controlled import failure, which also shadowed Homebrew's. Its hook now re-delegates to the real site-packages wiring instead of replacing it, so the deliberate injection still does its job.
- `scripts/ci/harness_gate_fault_injection.sh` no longer defaults `PYTHONPATH` to the repository root.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed.

## Notes
- **Counterfactual, measured on one machine and one interpreter** (`/opt/homebrew/bin/python3.12`), the same four test files:

  | tree | result |
  |---|---|
  | `origin/main` without this change | **8 failed**, 50 passed |
  | this branch | **58 passed** |

  The 8 failures are exactly the set the diagnosis identified. This is the acceptance evidence that matters: a green run under the project venv proves nothing here, because the venv is what masks the bug.
- **No skip or xfail markers**, deliberately. The failure is an interpreter-resolution quirk unrelated to the code under test, and there is no honest runtime signal to gate a skip on that could not also fire in a CI environment with a similar-but-different quirk — which would convert this noise into silence over a real regression. Fixing the `PYTHONPATH` construction has no such downside.
- This affects any contributor on a Homebrew Python, not one machine, which is why it belongs in the repo rather than in local setup notes.
- Why it is worth fixing at all: during the delivery of #4179 / PR #4182 a real regression was nearly dismissed as machine contention because the local suite was already reporting unexplained failures. A suite that lies locally corrupts every judgement made downstream of it.
- Out of scope, filed separately: the file-descriptor exhaustion that makes a single-process full sweep unable to complete on macOS (`kern.maxfilesperproc` = 10240, hit around test 5000 of 11116), and the fact that `scripts/run_with_host_lease.py` keys its lock on the `--resource` string, so callers using different names for the same resource never mutually exclude.
- Pre-existing and unrelated, present on `origin/main` too: `tests/knowledge_acquisition/test_youtube_api_client.py::test_recursive_provider_json_on_success_is_safely_normalized`.
