### PR TITLE
docs: correct required-check state for `Unit tests (not pg)`

### DIFF
--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -5,7 +5,7 @@ Owner: Builder System governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: observed repo files and read-only GitHub command output cited inline
-Last reviewed: 2026-07-28
+Last reviewed: 2026-07-29
 
 # Builder System Process Map
 
@@ -663,13 +663,13 @@ the Codex verdict path [`.codex/skills/verification-and-closure/SKILL.md`:116-17
 integration is missing; Claude-specific repo evidence is a compatibility entrypoint and local hook
 documentation only [CLAUDE.md:1-8], [`.claude/hooks/README.md`:1-50].
 
-No patch/merge authority should be enabled until branch protection and required guardrails are documented and enforced. Main is currently unprotected by read-only API output, and repo auto-merge is disabled.
+No patch/merge authority should be enabled until branch protection and required guardrails are documented and enforced. `main` now enforces one required status check (`Unit tests (not pg)`) but no review or contract check, and repo auto-merge is disabled.
 
 ## 13. Branch Protection And Merge Guardrails
 
 Current observed state:
 
-- `main` is the default branch and is not protected: `gh api repos/RasmusTho/agentic-pkm-mvp/branches/main/protection` returned HTTP 404 `Branch not protected`.
+- `main` is the default branch and is protected by a single required status check: `gh api repos/RasmusTho/agentic-pkm-mvp/branches/main/protection` on 2026-07-29 returned `contexts=["Unit tests (not pg)"]`, `strict=false`, `enforce_admins=true`, `required_pull_request_reviews=null`. (The same call returned HTTP 404 `Branch not protected` on 2026-07-08; protection was added between those observations — see `docs/development/GITHUB_GOVERNANCE_SETUP.md :: Governance receipts`.)
 - `stable` is protected with strict required checks `smoke`, `smoke-docker`, and `pr-contract`; required approving review count is 0 and CODEOWNERS review is not required by branch protection.
 - Repository auto-merge is disabled: `allow_auto_merge=false`.
 - CODEOWNERS exists and names Rasmus for prod-critical files, promotion skills, and migrations [`.github/CODEOWNERS`:1-9].
@@ -677,13 +677,13 @@ Current observed state:
 
 Required target state before autonomous merge is safe:
 
-- Protect `main` or make the autonomous target a protected branch.
-- Require the actual checks used by the Builder System (`pr-contract`, CI/smoke/import-linter as appropriate).
+- ~~Protect `main` or make the autonomous target a protected branch.~~ Done: `main` is protected (verified 2026-07-29).
+- Require the actual checks used by the Builder System (`pr-contract`, CI/smoke/import-linter as appropriate). Partially done: `main` requires `Unit tests (not pg)` only; `pr-contract`, `smoke`, `smoke-docker`, and import-linter still run without being required on `main`.
 - Decide whether CODEOWNERS review is required for prod-critical paths; current `stable` branch protection does not require it.
 - Keep auto-merge disabled until evidence pack, review gate, and closure gate are deterministic enough to audit.
 - Limit autonomous-merge eligibility to docs-only/governance Tier 1 or low-risk code after guardrails are enforced; prod/stable, migrations, release, vault/HKA/MEM authority, and external-facing irreversible changes remain human/operator exception paths [docs/development/AGENT_OPERATING_PROTOCOL.md:31-35], [`.codex/skills/promote-test-to-prod/SKILL.md`:109-113].
 
-Conclusion: autonomous merge to `main` is currently not platform-safe. Skills require CI and review gates even when a branch is unprotected [`.codex/skills/verification-and-closure/SKILL.md`:95-115], but platform protection does not enforce those gates on `main`.
+Conclusion: autonomous merge to `main` is not yet fully platform-safe. Platform protection now blocks a merge while `Unit tests (not pg)` is red, but it does not enforce `pr-contract`, smoke, import-linter, or any review requirement; those remain skill-enforced [`.codex/skills/verification-and-closure/SKILL.md`:95-115].
 
 ## 14. Human Exception Model
 

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -99,14 +99,29 @@ Enforcement note:
 
 ### CI / validation expectations
 
-The CI workflow runs a non-required `Unit tests (not pg)` check automatically on `pull_request`.
-That check uses `scripts/select_pr_tests.py` to execute affected-subsystem pytest targets without a
-Postgres service, so relevant unit regressions are visible before merge without paying for the
-repo-wide suite on every PR.
+`CI Smoke` (`.github/workflows/ci-smoke.yaml`) runs the `Unit tests (not pg)` check
+(`pr-unit-tests-not-pg`) automatically on `pull_request`. That check
+uses `scripts/select_pr_tests.py` to execute affected-subsystem pytest targets without a Postgres
+service, so relevant unit regressions are visible before merge without paying for the repo-wide
+suite on every PR. [`TEST_STRATEGY_HOT_PATH.md`](TEST_STRATEGY_HOT_PATH.md) owns that selection
+behavior and its paths filter.
 
-This PR check is intentionally non-required until it has been observed green on real PRs. Promoting
-the check to a required branch-protection gate, or adding `pg`-marked tests with a Postgres service
-to the PR path, is deferred to follow-up work based on observed signal and CI cost/flakiness.
+`Unit tests (not pg)` is a **required** status check in `main` branch protection. A red run blocks
+merge at the platform level: the REST merge API rejects the merge with HTTP 405 while the check is
+failing. `main` protection requires this single check, requires no approving review, does not
+require the branch to be up to date (`strict=false`), and applies to admins. Verified against
+`gh api repos/RasmusTho/agentic-pkm-mvp/branches/main/protection` on 2026-07-29; the durable receipt
+lives in [`GITHUB_GOVERNANCE_SETUP.md`](GITHUB_GOVERNANCE_SETUP.md).
+
+Platform enforcement is a floor, not the process gate. [`PR_HOT_PATH.md`](PR_HOT_PATH.md) still
+governs when a PR may merge, and the absence of a protection rule on any other surface never waives
+it.
+
+`pg`-marked tests reach the PR path only through the narrow `Index PG contracts`
+(`pr-index-pg-contracts`) job, which runs `pytest -m "pg"` against a pgvector service for the exact
+index/outbox/YouTube-quota acceptance files when those paths change. That job is not a required
+check. Broad `pg` and integration coverage stays on `integration-nightly.yaml` (nightly schedule
+plus `workflow_dispatch`).
 
 ## Documentation rules
 

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -341,7 +341,7 @@ GitHub platform limitations observed in this session:
 ## Required follow-up outside the repo
 
 ~~1. Optionally add branch protection or repository rules that require the governance workflow to pass before merge.~~
-Branch protection with required status checks is now active on `stable` (delivered 2026-05-10, issue #844).
+Branch protection with required status checks is now active on `stable` (delivered 2026-05-10, issue #844) and on `main` (`Unit tests (not pg)`; see the delivery receipt below).
 
 ## Governance receipts
 
@@ -355,3 +355,4 @@ Delivery receipt:
 - On 2026-03-30, the repository labels, Project v2 board, linked repository, required status taxonomy, custom `Agent State` field, and initial item states were applied on the GitHub platform.
 - On 2026-03-30, the required `Kanban` and `Agent Queue` views plus the built-in Project lifecycle automation were completed manually in the GitHub UI after the repo and field baseline was applied.
 - On 2026-05-10, required status checks (`smoke`, `smoke-docker`, `pr-contract`, `strict=true`) were added to `stable` branch protection via issue #844. A PR targeting `stable` now requires all three checks to pass before merge is permitted.
+- `main` is protected with a single required status check, `Unit tests (not pg)` (the `pr-unit-tests-not-pg` job in `.github/workflows/ci-smoke.yaml`): `contexts=["Unit tests (not pg)"]`, `strict=false`, `enforce_admins=true`, `required_pull_request_reviews=null`. A PR targeting `main` cannot be merged through the API while that check is red (HTTP 405). Verified via `gh api repos/RasmusTho/agentic-pkm-mvp/branches/main/protection` on 2026-07-29. The check was first observed hard-blocking a merge on 2026-07-17, shortly after PR #3913 (merged 2026-07-16, issue #3892) activated the PR-path gates and moved this job out of the retired `ci.yml`; the exact promotion timestamp is not recorded because branch protection is platform state, not repo state.


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governance lane: bounded correction to builder-governance docs under `docs/development/`. No code, runtime, or contract change; branch protection itself is untouched.

## Linked Issue

No governing issue — issue-free governance-lane docs correction.

## SBS Impact
- Primary subsystem: Builder System (delivery governance docs)
- Secondary subsystem(s): none
- Write class: docs-only
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none — the documented gate already exists on the platform
- Owner-doc impact: `docs/development/DEV_WORKFLOW.md`, `docs/development/GITHUB_GOVERNANCE_SETUP.md`, `docs/development/BUILDER_SYSTEM_PROCESS_MAP.md` updated in this PR
- Transition debt impact: removes stale "deferred to follow-up work" wording that read as pending
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `DEV_WORKFLOW.md :: CI / validation expectations` described `Unit tests (not pg)` as a **non-required** check whose promotion to a required branch-protection gate was "deferred to follow-up work". That is stale: the check has been required on `main` since mid-July.
- Verified against the platform on 2026-07-29: `gh api repos/RasmusTho/agentic-pkm-mvp/branches/main/protection` returns `contexts=["Unit tests (not pg)"]`, `strict=false`, `enforce_admins=true`, `required_pull_request_reviews=null`.
- Rewrote the section to shipped reality: the job lives in `CI Smoke` (`.github/workflows/ci-smoke.yaml`) — the `ci.yml` it once ran from was retired by PR #3913 (#3892) — it is required, a red run blocks the merge API with HTTP 405, and `PR_HOT_PATH.md` remains the process gate above the platform floor.
- Corrected the second stale claim in the same paragraph: `pg`-marked tests **do** reach the PR path now, through the narrow `Index PG contracts` (`pr-index-pg-contracts`) job against a pgvector service for the index/outbox/YouTube-quota acceptance files. That job is not required; broad PG/integration coverage stays on `integration-nightly.yaml`.
- Added the durable `main` protection receipt to `GITHUB_GOVERNANCE_SETUP.md` (owner of repo-external GitHub configuration), alongside the existing `stable` receipt.
- Repaired the same stale claim in `BUILDER_SYSTEM_PROCESS_MAP.md` §13, which still asserted in present tense that `main` is unprotected (a 2026-07-08 HTTP 404 observation) and concluded that autonomous merge is "not platform-safe" without qualification. The conclusion is now scoped to what protection actually enforces: the not-pg check only, no `pr-contract`/smoke/import-linter and no review requirement.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: current-state doc correction with no delivery run, promotion, or learning signal to route.

## Notes
- The exact protection-promotion timestamp is not recoverable — branch protection is platform state, not repo state. The receipt records what is verifiable: required as of 2026-07-29, first observed hard-blocking a merge 2026-07-17, shortly after PR #3913 (2026-07-16) activated the PR-path gates.
- Validation: `scripts/select_pr_tests.py` resolves this diff to the governance subsystem; that selected target set ran locally — 1007 passed after the fix, 1 initial failure was `tests/ops/test_review_before_ci_gate.py::test_validation_scope_defaults_to_affected_subsystem_across_owner_docs`, caused by my rewrap splitting the asserted phrase "uses `scripts/select_pr_tests.py`" across a line break; re-wrapped and green. Also ran `scripts/docs_guard.py` (OK), `scripts/lint_skills_consistency.py` (OK), and the doc TODO scan (clean).
- Follow-up not taken here: whether `pr-contract` and smoke should also become required checks on `main` is a real open question surfaced by the process map, but it is a protection change, not a doc correction.
