### PR TITLE
[CKM Design Hub] register design-agent adapters

### DIFF
--- a/app/builderops/design_agent_adapters.py
+++ b/app/builderops/design_agent_adapters.py
@@ -1,0 +1,384 @@
+"""Provider-free design-agent registry above the shared model-access substrate.
+
+The registry owns domain identities and sanitized availability only. Provider,
+model, credential reference, and effective identity are resolver outputs, while
+execution is delegated to an already-constructed ``ModelTurnAdapter``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+from app.builderops.design_run_contract import (
+    DesignAgentAvailabilityDescriptor,
+    DesignDeliverableKind,
+    is_safe_design_run_identifier,
+)
+from app.builderops.model_access_resolver import (
+    BUILDER_RUNTIME,
+    DESIGN_AGENT_CONSUMER,
+    BuilderModelAccessResolver,
+)
+from llm_contract import (
+    AdapterResult,
+    IndependenceRequirement,
+    ModelAccessIntent,
+    ModelAccessResolver,
+    ModelCapabilityRequirements,
+    ModelResolutionRequest,
+    ModelTurnAdapter,
+    ResolvedModelAccess,
+)
+
+DESIGN_AGENT_IDS: Final = (
+    "claude-design-via-claude-code",
+    "codex",
+    "fable",
+)
+DESIGN_AGENT_ROLE_PROFILES: Final = {
+    "claude-design-via-claude-code": "design.claude",
+    "codex": "design.codex",
+    "fable": "design.fable",
+}
+DESIGN_AGENT_CONSUMER_ID: Final = DESIGN_AGENT_CONSUMER
+_SUPPORTED_DELIVERABLES: Final[tuple[DesignDeliverableKind, ...]] = (
+    "content_review",
+    "interaction_specification",
+    "visual_handoff",
+)
+_DISPLAY_NAMES: Final = {
+    "claude-design-via-claude-code": "Claude Design via Claude Code",
+    "codex": "Codex",
+    "fable": "Fable",
+}
+_OUTPUT_SCHEMA_REF: Final = "builderops.design-agent-turn.v1"
+_SIDE_EFFECT_CLASS: Final = "builder_design_material"
+_INTERACTIVE_SUBSCRIPTION_ONLY: Final = frozenset(
+    {"claude-design-via-claude-code"}
+)
+_LIMITATION_DETAIL: Final = {
+    "model_access_unavailable": (
+        "Shared model access could not resolve this design agent for headless use."
+    ),
+    "headless_adapter_unavailable": (
+        "No headless model-turn adapter is registered for this resolved target."
+    ),
+    "adapter_identity_mismatch": (
+        "The registered model-turn adapter does not match the resolved target."
+    ),
+    "interactive_subscription_only": (
+        "This design-agent route is interactive-only and unavailable to headless runs."
+    ),
+}
+
+
+class UnknownDesignAgentError(ValueError):
+    """The requested domain adapter is not one of the exact registered IDs."""
+
+    def __init__(self) -> None:
+        super().__init__("unknown design agent")
+
+
+class DesignAgentUnavailableError(RuntimeError):
+    """The exact requested route is unavailable; no alternative is selected."""
+
+    def __init__(self, design_agent_id: str) -> None:
+        super().__init__(f"design agent unavailable: {design_agent_id}")
+        self.design_agent_id = design_agent_id
+
+
+@dataclass(frozen=True)
+class ResolvedDesignAgentAdapter:
+    """One exact domain selection backed by the shared neutral adapter port."""
+
+    design_agent_id: str
+    descriptor: DesignAgentAvailabilityDescriptor
+    model_turn_adapter: ModelTurnAdapter
+
+    def execute(self, request: Mapping[str, Any]) -> AdapterResult:
+        return self.model_turn_adapter.execute(request)
+
+
+@dataclass(frozen=True)
+class DesignAgentAdapterRegistry:
+    """Resolve exact design-agent selections without ranking or fallback."""
+
+    resolver: ModelAccessResolver
+    model_turn_adapters: Mapping[str, ModelTurnAdapter]
+    channel: str
+    runtime: str = BUILDER_RUNTIME
+    consumer: str = DESIGN_AGENT_CONSUMER
+
+    @classmethod
+    def from_declared_sources(
+        cls,
+        *,
+        channel: str,
+        model_turn_adapters: Mapping[str, ModelTurnAdapter] | None = None,
+    ) -> "DesignAgentAdapterRegistry":
+        """Build the production registry from repo-declared Builder sources.
+
+        An empty adapter map is the honest shipped state while metered
+        credentials remain intentionally unprovisioned. This path resolves
+        identity and capabilities but performs no credential read or provider
+        call and never reuses the Model Inquiry subscription session.
+        """
+
+        return cls(
+            resolver=BuilderModelAccessResolver.from_declared_sources(),
+            model_turn_adapters={} if model_turn_adapters is None else model_turn_adapters,
+            channel=channel,
+        )
+
+    def descriptors(
+        self,
+        *,
+        run_id: str,
+    ) -> tuple[DesignAgentAvailabilityDescriptor, ...]:
+        """Return all exact registrations as sanitized CKM-facing DTOs."""
+
+        if not is_safe_design_run_identifier(run_id):
+            return tuple(
+                self._descriptor(
+                    design_agent_id,
+                    available=False,
+                    limitation_code="model_access_unavailable",
+                )
+                for design_agent_id in DESIGN_AGENT_IDS
+            )
+        descriptors: list[DesignAgentAvailabilityDescriptor] = []
+        for design_agent_id in DESIGN_AGENT_IDS:
+            try:
+                resolution = self._resolve(
+                    (design_agent_id,),
+                    run_id=run_id,
+                    independence="none",
+                )[0]
+                if design_agent_id in _INTERACTIVE_SUBSCRIPTION_ONLY:
+                    descriptor = self._descriptor(
+                        design_agent_id,
+                        resolution=resolution,
+                        available=False,
+                        limitation_code="interactive_subscription_only",
+                    )
+                else:
+                    adapter = self.model_turn_adapters.get(resolution.adapter_id)
+                    if adapter is None:
+                        descriptor = self._descriptor(
+                            design_agent_id,
+                            resolution=resolution,
+                            available=False,
+                            limitation_code="headless_adapter_unavailable",
+                        )
+                    elif not self._adapter_matches(adapter, resolution):
+                        descriptor = self._descriptor(
+                            design_agent_id,
+                            resolution=resolution,
+                            available=False,
+                            limitation_code="adapter_identity_mismatch",
+                        )
+                    else:
+                        descriptor = self._descriptor(
+                            design_agent_id,
+                            resolution=resolution,
+                            available=True,
+                        )
+            except Exception:
+                descriptor = self._descriptor(
+                    design_agent_id,
+                    available=False,
+                    limitation_code="model_access_unavailable",
+                )
+            descriptors.append(descriptor)
+        return tuple(descriptors)
+
+    def select(
+        self,
+        design_agent_id: str,
+        *,
+        run_id: str,
+    ) -> ResolvedDesignAgentAdapter:
+        """Resolve one explicit selection through a one-request group."""
+
+        return self.resolve_group((design_agent_id,), run_id=run_id)[0]
+
+    def resolve_group(
+        self,
+        design_agent_ids: Sequence[str],
+        *,
+        run_id: str,
+        independence: IndependenceRequirement = "none",
+    ) -> tuple[ResolvedDesignAgentAdapter, ...]:
+        """Resolve a typed group before obtaining or invoking any adapter."""
+
+        selected_ids = tuple(design_agent_ids)
+        if not selected_ids:
+            raise ValueError("design-agent selection group must not be empty")
+        if not is_safe_design_run_identifier(run_id):
+            raise ValueError("invalid design-run identifier")
+        if any(
+            design_agent_id not in DESIGN_AGENT_ROLE_PROFILES
+            for design_agent_id in selected_ids
+        ):
+            raise UnknownDesignAgentError
+        try:
+            resolutions = self._resolve(
+                selected_ids,
+                run_id=run_id,
+                independence=independence,
+            )
+        except Exception:
+            raise DesignAgentUnavailableError(selected_ids[0]) from None
+        selected: list[ResolvedDesignAgentAdapter] = []
+        for design_agent_id, resolution in zip(
+            selected_ids,
+            resolutions,
+            strict=True,
+        ):
+            try:
+                if design_agent_id in _INTERACTIVE_SUBSCRIPTION_ONLY:
+                    raise DesignAgentUnavailableError(design_agent_id)
+                adapter = self.model_turn_adapters.get(resolution.adapter_id)
+                if adapter is None or not self._adapter_matches(adapter, resolution):
+                    raise DesignAgentUnavailableError(design_agent_id)
+                descriptor = self._descriptor(
+                    design_agent_id,
+                    resolution=resolution,
+                    available=True,
+                )
+            except DesignAgentUnavailableError:
+                raise
+            except Exception:
+                raise DesignAgentUnavailableError(design_agent_id) from None
+            selected.append(
+                ResolvedDesignAgentAdapter(
+                    design_agent_id=design_agent_id,
+                    descriptor=descriptor,
+                    model_turn_adapter=adapter,
+                )
+            )
+        return tuple(selected)
+
+    def _resolve(
+        self,
+        design_agent_ids: tuple[str, ...],
+        *,
+        run_id: str,
+        independence: IndependenceRequirement,
+    ) -> tuple[ResolvedModelAccess, ...]:
+        requests = tuple(
+            self._request(
+                design_agent_id,
+                run_id=run_id,
+                independence=independence,
+            )
+            for design_agent_id in design_agent_ids
+        )
+        return self.resolver.resolve_group(
+            requests,
+            runtime=self.runtime,
+            channel=self.channel,
+            consumer=self.consumer,
+        )
+
+    def _request(
+        self,
+        design_agent_id: str,
+        *,
+        run_id: str,
+        independence: IndependenceRequirement,
+    ) -> ModelResolutionRequest:
+        role_profile = DESIGN_AGENT_ROLE_PROFILES.get(design_agent_id)
+        if role_profile is None:
+            raise UnknownDesignAgentError
+        return ModelResolutionRequest(
+            intent=ModelAccessIntent(
+                capability_tier="frontier",
+                reasoning_effort="high",
+                determinism_required=False,
+                output_schema_ref=_OUTPUT_SCHEMA_REF,
+                independence=independence,
+                fallback_requirement="fallback_forbidden",
+                side_effect_class=_SIDE_EFFECT_CLASS,
+            ),
+            role_profile=role_profile,
+            resolution_group_id=f"design-run:{run_id}",
+            requirements=ModelCapabilityRequirements(
+                structured_output=True,
+                system_prompt_channel=True,
+            ),
+        )
+
+    @staticmethod
+    def _adapter_matches(
+        adapter: ModelTurnAdapter,
+        resolution: ResolvedModelAccess,
+    ) -> bool:
+        return (
+            adapter.adapter_id == resolution.adapter_id
+            and adapter.provider == resolution.provider
+            and adapter.model == resolution.model
+        )
+
+    @staticmethod
+    def _descriptor(
+        design_agent_id: str,
+        *,
+        available: bool,
+        resolution: ResolvedModelAccess | None = None,
+        limitation_code: Literal[
+            "model_access_unavailable",
+            "headless_adapter_unavailable",
+            "adapter_identity_mismatch",
+            "interactive_subscription_only",
+        ]
+        | None = None,
+    ) -> DesignAgentAvailabilityDescriptor:
+        return DesignAgentAvailabilityDescriptor(
+            design_agent_id=design_agent_id,
+            display_name=_DISPLAY_NAMES[design_agent_id],
+            role_profile_id=DESIGN_AGENT_ROLE_PROFILES[design_agent_id],
+            supported_deliverables=_SUPPORTED_DELIVERABLES,
+            available=available,
+            provider_identity=resolution.provider if resolution else None,
+            model_identity=resolution.model if resolution else None,
+            effective_identity=resolution.effective_identity if resolution else None,
+            capabilities=(
+                tuple(
+                    sorted(
+                        capability
+                        for capability in (
+                            "deterministic_execution",
+                            "native_tools",
+                            "structured_output",
+                            "system_prompt_channel",
+                        )
+                        if getattr(resolution.capabilities, capability)
+                    )
+                )
+                if resolution
+                else ()
+            ),
+            resolution_group_id=(
+                resolution.request.resolution_group_id if resolution else None
+            ),
+            limitation_code=limitation_code,
+            limitation_detail=(
+                _LIMITATION_DETAIL[limitation_code]
+                if limitation_code is not None
+                else None
+            ),
+        )
+
+
+__all__ = [
+    "DESIGN_AGENT_CONSUMER_ID",
+    "DESIGN_AGENT_IDS",
+    "DESIGN_AGENT_ROLE_PROFILES",
+    "DesignAgentAdapterRegistry",
+    "DesignAgentUnavailableError",
+    "ResolvedDesignAgentAdapter",
+    "UnknownDesignAgentError",
+]

--- a/app/builderops/design_agent_adapters.py
+++ b/app/builderops/design_agent_adapters.py
@@ -150,41 +150,42 @@ class DesignAgentAdapterRegistry:
             )
         descriptors: list[DesignAgentAvailabilityDescriptor] = []
         for design_agent_id in DESIGN_AGENT_IDS:
+            if design_agent_id in _INTERACTIVE_SUBSCRIPTION_ONLY:
+                descriptors.append(
+                    self._descriptor(
+                        design_agent_id,
+                        available=False,
+                        limitation_code="interactive_subscription_only",
+                    )
+                )
+                continue
             try:
                 resolution = self._resolve(
                     (design_agent_id,),
                     run_id=run_id,
                     independence="none",
                 )[0]
-                if design_agent_id in _INTERACTIVE_SUBSCRIPTION_ONLY:
+                adapter = self.model_turn_adapters.get(resolution.adapter_id)
+                if adapter is None:
                     descriptor = self._descriptor(
                         design_agent_id,
                         resolution=resolution,
                         available=False,
-                        limitation_code="interactive_subscription_only",
+                        limitation_code="headless_adapter_unavailable",
+                    )
+                elif not self._adapter_matches(adapter, resolution):
+                    descriptor = self._descriptor(
+                        design_agent_id,
+                        resolution=resolution,
+                        available=False,
+                        limitation_code="adapter_identity_mismatch",
                     )
                 else:
-                    adapter = self.model_turn_adapters.get(resolution.adapter_id)
-                    if adapter is None:
-                        descriptor = self._descriptor(
-                            design_agent_id,
-                            resolution=resolution,
-                            available=False,
-                            limitation_code="headless_adapter_unavailable",
-                        )
-                    elif not self._adapter_matches(adapter, resolution):
-                        descriptor = self._descriptor(
-                            design_agent_id,
-                            resolution=resolution,
-                            available=False,
-                            limitation_code="adapter_identity_mismatch",
-                        )
-                    else:
-                        descriptor = self._descriptor(
-                            design_agent_id,
-                            resolution=resolution,
-                            available=True,
-                        )
+                    descriptor = self._descriptor(
+                        design_agent_id,
+                        resolution=resolution,
+                        available=True,
+                    )
             except Exception:
                 descriptor = self._descriptor(
                     design_agent_id,

--- a/app/builderops/design_run_contract.py
+++ b/app/builderops/design_run_contract.py
@@ -57,6 +57,17 @@ def _normalized_identifier(value: Any) -> Any:
     return value.strip() if isinstance(value, str) else value
 
 
+def is_safe_design_run_identifier(value: object) -> bool:
+    """Return whether a caller identity is safe to include in descriptor provenance."""
+
+    return (
+        isinstance(value, str)
+        and value == value.strip()
+        and re.fullmatch(_ID, value) is not None
+        and _FORBIDDEN_DETAIL.search(value) is None
+    )
+
+
 NonEmpty = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 Identifier = Annotated[
     str,
@@ -80,6 +91,12 @@ DesignRunStatusValue: TypeAlias = Literal[
     "failed",
     "running",
     "succeeded",
+]
+DesignAgentLimitationCode: TypeAlias = Literal[
+    "model_access_unavailable",
+    "headless_adapter_unavailable",
+    "adapter_identity_mismatch",
+    "interactive_subscription_only",
 ]
 RefusalCode: TypeAlias = Literal[
     "unknown_adapter",
@@ -187,6 +204,58 @@ class DesignAgentDescriptor(CanonicalDesignRunContract):
         if not self.supported_deliverables:
             raise ValueError("design agent descriptor requires supported deliverables")
         _require_sorted_unique(self.supported_deliverables, "supported deliverables")
+        return self
+
+
+class DesignAgentAvailabilityDescriptor(_StrictFrozen):
+    """Secret-safe CKM projection of one registered design-agent route."""
+
+    design_agent_id: Identifier
+    display_name: NonEmpty
+    role_profile_id: Identifier
+    supported_deliverables: tuple[DesignDeliverableKind, ...]
+    available: bool
+    provider_identity: NonEmpty | None = None
+    model_identity: NonEmpty | None = None
+    effective_identity: NonEmpty | None = None
+    capabilities: tuple[NonEmpty, ...] = ()
+    resolution_group_id: NonEmpty | None = None
+    limitation_code: DesignAgentLimitationCode | None = None
+    limitation_detail: NonEmpty | None = None
+
+    @model_validator(mode="after")
+    def _validate_availability(self) -> "DesignAgentAvailabilityDescriptor":
+        if not self.supported_deliverables:
+            raise ValueError("design agent descriptor requires supported deliverables")
+        _require_sorted_unique(self.supported_deliverables, "supported deliverables")
+        _require_sorted_unique(self.capabilities, "capabilities")
+        resolved = (
+            self.provider_identity,
+            self.model_identity,
+            self.effective_identity,
+            self.resolution_group_id,
+        )
+        variable_text = (
+            self.provider_identity,
+            self.model_identity,
+            self.effective_identity,
+            self.resolution_group_id,
+            *self.capabilities,
+        )
+        if any(
+            value is not None and _FORBIDDEN_DETAIL.search(value)
+            for value in variable_text
+        ):
+            raise ValueError("design agent descriptor contains unsafe identity detail")
+        if self.available:
+            if any(value is None for value in resolved):
+                raise ValueError("available design agent requires resolved identity")
+            if self.limitation_code is not None or self.limitation_detail is not None:
+                raise ValueError("available design agent must not carry a limitation")
+        elif self.limitation_code is None or self.limitation_detail is None:
+            raise ValueError("unavailable design agent requires a safe limitation")
+        if self.limitation_detail and _FORBIDDEN_DETAIL.search(self.limitation_detail):
+            raise ValueError("design agent limitation contains unsafe detail")
         return self
 
 
@@ -500,10 +569,12 @@ def _contract_type_from_payload(payload: Mapping[str, Any]) -> type[CanonicalDes
 
 __all__ = [
     "CanonicalDesignRunContract", "ContractIdentityRef", "CuratedDesignBrief",
-    "DESIGN_RUN_CONTRACT_VERSION", "DesignAgentDescriptor", "DesignDeliverableKind",
+    "DESIGN_RUN_CONTRACT_VERSION", "DesignAgentAvailabilityDescriptor",
+    "DesignAgentDescriptor", "DesignAgentLimitationCode", "DesignDeliverableKind",
     "DesignHandoffRef", "DesignRunAdmission", "DesignRunApprovalEvidence",
     "DesignRunPolicyProfile", "DesignRunRefusalDetail", "DesignRunRequest", "DesignRunResult",
     "DesignRunStatus", "DigestBoundAttachmentRef", "DesignSourceRef", "YggdrasilGateReceipt",
     "canonical_hash", "canonical_json", "contract_ref", "parse_design_run_contract",
+    "is_safe_design_run_identifier",
     "validate_admission_bindings", "validate_approval_bindings", "validate_request_bindings",
 ]

--- a/app/builderops/model_access_resolver.py
+++ b/app/builderops/model_access_resolver.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from app.builderops.models import BuilderOpsValidationError
 from app.components.settings.providers_loader import (
+    DesignAgentProfile,
     ProviderCensus,
     ProviderEntry,
     RoleProfile,
@@ -47,6 +48,7 @@ BUILDER_RUNTIME = "builder"
 CKM_SEMANTIC_CONSUMER = "builderops-ckm-semantic"
 CKM_SEMANTIC_RESOLUTION_GROUP = "ckm-semantic-association"
 CKM_SEMANTIC_ROLE = "ckm_semantic"
+DESIGN_AGENT_CONSUMER = "builderops-design-run"
 MODEL_INQUIRY_CONSUMER = "builderops-model-inquiry"
 MODEL_INQUIRY_RESOLUTION_GROUP = "model-inquiry-independent-review"
 NON_PROVIDER_IDENTITIES = frozenset({"mock", "fake", "deterministic", "test"})
@@ -69,6 +71,11 @@ _CKM_REASONING_EFFORT = "low"
 _CKM_DETERMINISM_REQUIRED = False
 _CKM_OUTPUT_SCHEMA_REF = "builderops.ckm.semantic-association.v1"
 _CKM_SIDE_EFFECT_CLASS = "derived_candidate_evidence"
+_DESIGN_REASONING_EFFORT = "high"
+_DESIGN_DETERMINISM_REQUIRED = False
+_DESIGN_OUTPUT_SCHEMA_REF = "builderops.design-agent-turn.v1"
+_DESIGN_SIDE_EFFECT_CLASS = "builder_design_material"
+_DESIGN_RESOLUTION_GROUP_PREFIX = "design-run:"
 
 
 class ModelAccessResolutionError(BuilderOpsValidationError):
@@ -85,7 +92,7 @@ class DeclaredCredentialUnavailableError(RuntimeError):
 
 @dataclass(frozen=True)
 class BuilderModelAccessResolver:
-    """Builder runtime resolver for declared Model Inquiry and CKM consumers."""
+    """Builder resolver for declared Model Inquiry, CKM, and design consumers."""
 
     census: ProviderCensus
     contract: HostSecretContract
@@ -150,6 +157,13 @@ class BuilderModelAccessResolver:
         request_tuple = tuple(requests)
         if not request_tuple:
             raise ModelAccessResolutionError("resolution group must contain at least one request")
+        if consumer == DESIGN_AGENT_CONSUMER:
+            return self._resolve_design_group(
+                request_tuple,
+                runtime=runtime,
+                channel=channel,
+                consumer=consumer,
+            )
         self._require_builder_authority(runtime=runtime, consumer=consumer)
         profiles = self._channel_profiles(channel)
         resolutions = tuple(
@@ -166,6 +180,146 @@ class BuilderModelAccessResolver:
                 "resolved group requires distinct adapter_id values"
             )
         return validated
+
+    def _resolve_design_group(
+        self,
+        requests: tuple[ModelResolutionRequest, ...],
+        *,
+        runtime: str,
+        channel: str,
+        consumer: str,
+    ) -> tuple[ResolvedModelAccess, ...]:
+        """Resolve domain design roles without choosing a provider in the caller."""
+
+        if runtime != BUILDER_RUNTIME:
+            raise ModelAccessResolutionError(
+                "Builder resolver refuses a non-Builder runtime request"
+            )
+        profiles = self._design_profiles(channel)
+        resolutions = tuple(
+            self._resolve_design_request(
+                request,
+                profiles=profiles,
+            )
+            for request in requests
+        )
+        try:
+            validated = validate_resolved_group(requests, resolutions)
+        except ValueError as exc:
+            raise ModelAccessResolutionError(str(exc)) from exc
+        return validated
+
+    def _design_profiles(self, channel: str) -> dict[str, DesignAgentProfile]:
+        profiles = self.census.runtime_channels.design_agent_profiles.get(channel)
+        if not profiles:
+            raise ModelAccessResolutionError(
+                "declared census has no design-agent profiles for the requested channel"
+            )
+        by_role: dict[str, DesignAgentProfile] = {}
+        for profile in profiles:
+            if profile.role in by_role:
+                raise ModelAccessResolutionError(
+                    "declared census repeats a design-agent role profile"
+                )
+            by_role[profile.role] = profile
+        return by_role
+
+    def _resolve_design_request(
+        self,
+        request: ModelResolutionRequest,
+        *,
+        profiles: Mapping[str, DesignAgentProfile],
+    ) -> ResolvedModelAccess:
+        profile = profiles.get(request.role_profile)
+        if profile is None:
+            raise ModelAccessResolutionError(
+                f"declared census has no profile for role: {request.role_profile}"
+            )
+        intent = request.intent
+        if intent.fallback_requirement != "fallback_forbidden":
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy requires fallback_forbidden"
+            )
+        if intent.capability_tier != profile.capability_tier:
+            raise ModelAccessResolutionError(
+                "design-agent capability tier does not match the declared profile"
+            )
+        if intent.reasoning_effort != _DESIGN_REASONING_EFFORT:
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy requires high reasoning effort"
+            )
+        if intent.determinism_required is not _DESIGN_DETERMINISM_REQUIRED:
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy refuses deterministic execution"
+            )
+        if intent.output_schema_ref != _DESIGN_OUTPUT_SCHEMA_REF:
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy requires the declared response schema"
+            )
+        if intent.side_effect_class != _DESIGN_SIDE_EFFECT_CLASS:
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy permits Builder design material only"
+            )
+        if not request.resolution_group_id.startswith(
+            _DESIGN_RESOLUTION_GROUP_PREFIX
+        ) or not request.resolution_group_id.removeprefix(
+            _DESIGN_RESOLUTION_GROUP_PREFIX
+        ):
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy requires a run-bound resolution group"
+            )
+        provider = self._provider(profile.provider)
+        if provider.id.lower() in NON_PROVIDER_IDENTITIES or provider.tier == "test":
+            raise ModelAccessResolutionError(
+                "Builder design-agent policy refuses a mock identity"
+            )
+        model = next(
+            (item for item in provider.models if item.id == profile.model),
+            None,
+        )
+        if model is None:
+            raise ModelAccessResolutionError(
+                "declared design-agent profile references an undeclared model"
+            )
+        capabilities = self._capabilities(provider, model.capabilities)
+        missing = sorted(
+            capability
+            for capability in profile.requires
+            if not getattr(capabilities, capability)
+        )
+        if missing:
+            raise ModelAccessResolutionError(
+                "declared design-agent target lacks capabilities: "
+                + ", ".join(missing)
+            )
+        credential = self._design_credential_identity(
+            profile,
+            provider,
+        )
+        try:
+            return ResolvedModelAccess(
+                request=request,
+                provider=provider.id,
+                model=model.id,
+                adapter_id=f"{provider.id}-{model.id}",
+                effective_identity=model.effective_identity,
+                capabilities=capabilities,
+                credential_identity_ref=credential,
+            )
+        except ValueError as exc:
+            raise ModelAccessResolutionError(str(exc)) from exc
+
+    def _design_credential_identity(
+        self,
+        profile: DesignAgentProfile,
+        provider: ProviderEntry,
+    ) -> str:
+        credential = profile.credential_identifier
+        if credential not in provider.credential_identifiers:
+            raise ModelAccessResolutionError(
+                "declared design-agent profile uses an undeclared provider credential"
+            )
+        return credential
 
     def _resolve_ckm_semantic(
         self,
@@ -526,6 +680,7 @@ __all__ = [
     "CKM_SEMANTIC_CONSUMER",
     "CKM_SEMANTIC_RESOLUTION_GROUP",
     "CKM_SEMANTIC_ROLE",
+    "DESIGN_AGENT_CONSUMER",
     "MODEL_INQUIRY_CONSUMER",
     "MODEL_INQUIRY_RESOLUTION_GROUP",
     "BuilderModelAccessResolver",

--- a/app/builderops/model_access_resolver.py
+++ b/app/builderops/model_access_resolver.py
@@ -200,6 +200,8 @@ class BuilderModelAccessResolver:
             self._resolve_design_request(
                 request,
                 profiles=profiles,
+                channel=channel,
+                consumer=consumer,
             )
             for request in requests
         )
@@ -229,6 +231,8 @@ class BuilderModelAccessResolver:
         request: ModelResolutionRequest,
         *,
         profiles: Mapping[str, DesignAgentProfile],
+        channel: str,
+        consumer: str,
     ) -> ResolvedModelAccess:
         profile = profiles.get(request.role_profile)
         if profile is None:
@@ -295,6 +299,8 @@ class BuilderModelAccessResolver:
         credential = self._design_credential_identity(
             profile,
             provider,
+            channel=channel,
+            consumer=consumer,
         )
         try:
             return ResolvedModelAccess(
@@ -313,11 +319,32 @@ class BuilderModelAccessResolver:
         self,
         profile: DesignAgentProfile,
         provider: ProviderEntry,
+        *,
+        channel: str,
+        consumer: str,
     ) -> str:
         credential = profile.credential_identifier
         if credential not in provider.credential_identifiers:
             raise ModelAccessResolutionError(
                 "declared design-agent profile uses an undeclared provider credential"
+            )
+        try:
+            required = self.contract.required_secrets_for_role(
+                consumer=consumer,
+                role=profile.role,
+            )
+            self.contract.require_declared(
+                channel=channel,
+                consumer=consumer,
+                secret=credential,
+            )
+        except UndeclaredSecretConsumerError as exc:
+            raise ModelAccessResolutionError(
+                "design-agent credential authorization is unavailable"
+            ) from exc
+        if required != (credential,):
+            raise ModelAccessResolutionError(
+                "design-agent credential authorization does not match its role"
             )
         return credential
 

--- a/app/components/settings/providers_loader.py
+++ b/app/components/settings/providers_loader.py
@@ -2,10 +2,11 @@
 
 The running Product paths deliberately retain their compiled local provider
 sets, so for Product this module remains an authoring and verification surface
-rather than a routing dependency.  The Builder Model Access resolver
-(`app/builderops/model_access_resolver.py`, ADR-0064 / MAS-05) is the one
-runtime consumer: it selects provider, model, effective identity, and the
-declared credential identifier from these exact mappings.
+rather than a routing dependency. The Builder Model Access resolver
+(`app/builderops/model_access_resolver.py`, ADR-0064 / MAS-05) consumes the
+Builder-owned inquiry, CKM, and design-agent mappings: it selects provider,
+model, effective identity, and the declared credential identifier from these
+exact mappings.
 """
 
 from __future__ import annotations
