### PR TITLE
Rescope MAS-06 under the owner cost ruling

### DIFF
--- a/docs/MODEL_ACCESS_SUBSTRATE/PARENT_FEATURE_ISSUE.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/PARENT_FEATURE_ISSUE.md
@@ -3,9 +3,11 @@ the strict serial execution chain. GitHub holds the live acceptance ledger; this
 repo-governed contract. **Owner ruling 2026-07-30 (cost):** the two live receipts below
 (`provider_enabled_noninteractive_inquiry.v1`, legacy-bridge retirement) are withdrawn as acceptance
 gates — metered provider API keys are not provisioned and the subscription-backed session remains
-the sanctioned operational auth for host-local model inquiry
+the sanctioned operational auth for host-local model inquiry. MAS-06 instead enters on the delivered
+neutral mechanism plus this ruling and must fail closed with zero inferred edges while credentials
+are absent
 (`docs/adr/ADR-0064-model-access-substrate.md :: Amendment 2026-07-30 — owner cost ruling on the
-model-inquiry path`). Parent acceptance re-scopes accordingly; a correction is posted on #4286.
+model-inquiry path`). Parent acceptance is repo-verifiable under the re-scoped criteria below.
 Doc role: Parent feature issue contract (live validation hub #4286)
 Authority: Owns the capability-level validation-hub contract and the acceptance ledger. Subordinate to
 `docs/MODEL_ACCESS_SUBSTRATE/README.md` for task shape and to `docs/adr/ADR-0064-model-access-substrate.md`
@@ -14,7 +16,7 @@ Owner: Architecture spine / LLM boundary
 Temporal class: active delivery contract
 Review cadence: event-driven (filing, each child merge, capability acceptance)
 Source of truth: `docs/MODEL_ACCESS_SUBSTRATE/README.md`
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-30
 
 # Parent feature issue — Model Access Substrate (steps 1-5)
 
@@ -32,7 +34,9 @@ pickup issue.
 PR #4180. It rules that credential and session resolution is part of the model abstraction, and that
 declared API keys are the default programmatic auth path — subscription CLI sessions become
 interactive-only and must not be a dependency of any headless path. Its acceptance authorizes
-specification and backlog decomposition, not implementation.
+specification and backlog decomposition, not implementation. The 2026-07-30 owner-cost amendment
+suspends that headless-session prohibition only for host-local Model Inquiry; no other Builder
+consumer inherits the exception.
 
 `docs/MODEL_ACCESS_SUBSTRATE/README.md` is that decomposition, covering **migration steps 1-5** of
 `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md` §8. Steps 6 and 7 are out of scope.
@@ -46,9 +50,10 @@ model-provider credentials in another's out-of-scope.
 
 ## Scope
 
-The outcome, not one PR: a headless caller obtains an authenticated model channel through one contract,
-the provider set is defined once, and CKM stops resolving Builder inference through Product routing
-policy.
+The outcome, not one PR: the provider set and metered credential mechanism are defined once, the
+sanctioned host-local Model Inquiry subscription exception stays explicit, and CKM stops resolving
+Builder inference through Product routing policy. With metered credentials intentionally absent,
+CKM fails closed instead of claiming an authenticated inference channel.
 
 Six bounded tasks, specified in `docs/MODEL_ACCESS_SUBSTRATE/`. This issue is their validation hub and
 is never picked up directly.
@@ -87,20 +92,16 @@ These are the capability-level criteria. Per-task criteria live in the task spec
       contract, and a missing value fails the consumer closed while naming only the logical identifier.
       Verify: `tests/ops/test_host_secret_contract.py::test_model_provider_identifiers_are_declared_data`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_missing_model_provider_secret_fails_consumer_closed`
