### PR TITLE
Validate ready Issue Verify file paths

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -65,6 +65,9 @@ Every Acceptance Criterion declares its verification inline with a `Verify:` mar
   (`Verify: doc writeback at \`docs/<path> :: <anchor>\``), roadmap diff, or runtime receipt.
 - An AC without a resolvable `Verify:` target is not executable; the Issue must not be
   `agent:ready` until the AC is refined or split.
+- Ready-label validation resolves every file-based `Verify:` path against the current repository;
+  a referenced file must exist, while a new test function within that file may be written by the
+  implementing builder.
 - `Suggested Validation` lists the commands and procedures that execute the declared `Verify:`
   targets — coupled to the ACs, not a duplicate of them.
 

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -37,11 +37,17 @@ READINESS_CLASSES: tuple[str, ...] = (
     "missing_required_sections",
     "missing_source_docs",
     "missing_verify_markers",
+    "missing_verify_file_paths",
     "malformed_acceptance_criteria",
     "ambiguous_intent",
     "authority_risk",
     "not_agentable",
     "unknown",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERIFY_FILE_PATH_PATTERN = re.compile(
+    r"(?<![\w.-])(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+)"
 )
 
 AMBIGUOUS_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
@@ -95,6 +101,7 @@ class AcceptanceCriteriaReport:
     malformed: bool
     verify_markers_present: bool
     missing_verify_items: list[str]
+    missing_verify_file_paths: list[str]
 
 
 @dataclass(frozen=True)
@@ -189,6 +196,29 @@ def _has_concrete_verify_marker(item: str) -> bool:
     return False
 
 
+def _verify_targets(item: str) -> list[str]:
+    return [
+        match.group(1).strip().strip("`").strip()
+        for match in re.finditer(r"(?im)(?:^|\b)Verify:\s*(.+)$", item)
+        if match.group(1).strip()
+    ]
+
+
+def _missing_verify_file_paths(item: str) -> list[str]:
+    missing_paths: list[str] = []
+    for target in _verify_targets(item):
+        for match in VERIFY_FILE_PATH_PATTERN.finditer(target):
+            path = match.group("path")
+            candidate = Path(path)
+            if (
+                candidate.is_absolute()
+                or ".." in candidate.parts
+                or not (REPO_ROOT / candidate).is_file()
+            ):
+                missing_paths.append(path)
+    return missing_paths
+
+
 def analyze_acceptance_criteria(section: str | None) -> AcceptanceCriteriaReport:
     lines = _non_placeholder_lines(section)
     items = _extract_acceptance_items(section)
@@ -198,12 +228,16 @@ def analyze_acceptance_criteria(section: str | None) -> AcceptanceCriteriaReport
         for item in items
         if not _has_concrete_verify_marker(item)
     ]
+    missing_file_paths = [
+        path for item in items for path in _missing_verify_file_paths(item)
+    ]
     return AcceptanceCriteriaReport(
         present=bool(items),
         count=len(items),
         malformed=malformed,
         verify_markers_present=bool(items) and not missing_verify,
         missing_verify_items=missing_verify,
+        missing_verify_file_paths=missing_file_paths,
     )
 
 
