### PR TITLE
governance: add live pre-creation duplicate re-check to issue-producing skills

### DIFF
--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -80,6 +80,12 @@ For every candidate doc item, determine exactly one state:
    Also check whether the spec file's own `State:` line has already been promoted to "Implemented" — if so, classify as `delivered` and skip. If the code exists but `State:` still reads "Not yet implemented", treat the spec as stale, update the `State:` line (docs-authoring lane), and do not file a new issue.
 6. Decide whether the item should stay as one bounded issue or be turned into one parent feature issue plus child slices via `feature-breakdown`.
 7. If the candidate would only create bookkeeping churn, keep it out of the backlog and route it to the maintenance path instead.
+8. **Live duplicate re-check — immediately before creation.** The step 2–4 inspection is an analysis-time snapshot and goes stale: a concurrent session can file the same backlog between your inspection and your `gh issue create` (seen 2026-07-29: hub #4286 + children #4287–#4292 duplicated by #4298–#4304; mirrors `.codex/skills/publish-pr/SKILL.md :: Publication preflight — live open-PR overlap re-check`, whose precedent was PR #2757 duplicating #2755). Immediately before the first `gh issue create`, re-check live open issues via REST:
+   ```bash
+   REPO=$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+   gh api "repos/$REPO/issues?state=open&per_page=100" --jq '.[] | select(.pull_request | not) | "\(.number)\t\(.title)"'
+   ```
+   Any open issue already covering the same source docs or capability => STOP: keep the earlier compliant set, comment new evidence there instead, and file only the non-overlapping delta. When filing a multi-issue set (hub + children), run the re-check once immediately before the first creation, then file the whole set without interleaving further analysis.
 
 ## When a doc item becomes a new Issue
 

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -197,18 +197,19 @@ By contrast, additive work on a single surface that mirrors an existing pattern 
    - parent feature issue body, comments, or both
    - owner-doc promotion trigger
 7. If docs are still too vague, stop at `enrich-docs` instead of creating weak specs.
-8. Create or update the parent feature issue on GitHub (if needed).
+8. Immediately before the first `gh issue create` (parent or child), run the **Live duplicate re-check — immediately before creation** step from `.codex/skills/docs-to-issue/SKILL.md :: Before creating any Issue`. The step-3 search is an analysis-time snapshot, and spec authoring (steps 4–7) leaves a wide gap in which a concurrent session can file the same backlog (seen 2026-07-29: hub #4286 + children #4287–#4292 duplicated by #4298–#4304).
+9. Create or update the parent feature issue on GitHub (if needed).
    - If you create it, immediately update the local `PARENT_FEATURE_ISSUE.md` to state that the GitHub issue now exists and is the authoritative backlog/validation surface.
    - In the same commit, update the capability `README.md` so its `State:` line and relationship-to-GitHub-issues section match the new GitHub issue state.
    - If the GitHub parent issue later closes, update the local `PARENT_FEATURE_ISSUE.md` again so it no longer reads as an unfiled or active draft.
    - When closing, also update the capability `README.md` so it no longer reads as an active pre-delivery lane and so any now-satisfied acceptance checklist truthfully reflects the delivered docs/spec state.
-9. Create or update GitHub issues from the task specifications, in dependency order.
-10. Keep authoritative labels truthful; Project status is optional projection:
+10. Create or update GitHub issues from the task specifications, in dependency order.
+11. Keep authoritative labels truthful; Project status is optional projection:
     - parent feature issue normally starts with `agent:blocked`
     - ready tasks use `agent:ready` after strict validation
     - blocked tasks use `agent:blocked`
     - decision-dependent tasks use `agent:needs-human` only when a named human decision, tradeoff, missing input, or authority question is still open
-11. Emit one clear breakdown receipt showing the parent feature issue, implementation tasks, evidence surface, and execution order.
+12. Emit one clear breakdown receipt showing the parent feature issue, implementation tasks, evidence surface, and execution order.
 
 ## Parent feature issue requirements
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System / CES boundary (delivery skills)
- Secondary subsystem(s): none
- Write class: docs-only (skill instruction text)
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: workflow contract only: issue-producing skills now require a live open-issue overlap re-check immediately before the first gh issue create
- Owner-doc impact: none (the skill files are the owning artifacts)
- Transition debt impact: none
- Boundary risk: none: no Product/Runtime surface touched

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a mirrored immediately-before-creation live duplicate re-check to docs-to-issue (new step 8 of Before creating any Issue, with the publish-pr-style REST re-check) and feature-breakdown (new step 8 of Working procedure referencing that step). Root cause: analysis-time open-issue inspection goes stale, so two concurrent sessions filed the docs/MODEL_ACCESS_SUBSTRATE/ backlog twice (hub #4286 + children #4287-#4292, duplicate set #4298-#4304, not_planned). bug-to-issue and learning-to-issue were checked and need no change: their existing-issue checks sit directly adjacent to creation. Refs #4286

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260729132910_fe7a9044 (workflow_divergence: docs-to-issue lacks a live pre-creation duplicate re-check)
- Reason: This PR is the upstream repair promoted from that signal; captured via capture-learning before editing.

## Notes
Validation: pytest tests/governance/test_project_pickup_deprecation.py tests/architecture/test_agent_skill_entrypoints.py (24 passed); python3 scripts/docs_guard.py OK; review_before_ci_gate.py governance lane satisfied.
