### PR TITLE
Document parallel non-PG escalation suite

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -78,7 +78,7 @@ Practical rule:
 Escalate to the repo-wide non-PG suite only when the governing Issue/owner document names it or the
 change has cross-system blast radius that focused subsystem tests cannot cover:
 
-`python3 scripts/run_with_host_lease.py --resource pytest-not-pg --execution-id <issue-or-pr>:<sha> -- pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -q -m "not pg"`
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/run_with_host_lease.py --resource pytest-not-pg --execution-id <issue-or-pr>:<sha> -- pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -p xdist.plugin -q -m "not pg" -n auto --dist=loadfile`
 
 The full non-PG suite is host-global. The wrapper above holds an atomic repo-common kernel lock for
 the entire child process and releases it automatically when the process exits. A chat handshake,


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4266

## Linked Issue
Closes #4266

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: The documented full-suite escalation command now uses explicit xdist parallel execution.
- Owner-doc impact: docs/development/DEV_WORKFLOW.md updated
- Transition debt impact: reduces: documented command is runnable on macOS; underlying descriptor accumulation remains out of scope
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make the documented full non-PG escalation command use xdist loadfile distribution, with plugin autoload disabled and required plugins loaded explicitly.

## BuilderOps Routing
- Records/projections/receipts: AgentWorklog awl_20260729131547_4cd94f7e; AgentWorklog awl_20260729132123_a649b80f
- Reason: Claim and bounded validation receipts are operational BuilderOps evidence; no promotion is needed.

## Notes
Validation: python3 scripts/docs_guard.py passed. Host-leased parallel non-PG suite completed in 98.21s with 11,508 passed, 35 unrelated baseline failures, and no Errno 24 descriptor-exhaustion cascade.