-- [ ] No headless entrypoint depends on an interactive subscription CLI session.
-      Verify: `tests/governance/test_model_inquiry_host_install.py::test_headless_entrypoints_do_not_require_subscription_session`
+- [ ] The repo-owned metered launcher remains content/lineage verified and fail-closed, while the
+      sanctioned host subscription session is confined to Model Inquiry and is not a CKM fallback.
+      Verify: `tests/governance/test_model_inquiry_host_install.py::test_check_rejects_discoverable_stale_subscription_launcher`
+      Verify: `docs/adr/ADR-0064-model-access-substrate.md :: Amendment 2026-07-30 — owner cost ruling on the model-inquiry path`
 - [ ] The production inquiry caller submits provider-free intent and resolves provider/model through
       the Builder runtime/channel census mapping after capability checks.
       Verify: `tests/builderops/test_model_inquiry_runner.py::test_production_inquiry_resolves_provider_free_intent_through_builder_census`
 - [ ] The two neutral inquiry roles resolve as one independent group to distinct effective targets,
       and a colliding mapping is refused before provider execution.
       Verify: `tests/builderops/test_model_inquiry_runner.py::test_production_inquiry_resolves_distinct_effective_targets_for_role_group`
-- [ ] A model inquiry completes over a fresh non-interactive session on the configured inquiry host,
-      with a provider-returned request id in the persisted turn receipt.
-      Verify: `runtime receipt: model_access_substrate.provider_enabled_noninteractive_inquiry.v1`
-- [ ] The hand-built per-provider TLS bridge and its version-pinned CLI symlink dependency are retired
-      recoverably on the configured inquiry host after the provider-enabled path is accepted.
-      Verify: `runtime receipt: model_access_substrate.legacy_subscription_bridge_retirement.v1`
 - [ ] CKM resolves its semantic-association model through a Builder-side adapter, and a Product policy
       fallback cannot execute the Builder task.
       Verify: `tests/builderops/ckm/test_semantic.py::test_product_fallback_cannot_execute_builder_task`
@@ -125,10 +126,11 @@ Specification directory: `docs/MODEL_ACCESS_SUBSTRATE/`
 | 3 | `EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS.md` | MAS-03 | MAS-02 |
 | 4 | `PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md` | MAS-04 | MAS-03 |
 | 5 | `RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md` | MAS-05 | MAS-04 |
-| 6 | `REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md` | MAS-06 | accepted MAS-05 parent receipt |
+| 6 | `REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md` | MAS-06 | delivered MAS-05 mechanism + ADR-0064 owner-cost amendment |
 
-The chain is serial. MAS-06 remains blocked until the MAS-05 implementation merges and
-`model_access_substrate.provider_enabled_noninteractive_inquiry.v1` is accepted on this parent.
+The chain is serial. MAS-06 becomes executable after the MAS-05 mechanism and launcher-lineage
+repairs are merged and this owner-ruling re-scope is reflected in its live Issue contract. No live
+provider receipt or bridge retirement is required.
 
 ## Verification Path
 
