### PR TITLE
Make verification-closer receipt outcomes diagnosable, not opaque

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1811,7 +1811,13 @@ _SAFE_CAPABILITIES = frozenset(
 _SAFE_REASONING_EFFORTS = frozenset(
     {"minimal", "low", "medium", "high", "xhigh", "max"}
 )
-_SAFE_EVENT_OUTCOMES = frozenset({"blocking", "clean", "fixed", "repaired"})
+_SAFE_EVENT_OUTCOMES = frozenset(
+    {"blocking", "clean", "fixed", "repaired", "unrecognized-outcome"}
+)
+_SAFE_RECEIPT_VERDICTS = frozenset(
+    {"delivered", "blocked", "needs_human", "retry"}
+)
+_SAFE_REVIEW_EVENT_KINDS = frozenset({"repair", "review"})
 _CANONICAL_HUMAN_ACTION_COPY = {
     "hold": (
         "Keep delivery blocked",
@@ -2062,7 +2068,7 @@ def _sanitize_review_event(event: Mapping[str, object]) -> dict[str, object]:
         "outcome": _allowlisted_receipt_value(
             event["outcome"],
             allowed=_SAFE_EVENT_OUTCOMES,
-            fallback="recorded",
+            fallback="unrecognized-outcome",
         ),
         "finding_id": (
             _pseudonymous_receipt_identifier(finding, prefix="finding")
@@ -2242,7 +2248,14 @@ def sanitize_codex_failure_receipt(
 
 
 def redact_durable_diagnostics(value: object) -> object:
-    """Defence-in-depth redaction for status reads of pre-fix durable rows."""
+    """Defence-in-depth redaction for status reads of pre-fix durable rows.
+
+    Known enum-bounded receipt fields (``capability``, ``reasoning_effort``,
+    ``outcome``, ``verdict``, ``kind``, ``failure_domain``) are re-checked
+    against their own allowlist instead of the generic free-text redactor, so
+    an already-sanitized value stays readable at status-read time rather than
+    collapsing to ``"[REDACTED]"`` alongside genuinely unsafe prose.
+    """
 
     if isinstance(value, Mapping):
         redacted: dict[str, object] = {}
@@ -2265,6 +2278,44 @@ def redact_durable_diagnostics(value: object) -> object:
                 safe_error_type = bounded_error_type(child)
                 if safe_error_type is not None:
                     redacted[key] = safe_error_type
+                continue
+            if normalized == "capability" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child, allowed=_SAFE_CAPABILITIES, fallback="unknown-capability"
+                )
+                continue
+            if normalized == "reasoning_effort" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child, allowed=_SAFE_REASONING_EFFORTS, fallback="unknown"
+                )
+                continue
+            if normalized == "outcome" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child,
+                    allowed=_SAFE_EVENT_OUTCOMES,
+                    fallback="unrecognized-outcome",
+                )
+                continue
+            if normalized == "verdict" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child,
+                    allowed=_SAFE_RECEIPT_VERDICTS,
+                    fallback="unrecognized-verdict",
+                )
+                continue
+            if normalized == "kind" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child,
+                    allowed=_SAFE_REVIEW_EVENT_KINDS,
+                    fallback="unrecognized-kind",
+                )
+                continue
+            if normalized == "failure_domain" and isinstance(child, str):
+                redacted[key] = _allowlisted_receipt_value(
+                    child,
+                    allowed=REPAIR_FAILURE_DOMAINS,
+                    fallback="review_code_correctness",
+                )
                 continue
             redacted[key] = redact_durable_diagnostics(child)
         return redacted

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -282,8 +282,8 @@ class DeliveredLauncher(Launcher):
 class DeferredFindingRetryLauncher(Launcher):
     """A closer that recorded a known capability and an out-of-taxonomy outcome.
 
-    Mirrors the 2026-07-29 Demerzel pilot run (vrun-810951877d5ccce8): a
-    ``review`` event self-reports the run's actual capability but an outcome
+    Mirrors the 2026-07-29 verification_closer pilot run (vrun-810951877d5ccce8):
+    a ``review`` event self-reports the run's actual capability but an outcome
     word (``deferred``) outside ``{blocking, clean, fixed, repaired}``.
     """
 

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -279,6 +279,49 @@ class DeliveredLauncher(Launcher):
         }
 
 
