### PR TITLE
test(builder): expose optional subprocess packages

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -142,6 +142,11 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # BuilderOps store-access inventory fitness. Keep this exact file
             # owned without widening builder_system to all architecture tests.
             "tests/architecture/test_builderops_store_boundary.py",
+            # Isolated subprocess import wiring is a Builder test-harness
+            # contract; own both the helper and its focused regression without
+            # widening this subsystem to all helpers.
+            "tests/helpers/subprocess_pythonpath.py",
+            "tests/helpers/test_subprocess_pythonpath.py",
             "docs/builderops/",
             "importlinter.ini",
         ),

--- a/tests/helpers/subprocess_pythonpath.py
+++ b/tests/helpers/subprocess_pythonpath.py
@@ -25,9 +25,15 @@ of its own, and put THAT private directory on PYTHONPATH. First proven at
 from __future__ import annotations
 
 from pathlib import Path
+from collections.abc import Iterable
 
 
-def isolated_app_pythonpath(private_dir: Path, repo_root: Path) -> str:
+def isolated_app_pythonpath(
+    private_dir: Path,
+    repo_root: Path,
+    *,
+    optional_packages: Iterable[str] = (),
+) -> str:
     """Return a ``PYTHONPATH`` value exposing only ``app/`` and ``scripts/``
     from *repo_root*.
 
@@ -37,14 +43,18 @@ def isolated_app_pythonpath(private_dir: Path, repo_root: Path) -> str:
     ``PYTHONPATH``. ``scripts/`` is included because ``app`` modules import
     from it directly (e.g. ``app.builderops.model_inquiry_promotion`` imports
     ``scripts.validate_issue_readiness``); omitting it would trade one
-    ``ModuleNotFoundError`` for another.
+    ``ModuleNotFoundError`` for another. Callers can also declare optional
+    top-level packages; each is linked only when its source directory exists.
 
     Never pass *repo_root* itself as (or on) a subprocess ``PYTHONPATH`` --
     see the module docstring for why.
     """
     private_dir.mkdir(parents=True, exist_ok=True)
-    for package in ("app", "scripts"):
+    for package in ("app", "scripts", *optional_packages):
+        source = repo_root / package
+        if package not in {"app", "scripts"} and not source.is_dir():
+            continue
         link = private_dir / package
         if not link.exists():
-            link.symlink_to(repo_root / package)
+            link.symlink_to(source)
     return str(private_dir)

--- a/tests/helpers/test_subprocess_pythonpath.py
+++ b/tests/helpers/test_subprocess_pythonpath.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.helpers.subprocess_pythonpath import isolated_app_pythonpath
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_isolated_pythonpath_preserves_default_packages(tmp_path: Path) -> None:
+    private_dir = tmp_path / "pythonpath"
+
+    result = isolated_app_pythonpath(private_dir, REPO_ROOT)
+
+    assert result == str(private_dir)
+    assert (private_dir / "app").resolve() == REPO_ROOT / "app"
+    assert (private_dir / "scripts").resolve() == REPO_ROOT / "scripts"
+
+
+def test_isolated_pythonpath_exposes_existing_optional_package(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    optional_package = repo_root / "neutral_package"
+    optional_package.mkdir(parents=True)
+    private_dir = tmp_path / "pythonpath"
+
+    isolated_app_pythonpath(
+        private_dir,
+        repo_root,
+        optional_packages=("neutral_package",),
+    )
+
+    assert (private_dir / "neutral_package").resolve() == optional_package
+
+
+def test_isolated_pythonpath_skips_missing_optional_package(tmp_path: Path) -> None:
+    private_dir = tmp_path / "pythonpath"
+
+    isolated_app_pythonpath(
+        private_dir,
+        tmp_path / "repo",
+        optional_packages=("missing_package",),
+    )
+
+    assert not (private_dir / "missing_package").exists()
+    assert not (private_dir / "missing_package").is_symlink()
+
+
+def test_isolated_pythonpath_is_idempotent_for_optional_packages(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "app").mkdir(parents=True)
+    (repo_root / "scripts").mkdir()
+    optional_package = repo_root / "neutral_package"
+    optional_package.mkdir()
+    private_dir = tmp_path / "pythonpath"
+
+    first = isolated_app_pythonpath(
+        private_dir,
+        repo_root,
+        optional_packages=("neutral_package",),
+    )
+    second = isolated_app_pythonpath(
+        private_dir,
+        repo_root,
+        optional_packages=("neutral_package",),
+    )
+
+    assert first == second == str(private_dir)
+    assert (private_dir / "neutral_package").resolve() == optional_package

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -1041,6 +1041,21 @@ def test_builder_system_change_selects_its_own_regression_tests() -> None:
     assert "tests/architecture/test_builderops_store_boundary.py" in selection.targets
 
 
+def test_subprocess_pythonpath_helper_change_selects_builder_system_regressions() -> None:
+    helper_path = "tests/helpers/subprocess_pythonpath.py"
+    regression_path = "tests/helpers/test_subprocess_pythonpath.py"
+
+    selection = select_tests([helper_path, regression_path])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("builder_system",)
+    assert selection.unowned_paths == ()
+    assert "tests/builderops" in selection.targets
+    assert "tests/governance" in selection.targets
+    assert helper_path in selection.targets
+    assert regression_path in selection.targets
+
+
 def test_runtime_start_harness_change_selects_ops_deploy_regressions() -> None:
     selection = select_tests(
         [


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4358

## Linked Issue
Closes #4358

## SBS Impact
- Primary subsystem: Builder System test harness
- Secondary subsystem(s): BuilderOps isolated CLI verification and PR-test selection
- Write class: test-only helper and CI selector contract
- Persistence impact: none
- Derived/rebuildable impact: temporary test directories only
- New or changed contract: isolated subprocess fixtures may expose existing declared packages and are owned by Builder System CI selection
- Owner-doc impact: none; helper docstring and focused tests are sufficient
- Transition debt impact: unblocks MAS-04 without coupling the neutral package to app
- Boundary risk: helper and selector do not import install or mutate Product/runtime packages

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Expose declared top-level packages to isolated subprocesses and register the helper with Builder System PR-test selection.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was produced; delivery state is represented by the governing Issue dispatcher claim and PR.

## Notes
Validation: focused selector, helper, and BuilderOps config-path tests passed (21 passed); full selector suite passed (79 passed); ruff checks passed; mypy app passed. mypy scripts/select_pr_tests.py reports two pre-existing errors on unchanged lines 803 and 870.