### PR TITLE
fix: fail loud for explicit unservable embedding providers

### DIFF
--- a/app/components/embeddings/legacy.py
+++ b/app/components/embeddings/legacy.py
@@ -14,11 +14,17 @@ from typing import Iterable, Iterator, Protocol, Sequence
 
 from app.embedding_config import get_embed_dim
 from app.index import embeddings as _index_embeddings
-from app.llm.embeddings import EMBED_MODEL, get_embed_model, get_embedding_provider, get_primary_provider
+from app.llm.embeddings import (
+    EMBED_MODEL,
+    PROVIDER_REGISTRY,
+    get_embed_model,
+    get_embedding_provider,
+    get_primary_provider,
+)
 from app.settings.runtime import get_settings_bundle
 
 _MOCK_EMBED_MODEL = "mock-embedding"
-_SUPPORTED_EMBED_PROVIDERS = {"mock", "ollama", "openai", "deepseek", "deterministic", "gemini"}
+_CLIENT_LEVEL_EMBED_PROVIDERS = frozenset({"deterministic"})
 
 
 class EmbeddingClientProtocol(Protocol):
@@ -130,7 +136,17 @@ def _normalize_name(value: str | None) -> str | None:
     return value or None
 
 
-def _resolve_embedding_provider_name(value: str | None) -> str:
+def _supported_embed_providers() -> frozenset[str]:
+    """Return provider names executable by an adapter or client short-circuit."""
+
+    return frozenset(PROVIDER_REGISTRY) | _CLIENT_LEVEL_EMBED_PROVIDERS
+
+
+def _resolve_embedding_provider_name(
+    value: str | None,
+    *,
+    provider_source: str,
+) -> str:
     normalized = (_normalize_name(value) or "").lower()
     if normalized == "llm":
         return "ollama"
@@ -138,9 +154,15 @@ def _resolve_embedding_provider_name(value: str | None) -> str:
         return "mock"
     if not normalized:
         return "mock"
-    if normalized not in _SUPPORTED_EMBED_PROVIDERS:
+    if normalized in _supported_embed_providers():
+        return normalized
+    if provider_source == "LLM_PROVIDER":
         return "mock"
-    return normalized
+    servable = ", ".join(sorted(_supported_embed_providers()))
+    raise ValueError(
+        f"Embedding provider {normalized!r} from {provider_source} is not servable; "
+        f"servable providers: {servable}"
+    )
 
 
 def _resolve_embedding_model(provider: str, override_model: str | None, configured_model: str | None = None) -> str:
