### PR TITLE
bug(test): re-pin write_frontmatter census drift

### DIFF
--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -485,12 +485,12 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 1394): (
+    ("app/instance/vault_registry.py", 1403): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 (site unchanged); re-pinned after directly "
+        "Line drifted 1373 -> 1394 -> 1403 (site unchanged); re-pinned after directly "
         "related insertions earlier in vault_registry.py."
     ),
 }


### PR DESCRIPTION
Governing-Issue: #4364

Fixes #4364

Final-Review-Rounds: 0

## Summary
Re-pins the existing app-local settings `write_frontmatter` census entry to its live source coordinate. The call remains explicitly `out_of_scope`; runtime behavior and all other census entries are unchanged.

## BuilderOps Routing
- Records/projections/receipts: KD-EB441DB41403 is promoted operationally by Issue #4364.
- Reason: The registry helper failed closed on malformed legacy source; no registry comment was hand-edited. This PR is the bounded required-CI repair and does not create a separate BuilderOps record.

## Notes
Validation: `python -m pytest -q tests/properties/test_guard_at_seam.py::test_every_write_seam_asserts_writeguard`; `python -m ruff check tests/properties/_machinery.py`; `python -m ruff check app tests companion-ui/companion-app`; `git diff --check`.
---