@@ -89,6 +90,15 @@ class RoleProfile(TierMapping):
     resolution_group: str = Field(min_length=1)
 
 
+class DesignAgentProfile(TierMapping):
+    model_config = ConfigDict(extra="forbid")
+
+    design_agent_id: str = Field(min_length=1)
+    role: str = Field(min_length=1)
+    capability_tier: str = Field(min_length=1)
+    credential_identifier: str = Field(min_length=1)
+
+
 class ResolutionGroup(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -102,6 +112,9 @@ class RuntimeChannelMappings(BaseModel):
     product: dict[str, dict[str, TierMapping]] = Field(default_factory=dict)
     builder: dict[str, dict[str, TierMapping]] = Field(default_factory=dict)
     model_inquiry_profiles: dict[str, list[RoleProfile]] = Field(default_factory=dict)
+    design_agent_profiles: dict[str, list[DesignAgentProfile]] = Field(
+        default_factory=dict
+    )
     resolution_groups: list[ResolutionGroup] = Field(default_factory=list)
 
 
@@ -131,6 +144,11 @@ class ProviderCensus(BaseModel):
             for profiles in self.runtime_channels.model_inquiry_profiles.values()
             for profile in profiles
         )
+        mappings.extend(
+            profile
+            for profiles in self.runtime_channels.design_agent_profiles.values()
+            for profile in profiles
+        )
         for mapping in mappings:
             provider = self.provider(mapping.provider)
             model = next((item for item in provider.models if item.id == mapping.model), None)
