### PR TITLE
Bind the fixed Model Inquiry launcher to repo lineage

### DIFF
--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -89,12 +89,13 @@ only after staging deletion succeeded or the staged path was absent. Launcher st
 captured and validated before cleanup, so a cleanup failure is reported separately and cannot erase
 or reclassify the launcher outcome.
 
-The SSH host must expose both durable role entrypoints before its launcher is considered ready.
-They are installed and checked with the repository-owned
+The SSH host must expose the repository-owned fixed launcher and both durable role entrypoints
+before its launcher is considered ready. All three are installed and content/lineage-checked with the repository-owned
 `scripts/install_model_inquiry_host.py` routine documented in the host agent playbook. This
 stabilizes the versioned command boundary across shell and reboot changes without moving provider
 credential values into Git. Each installed wrapper enters the same `run_with_host_secrets` boundary
-before executing the versioned provider-API adapter; it never launches a subscription CLI.
+before executing the versioned provider-API adapter; it never launches a subscription CLI. A merely
+discoverable stale `yggdrasil-model-inquiry` is rejected.
 
 ## Concretely
 

--- a/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/MODEL_TURN_ADAPTERS.md
@@ -83,20 +83,23 @@ does not install it.
 
 ## Host role-entrypoint lifecycle
 
-The repository owns the two stable headless command names: `fable-model-inquiry-role` and
-`codex-model-inquiry-role`. Run `scripts/install_model_inquiry_host.py install` to create owner-only
-executable wrappers in an explicit host bin directory. Each wrapper binds exactly one role to the
-versioned `scripts/model_inquiry_role_adapter.py` through the host-secret bootstrap, which resolves a
-declared credential rather than an interactive session; an exact reinstall is a no-op, while a
-symlink, unsafe directory, or unrelated existing command fails closed without overwriting it.
+The repository owns the fixed launcher `yggdrasil-model-inquiry` plus the two stable headless role
+commands `fable-model-inquiry-role` and `codex-model-inquiry-role`. Run
+`scripts/install_model_inquiry_host.py install` to create all three owner-only executable wrappers
+in an explicit host bin directory. The fixed launcher binds to the digest-pinned
+`scripts/start_model_inquiry.py` declared-credential path; each role wrapper binds exactly one role
+to the versioned `scripts/model_inquiry_role_adapter.py` through the host-secret bootstrap. None can
+select an interactive session. An exact reinstall is a no-op, while a symlink, unsafe directory,
+stale subscription launcher, or unrelated existing command fails closed without overwriting it.
 
-The companion `check` operation is read-only. It reports only whether both installed entrypoints
-match the adapter digest committed into the installer in its own operator-authoritative checkout
-and Python interpreter, whether the launch `PATH` resolves both names to those exact files, and
-whether the host launcher command is discoverable. It probes no provider CLI, because no headless
-entrypoint depends on one. Host-time validation does not invoke Git; an adapter change and its
-installer digest update are one repo change. The check does not run either provider, inspect
-subscription state, reveal paths, or create inquiry artifacts.
+The companion `check` operation is read-only. It reports only whether all three installed
+entrypoints match the adapter/launcher digests committed into the installer in its own
+operator-authoritative checkout and Python interpreter, and whether the launch `PATH` resolves all
+three names to those exact files. Mere launcher discoverability is insufficient: a stale
+subscription-backed command with the fixed name is unavailable. It probes no provider CLI. Host-time
+validation does not invoke Git; an adapter or fixed-launcher change and its installer digest update
+are one repo change. The check does not run either provider, inspect subscription state, reveal
+paths, or create inquiry artifacts.
 
 ## Concretely
 

--- a/docs/MODEL_ACCESS_SUBSTRATE/RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md
@@ -9,10 +9,11 @@ depends_on: [PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md]
 can_parallelize_with: []
 ---
 