@@ -139,10 +141,10 @@ importlinter.ini` is a proof surface for MAS-02, MAS-04, and MAS-06.
 
 ## Validation / Acceptance Path
 
-Each merged child posts one short validation receipt here before the next child is picked up. Two
-acceptance items cannot live in a test and arrive as redacted operator receipts on this issue: a real
-model inquiry completing over a fresh non-interactive session, and retirement of the hand-built
-per-provider bridge on the configured inquiry host. Neither receipt may contain a credential value or a
+Each merged child posts one short validation receipt here before the next child is picked up.
+The provider-enabled inquiry and bridge-retirement receipts are withdrawn by the 2026-07-30 owner
+cost ruling. Parent acceptance now uses the repo-verifiable child criteria, including MAS-06's
+Product-import removal and fail-closed zero-edge behavior. No receipt may contain a credential value or a
 host identifier.
 
 Owner-doc promotion triggers only after every acceptance criterion above is satisfied: one PR updating

--- a/docs/MODEL_ACCESS_SUBSTRATE/README.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/README.md
@@ -5,25 +5,28 @@ subscription-backed session remains the sanctioned operational auth for host-loc
 (`docs/adr/ADR-0064-model-access-substrate.md :: Amendment 2026-07-30 — owner cost ruling on the
 model-inquiry path`). MAS-01..05 stay delivered as merged code; the parent live-proof receipt
 `provider_enabled_noninteractive_inquiry.v1` and the legacy-bridge retirement receipt are withdrawn
-as acceptance gates, and MAS-06's entry gate re-scopes with them. Capability re-scoping is pending.
+as acceptance gates. This specification re-scopes MAS-06 as an authority-leak removal: the CKM
+Builder path fails closed while the declared metered credentials remain intentionally absent and
+never substitutes the sanctioned Model Inquiry subscription session.
 Doc role: Capability specification (feature-breakdown lane)
 Authority: Owns the task decomposition, execution order, cross-task invariants, and acceptance path for the model access substrate. Subordinate to `docs/adr/ADR-0064-model-access-substrate.md` (the decision), `docs/adr/ADR-0063-shared-llm-contract-kernel.md` (contract seam and fallback vocabulary), ADR-0062 (Builder credential/process separation), `docs/LOCAL_SECRET_PROVISIONING/README.md` (host secret boundary and INV-HSP-1..4), and `docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md` (provider census and egress posture). Owner docs win on disagreement.
 Owner: Architecture spine / LLM boundary
 Temporal class: strategic
 Review cadence: event-driven (task merge, ADR amendment, or a change in the CKM orchestration question)
 Source of truth: this directory for task shape and acceptance; ADR-0064 for the decision; `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md` for the evidence baseline
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-30
 
 # Model Access Substrate
 
 ## Outcome
 
 Model-provider **credential and session resolution becomes part of the model abstraction** rather than
-infrastructure around it, and **declared API keys become the default programmatic auth path**. When
-this capability is accepted, Model Inquiry and CKM obtain an authenticated model channel through one
-contract, without a human at a GUI login, without a per-provider hand-built bridge, and without caller
-code naming a provider. The neutral seam enables later CI, scheduled-job, and verification-closer
-migrations; this Phase 1 does not deliver those consumers.
+infrastructure around it, and **declared API keys remain the default programmatic mechanism when a
+metered path is authorized**. Under the 2026-07-30 owner cost ruling, host-local Model Inquiry keeps
+its sanctioned subscription session while CKM moves off Product routing and fails closed when its
+declared metered credential is unavailable. The neutral seam enables later CI, scheduled-job, and
+verification-closer migrations; this Phase 1 does not deliver those consumers or claim active
+provider-backed CKM inference.
 
 Three mechanisms already exist unfinished, and this capability finishes them rather than designing a
 fourth:
@@ -110,8 +113,8 @@ this substrate's authority.
 | 2 | [Make builder-to-product LLM dependency visible](MAKE_BUILDER_TO_PRODUCT_LLM_DEPENDENCY_VISIBLE.md) | MAS-02 | MAS-01 | `importlinter` fails on `app.builderops -> app.components.llm` with exactly one named, dated exemption for `app/builderops/ckm/semantic.py`. |
 | 3 | [Extend credential contract to model providers](EXTEND_CREDENTIAL_CONTRACT_TO_MODEL_PROVIDERS.md) | MAS-03 | MAS-02 | Exact value-free model-key declarations join the existing contract; CI green-on-absent paths are removed. |
 | 4 | [Promote adapter contract to neutral kernel](PROMOTE_ADAPTER_CONTRACT_TO_NEUTRAL_KERNEL.md) | MAS-04 | MAS-03 | Neutral intent, resolution, capability, adapter/result, failure, fallback, and provenance contracts become importable by both runtimes. |
-| 5 | [Resolve model inquiry credentials through contract](RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md) | MAS-05 | MAS-04 | First beneficiary uses the Builder resolver and declared credentials; its PR hands the live proof to parent validation. |
-| 6 | [Replace CKM product routing with builder adapter](REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md) | MAS-06 | accepted MAS-05 parent receipt | CKM semantic association consumes the Builder resolver; Product fallback cannot execute the task and the transition exemption is removed. |
+| 5 | [Resolve model inquiry credentials through contract](RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md) | MAS-05 | MAS-04 | Delivers the Builder resolver, declared-credential mechanism, typed failure path, and repo-owned launcher lineage; the operational host remains on its sanctioned subscription session under the later owner ruling. |
+| 6 | [Replace CKM product routing with builder adapter](REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md) | MAS-06 | delivered MAS-05 mechanism + ADR-0064 owner-cost amendment | CKM semantic association consumes the Builder resolver; Product and subscription fallback cannot execute the task, absent metered credentials produce a visible zero-edge skip, and the transition exemption is removed. |
 
 Flat order: **MAS-01 → MAS-02 → MAS-03 → MAS-04 → MAS-05 → MAS-06.**
 
@@ -129,10 +132,12 @@ These hold *across* task boundaries. Each task names the ones it must preserve.
   provider is a census row plus a secret declaration; it is never a new bridge. Callers declare
   capability tier, reasoning effort, determinism, schema reference, independence, fallback
   requirement, and side-effect class; the owning runtime/channel resolver selects provider/model.
-- **INV-MAS-2 — credentials resolve only through the contract.** Every model-provider credential
-  consumer — host launcher, model inquiry, CKM, CI — obtains its value through
+- **INV-MAS-2 — metered credentials resolve only through the contract.** Every consumer of a raw
+  model-provider API key — CKM, CI, or a future metered Model Inquiry path — obtains its value through
   `app/ops/host_secret_contract.py` and `app/ops/host_secret_bootstrap.py`. INV-HSP-1..4 are inherited
   unchanged. No consumer reads a provider key from ambient process environment as its primary path.
+  ADR-0064's 2026-07-30 amendment permits the existing subscription session only for host-local
+  Model Inquiry; that exception is not a credential source or fallback for CKM.
 - **INV-MAS-3 — one failure vocabulary, two validators.** The adapter-side classification and the
   independent persistence-boundary re-validation both remain. They read one vocabulary source, so a
   member added in one place cannot be missing in the other.
@@ -155,13 +160,12 @@ These hold *across* task boundaries. Each task names the ones it must preserve.
 Each task is locally correct and can still lose truth in the seam. These are the seams and their
 invariants.
 
-- **Seam A — declaration lands before the value exists (MAS-03 → MAS-05/MAS-06).** MAS-03 may declare
-  `openai.api-key` / `anthropic.api-key` for a Builder consumer before any host holds the value. The
-  hazard is a consumer that finds no Keychain value and quietly reverts to the old subscription-session
-  path, restoring exactly the failure this capability exists to remove. **Invariant:** a declared
-  identifier whose value is absent or malformed fails the consuming process **closed** at startup,
-  names only the logical identifier, and never falls back to ambient environment or to an interactive
-  session. Verified inside each consuming task, not only in the contract task.
+- **Seam A — declaration lands while the value is intentionally absent (MAS-03 → MAS-05/MAS-06).**
+  The owner ruling leaves `openai.api-key` / `anthropic.api-key` unprovisioned. The hazard is a
+  consumer that treats this expected state as permission to select Product policy, an ambient value,
+  or the sanctioned Model Inquiry subscription session. **Invariant:** CKM and every metered path fail
+  **closed**, name only the logical identifier, and emit a visible zero-edge/unavailable outcome.
+  The subscription exception is confined to host-local Model Inquiry and is never a CKM fallback.
 - **Seam B — vocabulary added at the adapter but not at persistence (MAS-04 → MAS-05).** If
   `credential_unavailable` is emitted by an adapter but rejected by the persistence-boundary
   validator, a real authentication failure is recorded as a persistence failure and the diagnostic that
@@ -172,10 +176,12 @@ invariants.
   Removing it earlier reddens main; removing it later leaves a contract that passes for the wrong
   reason. **Invariant:** exemption removal and import removal are atomic, and the contract is never
   made to pass by widening `ignore_imports` or moving a module out of `source_modules`.
-- **Seam D — Model Inquiry proves the resolver while CKM remains on Product routing
-  (MAS-05 → MAS-06).** A successful Model Inquiry receipt proves the substrate, not CKM evidence
-  integrity. **Invariant:** CKM design-agent work remains blocked until the Phase 1 receipt is accepted;
-  the CKM semantic transition exemption is removed only with the production import.
+- **Seam D — the resolver mechanism is delivered while CKM remains on Product routing
+  (MAS-05 → MAS-06).** The withdrawn provider-enabled receipt is no longer an entry gate.
+  **Invariant:** MAS-06 may use the delivered neutral resolver/adapter mechanism, but it must treat the
+  intentionally absent metered credential as unavailable, write zero inferred edges, and never reuse
+  Model Inquiry's subscription session. The CKM semantic transition exemption is removed atomically
+  with the production Product import.
 - **Seam E — census declared, site not yet migrated (MAS-01 → everything).** A census projection that
   disagrees with a live site must fail, not be quietly widened. **Invariant:** the equality test's only
   escape hatch is a declared divergence entry carrying a linked issue number and a date; an entry
@@ -193,13 +199,11 @@ the per-task criteria live in the task files.
       contract, and a missing value fails the consumer closed while naming only the logical identifier.
       Verify: `tests/ops/test_host_secret_contract.py::test_model_provider_identifiers_are_declared_data`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_missing_model_provider_secret_fails_consumer_closed`
