### PR TITLE
Extend the pr-contract twin+parity pattern to Final-Review-Rounds and BuilderOps Routing

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -252,13 +252,17 @@ Any overlap with your staged file set => STOP: keep the earlier compliant PR, cl
 ### Step 6: Create or Update PR
 
 Execute based on lane classification. Every template below defaults to the light path with the
-required `Final-Review-Rounds: 0` line (the `pr-contract` gate rejects a body with zero or more than
-one match of `/^Final-Review-Rounds:[ \t]*[012][ \t]*$/`). Raise it to `1` or `2` only when
-`AGENTS.md :: Proportional delivery` selects the full path. The templates also carry concrete
-`## BuilderOps Routing` defaults instead of `<...>` placeholders
-(the gate rejects any routing value matching `^<.*>$`). The `none` / reason defaults shown match what
-`scripts/pr_body_generator.py` emits (`_builderops_section`) — replace them with the actual
-records/projections/receipts and reason whenever BuilderOps material was in fact routed.
+required `Final-Review-Rounds: 0` line and concrete `## BuilderOps Routing` defaults instead of
+`<...>` placeholders. Raise `Final-Review-Rounds` to `1` or `2` only when
+`AGENTS.md :: Proportional delivery` selects the full path. The exact shape both fields must satisfy
+is the canonical `app/dispatcher/verification_contract.py::resolve_pr_contract_final_review_rounds`
+and `::resolve_builderops_routing_status` (kept in proven parity with the `pr-contract` gate's own JS
+by `tests/governance/test_issue_pr_governance.py
+::test_final_review_rounds_check_executes_via_canonical_implementation` and
+`::test_builderops_routing_stub_detection_matches_workflow_js`) — do not re-derive the rule from this
+prose. The `none` / reason defaults shown match what `scripts/pr_body_generator.py` emits
+(`_builderops_section`) — replace them with the actual records/projections/receipts and reason
+whenever BuilderOps material was in fact routed.
 
 **Implementation Lane (Fixes an Issue):**
 ```bash
@@ -392,6 +396,11 @@ Pre-push PR-body contract gate:
   (`docs/development/GOVERNANCE_PROPORTIONALITY.md`); never leave the section present but unfilled,
   and never leave a `<...>` placeholder in a value the gate reads (`Records/projections/receipts:`
   or `Reason:`).
+- The exact shape both checks above enforce is not restated here — it is the canonical
+  `app/dispatcher/verification_contract.py::resolve_pr_contract_final_review_rounds` and
+  `::resolve_builderops_routing_status`, proven identical to the `pr-contract` gate's own JS by
+  `tests/governance/test_issue_pr_governance.py`. CI remains the enforcement point; this is a manual
+  pre-push read, not a substitute for it.
 
 Direct Repair block placement: prefer placing the `## Direct Repair` block as the first section of the PR body (before `## Summary`). The governance check accepts the block in any position — first, middle, or last — but first placement is preferred for reviewer clarity.
 
@@ -404,7 +413,9 @@ review-repair need. Otherwise hand the published PR directly to `verification-an
 
 ## PR body requirements
 
-Every lane, with no exception:
+Every lane, with no exception (canonical shape:
+`app/dispatcher/verification_contract.py::resolve_pr_contract_final_review_rounds` and
+`::resolve_builderops_routing_status`, not restated here):
 
 - include exactly one `Final-Review-Rounds: 0`, `1`, or `2` line (`0` = light delivery path)
 - include a `## BuilderOps Routing` section with concrete `Records/projections/receipts:` and

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -259,32 +259,73 @@ jobs:
             for (const warning of sbsImpactWarnings(body, changedFiles)) {
               core.warning(warning);
             }
