### PR TITLE
Stop materializing every evicted vault file to enforce SQLite confinement

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -380,13 +380,43 @@ def vault_init(root: Path, as_json: bool) -> None:
 @vault.command("validate", help="Validate shared-vault separation and ticket status integrity.")
 @click.argument("root", type=click.Path(file_okay=False, path_type=Path))
 @click.option("--json", "as_json", is_flag=True)
+@click.option(
+    "--progress",
+    is_flag=True,
+    help=(
+        "Report scan progress on stderr while walking the vault, so a slow "
+        "synchronized vault is distinguishable from a hung command."
+    ),
+)
 @click.pass_context
-def vault_validate(ctx: click.Context, root: Path, as_json: bool) -> None:
+def vault_validate(ctx: click.Context, root: Path, as_json: bool, progress: bool) -> None:
     paths = _effective_paths(ctx)
-    payload = validate_vault(root, paths)
+    on_progress = _sqlite_scan_progress_reporter() if progress else None
+    payload = validate_vault(root, paths, on_progress=on_progress)
+    if progress:
+        scan = payload["sqlite_scan"]
+        click.echo(
+            f"scanned {scan['files']} files, opened {scan['opened']}, "
+            f"skipped {scan['skipped_remote']} non-local, {scan['elapsed_ms']} ms",
+            err=True,
+        )
     _emit(payload, as_json)
     if not payload["ok"]:
         raise click.ClickException("Builder Ops Vault validation failed")
+
+
+def _sqlite_scan_progress_reporter(every: int = 200) -> Callable[[dict[str, int]], None]:
+    """Emit a stderr heartbeat every ``every`` files so the scan looks alive."""
+
+    def report(stats: dict[str, int]) -> None:
+        if stats["files"] % every == 0:
+            click.echo(
+                f"scanning… {stats['files']} files, {stats['opened']} opened, "
+                f"{stats['skipped_remote']} skipped as non-local",
+                err=True,
+            )
+
+    return report
 
 
 @vault.command("claim", help="Write a shared advisory TTL claim for a Ready ticket.")

--- a/app/builderops/vault_queue.py
+++ b/app/builderops/vault_queue.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
+import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -87,9 +90,15 @@ def vault_paths(paths: BuilderOpsPaths) -> dict[str, Any]:
     }
 
 
-def validate_vault(root: Path, paths: BuilderOpsPaths) -> dict[str, Any]:
+def validate_vault(
+    root: Path,
+    paths: BuilderOpsPaths,
+    *,
+    on_progress: Callable[[dict[str, int]], None] | None = None,
+) -> dict[str, Any]:
     requested_root = root.expanduser()
     errors: list[str] = []
+    sqlite_scan: dict[str, int] = {"files": 0, "opened": 0, "skipped_remote": 0, "elapsed_ms": 0}
     try:
         root = _trusted_vault_root(requested_root)
     except VaultQueueError as exc:
@@ -104,6 +113,7 @@ def validate_vault(root: Path, paths: BuilderOpsPaths) -> dict[str, Any]:
                 "errors": [message],
             },
             "claims_advisory": True,
+            "sqlite_scan": sqlite_scan,
         }
     configured_root = None
     if paths.vault_root is not None:
@@ -119,7 +129,8 @@ def validate_vault(root: Path, paths: BuilderOpsPaths) -> dict[str, Any]:
     if configured_db == root or root in configured_db.parents:
         errors.append(f"configured SQLite path is inside shared vault: {configured_db}")
     try:
-        for path in _sqlite_candidates(root):
+        found, sqlite_scan = _scan_sqlite_candidates(root, on_progress=on_progress)
+        for path in found:
             errors.append(f"forbidden SQLite state in shared vault: {path}")
     except VaultQueueError as exc:
         errors.append(str(exc))
@@ -148,7 +159,14 @@ def validate_vault(root: Path, paths: BuilderOpsPaths) -> dict[str, Any]:
     except VaultQueueError as exc:
         errors.append(str(exc))
         claims = {"root": str(root / ".builderops" / "claims"), "claims": [], "errors": [str(exc)]}
