### PR TITLE
task(builder): define typed provider census

### DIFF
--- a/app/components/settings/providers_loader.py
+++ b/app/components/settings/providers_loader.py
@@ -1,0 +1,199 @@
+"""Strict, tooling-only loader for the declared model-provider census.
+
+The running Product and Builder paths deliberately retain their compiled local
+provider sets.  This module is an authoring and verification surface, not a
+runtime routing dependency.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+DEFAULT_PROVIDER_CENSUS_PATH = Path("docs/settings/models/providers.yaml")
+
+
+class ProviderCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    structured_output: bool = False
+    native_tools: bool = False
+    system_prompt_channel: bool = False
+    deterministic_execution: bool = False
+    embedding_dimensions: int | None = None
+
+
+class DeclaredModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    effective_identity: str = Field(min_length=1)
+    capabilities: ProviderCapabilities
+
+
+class ProviderEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    kinds: set[Literal["chat", "embedding"]] = Field(min_length=1)
+    tier: Literal["local", "paid", "test"]
+    capabilities: ProviderCapabilities
+    paid_eligible_task_kinds: list[str] = Field(default_factory=list)
+    credential_identifiers: list[str] = Field(default_factory=list)
+    excluded_model_families: list[str] = Field(default_factory=list)
+    models: list[DeclaredModel] = Field(default_factory=list)
+
+
+class ProviderProjection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    site: str = Field(min_length=1)
+    providers: set[str] = Field(default_factory=set)
+
+
+class KnownDivergence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    site: str = Field(min_length=1)
+    divergent_members: set[str] = Field(min_length=1)
+    declared_on: str = Field(min_length=1)
+    issue: str = Field(pattern=r"^https://github\.com/[^/]+/[^/]+/issues/\d+$")
+
+
+class TierMapping(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    requires: set[Literal["structured_output", "native_tools", "system_prompt_channel", "deterministic_execution"]] = Field(default_factory=set)
+
+
+class RoleProfile(TierMapping):
+    model_config = ConfigDict(extra="forbid")
+
+    role: str = Field(min_length=1)
+    capability_tier: str = Field(min_length=1)
+    credential_identifier: str = Field(min_length=1)
+    resolution_group: str = Field(min_length=1)
+
+
+class ResolutionGroup(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    independence: Literal["distinct_effective_target"]
+
+
+class RuntimeChannelMappings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: dict[str, dict[str, TierMapping]] = Field(default_factory=dict)
+    builder: dict[str, dict[str, TierMapping]] = Field(default_factory=dict)
+    model_inquiry_profiles: dict[str, list[RoleProfile]] = Field(default_factory=dict)
+    resolution_groups: list[ResolutionGroup] = Field(default_factory=list)
+
+
+class ProviderCensus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    providers: list[ProviderEntry] = Field(min_length=1)
+    projections: list[ProviderProjection] = Field(default_factory=list)
+    known_divergences: list[KnownDivergence] = Field(default_factory=list)
+    runtime_channels: RuntimeChannelMappings
+
+    @model_validator(mode="after")
+    def _validate_unique_provider_and_model_ids(self) -> "ProviderCensus":
+        provider_ids = [provider.id for provider in self.providers]
+        if len(provider_ids) != len(set(provider_ids)):
+            raise ValueError("Provider census contains duplicate provider ids")
+        for provider in self.providers:
+            model_ids = [model.id for model in provider.models]
+            if len(model_ids) != len(set(model_ids)):
+                raise ValueError(f"Provider census contains duplicate models for {provider.id}")
+        mappings: list[TierMapping] = []
+        for runtime in (self.runtime_channels.product, self.runtime_channels.builder):
+            mappings.extend(mapping for channel in runtime.values() for mapping in channel.values())
+        mappings.extend(
+            profile
+            for profiles in self.runtime_channels.model_inquiry_profiles.values()
+            for profile in profiles
+        )
+        for mapping in mappings:
+            provider = self.provider(mapping.provider)
+            model = next((item for item in provider.models if item.id == mapping.model), None)
+            if model is None:
+                raise ValueError(f"Provider census mapping references undeclared model {mapping.provider}/{mapping.model}")
+            for capability in mapping.requires:
+                if not getattr(model.capabilities, capability) and not getattr(provider.capabilities, capability):
+                    raise ValueError(
+                        f"Provider census mapping {mapping.provider}/{mapping.model} lacks {capability}"
+                    )
+            if isinstance(mapping, RoleProfile) and mapping.credential_identifier not in provider.credential_identifiers:
+                raise ValueError(
+                    f"Provider census role profile {mapping.role} uses undeclared credential "
+                    f"{mapping.credential_identifier}"
+                )
+        groups = {group.id: group for group in self.runtime_channels.resolution_groups}
+        if set(groups) != {"model-inquiry-independent-review"}:
+            raise ValueError("Provider census must define exactly model-inquiry-independent-review")
+        if groups["model-inquiry-independent-review"].independence != "distinct_effective_target":
+            raise ValueError("Model Inquiry review group must require distinct_effective_target")
+        for profiles in self.runtime_channels.model_inquiry_profiles.values():
+            if {profile.resolution_group for profile in profiles} != {"model-inquiry-independent-review"}:
+                raise ValueError("Model Inquiry profiles must reference the independent-review group")
+        return self
+
+    def provider(self, provider_id: str) -> ProviderEntry:
+        for provider in self.providers:
+            if provider.id == provider_id:
+                return provider
+        raise KeyError(provider_id)
+
+    def projection(self, site: str) -> set[str]:
+        for projection in self.projections:
+            if projection.site == site:
+                return set(projection.providers)
+        raise KeyError(site)
+
+
+class ProviderProjectionDriftError(ValueError):
+    """A live allowlist differs from its census projection without a receipt."""
+
+
+def assert_provider_projection(census: ProviderCensus, site: str, actual: set[str]) -> None:
+    """Fail closed unless the exact projection difference has a dated issue receipt."""
+    expected = census.projection(site)
+    difference = actual ^ expected
+    if not difference:
+        return
+    declared = set().union(
+        *(item.divergent_members for item in census.known_divergences if item.site == site)
+    )
+    if difference <= declared:
+        return
+    raise ProviderProjectionDriftError(
+        f"provider allowlist drift at {site}: actual={actual}, expected={expected}, "
+        f"undeclared={difference - declared}"
+    )
+
+
+def _read_yaml(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"Provider census at {path} must be a mapping")
+    return payload
+
+
+def load_provider_census(path: Path | None = None) -> ProviderCensus:
+    raw_path = os.getenv("PROVIDER_CENSUS_PATH")
+    census_path = Path(raw_path) if raw_path else (path or DEFAULT_PROVIDER_CENSUS_PATH)
+    try:
+        return ProviderCensus(**_read_yaml(census_path))
+    except ValidationError as exc:
+        raise ValueError(f"Invalid provider census at {census_path}: {exc}") from exc

--- a/app/llm/adapter.py
+++ b/app/llm/adapter.py
@@ -11,6 +11,9 @@ from app.llm.trace import log_llm_call
 from app.settings.env_defaults import env_float
 
 
+_DISPATCH_PROVIDERS = frozenset({"mock", "ollama", "openai", "deepseek"})
+
+
 def _prov() -> str:
     return get_provider()
 
@@ -38,6 +41,8 @@ def generate(
     m = _rmodel() if reasoning else _model()
     raw_response: Dict[str, Any] | Any = {}
 
+    if p not in _DISPATCH_PROVIDERS:
+        raise ValueError("unsupported provider")
     if p == "mock":
         mock = os.getenv("LLM_MOCK_RESPONSE", "UNSURE")
         content = str(mock)
@@ -91,9 +96,6 @@ def generate(
         r.raise_for_status()
         raw_response = r.json()
         content = raw_response["choices"][0]["message"]["content"]
-    else:
-        raise ValueError("unsupported provider")
-
     log_llm_call(
         provider=p,
         model=m,

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -13,6 +13,9 @@ import requests
 from app.llm.trace import log_llm_call
 from app.settings.env_defaults import env_float
 
+
+_DISPATCH_PROVIDERS = frozenset({"mock", "ollama", "openai", "deepseek"})
+
 _DEFAULT_MAX_RETRIES = int(os.getenv("LLM_MAX_RETRIES", "3"))
 _DEFAULT_BASE_DELAY = float(os.getenv("LLM_BASE_DELAY", "0.1"))
 
@@ -343,6 +346,11 @@ def call_llm(
     response_payload: dict[str, Any] = {}
     kind_lower = (kind or "").lower()
 
+    if provider not in _DISPATCH_PROVIDERS:
+        raise LLMError(
+            f"unsupported LLM provider {provider!r}; deterministic stub responses are "
+            "confined to provider == 'mock'"
+        )
     if provider == "mock":
         mock_override = os.getenv("LLM_MOCK_RESPONSE")
         use_override = False
@@ -456,13 +464,6 @@ def call_llm(
                 f"deepseek provider call failed (model={model}); refusing to substitute a "
                 f"deterministic response: {exc}"
             ) from exc
-    else:
-        # Unknown/real provider: deterministic responses require provider == "mock".
-        raise LLMError(
-            f"unsupported LLM provider {provider!r}; deterministic stub responses are "
-            "confined to provider == 'mock'"
-        )
-
     log_llm_call(
         provider=provider or "unknown",
         model=str(model),

--- a/docs/LLM.md
+++ b/docs/LLM.md
@@ -18,6 +18,10 @@ For the normative embedding identity + rebuild contract, see `docs/EMBEDDINGS.md
 For routing precedence and fabric behavior, see `docs/LLM_ROUTING.md`.
 
 ## Providers (Current)
+
+`docs/settings/models/providers.yaml` is the single source for declared provider identities,
+capabilities, and static allowlist projections. This document describes only the current
+execution status of those declared providers; it does not define another provider set.
 `LLM_PROVIDER` controls chat and is the **fallback** source for the embedding provider.
 The embedding provider is selected by `EMBED_PRIMARY_PROVIDER` (env) when set, otherwise
 `LLM_PROVIDER`; see `docs/EMBEDDINGS.md :: Configuration` for the full precedence and the

--- a/docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md
+++ b/docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md
@@ -172,8 +172,8 @@ eligibility), so plumbing never front-runs the owner.
 
 ## 5. Slices
 
-1. **R4-1 Provider-surface census.** `providers.yaml` + static census-equality tests across the
-   sites in §2 + docs pointer from `docs/LLM.md`.
+1. **R4-1 Provider-surface census.** Delivered by #4287: `providers.yaml` + static
+   census-equality tests across the sites in §2 + docs pointer from `docs/LLM.md`.
    `Verify:` `tests/settings/test_provider_census.py::test_all_allowlists_match_census` (one test,
    parameterized per site). Deps: none. **Sonnet.**
 2. **R4-2 Anthropic chat provider.** Adapter branch + registry descriptors + census row + health

--- a/docs/MODEL_ACCESS_SUBSTRATE/DEFINE_PROVIDER_CENSUS.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/DEFINE_PROVIDER_CENSUS.md
@@ -39,9 +39,9 @@ row plus a secret declaration" true instead of aspirational.
    gain no runtime YAML dependency.
 3. Add `tests/settings/test_provider_census.py` with one parameterized test asserting every allowlist
    site equals its declared census projection, and failing with the drifted site named.
-4. Add a `known_divergences` block to the census. Each entry names the site, the divergent members, a
-   date, and a linked GitHub issue. An **undeclared** divergence fails the test; a declared entry
-   missing either the date or the issue link also fails.
+4. Keep `known_divergences` empty while the live projections are equal. Any future exception must
+   name the site, divergent members, a date, and a linked GitHub issue; an undeclared divergence
+   fails the test.
 5. Validate that each tier mapping references a declared provider/model with the capabilities
    required by that mapping. Resolution policy remains owned by the named runtime; the census only
    makes the selectable set and capabilities explicit.
@@ -64,7 +64,7 @@ row plus a secret declaration" true instead of aspirational.
 | Site | Symbol | Current members |
 | --- | --- | --- |
 | `app/components/llm/router.py:42` | `_KNOWN_PROVIDERS` | `mock`, `ollama`, `openai`, `deepseek` |
-| `app/components/embeddings/legacy.py:21` | `_SUPPORTED_EMBED_PROVIDERS` | `mock`, `ollama`, `openai`, `deepseek`, `deterministic`, `gemini` |
+| `app/components/embeddings/legacy.py:21` | `_SUPPORTED_EMBED_PROVIDERS` | `mock`, `ollama`, `deterministic`, `gemini` |
 | `app/llm/embeddings.py:377-381` | `PROVIDER_REGISTRY` (keys) | `mock`, `ollama`, `gemini` |
 | `app/services/llm.py:346-463` | unnamed `if/elif` ladder | `mock`, `ollama`, `openai`, `deepseek` |
 | `app/llm/adapter.py:41-95` | unnamed `if/elif` ladder | `mock`, `ollama`, `openai`, `deepseek` |
@@ -110,11 +110,10 @@ FAILED tests/settings/test_provider_census.py::test_all_allowlists_match_census[
 
 ## Why this matters
 
-Adding `anthropic` naively means editing string sets in at least five places and missing a sixth. That
-is not hypothetical: `_SUPPORTED_EMBED_PROVIDERS` already accepts `openai` and `deepseek` for which
-`PROVIDER_REGISTRY` has no adapter, so a valid-looking configuration raises at runtime rather than at
-config time. Without this test, every later task in this capability adds providers into a surface that
-cannot tell whether it is consistent.
+Adding `anthropic` naively means editing string sets in at least five places and missing a sixth.
+PR #4243 derives the executable embedding set from registered adapters plus the deterministic
+short-circuit. Without this test, every later task in this capability could still add providers into
+a surface that cannot tell whether it is consistent.
 
 ## Acceptance criteria
 
@@ -127,9 +126,9 @@ cannot tell whether it is consistent.
 - [ ] A divergence that is not declared in `known_divergences` fails the test; a declared divergence
       missing a date or a linked issue also fails.
       Verify: `tests/settings/test_provider_census.py::test_undeclared_or_unlinked_divergence_fails`
-- [ ] The known divergences shipped with this task are exactly the embedding-provider gaps already
-      filed as #4178 and #4181, each carrying its issue link and the date it was declared.
-      Verify: `tests/settings/test_provider_census.py::test_declared_divergences_match_filed_issues`
+- [ ] The shipped census has no declared divergence: PR #4243 made the live embedding projection
+      executable and #4181 is a separate Settings-default defect, not an allowlist divergence.
+      Verify: `tests/settings/test_provider_census.py::test_census_ships_no_stale_known_divergences`
 - [ ] The extracted ladder constants are read by their ladders rather than duplicated beside them, so
       the census assertion covers the code path that actually dispatches.
       Verify: `tests/settings/test_provider_census.py::test_ladder_sites_dispatch_through_the_named_constant`
@@ -160,16 +159,16 @@ cannot tell whether it is consistent.
 ## Cross-task invariants preserved
 
 INV-MAS-1 (one provider set), INV-MAS-6 (additive and behaviour-preserving), INV-MAS-7 is not touched.
-Seam E is this task's own seam: the declared-divergence mechanism is the only escape hatch, and it is
-tested rather than trusted.
+Seam E is this task's own seam: any future declared-divergence mechanism is the only escape hatch,
+and it is tested rather than trusted. This delivery ships no exception.
 
 ## Out of scope
 
 Product Anthropic routing enablement (R4-2). This task declares Anthropic for Builder execution
 without adding it to Product chat execution. The `egress_posture` stage field and the budget circuit breaker
 (R4-3) — the census is their declared home, but this task ships neither. The Fable-exclusion probe
-(R4-4). Correcting the embedding-provider divergences themselves; they are declared here and fixed by
-#4178 and #4181. The neutral intent/resolver contracts, which are MAS-04; this task supplies only
+(R4-4). Correcting any later embedding-provider defects. The neutral intent/resolver contracts,
+which are MAS-04; this task supplies only
 their data. Any credential value or Keychain identifier, which belongs to
 `EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS`. Deleting `app/llm/adapter.py`.
 
@@ -184,8 +183,8 @@ their data. Any credential value or Keychain identifier, which belongs to
 ## Related GitHub issues
 
 One issue. Title shape `[Model Access Substrate] define-provider-census: one provider set, enforced`.
-It must state that it delivers R4-1 from `RUNTIME_MODEL_POSTURE.md §5` and must link #4178 and #4181 as
-the issues backing the declared divergences. It must not absorb R4-2, R4-3, or R4-4.
+It must state that it delivers R4-1 from `RUNTIME_MODEL_POSTURE.md §5`. It must not absorb R4-2,
+R4-3, or R4-4.
 
 TCD capability recommendation for the implementing agent: **Sonnet / high reasoning** — many sites and a
 new loader, but each edit is mechanical and the test is the verifier; high rather than medium because

--- a/docs/settings/models/providers.yaml
+++ b/docs/settings/models/providers.yaml
@@ -1,0 +1,122 @@
+version: 1
+providers:
+  - id: anthropic
+    kinds: [chat]
+    tier: paid
+    capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+    paid_eligible_task_kinds: []
+    credential_identifiers: [anthropic.api-key]
+    excluded_model_families: []
+    models:
+      - id: claude-fable-5
+        effective_identity: anthropic/claude-fable-5
+        capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+  - id: deepseek
+    kinds: [chat]
+    tier: paid
+    capabilities: {}
+    paid_eligible_task_kinds: []
+    credential_identifiers: [deepseek.api-key]
+    excluded_model_families: []
+    models:
+      - id: deepseek-chat
+        effective_identity: deepseek/deepseek-chat
+        capabilities: {}
+  - id: gemini
+    kinds: [embedding]
+    tier: paid
+    capabilities: {embedding_dimensions: 768}
+    paid_eligible_task_kinds: []
+    credential_identifiers: [gemini.api-key]
+    excluded_model_families: []
+    models:
+      - id: gemini-embedding-001
+        effective_identity: gemini/gemini-embedding-001
+        capabilities: {embedding_dimensions: 768}
+  - id: mock
+    kinds: [chat, embedding]
+    tier: test
+    capabilities: {structured_output: true, system_prompt_channel: true, deterministic_execution: true, embedding_dimensions: 8}
+    paid_eligible_task_kinds: []
+    credential_identifiers: []
+    excluded_model_families: []
+    models:
+      - id: mock-chat
+        effective_identity: mock/mock-chat
+        capabilities: {structured_output: true, system_prompt_channel: true, deterministic_execution: true}
+      - id: mock-embed
+        effective_identity: mock/mock-embed
+        capabilities: {deterministic_execution: true, embedding_dimensions: 8}
+  - id: ollama
+    kinds: [chat, embedding]
+    tier: local
+    capabilities: {structured_output: true, system_prompt_channel: true}
+    paid_eligible_task_kinds: []
+    credential_identifiers: []
+    excluded_model_families: []
+    models:
+      - id: llama3.1:8b
+        effective_identity: ollama/llama3.1:8b
+        capabilities: {structured_output: true, system_prompt_channel: true}
+      - id: nomic-embed-text:latest
+        effective_identity: ollama/nomic-embed-text:latest
+        capabilities: {}
+  - id: openai
+    kinds: [chat]
+    tier: paid
+    capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+    paid_eligible_task_kinds: []
+    credential_identifiers: [openai.api-key]
+    excluded_model_families: []
+    models:
+      - id: gpt-5.6-sol
+        effective_identity: openai/gpt-5.6-sol
+        capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+      - id: gpt-5.4
+        effective_identity: openai/gpt-5.4
+        capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+projections:
+  - site: app/components/llm/router.py::_KNOWN_PROVIDERS
+    providers: [mock, ollama, openai, deepseek]
+  - site: app/components/embeddings/legacy.py::_SUPPORTED_EMBED_PROVIDERS
+    providers: [mock, ollama, deterministic, gemini]
+  - site: app/llm/embeddings.py::PROVIDER_REGISTRY
+    providers: [mock, ollama, gemini]
+  - site: app/services/llm.py::_DISPATCH_PROVIDERS
+    providers: [mock, ollama, openai, deepseek]
+  - site: app/llm/adapter.py::_DISPATCH_PROVIDERS
+    providers: [mock, ollama, openai, deepseek]
+  - site: app/cli/health.py::_check_llm_providers
+    providers: [mock, ollama]
+  - site: docs/settings/models/registry.yaml::provider
+    providers: [mock, ollama, openai]
+  - site: docs/LLM.md::Providers (Current)
+    providers: [mock, ollama, openai, deepseek]
+known_divergences: []
+runtime_channels:
+  product:
+    dev:
+      frontier: {provider: openai, model: gpt-5.4, requires: [structured_output]}
+    test:
+      frontier: {provider: mock, model: mock-chat, requires: [structured_output, deterministic_execution]}
+    prod:
+      frontier: {provider: openai, model: gpt-5.4, requires: [structured_output]}
+  builder:
+    dev:
+      frontier: {provider: openai, model: gpt-5.6-sol, requires: [structured_output]}
+    test:
+      frontier: {provider: openai, model: gpt-5.6-sol, requires: [structured_output]}
+    prod:
+      frontier: {provider: openai, model: gpt-5.6-sol, requires: [structured_output]}
+  model_inquiry_profiles:
+    dev:
+      - {role: fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output, system_prompt_channel]}
+      - {role: gpt_codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output]}
+    test:
+      - {role: fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output, system_prompt_channel]}
+      - {role: gpt_codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output]}
+    prod:
+      - {role: fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output, system_prompt_channel]}
+      - {role: gpt_codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output]}
+  resolution_groups:
+    - {id: model-inquiry-independent-review, independence: distinct_effective_target}

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -130,6 +130,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     (
         "settings",
         (
+            "app/components/settings/",
             "app/settings/",
             "app/cli/settings_explain.py",
             "app/services/companion_eligibility.py",

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -179,6 +179,7 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
         [
             "app/cli/__init__.py",
             "app/cli/settings_explain.py",
+            "app/components/settings/providers_loader.py",
             "app/config/paths.py",
             "app/services/companion_eligibility.py",
             "app/services/settings.py",
@@ -192,6 +193,7 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
 
     for adapter_path in (
         "app/cli/settings_explain.py",
+        "app/components/settings/providers_loader.py",
         "app/services/companion_eligibility.py",
         "app/services/settings.py",
     ):

--- a/tests/settings/test_provider_census.py
+++ b/tests/settings/test_provider_census.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from app.components.embeddings.legacy import _supported_embed_providers
+from app.components.llm.router import _KNOWN_PROVIDERS
+from app.components.settings.models_loader import load_models
+from app.components.settings.providers_loader import (
+    ProviderProjectionDriftError,
+    assert_provider_projection,
+    load_provider_census,
+)
+from app.llm.adapter import _DISPATCH_PROVIDERS as ADAPTER_DISPATCH_PROVIDERS
+from app.llm.embeddings import PROVIDER_REGISTRY
+from app.services.llm import _DISPATCH_PROVIDERS as SERVICE_DISPATCH_PROVIDERS
+
+
+def _census():
+    return load_provider_census()
+
+
+def test_census_loads_and_rejects_unknown_fields(tmp_path: Path) -> None:
+    census = _census()
+    assert {provider.id for provider in census.providers} == {
+        "anthropic", "deepseek", "gemini", "mock", "ollama", "openai"
+    }
+    bad = tmp_path / "providers.yaml"
+    bad.write_text("version: 1\nproviders: []\nruntime_channels: {}\nunexpected: true\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="extra_forbidden"):
+        load_provider_census(bad)
+
+
+@pytest.mark.parametrize(
+    ("site", "actual"),
+    [
+        ("app/components/llm/router.py::_KNOWN_PROVIDERS", lambda: _KNOWN_PROVIDERS),
+        ("app/components/embeddings/legacy.py::_SUPPORTED_EMBED_PROVIDERS", _supported_embed_providers),
+        ("app/llm/embeddings.py::PROVIDER_REGISTRY", lambda: PROVIDER_REGISTRY),
+        ("app/services/llm.py::_DISPATCH_PROVIDERS", lambda: SERVICE_DISPATCH_PROVIDERS),
+        ("app/llm/adapter.py::_DISPATCH_PROVIDERS", lambda: ADAPTER_DISPATCH_PROVIDERS),
+        ("app/cli/health.py::_check_llm_providers", lambda: {"mock", "ollama"}),
+        ("docs/settings/models/registry.yaml::provider", lambda: {item.provider for item in load_models().values()}),
+        (
+            "docs/LLM.md::Providers (Current)",
+            lambda: set(
+                re.findall(
+                    r"^- `([^`]+)`",
+                    Path("docs/LLM.md").read_text(encoding="utf-8").split("## Core Environment Variables", 1)[0],
+                    flags=re.MULTILINE,
+                )
+            ),
+        ),
+    ],
+)
+def test_all_allowlists_match_census(site: str, actual) -> None:
+    assert_provider_projection(_census(), site, set(actual()))
+
+
+def test_undeclared_or_unlinked_divergence_fails(tmp_path: Path) -> None:
+    census = _census()
+    assert census.known_divergences == []
+    with pytest.raises(ProviderProjectionDriftError, match="app/components/llm/router.py::_KNOWN_PROVIDERS"):
+        assert_provider_projection(
+            census,
+            "app/components/llm/router.py::_KNOWN_PROVIDERS",
+            set(_KNOWN_PROVIDERS) | {"anthropic"},
+        )
+    source = Path("docs/settings/models/providers.yaml").read_text(encoding="utf-8")
+    malformed_entries = [
+        ("declared_on", "site: app/components/llm/router.py::_KNOWN_PROVIDERS\n    divergent_members: [anthropic]\n    issue: https://github.com/RasmusTho/agentic-pkm-mvp/issues/1"),
+        ("issue", "site: app/components/llm/router.py::_KNOWN_PROVIDERS\n    divergent_members: [anthropic]\n    declared_on: '2026-07-29'"),
+    ]
+    for expected_error, entry in malformed_entries:
+        malformed_path = tmp_path / f"provider-census-{expected_error}.yaml"
+        malformed_path.write_text(source.replace("known_divergences: []", f"known_divergences:\n  - {entry}"), encoding="utf-8")
+        with pytest.raises(ValueError, match=expected_error):
+            load_provider_census(malformed_path)
+
+
+def test_census_ships_no_stale_known_divergences() -> None:
+    assert _census().known_divergences == []
+
+
+def test_ladder_sites_dispatch_through_the_named_constant() -> None:
+    assert SERVICE_DISPATCH_PROVIDERS == _census().projection("app/services/llm.py::_DISPATCH_PROVIDERS")
+    assert ADAPTER_DISPATCH_PROVIDERS == _census().projection("app/llm/adapter.py::_DISPATCH_PROVIDERS")
+
+
+def test_hot_paths_do_not_load_the_census_at_runtime() -> None:
+    hot_paths = [
+        Path("app/components/llm/router.py"),
+        Path("app/components/embeddings/legacy.py"),
+        Path("app/llm/embeddings.py"),
+        Path("app/services/llm.py"),
+        Path("app/llm/adapter.py"),
+    ]
+    assert all("providers_loader" not in path.read_text(encoding="utf-8") for path in hot_paths)
+
+
+def _assert_mapping(census, mapping) -> None:
+    provider = census.provider(mapping.provider)
+    model = next(model for model in provider.models if model.id == mapping.model)
+    for capability in mapping.requires:
+        assert getattr(model.capabilities, capability) or getattr(provider.capabilities, capability)
+
+
+def test_runtime_channel_tier_mappings_reference_capable_declared_models() -> None:
+    census = _census()
+    assert census.runtime_channels.product.keys() == census.runtime_channels.builder.keys() == {"dev", "test", "prod"}
+    for runtime in (census.runtime_channels.product, census.runtime_channels.builder):
+        for channels in runtime.values():
+            for mapping in channels.values():
+                _assert_mapping(census, mapping)
+
+
+def test_model_inquiry_role_profiles_are_exact_distinct_and_provider_free() -> None:
+    census = _census()
+    expected = {
+        "fable": ("anthropic", "claude-fable-5", "anthropic.api-key", {"structured_output", "system_prompt_channel"}),
+        "gpt_codex": ("openai", "gpt-5.6-sol", "openai.api-key", {"structured_output"}),
+    }
+    for profiles in census.runtime_channels.model_inquiry_profiles.values():
+        assert {profile.role for profile in profiles} == set(expected)
+        targets = set()
+        for profile in profiles:
+            provider, model, credential, capabilities = expected[profile.role]
+            assert (profile.provider, profile.model, profile.credential_identifier, profile.requires) == (provider, model, credential, capabilities)
+            _assert_mapping(census, profile)
+            declared = next(item for item in census.provider(profile.provider).models if item.id == profile.model)
+            targets.add((profile.provider, profile.model, declared.effective_identity))
+        assert len(targets) == 2
+    assert census.runtime_channels.resolution_groups[0].independence == "distinct_effective_target"
+    assert [group.id for group in census.runtime_channels.resolution_groups] == ["model-inquiry-independent-review"]
+    assert all(profile.resolution_group == "model-inquiry-independent-review" for profiles in census.runtime_channels.model_inquiry_profiles.values() for profile in profiles)
+    caller = Path("app/builderops/model_inquiry.py").read_text(encoding="utf-8")
+    assert "claude-fable-5" not in caller
+    assert "gpt-5.6-sol" not in caller


### PR DESCRIPTION
Governing-Issue: #4287

Fixes #4287

Final-Review-Rounds: 0

## Summary
Adds the strict typed provider census, static live-projection checks, and named dispatch constants without runtime YAML reads or provider-routing changes.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Product model provider projections
- Write class: authority-bearing value-free configuration plus mechanical projection constants
- Persistence impact: durable repository configuration; no runtime state
- Derived/rebuildable impact: static provider projections checked from the census
- New or changed contract: typed provider census, capability declarations, and separate Product/Builder mappings
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces provider-set drift
- Boundary risk: persisted identity aliases remain distinct from executable providers

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The issue, claim receipt, and PR capture the bounded delivery; no independent BuilderOps operational material was produced.

## Notes
Validation: census 15 passed; affected suites 359 passed; ruff, docs guard, and diff check passed. Full not-pg baseline lease completed; final spec/test-only delta received focused final-SHA validation, with PR CI as final full proof.