### PR TITLE
Paginate verification artifact discovery

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -650,7 +650,7 @@ class GhCliVerificationSource:
                     and (
                         not isinstance(total_count, int)
                         or isinstance(total_count, bool)
-                        or total_count < len(rows)
+                        or total_count < len(rows) + len(artifacts)
                     )
                 )
             ):
@@ -658,9 +658,11 @@ class GhCliVerificationSource:
             rows.extend(artifacts)
             if len(rows) > _MAX_ARTIFACT_LISTING_ROWS:
                 raise RuntimeError("GitHub artifact listing exceeds bounded scan")
-            if len(artifacts) < 100 or (
-                isinstance(total_count, int) and total_count <= len(rows)
-            ):
+            if isinstance(total_count, int) and total_count <= len(rows):
+                return rows
+            if len(artifacts) < 100:
+                if isinstance(total_count, int) and total_count > len(rows):
+                    raise RuntimeError("GitHub artifact listing is incomplete")
                 return rows
         raise RuntimeError("GitHub artifact listing exceeds bounded scan")
 

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -317,6 +317,7 @@ class TaggedProcessTreeCleanup:
 _MAX_ARTIFACT_COMPRESSED_BYTES = 2_000_000
 _MAX_ARTIFACT_MEMBERS = 16
 _MAX_ARTIFACT_UNCOMPRESSED_BYTES = 2_000_000
+_MAX_ARTIFACT_LISTING_ROWS = 1_000
 _MAX_REQUEST_BYTES = 1_000_000
 _MAX_CLOSURE_CANDIDATES = 20
 _MAX_REPOSITORY_CLOSURE_EVENTS = 500
@@ -632,6 +633,37 @@ class GhCliVerificationSource:
                 return rows
         raise RuntimeError("GitHub paginated response exceeds bounded scan")
 