-            const finalReviewRoundLines = body.match(
-              /^Final-Review-Rounds:[ \t]*.*$/gm
-            ) || [];
-            const validFinalReviewRoundLines = body.match(
-              /^Final-Review-Rounds:[ \t]*[012][ \t]*$/gm
-            ) || [];
-            if (
-              finalReviewRoundLines.length !== 1 ||
-              validFinalReviewRoundLines.length !== 1
-            ) {
+            // final-review-rounds:start
+            // Canonical Final-Review-Rounds shape check. Kept as a pure function (like
+            // classifyIssueAuthority below) so a marker-extraction parity test can prove
+            // this agrees with app/dispatcher/verification_contract.py without re-typing
+            // the rule in a third place. See tests/governance/test_issue_pr_governance.py
+            // :: test_final_review_rounds_check_executes_via_canonical_implementation.
+            const resolveFinalReviewRounds = (candidateBody) => {
+              const finalReviewRoundLines = candidateBody.match(
+                /^Final-Review-Rounds:[ \t]*.*$/gm
+              ) || [];
+              const validFinalReviewRoundLines = candidateBody.match(
+                /^Final-Review-Rounds:[ \t]*[012][ \t]*$/gm
+              ) || [];
+              return {
+                declaredCount: finalReviewRoundLines.length,
+                validCount: validFinalReviewRoundLines.length,
+                satisfied:
+                  finalReviewRoundLines.length === 1 &&
+                  validFinalReviewRoundLines.length === 1,
+              };
+            };
+            // final-review-rounds:end
+            const finalReviewRounds = resolveFinalReviewRounds(body);
+            if (!finalReviewRounds.satisfied) {
               core.setFailed(
                 "PR body must contain exactly one `Final-Review-Rounds: 0` (light delivery path per docs/development/GOVERNANCE_PROPORTIONALITY.md), `Final-Review-Rounds: 1` or `Final-Review-Rounds: 2` declaration."
               );
               return;
             }
+            // builderops-routing:start
             // BuilderOps routing is mandatory delivery traceability for Tier 2+ PRs.
             // It records the BuilderOps objects/projections/receipts created, or an explicit "none" reason.
             // Tier 1 (docs/development/GOVERNANCE_PROPORTIONALITY.md): PRs declaring the
             // docs-authoring or governance lane may omit the section entirely when nothing
             // was routed — absence means "none". A present-but-unfilled section still fails.
-            const tier1LanePattern = /^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b/im;
-            const isTier1Lane = tier1LanePattern.test(body);
-            // Anchored to line start so an inline mention of the section name in prose
-            // (e.g. a change list describing this very check) is not mistaken for the section.
-            const builderOpsRoutingMatch = body.match(/(?:^|\n)## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|(?:^|\n)## BuilderOps Routing[\s\S]*/i);
-            const builderOpsRoutingSection = builderOpsRoutingMatch ? builderOpsRoutingMatch[0] : "";
+            // Kept as a pure function (candidateBody + the already-classified
+            // hasIssueAuthority flag in) so a marker-extraction parity test can prove this
+            // agrees with app/dispatcher/verification_contract.py::resolve_builderops_routing_status.
+            const resolveBuilderOpsRouting = (candidateBody, hasIssueAuthority) => {
+              const tier1LanePattern = /^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b/im;
+              const isTier1Lane = tier1LanePattern.test(candidateBody);
+              // Anchored to line start so an inline mention of the section name in prose
+              // (e.g. a change list describing this very check) is not mistaken for the section.
+              const builderOpsRoutingMatch = candidateBody.match(/(?:^|\n)## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|(?:^|\n)## BuilderOps Routing[\s\S]*/i);
+              const builderOpsRoutingSection = builderOpsRoutingMatch ? builderOpsRoutingMatch[0] : "";
+              const hasConcreteBuilderOpsValue = (pattern) => {
+                const match = builderOpsRoutingSection.match(pattern);
+                if (!match) {
+                  return false;
+                }
+                const value = match[1].trim();
+                return value.length > 0 && !/^<.*>$/.test(value);
+              };
+              const hasBuilderOpsRouting =
+                Boolean(builderOpsRoutingSection) &&
+                hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Records\/projections\/receipts:\s*(.*?)\s*(?:\n|$)/i) &&
+                hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)/i);
+              const satisfied =
+                hasBuilderOpsRouting || (isTier1Lane && !hasIssueAuthority && !builderOpsRoutingSection);
+              return {
+                isTier1Lane,
+                hasSection: Boolean(builderOpsRoutingSection),
+                hasBuilderOpsRouting,
+                satisfied,
+              };
+            };
+            // builderops-routing:end
             // authority-classifier:start
             const classifyIssueAuthority = (candidateBody) => {
               const hasUnsupportedLineSeparator = /\r(?!\n)|[\u2028\u2029]/.test(candidateBody);
@@ -567,21 +608,8 @@ jobs:
               core.setFailed("Closing keywords belong only in the authenticated PR-body authority contract; commit-message closing references are forbidden because GitHub can apply them outside the persisted closing set.");
               return;
             }
