### PR TITLE
governance: align resume-work index recovery order

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -91,7 +91,7 @@ citation site. `_shared/READ_SCOPE.md` is the canonical protocol, including the 
 - `agentic-pkm`
   - default repo-dev context for code, tests, docs, and SoT reading order in this repository
 - `resume-work`
-  - dev-time recovery for interrupted Codex/Claude/ChatGPT sessions (quota, network, hung command, tool failure, context loss); reconstruct state from git first, keep a lightweight `.codex-tmp/HANDOFF.md`, continue when clear, and escalate only on destructive or contract/SoT ambiguity; not a runtime/product feature
+  - dev-time recovery for interrupted Codex/Claude/ChatGPT sessions (quota, network, hung command, tool failure, context loss); check resumable orchestration journals/runs before git reconstruction, use git reconstruction as the fallback, keep a lightweight `.codex-tmp/HANDOFF.md`, continue when clear, and escalate only on destructive or contract/SoT ambiguity; not a runtime/product feature
 - `issue-to-code`
   - implementation entrypoint for bounded GitHub Issue work
   - classifies the issue as Product/Runtime System, Builder System, or boundary work before pickup

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -82,6 +82,24 @@ def test_repo_skill_index_describes_connected_workflow_paths() -> None:
     assert "agentic-pkm -> issue-to-code -> publish-pr -> [pr-integration when repair/readiness is needed] -> verification-and-closure" in text
 
 
+def test_skill_readme_resume_work_summary_matches_recovery_order() -> None:
+    index = _read(".codex/skills/README.md")
+    skill = _read(".codex/skills/resume-work/SKILL.md")
+
+    summary = _section_between(index, "- `resume-work`", "- `issue-to-code`")
+    recovery_contract = _section_between(
+        skill,
+        "## Orchestrated runs: resume the engine before rebuilding from git",
+        "## Decide: continue or escalate",
+    )
+
+    assert "resumable orchestration journals/runs" in summary
+    assert "git reconstruction as the fallback" in summary
+    assert recovery_contract.index("Check for a resumable run") < recovery_contract.index(
+        "Fall back to git"
+    )
+
+
 def test_yggdrasil_design_handoff_is_routed_and_fail_closed() -> None:
     agents = _read("AGENTS.md")
     index = _read(".codex/skills/README.md")


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4316

## Linked Issue
Closes #4316

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): interrupted-work recovery
- Write class: governance/docs/process
- Persistence impact: durable repository workflow documentation and test
- Derived/rebuildable impact: none
- New or changed contract: Index states the existing orchestration-journal-first recovery order.
- Owner-doc impact: No owner-doc change: the index summary now reflects the existing resume-work contract.
- Transition debt impact: Reduces builder recovery-routing drift.
- Boundary risk: Builder workflow guidance remains separate from Product/Runtime behavior.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Align the skills index with the existing resumable-journal-first resume-work contract.
- Add a focused test that reads the published index and the canonical skill contract.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material: this is a straightforward, in-scope governance alignment with no delivery divergence.

## Notes
Validation: pytest -q tests/architecture/test_agent_skill_entrypoints.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; git diff --check.