+class DeferredFindingRetryLauncher(Launcher):
+    """A closer that recorded a known capability and an out-of-taxonomy outcome.
+
+    Mirrors the 2026-07-29 Demerzel pilot run (vrun-810951877d5ccce8): a
+    ``review`` event self-reports the run's actual capability but an outcome
+    word (``deferred``) outside ``{blocking, clean, fixed, repaired}``.
+    """
+
+    def launch(
+        self,
+        context_pack,
+        *,
+        resume_session_id=None,
+        on_thread_started=None,
+        on_heartbeat=None,
+    ):
+        self.calls.append((context_pack, resume_session_id))
+        session = resume_session_id or "01900000-0000-7000-8000-000000000099"
+        if on_thread_started:
+            on_thread_started(session)
+        return session, {
+            "verdict": "retry",
+            "head_sha": HEAD,
+            "summary": "independent review found a deferred finding pending owner triage",
+            "receipt_ids": ["receipt-69af138f7c6d7911"],
+            "retry_after": None,
+            "review_events": [
+                {
+                    "kind": "review",
+                    "session_id": "01900000-0000-7000-8000-000000000042",
+                    "capability": "gpt-5.6-terra",
+                    "reasoning_effort": "high",
+                    "outcome": "deferred",
+                    "finding_id": "finding-42",
+                    "failure_domain": "review_code_correctness",
+                    "mechanism_id": "mechanism-42",
+                    "strongest": False,
+                }
+            ],
+            "human_exception": None,
+        }
+
+
 class TransitionTruth:
     def __init__(
         self,
@@ -6525,6 +6568,92 @@ def test_negated_rate_limit_summary_does_not_enter_rate_limit_backoff(tmp_path) 
             "SELECT attempt_kind, outcome FROM verification_attempts"
         ).fetchall()
     assert [(row[0], row[1]) for row in attempts] == [("verification", "launched")]