-- [ ] No headless entrypoint depends on an interactive subscription CLI session.
-      Verify: `tests/governance/test_model_inquiry_host_install.py::test_headless_entrypoints_do_not_require_subscription_session`
-- [ ] A model inquiry completes over a fresh non-interactive session on the configured inquiry host,
-      with a provider-returned request id in the persisted turn receipt.
-      Verify: redacted operator receipt posted to the parent feature issue, compared against the
-      `final_state: provider_error` / `adapter_failure_class: command_exit_nonzero` failure recorded in
-      `docs/audits/MODEL_ACCESS_SUBSTRATE_2026-07-27.md :: 3.1 What the substrate owns`
+- [ ] The repo-owned metered launcher and role entrypoints remain content/lineage verified and fail
+      closed without declared credentials; the operational host's sanctioned subscription launcher
+      is documented as a Model Inquiry-only owner exception, not accepted as CKM execution.
+      Verify: `tests/governance/test_model_inquiry_host_install.py::test_check_rejects_discoverable_stale_subscription_launcher`
+      Verify: `docs/adr/ADR-0064-model-access-substrate.md :: Amendment 2026-07-30 — owner cost ruling on the model-inquiry path`
 - [ ] CKM resolves its semantic-association model through a Builder-side adapter, and a Product policy
       fallback cannot execute the Builder task.
       Verify: `tests/builderops/ckm/test_semantic.py::test_product_fallback_cannot_execute_builder_task`