-            const hasConcreteBuilderOpsValue = (pattern) => {
-              const match = builderOpsRoutingSection.match(pattern);
-              if (!match) {
-                return false;
-              }
-              const value = match[1].trim();
-              return value.length > 0 && !/^<.*>$/.test(value);
-            };
-            const hasBuilderOpsRouting =
-              Boolean(builderOpsRoutingSection) &&
-              hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Records\/projections\/receipts:\s*(.*?)\s*(?:\n|$)/i) &&
-              hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)/i);
-            const builderOpsRoutingSatisfied =
-              hasBuilderOpsRouting || (isTier1Lane && !hasIssueAuthority && !builderOpsRoutingSection);
-            if (!builderOpsRoutingSatisfied) {
+            const builderOpsRouting = resolveBuilderOpsRouting(body, hasIssueAuthority);
+            if (!builderOpsRouting.satisfied) {
               core.setFailed("PR body must include `## BuilderOps Routing` with concrete `Records/projections/receipts:` and `Reason:` lines. Tier 1 docs-authoring/governance-lane PRs may omit the section entirely when nothing was routed (absence = none); an unfilled template section is still rejected.");
               return;
             }

--- a/app/dispatcher/verification_contract.py
+++ b/app/dispatcher/verification_contract.py
@@ -61,6 +61,108 @@ def resolve_final_review_rounds(body: object) -> int | None:
     return int(matches[0])
 
 
+# --- pr-contract gate twins (issue #4272) -----------------------------------
+#
+# The two functions below are a distinct concern from resolve_final_review_rounds
+# above: that function resolves how many verified-merge review rounds the
+# full-path ceremony needs (1 or 2; 0 has no ceremony, so it resolves to None
+# there on purpose). The `pr-contract` CI gate instead only checks the PR
+# body's *shape* \u2014 exactly one Final-Review-Rounds declaration with a value of
+# 0, 1, or 2 \u2014 regardless of which path that value selects. These twins mirror
+# the workflow's own JS 1:1 (the `// final-review-rounds:start`/`:end` and
+# `// builderops-routing:start`/`:end` marker-delimited blocks in
+# .github/workflows/issue-pr-governance.yml), proven by
+# tests/governance/test_issue_pr_governance.py
+# ::test_final_review_rounds_check_executes_via_canonical_implementation and
+# ::test_builderops_routing_stub_detection_matches_workflow_js, following the
+# same marker-extraction parity pattern as
+# ::test_javascript_and_python_authority_grammar_are_identical.
+
+PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN = re.compile(
+    r"^Final-Review-Rounds:[ \t]*.*$", re.MULTILINE
+)
+PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN = re.compile(
+    r"^Final-Review-Rounds:[ \t]*[012][ \t]*$", re.MULTILINE
+)
+TIER1_LANE_PATTERN = re.compile(
+    r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b", re.IGNORECASE | re.MULTILINE
+)
+BUILDEROPS_ROUTING_SECTION_PATTERN = re.compile(
+    r"(?:^|\n)## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|(?:^|\n)## BuilderOps Routing[\s\S]*",
+    re.IGNORECASE,
+)
+BUILDEROPS_ROUTING_RECORDS_PATTERN = re.compile(
+    r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*(.*?)\s*(?:\n|$)",
+    re.IGNORECASE,
+)
+BUILDEROPS_ROUTING_REASON_PATTERN = re.compile(
+    r"(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)", re.IGNORECASE
+)
+BUILDEROPS_ROUTING_PLACEHOLDER_PATTERN = re.compile(r"^<.*>$")
+
+
+@dataclass(frozen=True)
+class PrContractFinalReviewRounds:
+    declared_count: int
+    valid_count: int
+    satisfied: bool
+
+
+def resolve_pr_contract_final_review_rounds(body: object) -> PrContractFinalReviewRounds:
+    """Shape-check twin of the `pr-contract` gate's Final-Review-Rounds assertion.
+
+    Unlike :func:`resolve_final_review_rounds`, this accepts a value of ``0``
+    (the light-delivery-path declaration) and only asserts shape, never
+    ceremony-round semantics.
+    """
+    text = body if isinstance(body, str) else ""
+    declared = PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN.findall(text)
+    valid = PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN.findall(text)
+    return PrContractFinalReviewRounds(
+        declared_count=len(declared),
+        valid_count=len(valid),
+        satisfied=len(declared) == 1 and len(valid) == 1,
+    )
+
+
+@dataclass(frozen=True)
+class BuilderOpsRoutingStatus:
+    is_tier1_lane: bool
+    has_section: bool
+    has_builderops_routing: bool
+    satisfied: bool
+
+
+def resolve_builderops_routing_status(
+    body: object, *, has_issue_authority: bool
+) -> BuilderOpsRoutingStatus:
+    """Twin of the `pr-contract` gate's `## BuilderOps Routing` filled-vs-stub check."""
+    text = body if isinstance(body, str) else ""
+    is_tier1_lane = TIER1_LANE_PATTERN.search(text) is not None
+    section_match = BUILDEROPS_ROUTING_SECTION_PATTERN.search(text)
+    section = section_match.group(0) if section_match else ""
+
+    def _has_concrete_value(pattern: re.Pattern[str]) -> bool:
+        match = pattern.search(section)
+        if not match:
+            return False
+        value = match.group(1).strip()
+        return len(value) > 0 and BUILDEROPS_ROUTING_PLACEHOLDER_PATTERN.match(value) is None
+
+    has_builderops_routing = bool(section) and _has_concrete_value(
+        BUILDEROPS_ROUTING_RECORDS_PATTERN
+    ) and _has_concrete_value(BUILDEROPS_ROUTING_REASON_PATTERN)
+    satisfied = has_builderops_routing or (
+        is_tier1_lane and not has_issue_authority and not section
+    )
+    return BuilderOpsRoutingStatus(
+        is_tier1_lane=is_tier1_lane,
+        has_section=bool(section),
+        has_builderops_routing=has_builderops_routing,
+        satisfied=satisfied,
+    )
+
+
 GOVERNING_ISSUE_LINE_PATTERN = re.compile(
     rf"(?m)^[ \t]*{_GOVERNING_KEYWORD}[ \t]*:.*$"
 )

--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -26,6 +26,13 @@ Deterministic, stdlib-only, read-only. Catches the defect classes found by the
    `.github/workflows/issue-pr-governance.yml` and the Python
    `REQUIRED_SECTIONS` tuple in `scripts/validate_issue_readiness.py` hold the
    same section names in the same order (regression guard for #4188).
+10. The `pr-contract` gate's marker-delimited `Final-Review-Rounds` /
+    `BuilderOps Routing` JS regex literals in
+    `.github/workflows/issue-pr-governance.yml` (`// final-review-rounds:start`/
+    `:end` and `// builderops-routing:start`/`:end`) hold the same regex source
+    text as their canonical Python twins in
+    `app/dispatcher/verification_contract.py` (regression guard for #4272 — the
+    canonical implementation must not silently drift from the gate it mirrors).
 
 Exit 0 with no output when clean; exit 1 with one error per line otherwise.
 
@@ -386,6 +393,117 @@ def check_required_sections_consistent(repo_root: Path) -> list[str]:
     return errors
 
 
+def _strip_js_line_comments(text: str) -> str:
+    return "\n".join(re.sub(r"//.*$", "", line) for line in text.splitlines())
+
+
+_JS_REGEX_LITERAL_RE = re.compile(r"/((?:\\.|[^/\\\n])*)/[a-z]*")
+
+
+def _extract_js_regex_literals(block: str) -> list[str]:
+    """Extract regex-literal source text (unescaped `\\/` -> `/`), in order.
+
+    Comments are stripped first so a `/`-containing path or URL in prose
+    (e.g. `app/dispatcher/...`) is never mistaken for a regex literal.
+    """
+    stripped = _strip_js_line_comments(block)
+    return [
+        match.group(1).replace("\\/", "/")
+        for match in _JS_REGEX_LITERAL_RE.finditer(stripped)
+    ]
+
+
+def _extract_python_regex_pattern(text: str, name: str) -> str | None:
+    match = re.search(
+        re.escape(name) + r"\s*=\s*re\.compile\(\s*\n?\s*r\"([^\"]*)\"", text
+    )
+    return match.group(1) if match else None
+
+
+# Order matters: this is the exact order the corresponding regex literals
+# appear in the workflow's `// final-review-rounds:start`/`:end` and
+# `// builderops-routing:start`/`:end` marker blocks.
+_PR_CONTRACT_FINAL_REVIEW_ROUNDS_PY_NAMES = (
+    "PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN",
+    "PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN",
+)
+_PR_CONTRACT_BUILDEROPS_ROUTING_PY_NAMES = (
+    "TIER1_LANE_PATTERN",
+    "BUILDEROPS_ROUTING_SECTION_PATTERN",
+    "BUILDEROPS_ROUTING_PLACEHOLDER_PATTERN",
+    "BUILDEROPS_ROUTING_RECORDS_PATTERN",
+    "BUILDEROPS_ROUTING_REASON_PATTERN",
+)
+
+
+def _check_pr_contract_marker_block(
+    workflow_text: str,
+    contract_text: str,
+    start_marker: str,
+    end_marker: str,
+    py_names: tuple[str, ...],
+    workflow_rel: str,
+    contract_rel: str,
+) -> list[str]:
+    if start_marker not in workflow_text or end_marker not in workflow_text:
+        return [f"{workflow_rel}: missing `{start_marker}`/`{end_marker}` marker pair"]
+    block = workflow_text.split(start_marker, 1)[1].split(end_marker, 1)[0]
+    js_literals = _extract_js_regex_literals(block)
+    if len(js_literals) != len(py_names):
+        return [
+            f"{workflow_rel}: expected {len(py_names)} regex literal(s) between "
+            f"`{start_marker}` and `{end_marker}`, found {len(js_literals)}"
+        ]
+    errors: list[str] = []
+    for name, js_pattern in zip(py_names, js_literals):
+        py_pattern = _extract_python_regex_pattern(contract_text, name)
+        if py_pattern is None:
+            errors.append(f"{contract_rel}: could not locate regex constant `{name}`")
+            continue
+        if py_pattern != js_pattern:
+            errors.append(
+                f"{contract_rel}::{name} pattern ({py_pattern!r}) does not match "
+                f"{workflow_rel} regex between `{start_marker}`/`{end_marker}` ({js_pattern!r})"
+            )
+    return errors
+
+
+def check_pr_contract_validator_matches_workflow(repo_root: Path) -> list[str]:
+    """Check 10: pr-contract regex twins agree with the workflow's own JS.
+
+    Tolerates a missing source file (synthetic test trees) by skipping the
+    check entirely, the same way checks 8 and 9 do.
+    """
+    workflow_path = repo_root / ".github" / "workflows" / "issue-pr-governance.yml"
+    contract_path = repo_root / "app" / "dispatcher" / "verification_contract.py"
+    if not workflow_path.is_file() or not contract_path.is_file():
+        return []
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    contract_text = contract_path.read_text(encoding="utf-8")
+    workflow_rel = ".github/workflows/issue-pr-governance.yml"
+    contract_rel = "app/dispatcher/verification_contract.py"
+    errors: list[str] = []
+    errors += _check_pr_contract_marker_block(
+        workflow_text,
+        contract_text,
+        "// final-review-rounds:start",
+        "// final-review-rounds:end",
+        _PR_CONTRACT_FINAL_REVIEW_ROUNDS_PY_NAMES,
+        workflow_rel,
+        contract_rel,
+    )
+    errors += _check_pr_contract_marker_block(
+        workflow_text,
+        contract_text,
+        "// builderops-routing:start",
+        "// builderops-routing:end",
+        _PR_CONTRACT_BUILDEROPS_ROUTING_PY_NAMES,
+        workflow_rel,
+        contract_rel,
+    )
+    return errors
+
+
 def run_lint(repo_root: Path) -> list[str]:
     skills_root = repo_root / ".codex" / "skills"
     if not skills_root.is_dir():
@@ -399,6 +517,7 @@ def run_lint(repo_root: Path) -> list[str]:
     errors += check_feature_breakdown_docs_index(skills_root)
     errors += check_sbs_impact_fields_consistent(repo_root)
     errors += check_required_sections_consistent(repo_root)
+    errors += check_pr_contract_validator_matches_workflow(repo_root)
     return errors
 
 

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -121,12 +121,12 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
 
     for fragment in (
         "const directRepairSectionMatch = body.match(/## Direct Repair",
-        "const builderOpsRoutingMatch = body.match(/(?:^|\\n)## BuilderOps Routing",
+        "const builderOpsRoutingMatch = candidateBody.match(/(?:^|\\n)## BuilderOps Routing",
         "const hasBuilderOpsRouting =",
         "const tier1LanePattern =",
         "const classifyIssueAuthority =",
         "const hasIssueAuthority =",
-        "const builderOpsRoutingSatisfied =",
+        "const builderOpsRouting = resolveBuilderOpsRouting(body, hasIssueAuthority);",
         "PR body must include `## BuilderOps Routing`",
         "const isDirectRepair =",
         "if (isDirectRepair) {",
@@ -140,7 +140,11 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
     assert text.index("const directRepairSectionMatch = body.match(/## Direct Repair") < text.index(
         "const docsAuthoringPattern ="
     )
-    assert text.index("const builderOpsRoutingMatch = body.match(/(?:^|\\n)## BuilderOps Routing") < text.index(
+    # resolveBuilderOpsRouting (issue #4272) is a pure function defined ahead of
+    # classifyIssueAuthority; the ordering invariant that matters is unchanged:
+    # the BuilderOps Routing section-matching logic is defined before the
+    # authority classifier.
+    assert text.index("const builderOpsRoutingMatch = candidateBody.match(/(?:^|\\n)## BuilderOps Routing") < text.index(
         "const classifyIssueAuthority ="
     )
     assert text.index("if (isDirectRepair) {") < text.index("const docsAuthoringPattern =")

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -15,36 +15,78 @@ from app.dispatcher.verification_contract import (
     IssueAuthority,
     MAX_CLOSING_ISSUES,
     neutralize_closing_issue_references,
+    resolve_builderops_routing_status,
     resolve_issue_authority,
     resolve_issue_contract,
     resolve_neutralized_issue_authority,
+    resolve_pr_contract_final_review_rounds,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_BUILDEROPS_ROUTING_REGEX = re.compile(
-    r"(?:^|\n)## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|(?:^|\n)## BuilderOps Routing[\s\S]*",
-    re.IGNORECASE,
-)
-_BUILDEROPS_ROUTING_FIELDS = (
-    re.compile(
-        r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*(.*?)\s*(?:\n|$)",
-        re.IGNORECASE,
-    ),
-    re.compile(r"(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)", re.IGNORECASE),
-)
+# The `_BUILDEROPS_ROUTING_REGEX`/`_BUILDEROPS_ROUTING_FIELDS`/`_TIER1_LANE_REGEX`
+# duplicate copies formerly declared here (issue #4272) are retired in favor of
+# the canonical `app.dispatcher.verification_contract` twins imported above,
+# proven against the workflow's own JS by
+# `test_final_review_rounds_check_executes_via_canonical_implementation` and
+# `test_builderops_routing_stub_detection_matches_workflow_js` below.
 
 
-def test_pr_contract_requires_one_bounded_final_review_declaration() -> None:
-    workflow = (
-        REPO_ROOT / ".github/workflows/issue-pr-governance.yml"
-    ).read_text(encoding="utf-8")
+def test_final_review_rounds_check_executes_via_canonical_implementation() -> None:
+    """Behavioral parity test replacing the former source-text tripwire.
 
-    assert "finalReviewRoundLines.length !== 1" in workflow
-    assert "validFinalReviewRoundLines.length !== 1" in workflow
-    assert "Final-Review-Rounds: 1` or `Final-Review-Rounds: 2" in workflow
-    # Light delivery path (AGENTS.md :: Proportional delivery) declares rounds 0.
-    assert r"Final-Review-Rounds:[ \t]*[012][ \t]*$" in workflow
+    Exercises `resolve_pr_contract_final_review_rounds` (the canonical Python
+    twin of the `pr-contract` gate's `// final-review-rounds:start`/`:end`
+    JS block) against the same JS via marker-extraction, mirroring
+    `test_javascript_and_python_authority_grammar_are_identical`.
+    """
+    fixture_bodies = [
+        "Final-Review-Rounds: 0\n",
+        "Final-Review-Rounds: 1\n",
+        "Final-Review-Rounds: 2\n",
+        "Final-Review-Rounds: 3\n",
+        "no declaration here\n",
+        "Final-Review-Rounds: 0\nFinal-Review-Rounds: 1\n",
+        "Final-Review-Rounds:0\n",
+        "Final-Review-Rounds:  2  \n",
+        "prose mentioning Final-Review-Rounds: 1 mid-line\n",
+    ]
+    for body in fixture_bodies:
+        js_result = _js_final_review_rounds(body)
+        py_result = resolve_pr_contract_final_review_rounds(body)
+        assert js_result["satisfied"] == py_result.satisfied, body
+        assert js_result["declaredCount"] == py_result.declared_count, body
+        assert js_result["validCount"] == py_result.valid_count, body
+
+
+def test_builderops_routing_stub_detection_matches_workflow_js() -> None:
+    """Behavioral parity test for the `## BuilderOps Routing` filled-vs-stub check.
+
+    Exercises `resolve_builderops_routing_status` (the canonical Python twin of
+    the `pr-contract` gate's `// builderops-routing:start`/`:end` JS block)
+    against the same JS via marker-extraction.
+    """
+    fixture_cases = [
+        ("## BuilderOps Routing\n- Records/projections/receipts: none\n- Reason: nothing routed\n", True),
+        ("## BuilderOps Routing\n- Records/projections/receipts: <...>\n- Reason: <...>\n", True),
+        ("## BuilderOps Routing\n", True),
+        ("", True),
+        ("- [x] Governance lane\n", False),
+        ("- [x] Docs authoring lane\n", True),
+        (
+            "- [x] Governance lane\n## BuilderOps Routing\n"
+            "- Records/projections/receipts: x\n- Reason: y\n",
+            True,
+        ),
+    ]
+    for body, has_issue_authority in fixture_cases:
+        js_result = _js_builderops_routing(body, has_issue_authority)
+        py_result = resolve_builderops_routing_status(
+            body, has_issue_authority=has_issue_authority
+        )
+        assert js_result["satisfied"] == py_result.satisfied, (body, has_issue_authority)
+        assert js_result["isTier1Lane"] == py_result.is_tier1_lane, (body, has_issue_authority)
+        assert js_result["hasSection"] == py_result.has_section, (body, has_issue_authority)
 
 
 def test_pr_contract_trigger_excludes_review_requested_and_cancels_stale_runs() -> None:
@@ -62,12 +104,6 @@ def test_pr_contract_trigger_excludes_review_requested_and_cancels_stale_runs() 
     concurrency_block = pr_contract_job[: pr_contract_job.index("runs-on:")]
     assert "group: pr-contract-${{ github.event.pull_request.number }}" in concurrency_block
     assert "cancel-in-progress: true" in concurrency_block
-
-
-_TIER1_LANE_REGEX = re.compile(
-    r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b",
-    re.IGNORECASE | re.MULTILINE,
-)
 
 
 def _read_workflow() -> str:
@@ -257,6 +293,61 @@ def _verified_merge_body_digest(body: str) -> str:
     return hashlib.sha256(canonical_body.encode()).hexdigest()
 
 
+def _js_final_review_rounds(body: str) -> dict[str, object]:
+    """Marker-extraction twin runner for `// final-review-rounds:start`/`:end`.
+
+    Mirrors `_js_issue_authority` below: extract the workflow's own pure JS
+    function and run it under Node so the parity assertion exercises the
+    literal CI code, not a hand-copied re-transcription of it.
+    """
+    workflow = _read_workflow()
+    block = workflow.split("// final-review-rounds:start", 1)[1].split(
+        "// final-review-rounds:end", 1
+    )[0]
+    script = (
+        block
+        + "\nconst candidate = JSON.parse(process.argv[1]);"
+        + "\nprocess.stdout.write(JSON.stringify(resolveFinalReviewRounds(candidate)));"
+    )
+    completed = subprocess.run(
+        ["node", "-e", script, json.dumps(body)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def _js_builderops_routing(body: str, has_issue_authority: bool) -> dict[str, object]:
+    """Marker-extraction twin runner for `// builderops-routing:start`/`:end`."""
+    workflow = _read_workflow()
+    block = workflow.split("// builderops-routing:start", 1)[1].split(
+        "// builderops-routing:end", 1
+    )[0]
+    script = (
+        block
+        + "\nconst inputs = JSON.parse(process.argv[1]);"
+        + "\nprocess.stdout.write(JSON.stringify("
+        + "resolveBuilderOpsRouting(inputs.body, inputs.hasIssueAuthority)));"
+    )
+    completed = subprocess.run(
+        [
+            "node",
+            "-e",
+            script,
+            json.dumps({"body": body, "hasIssueAuthority": has_issue_authority}),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
 def _js_issue_authority(body: str) -> dict[str, object]:
     workflow = _read_workflow()
     classifier = workflow.split("// authority-classifier:start", 1)[1].split(
@@ -435,29 +526,18 @@ def test_companion_design_audit_handoff_declares_guidance_not_sot() -> None:
     assert "durable design source-of-truth" not in lowered
 
 
-def _has_builderops_routing(body: str) -> bool:
-    match = _BUILDEROPS_ROUTING_REGEX.search(body)
-    if not match:
-        return False
-    section = match.group(0)
-    for pattern in _BUILDEROPS_ROUTING_FIELDS:
-        field = pattern.search(section)
-        if not field:
-            return False
-        value = field.group(1).strip()
-        if not value or re.fullmatch(r"<.*>", value):
-            return False
-    return True
-
-
 def _builderops_routing_satisfied(body: str) -> bool:
-    if _has_builderops_routing(body):
-        return True
-    return (
-        _TIER1_LANE_REGEX.search(body) is not None
-        and not _js_issue_authority(body)["hasIssueAuthority"]
-        and _BUILDEROPS_ROUTING_REGEX.search(body) is None
-    )
+    """Test oracle delegating to the canonical implementation (issue #4272).
+
+    Previously this reimplemented the `## BuilderOps Routing` filled-vs-stub
+    regex a fourth time; it now calls `resolve_builderops_routing_status`
+    directly so this test file cannot silently drift from the workflow's own
+    JS (proven by `test_builderops_routing_stub_detection_matches_workflow_js`).
+    """
+    has_issue_authority = bool(_js_issue_authority(body)["hasIssueAuthority"])
+    return resolve_builderops_routing_status(
+        body, has_issue_authority=has_issue_authority
+    ).satisfied
 
 
 def _governing_issue_identity_satisfied(body: str) -> bool:
@@ -1126,8 +1206,12 @@ def test_workflow_checks_issue_link_before_allowing_tier1_builderops_omission() 
     assert "// authority-classifier:start" in text
     assert "const issueAuthority = classifyIssueAuthority(body);" in text
     assert "isTier1Lane && !hasIssueAuthority && !builderOpsRoutingSection" in text
+    # resolveBuilderOpsRouting is a pure function (defined ahead of body-execution
+    # order, see // builderops-routing:start/:end); the ordering invariant that
+    # matters is the *call site* using the already-classified hasIssueAuthority,
+    # not the function definition.
     assert text.index("const issueAuthority = classifyIssueAuthority(body);") < text.index(
-        "const builderOpsRoutingSatisfied ="
+        "const builderOpsRouting = resolveBuilderOpsRouting(body, hasIssueAuthority);"
     )
 
 

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -276,6 +276,56 @@ def test_required_sections_lint_fails_when_one_copy_edited_alone(tmp_path: Path)
     assert any("required-sections lists diverge" in e for e in errors), errors
 
 
+def test_pr_contract_validator_matches_workflow_on_real_repo() -> None:
+    """The canonical Python twins must agree with the workflow's JS (issue #4272)."""
+    errors = run_lint(REPO_ROOT)
+    pr_contract_errors = [e for e in errors if "verification_contract.py" in e]
+    assert pr_contract_errors == [], pr_contract_errors
+
+
+def test_lint_fails_when_pr_contract_validator_diverges_from_workflow(tmp_path: Path) -> None:
+    """Editing exactly one side of a pr-contract regex twin must fail the lint.
+
+    Mirrors `test_required_sections_lint_fails_when_one_copy_edited_alone`:
+    seed both real files verbatim (baseline passes), then drift only the
+    Python side and confirm the lint catches it.
+    """
+    root = _seed_tree(tmp_path)
+
+    workflow = REPO_ROOT / ".github" / "workflows" / "issue-pr-governance.yml"
+    contract = REPO_ROOT / "app" / "dispatcher" / "verification_contract.py"
+
+    dest_workflows = root / ".github" / "workflows"
+    dest_workflows.mkdir(parents=True, exist_ok=True)
+    (dest_workflows / "issue-pr-governance.yml").write_text(
+        workflow.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    dest_app = root / "app" / "dispatcher"
+    dest_app.mkdir(parents=True, exist_ok=True)
+    (dest_app / "verification_contract.py").write_text(
+        contract.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    baseline_errors = run_lint(root)
+    assert not any("verification_contract.py" in e for e in baseline_errors), baseline_errors
+
+    # Drift the Python Final-Review-Rounds valid-line pattern alone: loosen
+    # `[012]` to `[0-9]` as if someone widened the rule on only one side.
+    drifted = contract.read_text(encoding="utf-8").replace(
+        r'r"^Final-Review-Rounds:[ \t]*[012][ \t]*$"',
+        r'r"^Final-Review-Rounds:[ \t]*[0-9][ \t]*$"',
+    )
+    assert drifted != contract.read_text(encoding="utf-8"), "fixture swap did not apply"
+    (dest_app / "verification_contract.py").write_text(drifted, encoding="utf-8")
+
+    errors = run_lint(root)
+    assert any(
+        "PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN" in e
+        and "does not match" in e
+        for e in errors
+    ), errors
+
+
 def test_planned_marker_allows_unknown_reference(tmp_path: Path) -> None:
     root = _seed_tree(tmp_path)
     skills_root = root / ".codex" / "skills"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4272

## Linked Issue
Fixes #4272

## SBS Impact
- Primary subsystem: Builder System / issue-PR governance
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none (the `pr-contract` gate's accept/reject behavior is unchanged; only its Final-Review-Rounds/BuilderOps Routing checks are refactored into named, marker-delimited pure functions with proven parity)
- Owner-doc impact: none (no owner doc references these internals at a level this refactor changes)
- Transition debt impact: reduces (removes one duplicated regex copy and one source-text tripwire; adds a drift-guard lint check)
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Narrowed delivery of #4272. Re-measured the residual `pr-contract` FORM-failure rate across the 42 PRs merged since PR #4192 (the last of the three already-merged repairs from issues #4185/#4187/#4188): only 1 of 42 showed a genuinely avoidable FORM failure a local check could have caught (a transient `Final-Review-Rounds` shape miss on PR #4246, self-corrected before merge); the other 2 failures were expected transient states of the verified-merge neutralization ceremony (Tier ≥1 PRs #4221/#4228), which the issue explicitly rules out of scope. Full numbers in the PR discussion / issue comment.
- Given that near-zero residual, did **not** build the full-scope local-run CLI harness (`scripts/validate_pr_contract.py` + base-ref-resolved changed-files check). Did build the drift-elimination half, which stands on its own merit regardless of failure counts: refactored the `pr-contract` workflow's inline `Final-Review-Rounds` and `## BuilderOps Routing` checks into two named, marker-delimited pure JS functions (`resolveFinalReviewRounds`, `resolveBuilderOpsRouting`), mirroring the existing `classifyIssueAuthority` pattern.
- Added canonical Python twins in `app/dispatcher/verification_contract.py` (`resolve_pr_contract_final_review_rounds`, `resolve_builderops_routing_status`, plus the underlying regex constants), proven identical to the workflow's JS via marker-extraction parity tests (mirrors `test_javascript_and_python_authority_grammar_are_identical`).
- Replaced the former source-text tripwire (`test_pr_contract_requires_one_bounded_final_review_declaration`) and the redundant fourth `## BuilderOps Routing` regex copy in `tests/governance/test_issue_pr_governance.py` with real behavioral parity tests against the canonical implementation.
- Extended `scripts/lint_skills_consistency.py` (check 10) to fail when the workflow's `Final-Review-Rounds`/`BuilderOps Routing` regex literals diverge from the new canonical Python copies — the same "drift fails CI" pattern #4188 established for `SBS Impact` fields and required-sections.
- Pointed `.codex/skills/publish-pr/SKILL.md` (the three prose restatements the issue names) at the canonical implementation instead of restating the regex/rule in prose.
- Preserved the Governing-Issue/closing-keyword piece unchanged (reused `verification_contract.py::resolve_issue_authority` as-is, per the issue's constraint) and left the Change Lane allowlist untouched (see "What I deliberately did not build" below).

## What I deliberately did not build, and why
- **`scripts/validate_pr_contract.py` CLI + local pre-push harness** (issue scope items 4-5, and the base-ref-resolved changed-files wiring). The residual-failure re-measurement found essentially nothing left for it to catch: 1 avoidable FORM failure in 42 merged PRs since PR #4192. Building a CLI, its base-ref resolution against `origin/main`, and the `publish-pr` wiring to run it before every `gh pr create` is real ongoing surface (a place to break, a thing to maintain) for a failure rate near zero. If the rate rises again, or the owner wants the pre-push run regardless, that CLI is a well-scoped follow-up issue built directly on the canonical functions this PR adds — it would be nearly mechanical at that point.
- **Change Lane allowlist canonicalization** (issue scope item 3). This is the one assertion class with a confirmed SUBSTANCE catch (PR #4160), so drift there is higher-consequence than the other three — but building a Python parity twin for it without also building the CLI that would run it locally provides no local-run benefit today, only lint-time drift insurance. Left this out of the narrower cut to keep this PR reviewable in one sitting; a future issue can add it using the same marker-extraction pattern established here.
- Did not touch the neutralized-authority-validator, the commit-message-closure enumeration, or the Governing-Issue/closing-keyword grammar (all explicitly out of scope, and #4185/#4196 already closed the neutralized-body deadlock).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: pure repo-governed artifact change (workflow JS refactor, Python twins, tests, lint, skill doc); no BuilderOps Vault material was produced or consumed by this work.

## Notes
- Both new marker-delimited JS functions (`resolveFinalReviewRounds`, `resolveBuilderOpsRouting`) are refactors of the *exact* pre-existing inline logic — same regexes, same branching — verified with a 37-case Python-vs-Node fuzz harness (0 mismatches) before the pytest parity tests were written.
- First full-suite pass (run without the host lease, concurrently with another agent's simultaneous full suite) surfaced a real regression: `tests/architecture/test_pr_hot_path_governance.py::test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox` is a **fifth**, previously-uncatalogued source-text tripwire against the workflow's literal JS (independent of the one already fixed in `test_issue_pr_governance.py`). Fixed its fragment list/ordering assertions to match the refactor (`candidateBody.match`, the renamed `builderOpsRouting` call site) — same behavior, just updated text matching. That same file also carries a **sixth** independent Python reimplementation of the BuilderOps Routing logic (`_has_builderops_routing`/`_builderops_routing_satisfied`, tests/architecture/test_pr_hot_path_governance.py:308-365) that this PR did not touch (behavior-preserving refactor means it stays correct unmodified) — flagging it as evidence the drift problem in the issue's own catalog was an undercount, and as a candidate for a future consolidation issue.
- Interpreter note: this worktree has no local `.venv`; used the shared repo's `.venv/bin/python` (3.12, has `pytest-xdist`) for all verification, since the ambient `python3` resolves to 3.14 which lacks it.
- `ruff check app tests`: all checks passed.
- Full suite, lease-protected (`scripts/run_with_host_lease.py --resource pytest-not-pg`), after the fifth-tripwire fix: **2 failed, 11480 passed, 63 skipped, 276 deselected, 18 xfailed** in 635s.
  - `tests/deploy/test_dev_channel_compose.py::test_channel_deploy_supplies_signboard_root` — fails identically on this branch and on an unmodified `origin/main` worktree (exit 127, missing shell dependency in this sandbox) — confirmed pre-existing, unrelated.
  - `tests/properties/test_guard_at_seam.py::test_every_write_seam_asserts_writeguard` — fails identically on this branch and on unmodified `origin/main` (unregistered `app/instance/vault_registry.py:1403` write-frontmatter site) — confirmed pre-existing, unrelated; this PR never touches `vault_registry.py`.
  - An earlier unprotected run (started before I read the host-lease requirement, concurrent with another agent's simultaneous full suite) additionally showed 3 more failures (`tests/deploy/test_deploy_channel.py` x2, `tests/ops/test_instance_state_volume_contract.py` x1) that did not reproduce in isolation on either base or branch — CPU-contention flakes from the two unprotected concurrent runs, not real failures.
