### PR TITLE
Govern Yggdrasil design handoffs

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -100,6 +100,10 @@ on CI checks — and the optional `--codex` verdict path — via REST without dr
   - review, plan, make ready, and deliver an epic, parent feature issue, Kanban/Project lane, or larger ready-issue set; use `issue-to-code` and `verification-and-closure` as the main lenses; if the ready pool is too small, repair or create bounded ready issues through `issue-maintenance-change-control`, `docs-to-issue`, or `feature-breakdown`; may claim multiple issues only for rational parallel sub-agent delivery with isolated worktrees and explicit receipts
 - `docs-governance`
   - decision and routing skill for docs-as-code ownership, anti-sprawl, DOCS_INDEX impact, and narrower docs workflow selection
+- `yggdrasil-design-handoff`
+  - prepare, run, revise, validate, or archive Claude Design and other UI/component handoffs;
+    fail closed unless the live Yggdrasil Design System is selected or attached and its token sheet
+    matches the repo's binding source
 - `docs-authoring`
   - docs-only authoritative authoring lane
 - `docs-to-issue`
@@ -172,6 +176,8 @@ workflow — see `## App-agent skill family (product-lane)` below for the full d
   `deliver-issue-set -> (issue-maintenance-change-control | docs-to-issue | feature-breakdown) -> issue-to-code -> publish-pr -> pr-integration as needed -> verification-and-closure`
 - Docs backlog path:
   `docs-governance -> (docs-authoring | docs-to-issue | feature-breakdown)`
