### PR TITLE
ckm: fail loud when a maturity dimension has no producing linker

### DIFF
--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -14,6 +14,7 @@ from typing import Callable, Mapping, Sequence
 
 from app.builderops.ckm.models import (
     MATURITY_DIMENSIONS,
+    UNMEASURABLE_MATURITY_DIMENSIONS,
     CkmArtifact,
     CkmEvidenceEdge,
     CkmValidationError,
@@ -489,9 +490,16 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
             candidate_shares[dimension] = (
                 len(candidates) / len(supporting) if supporting else 0.0
             )
-            dimension_status[dimension] = result.status or (
-                "measured" if result.edges else "missing"
-            )
+            if dimension in UNMEASURABLE_MATURITY_DIMENSIONS:
+                # No deterministic linker can ever populate this dimension
+                # (UNMEASURABLE_MATURITY_DIMENSIONS docstring in models.py);
+                # say so explicitly instead of reporting the ambiguous
+                # "missing" a scorer with zero evidence this run would emit.
+                dimension_status[dimension] = "unsupported"
+            else:
+                dimension_status[dimension] = result.status or (
+                    "measured" if result.edges else "missing"
+                )
             formula_ids[dimension] = _DIMENSION_FORMULA_IDS[dimension]
         assessment = store.append_assessment(
             capability_id=capability.id,

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -93,6 +93,22 @@ MATURITY_DIMENSIONS = (
     "requirement_coverage",
 )
 
+# Dimensions declared unmeasurable-for-now: no deterministic linker
+# (``app/builderops/ckm/linkers.py``) can emit a ``maturity_dimension`` value
+# for them, so a live edge count is structurally impossible, not merely absent
+# on this run. ``operational_readiness`` has no producing rule in any of the
+# five linker families (matrix, spec-directory/-source, adr-reference,
+# test-code, github-ref); building one is a separate, out-of-scope design
+# question (docs/CAPABILITY_KNOWLEDGE_MODEL/DETERMINISTIC_EVIDENCE_LINKERS.md).
+# ``app/builderops/ckm/assess.py`` reads this set and stamps every such
+# dimension's ``dimension_status`` as ``"unsupported"`` (a state
+# ``SUPPORTED_VALUE_STATES`` already carries) rather than the ambiguous
+# ``"missing"`` a scorer with genuinely zero evidence this run would report.
+# ``tests/builderops/ckm/test_linker_dimension_coverage.py`` enforces that
+# every dimension outside this set has at least one producing linker, and
+# that this set never masks a dimension that actually has one.
+UNMEASURABLE_MATURITY_DIMENSIONS = frozenset({"operational_readiness"})
+
 # --- Finding -----------------------------------------------------------------
 
 FINDING_KINDS = frozenset({"gap", "missing_evidence"})

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/DETERMINISTIC_EVIDENCE_LINKERS.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/DETERMINISTIC_EVIDENCE_LINKERS.md
@@ -27,6 +27,39 @@ Implements `app/builderops/ckm/linkers.py` — each linker reads ingested artifa
 
 Each linker is idempotent (INV-CKM-7: natural key = artifact+capability+basis) and re-runs incrementally over artifacts newer than its last watermark. CLI: `python -m app.builderops ckm link`.
 
+**Dimension coverage (2026-07-29, #4258).** Tracing every `_emit(...)` call site in
+`linkers.py` against `MATURITY_DIMENSIONS` (`app/builderops/ckm/models.py`) shows the
+five rule families jointly cover six of the seven dimensions: matrix → functional /
+test / documentation / architectural (by cited artifact kind); spec-directory →
+requirement coverage; github-ref's non-closing, non-merged branch → integration
+completeness. **`operational_readiness` has no producing rule in any linker** — a live
+run against this repo on 2026-07-28 confirmed it: `missing` for all 31 capabilities,
+scoring `0.0` for every one, permanently, because nothing ever emits that
+`maturity_dimension`. That is an instrument defect (a dimension that can never score,
+regardless of how operationally ready the system actually is), not a finding about the
+system. Building an operational-readiness linker is a separate design question (what
+would even constitute deterministic operational evidence — runbooks? health-check
+wiring? deploy scripts? — is unresolved) and is explicitly out of scope here.
+
+Resolution: `operational_readiness` stays a declared dimension in `MATURITY_DIMENSIONS`
+— narrowing the seven-dimension vector from
+`docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md :: 6` is a bigger, separate decision than
+this defect calls for — but it is named in
+`app/builderops/ckm/models.py :: UNMEASURABLE_MATURITY_DIMENSIONS`. `assess.py` reads
+that set and stamps every such dimension's `dimension_status` as `"unsupported"`, a
+state `SUPPORTED_VALUE_STATES` already defines and `overview_html.py` already renders
+distinctly ("Unsupported is not a zero score"). This replaces the ambiguous `"missing"`
+a scorer with genuinely zero evidence *this run* would otherwise report, so the
+resolution is readable straight off the model rather than inferred from an empty
+citations table.
+
+`tests/builderops/ckm/test_linker_dimension_coverage.py` is the standing, deterministic
+guard: it fails and names the offending dimension if any declared dimension outside
+`UNMEASURABLE_MATURITY_DIMENSIONS` ever loses its last producing linker (or a new
+dimension is declared without one), and separately checks that every declared
+"unmeasurable" dimension genuinely still has zero producers — so the escape hatch can
+never quietly cover for a regression instead of a real structural gap.
+
 ## Concretely
 
 ```bash

--- a/tests/builderops/ckm/test_linker_dimension_coverage.py
+++ b/tests/builderops/ckm/test_linker_dimension_coverage.py
@@ -1,0 +1,155 @@
+"""Every declared maturity dimension must have a producing linker, or be
+declared unmeasurable explicitly (models.py :: UNMEASURABLE_MATURITY_DIMENSIONS).
+
+A dimension with zero producing linkers and no declaration degrades silently:
+it is ``missing`` for every capability forever, scores ``0.0`` forever, and
+nothing fails loudly to say so. This module is the deterministic guard
+against that (issue #4258); it names the offending dimension when it fires.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.builderops.ckm.assess import assess_capabilities
+from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    UNMEASURABLE_MATURITY_DIMENSIONS,
+    CkmCapability,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+def _register(store: CkmStore, source_ref: str, artifact_kind: str, **provenance: object) -> None:
+    store.upsert_artifact(
+        source_ref=source_ref,
+        artifact_kind=artifact_kind,
+        source="fixture",
+        watermark="one",
+        provenance=json.dumps({"source_ref": source_ref, **provenance}),
+    )
+
+
+def _build_full_coverage_fixture(root: Path, store: CkmStore) -> CkmCapability:
+    """Register one capability plus a minimal artifact set that exercises
+    every deterministic-linker rule family capable of emitting a distinct
+    ``maturity_dimension`` value:
+
+    - matrix linker (single-candidate boundary, so no name/source selector is
+      needed): a document, an ADR, a source file, and a test cited by one row
+      -> documentation_quality, architectural_stability, functional_completeness,
+      test_completeness.
+    - spec-directory linker: a spec file naming the capability as its
+      ``parent_capability`` -> requirement_coverage.
+    - github-spec-ref linker: an open issue referencing that spec file
+      (neither a closed ``type:task`` nor a merged PR) -> integration_completeness.
+    """
+
+    capability = store.upsert_capability(
+        identity_key="fixture:coverage:ops-capability",
+        name="Ops Capability",
+        definition="Fixture capability spanning every linker-producible dimension.",
+        existence_provenance="seeded:docs/PLAN.md :: ops",
+        lifecycle="confirmed",
+        boundary_ref="RCA",
+    )
+
+    # NOTE: the doc's filename deliberately avoids the operational-readiness
+    # scorer's keyword fallback ("operat", "runbook", "health", "observab",
+    # "deploy" -- app/builderops/ckm/assess.py :: _operational) so this fixture
+    # stays a clean trace of what the *linkers* produce, not what that
+    # unrelated (out-of-scope) scorer heuristic happens to pick up.
+    matrix_path = root / "docs/architecture/traceability-matrix.md"
+    matrix_path.parent.mkdir(parents=True, exist_ok=True)
+    matrix_path.write_text(
+        "| # | Principle | Control boundaries | Contract | Tests |\n"
+        "| --- | --- | --- | --- | --- |\n"
+        "| 1 | Ops readiness needs coverage. | RCA | "
+        "[Ops doc](../../docs/PLAN.md) [ADR](../../docs/adr/ADR-9000.md) "
+        "[Ops source](../../app/ops.py) | [Ops test](../../tests/test_ops.py) |\n",
+        encoding="utf-8",
+    )
+
+    spec_path = root / "docs/CAP/TASK.md"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(
+        '---\nparent_capability: "Ops Capability"\n---\n\nOps task body.\n',
+        encoding="utf-8",
+    )
+
+    _register(store, "docs/PLAN.md", "document")
+    _register(store, "docs/adr/ADR-9000.md", "adr")
+    _register(store, "app/ops.py", "source_file")
+    _register(store, "tests/test_ops.py", "test")
+    _register(store, "docs/CAP/TASK.md", "spec")
+    _register(
+        store,
+        "github:issue:1",
+        "issue",
+        references=["docs/CAP/TASK.md"],
+        state="open",
+        labels=[],
+    )
+
+    return capability
+
+
+def test_every_dimension_has_a_producing_linker(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    _build_full_coverage_fixture(root, store)
+
+    link_deterministic(store, root)
+
+    produced_dimensions = {edge.maturity_dimension for edge in store.list_evidence_edges()}
+    expected_producible = set(MATURITY_DIMENSIONS) - UNMEASURABLE_MATURITY_DIMENSIONS
+    missing = sorted(expected_producible - produced_dimensions)
+    assert not missing, (
+        "declared maturity dimension(s) with no producing deterministic linker: "
+        f"{missing}. Either add a producing linker rule in "
+        "app/builderops/ckm/linkers.py or declare the dimension unmeasurable in "
+        "app/builderops/ckm/models.py :: UNMEASURABLE_MATURITY_DIMENSIONS."
+    )
+
+
+def test_unmeasurable_dimensions_are_declared(tmp_path: Path) -> None:
+    # The one currently-known case (issue #4258): operational_readiness has
+    # zero producing linkers and must be resolved explicitly rather than left
+    # to silently degrade to "missing" / score 0.0 forever.
+    assert "operational_readiness" in UNMEASURABLE_MATURITY_DIMENSIONS
+    # Declared-unmeasurable dimensions stay declared maturity dimensions; a
+    # removal from MATURITY_DIMENSIONS would be a separate, explicit decision.
+    assert UNMEASURABLE_MATURITY_DIMENSIONS <= set(MATURITY_DIMENSIONS)
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    capability = _build_full_coverage_fixture(root, store)
+    link_deterministic(store, root)
+
+    produced_dimensions = {edge.maturity_dimension for edge in store.list_evidence_edges()}
+    stale = sorted(UNMEASURABLE_MATURITY_DIMENSIONS & produced_dimensions)
+    assert not stale, (
+        f"dimension(s) declared unmeasurable actually have a live deterministic "
+        f"producer, so the declaration is stale: {stale}"
+    )
+
+    run = assess_capabilities(store)
+    assert run.assessed >= 1
+    assessment = store.latest_assessment_for_capability(capability.id)
+    assert assessment is not None
+    for dimension in UNMEASURABLE_MATURITY_DIMENSIONS:
+        # The resolution must be readable straight off the model -- a
+        # dedicated status, not inferred from an empty evidence/citation table.
+        assert assessment.dimension_status[dimension] == "unsupported", (
+            f"{dimension} is declared unmeasurable but its assessment "
+            f"dimension_status is {assessment.dimension_status[dimension]!r}, "
+            "not the model-visible 'unsupported' state"
+        )
+        assert assessment.scores[dimension] == 0.0
+        assert assessment.citations[dimension] == []


### PR DESCRIPTION
Governing-Issue: #4258

Fixes #4258

Final-Review-Rounds: 0

## Summary
`MATURITY_DIMENSIONS` declares seven dimensions but the deterministic linkers only ever produce evidence for six; `operational_readiness` has zero producing linkers, so it silently reads `missing` and scores `0.0` for every capability forever. This adds a standing test that fails and names any declared dimension with no producing linker, and resolves the current `operational_readiness` case explicitly by declaring it unmeasurable-for-now on the model (`UNMEASURABLE_MATURITY_DIMENSIONS`) rather than removing it or building a linker for it (out of scope per the issue).

## Resolution: operational_readiness
- Traced every `_emit(...)` call site in `app/builderops/ckm/linkers.py` against `MATURITY_DIMENSIONS`: the five rule families (matrix, spec-directory/-source, adr-reference, test-code, github-ref) jointly produce `functional_completeness`, `test_completeness`, `documentation_quality`, `architectural_stability`, `requirement_coverage`, and `integration_completeness` (the last only from github-ref's non-closing/non-merged branch). Confirmed empirically by running the linkers against a synthetic fixture that exercises every rule family (`tests/builderops/ckm/test_linker_dimension_coverage.py`) and against the real repo corpus.
- `operational_readiness` has no producing rule anywhere in `linkers.py`. Building one is explicitly out of scope (issue #4258 Constraints) since it requires a separate design decision about what would even constitute deterministic operational evidence.
- Kept `operational_readiness` in `MATURITY_DIMENSIONS` -- narrowing the seven-dimension vector from `docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md :: 6` is a bigger decision than this defect calls for, and the owner docs don't support it. Instead it's named in `app/builderops/ckm/models.py :: UNMEASURABLE_MATURITY_DIMENSIONS`, and `assess.py` now stamps its `dimension_status` as `"unsupported"` -- a state `SUPPORTED_VALUE_STATES` already defines and `overview_html.py` already renders distinctly ("Unsupported is not a zero score") -- instead of the ambiguous `"missing"` a scorer with genuinely zero evidence *this run* would otherwise report. The resolution is now readable straight off the model.
- This composes cleanly with #4257/#4260 (merged just before this branch rebased): its gap-detection gate already skips any dimension whose `dimension_status != "measured"`, so `"unsupported"` is skipped exactly like `"missing"` was -- no gaps.py change needed here, and this PR does not touch `gaps.py`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded code + test + doc change fully captured by the governing Issue and this PR; no BuilderOps operational record was needed.

## Notes
Validation (all run synchronously on the head SHA, post-rebase onto origin/main):
- `pytest -q tests/builderops/ckm/` -> 298 passed
- `ruff check app tests` -> All checks passed!
- `ruff check app tests companion-ui/companion-app` -> All checks passed! (matches `.github/workflows/ci-smoke.yaml`)

Doc writeback: `docs/CAPABILITY_KNOWLEDGE_MODEL/DETERMINISTIC_EVIDENCE_LINKERS.md :: What This Task Does` records the coverage tracing, the resolution, and the standing guard.
---