### PR TITLE
Canonicalize docker Mounts order in legacy-owner fingerprints

### DIFF
--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -587,6 +587,17 @@ def _roots_from_values(
     return list(dict.fromkeys(roots))
 
 
+def _canonical_mounts(mounts: object) -> object:
+    # docker inspect does not guarantee an ordering for Mounts, and json.dumps
+    # sorts dict keys but not list elements. Hashing the array verbatim therefore
+    # makes the two-snapshot stability check in produce_legacy_owners fail on
+    # unchanged host state. Only the digest input is canonicalized; root
+    # translation keeps consuming the payload exactly as docker returned it.
+    if not isinstance(mounts, list):
+        return mounts
+    return sorted(mounts, key=lambda entry: json.dumps(entry, sort_keys=True))
+
+
 def _docker_legacy_owner_sources() -> tuple[list[LegacyOwnerRecord], list[str]]:
     ids_output = _run_checked(
         ["docker", "ps", "-a", "--no-trunc", "--format", "{{.ID}}"],
@@ -641,7 +652,8 @@ def _docker_legacy_owner_sources() -> tuple[list[LegacyOwnerRecord], list[str]]:
                 if channel == "test"
                 else "/app/tmp/agentic-pkm/app-local.md"
             )
-        store_key = (channel, store_path, json.dumps(mounts, sort_keys=True))
+        canonical_mounts = _canonical_mounts(mounts)
+        store_key = (channel, store_path, json.dumps(canonical_mounts, sort_keys=True))
         if store_key not in stores:
             stores[store_key] = _docker_copy_file(container_id, store_path)
         raw_store = stores[store_key]
@@ -658,7 +670,7 @@ def _docker_legacy_owner_sources() -> tuple[list[LegacyOwnerRecord], list[str]]:
                         "channel": channel,
                         "service": service,
                         "env": values,
-                        "mounts": mounts,
+                        "mounts": canonical_mounts,
                         "store": None
                         if raw_store is None
                         else hashlib.sha256(raw_store).hexdigest(),

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -1,0 +1,147 @@
+"""Regression tests for the legacy-owner source inventory (Issue #4423).
+
+`produce_legacy_owners` requires two consecutive snapshots of unchanged host state
+to be byte-identical. The per-container fingerprint embeds the `Mounts` array from
+`docker inspect`, and Docker does not guarantee that array's ordering. These tests
+pin the fingerprint to mount *content* rather than to Docker's arbitrary ordering,
+while keeping the guard's ability to detect a genuine change.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.instance_state_writer_inventory as writer_inventory
+from scripts.instance_state_writer_inventory import InventoryError
+
+CONTAINER_ID = "a" * 64
+
+MOUNTS = [
+    {"Type": "bind", "Source": "/Users", "Destination": "/Users", "RW": True},
+    {"Type": "bind", "Source": "/Volumes", "Destination": "/Volumes", "RW": True},
+    {"Type": "volume", "Name": "pkm-dev-tmp", "Destination": "/app/tmp", "RW": True},
+    {"Type": "volume", "Name": "pkm-dev-tts", "Destination": "/data/tts", "RW": False},
+]
+
+ENV = ["PKM_ENVIRONMENT=dev", "PATH=/usr/local/bin"]
+
+
+def _inspect_payload(mounts):
+    return [
+        {
+            "Id": CONTAINER_ID,
+            "Config": {
+                "Env": list(ENV),
+                "Labels": {
+                    "com.docker.compose.project": "pkm-dev",
+                    "com.docker.compose.service": "api",
+                },
+            },
+            "Mounts": [dict(mount) for mount in mounts],
+        }
+    ]
+
+
+@pytest.fixture
+def docker_stub(monkeypatch):
+    """Drive `_docker_legacy_owner_sources` from a scripted sequence of mount orders."""
+
+    state = {"orders": [], "calls": 0}
+
+    def fake_run_checked(command, *, label, env=None):
+        command = list(command)
+        if command[:2] == ["docker", "ps"]:
+            return f"{CONTAINER_ID}\n"
+        if command[:2] == ["docker", "inspect"]:
+            index = min(state["calls"], len(state["orders"]) - 1)
+            state["calls"] += 1
+            return json.dumps(_inspect_payload(state["orders"][index]))
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(writer_inventory, "_run_checked", fake_run_checked)
+    monkeypatch.setattr(writer_inventory, "_docker_copy_file", lambda *_args: None)
+    return state
+
+
+def test_docker_legacy_owner_fingerprint_is_mount_order_invariant(docker_stub):
+    """Reordered mounts describe the same host state and must hash identically."""
+
+    reordered = [MOUNTS[2], MOUNTS[3], MOUNTS[0], MOUNTS[1]]
+    docker_stub["orders"] = [MOUNTS, reordered]
+
+    _, first = writer_inventory._docker_legacy_owner_sources()
+    _, second = writer_inventory._docker_legacy_owner_sources()
+
+    assert first == second
+
+
+def test_docker_legacy_owner_fingerprint_detects_mount_change(docker_stub):
+    """A real mount change must still move the fingerprint."""
+
+    changed = [dict(mount) for mount in MOUNTS]
+    changed[0]["Source"] = "/Users/someone-else"
+    docker_stub["orders"] = [MOUNTS, changed]
+
+    _, first = writer_inventory._docker_legacy_owner_sources()
+    _, second = writer_inventory._docker_legacy_owner_sources()
+
+    assert first != second
+
+    docker_stub["calls"] = 0
+    docker_stub["orders"] = [MOUNTS, MOUNTS[:-1]]
+
+    _, full = writer_inventory._docker_legacy_owner_sources()
+    _, dropped = writer_inventory._docker_legacy_owner_sources()
+
+    assert full != dropped
+
+
+@pytest.fixture
+def stub_config_sources(monkeypatch):
+    """Pin the config half of the snapshot so the docker half is what varies."""
+
+    monkeypatch.setattr(
+        writer_inventory,
+        "_config_legacy_owner_sources",
+        lambda repo_root, *, active_channel: ([], ["config:stub"]),
+    )
+
+
+def test_produce_legacy_owners_tolerates_mount_reordering(
+    docker_stub, stub_config_sources, tmp_path
+):
+    """The production entrypoint must not report a race for reordered mounts."""
+
+    docker_stub["orders"] = [MOUNTS, [MOUNTS[3], MOUNTS[1], MOUNTS[2], MOUNTS[0]]]
+    output = tmp_path / "legacy-owners.json"
+
+    writer_inventory.produce_legacy_owners(
+        repo_root=Path.cwd(), active_channel="dev", output=output
+    )
+
+    # Real-path assertion: the production call site wrote its inventory receipt,
+    # rather than the helper merely returning a stable value in isolation.
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema"] == writer_inventory.LEGACY_OWNER_INVENTORY_SCHEMA
+    assert payload["inventory_complete"] is True
+    assert payload["source_probe_count"] == 2
+    assert docker_stub["calls"] == 2
+
+
+def test_produce_legacy_owners_still_detects_real_race(
+    docker_stub, stub_config_sources, tmp_path
+):
+    """A genuine change between the two probes must still fail closed."""
+
+    raced = [dict(mount) for mount in MOUNTS]
+    raced[1]["Source"] = "/Volumes/OtherDisk"
+    docker_stub["orders"] = [MOUNTS, raced]
+    output = tmp_path / "legacy-owners.json"
+
+    with pytest.raises(InventoryError, match="incomplete or racing"):
+        writer_inventory.produce_legacy_owners(
+            repo_root=Path.cwd(), active_channel="dev", output=output
+        )
+
+    assert not output.exists()


### PR DESCRIPTION
Governing-Issue: #4423

Fixes #4423

Final-Review-Rounds: 1

## Summary

`docker inspect` does not guarantee an ordering for a container's `Mounts` array, and `json.dumps` sorts dict keys but not list elements. The per-container fingerprint in `_docker_legacy_owner_sources` therefore changed between the two probes that `produce_legacy_owners` requires to be identical, so the deploy gate raised `legacy owner sources are incomplete or racing` on unchanged host state and blocked every channel deploy. This canonicalizes the mounts list before it is used as a digest input, at both the store cache key and the fingerprint.

Root translation keeps consuming the payload exactly as docker returned it, so owner collection and the identity/collision semantics are untouched.

## Evidence

Test-first: the two ordering-invariance tests fail against unchanged `origin/main` with exactly `legacy owner sources are incomplete or racing`; the two detection tests pass both before and after, proving the guard never lost detection power.

Real-host reproduction on a three-channel host: `_legacy_owner_snapshot` probe pairs were **0/3 stable** before the fix and **5/5 stable** after.

## SBS Impact

- Primary subsystem: Builder System — release/deploy workflow (`deploy_channel.sh` pre-mutation gate)
- Secondary subsystem(s): Product/Runtime instance-state ownership substrate, which this gate guards
- Write class: mechanical
- Persistence impact: none — the fingerprint is derived, not durable
- Derived/rebuildable impact: the legacy-owner source digest becomes stable across repeated reads of unchanged host state
- New or changed contract: none — restores the two-snapshot stability contract the code already intends
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: only the digest input ordering changes; owner collection and `_normalize_legacy_owners` identity/collision semantics are untouched

## Independent review

Declared risk surface: `concurrency`. A mechanism convergence packet was built for mechanism key `legacy-owner-source-snapshot-stability` and reviewed by a fresh independent reviewer against the local publishable SHA. Verdict: **CLEAN**, no P0/P1.

The reviewer's central question — can this change let a genuine race or host-state change go undetected? — was answered by execution, not inspection: 20,000 randomized payloads found zero permutation instabilities and zero distinct multisets colliding on one digest; duplicates are not deduped, key-order-only differences collapse correctly, and `null` vs missing keys stay distinct. `sorted(..., key=json.dumps)` cannot raise on docker output, which is a `json.loads` product by construction, and the fail-closed posture survives even if it did.

Two non-blocking findings are recorded rather than fixed here:

- **P2 — `store_key` collapse** (`scripts/instance_state_writer_inventory.py:655-656`). The key carries no container id, so canonicalizing mounts widens an existing collision: two writer containers with identical mount *content* now share one cache entry where previously they also had to match in order. In a topology where `DESIGN_HANDOFF_APP_LOCAL_SETTINGS` points outside every mount, the second container's `docker cp` is skipped and its owner root is not collected — which does contradict this Issue's stated constraint that the collected `LegacyOwnerRecord` set must not change. That topology does not exist in this repo: `docker-compose.yaml` mounts the same `runtime-tmp` volume at `/app/tmp` for all four writer services (`docker-compose.test.yml` likewise at `/app/tmp-test`) and the default store path lives inside it, so the collapsed entries genuinely see identical bytes. The widening is also the semantically correct direction for a key whose intent is "same mount set ⇒ same filesystem view". Flagging rather than fixing, per `AGENTS.md :: Proportional delivery`.
- **P3 — store/cache path uncovered.** The new tests stub `_docker_copy_file` to `None`, so `stores`, `_parse_app_local_roots`, and the app-local branch of `_translate_container_root` are not exercised. That is the path the P2 lives on.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded single-mechanism defect repair with no plan divergence; the convergence packet and independent review are recorded in this PR body rather than as durable BuilderOps material.

## Notes

Validation:

- `tests/ops/test_instance_state_writer_inventory.py` — 4 passed on HEAD; 2 failed / 2 passed on unchanged `origin/main` (test-first confirmed by the independent reviewer in a separate detached worktree).
- `tests/deploy/test_deploy_channel.py` — passed; re-run green on the rebased head (38 passed together with the new module).
- `tests/governance/test_issue_pr_governance.py` + `tests/deploy/test_deploy_channel.py` — 136 passed.
- `ruff check app tests companion-ui/companion-app` — all checks passed.
- `tests/ops/test_instance_state_volume_contract.py` — 7 failures, **pre-existing**: the identical 7 test ids fail on a clean `origin/main` worktree (macOS native-process enumeration). Not attributable to this diff; independently confirmed by the reviewer.
- `mypy scripts/instance_state_writer_inventory.py` — 15 errors on HEAD, identical 15 on `origin/main`; no regression. CI's gate is `mypy app`, which does not cover `scripts/`.
- `scripts/docs_guard.py` — passed with `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1`, declared here explicitly. No temporal owner doc was updated because no documented behavior or contract changes: the fix makes the code match the stability contract the docs already describe.

Base drift: `origin/main` advanced from `a2ef714` to `f0bafe6` during the independent review. The branch was rebased; the stable patch ID (`25da0a4e…`) and both delivery-owned blob hashes are byte-identical across the rebase, the incoming commits do not touch either delivery-owned path, and no repair or conflict resolution occurred. The bounded `Verify:` targets were re-run green on the rebased head.

---
