### PR TITLE
MAS-05: resolve Model Inquiry credentials through the declared contract

### DIFF
--- a/app/builderops/model_access_resolver.py
+++ b/app/builderops/model_access_resolver.py
@@ -1,0 +1,342 @@
+"""Builder-owned resolution of neutral model-access intent through census policy.
+
+This module is the Builder System's implementation of the neutral
+``llm_contract.ModelAccessResolver`` port. Callers submit provider-free intent;
+this resolver applies Builder policy, selects the target from the exact
+declared provider census (MAS-01), verifies capabilities and grouped target
+independence through the neutral kernel (MAS-04), and resolves credential
+identities through the host secret contract (MAS-03).
+
+Provider, model, effective identity, endpoint, and credential identifier are
+outputs of this resolver. They are never caller fields and are never read from
+ambient process environment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.builderops.models import BuilderOpsValidationError
+from app.components.settings.providers_loader import (
+    ProviderCensus,
+    ProviderEntry,
+    RoleProfile,
+    load_provider_census,
+)
+from app.ops.host_secret_bootstrap import (
+    load_runtime_secret_values,
+    validate_secret_value,
+)
+from app.ops.host_secret_contract import (
+    HostSecretContract,
+    UndeclaredSecretConsumerError,
+    load_host_secret_contract,
+)
+from llm_contract import (
+    ModelCapabilities,
+    ModelResolutionRequest,
+    ResolvedModelAccess,
+    validate_resolved_group,
+)
+
+
+BUILDER_RUNTIME = "builder"
+MODEL_INQUIRY_CONSUMER = "builderops-model-inquiry"
+MODEL_INQUIRY_RESOLUTION_GROUP = "model-inquiry-independent-review"
+NON_PROVIDER_IDENTITIES = frozenset({"mock", "fake", "deterministic", "test"})
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROVIDER_CENSUS_PATH = _REPO_ROOT / "docs" / "settings" / "models" / "providers.yaml"
+_HOST_SECRET_CONTRACT_PATH = _REPO_ROOT / "config" / "secrets" / "host_secret_contract.json"
+
+_CAPABILITY_FIELDS = (
+    "structured_output",
+    "native_tools",
+    "system_prompt_channel",
+    "deterministic_execution",
+)
+
+
+class ModelAccessResolutionError(BuilderOpsValidationError):
+    """Builder policy refused to resolve a neutral request; no target was selected."""
+
+
+class DeclaredCredentialUnavailableError(RuntimeError):
+    """A declared credential is absent or unusable; names only the logical identifier."""
+
+    def __init__(self, credential_identity_ref: str) -> None:
+        super().__init__(f"declared credential unavailable: {credential_identity_ref}")
+        self.credential_identity_ref = credential_identity_ref
+
+
+@dataclass(frozen=True)
+class BuilderModelAccessResolver:
+    """Builder runtime resolver for the Model Inquiry independent-review group."""
+
+    census: ProviderCensus
+    contract: HostSecretContract
+    env: Mapping[str, str] | None = None
+
+    @classmethod
+    def from_declared_sources(
+        cls,
+        *,
+        env: Mapping[str, str] | None = None,
+        census_path: Path | None = None,
+        contract_path: Path | None = None,
+    ) -> "BuilderModelAccessResolver":
+        """Load the declared census and host secret contract from repository state."""
+        try:
+            census = load_provider_census(census_path or _PROVIDER_CENSUS_PATH)
+            contract = load_host_secret_contract(contract_path or _HOST_SECRET_CONTRACT_PATH)
+        except (OSError, ValueError) as exc:
+            raise ModelAccessResolutionError(
+                "declared model access sources are unavailable"
+            ) from exc
+        return cls(census=census, contract=contract, env=env)
+
+    def resolve(
+        self,
+        request: ModelResolutionRequest,
+        *,
+        runtime: str,
+        channel: str,
+        consumer: str,
+    ) -> ResolvedModelAccess:
+        """Resolve one neutral role request into a validated Builder target."""
+        return self.resolve_group(
+            [request],
+            runtime=runtime,
+            channel=channel,
+            consumer=consumer,
+        )[0]
+
+    def resolve_group(
+        self,
+        requests: Sequence[ModelResolutionRequest],
+        *,
+        runtime: str,
+        channel: str,
+        consumer: str,
+    ) -> tuple[ResolvedModelAccess, ...]:
+        """Resolve one caller-defined group and verify grouped target independence."""
+        request_tuple = tuple(requests)
+        if not request_tuple:
+            raise ModelAccessResolutionError("resolution group must contain at least one request")
+        self._require_builder_authority(runtime=runtime, consumer=consumer)
+        profiles = self._channel_profiles(channel)
+        resolutions = tuple(
+            self._resolve_one(request, profiles=profiles, channel=channel, consumer=consumer)
+            for request in request_tuple
+        )
+        try:
+            validated = validate_resolved_group(request_tuple, resolutions)
+        except ValueError as exc:
+            raise ModelAccessResolutionError(str(exc)) from exc
+        adapter_ids = [item.adapter_id for item in validated]
+        if len(set(adapter_ids)) != len(adapter_ids):
+            raise ModelAccessResolutionError(
+                "resolved group requires distinct adapter_id values"
+            )
+        return validated
+
+    def endpoint_for(self, resolved: ResolvedModelAccess) -> str:
+        """Return the declared provider API endpoint for a resolved target."""
+        provider = self._provider(resolved.provider)
+        if not provider.api_endpoint:
+            raise ModelAccessResolutionError(
+                f"declared provider has no API endpoint: {resolved.provider}"
+            )
+        return provider.api_endpoint
+
+    def credential_value(self, resolved: ResolvedModelAccess) -> str:
+        """Resolve the declared credential value through the host secret contract.
+
+        The value is read only from the mode-0600 runtime surface the host secret
+        bootstrap materialized for this process. An absent, undeclared, or
+        malformed value fails closed and names only the logical identifier.
+        """
+        secret = resolved.credential_identity_ref
+        try:
+            binding = self.contract.binding_for(secret)
+            kind = self.contract.kind_for(secret)
+        except UndeclaredSecretConsumerError as exc:
+            raise DeclaredCredentialUnavailableError(secret) from exc
+        values = load_runtime_secret_values(self.env)
+        value = values.get(binding, "")
+        if not value or not validate_secret_value(kind, value):
+            raise DeclaredCredentialUnavailableError(secret)
+        return value
+
+    def _require_builder_authority(self, *, runtime: str, consumer: str) -> None:
+        if runtime != BUILDER_RUNTIME:
+            raise ModelAccessResolutionError(
+                "Builder resolver refuses a non-Builder runtime request"
+            )
+        if consumer != MODEL_INQUIRY_CONSUMER:
+            raise ModelAccessResolutionError(
+                "Builder resolver refuses an undeclared model access consumer"
+            )
+
+    def _channel_profiles(self, channel: str) -> dict[str, RoleProfile]:
+        profiles = self.census.runtime_channels.model_inquiry_profiles.get(channel)
+        if not profiles:
+            raise ModelAccessResolutionError(
+                "declared census has no Model Inquiry profile for the requested channel"
+            )
+        by_role: dict[str, RoleProfile] = {}
+        for profile in profiles:
+            if profile.role in by_role:
+                raise ModelAccessResolutionError(
+                    "declared census repeats a Model Inquiry role profile"
+                )
+            by_role[profile.role] = profile
+        return by_role
+
+    def _resolve_one(
+        self,
+        request: ModelResolutionRequest,
+        *,
+        profiles: Mapping[str, RoleProfile],
+        channel: str,
+        consumer: str,
+    ) -> ResolvedModelAccess:
+        role = request.role_profile
+        profile = profiles.get(role)
+        if profile is None:
+            raise ModelAccessResolutionError(
+                f"declared census has no profile for role: {role}"
+            )
+        intent = request.intent
+        if intent.fallback_requirement != "fallback_forbidden":
+            raise ModelAccessResolutionError(
+                "Builder Model Inquiry policy forbids any fallback requirement other than "
+                "fallback_forbidden"
+            )
+        if intent.capability_tier != profile.capability_tier:
+            raise ModelAccessResolutionError(
+                "declared intent capability tier does not match the census role profile"
+            )
+        if request.resolution_group_id != profile.resolution_group:
+            raise ModelAccessResolutionError(
+                "declared intent resolution group does not match the census role profile"
+            )
+        group = next(
+            (
+                item
+                for item in self.census.runtime_channels.resolution_groups
+                if item.id == profile.resolution_group
+            ),
+            None,
+        )
+        if group is None:
+            raise ModelAccessResolutionError(
+                "declared census has no matching resolution group"
+            )
+        if intent.independence != group.independence:
+            raise ModelAccessResolutionError(
+                "declared intent independence does not match the census resolution group"
+            )
+        provider = self._provider(profile.provider)
+        if provider.id.lower() in NON_PROVIDER_IDENTITIES or provider.tier == "test":
+            raise ModelAccessResolutionError(
+                "provider-enabled roles cannot resolve a mock identity"
+            )
+        model = next((item for item in provider.models if item.id == profile.model), None)
+        if model is None:
+            raise ModelAccessResolutionError(
+                "declared census profile references an undeclared model"
+            )
+        capabilities = self._capabilities(provider, model.capabilities)
+        missing = sorted(
+            capability
+            for capability in profile.requires
+            if not getattr(capabilities, capability)
+        )
+        if missing:
+            raise ModelAccessResolutionError(
+                "declared target does not satisfy census-required capabilities: "
+                + ", ".join(missing)
+            )
+        credential = self._credential_identity(
+            profile,
+            provider,
+            role=role,
+            channel=channel,
+            consumer=consumer,
+        )
+        try:
+            return ResolvedModelAccess(
+                request=request,
+                provider=provider.id,
+                model=model.id,
+                adapter_id=f"{provider.id}-{model.id}",
+                effective_identity=model.effective_identity,
+                capabilities=capabilities,
+                credential_identity_ref=credential,
+            )
+        except ValueError as exc:
+            raise ModelAccessResolutionError(str(exc)) from exc
+
+    def _capabilities(self, provider: ProviderEntry, model_capabilities: object) -> ModelCapabilities:
+        resolved = {
+            field: bool(
+                getattr(model_capabilities, field) or getattr(provider.capabilities, field)
+            )
+            for field in _CAPABILITY_FIELDS
+        }
+        dimension = getattr(model_capabilities, "embedding_dimensions", None) or getattr(
+            provider.capabilities, "embedding_dimensions", None
+        )
+        return ModelCapabilities(**resolved, embedding_dimension=dimension)
+
+    def _credential_identity(
+        self,
+        profile: RoleProfile,
+        provider: ProviderEntry,
+        *,
+        role: str,
+        channel: str,
+        consumer: str,
+    ) -> str:
+        credential = profile.credential_identifier
+        if credential not in provider.credential_identifiers:
+            raise ModelAccessResolutionError(
+                "declared census role profile uses an undeclared provider credential"
+            )
+        try:
+            required = self.contract.required_secrets_for_role(consumer=consumer, role=role)
+            self.contract.require_declared(
+                channel=channel,
+                consumer=consumer,
+                secret=credential,
+            )
+        except UndeclaredSecretConsumerError as exc:
+            raise ModelAccessResolutionError(
+                "host secret contract does not declare this role credential"
+            ) from exc
+        if required != (credential,):
+            raise ModelAccessResolutionError(
+                "host secret contract role requirement does not match the census credential"
+            )
+        return credential
+
+    def _provider(self, provider_id: str) -> ProviderEntry:
+        try:
+            return self.census.provider(provider_id)
+        except KeyError as exc:
+            raise ModelAccessResolutionError(
+                f"declared census has no provider: {provider_id}"
+            ) from exc
+
+
+__all__ = [
+    "BUILDER_RUNTIME",
+    "MODEL_INQUIRY_CONSUMER",
+    "MODEL_INQUIRY_RESOLUTION_GROUP",
+    "BuilderModelAccessResolver",
+    "DeclaredCredentialUnavailableError",
+    "ModelAccessResolutionError",
+]

--- a/app/builderops/model_inquiry.py
+++ b/app/builderops/model_inquiry.py
@@ -44,6 +44,9 @@ SYNTHESIS_SCHEMA = "builderops.model-inquiry-synthesis.v1"
 READINESS_SCHEMA = "builderops.model-inquiry-readiness.v1"
 PROMOTION_INTENT_SCHEMA = "builderops.model-inquiry-promotion-intent.v1"
 SAFE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
+# Mirrors the declared logical-secret grammar in app/ops/host_secret_contract.py.
+CREDENTIAL_IDENTITY_RE = re.compile(r"[a-z][a-z0-9]{0,15}\.[a-z][a-z0-9-]{0,15}\Z")
+CREDENTIAL_ATTEMPT_REQUEST_ID = "adapter_req_credential"
 READINESS_OUTCOMES = frozenset({"issue_ready", "needs_input", "not_ready"})
 TERMINAL_TURN_OUTCOMES = frozenset({"accepted", "completed", "failed", "not_ready", "refused"})
 RUN_TERMINAL_OUTCOMES = frozenset(
@@ -2013,6 +2016,23 @@ def _validate_provider_attempt_receipt(
         ):
             raise BuilderOpsValidationError("invalid configuration attempt receipt")
         return
+    if request_id == CREDENTIAL_ATTEMPT_REQUEST_ID:
+        # A declared credential that is absent or unusable fails closed before a
+        # request packet exists, so this reserved attempt carries the classified
+        # diagnostic and the logical identifier instead of turn hashes.
+        if (
+            outcome != "provider_error"
+            or set(details) != {"adapter_request_id", "classification", "diagnostic"}
+            or details.get("classification") != "declared credential unavailable"
+        ):
+            raise BuilderOpsValidationError("invalid credential attempt receipt")
+        _validate_adapter_failure_diagnostic(details["diagnostic"])
+        diagnostic = cast(Mapping[str, Any], details["diagnostic"])
+        if diagnostic.get("adapter_failure_class") != "credential_unavailable" or not diagnostic.get(
+            "credential_identity_ref"
+        ):
+            raise BuilderOpsValidationError("invalid credential attempt receipt")
+        return
     expected_classifications = {
         "provider_refused": "provider returned explicit refusal",
         "malformed_output": "provider output failed strict response validation",
@@ -2052,12 +2072,23 @@ def _validate_adapter_failure_diagnostic(value: Any) -> None:
         raise BuilderOpsValidationError("adapter failure diagnostic must be an object")
     expected_fields = {"adapter_id", "adapter_failure_class"}
     optional_exit_code = "adapter_exit_code"
-    if set(value) not in (expected_fields, { *expected_fields, optional_exit_code }):
+    optional_credential = "credential_identity_ref"
+    if not expected_fields <= set(value) or not set(value) <= {
+        *expected_fields,
+        optional_exit_code,
+        optional_credential,
+    }:
         raise BuilderOpsValidationError("invalid adapter failure diagnostic fields")
     _safe_id(str(value.get("adapter_id", "")), "adapter failure adapter_id")
     failure_class = value.get("adapter_failure_class")
     if not isinstance(failure_class, str) or failure_class not in ADAPTER_FAILURE_CLASSES:
         raise BuilderOpsValidationError("invalid adapter failure class")
+    if optional_credential in value:
+        credential = value[optional_credential]
+        # Declared logical identifier grammar only: no value, environment name,
+        # provider secret, or host path can satisfy it.
+        if not isinstance(credential, str) or not CREDENTIAL_IDENTITY_RE.fullmatch(credential):
+            raise BuilderOpsValidationError("invalid credential identity reference")
     if optional_exit_code in value:
         exit_code = value[optional_exit_code]
         if (

--- a/app/builderops/model_inquiry_adapters.py
+++ b/app/builderops/model_inquiry_adapters.py
@@ -16,19 +16,75 @@ from typing import Any, Mapping, Never
 
 import requests  # type: ignore[import-untyped]  # third-party lib ships no type stubs
 
+from app.builderops.model_access_resolver import (
+    BuilderModelAccessResolver,
+    DeclaredCredentialUnavailableError,
+    ModelAccessResolutionError,
+)
 from app.builderops.model_inquiry_contract import canonical_hash, canonical_json
 from app.builderops.models import BuilderOpsValidationError
 from llm_contract import (
     ADAPTER_FAILURE_CLASSES,
     AdapterResult,
+    ModelAccessIntent,
+    ModelResolutionRequest,
     ModelTurnAdapter,
+    ResolvedModelAccess,
     validate_adapter_failure_class,
 )
 
-ADAPTER_CONFIG_ENV = "BUILDEROPS_INQUIRY_ADAPTERS_JSON"
+INQUIRY_INTENT_CONFIG_ENV = "BUILDEROPS_INQUIRY_ROLE_INTENT_JSON"
+INQUIRY_INTENT_SCHEMA = "builderops.model-inquiry-role-intent.v1"
 ROLE_NAMES = ("fable", "gpt_codex")
 SUBSCRIPTION_ADAPTER_TIMEOUT_EXIT_CODE = 124
+SUBSCRIPTION_ADAPTER_SESSION_EXPIRED_EXIT_CODE = 125
 CLEANUP_TIMEOUT_SECONDS = 2.0
+HTTP_ADAPTER_KIND = "http"
+
+# Conventional exit codes the still-permitted interactive command path uses to
+# report the real cause. Without them an expired session and a genuine command
+# failure collapse into one indistinguishable class.
+_LOCAL_COMMAND_FAILURE_CLASSES = {
+    SUBSCRIPTION_ADAPTER_TIMEOUT_EXIT_CODE: "command_timeout",
+    SUBSCRIPTION_ADAPTER_SESSION_EXPIRED_EXIT_CODE: "session_expired",
+}
+
+# The intent surface is provider-free by construction: any key that could carry
+# a provider, model, transport target, credential value, environment-variable
+# name, or host reference is refused before resolution runs.
+FORBIDDEN_INTENT_KEYS = frozenset(
+    {
+        "adapter_id",
+        "api_key",
+        "api_key_env",
+        "argv",
+        "command",
+        "credential",
+        "credential_value",
+        "endpoint",
+        "environment_allowlist",
+        "host",
+        "hostname",
+        "kind",
+        "model",
+        "provider",
+        "url",
+    }
+)
+_INTENT_FIELDS = frozenset(
+    {
+        "capability_tier",
+        "reasoning_effort",
+        "determinism_required",
+        "output_schema_ref",
+        "independence",
+        "fallback_requirement",
+        "side_effect_class",
+    }
+)
+_CONFIG_FIELDS = frozenset({"schema", "runtime", "channel", "consumer", "resolution_group_id", "roles"})
+
+
 class AdapterUnavailableError(RuntimeError):
     pass
 
@@ -50,6 +106,18 @@ class AdapterExecutionError(RuntimeError):
             if isinstance(exit_code, int) and not isinstance(exit_code, bool) and 1 <= exit_code <= 255
             else None
         )
+
+
+class CredentialUnavailableError(AdapterExecutionError):
+    """A declared credential is absent or unusable; it names only the logical id."""
+
+    def __init__(self, *, adapter_id: str, credential_identity_ref: str) -> None:
+        super().__init__(
+            f"declared credential unavailable: {credential_identity_ref}",
+            failure_class="credential_unavailable",
+        )
+        self.adapter_id = adapter_id
+        self.credential_identity_ref = credential_identity_ref
 
 
 @dataclass
@@ -119,10 +187,8 @@ class LocalCommandAdapter:
         if process.returncode != 0:
             raise AdapterExecutionError(
                 f"local command failed with exit {process.returncode}: {self.adapter_id}",
-                failure_class=(
-                    "command_timeout"
-                    if process.returncode == SUBSCRIPTION_ADAPTER_TIMEOUT_EXIT_CODE
-                    else "command_exit_nonzero"
+                failure_class=_LOCAL_COMMAND_FAILURE_CLASSES.get(
+                    process.returncode, "command_exit_nonzero"
                 ),
                 exit_code=process.returncode,
             )
@@ -248,51 +314,168 @@ class HttpModelAdapter:
         return AdapterResult(text, str(request_id) if request_id else None)
 
 
-def load_adapter_descriptors(env: Mapping[str, str] | None = None) -> dict[str, dict[str, Any]]:
+@dataclass(frozen=True)
+class InquiryRoleIntentConfig:
+    """One parsed, provider-free inquiry-role intent configuration."""
+
+    runtime: str
+    channel: str
+    consumer: str
+    resolution_group_id: str
+    requests: tuple[ModelResolutionRequest, ...]
+
+
+def load_inquiry_intent(
+    env: Mapping[str, str] | None = None,
+) -> InquiryRoleIntentConfig | None:
+    """Parse the value-free inquiry-role intent configuration, or return None.
+
+    The configuration declares only the seven neutral intent fields per role,
+    the role independence requirement, and channel/consumer references. Provider,
+    model, transport target, credential value, environment-variable name, and
+    host references are structurally refused here, before any resolution runs.
+    """
     source = dict(os.environ if env is None else env)
-    raw = source.get(ADAPTER_CONFIG_ENV, "").strip()
+    raw = source.get(INQUIRY_INTENT_CONFIG_ENV, "").strip()
     if not raw:
-        return {
-            role: {"role": role, "available": False, "reason": "explicit adapter not configured"}
-            for role in ROLE_NAMES
-        }
+        return None
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise BuilderOpsValidationError(f"{ADAPTER_CONFIG_ENV} must be valid JSON") from exc
+        raise BuilderOpsValidationError(
+            f"{INQUIRY_INTENT_CONFIG_ENV} must be valid JSON"
+        ) from exc
+    return parse_inquiry_intent(payload)
+
+
+def parse_inquiry_intent(payload: Any) -> InquiryRoleIntentConfig:
+    """Validate one inquiry-role intent document into neutral resolution requests."""
     if not isinstance(payload, dict):
-        raise BuilderOpsValidationError(f"{ADAPTER_CONFIG_ENV} must be a JSON object")
+        raise BuilderOpsValidationError(
+            f"{INQUIRY_INTENT_CONFIG_ENV} must be a JSON object"
+        )
+    _reject_forbidden_intent_keys(payload)
+    if set(payload) != _CONFIG_FIELDS:
+        raise BuilderOpsValidationError("inquiry role intent fields are invalid")
+    if payload["schema"] != INQUIRY_INTENT_SCHEMA:
+        raise BuilderOpsValidationError("inquiry role intent schema is unsupported")
+    roles = payload["roles"]
+    if not isinstance(roles, dict) or set(roles) != set(ROLE_NAMES):
+        raise BuilderOpsValidationError(
+            "inquiry role intent must declare exactly the independent review roles"
+        )
+    group_id = str(payload["resolution_group_id"])
+    requests: list[ModelResolutionRequest] = []
+    for role in ROLE_NAMES:
+        intent_payload = roles[role]
+        if not isinstance(intent_payload, dict) or set(intent_payload) != _INTENT_FIELDS:
+            raise BuilderOpsValidationError(
+                f"inquiry role intent for {role} must declare exactly the neutral fields"
+            )
+        try:
+            intent = ModelAccessIntent(**intent_payload)
+            requests.append(
+                ModelResolutionRequest(
+                    intent=intent,
+                    role_profile=role,
+                    resolution_group_id=group_id,
+                )
+            )
+        except ValueError as exc:
+            raise BuilderOpsValidationError(
+                f"inquiry role intent for {role} is not a valid neutral intent"
+            ) from exc
+    return InquiryRoleIntentConfig(
+        runtime=str(payload["runtime"]),
+        channel=str(payload["channel"]),
+        consumer=str(payload["consumer"]),
+        resolution_group_id=group_id,
+        requests=tuple(requests),
+    )
+
+
+def _reject_forbidden_intent_keys(value: Any) -> None:
+    if isinstance(value, Mapping):
+        forbidden = sorted(FORBIDDEN_INTENT_KEYS.intersection(str(key).lower() for key in value))
+        if forbidden:
+            raise BuilderOpsValidationError(
+                "inquiry role intent must not declare provider, model, transport, "
+                f"credential, or host fields: {', '.join(forbidden)}"
+            )
+        for nested in value.values():
+            _reject_forbidden_intent_keys(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            _reject_forbidden_intent_keys(nested)
+
+
+def resolve_inquiry_roles(
+    env: Mapping[str, str] | None = None,
+    *,
+    resolver: BuilderModelAccessResolver | None = None,
+) -> tuple[BuilderModelAccessResolver, dict[str, ResolvedModelAccess]]:
+    """Resolve both inquiry roles as one group through Builder census policy."""
+    source = dict(os.environ if env is None else env)
+    config = load_inquiry_intent(source)
+    if config is None:
+        raise AdapterUnavailableError("inquiry role intent is not configured")
+    selected = resolver or BuilderModelAccessResolver.from_declared_sources(env=source)
+    resolutions = selected.resolve_group(
+        config.requests,
+        runtime=config.runtime,
+        channel=config.channel,
+        consumer=config.consumer,
+    )
+    return selected, {
+        resolution.request.role_profile: resolution for resolution in resolutions
+    }
+
+
+def load_adapter_descriptors(
+    env: Mapping[str, str] | None = None,
+    *,
+    resolver: BuilderModelAccessResolver | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Project the resolved role targets into sanitized, value-free descriptors."""
+    source = dict(os.environ if env is None else env)
+    try:
+        selected, resolutions = resolve_inquiry_roles(source, resolver=resolver)
+    except AdapterUnavailableError:
+        return {
+            role: {"role": role, "available": False, "reason": "inquiry role intent not configured"}
+            for role in ROLE_NAMES
+        }
+    except ModelAccessResolutionError as exc:
+        return {
+            role: {"role": role, "available": False, "reason": str(exc)}
+            for role in ROLE_NAMES
+        }
     descriptors: dict[str, dict[str, Any]] = {}
     for role in ROLE_NAMES:
-        config = payload.get(role)
-        if not isinstance(config, dict):
-            descriptors[role] = {
-                "role": role,
-                "available": False,
-                "reason": "explicit adapter not configured",
-            }
+        resolution = resolutions[role]
+        try:
+            endpoint = selected.endpoint_for(resolution)
+        except ModelAccessResolutionError as exc:
+            descriptors[role] = {"role": role, "available": False, "reason": str(exc)}
             continue
-        kind = str(config.get("kind", "")).strip().lower()
         descriptors[role] = {
             "role": role,
-            "available": kind in {"command", "openai", "anthropic"},
-            "role_identity": str(config.get("role_identity", "")).strip(),
-            "kind": kind,
-            "adapter_id": str(config.get("adapter_id", "")).strip(),
-            "provider": str(config.get("provider", "")).strip(),
-            "model": str(config.get("model", "")).strip(),
+            "available": True,
+            "role_identity": resolution.request.role_profile,
+            "kind": HTTP_ADAPTER_KIND,
+            "adapter_id": resolution.adapter_id,
+            "provider": resolution.provider,
+            "model": resolution.model,
+            "credential_identity_ref": resolution.credential_identity_ref,
             "target_fingerprint": canonical_hash(
                 {
-                    "kind": kind,
-                    "provider": str(config.get("provider", "")).strip(),
-                    "model": str(config.get("model", "")).strip(),
-                    "target": config.get("argv") if kind == "command" else config.get("endpoint"),
+                    "kind": HTTP_ADAPTER_KIND,
+                    "provider": resolution.provider,
+                    "model": resolution.model,
+                    "target": endpoint,
                 }
             ),
         }
-        if not all(descriptors[role].get(key) for key in ("adapter_id", "provider", "model")):
-            descriptors[role]["available"] = False
-            descriptors[role]["reason"] = "adapter identity is incomplete"
         if descriptors[role]["role_identity"] != role:
             descriptors[role]["available"] = False
             descriptors[role]["reason"] = f"role_identity must explicitly attest {role}"