+
+
+def test_receipt_preserves_diagnosable_outcome_for_known_capability() -> None:
+    """Confirm _sanitize_review_event / _allowlisted_receipt_value is the seam.
+
+    Regression for #4271: a review event carrying the run's actual, allowlisted
+    capability (``gpt-5.6-terra``) alongside an outcome word outside
+    ``_SAFE_EVENT_OUTCOMES`` must keep the known capability intact and must not
+    collapse the unrecognized outcome onto a value that could be confused with
+    a real classification (the old ``"recorded"`` fallback was itself not a
+    member of ``_SAFE_EVENT_OUTCOMES``).
+    """
+
+    receipt = {
+        "verdict": "retry",
+        "head_sha": HEAD,
+        "summary": "independent review found a deferred finding",
+        "receipt_ids": ["receipt-1"],
+        "retry_after": None,
+        "review_events": [
+            {
+                "kind": "review",
+                "session_id": "01900000-0000-7000-8000-000000000042",
+                "capability": "gpt-5.6-terra",
+                "reasoning_effort": "high",
+                "outcome": "deferred",
+                "finding_id": "finding-42",
+                "failure_domain": "review_code_correctness",
+                "mechanism_id": "mechanism-42",
+                "strongest": False,
+            }
+        ],
+        "human_exception": None,
+    }
+    schema = (
+        Path(__file__).resolve().parents[2]
+        / "app/dispatcher/schemas/verification_closer_receipt.schema.json"
+    )
+
+    sanitized = verification_consumer.load_and_validate_verification_closer_receipt(
+        receipt,
+        schema,
+        trusted_repository=REPO,
+        trusted_evidence_urls=frozenset(),
+    )
+
+    event = sanitized["review_events"][0]
+    assert event["capability"] == "gpt-5.6-terra"
+    assert event["outcome"] == "unrecognized-outcome"
+    assert event["outcome"] not in {"blocking", "clean", "fixed", "repaired"}
+    assert event["outcome"] != "recorded"
+    assert event["outcome"] in verification_consumer._SAFE_EVENT_OUTCOMES
+
+
+def test_retry_verdict_receipt_is_diagnosable_without_raw_logs(tmp_path) -> None:
+    """A retry/backoff terminal receipt stays diagnosable through the normal
+    operator surface (``dispatcher verification-status``), not only via raw
+    DB/log access.
+
+    Regression for #4271: the CLI's ``_compact_verification_run`` applies
+    ``redact_durable_diagnostics`` as a read-time defense-in-depth pass. Before
+    this fix, that pass blindly ran every plain string through the free-text
+    redactor, so an already-safe capability/outcome/verdict collapsed to
+    ``"[REDACTED]"`` a second time on the exact surface an operator would use
+    to tell a legitimate finding apart from a receipt-generation malfunction.
+    """
+
+    state = ledger(tmp_path)
+    result = VerificationConsumer(
+        state,
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        DeferredFindingRetryLauncher(),
+        "host",
+    ).consume(request())
+
+    assert result.status == "backoff"
+
+    status_view = _compact_verification_run(result)
+    terminal_receipt = status_view["terminal_receipt"]
+    assert terminal_receipt["verdict"] == "retry"
+    event = terminal_receipt["review_events"][0]
+    assert event["capability"] == "gpt-5.6-terra"
+    assert event["outcome"] == "unrecognized-outcome"
+    assert event["outcome"] not in {"blocking", "clean", "fixed", "repaired"}
+    assert event["failure_domain"] == "review_code_correctness"
 
 
 def test_structured_rate_limit_receipt_replays_without_duplicate_attempt(


### PR DESCRIPTION
Governing-Issue: #4271

Fixes #4271

Final-Review-Rounds: 0

## Summary
A retry/backoff terminal receipt from the verification_closer pilot (run `vrun-810951877d5ccce8`, 2026-07-29) was structurally valid but semantically empty: the review-event `outcome` fallback (`"recorded"`) was itself not a member of `_SAFE_EVENT_OUTCOMES`, so a real classification and a sanitizer fallback were indistinguishable, and the CLI status surface's read-time `redact_durable_diagnostics` blanket-redacted every plain string (including already-safe `capability`/`outcome`/`verdict`/`kind`/`failure_domain`) a second time. This PR fixes both seams so a retry/backoff receipt stays diagnosable from the normal operator surface, without weakening secret redaction.

## Investigation (seam confirmation, per AC1)
Traced the full write path: `VerificationConsumer._launch` → `load_and_validate_verification_closer_receipt` (`app/dispatcher/verification_consumer.py:547`) → `sanitize_verification_closer_receipt` → `_sanitize_review_event`. This is the confirmed write-time seam (not "pattern-matched"): the `outcome`/`capability` fields on `review_events[]` are freeform LLM-authored JSON (the schema only requires `{"type": "string", "minLength": 1}`, no enum), so nothing constrains the coordinator to emit exactly `_SAFE_CAPABILITIES`/`_SAFE_EVENT_OUTCOMES` members. Built a regression fixture reproducing the reported shape (known capability `gpt-5.6-terra` + an out-of-taxonomy outcome) and proved:
- `capability` matching is already correct for exact allowlist members — no code bug found there; a specific historical mismatch can't be reproduced since the original run's raw value is already redacted/unrecoverable. Deliberately did **not** invent a speculative capability-matching fix (e.g. schema `enum` or fuzzy matching) — tightening the schema risks turning a cosmetic label mismatch into a hard validation failure that changes what verdict a run reaches, which the issue explicitly rules out.
- `outcome`'s fallback (`"recorded"`) was the real, provable bug: internally inconsistent (not itself an allowed member) and easily confused with a genuine value.
- A **second, previously-untraced seam**: `redact_durable_diagnostics` (used only by `dispatcher verification-status`/`_compact_verification_run`, `app/dispatcher/cli.py:385`) re-runs every plain string through the free-text-only redactor, so even a correctly-sanitized `verdict`/`capability`/`outcome` collapses to `"[REDACTED]"` a second time on the exact surface AC2 requires ("without raw log/DB access"). Confirmed by writing the AC2 test against pre-fix code — it failed on `terminal_receipt["verdict"] == "[REDACTED]"`, not just outcome/capability.

## Changes
- `_SAFE_EVENT_OUTCOMES`: add `"unrecognized-outcome"` as an explicit, self-evidently-sentinel member; `_sanitize_review_event`'s outcome fallback now maps to it instead of `"recorded"`.
- `redact_durable_diagnostics`: re-validate `capability`, `reasoning_effort`, `outcome`, `verdict`, `kind`, `failure_domain` against their own existing allowlists (mirroring the existing `session_id`/`error_type` special-casing) instead of running them through the generic free-text redactor. Preserves defense-in-depth for genuinely unsafe/legacy prose; only already-enum-bounded fields are affected.
- No change to any credential/secret-detection regex, `_sanitize_receipt_text`'s URL-only prose projection, or any verdict/merge/claim/lease decision logic. `verdict == "retry"` → `backoff` routing (`verification_consumer.py:4459`) reads the raw receipt's own `verdict` field directly and is untouched.

## Tests
- `tests/dispatcher/test_verification_consumer.py::test_receipt_preserves_diagnosable_outcome_for_known_capability` — proves a known capability survives sanitization and an out-of-taxonomy outcome becomes the distinguishable sentinel, not the old ambiguous fallback.
- `tests/dispatcher/test_verification_consumer.py::test_retry_verdict_receipt_is_diagnosable_without_raw_logs` — runs the full `VerificationConsumer` pipeline through `_compact_verification_run` (the exact CLI status-surface function) and proves `verdict`/`capability`/`outcome` all stay readable.
- Both tests were verified to fail against pre-fix code (`git stash` of the source change) before being confirmed green post-fix.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-issue bug fix with no BuilderOps operational material to route; owner already filed and scoped #4271 directly.

## Notes
- TCD/risk-surface: the diff lives in the receipt-sanitizer file but does not touch any secret-detection regex, prose redaction, or merge/claim/auth logic — only closed-set enum matching (`_allowlisted_receipt_value` can only ever return a member of its fixed `allowed` set or its fixed `fallback`, so no path admits arbitrary/secret content). Ran `scripts/review_before_ci_gate.py --lane implementation --risk-assessment-complete` with no risk surface declared → `status: not_required`. Assessed and declined `security` as a risk surface for this specific delta after tracing that no secret-matching code path is touched.
- Validation: `pytest tests/dispatcher/test_verification_consumer.py tests/dispatcher/test_verification_mechanism_budget.py tests/governance/test_verification_consumer_contract.py tests/dispatcher/test_control_plane.py tests/dispatcher/test_verification_review_repairs*.py` — 520 passed, 0 failed. `ruff check app tests companion-ui/companion-app` — clean. `mypy app/dispatcher/verification_consumer.py` — clean. `git diff --check` — clean.
- Owner-doc impact: none, per #4271's own SBS Impact section (receipt content only, no contract/behavior change).
- Did not reproduce against the live Demerzel host or run the dispatcher, per task scope; regression fixtures are modeled on the exact field values reported on #3603/#4271 (capability `gpt-5.6-terra`, `failure_domain: review_code_correctness`, `verdict: retry`).
