### PR TITLE
Stamp Signboard boards with their owning dispatcher store so --prune-absent cannot delete a board it does not own

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -516,7 +516,12 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
 def _cmd_export_signboard(args: argparse.Namespace, store: SqliteStore) -> int:
     from pathlib import Path
 
-    from app.dispatcher.signboard import NoActiveVaultError, default_signboard_root, export_signboard
+    from app.dispatcher.signboard import (
+        NoActiveVaultError,
+        SignboardStoreOwnershipError,
+        default_signboard_root,
+        export_signboard,
+    )
 
     if args.path:
         target_path = Path(args.path)
@@ -526,7 +531,11 @@ def _cmd_export_signboard(args: argparse.Namespace, store: SqliteStore) -> int:
         except NoActiveVaultError as exc:
             return _emit_error(str(exc), args.json)
 
-    result = export_signboard(store, target_path, prune_absent=args.prune_absent)
+    try:
+        result = export_signboard(store, target_path, prune_absent=args.prune_absent)
+    except SignboardStoreOwnershipError as exc:
+        # Fail closed and non-zero: nothing on the board was touched (#4370).
+        return _emit_error(str(exc), args.json)
     _emit({"ok": True, **result}, args.json)
     return 0
 

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -6,7 +6,9 @@ one-way Markdown projection that lightweight kanban tools can render from disk.
 
 from __future__ import annotations
 
+import json
 import re
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -33,10 +35,30 @@ _NOTES_HEADING = "## Notes"
 _RECEIPTS_HEADING = "## Receipts"
 _GENERATED_FILENAME_RE = re.compile(r".+--.+\.md$")
 
+# A board records which dispatcher store owns it (#4370). The store resolves
+# from the current working directory (``app/dispatcher/config.py ::
+# load_paths`` -> ``_default_state_dir`` -> ``discover_primary_worktree``), so
+# two checkouts of this repo on one host have two independent stores. Without
+# this fact, ``--prune-absent`` reads "unknown to whichever store this process
+# resolved" as "dead card": on 2026-07-29 it was run from the checkout that did
+# not own the board and deleted 404 live cards.
+#
+# The stamp is a durable *identity*, never the store's path — a path is exactly
+# the thing that cannot identify a store here, and a legitimate relocation must
+# not read as a foreign store.
+STORE_IDENTITY_META_KEY = "signboard_store_id"
+STORE_STAMP_FILENAME = ".signboard-store.json"
+STORE_STAMP_VERSION = 1
+
 
 class NoActiveVaultError(RuntimeError):
     """Raised when a default Signboard export path is requested but no vault
     is currently selected via the active-vault-selection mechanism."""
+
+
+class SignboardStoreOwnershipError(RuntimeError):
+    """Raised when a destructive board operation cannot prove the board belongs
+    to the dispatcher store this process resolved."""
 
 
 def default_signboard_root() -> Path:
@@ -89,6 +111,111 @@ def column_for_status(status: str) -> str:
     return STATUS_COLUMNS.get(normalized, "Backlog")
 
 
