### PR TITLE
Add design principle 10: Single-Operator Scale

### DIFF
--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -2,7 +2,7 @@ State: SoT v5.5 baseline locked with the forward line clarifying v6 design direc
 Doc role: Core SoT
 Authority: Canonical design principles for how architecture and roadmap changes should be framed. This document owns the stable principles for modularity, flexibility, authority boundaries, and documentation layering. It does not override current runtime behavior defined in `docs/ARCHITECTURE.md` and `docs/STATUS.md`.
 Owner: Architecture / SoT coordination
-Last reviewed: 2026-03-27
+Last reviewed: 2026-07-28
 
 # Design Principles
 
@@ -117,6 +117,21 @@ It exists to keep high-level design work systematic:
 - Mimer should be treated as a modular, differentiated decomposition, not as one undifferentiated agent runtime.
 - Interaction, cognition, execution, memory, and governance must be able to evolve at different speeds.
 - Cross-layer coupling should be deliberate, minimal, and documented.
+
+### 10. Single-Operator Scale
+
+- The system serves exactly one human on trusted personal infrastructure. Design for that
+  reality, not for a hypothetical enterprise deployment.
+- The simplest mechanism that satisfies the current contract wins. Enterprise-grade patterns —
+  high availability, horizontal scaling, multi-tenancy, zero-trust internal auth, pluggable
+  provider abstractions for hypothetical futures — require an explicit contract or ADR demand;
+  they are never default posture.
+- Ready beats perfect: ship the boring version and let real usage generate the evidence for the
+  next iteration. Robustness investment follows observed failure, not imagined failure.
+- Data integrity and the governed-mutation invariants (Principles 4–5) are not relaxed by this
+  principle; they are what single-operator trust rests on.
+- The builder-side twin of this principle is `AGENTS.md :: Proportional delivery` (right-size
+  default); this principle governs product architecture, that one governs how we build.
 
 ## Documentation Design Principles
 


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Add design principle 10 (Single-Operator Scale) to docs/DESIGN_PRINCIPLES.md: the product serves exactly one human on trusted infrastructure; the simplest mechanism that satisfies the contract wins; enterprise-grade patterns (HA, horizontal scaling, multi-tenancy, zero-trust internal auth, speculative provider abstractions) require an explicit contract/ADR demand; ready beats perfect; data integrity and governed mutation (principles 4-5) stay non-negotiable. Product-side twin of `AGENTS.md :: Proportional delivery` (merged in #4225). Owner-approved 2026-07-28.

## Changes
docs/DESIGN_PRINCIPLES.md: new principle 10 + Last reviewed bump.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring lane; the decision is recorded in the owner doc itself.

## Notes
Validation: docs-only; light delivery path per AGENTS.md :: Proportional delivery (Final-Review-Rounds: 0, merge on green required checks). First live use of the light path.
---