@@ -141,7 +159,10 @@ class ProviderCensus(BaseModel):
                     raise ValueError(
                         f"Provider census mapping {mapping.provider}/{mapping.model} lacks {capability}"
                     )
-            if isinstance(mapping, RoleProfile) and mapping.credential_identifier not in provider.credential_identifiers:
+            if (
+                isinstance(mapping, (RoleProfile, DesignAgentProfile))
+                and mapping.credential_identifier not in provider.credential_identifiers
+            ):
                 raise ValueError(
                     f"Provider census role profile {mapping.role} uses undeclared credential "
                     f"{mapping.credential_identifier}"
@@ -154,6 +175,26 @@ class ProviderCensus(BaseModel):
         for profiles in self.runtime_channels.model_inquiry_profiles.values():
             if {profile.resolution_group for profile in profiles} != {"model-inquiry-independent-review"}:
                 raise ValueError("Model Inquiry profiles must reference the independent-review group")
+        expected_design_roles = {
+            "claude-design-via-claude-code": "design.claude",
+            "codex": "design.codex",
+            "fable": "design.fable",
+        }
+        if set(self.runtime_channels.design_agent_profiles) != set(
+            self.runtime_channels.builder
+        ):
+            raise ValueError(
+                "Design-agent profiles must cover every declared Builder channel"
+            )
+        for profiles in self.runtime_channels.design_agent_profiles.values():
+            actual = {
+                profile.design_agent_id: profile.role
+                for profile in profiles
+            }
+            if actual != expected_design_roles or len(profiles) != len(actual):
+                raise ValueError(
+                    "Design-agent profiles must declare exactly the supported domain roles"
+                )
         return self
 
     def provider(self, provider_id: str) -> ProviderEntry:

--- a/docs/settings/models/providers.yaml
+++ b/docs/settings/models/providers.yaml
@@ -120,5 +120,18 @@ runtime_channels:
     prod:
       - {role: fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output, system_prompt_channel]}
       - {role: gpt_codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, resolution_group: model-inquiry-independent-review, requires: [structured_output]}