@@ -233,14 +255,28 @@ def resolve_embedding_identity(
         # profile.provider default ("mock"), otherwise EMBED_PRIMARY_PROVIDER is inert for
         # profiled clients (Codex P2). When the env is unset, profile fields are honored as
         # before (no regression).
-        env_primary = os.getenv("EMBED_PRIMARY_PROVIDER", "").strip().lower() or None
-        profile_provider = (
-            env_primary
-            or getattr(cfg, "primary_provider", None)
-            or cfg.provider
-            or get_embedding_provider()
+        env_primary = _normalize_name(os.getenv("EMBED_PRIMARY_PROVIDER"))
+        profile_primary = _normalize_name(getattr(cfg, "primary_provider", None))
+        profile_provider = _normalize_name(cfg.provider)
+        if override_provider:
+            provider_value = override_provider
+            provider_source = "override_provider"
+        elif env_primary:
+            provider_value = env_primary
+            provider_source = "EMBED_PRIMARY_PROVIDER"
+        elif profile_primary:
+            provider_value = profile_primary
+            provider_source = "profile.primary_provider"
+        elif profile_provider:
+            provider_value = profile_provider
+            provider_source = "profile.provider"
+        else:
+            provider_value = get_embedding_provider()
+            provider_source = "LLM_PROVIDER"
+        provider = _resolve_embedding_provider_name(
+            provider_value,
+            provider_source=provider_source,
         )
-        provider = _resolve_embedding_provider_name(override_provider or profile_provider)
         model = _resolve_embedding_model(provider, override_model, cfg.model)
         dim = cfg.dim or get_embed_dim()
         normalize = cfg.normalize if cfg.normalize is not None else True
@@ -248,7 +284,20 @@ def resolve_embedding_identity(
         return EmbeddingIdentity(provider=provider, model=model, dim=dim, normalize=normalize, no_prefix=no_prefix)
 
     # No profile matched: honor EMBED_PRIMARY_PROVIDER (env) > LLM_PROVIDER (Codex P2).
-    provider = _resolve_embedding_provider_name(override_provider or get_primary_provider())
+    env_primary = _normalize_name(os.getenv("EMBED_PRIMARY_PROVIDER"))
+    if override_provider:
+        provider_value = override_provider
+        provider_source = "override_provider"
+    elif env_primary:
+        provider_value = get_primary_provider()
+        provider_source = "EMBED_PRIMARY_PROVIDER"
+    else:
+        provider_value = get_primary_provider()
+        provider_source = "LLM_PROVIDER"
+    provider = _resolve_embedding_provider_name(
+        provider_value,
+        provider_source=provider_source,
+    )
     model = _resolve_embedding_model(provider, override_model)
     dim = get_embed_dim()
     return EmbeddingIdentity(provider=provider, model=model, dim=dim, normalize=True)

--- a/app/components/embeddings/legacy.py
+++ b/app/components/embeddings/legacy.py
@@ -165,6 +165,51 @@ def _resolve_embedding_provider_name(
     )
 
 
+def validate_explicit_embedding_provider_configuration() -> list[tuple[str, str]]:
+    """Return preflight errors for configured embedding-provider sources.
+
+    ``LLM_PROVIDER`` is deliberately excluded: it is chat-provider spillover and
+    retains the compatible mock fallback. Every embedding-specific source must
+    instead fail before a channel is declared healthy.
+    """
+
+    errors: list[tuple[str, str]] = []
+
+    def validate(value: str | None, source: str, ref: str) -> None:
+        if _normalize_name(value) is None:
+            return
+        try:
+            _resolve_embedding_provider_name(value, provider_source=source)
+        except ValueError as exc:
+            errors.append((ref, str(exc)))
+
+    validate(
+        os.getenv("EMBED_PRIMARY_PROVIDER"),
+        "EMBED_PRIMARY_PROVIDER",
+        "EMBED_PRIMARY_PROVIDER",
+    )
+
+    try:
+        profiles = get_settings_bundle().embedding_profiles
+    except Exception:
+        return errors
+
+    for profile_name, profile in profiles.profiles.items():
+        prefix = f"embedding_profiles:{profile_name}"
+        validate(
+            getattr(profile, "primary_provider", None),
+            "profile.primary_provider",
+            f"{prefix}.primary_provider",
+        )
+        validate(
+            getattr(profile, "provider", None),
+            "profile.provider",
+            f"{prefix}.provider",
+        )
+
+    return errors
+
+
 def _resolve_embedding_model(provider: str, override_model: str | None, configured_model: str | None = None) -> str:
     if provider == "mock":
         return _MOCK_EMBED_MODEL

--- a/app/settings/validate.py
+++ b/app/settings/validate.py
@@ -20,6 +20,7 @@ from app.components.settings.graphs_loader import load_graphs
 from app.components.settings.models_loader import load_models
 from app.components.settings.events_loader import load_events
 from app.components.settings.panel_actions_loader import DEFAULT_PANEL_ACTIONS_PATH
+from app.components.embeddings.legacy import validate_explicit_embedding_provider_configuration
 from app.index.ingest_md import parse_markdown
 from app.settings.panel_actions import resolve_panel_actions_root
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
@@ -231,6 +232,17 @@ def _validate_compiled_runtime_settings() -> list[ValidationIssue]:
     return issues
 
 
+def _validate_embedding_provider_configuration() -> list[ValidationIssue]:
+    return [
+        ValidationIssue(
+            code="embedding_provider.unservable",
+            message=message,
+            ref=ref,
+        )
+        for ref, message in validate_explicit_embedding_provider_configuration()
+    ]
+
+
 def validate_settings() -> List[ValidationIssue]:
     issues: List[ValidationIssue] = []
 
@@ -370,6 +382,7 @@ def validate_settings() -> List[ValidationIssue]:
                 )
             )
     issues.extend(_validate_compiled_runtime_settings())
+    issues.extend(_validate_embedding_provider_configuration())
     return issues
 
 

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -198,6 +198,10 @@ posture of resolving to `mock` instead of creating a new ingest/query outage. Em
 or unset provider input still defaults to `mock`, and the `llm` → `ollama` and
 `fake` → `mock` aliases remain supported. Accepted names are derived from the live
 adapter registry plus `deterministic`; no separate provider-name allowlist exists.
+`python -m app.cli settings-validate` is the channel/deployment preflight for this
+posture: it rejects unservable `EMBED_PRIMARY_PROVIDER` values and every explicit
+embedding-profile `primary_provider` or `provider` before a channel can be reported
+healthy. It intentionally does not reject an unservable `LLM_PROVIDER` spillover.
 
 **Requested identity vs written identity.** `index.embedding.requested` carries the identity the
 producer *asked for*, resolved through the same `get_embeddings_client` / `get_embedding_identity`

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -185,6 +185,20 @@ This identity must be:
 - recorded with the vector index metadata / provenance,
 - attached to emitted indexing events.
 
+**Provider-name resolution posture.** Provider precedence remains
+`override_provider` → `EMBED_PRIMARY_PROVIDER` → embedding-profile
+`primary_provider` → embedding-profile `provider` → `LLM_PROVIDER`. The first four
+sources are authoritative embedding configuration: a non-empty name that cannot be
+served by the live `PROVIDER_REGISTRY` (or by the client-level `deterministic`
+short-circuit) fails identity resolution before adapter dispatch or vector-index
+writes, with the rejected name and servable set in the error. The final
+`LLM_PROVIDER` source is chat-provider spillover, not an embedding-specific
+configuration statement; an unservable chat-only name retains the compatibility
+posture of resolving to `mock` instead of creating a new ingest/query outage. Empty
+or unset provider input still defaults to `mock`, and the `llm` → `ollama` and
+`fake` → `mock` aliases remain supported. Accepted names are derived from the live
+adapter registry plus `deterministic`; no separate provider-name allowlist exists.
+
 **Requested identity vs written identity.** `index.embedding.requested` carries the identity the
 producer *asked for*, resolved through the same `get_embeddings_client` / `get_embedding_identity`
 pair the indexer uses when it consumes the event, so the two cannot disagree about what was

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -339,6 +339,13 @@ health_gate() {
   wait_json_ok "http://127.0.0.1:${ui_port}/healthz" || return 1
 }
 
+embedding_provider_preflight_gate() {
+  # Explicit embedding sources are authoritative.  Validate them in the
+  # recreated API before the channel health gate can report this deployment
+  # healthy; LLM_PROVIDER spillover intentionally remains tolerant.
+  compose exec -T api python -m app.cli settings validate --json
+}
+
 recreate_channel_services() {
   local rc=0
   if [ "${action}" = "deploy" ] && [ "${ack_embedding_rebuild_required}" = "1" ]; then
@@ -786,6 +793,8 @@ run_postmutation_gate "migration execution failed" apply_changed_migrations || e
 run_postmutation_gate "service recreate/liveness gate failed" \
   recreate_channel_services || exit $?
 rollback_target_recreated=1
+run_postmutation_gate "embedding provider configuration preflight failed" \
+  embedding_provider_preflight_gate || exit $?
 run_postmutation_gate "health gate failed" health_gate || exit $?
 run_postmutation_gate "version gate failed" version_gate || exit $?
 run_postmutation_gate "fleet-model fitness gate failed" \

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -2171,7 +2171,11 @@ index_doctor_status="skipped"
 index_issue_count=0
 
 auto_bootstrap="${AUTO_BOOTSTRAP:-0}"
-if [ "${VERIFY_ACTIVE:-0}" -eq 1 ] && [ "$auto_bootstrap" -eq 1 ]; then
+# Explicit embedding-provider configuration must be rejected before this
+# startup path can report a vault-backed runtime healthy.  This is independent
+# of whether an index rebuild was requested, so it cannot be gated on
+# AUTO_BOOTSTRAP or VERIFY_ACTIVE.
+if [ "$NO_VAULT_MODE" -ne 1 ]; then
   set +e
   settings_validate_json=$(run_docker_compose exec -T api python -m app.cli settings validate --json)
   settings_validate_status=$?

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -283,6 +283,27 @@ def _run_deploy(
     )
 
 
+def test_deploy_channel_preflights_embedding_provider_before_health_gate() -> None:
+    script = (REPO_ROOT / "scripts/deploy_channel.sh").read_text(encoding="utf-8")
+    preflight = 'run_postmutation_gate "embedding provider configuration preflight failed"'
+    assert preflight in script
+    assert "embedding_provider_preflight_gate()" in script
+    assert "compose exec -T api python -m app.cli settings validate --json" in script
+    assert script.index(preflight) < script.index('run_postmutation_gate "health gate failed"')
+
+
+def test_deploy_channel_rolls_back_when_embedding_provider_preflight_fails(
+    tmp_path: Path,
+) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    env["FAKE_DOCKER_FAIL_MATCH"] = "exec -T api python -m app.cli settings validate --json"
+
+    result = _run_deploy(root, env, sha)
+
+    assert result.returncode == 24
+    assert "embedding provider configuration preflight failed" in result.stderr
+
+
 def _wait_for_path_or_process_exit(
     process: subprocess.Popen[str],
     path: Path,

--- a/tests/llm/test_provider_registry.py
+++ b/tests/llm/test_provider_registry.py
@@ -134,14 +134,20 @@ def test_primary_fallback_selection_precedence(monkeypatch) -> None:
 
 
 def test_gemini_name_supported() -> None:
-    """'gemini' is in _SUPPORTED_EMBED_PROVIDERS so it is not normalized to 'mock'."""
+    """'gemini' is registered, so embedding resolution preserves it."""
     from app.components.embeddings.legacy import (
-        _SUPPORTED_EMBED_PROVIDERS,
         _resolve_embedding_provider_name,
+        _supported_embed_providers,
     )
 
-    assert "gemini" in _SUPPORTED_EMBED_PROVIDERS
-    assert _resolve_embedding_provider_name("gemini") == "gemini"
+    assert "gemini" in _supported_embed_providers()
+    assert (
+        _resolve_embedding_provider_name(
+            "gemini",
+            provider_source="override_provider",
+        )
+        == "gemini"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -377,10 +383,13 @@ def test_gemini_name_not_normalized_to_mock() -> None:
     """_resolve_embedding_provider_name('gemini') returns 'gemini', not 'mock'."""
     from app.components.embeddings.legacy import _resolve_embedding_provider_name
 
-    result = _resolve_embedding_provider_name("gemini")
+    result = _resolve_embedding_provider_name(
+        "gemini",
+        provider_source="override_provider",
+    )
     assert result == "gemini", (
         f"Expected 'gemini' to pass through but got {result!r} — "
-        "'gemini' must be in _SUPPORTED_EMBED_PROVIDERS"
+        "'gemini' must be in the live provider registry"
     )
 
 
@@ -423,3 +432,166 @@ def test_dim_guardrail_fires_on_ollama_registry_path(monkeypatch) -> None:
         PROVIDER_REGISTRY.clear()
         PROVIDER_REGISTRY.update(original)
         embeddings._embed_single.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Provider-resolution posture (#4191)
+# ---------------------------------------------------------------------------
+
+def test_explicit_unservable_embed_provider_fails_loud(monkeypatch) -> None:
+    """Every embedding-specific configuration source rejects an unservable name."""
+    from unittest.mock import MagicMock
+
+    from app.components.embeddings import resolve_embedding_identity
+    from app.components.embeddings import legacy
+    from app.settings.models import EmbeddingProfile, EmbeddingProfiles
+
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("EMBED_MODEL", "nomic-embed-text:latest")
+    monkeypatch.delenv("EMBED_PRIMARY_PROVIDER", raising=False)
+
+    with pytest.raises(ValueError, match=r"openai.*servable.*gemini.*mock.*ollama"):
+        resolve_embedding_identity(
+            override_provider="openai",
+            use_implicit_profiles=False,
+        )
+
+    monkeypatch.setenv("EMBED_PRIMARY_PROVIDER", "deepseek")
+    with pytest.raises(ValueError, match=r"deepseek.*EMBED_PRIMARY_PROVIDER"):
+        resolve_embedding_identity(use_implicit_profiles=False)
+    monkeypatch.delenv("EMBED_PRIMARY_PROVIDER")
+
+    for field_name in ("primary_provider", "provider"):
+        profile_kwargs = {
+            "provider": "mock",
+            "model": "nomic-embed-text:latest",
+            "dim": 4,
+            field_name: "openai",
+        }
+        profile = EmbeddingProfile(**profile_kwargs)
+        bundle = MagicMock()
+        bundle.embedding_profiles = EmbeddingProfiles(
+            default_profile="default",
+            profiles={"default": profile},
+        )
+        bundle.global_ = MagicMock()
+        bundle.global_.profile = None
+        monkeypatch.setattr(legacy, "get_settings_bundle", lambda: bundle)
+
+        with pytest.raises(ValueError, match=rf"openai.*profile\.{field_name}"):
+            resolve_embedding_identity(
+                profile="default",
+                use_implicit_profiles=False,
+            )
+
+
+def test_chat_provider_spillover_does_not_fail_embedding_resolution(monkeypatch) -> None:
+    """A chat-only LLM_PROVIDER remains tolerant because it is not embed config."""
+    from app.components.embeddings import resolve_embedding_identity
+    from app.components.embeddings import legacy
+    from app.config import llm as llm_config
+
+    monkeypatch.setattr(legacy, "get_settings_bundle", lambda: None)
+    monkeypatch.delenv("EMBED_PRIMARY_PROVIDER", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    monkeypatch.setattr(llm_config, "_ACTIVE_PROVIDER", None)
+
+    identity = resolve_embedding_identity(use_implicit_profiles=False)
+
+    assert identity.provider == "mock"
+    assert identity.model == "mock-embedding"
+
+
+def test_resolved_provider_name_is_always_servable() -> None:
+    """Every non-error resolution result is executable by a live adapter/client."""
+    from app.components.embeddings.legacy import (
+        _resolve_embedding_provider_name,
+        _supported_embed_providers,
+    )
+
+    for candidate in (None, "", "anthropic", "not-a-provider"):
+        resolved = _resolve_embedding_provider_name(
+            candidate,
+            provider_source="LLM_PROVIDER",
+        )
+        assert resolved in _supported_embed_providers()
+
+    for candidate in (*PROVIDER_REGISTRY, "deterministic", "llm", "fake"):
+        resolved = _resolve_embedding_provider_name(
+            candidate,
+            provider_source="override_provider",
+        )
+        assert resolved in _supported_embed_providers()
+
+    with pytest.raises(ValueError, match="not-a-provider"):
+        _resolve_embedding_provider_name(
+            "not-a-provider",
+            provider_source="EMBED_PRIMARY_PROVIDER",
+        )
+
+
+def test_supported_embed_providers_derive_from_registry() -> None:
+    """Registry mutation changes the accepted set without a copied literal edit."""
+    from app.components.embeddings.legacy import _supported_embed_providers
+
+    assert _supported_embed_providers() == frozenset(PROVIDER_REGISTRY) | {
+        "deterministic"
+    }
+    assert "openai" not in _supported_embed_providers()
+    assert "deepseek" not in _supported_embed_providers()
+
+    original = dict(PROVIDER_REGISTRY)
+    try:
+        PROVIDER_REGISTRY["sentinel-live-provider"] = (
+            lambda text, *, model, dim, timeout: tuple(0.0 for _ in range(dim))
+        )
+        assert "sentinel-live-provider" in _supported_embed_providers()
+    finally:
+        PROVIDER_REGISTRY.clear()
+        PROVIDER_REGISTRY.update(original)
+
+
+def test_misconfigured_provider_cannot_silently_write_mock_vectors(
+    monkeypatch,
+) -> None:
+    """The production indexer path fails before adapter dispatch or vector writes."""
+    from app.components.embeddings import legacy
+    from app.services import indexer
+
+    calls = {"embed": 0, "vector_index": 0}
+
+    class _ObjectStore:
+        def get_object(self, _object_id):
+            return None
+
+        def save_object(self, *_args, **_kwargs) -> None:
+            return None
+
+    def _unexpected_embed(*_args, **_kwargs):
+        calls["embed"] += 1
+        raise AssertionError("embedding adapter must not run")
+
+    def _unexpected_vector_index():
+        calls["vector_index"] += 1
+        raise AssertionError("vector index must not be opened")
+
+    monkeypatch.setattr(legacy, "get_settings_bundle", lambda: None)
+    monkeypatch.setattr(indexer, "ObjectStore", _ObjectStore)
+    monkeypatch.setattr(indexer, "embed_with_fallback", _unexpected_embed)
+    monkeypatch.setattr(indexer, "get_vector_index", _unexpected_vector_index)
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("EMBED_PRIMARY_PROVIDER", "openai")
+    monkeypatch.setenv("EMBED_MODEL", "nomic-embed-text:latest")
+
+    with pytest.raises(ValueError, match=r"openai.*EMBED_PRIMARY_PROVIDER"):
+        indexer.handle_ingest_object_created(
+            {
+                "object_id": "00000000-0000-0000-0000-000000004191",
+                "kind": "note",
+                "source_ref": "issue-4191",
+                "content": "must not become a mock vector",
+                "payload": {},
+            }
+        )
+
+    assert calls == {"embed": 0, "vector_index": 0}

--- a/tests/ops/test_start_system_outbox_contract.py
+++ b/tests/ops/test_start_system_outbox_contract.py
@@ -227,6 +227,14 @@ def test_start_full_system_runs_runtime_verification_and_endpoint_probe() -> Non
     assert 'API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18000}"' in script
 
 
+def test_start_full_system_preflights_explicit_embedding_provider_before_health() -> None:
+    script = Path("scripts/start_full_system.sh").read_text(encoding="utf-8")
+    start = script.index('settings_validate_json=$(run_docker_compose exec -T api python -m app.cli settings validate --json)')
+    preflight = script[start - 500 : start + 500]
+    assert 'if [ "$NO_VAULT_MODE" -ne 1 ]; then' in preflight
+    assert 'if [ "${VERIFY_ACTIVE:-0}" -eq 1 ] && [ "$auto_bootstrap" -eq 1 ]; then' not in preflight
+
+
 def test_runtime_scripts_default_test_project_to_tmp_test_runtime_env() -> None:
     for path in (
         "scripts/start_full_system.sh",

--- a/tests/settings/test_validate_settings.py
+++ b/tests/settings/test_validate_settings.py
@@ -41,3 +41,46 @@ def test_validate_settings_flags_missing_secret_in_compiled_runtime(
     issues = validate_settings()
 
     assert any(issue.code == "runtime_settings.missing_secret" for issue in issues)
+
+
+def test_validate_settings_rejects_unservable_explicit_embedding_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EMBED_PRIMARY_PROVIDER", "openai")
+
+    issues = validate_settings()
+
+    assert any(
+        issue.code == "embedding_provider.unservable"
+        and issue.ref == "EMBED_PRIMARY_PROVIDER"
+        and "openai" in issue.message
+        for issue in issues
+    )
+
+
+def test_validate_settings_rejects_unservable_embedding_profile_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from app.components.embeddings import legacy
+    from app.settings.models import EmbeddingProfile, EmbeddingProfiles
+
+    monkeypatch.delenv("EMBED_PRIMARY_PROVIDER", raising=False)
+    profile = EmbeddingProfile(primary_provider="deepseek")
+    bundle = SimpleNamespace(
+        embedding_profiles=EmbeddingProfiles(
+            default_profile="default",
+            profiles={"default": profile},
+        )
+    )
+    monkeypatch.setattr(legacy, "get_settings_bundle", lambda: bundle)
+
+    issues = validate_settings()
+
+    assert any(
+        issue.code == "embedding_provider.unservable"
+        and issue.ref == "embedding_profiles:default.primary_provider"
+        and "deepseek" in issue.message
+        for issue in issues
+    )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4191

## Linked Issue
Fixes #4191

## SBS Impact
- Primary subsystem: EBF — embedding identity/provider resolution
- Secondary subsystem(s): DRI and OEF — retrieval/index provenance and external adapter boundary
- Write class: mechanical runtime resolution with fail-loud operator posture
- Authority impact: no authority-class change; explicit embedding configuration remains operator-owned
- Persistence impact: no schema or durable-authority change; prevents invalid derived vector writes
- Derived/rebuildable impact: protects rebuildable vector indexes from silently mocked vectors
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: preserves semantic retrieval integrity by rejecting false provider identity
- Sync/deployment impact: misconfiguration becomes a pre-write error; read-only channel census found no required mutation
- External boundary impact: only live registered adapters or deterministic can be selected explicitly
- New or changed contract: explicit embedding sources fail loud; chat-only LLM_PROVIDER spillover remains tolerant
- Owner-doc impact: docs/EMBEDDINGS.md Embedding identity updated in this PR
- Transition debt impact: removes the copied provider allowlist and closes the silent-mock posture debt
- Fitness rule impact: strengthens provider-resolution and no-vector-write regression coverage
- Boundary risk: incorrect source classification could either write mock vectors or create chat-only outages; both branches are pinned by tests

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reject explicit unservable embedding-provider names before adapter/vector writes while retaining tolerant LLM_PROVIDER chat spillover.
- Derive servable names from the live provider registry plus deterministic, preserve existing precedence/provenance, and document the posture.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Issue #4191, this PR, and its A/B validation receipts fully capture the bounded work; no separate operational record or authority crossing is needed.

## Notes
## Claim / Coordination Receipt
- Dispatcher task: `github-RasmusTho--agentic-pkm-mvp-issue-4191`
- Lease: `lease-daffc9a4` held by `codex-issue-4191` (dispatcher-backed; no fallback).
- Strict readiness passed before claim; no live PR/branch/worktree collision was found; `agent:ready` was removed before edits.
- Worktree: `/Users/rasmus/worktrees/issue-4191-embedding-provider-posture`
- Branch: `codex/issue-4191-embedding-provider-posture`
- Base: `aab241c8ea44b4684796604848defd15ebea4596` (`origin/main` before the current rebase)
- Head: `baf433c369c81bc38c2fa02bdbca0873baf176c5`

## Configuration Census
Read-only dev/test/prod channel census completed before the posture change. No secret values were printed or persisted. No explicit `EMBED_PRIMARY_PROVIDER` assignment was found in the inspected channel surfaces; the resolved channel classifications were already embedding-servable/alias or inherited from the base runtime, so no channel mutation was required.

## Test-First Receipt
- Red: the five named #4191 tests initially produced `4 failed, 1 passed`; after completing the fixture preconditions, both explicit-misconfiguration paths still failed with `DID NOT RAISE`.
- Green: all five named #4191 tests pass on the publishable SHA.

## Acceptance-Criteria Receipt
- `tests/llm/test_provider_registry.py::test_explicit_unservable_embed_provider_fails_loud` — pass.
- `tests/llm/test_provider_registry.py::test_chat_provider_spillover_does_not_fail_embedding_resolution` — pass.
- `tests/llm/test_provider_registry.py::test_resolved_provider_name_is_always_servable` — pass.
- `tests/llm/test_provider_registry.py::test_supported_embed_providers_derive_from_registry` — pass.
- `tests/llm/test_provider_registry.py::test_misconfigured_provider_cannot_silently_write_mock_vectors` — pass; production indexer path proves zero adapter/vector-index calls.
- `docs/EMBEDDINGS.md :: Embedding identity` — updated with authoritative-source vs chat-spillover posture, precedence, aliases, and registry-derived accepted names.

## Mechanism Convergence Receipt
- Invariant: every returned provider is executable by the live registry or deterministic client; explicit unservable embedding configuration fails before adapter/vector-index writes.
- States/transitions: empty input -> mock; valid explicit identity -> same provider; invalid explicit identity -> `ValueError`; invalid `LLM_PROVIDER` spillover -> documented tolerant mock.
- Producers: call override, `EMBED_PRIMARY_PROVIDER`, profile primary/provider, and final chat spillover; existing precedence and provenance are preserved.
- Consumers/recovery: identity resolution remains the choke point before adapter and vector-index access; failure has no vector side effect and requires configuration correction, with no retry/lock/crash-ordering expansion.
- Test map: the five named #4191 tests cover source classification, liveness, registry derivation, and production write prevention.

## Validation Receipt
- `pytest tests/llm/test_provider_registry.py tests/llm/test_provider_fail_loud.py tests/ingest/test_ingest_embedding_identity.py -q` — `33 passed`.
- `ruff check app tests` — pass.
- `mypy app` — pass (`812` source files).
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — pass; the explicit skip is appropriate because the required embedding owner doc was updated and no temporal/channel state changed.
- `git diff --check origin/main...HEAD` — pass.
- Required host-leased command, unchanged head and untouched `origin/main` A/B: both failed before collection because host plugin autoload registered AnyIO twice.
- Equivalent host-leased run with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and the Issue-required explicit AsyncIO/AnyIO plugins — `11285 passed, 41 skipped, 275 deselected, 18 xfailed` in `474.68s`; lease released with `return_code: 0`. Execution: `4191:9df008eb84c0b6b8ea2e8d331d4835a435fa7945-noautoload`.
- Independent reviews: two fresh `gpt-5.6-sol` / `xhigh` rounds on the unchanged publishable SHA, both clean with no commit-introduced regression identified.

## TCD Receipt
```yaml
tcd_plan:
  task_summary: fail loud for explicit unservable embedding providers while retaining tolerant chat-only spillover
  assumptions: live PROVIDER_REGISTRY plus deterministic is the executable set; existing precedence is binding
  complexity: medium
  risk: high
  verification_difficulty: moderate
  human_review_burden: low
  defect_blast_radius: high
  budget_pressure: low
  recommended_capability:
    workflow_or_skill: issue-to-code + publish-pr + mechanism convergence review
    model_family: Sol for independent review
    reasoning_effort: xhigh
    tools: focused tests, host-leased non-PG suite, static/doc gates, GitHub REST
    github_context_required: true
  cheapest_acceptable_path: bounded resolver change, five named regressions, owner-doc writeback
  escalation_triggers: adjacent provider-resolution blocker, vector-write side effect, config precedence regression
  deescalation_triggers: unchanged SHA, clean mechanism reviews, full-suite green
  review_gate: full path; data/external-API runtime surface; two clean rounds
tcd_review:
  verdict: accept
  risk_level: high
  model_used: gpt-5.6-sol
  reasoning_effort_used: xhigh
  under_modeling_detected: false
  over_modeling_detected: false
  blocking_issues: []
  non_blocking_issues: []
  missing_tests: []
  hidden_defect_risks: []
  recommended_fixes: []
  recommended_model_for_fix: gpt-5.6-sol
  recommended_reasoning_for_fix: xhigh
  residual_risk: chat-only unservable LLM_PROVIDER intentionally resolves to mock and is pinned by regression coverage
```

## Scope / Handoff
No merge, issue closure, deployment, release-channel mutation, or environment-value disclosure is part of this PR. Verification and closure remain for the separate downstream workflow.

## P1 Review Repair Receipt
- Finding: provider invariant lacked a settings/deployment preflight.
- Repair commit: `2e6ee92bde81536c038e833277cfcaef57c49998` validates `EMBED_PRIMARY_PROVIDER` and every explicit embedding-profile provider through the live registry-derived resolver; `LLM_PROVIDER` spillover remains tolerant.
- Verification: 37 affected tests passed; `ruff check app tests`, `mypy app`, settings validation, docs guard, and diff check passed; host-leased non-PG suite passed `11287 passed, 41 skipped, 275 deselected, 18 xfailed`.
- Convergence review: clean; final current-head CI and the two required final independent reviews remain pending.

## P1 Preflight Convergence Repair Receipt
- Adjacent review finding: settings validation was not wired into ordinary vault-backed startup or channel deployment; startup validation was also incorrectly gated by `VERIFY_ACTIVE` and `AUTO_BOOTSTRAP`.
- Repair head: `a540f7d94849189c693669531f515300eac86231` (rebased onto `30fdd6b7c07a4f66d3fde5de7b4737957de0a5d6`).
- Mechanism key: `embedding-provider-fail-loud-preflight`. All explicit sources (override, environment, profiles), aliases/servable set, no-vector-write fence, settings validation, normal startup, deploy-before-health, no-vault posture, and tolerant `LLM_PROVIDER` spillover were reviewed together.
- Focused matrix: `30 passed` across provider/settings/startup/deploy tests; both shell entrypoints parse cleanly.
- Fresh independent Sol/xhigh convergence review: P0/P1 clean. Current-head CI and the two fresh final independent review rounds remain pending.

## Rebase Verification Receipt
- Rebased unchanged #4191 mechanism onto current main `aab241c8ea44b4684796604848defd15ebea4596` after #4247 repaired the unrelated governance baseline test.
- Head: `baf433c369c81bc38c2fa02bdbca0873baf176c5`.
- Exact-head focused matrix: `98 passed` across provider, settings, deploy, and startup contract tests; shell parse, ruff, mypy, docs guard, and diff check passed.
- Fresh independent Sol/xhigh mechanism-convergence review: P0/P1 clean; no P2/P3 findings. Previous convergence evidence is retained as historical only.
- Current-head CI and two fresh final independent reviews remain pending.