### PR TITLE
docs: state valid worker metrics port range

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -109,7 +109,7 @@ export METRICS_ENABLED=1
 uvicorn app.main:app --reload --port 18000
 ```
 
-Optional worker metrics: the outbox worker exposes a Prometheus `/metrics` endpoint (via `prometheus_client`) only when `WORKER_METRICS_PORT` is set to a positive port; it stays off by default. The Prometheus scrape config expects port `9101`:
+Optional worker metrics: the outbox worker exposes a Prometheus `/metrics` endpoint (via `prometheus_client`) only when `WORKER_METRICS_PORT` is set to a valid TCP port from `1` through `65535`; it stays off by default. The Prometheus scrape config expects port `9101`:
 
 ```bash
 WORKER_METRICS_PORT=9101 python -m app.workers.outbox_worker


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Document that the optional worker metrics endpoint accepts only valid TCP ports 1–65535.

## Changes
- Align `docs/INFRASTRUCTURE.md` with the behavior delivered by PR #4334.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded post-merge owner-doc writeback; the PR #4334 receipt and P2 registry entry remain the durable delivery evidence.

## Notes
Validation: `git diff --check`; `python3 scripts/docs_guard.py`; `python3 scripts/review_before_ci_gate.py --lane docs-authoring --changed-file docs/INFRASTRUCTURE.md --review-gate-complete`.