+  design_agent_profiles:
+    dev:
+      - {design_agent_id: claude-design-via-claude-code, role: design.claude, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: codex, role: design.codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: fable, role: design.fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
+    test:
+      - {design_agent_id: claude-design-via-claude-code, role: design.claude, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: codex, role: design.codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: fable, role: design.fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
+    prod:
+      - {design_agent_id: claude-design-via-claude-code, role: design.claude, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: codex, role: design.codex, capability_tier: frontier, provider: openai, model: gpt-5.6-sol, credential_identifier: openai.api-key, requires: [structured_output, system_prompt_channel]}
+      - {design_agent_id: fable, role: design.fable, capability_tier: frontier, provider: anthropic, model: claude-fable-5, credential_identifier: anthropic.api-key, requires: [structured_output, system_prompt_channel]}
   resolution_groups:
     - {id: model-inquiry-independent-review, independence: distinct_effective_target}

--- a/tests/builderops/test_design_agent_adapters.py
+++ b/tests/builderops/test_design_agent_adapters.py
@@ -15,6 +15,10 @@ from app.builderops.design_agent_adapters import (
     UnknownDesignAgentError,
 )
 from app.builderops.model_access_resolver import ModelAccessResolutionError
+from app.ops.host_secret_contract import (
+    UndeclaredSecretConsumerError,
+    load_host_secret_contract,
+)
 from llm_contract import (
     AdapterResult,
     ModelCapabilities,
@@ -138,18 +142,52 @@ def test_supported_design_adapters_conform_to_common_contract() -> None:
     }
     assert all(item.supported_deliverables for item in descriptors)
     assert all(item.available is False for item in descriptors)
-    assert {item.provider_identity for item in descriptors} == {"anthropic", "openai"}
-    assert all("structured_output" in item.capabilities for item in descriptors)
+    assert all(item.provider_identity is None for item in descriptors)
+    assert all(item.capabilities == () for item in descriptors)
     assert {
         item.design_agent_id: item.limitation_code for item in descriptors
     } == {
         "claude-design-via-claude-code": "interactive_subscription_only",
-        "codex": "headless_adapter_unavailable",
-        "fable": "headless_adapter_unavailable",
+        "codex": "model_access_unavailable",
+        "fable": "model_access_unavailable",
     }
 
 
-def test_design_agents_use_the_shared_model_access_substrate() -> None:
+def test_design_agents_use_the_shared_model_access_substrate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = load_host_secret_contract(
+        Path("config/secrets/host_secret_contract.json")
+    )
+    for role in DESIGN_AGENT_ROLE_PROFILES.values():
+        with pytest.raises(UndeclaredSecretConsumerError):
+            contract.required_secrets_for_role(
+                consumer="builderops-design-run",
+                role=role,
+            )
+
+    def forbid_secret_read(*_args: object, **_kwargs: object) -> dict[str, str]:
+        raise AssertionError("design registry must not read a credential binding")
+
+    monkeypatch.setattr(
+        "app.builderops.model_access_resolver.load_runtime_secret_values",
+        forbid_secret_read,
+    )
+    production = DesignAgentAdapterRegistry.from_declared_sources(
+        channel="dev",
+        model_turn_adapters=_adapters(),
+    )
+    assert {
+        descriptor.design_agent_id: descriptor.limitation_code
+        for descriptor in production.descriptors(run_id="run.no-credential-grant")
+    } == {
+        "claude-design-via-claude-code": "interactive_subscription_only",
+        "codex": "model_access_unavailable",
+        "fable": "model_access_unavailable",
+    }
+    with pytest.raises(DesignAgentUnavailableError):
+        production.select("codex", run_id="run.no-credential-read")
+
     resolver = RecordingResolver(_targets())
     adapters = _adapters()
     registry = DesignAgentAdapterRegistry(

--- a/tests/builderops/test_design_agent_adapters.py
+++ b/tests/builderops/test_design_agent_adapters.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.builderops.design_agent_adapters import (
+    DESIGN_AGENT_IDS,
+    DESIGN_AGENT_ROLE_PROFILES,
+    DesignAgentAdapterRegistry,
+    DesignAgentUnavailableError,
+    UnknownDesignAgentError,
+)
+from app.builderops.model_access_resolver import ModelAccessResolutionError
+from llm_contract import (
+    AdapterResult,
+    ModelCapabilities,
+    ModelResolutionRequest,
+    ResolvedModelAccess,
+    validate_resolved_group,
+)
+
+
+@dataclass
+class RecordingResolver:
+    targets: Mapping[str, tuple[str, str, str]]
+    calls: list[tuple[tuple[ModelResolutionRequest, ...], str, str, str]] = field(
+        default_factory=list
+    )
+
+    def resolve(
+        self,
+        request: ModelResolutionRequest,
+        *,
+        runtime: str,
+        channel: str,
+        consumer: str,
+    ) -> ResolvedModelAccess:
+        return self.resolve_group(
+            (request,),
+            runtime=runtime,
+            channel=channel,
+            consumer=consumer,
+        )[0]
+
+    def resolve_group(
+        self,
+        requests: Sequence[ModelResolutionRequest],
+        *,
+        runtime: str,
+        channel: str,
+        consumer: str,
+    ) -> tuple[ResolvedModelAccess, ...]:
+        request_tuple = tuple(requests)
+        self.calls.append((request_tuple, runtime, channel, consumer))
+        resolutions = tuple(
+            ResolvedModelAccess(
+                request=request,
+                provider=self.targets[request.role_profile][0],
+                model=self.targets[request.role_profile][1],
+                adapter_id=(
+                    f"{self.targets[request.role_profile][0]}-"
+                    f"{self.targets[request.role_profile][1]}"
+                ),
+                effective_identity=self.targets[request.role_profile][2],
+                capabilities=ModelCapabilities(
+                    structured_output=True,
+                    system_prompt_channel=True,
+                ),
+                credential_identity_ref=(
+                    f"{self.targets[request.role_profile][0]}.api-key"
+                ),
+            )
+            for request in request_tuple
+        )
+        try:
+            return validate_resolved_group(request_tuple, resolutions)
+        except ValueError as exc:
+            raise ModelAccessResolutionError(str(exc)) from exc
+
+
+@dataclass
+class RecordingAdapter:
+    adapter_id: str
+    provider: str
+    model: str
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def execute(self, request: Mapping[str, Any]) -> AdapterResult:
+        self.calls.append(dict(request))
+        return AdapterResult(response_text="bounded design output")
+
+
+def _targets() -> dict[str, tuple[str, str, str]]:
+    return {
+        "design.codex": ("openai", "gpt-5.6-sol", "openai/gpt-5.6-sol"),
+        "design.claude": (
+            "anthropic",
+            "claude-fable-5",
+            "anthropic/claude-fable-5",
+        ),
+        "design.fable": (
+            "anthropic",
+            "claude-fable-5",
+            "anthropic/claude-fable-5",
+        ),
+    }
+
+
+def _adapters() -> dict[str, RecordingAdapter]:
+    return {
+        "openai-gpt-5.6-sol": RecordingAdapter(
+            "openai-gpt-5.6-sol", "openai", "gpt-5.6-sol"
+        ),
+        "anthropic-claude-fable-5": RecordingAdapter(
+            "anthropic-claude-fable-5", "anthropic", "claude-fable-5"
+        ),
+    }
+
+
+def test_supported_design_adapters_conform_to_common_contract() -> None:
+    production = DesignAgentAdapterRegistry.from_declared_sources(channel="dev")
+    descriptors = production.descriptors(run_id="run.discovery")
+
+    assert tuple(item.design_agent_id for item in descriptors) == DESIGN_AGENT_IDS
+    assert DESIGN_AGENT_IDS == (
+        "claude-design-via-claude-code",
+        "codex",
+        "fable",
+    )
+    assert {item.role_profile_id for item in descriptors} == {
+        "design.claude",
+        "design.codex",
+        "design.fable",
+    }
+    assert all(item.supported_deliverables for item in descriptors)
+    assert all(item.available is False for item in descriptors)
+    assert {item.provider_identity for item in descriptors} == {"anthropic", "openai"}
+    assert all("structured_output" in item.capabilities for item in descriptors)
+    assert {
+        item.design_agent_id: item.limitation_code for item in descriptors
+    } == {
+        "claude-design-via-claude-code": "interactive_subscription_only",
+        "codex": "headless_adapter_unavailable",
+        "fable": "headless_adapter_unavailable",
+    }
+
+
+def test_design_agents_use_the_shared_model_access_substrate() -> None:
+    resolver = RecordingResolver(_targets())
+    adapters = _adapters()
+    registry = DesignAgentAdapterRegistry(
+        resolver=resolver,
+        model_turn_adapters=adapters,
+        channel="test",
+    )
+
+    selected = registry.select("codex", run_id="run.one")
+    result = selected.execute({"brief_ref": "brief.one"})
+
+    assert result.response_text == "bounded design output"
+    assert adapters["openai-gpt-5.6-sol"].calls == [{"brief_ref": "brief.one"}]
+    requests, runtime, channel, consumer = resolver.calls[0]
+    assert (runtime, channel, consumer) == (
+        "builder",
+        "test",
+        "builderops-design-run",
+    )
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.role_profile == "design.codex"
+    assert request.resolution_group_id == "design-run:run.one"
+    assert set(request.intent.model_dump()) == {
+        "capability_tier",
+        "reasoning_effort",
+        "determinism_required",
+        "output_schema_ref",
+        "independence",
+        "fallback_requirement",
+        "side_effect_class",
+    }
+    assert request.intent.fallback_requirement == "fallback_forbidden"
+    source = Path("app/builderops/design_agent_adapters.py").read_text(
+        encoding="utf-8"
+    )
+    assert all(
+        forbidden not in source
+        for forbidden in (
+            "requests.",
+            "subprocess",
+            "credential_value(",
+            "load_runtime_secret_values",
+            "LocalCommandAdapter",
+            "HttpModelAdapter",
+        )
+    )
+
+
+def test_design_agents_use_grouped_builder_resolution_with_collision_refusal() -> None:
+    resolver = RecordingResolver(_targets())
+    adapters = _adapters()
+    registry = DesignAgentAdapterRegistry(
+        resolver=resolver,
+        model_turn_adapters=adapters,
+        channel="test",
+    )
+
+    with pytest.raises(DesignAgentUnavailableError):
+        registry.resolve_group(
+            ("claude-design-via-claude-code", "fable"),
+            run_id="run.collision",
+            independence="distinct_effective_target",
+        )
+
+    requests = resolver.calls[0][0]
+    assert tuple(request.role_profile for request in requests) == (
+        "design.claude",
+        "design.fable",
+    )
+    assert {request.resolution_group_id for request in requests} == {
+        "design-run:run.collision"
+    }
+    assert DESIGN_AGENT_ROLE_PROFILES == {
+        "claude-design-via-claude-code": "design.claude",
+        "codex": "design.codex",
+        "fable": "design.fable",
+    }
+    assert all(not adapter.calls for adapter in adapters.values())
+
+
+def test_descriptor_and_failure_surfaces_are_secret_safe() -> None:
+    class ExplodingResolver(RecordingResolver):
+        def resolve_group(
+            self,
+            requests: Sequence[ModelResolutionRequest],
+            *,
+            runtime: str,
+            channel: str,
+            consumer: str,
+        ) -> tuple[ResolvedModelAccess, ...]:
+            del requests, runtime, channel, consumer
+            raise ModelAccessResolutionError(
+                "Bearer secret-value from /Users/operator/private launcher command"
+            )
+
+    registry = DesignAgentAdapterRegistry(
+        resolver=ExplodingResolver(_targets()),
+        model_turn_adapters={},
+        channel="test",
+    )
+    rendered = " ".join(
+        descriptor.model_dump_json()
+        for descriptor in registry.descriptors(run_id="run.secret-safe")
+    ).lower()
+
+    assert "secret-value" not in rendered
+    assert "/users/" not in rendered
+    assert "launcher" not in rendered
+    assert "command" not in rendered
+    assert "credential" not in rendered
+    assert "retry" not in rendered
+    assert "stderr" not in rendered
+    with pytest.raises(DesignAgentUnavailableError) as resolver_failure:
+        registry.select("codex", run_id="run.resolver-failure")
+    assert str(resolver_failure.value) == "design agent unavailable: codex"
+
+    resolver = RecordingResolver(_targets())
+    adapters = _adapters()
+    invalid_run_registry = DesignAgentAdapterRegistry(
+        resolver=resolver,
+        model_turn_adapters=adapters,
+        channel="test",
+    )
+    invalid_run = " ".join(
+        descriptor.model_dump_json()
+        for descriptor in invalid_run_registry.descriptors(
+            run_id="/Users/operator/private-launcher"
+        )
+    ).lower()
+    assert "/users/" not in invalid_run
+    assert "launcher" not in invalid_run
+    assert resolver.calls == []
+    assert all(not adapter.calls for adapter in adapters.values())
+
+    class UnsafeIdentityResolver(RecordingResolver):
+        def resolve_group(
+            self,
+            requests: Sequence[ModelResolutionRequest],
+            *,
+            runtime: str,
+            channel: str,
+            consumer: str,
+        ) -> tuple[ResolvedModelAccess, ...]:
+            del runtime, channel, consumer
+            request = tuple(requests)[0]
+            return (
+                ResolvedModelAccess(
+                    request=request,
+                    provider="anthropic",
+                    model="/Users/operator/private-launcher",
+                    adapter_id="unsafe-adapter",
+                    effective_identity="Bearer secret-value",
+                    capabilities=ModelCapabilities(
+                        structured_output=True,
+                        system_prompt_channel=True,
+                    ),
+                    credential_identity_ref="anthropic.api-key",
+                ),
+            )
+
+    unsafe_adapter = RecordingAdapter(
+        "unsafe-adapter",
+        "anthropic",
+        "/Users/operator/private-launcher",
+    )
+    unsafe_registry = DesignAgentAdapterRegistry(
+        resolver=UnsafeIdentityResolver(_targets()),
+        model_turn_adapters={"unsafe-adapter": unsafe_adapter},
+        channel="test",
+    )
+    unsafe_rendered = " ".join(
+        descriptor.model_dump_json()
+        for descriptor in unsafe_registry.descriptors(run_id="run.unsafe-identity")
+    ).lower()
+    assert "/users/" not in unsafe_rendered
+    assert "secret-value" not in unsafe_rendered
+    assert "launcher" not in unsafe_rendered
+    assert unsafe_adapter.calls == []
+    with pytest.raises(DesignAgentUnavailableError):
+        unsafe_registry.select("codex", run_id="run.unsafe-selection")
+    assert unsafe_adapter.calls == []
+
+
+def test_unknown_or_unavailable_adapter_never_falls_back() -> None:
+    resolver = RecordingResolver(_targets())
+    adapters = _adapters()
+    registry = DesignAgentAdapterRegistry(
+        resolver=resolver,
+        model_turn_adapters=adapters,
+        channel="test",
+    )
+
+    with pytest.raises(UnknownDesignAgentError) as unknown:
+        registry.select(
+            "Bearer secret-value /Users/operator/private-launcher",
+            run_id="run.unknown",
+        )
+    assert str(unknown.value) == "unknown design agent"
+    assert resolver.calls == []
+
+    with pytest.raises(ValueError, match="invalid design-run identifier"):
+        registry.select("codex", run_id="/Users/operator/private-launcher")
+    assert resolver.calls == []
+
+    with pytest.raises(DesignAgentUnavailableError) as unavailable:
+        registry.select(
+            "claude-design-via-claude-code",
+            run_id="run.unavailable",
+        )
+    assert unavailable.value.design_agent_id == "claude-design-via-claude-code"
+    assert len(resolver.calls) == 1
+    assert all(not adapter.calls for adapter in adapters.values())


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4309

## Linked Issue
Closes #4309

## SBS Impact
- Primary subsystem: Builder System design-agent boundary
- Secondary subsystem(s): ADR-0064 model-access substrate and CKM descriptors
- Write class: adapter registry and neutral role-profile composition
- Persistence impact: none; configuration/registry only
- Derived/rebuildable impact: sanitized descriptor projection
- New or changed contract: three exact domain profiles over shared grouped model resolution
- Owner-doc impact: none until terminal parent acceptance
- Transition debt impact: no parallel provider transport
- Boundary risk: CKM cannot acquire credentials, choose providers, reuse subscription auth, or execute fallback

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Register the exact Codex, Claude Design via Claude Code, and Fable domain profiles above Builder model-access resolution with sanitized, fail-closed availability and ModelTurnAdapter-only execution.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This slice changes repo-governed code, tests, and declared provider-profile configuration only; it creates no BuilderOps record, projection, or receipt.

## Notes
TCD high-risk surfaces: external-api and credential-durability. Fresh Sol/high mechanism-convergence review passed on exact head `47386b5ed1cadc57cfadb00d9645f903de115288` after the second credential-boundary repair: exact HostSecretContract channel/consumer/role authorization is required before resolution; current absent design grants produce visible `model_access_unavailable` without reading credential bindings. Current-head local validation: 103 affected-surface tests; all six exact Verify targets; `ruff check app tests`; `mypy app` (828 files); settings validation; docs guard with `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1` because owner-doc promotion is contractually deferred to terminal #4131 acceptance; `git diff --check`. No provider calls, credential reads/provisioning, subscription bridge use, or external mutation.