@@ -217,17 +221,13 @@ the per-task criteria live in the task files.
 
 ## Validation and acceptance
 
-Each child PR proves its named tests and posts a receipt on the parent feature issue. Two pieces of
-evidence cannot live in a test and belong on the parent as redacted operator receipts:
-
-1. a model inquiry completing over a fresh non-interactive session on the configured inquiry host
-   (the reported failure, fixed as a consequence rather than patched); and
-2. retirement of the hand-built per-provider TLS bridge and its version-pinned CLI symlink dependency
-   on that host, which is host state and not repository state.
-
-Acceptance is those two receipts plus the capability criteria above. Post-acceptance owner-doc
-promotion updates `docs/LLM.md` and the already-named local capability owner docs; it does not touch
-`docs/SECURITY.md`, whose promotion remains owned by #3843.
+Each child PR proves its named tests and posts a receipt on the parent feature issue. The
+provider-enabled inquiry and legacy-bridge-retirement receipts were withdrawn by the 2026-07-30 owner
+cost ruling and are not acceptance gates. Phase 1 acceptance is repo-verifiable: the delivered
+mechanism and failure contracts plus MAS-06's removal of the Product authority leak, zero-exemption
+import boundary, and fail-closed zero-edge behavior while metered credentials are absent.
+Post-acceptance owner-doc promotion updates `docs/LLM.md` and the already-named local capability
+owner docs; it does not touch `docs/SECURITY.md`, whose promotion remains owned by #3843.
 
 ## Backlog reconciliation (2026-07-27)
 

