### PR TITLE
Give the two ReasoningFacade classes distinct names

### DIFF
--- a/app/api/routes/canvas.py
+++ b/app/api/routes/canvas.py
@@ -40,7 +40,7 @@ from app.api.routes.vault_resolution import (
     active_vault_root_or_selection_required,
     resolve_active_vault_root,
 )
-from app.reasoning.facade import ReasoningFacade, get_reasoning_facade
+from app.reasoning.facade import ReasoningModeFacade, get_reasoning_mode_facade
 from app.orientation.leave_point_cursor import capture_leave_point_cursor
 from app.panel.canvas_pipeline import CanvasPanelPipeline
 from app.panel.confirmation import _proposal_store as _panel_proposal_store
@@ -101,13 +101,13 @@ def _session_vault_root_or_picker(session: SessionLog) -> Path | JSONResponse:
     return _get_vault_root_or_picker()
 
 
-def _coauthor_facade_factory() -> ReasoningFacade:
+def _coauthor_facade_factory() -> ReasoningModeFacade:
     """Reasoning facade used by the co-authoring cognition.
 
     Indirected through a module-level function so tests can substitute a
     deterministic stub without a live LLM provider.
     """
-    return get_reasoning_facade()
+    return get_reasoning_mode_facade()
 
 
 def _intent_classifier_completion() -> CompletionFn | None:

--- a/app/chat/coauthoring_cognition.py
+++ b/app/chat/coauthoring_cognition.py
@@ -3,7 +3,7 @@
 This cognition is the missing *author* behind ``CanvasWriter``: given a
 user's natural-language intent plus the current note body (and optional
 retrieval context), it produces a generated **body revision** via the shared
-``ReasoningFacade`` (``app/reasoning/facade.py``).
+``ReasoningModeFacade`` (``app/reasoning/facade.py``).
 
 It is deliberately distinct from ``read_only_cognition.py``:
 
@@ -32,7 +32,7 @@ from typing import Any, Callable
 
 from app.chat.canvas_writer import GovernanceBearingMutationError
 from app.text.helpers import body_contains_frontmatter as _body_contains_frontmatter
-from app.reasoning.facade import ReasoningFacade, get_reasoning_facade
+from app.reasoning.facade import ReasoningModeFacade, get_reasoning_mode_facade
 
 # Sentinel prefixes emitted by the mock/degraded reasoning backend. When the
 # facade is not backed by an edit-capable provider, ``answer`` returns a
@@ -77,7 +77,7 @@ class CoAuthoringCognition:
     def __init__(
         self,
         *,
-        facade_factory: Callable[[], ReasoningFacade] = get_reasoning_facade,
+        facade_factory: Callable[[], ReasoningModeFacade] = get_reasoning_mode_facade,
     ) -> None:
         self._facade_factory = facade_factory
 

--- a/app/chat/read_only_cognition.py
+++ b/app/chat/read_only_cognition.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 import re
 from typing import Any, Callable
 
