### PR TITLE
feature: add prod-backup watcher for stale/failed nightly DB dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init bootstrap-test-channel bootstrap-test-channel-config start-test-system test-bootstrap prepare-instance-ownership dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down deploy-dev deploy-test deploy-prod rollback-dev rollback-test rollback-prod check-test-channel check-prod-channel live-prod-probe dev-ui dev-ui-doctor test-ui test-ui-doctor prod-ui prod-ui-doctor dispatcher-init dispatcher-sync db-snapshot db-restore db-dump-prod
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init bootstrap-test-channel bootstrap-test-channel-config start-test-system test-bootstrap prepare-instance-ownership dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down deploy-dev deploy-test deploy-prod rollback-dev rollback-test rollback-prod check-test-channel check-prod-channel live-prod-probe live-prod-backup-probe dev-ui dev-ui-doctor test-ui test-ui-doctor prod-ui prod-ui-doctor dispatcher-init dispatcher-sync db-snapshot db-restore db-dump-prod
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 # Test vault root for bootstrap / seeded test startup lanes. Honors an
@@ -291,6 +291,13 @@ check-prod-channel:
 ## For the channel-isolation pytest suites, use check-prod-channel / check-test-channel.
 live-prod-probe:
 	@$(PYTHON) ops/host-setup/mac-mini/prod_probe.py
+
+## live-prod-backup-probe: invoke the prod-backup watcher once for a manual spot-check
+## Checks dump freshness on $$BACKUP_DIR, the FAIL/OK verdict, and status-file staleness.
+## Exits non-zero when the backup is failed or stale. Set PROD_BACKUP_PROBE_CHANNEL=none
+## for a dry run that logs the verdict without pushing.
+live-prod-backup-probe:
+	@$(PYTHON) ops/host-setup/mac-mini/prod_backup_probe.py
 
 alpha-e2e-smoke:
 	@$(PYTHON) - <<'PY'

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -62,6 +62,21 @@ Tests: `tests/api/test_health_failures.py::test_health_handles_malformed_heartbe
 
 Logs are the primary tracing surface; no external APM is required for the current MVP.
 
+## Scheduled host watchers (push alerts)
+Two launchd jobs on the mac mini are the only push-alerting surface; both are
+transition-based (one alert on entering a bad state, one recovery signal on the first
+healthy run) and both default to the same `NTFY_TOPIC` so the operator watches one topic.
+
+- `com.yggdrasil.prod-probe` — hard-down backstop for the running prod stack
+  (`/readyz`, `/api/health` `required_ok`, worker-heartbeat staleness).
+- `com.yggdrasil.prod-backup-probe` — the nightly prod DB dump. Alerts on a **stale**
+  backup as well as a failed one: a job that stops firing writes no `FAIL` line, so
+  dump-file freshness on `/Volumes/T7` is the load-bearing signal and the status file is
+  only a secondary reason. An unreadable signal alerts rather than passing.
+
+Both are documented in `docs/OPERATIONS.md :: Prod probe and push alert` and
+`:: Prod backup watcher`. Neither depends on the subsystem it watches.
+
 ## Incident-triage contract
 - `docs/OPERATIONS.md` remains the top-level operator routing surface.
 - `docs/runbooks/RUNBOOK_AGENTOPS_INCIDENT_TRIAGE.md` is the canonical current-state incident workflow for watcher failures, panel runtime / panel intent failures, and CLI-first orchestrator failures.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -63,7 +63,7 @@ Tests: `tests/api/test_health_failures.py::test_health_handles_malformed_heartbe
 Logs are the primary tracing surface; no external APM is required for the current MVP.
 
 ## Scheduled host watchers (push alerts)
-Two launchd jobs on the mac mini are the only push-alerting surface; both are
+Two launchd jobs on the always-on host are the only push-alerting surface; both are
 transition-based (one alert on entering a bad state, one recovery signal on the first
 healthy run) and both default to the same `NTFY_TOPIC` so the operator watches one topic.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -323,6 +323,108 @@ is rebuildable; delete it to reset the transition state manually.
 **Install:** See `ops/host-setup/mac-mini/install.sh` for how to register the launchd
 job. The plist is at `ops/host-setup/mac-mini/com.yggdrasil.prod-probe.plist`.
 
