### PR TITLE
Publish acquisition candidates atomically without global serialization

### DIFF
--- a/app/knowledge/write_ops.py
+++ b/app/knowledge/write_ops.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
-from pathlib import Path
-from typing import TYPE_CHECKING
+from pathlib import Path, PurePosixPath
+import stat
+from typing import TYPE_CHECKING, Literal
+import uuid
 
+from app.knowledge.adapters import _atomic_rename_noreplace_at
 from app.knowledge.contracts import WriteReceipt
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.locators import make_note_locator, make_note_locator_from_absolute
@@ -27,6 +31,218 @@ if TYPE_CHECKING:
 # closes every one of those gaps in a single change, and is safe/idempotent
 # for callers that already asserted their own action.
 KNOWLEDGE_WRITE_ACTION = "knowledge.write_note"
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+)
+_CANDIDATE_STAGE_OPEN_FLAGS = (
+    os.O_WRONLY
+    | os.O_CREAT
+    | os.O_EXCL
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+)
+CandidateCreateResult = Literal["written", "already_exists"]
+
+
+def _candidate_relative_parts(note_rel_path: str) -> tuple[str, ...]:
+    if not note_rel_path or "\x00" in note_rel_path or "\\" in note_rel_path:
+        raise ValueError("candidate note path must be a portable vault-relative POSIX path")
+    path = PurePosixPath(note_rel_path)
+    if path.is_absolute() or path.as_posix() != note_rel_path:
+        raise ValueError("candidate note path must be a normalized vault-relative POSIX path")
+    parts = path.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("candidate note path must stay inside the vault")
+    return parts
+
+
+def _require_regular_candidate_target(
+    parent_fd: int,
+    target_name: str,
+) -> None:
+    target_stat = os.stat(target_name, dir_fd=parent_fd, follow_symlinks=False)
+    if not stat.S_ISREG(target_stat.st_mode):
+        raise OSError(
+            errno.EINVAL,
+            "candidate target exists but is not a regular file",
+            target_name,
+        )
+
+
+def candidate_note_exists_durable(
+    note_rel_path: str,
+    *,
+    vault_root: Path | str,
+) -> bool:
+    """Durably observe a regular candidate target without mutating the vault."""
+
+    parts = _candidate_relative_parts(note_rel_path)
+    resolved_root = Path(vault_root).expanduser().resolve()
+    current_dir_fd: int | None = None
+    try:
+        current_dir_fd = os.open(resolved_root, _DIRECTORY_OPEN_FLAGS)
+        for component in parts[:-1]:
+            try:
+                child_fd = os.open(
+                    component,
+                    _DIRECTORY_OPEN_FLAGS,
+                    dir_fd=current_dir_fd,
+                )
+            except FileNotFoundError:
+                return False
+            superseded_fd = current_dir_fd
+            current_dir_fd = child_fd
+            os.close(superseded_fd)
+
+        try:
+            _require_regular_candidate_target(current_dir_fd, parts[-1])
+        except FileNotFoundError:
+            return False
+        os.fsync(current_dir_fd)
+        return True
+    finally:
+        if current_dir_fd is not None:
+            owned_fd = current_dir_fd
+            current_dir_fd = None
+            os.close(owned_fd)
+
+
+def create_candidate_note_once(
+    note_rel_path: str,
+    content: str,
+    *,
+    vault_root: Path | str,
+    action: str,
+    write_guard: "WriteGuard | None" = None,
+) -> CandidateCreateResult:
+    """Create one candidate atomically, preserving any existing target.
+
+    This is deliberately candidate-specific. It owns only invocation-local
+    parent preparation and one hidden stage; it does not change generic
+    ``KnowledgePort.write_note`` semantics or coordinate other writers.
+    """
+
+    from app.write_guard import DEFAULT_WRITE_GUARD
+
+    parts = _candidate_relative_parts(note_rel_path)
+    resolved_root = Path(vault_root).expanduser().resolve()
+    guard = write_guard or DEFAULT_WRITE_GUARD
+    guard.assert_writes_allowed(action)
+    payload = content.encode("utf-8")
+
+    current_dir_fd: int | None = None
+    stage_fd: int | None = None
+    stage_name: str | None = None
+    stage_owned = False
+    stage_unlink_attempted = False
+    cleanup_error: BaseException | None = None
+
+    def record_cleanup_error(exc: BaseException) -> None:
+        nonlocal cleanup_error
+        if cleanup_error is None:
+            cleanup_error = exc
+
+    try:
+        current_dir_fd = os.open(resolved_root, _DIRECTORY_OPEN_FLAGS)
+        for component in parts[:-1]:
+            try:
+                os.mkdir(component, mode=0o777, dir_fd=current_dir_fd)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+            os.fsync(current_dir_fd)
+            child_fd = os.open(
+                component,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=current_dir_fd,
+            )
+            superseded_fd = current_dir_fd
+            current_dir_fd = child_fd
+            os.close(superseded_fd)
+
+        stage_name = f".candidate-stage-{uuid.uuid4().hex}"
+        stage_fd = os.open(
+            stage_name,
+            _CANDIDATE_STAGE_OPEN_FLAGS,
+            0o600,
+            dir_fd=current_dir_fd,
+        )
+        stage_owned = True
+        offset = 0
+        while offset < len(payload):
+            written = os.write(stage_fd, payload[offset:])
+            if written <= 0:
+                raise OSError(
+                    errno.EIO,
+                    "candidate stage write made no progress",
+                    stage_name,
+                )
+            offset += written
+        os.fsync(stage_fd)
+        owned_stage_fd = stage_fd
+        stage_fd = None
+        os.close(owned_stage_fd)
+
+        try:
+            _atomic_rename_noreplace_at(
+                current_dir_fd,
+                stage_name,
+                current_dir_fd,
+                parts[-1],
+            )
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+            stage_unlink_attempted = True
+            os.unlink(stage_name, dir_fd=current_dir_fd)
+            stage_owned = False
+            os.fsync(current_dir_fd)
+            _require_regular_candidate_target(current_dir_fd, parts[-1])
+            return "already_exists"
+
+        stage_owned = False
+        os.fsync(current_dir_fd)
+        return "written"
+    finally:
+        if stage_fd is not None:
+            owned_stage_fd = stage_fd
+            stage_fd = None
+            try:
+                os.close(owned_stage_fd)
+            except BaseException as exc:  # noqa: BLE001 - preserve fail-closed cleanup
+                record_cleanup_error(exc)
+
+        if (
+            stage_owned
+            and not stage_unlink_attempted
+            and stage_name is not None
+            and current_dir_fd is not None
+        ):
+            stage_unlink_attempted = True
+            try:
+                os.unlink(stage_name, dir_fd=current_dir_fd)
+            except BaseException as exc:  # noqa: BLE001 - exact owned-stage cleanup
+                record_cleanup_error(exc)
+            else:
+                stage_owned = False
+                try:
+                    os.fsync(current_dir_fd)
+                except BaseException as exc:  # noqa: BLE001 - cleanup durability is required
+                    record_cleanup_error(exc)
+
+        if current_dir_fd is not None:
+            owned_dir_fd = current_dir_fd
+            current_dir_fd = None
+            try:
+                os.close(owned_dir_fd)
+            except BaseException as exc:  # noqa: BLE001 - every owner gets one close attempt
+                record_cleanup_error(exc)
+
+        if cleanup_error is not None:
+            raise cleanup_error
 
 
 def default_vault_root_for_path(path: Path | str) -> Path:
@@ -107,15 +323,11 @@ def write_note_from_absolute(
         # different note. The filesystem adapter rejects an aliased
         # expected-version locator, while its descriptor/no-follow CAS protects
         # replacements after that check.
-        lexical_path = Path(
-            os.path.abspath(os.path.expanduser(os.fspath(path)))
-        )
+        lexical_path = Path(os.path.abspath(os.path.expanduser(os.fspath(path))))
         try:
             relative_path = lexical_path.relative_to(resolved_root)
         except ValueError:
-            lexical_root = Path(
-                os.path.abspath(os.path.expanduser(os.fspath(vault_root)))
-            )
+            lexical_root = Path(os.path.abspath(os.path.expanduser(os.fspath(vault_root))))
             relative_path = lexical_path.relative_to(lexical_root)
         locator = make_note_locator(relative_path.as_posix())
     # Absolute path writes target the local filesystem boundary directly.
@@ -215,9 +427,12 @@ def advanced_uri_from_vault_path(path: Path | str, *, vault_root: Path | str) ->
 
 
 __all__ = [
+    "CandidateCreateResult",
     "KNOWLEDGE_WRITE_ACTION",
     "advanced_uri_from_vault_path",
     "append_note_relative",
+    "candidate_note_exists_durable",
+    "create_candidate_note_once",
     "default_vault_root_for_path",
     "read_note_text_with_version",
     "write_note_from_absolute",

--- a/app/knowledge_acquisition/candidate_writeback.py
+++ b/app/knowledge_acquisition/candidate_writeback.py
@@ -50,7 +50,10 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
-from app.knowledge.write_ops import write_note_relative
+from app.knowledge.write_ops import (
+    candidate_note_exists_durable,
+    create_candidate_note_once,
+)
 from app.knowledge_acquisition.extraction_registry import ExtractionResult, run_extractor
 from app.knowledge_acquisition.note_renderer import (
     NoteRenderError,
@@ -150,15 +153,11 @@ def assemble_candidate(
     """
     content_identity = raw_record.get("content_identity")
     if not content_identity or not isinstance(content_identity, str):
-        raise CandidateAssemblyError(
-            "raw_record.content_identity is required and must be a string"
-        )
+        raise CandidateAssemblyError("raw_record.content_identity is required and must be a string")
     source_kind = raw_record.get("source_kind")
     item_ref = raw_record.get("item_ref")
     if not source_kind or not item_ref:
-        raise CandidateAssemblyError(
-            "raw_record.source_kind and item_ref are required"
-        )
+        raise CandidateAssemblyError("raw_record.source_kind and item_ref are required")
 
     metadata = raw_record.get("metadata") or {}
     provenance = raw_record.get("provenance") or {}
@@ -261,9 +260,7 @@ def render_candidate_note(candidate: Candidate) -> str:
                 module_id="summary",
                 title="Summary",
                 content=(
-                    f"**Model confidence (non-authoritative):** {confidence:g}\n"
-                    "\n"
-                    f"{summary}"
+                    f"**Model confidence (non-authoritative):** {confidence:g}\n" "\n" f"{summary}"
                 ),
             )
         )
@@ -305,11 +302,11 @@ def write_candidate_note(
     """The governed vault-write call site: the only place this module touches
     the filesystem.
 
-    `write_guard.assert_writes_allowed(CANDIDATE_WRITE_ACTION)` runs
-    immediately before the write via `write_note_relative` (the same
-    `KnowledgePort`-backed helper `materialize_moment` /
-    `materialize_promoted_memory` use) — WriteGuard is independently
-    authoritative and this stage has no other path to disk.
+    The existing-target probe runs before render and WriteGuard, and mutates
+    nothing. For a missing target, the candidate-only knowledge helper asserts
+    `write_guard.assert_writes_allowed(CANDIDATE_WRITE_ACTION)` before parent
+    preparation or stage creation. Long acquisition and render work therefore
+    owns no publication resource.
 
     A `WritesBlockedError` is caught here and returned as an item-scoped
     `status="blocked"` result: loud (the reason is preserved), never silent,
@@ -323,7 +320,18 @@ def write_candidate_note(
     vault_root = _vault_root(vault_context)
     artifact_path = candidate_note_path(candidate, sources_dir=sources_dir)
 
-    if (vault_root / artifact_path).exists():
+    try:
+        target_exists = candidate_note_exists_durable(
+            artifact_path,
+            vault_root=vault_root,
+        )
+    except Exception as exc:  # noqa: BLE001 - re-raised as the item-scoped error below
+        raise CandidateWritebackError(
+            f"candidate note probe failed for content_identity="
+            f"{candidate.content_identity!r} at {artifact_path!r}: {exc}"
+        ) from exc
+
+    if target_exists:
         return CandidateWriteResult(
             status="already_exists",
             artifact_path=artifact_path,
@@ -339,7 +347,13 @@ def write_candidate_note(
         ) from exc
 
     try:
-        write_guard.assert_writes_allowed(CANDIDATE_WRITE_ACTION)
+        status = create_candidate_note_once(
+            artifact_path,
+            content,
+            vault_root=vault_root,
+            action=CANDIDATE_WRITE_ACTION,
+            write_guard=write_guard,
+        )
     except WritesBlockedError as exc:
         return CandidateWriteResult(
             status="blocked",
@@ -347,9 +361,6 @@ def write_candidate_note(
             content_identity=candidate.content_identity,
             reason=str(exc),
         )
-
-    try:
-        write_note_relative(artifact_path, content, vault_root=vault_root)
     except Exception as exc:  # noqa: BLE001 - re-raised as the item-scoped error below
         raise CandidateWritebackError(
             f"candidate note write failed for content_identity="
@@ -357,7 +368,7 @@ def write_candidate_note(
         ) from exc
 
     return CandidateWriteResult(
-        status="written",
+        status=status,
         artifact_path=artifact_path,
         content_identity=candidate.content_identity,
     )

--- a/docs/KNOWLEDGE_ACQUISITION/CANDIDATE_WRITEBACK.md
+++ b/docs/KNOWLEDGE_ACQUISITION/CANDIDATE_WRITEBACK.md
@@ -23,7 +23,8 @@ pipeline ends here; triage is human territory.
 - Writes the note based on the shipped template with metadata + provenance frontmatter,
   `transcript_available`, owner-authored takeaways/open threads, one explicit
   `Proposals (non-authoritative)` wrapper, and deterministic evidence/lineage — through
-  WriteGuard/governed vault-write mechanics (mechanical durable, non-authority-bearing write).
+  WriteGuard and the candidate-only create-once knowledge helper (mechanical durable,
+  non-authority-bearing write). A durable existing-target probe stays before render and WriteGuard.
 - Composes the delivered `summary@2` result through a pure proposal-section seam. Empty optional
   modules are omitted; a no-proposals marker replaces empty module headings.
 - Parses generated Markdown before assembly and fails closed when visible prose falsely claims the
@@ -113,15 +114,31 @@ boundary visible inside the note: generated prose cannot occupy or impersonate t
 ## Out of Scope
 
 Human review UX; promotion; note updates on re-acquisition; claims, durable extraction or transcript
-storage, new content modules, and the unresolved atomic-create bug tracked separately by #4132.
+storage, new content modules, generic KnowledgePort create semantics, other candidate-family writer
+migration, and network/distributed writer guarantees.
 
 ## Restart / Durability Posture
 
-The note is durable (vault). Candidate assembly state is derived and re-runnable from `raw`; a
-crash between candidate assembly and note write loses nothing durable — replay reproduces the
-candidate, and the write retries idempotently (same note path, same content identity). Once the
-candidate note exists, later attempts return `already_exists` before rendering or writing. The
-entire file — including owner-authored takeaways and open threads — therefore remains byte-identical.
+The note is durable (vault). Candidate assembly state is derived and re-runnable from `raw`; source
+fetch, transcription, normalization, extraction, and rendering run without a vault-global writer
+lock or any publication ownership. A durable, non-mutating probe returns `already_exists` before
+rendering or WriteGuard only after verifying a regular target and fsyncing its existing parent.
+
+For a missing target, WriteGuard authorizes one short target-scoped publication. The candidate
+helper locally creates or observes each vault-relative parent component and fsyncs its containing
+directory, then writes complete immutable UTF-8 bytes to a unique extensionless hidden stage. File
+fsync and one raw-FD close precede descriptor-relative atomic no-replace publication; target-parent
+fsync precedes `written`. A same-target loser removes only its own stage, fsyncs the parent, verifies
+the regular winner, and returns `already_exists`, so an existing or human-edited note remains
+byte-identical.
+
+A failure before rename exposes no partial canonical note. A failed cleanup can leave only that
+invocation's hidden, scanner-inert rebuildable stage; retained `raw` evidence makes retry safe, and
+old remnants are ignored. After rename succeeds, a failed final durability fence emits no success
+but never deletes the complete canonical target; retry completes the durable probe. Parent
+directories created before a later failure remain harmless local preparation. These guarantees are
+for the supported one-user macOS/Linux single-local-filesystem runtime; they add no ordering,
+fairness, network-filesystem claim, global `Sources/` invariant, coordinator, or migration.
 
 ## Related Docs
 

--- a/docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md
+++ b/docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md
@@ -59,6 +59,16 @@ policy §3 mandates for AI-generated content, with full provenance, written back
 existing companion-note / vault mechanics named in the source spec. From this point the
 ingestion/triage policy governs; the pipeline is done.
 
+The shipped YouTube candidate writer preserves its deterministic path with a candidate-specific
+local create-once helper. Existing regular targets are durably observed before render and
+WriteGuard. Missing targets render without exclusion, then WriteGuard authorizes invocation-local
+parent preparation and one hidden raw-FD stage that is file-fsynced, closed once, atomically
+published without replacement, and parent-fsynced. Concurrent same-target attempts let the local
+filesystem select one winner; different targets and unrelated governed writes remain independent.
+Pre-publication failure is retryable from `raw`, while a post-rename fence failure preserves the
+complete target for the next durable probe. This is not a generic KnowledgePort contract, a global
+`Sources/` bootstrap invariant, or a migration of the Karakeep/Heimdal writers described below.
+
 **Karakeep handoff extension (contract selected, runtime pending).** KMA-01 / issue #3372 fixes the
 Mimer-side extension point as the shipped
 `app.heimdal.candidate_projection.project_pending_candidates` path with its existing

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -82,6 +82,14 @@ It does **not** own:
 - CI pipelines or hosted deployment automation (remains out of scope in this single-user wave);
 - multi-vault hot/cold decomposition in prod (future work; flagged below).
 
+Channel isolation also does not imply a vault-global writer lock. The shipped YouTube candidate
+path performs source fetch, real-time transcription, extraction, and rendering without publication
+ownership; unrelated governed writes and different candidate targets can proceed concurrently.
+Only the final local macOS/Linux create-once step is target-scoped: WriteGuard, invocation-owned
+parent preparation, hidden complete-file stage, atomic no-replace, and a parent durability fence.
+Same-target overlap is first-write-wins with no ordering or fairness guarantee. This mechanism adds
+no process coordinator, global `Sources/` invariant, migration, or network/distributed semantics.
+
 ## Channel model
 
 Three channels map one-to-one onto the existing environment model, but add identity and isolation guarantees.

--- a/docs/contracts/MIMER_CLIENT_CONTRACT.md
+++ b/docs/contracts/MIMER_CLIENT_CONTRACT.md
@@ -140,6 +140,15 @@ never silently rewrites the original. A Sources note becomes durable knowledge o
 governed candidate → proposal → human-confirm path (`WriteGuard` → `DecisionToken` →
 `AuthorityReceipt`). Moving or renaming the note into the knowledge tree is not a promotion.
 
+The shipped YouTube acquisition candidate is one narrow create-once producer in this zone. Long
+source work and rendering hold no zone-wide writer lock. After WriteGuard, it prepares only its own
+vault-relative parent chain, stages complete bytes under an extensionless hidden name, and uses the
+supported local filesystem's atomic no-replace operation plus parent durability fence. An existing
+regular target or atomic race winner is preserved byte-for-byte. A pre-publication failure remains
+rebuildable from retained raw evidence; a post-rename fence failure preserves the complete target
+for retry. This single-user macOS/Linux mechanism does not make `Sources/` a global initialized
+resource, coordinate other producers, or claim network/distributed semantics.
+
 The zone is attention-free by design: it is an archive, not an unread queue or processing
 obligation; material reaches the human only through governed Mimer proposals. The owner selected the
 default **Sources** on 2026-07-10 from the shortlist Observationer, Källor, Referenser, Corpus,

--- a/docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md
+++ b/docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md
@@ -27,6 +27,23 @@ This contract follows:
 - `search_notes(vault, query, limit=20)`
 - `open_note(locator)`
 
+Approved candidate-only helpers, not new `KnowledgePort` methods:
+
+- `candidate_note_exists_durable(note_rel_path, vault_root=...)` walks an existing parent chain
+  descriptor-relative without following symlinks or mutating the vault. It returns true only for a
+  regular target after target-parent fsync; missing paths return false, and all other probe or close
+  failures are loud.
+- `create_candidate_note_once(note_rel_path, content, vault_root=..., action=..., write_guard=...)`
+  asserts WriteGuard before mutation, durably prepares only the target's local parent chain, writes
+  a complete hidden raw-FD stage, and publishes through the existing descriptor-relative atomic
+  no-replace primitive. `written` follows target-parent fsync; an `EEXIST` loser cleans only its own
+  stage, fences the parent, verifies the regular winner, and returns `already_exists`.
+
+These helpers are restricted to the shipped YouTube candidate writeback. They neither broaden
+generic port/adapter semantics nor migrate Heimdal, Karakeep, or other `Sources/` producers. Their
+guarantees assume one user on macOS/Linux and one local filesystem; they provide no global lock,
+fairness, network-filesystem, or distributed-writer contract.
+
 The `write_note` receipt above is the low-level port result. Production/service callers use
 `write_note_from_absolute` or `write_note_relative`; those helpers raise
 `KnowledgeWriteConflict` with the staged receipt attached when `outcome="conflict_staged"`.

--- a/tests/architecture/test_architecture_tests_validation.py
+++ b/tests/architecture/test_architecture_tests_validation.py
@@ -144,6 +144,7 @@ def test_obsidian_boundary_guardrails_dont_allow_escape_hatches() -> None:
     expected_adapters_importers_allow = {
         REPO_ROOT / "app" / "knowledge" / "__init__.py",
         REPO_ROOT / "app" / "knowledge" / "service.py",
+        REPO_ROOT / "app" / "knowledge" / "write_ops.py",
     }
 
     note_func = _find_function(module, "test_note_locator_construction_is_centralized")

--- a/tests/architecture/test_obsidian_port_boundaries.py
+++ b/tests/architecture/test_obsidian_port_boundaries.py
@@ -4,6 +4,8 @@ import ast
 from pathlib import Path
 from typing import Iterable
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -37,6 +39,27 @@ def _imports(path: Path) -> set[str]:
         elif isinstance(node, ast.ImportFrom) and node.module:
             modules.add(node.module)
     return modules
+
+
+def _function_node(path: Path, name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    matches = [
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(matches) == 1, f"expected exactly one {name} in {path}"
+    return matches[0]
+
+
+def _call_names(node: ast.AST) -> list[str]:
+    calls: list[str] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        if isinstance(child.func, ast.Name):
+            calls.append(child.func.id)
+        elif isinstance(child.func, ast.Attribute):
+            calls.append(child.func.attr)
+    return calls
 
 
 def test_note_locator_construction_is_centralized() -> None:
@@ -101,6 +124,9 @@ def test_knowledge_adapters_are_resolved_only_via_service_boundary() -> None:
     allow_importers = {
         REPO_ROOT / "app" / "knowledge" / "__init__.py",
         REPO_ROOT / "app" / "knowledge" / "service.py",
+        # Candidate-only create-once publication reuses the existing private
+        # descriptor-relative no-replace primitive without broadening the port.
+        REPO_ROOT / "app" / "knowledge" / "write_ops.py",
     }
     offenders: list[str] = []
     for root in scan_roots:
@@ -225,3 +251,145 @@ def test_legacy_fs_watcher_does_not_depend_on_deprecated_sink_ports() -> None:
     imports = _imports(watcher_path)
     assert "app.ports.sink" not in imports
     assert "app.ports.pg_sink" not in imports
+
+
+def test_candidate_writer_topology_has_no_acquisition_long_lock() -> None:
+    acquire_path = REPO_ROOT / "app" / "knowledge_acquisition" / "acquire.py"
+    replay_path = REPO_ROOT / "app" / "knowledge_acquisition" / "replay.py"
+    drain_path = REPO_ROOT / "app" / "knowledge_acquisition" / "acquisition_requests.py"
+    writeback_path = REPO_ROOT / "app" / "knowledge_acquisition" / "candidate_writeback.py"
+
+    def assert_function_calls(source: str, function_name: str, called_name: str) -> ast.FunctionDef:
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == function_name
+        )
+        assert called_name in _call_names(function)
+        return function
+
+    def assert_default_drain_route(source: str) -> ast.FunctionDef:
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "drain_one"
+        )
+        route_assignments = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "fn" for target in node.targets)
+        ]
+        assert len(route_assignments) == 1
+        route_value = route_assignments[0].value
+        assert isinstance(route_value, ast.BoolOp)
+        assert isinstance(route_value.op, ast.Or)
+        assert [value.id for value in route_value.values if isinstance(value, ast.Name)] == [
+            "acquire_fn",
+            "acquire_youtube",
+        ]
+        assert "fn" in _call_names(function)
+        return function
+
+    acquire_source = acquire_path.read_text(encoding="utf-8")
+    replay_source = replay_path.read_text(encoding="utf-8")
+    drain_source = drain_path.read_text(encoding="utf-8")
+    acquire = assert_function_calls(
+        acquire_source,
+        "acquire_youtube",
+        "write_candidate_note",
+    )
+    replay = assert_function_calls(replay_source, "run_replay", "write_candidate_note")
+    drain = assert_default_drain_route(drain_source)
+
+    forbidden_imports = {
+        "fcntl",
+        "multiprocessing",
+        "threading",
+    }
+    assert _imports(writeback_path).isdisjoint(forbidden_imports)
+    forbidden_calls = {"Lock", "RLock", "flock", "lockf", "Semaphore"}
+    for function in (
+        acquire,
+        replay,
+        drain,
+        _function_node(writeback_path, "write_candidate_note"),
+    ):
+        assert set(_call_names(function)).isdisjoint(forbidden_calls)
+
+    # Mutants preserve comments/docstrings but bypass a real function-scoped call.
+    acquire_mutant = acquire_source.replace(
+        "write_result: CandidateWriteResult = write_candidate_note(",
+        "write_result: CandidateWriteResult = bypass_candidate_write(",
+        1,
+    )
+    with pytest.raises(AssertionError):
+        assert_function_calls(
+            acquire_mutant,
+            "acquire_youtube",
+            "write_candidate_note",
+        )
+
+    replay_mutant = replay_source.replace(
+        "write_result = write_candidate_note(",
+        "write_result = bypass_candidate_write(",
+        1,
+    )
+    with pytest.raises(AssertionError):
+        assert_function_calls(replay_mutant, "run_replay", "write_candidate_note")
+
+    with pytest.raises(AssertionError):
+        assert_default_drain_route(
+            drain_source.replace(
+                "fn = acquire_fn or acquire_youtube",
+                "fn = acquire_fn",
+                1,
+            )
+        )
+
+
+def test_create_once_stays_behind_knowledge_service_boundary() -> None:
+    app_root = REPO_ROOT / "app"
+    call_sites: list[tuple[str, str]] = []
+    for path in _iter_py_files(app_root):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            called = (
+                node.func.id
+                if isinstance(node.func, ast.Name)
+                else node.func.attr
+                if isinstance(node.func, ast.Attribute)
+                else None
+            )
+            if called != "create_candidate_note_once":
+                continue
+            owner: ast.AST | None = node
+            while owner is not None and not isinstance(owner, ast.FunctionDef):
+                owner = parents.get(owner)
+            assert isinstance(owner, ast.FunctionDef)
+            call_sites.append((str(path.relative_to(REPO_ROOT)), owner.name))
+
+    assert call_sites == [
+        ("app/knowledge_acquisition/candidate_writeback.py", "write_candidate_note")
+    ]
+    writeback_path = app_root / "knowledge_acquisition" / "candidate_writeback.py"
+    imports = [
+        node
+        for node in ast.walk(ast.parse(writeback_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "app.knowledge.write_ops"
+        and any(alias.name == "create_candidate_note_once" for alias in node.names)
+    ]
+    assert len(imports) == 1
+
+    acquisition_root = app_root / "knowledge_acquisition"
+    for path in _iter_py_files(acquisition_root):
+        assert "app.knowledge.adapters" not in _imports(path)

--- a/tests/knowledge/candidate_create_oracles.py
+++ b/tests/knowledge/candidate_create_oracles.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import os
+import re
+import threading
+
+import pytest
+
+FdToken = tuple[int, int, str, str]
+DuplicationEvent = tuple[str, int, int]
+_STAGE_NAME_RE = re.compile(r"^\.candidate-stage-[0-9a-f]{32}$")
+
+
+class FdOracle:
+    """Track logical FD generations across success, faults, and real races."""
+
+    def __init__(self) -> None:
+        self.opened: list[FdToken] = []
+        self.close_attempts: list[FdToken | None] = []
+        self.duplicates: list[DuplicationEvent] = []
+        self.active: dict[int, FdToken] = {}
+        self.events: list[tuple[object, ...]] = []
+        self._generation = 0
+        self._lock = threading.Lock()
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_open = os.open
+        real_close = os.close
+        real_dup = os.dup
+        real_dup2 = os.dup2
+        real_dup3 = getattr(os, "dup3", None)
+
+        def register_duplicate(
+            operation: str,
+            source_fd: int,
+            duplicate_fd: int,
+        ) -> int:
+            with self._lock:
+                source = self.active.get(source_fd)
+                if source is None:
+                    return duplicate_fd
+                self._generation += 1
+                token = (
+                    duplicate_fd,
+                    self._generation,
+                    f"duplicated_{source[2]}",
+                    f"{operation}:{source[3]}",
+                )
+                assert duplicate_fd not in self.active
+                self.active[duplicate_fd] = token
+                self.opened.append(token)
+                self.duplicates.append((operation, source_fd, duplicate_fd))
+                self.events.append((operation, source_fd, duplicate_fd, token))
+            return duplicate_fd
+
+        def traced_open(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            fd = real_open(path, flags, mode, dir_fd=dir_fd)
+            raw_path = os.fsdecode(path)
+            kind = (
+                "stage"
+                if raw_path.startswith(".candidate-stage-")
+                else "directory"
+                if flags & getattr(os, "O_DIRECTORY", 0)
+                else "file"
+            )
+            with self._lock:
+                self._generation += 1
+                token = (fd, self._generation, kind, raw_path)
+                assert fd not in self.active, f"raw fd {fd} reused while still owned"
+                self.active[fd] = token
+                self.opened.append(token)
+                self.events.append(("open", raw_path, flags, dir_fd, token))
+            return fd
+
+        def traced_close(fd: int) -> None:
+            with self._lock:
+                token = self.active.pop(fd, None)
+                self.close_attempts.append(token)
+                self.events.append(("close", fd, token))
+            real_close(fd)
+
+        def traced_dup(fd: int) -> int:
+            return register_duplicate("dup", fd, real_dup(fd))
+
+        def traced_dup2(fd: int, fd2: int, inheritable: bool = True) -> int:
+            duplicate = real_dup2(fd, fd2, inheritable=inheritable)
+            return register_duplicate("dup2", fd, duplicate)
+
+        monkeypatch.setattr(os, "open", traced_open)
+        monkeypatch.setattr(os, "close", traced_close)
+        monkeypatch.setattr(os, "dup", traced_dup)
+        monkeypatch.setattr(os, "dup2", traced_dup2)
+        if real_dup3 is not None:
+
+            def traced_dup3(fd: int, fd2: int, flags: int = 0) -> int:
+                duplicate = real_dup3(fd, fd2, flags)
+                return register_duplicate("dup3", fd, duplicate)
+
+            monkeypatch.setattr(os, "dup3", traced_dup3)
+
+
+def assert_exact_fd_ownership(
+    opened: list[FdToken],
+    close_attempts: list[FdToken | None],
+    duplicates: list[DuplicationEvent],
+) -> None:
+    assert duplicates == []
+    assert None not in close_attempts
+    assert len(close_attempts) == len(opened)
+    assert sorted(close_attempts) == sorted(opened)
+
+
+def assert_exact_stage_names(names: list[str]) -> None:
+    assert names
+    assert len(names) == len(set(names))
+    for name in names:
+        assert _STAGE_NAME_RE.fullmatch(name)
+        assert len(name.encode("utf-8")) == 49
+        assert not name.endswith(".md")
+
+
+def assert_cleanup_fence(events: list[tuple[object, ...]]) -> None:
+    unlink_indexes = [index for index, event in enumerate(events) if event[0] == "unlink"]
+    assert unlink_indexes
+    for unlink_index in unlink_indexes:
+        assert unlink_index + 1 < len(events)
+        assert events[unlink_index + 1][0] == "fsync"
+
+
+def assert_hidden_stage_state(
+    names: list[str],
+    *,
+    sentinel_name: str,
+    expected_owned_count: int,
+) -> None:
+    assert names.count(sentinel_name) == 1
+    owned_names = [name for name in names if name != sentinel_name]
+    assert len(owned_names) == expected_owned_count
+    if owned_names:
+        assert_exact_stage_names(owned_names)
+
+
+def assert_stage_publication_order(events: list[tuple[object, ...]]) -> None:
+    stage_opens = [
+        (index, event)
+        for index, event in enumerate(events)
+        if event[0] == "open" and isinstance(event[4], tuple) and event[4][2] == "stage"
+    ]
+    assert len(stage_opens) == 1
+    open_index, open_event = stage_opens[0]
+    stage_token = open_event[4]
+    assert isinstance(stage_token, tuple)
+    stage_fd = stage_token[0]
+    close_indexes = [
+        index
+        for index, event in enumerate(events)
+        if event[0] == "close" and event[2] == stage_token
+    ]
+    publish_indexes = [index for index, event in enumerate(events) if event[0] == "publish"]
+    assert len(close_indexes) == len(publish_indexes) == 1
+    fsync_indexes = [
+        index
+        for index, event in enumerate(events)
+        if event[0] == "fsync" and event[1] == stage_fd and open_index < index < close_indexes[0]
+    ]
+    assert len(fsync_indexes) == 1
+    assert open_index < fsync_indexes[0] < close_indexes[0] < publish_indexes[0]

--- a/tests/knowledge/candidate_create_oracles.py
+++ b/tests/knowledge/candidate_create_oracles.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import os
 import re
 import threading
@@ -21,7 +23,23 @@ class FdOracle:
         self.active: dict[int, FdToken] = {}
         self.events: list[tuple[object, ...]] = []
         self._generation = 0
+        self._ignored_active: set[int] = set()
+        self._retired_tracked: set[int] = set()
+        self._scope_depth = 0
         self._lock = threading.Lock()
+
+    @contextmanager
+    def observe(self) -> Iterator[None]:
+        """Limit ownership accounting to the production call under test."""
+
+        with self._lock:
+            self._scope_depth += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._scope_depth -= 1
+                assert self._scope_depth >= 0
 
     def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
         real_open = os.open
@@ -47,6 +65,8 @@ class FdOracle:
                     f"{operation}:{source[3]}",
                 )
                 assert duplicate_fd not in self.active
+                assert duplicate_fd not in self._ignored_active
+                self._retired_tracked.discard(duplicate_fd)
                 self.active[duplicate_fd] = token
                 self.opened.append(token)
                 self.duplicates.append((operation, source_fd, duplicate_fd))
@@ -70,9 +90,14 @@ class FdOracle:
                 else "file"
             )
             with self._lock:
+                assert fd not in self.active, f"raw fd {fd} reused while still owned"
+                assert fd not in self._ignored_active
+                self._retired_tracked.discard(fd)
+                if self._scope_depth == 0 or kind == "file":
+                    self._ignored_active.add(fd)
+                    return fd
                 self._generation += 1
                 token = (fd, self._generation, kind, raw_path)
-                assert fd not in self.active, f"raw fd {fd} reused while still owned"
                 self.active[fd] = token
                 self.opened.append(token)
                 self.events.append(("open", raw_path, flags, dir_fd, token))
@@ -81,8 +106,15 @@ class FdOracle:
         def traced_close(fd: int) -> None:
             with self._lock:
                 token = self.active.pop(fd, None)
-                self.close_attempts.append(token)
-                self.events.append(("close", fd, token))
+                if token is not None:
+                    self.close_attempts.append(token)
+                    self.events.append(("close", fd, token))
+                    self._retired_tracked.add(fd)
+                elif fd in self._ignored_active:
+                    self._ignored_active.remove(fd)
+                elif self._scope_depth > 0 and fd in self._retired_tracked:
+                    self.close_attempts.append(None)
+                    self.events.append(("close", fd, None))
             real_close(fd)
 
         def traced_dup(fd: int) -> int:

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import errno
 import hashlib
+import os
 from pathlib import Path
+import re
+import threading
 
 import pytest
 
@@ -10,6 +15,128 @@ from app.knowledge.contracts import WriteReceipt
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.settings import KnowledgeAdapter, KnowledgeSettings
 from app.write_guard import WriteGuard, WritesBlockedError
+
+
+_STAGE_NAME_RE = re.compile(r"^\.candidate-stage-[0-9a-f]{32}$")
+
+
+class _FdOracle:
+    """Track logical descriptor generations, including reused raw integers."""
+
+    def __init__(self) -> None:
+        self.opened: list[tuple[int, int, str, str]] = []
+        self.close_attempts: list[tuple[int, int, str, str] | None] = []
+        self.duplicates: list[tuple[str, int, int]] = []
+        self.active: dict[int, tuple[int, int, str, str]] = {}
+        self.events: list[tuple[object, ...]] = []
+        self._generation = 0
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_open = os.open
+        real_close = os.close
+        real_dup = os.dup
+        real_dup2 = os.dup2
+        real_dup3 = getattr(os, "dup3", None)
+
+        def register_duplicate(
+            operation: str,
+            source_fd: int,
+            duplicate_fd: int,
+        ) -> int:
+            self._generation += 1
+            source = self.active.get(source_fd)
+            kind = f"duplicated_{source[2]}" if source is not None else "duplicated_unknown"
+            path = f"{operation}:{source[3] if source is not None else source_fd}"
+            token = (duplicate_fd, self._generation, kind, path)
+            assert duplicate_fd not in self.active
+            self.active[duplicate_fd] = token
+            self.opened.append(token)
+            self.duplicates.append((operation, source_fd, duplicate_fd))
+            self.events.append((operation, source_fd, duplicate_fd, token))
+            return duplicate_fd
+
+        def traced_open(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            fd = real_open(path, flags, mode, dir_fd=dir_fd)
+            self._generation += 1
+            raw_path = os.fsdecode(path)
+            kind = (
+                "stage"
+                if raw_path.startswith(".candidate-stage-")
+                else "directory"
+                if flags & getattr(os, "O_DIRECTORY", 0)
+                else "file"
+            )
+            token = (fd, self._generation, kind, raw_path)
+            assert fd not in self.active, f"raw fd {fd} reused while still owned"
+            self.active[fd] = token
+            self.opened.append(token)
+            self.events.append(("open", raw_path, flags, dir_fd, token))
+            return fd
+
+        def traced_close(fd: int) -> None:
+            token = self.active.pop(fd, None)
+            self.close_attempts.append(token)
+            self.events.append(("close", fd, token))
+            real_close(fd)
+
+        def traced_dup(fd: int) -> int:
+            duplicate = real_dup(fd)
+            if fd not in self.active:
+                return duplicate
+            return register_duplicate("dup", fd, duplicate)
+
+        def traced_dup2(fd: int, fd2: int, inheritable: bool = True) -> int:
+            duplicate = real_dup2(fd, fd2, inheritable=inheritable)
+            if fd not in self.active:
+                return duplicate
+            return register_duplicate("dup2", fd, duplicate)
+
+        monkeypatch.setattr(os, "open", traced_open)
+        monkeypatch.setattr(os, "close", traced_close)
+        monkeypatch.setattr(os, "dup", traced_dup)
+        monkeypatch.setattr(os, "dup2", traced_dup2)
+        if real_dup3 is not None:
+
+            def traced_dup3(fd: int, fd2: int, flags: int = 0) -> int:
+                duplicate = real_dup3(fd, fd2, flags)
+                if fd not in self.active:
+                    return duplicate
+                return register_duplicate("dup3", fd, duplicate)
+
+            monkeypatch.setattr(os, "dup3", traced_dup3)
+
+
+def _assert_exact_fd_ownership(
+    opened: list[tuple[int, int, str, str]],
+    close_attempts: list[tuple[int, int, str, str] | None],
+    duplicates: list[tuple[str, int, int]],
+) -> None:
+    assert duplicates == []
+    assert None not in close_attempts
+    assert len(close_attempts) == len(opened)
+    assert sorted(close_attempts) == sorted(opened)
+
+
+def _assert_exact_stage_names(names: list[str]) -> None:
+    assert names
+    assert len(names) == len(set(names))
+    for name in names:
+        assert _STAGE_NAME_RE.fullmatch(name)
+        assert len(name.encode("utf-8")) == 49
+        assert not name.endswith(".md")
+
+
+def _assert_cleanup_fence(events: list[tuple[object, ...]]) -> None:
+    unlink_indexes = [index for index, event in enumerate(events) if event[0] == "unlink"]
+    for unlink_index in unlink_indexes:
+        assert unlink_index + 1 < len(events)
+        assert events[unlink_index + 1][0] == "fsync"
 
 
 def test_default_vault_root_for_path_uses_filesystem_anchor(tmp_path: Path) -> None:
@@ -63,7 +190,9 @@ def test_write_note_from_absolute_resolves_locator_and_port(monkeypatch, tmp_pat
     }
 
 
-def test_write_note_from_absolute_rejects_outside_vault_root_before_writing(monkeypatch, tmp_path: Path) -> None:
+def test_write_note_from_absolute_rejects_outside_vault_root_before_writing(
+    monkeypatch, tmp_path: Path
+) -> None:
     vault = tmp_path / "vault"
     outside = tmp_path / "outside" / "note.md"
     outside.parent.mkdir(parents=True)
@@ -365,3 +494,601 @@ def test_advanced_uri_from_vault_path_outside_root_falls_back_to_name(tmp_path: 
     uri = write_ops.advanced_uri_from_vault_path(other, vault_root=vault)
     assert "obsidian://advanced-uri" in uri
     assert "filepath=outside.md" in uri
+
+
+@pytest.mark.parametrize("existing_components", [0, 1, 2])
+def test_candidate_create_once_owns_durable_parent_chain(
+    existing_components: int,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    components = ("Sources", "Nested")
+    cursor = vault
+    for component in components[:existing_components]:
+        cursor /= component
+        cursor.mkdir()
+
+    oracle = _FdOracle()
+    oracle.install(monkeypatch)
+    real_mkdir = os.mkdir
+    real_fsync = os.fsync
+
+    def traced_mkdir(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        oracle.events.append(("mkdir", os.fsdecode(path), dir_fd))
+        real_mkdir(path, mode, dir_fd=dir_fd)
+
+    def traced_fsync(fd: int) -> None:
+        oracle.events.append(("fsync", fd))
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "mkdir", traced_mkdir)
+    monkeypatch.setattr(os, "fsync", traced_fsync)
+    guard_calls: list[str] = []
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    real_assert = guard.assert_writes_allowed
+
+    def tracked_assert(action: str) -> None:
+        guard_calls.append(action)
+        real_assert(action)
+
+    guard.assert_writes_allowed = tracked_assert  # type: ignore[method-assign]
+
+    result = write_ops.create_candidate_note_once(
+        "Sources/Nested/candidate.md",
+        "complete candidate",
+        vault_root=vault,
+        action="candidate.test",
+        write_guard=guard,
+    )
+
+    assert result == "written"
+    assert guard_calls == ["candidate.test"]
+    assert (vault / "Sources/Nested/candidate.md").read_text(encoding="utf-8") == (
+        "complete candidate"
+    )
+    for component in components:
+        mkdir_index = next(
+            index
+            for index, event in enumerate(oracle.events)
+            if event[0] == "mkdir" and event[1] == component
+        )
+        child_open_index = next(
+            index
+            for index, event in enumerate(oracle.events)
+            if event[0] == "open" and event[1] == component
+        )
+        containing_fd = oracle.events[mkdir_index][2]
+        assert any(
+            event == ("fsync", containing_fd)
+            for event in oracle.events[mkdir_index + 1 : child_open_index]
+        )
+    _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
+    assert oracle.active == {}
+    directory_tokens = [token for token in oracle.opened if token[2] == "directory"]
+    assert len(directory_tokens) >= 3
+    for missing in (directory_tokens[0], directory_tokens[-2], directory_tokens[-1]):
+        mutant_closes = [token for token in oracle.close_attempts if token != missing]
+        with pytest.raises(AssertionError):
+            _assert_exact_fd_ownership(oracle.opened, mutant_closes, [])
+
+
+def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    parent = vault / "Sources"
+    parent.mkdir(parents=True)
+    oracle = _FdOracle()
+    oracle.install(monkeypatch)
+    real_write = os.write
+    real_fsync = os.fsync
+    real_publish = write_ops._atomic_rename_noreplace_at
+    stage_fds: set[int] = set()
+    file_fsyncs: list[int] = []
+    publish_observations: list[tuple[str, str, bytes]] = []
+
+    def partial_write(fd: int, payload: bytes) -> int:
+        token = oracle.active.get(fd)
+        if token is not None and token[2] == "stage":
+            stage_fds.add(fd)
+            payload = payload[:3]
+        return real_write(fd, payload)
+
+    def traced_fsync(fd: int) -> None:
+        if fd in stage_fds:
+            file_fsyncs.append(fd)
+        real_fsync(fd)
+
+    def traced_publish(
+        source_dir_fd: int,
+        source_name: str,
+        destination_dir_fd: int,
+        destination_name: str,
+    ) -> None:
+        assert source_dir_fd == destination_dir_fd
+        assert not (parent / destination_name).exists()
+        publish_observations.append(
+            (source_name, destination_name, (parent / source_name).read_bytes())
+        )
+        real_publish(
+            source_dir_fd,
+            source_name,
+            destination_dir_fd,
+            destination_name,
+        )
+
+    monkeypatch.setattr(os, "write", partial_write)
+    monkeypatch.setattr(os, "fsync", traced_fsync)
+    monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", traced_publish)
+
+    result = write_ops.create_candidate_note_once(
+        "Sources/candidate.md",
+        "complete candidate",
+        vault_root=vault,
+        action="candidate.test",
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+    )
+
+    assert result == "written"
+    assert (parent / "candidate.md").read_bytes() == b"complete candidate"
+    assert publish_observations == [
+        (
+            publish_observations[0][0],
+            "candidate.md",
+            b"complete candidate",
+        )
+    ]
+    stage_names = [token[3] for token in oracle.opened if token[2] == "stage"]
+    _assert_exact_stage_names(stage_names)
+    assert file_fsyncs
+    assert list(parent.glob(".candidate-stage-*")) == []
+    _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
+    assert oracle.active == {}
+
+    # The test oracle must reject the false-green trace shapes seen in prior rounds.
+    with pytest.raises(AssertionError):
+        _assert_exact_fd_ownership(
+            oracle.opened,
+            [token for token in oracle.close_attempts if token and token[2] != "stage"],
+            [],
+        )
+    with pytest.raises(AssertionError):
+        _assert_exact_fd_ownership(
+            oracle.opened,
+            [*oracle.close_attempts, oracle.close_attempts[-1]],
+            [],
+        )
+    reused = [(41, 1, "directory", "one"), (41, 2, "directory", "two")]
+    with pytest.raises(AssertionError):
+        _assert_exact_fd_ownership(reused, [reused[0]], [])
+    with pytest.raises(AssertionError):
+        _assert_exact_fd_ownership(
+            oracle.opened,
+            oracle.close_attempts,
+            [("dup", oracle.opened[0][0], 99)],
+        )
+    actual_stage = stage_names[0]
+    target_derived_mutants = [
+        f".candidate-stage-candidate.md-{actual_stage.removeprefix('.candidate-stage-')}",
+        f"{actual_stage}-candidate.md",
+        f".candidate-stage-{actual_stage[-31:]}",
+        f".candidate-stage-{actual_stage[-32:].upper()}",
+    ]
+    for mutant in target_derived_mutants:
+        with pytest.raises(AssertionError):
+            _assert_exact_stage_names([mutant])
+
+    # A maximum-length canonical basename still publishes because the stage is fixed at 49 bytes.
+    name_max = os.pathconf(parent, "PC_NAME_MAX")
+    max_name = ("x" * (name_max - 3)) + ".md"
+    assert len(max_name.encode("ascii")) == name_max
+    assert (
+        write_ops.create_candidate_note_once(
+            f"Sources/{max_name}",
+            "max-name candidate",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
+        == "written"
+    )
+    assert (parent / max_name).read_text(encoding="utf-8") == "max-name candidate"
+
+
+def test_candidate_create_once_crash_boundaries_are_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    parent = vault / "Sources"
+    parent.mkdir(parents=True)
+    relative = "Sources/retry.md"
+    real_publish = write_ops._atomic_rename_noreplace_at
+
+    def fail_before_publish(*_args: object) -> None:
+        raise OSError(errno.EIO, "injected pre-publication failure")
+
+    monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", fail_before_publish)
+    with pytest.raises(OSError, match="pre-publication"):
+        write_ops.create_candidate_note_once(
+            relative,
+            "complete bytes",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
+    assert not (parent / "retry.md").exists()
+    assert list(parent.glob(".candidate-stage-*")) == []
+
+    old_remnant = parent / ".candidate-stage-00000000000000000000000000000000"
+    old_remnant.write_bytes(b"old remnant")
+    monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", real_publish)
+    assert (
+        write_ops.create_candidate_note_once(
+            relative,
+            "complete bytes",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
+        == "written"
+    )
+    assert (parent / "retry.md").read_bytes() == b"complete bytes"
+    assert old_remnant.read_bytes() == b"old remnant"
+
+    renamed = False
+    real_fsync = os.fsync
+
+    def publish_then_mark(*args: object) -> None:
+        nonlocal renamed
+        real_publish(*args)  # type: ignore[arg-type]
+        renamed = True
+
+    def fail_post_rename_fsync(fd: int) -> None:
+        if renamed:
+            raise OSError(errno.EIO, "injected post-rename directory fsync")
+        real_fsync(fd)
+
+    monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", publish_then_mark)
+    monkeypatch.setattr(os, "fsync", fail_post_rename_fsync)
+    with pytest.raises(OSError, match="post-rename"):
+        write_ops.create_candidate_note_once(
+            "Sources/post-rename.md",
+            "durable candidate bytes",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
+    canonical = parent / "post-rename.md"
+    assert canonical.read_bytes() == b"durable candidate bytes"
+    monkeypatch.setattr(os, "fsync", real_fsync)
+    assert write_ops.candidate_note_exists_durable(
+        "Sources/post-rename.md",
+        vault_root=vault,
+    )
+    assert canonical.read_bytes() == b"durable candidate bytes"
+
+
+def test_candidate_create_once_loser_preserves_target_and_cleans_owned_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    parent = vault / "Sources"
+    parent.mkdir(parents=True)
+    target = parent / "winner.md"
+    target.write_bytes(b"human winner")
+    unrelated = parent / ".candidate-stage-11111111111111111111111111111111"
+    unrelated.write_bytes(b"unrelated")
+    unlinked: list[str] = []
+    cleanup_events: list[tuple[object, ...]] = []
+    real_unlink = os.unlink
+    real_fsync = os.fsync
+    real_stat = os.stat
+
+    def traced_unlink(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        unlinked.append(os.fsdecode(path))
+        real_unlink(path, dir_fd=dir_fd)
+        cleanup_events.append(("unlink", os.fsdecode(path), dir_fd))
+
+    def traced_fsync(fd: int) -> None:
+        cleanup_events.append(("fsync", fd))
+        real_fsync(fd)
+
+    def traced_stat(
+        path: str | bytes | int | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> os.stat_result:
+        cleanup_events.append(("stat", os.fsdecode(path), dir_fd))
+        return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "unlink", traced_unlink)
+    monkeypatch.setattr(os, "fsync", traced_fsync)
+    monkeypatch.setattr(os, "stat", traced_stat)
+    result = write_ops.create_candidate_note_once(
+        "Sources/winner.md",
+        "loser bytes",
+        vault_root=vault,
+        action="candidate.test",
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+    )
+
+    assert result == "already_exists"
+    assert target.read_bytes() == b"human winner"
+    assert unrelated.read_bytes() == b"unrelated"
+    assert len(unlinked) == 1
+    _assert_exact_stage_names(unlinked)
+    assert [path.name for path in parent.glob(".candidate-stage-*")] == [unrelated.name]
+    unlink_index = next(index for index, event in enumerate(cleanup_events) if event[0] == "unlink")
+    _assert_cleanup_fence(cleanup_events[unlink_index:])
+    assert cleanup_events[unlink_index + 2][0] == "stat"
+    with pytest.raises(AssertionError):
+        _assert_cleanup_fence(
+            [event for event in cleanup_events[unlink_index:] if event[0] != "fsync"]
+        )
+    with pytest.raises(AssertionError):
+        _assert_cleanup_fence(
+            [
+                cleanup_events[unlink_index + 1],
+                cleanup_events[unlink_index],
+                *cleanup_events[unlink_index + 2 :],
+            ]
+        )
+
+
+def test_candidate_create_once_real_same_target_race(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    parent = vault / "Sources"
+    parent.mkdir(parents=True)
+    real_publish = write_ops._atomic_rename_noreplace_at
+    both_staged = threading.Barrier(2, timeout=5)
+
+    def synchronized_real_publish(*args: object) -> None:
+        both_staged.wait()
+        real_publish(*args)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        write_ops,
+        "_atomic_rename_noreplace_at",
+        synchronized_real_publish,
+    )
+    guard = WriteGuard(lambda: {"state": "healthy"})
+
+    def contender(content: str) -> str:
+        return write_ops.create_candidate_note_once(
+            "Sources/race.md",
+            content,
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=guard,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(contender, "contender one"),
+            executor.submit(contender, "contender two"),
+        ]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert sorted(results) == ["already_exists", "written"]
+    winner = (parent / "race.md").read_text(encoding="utf-8")
+    assert winner in {"contender one", "contender two"}
+    assert list(parent.glob(".candidate-stage-*")) == []
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "parent_mkdir",
+        "parent_fsync",
+        "parent_open",
+        "root_close",
+        "stage_open",
+        "stage_zero_write",
+        "stage_fsync",
+        "stage_close",
+        "publish",
+        "cleanup_unlink",
+        "cleanup_fsync",
+        "winner_stat",
+        "winner_parent_fsync",
+        "final_parent_close",
+    ],
+)
+def test_candidate_create_once_fault_matrix(
+    fault: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    parent = vault / "Sources"
+    if fault not in {"parent_mkdir", "parent_fsync", "parent_open"}:
+        parent.mkdir()
+    target = parent / "candidate.md"
+    if fault in {"winner_stat", "winner_parent_fsync"}:
+        target.write_bytes(b"winner")
+
+    real_mkdir = os.mkdir
+    real_open = os.open
+    real_write = os.write
+    real_fsync = os.fsync
+    real_close = os.close
+    real_unlink = os.unlink
+    real_stat = os.stat
+    real_publish = write_ops._atomic_rename_noreplace_at
+    stage_fd: int | None = None
+    fd_labels: dict[int, str] = {}
+    close_attempts: dict[str, int] = {}
+    fd_generation = 0
+    fd_tokens: dict[int, tuple[int, int]] = {}
+    opened_tokens: list[tuple[int, int]] = []
+    closed_tokens: list[tuple[int, int]] = []
+    cleanup_events: list[tuple[object, ...]] = []
+    publication_attempted = False
+    unlink_succeeded = False
+    fired = 0
+
+    def hit(message: str) -> None:
+        nonlocal fired
+        fired += 1
+        raise OSError(errno.EIO, message)
+
+    def faulting_mkdir(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        if fault == "parent_mkdir":
+            hit("parent mkdir fault")
+        real_mkdir(path, mode, dir_fd=dir_fd)
+
+    def faulting_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal fd_generation, stage_fd
+        decoded = os.fsdecode(path)
+        if fault == "parent_open" and decoded == "Sources":
+            hit("parent open fault")
+        if fault == "stage_open" and decoded.startswith(".candidate-stage-"):
+            hit("stage open fault")
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        fd_generation += 1
+        token = (fd, fd_generation)
+        assert fd not in fd_tokens
+        fd_tokens[fd] = token
+        opened_tokens.append(token)
+        fd_labels[fd] = (
+            "root"
+            if dir_fd is None
+            else "final_parent"
+            if decoded == "Sources"
+            else "stage"
+            if decoded.startswith(".candidate-stage-")
+            else decoded
+        )
+        if decoded.startswith(".candidate-stage-"):
+            stage_fd = fd
+        return fd
+
+    def faulting_write(fd: int, payload: bytes) -> int:
+        if fault == "stage_zero_write" and fd == stage_fd:
+            nonlocal_fired[0] += 1
+            return 0
+        return real_write(fd, payload)
+
+    def faulting_fsync(fd: int) -> None:
+        cleanup_events.append(("fsync", fd))
+        if fault == "parent_fsync" and stage_fd is None:
+            hit("parent fsync fault")
+        if fault == "stage_fsync" and fd == stage_fd:
+            hit("stage fsync fault")
+        if fault == "cleanup_fsync" and unlink_succeeded:
+            hit("cleanup fsync fault")
+        if fault == "winner_parent_fsync" and publication_attempted:
+            hit("winner parent fsync fault")
+        real_fsync(fd)
+
+    def faulting_close(fd: int) -> None:
+        token = fd_tokens.pop(fd, None)
+        assert token is not None
+        closed_tokens.append(token)
+        label = fd_labels.pop(fd, "unknown")
+        close_attempts[label] = close_attempts.get(label, 0) + 1
+        if fault == "stage_close" and fd == stage_fd:
+            real_close(fd)
+            hit("stage close fault")
+        if fault == f"{label}_close":
+            real_close(fd)
+            hit(f"{label} close fault")
+        real_close(fd)
+
+    def faulting_publish(*args: object) -> None:
+        nonlocal publication_attempted
+        publication_attempted = True
+        if fault in {"publish", "cleanup_unlink", "cleanup_fsync"}:
+            hit("publication fault")
+        real_publish(*args)  # type: ignore[arg-type]
+
+    def faulting_unlink(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        nonlocal unlink_succeeded
+        if fault == "cleanup_unlink":
+            hit("cleanup unlink fault")
+        real_unlink(path, dir_fd=dir_fd)
+        unlink_succeeded = True
+        cleanup_events.append(("unlink", os.fsdecode(path), dir_fd))
+
+    def faulting_stat(
+        path: str | bytes | int | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> os.stat_result:
+        if fault == "winner_stat" and path == "candidate.md":
+            hit("winner stat fault")
+        return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    nonlocal_fired = [0]
+    monkeypatch.setattr(os, "mkdir", faulting_mkdir)
+    monkeypatch.setattr(os, "open", faulting_open)
+    monkeypatch.setattr(os, "write", faulting_write)
+    monkeypatch.setattr(os, "fsync", faulting_fsync)
+    monkeypatch.setattr(os, "close", faulting_close)
+    monkeypatch.setattr(os, "unlink", faulting_unlink)
+    monkeypatch.setattr(os, "stat", faulting_stat)
+    monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", faulting_publish)
+
+    with pytest.raises((OSError, RuntimeError)):
+        write_ops.create_candidate_note_once(
+            "Sources/candidate.md",
+            "complete candidate",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
+
+    assert fired + nonlocal_fired[0] >= 1
+    assert fd_tokens == {}
+    assert sorted(opened_tokens) == sorted(closed_tokens)
+    if fault in {"root_close", "stage_close", "final_parent_close"}:
+        assert close_attempts[fault.removesuffix("_close")] == 1
+    if target.exists():
+        assert target.read_bytes() in {b"winner", b"complete candidate"}
+    if fault not in {"cleanup_unlink"}:
+        owned = [
+            path
+            for path in parent.glob(".candidate-stage-*")
+            if path.name != ".candidate-stage-11111111111111111111111111111111"
+        ]
+        assert owned == []
+    if fault in {"publish", "cleanup_fsync"}:
+        unlink_index = next(
+            index for index, event in enumerate(cleanup_events) if event[0] == "unlink"
+        )
+        _assert_cleanup_fence(cleanup_events[unlink_index:])

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -823,6 +823,10 @@ def test_candidate_create_once_real_same_target_race(
     _assert_exact_stage_names(stage_names)
 
 
+def _assert_candidate_fault_outcome(outcome: object) -> None:
+    assert isinstance(outcome, (OSError, RuntimeError))
+
+
 @pytest.mark.parametrize(
     "fault",
     [
@@ -840,6 +844,8 @@ def test_candidate_create_once_real_same_target_race(
         "loser_unlink",
         "loser_fsync",
         "winner_stat",
+        "winner_nonregular",
+        "post_rename_fsync",
         "final_parent_close",
     ],
 )
@@ -855,6 +861,8 @@ def test_candidate_create_once_fault_matrix(
     target = parent / "candidate.md"
     if fault in {"loser_unlink", "loser_fsync", "winner_stat"}:
         target.write_bytes(b"winner")
+    elif fault == "winner_nonregular":
+        target.mkdir()
     sentinel = parent / ".candidate-stage-11111111111111111111111111111111"
     sentinel.write_bytes(b"unrelated")
 
@@ -873,6 +881,7 @@ def test_candidate_create_once_fault_matrix(
     close_attempts: dict[str, int] = {}
     cleanup_events: list[tuple[object, ...]] = []
     unlink_succeeded = False
+    publication_succeeded = False
     arms: dict[str, int] = {}
 
     def hit(arm: str, message: str) -> None:
@@ -932,6 +941,8 @@ def test_candidate_create_once_fault_matrix(
             hit("cleanup_fsync", "cleanup fsync fault")
         if fault == "loser_fsync" and unlink_succeeded:
             hit("loser_fsync", "loser fsync fault")
+        if fault == "post_rename_fsync" and publication_succeeded:
+            hit("post_rename_fsync", "post-rename parent fsync fault")
         real_fsync(fd)
 
     def faulting_close(fd: int) -> None:
@@ -946,9 +957,11 @@ def test_candidate_create_once_fault_matrix(
         real_close(fd)
 
     def faulting_publish(*args: object) -> None:
+        nonlocal publication_succeeded
         if fault in {"publish", "cleanup_unlink", "cleanup_fsync"}:
             hit("publish", "publication fault")
         real_publish(*args)  # type: ignore[arg-type]
+        publication_succeeded = True
 
     def faulting_unlink(
         path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
@@ -972,6 +985,8 @@ def test_candidate_create_once_fault_matrix(
     ) -> os.stat_result:
         if fault == "winner_stat" and path == "candidate.md":
             hit("winner_stat", "winner stat fault")
+        if fault == "winner_nonregular" and path == "candidate.md":
+            arms["winner_nonregular"] = arms.get("winner_nonregular", 0) + 1
         return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
 
     monkeypatch.setattr(os, "mkdir", faulting_mkdir)
@@ -983,14 +998,18 @@ def test_candidate_create_once_fault_matrix(
     monkeypatch.setattr(os, "stat", faulting_stat)
     monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", faulting_publish)
 
-    with pytest.raises((OSError, RuntimeError)):
-        write_ops.create_candidate_note_once(
+    outcome: object
+    try:
+        outcome = write_ops.create_candidate_note_once(
             "Sources/candidate.md",
             "complete candidate",
             vault_root=vault,
             action="candidate.test",
             write_guard=WriteGuard(lambda: {"state": "healthy"}),
         )
+    except (OSError, RuntimeError) as exc:
+        outcome = exc
+    _assert_candidate_fault_outcome(outcome)
 
     expected_arms = (
         {"publish": 1, fault: 1} if fault in {"cleanup_unlink", "cleanup_fsync"} else {fault: 1}
@@ -1002,10 +1021,12 @@ def test_candidate_create_once_fault_matrix(
     if fault in {"root_close", "stage_close", "final_parent_close"}:
         assert close_attempts[fault.removesuffix("_close")] == 1
 
-    if fault == "final_parent_close":
+    if fault in {"final_parent_close", "post_rename_fsync"}:
         assert target.read_bytes() == b"complete candidate"
     elif fault in {"loser_unlink", "loser_fsync", "winner_stat"}:
         assert target.read_bytes() == b"winner"
+    elif fault == "winner_nonregular":
+        assert target.is_dir()
     else:
         assert not target.exists()
 
@@ -1021,3 +1042,17 @@ def test_candidate_create_once_fault_matrix(
             index for index, event in enumerate(cleanup_events) if event[0] == "unlink"
         )
         _assert_cleanup_fence(cleanup_events[unlink_index:])
+
+    if fault in {
+        "publish",
+        "cleanup_unlink",
+        "cleanup_fsync",
+        "loser_unlink",
+        "loser_fsync",
+        "winner_stat",
+        "winner_nonregular",
+        "post_rename_fsync",
+    }:
+        for false_success in ("already_exists", "written"):
+            with pytest.raises(AssertionError):
+                _assert_candidate_fault_outcome(false_success)

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -438,6 +438,28 @@ def test_candidate_create_once_owns_durable_parent_chain(
     assert (vault / "Sources/Nested/candidate.md").read_text(encoding="utf-8") == (
         "complete candidate"
     )
+
+    def assert_parent_chain_fences(events: list[tuple[object, ...]]) -> None:
+        for component in components:
+            mkdir_index = next(
+                index
+                for index, event in enumerate(events)
+                if event[0] == "mkdir" and event[1] == component
+            )
+            child_open_index = next(
+                index
+                for index, event in enumerate(events)
+                if event[0] == "open" and event[1] == component
+            )
+            containing_fd = events[mkdir_index][2]
+            matching_fsyncs = [
+                index
+                for index, event in enumerate(events)
+                if event == ("fsync", containing_fd) and mkdir_index < index < child_open_index
+            ]
+            assert len(matching_fsyncs) == 1
+
+    assert_parent_chain_fences(oracle.events)
     for component in components:
         mkdir_index = next(
             index
@@ -450,10 +472,14 @@ def test_candidate_create_once_owns_durable_parent_chain(
             if event[0] == "open" and event[1] == component
         )
         containing_fd = oracle.events[mkdir_index][2]
-        assert any(
-            event == ("fsync", containing_fd)
-            for event in oracle.events[mkdir_index + 1 : child_open_index]
+        fsync_index = next(
+            index
+            for index, event in enumerate(oracle.events)
+            if event == ("fsync", containing_fd) and mkdir_index < index < child_open_index
         )
+        missing_fence = [event for index, event in enumerate(oracle.events) if index != fsync_index]
+        with pytest.raises(AssertionError):
+            assert_parent_chain_fences(missing_fence)
     _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
     assert oracle.active == {}
     directory_tokens = [token for token in oracle.opened if token[2] == "directory"]
@@ -834,6 +860,7 @@ def _assert_candidate_fault_outcome(outcome: object) -> None:
         "parent_fsync",
         "parent_open",
         "root_close",
+        "intermediate_close",
         "stage_open",
         "stage_zero_write",
         "stage_fsync",
@@ -856,8 +883,8 @@ def test_candidate_create_once_fault_matrix(
 ) -> None:
     vault = tmp_path / "vault"
     vault.mkdir()
-    parent = vault / "Sources"
-    parent.mkdir()
+    parent = vault / "Sources/Nested"
+    parent.mkdir(parents=True)
     target = parent / "candidate.md"
     if fault in {"loser_unlink", "loser_fsync", "winner_stat"}:
         target.write_bytes(b"winner")
@@ -915,8 +942,10 @@ def test_candidate_create_once_fault_matrix(
         fd_labels[fd] = (
             "root"
             if dir_fd is None
-            else "final_parent"
+            else "intermediate"
             if decoded == "Sources"
+            else "final_parent"
+            if decoded == "Nested"
             else "stage"
             if decoded.startswith(".candidate-stage-")
             else decoded
@@ -1001,7 +1030,7 @@ def test_candidate_create_once_fault_matrix(
     outcome: object
     try:
         outcome = write_ops.create_candidate_note_once(
-            "Sources/candidate.md",
+            "Sources/Nested/candidate.md",
             "complete candidate",
             vault_root=vault,
             action="candidate.test",
@@ -1018,7 +1047,12 @@ def test_candidate_create_once_fault_matrix(
     _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
     assert oracle.active == {}
     assert fd_labels == {}
-    if fault in {"root_close", "stage_close", "final_parent_close"}:
+    if fault in {
+        "root_close",
+        "intermediate_close",
+        "stage_close",
+        "final_parent_close",
+    }:
         assert close_attempts[fault.removesuffix("_close")] == 1
 
     if fault in {"final_parent_close", "post_rename_fsync"}:

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -425,13 +425,14 @@ def test_candidate_create_once_owns_durable_parent_chain(
 
     guard.assert_writes_allowed = tracked_assert  # type: ignore[method-assign]
 
-    result = write_ops.create_candidate_note_once(
-        "Sources/Nested/candidate.md",
-        "complete candidate",
-        vault_root=vault,
-        action="candidate.test",
-        write_guard=guard,
-    )
+    with oracle.observe():
+        result = write_ops.create_candidate_note_once(
+            "Sources/Nested/candidate.md",
+            "complete candidate",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=guard,
+        )
 
     assert result == "written"
     assert guard_calls == ["candidate.test"]
@@ -499,6 +500,14 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
     parent.mkdir(parents=True)
     oracle = _FdOracle()
     oracle.install(monkeypatch)
+    unrelated_fd = os.open(os.devnull, os.O_RDONLY)
+    os.close(unrelated_fd)
+    with oracle.observe():
+        unrelated_fd = os.open(os.devnull, os.O_RDONLY)
+        os.close(unrelated_fd)
+    assert oracle.opened == []
+    assert oracle.close_attempts == []
+    assert oracle.active == {}
     real_write = os.write
     real_fsync = os.fsync
     real_publish = write_ops._atomic_rename_noreplace_at
@@ -542,13 +551,14 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
     monkeypatch.setattr(os, "fsync", traced_fsync)
     monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", traced_publish)
 
-    result = write_ops.create_candidate_note_once(
-        "Sources/candidate.md",
-        "complete candidate",
-        vault_root=vault,
-        action="candidate.test",
-        write_guard=WriteGuard(lambda: {"state": "healthy"}),
-    )
+    with oracle.observe():
+        result = write_ops.create_candidate_note_once(
+            "Sources/candidate.md",
+            "complete candidate",
+            vault_root=vault,
+            action="candidate.test",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        )
 
     assert result == "written"
     assert (parent / "candidate.md").read_bytes() == b"complete candidate"
@@ -616,16 +626,17 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
     name_max = os.pathconf(parent, "PC_NAME_MAX")
     max_name = ("x" * (name_max - 3)) + ".md"
     assert len(max_name.encode("ascii")) == name_max
-    assert (
-        write_ops.create_candidate_note_once(
-            f"Sources/{max_name}",
-            "max-name candidate",
-            vault_root=vault,
-            action="candidate.test",
-            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+    with oracle.observe():
+        assert (
+            write_ops.create_candidate_note_once(
+                f"Sources/{max_name}",
+                "max-name candidate",
+                vault_root=vault,
+                action="candidate.test",
+                write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            )
+            == "written"
         )
-        == "written"
-    )
     assert (parent / max_name).read_text(encoding="utf-8") == "max-name candidate"
 
 
@@ -831,12 +842,13 @@ def test_candidate_create_once_real_same_target_race(
             write_guard=guard,
         )
 
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [
-            executor.submit(contender, "contender one"),
-            executor.submit(contender, "contender two"),
-        ]
-        results = [future.result(timeout=10) for future in futures]
+    with oracle.observe():
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(contender, "contender one"),
+                executor.submit(contender, "contender two"),
+            ]
+            results = [future.result(timeout=10) for future in futures]
 
     assert sorted(results) == ["already_exists", "written"]
     winner = (parent / "race.md").read_text(encoding="utf-8")
@@ -1028,16 +1040,17 @@ def test_candidate_create_once_fault_matrix(
     monkeypatch.setattr(write_ops, "_atomic_rename_noreplace_at", faulting_publish)
 
     outcome: object
-    try:
-        outcome = write_ops.create_candidate_note_once(
-            "Sources/Nested/candidate.md",
-            "complete candidate",
-            vault_root=vault,
-            action="candidate.test",
-            write_guard=WriteGuard(lambda: {"state": "healthy"}),
-        )
-    except (OSError, RuntimeError) as exc:
-        outcome = exc
+    with oracle.observe():
+        try:
+            outcome = write_ops.create_candidate_note_once(
+                "Sources/Nested/candidate.md",
+                "complete candidate",
+                vault_root=vault,
+                action="candidate.test",
+                write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            )
+        except (OSError, RuntimeError) as exc:
+            outcome = exc
     _assert_candidate_fault_outcome(outcome)
 
     expected_arms = (

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -5,7 +5,6 @@ import errno
 import hashlib
 import os
 from pathlib import Path
-import re
 import threading
 
 import pytest
@@ -15,128 +14,14 @@ from app.knowledge.contracts import WriteReceipt
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.settings import KnowledgeAdapter, KnowledgeSettings
 from app.write_guard import WriteGuard, WritesBlockedError
-
-
-_STAGE_NAME_RE = re.compile(r"^\.candidate-stage-[0-9a-f]{32}$")
-
-
-class _FdOracle:
-    """Track logical descriptor generations, including reused raw integers."""
-
-    def __init__(self) -> None:
-        self.opened: list[tuple[int, int, str, str]] = []
-        self.close_attempts: list[tuple[int, int, str, str] | None] = []
-        self.duplicates: list[tuple[str, int, int]] = []
-        self.active: dict[int, tuple[int, int, str, str]] = {}
-        self.events: list[tuple[object, ...]] = []
-        self._generation = 0
-
-    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        real_open = os.open
-        real_close = os.close
-        real_dup = os.dup
-        real_dup2 = os.dup2
-        real_dup3 = getattr(os, "dup3", None)
-
-        def register_duplicate(
-            operation: str,
-            source_fd: int,
-            duplicate_fd: int,
-        ) -> int:
-            self._generation += 1
-            source = self.active.get(source_fd)
-            kind = f"duplicated_{source[2]}" if source is not None else "duplicated_unknown"
-            path = f"{operation}:{source[3] if source is not None else source_fd}"
-            token = (duplicate_fd, self._generation, kind, path)
-            assert duplicate_fd not in self.active
-            self.active[duplicate_fd] = token
-            self.opened.append(token)
-            self.duplicates.append((operation, source_fd, duplicate_fd))
-            self.events.append((operation, source_fd, duplicate_fd, token))
-            return duplicate_fd
-
-        def traced_open(
-            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
-            flags: int,
-            mode: int = 0o777,
-            *,
-            dir_fd: int | None = None,
-        ) -> int:
-            fd = real_open(path, flags, mode, dir_fd=dir_fd)
-            self._generation += 1
-            raw_path = os.fsdecode(path)
-            kind = (
-                "stage"
-                if raw_path.startswith(".candidate-stage-")
-                else "directory"
-                if flags & getattr(os, "O_DIRECTORY", 0)
-                else "file"
-            )
-            token = (fd, self._generation, kind, raw_path)
-            assert fd not in self.active, f"raw fd {fd} reused while still owned"
-            self.active[fd] = token
-            self.opened.append(token)
-            self.events.append(("open", raw_path, flags, dir_fd, token))
-            return fd
-
-        def traced_close(fd: int) -> None:
-            token = self.active.pop(fd, None)
-            self.close_attempts.append(token)
-            self.events.append(("close", fd, token))
-            real_close(fd)
-
-        def traced_dup(fd: int) -> int:
-            duplicate = real_dup(fd)
-            if fd not in self.active:
-                return duplicate
-            return register_duplicate("dup", fd, duplicate)
-
-        def traced_dup2(fd: int, fd2: int, inheritable: bool = True) -> int:
-            duplicate = real_dup2(fd, fd2, inheritable=inheritable)
-            if fd not in self.active:
-                return duplicate
-            return register_duplicate("dup2", fd, duplicate)
-
-        monkeypatch.setattr(os, "open", traced_open)
-        monkeypatch.setattr(os, "close", traced_close)
-        monkeypatch.setattr(os, "dup", traced_dup)
-        monkeypatch.setattr(os, "dup2", traced_dup2)
-        if real_dup3 is not None:
-
-            def traced_dup3(fd: int, fd2: int, flags: int = 0) -> int:
-                duplicate = real_dup3(fd, fd2, flags)
-                if fd not in self.active:
-                    return duplicate
-                return register_duplicate("dup3", fd, duplicate)
-
-            monkeypatch.setattr(os, "dup3", traced_dup3)
-
-
-def _assert_exact_fd_ownership(
-    opened: list[tuple[int, int, str, str]],
-    close_attempts: list[tuple[int, int, str, str] | None],
-    duplicates: list[tuple[str, int, int]],
-) -> None:
-    assert duplicates == []
-    assert None not in close_attempts
-    assert len(close_attempts) == len(opened)
-    assert sorted(close_attempts) == sorted(opened)
-
-
-def _assert_exact_stage_names(names: list[str]) -> None:
-    assert names
-    assert len(names) == len(set(names))
-    for name in names:
-        assert _STAGE_NAME_RE.fullmatch(name)
-        assert len(name.encode("utf-8")) == 49
-        assert not name.endswith(".md")
-
-
-def _assert_cleanup_fence(events: list[tuple[object, ...]]) -> None:
-    unlink_indexes = [index for index, event in enumerate(events) if event[0] == "unlink"]
-    for unlink_index in unlink_indexes:
-        assert unlink_index + 1 < len(events)
-        assert events[unlink_index + 1][0] == "fsync"
+from tests.knowledge.candidate_create_oracles import (
+    FdOracle as _FdOracle,
+    assert_cleanup_fence as _assert_cleanup_fence,
+    assert_exact_fd_ownership as _assert_exact_fd_ownership,
+    assert_exact_stage_names as _assert_exact_stage_names,
+    assert_hidden_stage_state,
+    assert_stage_publication_order,
+)
 
 
 def test_default_vault_root_for_path_uses_filesystem_anchor(tmp_path: Path) -> None:
@@ -603,6 +488,7 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
         return real_write(fd, payload)
 
     def traced_fsync(fd: int) -> None:
+        oracle.events.append(("fsync", fd))
         if fd in stage_fds:
             file_fsyncs.append(fd)
         real_fsync(fd)
@@ -615,6 +501,7 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
     ) -> None:
         assert source_dir_fd == destination_dir_fd
         assert not (parent / destination_name).exists()
+        oracle.events.append(("publish", source_name, destination_name))
         publish_observations.append(
             (source_name, destination_name, (parent / source_name).read_bytes())
         )
@@ -650,8 +537,21 @@ def test_candidate_create_once_publishes_fsynced_raw_stage_without_replace(
     _assert_exact_stage_names(stage_names)
     assert file_fsyncs
     assert list(parent.glob(".candidate-stage-*")) == []
+    assert_stage_publication_order(oracle.events)
     _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
     assert oracle.active == {}
+
+    premature_publication = list(oracle.events)
+    publish_event = next(event for event in premature_publication if event[0] == "publish")
+    premature_publication.remove(publish_event)
+    stage_open_index = next(
+        index
+        for index, event in enumerate(premature_publication)
+        if event[0] == "open" and isinstance(event[4], tuple) and event[4][2] == "stage"
+    )
+    premature_publication.insert(stage_open_index + 1, publish_event)
+    with pytest.raises(AssertionError):
+        assert_stage_publication_order(premature_publication)
 
     # The test oracle must reject the false-green trace shapes seen in prior rounds.
     with pytest.raises(AssertionError):
@@ -832,7 +732,12 @@ def test_candidate_create_once_loser_preserves_target_and_cleans_owned_stage(
     assert unrelated.read_bytes() == b"unrelated"
     assert len(unlinked) == 1
     _assert_exact_stage_names(unlinked)
-    assert [path.name for path in parent.glob(".candidate-stage-*")] == [unrelated.name]
+    hidden_names = [path.name for path in parent.glob(".candidate-stage-*")]
+    assert_hidden_stage_state(
+        hidden_names,
+        sentinel_name=unrelated.name,
+        expected_owned_count=0,
+    )
     unlink_index = next(index for index, event in enumerate(cleanup_events) if event[0] == "unlink")
     _assert_cleanup_fence(cleanup_events[unlink_index:])
     assert cleanup_events[unlink_index + 2][0] == "stat"
@@ -848,6 +753,24 @@ def test_candidate_create_once_loser_preserves_target_and_cleans_owned_stage(
                 *cleanup_events[unlink_index + 2 :],
             ]
         )
+    with pytest.raises(AssertionError):
+        assert_hidden_stage_state(
+            [*hidden_names, ".candidate-stage-22222222222222222222222222222222"],
+            sentinel_name=unrelated.name,
+            expected_owned_count=0,
+        )
+    with pytest.raises(AssertionError):
+        assert_hidden_stage_state(
+            [],
+            sentinel_name=unrelated.name,
+            expected_owned_count=0,
+        )
+    with pytest.raises(AssertionError):
+        assert_hidden_stage_state(
+            [".candidate-stage-22222222222222222222222222222222"],
+            sentinel_name=unrelated.name,
+            expected_owned_count=0,
+        )
 
 
 def test_candidate_create_once_real_same_target_race(
@@ -857,6 +780,8 @@ def test_candidate_create_once_real_same_target_race(
     vault = tmp_path / "vault"
     parent = vault / "Sources"
     parent.mkdir(parents=True)
+    oracle = _FdOracle()
+    oracle.install(monkeypatch)
     real_publish = write_ops._atomic_rename_noreplace_at
     both_staged = threading.Barrier(2, timeout=5)
 
@@ -891,6 +816,11 @@ def test_candidate_create_once_real_same_target_race(
     winner = (parent / "race.md").read_text(encoding="utf-8")
     assert winner in {"contender one", "contender two"}
     assert list(parent.glob(".candidate-stage-*")) == []
+    _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
+    assert oracle.active == {}
+    stage_names = [token[3] for token in oracle.opened if token[2] == "stage"]
+    assert len(stage_names) == 2
+    _assert_exact_stage_names(stage_names)
 
 
 @pytest.mark.parametrize(
@@ -907,8 +837,9 @@ def test_candidate_create_once_real_same_target_race(
         "publish",
         "cleanup_unlink",
         "cleanup_fsync",
+        "loser_unlink",
+        "loser_fsync",
         "winner_stat",
-        "winner_parent_fsync",
         "final_parent_close",
     ],
 )
@@ -920,12 +851,15 @@ def test_candidate_create_once_fault_matrix(
     vault = tmp_path / "vault"
     vault.mkdir()
     parent = vault / "Sources"
-    if fault not in {"parent_mkdir", "parent_fsync", "parent_open"}:
-        parent.mkdir()
+    parent.mkdir()
     target = parent / "candidate.md"
-    if fault in {"winner_stat", "winner_parent_fsync"}:
+    if fault in {"loser_unlink", "loser_fsync", "winner_stat"}:
         target.write_bytes(b"winner")
+    sentinel = parent / ".candidate-stage-11111111111111111111111111111111"
+    sentinel.write_bytes(b"unrelated")
 
+    oracle = _FdOracle()
+    oracle.install(monkeypatch)
     real_mkdir = os.mkdir
     real_open = os.open
     real_write = os.write
@@ -937,18 +871,12 @@ def test_candidate_create_once_fault_matrix(
     stage_fd: int | None = None
     fd_labels: dict[int, str] = {}
     close_attempts: dict[str, int] = {}
-    fd_generation = 0
-    fd_tokens: dict[int, tuple[int, int]] = {}
-    opened_tokens: list[tuple[int, int]] = []
-    closed_tokens: list[tuple[int, int]] = []
     cleanup_events: list[tuple[object, ...]] = []
-    publication_attempted = False
     unlink_succeeded = False
-    fired = 0
+    arms: dict[str, int] = {}
 
-    def hit(message: str) -> None:
-        nonlocal fired
-        fired += 1
+    def hit(arm: str, message: str) -> None:
+        arms[arm] = arms.get(arm, 0) + 1
         raise OSError(errno.EIO, message)
 
     def faulting_mkdir(
@@ -958,7 +886,7 @@ def test_candidate_create_once_fault_matrix(
         dir_fd: int | None = None,
     ) -> None:
         if fault == "parent_mkdir":
-            hit("parent mkdir fault")
+            hit("parent_mkdir", "parent mkdir fault")
         real_mkdir(path, mode, dir_fd=dir_fd)
 
     def faulting_open(
@@ -968,18 +896,13 @@ def test_candidate_create_once_fault_matrix(
         *,
         dir_fd: int | None = None,
     ) -> int:
-        nonlocal fd_generation, stage_fd
+        nonlocal stage_fd
         decoded = os.fsdecode(path)
         if fault == "parent_open" and decoded == "Sources":
-            hit("parent open fault")
+            hit("parent_open", "parent open fault")
         if fault == "stage_open" and decoded.startswith(".candidate-stage-"):
-            hit("stage open fault")
+            hit("stage_open", "stage open fault")
         fd = real_open(path, flags, mode, dir_fd=dir_fd)
-        fd_generation += 1
-        token = (fd, fd_generation)
-        assert fd not in fd_tokens
-        fd_tokens[fd] = token
-        opened_tokens.append(token)
         fd_labels[fd] = (
             "root"
             if dir_fd is None
@@ -995,41 +918,36 @@ def test_candidate_create_once_fault_matrix(
 
     def faulting_write(fd: int, payload: bytes) -> int:
         if fault == "stage_zero_write" and fd == stage_fd:
-            nonlocal_fired[0] += 1
+            arms["stage_zero_write"] = arms.get("stage_zero_write", 0) + 1
             return 0
         return real_write(fd, payload)
 
     def faulting_fsync(fd: int) -> None:
         cleanup_events.append(("fsync", fd))
         if fault == "parent_fsync" and stage_fd is None:
-            hit("parent fsync fault")
+            hit("parent_fsync", "parent fsync fault")
         if fault == "stage_fsync" and fd == stage_fd:
-            hit("stage fsync fault")
+            hit("stage_fsync", "stage fsync fault")
         if fault == "cleanup_fsync" and unlink_succeeded:
-            hit("cleanup fsync fault")
-        if fault == "winner_parent_fsync" and publication_attempted:
-            hit("winner parent fsync fault")
+            hit("cleanup_fsync", "cleanup fsync fault")
+        if fault == "loser_fsync" and unlink_succeeded:
+            hit("loser_fsync", "loser fsync fault")
         real_fsync(fd)
 
     def faulting_close(fd: int) -> None:
-        token = fd_tokens.pop(fd, None)
-        assert token is not None
-        closed_tokens.append(token)
         label = fd_labels.pop(fd, "unknown")
         close_attempts[label] = close_attempts.get(label, 0) + 1
         if fault == "stage_close" and fd == stage_fd:
             real_close(fd)
-            hit("stage close fault")
+            hit("stage_close", "stage close fault")
         if fault == f"{label}_close":
             real_close(fd)
-            hit(f"{label} close fault")
+            hit(fault, f"{label} close fault")
         real_close(fd)
 
     def faulting_publish(*args: object) -> None:
-        nonlocal publication_attempted
-        publication_attempted = True
         if fault in {"publish", "cleanup_unlink", "cleanup_fsync"}:
-            hit("publication fault")
+            hit("publish", "publication fault")
         real_publish(*args)  # type: ignore[arg-type]
 
     def faulting_unlink(
@@ -1039,7 +957,9 @@ def test_candidate_create_once_fault_matrix(
     ) -> None:
         nonlocal unlink_succeeded
         if fault == "cleanup_unlink":
-            hit("cleanup unlink fault")
+            hit("cleanup_unlink", "cleanup unlink fault")
+        if fault == "loser_unlink":
+            hit("loser_unlink", "loser unlink fault")
         real_unlink(path, dir_fd=dir_fd)
         unlink_succeeded = True
         cleanup_events.append(("unlink", os.fsdecode(path), dir_fd))
@@ -1051,10 +971,9 @@ def test_candidate_create_once_fault_matrix(
         follow_symlinks: bool = True,
     ) -> os.stat_result:
         if fault == "winner_stat" and path == "candidate.md":
-            hit("winner stat fault")
+            hit("winner_stat", "winner stat fault")
         return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
 
-    nonlocal_fired = [0]
     monkeypatch.setattr(os, "mkdir", faulting_mkdir)
     monkeypatch.setattr(os, "open", faulting_open)
     monkeypatch.setattr(os, "write", faulting_write)
@@ -1073,21 +992,31 @@ def test_candidate_create_once_fault_matrix(
             write_guard=WriteGuard(lambda: {"state": "healthy"}),
         )
 
-    assert fired + nonlocal_fired[0] >= 1
-    assert fd_tokens == {}
-    assert sorted(opened_tokens) == sorted(closed_tokens)
+    expected_arms = (
+        {"publish": 1, fault: 1} if fault in {"cleanup_unlink", "cleanup_fsync"} else {fault: 1}
+    )
+    assert arms == expected_arms
+    _assert_exact_fd_ownership(oracle.opened, oracle.close_attempts, oracle.duplicates)
+    assert oracle.active == {}
+    assert fd_labels == {}
     if fault in {"root_close", "stage_close", "final_parent_close"}:
         assert close_attempts[fault.removesuffix("_close")] == 1
-    if target.exists():
-        assert target.read_bytes() in {b"winner", b"complete candidate"}
-    if fault not in {"cleanup_unlink"}:
-        owned = [
-            path
-            for path in parent.glob(".candidate-stage-*")
-            if path.name != ".candidate-stage-11111111111111111111111111111111"
-        ]
-        assert owned == []
-    if fault in {"publish", "cleanup_fsync"}:
+
+    if fault == "final_parent_close":
+        assert target.read_bytes() == b"complete candidate"
+    elif fault in {"loser_unlink", "loser_fsync", "winner_stat"}:
+        assert target.read_bytes() == b"winner"
+    else:
+        assert not target.exists()
+
+    hidden_names = [path.name for path in parent.glob(".candidate-stage-*")]
+    assert_hidden_stage_state(
+        hidden_names,
+        sentinel_name=sentinel.name,
+        expected_owned_count=1 if fault in {"cleanup_unlink", "loser_unlink"} else 0,
+    )
+    assert sentinel.read_bytes() == b"unrelated"
+    if unlink_succeeded:
         unlink_index = next(
             index for index, event in enumerate(cleanup_events) if event[0] == "unlink"
         )

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -11,8 +11,10 @@ reachability of the DSN behind it, since these tests inject `conn=` directly).
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 from pathlib import Path
+import threading
 from typing import Any
 
 import pytest
@@ -25,6 +27,8 @@ from app.knowledge_acquisition.acquire import (
     acquire_youtube,
     require_configured_database_url,
 )
+from app.knowledge.write_ops import write_note_relative
+from app.knowledge_acquisition.candidate_writeback import Candidate, write_candidate_note
 from app.knowledge_acquisition.extraction_registry import clear_registry
 from app.knowledge_acquisition.extractors import summary_extractor
 from app.knowledge_acquisition.stage_events import (
@@ -150,7 +154,9 @@ _CAPTION_BODY = (
 )
 
 
-def _stub_caption_fetch(monkeypatch, *, info: dict[str, Any] | None = None, body: str = _CAPTION_BODY):
+def _stub_caption_fetch(
+    monkeypatch, *, info: dict[str, Any] | None = None, body: str = _CAPTION_BODY
+):
     monkeypatch.setattr(plugin, "yt_dlp_extract_info", lambda url: info or _base_info())
 
     def fake_caption_body(url: str) -> str:
@@ -247,12 +253,14 @@ def test_acquire_youtube_rerun_is_idempotent_dedup_noop(
     assert first.is_new_raw is True
     assert fetch_calls["count"] == 1
 
-    note_path = tmp_path / "vault" / next(
-        s.artifact_path for s in first.stages if s.stage == "candidate"
+    note_path = (
+        tmp_path / "vault" / next(s.artifact_path for s in first.stages if s.stage == "candidate")
     )
     bytes_first = note_path.read_bytes()
 
-    second = acquire_youtube(FAKE_URL, vault_context=vault, write_guard=_allowing_guard(), conn=conn)
+    second = acquire_youtube(
+        FAKE_URL, vault_context=vault, write_guard=_allowing_guard(), conn=conn
+    )
 
     # Caption path re-fetches the (cheap) metadata/caption body every call (the plugin's
     # dedup identity is the caption body's hash), but this proves the DOWNSTREAM pipeline is
@@ -275,7 +283,9 @@ def test_acquire_youtube_rerun_is_idempotent_dedup_noop(
     assert len(completed) == 3  # still exactly 3: normalize + extracted + candidate, deduped
 
 
-def test_acquire_youtube_asr_dedup_skips_reacquisition(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_acquire_youtube_asr_dedup_skips_reacquisition(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """The ASR (captionless) path pre-checks dedup BEFORE running ASR — the plugin's own
     `find_raw_record` short-circuit (`youtube_plugin.fetch`). A known captionless item's
     re-run must not re-invoke ASR."""
@@ -291,7 +301,9 @@ def test_acquire_youtube_asr_dedup_skips_reacquisition(monkeypatch: pytest.Monke
             }
         }
 
-    monkeypatch.setattr(plugin, "yt_dlp_extract_info", lambda url: _base_info(subtitles={}, automatic_captions={}))
+    monkeypatch.setattr(
+        plugin, "yt_dlp_extract_info", lambda url: _base_info(subtitles={}, automatic_captions={})
+    )
     monkeypatch.setattr(plugin, "transcribe_source", fake_asr)
 
     conn = FakeOutboxConn()
@@ -301,9 +313,101 @@ def test_acquire_youtube_asr_dedup_skips_reacquisition(monkeypatch: pytest.Monke
     assert first.is_new_raw is True
     assert asr_calls["count"] == 1
 
-    second = acquire_youtube(FAKE_URL, vault_context=vault, write_guard=_allowing_guard(), conn=conn)
+    second = acquire_youtube(
+        FAKE_URL, vault_context=vault, write_guard=_allowing_guard(), conn=conn
+    )
     assert second.is_new_raw is False
     assert asr_calls["count"] == 1  # ASR never re-invoked on the dedup hit
+
+
+def test_long_running_transcription_does_not_block_unrelated_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Acquisition owns no writer resource while the real ASR seam is blocked."""
+
+    monkeypatch.setattr(
+        plugin,
+        "yt_dlp_extract_info",
+        lambda _url: _base_info(subtitles={}, automatic_captions={}),
+    )
+    transcription_started = threading.Event()
+    release_transcription = threading.Event()
+
+    def blocking_asr(_item_ref_or_url: str) -> dict[str, Any]:
+        transcription_started.set()
+        if not release_transcription.wait(timeout=10):
+            raise TimeoutError("test did not release real-time transcription")
+        return {
+            "payload": {
+                "text": "ASR transcript after the barrier.",
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 2.0,
+                        "text": "ASR transcript after the barrier.",
+                    }
+                ],
+                "language": "en",
+            }
+        }
+
+    monkeypatch.setattr(plugin, "transcribe_source", blocking_asr)
+    vault_root = tmp_path / "vault"
+    vault = _vault(vault_root)
+    guard = _allowing_guard()
+    conn = FakeOutboxConn()
+    different_candidate = Candidate(
+        content_identity="sha256:different-ready-candidate",
+        source_kind="youtube_url",
+        item_ref="different01",
+        url="https://youtube.com/watch?v=different01",
+        title="Different candidate",
+        creator=None,
+        published=None,
+        acquisition_method="asr",
+        transcript_available=False,
+        extractions=(),
+    )
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        acquisition = executor.submit(
+            acquire_youtube,
+            FAKE_URL,
+            vault_context=vault,
+            write_guard=guard,
+            conn=conn,
+        )
+        assert transcription_started.wait(timeout=3)
+
+        unrelated = executor.submit(
+            write_note_relative,
+            "Inbox/unrelated.md",
+            "unrelated governed write",
+            vault_root=vault_root,
+            action="test.unrelated",
+            write_guard=guard,
+        )
+        different = executor.submit(
+            write_candidate_note,
+            different_candidate,
+            vault_context=vault,
+            write_guard=guard,
+        )
+
+        unrelated.result(timeout=3)
+        different_result = different.result(timeout=3)
+        assert different_result.status == "written"
+        assert (vault_root / "Inbox/unrelated.md").read_text(encoding="utf-8") == (
+            "unrelated governed write"
+        )
+        assert acquisition.done() is False
+
+        release_transcription.set()
+        acquisition_result = acquisition.result(timeout=10)
+
+    assert acquisition_result.ok is True
+    assert any(stage.status == "written" for stage in acquisition_result.stages)
 
 
 def test_acquire_valid_empty_asr_skips_extraction_and_writes_false_candidate(
@@ -454,7 +558,9 @@ def test_acquire_youtube_fetch_failure_is_loud_no_raw_record(
         ),
     )
     assert existing is None
-    assert conn.rows_for(STAGE_DEAD_LETTERED_TOPIC) == []  # no KA-06 stage reached; nothing to dead-letter there
+    assert (
+        conn.rows_for(STAGE_DEAD_LETTERED_TOPIC) == []
+    )  # no KA-06 stage reached; nothing to dead-letter there
 
 
 def test_acquire_youtube_extractor_dead_letter_skips_candidate(

--- a/tests/knowledge_acquisition/test_candidate_writeback.py
+++ b/tests/knowledge_acquisition/test_candidate_writeback.py
@@ -35,6 +35,10 @@ from app.knowledge_acquisition.extraction_registry import ExtractionResult, clea
 from app.knowledge_acquisition.extractors import summary_extractor
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard, WritesBlockedError
+from tests.knowledge.candidate_create_oracles import (
+    FdOracle,
+    assert_exact_fd_ownership,
+)
 
 RAW_RECORD_FIXTURE = {
     "source_kind": "youtube_url",
@@ -379,6 +383,8 @@ def test_rerun_existing_candidate_returns_before_render_and_creates_no_recovery_
         raise AssertionError("existing-target probe must return before WriteGuard")
 
     guard.assert_writes_allowed = forbidden_guard  # type: ignore[method-assign]
+    oracle = FdOracle()
+    oracle.install(monkeypatch)
     real_open = os.open
     real_close = os.close
     real_fsync = os.fsync
@@ -465,6 +471,12 @@ def test_rerun_existing_candidate_returns_before_render_and_creates_no_recovery_
         assert target.read_bytes() == expected_bytes
     assert list(target.parent.glob(".candidate-stage-*")) == []
     assert fd_labels == {}
+    assert_exact_fd_ownership(
+        oracle.opened,
+        oracle.close_attempts,
+        oracle.duplicates,
+    )
+    assert oracle.active == {}
 
 
 def test_composer_preserves_human_authored_band_on_rerun(tmp_path: Path) -> None:

--- a/tests/knowledge_acquisition/test_candidate_writeback.py
+++ b/tests/knowledge_acquisition/test_candidate_writeback.py
@@ -447,25 +447,26 @@ def test_rerun_existing_candidate_returns_before_render_and_creates_no_recovery_
     monkeypatch.setattr(os, "fsync", faulting_fsync)
     monkeypatch.setattr(os, "stat", faulting_stat)
 
-    if fault is None:
-        second = write_candidate_note(
-            candidate,
-            vault_context=vault,
-            write_guard=guard,
-            sources_dir=sources_dir,
-        )
-        assert second.status == "already_exists"
-        assert second.artifact_path == relative
-    else:
-        with pytest.raises(CandidateWritebackError):
-            write_candidate_note(
+    with oracle.observe():
+        if fault is None:
+            second = write_candidate_note(
                 candidate,
                 vault_context=vault,
                 write_guard=guard,
                 sources_dir=sources_dir,
             )
-        if fault != "nonregular_target":
-            assert fired == 1
+            assert second.status == "already_exists"
+            assert second.artifact_path == relative
+        else:
+            with pytest.raises(CandidateWritebackError):
+                write_candidate_note(
+                    candidate,
+                    vault_context=vault,
+                    write_guard=guard,
+                    sources_dir=sources_dir,
+                )
+            if fault != "nonregular_target":
+                assert fired == 1
 
     if expected_bytes is not None:
         assert target.read_bytes() == expected_bytes

--- a/tests/knowledge_acquisition/test_candidate_writeback.py
+++ b/tests/knowledge_acquisition/test_candidate_writeback.py
@@ -9,7 +9,9 @@ real vault path.
 from __future__ import annotations
 
 from dataclasses import replace
+import errno
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -23,6 +25,7 @@ from app.knowledge_acquisition.candidate_writeback import (
     TRIAGE_STATE_CAPTURED,
     Candidate,
     CandidateWriteResult,
+    CandidateWritebackError,
     assemble_candidate,
     candidate_note_path,
     render_candidate_note,
@@ -137,7 +140,7 @@ def test_write_goes_through_writeguard_callsite(tmp_path: Path) -> None:
     assert (vault_root / result.artifact_path).exists()
 
 
-def test_write_does_not_touch_filesystem_when_guard_denies(tmp_path: Path) -> None:
+def test_writeguard_denial_creates_no_candidate_parent(tmp_path: Path) -> None:
     """No direct filesystem write bypassing the guard: a denial leaves no artifact at all."""
     vault_root = tmp_path / "vault"
     vault = _vault(vault_root)
@@ -148,6 +151,7 @@ def test_write_does_not_touch_filesystem_when_guard_denies(tmp_path: Path) -> No
     assert result.status == "blocked"
     expected_path = candidate_note_path(candidate)
     assert not (vault_root / expected_path).exists()
+    assert not (vault_root / "Sources").exists()
     # Confirm nothing at all landed under the vault root.
     assert list(vault_root.rglob("*.md")) == []
 
@@ -321,22 +325,146 @@ def test_no_existing_artifact_mutation(tmp_path: Path) -> None:
     assert existing_note.stat().st_mtime_ns == existing_mtime_before
 
 
-def test_rerun_same_candidate_is_idempotent_not_duplicated(tmp_path: Path) -> None:
-    """Re-running the same candidate targets the same note path and does not duplicate it
-    (spec: 'the write retries idempotently — same note path, same content identity')."""
+@pytest.mark.parametrize(
+    "fault",
+    [
+        None,
+        "root_open",
+        "sources_open",
+        "intermediate_open",
+        "final_parent_open",
+        "parent_fsync",
+        "root_close",
+        "sources_close",
+        "intermediate_close",
+        "final_parent_close",
+        "target_stat",
+        "nonregular_target",
+    ],
+)
+def test_rerun_existing_candidate_returns_before_render_and_creates_no_recovery_artifact(
+    fault: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The durable existing-target probe is fail-closed and stays before render/guard."""
+
     vault_root = tmp_path / "vault"
     vault = _vault(vault_root)
     candidate = _assembled_candidate()
+    sources_dir = "Sources/one/two"
+    relative = candidate_note_path(candidate, sources_dir=sources_dir)
+    target = vault_root / relative
 
-    first = write_candidate_note(candidate, vault_context=vault, write_guard=_allowing_guard())
-    assert first.status == "written"
+    if fault == "nonregular_target":
+        target.mkdir(parents=True)
+        expected_bytes: bytes | None = None
+    else:
+        first = write_candidate_note(
+            candidate,
+            vault_context=vault,
+            write_guard=_allowing_guard(),
+            sources_dir=sources_dir,
+        )
+        assert first.status == "written"
+        expected_bytes = target.read_bytes()
 
-    second = write_candidate_note(candidate, vault_context=vault, write_guard=_allowing_guard())
-    assert second.status == "already_exists"
-    assert second.artifact_path == first.artifact_path
+    def forbidden_render(_candidate: Candidate) -> str:
+        raise AssertionError("existing-target probe must return before rendering")
 
-    all_notes = list(vault_root.rglob("*.md"))
-    assert len(all_notes) == 1
+    monkeypatch.setattr(candidate_writeback, "render_candidate_note", forbidden_render)
+    guard = _allowing_guard()
+
+    def forbidden_guard(_action: str) -> None:
+        raise AssertionError("existing-target probe must return before WriteGuard")
+
+    guard.assert_writes_allowed = forbidden_guard  # type: ignore[method-assign]
+    real_open = os.open
+    real_close = os.close
+    real_fsync = os.fsync
+    real_stat = os.stat
+    fd_labels: dict[int, str] = {}
+    fired = 0
+
+    def hit(message: str) -> None:
+        nonlocal fired
+        fired += 1
+        raise OSError(errno.EIO, message)
+
+    def faulting_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        decoded = os.fsdecode(path)
+        label = (
+            "root"
+            if dir_fd is None
+            else {
+                "Sources": "sources",
+                "one": "intermediate",
+                "two": "final_parent",
+            }.get(decoded, decoded)
+        )
+        if fault == f"{label}_open":
+            hit(f"{label} open fault")
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        fd_labels[fd] = label
+        return fd
+
+    def faulting_close(fd: int) -> None:
+        label = fd_labels.pop(fd, "unknown")
+        if fault == f"{label}_close":
+            real_close(fd)
+            hit(f"{label} close fault")
+        real_close(fd)
+
+    def faulting_fsync(fd: int) -> None:
+        if fault == "parent_fsync" and fd_labels.get(fd) == "final_parent":
+            hit("parent fsync fault")
+        real_fsync(fd)
+
+    def faulting_stat(
+        path: str | bytes | int | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> os.stat_result:
+        if fault == "target_stat" and path == target.name:
+            hit("target stat fault")
+        return real_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "open", faulting_open)
+    monkeypatch.setattr(os, "close", faulting_close)
+    monkeypatch.setattr(os, "fsync", faulting_fsync)
+    monkeypatch.setattr(os, "stat", faulting_stat)
+
+    if fault is None:
+        second = write_candidate_note(
+            candidate,
+            vault_context=vault,
+            write_guard=guard,
+            sources_dir=sources_dir,
+        )
+        assert second.status == "already_exists"
+        assert second.artifact_path == relative
+    else:
+        with pytest.raises(CandidateWritebackError):
+            write_candidate_note(
+                candidate,
+                vault_context=vault,
+                write_guard=guard,
+                sources_dir=sources_dir,
+            )
+        if fault != "nonregular_target":
+            assert fired == 1
+
+    if expected_bytes is not None:
+        assert target.read_bytes() == expected_bytes
+    assert list(target.parent.glob(".candidate-stage-*")) == []
+    assert fd_labels == {}
 
 
 def test_composer_preserves_human_authored_band_on_rerun(tmp_path: Path) -> None:
@@ -394,9 +522,7 @@ def test_composer_wraps_proposals_and_omits_absent_modules() -> None:
     assert rendered.count("## Proposals (non-authoritative)") == 1
     assert rendered.count("### Summary") == 1
     assert "## AI summary" not in rendered
-    assert rendered.index("## Owner notes") < rendered.index(
-        "## Proposals (non-authoritative)"
-    )
+    assert rendered.index("## Owner notes") < rendered.index("## Proposals (non-authoritative)")
     assert rendered.index("### Summary") < rendered.index("## Evidence and lineage")
     assert rendered.index("A deterministic test summary.") < rendered.index(
         "## Evidence and lineage"
@@ -450,7 +576,9 @@ def test_blocked_write_is_loud_and_retryable(tmp_path: Path) -> None:
 
     # Not terminal: the same candidate can be retried once writes are allowed again, and it
     # then succeeds normally (no leftover partial state blocked the retry).
-    retried_result = write_candidate_note(candidate, vault_context=vault, write_guard=_allowing_guard())
+    retried_result = write_candidate_note(
+        candidate, vault_context=vault, write_guard=_allowing_guard()
+    )
     assert retried_result.status == "written"
     assert retried_result.artifact_path == expected_path
 
@@ -466,9 +594,11 @@ def test_candidate_is_terminal_only_after_note_materialization(
     def _fail_materialization(*_args, **_kwargs) -> None:
         raise OSError("test materialization failure")
 
-    monkeypatch.setattr(candidate_writeback, "write_note_relative", _fail_materialization)
+    monkeypatch.setattr(candidate_writeback, "create_candidate_note_once", _fail_materialization)
 
-    with pytest.raises(candidate_writeback.CandidateWritebackError, match="materialization failure"):
+    with pytest.raises(
+        candidate_writeback.CandidateWritebackError, match="materialization failure"
+    ):
         write_candidate_note(candidate, vault_context=vault, write_guard=_allowing_guard())
 
     assert not (vault_root / candidate_note_path(candidate)).exists()

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -757,11 +757,6 @@ WRITE_NOTE_RELATIVE_SITE_CLASSIFICATION: dict[tuple[str, str, int], str] = {
         "staged receipt and passes the same guard/action to the port, in "
         "addition to the port's own guard (#3719)."
     ),
-    ("app/knowledge_acquisition/candidate_writeback.py", "write_candidate_note", 1): (
-        "guarded_by_caller: write_candidate_note asserts write_guard."
-        "assert_writes_allowed(CANDIDATE_WRITE_ACTION) immediately before "
-        "this call, in addition to the port's own guard (#2953)."
-    ),
     ("app/eval/failure_capture.py", "_write_draft", 1): (
         "guarded_by_caller: the shared draft-write helper asserts "
         "write_guard.assert_writes_allowed(FAILURE_CAPTURE_DRAFT_ACTION) "

--- a/tests/properties/test_guard_at_seam.py
+++ b/tests/properties/test_guard_at_seam.py
@@ -235,22 +235,81 @@ def test_every_candidate_create_once_seam_has_port_coverage() -> None:
         "DupFd",
         "FileIO",
         "TextIOWrapper",
+        "callback",
+        "closing",
         "dup",
         "dup2",
         "dup3",
+        "enter_async_context",
+        "enter_context",
         "fcntl",
         "fdopen",
+        "finalize",
         "fromfd",
+        "partial",
+        "push",
+        "push_async_callback",
+        "register",
     }
 
+    def assigned_names(target: ast.expr) -> list[str]:
+        if isinstance(target, ast.Name):
+            return [target.id]
+        if isinstance(target, (ast.List, ast.Tuple)):
+            return [name for element in target.elts for name in assigned_names(element)]
+        return []
+
+    def resolve_reference(
+        expression: ast.expr,
+        aliases: dict[str, str],
+    ) -> str | None:
+        if isinstance(expression, ast.Name):
+            return aliases.get(expression.id, expression.id)
+        if isinstance(expression, ast.Attribute):
+            owner = resolve_reference(expression.value, aliases)
+            return f"{owner}.{expression.attr}" if owner is not None else expression.attr
+        return None
+
     def assert_no_fd_aliases(function: ast.FunctionDef) -> None:
-        assert not any(isinstance(node, (ast.With, ast.AsyncWith)) for node in ast.walk(function))
+        aliases: dict[str, str] = {}
+        assignments = [
+            node for node in ast.walk(function) if isinstance(node, (ast.Assign, ast.AnnAssign))
+        ]
+        for _ in range(len(assignments) + 1):
+            changed = False
+            for assignment in assignments:
+                value = assignment.value
+                if value is None:
+                    continue
+                reference = resolve_reference(value, aliases)
+                if reference is None:
+                    continue
+                targets = (
+                    assignment.targets
+                    if isinstance(assignment, ast.Assign)
+                    else [assignment.target]
+                )
+                for target in targets:
+                    for name in assigned_names(target):
+                        if aliases.get(name) != reference:
+                            aliases[name] = reference
+                            changed = True
+            if not changed:
+                break
+
+        assert not any(
+            isinstance(node, (ast.With, ast.AsyncWith, ast.Lambda)) for node in ast.walk(function)
+        )
         for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
-            assert call_name(call) not in forbidden_wrapper_names
+            resolved = resolve_reference(call.func, aliases)
+            resolved_tail = resolved.rsplit(".", 1)[-1] if resolved is not None else None
+            assert resolved_tail not in forbidden_wrapper_names
             assert not (isinstance(call.func, ast.Name) and call.func.id == "open")
             if isinstance(call.func, ast.Attribute) and call.func.attr == "open":
                 assert isinstance(call.func.value, ast.Name)
                 assert call.func.value.id == "os"
+            if isinstance(call.func, ast.Name) and call.func.id in aliases:
+                assert resolved not in {"os.close", "os.open"}
 
     for function in (create, probe):
         assert_no_fd_aliases(function)
@@ -261,6 +320,12 @@ def test_every_candidate_create_once_seam_has_port_coverage() -> None:
         "def mutant(fd):\n    io.FileIO(fd, closefd=False)\n",
         "def mutant(fd):\n    io.TextIOWrapper(io.FileIO(fd, closefd=False))\n",
         "def mutant(path):\n    pathlib.Path(path).open()\n",
+        "def mutant(fd):\n    weakref.finalize(fd, os.close, fd)\n",
+        "def mutant(fd):\n    stack = ExitStack()\n    stack.callback(os.close, fd)\n",
+        "def mutant(fd):\n    clone = os.dup\n    clone(fd)\n",
+        "def mutant(fd):\n    clone = os.dup\n    clone_again = clone\n    clone_again(fd)\n",
+        "def mutant(fd):\n    closer = os.close\n    closer(fd)\n",
+        "def mutant(fd):\n    callback = lambda: os.close(fd)\n",
     ]
     for source in alias_mutants:
         mutant = next(

--- a/tests/properties/test_guard_at_seam.py
+++ b/tests/properties/test_guard_at_seam.py
@@ -37,6 +37,9 @@ separated APPEND-ONLY section below the P-2 content, so a concurrent sibling
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 
 from tests.properties._machinery import (
@@ -93,9 +96,9 @@ def test_every_write_seam_asserts_writeguard() -> None:
         for key, value in WRITE_FRONTMATTER_SITE_CLASSIFICATION.items()
         if not (value.startswith("guarded") or value.startswith("out_of_scope"))
     ]
-    assert not bad_classification, (
-        f"Every classification must start with 'guarded' or 'out_of_scope': {bad_classification}"
-    )
+    assert (
+        not bad_classification
+    ), f"Every classification must start with 'guarded' or 'out_of_scope': {bad_classification}"
 
     write_missing_sites = find_write_missing_call_sites()
     assert write_missing_sites, "expected known production write_missing call sites"
@@ -110,8 +113,7 @@ def test_every_write_seam_asserts_writeguard() -> None:
         site for site in WRITE_MISSING_SITE_CLASSIFICATION if site not in set(write_missing_sites)
     ]
     assert not stale_write_missing, (
-        "WRITE_MISSING_SITE_CLASSIFICATION has stale entries: "
-        f"{stale_write_missing}"
+        "WRITE_MISSING_SITE_CLASSIFICATION has stale entries: " f"{stale_write_missing}"
     )
     invalid_write_missing = [
         (site, classification)
@@ -119,8 +121,7 @@ def test_every_write_seam_asserts_writeguard() -> None:
         if not classification.startswith(("guarded", "bootstrap"))
     ]
     assert not invalid_write_missing, (
-        "write_missing classifications must be guarded or bootstrap: "
-        f"{invalid_write_missing}"
+        "write_missing classifications must be guarded or bootstrap: " f"{invalid_write_missing}"
     )
 
 
@@ -190,6 +191,107 @@ def test_every_write_note_relative_seam_has_port_coverage(tmp_path) -> None:
         _assert_write_note_relative_census_is_closed(new_sites)
 
 
+def test_every_candidate_create_once_seam_has_port_coverage() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    write_ops_path = repo_root / "app" / "knowledge" / "write_ops.py"
+    writeback_path = repo_root / "app" / "knowledge_acquisition" / "candidate_writeback.py"
+    write_ops_tree = ast.parse(write_ops_path.read_text(encoding="utf-8"))
+    create = next(
+        node
+        for node in ast.walk(write_ops_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "create_candidate_note_once"
+    )
+    probe = next(
+        node
+        for node in ast.walk(write_ops_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "candidate_note_exists_durable"
+    )
+
+    def call_name(call: ast.Call) -> str | None:
+        if isinstance(call.func, ast.Name):
+            return call.func.id
+        if isinstance(call.func, ast.Attribute):
+            return call.func.attr
+        return None
+
+    calls = [node for node in ast.walk(create) if isinstance(node, ast.Call)]
+    guard_calls = [node for node in calls if call_name(node) == "assert_writes_allowed"]
+    assert len(guard_calls) == 1
+    mutation_names = {
+        "_atomic_rename_noreplace_at",
+        "mkdir",
+        "unlink",
+        "write",
+    }
+    mutation_calls = [node for node in calls if call_name(node) in mutation_names]
+    assert mutation_calls
+    assert guard_calls[0].lineno < min(node.lineno for node in mutation_calls)
+
+    forbidden_wrapper_names = {
+        "FileIO",
+        "dup",
+        "dup2",
+        "dup3",
+        "fdopen",
+    }
+    for function in (create, probe):
+        assert not any(isinstance(node, (ast.With, ast.AsyncWith)) for node in ast.walk(function))
+        for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
+            assert call_name(call) not in forbidden_wrapper_names
+            assert not (isinstance(call.func, ast.Name) and call.func.id == "open")
+
+    call_sites: list[tuple[str, str]] = []
+    for path in (repo_root / "app").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            if call_name(call) != "create_candidate_note_once":
+                continue
+            owner: ast.AST | None = call
+            while owner is not None and not isinstance(owner, ast.FunctionDef):
+                owner = parents.get(owner)
+            assert isinstance(owner, ast.FunctionDef)
+            call_sites.append((str(path.relative_to(repo_root)), owner.name))
+    assert call_sites == [
+        ("app/knowledge_acquisition/candidate_writeback.py", "write_candidate_note")
+    ]
+
+    writeback_tree = ast.parse(writeback_path.read_text(encoding="utf-8"))
+    write_candidate = next(
+        node
+        for node in ast.walk(writeback_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "write_candidate_note"
+    )
+    assert (
+        sum(
+            call_name(call) == "create_candidate_note_once"
+            for call in ast.walk(write_candidate)
+            if isinstance(call, ast.Call)
+        )
+        == 1
+    )
+
+    mutant_tree = ast.parse(
+        write_ops_path.read_text(encoding="utf-8").replace(
+            "guard.assert_writes_allowed(action)",
+            "guard_was_not_asserted = action",
+            1,
+        )
+    )
+    mutant_create = next(
+        node
+        for node in ast.walk(mutant_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "create_candidate_note_once"
+    )
+    assert not any(
+        isinstance(node, ast.Call) and call_name(node) == "assert_writes_allowed"
+        for node in ast.walk(mutant_create)
+    )
+
+
 def test_registered_write_seams_cover_the_named_gap1_and_gap2_sites() -> None:
     """The P-1/P-4 runtime property registry names exactly the four sites
     this issue and its predecessor scope: the knowledge write port,
@@ -213,7 +315,11 @@ def test_registered_write_seams_cover_the_named_gap1_and_gap2_sites() -> None:
 
 
 @given(seam_index=st.sampled_from(range(len(REGISTERED_WRITE_SEAMS))))
-@settings(max_examples=len(REGISTERED_WRITE_SEAMS), deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=len(REGISTERED_WRITE_SEAMS),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
 def test_denying_guard_blocks_atomically(tmp_path_factory, seam_index: int) -> None:
     """``given(seam=sampled_from(REGISTERED_WRITE_SEAMS), guard_state=denying_guard())``
     (the spec's own vocabulary): a guard reporting a health-blocked state
@@ -233,7 +339,9 @@ def test_denying_guard_blocks_atomically(tmp_path_factory, seam_index: int) -> N
 
         guard_module = importlib.import_module(module_path)
         guard = getattr(guard_module, attr_name)
-        monkeypatch.setattr(guard, "snapshot_fn", lambda: {"state": "safe_mode", "reason": "p1-deny"})
+        monkeypatch.setattr(
+            guard, "snapshot_fn", lambda: {"state": "safe_mode", "reason": "p1-deny"}
+        )
         monkeypatch.setattr(guard, "bootstrap_actions", frozenset())
 
         from app.write_guard import WritesBlockedError
@@ -254,7 +362,11 @@ def test_denying_guard_blocks_atomically(tmp_path_factory, seam_index: int) -> N
 
 
 @given(seam_index=st.sampled_from(range(len(REGISTERED_WRITE_SEAMS))))
-@settings(max_examples=len(REGISTERED_WRITE_SEAMS), deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(
+    max_examples=len(REGISTERED_WRITE_SEAMS),
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
 def test_raising_guard_blocks_write(tmp_path_factory, seam_index: int) -> None:
     """``given(seam=sampled_from(REGISTERED_WRITE_SEAMS), guard=raising_guard())``:
     a WriteGuard whose evaluation itself errors (not merely denies) still

--- a/tests/properties/test_guard_at_seam.py
+++ b/tests/properties/test_guard_at_seam.py
@@ -228,17 +228,46 @@ def test_every_candidate_create_once_seam_has_port_coverage() -> None:
     assert guard_calls[0].lineno < min(node.lineno for node in mutation_calls)
 
     forbidden_wrapper_names = {
+        "BufferedRandom",
+        "BufferedReader",
+        "BufferedRWPair",
+        "BufferedWriter",
+        "DupFd",
         "FileIO",
+        "TextIOWrapper",
         "dup",
         "dup2",
         "dup3",
+        "fcntl",
         "fdopen",
+        "fromfd",
     }
-    for function in (create, probe):
+
+    def assert_no_fd_aliases(function: ast.FunctionDef) -> None:
         assert not any(isinstance(node, (ast.With, ast.AsyncWith)) for node in ast.walk(function))
         for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
             assert call_name(call) not in forbidden_wrapper_names
             assert not (isinstance(call.func, ast.Name) and call.func.id == "open")
+            if isinstance(call.func, ast.Attribute) and call.func.attr == "open":
+                assert isinstance(call.func.value, ast.Name)
+                assert call.func.value.id == "os"
+
+    for function in (create, probe):
+        assert_no_fd_aliases(function)
+
+    alias_mutants = [
+        "def mutant(fd):\n    os.dup(fd)\n",
+        "def mutant(fd):\n    fcntl.fcntl(fd, fcntl.F_DUPFD, 0)\n",
+        "def mutant(fd):\n    io.FileIO(fd, closefd=False)\n",
+        "def mutant(fd):\n    io.TextIOWrapper(io.FileIO(fd, closefd=False))\n",
+        "def mutant(path):\n    pathlib.Path(path).open()\n",
+    ]
+    for source in alias_mutants:
+        mutant = next(
+            node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.FunctionDef)
+        )
+        with pytest.raises(AssertionError):
+            assert_no_fd_aliases(mutant)
 
     call_sites: list[tuple[str, str]] = []
     for path in (repo_root / "app").rglob("*.py"):


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4132

## Linked Issue
Closes #4132

## SBS Impact
- Primary subsystem: Knowledge acquisition candidate writeback
- Secondary subsystem(s): Knowledge filesystem write seam; release-channel and client contracts
- Write class: Mechanical durable create-once candidate publication; non-authority-bearing
- Persistence impact: Adds complete hidden-stage durability and atomic no-replace canonical publication with target-parent fences
- Derived/rebuildable impact: Invocation-owned hidden remnants and assembled candidates remain rebuildable from retained raw evidence
- New or changed contract: candidate-atomic-create-if-absent-v1, restricted to shipped YouTube candidate writeback
- Owner-doc impact: Updated all five Issue-owned source documents in the same change
- Transition debt impact: No new transition mechanism, migration, coordinator, registry, or cleanup debt
- Boundary risk: Data, concurrency, and explicit state-machine risk bounded to one-user local macOS/Linux filesystems

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Publish YouTube acquisition candidates with a candidate-specific atomic no-replace create-once helper, while long fetch, transcription, extraction, and rendering remain outside publication ownership.
- Preserve existing or concurrent winners byte-for-byte, fail loudly across durability and cleanup faults, and keep generic KnowledgePort and other candidate families unchanged.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps cross-authority material; Issue #4132 and repo owner docs remain canonical.


## Notes
Mechanism: candidate-atomic-create-if-absent-v1. Issue-body SHA: 39cef228bd9ac6eb6d1c129ebf6e1cecca693d72a251ab37190ea79cd2176e82. Convergence packet SHA: 6bd073710ec0e40de41724764ef34b39ece5ee5a75d9564d3d5b93ea2da28bd4. Final current-SHA Sol/xhigh review: CLEAN (P0=0/P1=0/P2=0/P3=0) on ad6fc03e2b64c3aa2d77f73966291fc7393718e8. Current-SHA validation: Issue-focused suite plus incoming test-selector contract 227 passed; ruff passed; mypy passed (32 files); governed docs guard passed; diff check passed. Host-leased non-PG validation on byte-identical pre-rebase delivery febc8476e7c5665d24889232c0287942ddb287f3: 11,624 passed under xdist and all 35 host/xdist-shared-state failures passed in the leased serial rerun. Evidence carried to ad6fc03e2b64c3aa2d77f73966291fc7393718e8 under the base-drift contract: stable patch ID c737b8e3ad002325bd821fc410ec78d12a256053, six commits and all 15 delivery blobs identical; incoming 8b90366be85c467e685898a2887259683766e92c..79145fc797a41bea84ca714b785925a6315cf73c is Daily Briefing-only and cannot select #4132 paths.