-from app.reasoning.facade import ReasoningFacade, get_reasoning_facade
+from app.reasoning.facade import ReasoningModeFacade, get_reasoning_mode_facade
 
 _DENY_HINTS = (
     "write",
@@ -46,7 +46,7 @@ class ReadOnlyChatCognition:
     def __init__(
         self,
         *,
-        facade_factory: Callable[[], ReasoningFacade] = get_reasoning_facade,
+        facade_factory: Callable[[], ReasoningModeFacade] = get_reasoning_mode_facade,
         note_writer: Callable[..., None] | None = None,
         outbox_writer: Callable[..., None] | None = None,
     ) -> None:

--- a/app/reasoning/facade.py
+++ b/app/reasoning/facade.py
@@ -1,4 +1,4 @@
-"""ReasoningFacade -- mode-agnostic interface for agents.
+"""ReasoningModeFacade -- mode-agnostic interface for agents.
 
 Wraps the existing ``run_reasoning`` provider with convenience methods
 and adds a graph-builder post-processor that converts CLAIMS output
@@ -39,7 +39,7 @@ class GraphEdge(BaseModel):
 
 
 class GraphExtraction(BaseModel):
-    """Container returned by ``ReasoningFacade.build_graph``."""
+    """Container returned by ``ReasoningModeFacade.build_graph``."""
 
     nodes: list[GraphNode] = Field(default_factory=list)
     edges: list[GraphEdge] = Field(default_factory=list)
@@ -132,7 +132,7 @@ def _claims_to_graph(run: ReasoningRun) -> GraphExtraction:
 # Facade
 # ---------------------------------------------------------------------------
 
-class ReasoningFacade:
+class ReasoningModeFacade:
     """Simplified, mode-agnostic reasoning interface for agents.
 
     The provider is injectable (any callable with the ``run_reasoning``
@@ -245,11 +245,11 @@ class ReasoningFacade:
 # Factory
 # ---------------------------------------------------------------------------
 
-_singleton: ReasoningFacade | None = None
+_singleton: ReasoningModeFacade | None = None
 
 
-def get_reasoning_facade(*, provider: ProviderFn | None = None) -> ReasoningFacade:
-    """Return a (lazily-created) ReasoningFacade singleton.
+def get_reasoning_mode_facade(*, provider: ProviderFn | None = None) -> ReasoningModeFacade:
+    """Return a (lazily-created) ReasoningModeFacade singleton.
 
     Pass *provider* to override the default ``run_reasoning`` function
     (useful in tests).  When a custom provider is given the singleton
@@ -258,10 +258,10 @@ def get_reasoning_facade(*, provider: ProviderFn | None = None) -> ReasoningFaca
     global _singleton  # noqa: PLW0603
 
     if provider is not None:
-        return ReasoningFacade(provider=provider)
+        return ReasoningModeFacade(provider=provider)
 
     if _singleton is None:
-        _singleton = ReasoningFacade()
+        _singleton = ReasoningModeFacade()
     return _singleton
 
 
@@ -269,6 +269,6 @@ __all__ = [
     "GraphEdge",
     "GraphExtraction",
     "GraphNode",
-    "ReasoningFacade",
-    "get_reasoning_facade",
+    "ReasoningModeFacade",
+    "get_reasoning_mode_facade",
 ]

--- a/docs/CANVAS_CHAT_SURFACE/GENERATE_COAUTHORING_EDIT.md
+++ b/docs/CANVAS_CHAT_SURFACE/GENERATE_COAUTHORING_EDIT.md
@@ -28,7 +28,7 @@ The canvas runtime is plumbing without an agent. `app/chat/canvas_writer.py:57` 
 
 Introduces a **write-capable co-authoring cognition** that, during an active user-present canvas session, takes the user's natural-language intent plus the current note body (and optional retrieval context) and produces a generated new body, which is then applied through the existing `CanvasWriter` so all existing governance guards still hold.
 
-- New module `app/chat/coauthoring_cognition.py`: a cognition that plans/generates a body revision via the shared `ReasoningFacade` (`app/reasoning/facade.py`). It is distinct from `read_only_cognition.py`: it is authorized to produce body text, but only body text.
+- New module `app/chat/coauthoring_cognition.py`: a cognition that plans/generates a body revision via the shared `ReasoningModeFacade` (`app/reasoning/facade.py`). It is distinct from `read_only_cognition.py`: it is authorized to produce body text, but only body text.
 - New endpoint `POST /api/canvas/sessions/{session_id}/coauthor` in `app/api/routes/canvas.py` taking `{intent, change_summary?}`. It runs the cognition, applies the generated body via `CanvasWriter.apply_edit`, appends the intent + change summary to the `.chats/` session log as provenance, and returns the applied body.
 - The new path inherits every guard already enforced by `CanvasWriter`: active session required, in-vault note only, frontmatter rejected (a generated body containing frontmatter is a `GovernanceBearingMutationError`, routed to `GovernanceRouter`, never silently applied).
 

--- a/tests/architecture/test_reasoning_facade_names_are_distinct.py
+++ b/tests/architecture/test_reasoning_facade_names_are_distinct.py
@@ -1,0 +1,67 @@
+"""The two reasoning facades must not share a name.
+
+``app/reasoning/facade.py`` and ``app/components/reasoning/facade.py`` hold
+unrelated classes with no method overlap: the former is a thin dispatcher over
+``run_reasoning`` used by Chat/canvas, the latter is the LLM task client with
+routing and telemetry used by the LangGraph agents. Both were once named
+``ReasoningFacade`` and exposed by a factory named ``get_reasoning_facade``, so
+``from ... import get_reasoning_facade`` silently returned a different object
+depending on the module path and no import error ever fired.
+
+That collision is not cosmetic. It is why the missing ``PLANNING`` branch (D1 in
+``docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md``) went unnoticed: planning
+*was* implemented on the components facade, so the dead ``plan()`` on the other
+one looked covered. This guard keeps the names apart.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.components.reasoning import facade as components_facade
+from app.reasoning import facade as mode_facade
+
+pytestmark = pytest.mark.not_pg
+
+
+def test_facade_class_and_factory_names_do_not_collide() -> None:
+    mode_cls = mode_facade.ReasoningModeFacade
+    components_cls = components_facade.ReasoningFacade
+
+    assert mode_cls.__name__ != components_cls.__name__, (
+        "the two reasoning facades share a class name again; an importer "
+        "cannot tell them apart and gets a silently different object"
+    )
+    assert (
+        mode_facade.get_reasoning_mode_facade.__name__
+        != components_facade.get_reasoning_facade.__name__
+    ), "the two reasoning facade factories share a name again"
+
+
+def test_mode_facade_no_longer_exports_the_colliding_names() -> None:
+    # A backward-compatible alias would reintroduce exactly the ambiguity this
+    # guard exists to prevent, so absence is asserted, not just distinctness.
+    for gone in ("ReasoningFacade", "get_reasoning_facade"):
+        assert not hasattr(mode_facade, gone), (
+            f"app/reasoning/facade.py re-exports {gone!r}; that restores the "
+            "collision with app/components/reasoning/facade.py"
+        )
+        assert gone not in (mode_facade.__all__ or ()), (
+            f"{gone!r} is still advertised in app/reasoning/facade.py __all__"
+        )
+
+
+def test_the_two_facades_remain_behaviourally_distinct() -> None:
+    """Guard the premise: these are different objects, not duplicates.
+
+    If the two ever converge on the same surface, the right fix is to merge
+    them deliberately rather than to keep two names — so make that visible.
+    """
+    mode_methods = {m for m in dir(mode_facade.ReasoningModeFacade) if not m.startswith("_")}
+    components_methods = {
+        m for m in dir(components_facade.ReasoningFacade) if not m.startswith("_")
+    }
+    assert not (mode_methods & components_methods), (
+        "the two reasoning facades now share public methods; revisit whether "
+        "they should be one class instead of two names"
+    )

--- a/tests/chat/test_coauthoring_cognition.py
+++ b/tests/chat/test_coauthoring_cognition.py
@@ -2,7 +2,7 @@
 
 Covers the write-capable co-authoring cognition that turns a user intent
 plus the current note body into a generated body revision via the shared
-``ReasoningFacade``. The cognition produces body-only text and never emits
+``ReasoningModeFacade``. The cognition produces body-only text and never emits
 frontmatter; a frontmatter-bearing generation is rejected before write.
 
 The read-only cognition scaffold must remain unchanged and execution-denied.
@@ -88,7 +88,7 @@ def test_generates_body_from_intent() -> None:
     assert result.body == "# Hello\n\nExpanded decision section with trade-offs.\n"
     # Body-only output: no frontmatter delimiter.
     assert not result.body.lstrip().startswith("---")
-    # The cognition consulted the shared ReasoningFacade with intent + body.
+    # The cognition consulted the shared ReasoningModeFacade with intent + body.
     assert len(facade.calls) == 1
     call = facade.calls[0]
     assert "expand the decision section" in str(call["question"])

--- a/tests/reasoning/test_facade.py
+++ b/tests/reasoning/test_facade.py
@@ -1,4 +1,4 @@
-"""Tests for app.reasoning.facade -- ReasoningFacade and graph builder."""
+"""Tests for app.reasoning.facade -- ReasoningModeFacade and graph builder."""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ from typing import Any
 import pytest
 
 from app.reasoning.facade import (
-    ReasoningFacade,
+    ReasoningModeFacade,
     _claims_to_graph,
-    get_reasoning_facade,
+    get_reasoning_mode_facade,
 )
 from app.reasoning.models import ReasoningMode, ReasoningRun
 
@@ -90,7 +90,7 @@ def _failing_provider(
 
 class TestExtractClaims:
     def test_delegates_to_claims_mode(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.extract_claims("obj-1")
         assert run.mode == ReasoningMode.CLAIMS
         assert run.status == "ok"
@@ -98,28 +98,28 @@ class TestExtractClaims:
         assert len(run.result["claims"]) == 1
 
     def test_trace_id_passthrough(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.extract_claims("obj-1", trace_id="t-42")
         assert run.trace_id == "t-42"
 
 
 class TestReview:
     def test_delegates_to_review_mode(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.review("obj-2")
         assert run.mode == ReasoningMode.REVIEW
         assert run.status == "ok"
         assert run.result["summary"] == "looks good"
 
     def test_trace_id_passthrough(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.review("obj-2", trace_id="t-99")
         assert run.trace_id == "t-99"
 
 
 class TestRank:
     def test_delegates_to_ranking_mode(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.rank(["a", "b", "c"])
         assert run.mode == ReasoningMode.RANKING
         assert len(run.result["ranking"]) == 3
@@ -131,14 +131,14 @@ class TestRank:
             calls.append({"mode": mode, "kwargs": kw})
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=spy)
+        facade = ReasoningModeFacade(provider=spy)
         facade.rank(["x"], question="why?")
         assert calls[0]["kwargs"]["question"] == "why?"
 
 
 class TestAnswer:
     def test_delegates_to_ask_answer_mode(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.answer("What is 2+2?")
         assert run.mode == ReasoningMode.ASK_ANSWER
         assert "mock answer" in run.result["answer"]
@@ -150,7 +150,7 @@ class TestAnswer:
             calls.append({"ids": ids, "kwargs": kw})
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=spy)
+        facade = ReasoningModeFacade(provider=spy)
         facade.answer("q?", context="ctx", object_ids=["o1", "o2"])
         assert calls[0]["ids"] == ["o1", "o2"]
         assert calls[0]["kwargs"]["context"] == "ctx"
@@ -162,14 +162,14 @@ class TestAnswer:
             calls.append({"ids": ids})
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=spy)
+        facade = ReasoningModeFacade(provider=spy)
         facade.answer("q?")
         assert calls[0]["ids"] == []
 
 
 class TestPlan:
     def test_delegates_to_planning_mode(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         run = facade.plan(["a", "b"], goal="ship it")
         assert run.mode == ReasoningMode.PLANNING
 
@@ -180,7 +180,7 @@ class TestPlan:
             calls.append({"kwargs": kw})
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=spy)
+        facade = ReasoningModeFacade(provider=spy)
         facade.plan(["a"], goal="do X")
         assert calls[0]["kwargs"]["question"] == "do X"
 
@@ -191,13 +191,13 @@ class TestPlan:
 
 class TestErrorPropagation:
     def test_failed_run_surfaces_error(self) -> None:
-        facade = ReasoningFacade(provider=_failing_provider)
+        facade = ReasoningModeFacade(provider=_failing_provider)
         run = facade.extract_claims("obj-1")
         assert run.status == "failed"
         assert run.error == "provider exploded"
 
     def test_failed_claims_gives_empty_graph(self) -> None:
-        facade = ReasoningFacade(provider=_failing_provider)
+        facade = ReasoningModeFacade(provider=_failing_provider)
         graph = facade.build_graph("obj-1")
         assert graph.nodes == []
         assert graph.edges == []
@@ -210,7 +210,7 @@ class TestErrorPropagation:
 
 class TestBuildGraph:
     def test_claims_become_nodes(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         graph = facade.build_graph("obj-1")
         claim_nodes = [n for n in graph.nodes if n.kind == "claim"]
         assert len(claim_nodes) == 1
@@ -218,14 +218,14 @@ class TestBuildGraph:
         assert claim_nodes[0].label == "Sun is hot"
 
     def test_evidence_becomes_nodes(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         graph = facade.build_graph("obj-1")
         ev_nodes = [n for n in graph.nodes if n.kind == "evidence"]
         assert len(ev_nodes) == 1
         assert ev_nodes[0].label == "paper.pdf"
 
     def test_inferences_become_edges(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         graph = facade.build_graph("obj-1")
         assert len(graph.edges) == 1
         edge = graph.edges[0]
@@ -235,7 +235,7 @@ class TestBuildGraph:
         assert edge.properties["rationale"] == "trivial"
 
     def test_source_run_id_set(self) -> None:
-        facade = ReasoningFacade(provider=_fake_provider)
+        facade = ReasoningModeFacade(provider=_fake_provider)
         graph = facade.build_graph("obj-1")
         assert graph.source_run_id  # non-empty
 
@@ -246,7 +246,7 @@ class TestBuildGraph:
             calls.append(trace_id)
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=spy)
+        facade = ReasoningModeFacade(provider=spy)
         facade.build_graph("x", trace_id="t-graph")
         assert calls[0] == "t-graph"
 
@@ -301,7 +301,7 @@ class TestCustomProvider:
             called["count"] += 1
             return _fake_provider(mode, ids, trace_id, **kw)
 
-        facade = ReasoningFacade(provider=custom)
+        facade = ReasoningModeFacade(provider=custom)
         facade.extract_claims("x")
         facade.review("x")
         assert called["count"] == 2
@@ -311,12 +311,29 @@ class TestCustomProvider:
 # Factory function
 # ---------------------------------------------------------------------------
 
-class TestGetReasoningFacade:
+class TestGetReasoningModeFacade:
     def test_returns_facade_instance(self) -> None:
-        facade = get_reasoning_facade(provider=_fake_provider)
-        assert isinstance(facade, ReasoningFacade)
+        facade = get_reasoning_mode_facade(provider=_fake_provider)
+        assert isinstance(facade, ReasoningModeFacade)
+
+    def test_returns_mode_facade_and_old_names_are_gone(self) -> None:
+        """The module must not still offer the names it collided on.
+
+        An alias would keep ``from ... import get_reasoning_facade`` ambiguous
+        between this module and ``app/components/reasoning/facade.py``, which is
+        the whole defect (#4207, D8).
+        """
+        from app.reasoning import facade as mode_facade
+
+        assert isinstance(
+            get_reasoning_mode_facade(provider=_fake_provider), ReasoningModeFacade
+        )
+        assert not hasattr(mode_facade, "ReasoningFacade")
+        assert not hasattr(mode_facade, "get_reasoning_facade")
+        assert set(mode_facade.__all__) >= {"ReasoningModeFacade", "get_reasoning_mode_facade"}
+        assert not {"ReasoningFacade", "get_reasoning_facade"} & set(mode_facade.__all__)
 
     def test_custom_provider_bypasses_singleton(self) -> None:
-        f1 = get_reasoning_facade(provider=_fake_provider)
-        f2 = get_reasoning_facade(provider=_fake_provider)
+        f1 = get_reasoning_mode_facade(provider=_fake_provider)
+        f2 = get_reasoning_mode_facade(provider=_fake_provider)
         assert f1 is not f2  # each call with custom provider is fresh

--- a/tests/reasoning/test_provider_planning.py
+++ b/tests/reasoning/test_provider_planning.py
@@ -2,7 +2,7 @@
 
 Regression coverage for the defect where ``ReasoningMode.PLANNING`` was a
 first-class enum member with no branch in ``run_reasoning``, so every
-``ReasoningFacade.plan()`` call fell through to the terminal
+``ReasoningModeFacade.plan()`` call fell through to the terminal
 ``"mode planning not implemented"`` return.
 """
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4207

## Linked Issue
Closes #4207

## SBS Impact
- Primary subsystem: Product/Runtime System - Reasoning / cognition
- Secondary subsystem(s): Chat/canvas surface (call sites only)
- Write class: mechanical
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: unaffected
- Retrieval/context impact: unaffected
- Sync/deployment impact: none
- External boundary impact: none; no routing, provider, prompt, or egress change
- New or changed contract: the importable name of one class and one factory in app/reasoning/facade.py; no signature, argument, return type, or behavior change. No backward-compatible alias is added, because an alias would preserve the exact ambiguity being removed.
- Owner-doc impact: none; no owner doc names either symbol. The capability spec docs/CANVAS_CHAT_SURFACE/GENERATE_COAUTHORING_EDIT.md named it factually and is corrected in this change.
- Transition debt impact: reduces; removes the ambiguity that let a dead code path look implemented
- Fitness rule impact: strengthens; adds tests/architecture/test_reasoning_facade_names_are_distinct.py asserting the names stay distinct and that no alias reintroduces the collision
- Boundary risk: low; mechanical rename covered by the existing suites for both facades and all their consumers

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- app/reasoning/facade.py and app/components/reasoning/facade.py held unrelated classes sharing both a class name (ReasoningFacade) and a factory name (get_reasoning_facade) with zero method overlap, so an importer silently got a different object depending on the module path and no import error ever fired
- renames the smaller mode-dispatching facade to ReasoningModeFacade / get_reasoning_mode_facade and updates its three call sites; the components facade keeps the plain name (more consumers, and semantically the system's general reasoning client)

## BuilderOps Routing
- Records/projections/receipts: dispatcher claim lease-9ceb2b70 (task github-RasmusTho--agentic-pkm-mvp-issue-4207, evidence=verified-dispatcher-lease)
- Reason: Bounded Product/Runtime refactor with its own regression guards; no divergence, freshness, roadmap, or promotion material beyond the change itself.

## Notes
Validation: pytest tests/reasoning tests/chat tests/architecture tests/components/reasoning => 284 passed, 2 skipped. pytest tests/agents tests/e2e => 468 passed, 6 skipped (proves the components facade and every agent consumer are untouched). pytest tests/api -k canvas => 39 passed. ruff check app tests => All checks passed. Load-bearing check: appending 'ReasoningFacade = ReasoningModeFacade' plus the factory alias to app/reasoning/facade.py makes both new guards fail (test_mode_facade_no_longer_exports_the_colliding_names, TestGetReasoningModeFacade::test_returns_mode_facade_and_old_names_are_gone); removing the alias returns 28 passed. Scope proof: git diff --name-only lists exactly 7 files and does not include app/components/reasoning/facade.py or anything under app/agents/. Follow-up left open: #4195 (REVIEW/RANKING robustness). Merging the two facades was considered and rejected on the owner's decision - they do genuinely different jobs, so the duplication is in the name, not the design.