+- Design handoff path:
+  `yggdrasil-design-handoff -> governed exploration/handoff -> (Companion UI: Crossing B -> normalized spec | other surface: local owner doc/spec) -> docs-to-issue`
 - Architecture research path:
   `architecture-research -> feature-breakdown -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
 - Maintenance-learning intake path:

--- a/.codex/skills/yggdrasil-design-handoff/SKILL.md
+++ b/.codex/skills/yggdrasil-design-handoff/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: yggdrasil-design-handoff
+description: "Prepare, run, revise, validate, or archive governed Yggdrasil UI/component design handoffs, including Claude Design projects, prototypes, visual audits, interaction designs, and component specifications. Use whenever work creates or changes a visual surface, reusable component, design prototype, design-system-bound mockup, or Claude Design handoff for this repository."
+---
+
+# Yggdrasil Design Handoff
+
+Use this Builder System workflow to keep external design exploration inside Yggdrasil's design
+language and authority chain. Do not use a generic visual style when the canonical design system is
+available.
+
+## Required context
+
+Read:
+
+1. `AGENTS.md`
+2. `docs/DESIGN_PRINCIPLES.md`
+3. `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` when the surface enters the Companion UI
+   design-handoff chain
+4. `companion-ui/prompts/claude-design/README.md`
+5. `companion-ui/docs/CORE_TERM_MAPPING.md`
+6. the owner docs for the surface being designed
+
+For Claude Design work, use
+`companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md` as the binding prompt preamble.
+
+## Fail-closed design-system gate
+
+Complete this gate before asking a design model to produce or revise any visual:
+
+1. Resolve the live design system by the exact name **Yggdrasil Design System** using
+   `mcp__claude-design__list_design_systems`. The currently verified system ID is
+   **f2b13410-af14-4875-8029-445352123f57**; treat a different or ambiguous live result as drift and
+   stop for reconciliation.
+2. Read the live design system's `SKILL.md`, `README.md`, `colors_and_type.css`, and the relevant
+   component/reference previews. Do not rely on its name alone.
+3. Hash the live `colors_and_type.css` and the repo's binding token source,
+   `companion-ui/companion-app/colors_and_type.css`. They must match byte for byte. If they do not,
+   stop before design generation and reconcile the two authorities.
+4. Select the Yggdrasil Design System when creating the Claude Design project. If an existing
+   project cannot express selection, copy/attach the live skill, README, exact token sheet, and
+   relevant previews under `design-system/`, then put the binding preamble in the design request.
+   Never assume that a default project inherited the system.
+5. Record the exact system name and ID, selection/attachment mechanism, token source, and token
+   SHA-256 in the handoff package README.
+
+No successful gate means no design generation. Do not silently fall back to a generic aesthetic,
+invent a replacement token set, or continue with an unverified similarly named system.
+
+## Workflow
+
+1. **Classify the artifact.** Keep exploration/handoff guidance separate from normalized specs,
+   architecture authority, shipped components, and runtime truth.
+2. **Bound the request.** Name the operator journey, surface, states, authority limits, source
+   evidence, responsive/accessible states, and requested deliverables.
+3. **Run the design-system gate.** Preserve its receipt in the package README.
+4. **Prepare evidence.** Attach current screenshots, relevant implementation surfaces, the exact
+   token sheet, reusable components/previews, and the most local owner contracts. Prefer targeted
+   evidence over a repo-wide context dump.
+5. **Generate or revise.** Make Yggdrasil a binding component and visual constraint, not a palette
+   suggestion. Reuse existing primitives before proposing extensions. Write revisions to a new
+   versioned output folder; do not overwrite an earlier accepted or reviewable design.
+6. **Validate.** Inspect desktop, narrow, 200% zoom, keyboard, print, JavaScript-off, empty,
+   degraded, and blocked states when relevant. Confirm that colors, type, spacing, radii, icons,
+   and components are grounded in the design system. Name any proposed extension in
+   `open-questions.md`; do not use it silently in the prototype.
+7. **Archive and cross deliberately.** For Companion UI, preserve the package under
+   `companion-ui/design_handoff/<YYYY-MM-DD>-<slug>/` only when requested and route implementation
+   intent through Crossing B. For other Product or Builder surfaces, keep the external package as
+   supporting design input and normalize accepted intent through that surface's local owner
+   document or specification. In every case, implementation begins only from a bounded Issue and
+   the normal PR chain.
+
+Use `AGENTS.md :: Total Cost of Development` for model and review depth. Mechanical transport and
+file synchronization do not need the same capability as substantive interaction design.
+
+## Required receipt
+
+Return:
+
+```text
+Yggdrasil Design Handoff Receipt:
+- Surface:
+- Authority state:
+- Design system name:
+- Design system ID:
+- Selection/attachment mechanism:
+- Repo token source:
+- Token SHA-256:
+- Token parity: pass|fail
+- Output/project:
+- Visual verification:
+- Crossing state:
+- Open authority questions:
+```
+
+Set `Token parity` to `fail` and stop if the live and repo token sheets differ. Never report a
+handoff as Yggdrasil-compliant based only on visual resemblance.

--- a/.codex/skills/yggdrasil-design-handoff/agents/openai.yaml
+++ b/.codex/skills/yggdrasil-design-handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Yggdrasil Design Handoff"
+  short_description: "Create governed Yggdrasil design handoffs"
+  default_prompt: "Use $yggdrasil-design-handoff to prepare or revise a Claude Design handoff using the canonical Yggdrasil Design System."

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -634,6 +634,8 @@ jobs:
               "scripts/validate_issue_readiness.py",
               "scripts/await_pr_checks.sh",
               "scripts/lint_skills_consistency.py",
+              "companion-ui/design_handoff/README.md",
+              "companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md",
               "companion-ui/prompts/codex/deliver-epic-autonomous-runner.md",
               "tests/ops/test_git_hygiene.py",
               "tests/architecture/test_agent_skill_entrypoints.py",
@@ -653,6 +655,7 @@ jobs:
               ".github/ISSUE_TEMPLATE/",
               ".codex/skills/",
               ".codex/agents/",
+              "companion-ui/prompts/claude-design/",
               "tests/fixtures/issue_readiness/",
               "tests/fixtures/pr_body_generator/",
             ];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Repo-local workflow helpers live under `.codex/skills/`. They do not replace thi
   `.codex/skills/deliver-issue-set/SKILL.md`
 - Docs-as-code ownership, anti-sprawl, DOCS_INDEX impact, or docs workflow routing decisions:
   `.codex/skills/docs-governance/SKILL.md`
+- Claude Design projects, UI/component prototypes, visual audits, and governed design handoffs:
+  `.codex/skills/yggdrasil-design-handoff/SKILL.md`
 - Docs-only authoritative spec work:
   `.codex/skills/docs-authoring/SKILL.md`
 - Convert active docs into bounded GitHub backlog:

--- a/companion-ui/design_handoff/README.md
+++ b/companion-ui/design_handoff/README.md
@@ -32,6 +32,9 @@ Preserved Claude Design artifacts and handoff packages. These are reference/hand
 ## Rules
 
 - Design artifacts in this folder are guidance only. They are not architecture authority and not runtime truth.
+- UI/component/visual packages must carry a passing Yggdrasil design-system receipt in their
+  README and use the canonical token sheet per
+  [`.codex/skills/yggdrasil-design-handoff/SKILL.md`](../../.codex/skills/yggdrasil-design-handoff/SKILL.md).
 - Do not implement production UI components directly from a handoff package. Route through the governed chain.
 - Do not let a design package modify or override an owner-doc in `docs/**`.
 - Implementation issues #868–#874 (canvas suggestion flow) and others remain their own task contracts. This folder does not absorb them.

--- a/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
+++ b/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
@@ -6,7 +6,7 @@ Temporal class: stable
 Review cadence: event-driven
 Source of truth: authoritative for the handoff chain
 Last reviewed: 2026-06-10
-Last verified against: companion-ui/design_handoff/, companion-ui/prompts/claude-design/README.md, docs/COMPANION_UI_PRODUCT_SPEC.md, docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md, docs/INTEGRATION_FABRIC_CONTRACT.md, docs/CAPABILITY_CONTRACT_MODEL.md, companion-ui/design_handoff/2026-05-14-claude-design-package/README.md, companion-ui/design_handoff/2026-05-14-handoff-governance-pack/, companion-ui/design_handoff/2026-06-09-system-entry-point/, issue #901
+Last verified against: companion-ui/design_handoff/, companion-ui/prompts/claude-design/README.md, companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md, companion-ui/companion-app/colors_and_type.css, .codex/skills/yggdrasil-design-handoff/SKILL.md, docs/COMPANION_UI_PRODUCT_SPEC.md, docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md, docs/INTEGRATION_FABRIC_CONTRACT.md, docs/CAPABILITY_CONTRACT_MODEL.md, companion-ui/design_handoff/2026-05-14-claude-design-package/README.md, companion-ui/design_handoff/2026-05-14-handoff-governance-pack/, companion-ui/design_handoff/2026-06-09-system-entry-point/, issue #901
 
 # Design Handoff Governance
 
@@ -39,11 +39,36 @@ Each step-to-step transition is a **crossing**. The crossings that require expli
 
 Crossings A (exploration → handoff) and E (merge → receipt) are automatic / no formal gate required.
 
+## Yggdrasil design-system gate
+
+Every UI, component, interaction, prototype, or visual-audit exploration must use the canonical
+**Yggdrasil Design System** before its first generated visual. This is a pre-exploration gate, not
+a Crossing-B cleanup task.
+
+- Resolve the live Claude Design system by exact name through `list_design_systems`; the currently
+  verified ID is `f2b13410-af14-4875-8029-445352123f57`.
+- Select it at project creation. For an existing project that cannot express selection, attach its
+  `SKILL.md`, `README.md`, exact `colors_and_type.css`, and relevant component/reference previews
+  under `design-system/`, and include the binding prompt preamble.
+- Compare the live token sheet byte-for-byte with the binding repo source
+  `companion-ui/companion-app/colors_and_type.css`. The repo source wins on conflict, but generation
+  must stop until the live design system is reconciled.
+- Record the exact name, ID, selection/attachment mechanism, token path, and SHA-256 in the package
+  README.
+- Reuse established tokens and components. Any proposed extension stays explicit in
+  `open-questions.md` until normalized; it must not be silently used as if already canonical.
+
+Visual similarity, a copied color value, or the system being marked “default” is not proof that the
+project used the design system. A failed or ambiguous gate blocks generation and Crossing B.
+
 ### Maturity checklist (Crossing B)
 
 A handoff package passes Crossing B when all of the following are true:
 
 - [ ] The package README names the surface it covers and declares its authority status ("Visual guidance only" or equivalent).
+- [ ] The package README contains a passing Yggdrasil design-system receipt: exact live name and ID,
+      selection/attachment mechanism, binding repo token path, matching token SHA-256, and relevant
+      component/preview inputs.
 - [ ] `authority-boundaries.md` is present and distinguishes: design guidance / normalized spec / architecture contract / runtime truth.
 - [ ] `implementation-contracts.md` is present and lists the state enum, allowed transitions, and data attributes.
 - [ ] `open-questions.md` is present; each open question is triaged into: resolve-before-promotion / resolve-in-normalized-spec / defer-to-implementation-issue.
@@ -102,6 +127,10 @@ spec_chrome.css             — shared spec layout (import from sibling packages
 edge-states.md              — degraded / empty / loading / blocked / narrow states
 ```
 
+For UI/component/visual packages, `colors_and_type.css` is required rather than optional unless the
+prototype embeds the exact binding token sheet and the README records its matching hash. A package
+must not substitute an independently recreated palette.
+
 The index package `<date>-claude-design-package/` holds the executive summary, intake table, and CHANGELOG for a multi-package session. It is not a package itself — it does not require its own `prototype.html`.
 
 ## Handoff archive
@@ -135,14 +164,16 @@ The following are explicitly not authorized by this governance doc. They remain 
 
 ## How to introduce a new design exploration
 
-1. Run the Claude Design session using prompts from `companion-ui/prompts/claude-design/`.
-2. Export the output into a new dated folder under `companion-ui/design_handoff/`.
-3. Ensure the folder shape matches the requirements above (README, authority-boundaries, implementation-contracts, open-questions).
-4. Update `companion-ui/design_handoff/README.md` with the new entry.
-5. Route to Crossing B when the maturity checklist is complete.
-6. After Crossing B approval, author a normalized spec in `companion-ui/docs/`.
-7. Create a bounded GitHub issue from the normalized spec.
-8. Implement via the standard `issue-to-code` flow.
+1. Load `.codex/skills/yggdrasil-design-handoff/SKILL.md`.
+2. Complete its fail-closed Yggdrasil design-system gate.
+3. Run the Claude Design session using prompts from `companion-ui/prompts/claude-design/`.
+4. Export the output into a new dated folder under `companion-ui/design_handoff/`.
+5. Ensure the folder shape and design-system receipt match the requirements above.
+6. Update `companion-ui/design_handoff/README.md` with the new entry.
+7. Route to Crossing B when the maturity checklist is complete.
+8. After Crossing B approval, author a normalized spec in `companion-ui/docs/`.
+9. Create a bounded GitHub issue from the normalized spec.
+10. Implement via the standard `issue-to-code` flow.
 
 ## References
 

--- a/companion-ui/prompts/claude-design/README.md
+++ b/companion-ui/prompts/claude-design/README.md
@@ -6,14 +6,34 @@ Use this folder for prompts that generate or refine interaction and visual hando
 
 Output from Claude Design sessions must land in the governed handoff chain before becoming implementation work. See:
 
+- [`.codex/skills/yggdrasil-design-handoff/SKILL.md`](../../../.codex/skills/yggdrasil-design-handoff/SKILL.md)
+  — mandatory workflow and fail-closed design-system preflight.
 - [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../../docs/DESIGN_HANDOFF_GOVERNANCE.md) — the full handoff chain (exploration → handoff → normalized spec → issue → PR → receipt), maturity checklist, and authority boundaries.
 - [`companion-ui/docs/CORE_TERM_MAPPING.md`](../../docs/CORE_TERM_MAPPING.md) — maps design-language terms to Yggdrasil architecture language.
 - [`companion-ui/design_handoff/README.md`](../../design_handoff/README.md) — the handoff archive index.
 
 **Design output is guidance only.** It is not architecture authority and not runtime truth. Architecture authority lives in `docs/**` owner-docs.
 
+## Mandatory design-system preflight
+
+Use [`YGGDRASIL_HANDOFF_TEMPLATE.md`](YGGDRASIL_HANDOFF_TEMPLATE.md) as the first block in every
+Claude Design request that creates or changes a visual.
+
+Before generation:
+
+1. Resolve and select the live **Yggdrasil Design System**.
+2. Verify its `colors_and_type.css` matches
+   `companion-ui/companion-app/colors_and_type.css` byte for byte.
+3. Read the relevant reusable components and previews instead of reconstructing them from memory.
+4. Record the selection and token hash in the package README.
+
+If selection or token parity cannot be proved, stop. Do not let Claude Design use its generic
+default aesthetic and do not treat later recoloring as compliance.
+
 ## Prompt posture
 
+- Treat Yggdrasil tokens and existing components as binding; propose extensions explicitly instead
+  of silently inventing colors, type, spacing, radii, icons, or primitives.
 - Preserve document-first, overlay-first interaction.
 - Keep chat subordinate to document context.
 - Avoid dashboard-style AI UX.

--- a/companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md
+++ b/companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md
@@ -1,0 +1,40 @@
+# Yggdrasil Claude Design binding preamble
+
+Status: Reusable prompt preamble. Design guidance only; not architecture or runtime authority.
+
+Place this block before the task-specific brief and replace every bracketed receipt value.
+
+---
+
+You are designing for Yggdrasil. The selected **Yggdrasil Design System** is a binding input, not
+an optional aesthetic reference.
+
+Design-system receipt for this run:
+
+- exact live name: `Yggdrasil Design System`
+- live design-system ID: `[ID returned by list_design_systems]`
+- selection/attachment mechanism: `[selected at project creation | attached under design-system/]`
+- binding repo token source: `companion-ui/companion-app/colors_and_type.css`
+- verified token SHA-256: `[matching live and repo hash]`
+- reusable components/previews read: `[paths]`
+
+Before producing a visual:
+
+1. Read the selected design system's `SKILL.md`, `README.md`, `colors_and_type.css`, and relevant
+   component/reference previews.
+2. Reuse its tokens and existing components. Do not invent colors, typography, spacing, radii,
+   icon style, or primitives because a generic dashboard convention is familiar.
+3. If the brief needs something the system does not contain, name it as a proposed extension in
+   `open-questions.md`. Do not silently use the extension in the prototype as if it were canonical.
+4. Where design-system prose and the binding repo token sheet conflict, the repo token sheet wins.
+   Report the conflict and stop the affected visual instead of guessing.
+5. Preserve the task's product, authority, accessibility, responsive, JavaScript-off, and print
+   constraints while expressing them through Yggdrasil's established visual/component language.
+
+In the output README, repeat the receipt above and state whether token parity and visual compliance
+passed. Visual resemblance alone is not compliance.
+
+The output remains design guidance. It cannot modify owner docs, runtime contracts, shipped
+components, or production authority.
+
+---

--- a/companion-ui/prompts/codex/deliver-epic-autonomous-runner.md
+++ b/companion-ui/prompts/codex/deliver-epic-autonomous-runner.md
@@ -348,23 +348,32 @@ design-owned, create a complete handoff package request. Do not send Claude a va
 1. Freeze only the implementation branch whose acceptance depends on the unresolved design choice.
 2. Continue ready-pool repair, independent slices, tests/contracts not prejudging the design, and
    parent evidence work.
-3. Route Claude output through the governed chain in
-   `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`.
-4. Treat the output as visual/interaction guidance only. It cannot override owner docs, declare
+3. Load `.codex/skills/yggdrasil-design-handoff/SKILL.md` and complete its fail-closed live
+   design-system selection/attachment and token-parity gate before any design generation.
+4. For a Companion UI surface, route Claude output through the governed chain in
+   `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`. For another Product or Builder surface,
+   normalize accepted intent through that surface's local owner document or specification.
+5. Treat the output as visual/interaction guidance only. It cannot override owner docs, declare
    schemas, assert runtime truth, or authorize implementation by itself.
-5. Require Crossing-B maturity before normalized-spec promotion. Implementation begins only from a
-   bounded executable issue backed by the accepted normalized spec/authority chain.
-6. If a design package contains unresolved questions, triage each as resolve-before-promotion,
+6. For Companion UI, require Crossing-B maturity before normalized-spec promotion. For every
+   surface, implementation begins only from a bounded executable issue backed by the accepted
+   normalized spec/authority chain.
+7. If a design package contains unresolved questions, triage each as resolve-before-promotion,
    resolve-in-normalized-spec, or defer-to-implementation-issue. Only the dependent scope waits.
 
 ### Claude Design handoff template
 
-Send the following as a self-contained task, filling every bracket from live repo/issue evidence:
+First prepend the complete
+`companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md` binding block after replacing
+every receipt placeholder from the successful live preflight. Do not send the task with an
+unresolved receipt placeholder. Then send the following as one self-contained task, filling every
+bracket from live repo/issue evidence:
 
 ```markdown
 # Claude Design Handoff — [SURFACE / CAPABILITY]
 
-You are producing governed interaction and visual design guidance for Yggdrasil / Companion UI.
+You are producing governed interaction and visual design guidance for a Yggdrasil Product or
+Builder surface.
 This is a design handoff package, not architecture authority, schema authority, runtime truth, or
 implementation authorization.
 
@@ -392,9 +401,11 @@ capabilities to make the visual concept easier.
 
 Read these files in the repository before designing:
 
-- `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`
+- `docs/DESIGN_PRINCIPLES.md`
+- `.codex/skills/yggdrasil-design-handoff/SKILL.md`
+- `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` [COMPANION UI ONLY]
 - `companion-ui/docs/CORE_TERM_MAPPING.md`
-- `docs/COMPANION_UI_PRODUCT_SPEC.md`
+- `docs/COMPANION_UI_PRODUCT_SPEC.md` [COMPANION UI ONLY]
 - [RELEVANT INTERACTION OWNER DOCS]
 - [RELEVANT RUNTIME/CURRENT-STATE OWNER DOCS]
 - [ACCEPTED NORMALIZED SPEC, IF ANY]
@@ -446,7 +457,9 @@ contract or open question.
 
 ## Existing visual system
 
-- Reuse: [TOKENS / COMPONENTS / PRIOR HANDOFFS]
+- Binding system: `Yggdrasil Design System`
+- Verified receipt: [EXACT SYSTEM ID / SELECTION OR ATTACHMENT / MATCHING TOKEN SHA-256]
+- Reuse: [YGGDRASIL TOKENS / COMPONENTS / PREVIEWS / PRIOR HANDOFFS]
 - Preserve: [GEOMETRY / TYPOGRAPHY / INTERACTION GRAMMAR]
 - May explore: [BOUNDED VISUAL SPACE]
 - Must not change: [SETTLED SURFACE OR CONTRACT]
@@ -455,9 +468,11 @@ contract or open question.
 
 Export to:
 
-`companion-ui/design_handoff/[YYYY-MM-DD]-[SLUG]/`
+`[VERSIONED OUTPUT PATH RESOLVED BY yggdrasil-design-handoff]`
 
-Produce a Crossing-B-eligible package:
+For Companion UI, produce a Crossing-B-eligible package. For another Product or Builder surface,
+produce the same evidence shape as supporting design input, but route acceptance through that
+surface's local owner document or specification rather than claiming Crossing B:
 
 1. `README.md` — surface, human outcome, issue links, authority status “Visual / interaction
    guidance only”, source inventory, and crossing target.
@@ -474,8 +489,8 @@ Produce a Crossing-B-eligible package:
    `resolve-before-promotion`, `resolve-in-normalized-spec`, or `defer-to-implementation-issue`.
 8. `edge-states.md` when the edge-state detail would overload the gallery.
 
-Update `companion-ui/design_handoff/README.md` only if this task is authorized to write the archive
-index. Do not modify production code.
+Update `companion-ui/design_handoff/README.md` only for a Companion UI package when this task is
+authorized to write the archive index. Do not modify production code.
 
 ## Crossing-B acceptance test
 
@@ -499,7 +514,7 @@ Return:
 - package path;
 - concise design recommendation;
 - alternatives considered;
-- Crossing-B readiness verdict;
+- Crossing-B readiness verdict for Companion UI, otherwise the local normalization target;
 - unresolved questions by triage class;
 - exact normalized-spec decisions still required;
 - implementation issues unblocked versus still blocked; and

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -21,6 +21,7 @@ It exists to keep high-level design work systematic:
 
 - System-level design principles for modularity and flexibility.
 - Authority boundaries for interaction, cognition, execution, memory, and governance.
+- Shared visual-language rules for new and revised human-facing components.
 - Documentation-layer rules for where architectural intent, sequencing, and implementation detail belong.
 
 ## Out of Scope
@@ -36,6 +37,8 @@ It exists to keep high-level design work systematic:
 - `docs/STATUS.md` — present-tense operational posture.
 - `docs/AGENTS.md` — current runtime agent architecture.
 - `docs/plans/V60_ARCHITECTURE_TARGET.md` — wanted-state context for larger target-state moves.
+- `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` — governed external-design handoff for
+  Companion UI.
 
 ## Reading Order
 
@@ -132,6 +135,21 @@ It exists to keep high-level design work systematic:
   principle; they are what single-operator trust rests on.
 - The builder-side twin of this principle is `AGENTS.md :: Proportional delivery` (right-size
   default); this principle governs product architecture, that one governs how we build.
+
+### 11. Shared Visual Language
+
+- Every new or revised human-facing visual component, whether it belongs to a Product surface or a
+  Builder surface, must use the canonical **Yggdrasil Design System**.
+- `companion-ui/companion-app/colors_and_type.css` is the repository's binding token source for
+  governed design handoffs. The matching live design system must pass the
+  `.codex/skills/yggdrasil-design-handoff/SKILL.md` parity gate before external design generation.
+- Existing Yggdrasil primitives should be reused before a new primitive, token, or visual idiom is
+  proposed. A necessary extension is an explicit design-system proposal, not a silent local
+  invention.
+- This principle governs visual language only. A component's behavior, authority, persistence, and
+  shipped-state truth remain with its local owner contracts.
+- This is a rule for new and revised work; it does not claim that every historical surface already
+  conforms.
 
 ## Documentation Design Principles
 

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -183,6 +183,9 @@ Use this lane only when:
   - `scripts/validate_source_anchors.py`
   - `scripts/validate_issue_readiness.py`
   - `scripts/lint_skills_consistency.py`
+  - `companion-ui/design_handoff/README.md`
+  - `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`
+  - `companion-ui/prompts/claude-design/**`
   - `companion-ui/prompts/codex/deliver-epic-autonomous-runner.md`
   - `tests/ops/test_git_hygiene.py`
   - `tests/architecture/test_agent_skill_entrypoints.py`

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -58,6 +58,62 @@ def test_repo_skill_index_describes_connected_workflow_paths() -> None:
     assert "agentic-pkm -> issue-to-code -> publish-pr -> [pr-integration when repair/readiness is needed] -> verification-and-closure" in text
 
 
+def test_yggdrasil_design_handoff_is_routed_and_fail_closed() -> None:
+    agents = _read("AGENTS.md")
+    index = _read(".codex/skills/README.md")
+    skill = _read(".codex/skills/yggdrasil-design-handoff/SKILL.md")
+    principles = _read("docs/DESIGN_PRINCIPLES.md")
+    governance = _read("companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md")
+    prompts = _read("companion-ui/prompts/claude-design/README.md")
+    epic_runner = _read(
+        "companion-ui/prompts/codex/deliver-epic-autonomous-runner.md"
+    )
+    template = _read(
+        "companion-ui/prompts/claude-design/YGGDRASIL_HANDOFF_TEMPLATE.md"
+    )
+
+    skill_path = ".codex/skills/yggdrasil-design-handoff/SKILL.md"
+    token_path = "companion-ui/companion-app/colors_and_type.css"
+    design_system_name = "Yggdrasil Design System"
+    principles_flat = " ".join(principles.split())
+
+    assert skill_path in agents
+    assert "yggdrasil-design-handoff" in index
+    assert (
+        "yggdrasil-design-handoff -> governed exploration/handoff"
+        in index
+    )
+    assert "other surface: local owner doc/spec" in index
+
+    for surface in (skill, principles, governance, prompts, template):
+        assert design_system_name in surface
+        assert token_path in surface
+
+    for required_gate in (
+        "mcp__claude-design__list_design_systems",
+        "f2b13410-af14-4875-8029-445352123f57",
+        "They must match byte for byte",
+        "No successful gate means no design generation",
+    ):
+        assert required_gate in skill
+
+    assert "failed or ambiguous gate blocks generation and Crossing B" in governance
+    assert "Do not let Claude Design use its generic" in prompts
+    assert "Visual resemblance alone is not compliance" in template
+    assert ".codex/skills/yggdrasil-design-handoff/SKILL.md" in epic_runner
+    assert "YGGDRASIL_HANDOFF_TEMPLATE.md" in epic_runner
+    assert "For another Product or Builder surface" in epic_runner
+    assert (
+        "whether it belongs to a Product surface or a Builder surface"
+        in principles_flat
+    )
+    assert (
+        "it does not claim that every historical surface already conforms"
+        in principles_flat
+    )
+    assert "For other Product or Builder surfaces" in skill
+
+
 def test_issue_to_code_preflight_captures_expected_branch_and_worktree() -> None:
     text = _read(".codex/skills/issue-to-code/SKILL.md")
     section = _section_between(

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -1143,6 +1143,16 @@ def test_autonomous_runner_prompt_is_governance_lane_allowed() -> None:
     assert '"companion-ui/prompts/codex/deliver-epic-autonomous-runner.md"' not in prefixes
 
 
+def test_yggdrasil_design_handoff_surfaces_are_governance_lane_allowed() -> None:
+    text = _read_workflow()
+    exact = text.split("const governanceAllowedExact = new Set([", 1)[1].split("]);", 1)[0]
+    prefixes = text.split("const governanceAllowedPrefixes = [", 1)[1].split("];", 1)[0]
+
+    assert '"companion-ui/design_handoff/README.md"' in exact
+    assert '"companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md"' in exact
+    assert '"companion-ui/prompts/claude-design/"' in prefixes
+
+
 def test_governance_lane_companion_prompt_surface_matches_owner_doc() -> None:
     workflow = _read_development_workflow()
     governance_lane = workflow.split("## Governance lane", 1)[1].split(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Companion UI design-handoff governance; CKM BuilderOps presentation workflow
- Write class: governance
- Authority impact: Builder workflow only; no Product or Runtime authority change
- Persistence impact: Repository governance files only
- Derived/rebuildable impact: None
- Human knowledge impact: None
- Memory impact: None
- Retrieval/context impact: None
- Sync/deployment impact: None
- External boundary impact: Claude Design handoff preflight
- New or changed contract: Fail-closed Yggdrasil selection and token-parity gate
- Owner-doc impact: Updated Design Principles, Development Workflow, and Companion UI handoff governance
- Transition debt impact: None
- Fitness rule impact: Added focused architecture and PR-governance tests
- Boundary risk: Low; governance only

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make the Yggdrasil Design System mandatory for every new or revised Product and Builder visual component.
- Add a fail-closed Claude Design preflight, reusable prompt binding, epic-runner routing, and focused governance coverage.
- Align the governance-lane allowlist with the narrow Claude Design governance surfaces it documents.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed.

## Notes
Validation on 8dd64f7a: quick_validate; lint_skills_consistency.py; docs_guard.py; architecture and issue/PR governance tests (106 passed); independent Terra/high skill forward-test.
