### PR TITLE
governance: formalize transitional bug delivery policy

### DIFF
--- a/.codex/agents/issue-set-coordinator.toml
+++ b/.codex/agents/issue-set-coordinator.toml
@@ -1,7 +1,7 @@
 name = "issue_set_coordinator"
 description = "Coordinates issue-set delivery planning and dispatch through deliver-issue-set without implementing slices."
-model = "gpt-5.6-sol"
-model_reasoning_effort = "high"
+model = "gpt-5.6-luna"
+model_reasoning_effort = "low"
 sandbox_mode = "workspace-write"
 
 developer_instructions = """
@@ -9,6 +9,12 @@ Read AGENTS.md first.
 Read docs/development/BUILDER_SUBAGENT_ROLES.md.
 Load .codex/skills/deliver-issue-set/SKILL.md before any issue-set planning or dispatch.
 Treat that skill as the canonical workflow contract; this adapter does not restate it.
+
+The adapter default is Luna / low for deterministic read-only intake, lifecycle snapshots, and
+dispatch. When live classification needs judgment, route that bounded decision through Terra /
+medium under `AGENTS.md :: Transition-period bug-delivery policy`; the default is not an escalation
+waiver. For larger type:bug sets, retain the policy's serial default and never implement a claimed
+bug in this coordinator session.
 
 Coordinate only: build readiness tables, TCD plans, pickup order, fan-out rationale, and receipt
 reconciliation. Do not implement code. Do not claim child issues on behalf of workers.

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -98,6 +98,7 @@ on CI checks — and the optional `--codex` verdict path — via REST without dr
     Project projection when explicitly in scope
 - `deliver-issue-set`
   - review, plan, make ready, and deliver an epic, parent feature issue, Kanban/Project lane, or larger ready-issue set; use `issue-to-code` and `verification-and-closure` as the main lenses; if the ready pool is too small, repair or create bounded ready issues through `issue-maintenance-change-control`, `docs-to-issue`, or `feature-breakdown`; may claim multiple issues only for rational parallel sub-agent delivery with isolated worktrees and explicit receipts
+  - for larger `type:bug` sets, follow `AGENTS.md :: Transition-period bug-delivery policy`
 - `docs-governance`
   - decision and routing skill for docs-as-code ownership, anti-sprawl, DOCS_INDEX impact, and narrower docs workflow selection
 - `yggdrasil-design-handoff`

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -37,10 +37,15 @@ not registry intake.
 The classification decision may require engineering judgment, but appending, deduplicating, and
 looking up a confirmed registry entry do not require an LLM coordinator.
 
+When a normal `type:bug` Issue is selected from a larger bug set for implementation, its delivery
+session, worktree, and model routing follow `AGENTS.md :: Transition-period bug-delivery policy`.
+That policy is Builder System transition guidance, not Product/Runtime truth or an assertion that a
+future deterministic orchestrator is shipped.
+
 ## Deferred Known Defects registry
 
-The rolling registry is one open, locked Issue carrying `type:bug` and `state:known-defect`. It is a
-container for schema-marked comments, not an implementation contract, carries no `agent:*` state,
+The current rolling registry is Issue #4172: one open, locked Issue carrying `type:bug` and
+`state:known-defect`. It is a container for schema-marked comments, not an implementation contract, carries no `agent:*` state,
 and must never carry `agent:ready`. Locking limits comments to repository collaborators so marker
 comments remain within the builder authority boundary. `state:known-defect` is defined centrally in
 `.codex/skills/_shared/LABEL_TAXONOMY.md`.

--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -11,6 +11,10 @@ The goal is to produce an executable implementation plan and, when requested, de
 
 This skill is a coordinator. It does not replace `issue-to-code`, `verification-and-closure`, `issue-maintenance-change-control`, `docs-to-issue`, or `feature-breakdown`.
 
+For larger `type:bug` sets, the coordinator capability, session isolation, serial default, and
+independent-wave exception are canonical in `AGENTS.md :: Transition-period bug-delivery policy`.
+Apply that policy before the generic independent-issue fast lane or delivery-mode parallel rules.
+
 ## First Context To Load
 
 1. `AGENTS.md`
@@ -119,6 +123,9 @@ Delivery rules:
   lifecycle command only through the owning skill (`issue-to-code` for claim, `verification-and-closure`
   for terminal closure, or issue maintenance for drift repair).
 - Default to delivering one issue at a time.
+- For `type:bug` candidates, the transition-period policy in `AGENTS.md` is stricter: dispatch one
+  end-to-end bug implementation in its own Codex task/session and isolated worktree unless an
+  explicit independent-wave TCD rationale supports more.
 - You may claim multiple issues only when you are immediately assigning them to active sub-agents with isolated worktrees and the parallelization is rational from both token-budget and quality perspectives.
 - Before selecting or dispatching work, classify each candidate as Product/Runtime System,
   Builder System, or boundary work using

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -253,6 +253,9 @@ scope; it never adds steps to the implementation hot path.
 - If the work turns a roadmap/plan item into shipped reality, update the owner doc and rewrite roadmap/plan wording so it no longer reads as pending.
 - Scale validation and PR-body machinery to the risk tier per `docs/development/GOVERNANCE_PROPORTIONALITY.md`: Tier 1 (docs/skills/governance text) runs lightweight docs/governance checks only; Tier 2 (code slices, tests) runs the repo-standard gates below; Tier 3 (migrations, release channels, prod, boundary moves) keeps the full fail-closed machinery.
 - Route model family, reasoning effort, and escalation/de-escalation per `AGENTS.md :: Total Cost of Development`. The risk tier above, plus the artifact class, environment/channel risk, and stop conditions from the pre-implementation classification check, are the routing inputs — do not restate the policy here.
+- For a `type:bug` Issue dispatched from a larger bug set, also apply `AGENTS.md :: Transition-period
+  bug-delivery policy`: own one end-to-end Codex task/session and isolated worktree, normally Terra
+  / medium, with escalation only through the existing TCD or protected P0/P1/high-risk triggers.
 - Apply `AGENTS.md :: Proportional delivery`: build the most boring solution that satisfies the
   ACs — no new gate, receipt, registry, config surface, or abstraction without an explicit
   contract demand. Spend at most 2 CI-repair rounds per failure mechanism; when the budget is

--- a/.codex/skills/resume-work/SKILL.md
+++ b/.codex/skills/resume-work/SKILL.md
@@ -74,6 +74,11 @@ Then read the two context hints, if they exist:
 
 From that, classify into one of the four situations and act.
 
+For an interrupted `type:bug` implementation from a larger bug set, resume only its original
+dedicated Codex task/session and worktree. Do not absorb another bug into that session; the serial
+default and any independent-wave exception remain governed by
+`AGENTS.md :: Transition-period bug-delivery policy`.
+
 ## Orchestrated runs: resume the engine before rebuilding from git
 
 Git only sees what reached the working tree. When the interrupted work was driven by an

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -235,10 +235,10 @@ the disposition; there is no valid `blocking P2` category.
   repair/re-review loop.
 - **P2** — a real defect whose risk is accepted for this PR and deferred to bounded follow-up. Leave
   the PR code unchanged for that finding, invoke the existing
-  `.codex/skills/bug-to-issue/SKILL.md` intake path to create or update durable defect evidence,
-  mark the finding `deferred` in the review receipt, and reply on the original review finding/thread
-  with the Issue reference. Once that reference is live, the finding is non-blocking and allows
-  merge for that finding without another review round.
+  `.codex/skills/bug-to-issue/SKILL.md` intake path to create or update the rolling Known Defects
+  registry Issue #4172, mark the finding `deferred` in the review receipt, and reply on the original
+  review finding/thread with the registry Issue reference. Once that reference is live, the finding
+  is non-blocking and allows merge for that finding without another review round.
 - **P3** — informational advice, style guidance, or a non-defect suggestion. Record it when useful;
   it does not block merge, require defect intake, or trigger another review round.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,29 @@ Many agents run against this repo at once. C_coordination, C_delay, and C_rework
   fail or wait boundedly; never interrupt the holder. Do not background a leased command.
 - **Fail-closed gate composition.** Any command whose exit code gates a subsequent action (commit, push, merge, receipt) must run bare with its status captured directly (`rc=$?`) — never composed with `|| echo`, `| tail`, `| grep`, backgrounding, or anything that substitutes another command's exit status for the gate's. A gate whose failure mode is silent success is not a gate. (Instances: BRANCH_TRUTH_GATE `|| echo` 2026-06-13; PR #2759 pipe-masked merge gate 2026-07-02.)
 
+### Transition-period bug-delivery policy
+
+This is Builder System transition-period delivery policy only. It does not describe
+Product/Runtime truth and does not claim that a future deterministic orchestrator is shipped.
+
+For larger `type:bug` issue sets, use a minimal-context coordinator/dispatcher: Codex Luna / low
+reasoning is appropriate for deterministic read-only intake, live classification, lifecycle
+snapshots, and task dispatch; use Terra / medium only when that coordination requires judgment.
+The coordinator does not implement claimed bugs. Each claimed bug runs end-to-end in its own Codex
+task/session and isolated worktree. Default to serial delivery: no more than one active bug
+implementation. An independent wave may exceed that only with an explicit TCD rationale covering
+independence, coordination cost, isolated worktrees, and expected quality or delay benefit.
+
+Each bug implementation normally uses Codex Terra / medium. Escalate to Terra / high or Sol /
+high–xhigh only under the existing TCD escalation triggers or protected P0/P1/high-risk surfaces;
+resolve tier names to the current generation rather than hardcoding a generation-specific model.
+Severity and deferred-defect authority remain in
+`docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md` and `bug-to-issue`: only P0/P1
+findings enter repair/re-review; a confirmed P2 leaves the active PR unchanged and is recorded in
+the rolling Known Defects registry Issue #4172 with a `deferred` disposition and reply on the
+original review thread; P3 is informational/non-defect. Protected AC, data, authority, invariant,
+and other protected findings cannot be downgraded to P2/P3.
+
 ### TCD output blocks
 
 Planning/decomposition, review/verification, and retrospective skills reference these blocks by name instead of restating the policy. Emit only the block a skill calls for, and fill only the fields that skill's own output already implies.

--- a/docs/development/AGENT_OPERATING_PROTOCOL.md
+++ b/docs/development/AGENT_OPERATING_PROTOCOL.md
@@ -70,6 +70,11 @@ Before producing implementation guidance or code, answer each field:
 - explicit stop conditions
 - verifiable delivery at merge time
 
+**Classify larger bug-set coordination as Builder System governance.** Apply
+`AGENTS.md :: Transition-period bug-delivery policy` before dispatch: keep the coordinator
+read-only/minimal-context, give every claimed `type:bug` its own Codex task/session and isolated
+worktree, and retain serial delivery unless an explicit independent-wave TCD rationale exists.
+
 ## Stop conditions
 
 Stop and route to Issue maintenance, human review, or docs repair when any of the following is true:

--- a/docs/development/BUILDER_SUBAGENT_ROLES.md
+++ b/docs/development/BUILDER_SUBAGENT_ROLES.md
@@ -53,7 +53,7 @@ Four initial execution roles. Each maps to exactly one canonical skill and stays
 
 | Role (`name`) | Adapter file | Job | Canonical skill |
 |---|---|---|---|
-| `issue_set_coordinator` | `.codex/agents/issue-set-coordinator.toml` | Plan and dispatch an issue-set: readiness tables, pickup order, fan-out rationale, receipt reconciliation. Coordinates only; does not implement. | `.codex/skills/deliver-issue-set/SKILL.md` |
+| `issue_set_coordinator` | `.codex/agents/issue-set-coordinator.toml` | Plan and dispatch an issue-set: readiness tables, pickup order, fan-out rationale, receipt reconciliation. Coordinates only; does not implement. Defaults to Luna / low for deterministic intake and dispatch; judgment routes through the canonical TCD policy. | `.codex/skills/deliver-issue-set/SKILL.md` |
 | `slice_implementer` | `.codex/agents/slice-implementer.toml` | Implement exactly one bounded, strictly validated `agent:ready` issue end to end; Project Status is optional projection. | `.codex/skills/issue-to-code/SKILL.md` |
 | `backlog_contract_maintainer` | `.codex/agents/backlog-contract-maintainer.toml` | Repair stale, malformed, duplicate, or drifted Issue/PR/label state plus optional Project projection. | `.codex/skills/issue-maintenance-change-control/SKILL.md` |
 | `verification_closer` | `.codex/agents/verification-closer.toml` | Verify a PR against its governing contract, check CI/review state, and close delivery. | `.codex/skills/verification-and-closure/SKILL.md` |

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -19,6 +19,11 @@ For non-trivial changes:
 6. Update owner docs in the same change when behavior, contracts, or architecture changed.
 7. Run the relevant validation commands and record any gaps.
 
+For larger `type:bug` issue sets, apply `AGENTS.md :: Transition-period bug-delivery policy`: a
+minimal coordinator dispatches each bug to its own end-to-end Codex task/session and isolated
+worktree, with serial implementation as the default. This is Builder System transition guidance,
+not Product/Runtime behavior or evidence of a shipped deterministic orchestrator.
+
 ## Lightweight breakdown model
 
 Use the following practical breakdown model across docs, GitHub, and implementation:

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -31,6 +31,30 @@ def test_canonical_agents_entrypoint_routes_to_repo_skill_index() -> None:
     assert ".codex/skills/deliver-issue-set/SKILL.md" in text
     assert "In Progress" in text
     assert "remove `agent:ready`" in text
+    assert "Transition-period bug-delivery policy" in text
+    assert "Known Defects registry Issue #4172" in text
+
+
+def test_bug_delivery_transition_policy_is_linked_across_workflows() -> None:
+    canonical = "AGENTS.md :: Transition-period bug-delivery policy"
+    for path in (
+        ".codex/skills/README.md",
+        ".codex/skills/deliver-issue-set/SKILL.md",
+        ".codex/skills/issue-to-code/SKILL.md",
+        ".codex/skills/bug-to-issue/SKILL.md",
+        ".codex/skills/resume-work/SKILL.md",
+        "docs/development/DEV_WORKFLOW.md",
+        "docs/development/AGENT_OPERATING_PROTOCOL.md",
+    ):
+        assert canonical in " ".join(_read(path).split())
+
+    verification = _read(".codex/skills/verification-and-closure/SKILL.md")
+    assert "rolling Known Defects\n  registry Issue #4172" in verification
+
+    coordinator = _read(".codex/agents/issue-set-coordinator.toml")
+    assert 'model = "gpt-5.6-luna"' in coordinator
+    assert 'model_reasoning_effort = "low"' in coordinator
+    assert canonical in coordinator
 
 
 def test_compatibility_entrypoints_route_to_skill_index() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): Codex coordinator adapter, issue delivery workflows
- Write class: Builder System governance
- Authority impact: updates builder workflow policy only; no Product/Runtime authority change
- Persistence impact: repo-governed instruction and adapter text only
- Derived/rebuildable impact: unaffected
- Human knowledge impact: clarifies bug-set coordination and review disposition
- Memory impact: unaffected
- Retrieval/context impact: minimal coordinator context is explicit
- Sync/deployment impact: none
- External boundary impact: GitHub review-thread disposition only when a P2 occurs
- New or changed contract: transition-period bug-delivery policy and Luna-low coordinator default
- Owner-doc impact: AGENTS.md and development workflow authority updated in this PR
- Transition debt impact: explicitly does not claim the future deterministic orchestrator is shipped
- Fitness rule impact: focused workflow-entrypoint coverage
- Boundary risk: low

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make transition-period bug delivery routing durable across canonical workflow authority.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed.

## Notes
Validation: python3 scripts/lint_skills_consistency.py; pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/governance/test_known_defects_registry.py; python3 scripts/docs_guard.py.