### PR TITLE
governance: reuse proof across irrelevant base drift

### DIFF
--- a/.codex/skills/_shared/BRANCH_TRUTH_GATE.md
+++ b/.codex/skills/_shared/BRANCH_TRUTH_GATE.md
@@ -55,6 +55,12 @@ drifted between the gates. Non-zero exit => STOP, do not push; relocate the comm
 branch (for example cherry-pick onto `$EXPECTED_BRANCH` and reset the drifted branch) before
 pushing.
 
+This gate answers whether publication comes from the intended isolated branch and contains the
+current base. It does not by itself decide whether expensive validation must be repeated after an
+otherwise irrelevant rebase. That separate decision is fail-closed and owned by
+`docs/development/GOVERNANCE_PROPORTIONALITY.md :: Post-validation base-drift evidence reuse` as
+invoked by `publish-pr`.
+
 ## Fallback (no script available)
 
 If the preflight script cannot run, assert the branch name directly:

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -224,8 +224,13 @@ executable order is mandatory and fail-closed:
    execution id. Governance-only changes default to targeted governance/contract tests plus their
    lint/docs checks.
 4. Re-run the branch-truth pre-push gate and the `review_before_ci_gate.py` command above against
-   the still-unchanged SHA. A changed SHA invalidates both the review and validation evidence and
-   restarts this sequence.
+   the publishable SHA. A repair, scope change, conflict resolution, or changed delivery blob
+   invalidates the review and validation evidence and restarts this sequence. A SHA changed only by
+   rebasing over new base commits may carry expensive validation forward through
+   `docs/development/GOVERNANCE_PROPORTIONALITY.md :: Post-validation base-drift evidence reuse`;
+   all eligibility evidence and bounded current-head checks named there are mandatory. The
+   pre-expensive mechanism review may be carried forward only when its reviewed patch is proven
+   byte-identical; any required final review remains current-SHA after publication.
 5. Push only after all four preceding steps pass. Never proceed directly from review to push.
 
 ### Step 5: Push Branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,14 @@ TCD chooses capability *inside* the delivery chain; this section chooses how muc
 - **Delivery depth follows the risk tier.** Single-issue (or issue-free) Tier 1 and Tier 2 PRs take the light path: required CI green plus self-verified `Verify:` targets on the head SHA, then plain merge with `Final-Review-Rounds: 0` — no independent review round, no verified-merge ceremony. The full chain (independent local review gate, `Final-Review-Rounds: 1|2`, verified-merge sequence) applies only to Tier 3 work, multi-issue PRs, and PRs touching a TCD high-risk *surface* (auth / security / data / migration / concurrency / payments / external API). Process outcomes in the escalation-trigger list — a failed attempt, a CI flake, a reviewer nit — escalate capability, never delivery depth.
 - **Right-size default.** Build the most boring solution that satisfies the acceptance criteria. A new gate, receipt, ledger, registry, config surface, abstraction layer, or enterprise-grade pattern (high availability, multi-tenancy, pluggable providers, defense-in-depth beyond the single-operator trust model) requires an explicit demand in the governing contract — never default posture. "A simpler mechanism satisfies the contract" is a valid blocking review finding. A new permanent governance mechanism must name what it replaces or carry an explicit review-by date.
 - **Budget and stop-loss.** A delivery gets 2 CI-repair rounds per failure mechanism (the full path keeps the 2+2 escalated repair budget in `verification-and-closure`). When the budget is spent, stop grinding: ship the smallest passing subset, or hand back a one-paragraph stop report plus a `LearningSignal`. Budgets are never rebound to reset accounting. Light work runs without sub-agent fan-out. Repeated failure on a bounded change usually means the solution is too big — shrink it before escalating capability.
+- **Do not pay twice for irrelevant base drift.** Branch freshness and validation freshness are
+  separate questions. After a proof-complete local SHA is rebased only because `origin/main`
+  advanced, carry expensive review/validation evidence forward when
+  `docs/development/GOVERNANCE_PROPORTIONALITY.md :: Post-validation base-drift evidence reuse`
+  proves the patch byte-identical and the incoming base semantically irrelevant. Relevant source,
+  dependency, contract, configuration, migration, test-selection, or toolchain drift still requires
+  fresh affected-surface proof. Current-head CI and every required final review remain current-SHA
+  gates.
 
 ## Communicating with the owner
 

