### PR TITLE
Make the agent instruction chain section-addressable and condition-scoped

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -4,8 +4,13 @@ State: Compatibility pointer. Canonical builder-agent instructions now live in t
 
 This file is not the canonical builder-agent policy surface.
 
-Read `AGENTS.md` first.
-Then use `.codex/skills/README.md` to load the repo-local workflow skill that matches the task.
-For GitHub implementation work, load `.codex/skills/issue-to-code/SKILL.md` before coding.
-Use `docs/development/DEV_WORKFLOW.md` for workflow and validation details.
-Use `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md` for maintenance rules and rationale.
+At session entry read `AGENTS.md :: Reading order` — it is the scoped entry list and names which of
+its own sections and which external documents are required now versus only under a stated condition.
+Do not read `AGENTS.md` whole by default.
+
+Then use `.codex/skills/README.md :: Skill routing` to load the repo-local workflow skill that matches the task.
+For GitHub implementation work, load `.codex/skills/issue-to-code/SKILL.md` before coding; that skill states every further read it needs.
+Use `docs/development/DEV_WORKFLOW.md :: Validation baseline` before running or reporting validation, and `:: Working loop` when the loop is unclear.
+Use `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules` and `:: Canonical entrypoints` when the diff changes an instruction artifact.
+
+Read scope for every citation in this chain is `.codex/skills/_shared/READ_SCOPE.md`: `FILE :: Section` means read that section only, a citation with no `::` is a whole-file read that must state its reason, and `docs/DOCS_INDEX.md` is grep-only.

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -77,9 +77,16 @@ instead of carrying inline copies — `ISSUE_CONTRACT.md` (Issue section list + 
 `LABEL_TAXONOMY.md` (canonical labels + narrow `lane:governance` and
 `state:known-defect` exceptions), `LIFECYCLE_TRUTH_MATRIX.md`
 (optional legacy Project projection per Issue/PR state), `BRANCH_TRUTH_GATE.md` (publication workspace gate),
-`PROJECT_STATUS_OPERATIONS.md` (Project GraphQL operations), and `CI_WAIT_CONTRACT.md` (how to wait
-on CI checks — and the optional `--codex` verdict path — via REST without draining the shared API budget). A reference like
+`PROJECT_STATUS_OPERATIONS.md` (Project GraphQL operations), `CI_WAIT_CONTRACT.md` (how to wait
+on CI checks — and the optional `--codex` verdict path — via REST without draining the shared API budget),
+and `READ_SCOPE.md` (how much of a cited document to read). A reference like
 `_shared/<FILE>.md :: <section>` resolves there. `_shared/` is not a skill directory.
+
+Read scope: a `FILE :: Section` citation anywhere in this repo's instruction chain means **read that
+section only**; a citation with no `::` is a whole-file read and requires a stated reason at the
+citation site. `_shared/READ_SCOPE.md` is the canonical protocol, including the rule that
+`docs/DOCS_INDEX.md` is grep-only and that conditional reads key off the actual diff
+(`git diff --name-only origin/main...HEAD`), not the issue's declared scope.
 
 - `agentic-pkm`
   - default repo-dev context for code, tests, docs, and SoT reading order in this repository

--- a/.codex/skills/_shared/READ_SCOPE.md
+++ b/.codex/skills/_shared/READ_SCOPE.md
@@ -1,0 +1,40 @@
+State: Shared skill contract. Canonical read-scope protocol for every `FILE :: Section` citation in the agent instruction chain.
+
+# Read Scope
+
+Single source for **how much** of a cited document an agent must read. Instruction files
+(`AGENTS.md`, `CLAUDE.md`, `.codex/skills/**`, and the development docs they route to) cite sources
+in one of two shapes, and the shape is the instruction.
+
+## The protocol
+
+- **`FILE :: Section`** — read that heading's section only. Do not read the rest of the file.
+  The cited heading is the narrowest true owner of the rule; anything outside it is reference
+  material the citation does not require.
+- **`FILE` with no `::`** — a whole-file read. It requires a stated reason at the citation site
+  (for example "read whole; the file is a short checklist" or "read whole; the rule spans every
+  section"). A bare whole-file citation with no stated reason is a defect in the instruction file,
+  not a mandate to read the file.
+- **A citation under a stated condition** — read it only when the condition holds. Conditions are
+  keyed to the **actual diff** (`git diff --name-only origin/main...HEAD`), not to the issue's
+  declared scope, because the diff is what the downstream gates judge.
+- **`docs/DOCS_INDEX.md`** is grep-only. It is a ~250 KB, 700-row routing table; grep it for the
+  work area to find the owner document, and never read it whole.
+
+## Why this is safe
+
+Reducing read scope removes a *read*, never a *check*. Every rule whose read is narrowed here is
+still enforced by a downstream pre-merge gate — CI (`pr-contract`, `Unit tests (not pg)`,
+`harness-selfverify`), `scripts/lint_skills_consistency.py`, `scripts/docs_guard.py`, the branch-truth
+gate, or the verification step in `verification-and-closure`. If a rule has no such gate, its read
+stays mandatory and unconditional.
+
+The corollary is a maintenance rule: **before narrowing a citation, confirm the omitted content is
+either reproduced at the citation site or caught by an existing fail-loud gate.** Content that is
+unique to the cited section and has no gate must be inlined at the citation site before the parent
+document becomes conditional.
+
+## Scope
+
+This contract governs read scope only. It does not change any authority, gate, check, or lane rule,
+and it never authorizes skipping a section an instruction file marks as unconditional.

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -11,10 +11,24 @@ You are a builder agent implementing GitHub backlog work in a repo-first, docs-a
 
 Your governing rule:
 Only execute bounded implementation work from a GitHub Issue that is the canonical task contract.
-After PR creation or publish, route normal PRs to `docs/development/PR_HOT_PATH.md`.
+After PR creation or publish, route normal PRs to `docs/development/PR_HOT_PATH.md :: Mandatory Hot-Path Gates` and `:: PR Body Preparation`; the rest of that file is merge-time material owned by `verification-and-closure`.
 Route only triggered cases to `docs/development/PR_ESCALATION_PATHS.md` or the heavier `pr-integration` path.
 If the slice is the final child slice, route parent closure to `docs/development/PARENT_ISSUE_CLOSURE.md` after merge.
 Bounded direct repair PRs may proceed without a governing Issue when the PR body supplies the full contract via a complete Direct Repair block.
+
+## Read scope for this skill
+
+Citations here follow `.codex/skills/_shared/READ_SCOPE.md`. A `FILE :: Section` citation means
+**read that section only**; a citation with no `::` is a whole-file read and states its reason; a
+citation under a stated condition is read only when the condition holds. Conditions key off the
+**actual diff** (`git diff --name-only origin/main...HEAD`), not the issue's declared `Scope`,
+because the diff is what the pre-merge gates judge.
+
+This skill inlines the rules a normal slice needs from
+`docs/architecture/SBS_OPERATING_MODEL.md :: Classification Procedure` and
+`docs/development/AGENT_OPERATING_PROTOCOL.md :: Behavioral rules`, so a normal slice does not read
+either parent document. Read the parent section only when the inlined rule is genuinely
+insufficient for the case in front of you.
 
 ## Pre-implementation classification check
 
@@ -31,11 +45,17 @@ Before claiming an Issue or producing any implementation, answer the following. 
   issue/PR templates, GitHub governance, CI/fitness rails, release/promotion workflows,
   BuilderOps records/projections, delivery receipts, TCD policy, or builder-agent workflow docs.
   Route through the Builder System boundary and artifact map in
-  `docs/architecture/SBS_OPERATING_MODEL.md`.
+  `docs/architecture/SBS_OPERATING_MODEL.md :: Builder System Artifact And Workflow Map`, and fill
+  the PR's `SBS Impact` per
+  `docs/architecture/SBS_OPERATING_MODEL.md :: Builder System SBS Impact Guidance`.
 - Boundary work changes how Builder machinery affects Product/Runtime truth, such as owner-doc
   writeback, issue/PR classification, release promotion, architecture fitness enforcement, Product
   SBS contract updates, or BuilderOps promotion into repo artifacts. Route through both the Builder
   System model and the affected Product/Runtime owner docs.
+
+Tie-breaker (inlined from `docs/architecture/SBS_OPERATING_MODEL.md :: Classification Procedure`, the
+one rule in that section this skill does not otherwise reproduce): if the classification is still
+unclear, choose the stricter boundary route and name both owner surfaces in the Issue/PR.
 
 Do not treat Builder System records, projections, skills, prompts, or delivery learning as
 runtime/user memory or Human Knowledge Artifacts unless a Product/Runtime authority path explicitly
@@ -68,7 +88,17 @@ promotes them.
 - Product/Runtime vs Builder System vs boundary classification cannot be stated from the issue and
   source anchors, or from the PR Direct Repair block for bounded direct-repair work.
 
-Apply `docs/development/AGENT_OPERATING_PROTOCOL.md` for the full classification reference.
+**LLM-mediated mutation rule** (inlined from
+`docs/development/AGENT_OPERATING_PROTOCOL.md :: Behavioral rules`, the one rule in that document
+this skill does not otherwise reproduce): do not propose or implement LLM-mediated mutation without
+governance, receipts, and human authority. Any change that routes through a language model and
+results in vault writes, memory promotion, outbox emission, or watcher action must carry an explicit
+trust tier, a write guard, a provenance receipt, and a human-first review path. Do not shortcut this
+for performance or convenience.
+
+The classification tables above reproduce what a normal slice needs. Read
+`docs/development/AGENT_OPERATING_PROTOCOL.md :: Required pre-implementation checks` and
+`:: Stop conditions` only when a field above is unresolvable from the Issue and its source anchors.
 
 ## Canonical workflow
 
@@ -242,16 +272,31 @@ scope; it never adds steps to the implementation hot path.
 
 - Read the full Issue first.
 - For a bounded direct repair PR, treat the PR body as the contract and validate the Direct Repair block directly instead of requiring a governing Issue.
-- Read the owner docs and source docs referenced by `Source Anchors` before editing code. For
-  Product/Runtime System work this includes the relevant SBS/Product owner docs; for Builder System
-  work touching `.codex/skills/**`, issue/PR governance, CI, release workflows, BuilderOps, learning,
-  or TCD, include `docs/architecture/SBS_OPERATING_MODEL.md` and `.codex/skills/README.md`.
+- Read the owner docs and source docs referenced by `Source Anchors` before editing code. Locate the
+  owner document by grepping `docs/DOCS_INDEX.md` for the work area — it is a ~250 KB routing table
+  and is grep-only, never a whole-file read. For Product/Runtime System work this includes the
+  relevant SBS/Product owner docs. For Builder System work, add these reads **only when the actual
+  diff (`git diff --name-only origin/main...HEAD`) touches the matching paths**, not because the
+  Issue's `Scope` mentions them:
+  - `.codex/skills/**` changed → `.codex/skills/README.md :: Skill routing` and
+    `:: Cross-cutting invariant: acceptance verifiability`
+  - `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, or issue/PR governance changed →
+    `.codex/skills/_shared/ISSUE_CONTRACT.md`
+  - `.github/workflows/**` changed → `docs/development/PR_HOT_PATH.md :: Governance Lane vs Direct
+    Repair for Workflow Files` (the lane allowlist is file-set-keyed, so only a real workflow-file
+    diff needs it)
+  - CI/fitness rails, release/promotion workflows, BuilderOps records/projections, delivery receipts,
+    learning/retrospective workflows, or TCD policy changed →
+    `docs/architecture/SBS_OPERATING_MODEL.md :: Builder System Artifact And Workflow Map` (and
+    `:: Builder Learning, Evaluation, And TCD Governance Loop` for learning or TCD surfaces)
+  - `AGENTS.md`, `CLAUDE.md`, `.codex/AGENTS.md`, or `.codex/skills/**` changed →
+    `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules`
 - Stay strictly within Issue scope.
 - Do not expand scope without updating the Issue contract first.
 - Preserve architecture boundaries and event/outbox compatibility where relevant.
 - Update docs in the same change if behavior, contracts, or architecture change.
 - If the work turns a roadmap/plan item into shipped reality, update the owner doc and rewrite roadmap/plan wording so it no longer reads as pending.
-- Scale validation and PR-body machinery to the risk tier per `docs/development/GOVERNANCE_PROPORTIONALITY.md`: Tier 1 (docs/skills/governance text) runs lightweight docs/governance checks only; Tier 2 (code slices, tests) runs the repo-standard gates below; Tier 3 (migrations, release channels, prod, boundary moves) keeps the full fail-closed machinery.
+- Scale validation and PR-body machinery to the risk tier per `docs/development/GOVERNANCE_PROPORTIONALITY.md :: Risk tiers`: Tier 1 (docs/skills/governance text) runs lightweight docs/governance checks only; Tier 2 (code slices, tests) runs the repo-standard gates below; Tier 3 (migrations, release channels, prod, boundary moves) keeps the full fail-closed machinery. Read `:: Delivery budgets and stop-loss` only when a repair budget is actually in play.
 - Route model family, reasoning effort, and escalation/de-escalation per `AGENTS.md :: Total Cost of Development`. The risk tier above, plus the artifact class, environment/channel risk, and stop conditions from the pre-implementation classification check, are the routing inputs — do not restate the policy here.
 - For a `type:bug` Issue dispatched from a larger bug set, also apply `AGENTS.md :: Transition-period
   bug-delivery policy`: own one end-to-end Codex task/session and isolated worktree, normally Terra
@@ -358,8 +403,8 @@ When continuing through anchor drift:
     Re-run the same gate before pushing (`.codex/skills/_shared/BRANCH_TRUTH_GATE.md :: Procedure`, pre-push). If the gate fails at pre-push: stop, switch to the correct worktree, relocate the commit if needed, and re-run both phases.
 
 16. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
-17. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md` through `pr-integration` only as needed.
-18. If any hot-path trigger applies, read `docs/development/PR_ESCALATION_PATHS.md` and use the relevant escalation procedure.
+17. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md :: Mandatory Hot-Path Gates` through `pr-integration` only as needed. Read `:: Escalation Triggers` to decide whether a trigger applies; read `:: CI Status Handling` only once CI is attached and a check is failing or stuck.
+18. If any hot-path trigger applies, read the matching procedure section in `docs/development/PR_ESCALATION_PATHS.md` (whole-file read only when the trigger is unclassified) and use it.
 19. **Execute Action: Request Review** only when review is explicitly requested.
 20. If the slice merges and this is not the final child slice, keep the parent issue open for later acceptance.
 21. If this is the final child slice, route post-merge parent closure through `docs/development/PARENT_ISSUE_CLOSURE.md`.
@@ -384,7 +429,7 @@ On a plan divergence (you did something unexpected, or discovered an earlier art
 
 ## Output format
 
-Lead with the human summary; include later sections only when they have content, scaled to the tier (`docs/development/GOVERNANCE_PROPORTIONALITY.md`). For Tier 1, the summary plus a receipt line is enough.
+Lead with the human summary; include later sections only when they have content, scaled to the tier (`docs/development/GOVERNANCE_PROPORTIONALITY.md :: Output formats`). For Tier 1, the summary plus a receipt line is enough.
 
 1. Summary For The Human (2–4 sentences: what was done, what remains, what needs a decision)
 2. Selected Issue and Selection Rationale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,43 @@ It does not apply to runtime/system agents that exist inside the product. Runtim
 
 ## Reading order
 
-1. Read this file first.
-2. Use `.codex/skills/README.md` to identify the repo-local skill path that matches the task.
-3. Use `docs/DOCS_INDEX.md` to identify the owner document for the area you are touching.
-4. Read the owner document before editing code or nearby docs.
-5. Use `docs/development/DEV_WORKFLOW.md` for the working loop and validation expectations.
-6. Use `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md` for maintenance rules, rationale, and compatibility-entrypoint policy.
-7. Before producing implementation guidance or touching code, apply `docs/development/AGENT_OPERATING_PROTOCOL.md` to classify the task, identify artifact class and channel risk, and confirm stop conditions are clear.
+Citations in this file follow `.codex/skills/_shared/READ_SCOPE.md`: a `FILE :: Section` citation
+means **read that section only**, a citation with no `::` is a whole-file read and states why, and a
+citation under a condition is read only when the condition holds. Conditions key off the actual diff
+(`git diff --name-only origin/main...HEAD`), not the issue's declared scope.
+
+Required at session entry, before the task type is known:
+
+1. This file's `Reading order`, `Repo-local skill routing`, `Required rules`,
+   `Total Cost of Development` (any agent choosing its own capability), and
+   `Proportional delivery` sections. Read the remaining sections of this file only under the
+   conditions below.
+2. `.codex/skills/README.md :: Skill routing` to identify the repo-local skill path that matches the
+   task, then load that skill. The skill states what else it needs.
+
+Read on condition, not by default:
+
+3. `docs/DOCS_INDEX.md` — **grep-only**. It is ~250 KB / 700 rows; `grep` it for the work area to
+   locate the owner document. Never read it whole. Then read the owner document itself before
+   editing code or nearby docs.
+4. `docs/development/DEV_WORKFLOW.md :: Validation baseline` before running or reporting validation,
+   and `:: Working loop` when the loop itself is unclear. Other sections of that file are
+   reference material for the workflows that own them.
+5. `AGENTS.md :: Change classification` when the change touches a current-state doc, roadmap, or
+   status surface.
+6. `AGENTS.md :: Docs authoring lane` or `:: Governance lane` when the work will be published without
+   a governing Issue; `AGENTS.md :: GitHub delivery governance` when publishing an issue-backed PR.
+7. `AGENTS.md :: Communicating with the owner` before writing a report or escalation to the owner,
+   and `:: Specialist subagent roles` before dispatching subagents.
+8. `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules` and
+   `:: Canonical entrypoints` (compatibility-entrypoint policy) when the diff changes an
+   instruction artifact (`AGENTS.md`, `CLAUDE.md`, `.codex/AGENTS.md`, `.codex/skills/**`). Note the
+   `Maintenance rules` requirement that a change to canonical entrypoints, reading order, or doc
+   roles updates `docs/DOCS_INDEX.md` in the same change.
+9. `docs/development/AGENT_OPERATING_PROTOCOL.md :: Required pre-implementation checks`,
+   `:: Behavioral rules`, and `:: Stop conditions` before producing implementation guidance or
+   touching code, when the loaded skill does not already inline that classification step.
+   `issue-to-code` inlines all three.
 
 ## Repo-local skill routing
 
@@ -408,6 +438,14 @@ Builder-agent rules:
 - Batch project-field GraphQL mutations into one bounded pass near workflow completion, rather than interleaving repeated mutations throughout intake.
 
 ## Dispatcher policy
+
+**Superseded as an operational procedure — do not read this section to perform a pickup.**
+`scripts/issue_pickup_claim.sh`, driven by
+`.codex/skills/issue-to-code/SKILL.md :: Dispatcher Integration`, is the only claim entrypoint, and
+it supersedes every hand-run `dispatcher next` / `dispatcher claim` / `gh issue edit` sequence.
+Reconstructing that handshake by hand is forbidden, so reading a procedure for it makes an agent
+more likely to be wrong, not less. What remains below is the authority statement the wrapper
+implements — read it only when reasoning about dispatcher authority, never to execute a claim.
 
 The dispatcher is an optional collision guard for issue pickup, not lifecycle authority.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,14 @@
 # Claude Code Instructions
 
-Read `AGENTS.md` first. It is the canonical builder-agent instruction file for this repository.
-Then use `.codex/skills/README.md` to choose the repo-local workflow skill for the task.
-For GitHub implementation work, load `.codex/skills/issue-to-code/SKILL.md` before coding.
+`AGENTS.md` is the canonical builder-agent instruction file for this repository. At session entry read
+`AGENTS.md :: Reading order` — it is the scoped entry list and names which of its own sections and
+which external documents are required now versus only under a stated condition. Do not read
+`AGENTS.md` whole by default.
+
+Then use `.codex/skills/README.md` (specifically `:: Skill routing`) to choose the repo-local workflow skill for the task.
+For GitHub implementation work, load `.codex/skills/issue-to-code/SKILL.md` before coding; that skill states every further read it needs.
 For specialist subagent roles, use `docs/development/BUILDER_SUBAGENT_ROLES.md`; do not treat `.codex/agents/*.toml` as Claude authority.
+
+Read scope for every citation in this chain is `.codex/skills/_shared/READ_SCOPE.md`: `FILE :: Section` means read that section only, a citation with no `::` is a whole-file read that must state its reason, and `docs/DOCS_INDEX.md` is grep-only.
 
 This file is only a Claude compatibility entrypoint. If a Claude-specific workflow note is ever needed, keep it here and keep `AGENTS.md` authoritative.

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -27,7 +27,7 @@ First-read map for common work areas. Use `docs/DOCS_INDEX.md` (this file) to lo
 
 | Work area | First-read docs |
 | --- | --- |
-| Builder-agent workflow | `AGENTS.md` → `.codex/skills/README.md` → `docs/architecture/SBS_OPERATING_MODEL.md` (Builder System boundary) → `docs/development/AGENT_OPERATING_PROTOCOL.md` |
+| Builder-agent workflow | `AGENTS.md :: Reading order` (the scoped session-entry list; do not read `AGENTS.md` whole) → `.codex/skills/README.md :: Skill routing` → the matching skill, which names any further section reads. `docs/architecture/SBS_OPERATING_MODEL.md :: Builder System Boundary And Work Classification` and `docs/development/AGENT_OPERATING_PROTOCOL.md :: Behavioral rules` are inlined in `issue-to-code`; read them directly only outside that skill. Read scope: `.codex/skills/_shared/READ_SCOPE.md` |
 | Agent-facing flows / direct agent workspaces | `docs/AGENT-FLOWS.md`, `docs/CONCEPTS/AGENT_ONTOLOGY_CONTRACT.md` |
 | Human-flow to SBS allocation / verification mapping | `docs/HUMAN_FLOW_TO_RUNTIME_MAP.md`, then `docs/architecture/SBS_OPERATING_MODEL.md` and `docs/SYSTEM_BREAKDOWN_STRUCTURE.md` |
 | Runtime agents | `docs/AGENTS.md`, `docs/CONCEPTS/AGENT_ONTOLOGY_CONTRACT.md` |


### PR DESCRIPTION
## Change Lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4189

## Linked Issue
Fixes #4189

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): agent instruction chain
- Write class: governance/docs/process
- Persistence impact: none — git-tracked instruction artifacts only
- Derived/rebuildable impact: none
- New or changed contract: `FILE :: Section` citations become read-scope-bearing rather than advisory; `.codex/skills/_shared/READ_SCOPE.md` is the new canonical protocol
- Owner-doc impact: updated in this PR (`docs/DOCS_INDEX.md :: Agent quick routing`, required by `AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules` when the reading order changes)
- Transition debt impact: reduces
- Boundary risk: an agent that skips a section it needed pays it back as a defect invisible at read time. Mitigated structurally: this PR deletes no rule text from any document — it only rewrites citations, and the two pieces of content unique to a now-conditional parent (the SBS tie-breaker, the AOP LLM-mediated-mutation rule) are inlined at their consumption site before their parents become conditional.

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR.

## Summary
- Scopes the session-entry instruction chain (`CLAUDE.md`, `.codex/AGENTS.md`, `AGENTS.md :: Reading order`) from whole-file reads to named sections, and splits it into "required at session entry" versus "read on condition".
- Inlines the two pieces of content that exist nowhere else in the chain into `issue-to-code`: the SBS classification tie-breaker ("choose the stricter boundary route and name both owner surfaces") and the `AGENT_OPERATING_PROTOCOL :: Behavioral rules` LLM-mediated-mutation rule (explicit trust tier, write guard, provenance receipt, human-first review path). Only after inlining do their parent documents become conditional reads.
- Keys the conditional Builder-System reads in `issue-to-code` to the **actual diff** (`git diff --name-only origin/main...HEAD`) rather than the issue's declared `Scope`, so a lane-allowlist read fires when it is genuinely needed.
- States that `docs/DOCS_INDEX.md` is grep-only (255 KB / 717 rows — a literal whole-file read exceeds the entire measured per-slice read budget).
- Marks `AGENTS.md :: Dispatcher policy` superseded as an operational procedure and points at `scripts/issue_pickup_claim.sh` / `issue-to-code :: Dispatcher Integration`; the authority statement stays, the procedure reading does not.
- Adds `.codex/skills/_shared/READ_SCOPE.md` and registers it in the shared-contracts list.

## Changes
- `AGENTS.md` — `Reading order` rewritten as scoped session-entry list + conditional reads; `Dispatcher policy` marked superseded as a procedure.
- `CLAUDE.md`, `.codex/AGENTS.md` — entry citations scoped to sections; read-scope protocol named. `.codex/skills/README.md` and `.codex/skills/issue-to-code/SKILL.md` remain literal (asserted by `tests/architecture/test_agent_skill_entrypoints.py`).
- `.codex/skills/README.md` — `READ_SCOPE.md` registered in the shared-contracts list plus a read-scope paragraph.
- `.codex/skills/issue-to-code/SKILL.md` — new `Read scope for this skill` section; SBS tie-breaker and AOP behavioral rule inlined; every `SBS_OPERATING_MODEL`, `AGENT_OPERATING_PROTOCOL`, `PR_HOT_PATH`, and `GOVERNANCE_PROPORTIONALITY` citation re-pointed to a heading; owner-doc read bullet replaced by a diff-keyed conditional list.
- `.codex/skills/_shared/READ_SCOPE.md` — new shared contract.
- `docs/DOCS_INDEX.md` — `Agent quick routing` "Builder-agent workflow" row updated to the scoped chain (required by `AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules`).

Measured effect on the mandatory external read per slice (chars/4):

| Document | Before | After |
| --- | --- | --- |
| `AGENTS.md` | 10,080 (whole) | 8,708 (5 required sections = 7,093, TCD alone 3,933 and contractually required; plus `:: GitHub delivery governance` 1,267 and `:: Communicating with the owner` 348, whose conditions fire on essentially every issue-backed slice) |
| `.codex/skills/README.md` | 5,631 (whole) | 2,452 (`:: Skill routing`) |
| `docs/development/DEV_WORKFLOW.md` | 5,881 (whole) | 745 (`:: Validation baseline`, counting its `### CI / validation expectations` subsection) |
| `docs/development/AGENT_OPERATING_PROTOCOL.md` | 2,169 (whole) | 0 (inlined) |
| `docs/architecture/SBS_OPERATING_MODEL.md` | ~7,500 (cited heading) | 7,361 (**not** eliminated — see below) |
| `docs/development/PR_HOT_PATH.md` | 4,404 (whole) | 813 (two sections) |
| `docs/development/GOVERNANCE_PROPORTIONALITY.md` | 1,793 (whole) | ~865 (`:: Risk tiers`) |
| `.codex/skills/_shared/READ_SCOPE.md` | — | 592 (new) |
| **Total** | **~37,458** | **~21,536** |

Net saving ≈ **16,000 tokens per slice (~43%** of the mandatory external read), against a ~250-token
growth in `issue-to-code` for the inlined residue.

**Corrected after independent review — the first draft of this table claimed ~25,000 / 67%, and that
was wrong.** Two errors, both now fixed above:

- `SBS_OPERATING_MODEL.md` was recorded as `0 (inlined)`. Only the tie-breaker sentence was inlined.
  `.codex/skills/issue-to-code/SKILL.md:38` still carries an **unconditional** citation to
  `:: Builder System Boundary And Work Classification`, which is §3 (lines 69-303 on main, ~7,361
  tokens) and contains the Classification Procedure, the Builder-Agent Authority Model, the SBS
  Impact Guidance, the Artifact And Workflow Map, and the Builder Learning/TCD Governance Loop. Under
  this PR's own `READ_SCOPE.md` protocol a compliant agent reads all of it. No content is lost — this
  was a measurement error, not a safety defect — but the largest single claimed saving does not exist
  yet. Re-pointing that line to `:: Classification Procedure` is filed as a follow-up.
- `DEV_WORKFLOW :: Validation baseline` was counted at 581; the section including its
  `### CI / validation expectations` subsection is 745.

The saving is still substantial and real: the `AGENT_OPERATING_PROTOCOL`, `PR_HOT_PATH`,
`GOVERNANCE_PROPORTIONALITY`, and `DOCS_INDEX` narrowings are all genuine and correctly conditioned.
This receipt is deliberately conservative so a future TCD audit reads a measured figure rather than
an optimistic one.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Governance-lane instruction-text change delivered end-to-end from the governing Issue with no plan divergence, no docs-freshness queue entry, and no roadmap movement; the Issue and this PR carry the full record.

## Notes
- **No rule text is deleted anywhere in this diff.** It is 170 insertions / 29 deletions, and every deletion is a citation line replaced by a scoped equivalent. No cut removes a check — each removes a *read* whose omission an existing pre-merge gate still catches (`pr-contract`, `scripts/lint_skills_consistency.py`, the branch-truth gate, `verification-and-closure`). `READ_SCOPE.md` states that requirement as the maintenance rule for future narrowing.
- **Correction to that gate list, from independent review.** The first draft also named `Unit tests (not pg)`, `scripts/docs_guard.py`, and `harness-selfverify`. On an instruction-file-only diff none of the three is a real backstop: `Unit tests (not pg)` self-skips on these paths and reports success without executing (filed as #4281), `harness-selfverify` never triggers, and `docs_guard.py` runs only in `architecture-ci`, which is `on: workflow_dispatch` and therefore not a pre-merge gate at all. They are removed from the list above, and `READ_SCOPE.md`'s own "why this is safe" paragraph carries the same overstated list — corrected as a follow-up, since that file is now the canonical maintenance rule for all future narrowing and a wrong safety premise there is what would cause the next bad cut. What does genuinely run on this diff class: `pr-contract`, and three unconditional steps in the `smoke` job (`scripts/lint_skills_consistency.py`, doc integrity, and `tests/architecture/test_pr_hot_path_governance.py`).
- Validation: `python3 scripts/lint_skills_consistency.py` clean; `python3 scripts/docs_guard.py` OK; `python3 scripts/review_before_ci_gate.py --lane governance --risk-assessment-complete --review-gate-complete` satisfied; targeted set `tests/architecture/test_agent_skill_entrypoints.py tests/architecture/test_pr_hot_path_governance.py tests/architecture/test_dispatcher_skill_integration.py tests/architecture/test_docs_index.py tests/governance tests/ops/test_review_before_ci_gate.py` = 579 passed. Full-suite result recorded below.
- `Final-Review-Rounds: 1` rather than the Tier 1 light path: this touches every builder agent's entry contract simultaneously, which is a wider blast radius than the governance lane's usual single-surface text edit.
- Out of scope and deliberately untouched: splitting any document, any section-lookup tool, and the `AGENTS.md` binding-section list omission entangled with the open `SBS Impact` ruling.