### PR TITLE
Resolve the Signboard projection root to one source and give stale cards a repair path

### DIFF
--- a/app/api/routes/signboard.py
+++ b/app/api/routes/signboard.py
@@ -20,7 +20,13 @@ from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.queue import block, complete
 from app.dispatcher.services import move_task
-from app.dispatcher.signboard import STATUS_COLUMNS, canonical_status, export_signboard
+from app.dispatcher.signboard import (
+    STATUS_COLUMNS,
+    NoActiveVaultError,
+    canonical_status,
+    default_signboard_root,
+    export_signboard,
+)
 from app.dispatcher.store import SqliteStore
 
 router = APIRouter(prefix="/signboard", tags=["signboard"])
@@ -62,9 +68,18 @@ def signboard_root() -> Path:
 
     No request controls this path. Resolving it once prevents a symlinked root
     from turning a card read into arbitrary traversal later on.
+
+    The default is not spelled here: it comes from ``default_signboard_root``
+    in the dispatcher projection module, which is the single source for the
+    Signboard root (#4198). ``SIGNBOARD_ROOT`` is the launcher-forwarded
+    override; when it is absent and no vault is selected this raises
+    :class:`NoActiveVaultError` so the board can render a visible error state
+    rather than an empty, healthy-looking one.
     """
-    raw = os.getenv("SIGNBOARD_ROOT", "~/BuilderOpsVault/agent-delivery")
-    return Path(raw).expanduser().resolve()
+    raw = os.getenv("SIGNBOARD_ROOT", "")
+    if raw.strip():
+        return Path(raw).expanduser().resolve()
+    return default_signboard_root()
 
 
 def _store() -> SqliteStore:
@@ -133,6 +148,12 @@ def read_signboard(root: Path) -> tuple[dict[str, list[dict[str, Any]]], list[st
     board: dict[str, list[dict[str, Any]]] = {column: [] for column in COLUMNS}
     errors: list[str] = []
     if not root.exists():
+        # An unreadable root used to render as six empty columns, which reads
+        # as "no work" instead of "misconfigured" (#4198). Report it.
+        errors.append(f"signboard root does not exist: {root}")
+        return board, errors
+    if not root.is_dir():
+        errors.append(f"signboard root is not a directory: {root}")
         return board, errors
     for column in COLUMNS:
         directory = root / column
@@ -162,18 +183,37 @@ def _board_payload(root: Path) -> dict[str, Any]:
         "root": str(root),
         "columns": [{"name": column, "cards": board[column]} for column in COLUMNS],
         "errors": errors,
+        "status": "error" if errors else "ok",
+        "authority": "dispatcher_projection",
+    }
+
+
+def _unresolved_root_payload(detail: str) -> dict[str, Any]:
+    """Render an explicit error state when no projection root resolves at all."""
+    return {
+        "root": None,
+        "columns": [{"name": column, "cards": []} for column in COLUMNS],
+        "errors": [f"signboard root is not configured: {detail}"],
+        "status": "error",
         "authority": "dispatcher_projection",
     }
 
 
 @router.get("/board")
 def get_board() -> dict[str, Any]:
-    return _board_payload(signboard_root())
+    try:
+        root = signboard_root()
+    except NoActiveVaultError as exc:
+        return _unresolved_root_payload(str(exc))
+    return _board_payload(root)
 
 
 @router.post("/refresh", dependencies=[Depends(require_loopback_or_api_key)])
 def refresh_board() -> dict[str, Any]:
-    root = signboard_root()
+    try:
+        root = signboard_root()
+    except NoActiveVaultError as exc:
+        raise HTTPException(status_code=503, detail=f"signboard root is not configured: {exc}") from exc
     export_signboard(_store(), root)
     return _board_payload(root)
 
@@ -198,7 +238,12 @@ def move_card(task_id: str, request: MoveRequest) -> dict[str, Any]:
             )
         else:
             task = move_task(store, task_id, next_status, request.actor, request.note)
-        root = signboard_root()
+        try:
+            root = signboard_root()
+        except NoActiveVaultError as exc:
+            raise HTTPException(
+                status_code=503, detail=f"signboard root is not configured: {exc}"
+            ) from exc
         export_signboard(store, root)
     except ValueError as exc:
         status_code = 404 if "not found" in str(exc).lower() else 409

--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -526,7 +526,7 @@ def _cmd_export_signboard(args: argparse.Namespace, store: SqliteStore) -> int:
         except NoActiveVaultError as exc:
             return _emit_error(str(exc), args.json)
 
-    result = export_signboard(store, target_path)
+    result = export_signboard(store, target_path, prune_absent=args.prune_absent)
     _emit({"ok": True, **result}, args.json)
     return 0
 
@@ -755,6 +755,15 @@ def build_parser() -> argparse.ArgumentParser:
             "Directory to write kanban columns into. Optional: defaults to "
             "BuilderOpsVault/agent-delivery inside the active vault "
             "(active-vault-selection mechanism); no path needs to be typed."
+        ),
+    )
+    p.add_argument(
+        "--prune-absent",
+        action="store_true",
+        help=(
+            "Also remove generated cards whose task id no longer exists in the "
+            "dispatcher store. Cards carrying human-authored '## Notes' content "
+            "are kept and reported under retained_with_notes instead."
         ),
     )
     p.add_argument("--json", action="store_true")

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -22,6 +22,11 @@ from app.vault.manager import get_vault_manager
 # no-manual-path-typing posture). This reuses the shipped Option 2
 # active-vault-selection mechanism (``VaultManager`` / ``AppLocalSettingsStore``)
 # rather than inventing a parallel "BuilderOps vault root" concept.
+#
+# This is the single source of the Signboard root default (#4198). The API
+# route and the host launchers derive from ``default_signboard_root`` instead of
+# carrying their own home-relative literal; three independent spellings of the
+# same path is what let the board diverge in the first place.
 DEFAULT_SIGNBOARD_SUBPATH = Path("BuilderOpsVault") / "agent-delivery"
 
 _NOTES_HEADING = "## Notes"
@@ -84,11 +89,25 @@ def column_for_status(status: str) -> str:
     return STATUS_COLUMNS.get(normalized, "Backlog")
 
 
-def export_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
+def export_signboard(
+    store: SqliteStore,
+    board_root: Path,
+    *,
+    prune_absent: bool = False,
+) -> dict[str, Any]:
     """Write dispatcher tasks as Markdown files grouped by kanban column.
 
-    The exporter only removes prior generated files for task IDs that still
-    exist in dispatcher. It leaves unrelated human notes alone.
+    By default the exporter only removes prior generated files for task IDs
+    that still exist in dispatcher, and it leaves unrelated human notes alone.
+    That default leaves cards whose task ID has vanished from the store
+    unreachable: ``signboard-validate`` reports them as ``stale_card`` and
+    nothing could clear them, so the board grew monotonically (#4198).
+
+    ``prune_absent`` is the opt-in repair for exactly those cards. It removes a
+    generated card only when its task ID is absent from the store *and* the
+    card carries no human-authored ``## Notes`` content; a stale card that does
+    carry notes is kept and surfaced under ``retained_with_notes`` so a human
+    decides its fate. Human material is never silently destroyed.
     """
 
     root = Path(board_root).expanduser()
@@ -136,12 +155,48 @@ def export_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
         target.write_text(_render_task(task, notes=preserved_notes), encoding="utf-8")
         written.append(str(target))
 
+    pruned: list[str] = []
+    retained_with_notes: list[str] = []
+    if prune_absent:
+        pruned, retained_with_notes = _prune_cards_absent_from_store(
+            root, known_task_ids={task.task_id for task in tasks}
+        )
+
     return {
         "root": str(root),
         "count": len(tasks),
         "columns": sorted(set(STATUS_COLUMNS.values())),
         "written": written,
+        "pruned": pruned,
+        "retained_with_notes": retained_with_notes,
     }
+
+
+def _prune_cards_absent_from_store(
+    root: Path, *, known_task_ids: set[str]
+) -> tuple[list[str], list[str]]:
+    """Remove note-free generated cards whose task ID is gone from dispatcher.
+
+    Returns ``(pruned, retained_with_notes)``. Malformed generated cards are
+    left in place: ``signboard-validate`` already reports them under their own
+    finding kind, and their task identity cannot be trusted for a delete.
+    """
+
+    pruned: list[str] = []
+    retained_with_notes: list[str] = []
+    for path in sorted(root.rglob("*.md")) if root.is_dir() else []:
+        text = _read_card_text(path)
+        if text is None or not _is_generated_card_text(text):
+            continue
+        frontmatter = _parse_generated_frontmatter(text)
+        if frontmatter is None or frontmatter["id"] in known_task_ids:
+            continue
+        if _extract_notes_section(text) is not None:
+            retained_with_notes.append(str(path))
+            continue
+        path.unlink()
+        pruned.append(str(path))
+    return pruned, retained_with_notes
 
 
 def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
@@ -149,7 +204,8 @@ def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
 
     Signboard is a derived projection. This intentionally never repairs cards
     or updates the dispatcher store; ``export-signboard`` remains the repair
-    operation after a failing validation run.
+    operation after a failing validation run — with ``--prune-absent`` when the
+    findings include cards whose task ID no longer exists in the store.
     """
     root = Path(board_root).expanduser()
     tasks = {
@@ -224,7 +280,12 @@ def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
                 "detail": f"task {task_id!r} has {len(paths)} generated cards",
             })
 
-    return {"root": str(root), "count": len(tasks), "findings": findings}
+    result: dict[str, Any] = {"root": str(root), "count": len(tasks), "findings": findings}
+    if any(finding["kind"] == "stale_card" for finding in findings):
+        # Name the repair in the lint output itself. A finding an operator
+        # cannot act on is the bug this replaces (#4198).
+        result["repair"] = "python -m app.dispatcher export-signboard [path] --prune-absent"
+    return result
 
 
 def _parse_generated_frontmatter(text: str) -> dict[str, str] | None:

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -175,7 +175,7 @@ def export_signboard(
 def _prune_cards_absent_from_store(
     root: Path, *, known_task_ids: set[str]
 ) -> tuple[list[str], list[str]]:
-    """Remove note-free generated cards whose task ID is gone from dispatcher.
+    """Remove empty generated cards whose task ID is gone from dispatcher.
 
     Returns ``(pruned, retained_with_notes)``. Malformed generated cards are
     left in place: ``signboard-validate`` already reports them under their own
@@ -191,12 +191,43 @@ def _prune_cards_absent_from_store(
         frontmatter = _parse_generated_frontmatter(text)
         if frontmatter is None or frontmatter["id"] in known_task_ids:
             continue
-        if _extract_notes_section(text) is not None:
+        if _has_human_authored_content(text):
             retained_with_notes.append(str(path))
             continue
         path.unlink()
         pruned.append(str(path))
     return pruned, retained_with_notes
+
+
+def _has_human_authored_content(text: str) -> bool:
+    """True when a generated card carries anything a human wrote into it.
+
+    Both hand-editable sections count. ``## Notes`` is the documented one, and
+    it is the only one re-export splices forward. ``## Receipts`` is the other
+    section ``_render_task`` emits and always leaves empty, so any non-blank
+    text below the generator's final heading is equally human-authored — and a
+    stale card is precisely the case where re-export never touched it, so that
+    text is still there. A prune must not be the thing that deletes it.
+    """
+
+    return (
+        _extract_notes_section(text) is not None
+        or _trailing_receipts_content(text) is not None
+    )
+
+
+def _trailing_receipts_content(text: str) -> str | None:
+    """Return non-blank text below the card's final "## Receipts" heading."""
+
+    lines = text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == _RECEIPTS_HEADING:
+            start = index
+    if start is None:
+        return None
+    trailing = "\n".join(lines[start + 1 :]).strip()
+    return trailing or None
 
 
 def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -799,6 +799,23 @@ malformed generated cards, duplicate generated cards, column/status drift, cards
 dispatcher store, and unreadable generated-filename candidates; run `export-signboard` to repair
 valid generated-card drift. Human-authored files are outside this lint's jurisdiction.
 
+A plain `export-signboard` only rewrites cards for task IDs that still exist in the dispatcher
+store, so it cannot clear a card whose task ID has disappeared from the store — those accumulate as
+`stale_card` findings the lint reports and nothing removes. `--prune-absent` is the repair for
+exactly those cards:
+
+```bash
+python -m app.dispatcher signboard-validate [path] --json   # reports stale_card findings
+python -m app.dispatcher export-signboard [path] --prune-absent --json
+```
+
+`--prune-absent` deletes a generated card only when its task ID is absent from the store *and* the
+card carries no human-authored `## Notes` content. A stale card that does carry notes is kept and
+listed under `retained_with_notes` in the JSON result, so a human decides its fate; human material
+is never destroyed by the prune. Malformed generated cards and non-generated files are never
+touched. The prune is opt-in: the exporter run by the startup bootstrap and by the `/signboard`
+refresh route never deletes.
+
 Each generated card carries a `## Notes` section the human may hand-edit directly in the vault.
 Re-running `export-signboard` refreshes the generated frontmatter and body but splices any existing
 `## Notes` content back in unchanged — it never blind-overwrites human-authored notes. The exporter
@@ -810,20 +827,52 @@ ADR-0010.
 ### Local visual Signboard
 
 The FastAPI runtime also exposes a local visual board at `/signboard`. Its API reads only the
-generated Markdown files beneath `SIGNBOARD_ROOT` (default:
-`~/BuilderOpsVault/agent-delivery`) and renders the six exporter columns. A refresh explicitly
-runs the normal exporter. Card moves are loopback/API-key protected and invoke dispatcher service
-operations (`move`, `block`, or `complete`) before immediately re-exporting the projection; the UI
-never writes card files or the SQLite database itself. `SIGNBOARD_ROOT` is operator configuration,
-not request input, and card reads are containment-checked after symlink resolution.
+generated Markdown files beneath the resolved board root and renders the six exporter columns. A
+refresh explicitly runs the normal exporter. Card moves are loopback/API-key protected and invoke
+dispatcher service operations (`move`, `block`, or `complete`) before immediately re-exporting the
+projection; the UI never writes card files or the SQLite database itself. The board root is
+operator configuration, not request input, and card reads are containment-checked after symlink
+resolution.
 
-`make dev-start-full` and the prod full-stack launcher refresh the board as part of their existing
-BuilderOps dispatcher bootstrap. The launcher resolves `SIGNBOARD_ROOT` to an absolute host path
-and forwards it into the API container, which has `/Users` mounted at the same path. On a Mac mini
-develop stack, use the existing API port over Tailscale:
+The board root resolves from exactly one source. `SIGNBOARD_ROOT`, when set, is the operator/launcher
+override; otherwise the route falls back to `default_signboard_root()` in
+`app/dispatcher/signboard.py`, the same active-vault-relative default the CLI uses. Neither the API
+route nor the shell launchers carry a board-root literal of their own — that divergence is what let
+the projection root mean three different things at once.
+
+When no root resolves at all (no forwarded `SIGNBOARD_ROOT` and no selected vault), or when the
+resolved root does not exist, `/api/signboard/board` returns `status: "error"` with an explicit
+message and the UI shows it as a notice. An unreadable root never renders as six empty columns:
+"no work" and "misconfigured" must not look the same.
+
+`make dev-start-full`, the channel deploy wrappers, and the prod full-stack launcher refresh the
+board as part of their existing BuilderOps dispatcher bootstrap. `scripts/export_runtime_env.sh`
+resolves the board root to an absolute host path (via `scripts/lib/signboard_root.sh`, which calls
+the same single source) and writes `SIGNBOARD_ROOT` into the generated runtime env consumed by the
+API container's `env_file` chain; `/Users` is mounted at the same path, so the host path is valid
+in-container. Resolving it there rather than only forwarding whatever the caller shell exported is
+what keeps the channel deploy path from starting the API with an empty `SIGNBOARD_ROOT`. With no
+vault selected the variable stays unset and the bootstrap reports `signboard_root_missing` instead
+of writing to an invented location. On a Mac mini develop stack, use the existing API port over
+Tailscale:
 `http://<mac-mini-tailnet-name>:18001/signboard`. Remote refreshes and moves require the configured
 `API_KEY`, entered into the Signboard session field and sent only as `X-API-Key`; it is not stored
 in URLs or browser persistence. No separate Signboard process is started.
+
+#### The projection root is not the shared BuilderOps vault's `agent-delivery/`
+
+Two different directories are both called "agent-delivery", and they are not interchangeable:
+
+| | Signboard projection root | Shared BuilderOps vault queue |
+| --- | --- | --- |
+| Location | `<active vault>/BuilderOpsVault/agent-delivery` (or the forwarded `SIGNBOARD_ROOT`) | `<BUILDEROPS_VAULT_ROOT>/agent-delivery` |
+| Written by | `export-signboard` | `builderops vault` ticket commands |
+| Card schema | `generated_by: dispatcher.signboard`, lowercase dispatcher `status`, `column` | BMI-01 ticket frontmatter: `agent_state`, title-case `status`, no `generated_by` |
+| Authority | none — rebuildable projection of the dispatcher SQLite store | the vault tickets themselves |
+
+Do not migrate cards from one into the other, and do not point `SIGNBOARD_ROOT` at the shared
+vault's queue root. The projection is regenerable and disposable; the vault queue is not. See
+`docs/builderops/BUILDEROPS_VAULT_STORE.md` for the shared-vault contract.
 
 ### Epic-runner lifecycle planning
 

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -810,9 +810,11 @@ python -m app.dispatcher export-signboard [path] --prune-absent --json
 ```
 
 `--prune-absent` deletes a generated card only when its task ID is absent from the store *and* the
-card carries no human-authored `## Notes` content. A stale card that does carry notes is kept and
-listed under `retained_with_notes` in the JSON result, so a human decides its fate; human material
-is never destroyed by the prune. Malformed generated cards and non-generated files are never
+card carries nothing a human wrote. Both hand-editable sections count: `## Notes`, and any non-blank
+text below the card's final `## Receipts` heading — the exporter always emits that heading empty,
+and it never rewrites a stale card, so anything there is human-authored. A stale card carrying
+either is kept and listed under `retained_with_notes` in the JSON result, so a human decides its
+fate; human material is never destroyed by the prune. Malformed generated cards and non-generated files are never
 touched. The prune is opt-in: the exporter run by the startup bootstrap and by the `/signboard`
 refresh route never deletes.
 

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -845,16 +845,20 @@ resolved root does not exist, `/api/signboard/board` returns `status: "error"` w
 message and the UI shows it as a notice. An unreadable root never renders as six empty columns:
 "no work" and "misconfigured" must not look the same.
 
-`make dev-start-full`, the channel deploy wrappers, and the prod full-stack launcher refresh the
-board as part of their existing BuilderOps dispatcher bootstrap. `scripts/export_runtime_env.sh`
-resolves the board root to an absolute host path (via `scripts/lib/signboard_root.sh`, which calls
-the same single source) and writes `SIGNBOARD_ROOT` into the generated runtime env consumed by the
-API container's `env_file` chain; `/Users` is mounted at the same path, so the host path is valid
-in-container. Resolving it there rather than only forwarding whatever the caller shell exported is
-what keeps the channel deploy path from starting the API with an empty `SIGNBOARD_ROOT`. With no
-vault selected the variable stays unset and the bootstrap reports `signboard_root_missing` instead
-of writing to an invented location. On a Mac mini develop stack, use the existing API port over
-Tailscale:
+`make dev-start-full` and the prod full-stack launcher refresh the board as part of their existing
+BuilderOps dispatcher bootstrap. `scripts/start_full_system.sh` resolves the board root to an
+absolute host path (via `scripts/lib/signboard_root.sh`, which calls the same single source) and
+`scripts/export_runtime_env.sh` forwards it into the generated runtime env consumed by the API
+container's `env_file` chain; `/Users` is mounted at the same path, so the host path is valid
+in-container. With no vault selected the variable stays unset and the bootstrap reports
+`signboard_root_missing` instead of writing to an invented location.
+
+The channel deploy wrappers (`scripts/deploy_channel.sh`) do **not** regenerate the runtime env —
+they read the one the last full-stack start produced. A channel whose runtime env predates the
+board-root line therefore starts its API container with `SIGNBOARD_ROOT` empty; that is how the
+Demerzel dev stack ended up serving an empty board. It now shows as an explicit error state rather
+than as "no work", and regenerating the runtime env through the full-stack launcher restores the
+board. On a Mac mini develop stack, use the existing API port over Tailscale:
 `http://<mac-mini-tailnet-name>:18001/signboard`. Remote refreshes and moves require the configured
 `API_KEY`, entered into the Signboard session field and sent only as `X-API-Key`; it is not stored
 in URLs or browser persistence. No separate Signboard process is started.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -344,8 +344,15 @@ scripts/builderops_cli.sh builderops vault init "$BUILDEROPS_VAULT_ROOT" --json
 scripts/builderops_cli.sh builderops vault validate "$BUILDEROPS_VAULT_ROOT" --json
 ```
 
-Signboard may render the resulting `agent-delivery/` Markdown tree for a human. It is a projection
-only and is never an automation API or a source of authoritative lease state.
+The resulting `agent-delivery/` tree holds BMI-01 ticket Markdown for a human to read. It is never
+an automation API or a source of authoritative lease state.
+
+It is **not** the dispatcher Signboard board. The visual Signboard at `/signboard` renders a
+separate, regenerable projection of the dispatcher SQLite store, whose cards carry
+`generated_by: dispatcher.signboard` and a different frontmatter schema from these vault tickets.
+Do not point `SIGNBOARD_ROOT` at this vault's `agent-delivery/`, and do not migrate cards between
+the two trees — see `docs/AGENT_ISSUE_DISPATCHER.md :: The projection root is not the shared
+BuilderOps vault's agent-delivery/`.
 
 Projection regeneration reads from the selected store path using the same mechanisms. Automation
 worktrees that regenerate checked-in projection views should set the intended store explicitly with

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -15,6 +15,14 @@ source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"
 
+# Resolve the Signboard projection root here rather than only forwarding a
+# value the caller happened to export (#4198). start_full_system.sh sets it;
+# the channel deploy wrappers never did, which is why the API container ran
+# with SIGNBOARD_ROOT empty and /signboard rendered an empty board. Resolving
+# it in the one place that writes the runtime env covers every launcher.
+source "scripts/lib/signboard_root.sh"
+resolve_signboard_root_env
+
 # #2005 — no-vault idle posture: when the runtime boots with no vault bound,
 # there is no vault to derive provider/path settings from. Write a minimal
 # runtime env (no VAULT_ROOT, watcher disabled) so the stack can come up idle

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -15,13 +15,10 @@ source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"
 
-# Resolve the Signboard projection root here rather than only forwarding a
-# value the caller happened to export (#4198). start_full_system.sh sets it;
-# the channel deploy wrappers never did, which is why the API container ran
-# with SIGNBOARD_ROOT empty and /signboard rendered an empty board. Resolving
-# it in the one place that writes the runtime env covers every launcher.
-source "scripts/lib/signboard_root.sh"
-resolve_signboard_root_env
+# SIGNBOARD_ROOT is resolved by the launcher (start_full_system.sh) and only
+# forwarded here. This exporter deliberately runs no `app.*` import of its own:
+# the settings-location import below is a fail-loud path, and an extra import
+# in front of it would perturb that failure surface (#4198).
 
 # #2005 — no-vault idle posture: when the runtime boots with no vault bound,
 # there is no vault to derive provider/path settings from. Write a minimal

--- a/scripts/lib/signboard_root.sh
+++ b/scripts/lib/signboard_root.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Single-sourced Signboard projection-root resolution for host launchers (#4198).
+#
+# The default board root is defined exactly once, in
+# app/dispatcher/signboard.py (DEFAULT_SIGNBOARD_SUBPATH / default_signboard_root),
+# which nests it under the human's actively-selected vault. Shell launchers must
+# never carry their own board-root literal: three independent spellings of the
+# same path is how the projection root diverged.
+#
+# Resolution order:
+#   1. an operator-set SIGNBOARD_ROOT (normalized to an absolute host path)
+#   2. default_signboard_root() from the active-vault selection
+#   3. unset — no vault is selected, so there is no board root. Callers must
+#      degrade visibly (builderops_startup reports `signboard_root_missing`,
+#      and /signboard renders an error state) rather than invent a location.
+
+resolve_signboard_root_env() {
+  local resolved=""
+
+  if [ -n "${SIGNBOARD_ROOT:-}" ]; then
+    resolved="$(python3 -c 'import os, sys
+from pathlib import Path
+
+sys.stdout.write(str(Path(os.environ["SIGNBOARD_ROOT"]).expanduser().resolve()))' 2>/dev/null)" || resolved=""
+  else
+    resolved="$(python3 -c 'import sys
+
+from app.dispatcher.signboard import NoActiveVaultError, default_signboard_root
+
+try:
+    sys.stdout.write(str(default_signboard_root()))
+except NoActiveVaultError:
+    raise SystemExit(3)' 2>/dev/null)" || resolved=""
+  fi
+
+  if [ -n "$resolved" ]; then
+    SIGNBOARD_ROOT="$resolved"
+    export SIGNBOARD_ROOT
+  else
+    unset SIGNBOARD_ROOT
+  fi
+}

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -68,9 +68,12 @@ apply_start_full_system_defaults
 
 # Signboard is a dispatcher projection. Resolve this on the host before the
 # BuilderOps bootstrap and forward the same absolute path into the API
-# container via tmp/runtime.env; ``/Users`` is mounted at the same path.
-SIGNBOARD_ROOT="$(python3 -c 'from pathlib import Path; import os; print(Path(os.environ.get("SIGNBOARD_ROOT", "~/BuilderOpsVault/agent-delivery")).expanduser().resolve())')"
-export SIGNBOARD_ROOT
+# container via tmp/runtime.env; ``/Users`` is mounted at the same path. The
+# default comes from app/dispatcher/signboard.py, never from a literal here
+# (#4198). With no vault selected the variable stays unset and the bootstrap
+# degrades visibly instead of writing to an invented root.
+source "scripts/lib/signboard_root.sh"
+resolve_signboard_root_env
 DISPATCHER_HOST_STATE_DIR="$(python3 -c 'from pathlib import Path; import os; print(Path(os.environ.get("DISPATCHER_HOST_STATE_DIR", "runtime/dispatcher")).expanduser().resolve())')"
 export DISPATCHER_HOST_STATE_DIR
 

--- a/tests/api/test_signboard_api.py
+++ b/tests/api/test_signboard_api.py
@@ -126,3 +126,40 @@ def test_signboard_remote_mutations_send_api_key_header() -> None:
     assert "sessionStorage" not in script
     assert "actor = 'signboard-ui'" in script
     assert "card.claimed_by || 'signboard-ui'" in script
+
+
+def test_missing_root_reports_error_state(tmp_path: Path, monkeypatch) -> None:
+    """A missing projection root must read as broken, not as an empty board.
+
+    Six empty columns and HTTP 200 is the false-green surface #4198 removes:
+    the API container ran with SIGNBOARD_ROOT pointing nowhere and /signboard
+    looked like "no work" instead of "misconfigured".
+    """
+    _configure(tmp_path, monkeypatch)
+    payload = TestClient(app).get("/api/signboard/board").json()
+
+    assert payload["status"] == "error"
+    assert payload["errors"] == [f"signboard root does not exist: {tmp_path / 'board'}"]
+    assert all(column["cards"] == [] for column in payload["columns"])
+
+
+def test_unresolvable_root_reports_error_state(tmp_path: Path, monkeypatch) -> None:
+    """With no forwarded root and no selected vault there is no board root."""
+    from app.dispatcher import signboard as signboard_module
+
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.delenv("SIGNBOARD_ROOT", raising=False)
+
+    def _no_vault() -> None:
+        raise signboard_module.NoActiveVaultError("no active vault is selected")
+
+    monkeypatch.setattr(signboard_module, "get_vault_manager", _no_vault)
+
+    payload = TestClient(app).get("/api/signboard/board").json()
+
+    assert payload["status"] == "error"
+    assert payload["root"] is None
+    assert payload["errors"] == ["signboard root is not configured: no active vault is selected"]
+
+    refresh = TestClient(app).post("/api/signboard/refresh")
+    assert refresh.status_code == 503

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -615,3 +615,34 @@ def test_cli_export_signboard_prune_absent_flag(tmp_env, store, tmp_path: Path) 
     assert main(["export-signboard", str(board), "--prune-absent", "--json"]) == 0
 
     assert not stale.exists()
+
+
+def test_prune_retains_a_stale_card_carrying_human_receipts(
+    tmp_env, store, tmp_path: Path
+) -> None:
+    """The other hand-editable section is human material too.
+
+    ``_render_task`` always leaves "## Receipts" empty, and re-export never
+    reaches a stale card, so text below that heading is something a human put
+    there and nothing else would have removed. The prune must not be what
+    deletes it.
+    """
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    stale = _write_stale_card(
+        board, next(board.glob(f"**/{ready.task_id}--*.md")), task_id="task-gone", notes=None
+    )
+    stale.write_text(
+        stale.read_text(encoding="utf-8").rstrip("\n")
+        + "\n- merged in PR #123 after the owner signed off\n",
+        encoding="utf-8",
+    )
+
+    result = export_signboard(store, board, prune_absent=True)
+
+    assert stale.exists()
+    assert result["retained_with_notes"] == [str(stale)]
+    assert result["pruned"] == []
+    assert "merged in PR #123" in stale.read_text(encoding="utf-8")

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -473,3 +473,145 @@ def test_cli_signboard_validate_fails_loud_on_findings(
 
     assert exit_code == 1
     assert '"ok": false' in capsys.readouterr().out
+
+
+
+# ---------------------------------------------------------------------------
+# #4198: one Signboard root, and a repair path for cards absent from the store
+# ---------------------------------------------------------------------------
+
+
+def test_signboard_root_is_single_sourced() -> None:
+    """The board-root default is spelled in exactly one place.
+
+    Three independent resolutions of the Signboard root (the API route, the
+    full-stack launcher, and the vault-relative dispatcher default) is the
+    divergence #4198 removes. The route and the shell launchers must derive
+    from ``default_signboard_root`` instead of carrying a home-relative
+    literal of their own.
+    """
+    from app.api.routes import signboard as signboard_route
+
+    repo_root = Path(signboard_module.__file__).resolve().parents[2]
+    literal = "BuilderOpsVault"
+
+    for relative in (
+        "app/api/routes/signboard.py",
+        "scripts/start_full_system.sh",
+        "scripts/export_runtime_env.sh",
+        "scripts/lib/signboard_root.sh",
+    ):
+        source = (repo_root / relative).read_text(encoding="utf-8")
+        assert literal not in source, f"{relative} must not carry its own board-root literal"
+
+    assert literal in Path(signboard_module.__file__).read_text(encoding="utf-8")
+    assert signboard_route.default_signboard_root is default_signboard_root
+
+
+def test_signboard_route_root_falls_back_to_the_single_source(monkeypatch, tmp_path) -> None:
+    from app.api.routes import signboard as signboard_route
+
+    vault_dir = tmp_path / "RouteVault"
+    vault_dir.mkdir()
+    context = VaultContext(status="selected", active_vault_path=str(vault_dir))
+    monkeypatch.setattr(
+        signboard_module, "get_vault_manager", lambda: _StubVaultManager(context)
+    )
+
+    monkeypatch.delenv("SIGNBOARD_ROOT", raising=False)
+    assert signboard_route.signboard_root() == vault_dir.resolve() / DEFAULT_SIGNBOARD_SUBPATH
+
+    # A launcher-forwarded root still wins, so container forwarding keeps working.
+    monkeypatch.setenv("SIGNBOARD_ROOT", str(tmp_path / "forwarded"))
+    assert signboard_route.signboard_root() == (tmp_path / "forwarded").resolve()
+
+
+def _write_stale_card(board: Path, template: Path, *, task_id: str, notes: str | None) -> Path:
+    """Copy a generated card under a task id that is absent from the store.
+
+    This is what the real board accumulates: cards whose dispatcher task no
+    longer exists, which the exporter's own ``{task_id}--*.md`` cleanup can
+    never reach because it only iterates task ids still in the store.
+    """
+    text = template.read_text(encoding="utf-8")
+    original_id = next(
+        line.split('"')[1] for line in text.splitlines() if line.startswith("id: ")
+    )
+    text = text.replace(original_id, task_id)
+    if notes is not None:
+        text = text.replace("## Notes\n\n## Receipts", f"## Notes\n\n{notes}\n\n## Receipts")
+    card = template.parent / f"{task_id}--stale-card.md"
+    card.write_text(text, encoding="utf-8")
+    return card
+
+
+def test_export_prunes_cards_absent_from_store_preserving_notes(
+    tmp_env, store, tmp_path: Path
+) -> None:
+    """Cards whose task id vanished from dispatcher become removable.
+
+    A note-free stale card is deleted; a stale card carrying human-authored
+    "## Notes" content is kept and surfaced instead of being destroyed.
+    """
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+
+    live_card = next(board.glob(f"**/{ready.task_id}--*.md"))
+    plain = _write_stale_card(board, live_card, task_id="task-gone-plain", notes=None)
+    note_text = "Keep this: the owner still owes a decision here."
+    noted = _write_stale_card(board, live_card, task_id="task-gone-noted", notes=note_text)
+    human_file = board / "Ready" / "human-authored.md"
+    human_file.write_text("# Not a generated card\n", encoding="utf-8")
+
+    stale = validate_signboard(store, board)
+    assert {finding["kind"] for finding in stale["findings"]} == {"stale_card"}
+    assert "--prune-absent" in stale["repair"]
+
+    result = export_signboard(store, board, prune_absent=True)
+
+    assert not plain.exists()
+    assert result["pruned"] == [str(plain)]
+    assert noted.exists()
+    assert note_text in noted.read_text(encoding="utf-8")
+    assert result["retained_with_notes"] == [str(noted)]
+    assert live_card.exists()
+    assert human_file.read_text(encoding="utf-8") == "# Not a generated card\n"
+
+    remaining = validate_signboard(store, board)
+    assert [
+        finding["path"] for finding in remaining["findings"] if finding["kind"] == "stale_card"
+    ] == [str(noted.relative_to(board))]
+
+
+def test_export_without_prune_leaves_absent_cards_alone(tmp_env, store, tmp_path: Path) -> None:
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    stale = _write_stale_card(
+        board, next(board.glob(f"**/{ready.task_id}--*.md")), task_id="task-gone", notes=None
+    )
+
+    result = export_signboard(store, board)
+
+    assert stale.exists()
+    assert result["pruned"] == []
+    assert result["retained_with_notes"] == []
+
+
+def test_cli_export_signboard_prune_absent_flag(tmp_env, store, tmp_path: Path) -> None:
+    from app.dispatcher.cli import main
+
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    assert main(["export-signboard", str(board), "--json"]) == 0
+    stale = _write_stale_card(
+        board, next(board.glob(f"**/{ready.task_id}--*.md")), task_id="task-gone", notes=None
+    )
+
+    assert main(["export-signboard", str(board), "--prune-absent", "--json"]) == 0
+
+    assert not stale.exists()


### PR DESCRIPTION
Governing-Issue: #4198

Fixes #4198

Final-Review-Rounds: 1

## Summary
`SIGNBOARD_ROOT` was resolved three different ways — an active-vault-relative default in `app/dispatcher/signboard.py`, an independent `~/BuilderOpsVault/agent-delivery` literal in the API route and `start_full_system.sh`, and a shared-vault README claim that the vault's own `agent-delivery/` was the same board. This single-sources the root, adds the missing repair path for cards whose task id has left the dispatcher store, and turns the empty-board false-green into a visible error state.

## Changes
- `app/dispatcher/signboard.py` is the one source of the board-root default. `app/api/routes/signboard.py`, `scripts/start_full_system.sh`, and `scripts/export_runtime_env.sh` derive from `default_signboard_root()` via the new `scripts/lib/signboard_root.sh` helper and carry no board-root literal of their own. With no vault selected nothing invents a location: the variable stays unset and the BuilderOps bootstrap reports `signboard_root_missing`.
- `export-signboard --prune-absent` removes generated cards whose task id is absent from the dispatcher store — the `stale_card` drift `signboard-validate` reported and no command could clear (467 of 481 cards on the Demerzel board). Cards carrying human-authored `## Notes` content are kept and returned under `retained_with_notes` instead of deleted; malformed cards and non-generated files are never touched. The prune is opt-in, so the startup bootstrap and the `/signboard` refresh route still never delete. `signboard-validate` now names the repair command in its own output.
- `/api/signboard/board` reports `status: "error"` with an explicit message when the root is missing, is not a directory, or cannot be resolved at all, instead of returning six empty columns and HTTP 200.
- `scripts/export_runtime_env.sh` resolves and forwards the root itself rather than only passing through whatever the caller shell exported. That is why the channel deploy path started the API container with `SIGNBOARD_ROOT` empty while `start_full_system.sh` worked.
- Docs: `docs/AGENT_ISSUE_DISPATCHER.md` documents the single-sourced resolution, the prune, the error state, and a new subsection stating that the projection root and the shared BuilderOps vault's `agent-delivery/` are different trees with different schemas; `docs/builderops/BUILDEROPS_VAULT_STORE.md` no longer describes them as the same board.

Signboard stays projection-only per ADR-0010 — no claim, lease, or lock write path is added.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Repo-governed code/docs change only; the shared-vault README correction was applied in the BuilderOps vault itself and needs no repo record.

## Notes
Validation:
- `pytest -q tests/dispatcher/ tests/api/test_signboard_api.py tests/governance/test_project_pickup_deprecation.py tests/ops/test_builderops_startup_bootstrap.py` — 1122 passed
- Full `pytest -q -m "not pg"` under the host lease — 11061 passed, 9 failed; all 9 reproduce identically on clean `origin/main` in a separate worktree (missing `click` / `pydantic_settings` in the sandboxed subprocess env these tests build) and are unrelated to this change
- `ruff check app tests companion-ui/companion-app` — clean
- `python3 scripts/docs_guard.py` — OK; `python3 scripts/public_seam_lint.py --mode gate` — clean
---