### PR TITLE
Canonicalize check-run evidence identity

### DIFF
--- a/app/builderops/delivery_orchestration_contracts.py
+++ b/app/builderops/delivery_orchestration_contracts.py
@@ -82,6 +82,10 @@ GitSha = Annotated[
     str,
     StringConstraints(pattern=r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$"),
 ]
+GitHubCheckRunId = Annotated[
+    str,
+    StringConstraints(pattern=r"^[1-9][0-9]*$"),
+]
 UtcTimestamp = Annotated[str, AfterValidator(_validate_utc_timestamp)]
 PositiveInt = Annotated[int, Field(gt=0)]
 NonNegativeInt = Annotated[int, Field(ge=0)]
@@ -1101,7 +1105,9 @@ def resolve_current_authority(
     observed authority change bound to the same run and plan - move the current
     state forward. When no such prior event is supplied the plan input remains
     the resolved state, so resolution can never accept an unproven authority
-    claim.
+    claim. Equal event sequences are resolved by the canonical JSON form of
+    their authority snapshot, making the pure resolver independent of tuple
+    order until the reducer log establishes sequence uniqueness.
     """
 
     advancing = [
@@ -1116,7 +1122,10 @@ def resolve_current_authority(
     ]
     if not advancing:
         return planned_authority
-    resolved = max(advancing, key=lambda item: item.sequence).subject_authority
+    resolved = max(
+        advancing,
+        key=lambda item: (item.sequence, canonical_json(item.subject_authority)),
+    ).subject_authority
     assert resolved is not None
     return resolved
 
@@ -1630,6 +1639,9 @@ def validate_reducer_effect_evidence(
         and causal_event.result_ref.schema_version == REVIEW_RESULT_VERSION
         else None
     )
+    prior_events_before_causal = tuple(
+        item for item in prior_events if item.sequence < causal_event.sequence
+    )
     validate_reducer_event_evidence(
         causal_event,
         plan=plan,
@@ -1637,9 +1649,7 @@ def validate_reducer_effect_evidence(
         worker_result=causal_worker,
         review_result=causal_review,
         prior_effects=prior_effects,
-        prior_events=tuple(
-            item for item in prior_events if item.sequence < causal_event.sequence
-        ),
+        prior_events=prior_events_before_causal,
         worker_results=worker_results,
         review_results=review_results,
     )
@@ -1725,8 +1735,8 @@ def validate_reducer_effect_evidence(
             planned_authority=planned_authorities[0],
             run_id=effect.run_id,
             plan_ref=effect.plan_ref,
-            before_sequence=effect.causal_event.sequence + 1,
-            prior_events=prior_events,
+            before_sequence=effect.causal_event.sequence,
+            prior_events=prior_events_before_causal,
         )
     else:
         current_authority = causal_subject
@@ -1947,7 +1957,7 @@ def validate_reducer_event_evidence(
 class CheckEvidence(_StrictFrozenModel):
     check_name: NonEmptyStr
     repository: RepositoryId
-    check_run_id: NonEmptyStr
+    check_run_id: GitHubCheckRunId
     authority_id: NonEmptyStr
     pull_request_number: PositiveInt
     status: Literal["passed", "failed", "skipped"]

--- a/tests/builderops/test_delivery_orchestration_contracts.py
+++ b/tests/builderops/test_delivery_orchestration_contracts.py
@@ -47,6 +47,7 @@ from app.builderops.delivery_orchestration_contracts import (
     delivery_effect_input_hash,
     delivery_initiation_approval_hash,
     parse_delivery_contract,
+    resolve_current_authority,
     validate_delivery_plan_evidence,
     validate_delivery_receipt_evidence,
     validate_reducer_effect_evidence,
@@ -1637,6 +1638,101 @@ def test_contracts_round_trip_canonically() -> None:
     invalid_timestamp["provenance"]["created_at"] = "2026-99-99T99:99:99Z"
     with pytest.raises(ValidationError, match="real UTC calendar"):
         parse_delivery_contract(invalid_timestamp)
+
+
+def test_check_run_id_uses_canonical_github_identity() -> None:
+    issue = _issue(4165, SHA_A)
+    initiation = _initiation(issue)
+    plan = _plan(issue, initiation)
+    receipt = _receipt(
+        issue,
+        initiation,
+        plan,
+        _worker_result(issue, plan),
+        _review_result(issue, plan),
+    )
+    evidence = receipt.issue_proofs[0].check_evidence[0]
+
+    for check_run_id in ("09001", "not-a-run"):
+        evidence_payload = evidence.model_dump(mode="json")
+        evidence_payload["check_run_id"] = check_run_id
+        evidence_payload["authority_id"] = (
+            f"github:{issue.repository}/check-runs/{check_run_id}"
+        )
+        with pytest.raises(ValidationError, match="pattern"):
+            CheckEvidence.model_validate(evidence_payload)
+
+        receipt_payload = receipt.model_dump(mode="json")
+        receipt_payload["issue_proofs"][0]["check_evidence"][0].update(
+            evidence_payload
+        )
+        with pytest.raises(ValidationError, match="pattern"):
+            parse_delivery_contract(receipt_payload)
+
+
+def test_current_authority_resolution_is_order_independent() -> None:
+    issue = _issue(4165, SHA_A)
+    plan = _plan(issue, _initiation(issue))
+    plan_ref = ContractRef(
+        schema_version=plan.schema_version,
+        contract_id=plan.plan_id,
+        content_hash=plan.content_hash,
+    )
+    first_authority = _authority(
+        issue,
+        labels=("agent:in-progress", "type:task"),
+    )
+    second_authority = _authority(issue, labels=("type:task",))
+
+    def authority_changed_event(
+        subject: AuthoritySnapshot,
+        correlation_id: str,
+    ) -> ReducerEvent:
+        input_hash = delivery_event_input_hash(
+            run_id="run-4165",
+            plan_ref=plan_ref,
+            sequence=1,
+            event_type="authority_changed",
+            subject_authority=subject,
+            effect_ref=None,
+            result_ref=None,
+            exception=None,
+        )
+        return ReducerEvent(
+            event_id=delivery_event_id(input_hash),
+            input_hash=input_hash,
+            run_id="run-4165",
+            plan_ref=plan_ref,
+            sequence=1,
+            event_type="authority_changed",
+            subject_authority=subject,
+            effect_ref=None,
+            result_ref=None,
+            exception=None,
+            provenance=_provenance(correlation_id),
+        )
+
+    first_event = authority_changed_event(first_authority, "same-sequence-first")
+    second_event = authority_changed_event(second_authority, "same-sequence-second")
+    resolved = resolve_current_authority(
+        authority_id=issue.authority_id,
+        planned_authority=_authority(issue),
+        run_id="run-4165",
+        plan_ref=plan_ref,
+        before_sequence=2,
+        prior_events=(first_event, second_event),
+    )
+    reordered = resolve_current_authority(
+        authority_id=issue.authority_id,
+        planned_authority=_authority(issue),
+        run_id="run-4165",
+        plan_ref=plan_ref,
+        before_sequence=2,
+        prior_events=(second_event, first_event),
+    )
+
+    assert resolved == reordered
+    assert resolved == second_authority
 
 
 def test_claim_recovery_requires_ready_to_absent_transition() -> None:


### PR DESCRIPTION
Governing-Issue: #4213

Fixes #4213

Final-Review-Rounds: 1

## Summary
Constrain delivery receipt check-run IDs to canonical positive numeric GitHub identities and make equal reducer event sequences resolve by canonical authority order. The shared pre-causal event cutoff now expresses the causal sequence bound once.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded Builder System contract correction produces no BuilderOps operational material; the governing Issue, tests, PR, CI, and review provide the delivery evidence.

## Notes
- Lane: implementation (Builder System delivery orchestration contracts; no Product/Runtime or external-boundary change).
- Owner-doc writeback: none; the target-state owner specification already describes the contract module and this correction does not change accepted shipped-current-state claims.
- Validation: `python3 -m pytest tests/builderops/test_delivery_orchestration_contracts.py tests/architecture/test_sbs_fitness_rules.py` (14 passed); `ruff check app tests`; `mypy app`; `git diff --check`.
- Independent review: Sol/high accepted SHA `a457d0412dc203f9a320f50069bd1ec83ce08c38` with no findings.