@@ -260,6 +294,8 @@ def classify_issue_body(
         classification = "malformed_acceptance_criteria"
     elif not ac_report.verify_markers_present:
         classification = "missing_verify_markers"
+    elif ac_report.missing_verify_file_paths:
+        classification = "missing_verify_file_paths"
     elif _contains_any(AUTHORITY_RISK_PATTERNS, body):
         classification = "authority_risk"
         human_exception_required = True
@@ -338,6 +374,13 @@ def repair_guidance(
         return [
             "Add an inline `Verify:` marker to every acceptance criterion.",
             "Missing Verify marker on: " + missing_items + ".",
+        ]
+    if classification == "missing_verify_file_paths":
+        return [
+            "Update every file-based `Verify:` target to name an existing repository file.",
+            "Missing Verify file path(s): "
+            + ", ".join(ac_report.missing_verify_file_paths)
+            + ".",
         ]
     return ["Unable to determine repair guidance; rewrite using the canonical task template."]
 

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -47,7 +47,7 @@ READINESS_CLASSES: tuple[str, ...] = (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERIFY_FILE_PATH_PATTERN = re.compile(
-    r"(?<![\w.-])(?P<path>(?:(?:/|\.?\./)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+))"
+    r"(?<![\w.-])(?P<path>(?:(?:/|\.?\./)?(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+\.[A-Za-z0-9]+))"
 )
 
 AMBIGUOUS_PATTERNS: tuple[re.Pattern[str], ...] = tuple(

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -47,7 +47,7 @@ READINESS_CLASSES: tuple[str, ...] = (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERIFY_FILE_PATH_PATTERN = re.compile(
-    r"(?<![\w.-])(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+)"
+    r"(?<![\w.-])(?P<path>(?:(?:/|\.?\./)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+))"
 )
 
 AMBIGUOUS_PATTERNS: tuple[re.Pattern[str], ...] = tuple(

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -103,6 +103,25 @@ def test_ready_issue_does_not_require_future_verify_test_function() -> None:
     assert report.readiness_classification == "ready_candidate"
 
 
+@pytest.mark.parametrize(
+    "verify_path",
+    [
+        "/tests/scripts/test_validate_issue_readiness.py",
+        "../tests/scripts/test_validate_issue_readiness.py",
+    ],
+)
+def test_ready_issue_rejects_non_repo_relative_verify_file_path(verify_path: str) -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        f"{verify_path}::test_fixture_classifications",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+
+
 @pytest.mark.parametrize("target", ["<test pointer>", "none", "n/a", "TBD"])
 def test_placeholder_verify_targets_are_not_concrete(target: str) -> None:
     body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -69,6 +69,40 @@ def test_missing_verify_reports_exact_item_guidance() -> None:
     assert "acceptance criteria without verify markers" in report.repair_guidance[-1]
 
 
+def test_ready_issue_rejects_missing_verify_file_path() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "tests/scripts/test_missing_verify_path.py::test_missing_path",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+    assert any("tests/scripts/test_missing_verify_path.py" in item for item in report.repair_guidance)
+
+
+def test_ready_issue_accepts_existing_verify_file_path() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_ready_issue_does_not_require_future_verify_test_function() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "tests/scripts/test_validate_issue_readiness.py::test_new_readiness_case",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+
+
 @pytest.mark.parametrize("target", ["<test pointer>", "none", "n/a", "TBD"])
 def test_placeholder_verify_targets_are_not_concrete(target: str) -> None:
     body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -82,8 +82,34 @@ def test_ready_issue_rejects_missing_verify_file_path() -> None:
     assert any("tests/scripts/test_missing_verify_path.py" in item for item in report.repair_guidance)
 
 
+def test_ready_issue_rejects_missing_root_level_verify_file_path() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "pyproject.tmol::missing_target",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+    assert report.acceptance_criteria.missing_verify_file_paths == ["pyproject.tmol"]
+
+
 def test_ready_issue_accepts_existing_verify_file_path() -> None:
     body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_ready_issue_accepts_existing_root_level_verify_file_path() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "pyproject.toml::test_new_readiness_case",
+    )
 
     report = classify_issue_body(body, labels=["agent:ready"])
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4155

## Linked Issue
Fixes #4155

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): issue readiness validation
- Write class: governance/docs/process
- Authority impact: prevents nonexistent test paths from authorizing agent:ready
- Persistence impact: GitHub Issue labels only
- Derived/rebuildable impact: none
- Human knowledge impact: reduces false-ready issue pickup
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: GitHub Issues only
- New or changed contract: readiness validator resolves file-based Verify targets
- Owner-doc impact: none
- Transition debt impact: reduces
- Fitness rule impact: strengthens
- Boundary risk: must not validate future test functions as if they already exist

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reject agent-ready issues whose file-based Verify targets name absent repository paths.

## BuilderOps Routing
- Records/projections/receipts: AgentWorklog awl_20260728111135_ca3e85f0
- Reason: Implementation worklog records claim, validation, and PR handoff evidence.

## Notes
Validation: focused pytest (7 passed); full readiness-validator module (32 passed); python3 scripts/lint_skills_consistency.py; DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py (owner-doc expansion outside Issue scope); ruff check app tests; mypy scripts/validate_issue_readiness.py; git diff --check.