+def read_store_identity(store: SqliteStore) -> str | None:
+    """Return the store's durable identity, or ``None`` when it has none yet.
+
+    Read-only on purpose: ``validate_signboard`` must not write to the store,
+    and a store that owns a stamped board necessarily already carries the
+    identity that stamped it — so "no identity" is itself proof of non-ownership.
+    """
+
+    value = store.get_meta(STORE_IDENTITY_META_KEY)
+    if value is None:
+        return None
+    return value.strip() or None
+
+
+def resolve_store_identity(store: SqliteStore) -> str:
+    """Return the store's durable identity, minting one on first use.
+
+    The identity lives in the store's own metadata, so it travels with the
+    store when the store moves and is never inherited by a different store.
+    """
+
+    existing = read_store_identity(store)
+    if existing is not None:
+        return existing
+    minted = uuid.uuid4().hex
+    store.set_meta(STORE_IDENTITY_META_KEY, minted)
+    return minted
+
+
+def read_board_store_id(board_root: Path) -> str | None:
+    """Return the store id a board is stamped with, or ``None`` when unstamped.
+
+    A stamp file that exists but cannot be read as a stamp also returns
+    ``None``: every caller treats "cannot prove ownership" as "not owned", and
+    the claim below keys on the file's *absence*, so a corrupted stamp keeps
+    refusing until a human removes it instead of being silently re-claimed.
+    """
+
+    try:
+        data = json.loads((Path(board_root) / STORE_STAMP_FILENAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    store_id = data.get("store_id")
+    if not isinstance(store_id, str) or not store_id.strip():
+        return None
+    return store_id.strip()
+
+
+def _claim_board_stamp(root: Path, store_id: str) -> None:
+    """Stamp the board with its owning store, once.
+
+    Written only when no stamp file exists at all. A board already stamped by
+    another store is never re-stamped: a plain export must not become the way
+    the prune guard gets defeated.
+    """
+
+    path = root / STORE_STAMP_FILENAME
+    if path.exists():
+        return
+    path.write_text(
+        json.dumps(
+            {
+                "generated_by": "dispatcher.signboard",
+                "stamp_version": STORE_STAMP_VERSION,
+                "store_id": store_id,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _board_has_generated_cards(root: Path) -> bool:
+    if not root.is_dir():
+        return False
+    return any(_is_generated_card(path) for path in root.rglob("*.md"))
+
+
+def _require_board_ownership(root: Path, store_id: str) -> None:
+    """Refuse a destructive board operation this store cannot prove it owns."""
+
+    board_store_id = read_board_store_id(root)
+    if board_store_id == store_id:
+        return
+    if board_store_id is None:
+        if not _board_has_generated_cards(root):
+            # Nothing to lose: an unstamped board holding no generated cards
+            # cannot be another store's board in any way a prune could harm,
+            # so a first export may still prune in a single command.
+            return
+        raise SignboardStoreOwnershipError(
+            f"board {root} carries no store-identity stamp but already holds generated cards; "
+            "refusing to prune. Run 'export-signboard <path>' without --prune-absent from the "
+            "checkout that owns this board to stamp it, then retry."
+        )
+    raise SignboardStoreOwnershipError(
+        f"board {root} is stamped by dispatcher store {board_store_id!r}, but this process "
+        f"resolved store {store_id!r}; refusing to prune. Cards absent from this store may "
+        "simply belong to the other one — run the prune from the checkout that owns the board."
+    )
+
+
 def export_signboard(
     store: SqliteStore,
     board_root: Path,
@@ -108,12 +235,22 @@ def export_signboard(
     card carries no human-authored ``## Notes`` content; a stale card that does
     carry notes is kept and surfaced under ``retained_with_notes`` so a human
     decides its fate. Human material is never silently destroyed.
+
+    A prune additionally requires that the board's store-identity stamp match
+    this store (#4370). That check runs *before* anything is written or
+    unlinked: the per-task cleanup below already unlinks stale generated cards
+    of its own accord, so a refusal raised any later would not be total.
     """
 
     root = Path(board_root).expanduser()
+    store_id = resolve_store_identity(store)
+    if prune_absent:
+        _require_board_ownership(root, store_id)
+
     root.mkdir(parents=True, exist_ok=True)
     for column in sorted(set(STATUS_COLUMNS.values())):
         (root / column).mkdir(parents=True, exist_ok=True)
+    _claim_board_stamp(root, store_id)
 
     # Synchronization metadata is stored alongside tasks for dispatcher
     # compatibility, but it is not a user-facing Signboard card.
@@ -159,11 +296,14 @@ def export_signboard(
     retained_with_notes: list[str] = []
     if prune_absent:
         pruned, retained_with_notes = _prune_cards_absent_from_store(
-            root, known_task_ids={task.task_id for task in tasks}
+            root,
+            known_task_ids={task.task_id for task in tasks},
+            expected_store_id=store_id,
         )
 
     return {
         "root": str(root),
+        "store_id": store_id,
         "count": len(tasks),
         "columns": sorted(set(STATUS_COLUMNS.values())),
         "written": written,
@@ -173,14 +313,20 @@ def export_signboard(
 
 
 def _prune_cards_absent_from_store(
-    root: Path, *, known_task_ids: set[str]
+    root: Path, *, known_task_ids: set[str], expected_store_id: str
 ) -> tuple[list[str], list[str]]:
     """Remove empty generated cards whose task ID is gone from dispatcher.
 
     Returns ``(pruned, retained_with_notes)``. Malformed generated cards are
     left in place: ``signboard-validate`` already reports them under their own
     finding kind, and their task identity cannot be trusted for a delete.
+
+    This is the deleting primitive, so it re-asserts board ownership itself
+    rather than trusting its caller to have done it: "absent from the store" is
+    only a fact about a card when the store is the one that owns the board.
     """
+
+    _require_board_ownership(root, expected_store_id)
 
     pruned: list[str] = []
     retained_with_notes: list[str] = []
@@ -247,6 +393,23 @@ def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
     findings: list[dict[str, str]] = []
     cards_by_task: dict[str, list[str]] = {}
 
+    # Name a foreign-store comparison before the cards it explains (#4370).
+    # Against someone else's board every card reads as ``stale_card``, and that
+    # is the noise that hid the 2026-07-29 incident: 378 of 405 findings, each
+    # individually true and collectively the wrong conclusion.
+    board_store_id = read_board_store_id(root)
+    foreign_store = board_store_id is not None and board_store_id != read_store_identity(store)
+    if foreign_store:
+        findings.append({
+            "kind": "store_stamp_mismatch",
+            "path": STORE_STAMP_FILENAME,
+            "detail": (
+                f"board is stamped by dispatcher store {board_store_id!r}, which is not the "
+                "store this process resolved; cards reported below as absent from the store "
+                "may simply belong to the other one"
+            ),
+        })
+
     for path in sorted(root.rglob("*.md")) if root.is_dir() else []:
         relative_path = str(path.relative_to(root))
         text = _read_card_text(path)
@@ -312,7 +475,14 @@ def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
             })
 
     result: dict[str, Any] = {"root": str(root), "count": len(tasks), "findings": findings}
-    if any(finding["kind"] == "stale_card" for finding in findings):
+    if foreign_store:
+        # Never name the prune here: on a foreign board that repair is the
+        # command that destroys it (#4370).
+        result["repair"] = (
+            "this board belongs to another dispatcher store; run export-signboard from the "
+            "checkout that owns it. Do not prune from here."
+        )
+    elif any(finding["kind"] == "stale_card" for finding in findings):
         # Name the repair in the lint output itself. A finding an operator
         # cannot act on is the bug this replaces (#4198).
         result["repair"] = "python -m app.dispatcher export-signboard [path] --prune-absent"

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -797,8 +797,8 @@ Run `python -m app.dispatcher signboard-validate [path] --json` to lint the gene
 changing either the board or dispatcher store. As with `export-signboard`, the path is optional and
 defaults to the active vault's `BuilderOpsVault/agent-delivery` root. Validation exits nonzero for
 malformed generated cards, duplicate generated cards, column/status drift, cards stale against the
-dispatcher store, and unreadable generated-filename candidates; run `export-signboard` to repair
-valid generated-card drift. Human-authored files are outside this lint's jurisdiction.
+dispatcher store, unreadable generated-filename candidates, and a board stamped by a different
+dispatcher store; run `export-signboard` to repair valid generated-card drift. Human-authored files are outside this lint's jurisdiction.
 
 A plain `export-signboard` only rewrites cards for task IDs that still exist in the dispatcher
 store, so it cannot clear a card whose task ID has disappeared from the store — those accumulate as
@@ -809,6 +809,35 @@ exactly those cards:
 python -m app.dispatcher signboard-validate [path] --json   # reports stale_card findings
 python -m app.dispatcher export-signboard [path] --prune-absent --json
 ```
+
+A board records which dispatcher store owns it. Every export writes a `.signboard-store.json` stamp
+into the board root carrying that store's durable identity — an id minted once and kept in the
+store's own metadata, never the store's path, so relocating a store does not make its boards read as
+foreign. The stamp is not a card: it sits at the board root outside the column directories and is
+not a `.md` file, so neither the exporter, the lint, nor the `/signboard` API ever renders it, and
+it never becomes a second source of task truth.
+
+This matters because the store resolves from the **current working directory**
+(`app/dispatcher/config.py :: load_paths` → `_default_state_dir` → `discover_primary_worktree`).
+Two checkouts of this repo on one host therefore have two independent stores, and to the store that
+does not own a board *every* card on it is absent. On 2026-07-29 that deleted 404 live cards.
+`--prune-absent` now refuses, non-zero and before it writes or unlinks anything, unless the board's
+stamp matches the store the process resolved:
+
+- **Stamp matches** — prunes exactly as described below.
+- **Stamp belongs to another store** — refuses. Run the prune from the checkout that owns the board.
+  A plain export from the other checkout does *not* re-stamp the board; a board changes owner only
+  when a human deletes the stamp file.
+- **No stamp, and the board already holds generated cards** — refuses. This is every board that
+  predates the stamp. Claim it with a plain `export-signboard <path>` (no `--prune-absent`) run from
+  the checkout that owns it, then retry. An unstamped board is never adopted by the same command
+  that prunes it, because that would defeat the guard on exactly the boards that need it.
+- **No stamp and no generated cards** — proceeds and stamps the board. A first export has nothing to
+  lose, so a fresh board still works in one command.
+
+`signboard-validate` reports a mismatch read-only as its own `store_stamp_mismatch` finding, named
+before the `stale_card` findings it explains, and in that case its `repair` hint deliberately does
+not name `--prune-absent`.
 
 `--prune-absent` deletes a generated card only when its task ID is absent from the store *and* the
 card carries nothing a human wrote. Both hand-editable sections count: `## Notes`, and any non-blank

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -335,7 +335,14 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
   of their own, so with no vault selected there is no board root and the board reports an explicit
   error state rather than an empty one. `export-signboard --prune-absent` removes generated cards
   whose task id has left the dispatcher store, retaining any card that carries human-authored
-  `## Notes` or `## Receipts` text (#4198). The projection remains read-only for coordination fields
+  `## Notes` or `## Receipts` text (#4198). A board now also records which dispatcher store owns it:
+  every export writes a `.signboard-store.json` stamp carrying that store's durable identity (minted
+  into the store's own metadata, not derived from its path), and `--prune-absent` refuses non-zero,
+  before writing or unlinking anything, unless the stamp matches the store the process resolved —
+  the store resolves from the current working directory, so two checkouts on one host reached
+  opposite verdicts about the same board and one of them deleted 404 live cards on 2026-07-29
+  (#4370). `signboard-validate` reports a mismatch read-only as a `store_stamp_mismatch` finding.
+  The projection remains read-only for coordination fields
   and has no write path for claim, lease, or lock state; dispatcher SQLite remains sole claim/lease
   authority per ADR-0010.
 - Canvas co-authoring is materially implemented behind `CANVAS_ENABLED`: `canvas open` / `edit` /

--- a/tests/api/test_signboard_api.py
+++ b/tests/api/test_signboard_api.py
@@ -163,3 +163,25 @@ def test_unresolvable_root_reports_error_state(tmp_path: Path, monkeypatch) -> N
 
     refresh = TestClient(app).post("/api/signboard/refresh")
     assert refresh.status_code == 503
+
+
+def test_store_identity_stamp_is_never_rendered_as_a_card(tmp_path: Path, monkeypatch) -> None:
+    """The board's owning-store stamp (#4370) is not board content.
+
+    It sits at the board root outside the card namespace, so the projection
+    reader neither renders it nor reports it as an error.
+    """
+    from app.dispatcher.signboard import STORE_STAMP_FILENAME
+
+    store = _configure(tmp_path, monkeypatch)
+    _seed(store)
+    client = TestClient(app)
+
+    payload = client.post("/api/signboard/refresh").json()
+
+    assert (tmp_path / "board" / STORE_STAMP_FILENAME).is_file()
+    assert payload["errors"] == []
+    assert payload["status"] == "ok"
+    cards = [card for column in payload["columns"] for card in column["cards"]]
+    assert len(cards) == 1
+    assert all(STORE_STAMP_FILENAME not in card["id"] for card in cards)

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -17,9 +19,12 @@ import pytest
 from app.dispatcher import signboard as signboard_module
 from app.dispatcher.signboard import (
     DEFAULT_SIGNBOARD_SUBPATH,
+    STORE_STAMP_FILENAME,
     NoActiveVaultError,
+    SignboardStoreOwnershipError,
     default_signboard_root,
     export_signboard,
+    read_store_identity,
     validate_signboard,
 )
 from app.dispatcher.config import load_paths
@@ -646,3 +651,212 @@ def test_prune_retains_a_stale_card_carrying_human_receipts(
     assert result["retained_with_notes"] == [str(stale)]
     assert result["pruned"] == []
     assert "merged in PR #123" in stale.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #4370: a board records the dispatcher store that owns it
+#
+# The store resolves from the current working directory
+# (``app/dispatcher/config.py :: load_paths`` -> ``_default_state_dir`` ->
+# ``discover_primary_worktree``), so two checkouts on one host have two
+# independent stores. On 2026-07-29 ``--prune-absent`` was run from the checkout
+# that did *not* own the board; every card looked absent and 404 live cards were
+# deleted. These tests fix the missing fact: which store owns the board.
+# ---------------------------------------------------------------------------
+
+
+def _independent_store(state_dir: Path) -> SqliteStore:
+    """A second dispatcher store — exactly like a second checkout on one host.
+
+    It shares no tasks and no identity with the ``store`` fixture, so every card
+    on the other store's board looks absent to it.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    other = SqliteStore(
+        db_path=state_dir / "dispatcher.sqlite3",
+        event_writer=JsonlEventWriter(state_dir / "events.jsonl"),
+    )
+    other.initialize()
+    return other
+
+
+def test_export_writes_store_identity_stamp(tmp_env, store, tmp_path: Path) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+
+    result = export_signboard(store, board)
+
+    stamp = board / STORE_STAMP_FILENAME
+    assert stamp.is_file()
+    data = json.loads(stamp.read_text(encoding="utf-8"))
+    assert data["store_id"] == read_store_identity(store)
+    assert data["store_id"]
+    assert result["store_id"] == data["store_id"]
+    # The stamp lives outside the card namespace: not a ".md" file, and at the
+    # board root rather than inside a column, so no board consumer renders it.
+    assert stamp.suffix != ".md"
+    assert stamp.parent == board
+
+
+def test_prune_refuses_when_store_stamp_mismatches(tmp_env, store, tmp_path: Path) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    foreign = _independent_store(tmp_path / "other-checkout")
+
+    with pytest.raises(SignboardStoreOwnershipError) as excinfo:
+        export_signboard(foreign, board, prune_absent=True)
+
+    assert "stamped by dispatcher store" in str(excinfo.value)
+
+
+def test_prune_mismatch_leaves_every_card_intact(tmp_env, store, tmp_path: Path) -> None:
+    """The 2026-07-29 incident in miniature: the refusal must be total.
+
+    The foreign store knows none of this board's tasks, so without the guard
+    every card is a prune candidate — and the export loop that runs *before*
+    the prune already unlinks generated cards of its own accord. Nothing on the
+    board may change.
+    """
+    seed_tasks(store)
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    before = {path: path.read_bytes() for path in sorted(board.rglob("*.md"))}
+    assert before
+
+    foreign = _independent_store(tmp_path / "other-checkout")
+    with pytest.raises(SignboardStoreOwnershipError):
+        export_signboard(foreign, board, prune_absent=True)
+
+    after = {path: path.read_bytes() for path in sorted(board.rglob("*.md"))}
+    assert after == before
+
+
+def test_validate_reports_foreign_store_distinctly(tmp_env, store, tmp_path: Path) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    foreign = _independent_store(tmp_path / "other-checkout")
+
+    result = validate_signboard(foreign, board)
+
+    kinds = [finding["kind"] for finding in result["findings"]]
+    assert "store_stamp_mismatch" in kinds
+    # Distinct from stale_card, and named before the cards it explains.
+    assert kinds[0] == "store_stamp_mismatch"
+    assert kinds.count("store_stamp_mismatch") == 1
+    assert "stale_card" in kinds
+    # The read-only surface must not point the operator at the loaded gun.
+    assert "--prune-absent" not in result["repair"]
+
+
+def test_prune_unchanged_when_stamp_matches(tmp_env, store, tmp_path: Path) -> None:
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    live_card = next(board.glob(f"**/{ready.task_id}--*.md"))
+    plain = _write_stale_card(board, live_card, task_id="task-gone-plain", notes=None)
+    noted = _write_stale_card(board, live_card, task_id="task-gone-noted", notes="Owner decision pending.")
+
+    result = export_signboard(store, board, prune_absent=True)
+
+    assert not plain.exists()
+    assert result["pruned"] == [str(plain)]
+    assert noted.exists()
+    assert result["retained_with_notes"] == [str(noted)]
+    assert live_card.exists()
+
+
+def test_stamp_is_identity_not_path(tmp_env, store, tmp_path: Path) -> None:
+    """A legitimate relocation of the store must not read as a foreign store."""
+    tasks = seed_tasks(store)
+    ready = next(task for task in tasks if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    stale = _write_stale_card(
+        board, next(board.glob(f"**/{ready.task_id}--*.md")), task_id="task-gone", notes=None
+    )
+    stamped_id = json.loads((board / STORE_STAMP_FILENAME).read_text(encoding="utf-8"))["store_id"]
+
+    relocated_dir = tmp_path / "relocated-dispatcher"
+    shutil.move(str(Path(tmp_env["DISPATCHER_STATE_DIR"])), str(relocated_dir))
+    relocated = SqliteStore(
+        db_path=relocated_dir / "dispatcher.sqlite3",
+        event_writer=JsonlEventWriter(relocated_dir / "events.jsonl"),
+    )
+
+    result = export_signboard(relocated, board, prune_absent=True)
+
+    assert read_store_identity(relocated) == stamped_id
+    assert not stale.exists()
+    assert result["pruned"] == [str(stale)]
+
+
+def test_prune_refuses_on_unstamped_board_that_holds_cards(
+    tmp_env, store, tmp_path: Path
+) -> None:
+    """Every board that exists today is unstamped; none may be silently adopted."""
+    seed_tasks(store)
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    (board / STORE_STAMP_FILENAME).unlink()
+    before = {path: path.read_bytes() for path in sorted(board.rglob("*.md"))}
+
+    with pytest.raises(SignboardStoreOwnershipError) as excinfo:
+        export_signboard(store, board, prune_absent=True)
+
+    assert "no store-identity stamp" in str(excinfo.value)
+    assert {path: path.read_bytes() for path in sorted(board.rglob("*.md"))} == before
+
+
+def test_prune_on_a_board_with_nothing_to_lose_still_works(
+    tmp_env, store, tmp_path: Path
+) -> None:
+    """A fresh board holds no cards, so a first export may prune in one command."""
+    seed_tasks(store)
+    board = tmp_path / "board"
+
+    result = export_signboard(store, board, prune_absent=True)
+
+    assert result["pruned"] == []
+    assert (board / STORE_STAMP_FILENAME).is_file()
+    assert any(board.rglob("*.md"))
+
+
+def test_export_does_not_restamp_a_board_owned_by_another_store(
+    tmp_env, store, tmp_path: Path
+) -> None:
+    """A plain export must not be the way the guard gets defeated."""
+    seed_tasks(store)
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    owner_id = json.loads((board / STORE_STAMP_FILENAME).read_text(encoding="utf-8"))["store_id"]
+    foreign = _independent_store(tmp_path / "other-checkout")
+
+    export_signboard(foreign, board)
+
+    still = json.loads((board / STORE_STAMP_FILENAME).read_text(encoding="utf-8"))["store_id"]
+    assert still == owner_id
+    with pytest.raises(SignboardStoreOwnershipError):
+        export_signboard(foreign, board, prune_absent=True)
+
+
+def test_cli_export_signboard_prune_exits_nonzero_on_foreign_board(
+    tmp_env, store, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.dispatcher.cli import main
+
+    seed_tasks(store)
+    board = tmp_path / "board"
+    assert main(["export-signboard", str(board), "--json"]) == 0
+    before = {path: path.read_bytes() for path in sorted(board.rglob("*.md"))}
+
+    other_dir = tmp_path / "other-checkout"
+    _independent_store(other_dir)
+    monkeypatch.setenv("DISPATCHER_STATE_DIR", str(other_dir))
+    monkeypatch.setenv("DISPATCHER_DB_PATH", str(other_dir / "dispatcher.sqlite3"))
+    monkeypatch.setenv("DISPATCHER_EVENTS_PATH", str(other_dir / "events.jsonl"))
+
+    assert main(["export-signboard", str(board), "--prune-absent", "--json"]) == 1
+    assert {path: path.read_bytes() for path in sorted(board.rglob("*.md"))} == before

--- a/tests/governance/test_project_pickup_deprecation.py
+++ b/tests/governance/test_project_pickup_deprecation.py
@@ -176,6 +176,10 @@ def test_signboard_root_consumers_are_projection_layer_only() -> None:
     assert "SIGNBOARD_ROOT" not in _read("app/dispatcher/cli.py")
     assert _signboard_imports(_read("app/dispatcher/cli.py"), filename="app/dispatcher/cli.py") == {
         "NoActiveVaultError",
+        # The board-ownership refusal (#4370) surfaces as a non-zero exit, not
+        # as a traceback; that is projection-layer error handling, not pickup
+        # input.
+        "SignboardStoreOwnershipError",
         "default_signboard_root",
         "export_signboard",
         "validate_signboard",


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4370

## Linked Issue
Closes #4370

## SBS Impact
- Primary subsystem: Builder System (BuilderOps Signboard projection)
- Secondary subsystem(s): none
- Write class: authority-bearing (it governs when a delete is permitted)
- Persistence impact: rebuildable; adds one small durable artifact to the board root
- Derived/rebuildable impact: the projection can now prove its own provenance
- New or changed contract: board roots carry a store-identity stamp, and `--prune-absent` requires a match
- Owner-doc impact: updated
- Transition debt impact: reduces
- Boundary risk: the stamp identifies the owning store and nothing else; it never becomes a second source of task truth

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- A Signboard board recorded nothing about which dispatcher store produced it, so `--prune-absent` read "unknown to whichever store this process resolved" as "dead card". The store resolves from the current working directory, so two checkouts on one host reach opposite verdicts about the same board — on 2026-07-29 that deleted 404 live cards.
- Every export now writes a `.signboard-store.json` stamp into the board root carrying the store's durable identity: an id minted once into the store's own metadata (`dispatcher_meta`), never derived from its path, so relocating a store does not make its boards read as foreign.
- `--prune-absent` refuses non-zero unless the stamp matches. The check runs before anything is written or unlinked, because the export loop that precedes the prune already unlinks generated cards of its own accord — a refusal raised any later would not be total.
- `signboard-validate` reports a mismatch read-only as its own `store_stamp_mismatch` finding, named before the `stale_card` findings it explains, and in that case its `repair` hint deliberately stops naming `--prune-absent` — on a foreign board that "repair" is the command that destroys it.

### Unstamped-board posture (the explicit decision the issue asked for)
Every board that exists today is unstamped, so this is the case that matters:

- **Stamp matches** — prunes exactly as before.
- **Stamp belongs to another store** — refuses. A plain export from the other checkout does *not* re-stamp the board; a board changes owner only when a human deletes the stamp file. Without that rule the guard would be defeated by the very command an operator runs to repair a board.
- **No stamp, board already holds generated cards** — refuses, and instructs the operator to claim the board with a plain `export-signboard <path>` from the checkout that owns it. Adoption is never done by the same command that prunes.
- **No stamp and no generated cards** — proceeds and stamps. A first export has nothing to lose, so a fresh board still works in one command.

Producers of the guarded resource all migrate boards forward on their own: the CLI export, the `/signboard` refresh and move routes, and the startup bootstrap export each claim the stamp, and none of them prune. No automated caller passes `--prune-absent` anywhere in the repo — it is only ever run by hand.

## BuilderOps Routing
- Records/projections/receipts: Issue #4370 pickup claim receipt `github-comment:5127702602` (`coordination_mode=github-label-only-fallback`, because task `github-RasmusTho--agentic-pkm-mvp-issue-4370` was absent from the local dispatcher queue and syncing the shared-root queue was out of scope for this worktree task).
- Reason: no further BuilderOps material was produced — delivery matched plan, so no `LearningSignal` was named.

## Notes

**Acceptance criteria — every `Verify:` target resolves green**

| AC | Verify target | Result |
| --- | --- | --- |
| Export writes a durable store-identity stamp | `tests/dispatcher/test_signboard.py::test_export_writes_store_identity_stamp` | pass |
| Prune deletes nothing and exits non-zero on mismatch | `::test_prune_refuses_when_store_stamp_mismatches` + `::test_cli_export_signboard_prune_exits_nonzero_on_foreign_board` (exit code 1) | pass |
| The refusal is total | `::test_prune_mismatch_leaves_every_card_intact` (byte-compares every card before/after) | pass |
| Validate reports the mismatch as its own finding kind | `::test_validate_reports_foreign_store_distinctly` | pass |
| A matching stamp prunes as it does today | `::test_prune_unchanged_when_stamp_matches` | pass |
| The stamp survives a store path change | `::test_stamp_is_identity_not_path` (moves the store dir, reopens it, prunes) | pass |
| Unstamped-board posture documented | `docs/AGENT_ISSUE_DISPATCHER.md :: Signboard projection` | written back |

Additional coverage beyond the ACs: `::test_prune_refuses_on_unstamped_board_that_holds_cards`, `::test_prune_on_a_board_with_nothing_to_lose_still_works`, `::test_export_does_not_restamp_a_board_owned_by_another_store`, and `tests/api/test_signboard_api.py::test_store_identity_stamp_is_never_rendered_as_a_card` (the stamp is at the board root, not a `.md`, and outside the card namespace, so no board consumer renders it).

**Validation actually run**

- `pytest tests/dispatcher/test_signboard.py tests/api/test_signboard_api.py tests/governance/test_project_pickup_deprecation.py -q` → 63 passed
- `pytest tests/dispatcher -q` → 1099 passed
- `pytest tests/governance tests/architecture tests/ops -q` → 1303 passed, 5 skipped, **1 failed**: `tests/governance/test_start_model_inquiry_skill.py::test_launcher_fails_closed_on_an_absent_declared_credential`. Pre-existing and unrelated — verified failing identically on the clean base `a8504be7` with this change stashed (a laptop model-inquiry credential-launcher environment failure).
- `ruff check app tests companion-ui/companion-app` → All checks passed!
- `python3 scripts/docs_guard.py` → OK
- Device-independent repro from the issue's Suggested Validation, two stores with disjoint task sets and one board, run through the real CLI: store B validating A's board reports `store_stamp_mismatch` first with a repair hint that does not name the prune; `export-signboard <A's board> --prune-absent` from B exits 1 with all 5 cards intact; the same command from A exits 0.

**Delivery-path classification** — single-issue Tier 2 code slice, light path (`Final-Review-Rounds: 0`). No TCD high-risk surface is declared: the touched surface is a rebuildable Builder System projection, the change is a purely additive fail-closed refusal, and the worst case for a defect in it is a prune that refuses when it should not — an availability cost, not a data-loss one. The human-authored `## Notes` / `## Receipts` preservation logic is untouched.

**Base** — branched from `origin/main` at `a8504be7`. #4293 also edits `app/dispatcher/signboard.py`; it is still open and unlanded, so there was nothing to rebase onto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
