### PR TITLE
feat(ops): provision HEIMDAL_RAW_STORE_KEY to the api process

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -235,11 +235,28 @@ def _ingest_settings_at_startup() -> None:
         logger.warning("Settings ingestion at API startup failed: %s", exc)
 
 
+def _run_ingress_key_preflight() -> None:
+    """Detect a missing HEIMDAL_RAW_STORE_KEY before first use (#4422).
+
+    Degrade-visibly, never fail-exit: the preflight records and logs the
+    ingress-lane availability (surfaced on /api/status) while every other API
+    function keeps serving; the request-time raw_store_key_unavailable
+    contract on the capture routes is unchanged.
+    """
+    try:
+        from app.heimdal.ingress_preflight import run_ingress_preflight
+
+        run_ingress_preflight()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Heimdal ingress preflight failed to run: %s", exc)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.agent_memory.ask_provenance_manifest import start_ask_provenance_runtime
 
     start_ask_provenance_runtime()
+    _run_ingress_key_preflight()
     await _run_index_preflight()
     _log_v6_seam_status()
     _ingest_settings_at_startup()

--- a/app/heimdal/ingress_preflight.py
+++ b/app/heimdal/ingress_preflight.py
@@ -60,12 +60,14 @@ def run_ingress_preflight() -> IngressPreflightResult:
         resolve_raw_store_key()
         available = True
         detail = ""
-    except RawStoreKeyMissingError as exc:
+    except RawStoreKeyMissingError:
         available = False
-        detail = str(exc)
+        detail = "raw_store_key_missing"
     except Exception as exc:  # malformed key material etc. — same degradation
+        # Named class only, never the exception text: a future error embedding
+        # env material must not flow to the status surface.
         available = False
-        detail = f"{type(exc).__name__}: {exc}"
+        detail = f"raw_store_key_invalid:{type(exc).__name__}"
 
     state = STATE_AVAILABLE if available else STATE_UNAVAILABLE
     result = IngressPreflightResult(
@@ -80,7 +82,7 @@ def run_ingress_preflight() -> IngressPreflightResult:
             "Heimdal ingress preflight: HEIMDAL_RAW_STORE_KEY is not available to "
             "this process — the media and screen ingress lanes will refuse every "
             "admission with the named raw_store_key_unavailable 500 until it is "
-            "provisioned (host secret contract consumer 'api'). All other API "
+            "provisioned (host secret contract consumer 'heimdal-api-ingress'). All other API "
             "functions keep serving. Detail: %s",
             detail,
         )

