### PR TITLE
Include episode stream registry in runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,6 +35,10 @@ docs
 # app/settings/agents.py, app/config/paths.py), and panel-action wiring
 # (app/agents/panel_agent/wiring.py). Re-include so the runtime COPY sees it.
 !docs/settings
+# The episode registry declaration is loaded at runtime by
+# app.episodes.stream_registry; keep this single asset available without
+# widening the image to the ERE documentation tree.
+!docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md
 ops
 *.md
 .github

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,9 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 #                               plus app/settings/flows.py + agents.py
 #                               fallbacks and app/agents/panel_agent/wiring.py).
 #                               .dockerignore re-includes it (!docs/settings).
+# - docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md
+#                               the markdown declaration loaded by
+#                               app.episodes.stream_registry at runtime.
 # - companion-ui/companion-app/ the companion_ui package the companion-ui
 #                               service serves (working_dir + PYTHONPATH)
 # - alembic.ini                 root alembic entry (script_location=app/alembic)
@@ -129,6 +132,7 @@ COPY config/ ./config/
 COPY configs/ ./configs/
 COPY vault/ ./vault/
 COPY docs/settings/ ./docs/settings/
+COPY docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md ./docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md
 COPY companion-ui/companion-app/ ./companion-ui/companion-app/
 COPY alembic.ini sitecustomize.py ./
 COPY scripts/start_api.sh scripts/run_migrations.sh \

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -246,3 +246,23 @@ def test_docs_settings_runtime_tree_is_reincluded_and_copied() -> None:
         "runtime stage must COPY docs/settings/ (settings registries read at "
         "runtime by app/components/settings/*_loader.py)"
     )
+
+
+def test_episode_stream_registry_is_reincluded_and_copied() -> None:
+    """The default episode stream registry is runtime input, not dev-only docs."""
+    registry = "docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md"
+    patterns = _dockerignore_patterns()
+    assert f"!{registry}" in patterns, (
+        ".dockerignore must re-include the default episode stream registry "
+        "so the runtime stage can copy it"
+    )
+
+    final_stage = _dockerfile_text()[_dockerfile_text().rindex("FROM ") :]
+    assert re.search(
+        rf"^\s*COPY\s+{re.escape(registry)}\s+\./{re.escape(registry)}\s*$",
+        final_stage,
+        flags=re.MULTILINE,
+    ), (
+        "runtime stage must copy the default episode stream registry to its "
+        "existing /app/docs path"
+    )


### PR DESCRIPTION
Governing-Issue: #4314

Fixes #4314

Final-Review-Rounds: 1

## Summary
Includes only the default episode stream-registry declaration in the runtime build context and final image. The regression guard covers both its .dockerignore exception and explicit final-stage copy.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The claimed issue and this PR are the durable delivery records; no divergence or separate BuilderOps material was produced.

## Notes
Validation: `pytest -q tests/deploy/test_dockerfile_hardening.py::test_episode_stream_registry_is_reincluded_and_copied`; `pytest -q tests/deploy/test_ci_image_build.py tests/deploy/test_dockerfile_hardening.py`; `ruff check app tests companion-ui/companion-app`.
Claim receipt: `pickup-claim-complete issue=4314 branch=fix/4314-episode-stream-registry worktree=/Volumes/ColimaT7/worktrees/issue-4314 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4314 lease_id=lease-76c41cf8 holder=slice_implementer-4314 evidence=verified-dispatcher-lease`