### PR TITLE
MVR: seal dormant instance storage mutation boundary

### DIFF
--- a/app/instance/_storage_boundary.py
+++ b/app/instance/_storage_boundary.py
@@ -1,0 +1,44 @@
+"""Private capability for dormant MVR registry and ownership mutations."""
+
+from __future__ import annotations
+
+
+class RegistryError(RuntimeError):
+    """Base class for fail-closed registry errors."""
+
+
+class CapabilityNotReadyError(RegistryError):
+    """A later delivery floor has not been installed."""
+
+
+_CONSTRUCTION_SEAL = object()
+
+
+class _StorageMutationCapability:
+    """Identity capability whose constructor seal is private to this module."""
+
+    __slots__ = ()
+
+    def __new__(cls, construction_seal: object | None = None) -> _StorageMutationCapability:
+        if construction_seal is not _CONSTRUCTION_SEAL:
+            raise TypeError("storage mutation capability is not caller-constructible")
+        return super().__new__(cls)
+
+    def __init__(self, construction_seal: object | None = None) -> None:
+        if construction_seal is not _CONSTRUCTION_SEAL:
+            raise TypeError("storage mutation capability is not caller-constructible")
+
+
+_STORAGE_MUTATION_CAPABILITY = _StorageMutationCapability(_CONSTRUCTION_SEAL)
+
+
+def _require_storage_mutation_capability(
+    capability: _StorageMutationCapability | None,
+) -> None:
+    if capability is not _STORAGE_MUTATION_CAPABILITY:
+        raise CapabilityNotReadyError(
+            "private MVR storage mutation capability is required"
+        )
+
+
+__all__: list[str] = []

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Sequence
 from uuid import uuid4
 
+from app.instance._storage_boundary import (
+    _StorageMutationCapability,
+    _require_storage_mutation_capability,
+)
 from app.instance.filesystem_identity import (
     FilesystemIdentityError,
     resolve_filesystem_root_identity,
@@ -452,7 +456,9 @@ class OwnershipLedger:
         vault_binding_id: str,
         root: Path,
         allow_same_channel_nested: bool = True,
+        _capability: _StorageMutationCapability | None = None,
     ) -> OwnershipLease:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
@@ -478,7 +484,13 @@ class OwnershipLedger:
             self._write_ledger_locked(self._replace(current, leases=leases), key)
             return candidate
 
-    def activate(self, vault_binding_id: str) -> OwnershipLease:
+    def activate(
+        self,
+        vault_binding_id: str,
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
@@ -491,7 +503,13 @@ class OwnershipLedger:
             self._write_ledger_locked(self._replace(current, leases=leases), key)
             return active
 
-    def release_to_tombstone(self, vault_binding_id: str) -> OwnershipLease:
+    def release_to_tombstone(
+        self,
+        vault_binding_id: str,
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
@@ -509,7 +527,15 @@ class OwnershipLedger:
             )
             return retired
 
-    def reactivate(self, vault_binding_id: str, *, channel_id: str, root: Path) -> OwnershipLease:
+    def reactivate(
+        self,
+        vault_binding_id: str,
+        *,
+        channel_id: str,
+        root: Path,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
@@ -539,7 +565,9 @@ class OwnershipLedger:
         source_binding_id: str,
         destination_channel_id: str,
         destination_binding_id: str,
+        _capability: _StorageMutationCapability | None = None,
     ) -> TransferReservation:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
@@ -568,7 +596,12 @@ class OwnershipLedger:
             self._write_ledger_locked(self._replace(current, leases=leases, transfer=reservation), key)
             return reservation
 
-    def activate_transfer(self) -> OwnershipLease:
+    def activate_transfer(
+        self,
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -691,7 +691,9 @@ class OwnershipLedger:
         *,
         precondition: Callable[[LedgerSnapshot, Mapping[str, Path]], None],
         crash_after: str | None = None,
+        _capability: _StorageMutationCapability | None = None,
     ) -> LedgerSnapshot:
+        _require_storage_mutation_capability(_capability)
         self._assert_existing_artifacts()
         with self._locked(recover_rotation=False):
             if self.rotation_path.exists():

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -423,9 +423,11 @@ class OwnershipLedger:
         *,
         channel_id: str,
         root: Path,
+        _capability: _StorageMutationCapability | None = None,
     ) -> OwnershipLease:
         """Authenticate an active owner or finish a committed pending reservation."""
 
+        _require_storage_mutation_capability(_capability)
         self._assert_existing_artifacts()
         with self._locked():
             key = self._load_or_create_key_locked(allow_create=False)
@@ -657,7 +659,9 @@ class OwnershipLedger:
         *,
         inventory_complete: bool,
         writers_drained: bool,
+        _capability: _StorageMutationCapability | None = None,
     ) -> LedgerSnapshot:
+        _require_storage_mutation_capability(_capability)
         if not inventory_complete or not writers_drained:
             raise LedgerCollisionError("legacy owner inventory must be complete and writers drained")
         with self._locked():

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -101,6 +101,8 @@ class InstanceRegistryRuntime:
         vault_root: Path,
         watcher_vault_path: Path,
     ) -> VaultRegistration:
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
         root_identity = resolve_filesystem_root_identity(vault_root)
         watcher_identity = resolve_filesystem_root_identity(watcher_vault_path)
         if not same_filesystem_root(root_identity, watcher_identity):
@@ -120,6 +122,7 @@ class InstanceRegistryRuntime:
                     registration.vault_binding_id,
                     channel_id=self.layout.channel_id,
                     root=Path(root_identity.canonical_path),
+                    _capability=_STORAGE_MUTATION_CAPABILITY,
                 )
                 return registration
         for tombstone in current.removal_tombstones.values():
@@ -338,6 +341,8 @@ class InstanceRegistryRuntime:
         vault_id: str,
         local_instance_id: str,
     ) -> VaultRegistration:
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
         current = self.registry.lookup(vault_binding_id)
         if current is None:
             raise RegistryError(f"unknown vault_binding_id: {vault_binding_id}")
@@ -969,6 +974,8 @@ def _finish_instance_state_deployment(
 ) -> dict[str, object]:
     """Finalize legacy state while stopped, then clear the restart fence."""
 
+    from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
     if quiescence_proof is None:
         raise InstanceStatePreflightError("durable quiescence proof is required")
     state_mount = _assert_mount_root(instance_state_root, "instance-state")
@@ -1045,12 +1052,14 @@ def _finish_instance_state_deployment(
             owners,
             inventory_complete=True,
             writers_drained=True,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
         )
     for registration in registry.registrations.values():
         ledger.recover_or_require_active(
             registration.vault_binding_id,
             channel_id=channel,
             root=Path(registration.path),
+            _capability=_STORAGE_MUTATION_CAPABILITY,
         )
     if not ledger_snapshot.legacy_bootstrap_complete:
         raise InstanceStatePreflightError("legacy owner bootstrap did not complete")

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import yaml
 
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 from app.instance.filesystem_identity import (
     resolve_filesystem_root_identity,
     same_filesystem_root,
@@ -136,14 +137,22 @@ class InstanceRegistryRuntime:
             vault_binding_id=registration.vault_binding_id,
             root=Path(registration.path),
             allow_same_channel_nested=False,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
         )
         try:
-            self.registry.register(registration, expected_revision=current.revision)
+            self.registry.register(
+                registration,
+                expected_revision=current.revision,
+                _capability=_STORAGE_MUTATION_CAPABILITY,
+            )
         except Exception:
             # A retry can recover a prepared lease only when the registry commit exists;
             # otherwise leaving it pending is safer than allowing a conflicting owner.
             raise
-        self.ledger.activate(registration.vault_binding_id)
+        self.ledger.activate(
+            registration.vault_binding_id,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
         return registration
 
     def _require_established_ownership(self, current: RegistrySnapshot) -> None:
@@ -339,7 +348,10 @@ class InstanceRegistryRuntime:
             vault_id=vault_id,
             extensions={**current.extensions, "status": "initialized"},
         )
-        self.registry.update_registration(updated)
+        self.registry.update_registration(
+            updated,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
         return updated
 
     def _new_registration(self, root: Path) -> VaultRegistration:

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -16,7 +16,6 @@ from uuid import uuid4
 
 import yaml
 
-from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 from app.instance.filesystem_identity import (
     resolve_filesystem_root_identity,
     same_filesystem_root,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -236,6 +236,8 @@ class InstanceRegistryRuntime:
     ) -> LedgerSnapshot:
         """Rotate only inside the existing lease-bound all-owner drain fence."""
 
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
         if quiescence_proof is None:
             raise InstanceStatePreflightError("durable quiescence proof is required")
         if legacy_owner_inventory_path is None:
@@ -323,6 +325,7 @@ class InstanceRegistryRuntime:
         return self.ledger.rotate_key(
             precondition=require_rotation_authority,
             crash_after=crash_after,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
         )
 
     def require_initialized(self, vault_binding_id: str) -> VaultRegistration:

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -18,6 +18,12 @@ from uuid import uuid4
 
 import yaml
 
+from app.instance._storage_boundary import (
+    CapabilityNotReadyError,
+    RegistryError,
+    _StorageMutationCapability,
+    _require_storage_mutation_capability,
+)
 from app.instance.filesystem_identity import (
     FilesystemIdentityError,
     FilesystemRootIdentity,
@@ -56,20 +62,12 @@ _REGISTRATION_FIELDS = {
 }
 
 
-class RegistryError(RuntimeError):
-    """Base class for fail-closed registry errors."""
-
-
 class RegistryMigrationError(RegistryError):
     """Legacy state cannot be migrated without guessing identity."""
 
 
 class RegistryRevisionConflict(RegistryError):
     """A caller attempted to write from a stale registry revision."""
-
-
-class CapabilityNotReadyError(RegistryError):
-    """A later delivery floor has not been installed."""
 
 
 class RegistryParseError(RegistryError):
@@ -217,7 +215,9 @@ class VaultRegistryStore:
         registration: VaultRegistration,
         *,
         expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
+        _require_storage_mutation_capability(_capability)
         self._validate_registration(registration)
         with self._locked():
             current = (
@@ -250,9 +250,11 @@ class VaultRegistryStore:
         registration: VaultRegistration,
         *,
         expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
         """Update mutable binding metadata without changing stable identities."""
 
+        _require_storage_mutation_capability(_capability)
         self._validate_registration(registration)
         with self._locked():
             current = self._read_current_locked(recover=True)
@@ -277,9 +279,11 @@ class VaultRegistryStore:
         vault_binding_id: str,
         *,
         expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
         """Remove one dormant registration; production removal remains sealed."""
 
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             current = self._read_current_locked(recover=True)
             self._assert_revision(current, expected_revision)
@@ -299,9 +303,11 @@ class VaultRegistryStore:
         transfer_lineage: tuple[TransferLineage, ...] | None = None,
         extensions: dict[str, Any] | None = None,
         expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
         """Atomically commit one lifecycle/transfer state transition."""
 
+        _require_storage_mutation_capability(_capability)
         with self._locked():
             current = self._read_current_locked(recover=True)
             self._assert_revision(current, expected_revision)
@@ -341,9 +347,11 @@ class VaultRegistryStore:
         principal_state: Mapping[str, object],
         background_state: Mapping[str, object],
         runtime_floors: Mapping[str, object],
+        _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
         """Persist the 01B mechanical state that must survive backup/restore."""
 
+        _require_storage_mutation_capability(_capability)
         current = self.load()
         extensions = copy.deepcopy(current.extensions)
         extensions.update(
@@ -359,6 +367,7 @@ class VaultRegistryStore:
             registrations=dict(current.registrations),
             extensions=extensions,
             expected_revision=current.revision,
+            _capability=_capability,
         )
 
     def require_authoritative_activation(self, proof: RegistryActivationProof) -> None:

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -393,10 +393,11 @@ new-schema state before fork/merge protection exists.
   child selection remains usable, and duplicate-root aliases still coalesce or fail rather than
   creating two bindings.
   - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_same_channel_nested_vaults_preserve_child_boundary`
-- [ ] **MVR-01B:** Every issue-listed registry and ownership-ledger mutation primitive rejects
-  before reading or changing durable state unless it receives the private,
-  non-caller-constructible 01B storage capability; production import boundaries limit that
-  capability and the mutation modules to the sanctioned instance transaction paths.
+- [ ] **MVR-01B:** Every issue-listed registry and ownership-ledger mutation primitive (including
+  legacy-owner bootstrap, pending-lease recovery, and key rotation) rejects before reading or
+  changing durable state unless it receives the private, non-caller-constructible 01B storage
+  capability; production import boundaries limit that capability and the mutation modules to the
+  sanctioned instance transaction paths.
   - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_store_and_ledger_mutators_reject_uncapable_callers`
   - Verify: `tests/architecture/test_import_boundary.py::test_instance_storage_mutation_import_contract_is_complete`
 - [ ] **MVR-01B:** After scalar production cutover, every picker/API/CLI/import/bootstrap/direct-service

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -393,6 +393,12 @@ new-schema state before fork/merge protection exists.
   child selection remains usable, and duplicate-root aliases still coalesce or fail rather than
   creating two bindings.
   - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_same_channel_nested_vaults_preserve_child_boundary`
+- [ ] **MVR-01B:** Every issue-listed registry and ownership-ledger mutation primitive rejects
+  before reading or changing durable state unless it receives the private,
+  non-caller-constructible 01B storage capability; production import boundaries limit that
+  capability and the mutation modules to the sanctioned instance transaction paths.
+  - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_store_and_ledger_mutators_reject_uncapable_callers`
+  - Verify: `tests/architecture/test_import_boundary.py::test_instance_storage_mutation_import_contract_is_complete`
 - [ ] **MVR-01B:** After scalar production cutover, every picker/API/CLI/import/bootstrap/direct-service
   producer rejects registration #2 before reservation or mutation; an existing multi-registration
   registry keeps cutover dormant. No producer unseals until 01C's rollback floor and guards are

--- a/docs/adr/ADR-0013-code-dependency-direction.md
+++ b/docs/adr/ADR-0013-code-dependency-direction.md
@@ -1,4 +1,4 @@
-State: Accepted and enforced (blocking). Flipped from advisory to blocking 2026-06-24 via #2481: all known violations cleared before flip, no allowlist required, contract exits 0 whenever a PR changes the import graph or its contract. Defines code import-dependency direction as a directional, contract-based projection of DESIGN_PRINCIPLES §3 system layers onto `app.*` packages. v1 enforces one invariant — the interaction layer is import-protected — via a module-level import-linter `forbidden` contract, run BLOCKING on relevant PRs.
+State: Accepted and enforced (blocking). Flipped from advisory to blocking 2026-06-24 via #2481: all known violations cleared before flip, no allowlist required, contract exits 0 whenever a PR changes the import graph or its contract. Defines code import-dependency direction as a directional, contract-based projection of DESIGN_PRINCIPLES §3 system layers onto `app.*` packages. The v1 contract set enforces the interaction invariant plus issue-scoped protected stateful boundaries via module-level import-linter contracts, run BLOCKING on relevant PRs.
 Doc role: Decision record (ADR)
 Authority: Authoritative for code import-dependency direction; the governing rule for `importlinter.ini`.
 Owner: Architecture
@@ -34,7 +34,7 @@ The codebase itself is reasonably modular (~50 small, mostly-acyclic subsystems 
 Code import dependencies are **directional and contract-based**, as a projection of the §3 system layers onto `app.*` packages.
 
 1. **Forward-only.** A package may depend on packages in the same or a lower layer. It must not depend on a higher layer. Layer order, highest to lowest: `interaction → cognition → execution → memory`, with **governance** cross-cutting (depends downward) and a **foundation** (shared kernel) leaf any layer may import.
-2. **Interaction is import-protected.** No package outside the interaction layer may import an interaction-layer package. This is the primary invariant and the only one enforced in v1: nothing reaches *backward* into a human/agent-facing surface.
+2. **Interaction is import-protected.** No package outside the interaction layer may import an interaction-layer package. This is the primary invariant; the v1 contract set also protects explicitly named stateful modules where a slice requires a narrower importer boundary. Nothing reaches *backward* into a human/agent-facing surface or across a named protected boundary.
 3. **Depend on contracts, not internals.** Import another package through its public entrypoint, not a private submodule or underscore-prefixed symbol. Enforcement is **module-level** (import-linter catches cross-package imports of any submodule); symbol-level privacy (`_helper`) is a review convention on top.
 4. **Foundation is exempt.** Shared-kernel packages (`events`, `settings`, `schemas`, `config`, and similar pure contract/util modules) may be imported by any layer and carry no inward restriction. They must stay leaf-like (no upward imports) so they remain safe to depend on everywhere.
 5. **Enforcement posture.** The contract runs on every PR that changes `app/**`, `importlinter.ini`, or its workflow via `import-linter` (`.github/workflows/import-linter.yaml`), **blocking** (no `continue-on-error`). A new backward import from a non-interaction package into the interaction layer (`app.api`, `app.chat`, `app.cli`, `app.web`) will fail that job. Flipped from advisory to blocking in #2481 (2026-06-24) after all known violations were confirmed cleared — the contract ran clean (exit 0, 0 violations) on the first run after the flip. No `ignore_imports` allowlist was required.
@@ -58,11 +58,12 @@ Rationale notes:
 - **Governance depends downward** (reads memory, wraps execution) but nothing depends upward on it for non-governance reasons; it is cross-cutting, not a strict tier.
 - **Foundation must stay acyclic and upward-free.** The broad fan-out of `events` (~63 importers) and `settings` (~42 importers) is tolerable only because these are leaves; keeping them leaves is what makes them safe hubs.
 
-## Enforcement reality (v1, updated to blocking in #2481)
+## Enforcement reality (v1, extended in #4033 and blocking since #2481)
 
-- **One `forbidden` contract**, not a `layered` contract. A `layered` contract over package *groups* would forbid legitimate intra-layer imports (e.g. `orchestrator → services`, both execution) because import-linter treats sibling modules in a layer as mutually independent. The directional invariant that adds value without false positives is the single rule "nothing outside interaction imports interaction", expressed as `type = forbidden` (deeper packages → `app.api`/`chat`/`cli`/`web`). Fuller per-layer `layered`/`independence` contracts are a documented refinement, deferred.
+- **One foundational `forbidden` contract plus issue-scoped `protected` contracts**, not a broad `layered` contract. A `layered` contract over package *groups* would forbid legitimate intra-layer imports (e.g. `orchestrator → services`, both execution) because import-linter treats sibling modules in a layer as mutually independent. The foundational directional invariant is "nothing outside interaction imports interaction", expressed as `type = forbidden` (deeper packages → `app.api`/`chat`/`cli`/`web`). The current protected projections are: `instance-storage-mutation-protected` for `app.instance.instance_state` and `app.instance.ownership_ledger`, and `instance-storage-capability-protected` for `app.instance._storage_boundary`, each with an explicit sanctioned importer set in `importlinter.ini`. Fuller per-layer `layered`/`independence` contracts remain deferred.
 - **Namespace packages converted (#2085).** All 15 `app/` subdirectories that were implicit namespace packages (no `__init__.py`) now have empty `__init__.py` files, including `app.orientation` and `app.reasoning`. They are now included in `source_modules` in `importlinter.ini` and their inward leaks are machine-enforced.
 - **Contract flipped to blocking (#2481, 2026-06-24).** By the time this flip landed, all known violations had been resolved (helpers extracted to `app.text.helpers`, cycle broken). The contract runs clean with no `ignore_imports` allowlist. Any new backward import now fails the job.
+- **Protected storage contracts added in #4033.** These contracts are part of the same blocking `lint-imports --config importlinter.ini` gate; a new production importer outside the declared instance transaction boundary fails the job. Capability identity remains a runtime/test boundary in addition to the module import boundary.
 
 ## Known violations at adoption (all resolved before blocking flip)
 
@@ -87,7 +88,7 @@ The blocking gate is clean. No `ignore_imports` section was added to `importlint
 ## Consequences
 
 - `api → services` / `api → agents` are legitimate forward dependencies; the orphan `forbidden` rule is removed.
-- Module boundaries become legible and self-reporting on every PR without blocking delivery.
+- Module boundaries become legible and self-reporting on every PR, with violations blocking delivery.
 - The contract immediately surfaces genuine coupling (a backward reach + one cycle) that previously had no detector.
 - Foundation packages acquire an explicit obligation to stay leaf-like (no upward imports), constraining how `events`/`settings` may grow.
 - Coverage is partial: intra-interaction private reaches are not enforced (below module granularity). Namespace packages are now fully covered as of #2085. The inventory is the bridge for intra-interaction reaches.
@@ -110,14 +111,14 @@ The blocking gate is clean. No `ignore_imports` section was added to `importlint
 # Contract exists and protects the interaction layer:
 rg -n "interaction-protected|app\.api|app\.chat" importlinter.ini
 
-# Contract evaluates and reports the real leaks (expected exit 1 under non-blocking posture):
+# Contract set evaluates cleanly under the blocking posture:
 lint-imports --config importlinter.ini
 
 # Backward-import cross-check matches the reported violations:
 rg -n '^\s*from app\.(api|chat|cli|web)' app/ | rg -v '^app/(api|chat|cli|web)/'
 
-# The PR gate runs non-blocking:
-rg -n "pull_request|continue-on-error" .github/workflows/import-linter.yaml
+# The PR gate runs blocking:
+rg -n "pull_request" .github/workflows/import-linter.yaml
 ```
 
 ## References

--- a/importlinter.ini
+++ b/importlinter.ini
@@ -2,11 +2,13 @@
 #
 # Directional, contract-based projection of DESIGN_PRINCIPLES §3 system layers
 # (interaction > cognition/execution > memory; governance cross-cutting; foundation leaf)
-# onto app.* packages. v1 enforces the primary invariant only: nothing outside the
-# interaction layer may import the interaction layer. Run NON-BLOCKING on PRs
-# (.github/workflows/import-linter.yaml, continue-on-error). Add new packages to
-# source_modules below as they are introduced. Fuller per-layer layered/independence
-# contracts are a documented refinement (ADR-0013, Out of scope).
+# onto app.* packages. The primary invariant prevents inward imports of the
+# interaction layer. Issue-scoped protected contracts below also seal named
+# stateful mutation modules to their sanctioned importers. Run BLOCKING on
+# relevant PRs via `.github/workflows/import-linter.yaml`. Add new packages
+# to source_modules below as they are introduced. Fuller per-layer
+# layered/independence contracts are a documented refinement (ADR-0013, Out of
+# scope).
 #
 # Invoke with: lint-imports --config importlinter.ini  (bare `lint-imports` does not
 # auto-discover this filename; it looks for .importlinter / setup.cfg / pyproject).
@@ -122,3 +124,25 @@ forbidden_modules =
     app.chat
     app.cli
     app.web
+
+[importlinter:contract:instance-storage-mutation-protected]
+name = Instance storage mutation modules are import-protected
+type = protected
+protected_modules =
+    app.instance.instance_state
+    app.instance.ownership_ledger
+allowed_importers =
+    app.instance.instance_state
+    app.instance.runtime
+as_packages = False
+
+[importlinter:contract:instance-storage-capability-protected]
+name = Instance storage mutation capability is import-protected
+type = protected
+protected_modules =
+    app.instance._storage_boundary
+allowed_importers =
+    app.instance.ownership_ledger
+    app.instance.runtime
+    app.instance.vault_registry
+as_packages = False

--- a/tests/api/test_vault_registry_recovery.py
+++ b/tests/api/test_vault_registry_recovery.py
@@ -5,6 +5,7 @@ import pytest
 from app.instance.vault_registry import RegistryError, VaultRegistration, VaultRegistryStore
 from app.vault.manager import VaultManager
 from app.vault.markdown_settings import MarkdownSettingsStore
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 def test_picker_recovers_parse_corrupt_registry_with_backup(tmp_path) -> None:
@@ -71,6 +72,7 @@ def test_populated_registry_corruption_never_reseeds_empty(tmp_path) -> None:
     mutated_missing_main = VaultRegistryStore(path).register(
         VaultRegistration("binding-c", "path:/c", "/c"),
         expected_revision=recovered.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     assert mutated_missing_main.revision == recovered.revision + 1
     assert len(mutated_missing_main.registrations) == 3

--- a/tests/architecture/test_import_boundary.py
+++ b/tests/architecture/test_import_boundary.py
@@ -39,6 +39,18 @@ def _contract_section() -> configparser.SectionProxy:
     return parser["importlinter:contract:interaction-protected"]
 
 
+def _instance_storage_contract_section() -> configparser.SectionProxy:
+    parser = configparser.ConfigParser()
+    parser.read(IMPORTLINTER_INI)
+    return parser["importlinter:contract:instance-storage-mutation-protected"]
+
+
+def _instance_storage_capability_contract_section() -> configparser.SectionProxy:
+    parser = configparser.ConfigParser()
+    parser.read(IMPORTLINTER_INI)
+    return parser["importlinter:contract:instance-storage-capability-protected"]
+
+
 def _module_list(raw: str) -> Set[str]:
     # configparser drops full-line "#" comments inside multiline values, so the
     # surviving lines are real module names.
@@ -172,6 +184,33 @@ def test_source_modules_exclude_interaction_and_resolve() -> None:
     assert not unresolvable, (
         f"source_modules names packages that do not exist under app/: {unresolvable}"
     )
+
+
+def test_instance_storage_mutation_import_contract_is_complete() -> None:
+    """Only the sanctioned transaction modules may import storage mutators."""
+
+    section = _instance_storage_contract_section()
+    assert section["type"] == "protected"
+    assert section.getboolean("as_packages") is False
+    assert _module_list(section["protected_modules"]) == {
+        "app.instance.instance_state",
+        "app.instance.ownership_ledger",
+    }
+    assert _module_list(section["allowed_importers"]) == {
+        "app.instance.instance_state",
+        "app.instance.runtime",
+    }
+    capability_section = _instance_storage_capability_contract_section()
+    assert capability_section["type"] == "protected"
+    assert capability_section.getboolean("as_packages") is False
+    assert _module_list(capability_section["protected_modules"]) == {
+        "app.instance._storage_boundary",
+    }
+    assert _module_list(capability_section["allowed_importers"]) == {
+        "app.instance.ownership_ledger",
+        "app.instance.runtime",
+        "app.instance.vault_registry",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/architecture/test_import_boundary.py
+++ b/tests/architecture/test_import_boundary.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import configparser
+import importlib
 from pathlib import Path
 from typing import Set
 
@@ -211,6 +212,8 @@ def test_instance_storage_mutation_import_contract_is_complete() -> None:
         "app.instance.runtime",
         "app.instance.vault_registry",
     }
+    runtime_module = importlib.import_module("app.instance.runtime")
+    assert not hasattr(runtime_module, "_STORAGE_MUTATION_CAPABILITY")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/helpers/instance_storage_capability.py
+++ b/tests/helpers/instance_storage_capability.py
@@ -1,0 +1,13 @@
+"""Explicit test-only access to the private MVR storage capability."""
+
+from app.instance._storage_boundary import (
+    _STORAGE_MUTATION_CAPABILITY,
+    _StorageMutationCapability,
+)
+
+
+def storage_mutation_capability() -> _StorageMutationCapability:
+    return _STORAGE_MUTATION_CAPABILITY
+
+
+STORAGE_MUTATION_CAPABILITY = storage_mutation_capability()

--- a/tests/instance/test_vault_registry.py
+++ b/tests/instance/test_vault_registry.py
@@ -7,6 +7,7 @@ import pytest
 import app.instance.vault_registry as registry_module
 from app.instance.filesystem_identity import FilesystemRootIdentity
 from app.instance.vault_registry import RegistryError, VaultRegistration, VaultRegistryStore
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
@@ -20,7 +21,8 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
             path="/vault/a",
             vault_id="logical-shared",
             local_instance_id="clone-a",
-        )
+        ),
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     store.register(
         VaultRegistration(
@@ -29,7 +31,8 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
             path="/vault/b",
             vault_id="logical-shared",
             local_instance_id="clone-b",
-        )
+        ),
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
 
     assert [item.vault_binding_id for item in store.list_registrations()] == ["binding-a", "binding-b"]
@@ -43,6 +46,7 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
             local_instance_id="clone-a",
         ),
         expected_revision=2,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     assert updated.revision == 3
 
@@ -56,6 +60,7 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
                 local_instance_id="different-clone",
             ),
             expected_revision=3,
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert store.load().revision == 3
 
@@ -69,11 +74,19 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
                 local_instance_id="clone-a",
             ),
             expected_revision=3,
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert store.load().revision == 3
 
-    store.register(VaultRegistration("binding-temporary", "path:/temporary", "/temporary"))
-    store.remove_registration("binding-temporary", expected_revision=4)
+    store.register(
+        VaultRegistration("binding-temporary", "path:/temporary", "/temporary"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    store.remove_registration(
+        "binding-temporary",
+        expected_revision=4,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
 
     reloaded = VaultRegistryStore(path).load()
     assert reloaded.authority == "dormant"
@@ -88,7 +101,10 @@ def test_registry_round_trip_preserves_multiple_vaults(tmp_path) -> None:
 def test_persisted_registry_rejects_canonical_and_physical_identity_collisions(tmp_path, monkeypatch) -> None:
     canonical_path = tmp_path / "canonical.md"
     canonical_store = VaultRegistryStore(canonical_path)
-    canonical_store.register(VaultRegistration("binding-a", "path:/vault/a", "/vault/a"))
+    canonical_store.register(
+        VaultRegistration("binding-a", "path:/vault/a", "/vault/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     document = registry_module._read_document(canonical_path)
     document.frontmatter["registrations"]["binding-alias"] = {
         "ref": "alias:/vault/a",
@@ -104,8 +120,14 @@ def test_persisted_registry_rejects_canonical_and_physical_identity_collisions(t
 
     physical_path = tmp_path / "physical.md"
     physical_store = VaultRegistryStore(physical_path)
-    physical_store.register(VaultRegistration("binding-a", "path:/mount/a", "/mount/a"))
-    physical_store.register(VaultRegistration("binding-b", "path:/mount/b", "/mount/b"))
+    physical_store.register(
+        VaultRegistration("binding-a", "path:/mount/a", "/mount/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    physical_store.register(
+        VaultRegistration("binding-b", "path:/mount/b", "/mount/b"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     real_resolver = registry_module.resolve_filesystem_root_identity
 
     def same_inode(value):

--- a/tests/instance/test_vault_registry_concurrency.py
+++ b/tests/instance/test_vault_registry_concurrency.py
@@ -9,6 +9,7 @@ import pytest
 
 import app.instance.vault_registry as registry_module
 from app.instance.vault_registry import RegistryError, RegistryRevisionConflict, VaultRegistration, VaultRegistryStore
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 def _registration(index: int) -> VaultRegistration:
@@ -22,21 +23,36 @@ def _registration(index: int) -> VaultRegistration:
 
 
 def _process_register(path: str, index: int) -> None:
-    VaultRegistryStore(Path(path)).register(_registration(index))
+    VaultRegistryStore(Path(path)).register(
+        _registration(index),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
 
 
 def test_production_mutations_are_locked_atomic_and_revision_checked(tmp_path) -> None:
     path = tmp_path / "vault-registry.md"
     store = VaultRegistryStore(path)
     with ThreadPoolExecutor(max_workers=8) as pool:
-        list(pool.map(lambda index: VaultRegistryStore(path).register(_registration(index)), range(8)))
+        list(
+            pool.map(
+                lambda index: VaultRegistryStore(path).register(
+                    _registration(index),
+                    _capability=STORAGE_MUTATION_CAPABILITY,
+                ),
+                range(8),
+            )
+        )
 
     loaded = store.load()
     assert loaded.revision == 8
     assert len(loaded.registrations) == 8
 
     with pytest.raises(RegistryRevisionConflict, match="expected revision 0"):
-        store.register(_registration(99), expected_revision=0)
+        store.register(
+            _registration(99),
+            expected_revision=0,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
     assert store.load().revision == 8
 
     process_path = tmp_path / "process-registry.md"
@@ -57,7 +73,7 @@ def test_production_mutations_are_locked_atomic_and_revision_checked(tmp_path) -
 def test_restart_recovers_every_precommit_interruption(tmp_path, monkeypatch, interruption_artifact) -> None:
     path = tmp_path / f"interrupted-{interruption_artifact}.md"
     store = VaultRegistryStore(path)
-    store.register(_registration(1))
+    store.register(_registration(1), _capability=STORAGE_MUTATION_CAPABILITY)
     previous = {
         store.path: store.path.read_bytes(),
         store.snapshot_path: store.snapshot_path.read_bytes(),
@@ -79,7 +95,11 @@ def test_restart_recovers_every_precommit_interruption(tmp_path, monkeypatch, in
 
     monkeypatch.setattr(registry_module, "_atomic_private_write", interrupt_after_write)
     with pytest.raises(KeyboardInterrupt, match=f"crash after {interruption_artifact}"):
-        store.register(_registration(2), expected_revision=1)
+        store.register(
+            _registration(2),
+            expected_revision=1,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
     assert store.transaction_path.exists()
     assert store.transaction_path.stat().st_mode & 0o777 == 0o600
 
@@ -95,7 +115,7 @@ def test_restart_recovers_every_precommit_interruption(tmp_path, monkeypatch, in
 def test_restart_rolls_forward_after_committed_marker(tmp_path, monkeypatch) -> None:
     path = tmp_path / "committed-interruption.md"
     store = VaultRegistryStore(path)
-    store.register(_registration(1))
+    store.register(_registration(1), _capability=STORAGE_MUTATION_CAPABILITY)
     real_write = registry_module._atomic_private_write
 
     def interrupt_after_commit_marker(candidate, payload):
@@ -105,7 +125,11 @@ def test_restart_rolls_forward_after_committed_marker(tmp_path, monkeypatch) -> 
 
     monkeypatch.setattr(registry_module, "_atomic_private_write", interrupt_after_commit_marker)
     with pytest.raises(KeyboardInterrupt, match="crash after committed marker"):
-        store.register(_registration(2), expected_revision=1)
+        store.register(
+            _registration(2),
+            expected_revision=1,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
     monkeypatch.setattr(registry_module, "_atomic_private_write", real_write)
 
     recovered = VaultRegistryStore(path).load()
@@ -121,7 +145,7 @@ def test_restart_rolls_forward_after_committed_marker(tmp_path, monkeypatch) -> 
 def test_corrupt_transaction_journal_fails_closed(tmp_path, monkeypatch) -> None:
     path = tmp_path / "corrupt-transaction.md"
     store = VaultRegistryStore(path)
-    store.register(_registration(1))
+    store.register(_registration(1), _capability=STORAGE_MUTATION_CAPABILITY)
     original = path.read_bytes()
     store.transaction_path.write_text('{"schema":')
     store.transaction_path.chmod(0o600)
@@ -132,7 +156,10 @@ def test_corrupt_transaction_journal_fails_closed(tmp_path, monkeypatch) -> None
 
     digest_path = tmp_path / "digest-transaction.md"
     digest_store = VaultRegistryStore(digest_path)
-    digest_store.register(_registration(1))
+    digest_store.register(
+        _registration(1),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     digest_original = digest_path.read_bytes()
     real_write = registry_module._atomic_private_write
 
@@ -144,7 +171,11 @@ def test_corrupt_transaction_journal_fails_closed(tmp_path, monkeypatch) -> None
     with monkeypatch.context() as patch:
         patch.setattr(registry_module, "_atomic_private_write", interrupt_after_snapshot)
         with pytest.raises(KeyboardInterrupt, match="leave prepared journal"):
-            digest_store.register(_registration(2), expected_revision=1)
+            digest_store.register(
+                _registration(2),
+                expected_revision=1,
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
     journal = json.loads(digest_store.transaction_path.read_text())
     journal["previous"]["main"]["sha256"] = "0" * 64
     digest_store.transaction_path.write_text(json.dumps(journal))

--- a/tests/instance/test_vault_registry_migration.py
+++ b/tests/instance/test_vault_registry_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import app.instance.vault_registry as registry_module
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 from app.instance.filesystem_identity import FilesystemRootIdentity
 from app.instance.vault_registry import RegistryMigrationError, VaultRegistryStore
 from app.vault.markdown_settings import MarkdownSettingsStore
@@ -228,7 +229,8 @@ def test_ambiguous_registry_migration_fails_without_destructive_reset(tmp_path, 
     collision_path = tmp_path / "collision.md"
     collision_store = VaultRegistryStore(collision_path)
     collision_store.register(
-        registry_module.VaultRegistration("binding-a", "path:/vault/a", "/vault/a")
+        registry_module.VaultRegistration("binding-a", "path:/vault/a", "/vault/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     collision_before = collision_path.read_bytes()
     with pytest.raises(registry_module.RegistryError, match="path identity collision"):
@@ -237,6 +239,7 @@ def test_ambiguous_registry_migration_fails_without_destructive_reset(tmp_path, 
                 "binding-alias",
                 "path:/vault/alias",
                 "/vault/../vault/a",
-            )
+            ),
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert collision_path.read_bytes() == collision_before

--- a/tests/instance/test_vault_registry_permissions.py
+++ b/tests/instance/test_vault_registry_permissions.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from app.instance.vault_registry import RegistryError, VaultRegistration, VaultRegistryStore, preflight_registry_payload
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 def test_registry_transaction_files_are_private(tmp_path) -> None:
@@ -12,7 +13,10 @@ def test_registry_transaction_files_are_private(tmp_path) -> None:
     previous_umask = os.umask(0)
     try:
         store = VaultRegistryStore(path)
-        store.register(VaultRegistration("binding-a", "path:/a", "/a"))
+        store.register(
+            VaultRegistration("binding-a", "path:/a", "/a"),
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
     finally:
         os.umask(previous_umask)
 
@@ -47,14 +51,20 @@ def test_registry_transaction_files_are_private(tmp_path) -> None:
 def test_registry_write_rejects_symlinked_snapshot_without_mutating_state(tmp_path) -> None:
     path = tmp_path / "state" / "vault-registry.md"
     store = VaultRegistryStore(path)
-    initial = store.register(VaultRegistration("binding-a", "path:/a", "/a"))
+    initial = store.register(
+        VaultRegistration("binding-a", "path:/a", "/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     external = tmp_path / "external.md"
     external.write_text("do not overwrite\n", encoding="utf-8")
     store.snapshot_path.unlink()
     store.snapshot_path.symlink_to(external)
 
     with pytest.raises(RegistryError, match="unsafe registry transaction path"):
-        store.register(VaultRegistration("binding-b", "path:/b", "/b"))
+        store.register(
+            VaultRegistration("binding-b", "path:/b", "/b"),
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
 
     assert external.read_text(encoding="utf-8") == "do not overwrite\n"
     assert store.load().revision == initial.revision

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -22,6 +22,7 @@ from app.instance.instance_state import (
     InstanceStatePreflightError,
     validate_registry_disjoint_from_content,
 )
+from app.instance._storage_boundary import _StorageMutationCapability
 from app.instance.ownership_ledger import (
     LedgerCollisionError,
     LedgerError,
@@ -44,6 +45,7 @@ from app.instance.vault_registry import (
     VaultRegistration,
 )
 from app.vault.manager import iter_vault_markdown_files
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 def _runtime(tmp_path: Path, channel: str, host_global: Path) -> InstanceRegistryRuntime:
@@ -97,9 +99,17 @@ def _mechanically_register_nested_binding(
         vault_binding_id=registration.vault_binding_id,
         root=Path(registration.path),
         allow_same_channel_nested=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
-    runtime.registry.register(registration, expected_revision=current.revision)
-    runtime.ledger.activate(registration.vault_binding_id)
+    runtime.registry.register(
+        registration,
+        expected_revision=current.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    runtime.ledger.activate(
+        registration.vault_binding_id,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     return registration
 
 
@@ -117,6 +127,7 @@ def _mechanically_prepare_transfer(
         source_binding_id=vault_binding_id,
         destination_channel_id=destination_runtime.layout.channel_id,
         destination_binding_id=destination_binding_id,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     destination_snapshot = destination_runtime.registry.load()
     destination_registration = replace(
@@ -143,6 +154,7 @@ def _mechanically_prepare_transfer(
         registrations=registrations,
         transfer_lineage=lineage,
         expected_revision=destination_snapshot.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     return destination_registration.vault_binding_id
 
@@ -171,10 +183,13 @@ def _mechanically_recover_transfer(
             registrations=registrations,
             removal_tombstones=tombstones,
             expected_revision=source_snapshot.revision,
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
     if transfer.destination_binding_id not in destination_snapshot.registrations:
         raise LedgerError("prepared transfer is missing its destination registration")
-    source_runtime.ledger.activate_transfer()
+    source_runtime.ledger.activate_transfer(
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     return transfer.destination_binding_id
 
 
@@ -204,8 +219,12 @@ def _mechanically_remove_binding(
         registrations=registrations,
         removal_tombstones=tombstones,
         expected_revision=current.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
-    runtime.ledger.release_to_tombstone(vault_binding_id)
+    runtime.ledger.release_to_tombstone(
+        vault_binding_id,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     return retired
 
 
@@ -226,6 +245,7 @@ def _mechanically_reactivate_binding(
         matched.vault_binding_id,
         channel_id=runtime.layout.channel_id,
         root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     registration = VaultRegistration(
         vault_binding_id=matched.vault_binding_id,
@@ -240,6 +260,7 @@ def _mechanically_reactivate_binding(
     runtime.registry.commit_state(
         registrations=registrations,
         expected_revision=current.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     return registration
 
@@ -273,6 +294,80 @@ def test_dormant_runtime_api_exports_no_caller_constructible_activation_seam() -
         assert "CapabilityNotReadyError" in method_source
         assert "self.registry" not in method_source
         assert "self.ledger" not in method_source
+
+
+def test_store_and_ledger_mutators_reject_uncapable_callers(tmp_path) -> None:
+    """Public storage objects reject before any registry or ledger write."""
+
+    with pytest.raises(
+        TypeError,
+        match="storage mutation capability is not caller-constructible",
+    ):
+        _StorageMutationCapability()
+
+    host_global = tmp_path / "host-global"
+    runtime = _runtime(tmp_path, "dev", host_global)
+    root = tmp_path / "vault"
+    root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=root,
+        watcher_vault_path=root,
+    )
+    snapshot = runtime.registry.load()
+    replacement = replace(
+        registration,
+        vault_name="must-not-persist",
+    )
+    extra = VaultRegistration(
+        vault_binding_id="binding-uncapable",
+        ref="path:/uncapable",
+        path="/uncapable",
+        vault_id="vault-uncapable",
+        local_instance_id="local-uncapable",
+    )
+    before = _runtime_state_bytes(tmp_path, runtime)
+    mutations = (
+        lambda: runtime.registry.register(extra),
+        lambda: runtime.registry.update_registration(replacement),
+        lambda: runtime.registry.remove_registration(registration.vault_binding_id),
+        lambda: runtime.registry.commit_state(
+            registrations=dict(snapshot.registrations),
+            expected_revision=snapshot.revision,
+        ),
+        lambda: runtime.registry.set_extension_state(
+            default_vault_binding_id=registration.vault_binding_id,
+            dimensions={},
+            principal_state={},
+            background_state={},
+            runtime_floors={},
+        ),
+        lambda: runtime.ledger.reserve(
+            channel_id="test",
+            vault_binding_id="binding-uncapable",
+            root=root,
+        ),
+        lambda: runtime.ledger.activate(registration.vault_binding_id),
+        lambda: runtime.ledger.begin_transfer(
+            source_binding_id=registration.vault_binding_id,
+            destination_channel_id="test",
+            destination_binding_id="binding-destination",
+        ),
+        lambda: runtime.ledger.activate_transfer(),
+        lambda: runtime.ledger.release_to_tombstone(registration.vault_binding_id),
+        lambda: runtime.ledger.reactivate(
+            registration.vault_binding_id,
+            channel_id="dev",
+            root=root,
+        ),
+    )
+
+    for mutate in mutations:
+        with pytest.raises(
+            CapabilityNotReadyError,
+            match="private MVR storage mutation capability is required",
+        ):
+            mutate()
+        assert _runtime_state_bytes(tmp_path, runtime) == before
 
 
 def _rotation_authority(
@@ -665,12 +760,16 @@ def test_retry_recovers_pending_owner_after_registry_commit(tmp_path, monkeypatc
     original_activate = runtime.ledger.activate
     failures = 0
 
-    def fail_once(vault_binding_id: str):
+    def fail_once(
+        vault_binding_id: str,
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ):
         nonlocal failures
         failures += 1
         if failures == 1:
             raise RuntimeError("injected activate failure")
-        return original_activate(vault_binding_id)
+        return original_activate(vault_binding_id, _capability=_capability)
 
     monkeypatch.setattr(runtime.ledger, "activate", fail_once)
     with pytest.raises(RuntimeError, match="injected activate failure"):

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -304,6 +304,7 @@ def test_store_and_ledger_mutators_reject_uncapable_callers(tmp_path) -> None:
         match="storage mutation capability is not caller-constructible",
     ):
         _StorageMutationCapability()
+    forged_capability = object.__new__(_StorageMutationCapability)
 
     host_global = tmp_path / "host-global"
     runtime = _runtime(tmp_path, "dev", host_global)
@@ -368,6 +369,33 @@ def test_store_and_ledger_mutators_reject_uncapable_callers(tmp_path) -> None:
         ):
             mutate()
         assert _runtime_state_bytes(tmp_path, runtime) == before
+
+    with pytest.raises(
+        CapabilityNotReadyError,
+        match="private MVR storage mutation capability is required",
+    ):
+        runtime.registry.register(extra, _capability=forged_capability)
+    assert _runtime_state_bytes(tmp_path, runtime) == before
+
+    with pytest.raises(
+        CapabilityNotReadyError,
+        match="private MVR storage mutation capability is required",
+    ):
+        runtime.ledger.recover_or_require_active(
+            registration.vault_binding_id,
+            channel_id="dev",
+            root=root,
+        )
+    assert _runtime_state_bytes(tmp_path, runtime) == before
+
+    with pytest.raises(
+        CapabilityNotReadyError,
+        match="private MVR storage mutation capability is required",
+    ):
+        runtime.ledger.bootstrap_legacy_owners(
+            [], inventory_complete=True, writers_drained=True
+        )
+    assert _runtime_state_bytes(tmp_path, runtime) == before
 
 
 def _rotation_authority(
@@ -796,12 +824,18 @@ def test_first_upgrade_seeds_all_legacy_channel_owners_before_claim(tmp_path) ->
         ],
         inventory_complete=True,
         writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     assert {lease.channel_id for lease in seeded.leases.values()} == {"dev", "prod"}
 
     missing = OwnershipLedger(tmp_path / "missing-host-global")
     with pytest.raises(LedgerCollisionError, match="complete"):
-        missing.bootstrap_legacy_owners([], inventory_complete=False, writers_drained=True)
+        missing.bootstrap_legacy_owners(
+            [],
+            inventory_complete=False,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
 
 
 def test_env_only_bootstrap_atomically_enrolls_one_stable_binding_or_fails_closed(tmp_path) -> None:

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -360,6 +360,7 @@ def test_store_and_ledger_mutators_reject_uncapable_callers(tmp_path) -> None:
             channel_id="dev",
             root=root,
         ),
+        lambda: runtime.ledger.rotate_key(precondition=lambda snapshot, roots: None),
     )
 
     for mutate in mutations:

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -51,6 +51,7 @@ from scripts.instance_state_writer_inventory import (
     _parse_linux_stat,
     _parse_macos_ps_row,
 )
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -420,7 +421,10 @@ def _install_linux_proc_fixture(
 def test_mvr01a_schema_activation_requires_rollback_capability(tmp_path) -> None:
     registry_path = tmp_path / "vault-registry.md"
     store = VaultRegistryStore(registry_path)
-    store.register(VaultRegistration("binding-a", "path:/a", "/a"))
+    store.register(
+        VaultRegistration("binding-a", "path:/a", "/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
 
     with pytest.raises(CapabilityNotReadyError, match="MVR-01B rollback exporter/transformer"):
         store.require_authoritative_activation(RegistryActivationProof())
@@ -2579,8 +2583,12 @@ def test_backup_resolves_foreign_binding_ids_omitted_by_owner_producer(tmp_path)
         channel_id="dev",
         vault_binding_id=foreign_binding,
         root=foreign_root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
-    runtime.ledger.activate(foreign_binding)
+    runtime.ledger.activate(
+        foreign_binding,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     proof, owner_receipt = _canonical_test_quiescence_authority(
         layout=layout,
         host_global_root=runtime.ledger.root,
@@ -2744,6 +2752,7 @@ def test_backup_capture_blocks_concurrent_writer_until_generation_is_captured(
                         path=str(second_root.resolve()),
                     ),
                     expected_revision=initial_registry.revision,
+                    _capability=STORAGE_MUTATION_CAPABILITY,
                 )
         except BaseException as exc:
             writer_errors.append(exc)
@@ -2808,14 +2817,19 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                     path=str(second_root.resolve()),
                 ),
                 expected_revision=current.revision,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
         else:
             runtime.ledger.reserve(
                 channel_id="prod",
                 vault_binding_id=second_binding,
                 root=second_root,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            runtime.ledger.activate(second_binding)
+            runtime.ledger.activate(
+                second_binding,
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
         proof, owner_receipt = _canonical_test_quiescence_authority(
             layout=layout,
             host_global_root=runtime.ledger.root,
@@ -2867,6 +2881,7 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                     path=str(tampered_root.resolve()),
                 ),
                 expected_revision=backup_snapshot.revision,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
         else:
             backup_ledger = InstanceRegistryRuntime.for_paths(
@@ -2880,8 +2895,12 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                 channel_id="prod",
                 vault_binding_id=second_binding,
                 root=tampered_root,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            backup_ledger.activate(second_binding)
+            backup_ledger.activate(
+                second_binding,
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
         _refresh_backup_checksums(backup_root)
         protected_roots = (valid_layout.root, valid_runtime.ledger.root)
         before = {
@@ -2934,8 +2953,12 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
             channel_id="dev",
             vault_binding_id=foreign_binding,
             root=foreign_root,
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
-        runtime.ledger.activate(foreign_binding)
+        runtime.ledger.activate(
+            foreign_binding,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
         live_channel = "dev"
         live_binding = foreign_binding
         if divergence.endswith("tombstone") or "lineage" in divergence:
@@ -2944,8 +2967,11 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                 source_binding_id=foreign_binding,
                 destination_channel_id="test",
                 destination_binding_id=destination_binding,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            runtime.ledger.activate_transfer()
+            runtime.ledger.activate_transfer(
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
             live_channel = "test"
             live_binding = destination_binding
         if divergence == "cross-channel-self-lineage":
@@ -2954,8 +2980,11 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                 source_binding_id=destination_binding,
                 destination_channel_id="native",
                 destination_binding_id=final_binding,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            runtime.ledger.activate_transfer()
+            runtime.ledger.activate_transfer(
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
             live_channel = "native"
             live_binding = final_binding
 
@@ -3040,8 +3069,12 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
             channel_id="dev",
             vault_binding_id=restore_foreign_binding,
             root=restore_foreign_root,
+            _capability=STORAGE_MUTATION_CAPABILITY,
         )
-        restore_runtime.ledger.activate(restore_foreign_binding)
+        restore_runtime.ledger.activate(
+            restore_foreign_binding,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
         restore_live_channel = "dev"
         restore_live_binding = restore_foreign_binding
         if divergence.endswith("tombstone") or "lineage" in divergence:
@@ -3050,8 +3083,11 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                 source_binding_id=restore_foreign_binding,
                 destination_channel_id="test",
                 destination_binding_id=restore_destination,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            restore_runtime.ledger.activate_transfer()
+            restore_runtime.ledger.activate_transfer(
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
             restore_live_channel = "test"
             restore_live_binding = restore_destination
         if divergence == "cross-channel-self-lineage":
@@ -3060,8 +3096,11 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
                 source_binding_id=restore_destination,
                 destination_channel_id="native",
                 destination_binding_id=restore_final,
+                _capability=STORAGE_MUTATION_CAPABILITY,
             )
-            restore_runtime.ledger.activate_transfer()
+            restore_runtime.ledger.activate_transfer(
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
             restore_live_channel = "native"
             restore_live_binding = restore_final
         restore_complete_owners = _current_registry_owners(restore_runtime) + [
@@ -3316,6 +3355,7 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
         principal_state={"operator": "local"},
         background_state={"mode": "compatibility"},
         runtime_floors={"registry": "01b"},
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     _create_canonical_backup(
         runtime=runtime,
@@ -3420,6 +3460,7 @@ def test_prod_restore_rejects_noncanonical_quiescence_authority_without_mutation
         principal_state={"operator": "changed"},
         background_state={"mode": "changed"},
         runtime_floors={"registry": "changed"},
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
 
     owner_receipt = None
@@ -3551,6 +3592,7 @@ def test_prod_restore_rejects_foreign_channel_before_writing_target_state(tmp_pa
         principal_state={"operator": "prod"},
         background_state={"mode": "prod"},
         runtime_floors={"registry": "prod"},
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
 
     proof, owner_receipt = _canonical_test_quiescence_authority(

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -2268,7 +2268,8 @@ def test_runtime_preflight_rejects_foreign_channel_host_global_lease_without_mut
         watcher_vault_path=prod_vault,
     )
     prod_runtime.ledger.bootstrap_legacy_owners(
-        [], inventory_complete=True, writers_drained=True
+        [], inventory_complete=True, writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
     )
     dev_state_root = tmp_path / "dev-state"
     dev_state_root.mkdir()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4033

## Linked Issue
Fixes #4033

## SBS Impact
- Primary subsystem: WSP
- Secondary subsystem(s): PDM, SFC, EBF, Builder System architecture-fitness boundary
- Write class: mechanical durable instance-local and host-global state; governance enforcement for the import contract
- Authority impact: none; strengthens the existing dormant boundary and grants no registry authority
- Persistence impact: no schema change; rejects unauthorized registry/ledger mutations before on-disk writes
- Derived/rebuildable impact: import-linter output is rebuildable CI evidence
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: preserves sanctioned MVR-01B bootstrap, deployment, rotation, backup, and restore transactions
- External boundary impact: none; protected path fingerprints and ownership state retain the existing EBF posture
- New or changed contract: private dormant MVR storage mutation capability and ADR-0013 import-boundary projection
- Owner-doc impact: updates the MVR-01B acceptance surface and ADR-0013 enforcement-reality text with the delivered storage-boundary/import-contract proof
- Transition debt impact: reduces the known facade-only dormant-seal gap without adding transition debt
- Fitness rule impact: strengthens ADR-0013 enforcement and the WSP/PDM dormant-authority boundary
- Boundary risk: an uncapable caller must not obtain or construct the private capability or mutate durable registry/ledger state

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Seal every issue-listed registry and ownership-ledger mutator—including legacy-owner bootstrap, pending-lease recovery, and key rotation—with one private, non-caller-constructible identity capability before any read, lock, or write.
- Preserve sanctioned MVR-01B runtime and fixture producers through explicit capability paths, and protect the mutation modules and capability module with blocking import-linter contracts.
- Add public-object negative proof that all listed calls fail without changing durable bytes, while preserving the existing `RegistryError` hierarchy.
- Write the delivered boundary and exact proof selectors back to the owning MVR-01B acceptance surface.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260728211502_2555ca48`
- Reason: the readiness repair initially over-scoped the import-linter protected module set; focused proof exposed legitimate legacy/read importers and the signal records the upstream contract-repair divergence.

## Validation
- `pytest -q tests/integration/test_vault_registry_channel_isolation.py::test_store_and_ledger_mutators_reject_uncapable_callers tests/architecture/test_import_boundary.py::test_instance_storage_mutation_import_contract_is_complete` — 2 passed
- Five issue-declared sanctioned-path selectors — 5 passed
- `lint-imports --config importlinter.ini` — 3 contracts kept, 0 broken
- `pytest -q tests/ops/test_instance_state_volume_contract.py tests/integration/test_vault_registry_container_durability.py tests/integration/test_vault_registry_channel_isolation.py tests/integration/test_vault_registry_rollback.py` — 122 passed, 3 skipped
- `ruff check app tests` — passed
- `mypy app` — no issues in 813 source files
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — OK; temporal skip is justified because this change does not alter temporal truth surfaces

## Notes
- Claim: dispatcher lease `lease-d8ec6f79` held by `mvr-4033-delivery`.
- Low-convergence receipt: mechanism `mvr-dormant-storage-mutation-capability`, domain `data/state-machine`; standard attempts 2/2 exhausted; strongest attempt 1/2 repaired rotate_key, strongest attempt 2/2 repairs ADR-0013 contract truth and is pending fresh exact-head review on `3cb0aa608a07bfe9f4ce9c9d7a24ae2bc88dd85e`.
- Repair receipt: `recover_or_require_active`, `bootstrap_legacy_owners`, and `rotate_key` now guard before reads/locks/writes; runtime no longer exposes a module-level capability attribute; forged-capability, no-op rotation, and durable-byte negative proof are included.
- P3 residual: Python privacy remains architectural rather than language-enforced; constructor sealing, exact-identity comparison, protected imports, and direct negative proof form the boundary.
- MVR-01C (#3855) and the separate backup-consistency slice (#4034) remain out of scope.