@@ -320,53 +503,43 @@ def load_adapter_descriptors(env: Mapping[str, str] | None = None) -> dict[str, 
     return descriptors
 
 
-def load_adapters(env: Mapping[str, str] | None = None) -> dict[str, ModelTurnAdapter]:
+def load_adapters(
+    env: Mapping[str, str] | None = None,
+    *,
+    resolver: BuilderModelAccessResolver | None = None,
+) -> dict[str, ModelTurnAdapter]:
+    """Build provider-API adapters with credentials injected at descriptor load.
+
+    Every identity is a resolver output and every credential is resolved through
+    the host secret contract. No provider key is read from caller configuration
+    or ambient process environment, and no missing credential falls back to a
+    subscription CLI, another provider, or a mock identity.
+    """
     source = dict(os.environ if env is None else env)
-    descriptors = load_adapter_descriptors(source)
-    raw = source.get(ADAPTER_CONFIG_ENV, "").strip()
-    payload = json.loads(raw) if raw else {}
+    selected, resolutions = resolve_inquiry_roles(source, resolver=resolver)
+    descriptors = load_adapter_descriptors(source, resolver=selected)
     adapters: dict[str, ModelTurnAdapter] = {}
     for role in ROLE_NAMES:
         descriptor = descriptors[role]
         if not descriptor.get("available"):
-            raise AdapterUnavailableError(f"{role}: {descriptor.get('reason', 'adapter unavailable')}")
-        config = payload[role]
-        common = {
-            "adapter_id": descriptor["adapter_id"],
-            "provider": descriptor["provider"],
-            "model": descriptor["model"],
-        }
-        kind = descriptor["kind"]
-        if kind == "command":
-            argv = config.get("argv")
-            if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
-                raise BuilderOpsValidationError(f"{role} command argv must be a list of strings")
-            allow_names = config.get("environment_allowlist", [])
-            if not isinstance(allow_names, list) or not all(
-                isinstance(item, str) for item in allow_names
-            ):
-                raise BuilderOpsValidationError(f"{role} environment_allowlist is invalid")
-            adapters[role] = LocalCommandAdapter(
-                **common,
-                argv=tuple(argv),
-                timeout_seconds=_positive_float(config.get("timeout_seconds", 60), role, "timeout_seconds"),
-                max_output_bytes=_positive_int(
-                    config.get("max_output_bytes", 1_000_000), role, "max_output_bytes"
-                ),
-                environment={name: source[name] for name in allow_names if name in source},
+            raise AdapterUnavailableError(
+                f"{role}: {descriptor.get('reason', 'adapter unavailable')}"
             )
-        else:
-            key_env = str(config.get("api_key_env", "")).strip()
-            endpoint = str(config.get("endpoint", "")).strip()
-            api_key = source.get(key_env, "") if key_env else ""
-            if not endpoint or not api_key:
-                raise AdapterUnavailableError(f"{role}: HTTP endpoint or API key unavailable")
-            adapters[role] = HttpModelAdapter(
-                **common,
-                endpoint=endpoint,
-                api_key=api_key,
-                timeout_seconds=_positive_float(config.get("timeout_seconds", 60), role, "timeout_seconds"),
-            )
+        resolution = resolutions[role]
+        try:
+            api_key = selected.credential_value(resolution)
+        except DeclaredCredentialUnavailableError as exc:
+            raise CredentialUnavailableError(
+                adapter_id=resolution.adapter_id,
+                credential_identity_ref=exc.credential_identity_ref,
+            ) from None
+        adapters[role] = HttpModelAdapter(
+            adapter_id=resolution.adapter_id,
+            provider=resolution.provider,
+            model=resolution.model,
+            endpoint=selected.endpoint_for(resolution),
+            api_key=api_key,
+        )
     return adapters
 
 
@@ -391,29 +564,11 @@ def sanitized_adapter_failure(error: Exception, *, adapter_id: str) -> dict[str,
     }
     if exit_code is not None:
         result["adapter_exit_code"] = exit_code
+    if isinstance(error, CredentialUnavailableError):
+        # The logical identifier only. It is declared, value-free data from the
+        # host secret contract and is the whole point of this failure class.
+        result["credential_identity_ref"] = error.credential_identity_ref
     return result
-
-
-def _positive_float(value: Any, role: str, field: str) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError) as exc:
-        raise BuilderOpsValidationError(f"{role} {field} must be numeric") from exc
-    if parsed <= 0:
-        raise BuilderOpsValidationError(f"{role} {field} must be positive")
-    return parsed
-
-
-def _positive_int(value: Any, role: str, field: str) -> int:
-    if isinstance(value, bool):
-        raise BuilderOpsValidationError(f"{role} {field} must be an integer")
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError) as exc:
-        raise BuilderOpsValidationError(f"{role} {field} must be an integer") from exc
-    if parsed <= 0:
-        raise BuilderOpsValidationError(f"{role} {field} must be positive")
-    return parsed
 
 
 def _read_bounded_process_output(
@@ -647,12 +802,15 @@ def adapter_request_id(request: Mapping[str, Any]) -> str:
 
 
 __all__ = [
-    "ADAPTER_CONFIG_ENV",
     "ADAPTER_FAILURE_CLASSES",
+    "INQUIRY_INTENT_CONFIG_ENV",
+    "INQUIRY_INTENT_SCHEMA",
     "AdapterExecutionError",
     "AdapterResult",
     "AdapterUnavailableError",
+    "CredentialUnavailableError",
     "HttpModelAdapter",
+    "InquiryRoleIntentConfig",
     "LocalCommandAdapter",
     "ModelTurnAdapter",
     "ScriptedAdapter",
@@ -660,5 +818,8 @@ __all__ = [
     "sanitized_adapter_failure",
     "load_adapter_descriptors",
     "load_adapters",
+    "load_inquiry_intent",
+    "parse_inquiry_intent",
+    "resolve_inquiry_roles",
     "sanitized_adapter_identity",
 ]

--- a/app/builderops/model_inquiry_runner.py
+++ b/app/builderops/model_inquiry_runner.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from app.builderops.model_inquiry import ModelInquiryService
+from app.builderops.model_access_resolver import BuilderModelAccessResolver
+from app.builderops.model_inquiry import (
+    CREDENTIAL_ATTEMPT_REQUEST_ID,
+    ModelInquiryService,
+)
 from app.builderops.model_inquiry_adapters import (
     AdapterExecutionError,
     AdapterUnavailableError,
+    CredentialUnavailableError,
     ModelTurnAdapter,
     load_adapter_descriptors,
     load_adapters,
@@ -41,16 +46,20 @@ class ModelInquiryRunner:
         adapters: Mapping[str, ModelTurnAdapter] | None = None,
         *,
         env: Mapping[str, str] | None = None,
+        resolver: BuilderModelAccessResolver | None = None,
     ) -> None:
         self.service = service
         self._adapters = dict(adapters) if adapters is not None else None
         self._env = dict(env) if env is not None else None
+        # Builder resolution authority. Injected only so a caller can bind
+        # declared sources explicitly; it is never a provider or credential.
+        self._resolver = resolver
 
     def plan(self, inquiry_id: str, *, max_rounds: int) -> dict[str, Any]:
         _validate_max_rounds(max_rounds)
         trace = self.service.trace(inquiry_id)
         context = _initial_context(trace)
-        descriptors = load_adapter_descriptors(self._env)
+        descriptors = load_adapter_descriptors(self._env, resolver=self._resolver)
         draft_requests = [
             self._request_packet(
                 trace,
@@ -128,7 +137,11 @@ class ModelInquiryRunner:
             if terminal is not None:
                 return self._finalize_terminal(inquiry_id, terminal, replayed=True)
             try:
-                adapters = self._adapters if self._adapters is not None else load_adapters(self._env)
+                adapters = self._adapters if self._adapters is not None else load_adapters(self._env, resolver=self._resolver)
+            except CredentialUnavailableError as exc:
+                # Fail closed before any adapter call. No subscription CLI, no
+                # ambient environment, and no other provider is attempted.
+                return self._credential_failure(inquiry_id, trace, exc)
             except (AdapterUnavailableError, BuilderOpsValidationError):
                 return self._configuration_failure(
                     inquiry_id,
@@ -500,6 +513,32 @@ class ModelInquiryRunner:
         return self._terminate(
             inquiry_id,
             "provider_unavailable",
+            details,
+            self.service.trace(inquiry_id),
+        )
+
+    def _credential_failure(
+        self,
+        inquiry_id: str,
+        trace: Mapping[str, Any],
+        error: CredentialUnavailableError,
+    ) -> dict[str, Any]:
+        request_id = CREDENTIAL_ATTEMPT_REQUEST_ID
+        details = {
+            "adapter_request_id": request_id,
+            "classification": "declared credential unavailable",
+            "diagnostic": sanitized_adapter_failure(error, adapter_id=error.adapter_id),
+        }
+        self.service.commit_provider_attempt_receipt(
+            inquiry_id,
+            adapter_request_id=request_id,
+            outcome="provider_error",
+            details=details,
+            source_refs=list(trace["source_refs"]),
+        )
+        return self._terminate(
+            inquiry_id,
+            "provider_error",
             details,
             self.service.trace(inquiry_id),
         )

--- a/app/components/settings/providers_loader.py
+++ b/app/components/settings/providers_loader.py
@@ -1,8 +1,11 @@
-"""Strict, tooling-only loader for the declared model-provider census.
+"""Strict loader for the declared model-provider census.
 
-The running Product and Builder paths deliberately retain their compiled local
-provider sets.  This module is an authoring and verification surface, not a
-runtime routing dependency.
+The running Product paths deliberately retain their compiled local provider
+sets, so for Product this module remains an authoring and verification surface
+rather than a routing dependency.  The Builder Model Access resolver
+(`app/builderops/model_access_resolver.py`, ADR-0064 / MAS-05) is the one
+runtime consumer: it selects provider, model, effective identity, and the
+declared credential identifier from these exact mappings.
 """
 
 from __future__ import annotations
@@ -43,6 +46,10 @@ class ProviderEntry(BaseModel):
     kinds: set[Literal["chat", "embedding"]] = Field(min_length=1)
     tier: Literal["local", "paid", "test"]
     capabilities: ProviderCapabilities
+    # Declared provider API endpoint. It is provider-owned census data, never
+    # caller configuration; a runtime resolver reads it and no caller may supply
+    # or override it.
+    api_endpoint: str | None = None
     paid_eligible_task_kinds: list[str] = Field(default_factory=list)
     credential_identifiers: list[str] = Field(default_factory=list)
     excluded_model_families: list[str] = Field(default_factory=list)

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 import ctypes
 import os
@@ -188,6 +188,44 @@ def _validate_secret(kind: str, value: str) -> bool:
             and all(char.isprintable() and not char.isspace() for char in value)
         )
     return False
+
+
+def validate_secret_value(kind: str, value: str) -> bool:
+    """Return whether *value* satisfies the declared validation kind.
+
+    Public so a declared consumer can fail closed on a malformed value using the
+    same rule the bootstrap applies, without duplicating the grammar.
+    """
+    return _validate_secret(kind, value)
+
+
+def load_runtime_secret_values(
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Read the declared bindings this process received from the bootstrap.
+
+    The bootstrap never copies declared bindings into the ambient environment;
+    it materializes one mode-0600 file and names it in
+    ``HOST_SECRET_RUNTIME_ENV_FILE``. This reader is therefore the contract
+    path for a consumer, and it never falls back to ambient environment. An
+    absent or unreadable surface returns no values so the caller fails closed
+    while naming only its logical identifier.
+    """
+    source = os.environ if env is None else env
+    raw_path = str(source.get(HOST_SECRET_RUNTIME_ENV_FILE, "")).strip()
+    if not raw_path:
+        return {}
+    try:
+        content = Path(raw_path).read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    values: dict[str, str] = {}
+    for line in content.splitlines():
+        name, separator, value = line.partition("=")
+        if not separator or not name.strip():
+            continue
+        values[name.strip()] = value
+    return values
 
 
 def _secret_failure(*, secret: str, kind: str) -> HostSecretBootstrapError:

--- a/config/builderops/model_inquiry_role_intent.example.json
+++ b/config/builderops/model_inquiry_role_intent.example.json
@@ -1,0 +1,27 @@
+{
+  "schema": "builderops.model-inquiry-role-intent.v1",
+  "runtime": "builder",
+  "channel": "dev",
+  "consumer": "builderops-model-inquiry",
+  "resolution_group_id": "model-inquiry-independent-review",
+  "roles": {
+    "fable": {
+      "capability_tier": "frontier",
+      "reasoning_effort": "xhigh",
+      "determinism_required": false,
+      "output_schema_ref": "builderops.model-turn-response.v1",
+      "independence": "distinct_effective_target",
+      "fallback_requirement": "fallback_forbidden",
+      "side_effect_class": "advisory_review"
+    },
+    "gpt_codex": {
+      "capability_tier": "frontier",
+      "reasoning_effort": "xhigh",
+      "determinism_required": false,
+      "output_schema_ref": "builderops.model-turn-response.v1",
+      "independence": "distinct_effective_target",
+      "fallback_requirement": "fallback_forbidden",
+      "side_effect_class": "advisory_review"
+    }
+  }
+}

--- a/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
@@ -17,68 +17,64 @@ Make model interaction executable without relying on copy-paste or desktop-windo
 
 ## What This Task Does
 
-Define one structured response contract and adapter boundary. Support configured OpenAI/Anthropic
-API adapters or explicitly configured local commands. Run independent drafts before cross-review,
-limit adversarial rounds, and persist provider request IDs and output hashes.
+Define one structured response contract and adapter boundary. Resolve both role adapters through the
+declared Model Access substrate, run independent drafts before cross-review, limit adversarial
+rounds, and persist provider request IDs and output hashes.
 
 The implementation uses a BuilderOps-only adapter boundary; it does not reuse Product/Runtime LLM
 routing because that surface returns text without the required provider envelope and may select a
-mock fallback. Role adapters are configured explicitly through the machine-local
-`BUILDEROPS_INQUIRY_ADAPTERS_JSON` environment value. The shared vault stores only sanitized
-identity, request IDs, hashes, structured output, and classified receipts.
+mock fallback. Since MAS-05 (ADR-0064), **the caller declares intent and resolves nothing itself**:
 
-Each role configuration must explicitly set matching `role_identity`, a non-mock provider, and a
-distinct adapter ID plus runtime-target fingerprint. This is operator attestation, not proof that a
-remote model is genuinely Fable; parent acceptance must retain provider-returned request evidence.
-Example shape (credentials stay in the separately named local environment variable):
+- The caller supplies `BUILDEROPS_INQUIRY_ROLE_INTENT_JSON`, a value-free document carrying the seven
+  neutral intent fields per role, the role independence requirement, and channel/consumer references.
+  It carries no provider, model, endpoint, credential value, environment-variable name, or host
+  identifier. The committed example is
+  `config/builderops/model_inquiry_role_intent.example.json`.
+- The Builder resolver (`app/builderops/model_access_resolver.py`) applies Builder policy, selects
+  provider, model, effective identity, and API endpoint from the exact declared provider census
+  (`docs/settings/models/providers.yaml`), verifies the census-required capabilities, and verifies
+  distinct effective targets for the `model-inquiry-independent-review` group through the neutral
+  kernel before any model call.
+- **Credentials are resolved through the host secret contract, not through a machine-local
+  environment value.** The resolver maps each role to its declared logical identifier
+  (`anthropic.api-key`, `gpt_codex` → `openai.api-key`) via
+  `config/secrets/host_secret_contract.json`, and reads the value only from the mode-0600 runtime
+  surface that `app/ops/host_secret_bootstrap.py` materializes. No role adapter reads a provider key
+  from adapter configuration or from ambient process environment.
+- A declared credential that is absent or malformed produces the typed `credential_unavailable`
+  failure class, fails the run closed before any adapter call, names only the logical identifier, and
+  never falls back to a subscription CLI, ambient environment, or another provider. An expired
+  session on the still-permitted interactive command path produces `session_expired`. Neither
+  collapses into `command_exit_nonzero`.
 
-```json
-{
-  "fable": {
-    "kind": "anthropic",
-    "role_identity": "fable",
-    "adapter_id": "fable-primary",
-    "provider": "anthropic",
-    "model": "configured-fable-model",
-    "endpoint": "https://api.anthropic.com/v1/messages",
-    "api_key_env": "LOCAL_FABLE_API_KEY"
-  },
-  "gpt_codex": {
-    "kind": "openai",
-    "role_identity": "gpt_codex",
-    "adapter_id": "gpt-primary",
-    "provider": "openai",
-    "model": "configured-gpt-model",
-    "endpoint": "https://api.openai.com/v1/chat/completions",
-    "api_key_env": "LOCAL_OPENAI_API_KEY"
-  }
-}
-```
+Role identity remains attested: each role resolves to a distinct `adapter_id` and a distinct
+runtime-target fingerprint, and a mock, fake, or deterministic identity is refused as a
+provider-enabled role. This is declared policy, not proof that a remote model is genuinely Fable;
+parent acceptance must retain provider-returned request evidence. The shared vault stores only
+sanitized identity, request IDs, hashes, structured output, and classified receipts.
 
-A configured remote subscription host may provide local command adapters for both roles. Its
-versioned profile uses explicit `xhigh` reasoning effort for Fable and GPT/Codex, a 1200-second
-inner command deadline, and a 1500-second host adapter deadline. Credentials, subscription sessions,
-and host-specific executable paths remain outside Git. It never substitutes Codex, Claude,
-Anthropic, OpenAI, mock, or the deterministic dry-run planner for a missing Fable role.
+`scripts/model_inquiry_subscription_adapter.py` remains for interactive, human-driven use. Its
+versioned profile uses explicit `xhigh` reasoning effort for Fable and GPT/Codex, a 1200-second inner
+command deadline, and a 1500-second host adapter deadline. It is not reachable from any headless
+entrypoint: the inquiry-role intent surface cannot select a command transport, and the host installer
+does not install it.
 
 ## Host role-entrypoint lifecycle
 
-The repository owns the two stable command names consumed by that profile:
-`fable-subscription-cli` and `codex-subscription-cli`. Run
-`scripts/install_model_inquiry_host.py install` to create owner-only executable wrappers in an
-explicit host bin directory. Each wrapper binds exactly one role to the versioned
-`scripts/model_inquiry_subscription_adapter.py`; an exact reinstall is a no-op, while a symlink,
-unsafe directory, or unrelated existing command fails closed without overwriting it.
+The repository owns the two stable headless command names: `fable-model-inquiry-role` and
+`codex-model-inquiry-role`. Run `scripts/install_model_inquiry_host.py install` to create owner-only
+executable wrappers in an explicit host bin directory. Each wrapper binds exactly one role to the
+versioned `scripts/model_inquiry_role_adapter.py`, which resolves a declared credential rather than
+an interactive session; an exact reinstall is a no-op, while a symlink, unsafe directory, or
+unrelated existing command fails closed without overwriting it.
 
 The companion `check` operation is read-only. It reports only whether both installed entrypoints
 match the adapter digest committed into the installer in its own operator-authoritative checkout
 and Python interpreter, whether the launch `PATH` resolves both names to those exact files, and
-whether the underlying `claude`, `codex`, and host launcher commands are discoverable. Host-time
-validation does not invoke Git; an adapter change and its installer digest update are one repo
-change. The recognized
-subscription profile runs the same lineage check during desktop preflight; arbitrary same-name
-executables cannot make it healthy. The check does not run either provider, inspect subscription
-state, reveal paths, or create inquiry artifacts.
+whether the host launcher command is discoverable. It probes no provider CLI, because no headless
+entrypoint depends on one. Host-time validation does not invoke Git; an adapter change and its
+installer digest update are one repo change. The check does not run either provider, inspect
+subscription state, reveal paths, or create inquiry artifacts.
 
 ## Concretely
 
@@ -123,12 +119,13 @@ receipt file. Provider-enabled execution serializes one runner per inquiry on th
 valid turn before any successor, and derives restart progress from deterministic turn IDs plus
 terminal receipts.
 
-Local commands receive canonical JSON on stdin with `shell=False`, an explicit environment
-allowlist, a timeout, and an incremental output ceiling. Stderr is discarded rather than persisted.
-On a command failure, receipts may retain only the allowlisted adapter ID, diagnostic class, and
-numeric exit code when present. HTTP and command adapters reject output containing a configured
-credential value. Raw provider errors, headers, argv, inherited environment, and credentials never
-enter receipts or trace.
+Local commands on the interactive path receive canonical JSON on stdin with `shell=False`, an
+explicit environment allowlist, a timeout, and an incremental output ceiling. Stderr is discarded
+rather than persisted. On a failure, receipts may retain only the allowlisted adapter ID, diagnostic
+class, the numeric exit code when present, and — for `credential_unavailable` — the declared logical
+credential identifier. HTTP and command adapters reject output containing a configured credential
+value. Raw provider errors, headers, argv, inherited environment, and credential values never enter
+receipts or trace.
 
 ## Out of Scope
 

--- a/docs/settings/models/providers.yaml
+++ b/docs/settings/models/providers.yaml
@@ -4,6 +4,7 @@ providers:
     kinds: [chat]
     tier: paid
     capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+    api_endpoint: https://api.anthropic.com/v1/messages
     paid_eligible_task_kinds: []
     credential_identifiers: [anthropic.api-key]
     excluded_model_families: []
@@ -65,6 +66,7 @@ providers:
     kinds: [chat]
     tier: paid
     capabilities: {structured_output: true, native_tools: true, system_prompt_channel: true}
+    api_endpoint: https://api.openai.com/v1/chat/completions
     paid_eligible_task_kinds: []
     credential_identifiers: [openai.api-key]
     excluded_model_families: []

--- a/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
+++ b/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
@@ -48,9 +48,11 @@ Work top to bottom; stop and report if a step fails.
 
 ## BuilderOps Model Inquiry host entrypoints
 
-The Model Inquiry launcher expects two stable host commands:
-`fable-subscription-cli` and `codex-subscription-cli`. Install them as durable,
-owner-only wrappers bound to the current repository checkout:
+The Model Inquiry host owns two stable headless role commands:
+`fable-model-inquiry-role` and `codex-model-inquiry-role`. They resolve declared
+credentials through the host secret contract and require no interactive
+subscription session. Install them as durable, owner-only wrappers bound to the
+current repository checkout:
 
 ```bash
 repo_root="$(git rev-parse --show-toplevel)"
@@ -81,10 +83,12 @@ python3 "$repo_root/scripts/install_model_inquiry_host.py" check \
 
 The check succeeds only when both wrappers match the selected checkout and
 interpreter, the current `PATH` resolves both role names to those exact wrapper
-files, and the underlying `claude`, `codex`, and `yggdrasil-model-inquiry`
-commands are discoverable. It does not invoke either provider or inspect
-authentication. If the host needs a GUI-session proxy for subscription access,
-configure that separately outside Git and rerun the check afterward.
+files, and `yggdrasil-model-inquiry` is discoverable. It probes no provider CLI,
+because no headless entrypoint depends on one, and it does not invoke a provider
+or inspect authentication. Provider access instead requires the declared
+`anthropic.api-key` and `openai.api-key` Keychain items for the consumer
+`builderops-model-inquiry`; a missing value fails a run closed as
+`credential_unavailable` naming only that logical identifier.
 
 After a reboot or checkout promotion, run the same `check` command through the
 actual non-interactive transport:

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -21,19 +21,24 @@ from typing import Sequence
 SCHEMA_INSTALL = "builderops.model-inquiry-host-install.v1"
 SCHEMA_CHECK = "builderops.model-inquiry-host-check.v1"
 TRUSTED_REPO_ROOT = Path(__file__).resolve().parents[1]
-VERSIONED_ADAPTER_SHA256 = "3d037cded9ba4905c42cbccd0b660dcf2f4f70ea44d55704209e50cb510dbc0b"
+# The installed headless role entrypoints bind to the provider-API role adapter.
+# The interactive subscription adapter is deliberately not installable from here:
+# no headless entrypoint may depend on an interactive subscription session
+# (ADR-0064 §4).
+VERSIONED_ADAPTER_NAME = "model_inquiry_role_adapter.py"
+VERSIONED_ADAPTER_SHA256 = "51510b1e8095f322ec410cf073bdb534b5e8a690e18cfa34c82eff91222aae77"
+CREDENTIAL_RESOLUTION = "host-secret-contract"
 
 
 @dataclass(frozen=True)
 class RoleSpec:
     role: str
     entrypoint: str
-    provider_command: str
 
 
 ROLE_SPECS = (
-    RoleSpec("fable", "fable-subscription-cli", "claude"),
-    RoleSpec("gpt_codex", "codex-subscription-cli", "codex"),
+    RoleSpec("fable", "fable-model-inquiry-role"),
+    RoleSpec("gpt_codex", "codex-model-inquiry-role"),
 )
 
 
@@ -167,18 +172,18 @@ def _resolve_repo_root(path: Path) -> Checkout:
         try:
             adapter_bytes, adapter_details = _read_regular_file_at(
                 scripts_fd,
-                "model_inquiry_subscription_adapter.py",
-                label="versioned subscription adapter",
+                VERSIONED_ADAPTER_NAME,
+                label="versioned role adapter",
             )
         finally:
             os.close(scripts_fd)
         adapter_sha256 = hashlib.sha256(adapter_bytes).hexdigest()
         if adapter_sha256 != VERSIONED_ADAPTER_SHA256:
             raise HostInstallError(
-                "versioned subscription adapter must match the installer digest"
+                "versioned role adapter must match the installer digest"
             )
         _assert_directory_identity(resolved, root_identity, label="repo root")
-        adapter = resolved / "scripts" / "model_inquiry_subscription_adapter.py"
+        adapter = resolved / "scripts" / VERSIONED_ADAPTER_NAME
         return Checkout(
             resolved,
             adapter,
@@ -225,9 +230,10 @@ def _wrapper_content(
     return (
         "#!/bin/sh\n"
         f"# adapter-sha256={adapter_sha256}\n"
+        f"# credential-resolution={CREDENTIAL_RESOLUTION}\n"
         "set -eu\n"
-        f"INQUIRY_ROLE={shlex.quote(role)} "
-        f"exec {shlex.quote(str(python))} {shlex.quote(str(adapter))}\n"
+        f"exec {shlex.quote(str(python))} {shlex.quote(str(adapter))} "
+        f"--role {shlex.quote(role)}\n"
     )
 
 
@@ -248,8 +254,8 @@ def _assert_adapter_identity(checkout: Checkout) -> None:
         try:
             adapter_bytes, adapter_details = _read_regular_file_at(
                 scripts_fd,
-                "model_inquiry_subscription_adapter.py",
-                label="versioned subscription adapter",
+                VERSIONED_ADAPTER_NAME,
+                label="versioned role adapter",
             )
         finally:
             os.close(scripts_fd)
@@ -259,7 +265,7 @@ def _assert_adapter_identity(checkout: Checkout) -> None:
         (adapter_details.st_dev, adapter_details.st_ino) != checkout.adapter_identity
         or hashlib.sha256(adapter_bytes).hexdigest() != checkout.adapter_sha256
     ):
-        raise HostInstallError("versioned subscription adapter identity changed")
+        raise HostInstallError("versioned role adapter identity changed")
 
 
 def _assert_checkout_authority(checkout: Checkout) -> None:
@@ -472,16 +478,13 @@ def check(
                 and path_matches
                 and _entrypoint_matches(directory_fd, spec.entrypoint, content)
             )
-            provider_available = (
-                shutil.which(spec.provider_command, path=command_path) is not None
-            )
-            role_ok = entrypoint_available and provider_available
-            ok = ok and role_ok
+            # No provider CLI is probed: a headless role entrypoint resolves a
+            # declared credential and never an interactive session.
+            ok = ok and entrypoint_available
             roles[spec.role] = {
                 "entrypoint": spec.entrypoint,
                 "entrypoint_status": "available" if entrypoint_available else "unavailable",
-                "provider_command": spec.provider_command,
-                "provider_status": "available" if provider_available else "unavailable",
+                "credential_resolution": CREDENTIAL_RESOLUTION,
             }
         launcher_available = (
             shutil.which("yggdrasil-model-inquiry", path=command_path) is not None

--- a/scripts/model_inquiry_role_adapter.py
+++ b/scripts/model_inquiry_role_adapter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Run one headless Model Inquiry role turn through a declared provider API.
+
+This is the installed headless role entrypoint. It requires no interactive
+subscription session: provider, model, and endpoint are resolved from the
+declared provider census, and the credential is resolved through the host secret
+contract. A declared credential that is absent or unusable fails the process
+closed while naming only its logical identifier.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.builderops.model_inquiry_adapters import (  # noqa: E402
+    ROLE_NAMES,
+    AdapterExecutionError,
+    AdapterUnavailableError,
+    CredentialUnavailableError,
+    load_adapters,
+)
+from app.builderops.models import BuilderOpsValidationError  # noqa: E402
+
+CREDENTIAL_UNAVAILABLE_EXIT_CODE = 1
+CONFIGURATION_EXIT_CODE = 2
+EXECUTION_EXIT_CODE = 3
+
+
+def run_role(role: str, request: object) -> str:
+    """Execute one turn for *role* and return the provider response text."""
+    if role not in ROLE_NAMES:
+        raise BuilderOpsValidationError("--role must name a declared inquiry role")
+    if not isinstance(request, dict):
+        raise BuilderOpsValidationError("role adapter request must be a JSON object")
+    adapters = load_adapters()
+    return adapters[role].execute(request).response_text
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--role", required=True, choices=ROLE_NAMES)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        request = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print("ERROR: role adapter stdin is not valid JSON", file=sys.stderr)
+        return CONFIGURATION_EXIT_CODE
+    try:
+        print(run_role(args.role, request), flush=True)
+    except CredentialUnavailableError as exc:
+        print(
+            "ERROR: declared credential unavailable: "
+            f"{exc.credential_identity_ref}",
+            file=sys.stderr,
+        )
+        return CREDENTIAL_UNAVAILABLE_EXIT_CODE
+    except (AdapterUnavailableError, BuilderOpsValidationError) as exc:
+        print(f"ERROR: role adapter is unavailable: {exc}", file=sys.stderr)
+        return CONFIGURATION_EXIT_CODE
+    except AdapterExecutionError as exc:
+        print(f"ERROR: role adapter execution failed: {exc}", file=sys.stderr)
+        return EXECUTION_EXIT_CODE
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model_inquiry_subscription_adapter.py
+++ b/scripts/model_inquiry_subscription_adapter.py
@@ -16,6 +16,20 @@ from typing import Any, Mapping
 # with the host wrapper's larger 1500-second bound.
 COMMAND_TIMEOUT_SECONDS = 1200
 TIMEOUT_EXIT_CODE = 124
+# An expired interactive session is not a generic command failure. The parent
+# LocalCommandAdapter maps this conventional code to the session_expired
+# diagnostic class so the two never collapse into command_exit_nonzero.
+SESSION_EXPIRED_EXIT_CODE = 125
+SESSION_EXPIRED_MARKERS = (
+    "please run /login",
+    "please log in",
+    "not logged in",
+    "session expired",
+    "session has expired",
+    "authentication required",
+    "unauthorized",
+    "invalid credentials",
+)
 FABLE_MODEL = "claude-fable-5"
 CODEX_MODEL = "gpt-5.6-sol"
 
@@ -92,8 +106,16 @@ def run_role(request: Mapping[str, Any], role: str) -> dict[str, Any]:
         # code to its closed, receipt-safe command_timeout diagnostic class.
         raise SystemExit(TIMEOUT_EXIT_CODE) from exc
     if result.returncode:
+        if _is_expired_session(result.stderr) or _is_expired_session(result.stdout):
+            raise SystemExit(SESSION_EXPIRED_EXIT_CODE)
         raise SystemExit(result.returncode)
     return _response_from_text(result.stdout)
+
+
+def _is_expired_session(text: str) -> bool:
+    """Classify an interactive session failure without echoing provider output."""
+    lowered = (text or "").lower()
+    return any(marker in lowered for marker in SESSION_EXPIRED_MARKERS)
 
 
 def _response_from_text(text: str) -> dict[str, Any]:

--- a/scripts/start_model_inquiry.py
+++ b/scripts/start_model_inquiry.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -20,16 +19,13 @@ if str(REPO_ROOT) not in sys.path:
 from app.builderops.model_inquiry import ModelInquiryService
 from app.builderops.model_inquiry_adapters import (
     ADAPTER_FAILURE_CLASSES,
+    AdapterExecutionError,
     AdapterUnavailableError,
-    LocalCommandAdapter,
     load_adapters,
     sanitized_adapter_identity,
 )
 from app.builderops.models import BuilderOpsValidationError
-from scripts.install_model_inquiry_host import (
-    HostInstallError,
-    check as check_host_entrypoints,
-)
+from scripts.install_model_inquiry_host import CREDENTIAL_RESOLUTION
 
 WORKFLOW = "fable-gpt-architecture"
 SOURCE_REF = "desktop_skill:start-model-inquiry"
@@ -44,82 +40,23 @@ def preflight_dependencies(
     *,
     command_cwd: Path,
 ) -> dict[str, Any]:
-    """Validate the durable store and explicit adapters without mutation."""
+    """Validate the durable store and the resolved role adapters without mutation.
+
+    Building the adapters is the whole preflight: identities come from the
+    declared census and credentials from the host secret contract, so an absent
+    credential fails here rather than after a model call. No interactive
+    subscription session is probed, required, or discovered.
+    """
     ModelInquiryService.from_env(env)
     adapters = load_adapters(env)
-    subscription_entrypoints = {
-        "fable": "fable-subscription-cli",
-        "gpt_codex": "codex-subscription-cli",
-    }
-    if all(
-        isinstance(adapters.get(role), LocalCommandAdapter)
-        and adapters[role].adapter_id == entrypoint
-        and adapters[role].argv == (entrypoint,)
-        for role, entrypoint in subscription_entrypoints.items()
-    ):
-        path = env.get("PATH", os.defpath)
-        discovered = {
-            role: shutil.which(entrypoint, path=path)
-            for role, entrypoint in subscription_entrypoints.items()
-        }
-        if not all(discovered.values()):
-            missing_role = next(role for role, value in discovered.items() if value is None)
-            adapter = adapters[missing_role]
-            raise AdapterUnavailableError(
-                f"{missing_role}: local command unavailable: {adapter.adapter_id}"
-            )
-        bin_dirs = {
-            str(Path(value).absolute().parent)
-            for value in discovered.values()
-            if value is not None
-        }
-        if len(bin_dirs) != 1:
-            raise AdapterUnavailableError(
-                "subscription role entrypoints do not share one validated host bin directory"
-            )
-        try:
-            selected_python = Path(env.get("BUILDEROPS_PYTHON", sys.executable))
-            host_status = check_host_entrypoints(
-                repo_root=command_cwd,
-                bin_dir=Path(bin_dirs.pop()),
-                python=selected_python,
-                path=path,
-            )
-        except HostInstallError as exc:
-            raise AdapterUnavailableError(
-                "subscription role entrypoints failed installed-lineage preflight"
-            ) from exc
-        if not host_status["ok"]:
-            raise AdapterUnavailableError(
-                "subscription role entrypoints failed installed-lineage preflight"
-            )
-    for role, adapter in adapters.items():
-        if not isinstance(adapter, LocalCommandAdapter):
-            continue
-        executable = adapter.argv[0] if adapter.argv else ""
-        path = (adapter.environment or {}).get("PATH", env.get("PATH", os.defpath))
-        if not _command_available(executable, path=path, cwd=command_cwd):
-            raise AdapterUnavailableError(
-                f"{role}: local command unavailable: {adapter.adapter_id}"
-            )
     return {
         "vault": "available",
+        "credential_resolution": CREDENTIAL_RESOLUTION,
         "adapters": {
             role: sanitized_adapter_identity(adapter)
             for role, adapter in sorted(adapters.items())
         },
     }
-
-
-def _command_available(executable: str, *, path: str, cwd: Path) -> bool:
-    if not executable:
-        return False
-    if os.sep in executable:
-        candidate = Path(executable)
-        if not candidate.is_absolute():
-            candidate = cwd / candidate
-        return candidate.is_file() and os.access(candidate, os.X_OK)
-    return shutil.which(executable, path=path) is not None
 
 
 def launch(
@@ -251,6 +188,9 @@ def _desktop_diagnostic(value: Any) -> dict[str, str | int] | None:
     exit_code = candidate.get("adapter_exit_code")
     if isinstance(exit_code, int) and not isinstance(exit_code, bool) and 1 <= exit_code <= 255:
         result["adapter_exit_code"] = exit_code
+    credential = candidate.get("credential_identity_ref")
+    if isinstance(credential, str) and credential:
+        result["credential_identity_ref"] = credential
     return result
 
 
@@ -276,7 +216,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             else args.question
         )
         result = launch(question, max_rounds=args.max_rounds)
-    except (AdapterUnavailableError, BuilderOpsValidationError, LauncherError, OSError) as exc:
+    except (
+        AdapterExecutionError,
+        AdapterUnavailableError,
+        BuilderOpsValidationError,
+        LauncherError,
+        OSError,
+    ) as exc:
         print(f"ERROR: model inquiry preflight/launch failed: {exc}", file=sys.stderr)
         return 2
     print(json.dumps(result, ensure_ascii=False, sort_keys=True), flush=True)

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -270,7 +270,7 @@ def test_model_inquiry_local_host_route_is_identity_gated_and_fail_closed() -> N
 
     for forbidden_bypass in (
         "BUILDEROPS_VAULT_ROOT",
-        "BUILDEROPS_INQUIRY_ADAPTERS_JSON",
+        "BUILDEROPS_INQUIRY_ROLE_INTENT_JSON",
         "scripts/start_model_inquiry.sh",
         "/etc/ssh/ssh_host_ed25519_key",
         "/etc/ssh/ssh_host_rsa_key",

--- a/tests/builderops/inquiry_intent.py
+++ b/tests/builderops/inquiry_intent.py
@@ -1,0 +1,157 @@
+"""Shared fixtures for the provider-free Model Inquiry role intent surface.
+
+Every helper here works through the production surfaces: the committed intent
+example, the declared provider census, and the host secret contract's runtime
+env-file delivery. Nothing fabricates a provider, model, endpoint, or
+environment-variable name on the caller side.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from app.builderops.model_access_resolver import BuilderModelAccessResolver
+
+from app.builderops.model_inquiry_adapters import INQUIRY_INTENT_CONFIG_ENV
+from app.ops.host_secret_bootstrap import HOST_SECRET_RUNTIME_ENV_FILE
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMITTED_INTENT_PATH = (
+    REPO_ROOT / "config" / "builderops" / "model_inquiry_role_intent.example.json"
+)
+COMMITTED_INTENT_CONFIG: dict[str, Any] = json.loads(
+    COMMITTED_INTENT_PATH.read_text(encoding="utf-8")
+)
+CENSUS_PATH = REPO_ROOT / "docs" / "settings" / "models" / "providers.yaml"
+CONTRACT_PATH = REPO_ROOT / "config" / "secrets" / "host_secret_contract.json"
+
+# Declared api-key grammar: trimmed, printable, 20-512 characters.
+DECLARED_TEST_CREDENTIALS = {
+    "ANTHROPIC_API_KEY": "declared-anthropic-credential-0001",
+    "OPENAI_API_KEY": "declared-openai-credential-0001",
+}
+
+
+def intent_config(**overrides: Any) -> dict[str, Any]:
+    """Return the committed intent example, optionally with top-level overrides."""
+    payload = json.loads(json.dumps(COMMITTED_INTENT_CONFIG))
+    payload.update(overrides)
+    return payload
+
+
+def intent_env(**overrides: Any) -> dict[str, str]:
+    """Return an environment carrying only the value-free intent configuration."""
+    return {INQUIRY_INTENT_CONFIG_ENV: json.dumps(intent_config(**overrides))}
+
+
+def runtime_secret_file(
+    directory: Path,
+    values: dict[str, str] | None = None,
+) -> Path:
+    """Materialize the mode-0600 runtime surface the host secret bootstrap writes."""
+    selected = DECLARED_TEST_CREDENTIALS if values is None else values
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "host-secret-runtime.env"
+    path.write_text(
+        "".join(f"{name}={value}\n" for name, value in sorted(selected.items())),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def resolver_for_targets(
+    directory: Path,
+    targets: dict[str, tuple[str, str]],
+) -> "BuilderModelAccessResolver":
+    """Build a resolver whose declared sources map both roles to *targets*."""
+    from app.builderops.model_access_resolver import BuilderModelAccessResolver
+
+    return BuilderModelAccessResolver.from_declared_sources(
+        census_path=census_with_role_targets(directory, targets),
+        contract_path=contract_with_role_targets(directory, targets),
+    )
+
+
+def provisioned_env(directory: Path, **overrides: Any) -> dict[str, str]:
+    """Return intent configuration plus a declared, resolvable credential surface."""
+    return {
+        **intent_env(**overrides),
+        HOST_SECRET_RUNTIME_ENV_FILE: str(runtime_secret_file(directory)),
+    }
+
+
+def census_with_role_targets(
+    directory: Path,
+    targets: dict[str, tuple[str, str]],
+) -> Path:
+    """Write a census whose Model Inquiry role profiles point at *targets*.
+
+    Used to prove that a colliding or non-provider policy mapping is refused by
+    the resolver before any model call, without touching the shipped census.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = yaml.safe_load(CENSUS_PATH.read_text(encoding="utf-8"))
+    providers = {provider["id"]: provider for provider in payload["providers"]}
+    for role, (provider_id, _model) in targets.items():
+        provider = providers[provider_id]
+        credential = _credential_for(provider_id)
+        if credential not in (provider.get("credential_identifiers") or []):
+            provider.setdefault("credential_identifiers", []).append(credential)
+        del role
+    for profiles in payload["runtime_channels"]["model_inquiry_profiles"].values():
+        for profile in profiles:
+            provider_id, model = targets[profile["role"]]
+            profile["provider"] = provider_id
+            profile["model"] = model
+            profile["credential_identifier"] = _credential_for(provider_id)
+    path = directory / "providers.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def contract_with_role_targets(
+    directory: Path,
+    targets: dict[str, tuple[str, str]],
+) -> Path:
+    """Write a host secret contract whose role requirements match *targets*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    declared = {secret["logical_id"] for secret in payload["secrets"]}
+    for consumer in payload["consumers"]:
+        if not consumer["role_requirements"]:
+            continue
+        requirements = {
+            role: [_credential_for(provider_id)]
+            for role, (provider_id, _model) in targets.items()
+        }
+        for secrets in requirements.values():
+            for secret in secrets:
+                if secret not in declared:
+                    payload["secrets"].append(
+                        {
+                            "logical_id": secret,
+                            "child_binding": secret.replace(".", "_")
+                            .replace("-", "_")
+                            .upper(),
+                            "kind": secret.rsplit(".", maxsplit=1)[1],
+                        }
+                    )
+                    declared.add(secret)
+        consumer["role_requirements"] = requirements
+        consumer["secrets"] = sorted(
+            {secret for secrets in requirements.values() for secret in secrets}
+        )
+    path = directory / "host_secret_contract.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _credential_for(provider_id: str) -> str:
+    return f"{provider_id}.api-key"

--- a/tests/builderops/test_model_inquiry_adapters.py
+++ b/tests/builderops/test_model_inquiry_adapters.py
@@ -13,14 +13,21 @@ import pytest
 
 from app.builderops.model_inquiry_adapters import (
     ADAPTER_FAILURE_CLASSES,
-    ADAPTER_CONFIG_ENV,
+    INQUIRY_INTENT_CONFIG_ENV,
     AdapterExecutionError,
     AdapterResult,
+    CredentialUnavailableError,
+    HttpModelAdapter,
     LocalCommandAdapter,
     ModelTurnAdapter,
     ScriptedAdapter,
     load_adapter_descriptors,
+    load_adapters,
+    sanitized_adapter_failure,
 )
+from app.builderops.models import BuilderOpsValidationError
+from app.ops.host_secret_bootstrap import HOST_SECRET_RUNTIME_ENV_FILE
+from app.ops.host_secret_contract import load_host_secret_contract
 from llm_contract import (
     ADAPTER_FAILURE_CLASSES as KERNEL_ADAPTER_FAILURE_CLASSES,
     AdapterResult as KernelAdapterResult,
@@ -28,6 +35,16 @@ from llm_contract import (
 )
 from app.builderops import model_inquiry_adapters as adapters_module
 from app.builderops.model_inquiry_contract import RESPONSE_SCHEMA_VERSION
+from tests.builderops.inquiry_intent import (
+    COMMITTED_INTENT_CONFIG,
+    COMMITTED_INTENT_PATH,
+    CONTRACT_PATH,
+    DECLARED_TEST_CREDENTIALS,
+    intent_config,
+    intent_env,
+    resolver_for_targets,
+    runtime_secret_file,
+)
 
 
 def _response() -> dict[str, object]:
@@ -97,6 +114,32 @@ def test_local_command_adapter_is_bounded_and_secret_safe(tmp_path: Path) -> Non
     )
     with pytest.raises(AdapterExecutionError, match="contained an allowed environment value"):
         echo_secret.execute({"request": True})
+
+    # An injected provider credential leaves no value in the classified
+    # diagnostic a receipt is allowed to retain; only the logical identifier.
+    credential_failure = CredentialUnavailableError(
+        adapter_id="anthropic-configured-model",
+        credential_identity_ref="anthropic.api-key",
+    )
+    diagnostic = sanitized_adapter_failure(
+        credential_failure, adapter_id="anthropic-configured-model"
+    )
+    assert diagnostic == {
+        "adapter_id": "anthropic-configured-model",
+        "adapter_failure_class": "credential_unavailable",
+        "credential_identity_ref": "anthropic.api-key",
+    }
+    assert "credential-sentinel" not in json.dumps(diagnostic)
+    http_adapter = HttpModelAdapter(
+        adapter_id="anthropic-configured-model",
+        provider="anthropic",
+        model="configured-model",
+        endpoint="https://api.anthropic.com/v1/messages",
+        api_key="credential-sentinel",
+    )
+    assert "credential-sentinel" not in json.dumps(
+        adapters_module.sanitized_adapter_identity(http_adapter)
+    )
 
 
 def test_local_command_adapter_translates_process_group_permission_error(
@@ -334,22 +377,154 @@ def test_local_command_adapter_maps_subscription_timeout_exit_to_timeout() -> No
     assert raised.value.exit_code == 124
 
 
-def test_provider_enabled_roles_require_distinct_non_mock_attestation() -> None:
-    config = {
-        role: {
-            "kind": "command",
-            "role_identity": role,
-            "adapter_id": f"{role}-adapter",
-            "provider": "mock",
-            "model": "not-fable",
-            "argv": [sys.executable, "-c", "print('{}')"],
+def test_provider_enabled_roles_require_distinct_non_mock_attestation(
+    tmp_path: Path,
+) -> None:
+    mock_resolver = resolver_for_targets(
+        tmp_path / "mock",
+        {"fable": ("mock", "mock-chat"), "gpt_codex": ("mock", "mock-chat")},
+    )
+    mocked = load_adapter_descriptors(intent_env(), resolver=mock_resolver)
+    assert [item["available"] for item in mocked.values()] == [False, False]
+    assert all("mock" in item["reason"] for item in mocked.values())
+
+    collided_resolver = resolver_for_targets(
+        tmp_path / "collided",
+        {
+            "fable": ("anthropic", "claude-fable-5"),
+            "gpt_codex": ("anthropic", "claude-fable-5"),
+        },
+    )
+    collided = load_adapter_descriptors(intent_env(), resolver=collided_resolver)
+    assert [item["available"] for item in collided.values()] == [False, False]
+    assert all("distinct_effective_target" in item["reason"] for item in collided.values())
+    with pytest.raises(BuilderOpsValidationError, match="distinct_effective_target"):
+        load_adapters(intent_env(), resolver=collided_resolver)
+
+    resolved = load_adapter_descriptors(intent_env())
+    assert resolved["fable"]["adapter_id"] != resolved["gpt_codex"]["adapter_id"]
+    assert (
+        resolved["fable"]["target_fingerprint"]
+        != resolved["gpt_codex"]["target_fingerprint"]
+    )
+
+
+def test_role_credentials_resolve_through_the_host_secret_contract(
+    tmp_path: Path,
+) -> None:
+    contract = load_host_secret_contract(CONTRACT_PATH)
+    descriptors = load_adapter_descriptors(intent_env())
+    for role in ("fable", "gpt_codex"):
+        assert contract.required_secrets_for_role(
+            consumer="builderops-model-inquiry", role=role
+        ) == (descriptors[role]["credential_identity_ref"],)
+
+    secret_file = runtime_secret_file(tmp_path)
+    adapters = load_adapters(
+        {**intent_env(), HOST_SECRET_RUNTIME_ENV_FILE: str(secret_file)}
+    )
+    assert set(adapters) == {"fable", "gpt_codex"}
+    for role, binding in (("fable", "ANTHROPIC_API_KEY"), ("gpt_codex", "OPENAI_API_KEY")):
+        adapter = adapters[role]
+        assert isinstance(adapter, HttpModelAdapter)
+        assert adapter.api_key == DECLARED_TEST_CREDENTIALS[binding]
+
+    # The same values in ambient process environment are not a credential source.
+    with pytest.raises(CredentialUnavailableError) as ambient:
+        load_adapters({**intent_env(), **DECLARED_TEST_CREDENTIALS})
+    assert ambient.value.credential_identity_ref == "anthropic.api-key"
+    assert ambient.value.failure_class == "credential_unavailable"
+
+    # A malformed declared value fails closed rather than reaching a provider.
+    malformed = runtime_secret_file(
+        tmp_path / "malformed",
+        {"ANTHROPIC_API_KEY": "short", "OPENAI_API_KEY": "short"},
+    )
+    with pytest.raises(CredentialUnavailableError) as invalid:
+        load_adapters({**intent_env(), HOST_SECRET_RUNTIME_ENV_FILE: str(malformed)})
+    assert invalid.value.credential_identity_ref == "anthropic.api-key"
+
+    # Caller configuration may not name a credential, its environment binding,
+    # a provider, a model, or a transport target.
+    for forbidden in ("api_key_env", "provider", "model", "endpoint", "argv"):
+        payload = intent_config()
+        payload["roles"]["fable"][forbidden] = "declared-elsewhere"
+        with pytest.raises(BuilderOpsValidationError):
+            load_adapter_descriptors(
+                {INQUIRY_INTENT_CONFIG_ENV: json.dumps(payload)}
+            )
+
+
+def test_committed_inquiry_intent_config_is_provider_free_and_value_free() -> None:
+    raw = COMMITTED_INTENT_PATH.read_text(encoding="utf-8")
+    lowered = raw.lower()
+    for forbidden in (
+        "anthropic",
+        "openai",
+        "claude",
+        "gpt-",
+        "api_key",
+        "api-key",
+        "apikey",
+        "endpoint",
+        "http",
+        "_env",
+        "keychain",
+        "/users/",
+        "ssh",
+        "localhost",
+        "argv",
+        "command",
+    ):
+        assert forbidden not in lowered, forbidden
+    assert set(COMMITTED_INTENT_CONFIG["roles"]) == {"fable", "gpt_codex"}
+    for intent in COMMITTED_INTENT_CONFIG["roles"].values():
+        assert set(intent) == {
+            "capability_tier",
+            "reasoning_effort",
+            "determinism_required",
+            "output_schema_ref",
+            "independence",
+            "fallback_requirement",
+            "side_effect_class",
         }
-        for role in ("fable", "gpt_codex")
-    }
-    descriptors = load_adapter_descriptors({ADAPTER_CONFIG_ENV: json.dumps(config)})
-    assert descriptors["fable"]["available"] is False
-    assert descriptors["gpt_codex"]["available"] is False
-    assert all("mock" in item["reason"] for item in descriptors.values())
+        assert intent["independence"] == "distinct_effective_target"
+        assert intent["fallback_requirement"] == "fallback_forbidden"
+
+    # It validates through the production resolver path and yields the declared
+    # census targets, which the committed document itself never names.
+    descriptors = load_adapter_descriptors(intent_env())
+    assert [descriptors[role]["available"] for role in ("fable", "gpt_codex")] == [
+        True,
+        True,
+    ]
+    assert descriptors["fable"]["provider"] != descriptors["gpt_codex"]["provider"]
+    assert all(
+        descriptor["credential_identity_ref"].endswith(".api-key")
+        for descriptor in descriptors.values()
+    )
+
+
+def test_expired_interactive_session_is_not_a_generic_command_failure() -> None:
+    adapter = LocalCommandAdapter(
+        adapter_id="interactive-session",
+        provider="fable",
+        model="configured-specialist",
+        argv=(
+            sys.executable,
+            "-c",
+            f"import sys; sys.exit({adapters_module.SUBSCRIPTION_ADAPTER_SESSION_EXPIRED_EXIT_CODE})",
+        ),
+        timeout_seconds=5,
+    )
+
+    with pytest.raises(AdapterExecutionError) as raised:
+        adapter.execute({"request": True})
+
+    assert raised.value.failure_class == "session_expired"
+    assert raised.value.exit_code == (
+        adapters_module.SUBSCRIPTION_ADAPTER_SESSION_EXPIRED_EXIT_CODE
+    )
 
 
 def test_auth_failure_classes_are_in_the_closed_vocabulary() -> None:

--- a/tests/builderops/test_model_inquiry_runner.py
+++ b/tests/builderops/test_model_inquiry_runner.py
@@ -12,7 +12,7 @@ from app.builderops.model_inquiry import (
     _validate_adapter_failure_diagnostic,
 )
 from app.builderops.model_inquiry_adapters import (
-    ADAPTER_CONFIG_ENV,
+    INQUIRY_INTENT_CONFIG_ENV,
     AdapterExecutionError,
     AdapterResult,
     ScriptedAdapter,
@@ -20,6 +20,13 @@ from app.builderops.model_inquiry_adapters import (
 from app.builderops.model_inquiry_contract import RESPONSE_SCHEMA_VERSION, canonical_hash
 from app.builderops.model_inquiry_runner import ModelInquiryRunner
 from app.builderops.models import BuilderOpsValidationError
+from tests.builderops.inquiry_intent import (
+    DECLARED_TEST_CREDENTIALS,
+    intent_config,
+    intent_env,
+    provisioned_env,
+    resolver_for_targets,
+)
 
 
 def _start(tmp_path: Path, inquiry_id: str) -> tuple[ModelInquiryService, Path]:
@@ -101,9 +108,13 @@ def test_review_turn_uses_persisted_inputs_and_validates_output(tmp_path: Path) 
     assert not any(turn["turn_id"] == "review-000-gpt_codex" for turn in service.trace("inq_runner_review")["turns"])
 
 
-def test_dry_run_is_deterministic_and_side_effect_free(tmp_path: Path) -> None:
+def test_dry_run_performs_no_adapter_call_and_writes_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service, vault = _start(tmp_path, "inq_runner_dry")
     before = {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()}
+    posts = _forbid_provider_calls(monkeypatch)
     runner = ModelInquiryRunner(service, env={})
 
     first = runner.run("inq_runner_dry", max_rounds=2, dry_run=True)
@@ -112,6 +123,48 @@ def test_dry_run_is_deterministic_and_side_effect_free(tmp_path: Path) -> None:
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
     assert first["unavailable_roles"] == ["fable", "gpt_codex"]
     assert {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()} == before
+
+    # A fully provisioned, resolvable configuration still performs no call and
+    # writes nothing, and a mock identity is still refused as a provider role.
+    provisioned = ModelInquiryRunner(
+        service, env=provisioned_env(tmp_path / "secrets")
+    ).run("inq_runner_dry", max_rounds=2, dry_run=True)
+    assert provisioned["unavailable_roles"] == []
+    assert provisioned["adapter_descriptors"]["fable"]["available"] is True
+
+    mocked = ModelInquiryRunner(
+        service,
+        env=provisioned_env(tmp_path / "secrets"),
+        resolver=resolver_for_targets(
+            tmp_path / "mock-census",
+            {"fable": ("mock", "mock-chat"), "gpt_codex": ("mock", "mock-chat")},
+        ),
+    ).run("inq_runner_dry", max_rounds=2, dry_run=True)
+    assert mocked["unavailable_roles"] == ["fable", "gpt_codex"]
+    assert all(
+        "mock" in descriptor["reason"]
+        for descriptor in mocked["adapter_descriptors"].values()
+    )
+    assert not posts
+    assert {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()} == before
+    assert "credential" not in json.dumps(provisioned).replace(
+        "credential_identity_ref", ""
+    ).replace("anthropic.api-key", "").replace("openai.api-key", "")
+
+
+def _forbid_provider_calls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Fail loudly if any code path reaches a provider transport."""
+    calls: list[str] = []
+
+    def refuse(url: str, **_kwargs: Any) -> None:
+        calls.append(url)
+        raise AssertionError(f"unexpected provider call: {url}")
+
+    monkeypatch.setattr(
+        "app.builderops.model_inquiry_adapters.requests.post",
+        refuse,
+    )
+    return calls
 
 
 @dataclass
@@ -285,29 +338,177 @@ def test_adapter_failures_and_bad_config_are_terminal_without_secret_leak(tmp_pa
 
     inquiry_id = "inq_runner_bad_config"
     service, _ = _start(tmp_path, inquiry_id)
-    config = {
-        "fable": {
-            "kind": "command",
-            "role_identity": "fable",
-            "adapter_id": "fable-command",
-            "provider": "fable",
-            "model": "fable-model",
-            "argv": ["/missing/fable"],
-            "timeout_seconds": "not-a-number",
-        },
-        "gpt_codex": {
-            "kind": "command",
-            "role_identity": "gpt_codex",
-            "adapter_id": "codex-command",
-            "provider": "codex",
-            "model": "codex-model",
-            "argv": ["/missing/codex"],
-        },
-    }
+    config = intent_config()
+    config["roles"]["fable"]["capability_tier"] = "economy"
     result = ModelInquiryRunner(
-        service, env={ADAPTER_CONFIG_ENV: json.dumps(config)}
+        service, env={INQUIRY_INTENT_CONFIG_ENV: json.dumps(config)}
     ).run(inquiry_id, max_rounds=1)
     assert result["outcome"] == "provider_unavailable"
+
+
+class _FakeProviderResponse:
+    """Minimal provider transport double; it never carries a credential back."""
+
+    def __init__(self, provider: str, payload: dict[str, Any]) -> None:
+        self.headers = {
+            "request-id" if provider == "anthropic" else "x-request-id": (
+                f"{'req' if provider == 'anthropic' else 'resp'}_{provider}_fixture"
+            )
+        }
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _provider_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Record provider calls and answer them with schema-valid role responses."""
+    calls: list[dict[str, Any]] = []
+
+    def post(url: str, **kwargs: Any) -> _FakeProviderResponse:
+        body = kwargs["json"]
+        headers = kwargs["headers"]
+        calls.append({"url": url, "model": body["model"], "headers": headers})
+        request = json.loads(
+            body["messages"][-1]["content"]
+            if "messages" in body
+            else body["messages"][0]["content"]
+        )
+        if request["phase"] == "draft":
+            text = _response("draft")
+        else:
+            text = _response(
+                "accept",
+                reviewed=list(request["reviewed_artifact_refs"]),
+                accepted_hash=request["input_artifacts"][0]["artifact_hash"],
+            )
+        if "x-api-key" in headers:
+            return _FakeProviderResponse(
+                "anthropic", {"content": [{"type": "text", "text": text}]}
+            )
+        return _FakeProviderResponse(
+            "openai", {"choices": [{"message": {"content": text}}]}
+        )
+
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.requests.post", post)
+    return calls
+
+
+def test_production_inquiry_resolves_provider_free_intent_through_builder_census(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, vault = _start(tmp_path, "inq_runner_declared")
+    calls = _provider_transport(monkeypatch)
+    env = provisioned_env(tmp_path / "secrets")
+
+    # The caller submits provider-free intent only.
+    submitted = json.dumps(json.loads(env[INQUIRY_INTENT_CONFIG_ENV])).lower()
+    for forbidden in ("anthropic", "openai", "claude", "gpt-5", "api_key", "endpoint"):
+        assert forbidden not in submitted
+
+    result = ModelInquiryRunner(service, env=env).run("inq_runner_declared", max_rounds=1)
+
+    assert result["outcome"] == "consensus"
+    turns = service.trace("inq_runner_declared")["turns"]
+    assert {turn["provider"] for turn in turns} == {"anthropic", "openai"}
+    assert {turn["model"] for turn in turns} == {"claude-fable-5", "gpt-5.6-sol"}
+    assert all(turn["provider_request_id"] for turn in turns)
+    assert {call["url"] for call in calls} == {
+        "https://api.anthropic.com/v1/messages",
+        "https://api.openai.com/v1/chat/completions",
+    }
+    persisted = "".join(
+        path.read_text(encoding="utf-8") for path in vault.rglob("*.json")
+    )
+    for value in DECLARED_TEST_CREDENTIALS.values():
+        assert value not in persisted
+
+
+def test_production_inquiry_resolves_distinct_effective_targets_for_role_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _ = _start(tmp_path, "inq_runner_distinct")
+    calls = _provider_transport(monkeypatch)
+
+    ModelInquiryRunner(
+        service, env=provisioned_env(tmp_path / "secrets")
+    ).run("inq_runner_distinct", max_rounds=1)
+    turns = service.trace("inq_runner_distinct")["turns"]
+    targets = {(turn["provider"], turn["model"], turn["adapter_id"]) for turn in turns}
+    assert len(targets) == 2
+    assert len({turn["adapter_id"] for turn in turns}) == 2
+
+    collided_service, collided_vault = _start(tmp_path, "inq_runner_collided")
+    calls.clear()
+    collided = ModelInquiryRunner(
+        collided_service,
+        env=provisioned_env(tmp_path / "secrets"),
+        resolver=resolver_for_targets(
+            tmp_path / "collided-census",
+            {
+                "fable": ("anthropic", "claude-fable-5"),
+                "gpt_codex": ("anthropic", "claude-fable-5"),
+            },
+        ),
+    ).run("inq_runner_collided", max_rounds=1)
+
+    assert collided["outcome"] == "provider_unavailable"
+    assert calls == []
+    assert collided_service.trace("inq_runner_collided")["turns"] == []
+    assert not list((collided_vault / "model-inquiries" / "inq_runner_collided" / "turns").glob("*"))
+
+
+def test_absent_credential_fails_closed_as_credential_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, vault = _start(tmp_path, "inq_runner_no_credential")
+    posts = _forbid_provider_calls(monkeypatch)
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(
+        "app.builderops.model_inquiry_adapters.subprocess.Popen",
+        lambda argv, **_kwargs: spawned.append(list(argv)),
+    )
+
+    result = ModelInquiryRunner(service, env=intent_env()).run(
+        "inq_runner_no_credential", max_rounds=1
+    )
+
+    assert result["outcome"] == "provider_error"
+    diagnostic = result["details"]["diagnostic"]
+    assert diagnostic["adapter_failure_class"] == "credential_unavailable"
+    assert diagnostic["credential_identity_ref"] == "anthropic.api-key"
+    assert "adapter_exit_code" not in diagnostic
+    # No fallback: no provider transport, no subscription CLI, no second provider.
+    assert posts == []
+    assert spawned == []
+    assert service.trace("inq_runner_no_credential")["turns"] == []
+
+    # The typed class survives the independent persistence-boundary validation.
+    reloaded = ModelInquiryService(vault).trace("inq_runner_no_credential")
+    attempt = next(
+        receipt
+        for receipt in reloaded["receipts"]
+        if receipt["event_type"] == "inquiry_provider_attempt_terminal"
+    )
+    assert attempt["details"]["diagnostic"] == diagnostic
+
+    # Ambient environment is not a credential source either.
+    ambient_service, _ = _start(tmp_path, "inq_runner_ambient")
+    ambient = ModelInquiryRunner(
+        ambient_service, env={**intent_env(), **DECLARED_TEST_CREDENTIALS}
+    ).run("inq_runner_ambient", max_rounds=1)
+    assert ambient["details"]["diagnostic"]["adapter_failure_class"] == (
+        "credential_unavailable"
+    )
+    assert posts == []
 
 
 def test_auth_failure_class_survives_persistence_revalidation(tmp_path: Path) -> None:

--- a/tests/builderops/test_model_inquiry_trace.py
+++ b/tests/builderops/test_model_inquiry_trace.py
@@ -10,6 +10,11 @@ from app.builderops.models import BuilderOpsValidationError, normalize_record
 from app.builderops.model_inquiry_adapters import ScriptedAdapter
 from app.builderops.model_inquiry_contract import RESPONSE_SCHEMA_VERSION, canonical_hash
 from app.builderops.model_inquiry_runner import ModelInquiryRunner
+from tests.builderops.inquiry_intent import (
+    DECLARED_TEST_CREDENTIALS,
+    intent_env,
+    provisioned_env,
+)
 
 
 def test_trace_links_question_turns_and_synthesis(tmp_path: Path) -> None:
@@ -542,3 +547,129 @@ def test_trace_rejects_forged_canonical_run_terminal_receipt(tmp_path: Path) -> 
     )
     with pytest.raises(BuilderOpsValidationError, match="details do not match"):
         failure_service.trace("inq_test_false_failure")
+
+
+def test_trace_never_contains_credential_material(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolved credential never reaches a durable turn, receipt, or report."""
+    vault = tmp_path / "shared-vault"
+    vault.mkdir()
+    source_refs = [{"ref_type": "github_issue", "ref": "#4291"}]
+    service = ModelInquiryService(vault)
+    service.start(
+        question="Prove credential material stays out of durable state",
+        workflow="fable-gpt-architecture",
+        inquiry_id="inq_test_credential_trace",
+        source_refs=source_refs,
+    )
+
+    def post(url: str, **kwargs: object) -> object:
+        headers = kwargs["headers"]
+        assert isinstance(headers, dict)
+        # The credential reaches the transport and nothing else.
+        assert any(
+            value in DECLARED_TEST_CREDENTIALS.values()
+            for value in headers.values()
+            if isinstance(value, str)
+        ) or any(
+            credential in str(value)
+            for credential in DECLARED_TEST_CREDENTIALS.values()
+            for value in headers.values()
+        )
+        body = kwargs["json"]
+        assert isinstance(body, dict)
+        request = json.loads(body["messages"][-1]["content"])
+        if request["phase"] == "draft":
+            text = _credential_trace_response("draft")
+        else:
+            text = _credential_trace_response(
+                "accept",
+                reviewed=list(request["reviewed_artifact_refs"]),
+                accepted_hash=request["input_artifacts"][0]["artifact_hash"],
+            )
+        if "x-api-key" in headers:
+            return _CredentialTraceResponse(
+                {"content": [{"type": "text", "text": text}]},
+                {"request-id": "req_anthropic_fixture"},
+            )
+        return _CredentialTraceResponse(
+            {"choices": [{"message": {"content": text}}]},
+            {"x-request-id": "resp_openai_fixture"},
+        )
+
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.requests.post", post)
+    result = ModelInquiryRunner(
+        service, env=provisioned_env(tmp_path / "secrets")
+    ).run("inq_test_credential_trace", max_rounds=1)
+    assert result["outcome"] == "consensus"
+
+    trace = ModelInquiryService(vault).trace("inq_test_credential_trace")
+    serialized = json.dumps(trace, sort_keys=True)
+    durable = "".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in vault.rglob("*")
+        if path.is_file()
+    )
+    for credential in DECLARED_TEST_CREDENTIALS.values():
+        assert credential not in serialized
+        assert credential not in durable
+    for binding in DECLARED_TEST_CREDENTIALS:
+        assert binding not in serialized
+    assert all(turn["provider_request_id"] for turn in trace["turns"])
+
+    # The credential-unavailable diagnostic keeps the logical identifier only.
+    (tmp_path / "absent-vault").mkdir()
+    absent_service = ModelInquiryService(tmp_path / "absent-vault")
+    absent_service.start(
+        question="Fail closed without a declared value",
+        workflow="fable-gpt-architecture",
+        inquiry_id="inq_test_credential_absent",
+        source_refs=source_refs,
+    )
+    absent = ModelInquiryRunner(absent_service, env=intent_env()).run(
+        "inq_test_credential_absent", max_rounds=1
+    )
+    absent_trace = ModelInquiryService(tmp_path / "absent-vault").trace(
+        "inq_test_credential_absent"
+    )
+    assert absent["details"]["diagnostic"]["credential_identity_ref"] == (
+        "anthropic.api-key"
+    )
+    absent_serialized = json.dumps(absent_trace, sort_keys=True)
+    for credential in DECLARED_TEST_CREDENTIALS.values():
+        assert credential not in absent_serialized
+    assert "ANTHROPIC_API_KEY" not in absent_serialized
+
+
+class _CredentialTraceResponse:
+    def __init__(self, payload: dict[str, object], headers: dict[str, str]) -> None:
+        self._payload = payload
+        self.headers = headers
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def _credential_trace_response(
+    stance: str,
+    *,
+    reviewed: list[str] | None = None,
+    accepted_hash: str | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "stance": stance,
+            "content": f"{stance} content",
+            "claims": ["bounded claim"],
+            "risks": [],
+            "blocking_questions": [],
+            "reviewed_artifact_refs": reviewed or [],
+            "accepted_artifact_hash": accepted_hash,
+        }
+    )

--- a/tests/governance/stub_provider_api.py
+++ b/tests/governance/stub_provider_api.py
@@ -1,0 +1,130 @@
+"""Loopback provider API stub for end-to-end launcher tests.
+
+The stub is reached exactly the way production reaches a provider: through the
+declared `api_endpoint` in a census the test points `PROVIDER_CENSUS_PATH` at.
+No test-only override exists in the resolver, the adapters, or the launcher.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any, Iterator
+
+import yaml
+
+RESPONSE_SCHEMA_VERSION = "builderops.model-turn-response.v1"
+
+
+def _role_response(role: str, request: dict[str, Any]) -> dict[str, Any]:
+    reviewed = request.get("reviewed_artifact_refs") or []
+    if reviewed:
+        return {
+            "schema_version": RESPONSE_SCHEMA_VERSION,
+            "stance": "accept",
+            "content": f"{role} accepts the shared artifact",
+            "claims": ["shared contract is coherent"],
+            "risks": [],
+            "blocking_questions": [],
+            "reviewed_artifact_refs": list(reviewed),
+            "accepted_artifact_hash": request["input_artifacts"][0]["artifact_hash"],
+        }
+    return {
+        "schema_version": RESPONSE_SCHEMA_VERSION,
+        "stance": "draft",
+        "content": f"{role} independent draft",
+        "claims": [f"{role} claim"],
+        "risks": [],
+        "blocking_questions": [],
+        "reviewed_artifact_refs": [],
+        "accepted_artifact_hash": None,
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    failing_paths: frozenset[str] = frozenset()
+
+    def log_message(self, *_args: Any) -> None:
+        return None
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        if self.path in self.failing_paths:
+            payload = json.dumps({"error": "credential-sentinel"}).encode("utf-8")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        anthropic = "x-api-key" in {key.lower() for key in self.headers}
+        role = "fable" if anthropic else "gpt_codex"
+        request = json.loads(body["messages"][-1]["content"])
+        text = json.dumps(_role_response(role, request))
+        if anthropic:
+            payload_body: dict[str, Any] = {
+                "id": "req_stub_anthropic",
+                "content": [{"type": "text", "text": text}],
+            }
+        else:
+            payload_body = {
+                "id": "resp_stub_openai",
+                "choices": [{"message": {"content": text}}],
+            }
+        payload = json.dumps(payload_body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+@contextmanager
+def stub_provider_api(
+    directory: Path,
+    *,
+    failing_roles: tuple[str, ...] = (),
+) -> Iterator[Path]:
+    """Serve both provider shapes on loopback and yield a census pointing at it."""
+    handler = type(
+        "_ScopedHandler",
+        (_Handler,),
+        {
+            "failing_paths": frozenset(
+                {"/anthropic"} if "fable" in failing_roles else set()
+            )
+            | frozenset({"/openai"} if "gpt_codex" in failing_roles else set())
+        },
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        base = f"http://{host}:{port}"
+        census_path = census_with_stub_endpoints(directory, base)
+        yield census_path
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def census_with_stub_endpoints(directory: Path, base_url: str) -> Path:
+    """Write a census whose declared provider endpoints resolve to the stub."""
+    repo_root = Path(__file__).resolve().parents[2]
+    source = repo_root / "docs" / "settings" / "models" / "providers.yaml"
+    payload = yaml.safe_load(source.read_text(encoding="utf-8"))
+    for provider in payload["providers"]:
+        if provider["id"] == "anthropic":
+            provider["api_endpoint"] = f"{base_url}/anthropic"
+        elif provider["id"] == "openai":
+            provider["api_endpoint"] = f"{base_url}/openai"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "providers.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -44,10 +44,10 @@ def _install(bin_dir: Path) -> subprocess.CompletedProcess[str]:
 
 
 def _init_adapter_checkout(root: Path) -> Path:
-    adapter = root / "scripts" / "model_inquiry_subscription_adapter.py"
+    adapter = root / "scripts" / host_installer.VERSIONED_ADAPTER_NAME
     adapter.parent.mkdir(parents=True)
     adapter.write_bytes(
-        (REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py").read_bytes()
+        (REPO_ROOT / "scripts" / host_installer.VERSIONED_ADAPTER_NAME).read_bytes()
     )
     return adapter
 
@@ -64,20 +64,20 @@ def test_installer_creates_both_role_entrypoints_and_exact_retry_is_noop(
     first_payload = json.loads(first.stdout)
     second_payload = json.loads(second.stdout)
     assert first_payload["roles"] == {
-        "fable": {"entrypoint": "fable-subscription-cli", "status": "installed"},
+        "fable": {"entrypoint": "fable-model-inquiry-role", "status": "installed"},
         "gpt_codex": {
-            "entrypoint": "codex-subscription-cli",
+            "entrypoint": "codex-model-inquiry-role",
             "status": "installed",
         },
     }
     assert second_payload["roles"] == {
-        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "fable": {"entrypoint": "fable-model-inquiry-role", "status": "unchanged"},
         "gpt_codex": {
-            "entrypoint": "codex-subscription-cli",
+            "entrypoint": "codex-model-inquiry-role",
             "status": "unchanged",
         },
     }
-    for name in ("fable-subscription-cli", "codex-subscription-cli"):
+    for name in ("fable-model-inquiry-role", "codex-model-inquiry-role"):
         path = bin_dir / name
         assert path.is_file()
         assert path.stat().st_mode & 0o777 == 0o700
@@ -86,7 +86,7 @@ def test_installer_creates_both_role_entrypoints_and_exact_retry_is_noop(
 def test_installer_rejects_conflicting_or_unsafe_destinations(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    conflicting = bin_dir / "fable-subscription-cli"
+    conflicting = bin_dir / "fable-model-inquiry-role"
     conflicting.write_text("unrelated host command\n", encoding="utf-8")
     conflicting.chmod(0o700)
 
@@ -95,7 +95,7 @@ def test_installer_rejects_conflicting_or_unsafe_destinations(tmp_path: Path) ->
     assert conflict.returncode == 2
     assert "conflicting entrypoint" in conflict.stderr
     assert conflicting.read_text(encoding="utf-8") == "unrelated host command\n"
-    assert not (bin_dir / "codex-subscription-cli").exists()
+    assert not (bin_dir / "codex-model-inquiry-role").exists()
 
     real_bin = tmp_path / "real-bin"
     real_bin.mkdir()
@@ -121,13 +121,13 @@ def test_installer_rejects_conflicting_or_unsafe_destinations(tmp_path: Path) ->
     symlink_target_bin.mkdir()
     unrelated = tmp_path / "unrelated-command"
     unrelated.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    (symlink_target_bin / "fable-subscription-cli").symlink_to(unrelated)
+    (symlink_target_bin / "fable-model-inquiry-role").symlink_to(unrelated)
     symlink_target = _install(symlink_target_bin)
 
     assert symlink_target.returncode == 2
     assert "conflicting entrypoint" in symlink_target.stderr
-    assert (symlink_target_bin / "fable-subscription-cli").is_symlink()
-    assert not (symlink_target_bin / "codex-subscription-cli").exists()
+    assert (symlink_target_bin / "fable-model-inquiry-role").is_symlink()
+    assert not (symlink_target_bin / "codex-model-inquiry-role").exists()
 
     missing_checkout = _run_installer(
         "install",
@@ -192,7 +192,7 @@ def test_installer_does_not_require_git_on_host(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert (bin_dir / "fable-subscription-cli").is_file()
+    assert (bin_dir / "fable-model-inquiry-role").is_file()
 
 
 def test_new_bin_directory_is_durably_linked_from_parent(
@@ -392,20 +392,20 @@ def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
     assert result.returncode == 0, result.stderr
 
     expected = {
-        "fable-subscription-cli": "fable",
-        "codex-subscription-cli": "gpt_codex",
+        "fable-model-inquiry-role": "fable",
+        "codex-model-inquiry-role": "gpt_codex",
     }
-    adapter = str((REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py").resolve())
+    adapter = str((REPO_ROOT / "scripts" / host_installer.VERSIONED_ADAPTER_NAME).resolve())
     adapter_sha256 = hashlib.sha256(Path(adapter).read_bytes()).hexdigest()
     assert host_installer.VERSIONED_ADAPTER_SHA256 == adapter_sha256
     python = str(Path(sys.executable))
     for name, role in expected.items():
         content = (bin_dir / name).read_text(encoding="utf-8")
-        assert f"INQUIRY_ROLE={role}" in content
+        assert f"--role {role}" in content
         assert adapter in content
         assert f"adapter-sha256={adapter_sha256}" in content
         assert python in content
-        assert "BUILDEROPS_INQUIRY_ADAPTERS_JSON" not in content
+        assert "BUILDEROPS_INQUIRY_ROLE_INTENT_JSON" not in content
         assert "TOKEN" not in content
         assert "KEY" not in content
 
@@ -432,7 +432,7 @@ def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) 
     )
 
     assert result.returncode == 0, result.stderr
-    for entrypoint in ("fable-subscription-cli", "codex-subscription-cli"):
+    for entrypoint in ("fable-model-inquiry-role", "codex-model-inquiry-role"):
         content = (bin_dir / entrypoint).read_text(encoding="utf-8")
         assert str(selected_python) in content
         executed = subprocess.run([str(bin_dir / entrypoint)], check=False)
@@ -475,16 +475,14 @@ def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
         },
         "roles": {
             "fable": {
-                "entrypoint": "fable-subscription-cli",
+                "entrypoint": "fable-model-inquiry-role",
                 "entrypoint_status": "available",
-                "provider_command": "claude",
-                "provider_status": "available",
+                "credential_resolution": "host-secret-contract",
             },
             "gpt_codex": {
-                "entrypoint": "codex-subscription-cli",
+                "entrypoint": "codex-model-inquiry-role",
                 "entrypoint_status": "available",
-                "provider_command": "codex",
-                "provider_status": "available",
+                "credential_resolution": "host-secret-contract",
             },
         },
     }
@@ -518,10 +516,9 @@ def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
     assert missing_from_path.returncode == 1
     missing_payload = json.loads(missing_from_path.stdout)
     assert missing_payload["roles"]["fable"] == {
-        "entrypoint": "fable-subscription-cli",
+        "entrypoint": "fable-model-inquiry-role",
         "entrypoint_status": "unavailable",
-        "provider_command": "claude",
-        "provider_status": "available",
+        "credential_resolution": "host-secret-contract",
     }
     assert missing_payload["roles"]["gpt_codex"]["entrypoint_status"] == "unavailable"
 
@@ -534,7 +531,7 @@ def test_partial_install_is_retained_for_exact_retry(
     real_install = host_installer._install_no_overwrite
 
     def fail_second_role(directory_fd: int, name: str, content: str) -> bool:
-        if name == "codex-subscription-cli":
+        if name == "codex-model-inquiry-role":
             raise host_installer.HostInstallError("injected second-role failure")
         return real_install(directory_fd, name, content)
 
@@ -546,16 +543,16 @@ def test_partial_install_is_retained_for_exact_retry(
             python=Path(sys.executable),
         )
 
-    assert (bin_dir / "fable-subscription-cli").is_file()
-    assert not (bin_dir / "codex-subscription-cli").exists()
+    assert (bin_dir / "fable-model-inquiry-role").is_file()
+    assert not (bin_dir / "codex-model-inquiry-role").exists()
     monkeypatch.undo()
 
     retry = _install(bin_dir)
     assert retry.returncode == 0, retry.stderr
     assert json.loads(retry.stdout)["roles"] == {
-        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "fable": {"entrypoint": "fable-model-inquiry-role", "status": "unchanged"},
         "gpt_codex": {
-            "entrypoint": "codex-subscription-cli",
+            "entrypoint": "codex-model-inquiry-role",
             "status": "installed",
         },
     }
@@ -620,9 +617,9 @@ def test_concurrent_exact_writer_produces_truthful_unchanged_receipt(
     )
 
     assert receipt["roles"] == {
-        "fable": {"entrypoint": "fable-subscription-cli", "status": "unchanged"},
+        "fable": {"entrypoint": "fable-model-inquiry-role", "status": "unchanged"},
         "gpt_codex": {
-            "entrypoint": "codex-subscription-cli",
+            "entrypoint": "codex-model-inquiry-role",
             "status": "unchanged",
         },
     }
@@ -636,7 +633,7 @@ def test_concurrent_conflicting_writer_fails_closed(
     real_install = host_installer._install_no_overwrite
 
     def conflicting_writer_wins(directory_fd: int, name: str, content: str) -> bool:
-        if name == "fable-subscription-cli":
+        if name == "fable-model-inquiry-role":
             fd = os.open(
                 name,
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -661,10 +658,10 @@ def test_concurrent_conflicting_writer_fails_closed(
             python=Path(sys.executable),
         )
 
-    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+    assert (bin_dir / "fable-model-inquiry-role").read_text(encoding="utf-8") == (
         "unrelated concurrent command\n"
     )
-    assert not (bin_dir / "codex-subscription-cli").exists()
+    assert not (bin_dir / "codex-model-inquiry-role").exists()
 
 
 def test_install_rejects_bin_directory_replacement(
@@ -698,8 +695,8 @@ def test_install_rejects_bin_directory_replacement(
 
     assert replaced
     assert not list(bin_dir.iterdir())
-    assert (detached_bin / "fable-subscription-cli").is_file()
-    assert (detached_bin / "codex-subscription-cli").is_file()
+    assert (detached_bin / "fable-model-inquiry-role").is_file()
+    assert (detached_bin / "codex-model-inquiry-role").is_file()
 
 
 def test_check_rejects_bin_directory_replacement_during_path_discovery(
@@ -719,8 +716,8 @@ def test_check_rejects_bin_directory_replacement_during_path_discovery(
             bin_dir.rename(detached_bin)
             bin_dir.mkdir()
             for name in (
-                "fable-subscription-cli",
-                "codex-subscription-cli",
+                "fable-model-inquiry-role",
+                "codex-model-inquiry-role",
                 "claude",
                 "codex",
                 "yggdrasil-model-inquiry",
@@ -740,8 +737,8 @@ def test_check_rejects_bin_directory_replacement_during_path_discovery(
         )
 
     assert replaced
-    assert (detached_bin / "fable-subscription-cli").is_file()
-    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+    assert (detached_bin / "fable-model-inquiry-role").is_file()
+    assert (bin_dir / "fable-model-inquiry-role").read_text(encoding="utf-8") == (
         "#!/bin/sh\nexit 0\n"
     )
 
@@ -803,10 +800,10 @@ def test_install_revalidates_all_wrappers_before_success(
         name: str,
         content: str,
     ) -> bool:
-        if name == "codex-subscription-cli":
-            os.unlink("fable-subscription-cli", dir_fd=directory_fd)
+        if name == "codex-model-inquiry-role":
+            os.unlink("fable-model-inquiry-role", dir_fd=directory_fd)
             fd = os.open(
-                "fable-subscription-cli",
+                "fable-model-inquiry-role",
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL,
                 0o700,
                 dir_fd=directory_fd,
@@ -832,7 +829,7 @@ def test_install_revalidates_all_wrappers_before_success(
             python=Path(sys.executable),
         )
 
-    assert (bin_dir / "fable-subscription-cli").read_text(encoding="utf-8") == (
+    assert (bin_dir / "fable-model-inquiry-role").read_text(encoding="utf-8") == (
         "unrelated replacement\n"
     )
 
@@ -860,9 +857,9 @@ def test_check_revalidates_earlier_wrapper_after_later_discovery(
         path: str | None = None,
     ) -> str | None:
         nonlocal replaced
-        if command == "codex-subscription-cli" and not replaced:
+        if command == "codex-model-inquiry-role" and not replaced:
             replaced = True
-            fable = bin_dir / "fable-subscription-cli"
+            fable = bin_dir / "fable-model-inquiry-role"
             fable.unlink()
             fable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             fable.chmod(0o700)
@@ -923,3 +920,70 @@ def test_check_rejects_bin_replacement_during_launcher_discovery(
 
     assert replaced
     assert not list(bin_dir.iterdir())
+
+
+def test_headless_entrypoints_do_not_require_subscription_session(
+    tmp_path: Path,
+) -> None:
+    """The installer's own installation path must produce credential-resolving roles."""
+    bin_dir = tmp_path / "bin"
+    installed = _install(bin_dir)
+    assert installed.returncode == 0, installed.stderr
+
+    installer_source = INSTALLER.read_text(encoding="utf-8")
+    assert "model_inquiry_subscription_adapter" not in installer_source
+    assert host_installer.VERSIONED_ADAPTER_NAME == "model_inquiry_role_adapter.py"
+    assert all(
+        not hasattr(spec, "provider_command") for spec in host_installer.ROLE_SPECS
+    )
+
+    adapter_source = (
+        REPO_ROOT / "scripts" / host_installer.VERSIONED_ADAPTER_NAME
+    ).read_text(encoding="utf-8")
+    assert "host secret contract" in " ".join(adapter_source.split())
+    # It resolves a declared credential; it launches no CLI and no session.
+    assert "model_inquiry_subscription_adapter" not in adapter_source
+    assert "subprocess" not in adapter_source
+    assert "shutil.which" not in adapter_source
+    for wrapper_name in ("fable-model-inquiry-role", "codex-model-inquiry-role"):
+        content = (bin_dir / wrapper_name).read_text(encoding="utf-8")
+        assert host_installer.VERSIONED_ADAPTER_NAME in content
+        assert "credential-resolution=host-secret-contract" in content
+        exec_line = next(
+            line for line in content.splitlines() if line.startswith("exec ")
+        )
+        executed = shlex.split(exec_line)[1:]
+        assert Path(executed[1]).name == host_installer.VERSIONED_ADAPTER_NAME
+        assert executed[2] == "--role"
+        assert not any(
+            Path(argument).name in {"claude", "codex"} for argument in executed
+        )
+        assert "subscription" not in " ".join(
+            Path(argument).name for argument in executed
+        )
+
+    payload = json.loads(installed.stdout)
+    assert "provider_command" not in json.dumps(payload)
+
+    # The installed entrypoint fails closed on the declared credential and never
+    # looks for an interactive session: no provider CLI exists on this PATH.
+    intent = (
+        REPO_ROOT / "config" / "builderops" / "model_inquiry_role_intent.example.json"
+    ).read_text(encoding="utf-8")
+    executed = subprocess.run(
+        [str(bin_dir / "fable-model-inquiry-role")],
+        input=json.dumps({"phase": "draft", "system_prompt": "x"}),
+        env={
+            "PATH": str(bin_dir),
+            "HOME": str(tmp_path),
+            "BUILDEROPS_INQUIRY_ROLE_INTENT_JSON": intent,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert executed.returncode == 1, executed.stderr
+    assert "anthropic.api-key" in executed.stderr
+    assert "ANTHROPIC_API_KEY" not in executed.stderr
+    assert executed.stdout == ""

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -11,8 +11,15 @@ from pathlib import Path
 import pytest
 
 from app.builderops.model_inquiry import ModelInquiryService
-from app.builderops.model_inquiry_adapters import AdapterUnavailableError
+from app.builderops.model_inquiry_adapters import CredentialUnavailableError
+from app.builderops.models import BuilderOpsValidationError
 from scripts.start_model_inquiry import preflight_dependencies
+from tests.builderops.inquiry_intent import (
+    census_with_role_targets,
+    intent_env,
+    provisioned_env,
+)
+from tests.governance.stub_provider_api import stub_provider_api
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LAUNCHER = REPO_ROOT / "scripts" / "start_model_inquiry.sh"
@@ -20,96 +27,52 @@ PYTHON_LAUNCHER = REPO_ROOT / "scripts" / "start_model_inquiry.py"
 SUBSCRIPTION_ADAPTER = REPO_ROOT / "scripts" / "model_inquiry_subscription_adapter.py"
 
 
-def _adapter_script(tmp_path: Path) -> Path:
-    script = tmp_path / "adapter.py"
-    script.write_text(
-        """\
-import json
-import sys
-
-request = json.load(sys.stdin)
-role = sys.argv[1]
-reviewed = request["reviewed_artifact_refs"]
-if reviewed:
-    response = {
-        "schema_version": "builderops.model-turn-response.v1",
-        "stance": "accept",
-        "content": f"{role} accepts the shared artifact",
-        "claims": ["shared contract is coherent"],
-        "risks": [],
-        "blocking_questions": [],
-        "reviewed_artifact_refs": reviewed,
-        "accepted_artifact_hash": request["input_artifacts"][0]["artifact_hash"],
-    }
-else:
-    response = {
-        "schema_version": "builderops.model-turn-response.v1",
-        "stance": "draft",
-        "content": f"{role} independent draft",
-        "claims": [f"{role} claim"],
-        "risks": [],
-        "blocking_questions": [],
-        "reviewed_artifact_refs": [],
-        "accepted_artifact_hash": None,
-    }
-print(json.dumps(response))
-""",
-        encoding="utf-8",
-    )
-    return script
-
-
-def _configured_env(tmp_path: Path) -> dict[str, str]:
+def _configured_env(tmp_path: Path, census: Path) -> dict[str, str]:
+    """Provider-free intent, a declared credential surface, and a stub census."""
     vault = tmp_path / "vault"
-    vault.mkdir()
-    script = _adapter_script(tmp_path)
-    config = {
-        role: {
-            "kind": "command",
-            "role_identity": role,
-            "adapter_id": f"adapter-{role}",
-            "provider": role,
-            "model": f"test-{role}",
-            "argv": [sys.executable, str(script), role],
-        }
-        for role in ("fable", "gpt_codex")
-    }
+    vault.mkdir(exist_ok=True)
     return {
         **os.environ,
         "PATH": "/usr/bin:/bin",
         "BUILDEROPS_PYTHON": sys.executable,
         "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
         "BUILDEROPS_VAULT_ROOT": str(vault),
-        "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(config),
+        "PROVIDER_CENSUS_PATH": str(census),
+        **provisioned_env(tmp_path / "secrets"),
     }
 
 
 def test_local_launcher_runs_common_command(tmp_path: Path) -> None:
-    env = _configured_env(tmp_path)
     marker = tmp_path / "must-not-exist"
     question = f"Keep quotes ' and newlines safe\n$(touch {marker})"
     question_file = tmp_path / "question.md"
     question_file.write_text(question, encoding="utf-8")
-    result = subprocess.run(
-        [
-            str(LAUNCHER),
-            "--question-file",
-            str(question_file),
-            "--max-rounds",
-            "1",
-        ],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    with stub_provider_api(tmp_path / "census") as census:
+        env = _configured_env(tmp_path, census)
+        result = subprocess.run(
+            [
+                str(LAUNCHER),
+                "--question-file",
+                str(question_file),
+                "--max-rounds",
+                "1",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["inquiry_id"].startswith("inq_")
     assert payload["final_state"] == "consensus"
     assert payload["terminal_receipt_id"]
+    assert payload["preflight"]["credential_resolution"] == "host-secret-contract"
+    assert {
+        identity["provider"] for identity in payload["preflight"]["adapters"].values()
+    } == {"anthropic", "openai"}
     report = Path(payload["human_readable_report"])
     assert report.is_file()
     assert report.parent.name == payload["inquiry_id"]
@@ -119,50 +82,65 @@ def test_local_launcher_runs_common_command(tmp_path: Path) -> None:
     assert trace["question"]["source_refs"] == [
         {"ref_type": "desktop_skill", "ref": "start-model-inquiry"}
     ]
+    assert all(turn["provider_request_id"] for turn in trace["turns"])
     launcher = PYTHON_LAUNCHER.read_text()
     assert '"builderops",\n                "inquiry",\n                "start"' in launcher
 
 
 def test_local_launcher_emits_terminal_provider_error_json(tmp_path: Path) -> None:
-    env = _configured_env(tmp_path)
-    failing_adapter = tmp_path / "failing_adapter.py"
-    failing_adapter.write_text(
-        "import sys\nprint('credential-sentinel', file=sys.stderr)\nsys.exit(17)\n",
-        encoding="utf-8",
-    )
-    config = json.loads(env["BUILDEROPS_INQUIRY_ADAPTERS_JSON"])
-    config["fable"]["argv"] = [sys.executable, str(failing_adapter)]
-    env["BUILDEROPS_INQUIRY_ADAPTERS_JSON"] = json.dumps(config)
     question_file = tmp_path / "question.md"
     question_file.write_text("Produce a safe failure receipt.", encoding="utf-8")
-
-    result = subprocess.run(
-        [str(LAUNCHER), "--question-file", str(question_file), "--max-rounds", "1"],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    with stub_provider_api(tmp_path / "census", failing_roles=("fable",)) as census:
+        env = _configured_env(tmp_path, census)
+        result = subprocess.run(
+            [str(LAUNCHER), "--question-file", str(question_file), "--max-rounds", "1"],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.count("\n") == 1
     payload = json.loads(result.stdout)
     assert payload["final_state"] == "provider_error"
-    assert payload["inquiry_id"]
-    assert payload["terminal_receipt_id"]
-    assert Path(payload["human_readable_report"]).is_file()
-    assert payload["diagnostic"] == {
-        "adapter_id": "adapter-fable",
-        "adapter_failure_class": "command_exit_nonzero",
-        "adapter_exit_code": 17,
-    }
+    assert payload["diagnostic"]["adapter_failure_class"] == "unexpected_adapter_error"
     rendered = "".join(
         path.read_text(encoding="utf-8")
         for path in (tmp_path / "vault").rglob("*.json")
     )
     assert "credential-sentinel" not in rendered
     assert "credential-sentinel" not in result.stdout
+
+
+def test_launcher_fails_closed_on_an_absent_declared_credential(
+    tmp_path: Path,
+) -> None:
+    """The reported failure class is the credential, never a session or CLI exit."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    question_file = tmp_path / "question.md"
+    question_file.write_text("Fail closed without a declared value.", encoding="utf-8")
+    result = subprocess.run(
+        [str(LAUNCHER), "--question-file", str(question_file), "--max-rounds", "1"],
+        cwd=REPO_ROOT,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(tmp_path),
+            "BUILDEROPS_PYTHON": sys.executable,
+            "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
+            "BUILDEROPS_VAULT_ROOT": str(vault),
+            **intent_env(),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "anthropic.api-key" in result.stderr
+    assert "ANTHROPIC_API_KEY" not in result.stderr
+    assert not (vault / "model-inquiries").exists()
 
 
 def test_subscription_adapter_uses_high_reasoning_profile(monkeypatch) -> None:
@@ -307,97 +285,68 @@ def test_skill_preflight_reports_missing_dependencies(tmp_path: Path) -> None:
         check=False,
     )
     assert missing_adapters.returncode == 2
-    assert "explicit adapter not configured" in missing_adapters.stderr
+    assert "inquiry role intent is not configured" in missing_adapters.stderr
     assert not (vault / "model-inquiries").exists()
 
-    config = {
-        role: {
-            "kind": "command",
-            "role_identity": role,
-            "adapter_id": f"adapter-{role}",
-            "provider": role,
-            "model": f"test-{role}",
-            "argv": [f"definitely-missing-{role}"],
-        }
-        for role in ("fable", "gpt_codex")
-    }
-    missing_executable = subprocess.run(
+    missing_credential = subprocess.run(
         [str(LAUNCHER), "Question"],
         cwd=REPO_ROOT,
         env={
             **clean_env,
             "BUILDEROPS_VAULT_ROOT": str(vault),
-            "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(config),
+            **intent_env(),
         },
         capture_output=True,
         text=True,
         check=False,
     )
-    assert missing_executable.returncode == 2
-    assert "local command unavailable" in missing_executable.stderr
+    assert missing_credential.returncode == 2
+    assert "anthropic.api-key" in missing_credential.stderr
     assert not (vault / "model-inquiries").exists()
 
 
-def test_host_role_entrypoints_gate_desktop_preflight(tmp_path: Path) -> None:
+def test_desktop_preflight_resolves_declared_roles_without_a_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight needs no host role entrypoint, provider CLI, or session lineage."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    adapter_config = {
-        "fable": {
-            "kind": "command",
-            "role_identity": "fable",
-            "adapter_id": "fable-subscription-cli",
-            "provider": "anthropic-subscription",
-            "model": "configured-fable",
-            "argv": ["fable-subscription-cli"],
-            "environment_allowlist": ["PATH"],
-        },
-        "gpt_codex": {
-            "kind": "command",
-            "role_identity": "gpt_codex",
-            "adapter_id": "codex-subscription-cli",
-            "provider": "openai-subscription",
-            "model": "configured-codex",
-            "argv": ["codex-subscription-cli"],
-            "environment_allowlist": ["PATH"],
-        },
-    }
+    vault = tmp_path / "vault"
+    vault.mkdir()
     env = {
         **os.environ,
         "PATH": str(bin_dir),
         "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
-        "BUILDEROPS_VAULT_ROOT": str(tmp_path / "vault"),
-        "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(adapter_config),
+        "BUILDEROPS_VAULT_ROOT": str(vault),
+        **provisioned_env(tmp_path / "secrets"),
     }
-    (tmp_path / "vault").mkdir()
-    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
-        executable = bin_dir / command
-        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        executable.chmod(0o700)
 
-    with pytest.raises(AdapterUnavailableError, match="fable-subscription-cli"):
-        preflight_dependencies(env, command_cwd=REPO_ROOT)
-
-    for command in ("fable-subscription-cli", "codex-subscription-cli"):
-        executable = bin_dir / command
-        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        executable.chmod(0o700)
-    with pytest.raises(AdapterUnavailableError, match="installed-lineage preflight"):
-        preflight_dependencies(env, command_cwd=REPO_ROOT)
-    for command in ("fable-subscription-cli", "codex-subscription-cli"):
-        (bin_dir / command).unlink()
-
-    selected_python = tmp_path / "selected-python"
-    selected_python.symlink_to(Path(sys.executable))
-    env["BUILDEROPS_PYTHON"] = str(selected_python)
-    installed = _run_host_installer(tmp_path, bin_dir, python=selected_python)
-    assert installed.returncode == 0, installed.stderr
     result = preflight_dependencies(env, command_cwd=REPO_ROOT)
 
     assert set(result["adapters"]) == {"fable", "gpt_codex"}
-    assert not (tmp_path / "vault" / "model-inquiries").exists()
-    mismatched_env = {key: value for key, value in env.items() if key != "BUILDEROPS_PYTHON"}
-    with pytest.raises(AdapterUnavailableError, match="installed-lineage preflight"):
-        preflight_dependencies(mismatched_env, command_cwd=REPO_ROOT)
+    assert result["credential_resolution"] == "host-secret-contract"
+    assert {identity["provider"] for identity in result["adapters"].values()} == {
+        "anthropic",
+        "openai",
+    }
+    assert not (vault / "model-inquiries").exists()
+    assert not list(bin_dir.iterdir())
+
+    # A mock policy target is refused rather than silently substituted, and a
+    # declared credential that is absent fails closed instead of degrading.
+    with pytest.raises(CredentialUnavailableError, match="anthropic.api-key"):
+        preflight_dependencies(
+            {key: value for key, value in env.items() if "HOST_SECRET" not in key},
+            command_cwd=REPO_ROOT,
+        )
+    mocked_census = census_with_role_targets(
+        tmp_path / "mock-census",
+        {"fable": ("mock", "mock-chat"), "gpt_codex": ("mock", "mock-chat")},
+    )
+    monkeypatch.setenv("PROVIDER_CENSUS_PATH", str(mocked_census))
+    with pytest.raises(BuilderOpsValidationError, match="mock"):
+        preflight_dependencies(env, command_cwd=REPO_ROOT)
 
 
 def _run_host_installer(
@@ -424,39 +373,6 @@ def _run_host_installer(
         text=True,
         check=False,
     )
-
-
-def test_generic_command_adapters_do_not_require_host_entrypoint_lineage(
-    tmp_path: Path,
-) -> None:
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    config: dict[str, dict[str, object]] = {}
-    for role in ("fable", "gpt_codex"):
-        command = bin_dir / f"generic-{role}"
-        command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        command.chmod(0o700)
-        config[role] = {
-            "kind": "command",
-            "role_identity": role,
-            "adapter_id": f"generic-{role}",
-            "provider": f"provider-{role}",
-            "model": f"model-{role}",
-            "argv": [str(command)],
-        }
-    vault = tmp_path / "vault"
-    vault.mkdir()
-    env = {
-        **os.environ,
-        "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
-        "BUILDEROPS_VAULT_ROOT": str(vault),
-        "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(config),
-    }
-
-    result = preflight_dependencies(env, command_cwd=REPO_ROOT)
-
-    assert set(result["adapters"]) == {"fable", "gpt_codex"}
-    assert not (vault / "model-inquiries").exists()
 
 
 def test_launcher_fails_loud_without_venv_or_override(tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4291

## Linked Issue

Closes #4291

## SBS Impact
- Primary subsystem: BuilderOps Model Inquiry / CES boundary
- Secondary subsystem(s): host-secret bootstrap and provider APIs; the declared provider census gains one provider-owned field
- Write class: Builder execution and immutable receipts
- Persistence impact: existing inquiry trace/receipt store only; one new optional diagnostic field (`credential_identity_ref`) and one reserved attempt id (`adapter_req_credential`)
- Derived/rebuildable impact: none
- New or changed contract: production Builder `ModelAccessResolver` implementation; provider-free inquiry-role intent configuration replacing `BUILDEROPS_INQUIRY_ADAPTERS_JSON`; headless role entrypoint names and their bound adapter
- Owner-doc impact: `docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md` and `ops/host-setup/mac-mini/AGENT_PLAYBOOK.md` updated in this PR
- Transition debt impact: removes the headless subscription-session dependency; the interactive subscription adapter remains and is now structurally unreachable from headless paths
- Boundary risk: no credential value, provider choice, endpoint, or fallback may enter caller configuration; all are resolver outputs from declared data

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds `app/builderops/model_access_resolver.py`, a Builder-owned `ModelAccessResolver` behind the neutral MAS-04 protocol. It accepts the `fable` and `gpt_codex` role requests as one `model-inquiry-independent-review` group with `(runtime="builder", channel, consumer)`, applies Builder policy (fallback forbidden, declared consumer only, no mock/test-tier identity), resolves exclusively through the exact MAS-01 census role/tier mappings, verifies census-required capabilities plus distinct effective targets through `validate_resolved_group`, and resolves credential identities through the MAS-03 host secret contract. Provider, model, effective identity, endpoint, `adapter_id`, and credential identifier are outputs.
- Replaces the provider-bearing `BUILDEROPS_INQUIRY_ADAPTERS_JSON` with `BUILDEROPS_INQUIRY_ROLE_INTENT_JSON`: the seven neutral intent fields per role, the role independence requirement, and channel/consumer references. Provider, model, transport, endpoint, credential, environment-name, and host keys are refused structurally before resolution runs. Committed example: `config/builderops/model_inquiry_role_intent.example.json`.
- Injects credentials at descriptor-load time. `load_adapters` builds `HttpModelAdapter` with the value read only from the mode-0600 runtime surface `app/ops/host_secret_bootstrap.py` materializes (new public `load_runtime_secret_values` / `validate_secret_value`). Ambient process environment is never a credential source, and caller configuration can no longer carry `api_key_env`.
- Emits the real failure class. An absent or malformed declared credential raises `CredentialUnavailableError`, fails the run closed before any adapter call with zero fallback and zero subscription-CLI spawn, and names only the logical identifier. The diagnostic carries a grammar-validated `credential_identity_ref` that survives the independent persistence-boundary re-validation (INV-MAS-3 / Seam B). An expired interactive session now maps to `session_expired` instead of collapsing into `command_exit_nonzero`.
- Makes installed headless entrypoints provider-API based: `fable-model-inquiry-role` and `codex-model-inquiry-role` bind to the new `scripts/model_inquiry_role_adapter.py`. `scripts/install_model_inquiry_host.py` no longer references, digests, or installs `scripts/model_inquiry_subscription_adapter.py`, and `check` no longer probes `claude`/`codex`. The subscription adapter remains for interactive human use and is unreachable from every headless entrypoint.
- Declares provider API endpoints in the census (`ProviderEntry.api_endpoint`) so no caller supplies a transport target, and rewrites the desktop launcher preflight to resolve declared roles instead of validating subscription-entrypoint lineage.
- Updates `docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md :: What This Task Does` and `:: Host role-entrypoint lifecycle` to describe declared resolution.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: implementation-only slice; no BuilderOps record, projection, or receipt was created. The `model_access_substrate.mas05_validation_handoff.v1` parent-validation handoff is posted to #4286 by the coordinating agent before merge; live provider proof and legacy-bridge retirement remain parent validation and are not claimed here.

## Notes
Head SHA validated: `d867fe70ff61647bcbb1e50d55374e528411e3b8` (implementation `ef8e865455fbe15e6ea849688d9f9dd9eca26b6c` plus the host-playbook writeback)

Per-command results (worktree `.claude/worktrees/mas05-resolver`, Python 3.14):
- `python3 -m pytest -q tests/builderops/test_model_inquiry_adapters.py tests/builderops/test_model_inquiry_runner.py tests/builderops/test_model_inquiry_trace.py tests/builderops/test_model_inquiry_resume.py tests/governance/test_model_inquiry_host_install.py` — pass
- All ten named Verify node ids run explicitly by id — 10 passed
- `python3 -m pytest -q tests/builderops tests/governance tests/architecture tests/model_access tests/settings tests/ops` — 2276 passed, 142 skipped
- `python3 -m pytest -q tests/properties tests/scripts tests/docs tests/ci` — 311 passed, 3 skipped
- Full CI-selected target set for this diff (`builder_system,settings,ops,ops_deploy`) — 3698 passed, 20 skipped, 1 failed: `tests/deploy/test_dev_channel_compose.py::test_channel_deploy_supplies_signboard_root` exits 127 because `docker` is absent on this laptop by design. It touches nothing in this diff and is an environment failure, not a regression.
- `python3 -m ruff check app tests scripts llm_contract` — All checks passed
- `python3 -m mypy app llm_contract` — Success: no issues found in 818 source files
- `lint-imports --config importlinter.ini` — 5 kept, 0 broken (the Builder resolver imports `app.components.settings.providers_loader` and `app.ops.*`, never `app.components.llm`)
- `python3 scripts/public_seam_lint.py --mode gate` — 0 hits
- `python3 scripts/docs_guard.py` — reports the temporal-owner-doc rule (no `docs/STATUS.md` / `ROADMAP` / `ARCHITECTURE` / `OPERATIONS` / `HUMAN-FLOWS` / `AGENT-FLOWS` touch). That step is scoped in `ci-smoke.yaml` to governance/docs-only PRs and is skipped for this runtime shape. The operator-facing surface this change actually moves is `ops/host-setup/mac-mini/AGENT_PLAYBOOK.md`, which is updated here; `docs/OPERATIONS.md` does not cover Model Inquiry host entrypoints, so touching it would be noise rather than writeback.

Residual risks, follow-ups, and assumptions:
- `scripts/select_pr_tests.py` maps this diff to `builder_system,settings,ops,ops_deploy`, which does not include `tests/architecture/test_import_boundary.py` or `test_llm_contract_kernel.py`. Both were run locally and pass, as does `lint-imports`. Adding `app/builderops/model_access_resolver.py` to the `model_access` subsystem SoI would have forced a full-suite run, so it is deliberately deferred rather than done here.
- Two tests were replaced rather than kept, because the mechanism they asserted is the one this task removes. `test_host_role_entrypoints_gate_desktop_preflight` and `test_generic_command_adapters_do_not_require_host_entrypoint_lineage` asserted caller-configured command adapters and subscription-entrypoint lineage; they are replaced by `test_desktop_preflight_resolves_declared_roles_without_a_session`, which asserts the same preflight properties (no vault mutation, both roles resolved, mock refused, credential fail-closed) on the declared path.
- The two launcher end-to-end tests now reach a loopback provider stub through the census's declared `api_endpoint` using the existing `PROVIDER_CENSUS_PATH` seam. No test-only override exists in the resolver, the adapters, or the launcher.
- No credential value was provisioned, read, or exposed. Live non-interactive provider proof on the configured inquiry host and recoverable retirement of the hand-built TLS bridge remain parent validation on #4286.



Independent review gate (round 1, 2026-07-29): PASS at head d867fe70f — zero P0/P1, zero P2; two P3 informational findings posted on the PR (redundant group re-resolution in load_adapters; stale doc line citations), dispositioned informational per severity routing. Parent validation handoff posted: https://github.com/RasmusTho/agentic-pkm-mvp/issues/4286#issuecomment-5122010264