-State: Implemented. Delivered by repair PR #4392 (issue #4291, 2026-07-30), superseding the rejected
-PR #4368 delivery claim and its invalid parent handoff. The live provider run and legacy-bridge
-retirement remain parent validation on #4286. **This is the first task in the capability that
-changes runtime behaviour.**
+State: Repair in progress on reopened issue #4291. The PR #4392 implementation is retained, but live
+parent validation proved that the host installer/check accepted a discoverable stale subscription
+launcher instead of binding the fixed launcher to repo-owned declared-credential lineage. The live
+provider run and legacy-bridge retirement remain parent validation on #4286. **This is the first
+task in the capability that changes runtime behaviour.**
 
 # Resolve Model Inquiry Credentials Through Contract
 
@@ -42,13 +43,12 @@ and is unexercised. Switching to it is a configuration and resolution change, no
    `HttpModelAdapter` takes `api_key` as an injected field and reads no environment itself, so
    `load_adapter_descriptors` no longer accepts provider/model/`api_key_env` from inquiry caller
    configuration or ambient environment.
-3. Make the installed headless entrypoints use provider-API adapters.
-   `scripts/install_model_inquiry_host.py:33-36` currently pins
-   `RoleSpec("fable", "fable-subscription-cli", "claude")` and
-   `RoleSpec("gpt_codex", "codex-subscription-cli", "codex")` — two subscription CLIs as the only
-   installable headless roles. Headless role installation must no longer require a subscription
-   session. Both `xhigh` provider-API roles use the extended 1200-second per-role request deadline;
-   the generic 60-second HTTP posture must not truncate production Model Inquiry turns.
+3. Make the installed headless entrypoints use provider-API adapters. The host installer owns the
+   fixed `yggdrasil-model-inquiry` launcher plus both role wrappers, pins the repo launcher/adapter
+   content, and rejects a stale but discoverable subscription launcher. Headless role installation
+   requires no subscription session. Both `xhigh` provider-API roles use the extended 1200-second
+   per-role request deadline; the generic 60-second HTTP posture must not truncate production Model
+   Inquiry turns.
 4. Replace the provider-bearing `BUILDEROPS_INQUIRY_ADAPTERS_JSON` mechanism with a value-free
    inquiry-role intent configuration. The committed example contains the seven neutral intent fields,
    role independence requirement, channel/consumer references, and no provider, model, credential

--- a/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
+++ b/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
@@ -48,11 +48,11 @@ Work top to bottom; stop and report if a step fails.
 
 ## BuilderOps Model Inquiry host entrypoints
 
-The Model Inquiry host owns two stable headless role commands:
-`fable-model-inquiry-role` and `codex-model-inquiry-role`. They resolve declared
-credentials through the host secret contract and require no interactive
-subscription session. Install them as durable, owner-only wrappers bound to the
-current repository checkout:
+The Model Inquiry host owns the fixed `yggdrasil-model-inquiry` launcher plus
+two stable headless role commands: `fable-model-inquiry-role` and
+`codex-model-inquiry-role`. They resolve declared credentials through the host
+secret contract and require no interactive subscription session. Install all
+three as durable, owner-only wrappers bound to the current repository checkout:
 
 ```bash
 repo_root="$(git rev-parse --show-toplevel)"
@@ -62,9 +62,10 @@ python3 "$repo_root/scripts/install_model_inquiry_host.py" install \
   --python "$repo_root/.venv/bin/python3"
 ```
 
-The operation is idempotent. An exact rerun reports both entrypoints as
-`unchanged`; an unrelated existing file, symlinked bin directory, or unsafe
-permissions fail closed and must be inspected rather than overwritten.
+The operation is idempotent. An exact rerun reports the launcher and both role
+entrypoints as `unchanged`; an unrelated existing file, stale subscription
+launcher, symlinked bin directory, or unsafe permissions fails closed and must
+be inspected rather than overwritten.
 If an I/O failure interrupts the two-role install, an exact first wrapper may
 remain while the second is absent. Do not delete it as rollback: rerun the same
 command, which validates the retained wrapper and converges the missing role.