+## Prod backup watcher (stale or failed nightly dump)
+
+`ops/host-setup/mac-mini/prod_backup_probe.py` is the watcher for the nightly prod DB
+dump (`local.prod-pgdump` on the mac mini, which runs `~/bin/prod-pgdump-run.sh`). It is
+installed as its own launchd job, `com.yggdrasil.prod-backup-probe`, and runs hourly.
+
+**Why it exists:** the dump job failed every night from 2026-07-06 to 2026-07-29 and the
+gap went unseen for three weeks, because nothing read its log. The underlying TCC
+permission bug is fixed; this watcher closes the detection gap that let it hide.
+
+**It does not depend on the backup job working.** The load-bearing signal is the dump
+directory itself, so a job that stops firing entirely — and therefore writes no `FAIL`
+line at all — is still caught. Three checks run on every pass and every failure is
+reported in one alert:
+
+| Check | Signal | Default budget |
+| --- | --- | --- |
+| Dump freshness | newest `prod-*.dump` in `BACKUP_DIR` (`/Volumes/T7/prod-db-backups`) | `BACKUP_MAX_AGE_HOURS=48` — tolerates one missed night |
+| Status verdict | last line of `BACKUP_STATUS_FILE` (`~/Library/Logs/prod-pgdump.status`) reports `OK`, not `FAIL` | — |
+| Status freshness | that line's own ISO-8601 timestamp | `BACKUP_STATUS_MAX_AGE_HOURS=30` — a job that did not fire |
+
+**Unverifiable is never healthy.** A missing or unmounted `/Volumes/T7`, an unreadable
+directory, an empty status file, or a garbled status line all alert. The watcher never
+reports green on a signal it could not read.
+
+### The TCC hop (one-time setup)
+
+launchd starts jobs unattributed, with no TCC grants, so it cannot read the removable
+volume holding the dumps. Verified on the mini 2026-07-29 — and the failure mode is
+deceptive:
+
+```
+py_isdir True                                        # stat is allowed
+py_listdir_ERR PermissionError [Errno 1] Operation not permitted
+```
+
+`Path.glob` silently swallows that `PermissionError` and yields nothing, so a naive
+implementation reports "no dumps found" forever instead of "I am blind". The watcher
+therefore uses `os.scandir` and separates *not mounted* from *permission denied*.
+
+The fix is the same loopback ssh hop the backup job itself uses, through this watcher's
+own key and its own read-only lister (`ops/host-setup/mac-mini/prod_backup_list.sh`,
+installed to `~/bin/prod-backup-list.sh`) — no credential or code path is shared with the
+backup job. `install.sh` wires the plist and prints these steps; run them once:
+
+```bash
+ssh-keygen -t ed25519 -N '' -C prod-backup-list -f ~/.ssh/id_ed25519_prod_backup_list
+```
+
+Then add the public key to `~/.ssh/authorized_keys` as a single line, locked to a forced
+command so it can only ever list dumps:
+
+```
+command="$HOME/bin/prod-backup-list.sh",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ssh-ed25519 AAAA... prod-backup-list
+```
+
+Until that is done the watcher sends **one** alert saying it cannot see the dump volume
+and naming the fix, then suppresses. The status-file checks keep working meanwhile, so a
+failed or non-firing backup is still caught. Verify the hop with:
+
+```bash
+ssh -F /dev/null -i ~/.ssh/id_ed25519_prod_backup_list -o IdentitiesOnly=yes -o BatchMode=yes localhost
+# → one "<epoch-mtime> <path>" line per dump, or MISSING / DENIED / EMPTY
+```
+
+**Transition / recovery guarantee:** identical to the prod probe — one alert on entering
+a bad state, suppressed while it persists, one recovery signal on the first healthy run,
+then re-armed for a later distinct failure. A failed push does *not* record the state, so
+a channel outage retries on the next run instead of swallowing the alert. The state
+marker (`PROD_BACKUP_PROBE_STATE_FILE`, default
+`/tmp/yggdrasil-prod-backup-probe.state`) is rebuildable; delete it to re-arm manually.
+
+The channel is pluggable via `PROD_BACKUP_PROBE_CHANNEL` (`ntfy` | `telegram` | `mail` |
+`none`) and defaults to the same `NTFY_TOPIC` the prod probe pushes to, so the operator
+watches one topic for both.
+
+```bash
+make live-prod-backup-probe                              # live spot-check; exit 1 = backup failed or stale
+PROD_BACKUP_PROBE_CHANNEL=none make live-prod-backup-probe   # dry run: log the verdict, push nothing
+launchctl list | grep prod-backup-probe                  # confirm the job is loaded
+```
+
+**Known current state:** prod is down entirely (issue #4282 — the `pkm-prod_pgdata`
+volume is gone), so the status file legitimately reports `FAIL pg_dump_failed` and the
+newest dump is from 2026-07-11. The watcher alerts on both facts, which is correct: there
+is no current prod backup. Expect it to stay in the alerted (suppressed) state until prod
+is restored and a dump lands.
+
+**Install:** `ops/host-setup/mac-mini/install.sh` step 4c registers the launchd job. The
+plist is at `ops/host-setup/mac-mini/com.yggdrasil.prod-backup-probe.plist`.
+
+The probe and its lister are installed to `~/bin/` and run under `/usr/bin/python3`, not
+out of the repo checkout and not under the gateway venv. Both are deliberate: the probe
+is stdlib-only, and a backup watcher must not go dark because the repo is parked on a
+feature branch or the gateway venv was never built. `install.sh` is the single producer
+of those copies, so the host and the repo cannot drift.
+
+**Status as of 2026-07-29:** both `com.yggdrasil.prod-backup-probe` and
+`com.yggdrasil.prod-probe` are loaded on the mini and have each pushed one live alert to
+the `yggdrasil-prod-alerts` ntfy topic. The backup watcher is in its suppressed
+alerted state pending the one-time key setup and the prod restore (#4282).
+
 ## Runtime health: watcher → DB outbox → worker
 - Watcher heartbeat: `WATCHER_HEARTBEAT_PATH` (default `/app/tmp/watcher_heartbeat.json` in containers, `tmp/watcher_heartbeat.json` on host).
 - Worker heartbeat: `WORKER_HEARTBEAT_PATH` (default `/app/tmp/worker_heartbeat.json`).
@@ -502,6 +604,9 @@ make db-dump-prod                           # → .db-snapshots/prod_20260628T..
 ```
 
 **Constraints:**
-- No scheduling, no off-host/cloud backup strategy, and no automated purge.
+- These `make` targets are unscheduled and manual; there is no off-host/cloud backup
+  strategy and no automated purge. Scheduling exists only for the separate nightly mac
+  mini job `local.prod-pgdump` (dumps to `/Volumes/T7/prod-db-backups`), which is watched
+  by `com.yggdrasil.prod-backup-probe` — see *Prod backup watcher* above.
 - These dumps must not become a production DR restore path.
 - pg_dump / pg_restore must be installed on the host (they are not bundled in containers).

--- a/ops/host-setup/mac-mini/com.yggdrasil.prod-backup-probe.plist
+++ b/ops/host-setup/mac-mini/com.yggdrasil.prod-backup-probe.plist
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Installed to ~/Library/LaunchAgents/ by install.sh (see install.sh for sed substitution).
+     Replaces __PYTHON__ with the absolute path to the venv python interpreter and
+     __BACKUP_PROBE__ with the absolute path to prod_backup_probe.py.
+
+     Watches the nightly prod DB dump (local.prod-pgdump) from the outside: it
+     checks dump freshness on /Volumes/T7, the FAIL/OK verdict in the status
+     file, and the status file's own staleness. It never invokes the backup job,
+     so it still alerts when that job stops firing entirely and writes nothing.
+
+     Runs hourly. The dump job is nightly, so hourly is frequent enough to bound
+     detection to about an hour while keeping the transition-based alert quiet. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.yggdrasil.prod-backup-probe</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__PYTHON__</string>
+    <string>__BACKUP_PROBE__</string>
+  </array>
+
+  <!-- Hourly. -->
+  <key>StartInterval</key>
+  <integer>3600</integer>
+
+  <!-- Run once at load so a freshly installed watcher reports immediately
+       rather than staying silent for the first hour. The probe is a one-shot
+       script: no KeepAlive. -->
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- Ground truth: the dumps on the external SSD -->
+    <key>BACKUP_DIR</key>
+    <string>/Volumes/T7/prod-db-backups</string>
+    <!-- Machine-readable single-line status written by the backup job -->
+    <key>BACKUP_STATUS_FILE</key>
+    <string>__BACKUP_STATUS__</string>
+    <!-- Newest dump older than this many hours = stale (nightly job, so 48h
+         tolerates one missed night) -->
+    <key>BACKUP_MAX_AGE_HOURS</key>
+    <string>48</string>
+    <!-- Status file older than this many hours = the job did not fire -->
+    <key>BACKUP_STATUS_MAX_AGE_HOURS</key>
+    <string>30</string>
+    <!-- Loopback ssh hop for reading the dump volume. launchd runs unattributed
+         with no TCC grants, so a direct read of /Volumes/T7 returns EPERM
+         (verified on this host 2026-07-29: stat succeeds, listdir does not).
+         Until the one-time key setup in docs/OPERATIONS.md is done, this path
+         will not exist and the watcher alerts once saying exactly that; the
+         status-file checks keep working meanwhile. -->
+    <key>BACKUP_LIST_SSH_KEY</key>
+    <string>__BACKUP_LIST_KEY__</string>
+    <key>BACKUP_LIST_REMOTE_CMD</key>
+    <string>__BACKUP_LIST_CMD__</string>
+    <!-- Alert state file (rebuildable; delete to re-arm the transition) -->
+    <key>PROD_BACKUP_PROBE_STATE_FILE</key>
+    <string>/tmp/yggdrasil-prod-backup-probe.state</string>
+    <!-- Notification channel: ntfy | telegram | mail | none -->
+    <key>PROD_BACKUP_PROBE_CHANNEL</key>
+    <string>ntfy</string>
+    <!-- ntfy topic (used when PROD_BACKUP_PROBE_CHANNEL=ntfy); shares the
+         operator's prod alert topic with com.yggdrasil.prod-probe -->
+    <key>NTFY_TOPIC</key>
+    <string>yggdrasil-prod-alerts</string>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/yggdrasil-prod-backup-probe.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/yggdrasil-prod-backup-probe.err</string>
+</dict>
+</plist>

--- a/ops/host-setup/mac-mini/install.sh
+++ b/ops/host-setup/mac-mini/install.sh
@@ -50,6 +50,44 @@ launchctl unload "$PROBE_PLIST" 2>/dev/null || true
 launchctl load "$PROBE_PLIST"
 sleep 1
 
+# 4c. prod-backup watcher launchd service -----------------------------------
+# Watches the nightly prod DB dump (local.prod-pgdump) from the outside: dump
+# freshness on /Volumes/T7, the FAIL/OK verdict, and status-file staleness. It
+# does not depend on the backup job running, so a job that silently stops
+# firing still alerts.
+# The watcher is installed to ~/bin rather than run out of the repo checkout,
+# and uses the system interpreter rather than the gateway venv. It is
+# stdlib-only, and a backup watcher must not stop working because the repo is
+# on a feature branch or the gateway venv was never built. install.sh stays the
+# single producer of those copies, so host and repo cannot drift.
+mkdir -p "$HOME/bin"
+install -m 0755 "$HERE/prod_backup_list.sh" "$HOME/bin/prod-backup-list.sh"
+install -m 0755 "$HERE/prod_backup_probe.py" "$HOME/bin/prod-backup-probe.py"
+
+BACKUP_PROBE_PLIST="$HOME/Library/LaunchAgents/com.yggdrasil.prod-backup-probe.plist"
+BACKUP_LIST_KEY="$HOME/.ssh/id_ed25519_prod_backup_list"
+sed -e "s#__PYTHON__#/usr/bin/python3#g" \
+    -e "s#__BACKUP_PROBE__#$HOME/bin/prod-backup-probe.py#g" \
+    -e "s#__BACKUP_STATUS__#$HOME/Library/Logs/prod-pgdump.status#g" \
+    -e "s#__BACKUP_LIST_KEY__#$BACKUP_LIST_KEY#g" \
+    -e "s#__BACKUP_LIST_CMD__#$HOME/bin/prod-backup-list.sh#g" \
+    "$HERE/com.yggdrasil.prod-backup-probe.plist" >"$BACKUP_PROBE_PLIST"
+launchctl unload "$BACKUP_PROBE_PLIST" 2>/dev/null || true
+launchctl load "$BACKUP_PROBE_PLIST"
+sleep 1
+
+if [ ! -r "$BACKUP_LIST_KEY" ]; then
+  echo
+  echo "NOTE: the prod-backup watcher is loaded but cannot yet read /Volumes/T7."
+  echo "      launchd has no TCC grant for removable volumes, so it needs a"
+  echo "      loopback ssh hop. One-time setup (see docs/OPERATIONS.md ::"
+  echo "      Prod backup watcher) — it will alert once until this is done:"
+  echo "        ssh-keygen -t ed25519 -N '' -C prod-backup-list -f $BACKUP_LIST_KEY"
+  echo "        # then add to ~/.ssh/authorized_keys, on one line:"
+  echo "        #   command=\"\$HOME/bin/prod-backup-list.sh\",no-port-forwarding,\\"
+  echo "        #   no-agent-forwarding,no-X11-forwarding,no-pty <contents of $BACKUP_LIST_KEY.pub>"
+fi
+
 # 5. Verify + next steps ----------------------------------------------------
 echo
 echo "== Gateway health =="

--- a/ops/host-setup/mac-mini/prod_backup_list.sh
+++ b/ops/host-setup/mac-mini/prod_backup_list.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Read-only dump lister for the prod-backup watcher's loopback ssh hop.
+#
+# Why this exists: launchd starts the watcher as an unattributed process with no
+# TCC grants, so macOS refuses it access to /Volumes/T7 (verified on this host
+# 2026-07-29 — `stat` succeeds while `listdir` returns EPERM). An sshd session
+# does hold that access, so prod_backup_probe.py re-reads the directory through
+# a loopback ssh into the same account and runs this script there.
+#
+# This is the only thing that key should ever be able to do. Install it as a
+# forced command in ~/.ssh/authorized_keys:
+#
+#   command="$HOME/bin/prod-backup-list.sh",no-port-forwarding,no-agent-forwarding,\
+#   no-X11-forwarding,no-pty ssh-ed25519 AAAA... prod-backup-list
+#
+# It only ever reads. It never writes, never touches the backup job, and never
+# runs pg_dump — a broken backup must not be able to hide behind a broken watcher.
+set -uo pipefail
+export PATH=/usr/bin:/bin
+
+DIR="${BACKUP_DIR:-/Volumes/T7/prod-db-backups}"
+
+# Distinguish the three blind states the watcher must report differently:
+# not mounted, mounted-but-unreadable, and readable-but-empty.
+if [ ! -d "$DIR" ]; then
+  echo "MISSING"
+  exit 0
+fi
+if ! /bin/ls "$DIR" >/dev/null 2>&1; then
+  echo "DENIED"
+  exit 0
+fi
+
+# BSD stat: "<epoch-mtime> <path>" per matching file.
+found=0
+for f in "$DIR"/${BACKUP_GLOB:-prod-*.dump}; do
+  [ -f "$f" ] || continue
+  /usr/bin/stat -f '%m %N' "$f"
+  found=1
+done
+[ "$found" -eq 1 ] || echo "EMPTY"
+exit 0

--- a/ops/host-setup/mac-mini/prod_backup_probe.py
+++ b/ops/host-setup/mac-mini/prod_backup_probe.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Scheduled prod-backup watcher — transition-based stale/failed-backup alert.
+
+The nightly prod dump job (`local.prod-pgdump`) writes a human log and a
+machine-readable status line, but nothing reads either one. Between 2026-07-06
+and 2026-07-29 every run failed and the gap went unseen for three weeks. This
+probe closes that detection gap.
+
+Independence
+------------
+This probe never invokes the backup job and never trusts it to report its own
+failure. The load-bearing signal is the *dump directory itself*: if the newest
+`prod-*.dump` is older than the freshness budget, the operator is alerted even
+when the backup job stopped firing entirely and therefore wrote no FAIL line.
+The status file is a secondary signal that adds a reason, not a precondition.
+
+Checks (all three run; every failure is reported):
+  1. Dump freshness — newest `prod-*.dump` in BACKUP_DIR younger than
+     BACKUP_MAX_AGE_HOURS. A missing or unmounted backup volume is a failure,
+     never a pass: an unverifiable backup is treated as a broken backup.
+  2. Status verdict — the status file's last line reports OK, not FAIL.
+  3. Status freshness — the status file's own timestamp is younger than
+     BACKUP_STATUS_MAX_AGE_HOURS. A job that silently stops firing leaves a
+     stale-but-OK status line; this is what catches it.
+
+Alerting is transition-based, mirroring `prod_probe.py`: one alert on entering
+a bad state, suppressed while it persists, one recovery signal on the first
+healthy run, then re-armed for a later distinct failure.
+
+Channel selection
+-----------------
+Set PROD_BACKUP_PROBE_CHANNEL to one of:
+  - "ntfy"      (default) — posts to ntfy.sh topic $NTFY_TOPIC
+  - "telegram"  — sends via Telegram Bot $TELEGRAM_BOT_TOKEN / $TELEGRAM_CHAT_ID
+  - "mail"      — sends via Python's smtplib (requires SMTP_* env vars)
+  - "none"      — dry-run; logs but does not push
+
+The channel is swappable without changing the launchd job.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any, Protocol
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    format="%(asctime)s [prod-backup-probe] %(levelname)s %(message)s",
+    level=logging.INFO,
+)
+log = logging.getLogger("prod_backup_probe")
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+# Ground truth: the dumps themselves, on the external SSD the backup job
+# refuses to write around.
+BACKUP_DIR = Path(os.environ.get("BACKUP_DIR", "/Volumes/T7/prod-db-backups"))
+BACKUP_GLOB = os.environ.get("BACKUP_GLOB", "prod-*.dump")
+
+# launchd has no TCC grant for the removable volume holding the dumps, so a
+# direct read returns EPERM. When this key is configured the probe re-reads the
+# directory through a loopback ssh hop, which does hold that access. Its own
+# key, its own read-only lister — nothing shared with the backup job.
+BACKUP_LIST_SSH_KEY = os.environ.get("BACKUP_LIST_SSH_KEY", "")
+BACKUP_LIST_REMOTE_CMD = os.environ.get(
+    "BACKUP_LIST_REMOTE_CMD", str(Path.home() / "bin" / "prod-backup-list.sh")
+)
+
+# The machine-readable single-line status the backup job writes (added
+# 2026-07-29): "<iso-ts> OK <path>" or "<iso-ts> FAIL <reason>".
+BACKUP_STATUS_FILE = Path(
+    os.environ.get(
+        "BACKUP_STATUS_FILE",
+        str(Path.home() / "Library" / "Logs" / "prod-pgdump.status"),
+    )
+)
+
+# The job runs nightly. 48h tolerates one missed night without paging; 2 missed
+# nights is a real signal.
+BACKUP_MAX_AGE_HOURS = float(os.environ.get("BACKUP_MAX_AGE_HOURS", "48"))
+# A status file older than ~1.25 nightly cycles means the job did not fire.
+BACKUP_STATUS_MAX_AGE_HOURS = float(os.environ.get("BACKUP_STATUS_MAX_AGE_HOURS", "30"))
+
+ALERT_STATE_FILE = Path(
+    os.environ.get(
+        "PROD_BACKUP_PROBE_STATE_FILE", "/tmp/yggdrasil-prod-backup-probe.state"
+    )
+)
+
+PROD_BACKUP_PROBE_CHANNEL = os.environ.get("PROD_BACKUP_PROBE_CHANNEL", "ntfy")
+
+_HOUR = 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Notification channel protocol + adapters
+# ---------------------------------------------------------------------------
+class NotificationChannel(Protocol):
+    def send(self, subject: str, body: str) -> None:
+        ...
+
+
+def ascii_header(value: str) -> str:
+    """Make a string safe for an HTTP header.
+
+    httplib encodes headers as latin-1, so a single em-dash in the title raises
+    UnicodeEncodeError and the alert is lost — the exact failure that kept this
+    channel from ever delivering. The body is a UTF-8 payload and is unaffected.
+    """
+    replacements = {"—": "-", "–": "-", "‘": "'", "’": "'", "…": "..."}
+    for bad, good in replacements.items():
+        value = value.replace(bad, good)
+    return value.encode("latin-1", "replace").decode("latin-1")
+
+
+class NtfyChannel:
+    """ntfy.sh push via HTTP POST."""
+
+    def __init__(self) -> None:
+        self.topic = os.environ.get("NTFY_TOPIC", "yggdrasil-prod-alerts")
+        self.server = os.environ.get("NTFY_SERVER", "https://ntfy.sh").rstrip("/")
+
+    def send(self, subject: str, body: str) -> None:
+        import urllib.request
+
+        url = f"{self.server}/{self.topic}"
+        req = urllib.request.Request(
+            url,
+            data=body.encode("utf-8"),
+            headers={
+                "Title": ascii_header(subject),
+                "Priority": "high",
+                "Tags": "floppy_disk,warning",
+                "Content-Type": "text/plain; charset=utf-8",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            log.info("ntfy push sent: %s %s", resp.status, url)
+
+
+class TelegramChannel:
+    """Telegram Bot API push."""
+
+    def __init__(self) -> None:
+        self.token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        self.chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+
+    def send(self, subject: str, body: str) -> None:
+        import urllib.parse
+        import urllib.request
+
+        text = f"*{subject}*\n{body}"
+        url = f"https://api.telegram.org/bot{self.token}/sendMessage"
+        payload = urllib.parse.urlencode(
+            {"chat_id": self.chat_id, "text": text, "parse_mode": "Markdown"}
+        ).encode()
+        req = urllib.request.Request(url, data=payload, method="POST")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            log.info("telegram push sent: %s", resp.status)
+
+
+class MailChannel:
+    """SMTP mail push."""
+
+    def send(self, subject: str, body: str) -> None:
+        import smtplib
+        from email.mime.text import MIMEText
+
+        smtp_host = os.environ.get("SMTP_HOST", "localhost")
+        smtp_port = int(os.environ.get("SMTP_PORT", "25"))
+        from_addr = os.environ.get("SMTP_FROM", "probe@yggdrasil.local")
+        to_addr = os.environ.get("SMTP_TO", "operator@yggdrasil.local")
+        msg = MIMEText(body)
+        msg["Subject"] = subject
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as s:
+            s.sendmail(from_addr, [to_addr], msg.as_string())
+        log.info("mail push sent to %s", to_addr)
+
+
+class NullChannel:
+    """Dry-run: log only."""
+
+    def send(self, subject: str, body: str) -> None:
+        log.info("[dry-run] would push: %s — %s", subject, body)
+
+
+def build_channel(name: str) -> NotificationChannel:
+    """Return the appropriate channel adapter by name (env-selected)."""
+    mapping: dict[str, type] = {
+        "ntfy": NtfyChannel,
+        "telegram": TelegramChannel,
+        "mail": MailChannel,
+        "none": NullChannel,
+    }
+    cls = mapping.get(name.lower())
+    if cls is None:
+        raise ValueError(
+            f"Unknown PROD_BACKUP_PROBE_CHANNEL={name!r}. Choose one of: {list(mapping)}"
+        )
+    return cls()
+
+
+# ---------------------------------------------------------------------------
+# Alert state (transition-based; mirrors prod_probe.py)
+# ---------------------------------------------------------------------------
+def _load_alert_state() -> dict[str, Any] | None:
+    """Return the persisted alert state, or None if absent/invalid."""
+    if not ALERT_STATE_FILE.exists():
+        return None
+    try:
+        payload = json.loads(ALERT_STATE_FILE.read_text())
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _alert_state_is_active(state: dict[str, Any] | None) -> bool:
+    return bool(state and state.get("status") == "down")
+
+
+def _record_alert_state(failures: list[str]) -> None:
+    """Persist the current bad state after a successful alert."""
+    ALERT_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ALERT_STATE_FILE.write_text(
+        json.dumps(
+            {"status": "down", "ts": int(time.time()), "failures": failures},
+            sort_keys=True,
+        )
+    )
+
+
+def _clear_alert_state() -> None:
+    try:
+        ALERT_STATE_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _send_down_alert(channel: NotificationChannel, failures: list[str]) -> bool:
+    subject = "Prod backup unhealthy - Yggdrasil"
+    body = (
+        "The nightly prod DB dump is failing or stale:\n"
+        + "\n".join(f"  - {f}" for f in failures)
+        + f"\n\nLog: {BACKUP_STATUS_FILE.parent / 'prod-pgdump.log'}"
+        + f"\nDumps: {BACKUP_DIR}"
+    )
+    try:
+        channel.send(subject, body)
+    except Exception as exc:
+        log.error("failed to send prod-backup alert: %s", exc)
+        return False
+    _record_alert_state(failures)
+    log.warning("prod-backup alert sent and state recorded. failures=%s", failures)
+    return True
+
+
+def _send_recovery_alert(channel: NotificationChannel) -> bool:
+    subject = "Prod backup recovered - Yggdrasil"
+    body = "A fresh prod dump landed and the status file reports OK."
+    try:
+        channel.send(subject, body)
+    except Exception as exc:
+        log.error("failed to send prod-backup recovery alert: %s", exc)
+        return False
+    _clear_alert_state()
+    log.info("prod-backup recovery alert sent; state cleared")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Timestamp helpers
+# ---------------------------------------------------------------------------
+def _parse_iso_utc(token: str) -> float | None:
+    """Parse an ISO-8601 UTC timestamp into an epoch float, or None."""
+    text = token.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _format_age(seconds: float) -> str:
+    return f"{seconds / _HOUR:.1f}h"
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+def _list_dumps_direct(backup_dir: Path) -> tuple[list[tuple[float, str]] | None, str]:
+    """List dumps by reading the filesystem. Returns (entries, error).
+
+    `entries is None` means the listing could not be performed at all; the
+    error string says why. Note that under macOS TCC a removable volume can be
+    `stat`-able while `listdir` raises PermissionError, so the two conditions
+    are separated deliberately — `Path.glob` silently swallows that
+    PermissionError and would otherwise report a readable-but-empty directory.
+    """
+    if not backup_dir.is_dir():
+        return None, f"backup directory {backup_dir} is missing or not mounted"
+    try:
+        with os.scandir(backup_dir) as it:
+            entries = [
+                (entry.stat().st_mtime, entry.name)
+                for entry in it
+                if entry.is_file() and fnmatch(entry.name, BACKUP_GLOB)
+            ]
+    except PermissionError:
+        return None, f"permission denied reading {backup_dir}"
+    except OSError as exc:
+        return None, f"backup directory {backup_dir} unreadable: {exc}"
+    return entries, ""
+
+
+def _list_dumps_via_ssh(backup_dir: Path) -> tuple[list[tuple[float, str]] | None, str]:
+    """List dumps through a loopback ssh hop. Returns (entries, error).
+
+    launchd starts unattributed processes with no TCC grants, so macOS refuses
+    them access to the removable volume holding the dumps (verified on this
+    host 2026-07-29: `stat` succeeds, `listdir` returns EPERM). An sshd session
+    does hold that access. This mirrors the mechanism the backup job itself
+    uses, but through this watcher's own key and its own read-only lister — it
+    shares no credential or code path with the backup job.
+
+    Configure with BACKUP_LIST_SSH_KEY; the remote lister emits `<mtime> <name>`
+    lines, or a bare MISSING / DENIED / EMPTY token.
+    """
+    import subprocess
+
+    if not BACKUP_LIST_SSH_KEY:
+        return None, "no BACKUP_LIST_SSH_KEY configured for the loopback hop"
+    if not os.access(BACKUP_LIST_SSH_KEY, os.R_OK):
+        return None, (
+            f"loopback hop key {BACKUP_LIST_SSH_KEY} is missing or unreadable — "
+            "run the one-time watcher key setup"
+        )
+
+    argv = [
+        "/usr/bin/ssh",
+        "-F",
+        "/dev/null",
+        "-i",
+        BACKUP_LIST_SSH_KEY,
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=20",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        f"UserKnownHostsFile={Path.home() / '.ssh' / 'known_hosts'}",
+        "-l",
+        os.environ.get("USER") or Path.home().name,
+        "localhost",
+        BACKUP_LIST_REMOTE_CMD,
+    ]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    except Exception as exc:
+        return None, f"loopback ssh hop failed: {type(exc).__name__}: {exc}"
+
+    if proc.returncode == 255:
+        return None, (
+            "loopback ssh to localhost failed (Remote Login disabled, key "
+            "rejected, or host key changed)"
+        )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip().splitlines()
+        return None, f"remote dump lister failed: {detail[-1] if detail else 'no output'}"
+
+    entries: list[tuple[float, str]] = []
+    for line in proc.stdout.splitlines():
+        token = line.strip()
+        if not token:
+            continue
+        if token == "MISSING":
+            return None, f"backup directory {backup_dir} is missing or not mounted"
+        if token == "DENIED":
+            return None, f"permission denied reading {backup_dir} even over the ssh hop"
+        if token == "EMPTY":
+            return [], ""
+        mtime, _, name = token.partition(" ")
+        try:
+            entries.append((float(mtime), Path(name).name))
+        except ValueError:
+            return None, f"remote dump lister emitted an unparseable line: {token!r}"
+    return entries, ""
+
+
+def check_dump_freshness(
+    backup_dir: Path = BACKUP_DIR,
+    max_age_hours: float = BACKUP_MAX_AGE_HOURS,
+    now: float | None = None,
+    lister: Any = None,
+) -> tuple[bool, str]:
+    """Ground truth: is there a recent dump on disk? Returns (ok, reason).
+
+    An absent or unreadable backup directory is a failure, not a pass — the
+    probe never reports healthy on a signal it could not read.
+    """
+    now = time.time() if now is None else now
+
+    if lister is not None:
+        entries, error = lister(backup_dir)
+    else:
+        entries, error = _list_dumps_direct(backup_dir)
+        # Under launchd the direct read is TCC-denied; retry through the hop
+        # when one is configured, so the watcher is not permanently blind.
+        if entries is None and "permission denied" in error and BACKUP_LIST_SSH_KEY:
+            entries, error = _list_dumps_via_ssh(backup_dir)
+
+    if entries is None:
+        reason = f"cannot verify any prod dump exists: {error}"
+        if "permission denied" in error and not BACKUP_LIST_SSH_KEY:
+            # launchd has no TCC grant for the removable volume. This fires
+            # exactly once (transition-based) and tells the operator how to
+            # finish installing the watcher.
+            reason += (
+                "; launchd cannot read the dump volume — set BACKUP_LIST_SSH_KEY "
+                "to enable the loopback hop (see docs/OPERATIONS.md :: Prod backup watcher)"
+            )
+        return False, reason
+
+    if not entries:
+        return False, f"no {BACKUP_GLOB} files in {backup_dir}"
+
+    newest_mtime, newest_name = max(entries)
+    age = now - newest_mtime
+    if age > max_age_hours * _HOUR:
+        return False, (
+            f"newest dump {newest_name} is {_format_age(age)} old "
+            f"(budget {max_age_hours:.0f}h)"
+        )
+    return True, f"newest dump {newest_name} is {_format_age(age)} old"
+
+
+def check_status_file(
+    status_file: Path = BACKUP_STATUS_FILE,
+    max_age_hours: float = BACKUP_STATUS_MAX_AGE_HOURS,
+    now: float | None = None,
+) -> list[str]:
+    """Read the machine-readable status line. Returns a list of failure reasons.
+
+    Two distinct failure modes are separated deliberately:
+      - the job ran and reported FAIL (a verdict), and
+      - the job did not run at all (a stale or missing status file).
+    The second is the one that went unnoticed for three weeks.
+    """
+    now = time.time() if now is None else now
+    failures: list[str] = []
+
+    if not status_file.exists():
+        return [f"status file {status_file} missing — backup job may never have run"]
+
+    try:
+        raw = status_file.read_text().strip()
+    except OSError as exc:
+        return [f"status file {status_file} unreadable: {exc}"]
+
+    if not raw:
+        return [f"status file {status_file} is empty"]
+
+    # Tolerate a multi-line file: the last non-empty line is the current verdict.
+    line = [ln for ln in raw.splitlines() if ln.strip()][-1].strip()
+    parts = line.split(None, 2)
+    ts_token = parts[0] if parts else ""
+    verdict = parts[1].upper() if len(parts) > 1 else ""
+    detail = parts[2] if len(parts) > 2 else ""
+
+    ts = _parse_iso_utc(ts_token)
+    if ts is None:
+        failures.append(f"status file timestamp unparseable: {line!r}")
+        # Fall back to mtime so a garbled line still yields a staleness verdict.
+        ts = status_file.stat().st_mtime
+
+    age = now - ts
+    if age > max_age_hours * _HOUR:
+        failures.append(
+            f"status file is {_format_age(age)} old (budget {max_age_hours:.0f}h) — "
+            "the nightly job did not fire"
+        )
+
+    if verdict == "FAIL":
+        failures.append(f"last backup run reported FAIL: {detail or 'no reason given'}")
+    elif verdict != "OK":
+        failures.append(f"status file verdict unrecognised: {line!r}")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Core probe logic
+# ---------------------------------------------------------------------------
+def run_probe(
+    backup_dir: Path = BACKUP_DIR,
+    status_file: Path = BACKUP_STATUS_FILE,
+    max_age_hours: float = BACKUP_MAX_AGE_HOURS,
+    status_max_age_hours: float = BACKUP_STATUS_MAX_AGE_HOURS,
+    channel: NotificationChannel | None = None,
+    now: float | None = None,
+) -> bool:
+    """Run the full backup probe. Return True if the backup is healthy.
+
+    This function is the unit-testable boundary: tests call it directly with a
+    temp backup dir, a temp status file, and an injected channel.
+    """
+    if channel is None:
+        channel = build_channel(PROD_BACKUP_PROBE_CHANNEL)
+
+    failures: list[str] = []
+
+    ok_dump, reason_dump = check_dump_freshness(backup_dir, max_age_hours, now=now)
+    if not ok_dump:
+        failures.append(reason_dump)
+
+    failures.extend(check_status_file(status_file, status_max_age_hours, now=now))
+
+    if not failures:
+        log.info("backup probe ok: %s", reason_dump)
+        state = _load_alert_state()
+        if _alert_state_is_active(state):
+            _send_recovery_alert(channel)
+        elif state is not None:
+            _clear_alert_state()
+        return True
+
+    state = _load_alert_state()
+    if _alert_state_is_active(state):
+        log.info(
+            "backup unhealthy but alert already recorded; suppressing duplicate. failures=%s",
+            failures,
+        )
+        return False
+
+    _send_down_alert(channel, failures)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+def main() -> None:
+    healthy = run_probe()
+    sys.exit(0 if healthy else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/host-setup/mac-mini/prod_probe.py
+++ b/ops/host-setup/mac-mini/prod_probe.py
@@ -74,6 +74,20 @@ class NotificationChannel(Protocol):
         ...
 
 
+def ascii_header(value: str) -> str:
+    """Make a string safe for an HTTP header.
+
+    httplib encodes headers as latin-1, so a single em-dash in the title raises
+    UnicodeEncodeError and the alert is lost. Observed on the mini 2026-07-29
+    the first time this channel was actually exercised. The body is a UTF-8
+    payload and is unaffected.
+    """
+    replacements = {"—": "-", "–": "-", "‘": "'", "’": "'", "…": "..."}
+    for bad, good in replacements.items():
+        value = value.replace(bad, good)
+    return value.encode("latin-1", "replace").decode("latin-1")
+
+
 class NtfyChannel:
     """ntfy.sh push via HTTP POST."""
 
@@ -85,14 +99,15 @@ class NtfyChannel:
         import urllib.request
 
         url = f"{self.server}/{self.topic}"
-        data = body.encode()
+        data = body.encode("utf-8")
         req = urllib.request.Request(
             url,
             data=data,
             headers={
-                "Title": subject,
+                "Title": ascii_header(subject),
                 "Priority": "high",
                 "Tags": "warning,robot",
+                "Content-Type": "text/plain; charset=utf-8",
             },
             method="POST",
         )
@@ -204,7 +219,7 @@ def _clear_alert_state() -> None:
 
 
 def _send_down_alert(channel: NotificationChannel, failures: list[str]) -> bool:
-    subject = "Prod down — Yggdrasil"
+    subject = "Prod down - Yggdrasil"
     body = "Failures detected:\n" + "\n".join(f"  - {f}" for f in failures)
     try:
         channel.send(subject, body)
@@ -217,7 +232,7 @@ def _send_down_alert(channel: NotificationChannel, failures: list[str]) -> bool:
 
 
 def _send_recovery_alert(channel: NotificationChannel) -> bool:
-    subject = "Prod recovered — Yggdrasil"
+    subject = "Prod recovered - Yggdrasil"
     body = "The prod probe saw a healthy run after a previous outage."
     try:
         channel.send(subject, body)

--- a/tests/ops/test_prod_backup_probe_alert_state.py
+++ b/tests/ops/test_prod_backup_probe_alert_state.py
@@ -1,0 +1,488 @@
+"""Regression tests for the prod-backup watcher and its alert state machine.
+
+The failure this guards against is a nightly dump job that fails — or stops
+firing entirely — without anyone noticing for three weeks (2026-07-06..07-29).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+PROBE_MODULE_DIR = Path(__file__).parent.parent.parent / "ops" / "host-setup" / "mac-mini"
+sys.path.insert(0, str(PROBE_MODULE_DIR))
+
+import prod_backup_probe  # noqa: E402
+
+HOUR = 3600.0
+NOW = 1_785_000_000.0  # fixed clock; the probe takes `now` explicitly
+
+
+def _make_spy_channel() -> MagicMock:
+    return MagicMock(spec=prod_backup_probe.NullChannel)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _write_dump(backup_dir: Path, name: str, age_hours: float) -> Path:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    path = backup_dir / name
+    path.write_bytes(b"PGDMP-fake")
+    mtime = NOW - age_hours * HOUR
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def _write_status(
+    tmp_path: Path,
+    verdict: str,
+    detail: str,
+    age_hours: float,
+    name: str = "prod-pgdump.status",
+) -> Path:
+    path = tmp_path / name
+    path.write_text(f"{_iso(NOW - age_hours * HOUR)} {verdict} {detail}\n")
+    return path
+
+
+@pytest.fixture()
+def healthy_world(tmp_path: Path) -> tuple[Path, Path]:
+    """A fresh dump plus a fresh OK status line."""
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=6)
+    status = _write_status(
+        tmp_path, "OK", "/Volumes/T7/prod-db-backups/prod-20260729-030000.dump", age_hours=6
+    )
+    return backup_dir, status
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    state_file = tmp_path / "backup-probe.state"
+    monkeypatch.setattr(prod_backup_probe, "ALERT_STATE_FILE", state_file)
+    return state_file
+
+
+def _run(
+    backup_dir: Path,
+    status: Path,
+    channel: MagicMock,
+    now: float = NOW,
+) -> bool:
+    return prod_backup_probe.run_probe(
+        backup_dir=backup_dir,
+        status_file=status,
+        channel=channel,
+        now=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Healthy baseline
+# ---------------------------------------------------------------------------
+def test_fresh_dump_and_ok_status_is_healthy_and_silent(
+    healthy_world: tuple[Path, Path],
+) -> None:
+    backup_dir, status = healthy_world
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is True
+    channel.send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Staleness — the failure mode that produces no FAIL line at all
+# ---------------------------------------------------------------------------
+def test_stale_dump_alerts_even_when_status_says_ok(tmp_path: Path) -> None:
+    """A job that stopped firing leaves a stale dump behind an OK verdict."""
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260711-092810.dump", age_hours=18 * 24)
+    status = _write_status(tmp_path, "OK", "/Volumes/T7/…/prod-20260711.dump", age_hours=18 * 24)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+
+    channel.send.assert_called_once()
+    body = channel.send.call_args[0][1]
+    assert "prod-20260711-092810.dump" in body
+    assert "budget 48h" in body
+    assert "did not fire" in body
+
+
+def test_stale_status_file_alerts_even_when_dump_is_fresh(tmp_path: Path) -> None:
+    """The status file itself going stale is its own signal."""
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=2)
+    status = _write_status(tmp_path, "OK", "/Volumes/T7/…/prod.dump", age_hours=40)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+    assert "did not fire" in channel.send.call_args[0][1]
+
+
+def test_missing_status_file_alerts(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=2)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, tmp_path / "absent.status", channel) is False
+    assert "missing" in channel.send.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Reported failure
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "not_mounted",
+        "permission_denied",
+        "empty_dump",
+        "pg_dump_failed",
+        "missing_key",
+        "ssh_hop_failed",
+    ],
+)
+def test_every_documented_fail_reason_alerts(tmp_path: Path, reason: str) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=2)
+    status = _write_status(tmp_path, "FAIL", reason, age_hours=1)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+    assert reason in channel.send.call_args[0][1]
+
+
+def test_prod_down_pg_dump_failed_against_stale_dumps_reports_both(tmp_path: Path) -> None:
+    """Current mini reality (issue #4282): prod is gone, dumps are 18 days old.
+
+    Both the stale-dump and the FAIL verdict must appear, in one alert.
+    """
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260711-092810-preops2978.dump", age_hours=18 * 24)
+    status = _write_status(tmp_path, "FAIL", "pg_dump_failed", age_hours=0.5)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+
+    channel.send.assert_called_once()
+    body = channel.send.call_args[0][1]
+    assert "prod-20260711-092810-preops2978.dump" in body
+    assert "pg_dump_failed" in body
+
+
+# ---------------------------------------------------------------------------
+# Unverifiable is never healthy
+# ---------------------------------------------------------------------------
+def test_unmounted_backup_volume_alerts_rather_than_passing(tmp_path: Path) -> None:
+    """The probe must never report healthy on a signal it could not read."""
+    status = _write_status(tmp_path, "OK", "/Volumes/T7/…/prod.dump", age_hours=2)
+    channel = _make_spy_channel()
+
+    assert _run(tmp_path / "not-mounted", status, channel) is False
+    assert "not mounted" in channel.send.call_args[0][1]
+
+
+def test_empty_backup_dir_alerts(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    backup_dir.mkdir()
+    status = _write_status(tmp_path, "OK", "/Volumes/T7/…/prod.dump", age_hours=2)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+    assert "no prod-*.dump" in channel.send.call_args[0][1]
+
+
+def test_unparseable_status_line_alerts(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=2)
+    status = tmp_path / "prod-pgdump.status"
+    status.write_text("garbage-not-a-status-line\n")
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+    assert "unparseable" in channel.send.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Transition-based alerting
+# ---------------------------------------------------------------------------
+def test_sustained_failure_alerts_once_and_recovers(
+    tmp_path: Path, isolated_state: Path
+) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260711-092810.dump", age_hours=18 * 24)
+    status = _write_status(tmp_path, "FAIL", "pg_dump_failed", age_hours=0.5)
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, status, channel) is False
+    assert channel.send.call_count == 1
+    assert isolated_state.exists()
+
+    # Three more hourly runs while the failure persists: silent.
+    for _ in range(3):
+        assert _run(backup_dir, status, channel) is False
+    assert channel.send.call_count == 1
+
+    # Backup starts working again: exactly one recovery signal.
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=1)
+    good_status = _write_status(tmp_path, "OK", "/Volumes/T7/…/prod.dump", age_hours=1)
+    assert _run(backup_dir, good_status, channel) is True
+    assert channel.send.call_count == 2
+    assert "recovered" in channel.send.call_args[0][0].lower()
+    assert not isolated_state.exists()
+
+
+def test_distinct_failure_after_recovery_realerts(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=1)
+    good_status = _write_status(
+        tmp_path, "OK", "/Volumes/T7/…/prod.dump", age_hours=1, name="good.status"
+    )
+    channel = _make_spy_channel()
+
+    assert _run(backup_dir, good_status, channel) is True
+    assert channel.send.call_count == 0
+
+    bad_status = _write_status(
+        tmp_path, "FAIL", "not_mounted", age_hours=0.5, name="bad.status"
+    )
+    assert _run(backup_dir, bad_status, channel) is False
+    assert channel.send.call_count == 1
+
+    assert _run(backup_dir, good_status, channel) is True
+    assert channel.send.call_count == 2  # recovery
+
+    later_bad = _write_status(
+        tmp_path, "FAIL", "empty_dump", age_hours=0.25, name="later-bad.status"
+    )
+    assert _run(backup_dir, later_bad, channel) is False
+    assert channel.send.call_count == 3  # re-armed
+
+
+def test_state_is_not_recorded_when_the_push_fails(
+    tmp_path: Path, isolated_state: Path
+) -> None:
+    """A channel outage must not swallow the alert — stay armed, retry next run."""
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-20260711-092810.dump", age_hours=18 * 24)
+    status = _write_status(tmp_path, "FAIL", "pg_dump_failed", age_hours=0.5)
+    channel = _make_spy_channel()
+    channel.send.side_effect = RuntimeError("ntfy unreachable")
+
+    assert _run(backup_dir, status, channel) is False
+    assert not isolated_state.exists()
+
+    channel.send.side_effect = None
+    assert _run(backup_dir, status, channel) is False
+    assert channel.send.call_count == 2
+    assert isolated_state.exists()
+
+
+# ---------------------------------------------------------------------------
+# TCC blindness (launchd cannot read the removable volume)
+# ---------------------------------------------------------------------------
+def test_permission_denied_alerts_and_is_not_reported_as_empty(tmp_path: Path) -> None:
+    """Verified on the mini 2026-07-29: launchd can stat /Volumes/T7 but not list it.
+
+    `Path.glob` swallows that PermissionError and yields nothing, which would
+    make the watcher alert forever with the wrong reason ("no dumps") instead of
+    the actionable one. The direct lister must surface the denial itself.
+    """
+    backup_dir = tmp_path / "prod-db-backups"
+    backup_dir.mkdir()
+    _write_dump(backup_dir, "prod-20260729-030000.dump", age_hours=1)
+    backup_dir.chmod(0o000)
+    try:
+        entries, error = prod_backup_probe._list_dumps_direct(backup_dir)
+    finally:
+        backup_dir.chmod(0o755)
+
+    assert entries is None
+    assert "permission denied" in error
+
+
+def test_blind_watcher_never_reports_healthy(tmp_path: Path) -> None:
+    """A listing the probe could not perform is a failure, never a pass."""
+
+    def blind_lister(_: Path) -> tuple[None, str]:
+        return None, "permission denied reading /Volumes/T7/prod-db-backups"
+
+    ok, reason = prod_backup_probe.check_dump_freshness(
+        tmp_path, 48.0, now=NOW, lister=blind_lister
+    )
+    assert ok is False
+    assert "cannot verify" in reason
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [("MISSING", "not mounted"), ("DENIED", "permission denied")],
+)
+def test_ssh_hop_blind_tokens_map_to_distinct_reasons(
+    tmp_path: Path, token: str, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The remote lister's blind states stay distinguishable to the operator."""
+    monkeypatch.setattr(prod_backup_probe, "BACKUP_LIST_SSH_KEY", "/dev/null")
+
+    class _Proc:
+        returncode = 0
+        stdout = f"{token}\n"
+        stderr = ""
+
+    monkeypatch.setattr(
+        "subprocess.run", lambda *a, **k: _Proc()
+    )
+    entries, error = prod_backup_probe._list_dumps_via_ssh(tmp_path)
+    assert entries is None
+    assert expected in error
+
+
+def test_ssh_hop_parses_stat_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prod_backup_probe, "BACKUP_LIST_SSH_KEY", "/dev/null")
+
+    class _Proc:
+        returncode = 0
+        stdout = (
+            f"{NOW - 2 * HOUR:.0f} /Volumes/T7/prod-db-backups/prod-20260729-030000.dump\n"
+            f"{NOW - 400 * HOUR:.0f} /Volumes/T7/prod-db-backups/prod-20260711-092810.dump\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _Proc())
+
+    ok, reason = prod_backup_probe.check_dump_freshness(
+        tmp_path, 48.0, now=NOW, lister=prod_backup_probe._list_dumps_via_ssh
+    )
+    assert ok is True
+    assert "prod-20260729-030000.dump" in reason
+
+
+def test_missing_hop_key_names_the_setup_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install.sh wires a key path before the operator has generated the key."""
+    monkeypatch.setattr(
+        prod_backup_probe, "BACKUP_LIST_SSH_KEY", str(tmp_path / "absent_key")
+    )
+    entries, error = prod_backup_probe._list_dumps_via_ssh(tmp_path)
+    assert entries is None
+    assert "one-time watcher key setup" in error
+
+
+def test_ssh_transport_failure_alerts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prod_backup_probe, "BACKUP_LIST_SSH_KEY", "/dev/null")
+
+    class _Proc:
+        returncode = 255
+        stdout = ""
+        stderr = "Permission denied (publickey)."
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _Proc())
+    entries, error = prod_backup_probe._list_dumps_via_ssh(tmp_path)
+    assert entries is None
+    assert "Remote Login disabled" in error
+
+
+# ---------------------------------------------------------------------------
+# Push encoding — the defect that silently swallowed every alert
+# ---------------------------------------------------------------------------
+def test_alert_subjects_survive_latin1_header_encoding() -> None:
+    """HTTP headers are latin-1. An em-dash in the title lost the whole alert.
+
+    Observed live on the mini 2026-07-29 the first time this channel was ever
+    exercised: `'latin-1' codec can't encode character '\\u2014'`.
+    """
+    import prod_probe
+
+    for module in (prod_backup_probe, prod_probe):
+        source = (PROBE_MODULE_DIR / f"{module.__name__}.py").read_text()
+        for line in source.splitlines():
+            if line.strip().startswith("subject = "):
+                line.encode("latin-1")  # raises if a non-latin-1 char sneaks back in
+
+
+@pytest.mark.parametrize("module_name", ["prod_backup_probe", "prod_probe"])
+def test_ascii_header_neutralises_non_latin1_titles(module_name: str) -> None:
+    import importlib
+
+    module = importlib.import_module(module_name)
+    cleaned = module.ascii_header("Prod backup unhealthy — Yggdrasil … ’")
+    cleaned.encode("latin-1")
+    assert "—" not in cleaned
+
+
+def test_ntfy_send_does_not_raise_on_unicode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end guard: a unicode subject must reach the request unbroken."""
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+    def fake_urlopen(req: object, timeout: int = 10) -> _Resp:
+        # Mirrors what httplib does to headers; raises on the original bug.
+        for key, value in req.headers.items():  # type: ignore[attr-defined]
+            str(value).encode("latin-1")
+        captured["ok"] = True
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    prod_backup_probe.NtfyChannel().send("Prod backup unhealthy — Yggdrasil", "body — ok")
+    assert captured["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Independence from the backup job
+# ---------------------------------------------------------------------------
+def test_probe_never_invokes_the_backup_job() -> None:
+    """The watcher reads signals; it must never run, trigger, or import the job.
+
+    The loopback ssh hop is allowed — it is this watcher's own key and its own
+    read-only lister — but nothing that could make a broken backup hide behind
+    a broken watcher.
+    """
+    source = (PROBE_MODULE_DIR / "prod_backup_probe.py").read_text()
+    for forbidden in ("prod-pgdump-run.sh", "prod-pgdump.sh", "pg_dump(", "pg_dump "):
+        assert forbidden not in source, f"probe must not depend on {forbidden}"
+
+
+def test_remote_lister_is_read_only() -> None:
+    """The forced-command lister must not be able to write or run the backup."""
+    raw = (PROBE_MODULE_DIR / "prod_backup_list.sh").read_text()
+    # Scan executable lines only; the header comment legitimately explains what
+    # the lister deliberately does *not* do.
+    code = "\n".join(
+        line for line in raw.splitlines() if not line.lstrip().startswith("#")
+    )
+    for forbidden in ("pg_dump", "prod-pgdump", "rm ", 'echo "$', "mv ", "cp "):
+        assert forbidden not in code, f"lister must not contain {forbidden}"
+
+
+def test_alert_state_file_defaults_outside_the_repo() -> None:
+    """launchd runs with cwd=/; a relative state path would be unwritable."""
+    assert prod_backup_probe.ALERT_STATE_FILE.is_absolute()
+
+
+def test_stale_dump_boundary_is_the_configured_budget(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "prod-db-backups"
+    _write_dump(backup_dir, "prod-recent.dump", age_hours=47)
+    ok, reason = prod_backup_probe.check_dump_freshness(backup_dir, 48.0, now=NOW)
+    assert ok, reason
+
+    _write_dump(backup_dir, "prod-recent.dump", age_hours=49)
+    ok, reason = prod_backup_probe.check_dump_freshness(backup_dir, 48.0, now=NOW)
+    assert not ok
+    assert "49.0h" in reason


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4403

## Linked Issue
Closes #4403

## SBS Impact
- Primary subsystem: Product/Runtime System — Observability/Ops
- Secondary subsystem(s): none
- Write class: mechanical
- Persistence impact: rebuildable
- Derived/rebuildable impact: none
- New or changed contract: none
- Owner-doc impact: updated
- Transition debt impact: no effect
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a launchd watcher for the nightly prod DB backup (stale-dump and FAIL-verdict detection via its own loopback-ssh lister, since launchd cannot read /Volumes/T7); fix a latin-1 header defect in both this and the existing prod-down probe that had silently swallowed every ntfy push.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 host-tooling/observability slice; no BuilderOps record, projection, or receipt material was routed by this change.

## Notes
Validation: tests/ops/test_prod_backup_probe_alert_state.py + tests/ops/test_prod_probe_alert_state.py (35 passed), ruff, mypy, plutil -lint, bash -n install.sh, scripts/docs_guard.py — all clean. Live-verified on the mac mini: both com.yggdrasil.prod-backup-probe and com.yggdrasil.prod-probe are loaded and each pushed one real alert to the yggdrasil-prod-alerts ntfy topic (confirmed delivered).
