### PR TITLE
Reject out-of-range worker metrics ports

### DIFF
--- a/app/workers/metrics.py
+++ b/app/workers/metrics.py
@@ -1,7 +1,7 @@
 """Minimal opt-in Prometheus metrics endpoint for the outbox worker.
 
 Off by default: the /metrics HTTP server only starts when WORKER_METRICS_PORT
-is set to a positive integer port (builder-ops-stability spec Issue 6). The
+is set to a TCP port in the range 1–65535 (builder-ops-stability spec Issue 6). The
 metric objects themselves are always defined so call sites stay unconditional;
 they are only observable once the server is enabled.
 """
@@ -40,7 +40,7 @@ def resolve_worker_metrics_port(environ: Mapping[str, str] | None = None) -> int
     except ValueError:
         logger.warning("Ignoring invalid %s=%r; worker metrics stay off", WORKER_METRICS_PORT_ENV, raw)
         return None
-    if port <= 0:
+    if not 1 <= port <= 65535:
         return None
     return port
 

--- a/tests/workers/test_worker_metrics.py
+++ b/tests/workers/test_worker_metrics.py
@@ -1,7 +1,7 @@
 """Opt-in Prometheus metrics endpoint for the outbox worker (builder-ops-stability Issue 6).
 
 Contract: the worker exposes /metrics via prometheus_client only when
-WORKER_METRICS_PORT is set to a positive integer port; it stays off by default.
+WORKER_METRICS_PORT is a TCP port in the range 1–65535; it stays off by default.
 """
 
 from __future__ import annotations
@@ -30,16 +30,20 @@ def test_metrics_server_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     assert maybe_start_worker_metrics_server() is None
 
 
-@pytest.mark.parametrize("raw", ["", "   ", "0", "-1", "not-a-port"])
+@pytest.mark.parametrize("raw", ["", "   ", "0", "-1", "65536", "not-a-port"])
 def test_metrics_port_invalid_values_stay_off(
     monkeypatch: pytest.MonkeyPatch, raw: str
 ) -> None:
+    def fail_if_started(port: int) -> None:
+        raise AssertionError(f"metrics server unexpectedly started on port {port}")
+
     monkeypatch.setenv(WORKER_METRICS_PORT_ENV, raw)
+    monkeypatch.setattr("app.workers.metrics.start_http_server", fail_if_started)
     assert resolve_worker_metrics_port() is None
     assert maybe_start_worker_metrics_server() is None
 
 
-def test_metrics_server_starts_and_serves_metrics(
+def test_metrics_server_starts_when_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     port = _free_port()


### PR DESCRIPTION
Governing-Issue: #4315

Fixes #4315

Final-Review-Rounds: 1

## Summary
Reject worker metrics ports outside the TCP range 1–65535 so invalid optional configuration leaves the endpoint disabled instead of reaching Prometheus startup. Valid in-range ports retain the existing endpoint behavior.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Routine bounded Tier 2 implementation; the issue and PR provide the durable delivery contract and evidence, with no divergence or operational material requiring a BuilderOps record.

## Notes
Validation: `pytest -q tests/workers/test_worker_metrics.py` (8 passed); `ruff check app tests companion-ui/companion-app` (passed); `mypy app` (passed).

Claim receipt: `pickup-claim-complete issue=4315 branch=fix/4315-worker-metrics-port worktree=/Users/rasmus/worktrees/issue-4315-worker-metrics-port coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4315 lease_id=lease-a35f6143 holder=codex-issue-4315 evidence=verified-dispatcher-lease`.

Owner-doc assessment: none; this is a mechanical bounds correction and the governing issue explicitly declares no owner-doc impact.