### PR TITLE
Increase model inquiry turn budgets

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -799,8 +799,8 @@ components are shipped under `app/builderops/` as build-plane infrastructure:
   `docs-freshness`, `roadmap-execution`, and `promotion-queue` views over BuilderOps Vault records.
 - **Model Inquiry bridge** — the repository provides a fail-closed remote launcher contract and a
   versioned subscription-adapter profile for independent Fable and GPT/Codex turns. The profile
-  requires `xhigh` reasoning, a 540-second inner command bound, and secret-safe terminal receipts;
-  host credentials, CLI paths, the 600-second wrapper deadline, and deployment remain operator
+  requires `xhigh` reasoning, a 1200-second inner command bound, and secret-safe terminal receipts;
+  host credentials, CLI paths, the 1500-second wrapper deadline, and deployment remain operator
   configuration outside Git. See `docs/BUILDEROPS_MODEL_INQUIRY/`; the current remote-host deployment
   is tracked separately in #3586.
 

--- a/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
@@ -56,8 +56,8 @@ Example shape (credentials stay in the separately named local environment variab
 ```
 
 A configured remote subscription host may provide local command adapters for both roles. Its
-versioned profile uses explicit `xhigh` reasoning effort for Fable and GPT/Codex, a 540-second
-inner command deadline, and a 600-second host adapter deadline. Credentials, subscription sessions,
+versioned profile uses explicit `xhigh` reasoning effort for Fable and GPT/Codex, a 1200-second
+inner command deadline, and a 1500-second host adapter deadline. Credentials, subscription sessions,
 and host-specific executable paths remain outside Git. It never substitutes Codex, Claude,
 Anthropic, OpenAI, mock, or the deterministic dry-run planner for a missing Fable role.
 

--- a/docs/BUILDEROPS_MODEL_INQUIRY/README.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/README.md
@@ -54,7 +54,7 @@ BMI-04 adds Codex and portable Claude bridge skills that transfer the question t
 remote-host launcher. The configured remote host owns the BuilderOps command, configured role
 adapters, subscription sessions, and durable artifacts; its credentials and launcher-path settings
 remain outside Git. The versioned subscription adapter profile gives both roles explicit `xhigh`
-reasoning effort and a 540-second inner deadline; the host wrapper permits 600 seconds per role.
+reasoning effort and a 1200-second inner deadline; the host wrapper permits 1500 seconds per role.
 BMI-05 adds the structured Issue proposal, readiness receipt, file-first
 PromotionIntent, REST-only Issue crossing, crash reconciliation marker, and append-only delivery
 references.

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -21,7 +21,7 @@ from typing import Sequence
 SCHEMA_INSTALL = "builderops.model-inquiry-host-install.v1"
 SCHEMA_CHECK = "builderops.model-inquiry-host-check.v1"
 TRUSTED_REPO_ROOT = Path(__file__).resolve().parents[1]
-VERSIONED_ADAPTER_SHA256 = "59bd9ec13f96ac990b0ba3f5ee1e08df760201e54255bbd5033b10df174a8e59"
+VERSIONED_ADAPTER_SHA256 = "3d037cded9ba4905c42cbccd0b660dcf2f4f70ea44d55704209e50cb510dbc0b"
 
 
 @dataclass(frozen=True)

--- a/scripts/model_inquiry_subscription_adapter.py
+++ b/scripts/model_inquiry_subscription_adapter.py
@@ -11,7 +11,10 @@ import subprocess
 import sys
 from typing import Any, Mapping
 
-COMMAND_TIMEOUT_SECONDS = 540
+# xhigh subscription turns can spend several minutes in provider-side reasoning
+# before producing their structured response. Keep this inner deadline aligned
+# with the host wrapper's larger 1500-second bound.
+COMMAND_TIMEOUT_SECONDS = 1200
 TIMEOUT_EXIT_CODE = 124
 FABLE_MODEL = "claude-fable-5"
 CODEX_MODEL = "gpt-5.6-sol"

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -175,7 +175,7 @@ def test_subscription_adapter_uses_high_reasoning_profile(monkeypatch) -> None:
     fable_argv = module.build_argv("fable", "system prompt")
     codex_argv = module.build_argv("gpt_codex", "system prompt")
 
-    assert module.COMMAND_TIMEOUT_SECONDS == 540
+    assert module.COMMAND_TIMEOUT_SECONDS == 1200
     assert fable_argv[fable_argv.index("--effort") + 1] == "xhigh"
     assert codex_argv[codex_argv.index("-c") + 1] == 'model_reasoning_effort="xhigh"'
 
@@ -189,7 +189,7 @@ def test_subscription_adapter_uses_safe_timeout_exit(monkeypatch) -> None:
     monkeypatch.setattr(
         module.subprocess,
         "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(module.subprocess.TimeoutExpired(args[0], 540)),
+        lambda *args, **kwargs: (_ for _ in ()).throw(module.subprocess.TimeoutExpired(args[0], 1200)),
     )
 
     with pytest.raises(SystemExit) as raised:


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: The latest durable inquiry receipt shows the Codex role hitting the hardcoded 540-second inner timeout after the Fable role completed. This bounded repair raises the versioned inner deadline to 1200 seconds, aligns the documented host adapter deadline to 1500 seconds, and keeps the installed-lineage digest fail-closed.
Validation: 81 model-inquiry tests passed; ruff check app tests; mypy app; python3 scripts/docs_guard.py; review_before_ci_gate.py; git diff --check.
Issue required: no

Final-Review-Rounds: 1

## Summary
Raise the xhigh model-inquiry turn budget from 540 to 1200 seconds and the host adapter budget from 600 to 1500 seconds. Update the installer digest, regression expectation, and BuilderOps architecture/spec documentation together.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The durable inquiry receipts supplied the RCA; this bounded repair is fully represented by the repository code, tests, and owner-doc writeback.

## SBS Impact
Builder System model-inquiry infrastructure only; no Product/Runtime behavior, vault authority, deployment channel, or credential path changes.

## Owner-doc writeback
Updated `docs/ARCHITECTURE.md`, `docs/BUILDEROPS_MODEL_INQUIRY/README.md`, and `docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md` to reflect the shipped 1200/1500-second profile.

## Notes
The host-specific launcher remains operator configuration outside Git; after merge it must be refreshed from the merged checkout and its installed profile revalidated.
---