--- a/docs/MODEL_ACCESS_SUBSTRATE/REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md
+++ b/docs/MODEL_ACCESS_SUBSTRATE/REPLACE_CKM_PRODUCT_ROUTING_WITH_BUILDER_ADAPTER.md
@@ -9,8 +9,9 @@ depends_on: [RESOLVE_MODEL_INQUIRY_CREDENTIALS_THROUGH_CONTRACT.md]
 can_parallelize_with: []
 ---
 
-State: Authored task specification (child issue #4292, filed 2026-07-29). Closes the interim window
-opened by MAS-02. It follows accepted MAS-05 parent validation; the order does not swap.
+State: Re-scoped task specification (child issue #4292, filed 2026-07-29; owner-cost amendment
+applied 2026-07-30). Closes the interim window opened by MAS-02. It follows the delivered MAS-05
+mechanism and launcher-lineage repairs; the order does not swap.
 
 # Replace CKM Product Routing With Builder Adapter
 
@@ -24,18 +25,25 @@ candidate the router appends. That is the authority leakage ADR-0063 rejected it
 and `importlinter.ini` did not catch it because `app.builderops` and `app.components` sit on the same
 side of the only existing contract.
 
-ADR-0064 §8 **amends ADR-0063's sequencing**: CKM migrates after Model Inquiry proves the substrate,
+ADR-0064 §8 **amends ADR-0063's sequencing**: CKM migrates after the Model Inquiry mechanism,
 requiring credential resolution and the neutral intent/resolver/adapter contracts — not a complete
-Builder Capability Runtime.
+Builder Capability Runtime or a live metered-provider receipt.
 
 ## Position in the order
 
-The amended ADR-0064 §8 keeps Model Inquiry first and CKM migration at step 5. This issue remains
-blocked until `model_access_substrate.provider_enabled_noninteractive_inquiry.v1` is accepted on the
-parent. **Owner ruling 2026-07-30 (cost):** that receipt is withdrawn as a gate — metered provider
-API keys are not provisioned (`docs/adr/ADR-0064-model-access-substrate.md :: Amendment 2026-07-30 —
-owner cost ruling on the model-inquiry path`); this task's entry gate must be re-scoped before it
-can become ready, and it stays `agent:blocked` until that re-scoping lands. A builder agent may read CKM evidence during the window; CKM itself remains projection-only.
+The amended ADR-0064 §8 keeps Model Inquiry first and CKM migration at step 5. The 2026-07-30 owner
+cost ruling withdraws `model_access_substrate.provider_enabled_noninteractive_inquiry.v1` and bridge
+retirement as gates. MAS-06's replacement entry gate is:
+
+1. the MAS-05 neutral resolver, declared-credential failure path, and launcher-lineage repairs are
+   merged; and
+2. the ADR-0064 cost amendment is merged and the live Issue contract states that CKM must not reuse
+   Model Inquiry's sanctioned subscription session.
+
+Those conditions are repo-verifiable and satisfied once this re-scope is merged. MAS-06 may then
+remove the Product authority leak, but with intentionally absent metered credentials its production
+association result is a visible zero-edge skip. It does not claim active provider-backed inference.
+A builder agent may read CKM evidence during the window; CKM itself remains projection-only.
 
 ## What this task does
 
@@ -43,7 +51,9 @@ can become ready, and it stays `agent:blocked` until that re-scoping lands. A bu
    (`app/builderops/ckm/semantic.py:104`) on top of the MAS-05 Builder resolver and kernel
    `ModelTurnAdapter`. It submits provider-free `ModelAccessIntent`, declares
    `fallback_forbidden`, and receives provider/model/capability/credential provenance only as a
-   resolved result.
+   resolved result. The production host's intentionally absent metered credential is an expected
+   unavailable state: it writes zero inferred edges and never selects Product policy or Model
+   Inquiry's subscription session.
 2. Remove `FabricSemanticAssociator` and both Product imports from `app/builderops/ckm/semantic.py`:
    `app.components.llm.fabric` (`LLMTaskIntent`, `get_chat_client`) and `app.components.llm.constrained`
    (`ConstrainedCompletionError`, `register_schema`, `validate_payload`). The schema-reference and
@@ -93,8 +103,8 @@ live; this task is the only thing that removes it.
 
 ## Acceptance criteria
 
-- [ ] CKM semantic association resolves its model through the kernel adapter with a contract-resolved
-      credential, and `FabricSemanticAssociator` no longer exists.
+- [ ] CKM semantic association resolves through the kernel adapter and declared credential identity,
+      fails closed when its value is unavailable, and `FabricSemanticAssociator` no longer exists.
       Verify: `tests/builderops/ckm/test_semantic.py::test_semantic_association_resolves_through_builder_adapter`
 - [ ] The production CKM call site submits no provider/model and resolves exclusively through the
       Builder runtime/channel census mapping.
@@ -150,9 +160,10 @@ the production import and exemption disappear together.
 
 ## Out of scope
 
-CKM dispatch, mutation, ranking, gating, prioritization, or decision authority. Changing the CKM
-object model, maturity engine, projections, or any other CKM surface. Deterministic linkers, migration
-steps 6 and 7, and Product routing remain unchanged.
+CKM dispatch, mutation, ranking, gating, prioritization, or decision authority. Active
+provider-backed CKM inference, provisioning metered credentials, or reusing Model Inquiry's
+subscription session. Changing the CKM object model, maturity engine, projections, or any other CKM
+surface. Deterministic linkers, migration steps 6 and 7, and Product routing remain unchanged.
 
 ## Related docs
 
@@ -168,10 +179,11 @@ steps 6 and 7, and Product routing remain unchanged.
 
 One issue. Title shape
 `[Model Access Substrate] replace-ckm-product-routing-with-builder-adapter: end the interim authority leak`.
-Its `Context` must state that amended ADR-0064 §8 keeps this after the accepted MAS-05 receipt, that
-the task removes the MAS-02 exemption, and that CKM remains projection-only. It stays
-`agent:blocked` until the parent records
-`model_access_substrate.provider_enabled_noninteractive_inquiry.v1`.
+Its `Context` must state that amended ADR-0064 keeps this after the delivered MAS-05 mechanism and
+the 2026-07-30 owner-cost ruling, that the task removes the MAS-02 exemption, that intentionally
+absent metered credentials produce a visible zero-edge skip, and that CKM remains projection-only.
+After this re-scope is merged, the old provider receipt is no longer a blocker and the live Issue may
+be made `agent:ready` through strict readiness validation.
 
 TCD capability recommendation for the implementing agent: **Opus / high reasoning** — authority-boundary
 work with a negative-proof requirement and a thirteen-test regression contract; the defect mode is a


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

Refs #4286
Refs #4292

## Summary
- Replaces the withdrawn provider-enabled and bridge-retirement gates with a repo-verifiable MAS-06 entry gate under ADR-0064’s 2026-07-30 owner cost amendment.
- Keeps CKM projection-only and removes the Product routing authority leak without promising active provider-backed inference.
- Makes intentionally absent metered credentials a visible zero-edge skip and forbids reuse of Model Inquiry’s sanctioned subscription session by CKM.

## Validation
- `python3 scripts/docs_guard.py`
- `python3 scripts/public_seam_lint.py --mode gate`
- `python -m pytest -q tests/architecture/test_docs_index.py tests/governance/test_ci_smoke_docs_only_gate.py` (11 passed)
- `git diff --check`
- docs-authoring review-before-CI gate satisfied

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the owner ruling is already durable in ADR-0064/PR #4415 and #4286; this PR only reconciles the repo-governed execution contract.