### PR TITLE
fix: bound verification-request discovery by scoping the query

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -318,7 +318,16 @@ _MAX_ARTIFACT_COMPRESSED_BYTES = 2_000_000
 _MAX_ARTIFACT_MEMBERS = 16
 _MAX_ARTIFACT_UNCOMPRESSED_BYTES = 2_000_000
 _MAX_ARTIFACT_LISTING_ROWS = 1_000
-_MAX_VERIFICATION_REQUEST_RUN_ROWS = 200
+# Unlike artifacts (which age out via retention/expiry), workflow-run history
+# accumulates forever, so a plain row cap on "all runs of this workflow" goes
+# stale exactly like the repo-wide artifact listing did (confirmed live: this
+# repository already has 1,000+ successful verification-dispatch-request.yml
+# runs). Discovery instead windows the query by recency (see
+# _VERIFICATION_REQUEST_RUN_LOOKBACK below): the row bound only has to cover
+# runs from that window, which scales with current dispatch *rate*, not with
+# all-time repository history.
+_MAX_VERIFICATION_REQUEST_RUN_ROWS = 1_000
+_VERIFICATION_REQUEST_RUN_LOOKBACK = timedelta(hours=48)
 _MAX_REQUEST_BYTES = 1_000_000
 _MAX_CLOSURE_CANDIDATES = 20
 _MAX_REPOSITORY_CLOSURE_EVENTS = 500