@@ -81,11 +82,12 @@ python3 "$repo_root/scripts/install_model_inquiry_host.py" check \
   --python "$repo_root/.venv/bin/python3"
 ```
 
-The check succeeds only when both wrappers match the selected checkout and
-interpreter, the current `PATH` resolves both role names to those exact wrapper
-files, and `yggdrasil-model-inquiry` is discoverable. It probes no provider CLI,
-because no headless entrypoint depends on one, and it does not invoke a provider
-or inspect authentication. Provider access instead requires the declared
+The check succeeds only when all three wrappers match the selected checkout and
+interpreter and the current `PATH` resolves all three names to those exact
+files. Discoverability alone is not sufficient for `yggdrasil-model-inquiry`;
+its exact repo-owned declared-credential lineage/content must match. It probes
+no provider CLI, does not invoke a provider, and does not inspect
+authentication. Provider access instead requires the declared
 `anthropic.api-key` and `openai.api-key` Keychain items for the consumer
 `builderops-model-inquiry`; a missing value fails a run closed as
 `credential_unavailable` naming only that logical identifier.
@@ -99,11 +101,12 @@ ssh -T Tailscale_macmini \
 ```
 
 If `check` reports a stale wrapper after an intentional checkout or interpreter
-move, inspect both wrapper files first. Only when they are confirmed as products
-of this installer, move them to an owner-only backup directory and rerun
+move, inspect the fixed launcher and both role wrappers first. Only when they are
+confirmed as superseded installation artifacts, move them to an owner-only
+backup directory and rerun
 `install`. The installer intentionally does not overwrite or delete a stale,
 symlinked, or unrelated command. Uninstall uses the same rule: verify lineage,
