### PR TITLE
fix: chain-delegate the #4186 sitecustomize guard test's stand-in hook

### DIFF
--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -374,8 +374,11 @@ def test_export_runtime_env_delegated_sitecustomize_preserves_loader_metadata(
     metadata_path = tmp_path / "delegated-sitecustomize-metadata"
     (real_hook_dir / "sitecustomize.py").write_text(
         """\
+import importlib.machinery
+import importlib.util
 import os
 from pathlib import Path
+import sys
 
 if __spec__ is None or __spec__.name != "sitecustomize":
     raise RuntimeError("delegated sitecustomize lost its spec")
@@ -387,6 +390,54 @@ Path(os.environ["PKM_DELEGATED_SITECUSTOMIZE_METADATA"]).write_text(
     f"{__spec__.name}|{Path(__file__).resolve()}|{type(__loader__).__name__}",
     encoding="utf-8",
 )
+
+# This module stands in for "an interpreter that already ships its own
+# sitecustomize.py". On a plain interpreter that is the end of the line.
+# But on some real developer interpreters (e.g. Homebrew's macOS CPython)
+# this stand-in is not actually the last word: the interpreter needs a
+# *further* sitecustomize hop of its own -- e.g. Homebrew's ships one,
+# further down sys.path, whose only load-bearing line wires up the
+# interpreter's actual third-party site-packages directory via
+# ``site.addsitedir(...)`` -- to make third-party imports (like
+# ``pydantic_settings``) work at all. A fixture that stops delegating
+# after this one hop silently breaks every such interpreter, which is
+# the same class of defect this whole fixture chain exists to guard
+# against (issue #4186), just one layer deeper. Re-run the identical
+# re-delegation search used by the settings-location-failure hook, one
+# level further down, so this stand-in stays host-agnostic instead of
+# only working on interpreters that need exactly one sitecustomize hop.
+#
+# Excluding only this module's own directory is not enough here: the
+# settings-location-failure hook's directory still precedes this one on
+# sys.path (it put itself first specifically so it would be found before
+# this stand-in), and searching that back into scope would re-find *it*
+# and recurse forever. Search only what comes after this module's own
+# sys.path entry, so both this stand-in and everything already visited
+# ahead of it are excluded.
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+_this_index = next(
+    i for i, p in enumerate(sys.path) if os.path.abspath(p) == _this_dir
+)
+_search_path = sys.path[_this_index + 1 :]
+_further_spec = importlib.machinery.PathFinder().find_spec(
+    "sitecustomize", path=_search_path
+)
+if (
+    _further_spec is not None
+    and _further_spec.loader is not None
+    and hasattr(_further_spec.loader, "exec_module")
+    and (
+        _further_spec.origin is None
+        or os.path.abspath(_further_spec.origin) != os.path.abspath(__file__)
+    )
+):
+    _further_module = importlib.util.module_from_spec(_further_spec)
+    _this_module = sys.modules[__name__]
+    sys.modules[_further_spec.name] = _further_module
+    try:
+        _further_spec.loader.exec_module(_further_module)
+    finally:
+        sys.modules[_further_spec.name] = _this_module
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
Governing-Issue: #4276

Fixes #4276

Final-Review-Rounds: 0

## Summary
`test_export_runtime_env_delegated_sitecustomize_preserves_loader_metadata` (a guard test for #4186) failed on a Homebrew macOS Python interpreter with `ModuleNotFoundError: No module named 'pydantic_settings'` instead of exercising the assertion it exists to make — a false-negative-in-disguise: `returncode != 0` still passed for the wrong reason, so the test was green on that host without ever proving its real intent. Root cause: the test's own synthetic "real" `sitecustomize.py` stand-in stops the fixture's re-delegation search at itself, so it never reaches a further `sitecustomize` hop some interpreters genuinely need (Homebrew's, whose real `sitecustomize.py` is what wires up the actual third-party site-packages directory via `site.addsitedir(...)`). Fix: make the stand-in re-run the same delegation search one level further down (searching only `sys.path` entries past its own position, so it can't loop back into the outer injected hook), so the fixture stays host-agnostic instead of only working on interpreters needing exactly one hop.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 test-only fixture fix; no operational BuilderOps material to route.

## Notes
Validation:
- `pytest -q tests/ops/test_export_runtime_env.py` — 21 passed (previously 1 failed, 20 passed on this host)
- `ruff check tests/ops/test_export_runtime_env.py` — all checks passed
- `pytest -q -m "not pg" -n auto --dist=loadfile` (full "not pg" suite, host-leased) — 35 failed, 11379 passed, 63 skipped, 18 xfailed; none of the 35 failures are in `tests/ops/test_export_runtime_env.py` or touch anything this change modifies (pre-existing, environment-shaped failures in `tests/deploy/*`, `tests/ops/test_instance_state_volume_contract.py`, `tests/properties/test_guard_at_seam.py`, `tests/boundaries/test_domain_separation_defaults.py` — unrelated to this fixture change and out of scope here)

Root-cause instrumentation and the CI-vs-local divergence analysis are recorded in full on Issue #4276.
---
