### PR TITLE
[CKM Design Hub] define provider-neutral design-run contracts

### DIFF
--- a/app/builderops/design_run_contract.py
+++ b/app/builderops/design_run_contract.py
@@ -1,0 +1,509 @@
+"""Provider-neutral, immutable contracts for BuilderOps design runs.
+
+This module deliberately contains no adapter, provider, policy evaluation, persistence, or
+command semantics.  It is the small vocabulary those later layers must agree on.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Annotated, Any, Final, Literal, TypeAlias, cast
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    model_validator,
+)
+
+from app.builderops.delivery_orchestration_contracts import canonical_hash, canonical_json
+
+DESIGN_RUN_CONTRACT_VERSION: Final[Literal["builderops.design-run-contract.v1"]] = (
+    "builderops.design-run-contract.v1"
+)
+
+_UTC_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_ID = r"^[a-z][a-z0-9_.:-]{2,127}$"
+_FORBIDDEN_DETAIL = re.compile(
+    r"(?:api[_-]?key|authorization|bearer\s+|password|secret|raw[_ -]?stderr|"
+    r"raw[_ -]?stdout|\bcommand\b|/users/|/home/|/tmp/|~[/\\]|[a-z]:\\)",
+    re.IGNORECASE,
+)
+_AMBIENT_CONTEXT = re.compile(
+    r"(?:whole[ _-]?(?:repo|vault)|implicit[ _-]?(?:cwd|context)|ambient|"
+    r"chat[ _-]?history|unbounded|\bcwd\b)",
+    re.IGNORECASE,
+)
+
+
+def _utc_timestamp(value: str) -> str:
+    if not _UTC_TIMESTAMP.fullmatch(value):
+        raise ValueError("timestamp must be second-precision RFC 3339 UTC ending in Z")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise ValueError("timestamp must be a real UTC calendar value") from exc
+    return value
+
+
+def _normalized_identifier(value: Any) -> Any:
+    return value.strip() if isinstance(value, str) else value
+
+
+NonEmpty = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+Identifier = Annotated[
+    str,
+    BeforeValidator(_normalized_identifier),
+    StringConstraints(strip_whitespace=True, pattern=_ID),
+]
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+UtcTimestamp = Annotated[str, AfterValidator(_utc_timestamp)]
+DesignDeliverableKind: TypeAlias = Literal[
+    "visual_handoff",
+    "interaction_specification",
+    "content_review",
+]
+DesignRunStatusValue: TypeAlias = Literal[
+    "unknown",
+    "unavailable",
+    "denied",
+    "approval_pending",
+    "malformed",
+    "timed_out",
+    "failed",
+    "running",
+    "succeeded",
+]
+RefusalCode: TypeAlias = Literal[
+    "unknown_adapter",
+    "adapter_unavailable",
+    "admission_denied",
+    "approval_pending",
+    "approval_mismatch",
+    "malformed_request",
+    "timed_out",
+    "execution_failed",
+    "yggdrasil_gate_missing",
+    "yggdrasil_gate_stale",
+    "yggdrasil_token_drift",
+]
+
+
+def _require_sorted_unique(values: tuple[Any, ...], label: str) -> None:
+    if len(values) != len(set(values)):
+        raise ValueError(f"{label} must not contain duplicates")
+    if values != tuple(sorted(values)):
+        raise ValueError(f"{label} must use canonical sorted order")
+
+
+class _StrictFrozen(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, str_min_length=1)
+
+
+class CanonicalDesignRunContract(_StrictFrozen):
+    schema_version: Literal["builderops.design-run-contract.v1"] = DESIGN_RUN_CONTRACT_VERSION
+
+    def canonical_json(self) -> str:
+        return canonical_json(self)
+
+    @property
+    def content_hash(self) -> str:
+        return canonical_hash(self)
+
+
+class DesignSourceRef(_StrictFrozen):
+    source_type: Literal["ckm_observation", "github_issue", "repo_document", "builderops_receipt"]
+    source_id: NonEmpty
+    content_hash: Sha256
+
+    @model_validator(mode="after")
+    def _validate_explicit_source(self) -> "DesignSourceRef":
+        if _AMBIENT_CONTEXT.search(self.source_id) or _FORBIDDEN_DETAIL.search(self.source_id):
+            raise ValueError("source ref must be explicit and must not contain ambient or host-local context")
+        return self
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.source_type, self.source_id)
+
+
+class DigestBoundAttachmentRef(_StrictFrozen):
+    attachment_id: Identifier
+    media_type: Literal["image/png", "image/jpeg", "application/pdf", "text/html", "text/markdown"]
+    content_hash: Sha256
+
+
+class ContractIdentityRef(_StrictFrozen):
+    schema_version: NonEmpty
+    contract_id: Identifier
+    content_hash: Sha256
+
+
+class YggdrasilGateReceipt(_StrictFrozen):
+    receipt_id: Identifier
+    system_name: NonEmpty
+    system_id: Identifier
+    selection_mechanism: Literal["live_selection", "explicit_attachment"]
+    repo_token_source: NonEmpty
+    live_token_hash: Sha256
+    repo_token_hash: Sha256
+    parity_passed: Literal[True]
+    verified_at: UtcTimestamp
+    expires_at: UtcTimestamp
+    preview_refs: tuple[DigestBoundAttachmentRef, ...]
+
+    @model_validator(mode="after")
+    def _validate_complete_current_parity(self) -> "YggdrasilGateReceipt":
+        if self.live_token_hash != self.repo_token_hash:
+            raise ValueError("Yggdrasil live and repo token hashes must match")
+        if not self.preview_refs:
+            raise ValueError("Yggdrasil gate receipt requires referenced previews")
+        _require_sorted_unique(tuple(item.attachment_id for item in self.preview_refs), "preview refs")
+        if self.verified_at > self.expires_at:
+            raise ValueError("Yggdrasil gate receipt expiry must not precede verification")
+        return self
+
+    def valid_at(self, evaluated_at: UtcTimestamp) -> bool:
+        return self.verified_at <= evaluated_at <= self.expires_at
+
+
+class DesignAgentDescriptor(CanonicalDesignRunContract):
+    contract_kind: Literal["descriptor"] = "descriptor"
+    descriptor_id: Identifier
+    display_name: NonEmpty
+    role_profile_id: Identifier
+    supported_deliverables: tuple[DesignDeliverableKind, ...]
+    descriptor_revision: NonEmpty
+
+    @model_validator(mode="after")
+    def _validate_deliverables(self) -> "DesignAgentDescriptor":
+        if not self.supported_deliverables:
+            raise ValueError("design agent descriptor requires supported deliverables")
+        _require_sorted_unique(self.supported_deliverables, "supported deliverables")
+        return self
+
+
+class CuratedDesignBrief(CanonicalDesignRunContract):
+    contract_kind: Literal["brief"] = "brief"
+    brief_id: Identifier
+    projection_id: Identifier
+    requested_deliverable: DesignDeliverableKind
+    source_refs: tuple[DesignSourceRef, ...]
+    attachment_refs: tuple[DigestBoundAttachmentRef, ...] = ()
+    constraints: tuple[NonEmpty, ...]
+    yggdrasil_gate_receipt: YggdrasilGateReceipt | None = None
+    non_visual_exemption: Literal[True] | None = None
+
+    @model_validator(mode="after")
+    def _validate_bounded_brief(self) -> "CuratedDesignBrief":
+        if not self.source_refs:
+            raise ValueError("brief requires explicit source refs")
+        identities = tuple(ref.identity for ref in self.source_refs)
+        if len(identities) != len(set(identities)):
+            raise ValueError("brief source refs must not contain duplicates")
+        if self.source_refs != tuple(sorted(self.source_refs, key=lambda ref: ref.identity)):
+            raise ValueError("brief source refs must use canonical sorted order")
+        _require_sorted_unique(tuple(ref.attachment_id for ref in self.attachment_refs), "brief attachment refs")
+        _require_sorted_unique(self.constraints, "brief constraints")
+        if any(_AMBIENT_CONTEXT.search(constraint) for constraint in self.constraints):
+            raise ValueError("brief constraints must not request ambient or unbounded context")
+        is_visual = self.requested_deliverable == "visual_handoff"
+        if is_visual and (self.yggdrasil_gate_receipt is None or self.non_visual_exemption is not None):
+            raise ValueError("visual briefs require a Yggdrasil gate receipt and no exemption")
+        if not is_visual and (self.yggdrasil_gate_receipt is not None or self.non_visual_exemption is not True):
+            raise ValueError("non-visual briefs require an explicit exemption and no Yggdrasil receipt")
+        return self
+
+
+class DesignRunPolicyProfile(CanonicalDesignRunContract):
+    contract_kind: Literal["policy"] = "policy"
+    profile_id: Identifier
+    profile_version: NonEmpty
+    allowed_deliverables: tuple[DesignDeliverableKind, ...]
+    max_source_refs: Annotated[int, Field(gt=0)]
+    max_attachment_refs: Annotated[int, Field(ge=0)]
+    approval_required: bool
+    visual_yggdrasil_receipt_required: bool
+
+    @model_validator(mode="after")
+    def _validate_profile(self) -> "DesignRunPolicyProfile":
+        if not self.allowed_deliverables:
+            raise ValueError("design-run policy requires allowed deliverables")
+        _require_sorted_unique(self.allowed_deliverables, "allowed deliverables")
+        return self
+
+
+class DesignRunRequest(CanonicalDesignRunContract):
+    contract_kind: Literal["request"] = "request"
+    request_id: Identifier
+    brief_ref: ContractIdentityRef
+    adapter_ref: ContractIdentityRef
+    policy_ref: ContractIdentityRef
+    requested_at: UtcTimestamp
+
+
+class DesignRunAdmission(CanonicalDesignRunContract):
+    contract_kind: Literal["admission"] = "admission"
+    admission_id: Identifier
+    request_ref: ContractIdentityRef
+    brief_ref: ContractIdentityRef
+    adapter_ref: ContractIdentityRef
+    policy_ref: ContractIdentityRef
+    evaluated_at: UtcTimestamp
+    outcome: Literal["allow", "deny", "approval_required"]
+    refusal: "DesignRunRefusalDetail | None" = None
+
+    @model_validator(mode="after")
+    def _validate_admission(self) -> "DesignRunAdmission":
+        if self.outcome == "allow" and self.refusal is not None:
+            raise ValueError("allowed admission must not carry refusal detail")
+        if self.outcome != "allow" and self.refusal is None:
+            raise ValueError("non-allowed admission requires refusal detail")
+        return self
+
+
+class DesignRunApprovalEvidence(CanonicalDesignRunContract):
+    contract_kind: Literal["approval"] = "approval"
+    approval_id: Identifier
+    request_ref: ContractIdentityRef
+    admission_ref: ContractIdentityRef
+    brief_ref: ContractIdentityRef
+    adapter_ref: ContractIdentityRef
+    policy_ref: ContractIdentityRef
+    approved_at: UtcTimestamp
+    state: Literal["approved", "revoked"]
+
+
+class DesignRunRefusalDetail(_StrictFrozen):
+    code: RefusalCode
+    public_message: NonEmpty
+    retryable: bool
+
+    @model_validator(mode="after")
+    def _reject_sensitive_detail(self) -> "DesignRunRefusalDetail":
+        if _FORBIDDEN_DETAIL.search(self.public_message):
+            raise ValueError("refusal detail must not contain secret, command, stderr, or host-path material")
+        return self
+
+
+_ALLOWED_TRANSITIONS: Final[dict[DesignRunStatusValue, frozenset[DesignRunStatusValue]]] = {
+    "unknown": frozenset({"unavailable", "denied", "approval_pending", "malformed", "running"}),
+    "running": frozenset({"timed_out", "failed", "succeeded"}),
+    "unavailable": frozenset(), "denied": frozenset(), "approval_pending": frozenset(),
+    "malformed": frozenset(), "timed_out": frozenset(), "failed": frozenset(), "succeeded": frozenset(),
+}
+
+
+class DesignRunStatus(_StrictFrozen):
+    run_id: Identifier
+    state: DesignRunStatusValue
+    previous_state: DesignRunStatusValue | None = None
+    observed_at: UtcTimestamp
+
+    @model_validator(mode="after")
+    def _validate_transition(self) -> "DesignRunStatus":
+        if self.previous_state is None:
+            if self.state != "unknown":
+                raise ValueError("initial design-run status must be unknown")
+        elif self.state not in _ALLOWED_TRANSITIONS[self.previous_state]:
+            raise ValueError("invalid design-run status transition")
+        return self
+
+
+class DesignHandoffRef(_StrictFrozen):
+    handoff_id: Identifier
+    content_hash: Sha256
+    source_refs: tuple[DesignSourceRef, ...]
+    adapter_ref: ContractIdentityRef
+    run_id: Identifier
+    receipt_ref: ContractIdentityRef
+    limitations: tuple[NonEmpty, ...]
+    produced_at: UtcTimestamp
+    acceptance_state: Literal["unaccepted_builder_material"] = "unaccepted_builder_material"
+
+    @model_validator(mode="after")
+    def _validate_handoff(self) -> "DesignHandoffRef":
+        if not self.source_refs:
+            raise ValueError("handoff requires source refs")
+        if self.source_refs != tuple(sorted(self.source_refs, key=lambda ref: ref.identity)):
+            raise ValueError("handoff source refs must use canonical sorted order")
+        _require_sorted_unique(tuple(ref.identity for ref in self.source_refs), "handoff source refs")
+        _require_sorted_unique(self.limitations, "handoff limitations")
+        return self
+
+
+class DesignRunResult(CanonicalDesignRunContract):
+    contract_kind: Literal["result"] = "result"
+    result_id: Identifier
+    run_id: Identifier
+    request_ref: ContractIdentityRef
+    final_status: Literal["succeeded", "failed", "timed_out", "malformed"]
+    completed_at: UtcTimestamp
+    handoff: DesignHandoffRef | None = None
+    refusal: DesignRunRefusalDetail | None = None
+
+    @model_validator(mode="after")
+    def _validate_result(self) -> "DesignRunResult":
+        if self.final_status == "succeeded":
+            if self.handoff is None or self.refusal is not None:
+                raise ValueError("successful result requires exactly one validated handoff")
+        elif self.handoff is not None or self.refusal is None:
+            raise ValueError("non-success result requires refusal and no handoff")
+        return self
+
+
+def contract_ref(contract: CanonicalDesignRunContract, contract_id: Identifier) -> ContractIdentityRef:
+    """Return the exact identity used to bind an immutable design-run envelope."""
+
+    return ContractIdentityRef(
+        schema_version=contract.schema_version,
+        contract_id=contract_id,
+        content_hash=contract.content_hash,
+    )
+
+
+def validate_request_bindings(
+    request: DesignRunRequest,
+    *,
+    brief: CuratedDesignBrief,
+    adapter: DesignAgentDescriptor,
+    policy: DesignRunPolicyProfile,
+) -> None:
+    """Fail closed unless a request names exactly these immutable inputs."""
+
+    expected = (
+        ("brief", request.brief_ref, contract_ref(brief, brief.brief_id)),
+        ("adapter", request.adapter_ref, contract_ref(adapter, adapter.descriptor_id)),
+        ("policy", request.policy_ref, contract_ref(policy, policy.profile_id)),
+    )
+    for label, actual, required in expected:
+        if actual != required:
+            raise ValueError(f"design-run request {label} ref does not bind the exact contract")
+    if brief.requested_deliverable not in adapter.supported_deliverables:
+        raise ValueError("design-run adapter does not support requested deliverable")
+    if brief.requested_deliverable not in policy.allowed_deliverables:
+        raise ValueError("design-run policy does not allow requested deliverable")
+    if len(brief.source_refs) > policy.max_source_refs or len(brief.attachment_refs) > policy.max_attachment_refs:
+        raise ValueError("design-run brief exceeds policy context bounds")
+
+
+def validate_admission_bindings(
+    admission: DesignRunAdmission,
+    *,
+    request: DesignRunRequest,
+    brief: CuratedDesignBrief,
+    adapter: DesignAgentDescriptor,
+    policy: DesignRunPolicyProfile,
+    current_repo_token_hash: Sha256 | None = None,
+) -> None:
+    """Require admission to name the exact request and all inputs it admits."""
+
+    validate_request_bindings(request, brief=brief, adapter=adapter, policy=policy)
+    expected = (
+        ("request", admission.request_ref, contract_ref(request, request.request_id)),
+        ("brief", admission.brief_ref, contract_ref(brief, brief.brief_id)),
+        ("adapter", admission.adapter_ref, contract_ref(adapter, adapter.descriptor_id)),
+        ("policy", admission.policy_ref, contract_ref(policy, policy.profile_id)),
+    )
+    for label, actual, required in expected:
+        if actual != required:
+            raise ValueError(f"design-run admission {label} ref does not bind the exact contract")
+    if brief.requested_deliverable == "visual_handoff":
+        receipt = brief.yggdrasil_gate_receipt
+        if receipt is None or not policy.visual_yggdrasil_receipt_required:
+            raise ValueError("visual admission requires Yggdrasil receipt policy")
+        if current_repo_token_hash is None or receipt.repo_token_hash != current_repo_token_hash:
+            raise ValueError("visual admission Yggdrasil repo token hash drifted")
+        if not receipt.valid_at(admission.evaluated_at):
+            raise ValueError("visual admission Yggdrasil receipt is stale")
+
+
+def validate_approval_bindings(
+    approval: DesignRunApprovalEvidence,
+    *,
+    request: DesignRunRequest,
+    admission: DesignRunAdmission,
+    brief: CuratedDesignBrief,
+    adapter: DesignAgentDescriptor,
+    policy: DesignRunPolicyProfile,
+) -> None:
+    """Ensure approval cannot be replayed for an expanded or substituted request."""
+
+    expected = (
+        ("request", approval.request_ref, contract_ref(request, request.request_id)),
+        ("admission", approval.admission_ref, contract_ref(admission, admission.admission_id)),
+        ("brief", approval.brief_ref, contract_ref(brief, brief.brief_id)),
+        ("adapter", approval.adapter_ref, contract_ref(adapter, adapter.descriptor_id)),
+        ("policy", approval.policy_ref, contract_ref(policy, policy.profile_id)),
+    )
+    for label, actual, required in expected:
+        if actual != required:
+            raise ValueError(f"design-run approval {label} ref does not bind the exact contract")
+
+
+DesignRunContract: TypeAlias = (
+    DesignAgentDescriptor | CuratedDesignBrief | DesignRunPolicyProfile | DesignRunRequest |
+    DesignRunAdmission | DesignRunApprovalEvidence | DesignRunResult
+)
+
+def parse_design_run_contract(raw: str | bytes | bytearray | Mapping[str, Any]) -> DesignRunContract:
+    """Parse one strict contract object, refusing duplicate JSON keys and unknown fields."""
+    try:
+        if isinstance(raw, Mapping):
+            payload = dict(raw)
+        else:
+            source = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
+            payload = json.loads(source, object_pairs_hook=_reject_duplicate_keys)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("design-run contract must be one JSON object") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("design-run contract must be one JSON object")
+    contract_type = _contract_type_from_payload(payload)
+    try:
+        # JSON arrays are the canonical representation of immutable tuples; validate them through
+        # Pydantic's JSON path while retaining strict Python-value validation for programmatic use.
+        return cast(DesignRunContract, contract_type.model_validate_json(canonical_json(payload)))
+    except ValidationError:
+        raise
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate design-run contract JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _contract_type_from_payload(payload: Mapping[str, Any]) -> type[CanonicalDesignRunContract]:
+    # A typed discriminator belongs to every public contract so one shared schema version cannot
+    # silently turn a brief into an admission or result.
+    kind = payload.get("contract_kind")
+    types: dict[str, type[CanonicalDesignRunContract]] = {
+        "descriptor": DesignAgentDescriptor, "brief": CuratedDesignBrief,
+        "policy": DesignRunPolicyProfile, "request": DesignRunRequest,
+        "admission": DesignRunAdmission, "approval": DesignRunApprovalEvidence,
+        "result": DesignRunResult,
+    }
+    if payload.get("schema_version") != DESIGN_RUN_CONTRACT_VERSION or kind not in types:
+        raise ValueError("unsupported design-run contract schema_version or contract_kind")
+    return types[cast(str, kind)]
+
+
+__all__ = [
+    "CanonicalDesignRunContract", "ContractIdentityRef", "CuratedDesignBrief",
+    "DESIGN_RUN_CONTRACT_VERSION", "DesignAgentDescriptor", "DesignDeliverableKind",
+    "DesignHandoffRef", "DesignRunAdmission", "DesignRunApprovalEvidence",
+    "DesignRunPolicyProfile", "DesignRunRefusalDetail", "DesignRunRequest", "DesignRunResult",
+    "DesignRunStatus", "DigestBoundAttachmentRef", "DesignSourceRef", "YggdrasilGateReceipt",
+    "canonical_hash", "canonical_json", "contract_ref", "parse_design_run_contract",
+    "validate_admission_bindings", "validate_approval_bindings", "validate_request_bindings",
+]

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/DEFINE_DESIGN_RUN_CONTRACTS.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/DEFINE_DESIGN_RUN_CONTRACTS.md
@@ -2,7 +2,7 @@
 name: Define Design-Run Contracts
 description: Define strict provider-neutral design descriptors, briefs, requests, admissions, statuses, results, handoffs, and canonical hashes.
 task_id: CDH-01
-source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Reuse boundary
+source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Reuse boundary and external prerequisite
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: []
 depends_on: []

--- a/tests/builderops/test_design_run_contract.py
+++ b/tests/builderops/test_design_run_contract.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.builderops.design_run_contract import (
+    CuratedDesignBrief,
+    DesignAgentDescriptor,
+    DesignRunAdmission,
+    DesignRunApprovalEvidence,
+    DesignRunPolicyProfile,
+    DesignRunRefusalDetail,
+    DesignRunRequest,
+    DesignRunResult,
+    DesignRunStatus,
+    DesignSourceRef,
+    DigestBoundAttachmentRef,
+    YggdrasilGateReceipt,
+    contract_ref,
+    validate_admission_bindings,
+    validate_approval_bindings,
+)
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+SHA_C = "c" * 64
+TS = "2026-07-29T10:00:00Z"
+
+
+def _source(source_id: str = "ckm:observation:one") -> DesignSourceRef:
+    return DesignSourceRef(source_type="ckm_observation", source_id=source_id, content_hash=SHA_A)
+
+
+def _attachment(attachment_id: str = "attachment.one") -> DigestBoundAttachmentRef:
+    return DigestBoundAttachmentRef(attachment_id=attachment_id, media_type="image/png", content_hash=SHA_B)
+
+
+def _receipt() -> YggdrasilGateReceipt:
+    return YggdrasilGateReceipt(
+        receipt_id="receipt.yggdrasil.one",
+        system_name="Yggdrasil",
+        system_id="yggdrasil.design.system",
+        selection_mechanism="explicit_attachment",
+        repo_token_source="companion-ui/design_tokens.css",
+        live_token_hash=SHA_C,
+        repo_token_hash=SHA_C,
+        parity_passed=True,
+        verified_at=TS,
+        expires_at="2026-07-29T11:00:00Z",
+        preview_refs=(_attachment(),),
+    )
+
+
+def _brief(*, visual: bool = True) -> CuratedDesignBrief:
+    return CuratedDesignBrief(
+        brief_id="brief.design.one",
+        projection_id="ckm.projection.one",
+        requested_deliverable="visual_handoff" if visual else "interaction_specification",
+        source_refs=(_source(),),
+        attachment_refs=(_attachment(),),
+        constraints=("Use explicit evidence only.",),
+        yggdrasil_gate_receipt=_receipt() if visual else None,
+        non_visual_exemption=None if visual else True,
+    )
+
+
+def _adapter() -> DesignAgentDescriptor:
+    return DesignAgentDescriptor(
+        descriptor_id="adapter.claude.design",
+        display_name="Claude Design",
+        role_profile_id="design.claude",
+        supported_deliverables=("interaction_specification", "visual_handoff"),
+        descriptor_revision="v1",
+    )
+
+
+def _policy() -> DesignRunPolicyProfile:
+    return DesignRunPolicyProfile(
+        profile_id="design.policy.local",
+        profile_version="v1",
+        allowed_deliverables=("interaction_specification", "visual_handoff"),
+        max_source_refs=4,
+        max_attachment_refs=2,
+        approval_required=True,
+        visual_yggdrasil_receipt_required=True,
+    )
+
+
+def _request(brief: CuratedDesignBrief, adapter: DesignAgentDescriptor, policy: DesignRunPolicyProfile) -> DesignRunRequest:
+    return DesignRunRequest(
+        request_id="request.design.one",
+        brief_ref=contract_ref(brief, brief.brief_id),
+        adapter_ref=contract_ref(adapter, adapter.descriptor_id),
+        policy_ref=contract_ref(policy, policy.profile_id),
+        requested_at=TS,
+    )
+
+
+def test_curated_brief_is_bounded_provenanced_and_deterministic() -> None:
+    first = _brief()
+    assert first.content_hash == _brief().content_hash
+    with pytest.raises(ValidationError, match="canonical sorted"):
+        CuratedDesignBrief(**(_brief().model_dump() | {"source_refs": (_source("ckm:observation:z"), _source())}))
+    with pytest.raises(ValidationError, match="explicit exemption"):
+        CuratedDesignBrief(**(_brief(visual=False).model_dump() | {"non_visual_exemption": None}))
+    with pytest.raises(ValidationError, match="Yggdrasil gate receipt"):
+        CuratedDesignBrief(**(_brief().model_dump() | {"yggdrasil_gate_receipt": None}))
+    with pytest.raises(ValidationError, match="ambient"):
+        DesignSourceRef(source_type="repo_document", source_id="whole-repo", content_hash=SHA_A)
+
+
+def test_admission_and_approval_bind_the_exact_request() -> None:
+    brief, adapter, policy = _brief(), _adapter(), _policy()
+    request = _request(brief, adapter, policy)
+    admission = DesignRunAdmission(
+        admission_id="admission.design.one", request_ref=contract_ref(request, request.request_id),
+        brief_ref=contract_ref(brief, brief.brief_id), adapter_ref=contract_ref(adapter, adapter.descriptor_id),
+        policy_ref=contract_ref(policy, policy.profile_id), evaluated_at=TS, outcome="approval_required",
+        refusal=DesignRunRefusalDetail(code="approval_pending", public_message="Operator approval is required.", retryable=False),
+    )
+    validate_admission_bindings(admission, request=request, brief=brief, adapter=adapter, policy=policy, current_repo_token_hash=SHA_C)
+    approval = DesignRunApprovalEvidence(
+        approval_id="approval.design.one", request_ref=contract_ref(request, request.request_id),
+        admission_ref=contract_ref(admission, admission.admission_id), brief_ref=contract_ref(brief, brief.brief_id),
+        adapter_ref=contract_ref(adapter, adapter.descriptor_id), policy_ref=contract_ref(policy, policy.profile_id),
+        approved_at=TS, state="approved",
+    )
+    validate_approval_bindings(approval, request=request, admission=admission, brief=brief, adapter=adapter, policy=policy)
+    with pytest.raises(ValueError, match="exact contract"):
+        validate_admission_bindings(admission, request=request, brief=_brief(visual=False), adapter=adapter, policy=policy)
+
+
+def test_visual_deliverables_bind_current_yggdrasil_gate_receipt() -> None:
+    brief, adapter, policy = _brief(), _adapter(), _policy()
+    request = _request(brief, adapter, policy)
+    admission = DesignRunAdmission(
+        admission_id="admission.visual.one", request_ref=contract_ref(request, request.request_id),
+        brief_ref=contract_ref(brief, brief.brief_id), adapter_ref=contract_ref(adapter, adapter.descriptor_id),
+        policy_ref=contract_ref(policy, policy.profile_id), evaluated_at=TS, outcome="allow",
+    )
+    validate_admission_bindings(admission, request=request, brief=brief, adapter=adapter, policy=policy, current_repo_token_hash=SHA_C)
+    with pytest.raises(ValueError, match="token hash drifted"):
+        validate_admission_bindings(admission, request=request, brief=brief, adapter=adapter, policy=policy, current_repo_token_hash=SHA_A)
+    assert _brief(visual=False).non_visual_exemption is True
+
+
+def test_result_and_refusal_contracts_are_closed_and_secret_safe() -> None:
+    with pytest.raises(ValidationError, match="secret"):
+        DesignRunRefusalDetail(code="execution_failed", public_message="api_key leaked", retryable=False)
+    with pytest.raises(ValidationError, match="invalid design-run status transition"):
+        DesignRunStatus(run_id="run.design.one", previous_state="succeeded", state="running", observed_at=TS)
+    with pytest.raises(ValidationError, match="requires refusal"):
+        DesignRunResult(result_id="result.design.one", run_id="run.design.one", request_ref=contract_ref(_brief(), "brief.design.one"), final_status="failed", completed_at=TS)
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        DesignRunStatus(run_id="run.design.one", state="unknown", observed_at=TS, raw_stderr="no")
+    assert DesignRunStatus(run_id="run.design.one", state="unknown", observed_at=TS).state == "unknown"

--- a/tests/builderops/test_model_inquiry_contract.py
+++ b/tests/builderops/test_model_inquiry_contract.py
@@ -1,0 +1,31 @@
+"""Regression boundary: design runs share hashing, never inquiry semantics."""
+
+from __future__ import annotations
+
+import inspect
+
+import app.builderops.design_run_contract as design_run_contract
+from app.builderops.design_run_contract import CuratedDesignBrief, DesignSourceRef, parse_design_run_contract
+from app.builderops.model_inquiry_contract import ModelTurnResponse
+
+
+def test_design_contract_reuses_hashing_without_inheriting_inquiry_roles() -> None:
+    source = inspect.getsource(design_run_contract)
+    assert "model_inquiry" not in source
+
+    inquiry_response = ModelTurnResponse(
+        schema_version="builderops.model-turn-response.v1",
+        stance="draft",
+        content="Keep inquiry semantics isolated.",
+        claims=[], risks=[], blocking_questions=[], reviewed_artifact_refs=[], accepted_artifact_hash=None,
+    )
+    assert inquiry_response.schema_version == "builderops.model-turn-response.v1"
+
+    brief = CuratedDesignBrief(
+        brief_id="brief.design.one", projection_id="ckm.projection.one",
+        requested_deliverable="interaction_specification",
+        source_refs=(DesignSourceRef(source_type="ckm_observation", source_id="ckm:observation:one", content_hash="a" * 64),),
+        attachment_refs=(), constraints=("Use bounded context.",),
+        non_visual_exemption=True,
+    )
+    assert isinstance(parse_design_run_contract(brief.canonical_json()), CuratedDesignBrief)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4308

## Linked Issue
Closes #4308

## SBS Impact
- Primary subsystem: Builder System / CKM contracts
- Secondary subsystem(s): BuilderOps governance and model-access boundary
- Write class: immutable provider-neutral domain contracts
- Persistence impact: none in this slice
- Derived/rebuildable impact: none in this slice
- New or changed contract: design-run descriptor, brief, request, admission, approval, status, result, handoff, and refusal vocabulary
- Owner-doc impact: none until terminal parent acceptance
- Transition debt impact: establishes vocabulary before adapters or execution
- Boundary risk: contract must carry no provider command, secret, or decision authority

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add immutable provider-neutral design-run contracts with exact request, admission, approval, status, refusal, and handoff binding.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The slice creates repo-governed contract code and tests only; it produces no BuilderOps record or projection.

## Notes
Validation: pytest -q tests/builderops/test_design_run_contract.py tests/builderops/test_model_inquiry_contract.py (5 passed); ruff check app tests; mypy app; python3 scripts/docs_guard.py. TCD risk surfaces: none; Tier 2 light path. Source-anchor metadata corrected to the live README heading.
