### PR TITLE
Stop janitor_apply's stash drop from resolving stale positional indices

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -346,6 +346,17 @@ Enforcement surfaces:
   forward on the new record (`prior_bindings`, deduplicated by branch and bounded to the 8 most
   recent) rather than dropping it. Broad `git worktree prune`
   remains report-only. The current checkout is always skipped.
+- Stash cleanup within the same apply run only ever drops a stash it resolved as a
+  `preserve-local-drift`-marked, age-eligible candidate; it never drops by a stale positional
+  index. `stash@{N}` is a position in the stash reflog, not a stable name — worktree paths and
+  branch names do not shift when a sibling is removed, but every drop of an earlier stash renumbers
+  every later one, and (independently) capturing that selector from a `--date`-formatted listing
+  can make it unresolvable to any real reflog position at all. Each candidate is instead identified
+  by its stash commit hash, captured once at plan time; immediately before every drop, `janitor_apply`
+  re-resolves that hash to whichever `stash@{N}` currently holds it and verifies the match. A
+  candidate that cannot be re-resolved, or whose re-resolved entry no longer matches, aborts the
+  remaining stash cleanup for that run with a recorded error rather than dropping a different,
+  non-candidate stash.
 - Resuming interrupted work: when a session breaks mid-task (quota, network, hung command, tool failure) and the tree is dirty or the branch has unmerged work, reconstruct state from git first, then continue — see `.codex/skills/resume-work/SKILL.md`.
 - Closure: `verification-and-closure` resolves every AC's `Verify:` target and blocks merge if any behavioral test is missing, skipped, or xfailed.
 

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -377,6 +377,22 @@ def _stash_ref(line: str) -> str:
     return line.split(":", 1)[0]
 
 
+def _current_stash_selector_for_sha(cwd: Path, sha: str) -> str | None:
+    """Resolve which `stash@{N}` currently holds commit `sha`, or None.
+
+    Uses a plain (no `--date`) listing so the returned selector is always a
+    small positional index that `git stash drop` can act on directly. Called
+    fresh immediately before every drop so a prior drop's renumbering of the
+    stash reflog can never make this resolution stale.
+    """
+    listing = run_git(["stash", "list", "--format=%gd %H"], cwd)
+    for entry in listing.splitlines():
+        selector, _, entry_sha = entry.partition(" ")
+        if entry_sha == sha:
+            return selector
+    return None
+
+
 def _utc_stamp(now: float | None = None) -> str:
     value = dt.datetime.fromtimestamp(time.time() if now is None else now, tz=dt.UTC)
     return value.strftime("%Y%m%dT%H%M%SZ")
