### PR TITLE
docs: owner-doc promotion for #4198

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -302,8 +302,14 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
   across re-export instead of overwriting it, and its export path defaults to
   `BuilderOpsVault/agent-delivery` under the currently active vault (resolved through the shipped
   `VaultManager` active-vault-selection mechanism) so no CLI/automation caller has to type a manual
-  path (#3312). The projection remains read-only for coordination fields and has no write path for
-  claim, lease, or lock state; dispatcher SQLite remains sole claim/lease authority per ADR-0010.
+  path (#3312). That default is now the single source for the board root: the `/signboard` API route
+  and the full-stack launcher derive from it instead of a home-relative `~/BuilderOpsVault` literal
+  of their own, so with no vault selected there is no board root and the board reports an explicit
+  error state rather than an empty one. `export-signboard --prune-absent` removes generated cards
+  whose task id has left the dispatcher store, retaining any card that carries human-authored
+  `## Notes` or `## Receipts` text (#4198). The projection remains read-only for coordination fields
+  and has no write path for claim, lease, or lock state; dispatcher SQLite remains sole claim/lease
+  authority per ADR-0010.
 - Canvas co-authoring is materially implemented behind `CANVAS_ENABLED`: `canvas open` / `edit` /
   `close`, `/api/canvas/sessions*`, session-log persistence, and governance-bearing mutation routing
   are shipped; broader Chat cognition and hybrid Panel/Chat mutation remain separate follow-up work.


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 1

## Summary
Owner-doc promotion for #4198 (delivered by #4210, merged as `0930961`). The `docs/STATUS.md` Signboard bullet described only the CLI default shipped by #3312; after #4198 that default is the single source for the `/signboard` API route and the full-stack launcher as well.

## Changes
`docs/STATUS.md` — the Signboard projection bullet now also states that the vault-relative default is the single board-root source, that a host with no selected vault has no board root and reports an explicit error state instead of an empty board, and that `export-signboard --prune-absent` exists and retains cards carrying human-authored `## Notes` or `## Receipts` text.

No other owner doc claim was made false by the merge: `docs/AGENT_ISSUE_DISPATCHER.md` and `docs/builderops/BUILDEROPS_VAULT_STORE.md` were updated in the implementation PR itself.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs lane with no BuilderOps material routed.

## Notes
Validation: `python3 scripts/docs_guard.py` — OK. Docs-only change; no code or test surface touched.
---