-    return {"ok": not errors, "ticket_count": len(tickets), "errors": errors, "advisory_claims": claims, "claims_advisory": True}
+    return {
+        "ok": not errors,
+        "ticket_count": len(tickets),
+        "errors": errors,
+        "advisory_claims": claims,
+        "claims_advisory": True,
+        "sqlite_scan": sqlite_scan,
+    }
 
 
 def claim_ticket(
@@ -324,27 +342,108 @@ def _require_within_vault(candidate: Path, vault_root: Path, *, label: str) -> N
         raise VaultQueueError(f"{label} escapes shared vault: {candidate}")
 
 
+_SQLITE_HEADER_MAGIC = b"SQLite format 3\x00"
+_SQLITE_EXTENSIONS = frozenset({".db", ".db3", ".sqlite", ".sqlite3"})
+
+# The smallest page size the SQLite file format allows. Every database image is
+# a whole number of pages, and every legal page size (512..65536, powers of two)
+# is a multiple of this, so a database image's size is always a non-zero
+# multiple of 512 bytes.
+_SQLITE_PAGE_UNIT = 512
+
+# macOS `st_flags` bit marking a file whose metadata is local but whose content
+# is not — an iCloud Drive "dataless" file. Reading one byte of it triggers an
+# on-demand materialization over the network.
+_SF_DATALESS = 0x40000000
+
+
+def _content_is_local(stat_result: os.stat_result) -> bool:
+    """True when the file's bytes are already on this disk.
+
+    A synchronized vault (iCloud Drive) evicts file *contents* while keeping
+    metadata local. Opening such a file costs a network round-trip — measured
+    at ~1.0-1.2 s per file, which is what made `vault validate` fail to
+    terminate on the real shared vault (#4199). ``SF_DATALESS`` is the direct
+    macOS signal; zero allocated blocks against a non-zero logical size is the
+    portable fallback for the same state.
+    """
+
+    if getattr(stat_result, "st_flags", 0) & _SF_DATALESS:
+        return False
+    return not (stat_result.st_size > 0 and getattr(stat_result, "st_blocks", 1) == 0)
+
+
+def _may_be_sqlite_image(size: int) -> bool:
+    """True when ``size`` is consistent with a SQLite database image.
+
+    Used only to decide whether materializing an evicted file is worth it. It
+    can never hide a real database: a SQLite image is always a whole number of
+    pages, so its size is always a non-zero multiple of 512. What it does skip
+    is an evicted file that merely *starts* with the magic bytes without being
+    a database image — which is not the thing the confinement invariant exists
+    to catch, and which is still sniffed whenever the content is local.
+    """
+
+    return size >= _SQLITE_PAGE_UNIT and size % _SQLITE_PAGE_UNIT == 0
+
+
 def _sqlite_candidates(root: Path) -> list[Path]:
+    """Return every file in the vault that is (or could be) a SQLite database."""
+
+    return _scan_sqlite_candidates(root)[0]
+
+
+def _scan_sqlite_candidates(
+    root: Path,
+    *,
+    on_progress: Callable[[dict[str, int]], None] | None = None,
+) -> tuple[list[Path], dict[str, int]]:
+    """Scan for SQLite candidates and report what the scan actually did.
+
+    Files whose content is already local are sniffed exactly as before: full
+    header check, no narrowing. The only change is that an *evicted* file is
+    materialized solely when its size is consistent with a database image, so a
+    synchronized vault no longer costs one network round-trip per Markdown
+    note. Symlink rejection is unchanged and still happens before any read.
+    """
+
+    started = time.monotonic()
+    stats = {"files": 0, "opened": 0, "skipped_remote": 0, "elapsed_ms": 0}
     root = _trusted_vault_root(root)
     if not root.exists():
-        return []
+        return [], stats
     candidates: list[Path] = []
     for path in sorted(root.rglob("*")):
         if path.is_symlink():
             raise VaultQueueError(f"vault entry must not be a symlink: {path}")
-        if not path.is_file():
+        try:
+            stat_result = path.stat()
+        except OSError:
+            # ``Path.is_file()`` swallowed this before the stat-first rewrite;
+            # keep that tolerance so an entry that vanishes mid-walk (a live
+            # synchronized vault) is skipped rather than failing validation.
             continue
-        if path.suffix.lower() in {".db", ".db3", ".sqlite", ".sqlite3"}:
+        if not stat.S_ISREG(stat_result.st_mode):
+            continue
+        stats["files"] += 1
+        if on_progress is not None:
+            on_progress(dict(stats))
+        if path.suffix.lower() in _SQLITE_EXTENSIONS:
             candidates.append(path)
             continue
+        if not _content_is_local(stat_result) and not _may_be_sqlite_image(stat_result.st_size):
+            stats["skipped_remote"] += 1
+            continue
+        stats["opened"] += 1
         try:
             with path.open("rb") as handle:
                 header = handle.read(16)
-            if header == b"SQLite format 3\x00":
-                candidates.append(path)
         except OSError as exc:
             raise VaultQueueError(f"unable to inspect vault file: {path}") from exc
-    return candidates
+        if header == _SQLITE_HEADER_MAGIC:
+            candidates.append(path)
+    stats["elapsed_ms"] = int((time.monotonic() - started) * 1000)
+    return candidates, stats
 
 
 class _UniqueKeySafeLoader(yaml.SafeLoader):

--- a/docs/BUILDEROPS_MODEL_INQUIRY/EXTERNAL_BUILDEROPS_VAULT_CONFIGURATION.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/EXTERNAL_BUILDEROPS_VAULT_CONFIGURATION.md
@@ -43,6 +43,16 @@ boundary, not only during CLI configuration, so explicit API/MCP paths, complete
 and direct store construction cannot bypass it. Completeness inspection uses SQLite read-only mode;
 it never creates a database when the inspected file is missing or disappears before open.
 
+`builderops vault validate` additionally scans the vault for a SQLite database that is *already*
+there, including an extension-less one, by reading each file's 16-byte header. On a synchronized
+vault most files' contents are not local: iCloud Drive keeps the metadata and evicts the bytes, so
+the first `open()` of an evicted file costs a network round-trip (~1.0-1.2 s each, measured
+2026-07-28). The scan therefore reads a file's header when its content is local, and materializes an
+evicted file only when its size is consistent with a SQLite database image — a whole number of
+pages, so always a non-zero multiple of 512 bytes. No real database can hide behind that: it is a
+property of the file format, not a heuristic about names or locations. `builderops vault paths`
+performs no scan at all and stays instant.
+
 ## Ticket And Advisory Claim Schemas
 
 Queue tickets are Markdown files with YAML mapping frontmatter. `id` is a required, non-empty,

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -344,6 +344,17 @@ scripts/builderops_cli.sh builderops vault init "$BUILDEROPS_VAULT_ROOT" --json
 scripts/builderops_cli.sh builderops vault validate "$BUILDEROPS_VAULT_ROOT" --json
 ```
 
+`vault paths` is pure path arithmetic and returns instantly. `vault validate` walks the whole vault
+to enforce the SQLite confinement invariant, so its cost scales with vault size — add `--progress`
+to get a stderr heartbeat and a final `scanned N files, opened M, skipped K non-local` line, which
+is how you tell a slow synchronized vault from a hung command. The JSON payload carries the same
+counts under `sqlite_scan`. On a synchronized (iCloud) vault the scan deliberately does not
+materialize evicted files whose size cannot be a SQLite database image; see
+`docs/BUILDEROPS_MODEL_INQUIRY/EXTERNAL_BUILDEROPS_VAULT_CONFIGURATION.md :: SQLite Confinement
+Invariant` for why that cannot hide a real database. Measured on the ~900-file shared vault
+2026-07-28: 0.13 s scan, versus ~1.4 s of extra network wait for every evicted file the previous
+scan downloaded.
+
 The resulting `agent-delivery/` tree holds BMI-01 ticket Markdown for a human to read. It is never
 an automation API or a source of authoritative lease state.
 

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -281,6 +281,12 @@ inspection opens existing databases in SQLite read-only mode so a discovery/open
 a replacement file. The guard checks both lexical and resolved containment, so a database symlink
 located in the shared vault cannot redirect a store open to an outside target.
 
+`builderops vault validate` additionally scans the vault for a SQLite database that is already
+there. That scan is the only part of these commands whose cost grows with vault size, and on a
+synchronized vault it deliberately avoids downloading evicted files it can prove are not database
+images; `--progress` reports what it is doing. See the operator-check block under
+`Model-inquiry artifact records` below for the command, the flag, and the measured cost.
+
 ### Model-inquiry artifact records
 
 Pre-ticket model inquiries are durable file-first records under

--- a/tests/builderops/test_builderops_paths.py
+++ b/tests/builderops/test_builderops_paths.py
@@ -277,3 +277,123 @@ def test_validation_rejects_symlinked_sqlite_candidate_without_following_it(
     assert result.exit_code != 0
     assert "symlink" in result.output.lower()
     assert outside.read_bytes() == b"SQLite format 3\x00" + b"external-marker"
+
+
+def _simulate_evicted_vault(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Make every vault file look like an un-materialized iCloud file.
+
+    On the real shared vault the first ``open()`` of an evicted file costs a
+    network round-trip (measured ~1.0-1.2 s each), which is why validating a
+    ~900-file vault did not terminate. Here the eviction is simulated and the
+    opened paths are recorded, so the test can assert what the scan actually
+    reads rather than how long it takes.
+    """
+    from app.builderops import vault_queue
+
+    opened: list[Path] = []
+    monkeypatch.setattr(vault_queue, "_content_is_local", lambda stat_result: False)
+
+    real_open = Path.open
+
+    def recording_open(self: Path, *args: object, **kwargs: object):
+        opened.append(self)
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", recording_open)
+    return opened
+
+
+def test_vault_validate_detects_extensionless_sqlite_without_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The confinement invariant holds without opening every vault file."""
+    import sqlite3
+
+    vault = tmp_path / "shared-vault"
+    notes = vault / "model-inquiries"
+    notes.mkdir(parents=True)
+    for index in range(50):
+        # Ordinary vault material: never a page-size multiple, so an evicted
+        # copy must not be materialized just to read 16 bytes.
+        (notes / f"note-{index:03d}.md").write_text("x" * (700 + index), encoding="utf-8")
+
+    hidden = vault / "transient" / "opaque-state"
+    hidden.parent.mkdir(parents=True)
+    connection = sqlite3.connect(hidden)
+    connection.execute("CREATE TABLE t (a INTEGER)")
+    connection.commit()
+    connection.close()
+    assert hidden.suffix == ""
+    assert hidden.stat().st_size % 512 == 0
+
+    opened = _simulate_evicted_vault(monkeypatch)
+
+    env = {
+        "BUILDEROPS_VAULT_ROOT": str(vault),
+        "BUILDEROPS_DB_PATH": str(tmp_path / "local" / "builderops.sqlite3"),
+    }
+    result = _run(["vault", "validate", str(vault), "--json"], env)
+
+    assert result.exit_code != 0
+    assert f"forbidden SQLite state in shared vault: {hidden}" in result.output
+
+    # The database was read; the notes that cannot be database images were not.
+    assert hidden in opened
+    assert [path for path in opened if path.parent == notes] == []
+
+
+def test_vault_validate_still_opens_local_files_for_the_header_sniff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing narrows for a normal local vault: the sniff is unchanged there.
+
+    Local reads are cheap (a full 900-file vault sniffs in ~0.1 s), so an
+    extension-less file that merely starts with the magic bytes is still
+    caught exactly as before.
+    """
+    from app.builderops import vault_queue
+
+    vault = tmp_path / "shared-vault"
+    nested = vault / "transient" / "opaque-state"
+    nested.parent.mkdir(parents=True)
+    nested.write_bytes(b"SQLite format 3\x00" + b"\x00" * 16)
+
+    assert vault_queue._content_is_local(nested.stat()) is True
+    assert vault_queue._sqlite_candidates(vault) == [nested]
+
+
+def test_vault_validate_reports_scan_stats_and_preserves_symlink_rejection(
+    tmp_path: Path,
+) -> None:
+    from app.builderops import vault_queue
+    from app.builderops.config import load_paths
+
+    vault = tmp_path / "shared-vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("hello\n", encoding="utf-8")
+    seen: list[dict[str, int]] = []
+
+    payload = vault_queue.validate_vault(
+        vault,
+        load_paths(
+            {
+                "BUILDEROPS_VAULT_ROOT": str(vault),
+                "BUILDEROPS_DB_PATH": str(tmp_path / "local" / "builderops.sqlite3"),
+            }
+        ),
+        on_progress=seen.append,
+    )
+
+    assert payload["sqlite_scan"]["files"] == 1
+    assert payload["sqlite_scan"]["opened"] == 1
+    assert payload["sqlite_scan"]["skipped_remote"] == 0
+    assert seen == [{"files": 1, "opened": 0, "skipped_remote": 0, "elapsed_ms": 0}]
+
+    outside = tmp_path / "outside.md"
+    outside.write_text("elsewhere\n", encoding="utf-8")
+    try:
+        (vault / "linked.md").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    with pytest.raises(vault_queue.VaultQueueError, match="must not be a symlink"):
+        vault_queue._sqlite_candidates(vault)


### PR DESCRIPTION
Governing-Issue: #4199

Fixes #4199

Final-Review-Rounds: 1

## Summary
`builderops vault validate` opened every file in the shared vault to read a 16-byte SQLite header. On iCloud Drive most of those files are *dataless* — metadata local, bytes evicted — so each `open()` is a network round-trip and the documented operator check did not terminate on the real vault. The scan now stats first and materializes an evicted file only when its size could belong to a SQLite database image. The confinement invariant is unchanged.

## Changes
- `app/builderops/vault_queue.py`: `_sqlite_candidates` stats each entry before reading it. A file whose content is **local** is sniffed exactly as before — full header check, no narrowing, so an extension-less file that merely starts with the magic bytes is still caught. An **evicted** file (macOS `SF_DATALESS`, or zero allocated blocks against a non-zero size) is opened only when `size >= 512 and size % 512 == 0`. A SQLite image is always a whole number of pages and every legal page size is a multiple of 512, so that condition can never hide a real database — it is a property of the file format, not a heuristic about names or locations.
- Symlink rejection is untouched and still runs before any read. A `stat()` failure is skipped rather than raised, preserving the tolerance `Path.is_file()` provided for an entry that vanishes mid-walk.
- `builderops vault validate --progress` reports a stderr heartbeat plus a final `scanned N files, opened M, skipped K non-local` line; the JSON payload carries the same counts under `sqlite_scan`. That is the "slow vs hung" affordance the issue asked for.
- Doc writeback in `docs/builderops/BUILDEROPS_VAULT_STORE.md` (operator-check block: runtime cost, the new flag, `vault paths` stays instant) and `docs/BUILDEROPS_MODEL_INQUIRY/EXTERNAL_BUILDEROPS_VAULT_CONFIGURATION.md :: SQLite Confinement Invariant` (why the narrowing cannot weaken the invariant).

Nothing is written into the shared vault; no cache, no SQLite, no credentials.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Repo-governed code/docs change only; no operational record was produced.

## Notes
Validation:
- Real-vault before/after on the laptop against the shared BuilderOps vault (916 files). One file evicted with `brctl evict` to reproduce the dataless state (`st_flags 0x40000000`, `st_blocks 0`):
  - this branch: `0.13 s` scan, `{"files": 916, "opened": 915, "skipped_remote": 1}`, and the evicted file was **still dataless afterwards** — the scan did not download it.
  - `origin/main` on the same vault and the same single evicted file: `1.57 s` scan and the file came back **materialized**. One evicted file costs ~1.4 s, matching the ~1.0-1.2 s/file the issue measured; at ~900 evicted files that is the non-terminating cold run.
- `pytest -q tests/builderops/test_builderops_paths.py tests/builderops/test_builderops_claims.py` — 46 passed, including the unchanged extension-less and symlink-rejection confinement tests
- New `test_vault_validate_detects_extensionless_sqlite_without_full_scan` simulates a fully evicted vault: a real extension-less SQLite database is still rejected while 50 Markdown notes are never opened. Verified against `origin/main` in a separate worktree, where all 50 notes are opened.
- Full `pytest -q -m "not pg"` under the host lease — 11091 passed, 9 failed; all 9 reproduce identically on clean `origin/main` (missing `click` / `pydantic_settings` in the sandboxed subprocess env those tests construct on this host) and are unrelated to this change
- `ruff check app tests` — clean; `python3 scripts/docs_guard.py` — OK
---
