### PR TITLE
Point the model-access-substrate spec State lines at their filed issues

### DIFF
--- a/docs/MODEL_ACCESS_SUBSTRATE/DEFINE_PROVIDER_CENSUS.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/DEFINE_PROVIDER_CENSUS.md
@@ -9,7 +9,7 @@ depends_on: []
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). Delivers R4-1, which was
+State: Authored task specification (child issue #4287, filed 2026-07-29). Delivers R4-1, which was
 specified on 2026-07-05 and never decomposed into an issue.
 
 # Define Provider Census

--- a/docs/MODEL_ACCESS_SUBSTRATE/EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS.md
@@ -9,7 +9,7 @@ depends_on: [MAKE_BUILDER_TO_PRODUCT_LLM_DEPENDENCY_VISIBLE.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). Sibling extension of the
+State: Authored task specification (child issue #4289, filed 2026-07-29). Sibling extension of the
 delivered Local Secret Provisioning mechanism; **not** a re-filing of HSP-02, which is closed (#3846 /
 PR #4008).
 

--- a/docs/MODEL_ACCESS_SUBSTRATE/MAKE_BUILDER_TO_PRODUCT_LLM_DEPENDENCY_VISIBLE.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/MAKE_BUILDER_TO_PRODUCT_LLM_DEPENDENCY_VISIBLE.md
@@ -9,7 +9,7 @@ depends_on: [DEFINE_PROVIDER_CENSUS.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). Makes the transition
+State: Authored task specification (child issue #4288, filed 2026-07-29). Makes the transition
 debt scheduled by amended ADR-0064 §8 visible before its removal in MAS-06.
 
 # Make Builder-To-Product LLM Dependency Visible

--- a/docs/MODEL_ACCESS_SUBSTRATE/PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md
@@ -9,7 +9,7 @@ depends_on: [EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). Establishes the ADR-0063
+State: Authored task specification (child issue #4290, filed 2026-07-29). Establishes the ADR-0063
 kernel in code for the first time; ADR-0063 deliberately chose no package path.
 
 # Promote Adapter Contract To Neutral Kernel

--- a/docs/MODEL_ACCESS_SUBSTRATE/README.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/README.md
@@ -194,7 +194,7 @@ the per-task criteria live in the task files.
       with a provider-returned request id in the persisted turn receipt.
       Verify: redacted operator receipt posted to the parent feature issue, compared against the
       `final_state: provider_error` / `adapter_failure_class: command_exit_nonzero` failure recorded in
-      `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md :: Context`
+      `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md :: 3.1 What the substrate owns`
 - [ ] CKM resolves its semantic-association model through a Builder-side adapter, and a Product policy
       fallback cannot execute the Builder task.
       Verify: `tests/builderops/ckm/test_semantic.py::test_product_fallback_cannot_execute_builder_task`

--- a/docs/MODEL_ACCESS_SUBSTRATE/REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md
@@ -9,7 +9,7 @@ depends_on: [RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). Closes the interim window
+State: Authored task specification (child issue #4292, filed 2026-07-29). Closes the interim window
 opened by MAS-02. It follows accepted MAS-05 parent validation; the order does not swap.
 
 # Replace CKM Product Routing With Builder Adapter

--- a/docs/MODEL_ACCESS_SUBSTRATE/RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md
@@ -9,7 +9,7 @@ depends_on: [PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed). **This is the first task
+State: Authored task specification (child issue #4291, filed 2026-07-29). **This is the first task
 in the capability that changes runtime behaviour.**
 
 # Resolve Model Inquiry Credentials Through Contract


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Two residuals the filing writeback (PR #4294) missed after hub #4286 / children #4287–#4292 were filed: the six task-spec `State:` lines still claimed "child issue not yet filed", and the README capability criterion cited `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md :: Context` — an anchor that does not exist (the cited failure record lives under `:: 3.1 What the substrate owns`).

## Changes
- Six `docs/MODEL_ACCESS_SUBSTRATE/*.md` task-spec State lines now name their filed child issue (#4287–#4292, filed 2026-07-29). Single-line edits.
- `docs/MODEL_ACCESS_SUBSTRATE/README.md` capability criterion 4's Verify anchor corrected to `:: 3.1 What the substrate owns`. Single-line edit.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs breadcrumb repair; no BuilderOps material produced.

## Notes
Validation: `python3 scripts/docs_guard.py` OK; review-before-CI gate satisfied; branch-truth pre-commit and pre-push gates green; grep confirms no "not yet filed" line and no `:: Context` anchor remain in the directory.
---