--- a/app/heimdal/ingress_preflight.py
+++ b/app/heimdal/ingress_preflight.py
@@ -1,0 +1,112 @@
+"""Startup preflight for the governed ingress lanes' raw-store key (#4422).
+
+The media (`POST /api/heimdal/capture/media`) and screen
+(`POST /api/heimdal/screen/capture`) ingress lanes encrypt through the raw
+store, so they need ``HEIMDAL_RAW_STORE_KEY`` in the api process. Before this
+preflight, a missing key was invisible until the first upload returned the
+named 500 — a dead lane that looked calm (#4369's failure class).
+
+Posture is **degrade-visibly, never fail-exit**: the api process also serves
+search, ask, note-read, and text capture, so a missing key must not take the
+runtime down. The preflight runs once from the api lifespan, records a named
+result, logs loudly when the lanes are unavailable, and surfaces the lane
+state on ``/api/status`` — the request-time ``raw_store_key_unavailable``
+contract in the routes is unchanged and remains the per-request truth.
+
+Never logs, stores, or echoes key material — only availability.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from app.heimdal.raw_store import RawStoreKeyMissingError, resolve_raw_store_key
+
+logger = logging.getLogger(__name__)
+
+LANE_MEDIA = "media_ingress"
+LANE_SCREEN = "screen_capture"
+_KEY_LANES = (LANE_MEDIA, LANE_SCREEN)
+
+STATE_AVAILABLE = "available"
+STATE_UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class IngressPreflightResult:
+    """One recorded preflight outcome (no key material, ever)."""
+
+    raw_store_key_available: bool
+    lanes: Dict[str, str] = field(default_factory=dict)
+    detail: str = ""
+    checked_at: Optional[datetime] = None
+
+
+_LAST_RESULT: Optional[IngressPreflightResult] = None
+
+
+def run_ingress_preflight() -> IngressPreflightResult:
+    """Check the raw-store key once and record the lane availability.
+
+    Called from the api lifespan startup. Never raises and never exits the
+    process: an unavailable key is a named, logged, surfaced degradation of
+    exactly the ingress lanes, not a runtime failure.
+    """
+    global _LAST_RESULT
+    try:
+        resolve_raw_store_key()
+        available = True
+        detail = ""
+    except RawStoreKeyMissingError as exc:
+        available = False
+        detail = str(exc)
+    except Exception as exc:  # malformed key material etc. — same degradation
+        available = False
+        detail = f"{type(exc).__name__}: {exc}"
+
+    state = STATE_AVAILABLE if available else STATE_UNAVAILABLE
+    result = IngressPreflightResult(
+        raw_store_key_available=available,
+        lanes={lane: state for lane in _KEY_LANES},
+        detail=detail,
+        checked_at=datetime.now(timezone.utc),
+    )
+    _LAST_RESULT = result
+    if not available:
+        logger.error(
+            "Heimdal ingress preflight: HEIMDAL_RAW_STORE_KEY is not available to "
+            "this process — the media and screen ingress lanes will refuse every "
+            "admission with the named raw_store_key_unavailable 500 until it is "
+            "provisioned (host secret contract consumer 'api'). All other API "
+            "functions keep serving. Detail: %s",
+            detail,
+        )
+    else:
+        logger.info("Heimdal ingress preflight: raw-store key available; ingress lanes ready.")
+    return result
+
+
+def current_ingress_status() -> Optional[IngressPreflightResult]:
+    """The last recorded preflight result, or None before startup ran it."""
+    return _LAST_RESULT
+
+
+def reset_ingress_preflight() -> None:
+    """Test-only reset."""
+    global _LAST_RESULT
+    _LAST_RESULT = None
+
+
+__all__ = [
+    "LANE_MEDIA",
+    "LANE_SCREEN",
+    "STATE_AVAILABLE",
+    "STATE_UNAVAILABLE",
+    "IngressPreflightResult",
+    "current_ingress_status",
+    "reset_ingress_preflight",
+    "run_ingress_preflight",
+]

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -180,6 +180,19 @@ class IntegratedRuntimeCapabilityStatus(BaseModel):
     reasons: list[str] = Field(default_factory=list)
 
 
+class HeimdalIngressStatus(BaseModel):
+    """Startup-preflight availability of the governed ingress lanes (#4422).
+
+    Carries availability only — never key material. ``lanes`` maps
+    media_ingress/screen_capture to "available" or "unavailable".
+    """
+
+    raw_store_key_available: bool
+    lanes: Dict[str, str] = Field(default_factory=dict)
+    detail: str = ""
+    checked_at: Optional[datetime] = None
+
+
 class SystemStatus(BaseModel):
     timestamp: datetime
     environment: str
@@ -208,9 +221,11 @@ class SystemStatus(BaseModel):
     context_dimensions: Optional[ContextDimensionsStatus] = None
     v6_0_seams: Optional[Dict[str, str]] = None
     integrated_runtime_v1: Optional[Dict[str, IntegratedRuntimeCapabilityStatus]] = None
+    heimdal_ingress: Optional[HeimdalIngressStatus] = None
 
 
 __all__ = [
+    "HeimdalIngressStatus",
     "IngestionPlaneStatus",
     "StoreStatus",
     "IngestionStatus",

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -1235,6 +1235,30 @@ def _integrated_runtime_v1_matrix(
     return matrix
 
 
+def _get_heimdal_ingress_status():
+    """Project the startup ingress preflight (#4422) into /api/status.
+
+    Lazy import to keep observability decoupled from the heimdal package at
+    module import time; None before the lifespan preflight has run.
+    """
+    try:
+        from app.heimdal.ingress_preflight import current_ingress_status
+
+        result = current_ingress_status()
+    except Exception:  # pragma: no cover - status must never fail on this
+        return None
+    if result is None:
+        return None
+    from app.observability.status_model import HeimdalIngressStatus
+
+    return HeimdalIngressStatus(
+        raw_store_key_available=result.raw_store_key_available,
+        lanes=dict(result.lanes),
+        detail=result.detail,
+        checked_at=result.checked_at,
+    )
+
+
 def get_system_status() -> SystemStatus:
     sot_meta = get_sot_metadata()
     ingestion = get_ingestion_status()
@@ -1255,6 +1279,7 @@ def get_system_status() -> SystemStatus:
         ingestion=ingestion,
         worker_queue=worker_queue,
     )
+    heimdal_ingress = _get_heimdal_ingress_status()
     return SystemStatus(
         timestamp=datetime.now(timezone.utc),
         environment=active_environment(),
@@ -1282,6 +1307,7 @@ def get_system_status() -> SystemStatus:
         instance_provenance=_get_instance_provenance_status(),
         context_dimensions=_status_context_dimensions(Path(INDEX_OUTBOX_PATH)),
         v6_0_seams=_get_v6_seams(),
+        heimdal_ingress=heimdal_ingress,
         integrated_runtime_v1=_integrated_runtime_v1_matrix(
             write_guard=write_guard,
             worker_queue=worker_queue,

--- a/config/secrets/host_secret_contract.json
+++ b/config/secrets/host_secret_contract.json
@@ -2,7 +2,11 @@
   "version": 1,
   "keychain_service": "yggdrasil.host-secrets",
   "keychain_account_template": "{channel}:{consumer}:{secret}",
-  "channels": ["dev", "test", "prod"],
+  "channels": [
+    "dev",
+    "test",
+    "prod"
+  ],
   "secrets": [
     {
       "logical_id": "heimdal.raw-store-key",
@@ -22,26 +26,63 @@
   ],
   "consumers": [
     {
+      "consumer": "heimdal-api-ingress",
+      "channels": [
+        "dev",
+        "test",
+        "prod"
+      ],
+      "secrets": [
+        "heimdal.raw-store-key"
+      ],
+      "role_requirements": {}
+    },
+    {
       "consumer": "heimdal-capture-watch",
-      "channels": ["dev", "test", "prod"],
-      "secrets": ["heimdal.raw-store-key"],
+      "channels": [
+        "dev",
+        "test",
+        "prod"
+      ],
+      "secrets": [
+        "heimdal.raw-store-key"
+      ],
       "role_requirements": {}
     },
     {
       "consumer": "builderops-model-inquiry",
-      "channels": ["dev", "test", "prod"],
-      "secrets": ["openai.api-key", "anthropic.api-key"],
+      "channels": [
+        "dev",
+        "test",
+        "prod"
+      ],
+      "secrets": [
+        "openai.api-key",
+        "anthropic.api-key"
+      ],
       "role_requirements": {
-        "gpt_codex": ["openai.api-key"],
-        "fable": ["anthropic.api-key"]
+        "gpt_codex": [
+          "openai.api-key"
+        ],
+        "fable": [
+          "anthropic.api-key"
+        ]
       }
     },
     {
       "consumer": "builderops-ckm-semantic",
-      "channels": ["dev", "test", "prod"],
-      "secrets": ["openai.api-key"],
+      "channels": [
+        "dev",
+        "test",
+        "prod"
+      ],
+      "secrets": [
+        "openai.api-key"
+      ],
       "role_requirements": {
-        "ckm_semantic": ["openai.api-key"]
+        "ckm_semantic": [
+          "openai.api-key"
+        ]
       }
     }
   ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,6 +124,14 @@ services:
       - ./config/runtime.defaults.env
       - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
         required: false
+      # Governed host-secret layer for the declared `api` consumer (#4422):
+      # the deploy wrapper materializes the file from the Keychain and
+      # re-exports its handle as HOST_SECRET_RUNTIME_ENV_FILE_API (distinct
+      # from the capture-watch consumer's handle, which a nested bootstrap
+      # scrubs). Delivers HEIMDAL_RAW_STORE_KEY so the shipped media/screen
+      # ingress lanes can admit.
+      - path: ${HOST_SECRET_RUNTIME_ENV_FILE_API:-/dev/null}
+        required: false
     user: "${LOCAL_UID:-0}:${LOCAL_GID:-0}"
     volumes:
       # Dispatcher remains host-owned operational state. Mount its one shared

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -73,12 +73,19 @@ promote public internet readiness.
   arrived. Watched-folder admissions are receipted through the same seam (content-hash keyed) but
   gain no receipt-gated retention — that stays an outbox-lane property owned by CDLM-03. This slice
   ships no session/segment ledger, no ASR or derivation, no streaming/resumable upload, no auth
-  keys, and no public ingress: both routes refuse peers outside loopback/LAN/tailnet. **Operator
-  precondition, not yet provisioned:** admission encrypts through the raw store, so the api process
-  needs `HEIMDAL_RAW_STORE_KEY`, which `config/secrets/host_secret_contract.json` currently declares
-  for the `heimdal-capture-watch` consumer only; without it every admission returns a named 500
-  `raw_store_key_unavailable` / `not_acknowledged` rather than failing silently. The pre-existing
-  `POST /api/heimdal/screen/capture` shares that gap. Contract detail
+  keys, and no public ingress: both routes refuse peers outside loopback/LAN/tailnet. **Key
+  provisioning is delivered (#4422):** the api process is a declared consumer of
+  `heimdal.raw-store-key` (`heimdal-api-ingress` in `config/secrets/host_secret_contract.json`,
+  dev/test/prod); the governed deploy wrapper bootstraps its secret layer for every `up` that
+  includes the api service (degrade-visibly — a missing Keychain item or contract never fails the
+  deploy) and the `api` Compose service consumes it via its own env-file handle, without changing
+  how `heimdal-capture-watch` is provisioned. An api startup preflight detects a missing
+  `HEIMDAL_RAW_STORE_KEY` before first use, logs it loudly, and reports the media and screen
+  ingress lanes `unavailable` on `/api/status` while every other API function keeps serving; the
+  request-time named 500 `raw_store_key_unavailable` / `not_acknowledged` contract is unchanged.
+  The one remaining operator step is placing the actual key material into the Keychain item for
+  the `heimdal-api-ingress` consumer per channel (`{channel}:heimdal-api-ingress:heimdal.raw-store-key`
+  under service `yggdrasil.host-secrets`). Contract detail
   is owned by `docs/EVENTS.md :: Heimdal governed media ingress + durable receipts` and
   `docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/ADMIT_MEDIA_WITH_DURABLE_RECEIPTS.md`; promotion into
   `docs/contracts/MIMER_CLIENT_CONTRACT.md` §4 remains parent-acceptance work on #4383.
@@ -93,8 +100,8 @@ promote public internet readiness.
   emits `heimdal.meeting.segment.late_admitted` (the CDLM-06/08 re-derive trigger) without
   re-opening. Ledger state is durable — migration `a7c2e9f4b1d3` for Postgres/PDM, a file-backed
   SQLite lane for dev/test — so a hub restart rebuilds nothing from memory. The
-  `HEIMDAL_RAW_STORE_KEY` provisioning gap above bounds live use of the admission-fed segment path
-  the same way it bounds CDLM-01. Contract detail is owned by `docs/EVENTS.md` and
+  `HEIMDAL_RAW_STORE_KEY` posture above (provisioning delivered, key material an operator Keychain
+  step) bounds live use of the admission-fed segment path the same way it bounds CDLM-01. Contract detail is owned by `docs/EVENTS.md` and
   `docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/TRACK_MEETING_SESSIONS_AND_SEGMENT_GAPS.md`.
 - Live meeting projections are shipped (CDLM-06, #4386): every admitted meeting segment derives ASR
   exactly once per content hash through the shared engine seam (`app.media.transcribe.run_asr`),

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -137,9 +137,10 @@ _deploy_channel_needs_dev_capture_secret() {
 # The api process is a declared consumer of heimdal.raw-store-key (#4422): the
 # governed media/screen ingress lanes encrypt through the raw store. Bootstrap
 # fires whenever `up` includes the api service (named explicitly, or implied by
-# an un-filtered `up`). Posture is degrade-visibly, never fail-deploy:
-# --run-on-credential-unavailable launches the stack without the binding, and
-# the api startup preflight reports the ingress lanes unavailable.
+# an un-filtered `up`). Posture is degrade-visibly, never fail-deploy: the
+# availability precheck proves the contract and Keychain item resolve before
+# any wrap is added, so an unprovisioned key skips the layer loudly and the
+# api startup preflight reports the ingress lanes unavailable.
 # The api ingress secret layer is additive and degrade-visibly: when the host
 # secret contract cannot be loaded or does not declare the api consumer in this
 # environment (e.g. a harness root without config/secrets), the deploy proceeds

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -148,18 +148,40 @@ _deploy_channel_needs_dev_capture_secret() {
 # be prepared.
 _deploy_channel_api_ingress_bootstrap_available() {
   local channel="${1:?channel required}"
-  if "${PYTHON:-python3}" - "${channel}" <<'PY' 2>/dev/null
+  local root="${2:?repo root required}"
+  # Runs from ${root} with ${root} on PYTHONPATH: the contract path is
+  # repo-relative and the app package must be THIS deploy's, never whatever
+  # checkout the caller's shell happens to sit in.
+  # The precheck also proves the Keychain item is actually resolvable
+  # (value discarded, never printed): the bootstrap mechanism is fail-closed
+  # for kind raw-store-key, so wrapping compose while the item is missing
+  # would fail the whole deploy — the opposite of this slice's
+  # degrade-visibly posture. Missing item ⇒ skip the layer loudly; the api
+  # startup preflight then reports the ingress lanes unavailable.
+  if (
+    cd "${root}" \
+      && PYTHONPATH="${root}${PYTHONPATH:+:${PYTHONPATH}}" "${PYTHON:-python3}" - "${channel}" <<'PY' 2>/dev/null
 import sys
+
+from app.ops.host_secret_bootstrap import _security_keychain_lookup
 from app.ops.host_secret_contract import load_host_secret_contract
 
-load_host_secret_contract().require_declared(
+contract = load_host_secret_contract()
+contract.require_declared(
     channel=sys.argv[1], consumer="heimdal-api-ingress", secret="heimdal.raw-store-key"
 )
+account = contract.keychain_account(
+    channel=sys.argv[1], consumer="heimdal-api-ingress", secret="heimdal.raw-store-key"
+)
+value = _security_keychain_lookup(contract.keychain_service, account)
+if not value:
+    raise SystemExit(1)
 PY
+  )
   then
     return 0
   fi
-  echo "deploy: api ingress secret layer unavailable (contract missing or heimdal-api-ingress consumer undeclared); continuing without it — ingress lanes will report unavailable" >&2
+  echo "deploy: api ingress secret layer unavailable (contract missing, heimdal-api-ingress consumer undeclared, or Keychain item unresolvable); continuing without it — the api startup preflight will report the ingress lanes unavailable" >&2
   return 1
 }
 
@@ -316,19 +338,26 @@ deploy_channel_compose() {
     fi
 
     if _deploy_channel_needs_api_ingress_secret "${channel}" "$@" \
-        && _deploy_channel_api_ingress_bootstrap_available "${channel}"; then
+        && _deploy_channel_api_ingress_bootstrap_available "${channel}" "${root}"; then
       # Outer wrap: materialize the api consumer's secret env file, then
       # re-export its handle under HOST_SECRET_RUNTIME_ENV_FILE_API before the
       # (possibly nested) capture-watch bootstrap runs — that inner bootstrap
       # scrubs the shared HOST_SECRET_RUNTIME_ENV_FILE name from the child
       # environment, and the renamed handle is what the api service's
-      # env_file layer reads. Never echoes or logs a secret value; the file
-      # itself is bootstrap-owned and removed after Compose returns.
+      # env_file layer reads. The precheck above already proved the contract
+      # AND the Keychain item resolve, so a bootstrap failure here is a real
+      # fault, not the unprovisioned-key case (which skips the wrap). Runs
+      # from ${root} with ${root} on PYTHONPATH so the contract and app
+      # package are this deploy's; every compose path in the command is
+      # absolute or compose-file-relative, so the cd is inert for Compose.
+      # Never echoes or logs a secret value; the shim exports only a file
+      # path, and the file is bootstrap-owned and removed after Compose
+      # returns.
       compose_command=(
+        sh -c 'cd "$1" && export PYTHONPATH="$1${PYTHONPATH:+:${PYTHONPATH}}" && shift && exec "$@"' _ "${root}"
         "${PYTHON:-python3}" -m app.ops.host_secret_bootstrap
         --channel "${channel}"
         --consumer heimdal-api-ingress
-        --run-on-credential-unavailable
         -- sh -c 'export HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; exec "$@"' _
         "${compose_command[@]}"
       )

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -134,6 +134,52 @@ _deploy_channel_needs_dev_capture_secret() {
   return 1
 }
 
+# The api process is a declared consumer of heimdal.raw-store-key (#4422): the
+# governed media/screen ingress lanes encrypt through the raw store. Bootstrap
+# fires whenever `up` includes the api service (named explicitly, or implied by
+# an un-filtered `up`). Posture is degrade-visibly, never fail-deploy:
+# --run-on-credential-unavailable launches the stack without the binding, and
+# the api startup preflight reports the ingress lanes unavailable.
+# The api ingress secret layer is additive and degrade-visibly: when the host
+# secret contract cannot be loaded or does not declare the api consumer in this
+# environment (e.g. a harness root without config/secrets), the deploy proceeds
+# WITHOUT the layer — loudly — and the api startup preflight reports the
+# ingress lanes unavailable. A deploy never fails because this layer could not
+# be prepared.
+_deploy_channel_api_ingress_bootstrap_available() {
+  local channel="${1:?channel required}"
+  if "${PYTHON:-python3}" - "${channel}" <<'PY' 2>/dev/null
+import sys
+from app.ops.host_secret_contract import load_host_secret_contract
+
+load_host_secret_contract().require_declared(
+    channel=sys.argv[1], consumer="heimdal-api-ingress", secret="heimdal.raw-store-key"
+)
+PY
+  then
+    return 0
+  fi
+  echo "deploy: api ingress secret layer unavailable (contract missing or heimdal-api-ingress consumer undeclared); continuing without it — ingress lanes will report unavailable" >&2
+  return 1
+}
+
+_deploy_channel_needs_api_ingress_secret() {
+  local channel="${1:?channel required}"
+  shift
+  [ "${1:-}" = "up" ] || return 1
+  shift
+  local arg saw_service=0
+  for arg in "$@"; do
+    case "${arg}" in
+      -*) continue ;;
+    esac
+    saw_service=1
+    [ "${arg}" = "api" ] && return 0
+  done
+  [ "${saw_service}" = "0" ] && return 0
+  return 1
+}
+
 deploy_channel_compose() {
   local root="${1:?repo root required}"
   local channel="${2:?channel required}"
@@ -266,6 +312,25 @@ deploy_channel_compose() {
         --channel "${channel}"
         --consumer heimdal-capture-watch
         -- "${compose_command[@]}"
+      )
+    fi
+
+    if _deploy_channel_needs_api_ingress_secret "${channel}" "$@" \
+        && _deploy_channel_api_ingress_bootstrap_available "${channel}"; then
+      # Outer wrap: materialize the api consumer's secret env file, then
+      # re-export its handle under HOST_SECRET_RUNTIME_ENV_FILE_API before the
+      # (possibly nested) capture-watch bootstrap runs — that inner bootstrap
+      # scrubs the shared HOST_SECRET_RUNTIME_ENV_FILE name from the child
+      # environment, and the renamed handle is what the api service's
+      # env_file layer reads. Never echoes or logs a secret value; the file
+      # itself is bootstrap-owned and removed after Compose returns.
+      compose_command=(
+        "${PYTHON:-python3}" -m app.ops.host_secret_bootstrap
+        --channel "${channel}"
+        --consumer heimdal-api-ingress
+        --run-on-credential-unavailable
+        -- sh -c 'export HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; exec "$@"' _
+        "${compose_command[@]}"
       )
     fi
 

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -359,7 +359,7 @@ deploy_channel_compose() {
         "${PYTHON:-python3}" -m app.ops.host_secret_bootstrap
         --channel "${channel}"
         --consumer heimdal-api-ingress
-        -- sh -c 'export HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; exec "$@"' _
+        -- sh -c 'export HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; unset HOST_SECRET_RUNTIME_ENV_FILE; exec "$@"' _
         "${compose_command[@]}"
       )
     fi

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -999,6 +999,11 @@ def test_api_service_receives_raw_store_key() -> None:
     assert "_security_keychain_lookup" in lib
     assert "continuing without it" in lib
     assert 'HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"' in lib
+    # The shim must also UNSET the shared handle: on a dev unfiltered `up`
+    # no inner capture-watch bootstrap runs to scrub it, and a lingering
+    # shared handle would deliver the api consumer's layer to the
+    # capture-watch service's env_file chain.
+    assert "unset HOST_SECRET_RUNTIME_ENV_FILE;" in lib
     # The capture-watch provisioning is unchanged.
     assert "--consumer heimdal-capture-watch" in lib
     assert "_deploy_channel_needs_dev_capture_secret" in lib
@@ -1056,17 +1061,36 @@ def test_api_service_receives_raw_store_key() -> None:
     # still sees the renamed api handle.
     shim = (
         'export HOST_SECRET_RUNTIME_ENV_FILE_API='
-        '"${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; exec "$@"'
+        '"${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; '
+        'unset HOST_SECRET_RUNTIME_ENV_FILE; exec "$@"'
     )
+    probe_env = (
+        'printf "%s|%s" "${HOST_SECRET_RUNTIME_ENV_FILE_API:-missing}" '
+        '"${HOST_SECRET_RUNTIME_ENV_FILE:-scrubbed}"'
+    )
+    # Without any inner bootstrap (the dev unfiltered-up shape): the shim
+    # itself must scrub the shared handle so it can never reach the
+    # capture-watch service's env_file chain.
+    run = subprocess.run(
+        [
+            "env", "HOST_SECRET_RUNTIME_ENV_FILE=/tmp/api-layer.env",
+            "sh", "-c", shim, "_",
+            "sh", "-c", probe_env,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert run.stdout == "/tmp/api-layer.env|scrubbed", run.stderr
+    # And with a simulated nested capture-watch bootstrap scrub in between,
+    # the renamed api handle still survives.
     inner_scrub = 'unset HOST_SECRET_RUNTIME_ENV_FILE HEIMDAL_RAW_STORE_KEY; exec "$@"'
     run = subprocess.run(
         [
             "env", "HOST_SECRET_RUNTIME_ENV_FILE=/tmp/api-layer.env",
             "sh", "-c", shim, "_",
             "sh", "-c", inner_scrub, "_",
-            "sh", "-c",
-            'printf "%s|%s" "${HOST_SECRET_RUNTIME_ENV_FILE_API:-missing}" '
-            '"${HOST_SECRET_RUNTIME_ENV_FILE:-scrubbed}"',
+            "sh", "-c", probe_env,
         ],
         check=False,
         capture_output=True,

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -977,3 +977,68 @@ def test_same_target_retry_preserves_rollback_anchor(tmp_path: Path) -> None:
         "the rollback anchor must survive a same-target retry"
     )
     assert f"APP_IMAGE_TAG={target}" in (root / "config/deploy/dev.env").read_text(encoding="utf-8")
+
+
+def test_api_service_receives_raw_store_key() -> None:
+    """#4422: the deploy wrapper bootstraps the declared api consumer and the
+    api service consumes its materialized secret layer, without changing how
+    heimdal-capture-watch is provisioned."""
+    lib = (REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh").read_text(
+        encoding="utf-8"
+    )
+    # The api consumer bootstrap wrap exists, degrade-visibly, and re-exports
+    # its env-file handle under the api-specific name before any nested
+    # capture-watch bootstrap can scrub the shared one.
+    assert "_deploy_channel_needs_api_ingress_secret" in lib
+    assert "--consumer heimdal-api-ingress" in lib
+    assert "--run-on-credential-unavailable" in lib
+    assert 'HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"' in lib
+    # The capture-watch provisioning is unchanged.
+    assert "--consumer heimdal-capture-watch" in lib
+    assert "_deploy_channel_needs_dev_capture_secret" in lib
+
+    syntax = subprocess.run(
+        ["bash", "-n", str(REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh")],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+    # The api service's env_file chain consumes the api consumer's layer.
+    import yaml
+
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8"))
+    env_files = compose["services"]["api"]["env_file"]
+    api_layers = [
+        entry
+        for entry in env_files
+        if isinstance(entry, dict)
+        and "HOST_SECRET_RUNTIME_ENV_FILE_API" in str(entry.get("path", ""))
+    ]
+    assert len(api_layers) == 1
+    assert api_layers[0].get("required") is False
+
+    # The gating helper fires for an unfiltered `up` and for `up api`, not for
+    # unrelated service-scoped ups, in every channel.
+    probe = (
+        'source "$1"; shift; '
+        "if _deploy_channel_needs_api_ingress_secret \"$@\"; then echo yes; else echo no; fi"
+    )
+    lib_path = str(REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh")
+
+    def gate(*args: str) -> str:
+        run = subprocess.run(
+            ["bash", "-c", probe, "_", lib_path, *args],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return run.stdout.strip().splitlines()[-1] if run.stdout.strip() else run.stderr
+
+    assert gate("prod", "up", "-d") == "yes"
+    assert gate("test", "up", "-d", "api") == "yes"
+    assert gate("dev", "up", "-d", "heimdal-capture-watch") == "no"
+    assert gate("dev", "logs") == "no"

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -990,8 +990,14 @@ def test_api_service_receives_raw_store_key() -> None:
     # its env-file handle under the api-specific name before any nested
     # capture-watch bootstrap can scrub the shared one.
     assert "_deploy_channel_needs_api_ingress_secret" in lib
+    assert "_deploy_channel_api_ingress_bootstrap_available" in lib
     assert "--consumer heimdal-api-ingress" in lib
-    assert "--run-on-credential-unavailable" in lib
+    # Degrade-visibly: the precheck proves contract + Keychain item resolve
+    # before the wrap is added, so an unprovisioned key skips the layer
+    # loudly instead of failing the deploy (the bootstrap mechanism is
+    # fail-closed for kind raw-store-key).
+    assert "_security_keychain_lookup" in lib
+    assert "continuing without it" in lib
     assert 'HOST_SECRET_RUNTIME_ENV_FILE_API="${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"' in lib
     # The capture-watch provisioning is unchanged.
     assert "--consumer heimdal-capture-watch" in lib
@@ -1042,3 +1048,28 @@ def test_api_service_receives_raw_store_key() -> None:
     assert gate("test", "up", "-d", "api") == "yes"
     assert gate("dev", "up", "-d", "heimdal-capture-watch") == "no"
     assert gate("dev", "logs") == "no"
+
+    # Functional proof of the handle-rename shim and its survival across the
+    # nested capture-watch bootstrap's environment scrub: the outer shim
+    # renames the shared handle, a simulated inner bootstrap unsets the shared
+    # name (exactly what _clean_child_environment does), and the final child
+    # still sees the renamed api handle.
+    shim = (
+        'export HOST_SECRET_RUNTIME_ENV_FILE_API='
+        '"${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"; exec "$@"'
+    )
+    inner_scrub = 'unset HOST_SECRET_RUNTIME_ENV_FILE HEIMDAL_RAW_STORE_KEY; exec "$@"'
+    run = subprocess.run(
+        [
+            "env", "HOST_SECRET_RUNTIME_ENV_FILE=/tmp/api-layer.env",
+            "sh", "-c", shim, "_",
+            "sh", "-c", inner_scrub, "_",
+            "sh", "-c",
+            'printf "%s|%s" "${HOST_SECRET_RUNTIME_ENV_FILE_API:-missing}" '
+            '"${HOST_SECRET_RUNTIME_ENV_FILE:-scrubbed}"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert run.stdout == "/tmp/api-layer.env|scrubbed", run.stderr

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -1057,3 +1057,68 @@ def test_append_only_enforced_pg_media_receipt(monkeypatch: pytest.MonkeyPatch) 
         )
     finally:
         conn.close()
+
+
+def test_startup_preflight_reports_ingress_unavailable_without_exiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#4422 enforcement: with the key absent, the api LIFESPAN startup runs the
+    ingress preflight, the status surface reports both ingress lanes
+    unavailable before any request, the process serves unrelated routes, and
+    the request-time raw_store_key_unavailable contract is unchanged."""
+    from app.heimdal import ingress_preflight
+
+    monkeypatch.delenv("HEIMDAL_RAW_STORE_KEY", raising=False)
+    ingress_preflight.reset_ingress_preflight()
+    assert ingress_preflight.current_ingress_status() is None
+
+    # TestClient's context manager runs the real lifespan — the production
+    # startup path, not the helper in isolation.
+    with TestClient(app) as started:
+        recorded = ingress_preflight.current_ingress_status()
+        assert recorded is not None
+        assert recorded.raw_store_key_available is False
+        assert recorded.lanes == {
+            "media_ingress": "unavailable",
+            "screen_capture": "unavailable",
+        }
+
+        # Surfaced on the status endpoint before any ingress request was made.
+        status = started.get("/api/status")
+        assert status.status_code == 200
+        ingress = status.json()["heimdal_ingress"]
+        assert ingress["raw_store_key_available"] is False
+        assert ingress["lanes"]["media_ingress"] == "unavailable"
+        assert ingress["lanes"]["screen_capture"] == "unavailable"
+
+        # Unrelated routes keep serving: the process did not exit or degrade.
+        assert started.get("/api/health").status_code in (200, 503)
+
+        # The request-time named contract is unchanged.
+        media = b"still refused bytes"
+        refused = _post_media(started, media, _sidecar(media))
+        assert refused.status_code == 500
+        assert refused.json()["detail"]["error"] == "raw_store_key_unavailable"
+        assert refused.json()["detail"]["state"] == "not_acknowledged"
+
+
+def test_admission_succeeds_when_key_provisioned(client: TestClient) -> None:
+    """#4422: with the key present, the preflight passes and admission returns
+    a durable receipt through the production route."""
+    from app.heimdal import ingress_preflight
+
+    ingress_preflight.reset_ingress_preflight()
+    with TestClient(app) as started:
+        recorded = ingress_preflight.current_ingress_status()
+        assert recorded is not None
+        assert recorded.raw_store_key_available is True
+        assert recorded.lanes == {
+            "media_ingress": "available",
+            "screen_capture": "available",
+        }
+        media = b"provisioned admission bytes"
+        admitted = _post_media(started, media, _sidecar(media))
+        assert admitted.status_code == 200, admitted.text
+        body = admitted.json()
+        assert body["outcome"] == "admitted"
+        assert body["receipt_id"].startswith("rcp_")

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -207,6 +207,12 @@ def test_model_inquiry_secret_contract_is_exact_and_value_free() -> None:
     ]
     assert payload["consumers"] == [
         {
+            "consumer": "heimdal-api-ingress",
+            "channels": ["dev", "test", "prod"],
+            "secrets": ["heimdal.raw-store-key"],
+            "role_requirements": {},
+        },
+        {
             "consumer": "heimdal-capture-watch",
             "channels": ["dev", "test", "prod"],
             "secrets": ["heimdal.raw-store-key"],
@@ -298,3 +304,24 @@ def test_channel_isolation_holds_for_model_provider_secrets() -> None:
             consumer="builderops-model-inquiry",
             secret="openai.api-key",
         )
+
+
+def test_api_consumer_declares_raw_store_key() -> None:
+    """#4422: the api process (consumer heimdal-api-ingress) is declared of heimdal.raw-store-key.
+
+    Loaded through the production loader with its existing validation, for
+    every channel the ingress lane serves — and the pre-existing
+    heimdal-capture-watch declaration is unchanged.
+    """
+    contract = load_host_secret_contract()
+    for channel in ("dev", "test", "prod"):
+        contract.require_declared(
+            channel=channel, consumer="heimdal-api-ingress", secret="heimdal.raw-store-key"
+        )
+        contract.require_declared(
+            channel=channel,
+            consumer="heimdal-capture-watch",
+            secret="heimdal.raw-store-key",
+        )
+    with pytest.raises(UndeclaredSecretConsumerError):
+        contract.require_declared(channel="dev", consumer="heimdal-api-ingress", secret="openai.api-key")


### PR DESCRIPTION
Governing-Issue: #4422

Fixes #4422

Final-Review-Rounds: 2

## Summary
Makes the shipped media/screen ingress lanes able to admit in a running channel: declares the `heimdal-api-ingress` consumer for `heimdal.raw-store-key` in the host secret contract (dev/test/prod; capture-watch unchanged); the governed deploy wrapper adds the api secret layer for every `up` that includes the api service, **degrade-visibly** — an availability precheck proves the contract and the Keychain item resolve (value discarded, never printed) before any wrap is added, so an unprovisioned key skips the layer loudly instead of failing the deploy (the bootstrap mechanism stays untouched and fail-closed); the materialized handle is re-exported as `HOST_SECRET_RUNTIME_ENV_FILE_API` so it survives the nested capture-watch bootstrap's environment scrub, and the base `api` Compose service consumes it via a dedicated optional env-file layer. An api-lifespan startup preflight detects a missing `HEIMDAL_RAW_STORE_KEY` before first use, logs it loudly, and reports both ingress lanes `unavailable` on `/api/status` (named reasons only, never exception text) while every other API function keeps serving; the request-time `raw_store_key_unavailable` contract is unchanged. Both the precheck and the bootstrap run anchored to the deploy root so the contract and app package are this deploy's, never the caller's CWD. The single remaining operator step — placing the actual key material into `{channel}:heimdal-api-ingress:heimdal.raw-store-key` under service `yggdrasil.host-secrets` — is stated in `docs/STATUS.md`.

## Claim receipt
`pickup-claim-complete issue=4422 branch=feat/4422-rawkey-api-provisioning worktree=/Users/rasmus/worktrees/rawkey-4422 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4422 lease_id=lease-b6bde9a3 holder=cdlm-hub-coordinator evidence=verified-dispatcher-lease`

## Risk gates
- TCD risk surfaces: security, credential-durability. `scripts/review_before_ci_gate.py` satisfied at push SHA.
- Convergence packet (`heimdal-api-ingress-secret`) built; pre-CI independent review found one P0 (the mechanism's degrade flag is inert for kind `raw-store-key`, so a missing Keychain item would have failed the whole deploy) and one P1 (contract/app resolution from the caller's CWD — silent skip or cross-repo secret-path divergence) plus a P2 (textual-only deploy proof) — all fixed; post-fix convergence re-review CLEAN (P3 residuals recorded: precheck uses the mechanism's private lookup helper; keychain-locked conflates with unprovisioned under the degrade posture; millisecond precheck→bootstrap TOCTOU documented).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: no plan divergence with a repairable upstream artifact; claim state carried by the lease receipt above.

## Notes
Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/ops/test_host_secret_contract.py tests/deploy/test_deploy_channel_script.py tests/heimdal/test_media_ingress.py` — 104 passed, including the two new AC tests (the missing-key test drives the real api lifespan startup path via TestClient's context manager and asserts /api/status lane state, an unrelated route serving, and the unchanged request-time 500; the deploy test functionally proves the handle-rename shim survives a simulated inner-bootstrap scrub and probes the gating helper's call shapes). The existing 38 media-ingress tests stay green.
- Full `pytest -m "not pg and not alpha_llm" -n auto tests` — 11850 passed; failures were the known pre-existing host-environment set and the two parallel-only flakes (pass serially).
- `ruff` clean; `mypy app` clean (833 files); `docs_guard.py` OK; `bash -n` clean on the deploy wrapper.
---