### PR TITLE
docs(BCP-03): record the verified Demerzel two-dispatcher-store condition

### DIFF
--- a/docs/BUILDEROPS_CONTROL_PLANE/LEGACY_AUTHORITY_MIGRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/LEGACY_AUTHORITY_MIGRATION.md
@@ -25,6 +25,26 @@ SQLite/JSONL, file-first model inquiries/promotions, and epic-run JSON. Issue #3
 prove path fragmentation; their host-stable SQLite destination is superseded, but their discovery and
 host-identity lessons remain migration inputs.
 
+The dispatcher store fragments the same way, and this is verified live rather than inferred. On
+2026-07-29 Demerzel carried two dispatcher stores simultaneously, because
+`app/dispatcher/config.py :: load_paths` falls through to `_default_state_dir`, which resolves the
+state directory via `discover_primary_worktree(cwd=...)`:
+
+| Checkout | Store | Live tasks |
+| --- | --- | --- |
+| `~/workspace` | `/Volumes/ColimaT7/workspace-root/runtime/dispatcher/dispatcher.sqlite3` | 431 |
+| `~/agentic-pkm-builderops` | `~/agentic-pkm-builderops/runtime/dispatcher/dispatcher.sqlite3` | 27 |
+
+The two are not views of one store: validating the same Signboard board against the first reported
+zero cards absent, against the second 378. A `export-signboard --prune-absent` run from the second
+checkout deleted 404 live cards; the board was rebuilt from the owning store, and #4370 (PR #4402,
+merge `168edbe2`) added a store-ownership stamp so a mismatched prune now refuses.
+
+This is the #3686 defect class one store over, and it is a concrete acceptance case for the
+worktree-enumeration coverage this task already requires: an inventory that finds only the dispatcher
+store belonging to the invoking checkout would silently omit the other, along with every task and
+event recorded in it.
+
 ## What This Task Does
 
 - derive an expected-source manifest from every repo-owned legacy producer/default-path rule, then
@@ -139,7 +159,11 @@ knowledge, runtime data, and GitHub/repo delivery authority are unchanged.
 - construct fixtures for omitted caller roots, multiple worktrees, host/container path divergence,
   unmounted/inaccessible volumes, ambiguous/missing repo provenance, stale acknowledgements, partial
   imports, and source mutation;
-- run importer twice and compare database/result hashes; and
+- run importer twice and compare database/result hashes;
+- exercise the verified Demerzel two-dispatcher-store case from Purpose: an inventory run from one
+  checkout must still enumerate the dispatcher store belonging to the other, and the reconciliation
+  receipt must account for both rather than reporting the invoking checkout's store as the universe;
+  and
 - preserve #3686/PR #3695 evidence in the migration receipt.
 
 ## Related Docs
@@ -152,3 +176,6 @@ knowledge, runtime data, and GitHub/repo delivery authority are unchanged.
 
 - [#3789](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3789), blocked on BCP-01.
 - Reconciles issue #3686 / PR #3695 as discovery evidence with a superseded target.
+- [#4370](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4370) (closed by PR #4402) records the
+  verified Demerzel two-dispatcher-store condition described in Purpose. It shipped a guard at the
+  projection layer; the underlying CWD-derived fragmentation is this task's to migrate.


### PR DESCRIPTION
## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue
No governing issue — docs authoring lane. Records verified host evidence into an existing BCP-03 spec; no scope, contract, or acceptance criterion changes.

## SBS Impact
- Primary subsystem: Builder System (BuilderOps control plane, BCP-03 legacy authority migration)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none — the coverage requirement already existed; this supplies a verified instance of it
- Owner-doc impact: updated
- Transition debt impact: reduces — the condition was recorded only on a now-closed issue
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary

`LEGACY_AUTHORITY_MIGRATION.md` (BCP-03) already named "CWD/worktree-local BuilderOps SQLite … dispatcher SQLite/JSONL" as source classes the cutover inventory must cover, and cited #3686/PR #3695 as proof of path fragmentation. It carried no verified instance of the *dispatcher* half.

One exists. On 2026-07-29 Demerzel held two dispatcher stores at once, because `app/dispatcher/config.py :: load_paths` falls through to `_default_state_dir`, which resolves the state directory via `discover_primary_worktree(cwd=...)`:

| Checkout | Store | Live tasks |
| --- | --- | --- |
| `~/workspace` | `/Volumes/ColimaT7/workspace-root/runtime/dispatcher/dispatcher.sqlite3` | 431 |
| `~/agentic-pkm-builderops` | `~/agentic-pkm-builderops/runtime/dispatcher/dispatcher.sqlite3` | 27 |

They are not two views of one store. Validating the same Signboard board against the first reported zero cards absent; against the second, 378. An `export-signboard --prune-absent` run from the second checkout deleted 404 live cards. The board was rebuilt from the owning store, and #4370 (PR #4402, merge `168edbe2`) shipped a store-ownership stamp so a mismatched prune now refuses.

That guard sits at the projection layer. The fragmentation underneath it is BCP-03's to migrate, and it was documented only on #4370 — which is now closed, so it would have left the inventory with a category and no case.

Three edits, all additive:

- **Purpose** — the two-store table, the resolution path that produces it, and why it is the #3686 defect class one store over. Stated as an acceptance case for the worktree-enumeration coverage the task already requires: an inventory that finds only the invoking checkout's dispatcher store would silently omit the other, along with every task and event in it.
- **How to Verify (Pre-Merge)** — a bullet requiring the case to be exercised: an inventory run from one checkout must still enumerate the other checkout's dispatcher store, and the reconciliation receipt must account for both.
- **Related GitHub Issues** — #4370, with the distinction between what it shipped and what remains BCP-03's.

**No scope change.** The spec's delivery status is "implemented in the development baseline by #3789/PR #3929" with all acceptance criteria checked; adding an unchecked AC to an implemented spec would misreport it. The finding is confirming evidence for existing coverage, not new work, and is recorded as such.

**Validation**

- `python3 scripts/docs_guard.py` → `Docs guard: OK`
- Every issue and PR reference in the diff resolved against GitHub: #3686, #3695, #3789, #3929, #4370, #4402.
- Store paths, task counts, absent-card counts, and the deletion figure were each measured on the host rather than recalled; the two-store split was confirmed by validating one board against both stores.

**Base** — branched from `origin/main` at `168edbe2`, which is PR #4402's merge commit, so the #4370 outcome referenced here is present in the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
