### PR TITLE
Accept real verify paths containing vague tokens

### DIFF
--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -224,6 +224,20 @@ def _target_has_missing_file_path(target: str) -> bool:
     )
 
 
+def _target_has_existing_file_path(target: str) -> bool:
+    if re.search(r"<[^>]+>", target):
+        return False
+    path = _verify_file_path(target)
+    if path is None:
+        return False
+    candidate = Path(path)
+    return (
+        not candidate.is_absolute()
+        and ".." not in candidate.parts
+        and (REPO_ROOT / candidate).is_file()
+    )
+
+
 def _has_concrete_verify_marker(item: str) -> bool:
     targets = tuple(
         match.group(1).strip()
@@ -237,6 +251,7 @@ def _has_concrete_verify_marker(item: str) -> bool:
         and len(set(targets)) == len(targets)
         and all(
             is_resolvable_verify_target(target)
+            or _target_has_existing_file_path(target)
             or _target_has_missing_file_path(target)
             for target in targets
         )

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -120,6 +120,37 @@ def test_ready_issue_accepts_existing_verify_file_path() -> None:
     assert report.acceptance_criteria.missing_verify_file_paths == []
 
 
+def test_readiness_accepts_real_path_containing_vague_authority_token() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        (
+            "tests/architecture/test_pr_hot_path_governance.py::"
+            "test_hot_path_doc_defers_escalation_and_names_direct_repair_contract"
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_readiness_still_rejects_nonexistent_path_with_vague_token() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "tests/architecture/test_nonexistent_hot_path_thing.py::test_x",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+    assert report.acceptance_criteria.missing_verify_file_paths == [
+        "tests/architecture/test_nonexistent_hot_path_thing.py"
+    ]
+
+
 def test_ready_issue_accepts_existing_root_level_verify_file_path() -> None:
     body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
     body = body.replace(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4344

## Linked Issue
Closes #4344

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): none
- Write class: mechanical
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: Readiness classification gives confirmed repo-file existence precedence over vague-token shape rejection.
- Owner-doc impact: none
- Transition debt impact: reduces an active readiness-gate false positive
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Accept confirmed repository files before applying vague-token shape rejection in issue readiness classification.
- Keep unresolved vague-token paths, placeholders, absolute paths, and parent traversal rejected.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded planned repair with no delivery divergence or operational material requiring a durable BuilderOps record.

## Notes
Validation: both Issue Verify targets passed; pytest -q tests/scripts/test_validate_issue_readiness.py (42 passed); pytest -q tests/governance/test_known_defects_registry.py (160 passed); ruff check app tests companion-ui/companion-app; mypy app; docs guard informational temporal-doc notice. The non-governing suggested pure-function assertion was executed and fails because it contradicts the explicit constraint that shape validation remain filesystem-independent; acceptance is proved through the filesystem-aware readiness classifier.