### PR TITLE
builder: dispatch issues into fresh Codex sessions

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -62,7 +62,12 @@ from app.builderops.evidence_bridge import (
     EvidenceBridgeError,
     build_evidence_bridge_report,
 )
-from app.builderops.epic_dispatch import EpicDispatchError, build_dispatch_plan
+from app.builderops.epic_dispatch import (
+    CodexIssueSessionLauncher,
+    EpicDispatchError,
+    build_dispatch_plan,
+    dispatch_issue_sessions,
+)
 from app.builderops.epic_delivery_ledger import (
     EpicDeliveryLedgerError,
     build_parent_epic_delivery_ledger,
@@ -1738,6 +1743,37 @@ def dispatch_plan(
     except (EpicDispatchError, EpicRunStateError) as exc:
         raise click.ClickException(str(exc)) from exc
     _emit(plan, as_json)
+
+
+@epic_run_state.command(
+    "dispatch-sessions",
+    help="Run a frozen dispatch plan serially in fresh Codex sessions.",
+)
+@click.option(
+    "--plan-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Frozen JSON output from dispatch-plan.",
+)
+@click.option(
+    "--repo-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="current directory",
+)
+@click.option("--json", "as_json", is_flag=True)
+def dispatch_sessions(
+    plan_file: Path,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    plan = _load_json_object_file(plan_file, field="plan-file")
+    try:
+        launcher = CodexIssueSessionLauncher(repo_root=repo_root)
+        receipt = dispatch_issue_sessions(plan, launcher)
+    except EpicDispatchError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit(receipt, as_json)
 
 
 @epic_run_state.command(

--- a/app/builderops/epic_dispatch.py
+++ b/app/builderops/epic_dispatch.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Iterable, Mapping
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Protocol
 
 from app.builderops.epic_run_state import validate_run_id
 
@@ -34,6 +37,176 @@ HANDOFF_RECEIPT_SCHEMA: dict[str, Any] = {
 
 class EpicDispatchError(ValueError):
     """Raised when dispatch planning input is invalid or unsafe."""
+
+
+class IssueSessionLaunchError(RuntimeError):
+    """Raised when one fresh worker session cannot finish truthfully."""
+
+    def __init__(self, message: str, *, session_id: str | None = None) -> None:
+        self.session_id = session_id
+        super().__init__(message)
+
+
+class IssueSessionLauncher(Protocol):
+    """Minimal transitional seam for one fresh issue-worker session."""
+
+    def launch(self, context_pack: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+_TCD_CODEX_ROUTE = {
+    "low-cost": ("gpt-5.6-luna", "low"),
+    "standard": ("gpt-5.6-terra", "medium"),
+    "high-reasoning": ("gpt-5.6-sol", "high"),
+}
+
+
+class CodexIssueSessionLauncher:
+    """Run one issue context pack to terminal in a fresh local Codex session."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        adapter_path: Path | None = None,
+        runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.adapter_path = adapter_path or (
+            Path(__file__).resolve().parents[2]
+            / ".codex"
+            / "agents"
+            / "slice-implementer.toml"
+        )
+        self.runner = runner or subprocess.run
+        try:
+            adapter = tomllib.loads(self.adapter_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise EpicDispatchError("slice_implementer adapter is unavailable") from exc
+        if adapter.get("name") != "slice_implementer":
+            raise EpicDispatchError("slice_implementer adapter contract mismatch")
+        instructions = adapter.get("developer_instructions")
+        if not isinstance(instructions, str) or not instructions.strip():
+            raise EpicDispatchError("slice_implementer instructions are missing")
+        sandbox = adapter.get("sandbox_mode")
+        if sandbox != "workspace-write":
+            raise EpicDispatchError("slice_implementer sandbox contract mismatch")
+        self.developer_instructions = instructions.strip()
+        self.sandbox = sandbox
+
+    def command(self, context_pack: Mapping[str, Any]) -> list[str]:
+        model, reasoning_effort = self._tcd_route(context_pack)
+        worktree = self._planned_worktree(context_pack)
+        return [
+            "codex",
+            "exec",
+            "--json",
+            "--sandbox",
+            self.sandbox,
+            "--model",
+            model,
+            "-c",
+            f'model_reasoning_effort="{reasoning_effort}"',
+            "-C",
+            str(self.repo_root),
+            "--add-dir",
+            str(worktree.parent),
+            "-",
+        ]
+
+    def prompt(self, context_pack: Mapping[str, Any]) -> str:
+        try:
+            serialized = json.dumps(
+                context_pack,
+                sort_keys=True,
+                indent=2,
+                ensure_ascii=False,
+            )
+        except (TypeError, ValueError) as exc:
+            raise EpicDispatchError("context pack must be JSON serializable") from exc
+        return (
+            "Use the registered slice_implementer execution role.\n"
+            f"{self.developer_instructions}\n"
+            "Load and obey .codex/skills/issue-to-code/SKILL.md. "
+            "Perform exactly the one Issue in this immutable context pack. "
+            "Self-claim through issue-to-code before editing, work in the named dedicated "
+            "worktree, and return the requested subagent_handoff_receipt. "
+            "This invocation is a fresh session; do not resume or reuse another Issue's session.\n"
+            f"{serialized}\n"
+        )
+
+    def launch(self, context_pack: Mapping[str, Any]) -> Mapping[str, Any]:
+        result = self.runner(
+            self.command(context_pack),
+            cwd=self.repo_root,
+            input=self.prompt(context_pack),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        session_id: str | None = None
+        worker_receipt: object | None = None
+        terminal_error: str | None = None
+        for line in result.stdout.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, Mapping):
+                continue
+            if event.get("type") == "thread.started":
+                candidate = event.get("thread_id")
+                if isinstance(candidate, str) and candidate.strip():
+                    session_id = candidate.strip()
+            if event.get("type") in {"turn.failed", "error"}:
+                terminal_error = json.dumps(event, sort_keys=True)
+            if event.get("type") == "item.completed":
+                item = event.get("item")
+                if isinstance(item, Mapping) and item.get("type") == "agent_message":
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        worker_receipt = _parse_worker_receipt(text)
+        if result.returncode != 0 or terminal_error is not None:
+            detail = result.stderr.strip() or terminal_error or "codex exec failed"
+            raise IssueSessionLaunchError(
+                detail[-2_000:],
+                session_id=session_id,
+            )
+        if session_id is None:
+            raise IssueSessionLaunchError("codex exec produced no session id")
+        if worker_receipt is None:
+            raise IssueSessionLaunchError(
+                "codex exec produced no terminal worker receipt",
+                session_id=session_id,
+            )
+        return {
+            "session_id": session_id,
+            "worker_receipt": worker_receipt,
+        }
+
+    @staticmethod
+    def _tcd_route(context_pack: Mapping[str, Any]) -> tuple[str, str]:
+        runtime = context_pack.get("runtime")
+        if not isinstance(runtime, Mapping) or runtime.get("runtime") != "codex":
+            raise EpicDispatchError("serial session launcher supports codex runtime only")
+        model_class = runtime.get("model_class")
+        if not isinstance(model_class, str) or model_class not in _TCD_CODEX_ROUTE:
+            raise EpicDispatchError("context pack has no supported TCD model class")
+        return _TCD_CODEX_ROUTE[model_class]
+
+    @staticmethod
+    def _planned_worktree(context_pack: Mapping[str, Any]) -> Path:
+        plan = context_pack.get("branch_worktree_plan")
+        if not isinstance(plan, Mapping):
+            raise EpicDispatchError("context pack has no branch/worktree plan")
+        value = plan.get("worktree")
+        if not isinstance(value, str) or not value.strip():
+            raise EpicDispatchError("context pack has no planned worktree")
+        worktree = Path(value)
+        if not worktree.is_absolute() or "<" in value or ">" in value:
+            raise EpicDispatchError("planned worktree must be an explicit absolute path")
+        if not worktree.parent.is_dir():
+            raise EpicDispatchError("planned worktree parent does not exist")
+        return worktree
 
 
 def build_dispatch_plan(
@@ -176,6 +349,203 @@ def build_dispatch_plan(
     else:
         result["epic_issue_number"] = normalized_epic
     return result
+
+
+def dispatch_issue_sessions(
+    plan: Mapping[str, Any],
+    launcher: IssueSessionLauncher,
+) -> dict[str, Any]:
+    """Execute a frozen dispatch plan serially, with one fresh session per Issue."""
+
+    run_id, ordered = _validated_session_contexts(plan)
+    sessions: list[dict[str, Any]] = []
+    seen_session_ids: set[str] = set()
+
+    for decision, context_pack in ordered:
+        issue_number = decision["issue_number"]
+        context_pack_id = decision["context_pack_id"]
+        try:
+            launch_result = launcher.launch(context_pack)
+            if not isinstance(launch_result, Mapping):
+                raise IssueSessionLaunchError(
+                    "session launcher returned a non-object result"
+                )
+            session_id = _normalize_string(
+                launch_result.get("session_id"),
+                "launch_result.session_id",
+            )
+            if session_id in seen_session_ids:
+                sessions.append(
+                    {
+                        "issue_number": issue_number,
+                        "context_pack_id": context_pack_id,
+                        "session_id": session_id,
+                        "fresh_session": False,
+                        "status": "rejected",
+                        "error_type": "EpicDispatchError",
+                        "error": "session id was already used by another Issue",
+                    }
+                )
+                return _session_dispatch_receipt(
+                    run_id,
+                    sessions,
+                    status="stopped",
+                    stopped_reason="cross-issue-session-reuse",
+                )
+            seen_session_ids.add(session_id)
+            sessions.append(
+                {
+                    "issue_number": issue_number,
+                    "context_pack_id": context_pack_id,
+                    "session_id": session_id,
+                    "fresh_session": True,
+                    "status": "completed",
+                    "worker_receipt": launch_result.get("worker_receipt"),
+                }
+            )
+        except Exception as exc:
+            failed_session_id = getattr(exc, "session_id", None)
+            if (
+                not isinstance(failed_session_id, str)
+                or not failed_session_id.strip()
+            ):
+                failed_session_id = None
+            sessions.append(
+                {
+                    "issue_number": issue_number,
+                    "context_pack_id": context_pack_id,
+                    "session_id": failed_session_id,
+                    "fresh_session": True,
+                    "status": "failed",
+                    "error_type": type(exc).__name__,
+                    "error": (str(exc).strip() or type(exc).__name__)[-2_000:],
+                }
+            )
+            return _session_dispatch_receipt(
+                run_id,
+                sessions,
+                status="stopped",
+                stopped_reason="session-launch-failed",
+            )
+
+    return _session_dispatch_receipt(
+        run_id,
+        sessions,
+        status="completed",
+        stopped_reason=None,
+    )
+
+
+def _validated_session_contexts(
+    plan: Mapping[str, Any],
+) -> tuple[str, list[tuple[dict[str, Any], dict[str, Any]]]]:
+    if not isinstance(plan, Mapping):
+        raise EpicDispatchError("dispatch plan must be an object")
+    if plan.get("source") != "builderops.epic_dispatch.dry_run":
+        raise EpicDispatchError("dispatch sessions requires a frozen dry-run plan")
+    run_id = validate_run_id(_normalize_string(plan.get("run_id"), "plan.run_id"))
+    decisions_raw = plan.get("decisions")
+    contexts_raw = plan.get("context_packs")
+    if not isinstance(decisions_raw, list) or not isinstance(contexts_raw, list):
+        raise EpicDispatchError("dispatch plan decisions and context_packs must be lists")
+
+    selected: list[dict[str, Any]] = []
+    for raw in decisions_raw:
+        if not isinstance(raw, Mapping):
+            raise EpicDispatchError("dispatch decision must be an object")
+        if raw.get("selected_for_dispatch") is True:
+            selected.append(dict(raw))
+    selected.sort(key=lambda item: _dispatch_slot(item))
+    if [_dispatch_slot(item) for item in selected] != list(
+        range(1, len(selected) + 1)
+    ):
+        raise EpicDispatchError("selected dispatch slots must be unique and contiguous")
+    selected_count = plan.get("selected_count")
+    if (
+        not isinstance(selected_count, int)
+        or isinstance(selected_count, bool)
+        or selected_count != len(selected)
+    ):
+        raise EpicDispatchError("selected_count does not match selected decisions")
+
+    contexts_by_id: dict[str, dict[str, Any]] = {}
+    for raw in contexts_raw:
+        if not isinstance(raw, Mapping):
+            raise EpicDispatchError("context pack must be an object")
+        context_payload = dict(raw)
+        context_id = _normalize_string(
+            context_payload.get("context_pack_id"),
+            "context_pack_id",
+        )
+        if context_id in contexts_by_id:
+            raise EpicDispatchError("context_pack_id must be unique")
+        contexts_by_id[context_id] = context_payload
+    if len(contexts_by_id) != len(selected):
+        raise EpicDispatchError(
+            "selected decisions must have exactly one context pack each"
+        )
+
+    ordered: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for decision in selected:
+        issue_number = _normalize_positive_int(
+            decision.get("issue_number"),
+            "decision.issue_number",
+        )
+        context_id = _normalize_string(
+            decision.get("context_pack_id"),
+            "decision.context_pack_id",
+        )
+        matching_context = contexts_by_id.get(context_id)
+        if matching_context is None:
+            raise EpicDispatchError("selected decision is missing its context pack")
+        issue_contract = matching_context.get("issue_contract")
+        runtime = matching_context.get("runtime")
+        if (
+            not isinstance(issue_contract, Mapping)
+            or issue_contract.get("number") != issue_number
+            or matching_context.get("dispatch_slot") != decision.get("dispatch_slot")
+            or not isinstance(runtime, Mapping)
+            or runtime.get("runtime") != "codex"
+        ):
+            raise EpicDispatchError("context pack does not match its selected decision")
+        ordered.append((decision, matching_context))
+    return run_id, ordered
+
+
+def _dispatch_slot(decision: Mapping[str, Any]) -> int:
+    return _normalize_positive_int(
+        decision.get("dispatch_slot"),
+        "decision.dispatch_slot",
+    )
+
+
+def _session_dispatch_receipt(
+    run_id: str,
+    sessions: list[dict[str, Any]],
+    *,
+    status: str,
+    stopped_reason: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "execution_mode": "serial-fresh-sessions",
+        "status": status,
+        "sessions": sessions,
+        "stopped_reason": stopped_reason,
+        "github_mutations": [],
+        "coordinator_claims": [],
+        "source": "builderops.epic_dispatch.serial_sessions",
+    }
+
+
+def _parse_worker_receipt(text: str) -> object:
+    stripped = text.strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped[-8_000:]
+    return parsed
 
 
 def _build_tcd_decision(
@@ -600,9 +970,13 @@ def _budget_class_for(risk: str, expected_value: str) -> str:
 
 
 __all__ = [
+    "CodexIssueSessionLauncher",
     "DEFAULT_MAX_PARALLEL",
     "HANDOFF_RECEIPT_SCHEMA",
+    "IssueSessionLaunchError",
+    "IssueSessionLauncher",
     "SCHEMA_VERSION",
     "EpicDispatchError",
     "build_dispatch_plan",
+    "dispatch_issue_sessions",
 ]

--- a/app/builderops/epic_dispatch.py
+++ b/app/builderops/epic_dispatch.py
@@ -129,7 +129,8 @@ class CodexIssueSessionLauncher:
             "Load and obey .codex/skills/issue-to-code/SKILL.md. "
             "Perform exactly the one Issue in this immutable context pack. "
             "Self-claim through issue-to-code before editing, work in the named dedicated "
-            "worktree, and return the requested subagent_handoff_receipt. "
+            "worktree, and return only one JSON object matching the requested "
+            "subagent_handoff_receipt. "
             "This invocation is a fresh session; do not resume or reuse another Issue's session.\n"
             f"{serialized}\n"
         )
@@ -393,16 +394,32 @@ def dispatch_issue_sessions(
                     stopped_reason="cross-issue-session-reuse",
                 )
             seen_session_ids.add(session_id)
+            worker_receipt = _validated_worker_receipt(
+                launch_result.get("worker_receipt"),
+                session_id=session_id,
+            )
+            final_state = worker_receipt["final_state"]
             sessions.append(
                 {
                     "issue_number": issue_number,
                     "context_pack_id": context_pack_id,
                     "session_id": session_id,
                     "fresh_session": True,
-                    "status": "completed",
-                    "worker_receipt": launch_result.get("worker_receipt"),
+                    "status": (
+                        "completed"
+                        if final_state in {"done", "handoff"}
+                        else final_state
+                    ),
+                    "worker_receipt": worker_receipt,
                 }
             )
+            if final_state not in {"done", "handoff"}:
+                return _session_dispatch_receipt(
+                    run_id,
+                    sessions,
+                    status="stopped",
+                    stopped_reason=f"worker-{final_state}",
+                )
         except Exception as exc:
             failed_session_id = getattr(exc, "session_id", None)
             if (
@@ -546,6 +563,35 @@ def _parse_worker_receipt(text: str) -> object:
     except json.JSONDecodeError:
         return stripped[-8_000:]
     return parsed
+
+
+def _validated_worker_receipt(
+    receipt: object,
+    *,
+    session_id: str,
+) -> dict[str, Any]:
+    if not isinstance(receipt, Mapping):
+        raise IssueSessionLaunchError(
+            "worker returned no structured handoff receipt",
+            session_id=session_id,
+        )
+    missing = [
+        field
+        for field in HANDOFF_RECEIPT_SCHEMA["required_fields"]
+        if field not in receipt
+    ]
+    if missing:
+        raise IssueSessionLaunchError(
+            f"worker handoff receipt is missing fields: {', '.join(missing)}",
+            session_id=session_id,
+        )
+    final_state = receipt.get("final_state")
+    if final_state not in {"done", "blocked", "needs-human", "handoff"}:
+        raise IssueSessionLaunchError(
+            "worker handoff receipt has an invalid final_state",
+            session_id=session_id,
+        )
+    return dict(receipt)
 
 
 def _build_tcd_decision(

--- a/docs/development/BUILDER_SUBAGENT_ROLES.md
+++ b/docs/development/BUILDER_SUBAGENT_ROLES.md
@@ -99,6 +99,24 @@ The dry-run helper for generating these packets is:
 It does not claim issues, mutate GitHub/Project/PR state, reserve branches/worktrees, touch dispatcher
 leases, or spawn agents. Workers still self-claim through `issue-to-code` before editing.
 
+## Executable serial dispatch
+
+For a small ready Issue set, save the dry-run output and run:
+
+`python3 -m app.builderops builderops epic-run-state dispatch-sessions --plan-file <frozen-plan.json> --repo-root <repo> --json`
+
+This transitional local command validates the complete frozen plan before execution, then runs each
+selected Issue to its worker handoff in deterministic order. Every Issue uses a new Codex session;
+the command never resumes or reuses another Issue's session, and it stops before later Issues when
+one session fails. Each candidate must name an explicit absolute worktree path; the worker creates or
+enters that dedicated worktree and self-claims through `issue-to-code`. The coordinator does not
+preclaim, mutate GitHub lifecycle state, merge, or close.
+
+The command is intentionally Codex-only and serial. It is the simplest executable bridge from the
+existing context-pack planner, not a second durable orchestrator. DDO-04's provider-neutral
+`WorkerRuntimePort` must replace or absorb it before provider-neutral lifecycle control, reattachment,
+retry, or crash recovery is claimed.
+
 ```yaml
 subagent_handoff_receipt:
   role:                 # e.g. slice_implementer

--- a/docs/development/BUILDER_SUBAGENT_ROLES.md
+++ b/docs/development/BUILDER_SUBAGENT_ROLES.md
@@ -108,9 +108,10 @@ For a small ready Issue set, save the dry-run output and run:
 This transitional local command validates the complete frozen plan before execution, then runs each
 selected Issue to its worker handoff in deterministic order. Every Issue uses a new Codex session;
 the command never resumes or reuses another Issue's session, and it stops before later Issues when
-one session fails. Each candidate must name an explicit absolute worktree path; the worker creates or
-enters that dedicated worktree and self-claims through `issue-to-code`. The coordinator does not
-preclaim, mutate GitHub lifecycle state, merge, or close.
+one session fails or returns a `blocked` / `needs-human` handoff. Each candidate must name an
+explicit absolute worktree path; the worker creates or enters that dedicated worktree and
+self-claims through `issue-to-code`. The coordinator does not preclaim, mutate GitHub lifecycle
+state, merge, or close.
 
 The command is intentionally Codex-only and serial. It is the simplest executable bridge from the
 existing context-pack planner, not a second durable orchestrator. DDO-04's provider-neutral

--- a/tests/builderops/test_epic_dispatch.py
+++ b/tests/builderops/test_epic_dispatch.py
@@ -96,6 +96,28 @@ class _RecordingSessionLauncher:
         return response
 
 
+def _worker_receipt(
+    issue_number: int,
+    *,
+    final_state: str = "handoff",
+) -> dict[str, object]:
+    return {
+        "role": "slice_implementer",
+        "task": f"#{issue_number}",
+        "skill_loaded": ".codex/skills/issue-to-code/SKILL.md",
+        "branch": f"codex/issue-{issue_number}",
+        "worktree": f"/tmp/issue-{issue_number}",
+        "actions": ["implemented"],
+        "ac_verdicts": ["pass"],
+        "lifecycle_mutations": [],
+        "validation": ["pass"],
+        "owner_doc_result": "none",
+        "residual_risk": "none",
+        "final_state": final_state,
+        "next_step": "verify PR",
+    }
+
+
 def test_tcd_decisions_cover_inline_subagent_and_overfan() -> None:
     plan = build_dispatch_plan(
         epic_issue_number=3229,
@@ -428,11 +450,11 @@ def test_dispatch_sessions_starts_one_fresh_serial_session_per_issue() -> None:
         [
             {
                 "session_id": "session-5401",
-                "worker_receipt": {"final_state": "handoff", "task": "#5401"},
+                "worker_receipt": _worker_receipt(5401),
             },
             {
                 "session_id": "session-5402",
-                "worker_receipt": {"final_state": "handoff", "task": "#5402"},
+                "worker_receipt": _worker_receipt(5402),
             },
         ]
     )
@@ -497,8 +519,8 @@ def test_dispatch_sessions_rejects_cross_issue_session_reuse() -> None:
     )
     launcher = _RecordingSessionLauncher(
         [
-            {"session_id": "same-session", "worker_receipt": {"task": "#5601"}},
-            {"session_id": "same-session", "worker_receipt": {"task": "#5602"}},
+            {"session_id": "same-session", "worker_receipt": _worker_receipt(5601)},
+            {"session_id": "same-session", "worker_receipt": _worker_receipt(5602)},
         ]
     )
 
@@ -525,7 +547,7 @@ def test_dispatch_sessions_stops_after_first_failed_session() -> None:
                 "codex exec failed",
                 session_id="session-5701",
             ),
-            {"session_id": "session-5702", "worker_receipt": {"task": "#5702"}},
+            {"session_id": "session-5702", "worker_receipt": _worker_receipt(5702)},
         ]
     )
 
@@ -545,6 +567,23 @@ def test_dispatch_sessions_stops_after_first_failed_session() -> None:
             "error": "codex exec failed",
         }
     ]
+
+    blocked_launcher = _RecordingSessionLauncher(
+        [
+            {
+                "session_id": "session-5701-blocked",
+                "worker_receipt": _worker_receipt(5701, final_state="blocked"),
+            },
+            {"session_id": "session-5702", "worker_receipt": _worker_receipt(5702)},
+        ]
+    )
+
+    blocked_receipt = dispatch_issue_sessions(plan, blocked_launcher)
+
+    assert blocked_receipt["status"] == "stopped"
+    assert blocked_receipt["stopped_reason"] == "worker-blocked"
+    assert len(blocked_launcher.calls) == 1
+    assert blocked_receipt["sessions"][0]["status"] == "blocked"
 
 
 def test_codex_issue_session_command_is_fresh_and_tcd_bounded(tmp_path: Path) -> None:
@@ -590,7 +629,7 @@ def test_dispatch_sessions_cli_emits_receipt_without_github_mutations(
         [
             {
                 "session_id": "session-5901",
-                "worker_receipt": {"final_state": "handoff", "task": "#5901"},
+                "worker_receipt": _worker_receipt(5901),
             }
         ]
     )

--- a/tests/builderops/test_epic_dispatch.py
+++ b/tests/builderops/test_epic_dispatch.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Mapping
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from app.builderops.__main__ import _root as builderops_standalone_root
-from app.builderops.epic_dispatch import build_dispatch_plan
+from app.builderops.epic_dispatch import (
+    CodexIssueSessionLauncher,
+    EpicDispatchError,
+    IssueSessionLaunchError,
+    build_dispatch_plan,
+    dispatch_issue_sessions,
+)
 from app.builderops.epic_run_state import (
     apply_epic_run_update,
     create_epic_run_state,
@@ -30,6 +38,7 @@ def _candidate(
     project_status: str = "Ready",
     preferred_path: str | None = None,
     scriptable: bool = False,
+    worktree: str | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "issue_number": issue_number,
@@ -60,6 +69,8 @@ def _candidate(
         payload["preferred_path"] = preferred_path
     if scriptable:
         payload["scriptable"] = True
+    if worktree is not None:
+        payload["worktree"] = worktree
     return payload
 
 
@@ -69,6 +80,20 @@ def _run_builderops(args: list[str]):
         ["builderops", *args],
         catch_exceptions=False,
     )
+
+
+class _RecordingSessionLauncher:
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = iter(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def launch(self, context_pack: Mapping[str, object]) -> Mapping[str, object]:
+        self.calls.append(dict(context_pack))
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        assert isinstance(response, dict)
+        return response
 
 
 def test_tcd_decisions_cover_inline_subagent_and_overfan() -> None:
@@ -388,3 +413,207 @@ def test_fast_lane_context_pack_is_minimal_and_receipted() -> None:
         "discovered_overlap": "typed-coordinator-exception",
     }
     assert "epic_history" not in json.dumps(pack)
+
+
+def test_dispatch_sessions_starts_one_fresh_serial_session_per_issue() -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5401, 5402],
+        run_id="serial-sessions",
+        candidates=[
+            _candidate(5401, risk="high", files=["app/a.py"]),
+            _candidate(5402, risk="high", files=["app/b.py"]),
+        ],
+    )
+    launcher = _RecordingSessionLauncher(
+        [
+            {
+                "session_id": "session-5401",
+                "worker_receipt": {"final_state": "handoff", "task": "#5401"},
+            },
+            {
+                "session_id": "session-5402",
+                "worker_receipt": {"final_state": "handoff", "task": "#5402"},
+            },
+        ]
+    )
+
+    receipt = dispatch_issue_sessions(plan, launcher)
+
+    assert [call["issue_contract"]["number"] for call in launcher.calls] == [5401, 5402]
+    assert receipt["status"] == "completed"
+    assert receipt["execution_mode"] == "serial-fresh-sessions"
+    assert [item["session_id"] for item in receipt["sessions"]] == [
+        "session-5401",
+        "session-5402",
+    ]
+    assert all(item["fresh_session"] is True for item in receipt["sessions"])
+    assert receipt["github_mutations"] == []
+    assert receipt["coordinator_claims"] == []
+
+
+def test_dispatch_sessions_rejects_invalid_plan_before_launch() -> None:
+    valid = build_dispatch_plan(
+        independent_issue_numbers=[5501],
+        run_id="invalid-plan",
+        candidates=[_candidate(5501, risk="high", files=["app/a.py"])],
+    )
+    invalid_plans = []
+
+    missing = json.loads(json.dumps(valid))
+    missing["context_packs"] = []
+    invalid_plans.append(missing)
+
+    duplicate = json.loads(json.dumps(valid))
+    duplicate["context_packs"].append(dict(duplicate["context_packs"][0]))
+    invalid_plans.append(duplicate)
+
+    mismatched = json.loads(json.dumps(valid))
+    mismatched["context_packs"][0]["issue_contract"]["number"] = 9999
+    invalid_plans.append(mismatched)
+
+    unsupported_runtime = json.loads(json.dumps(valid))
+    unsupported_runtime["context_packs"][0]["runtime"]["runtime"] = "claude"
+    invalid_plans.append(unsupported_runtime)
+
+    for plan in invalid_plans:
+        launcher = _RecordingSessionLauncher([])
+        try:
+            dispatch_issue_sessions(plan, launcher)
+        except EpicDispatchError:
+            pass
+        else:  # pragma: no cover - assertion keeps validation fail closed.
+            raise AssertionError("invalid dispatch plan should be rejected")
+        assert launcher.calls == []
+
+
+def test_dispatch_sessions_rejects_cross_issue_session_reuse() -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5601, 5602],
+        run_id="session-reuse",
+        candidates=[
+            _candidate(5601, risk="high", files=["app/a.py"]),
+            _candidate(5602, risk="high", files=["app/b.py"]),
+        ],
+    )
+    launcher = _RecordingSessionLauncher(
+        [
+            {"session_id": "same-session", "worker_receipt": {"task": "#5601"}},
+            {"session_id": "same-session", "worker_receipt": {"task": "#5602"}},
+        ]
+    )
+
+    receipt = dispatch_issue_sessions(plan, launcher)
+
+    assert receipt["status"] == "stopped"
+    assert receipt["stopped_reason"] == "cross-issue-session-reuse"
+    assert len(launcher.calls) == 2
+    assert receipt["sessions"][1]["status"] == "rejected"
+
+
+def test_dispatch_sessions_stops_after_first_failed_session() -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5701, 5702],
+        run_id="failed-session",
+        candidates=[
+            _candidate(5701, risk="high", files=["app/a.py"]),
+            _candidate(5702, risk="high", files=["app/b.py"]),
+        ],
+    )
+    launcher = _RecordingSessionLauncher(
+        [
+            IssueSessionLaunchError(
+                "codex exec failed",
+                session_id="session-5701",
+            ),
+            {"session_id": "session-5702", "worker_receipt": {"task": "#5702"}},
+        ]
+    )
+
+    receipt = dispatch_issue_sessions(plan, launcher)
+
+    assert receipt["status"] == "stopped"
+    assert receipt["stopped_reason"] == "session-launch-failed"
+    assert len(launcher.calls) == 1
+    assert receipt["sessions"] == [
+        {
+            "issue_number": 5701,
+            "context_pack_id": "ctx-5701",
+            "session_id": "session-5701",
+            "fresh_session": True,
+            "status": "failed",
+            "error_type": "IssueSessionLaunchError",
+            "error": "codex exec failed",
+        }
+    ]
+
+
+def test_codex_issue_session_command_is_fresh_and_tcd_bounded(tmp_path: Path) -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5801],
+        run_id="codex-command",
+        candidates=[
+            _candidate(
+                5801,
+                risk="high",
+                files=["app/a.py"],
+                worktree=str(tmp_path / "issue-5801"),
+            )
+        ],
+    )
+    launcher = CodexIssueSessionLauncher(repo_root=tmp_path)
+
+    command = launcher.command(plan["context_packs"][0])
+
+    assert command[:3] == ["codex", "exec", "--json"]
+    assert command[command.index("--model") + 1] == "gpt-5.6-sol"
+    assert 'model_reasoning_effort="high"' in command
+    assert "resume" not in command
+    assert command[command.index("--add-dir") + 1] == str(tmp_path)
+    assert command[-1] == "-"
+    prompt = launcher.prompt(plan["context_packs"][0])
+    assert "slice_implementer" in prompt
+    assert ".codex/skills/issue-to-code/SKILL.md" in prompt
+    assert '"number": 5801' in prompt
+
+
+def test_dispatch_sessions_cli_emits_receipt_without_github_mutations(
+    tmp_path: Path,
+) -> None:
+    plan = build_dispatch_plan(
+        independent_issue_numbers=[5901],
+        run_id="cli-sessions",
+        candidates=[_candidate(5901, risk="high", files=["app/a.py"])],
+    )
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+    launcher = _RecordingSessionLauncher(
+        [
+            {
+                "session_id": "session-5901",
+                "worker_receipt": {"final_state": "handoff", "task": "#5901"},
+            }
+        ]
+    )
+
+    with patch(
+        "app.builderops.cli.CodexIssueSessionLauncher",
+        return_value=launcher,
+    ):
+        result = _run_builderops(
+            [
+                "epic-run-state",
+                "dispatch-sessions",
+                "--plan-file",
+                str(plan_file),
+                "--repo-root",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+    assert result.exit_code == 0, result.output
+    receipt = json.loads(result.output)
+    assert receipt["status"] == "completed"
+    assert receipt["sessions"][0]["session_id"] == "session-5901"
+    assert receipt["github_mutations"] == []
+    assert receipt["coordinator_claims"] == []


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4248

## Linked Issue
Fixes #4248

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): local Codex worker invocation
- Write class: Builder System code, tests, and governance documentation
- Authority impact: none; worker self-claim and GitHub/dispatcher/PR/CI authority are unchanged
- Persistence impact: none; session receipts are caller-managed output
- Derived/rebuildable impact: compact receipt derived from the frozen plan and Codex JSON events
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: one minimal context pack per Issue
- Sync/deployment impact: none
- External boundary impact: invokes the installed local Codex CLI without storing credentials
- New or changed contract: transitional serial issue-session dispatch receipt
- Owner-doc impact: updated in this PR
- Transition debt impact: bounded bridge explicitly replaced or absorbed by DDO-04 WorkerRuntimePort
- Fitness rule impact: one fresh session per Issue, deterministic order, fail-closed plan validation, stop on failure
- Boundary risk: session/process state never grants claim, merge, or closure authority

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds `epic-run-state dispatch-sessions`, which validates a frozen dispatch plan and runs selected Issues serially in fresh Codex sessions.
- Reuses the `slice_implementer` role and TCD risk class while leaving claim, PR, CI, merge, and closure authority with the existing workflows.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the bounded implementation contract and delivery evidence are fully represented by Issue #4248 and this PR; no separate operational record is needed.

## Notes
- Transitional Codex-only bridge; durable reattachment, retries, lifecycle controls, provider neutrality, and crash recovery remain DDO-04/DDO-05 work.
- Review repair: a worker `blocked` / `needs-human` handoff now stops the serial run before any later Issue starts.
- Pickup: `task_id=github-RasmusTho--agentic-pkm-mvp-issue-4248`, `lease_id=lease-0d2370c7`, `holder=codex-implement-4248`, `evidence=verified-dispatcher-lease`.
- Verification at `8d044ecb2`: `pytest -q tests/builderops/test_epic_dispatch.py` (17 passed); `ruff check app tests`; `mypy app` (812 files); `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` (Builder System owner doc updated; no Product temporal owner doc applies).