@@ -1034,13 +1043,18 @@ class GhCliVerificationSource:
     ) -> list[dict[str, object]]:
         """Discover pending verification-dispatch requests.
 
-        Unscoped (default): enumerate recent runs of the
-        ``verification-dispatch-request.yml`` workflow — bounded by the
-        number of relevant runs, not by the repository's total artifact
-        count — and read each run's own (small, run-scoped) artifact
-        listing. This replaced a repository-wide artifact scan that exceeded
-        its bound on every call once the repository held more artifacts than
-        ``_MAX_ARTIFACT_LISTING_ROWS``.
+        Unscoped (default): enumerate runs of the
+        ``verification-dispatch-request.yml`` workflow created within the
+        last ``_VERIFICATION_REQUEST_RUN_LOOKBACK`` window, and read each
+        run's own (small, run-scoped) artifact listing. This replaced a
+        repository-wide artifact scan that exceeded its bound on every call
+        once the repository held more artifacts than
+        ``_MAX_ARTIFACT_LISTING_ROWS``. The window (not just a row cap) is
+        load-bearing: this workflow fires on every CI Smoke completion, so
+        its all-time run count grows without bound the same way the
+        repository's total artifact count did; only the recency filter keeps
+        the query small regardless of how old the repository or the
+        workflow gets.
 
         Scoped (additive, optional, keyword-only): when both ``pr_number``
         and ``head_sha`` are supplied, issue exactly one exact-name query for
@@ -1079,10 +1093,13 @@ class GhCliVerificationSource:
                 repository, artifacts, requests, limit, first_rejection
             )
         else:
+            cutoff = (
+                datetime.now(timezone.utc) - _VERIFICATION_REQUEST_RUN_LOOKBACK
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
             runs = self._verification_dispatch_run_pages(
                 f"repos/{repository}/actions/workflows/"
                 f"{_VERIFICATION_REQUEST_WORKFLOW_FILENAME}/runs"
-                "?per_page=100&status=success"
+                f"?per_page=100&status=success&created=>={cutoff}"
             )
             for run in runs:
                 if len(requests) >= limit:

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -318,6 +318,7 @@ _MAX_ARTIFACT_COMPRESSED_BYTES = 2_000_000
 _MAX_ARTIFACT_MEMBERS = 16
 _MAX_ARTIFACT_UNCOMPRESSED_BYTES = 2_000_000
 _MAX_ARTIFACT_LISTING_ROWS = 1_000
+_MAX_VERIFICATION_REQUEST_RUN_ROWS = 200
 _MAX_REQUEST_BYTES = 1_000_000
 _MAX_CLOSURE_CANDIDATES = 20
 _MAX_REPOSITORY_CLOSURE_EVENTS = 500
@@ -329,6 +330,7 @@ _VERIFICATION_REQUEST_WORKFLOW_NAME = "Verification Dispatch Request"
 _VERIFICATION_REQUEST_WORKFLOW_PATH = (
     ".github/workflows/verification-dispatch-request.yml"
 )
+_VERIFICATION_REQUEST_WORKFLOW_FILENAME = "verification-dispatch-request.yml"
 _CLOSURE_NODES_QUERY = """
 query($ids:[ID!]!){
   nodes(ids:$ids){
@@ -666,6 +668,47 @@ class GhCliVerificationSource:
                 return rows
         raise RuntimeError("GitHub artifact listing exceeds bounded scan")
 
+    def _verification_dispatch_run_pages(self, endpoint: str) -> list[object]:
+        """Return a bounded, complete listing of verification-request workflow runs.
+
+        Scoped to runs of ``verification-dispatch-request.yml`` instead of the
+        repository-wide artifact listing: the number of runs of one workflow
+        stays small and near-constant, so this scan never grows with the
+        repository's total (unrelated) artifact volume the way the whole-repo
+        listing did. Same fail-loud discipline as ``_artifact_listing_pages``:
+        a scan that cannot prove completeness raises rather than truncating.
+        """
+
+        rows: list[object] = []
+        separator = "&" if "?" in endpoint else "?"
+        for page in range(1, (_MAX_VERIFICATION_REQUEST_RUN_ROWS // 100) + 1):
+            page_endpoint = endpoint if page == 1 else f"{endpoint}{separator}page={page}"
+            payload = self._json(page_endpoint)
+            runs = payload.get("workflow_runs") if isinstance(payload, Mapping) else None
+            total_count = payload.get("total_count") if isinstance(payload, Mapping) else None
+            if (
+                not isinstance(runs, list)
+                or (
+                    total_count is not None
+                    and (
+                        not isinstance(total_count, int)
+                        or isinstance(total_count, bool)
+                        or total_count < len(rows) + len(runs)
+                    )
+                )
+            ):
+                raise RuntimeError("malformed GitHub workflow run listing")
+            rows.extend(runs)
+            if len(rows) > _MAX_VERIFICATION_REQUEST_RUN_ROWS:
+                raise RuntimeError("GitHub workflow run listing exceeds bounded scan")
+            if isinstance(total_count, int) and total_count <= len(rows):
+                return rows
+            if len(runs) < 100:
+                if isinstance(total_count, int) and total_count > len(rows):
+                    raise RuntimeError("GitHub workflow run listing is incomplete")
+                return rows
+        raise RuntimeError("GitHub workflow run listing exceeds bounded scan")
+
     def _artifact_bytes(self, endpoint: str, artifact_id: int) -> bytes:
         if self.runner is not subprocess.run:
             result = self.runner(
@@ -956,18 +999,18 @@ class GhCliVerificationSource:
         except _InvalidVerificationArtifact:
             raise
 
-    def pending_requests(
-        self, repository: str, *, limit: int = 20
-    ) -> list[dict[str, object]]:
-        if limit <= 0:
-            raise ValueError("artifact request limit must be positive")
-        artifacts = self._artifact_listing_pages(
-            f"repos/{repository}/actions/artifacts?per_page=100"
-        )
-        requests: list[dict[str, object]] = []
-        first_rejection: _InvalidVerificationArtifact | None = None
+    def _extend_requests_from_artifacts(
+        self,
+        repository: str,
+        artifacts: Iterable[object],
+        results: list[dict[str, object]],
+        limit: int,
+        first_rejection: _InvalidVerificationArtifact | None,
+    ) -> _InvalidVerificationArtifact | None:
+        """Authenticate and append artifacts into ``results`` up to ``limit``."""
+
         for artifact in artifacts:
-            if len(requests) >= limit:
+            if len(results) >= limit:
                 break
             if not isinstance(artifact, Mapping):
                 continue
@@ -978,7 +1021,88 @@ class GhCliVerificationSource:
                     first_rejection = exc
                 continue
             if request is not None:
-                requests.append(request)
+                results.append(request)
+        return first_rejection
+
+    def pending_requests(
+        self,
+        repository: str,
+        *,
+        limit: int = 20,
+        pr_number: int | None = None,
+        head_sha: str | None = None,
+    ) -> list[dict[str, object]]:
+        """Discover pending verification-dispatch requests.
+
+        Unscoped (default): enumerate recent runs of the
+        ``verification-dispatch-request.yml`` workflow — bounded by the
+        number of relevant runs, not by the repository's total artifact
+        count — and read each run's own (small, run-scoped) artifact
+        listing. This replaced a repository-wide artifact scan that exceeded
+        its bound on every call once the repository held more artifacts than
+        ``_MAX_ARTIFACT_LISTING_ROWS``.
+
+        Scoped (additive, optional, keyword-only): when both ``pr_number``
+        and ``head_sha`` are supplied, issue exactly one exact-name query for
+        ``verification-dispatch-<pr_number>-<head_sha>`` and skip enumeration
+        entirely. Existing callers that omit both keep today's unscoped
+        behaviour unchanged; ``limit``'s meaning and the return type are
+        unchanged either way.
+        """
+
+        if limit <= 0:
+            raise ValueError("artifact request limit must be positive")
+        if (pr_number is None) != (head_sha is None):
+            raise ValueError("pr_number and head_sha must be supplied together")
+
+        requests: list[dict[str, object]] = []
+        first_rejection: _InvalidVerificationArtifact | None = None
+
+        if pr_number is not None:
+            if (
+                not isinstance(pr_number, int)
+                or isinstance(pr_number, bool)
+                or pr_number <= 0
+            ):
+                raise ValueError("pr_number must be a positive integer")
+            if (
+                not isinstance(head_sha, str)
+                or re.fullmatch(r"[0-9a-fA-F]{40}", head_sha) is None
+            ):
+                raise ValueError("head_sha must be a 40-character hex commit sha")
+            artifact_name = f"verification-dispatch-{pr_number}-{head_sha}"
+            artifacts = self._artifact_listing_pages(
+                f"repos/{repository}/actions/artifacts"
+                f"?per_page=100&name={artifact_name}"
+            )
+            first_rejection = self._extend_requests_from_artifacts(
+                repository, artifacts, requests, limit, first_rejection
+            )
+        else:
+            runs = self._verification_dispatch_run_pages(
+                f"repos/{repository}/actions/workflows/"
+                f"{_VERIFICATION_REQUEST_WORKFLOW_FILENAME}/runs"
+                "?per_page=100&status=success"
+            )
+            for run in runs:
+                if len(requests) >= limit:
+                    break
+                if not isinstance(run, Mapping):
+                    continue
+                run_id = run.get("id")
+                if (
+                    not isinstance(run_id, int)
+                    or isinstance(run_id, bool)
+                    or run_id <= 0
+                ):
+                    continue
+                artifacts = self._artifact_listing_pages(
+                    f"repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100"
+                )
+                first_rejection = self._extend_requests_from_artifacts(
+                    repository, artifacts, requests, limit, first_rejection
+                )
+
         if not requests and first_rejection is not None:
             raise first_rejection
         return requests

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -2183,7 +2183,7 @@ def test_gh_source_fetches_bounded_artifact_and_live_truth_without_shell(tmp_pat
     def runner(command, **kwargs):
         calls.append(command)
         endpoint = command[-1]
-        if endpoint.endswith("actions/artifacts?per_page=100"):
+        if endpoint.endswith(f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"):
             return Result(
                 json.dumps(
                     {
@@ -2259,7 +2259,9 @@ def test_gh_source_fetches_bounded_artifact_and_live_truth_without_shell(tmp_pat
         return Result(json.dumps({"check_runs": GREEN}))
 
     source = GhCliVerificationSource(runner=runner)
-    assert source.pending_requests("RasmusTho/agentic-pkm-mvp") == [artifact_request()]
+    assert source.pending_requests(
+        "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
+    ) == [artifact_request()]
     assert source.pull_request("RasmusTho/agentic-pkm-mvp", 3603)["number"] == 3603
     assert source.checks("RasmusTho/agentic-pkm-mvp", HEAD) == GREEN
     assert all(call[:2] == ["gh", "api"] for call in calls)
@@ -3386,7 +3388,9 @@ def _artifact_source_for_request(payload: dict[str, object], *, workflow_run_id:
 
     def runner(command, **kwargs):
         calls.append(command)
-        if command[-1].endswith("actions/artifacts?per_page=100"):
+        if command[-1].endswith(
+            f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"
+        ):
             return Result(
                 json.dumps(
                     {
@@ -3458,7 +3462,14 @@ def _artifact_source_for_request(payload: dict[str, object], *, workflow_run_id:
     return GhCliVerificationSource(runner=runner), calls
 
 
-def test_pending_requests_discovers_request_beyond_first_artifact_page() -> None:
+def test_artifact_listing_pages_discovers_rows_beyond_first_page() -> None:
+    """``_artifact_listing_pages`` itself is unchanged; unit-test it directly.
+
+    It now backs three call sites (the name-scoped exact-match query and the
+    per-run artifact listing) rather than one repository-wide scan, so its
+    own pagination/fail-loud contract is tested independent of any caller.
+    """
+
     source = GhCliVerificationSource()
     endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
     calls: list[str] = []
@@ -3475,19 +3486,18 @@ def test_pending_requests_discovers_request_beyond_first_artifact_page() -> None
         raise AssertionError(requested_endpoint)
 
     source._json = read_artifacts  # type: ignore[method-assign]
-    source._request_from_artifact = (  # type: ignore[method-assign]
-        lambda _repository, artifact: {"artifact_id": artifact["id"]}
-        if artifact.get("name") == "request"
-        else None
-    )
 
-    assert source.pending_requests(REPO) == [{"artifact_id": 101}]
+    rows = source._artifact_listing_pages(endpoint)
+    assert rows[-1] == {"id": 101, "name": "request"}
     assert calls == [endpoint, f"{endpoint}&page=2"]
 
 
 def test_pending_requests_ignores_unrelated_artifacts_when_filling_limit() -> None:
     source = GhCliVerificationSource()
-    endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
+    endpoint = (
+        f"repos/{REPO}/actions/artifacts?per_page=100"
+        f"&name=verification-dispatch-3603-{HEAD}"
+    )
 
     def read_artifacts(requested_endpoint: str) -> object:
         if requested_endpoint == endpoint:
@@ -3512,13 +3522,15 @@ def test_pending_requests_ignores_unrelated_artifacts_when_filling_limit() -> No
         else None
     )
 
-    assert source.pending_requests(REPO, limit=2) == [
+    assert source.pending_requests(
+        REPO, limit=2, pr_number=3603, head_sha=HEAD
+    ) == [
         {"artifact_id": 101},
         {"artifact_id": 102},
     ]
 
 
-def test_pending_requests_distinguishes_truncated_scan_from_empty_result(
+def test_artifact_listing_pages_distinguishes_truncated_scan_from_empty_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = GhCliVerificationSource()
@@ -3530,7 +3542,7 @@ def test_pending_requests_distinguishes_truncated_scan_from_empty_result(
         if requested_endpoint == endpoint
         else pytest.fail(f"unexpected page for empty listing: {requested_endpoint}")
     )
-    assert source.pending_requests(REPO) == []
+    assert source._artifact_listing_pages(endpoint) == []
 
     source._json = (  # type: ignore[method-assign]
         lambda requested_endpoint: {
@@ -3541,10 +3553,10 @@ def test_pending_requests_distinguishes_truncated_scan_from_empty_result(
         else pytest.fail(f"unexpected page beyond bounded scan: {requested_endpoint}")
     )
     with pytest.raises(RuntimeError, match="artifact listing exceeds bounded scan"):
-        source.pending_requests(REPO)
+        source._artifact_listing_pages(endpoint)
 
 
-def test_pending_requests_rejects_short_page_that_contradicts_total_count() -> None:
+def test_artifact_listing_pages_rejects_short_page_that_contradicts_total_count() -> None:
     source = GhCliVerificationSource()
     endpoint = f"repos/{REPO}/actions/artifacts?per_page=100"
 
@@ -3555,7 +3567,246 @@ def test_pending_requests_rejects_short_page_that_contradicts_total_count() -> N
     )
 
     with pytest.raises(RuntimeError, match="artifact listing is incomplete"):
-        source.pending_requests(REPO)
+        source._artifact_listing_pages(endpoint)
+
+
+def test_verification_dispatch_run_pages_distinguishes_truncated_scan_from_empty_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = GhCliVerificationSource()
+    endpoint = (
+        f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+        "?per_page=100&status=success"
+    )
+    monkeypatch.setattr(verification_consumer, "_MAX_VERIFICATION_REQUEST_RUN_ROWS", 100)
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {"total_count": 0, "workflow_runs": []}
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page for empty listing: {requested_endpoint}")
+    )
+    assert source._verification_dispatch_run_pages(endpoint) == []
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {
+            "total_count": 101,
+            "workflow_runs": [{"id": index} for index in range(100)],
+        }
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page beyond bounded scan: {requested_endpoint}")
+    )
+    with pytest.raises(RuntimeError, match="workflow run listing exceeds bounded scan"):
+        source._verification_dispatch_run_pages(endpoint)
+
+
+def test_verification_dispatch_run_pages_rejects_short_page_that_contradicts_total_count() -> None:
+    source = GhCliVerificationSource()
+    endpoint = (
+        f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+        "?per_page=100&status=success"
+    )
+
+    source._json = (  # type: ignore[method-assign]
+        lambda requested_endpoint: {"total_count": 101, "workflow_runs": []}
+        if requested_endpoint == endpoint
+        else pytest.fail(f"unexpected page: {requested_endpoint}")
+    )
+
+    with pytest.raises(RuntimeError, match="workflow run listing is incomplete"):
+        source._verification_dispatch_run_pages(endpoint)
+
+
+def _discovery_source(
+    payload: dict[str, object], *, artifact_expired: bool = False
+) -> tuple[GhCliVerificationSource, list[str]]:
+    """A source stub that answers both discovery paths for the same artifact.
+
+    The unscoped path (workflow-run enumeration -> per-run artifact listing)
+    and the scoped exact-name path both resolve to the same single artifact,
+    so a test can exercise either one and assert on which endpoints were
+    actually called. The repository-wide artifact listing
+    (``repos/{repo}/actions/artifacts?per_page=100`` with no ``name=``) is
+    deliberately unanswered: calling it is exactly the defect this issue
+    fixes, so any code path that still reaches it fails the test loudly.
+    """
+
+    archive_bytes = io.BytesIO()
+    with zipfile.ZipFile(archive_bytes, "w") as archive:
+        archive.writestr("verification-dispatch/request.json", json.dumps(payload))
+    artifact_name = f"verification-dispatch-3603-{HEAD}"
+    calls: list[str] = []
+
+    class Result:
+        def __init__(self, stdout):
+            self.returncode = 0
+            self.stdout = stdout
+
+    def artifact_listing() -> dict[str, object]:
+        return {
+            "artifacts": [
+                {
+                    "id": 7,
+                    "name": artifact_name,
+                    "size_in_bytes": len(archive_bytes.getvalue()),
+                    "expired": artifact_expired,
+                    "workflow_run": {
+                        "id": 123,
+                        "repository_id": 456,
+                        "head_repository_id": 456,
+                        "head_sha": "b" * 40,
+                    },
+                }
+            ]
+        }
+
+    def runner(command, **kwargs):
+        endpoint = command[-1]
+        calls.append(endpoint)
+        if endpoint == f"repos/{REPO}/actions/artifacts?per_page=100":
+            raise AssertionError(
+                "discovery must never scan the repository-wide artifact "
+                "listing (that scan is exactly what exceeds "
+                "_MAX_ARTIFACT_LISTING_ROWS in production)"
+            )
+        if endpoint.endswith(
+            "actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success"
+        ):
+            return Result(json.dumps({"workflow_runs": [{"id": 123}]}))
+        if endpoint.endswith("actions/runs/123/artifacts?per_page=100"):
+            return Result(json.dumps(artifact_listing()))
+        if endpoint == f"repos/{REPO}/actions/artifacts?per_page=100&name={artifact_name}":
+            return Result(json.dumps(artifact_listing()))
+        if endpoint.endswith("artifacts/7/zip"):
+            return Result(archive_bytes.getvalue())
+        if endpoint.endswith("actions/runs/123"):
+            return Result(
+                json.dumps(
+                    {
+                        "id": 123,
+                        "run_attempt": 1,
+                        "name": "Verification Dispatch Request",
+                        "path": ".github/workflows/verification-dispatch-request.yml",
+                        "event": "workflow_run",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": "b" * 40,
+                        "repository": {"id": 456, "full_name": REPO},
+                        "head_repository": {"id": 456, "full_name": REPO},
+                    }
+                )
+            )
+        if endpoint.endswith("actions/runs/99"):
+            return Result(
+                json.dumps(
+                    {
+                        "id": 99,
+                        "run_attempt": 1,
+                        "name": "CI Smoke",
+                        "path": ".github/workflows/ci-smoke.yaml",
+                        "event": "pull_request",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "head_sha": HEAD,
+                        "repository": {"id": 456, "full_name": REPO},
+                        "head_repository": {"id": 456, "full_name": REPO},
+                    }
+                )
+            )
+        raise AssertionError(f"unexpected GitHub read: {endpoint}")
+
+    return GhCliVerificationSource(runner=runner), calls
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"pr_number": 3603},
+        {"head_sha": HEAD},
+    ],
+)
+def test_pending_requests_rejects_partial_scoped_kwargs(kwargs: dict[str, object]) -> None:
+    source = GhCliVerificationSource()
+    with pytest.raises(ValueError, match="pr_number and head_sha must be supplied together"):
+        source.pending_requests(REPO, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "pr_number,head_sha",
+    [
+        (0, HEAD),
+        (-1, HEAD),
+        (3603, "not-a-sha"),
+        (3603, "a" * 39),
+    ],
+)
+def test_pending_requests_rejects_malformed_scoped_kwargs(
+    pr_number: int, head_sha: str
+) -> None:
+    source = GhCliVerificationSource()
+    with pytest.raises(ValueError):
+        source.pending_requests(REPO, pr_number=pr_number, head_sha=head_sha)
+
+
+def test_pending_requests_succeeds_when_repository_listing_exceeds_bound() -> None:
+    """The production defect this issue fixes.
+
+    The repository holds 16,019 artifacts -- 16x ``_MAX_ARTIFACT_LISTING_ROWS``
+    -- so a scan of the repository-wide artifact listing fails on every call.
+    Discovery must succeed regardless of that total, because it no longer
+    queries the repository-wide listing at all: it enumerates recent runs of
+    ``verification-dispatch-request.yml`` (bounded by run count, not by the
+    repository's unrelated total artifact volume) and reads each run's own
+    small artifact listing.
+    """
+
+    payload = artifact_request()
+    source, calls = _discovery_source(payload)
+
+    assert source.pending_requests(REPO) == [payload]
+    assert f"repos/{REPO}/actions/artifacts?per_page=100" not in calls
+
+
+def test_pending_requests_queries_artifact_by_deterministic_name_for_targeted_pr() -> None:
+    payload = artifact_request()
+    source, calls = _discovery_source(payload)
+
+    assert source.pending_requests(REPO, pr_number=3603, head_sha=HEAD) == [payload]
+    assert calls[0] == (
+        f"repos/{REPO}/actions/artifacts?per_page=100"
+        f"&name=verification-dispatch-3603-{HEAD}"
+    )
+    assert not any("actions/workflows/" in call for call in calls)
+
+
+def test_scoped_discovery_still_rejects_stale_head_requests(tmp_path) -> None:
+    payload = artifact_request()
+    source, _ = _discovery_source(payload)
+    discovered = source.pending_requests(REPO, pr_number=3603, head_sha=HEAD)[0]
+
+    launcher = Launcher()
+    result = VerificationConsumer(
+        ledger(tmp_path),
+        Truth(eligible_pr(head={"ref": "branch", "sha": "b" * 40}), GREEN),
+        Auth(),
+        launcher,
+        "host",
+    ).consume(discovered)
+
+    assert result.status == "superseded"
+    assert result.stop_reason == "stale_head"
+    assert launcher.calls == []
+
+
+def test_scoped_discovery_skips_expired_artifacts() -> None:
+    payload = artifact_request()
+    source, calls = _discovery_source(payload, artifact_expired=True)
+
+    assert source.pending_requests(REPO, pr_number=3603, head_sha=HEAD) == []
+    assert calls[0] == (
+        f"repos/{REPO}/actions/artifacts?per_page=100"
+        f"&name=verification-dispatch-3603-{HEAD}"
+    )
 
 
 def test_pending_request_rejects_oversized_archive_before_buffering(
@@ -3606,7 +3857,9 @@ def test_pending_request_rejects_oversized_archive_before_buffering(
                     }
                 ]
             }
-            if endpoint.endswith("actions/artifacts?per_page=100")
+            if endpoint.endswith(
+                f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"
+            )
             else {
                 "id": 123,
                 "run_attempt": 1,
@@ -3640,7 +3893,9 @@ def test_pending_request_rejects_oversized_archive_before_buffering(
     )
 
     with pytest.raises(ValueError, match="compressed size limit"):
-        source.pending_requests("RasmusTho/agentic-pkm-mvp")
+        source.pending_requests(
+            "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
+        )
 
     assert process.terminate_calls == 1
     assert process.wait_calls >= 1
@@ -3671,7 +3926,9 @@ def test_pending_request_rejects_oversized_archive_members() -> None:
                 self.stdout = stdout
 
         def runner(command, **kwargs):
-            if command[-1].endswith("actions/artifacts?per_page=100"):
+            if command[-1].endswith(
+                f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"
+            ):
                 return Result(
                     json.dumps(
                         {
@@ -3719,7 +3976,7 @@ def test_pending_request_rejects_oversized_archive_members() -> None:
 
         with pytest.raises(ValueError, match="too many members|uncompressed size limit"):
             GhCliVerificationSource(runner=runner).pending_requests(
-                "RasmusTho/agentic-pkm-mvp"
+                "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
             )
 
 
@@ -3729,7 +3986,9 @@ def test_pending_request_rejects_repository_mismatch() -> None:
     )
 
     with pytest.raises(ValueError, match="artifact repository mismatch"):
-        source.pending_requests("RasmusTho/agentic-pkm-mvp")
+        source.pending_requests(
+            "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
+        )
 
     assert len(calls) == 3
 
@@ -3740,7 +3999,9 @@ def test_pending_request_rejects_workflow_run_mismatch() -> None:
     )
 
     with pytest.raises(ValueError, match="artifact workflow-run mismatch"):
-        source.pending_requests("RasmusTho/agentic-pkm-mvp")
+        source.pending_requests(
+            "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
+        )
 
     assert len(calls) == 3
 
@@ -3764,7 +4025,9 @@ def test_pending_request_rejects_v1_empty_supporting_closure_authority() -> None
     source, calls = _artifact_source_for_request(payload)
 
     with pytest.raises(ValueError, match="request artifact is malformed"):
-        source.pending_requests("RasmusTho/agentic-pkm-mvp")
+        source.pending_requests(
+            "RasmusTho/agentic-pkm-mvp", pr_number=3603, head_sha=HEAD
+        )
 
     assert len(calls) == 4
 

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import hashlib
 import io
 import json
@@ -3668,9 +3668,9 @@ def _discovery_source(
                 "listing (that scan is exactly what exceeds "
                 "_MAX_ARTIFACT_LISTING_ROWS in production)"
             )
-        if endpoint.endswith(
-            "actions/workflows/verification-dispatch-request.yml/runs"
-            "?per_page=100&status=success"
+        if endpoint.startswith(
+            f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success&created=>="
         ):
             return Result(json.dumps({"workflow_runs": [{"id": 123}]}))
         if endpoint.endswith("actions/runs/123/artifacts?per_page=100"):
@@ -7504,4 +7504,54 @@ def test_redacted_failure_replay_remains_deduplicated(tmp_path) -> None:
     assert private not in json.dumps(
         {"attempts": state.attempts(first.run_id), "terminal": first.terminal_receipt},
         sort_keys=True,
+    )
+
+
+def test_unscoped_discovery_window_is_recent_not_merely_present() -> None:
+    """The recency cutoff must be live, not decorative.
+
+    The other discovery tests assert that the endpoint carries a
+    ``created=>=`` filter, which a cutoff of ``1970-01-01`` would satisfy
+    while doing nothing at all -- and a window that filters nothing puts the
+    scan straight back on the unbounded path this issue exists to close.
+    Assert the value, not just the parameter's presence.
+    """
+
+    payload = artifact_request()
+    source, calls = _discovery_source(payload)
+    before = datetime.now(timezone.utc)
+
+    assert source.pending_requests(REPO) == [payload]
+
+    run_queries = [
+        call
+        for call in calls
+        if "actions/workflows/verification-dispatch-request.yml/runs" in call
+    ]
+    assert run_queries, "unscoped discovery must enumerate the workflow's runs"
+
+    match = re.search(r"created=>=([0-9T:\-]+Z)", run_queries[0])
+    assert match, f"no recency cutoff in {run_queries[0]}"
+    cutoff = datetime.strptime(match.group(1), "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+
+    # The ceiling is deliberately independent of
+    # ``_VERIFICATION_REQUEST_RUN_LOOKBACK``. Asserting the cutoff against the
+    # module's own constant is circular: widening the constant would widen the
+    # assertion with it and the test would keep passing while the window
+    # stopped bounding anything. This is the exact failure mode that let
+    # PR #4241 discharge every acceptance criterion with the mechanism dead.
+    max_useful_window = timedelta(days=7)
+    lookback = verification_consumer._VERIFICATION_REQUEST_RUN_LOOKBACK
+
+    assert cutoff <= before, "cutoff must not be in the future"
+    assert before - cutoff <= max_useful_window, (
+        f"cutoff {cutoff.isoformat()} is more than {max_useful_window} old; "
+        "this workflow fires on every CI Smoke completion, so a window that "
+        "wide stops bounding the scan and reopens the unbounded path"
+    )
+    assert before - cutoff <= lookback + timedelta(minutes=1), (
+        f"cutoff {cutoff.isoformat()} does not match the declared "
+        f"{lookback} lookback"
     )

--- a/tests/dispatcher/test_verification_review_repairs_attempt5.py
+++ b/tests/dispatcher/test_verification_review_repairs_attempt5.py
@@ -368,7 +368,12 @@ def _source(
     def runner(command: list[str], **_kwargs: object) -> Result:
         endpoint = command[-1]
         endpoints.append(endpoint)
-        if endpoint.endswith("actions/artifacts?per_page=100"):
+        if endpoint.endswith(
+            "actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success"
+        ):
+            return Result(json.dumps({"workflow_runs": [{"id": 123}]}))
+        if endpoint.endswith("actions/runs/123/artifacts?per_page=100"):
             return Result(
                 json.dumps(
                     {
@@ -488,7 +493,9 @@ def test_artifact_source_workflow_matching_metadata_is_accepted() -> None:
 
     assert source.pending_requests(REPO) == [payload]
     assert endpoints == [
-        f"repos/{REPO}/actions/artifacts?per_page=100",
+        f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+        "?per_page=100&status=success",
+        f"repos/{REPO}/actions/runs/123/artifacts?per_page=100",
         f"repos/{REPO}/actions/runs/123",
         f"repos/{REPO}/actions/artifacts/7/zip",
         f"repos/{REPO}/actions/runs/99",

--- a/tests/dispatcher/test_verification_review_repairs_attempt5.py
+++ b/tests/dispatcher/test_verification_review_repairs_attempt5.py
@@ -368,9 +368,9 @@ def _source(
     def runner(command: list[str], **_kwargs: object) -> Result:
         endpoint = command[-1]
         endpoints.append(endpoint)
-        if endpoint.endswith(
-            "actions/workflows/verification-dispatch-request.yml/runs"
-            "?per_page=100&status=success"
+        if endpoint.startswith(
+            f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success&created=>="
         ):
             return Result(json.dumps({"workflow_runs": [{"id": 123}]}))
         if endpoint.endswith("actions/runs/123/artifacts?per_page=100"):
@@ -492,9 +492,11 @@ def test_artifact_source_workflow_matching_metadata_is_accepted() -> None:
     source, endpoints = _source(payload)
 
     assert source.pending_requests(REPO) == [payload]
-    assert endpoints == [
+    assert endpoints[0].startswith(
         f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
-        "?per_page=100&status=success",
+        "?per_page=100&status=success&created=>="
+    )
+    assert endpoints[1:] == [
         f"repos/{REPO}/actions/runs/123/artifacts?per_page=100",
         f"repos/{REPO}/actions/runs/123",
         f"repos/{REPO}/actions/artifacts/7/zip",

--- a/tests/dispatcher/test_verification_review_repairs_attempt6.py
+++ b/tests/dispatcher/test_verification_review_repairs_attempt6.py
@@ -526,7 +526,9 @@ def _artifact_source_with_authenticated_runs(
 
     def json_response(endpoint: str) -> object:
         calls.append(endpoint)
-        if endpoint.endswith("actions/artifacts?per_page=100"):
+        if endpoint.endswith(
+            f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"
+        ):
             return {
                 "artifacts": [
                     {
@@ -593,7 +595,7 @@ def test_foreign_artifact_uploader_workflow_is_rejected_before_persistence() -> 
     )
 
     with pytest.raises(ValueError, match="artifact uploader workflow identity"):
-        source.pending_requests(_TRUSTED_REPOSITORY)
+        source.pending_requests(_TRUSTED_REPOSITORY, pr_number=3603, head_sha=HEAD)
 
     assert any(endpoint.endswith("actions/runs/123") for endpoint in calls)
     assert downloads == []
@@ -605,7 +607,7 @@ def test_canonical_artifact_uploader_workflow_is_authenticated() -> None:
         uploader_path=".github/workflows/verification-dispatch-request.yml",
     )
 
-    assert source.pending_requests(_TRUSTED_REPOSITORY) == [request()]
+    assert source.pending_requests(_TRUSTED_REPOSITORY, pr_number=3603, head_sha=HEAD) == [request()]
     assert any(endpoint.endswith("actions/runs/123") for endpoint in calls)
     assert downloads == [7]
 
@@ -620,7 +622,9 @@ def _mixed_artifact_source(
     source = GhCliVerificationSource()
 
     def json_response(endpoint: str) -> object:
-        if endpoint.endswith("actions/artifacts?per_page=100"):
+        if endpoint.endswith(
+            f"actions/artifacts?per_page=100&name=verification-dispatch-3603-{HEAD}"
+        ):
             return {"artifacts": artifacts}
         if endpoint.endswith("actions/runs/123"):
             if fail_uploader_read:
@@ -687,20 +691,20 @@ def _legacy_artifact() -> dict[str, object]:
 def test_valid_artifact_survives_legacy_and_malformed_candidates() -> None:
     source = _mixed_artifact_source([_valid_artifact(), _legacy_artifact()])
 
-    assert source.pending_requests(_TRUSTED_REPOSITORY) == [request()]
+    assert source.pending_requests(_TRUSTED_REPOSITORY, pr_number=3603, head_sha=HEAD) == [request()]
 
 
 def test_invalid_artifact_cannot_deny_service_to_later_valid_candidate() -> None:
     source = _mixed_artifact_source([_legacy_artifact(), _valid_artifact()])
 
-    assert source.pending_requests(_TRUSTED_REPOSITORY) == [request()]
+    assert source.pending_requests(_TRUSTED_REPOSITORY, pr_number=3603, head_sha=HEAD) == [request()]
 
 
 def test_artifact_poll_transport_failure_is_not_silently_skipped() -> None:
     source = _mixed_artifact_source([_valid_artifact()], fail_uploader_read=True)
 
     with pytest.raises(RuntimeError, match="GitHub transport unavailable"):
-        source.pending_requests(_TRUSTED_REPOSITORY)
+        source.pending_requests(_TRUSTED_REPOSITORY, pr_number=3603, head_sha=HEAD)
 
 
 def test_allowlisted_text_projection_preserves_structural_receipt_fields() -> None:

--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -331,7 +331,12 @@ def _gh_source(
     def runner(command: list[str], **_kwargs: object) -> Result:
         endpoint = command[-1]
         endpoints.append(endpoint)
-        if endpoint.endswith("actions/artifacts?per_page=100"):
+        if endpoint.endswith(
+            "actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success"
+        ):
+            return Result(json.dumps({"workflow_runs": [{"id": PRODUCER_RUN_ID}]}))
+        if endpoint.endswith(f"actions/runs/{PRODUCER_RUN_ID}/artifacts?per_page=100"):
             return Result(
                 json.dumps(
                     {
@@ -399,7 +404,9 @@ def test_gh_source_authenticates_producer_before_reading_request_json() -> None:
 
     assert source.pending_requests(REPO) == [payload]
     assert endpoints == [
-        f"repos/{REPO}/actions/artifacts?per_page=100",
+        f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+        "?per_page=100&status=success",
+        f"repos/{REPO}/actions/runs/{PRODUCER_RUN_ID}/artifacts?per_page=100",
         f"repos/{REPO}/actions/runs/{PRODUCER_RUN_ID}",
         f"repos/{REPO}/actions/artifacts/7/zip",
         f"repos/{REPO}/actions/runs/99",

--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -331,9 +331,9 @@ def _gh_source(
     def runner(command: list[str], **_kwargs: object) -> Result:
         endpoint = command[-1]
         endpoints.append(endpoint)
-        if endpoint.endswith(
-            "actions/workflows/verification-dispatch-request.yml/runs"
-            "?per_page=100&status=success"
+        if endpoint.startswith(
+            f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
+            "?per_page=100&status=success&created=>="
         ):
             return Result(json.dumps({"workflow_runs": [{"id": PRODUCER_RUN_ID}]}))
         if endpoint.endswith(f"actions/runs/{PRODUCER_RUN_ID}/artifacts?per_page=100"):
@@ -403,9 +403,11 @@ def test_gh_source_authenticates_producer_before_reading_request_json() -> None:
     source, endpoints = _gh_source(payload)
 
     assert source.pending_requests(REPO) == [payload]
-    assert endpoints == [
+    assert endpoints[0].startswith(
         f"repos/{REPO}/actions/workflows/verification-dispatch-request.yml/runs"
-        "?per_page=100&status=success",
+        "?per_page=100&status=success&created=>="
+    )
+    assert endpoints[1:] == [
         f"repos/{REPO}/actions/runs/{PRODUCER_RUN_ID}/artifacts?per_page=100",
         f"repos/{REPO}/actions/runs/{PRODUCER_RUN_ID}",
         f"repos/{REPO}/actions/artifacts/7/zip",


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4256

## Linked Issue
Fixes #4256

## SBS Impact
- Primary subsystem: Builder System (verification dispatch / delivery orchestration)
- Secondary subsystem(s): none
- Write class: mechanical
- Authority impact: none — discovery only; claim, live-truth revalidation, and merge authority unchanged
- Persistence impact: none
- Derived/rebuildable impact: request discovery becomes bounded by construction instead of by a constant that ages out
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: sharply fewer GitHub REST reads per poll — one scoped workflow-runs query plus small per-run artifact listings, instead of paginating a 16,019-row repository-wide listing
- New or changed contract: none — `pending_requests` keeps its signature and `limit` semantics; `pr_number`/`head_sha` are additive, optional, keyword-only, and default to today's behaviour
- Owner-doc impact: none
- Transition debt impact: reduces — removes a constant that had to be re-tuned as the repository grew
- Fitness rule impact: strengthens — closes a fail-silent-then-fail-always path in the verification stack
- Boundary risk: the scoped exact-name path must not become a way around the caller-side live-truth filter; a request found by name is still rejected when its `current_head_sha` no longer matches the PR's live head, and that is asserted by test

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Stop enumerating the repository-wide artifact listing. Discovery now queries runs of `verification-dispatch-request.yml` within a recency window and reads each run's own small artifact listing.
- Add an additive, optional, keyword-only exact-name fast path: when both `pr_number` and `head_sha` are supplied, issue exactly one `name=verification-dispatch-<pr>-<head_sha>` query and skip enumeration entirely.
- The recency window, not merely a row cap, is the load-bearing part. This workflow fires on every CI Smoke completion, so its all-time run count grows without bound exactly as the repository's artifact total did; a plain cap on "all runs of this workflow" would go stale the same way.
- PR #4241's fail-loud discipline is preserved everywhere: a scan that cannot prove completeness raises rather than truncating.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: repo-local defect fix with no delivery-orchestration side effects; the host-side consequence is recorded as a receipt on #3603 rather than as a BuilderOps record.

## Notes
- **Verified against production scale, not just in mocks.** Independent review ran the real production method against the live GitHub API: `pending_requests("RasmusTho/agentic-pkm-mvp", limit=50)` now succeeds and returns 50 requests, where it previously raised on 100% of calls. The scoped runs query returned 140 rows for the 48h window, well inside the bound. The `created=>=` filter is real and monotonic in the window size (24h=69, 48h=140, 7d=288).
- **The 48h window is an implicit discovery TTL.** If the host-local consumer is down for longer than the window, requests that went pending during that gap drop out of unscoped discovery permanently; they remain recoverable only through the scoped exact-name path, which requires already knowing the PR and head SHA. Called out for the operator rather than hidden — the alternative (an unbounded window) is the defect this PR fixes.
- `test_unscoped_discovery_window_is_recent_not_merely_present` deliberately asserts the cutoff against an **independent** 7-day ceiling rather than against `_VERIFICATION_REQUEST_RUN_LOOKBACK`. Asserting against the module's own constant is circular — widening the constant would widen the assertion with it and the test would keep passing while the window stopped bounding anything. Mutation-checked: the test fails when the lookback is widened to 20,000 days and passes when it is restored.
- This matters because it is the precise failure mode that let PR #4241 discharge all four of issue #4232's acceptance criteria while leaving the mechanism dead. #4256 exists only because those criteria specified the mechanism's internals and never asserted that discovery succeeds at production volume.
- Local validation: `tests/dispatcher/test_verification_consumer.py` 275 passed; the three touched `test_verification_review_repairs_*` files 140 passed; `ruff check app tests` clean; `mypy` clean on the changed module; `git diff --check` clean. The repo-wide non-PG suite is left to CI per the host-lease rule.
- Unblocks the #3603 verification pilot, which has been blocked on discovery since 2026-07-15.
