### PR TITLE
Reject narrative PR authority references

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -418,6 +418,8 @@ Implementation lane:
 - include exactly one `Governing-Issue: #<id>` line and closing keywords only for fully delivered
   Issues; the normal single-Issue body uses a matching `Fixes #<id>`, while approved multi-Issue
   delivery may keep the governing parent open and close delivered children
+- put each closing keyword on its own dedicated declaration line; never use a closing keyword
+  directly adjacent to `#<id>` in narrative prose, including BuilderOps routing or learning notes
 - summarize the bounded change
 - state focused validation that actually ran
 

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -265,9 +265,31 @@ jobs:
               const issueLinkMentions = canonicalBody.match(
                 new RegExp(`${issueTokenPrefix}${closingKeyword}${closingAttemptSeparator}${closingAttemptTarget}`, "gm")
               ) || [];
-              const exactIssueLinkMatches = canonicalBody.match(
-                new RegExp(`${issueTokenPrefix}${closingKeyword}${asciiClosingSeparator}#[1-9][0-9]*${issueTokenTerminator}`, "gm")
+              const canonicalClosingLinePattern = new RegExp(
+                `^[ \\t]*${closingKeyword}${asciiClosingSeparator}#[1-9][0-9]*[ \\t]*$`,
+                "i"
+              );
+              const declaredClosingLines = canonicalBody.match(
+                new RegExp(
+                  `^[ \\t]*${closingKeyword}${asciiClosingSeparator}#[1-9][0-9]*[ \\t]*$`,
+                  "gm"
+                )
               ) || [];
+              const exactIssueLinkMatches = declaredClosingLines;
+              const proseClosingMentionPattern = new RegExp(
+                `${issueTokenPrefix}${closingKeyword}${asciiClosingSeparator}#([1-9][0-9]*)${issueTokenTerminator}`,
+                "g"
+              );
+              const undeclaredClosingMentions = canonicalBody
+                .split("\n")
+                .flatMap((line, lineIndex) => {
+                  if (canonicalClosingLinePattern.test(line)) return [];
+                  return [...line.matchAll(proseClosingMentionPattern)].map(match => ({
+                    issueNumber: Number(match[1]),
+                    line: line,
+                    lineNumber: lineIndex + 1,
+                  }));
+                });
               const neutralizedClosingLines = canonicalBody.match(
                 /^[ \t]*Verified-Closing-Issues[ \t]*:.*$/gm
               ) || [];
@@ -334,6 +356,7 @@ jobs:
                 hasIssueLink,
                 hasUnsupportedLineSeparator,
                 issueLinkMentions,
+                undeclaredClosingMentions,
                 governingIssue: governingIssueNumber,
                 neutralizedClosingIssues: neutralizedIssueNumbers,
                 neutralizedValid,
@@ -463,6 +486,13 @@ jobs:
             // neutralized-authority-validator:end
             const issueAuthority = classifyIssueAuthority(body);
             const hasIssueAuthority = issueAuthority.hasIssueAuthority;
+            if (issueAuthority.undeclaredClosingMentions.length > 0) {
+              const offending = issueAuthority.undeclaredClosingMentions[0];
+              core.setFailed(
+                `PR body closing issue #${offending.issueNumber} on line ${offending.lineNumber}: ${offending.line}. Reword narrative prose to avoid a closing keyword directly adjacent to \`#<id>\`.`
+              );
+              return;
+            }
             const titleClosureAttempt = classifyIssueAuthority(
               pullRequest.title || ""
             ).issueLinkMentions.length > 0;

--- a/app/dispatcher/verification_contract.py
+++ b/app/dispatcher/verification_contract.py
@@ -73,9 +73,8 @@ CLOSING_ISSUE_ATTEMPT_PATTERN = re.compile(
     re.M,
 )
 CLOSING_ISSUE_PATTERN = re.compile(
-    rf"{_ISSUE_TOKEN_PREFIX}{_CLOSING_KEYWORD}{_ASCII_CLOSING_SEPARATOR}"
-    rf"#([1-9][0-9]*)"
-    rf"{_ISSUE_TOKEN_TERMINATOR}",
+    rf"(?m)^[ \t]*{_CLOSING_KEYWORD}{_ASCII_CLOSING_SEPARATOR}"
+    rf"#([1-9][0-9]*)[ \t]*$",
     re.M,
 )
 SUPPORTING_ISSUE_PATTERN = re.compile(

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -63,6 +63,9 @@ the ruling lands. Whichever source is used — skill template or generator — r
 be concrete before any PR is opened:
 
 - implementation lane requires a linked issue;
+- closing authority must be declared only on a dedicated `Fixes #<id>`, `Closes #<id>`, or
+  `Resolves #<id>` line; narrative prose must never place a closing keyword directly adjacent to
+  `#<id>`;
 - every body requires concrete SBS impact, validation, and owner-doc writeback resolution;
 - issue-backed and direct-repair bodies require concrete BuilderOps routing lines;
 - direct repair requires `Type`, `Reason`, `Validation`, and `Issue required: no`.

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -376,6 +376,56 @@ _VALID_BUILDEROPS_ROUTING = (
 )
 
 
+_CLOSING_LINE = _re.compile(
+    r"^[ \t]*(?:fix(?:es|ed)?|close(?:s|d)?|resolve(?:s|d)?)[ \t]*:?[ \t]+#[1-9][0-9]*[ \t]*$",
+    _re.IGNORECASE,
+)
+_CLOSING_MENTION = _re.compile(
+    r"(?<![0-9A-Za-z_])(?:fix(?:es|ed)?|close(?:s|d)?|resolve(?:s|d)?)[ \t]*:?[ \t]+#([1-9][0-9]*)(?=$|[ \t.,;:)\]}])",
+    _re.IGNORECASE,
+)
+
+
+def _undeclared_prose_closers(body: str) -> list[tuple[int, int, str]]:
+    """Mirror the pr-contract rule: closers belong on dedicated declaration lines."""
+    found: list[tuple[int, int, str]] = []
+    for line_number, line in enumerate(body.splitlines(), start=1):
+        if _CLOSING_LINE.fullmatch(line):
+            continue
+        for match in _CLOSING_MENTION.finditer(line):
+            found.append((int(match.group(1)), line_number, line))
+    return found
+
+
+def test_prose_closing_keyword_is_rejected() -> None:
+    """AC1: prose cannot grant GitHub closing authority."""
+    body = (
+        "## BuilderOps Routing\n"
+        "Daily audit found PR #4141 closed #4140 while review comments remained."
+    )
+    assert _undeclared_prose_closers(body) == [
+        (4140, 2, "Daily audit found PR #4141 closed #4140 while review comments remained.")
+    ]
+
+    workflow = _read(".github/workflows/issue-pr-governance.yml")
+    assert "const undeclaredClosingMentions =" in workflow
+    assert "PR body closing issue #${offending.issueNumber} on line ${offending.lineNumber}" in workflow
+    assert "Reword narrative prose to avoid a closing keyword directly adjacent" in workflow
+
+
+def test_declared_closing_lines_still_pass() -> None:
+    """AC2: canonical single- and multi-issue declarations remain valid authority."""
+    single_issue = "Governing-Issue: #4211\n\nFixes #4211"
+    multi_issue = "Governing-Issue: #4200\n\nCloses #4201\nResolves #4202"
+
+    assert _undeclared_prose_closers(single_issue) == []
+    assert _undeclared_prose_closers(multi_issue) == []
+
+    workflow = _read(".github/workflows/issue-pr-governance.yml")
+    assert "const canonicalClosingLinePattern =" in workflow
+    assert "const declaredClosingLines = canonicalBody.match(" in workflow
+
+
 def test_direct_repair_accepted_when_block_is_first_section() -> None:
     """AC1: Direct Repair block followed by another section."""
     body = (

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -442,6 +442,18 @@ def test_issue_backed_pr_accepts_single_and_multi_issue_authority() -> None:
     assert authority.supporting_issues == (3626, 3698)
 
 
+def test_narrative_closer_is_rejected_by_javascript_and_python_authority() -> None:
+    """The shared resolver must not authenticate closure authority from prose."""
+    body = (
+        "Governing-Issue: #4211\n\n"
+        "Fixes #4211\n\n"
+        "Daily audit says PR #4141 closed #4140 while review comments remain."
+    )
+
+    assert _js_issue_authority(body)["valid"] is False
+    assert resolve_issue_authority(body) is None
+
+
 def test_verified_merge_neutralized_authority_matches_javascript_and_python() -> None:
     body = (
         "Governing-Issue: #3821\n"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4211

Fixes #4211

## SBS Impact
- Primary subsystem: Builder System / issue-PR governance
- Secondary subsystem(s): verified issue-set merge authority; delivery closure ledger
- Write class: governance/docs/process
- Authority impact: prevents narrative prose from granting closure authority
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: GitHub closing-reference resolution
- New or changed contract: closure authority requires a declared dedicated closer line
- Owner-doc impact: updated PR hot-path authoring contract
- Transition debt impact: reduces false-attribution debt
- Fitness rule impact: strengthens PR authority enforcement
- Boundary risk: low; Builder System governance only

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Restricts PR-body closure authority to dedicated declaration lines and rejects narrative keyword links with actionable line-level feedback.
- Keeps the shared resolver in declaration-line grammar parity and proves it rejects a declared closer plus narrative closer.

## BuilderOps Routing
- Records/projections/receipts: dispatcher lease-746a2fb6
- Reason: Issue claim is the only BuilderOps-adjacent operational receipt.

## Notes
Validation: pytest -q tests/architecture/test_pr_hot_path_governance.py; pytest -q tests/governance/test_issue_pr_governance.py; pytest -q tests/dispatcher/test_verification_dispatch.py tests/dispatcher/test_verified_merge.py tests/governance/test_pr_evidence_pack_workflow.py tests/scripts/test_pr_body_generator.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; ruff check app tests; mypy app; git diff --check; review_before_ci_gate (governance, risk assessment complete).
---