@@ -935,12 +951,30 @@ def build_janitor_plan(
     cutoff = (time.time() if now is None else now) - stale_after_days * 24 * 60 * 60
     old_stashes = []
     stash_output = run_git(["stash", "list", "--date=unix"], cwd)
-    for line in stash_output.splitlines():
+    stash_lines = stash_output.splitlines()
+    candidate_rows: list[tuple[int, str]] = []
+    for index, line in enumerate(stash_lines):
         epoch = _stash_epoch(line)
         if epoch and epoch < cutoff and "preserve-local-drift" in line:
-            old_stashes.append({"ref": _stash_ref(line), "line": line})
+            candidate_rows.append((index, line))
         elif epoch and epoch < cutoff:
             skipped.append({"artifact": "stash", "name": _stash_ref(line), "reason": "missing_preserve_local_drift_marker"})
+    if candidate_rows:
+        # A companion plain listing (no --date), taken immediately after this
+        # scan with no intervening mutation, recovers each candidate's stable
+        # commit hash by position. `_stash_ref(line)` (the `--date=unix`
+        # selector) must never be treated as that identity: it is a
+        # positional index that a prior drop in the same apply run
+        # renumbers, and with `--date` applied git can additionally fold
+        # several entries pushed within the same second into one rendered
+        # selector, so it cannot even be resolved back to a specific reflog
+        # position on its own. `janitor_apply` re-resolves this hash to
+        # whatever position currently holds it immediately before every
+        # drop, instead of trusting any positional selector.
+        stash_shas = run_git(["stash", "list", "--format=%H"], cwd).splitlines()
+        for index, line in candidate_rows:
+            sha = stash_shas[index] if index < len(stash_shas) else None
+            old_stashes.append({"ref": _stash_ref(line), "line": line, "sha": sha})
 
     prune_candidates = {
         "worktree": run_git(["worktree", "prune", "--dry-run"], cwd).splitlines(),
@@ -1399,7 +1433,70 @@ def janitor_apply(
                 },
             )
     for stash in plan["candidates"]["old_stashes"]:
-        apply_git(["stash", "drop", stash["ref"]], {"artifact": "stash", "action": "drop", **stash})
+        expected_sha = stash.get("sha")
+        if not expected_sha:
+            errors.append(
+                {
+                    "artifact": "stash",
+                    "action": "drop",
+                    "reason": "missing_stash_identity",
+                    **stash,
+                }
+            )
+            return {
+                **plan,
+                "mode": "apply",
+                "destructive_actions": actions,
+                "errors": errors,
+                "ok": False,
+            }
+        # Never trust `stash["ref"]`: it is the positional selector captured
+        # when the plan was built, and a prior drop in this same loop
+        # renumbers every stash above the one it removed. Re-resolve the
+        # candidate's stable commit hash to whatever selector currently holds
+        # it, verify that selector still names the intended commit, and only
+        # then drop it. A candidate that can no longer be found or no longer
+        # matches aborts the whole loop rather than risk touching an
+        # unrelated stash.
+        current_selector = _current_stash_selector_for_sha(cwd, expected_sha)
+        if current_selector is None:
+            errors.append(
+                {
+                    "artifact": "stash",
+                    "action": "drop",
+                    "reason": "stash_identity_not_found",
+                    **stash,
+                }
+            )
+            return {
+                **plan,
+                "mode": "apply",
+                "destructive_actions": actions,
+                "errors": errors,
+                "ok": False,
+            }
+        verify = run_git_result(["rev-parse", "--verify", f"{current_selector}^{{commit}}"], cwd)
+        if verify.returncode != 0 or verify.stdout.strip() != expected_sha:
+            errors.append(
+                {
+                    "artifact": "stash",
+                    "action": "drop",
+                    "reason": "stash_identity_mismatch",
+                    "resolved_selector": current_selector,
+                    **stash,
+                }
+            )
+            return {
+                **plan,
+                "mode": "apply",
+                "destructive_actions": actions,
+                "errors": errors,
+                "ok": False,
+            }
+        apply_git(
+            ["stash", "drop", current_selector],
+            {"artifact": "stash", "action": "drop", **stash},
+        )
 
     return {
         **plan,

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess
+import time
 from contextlib import nullcontext
 
 import pytest
@@ -2248,3 +2249,99 @@ def test_cli_without_require_flag_zero_even_if_in_shared_root(
     exit_code = git_hygiene.main(["--cwd", str(tmp_path), "preflight"])
 
     assert exit_code == 0, "Expected zero exit when flag is absent (library default is off)"
+
+
+def test_janitor_apply_stash_drop_targets_survive_index_shift(tmp_path) -> None:
+    """Regression for #4333: a stale positional stash index must never cause
+    ``janitor_apply`` to drop a stash that was not itself a candidate.
+
+    Real ``git stash`` state, newest to oldest after four ``git stash push``
+    calls:
+
+        stash@{0} B  (candidate: preserve-local-drift marker)
+        stash@{1} X  (non-candidate, interleaved between the two candidates)
+        stash@{2} A  (candidate: preserve-local-drift marker)
+        stash@{3} Y  (non-candidate, sits below A)
+
+    ``build_janitor_plan`` captures A's positional selector as ``stash@{2}``
+    when the plan is built. Dropping B first (``stash@{0}``) shifts every
+    entry below it up by one, so the stale ``stash@{2}`` now names Y, not A.
+    The unfixed loop in ``janitor_apply`` drops B, then blindly drops
+    whatever now sits at ``stash@{2}``: Y is destroyed as collateral damage
+    and A survives untouched -- exactly the incident's signature (a marked
+    candidate survives while an unrelated, unmarked entry is destroyed). The
+    fix must re-resolve each candidate's stable commit identity immediately
+    before dropping it, so both real candidates (A, B) are dropped and both
+    non-candidates (X, Y) survive.
+    """
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", "--initial-branch=main", str(remote)], check=True)
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--initial-branch=main", str(repo)], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+
+    def push_stash(content: str, message: str) -> str:
+        (repo / "file.txt").write_text(content, encoding="utf-8")
+        subprocess.run(["git", "stash", "push", "-m", message], cwd=repo, check=True)
+        return subprocess.run(
+            ["git", "rev-parse", "stash@{0}"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    sha_y = push_stash("y\n", "unrelated Y (oldest, becomes collateral target)")
+    sha_a = push_stash("a\n", "preserve-local-drift A")
+    sha_x = push_stash("x\n", "unrelated X (interleaved non-candidate)")
+    sha_b = push_stash("b\n", "preserve-local-drift B")
+
+    # Let real wall-clock time move past the pushes above so stale_after_days=0
+    # reliably makes every entry's committer epoch compare as "old".
+    time.sleep(1.1)
+
+    def current_shas() -> set[str]:
+        listing = subprocess.run(
+            ["git", "stash", "list", "--format=%H"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+        return set(listing)
+
+    assert current_shas() == {sha_y, sha_a, sha_x, sha_b}
+
+    report = git_hygiene.janitor_apply(
+        repo,
+        active_lease_loader=lambda: [],
+        lifecycle_authority_guard=_allow_lifecycle_authority,
+        lifecycle_records={},
+        pr_states={},
+        stale_after_days=0,
+    )
+
+    after = current_shas()
+
+    # Exactly the two marked candidates were dropped ...
+    assert sha_b not in after, "B (marked, index 0) should have been dropped"
+    assert sha_a not in after, (
+        "A (marked, index 2 at plan time) should have been dropped -- if this "
+        "fails, A survived because the drop loop is still using a stale "
+        "positional index instead of re-resolving A's identity"
+    )
+    # ... and both non-candidates survive untouched.
+    assert sha_x in after, "X (unmarked, between the two candidates) must survive"
+    assert sha_y in after, (
+        "Y (unmarked, below A) must survive -- if this fails, Y was destroyed "
+        "as collateral damage by a stale stash@{2} that shifted onto it after "
+        "B's drop, reproducing the #4333 incident"
+    )
+    assert after == {sha_x, sha_y}
+    assert report["ok"] is True, report["errors"]


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4333

## Linked Issue
Fixes #4333

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: mechanical (destructive local-repo cleanup automation)
- Persistence impact: durable — operator/agent working-tree state (stashed WIP) can be permanently destroyed with no lease, authority, or content check
- Derived/rebuildable impact: none — stashed diffs are not reconstructable once the drop succeeds and the reflog entry is gone
- New or changed contract: janitor_apply's stash cleanup only ever drops a stash it re-resolved and verified as the intended candidate; a stale positional index or a resolution mismatch aborts the remaining stash cleanup instead of dropping a different stash
- Owner-doc impact: docs/development/DEV_WORKFLOW.md :: Safe cleanup apply updated in this PR
- Transition debt impact: reduces — closes a real, demonstrated data-loss gap left open since PR #4129 (listed there as deferred F4) and named again in issue #4273, which then caused a real incident (8 stashes destroyed, 7 recovered from dangling commits) before a bounded issue was ever filed
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Fix janitor_apply's stash-drop loop (scripts/git_hygiene.py) so it never trusts a stale positional stash@{N} index across multiple drops in the same run.
- Each old_stashes candidate is now identified by its stash commit hash captured at plan time; janitor_apply re-resolves that hash to whichever stash@{N} currently holds it and verifies the match immediately before every drop, aborting the remaining stash cleanup with a recorded error if a candidate cannot be re-resolved or no longer matches.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Builder System dev-tooling bug fix with its own governing Issue (#4333) and PR; no separate BuilderOps record/projection applies.

## Notes

**Final-Review-Rounds justification:** this is Tier 2 (bounded code slice + regression test + owner-doc
writeback), which would default to the light path (`Final-Review-Rounds: 0`). This PR declares `1`
instead because the surface is destructive local-repo cleanup automation that has already caused a
real, confirmed data-loss incident today (8 stashes destroyed, 7 recovered only via
`refs/recovered-stash/*`, one bare `autostash` entry unrecoverable) — an extra independent review
round on the fix for that exact mechanism is cheap insurance against shipping a second, differently
wrong version of the same destructive loop. No TCD high-risk-surface local review gate (auth/
security/data/migration/concurrency/external-api/credential-durability/state-machine) applies: this
is Builder-System dev-tooling operating on local git-worktree state, not product/runtime data,
migrations, or auth.

**Additional finding beyond the issue's own framing:** the issue's reproduction demonstrated the
stale-index defect using plain small-integer `stash@{N}` refs. The actual code on `main` instead
builds `old_stashes["ref"]` from `git stash list --date=unix`, and `--date=unix` changes how git
renders the reflog selector (`%gd`) from a small index into a `stash@{<unix-epoch>}` form. Verified
empirically (real `git`, not mocked) that `git stash drop stash@{<unix-epoch>}` and the equivalent
`git reflog delete refs/stash@{<unix-epoch>}` both return exit 0 and print a plausible "Dropped ..."
message naming the correct top-of-stack SHA, while leaving `.git/logs/refs/stash` completely
unchanged on disk — i.e. today's drop can silently no-op while falsely reporting success, a distinct
and arguably worse failure mode than "wrong stash dropped," on top of the stale-index bug the issue
describes. The fix eliminates dependence on that selector for identity entirely (captures the stash
commit hash instead, and re-resolves a plain non-`--date` `stash@{N}` fresh before every drop), so it
closes both failure modes with the same change.

**Sibling-loop check (Scope item 4):** no other destructive loop in `scripts/git_hygiene.py` shares
this defect shape. The worktree-removal loop targets by filesystem path, and the local/remote branch
deletion loops target by branch name — both are stable identities that git does not renumber when a
sibling is removed. Only `refs/stash`'s reflog is positional (a stack, not a set of names), which is
why stash cleanup alone needed this fix. Nothing to flag as a follow-up.

Validation: `pytest -q tests/ops/test_git_hygiene.py tests/scripts/test_git_hygiene_reclaim.py` (70
passed); new regression test `tests/ops/test_git_hygiene.py::test_janitor_apply_stash_drop_targets_survive_index_shift`
confirmed to FAIL on the unfixed `scripts/git_hygiene.py` (checked out from HEAD) with `AssertionError:
B (marked, index 0) should have been dropped`, and PASS with the fix restored; `ruff check
scripts/git_hygiene.py tests/ops/test_git_hygiene.py` clean; `mypy scripts/git_hygiene.py` clean;
full `pytest -q -m "not pg"` run under `scripts/run_with_host_lease.py --resource pytest-not-pg`
(see PR thread for exact counts once the run completes).