-back up or remove exactly those two wrapper files, then rerun `check` to confirm
+back up or remove exactly those three wrapper files, then rerun `check` to confirm
 they are unavailable.
 
 ## Notes

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -274,6 +274,7 @@ def _launcher_content(
         f"# launcher-lineage={LAUNCHER_LINEAGE}\n"
         "set -eu\n"
         f"cd {shlex.quote(str(launcher.parents[1]))}\n"
+        f"export BUILDEROPS_PYTHON={shlex.quote(str(python))}\n"
         f"exec {shlex.quote(str(python))} -m app.ops.host_secret_bootstrap "
         "--channel dev --consumer builderops-model-inquiry "
         "--run-on-credential-unavailable -- "

--- a/scripts/install_model_inquiry_host.py
+++ b/scripts/install_model_inquiry_host.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install and verify durable BuilderOps Model Inquiry role entrypoints."""
+"""Install and verify the fixed BuilderOps Model Inquiry launcher and role entrypoints."""
 
 from __future__ import annotations
 
@@ -21,13 +21,17 @@ from typing import Sequence
 SCHEMA_INSTALL = "builderops.model-inquiry-host-install.v1"
 SCHEMA_CHECK = "builderops.model-inquiry-host-check.v1"
 TRUSTED_REPO_ROOT = Path(__file__).resolve().parents[1]
-# The installed headless role entrypoints bind to the provider-API role adapter.
-# The interactive subscription adapter is deliberately not installable from here:
-# no headless entrypoint may depend on an interactive subscription session
-# (ADR-0064 §4).
+# The installed fixed launcher and headless role entrypoints bind to the
+# declared-credential provider-API path. The interactive subscription adapter
+# is deliberately not installable from here: no headless entrypoint may depend
+# on an interactive subscription session (ADR-0064 §4).
 VERSIONED_ADAPTER_NAME = "model_inquiry_role_adapter.py"
 VERSIONED_ADAPTER_SHA256 = "51510b1e8095f322ec410cf073bdb534b5e8a690e18cfa34c82eff91222aae77"
+VERSIONED_LAUNCHER_NAME = "start_model_inquiry.py"
+VERSIONED_LAUNCHER_SHA256 = "ff70bd2aea2f5a5ac79ce9831c12cc095be18973547a2688f610db1af0f8c3b4"
+FIXED_LAUNCHER_NAME = "yggdrasil-model-inquiry"
 CREDENTIAL_RESOLUTION = "host-secret-contract"
+LAUNCHER_LINEAGE = "repo-owned-declared-credential"
 
 
 @dataclass(frozen=True)
@@ -53,6 +57,9 @@ class Checkout:
     adapter_sha256: str
     root_identity: tuple[int, int]
     adapter_identity: tuple[int, int]
+    launcher: Path
+    launcher_sha256: str
+    launcher_identity: tuple[int, int]
 
 
 def _resolve_file(path: Path, *, label: str, executable: bool = False) -> Path:
@@ -175,6 +182,11 @@ def _resolve_repo_root(path: Path) -> Checkout:
                 VERSIONED_ADAPTER_NAME,
                 label="versioned role adapter",
             )
+            launcher_bytes, launcher_details = _read_regular_file_at(
+                scripts_fd,
+                VERSIONED_LAUNCHER_NAME,
+                label="versioned fixed launcher",
+            )
         finally:
             os.close(scripts_fd)
         adapter_sha256 = hashlib.sha256(adapter_bytes).hexdigest()
@@ -182,14 +194,23 @@ def _resolve_repo_root(path: Path) -> Checkout:
             raise HostInstallError(
                 "versioned role adapter must match the installer digest"
             )
+        launcher_sha256 = hashlib.sha256(launcher_bytes).hexdigest()
+        if launcher_sha256 != VERSIONED_LAUNCHER_SHA256:
+            raise HostInstallError(
+                "versioned fixed launcher must match the installer digest"
+            )
         _assert_directory_identity(resolved, root_identity, label="repo root")
         adapter = resolved / "scripts" / VERSIONED_ADAPTER_NAME
+        launcher = resolved / "scripts" / VERSIONED_LAUNCHER_NAME
         return Checkout(
             resolved,
             adapter,
             adapter_sha256,
             root_identity,
             (adapter_details.st_dev, adapter_details.st_ino),
+            launcher,
+            launcher_sha256,
+            (launcher_details.st_dev, launcher_details.st_ino),
         )
     finally:
         os.close(root_fd)
@@ -240,7 +261,27 @@ def _wrapper_content(
     )
 
 
-def _assert_adapter_identity(checkout: Checkout) -> None:
+def _launcher_content(
+    *,
+    python: Path,
+    launcher: Path,
+    launcher_sha256: str,
+) -> str:
+    return (
+        "#!/bin/sh\n"
+        f"# launcher-sha256={launcher_sha256}\n"
+        f"# credential-resolution={CREDENTIAL_RESOLUTION}\n"
+        f"# launcher-lineage={LAUNCHER_LINEAGE}\n"
+        "set -eu\n"
+        f"cd {shlex.quote(str(launcher.parents[1]))}\n"
+        f"exec {shlex.quote(str(python))} -m app.ops.host_secret_bootstrap "
+        "--channel dev --consumer builderops-model-inquiry "
+        "--run-on-credential-unavailable -- "
+        f"{shlex.quote(str(python))} {shlex.quote(str(launcher))} \"$@\"\n"
+    )
+
+
+def _assert_versioned_sources_identity(checkout: Checkout) -> None:
     root_fd = _open_directory_chain(checkout.root, label="repo root")
     try:
         if _directory_identity(root_fd) != checkout.root_identity:
@@ -260,6 +301,11 @@ def _assert_adapter_identity(checkout: Checkout) -> None:
                 VERSIONED_ADAPTER_NAME,
                 label="versioned role adapter",
             )
+            launcher_bytes, launcher_details = _read_regular_file_at(
+                scripts_fd,
+                VERSIONED_LAUNCHER_NAME,
+                label="versioned fixed launcher",
+            )
         finally:
             os.close(scripts_fd)
     finally:
@@ -269,6 +315,12 @@ def _assert_adapter_identity(checkout: Checkout) -> None:
         or hashlib.sha256(adapter_bytes).hexdigest() != checkout.adapter_sha256
     ):
         raise HostInstallError("versioned role adapter identity changed")
+    if (
+        (launcher_details.st_dev, launcher_details.st_ino)
+        != checkout.launcher_identity
+        or hashlib.sha256(launcher_bytes).hexdigest() != checkout.launcher_sha256
+    ):
+        raise HostInstallError("versioned fixed launcher identity changed")
 
 
 def _assert_checkout_authority(checkout: Checkout) -> None:
@@ -277,7 +329,7 @@ def _assert_checkout_authority(checkout: Checkout) -> None:
         checkout.root_identity,
         label="repo root",
     )
-    _assert_adapter_identity(checkout)
+    _assert_versioned_sources_identity(checkout)
 
 
 def _expected_wrappers(*, checkout: Checkout, python: Path) -> dict[RoleSpec, str]:
@@ -293,6 +345,17 @@ def _expected_wrappers(*, checkout: Checkout, python: Path) -> dict[RoleSpec, st
     }
     _assert_checkout_authority(checkout)
     return wrappers
+
+
+def _expected_launcher(*, checkout: Checkout, python: Path) -> str:
+    _assert_checkout_authority(checkout)
+    launcher = _launcher_content(
+        python=python,
+        launcher=checkout.launcher,
+        launcher_sha256=checkout.launcher_sha256,
+    )
+    _assert_checkout_authority(checkout)
+    return launcher
 
 
 def _entrypoint_matches(directory_fd: int, name: str, expected: str) -> bool:
@@ -378,6 +441,7 @@ def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object
     checkout = _resolve_repo_root(repo_root)
     interpreter = _resolve_file(python, label="host Python", executable=True)
     wrappers = _expected_wrappers(checkout=checkout, python=interpreter)
+    launcher = _expected_launcher(checkout=checkout, python=interpreter)
     destination, directory_fd, destination_identity = _open_bin_dir(
         bin_dir,
         create=True,
@@ -399,6 +463,16 @@ def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object
                 if not _entrypoint_matches(directory_fd, spec.entrypoint, content):
                     raise HostInstallError(f"conflicting entrypoint: {spec.entrypoint}")
                 states[spec] = "unchanged"
+        try:
+            os.stat(FIXED_LAUNCHER_NAME, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            launcher_state = "installed"
+        else:
+            if not _entrypoint_matches(directory_fd, FIXED_LAUNCHER_NAME, launcher):
+                raise HostInstallError(
+                    f"conflicting entrypoint: {FIXED_LAUNCHER_NAME}"
+                )
+            launcher_state = "unchanged"
 
         for spec, content in wrappers.items():
             if states[spec] == "installed":
@@ -409,6 +483,14 @@ def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object
                 )
                 if not installed:
                     states[spec] = "unchanged"
+        if launcher_state == "installed":
+            launcher_installed = _install_no_overwrite(
+                directory_fd,
+                FIXED_LAUNCHER_NAME,
+                launcher,
+            )
+            if not launcher_installed:
+                launcher_state = "unchanged"
         _assert_directory_identity(
             destination,
             destination_identity,
@@ -419,6 +501,10 @@ def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object
                 raise HostInstallError(
                     f"entrypoint changed during installation: {spec.entrypoint}"
                 )
+        if not _entrypoint_matches(directory_fd, FIXED_LAUNCHER_NAME, launcher):
+            raise HostInstallError(
+                f"entrypoint changed during installation: {FIXED_LAUNCHER_NAME}"
+            )
         _assert_directory_identity(
             destination,
             destination_identity,
@@ -431,6 +517,11 @@ def install(*, repo_root: Path, bin_dir: Path, python: Path) -> dict[str, object
     return {
         "schema": SCHEMA_INSTALL,
         "ok": True,
+        "launcher": {
+            "entrypoint": FIXED_LAUNCHER_NAME,
+            "lineage": LAUNCHER_LINEAGE,
+            "status": launcher_state,
+        },
         "roles": {
             spec.role: {"entrypoint": spec.entrypoint, "status": states[spec]}
             for spec in ROLE_SPECS
@@ -448,6 +539,7 @@ def check(
     checkout = _resolve_repo_root(repo_root)
     interpreter = _resolve_file(python, label="host Python", executable=True)
     wrappers = _expected_wrappers(checkout=checkout, python=interpreter)
+    launcher = _expected_launcher(checkout=checkout, python=interpreter)
     try:
         destination, directory_fd, destination_identity = _open_bin_dir(
             bin_dir,
@@ -489,8 +581,17 @@ def check(
                 "entrypoint_status": "available" if entrypoint_available else "unavailable",
                 "credential_resolution": CREDENTIAL_RESOLUTION,
             }
+        discovered_launcher = shutil.which(FIXED_LAUNCHER_NAME, path=command_path)
+        expected_launcher_path = destination / FIXED_LAUNCHER_NAME
         launcher_available = (
-            shutil.which("yggdrasil-model-inquiry", path=command_path) is not None
+            directory_fd is not None
+            and discovered_launcher is not None
+            and Path(os.path.abspath(discovered_launcher)) == expected_launcher_path
+            and _entrypoint_matches(
+                directory_fd,
+                FIXED_LAUNCHER_NAME,
+                launcher,
+            )
         )
         ok = ok and launcher_available
         if directory_fd is not None and destination_identity is not None:
@@ -512,6 +613,22 @@ def check(
                     role_status = roles[spec.role]
                     if isinstance(role_status, dict):
                         role_status["entrypoint_status"] = "unavailable"
+            discovered_launcher = shutil.which(
+                FIXED_LAUNCHER_NAME,
+                path=command_path,
+            )
+            launcher_available = (
+                discovered_launcher is not None
+                and Path(os.path.abspath(discovered_launcher))
+                == expected_launcher_path
+                and _entrypoint_matches(
+                    directory_fd,
+                    FIXED_LAUNCHER_NAME,
+                    launcher,
+                )
+            )
+            if not launcher_available:
+                ok = False
             _assert_directory_identity(
                 destination,
                 destination_identity,
@@ -525,7 +642,8 @@ def check(
         "schema": SCHEMA_CHECK,
         "ok": ok,
         "launcher": {
-            "command": "yggdrasil-model-inquiry",
+            "command": FIXED_LAUNCHER_NAME,
+            "lineage": LAUNCHER_LINEAGE,
             "status": "available" if launcher_available else "unavailable",
         },
         "roles": roles,

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -49,6 +49,9 @@ def _init_adapter_checkout(root: Path) -> Path:
     adapter.write_bytes(
         (REPO_ROOT / "scripts" / host_installer.VERSIONED_ADAPTER_NAME).read_bytes()
     )
+    (root / "scripts" / host_installer.VERSIONED_LAUNCHER_NAME).write_bytes(
+        (REPO_ROOT / "scripts" / host_installer.VERSIONED_LAUNCHER_NAME).read_bytes()
+    )
     return adapter
 
 
@@ -77,6 +80,16 @@ def test_installer_creates_both_role_entrypoints_and_exact_retry_is_noop(
             "status": "unchanged",
         },
     }
+    assert first_payload["launcher"] == {
+        "entrypoint": "yggdrasil-model-inquiry",
+        "lineage": "repo-owned-declared-credential",
+        "status": "installed",
+    }
+    assert second_payload["launcher"] == {
+        "entrypoint": "yggdrasil-model-inquiry",
+        "lineage": "repo-owned-declared-credential",
+        "status": "unchanged",
+    }
     for name in ("fable-model-inquiry-role", "codex-model-inquiry-role"):
         path = bin_dir / name
         assert path.is_file()
@@ -96,6 +109,22 @@ def test_installer_rejects_conflicting_or_unsafe_destinations(tmp_path: Path) ->
     assert "conflicting entrypoint" in conflict.stderr
     assert conflicting.read_text(encoding="utf-8") == "unrelated host command\n"
     assert not (bin_dir / "codex-model-inquiry-role").exists()
+
+    stale_launcher_bin = tmp_path / "stale-launcher-bin"
+    stale_launcher_bin.mkdir()
+    stale_launcher = stale_launcher_bin / host_installer.FIXED_LAUNCHER_NAME
+    stale_launcher.write_text(
+        "#!/bin/sh\nexec fable-subscription-cli \"$@\"\n",
+        encoding="utf-8",
+    )
+    stale_launcher.chmod(0o700)
+    stale_conflict = _install(stale_launcher_bin)
+
+    assert stale_conflict.returncode == 2
+    assert "conflicting entrypoint: yggdrasil-model-inquiry" in stale_conflict.stderr
+    assert "fable-subscription-cli" in stale_launcher.read_text(encoding="utf-8")
+    assert not (stale_launcher_bin / "fable-model-inquiry-role").exists()
+    assert not (stale_launcher_bin / "codex-model-inquiry-role").exists()
 
     real_bin = tmp_path / "real-bin"
     real_bin.mkdir()
@@ -175,6 +204,25 @@ def test_installer_rejects_dirty_tracked_adapter(
     with pytest.raises(
         host_installer.HostInstallError,
         match="must match the installer digest",
+    ):
+        host_installer._resolve_repo_root(checkout)
+
+
+def test_installer_rejects_dirty_tracked_fixed_launcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    _init_adapter_checkout(checkout)
+    launcher = checkout / "scripts" / host_installer.VERSIONED_LAUNCHER_NAME
+    monkeypatch.setattr(host_installer, "TRUSTED_REPO_ROOT", checkout.resolve())
+
+    host_installer._resolve_repo_root(checkout)
+    launcher.write_text("raise SystemExit('stale subscription launcher')\n", encoding="utf-8")
+
+    with pytest.raises(
+        host_installer.HostInstallError,
+        match="fixed launcher must match the installer digest",
     ):
         host_installer._resolve_repo_root(checkout)
 
@@ -409,6 +457,15 @@ def test_installed_entrypoints_bind_exact_role_and_versioned_adapter(
         assert "TOKEN" not in content
         assert "KEY" not in content
 
+    launcher = (bin_dir / host_installer.FIXED_LAUNCHER_NAME).read_text(
+        encoding="utf-8"
+    )
+    assert host_installer.VERSIONED_LAUNCHER_NAME in launcher
+    assert f"launcher-sha256={host_installer.VERSIONED_LAUNCHER_SHA256}" in launcher
+    assert "launcher-lineage=repo-owned-declared-credential" in launcher
+    assert "--run-on-credential-unavailable" in launcher
+    assert "model_inquiry_subscription_adapter" not in launcher
+
 
 def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
@@ -442,7 +499,7 @@ def test_installed_entrypoints_retain_selected_interpreter_path(tmp_path: Path) 
 def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     assert _install(bin_dir).returncode == 0
-    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+    for command in ("claude", "codex"):
         executable = bin_dir / command
         executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         executable.chmod(0o700)
@@ -471,6 +528,7 @@ def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
         "ok": True,
         "launcher": {
             "command": "yggdrasil-model-inquiry",
+            "lineage": "repo-owned-declared-credential",
             "status": "available",
         },
         "roles": {
@@ -521,6 +579,42 @@ def test_check_mode_is_sanitized_read_only_and_complete(tmp_path: Path) -> None:
         "credential_resolution": "host-secret-contract",
     }
     assert missing_payload["roles"]["gpt_codex"]["entrypoint_status"] == "unavailable"
+
+
+def test_check_rejects_discoverable_stale_subscription_launcher(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    assert _install(bin_dir).returncode == 0
+    stale_bin = tmp_path / "stale-bin"
+    stale_bin.mkdir()
+    stale_launcher = stale_bin / host_installer.FIXED_LAUNCHER_NAME
+    stale_launcher.write_text(
+        "#!/bin/sh\nexec fable-subscription-cli \"$@\"\n",
+        encoding="utf-8",
+    )
+    stale_launcher.chmod(0o700)
+
+    result = _run_installer(
+        "check",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--bin-dir",
+        str(bin_dir),
+        "--python",
+        sys.executable,
+        env={**os.environ, "PATH": f"{stale_bin}{os.pathsep}{bin_dir}"},
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["launcher"] == {
+        "command": "yggdrasil-model-inquiry",
+        "lineage": "repo-owned-declared-credential",
+        "status": "unavailable",
+    }
+    assert payload["roles"]["fable"]["entrypoint_status"] == "available"
+    assert payload["roles"]["gpt_codex"]["entrypoint_status"] == "available"
 
 
 def test_partial_install_is_retained_for_exact_retry(
@@ -835,7 +929,7 @@ def test_install_revalidates_all_wrappers_before_success(
 
 
 def _add_fake_host_dependencies(bin_dir: Path) -> None:
-    for command in ("claude", "codex", "yggdrasil-model-inquiry"):
+    for command in ("claude", "codex"):
         executable = bin_dir / command
         executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         executable.chmod(0o700)

--- a/tests/governance/test_model_inquiry_host_install.py
+++ b/tests/governance/test_model_inquiry_host_install.py
@@ -1016,6 +1016,51 @@ def test_check_rejects_bin_replacement_during_launcher_discovery(
     assert not list(bin_dir.iterdir())
 
 
+def test_installed_launcher_pins_python_against_hostile_ambient_override(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    selected_python = tmp_path / "selected-python"
+    hostile_python = tmp_path / "hostile-python"
+    capture = tmp_path / "selected-environment"
+    hostile_marker = tmp_path / "hostile-executed"
+    selected_python.write_text(
+        '#!/bin/sh\nprintf "%s" "$BUILDEROPS_PYTHON" > "$CAPTURE_PATH"\n',
+        encoding="utf-8",
+    )
+    hostile_python.write_text(
+        '#!/bin/sh\nprintf "executed" > "$HOSTILE_MARKER"\n',
+        encoding="utf-8",
+    )
+    selected_python.chmod(0o700)
+    hostile_python.chmod(0o700)
+
+    installed = host_installer.install(
+        repo_root=REPO_ROOT,
+        bin_dir=bin_dir,
+        python=selected_python,
+    )
+    assert installed["ok"] is True
+
+    result = subprocess.run(
+        [str(bin_dir / host_installer.FIXED_LAUNCHER_NAME), "--help"],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "BUILDEROPS_PYTHON": str(hostile_python),
+            "CAPTURE_PATH": str(capture),
+            "HOSTILE_MARKER": str(hostile_marker),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert capture.read_text(encoding="utf-8") == str(selected_python.resolve())
+    assert not hostile_marker.exists()
+
+
 def test_headless_entrypoints_do_not_require_subscription_session(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4291

## Linked Issue
Closes #4291

## SBS Impact
- Primary subsystem: BuilderOps Model Inquiry / CES boundary
- Secondary subsystem(s): host-secret bootstrap and provider APIs
- Write class: Builder execution and immutable receipts
- Persistence impact: existing inquiry trace/receipt store only
- Derived/rebuildable impact: none
- New or changed contract: fixed host launcher lineage and exact content health check
- Owner-doc impact: updated Model Inquiry adapter, launcher, host playbook, and MAS-05 spec truth
- Transition debt impact: rejects the stale subscription-launcher lineage
- Boundary risk: no credential value, provider choice, or subscription adapter may enter caller config or receipts

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Bind the fixed model-inquiry launcher to the digest-pinned repo launcher, fail closed on stale subscription lineage, and make install/check prove exact owner-mode-content identity before any live provider validation.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record required; issue, PR, repo docs, and post-merge runtime receipts are the governed surfaces.

## Notes
Convergence review CLEAN on byte-identical patch f54aba1 (Sol/xhigh); rebased candidate 8ddc35c preserves patch-id fb8e311. Current-head focused installer tests: 25 passed. Prior selected validation on the identical patch: 195 focused tests, Ruff, mypy (822 files), docs guard, skill consistency, public seam lint, settings validation, and diff check all passed. Live provider acceptance is deliberately withheld until the merged launcher is installed on the inquiry host and exactly one governed inquiry proves provider request IDs for both roles.