--- a/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
+++ b/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
@@ -330,6 +330,13 @@ classification alone does not expand it to a repo-wide full suite.
 Creating the packet or changing reviewer capability never resets the existing per-mechanism repair
 budget.
 
+If `origin/main` advances after a clean convergence review or expensive validation, an eligible
+base-only rebase may reuse that evidence under
+`GOVERNANCE_PROPORTIONALITY.md :: Post-validation base-drift evidence reuse`. This is not a repair
+round and does not reset a budget. Any changed delivery blob, conflict resolution, scope change, or
+relevant base change returns to convergence/affected-surface validation. Current-head CI and the
+final independent review gate are never carried forward.
+
 ### Low-convergence receipt
 
 Record the triggering review round, mechanism key, packet location or concise receipt, reviewer

--- a/docs/development/GOVERNANCE_PROPORTIONALITY.md
+++ b/docs/development/GOVERNANCE_PROPORTIONALITY.md
@@ -65,6 +65,32 @@ expensive. Budgets are never rebound to a new mechanism key to reset accounting.
 deliveries run without sub-agent fan-out. Repeated failure on a bounded change is evidence the
 solution is too big — shrink the solution before escalating capability.
 
+## Post-validation base-drift evidence reuse
+
+Branch freshness does not make byte-identical validation evidence false. When `origin/main`
+advances after expensive local validation but before the first push, rebase as required by the
+branch-truth gate and carry that evidence forward only when every condition below is proven:
+
+- the rebased delivery patch has the same stable patch ID as the validated patch;
+- every delivery-owned file blob is byte-identical to the validated patch;
+- the incoming base commits do not overlap delivery-owned paths and a changed-surface review finds
+  no semantic effect on dependencies, contracts, runtime configuration, schemas, migrations,
+  generated inputs, test selection, CI/build tooling, or the validation command itself;
+- no repair, scope change, conflict resolution, or delivery-owned edit occurred during the rebase;
+- the rebased head passes the bounded `Verify:` targets and cheap integration/contract checks that
+  can detect interaction with the incoming base; and
+- the publication receipt records the validated SHA, rebased SHA, stable patch ID, incoming commit
+  range, overlap result, checks rerun, and the expensive validation carried forward.
+
+Any unresolved relevance question fails closed and reruns the affected validation. A code,
+dependency, configuration, schema, migration, test-selection, CI/build-tooling, or contract change
+that can affect the delivery is relevant even when filenames do not overlap.
+
+This rule replaces unconditional full-suite repetition for irrelevant base-only SHA changes. It
+does not carry forward GitHub CI, live-environment proof, mergeability, or a required final review:
+those remain bound to the current PR head. It also never carries evidence across a repair commit,
+scope change, conflict resolution, or changed delivery blob.
+
 ## Right-size default
 
 The default solution is the most boring one that satisfies the acceptance criteria. A new gate,
@@ -82,6 +108,8 @@ Product-side scale posture is owned by `docs/DESIGN_PRINCIPLES.md`.
 - `Verify:` targets on issue-backed acceptance criteria.
 - Branch-truth gates at the publication boundary.
 - Required CI checks green on the current head SHA before any merge, at every tier.
+- Required final reviews run on the current head SHA; only eligible pre-publication expensive
+  validation may use the base-drift evidence-reuse rule above.
 
 ## CI enforcement
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Summary

Separates branch freshness from validation freshness. A rebase over semantically irrelevant base commits may now carry expensive local proof forward only when stable patch identity, byte-identical delivery blobs, zero relevant overlap, bounded current-head checks, and a durable receipt are all present.

Current-head CI and required final reviews remain mandatory; repairs, conflict resolution, scope changes, relevant dependency/config/test/tooling drift, or any changed delivery blob still invalidate prior proof.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260729211009_77280a52`
- Reason: #4291 repeated two green 11,611-test proofs after unrelated docs-only base drift changed commit identity without changing the repair patch.

## Validation
- `git diff --check`
- `python3 scripts/docs_guard.py`
- `python3 -m pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/governance/test_issue_pr_governance.py` — 112 passed
- `python3 scripts/review_before_ci_gate.py --lane governance --review-gate-complete --risk-assessment-complete ...` — satisfied

## Scope

Governance contracts and skills only. No Product/Runtime behavior, release, promotion, credential, or CKM projection changes.