+    def _artifact_listing_pages(self, endpoint: str) -> list[object]:
+        """Return a bounded, complete artifact listing or fail before it truncates."""
+
+        rows: list[object] = []
+        separator = "&" if "?" in endpoint else "?"
+        for page in range(1, (_MAX_ARTIFACT_LISTING_ROWS // 100) + 1):
+            page_endpoint = endpoint if page == 1 else f"{endpoint}{separator}page={page}"
+            payload = self._json(page_endpoint)
+            artifacts = payload.get("artifacts") if isinstance(payload, Mapping) else None
+            total_count = payload.get("total_count") if isinstance(payload, Mapping) else None
+            if (
+                not isinstance(artifacts, list)
+                or (
+                    total_count is not None
+                    and (
+                        not isinstance(total_count, int)
+                        or isinstance(total_count, bool)
+                        or total_count < len(rows)
+                    )
+                )
+            ):
+                raise RuntimeError("malformed GitHub artifact listing")
+            rows.extend(artifacts)
+            if len(rows) > _MAX_ARTIFACT_LISTING_ROWS:
+                raise RuntimeError("GitHub artifact listing exceeds bounded scan")
+            if len(artifacts) < 100 or (
+                isinstance(total_count, int) and total_count <= len(rows)
+            ):
+                return rows
+        raise RuntimeError("GitHub artifact listing exceeds bounded scan")
+
     def _artifact_bytes(self, endpoint: str, artifact_id: int) -> bytes:
         if self.runner is not subprocess.run:
             result = self.runner(
@@ -927,12 +959,12 @@ class GhCliVerificationSource:
     ) -> list[dict[str, object]]:
         if limit <= 0:
             raise ValueError("artifact request limit must be positive")
-        payload = self._json(f"repos/{repository}/actions/artifacts?per_page=100")
-        if not isinstance(payload, Mapping) or not isinstance(payload.get("artifacts"), list):
-            raise RuntimeError("malformed GitHub artifact listing")
+        artifacts = self._artifact_listing_pages(
+            f"repos/{repository}/actions/artifacts?per_page=100"
+        )
         requests: list[dict[str, object]] = []
         first_rejection: _InvalidVerificationArtifact | None = None
-        for artifact in payload["artifacts"]:
+        for artifact in artifacts:
             if len(requests) >= limit:
                 break
             if not isinstance(artifact, Mapping):

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3544,6 +3544,20 @@ def test_pending_requests_distinguishes_truncated_scan_from_empty_result(
         source.pending_requests(REPO)
 
 
+def test_pending_requests_rejects_short_page_that_contradicts_total_count() -> None:
+    source = GhCliVerificationSource()
+    endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {"total_count": 101, "artifacts": []}
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page: {requested_endpoint}")
+    )
+
+    with pytest.raises(RuntimeError, match="artifact listing is incomplete"):
+        source.pending_requests(REPO)
+
+
 def test_pending_request_rejects_oversized_archive_before_buffering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3458,6 +3458,92 @@ def _artifact_source_for_request(payload: dict[str, object], *, workflow_run_id:
     return GhCliVerificationSource(runner=runner), calls
 
 
+def test_pending_requests_discovers_request_beyond_first_artifact_page() -> None:
+    source = GhCliVerificationSource()
+    endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
+    calls: list[str] = []
+
+    def read_artifacts(requested_endpoint: str) -> object:
+        calls.append(requested_endpoint)
+        if requested_endpoint == endpoint:
+            return {
+                "total_count": 101,
+                "artifacts": [{"id": index, "name": "unrelated"} for index in range(100)],
+            }
+        if requested_endpoint == f"{endpoint}&page=2":
+            return {"total_count": 101, "artifacts": [{"id": 101, "name": "request"}]}
+        raise AssertionError(requested_endpoint)
+
+    source._json = read_artifacts  # type: ignore[method-assign]
+    source._request_from_artifact = (  # type: ignore[method-assign]
+        lambda _repository, artifact: {"artifact_id": artifact["id"]}
+        if artifact.get("name") == "request"
+        else None
+    )
+
+    assert source.pending_requests(REPO) == [{"artifact_id": 101}]
+    assert calls == [endpoint, f"{endpoint}&page=2"]
+
+
+def test_pending_requests_ignores_unrelated_artifacts_when_filling_limit() -> None:
+    source = GhCliVerificationSource()
+    endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
+
+    def read_artifacts(requested_endpoint: str) -> object:
+        if requested_endpoint == endpoint:
+            return {
+                "total_count": 102,
+                "artifacts": [{"id": index, "name": "unrelated"} for index in range(100)],
+            }
+        if requested_endpoint == f"{endpoint}&page=2":
+            return {
+                "total_count": 102,
+                "artifacts": [
+                    {"id": 101, "name": "request"},
+                    {"id": 102, "name": "request"},
+                ],
+            }
+        raise AssertionError(requested_endpoint)
+
+    source._json = read_artifacts  # type: ignore[method-assign]
+    source._request_from_artifact = (  # type: ignore[method-assign]
+        lambda _repository, artifact: {"artifact_id": artifact["id"]}
+        if artifact.get("name") == "request"
+        else None
+    )
+
+    assert source.pending_requests(REPO, limit=2) == [
+        {"artifact_id": 101},
+        {"artifact_id": 102},
+    ]
+
+
+def test_pending_requests_distinguishes_truncated_scan_from_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = GhCliVerificationSource()
+    endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
+    monkeypatch.setattr(verification_consumer, "_MAX_ARTIFACT_LISTING_ROWS", 100)
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {"total_count": 0, "artifacts": []}
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page for empty listing: {requested_endpoint}")
+    )
+    assert source.pending_requests(REPO) == []
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {
+            "total_count": 101,
+            "artifacts": [{"id": index, "name": "unrelated"} for index in range(100)],
+        }
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page beyond bounded scan: {requested_endpoint}")
+    )
+    with pytest.raises(RuntimeError, match="artifact listing exceeds bounded scan"):
+        source.pending_requests(REPO)
+
+
 def test_pending_request_rejects_oversized_archive_before_buffering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #4232

Fixes #4232

Final-Review-Rounds: 0

## SBS Impact
- Primary subsystem: Builder System (verification dispatch / delivery orchestration)
- Secondary subsystem(s): none
- Write class: mechanical
- Authority impact: none; caller-side live-head eligibility remains authoritative.
- Persistence impact: none
- Derived/rebuildable impact: bounded request discovery now fails loudly rather than silently truncating.
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: up to 10 bounded GitHub REST artifact-list reads per poll.
- New or changed contract: none; `pending_requests` signature and request-return limit semantics are preserved.
- Owner-doc impact: none
- Transition debt impact: no effect
- Fitness rule impact: removes the fail-silent artifact-listing window.
- Boundary risk: bounded scans raise instead of being reported as no work; live-head filtering remains in the caller.

## Owner-Doc Writeback
- [x] No owner-doc change implied.

## Summary
- Paginate bounded verification-dispatch artifact discovery so requests beyond the first artifact page remain discoverable.
- Reject a short artifact page when its `total_count` proves the listing is incomplete, so it cannot be reported as no work.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue, claimant receipt, PR, and validation results are the durable implementation and lifecycle records; no divergence occurred.

## Notes
Validation on `4d571436522aaf27fdc13431232e61a9fb75807b`: AC-focused tests (4 passed); `tests/dispatcher/test_verification_consumer.py` (262 passed); `ruff check app tests`; `mypy app`; `git diff --check`; host-leased `pytest -q -m \"not pg\" -p no:cacheprovider` (11,278 passed, 41 skipped, 275 deselected, 18 xfailed).

`python3 scripts/docs_guard.py` was run and returned non-zero because this two-file `app/**`/test repair has no docs/contracts/settings diff. The governing Issue explicitly records `Owner-doc impact: none`, and repair ownership excludes docs; no bypass or unrelated doc change was made.

No deployment or host confirmation was performed or claimed; the issue's post-merge host observation remains out of scope.