### PR TITLE
feat(heimdal): CDLM-10 composed cross-device round-trip proof

### DIFF
--- a/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/README.md
+++ b/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/README.md
@@ -175,10 +175,12 @@ receipts are recorded on the parent issue.
   **superseded as the target contract** by CDLM-03's receipt-gated retention for everything the
   outbox carries. The watched-folder lane continues to exist as the phoneless/legacy floor without
   receipt-gated retention, stated honestly.
-- **bifrost#21 (HCAP-09 UAT)** remains later validation work and is blocked on this vertical's
-  foundation (its body carries the 2026-07-29 product-priority reconciliation); its journeys will
-  compose with the outbox and receipt states once CDLM-03/05 land. Its label was corrected
-  `agent:ready` → `agent:blocked` on 2026-07-29, naming bifrost#57/#59 and hub #4389 as blockers.
+- **bifrost#21 (HCAP-09 UAT)** is now the named remaining **human step** — the physical-device
+  walkthrough (locked-screen capture, real calls, wrist haptics, on-device app-lifecycle truths).
+  CDLM-10's scripted proof (#4389, `scripts/cdlm_roundtrip_proof.py`) covers the hub contract and
+  the simulator-verifiable composition only; those simulator-only limits are stated in its run
+  report on #4383. With CDLM-03/05/08/09 delivered and the CDLM-10 receipt posted, bifrost#21 is
+  unblocked for the operator's walkthrough.
 - **Execution gate G-CI is retired (2026-07-30).** This directory originally required bifrost#52
   to be fixed, or local `xcodebuild test` evidence attached, before any bifrost child could merge.
   That gate rested on a stale premise: all three defects bifrost#52 described had already been

--- a/docs/architecture/inv-ef1-register.json
+++ b/docs/architecture/inv-ef1-register.json
@@ -115,14 +115,14 @@
     },
     {
       "artifact": "companion-ui/design_handoff/2026-05-24-vault-browser-foundation/VAULT_BROWSER_DESIGN_HANDOFF.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "companion-ui/design_handoff/2026-05-24-vault-browser-foundation/VAULT_BROWSER_DESIGN_HANDOFF.md",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -185,14 +185,14 @@
     },
     {
       "artifact": "companion-ui/design_handoff/2026-07-07-uat-design-audit/DESIGN_AUDIT.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "companion-ui/design_handoff/2026-07-07-uat-design-audit/DESIGN_AUDIT.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -227,14 +227,14 @@
     },
     {
       "artifact": "companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -254,11 +254,11 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/AGENT_ISSUE_DISPATCHER.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "artifact": "docker-compose.prod.yml",
+      "category": "iii",
+      "why_load_bearing": "Production Compose documents the operator-bound host capacity constraint needed to avoid an unsafe Ollama topology.",
       "disposition": "stay",
-      "issue": "#2892"
+      "issue": "#3462"
     },
     {
       "artifact": "docs/AGENT_ISSUE_DISPATCHER.md",
@@ -268,7 +268,7 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/BIFROST/APP_DEPLOYMENT_POSTURE.md",
+      "artifact": "docs/AGENT_ISSUE_DISPATCHER.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -282,7 +282,7 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/BIFROST/APP_TOPOLOGY_AND_PLATFORMS.md",
+      "artifact": "docs/BIFROST/APP_DEPLOYMENT_POSTURE.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -291,6 +291,13 @@
     {
       "artifact": "docs/BIFROST/APP_TOPOLOGY_AND_PLATFORMS.md",
       "category": "ii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/BIFROST/APP_TOPOLOGY_AND_PLATFORMS.md",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -374,69 +381,6 @@
     },
     {
       "artifact": "docs/COMPANION_UI_DEEP_REVIEW_REMEDIATION/MIST_LADDER_SUBTRACTIVE.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/DAILY_BRIEFING/README.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/DOCS_INDEX.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/DOCS_INDEX.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/EMBEDDING_RELIABILITY/GOOGLE_GEMINI_ADAPTER.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/EMBEDDING_RELIABILITY/OPERATOR_EGRESS_DECISION.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/EMBEDDING_RELIABILITY/README.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/COMMIT_OPERATION_AND_OUTBOX_VISIBILITY.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/PARENT_FEATURE_ISSUE.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -527,6 +471,76 @@
       "issue": "#2892"
     },
     {
+      "artifact": "docs/DAILY_BRIEFING/README.md",
+      "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/DOCS_INDEX.md",
+      "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/DOCS_INDEX.md",
+      "category": "iv",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/EMBEDDING_RELIABILITY/GOOGLE_GEMINI_ADAPTER.md",
+      "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/EMBEDDING_RELIABILITY/OPERATOR_EGRESS_DECISION.md",
+      "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/EMBEDDING_RELIABILITY/README.md",
+      "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/COMMIT_OPERATION_AND_OUTBOX_VISIBILITY.md",
+      "category": "iv",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/PARENT_FEATURE_ISSUE.md",
+      "category": "iv",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md",
+      "category": "iv",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/ENVIRONMENTS.md",
+      "category": "iii",
+      "why_load_bearing": "The production topology runbook documents the operator-bound Mac mini capacity constraint needed for a safe redeploy.",
+      "disposition": "stay",
+      "issue": "#3462"
+    },
+    {
       "artifact": "docs/ENVIRONMENTS.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
@@ -591,14 +605,14 @@
     },
     {
       "artifact": "docs/EPISODE_RESOLUTION_ENGINE/README.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/EPISODE_RESOLUTION_ENGINE/README.md",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -626,6 +640,13 @@
     },
     {
       "artifact": "docs/HEIMDAL/CAPTURE_TRANSPORT_FEASIBILITY.md",
+      "category": "ii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/HEIMDAL/CAPTURE_TRANSPORT_FEASIBILITY.md",
       "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -634,13 +655,6 @@
     {
       "artifact": "docs/HEIMDAL/CAPTURE_TRANSPORT_FEASIBILITY.md",
       "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/HEIMDAL/CAPTURE_TRANSPORT_FEASIBILITY.md",
-      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -759,13 +773,6 @@
     },
     {
       "artifact": "docs/HEIMDAL_CAPTURE_CLIENT/README.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/HEIMDAL_CAPTURE_CLIENT/README.md",
       "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -774,6 +781,13 @@
     {
       "artifact": "docs/HEIMDAL_CAPTURE_CLIENT/README.md",
       "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/HEIMDAL_CAPTURE_CLIENT/README.md",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -794,14 +808,14 @@
     },
     {
       "artifact": "docs/HEIMDAL_SCREEN_STREAM/BUILD_MACOS_OBSERVER_CLIENT.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/HEIMDAL_SCREEN_STREAM/BUILD_MACOS_OBSERVER_CLIENT.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -822,20 +836,13 @@
     },
     {
       "artifact": "docs/HEIMDAL_SCREEN_STREAM/PARENT_FEATURE_ISSUE.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/HEIMDAL_SCREEN_STREAM/PARENT_FEATURE_ISSUE.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/HEIMDAL_SCREEN_STREAM/README.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -849,7 +856,7 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/HUMAN-FLOWS.md",
+      "artifact": "docs/HEIMDAL_SCREEN_STREAM/README.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -858,6 +865,13 @@
     {
       "artifact": "docs/HUMAN-FLOWS.md",
       "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/HUMAN-FLOWS.md",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -955,14 +969,14 @@
     },
     {
       "artifact": "docs/MIMER_IPAD_THINKING_CANVAS/README.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/MIMER_IPAD_THINKING_CANVAS/README.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -997,20 +1011,13 @@
     },
     {
       "artifact": "docs/MIMER_VOICE_LOOP/PARENT_FEATURE_ISSUE.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/MIMER_VOICE_LOOP/PARENT_FEATURE_ISSUE.md",
-      "category": "iii",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/MIMER_VOICE_LOOP/README.md",
       "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1019,6 +1026,13 @@
     {
       "artifact": "docs/MIMER_VOICE_LOOP/README.md",
       "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/MIMER_VOICE_LOOP/README.md",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1053,14 +1067,14 @@
     },
     {
       "artifact": "docs/RELEASE_CHANNELS/README.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/RELEASE_CHANNELS/README.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1151,14 +1165,14 @@
     },
     {
       "artifact": "docs/YGGDRASIL_APP_SHELL_COMPLETION/README.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/YGGDRASIL_APP_SHELL_COMPLETION/README.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1214,6 +1228,13 @@
     },
     {
       "artifact": "docs/adr/ADR-0046-inv-ef1-public-private-seam.md",
+      "category": "ii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/adr/ADR-0046-inv-ef1-public-private-seam.md",
       "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1222,13 +1243,6 @@
     {
       "artifact": "docs/adr/ADR-0046-inv-ef1-public-private-seam.md",
       "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/adr/ADR-0046-inv-ef1-public-private-seam.md",
-      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1249,14 +1263,14 @@
     },
     {
       "artifact": "docs/adr/ADR-0050-cross-repo-governance-and-bifrost-client-repo.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/adr/ADR-0050-cross-repo-governance-and-bifrost-client-repo.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1270,14 +1284,14 @@
     },
     {
       "artifact": "docs/adr/ADR-0053-interim-vault-multiwriter-posture.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/adr/ADR-0053-interim-vault-multiwriter-posture.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1291,14 +1305,14 @@
     },
     {
       "artifact": "docs/adr/ADR-0055-vault-multiwriter-consistency-model.md",
-      "category": "iv",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/adr/ADR-0055-vault-multiwriter-consistency-model.md",
-      "category": "ii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1389,6 +1403,13 @@
     },
     {
       "artifact": "docs/architecture/ecosystem-federation.md",
+      "category": "ii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/architecture/ecosystem-federation.md",
       "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1402,14 +1423,14 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/architecture/ecosystem-federation.md",
-      "category": "ii",
+      "artifact": "docs/archive/INTEGRATED_RUNTIME_V1/FABLE_HANDOFF_PROMPT.md",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
-      "artifact": "docs/archive/INTEGRATED_RUNTIME_V1/FABLE_HANDOFF_PROMPT.md",
+      "artifact": "docs/audits/ADR-0062_POST_RATIFICATION_2026-07-16.md",
       "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1431,6 +1452,13 @@
     },
     {
       "artifact": "docs/audits/MIMER_WHOLE_SYSTEM_INTEGRATION_2026-07-05.md",
+      "category": "ii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/audits/MIMER_WHOLE_SYSTEM_INTEGRATION_2026-07-05.md",
       "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1439,13 +1467,6 @@
     {
       "artifact": "docs/audits/MIMER_WHOLE_SYSTEM_INTEGRATION_2026-07-05.md",
       "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/audits/MIMER_WHOLE_SYSTEM_INTEGRATION_2026-07-05.md",
-      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1465,8 +1486,8 @@
       "issue": "#2892"
     },
     {
-      "artifact": "docs/audits/ADR-0062_POST_RATIFICATION_2026-07-16.md",
-      "category": "iii",
+      "artifact": "docs/contracts/MIMER_CLIENT_CONTRACT.md",
+      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1474,13 +1495,6 @@
     {
       "artifact": "docs/contracts/MIMER_CLIENT_CONTRACT.md",
       "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/contracts/MIMER_CLIENT_CONTRACT.md",
-      "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1529,13 +1543,6 @@
     },
     {
       "artifact": "docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md",
-      "category": "iv",
-      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
-      "disposition": "stay",
-      "issue": "#2892"
-    },
-    {
-      "artifact": "docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md",
       "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
@@ -1544,6 +1551,13 @@
     {
       "artifact": "docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md",
       "category": "iii",
+      "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1585,14 +1599,14 @@
     },
     {
       "artifact": "docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
     },
     {
       "artifact": "docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",
       "disposition": "stay",
       "issue": "#2892"
@@ -1638,6 +1652,13 @@
       "why_load_bearing": "Existing repository artifact retains an operator-bound reference pending its scoped migration review.",
       "disposition": "migrate-to-private-sibling",
       "issue": "#2892"
+    },
+    {
+      "artifact": "scripts/cdlm_roundtrip_proof.py",
+      "category": "iv",
+      "why_load_bearing": "The CDLM-10 composed proof script names the Bifrost client repo whose build SHA and delivered slices its run report must cite (#4389); the reference is repo-coordination lineage, not an operator-bound host detail.",
+      "disposition": "stay",
+      "issue": "#4389"
     },
     {
       "artifact": "scripts/dev/dev_ui_doctor.sh",
@@ -1690,14 +1711,14 @@
     },
     {
       "artifact": "scripts/start_full_system.sh",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Builder or channel automation still refers to an operator-bound deployment value.",
       "disposition": "parameterize",
       "issue": "#2892"
     },
     {
       "artifact": "scripts/start_full_system.sh",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Builder or channel automation still refers to an operator-bound deployment value.",
       "disposition": "parameterize",
       "issue": "#2892"
@@ -1795,14 +1816,14 @@
     },
     {
       "artifact": "tests/capture/test_capture_writer_layout.py",
-      "category": "iii",
+      "category": "ii",
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
     },
     {
       "artifact": "tests/capture/test_capture_writer_layout.py",
-      "category": "ii",
+      "category": "iii",
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
@@ -1963,14 +1984,14 @@
     },
     {
       "artifact": "tests/companion_ui/test_workspace_shell_alignment.py",
-      "category": "iv",
+      "category": "iii",
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
     },
     {
       "artifact": "tests/companion_ui/test_workspace_shell_alignment.py",
-      "category": "iii",
+      "category": "iv",
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
@@ -2016,6 +2037,13 @@
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
+    },
+    {
+      "artifact": "tests/heimdal/test_cdlm_roundtrip_script.py",
+      "category": "iv",
+      "why_load_bearing": "The proof-script contract test asserts the run report names the Bifrost client walkthrough as the remaining human step (#4389); repo-coordination lineage, not an operator-bound host detail.",
+      "disposition": "stay",
+      "issue": "#4389"
     },
     {
       "artifact": "tests/ops/test_builderops_startup_bootstrap.py",
@@ -2100,20 +2128,6 @@
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",
       "disposition": "parameterize",
       "issue": "#2892"
-    },
-    {
-      "artifact": "docker-compose.prod.yml",
-      "category": "iii",
-      "why_load_bearing": "Production Compose documents the operator-bound host capacity constraint needed to avoid an unsafe Ollama topology.",
-      "disposition": "stay",
-      "issue": "#3462"
-    },
-    {
-      "artifact": "docs/ENVIRONMENTS.md",
-      "category": "iii",
-      "why_load_bearing": "The production topology runbook documents the operator-bound Mac mini capacity constraint needed for a safe redeploy.",
-      "disposition": "stay",
-      "issue": "#3462"
     },
     {
       "artifact": "vault/_system/events/ingest.log.jsonl",

--- a/scripts/cdlm_roundtrip_proof.py
+++ b/scripts/cdlm_roundtrip_proof.py
@@ -268,7 +268,12 @@ def stage_1_multi_modality(hub: Hub) -> StageResult:
     return result
 
 
-def stage_2_kill_restart(hub: Hub, api_container: Optional[str], admissions: List[Dict[str, Any]]) -> StageResult:
+def stage_2_kill_restart(
+    hub: Hub,
+    api_container: Optional[str],
+    admissions: List[Dict[str, Any]],
+    restart_cmd: Optional[str] = None,
+) -> StageResult:
     result = StageResult(stage=2, id="kill_restart_chaos")
     if not admissions:
         result.status = "limited"
@@ -278,12 +283,19 @@ def stage_2_kill_restart(hub: Hub, api_container: Optional[str], admissions: Lis
     ids = "&".join(f"capture_id={a['capture_id']}" for a in admissions)
     result.evidence["pre_restart_receipts"] = hub.get(f"/api/heimdal/capture/receipts?{ids}")
 
-    if api_container:
-        restart = subprocess.run(
-            ["docker", "restart", api_container], capture_output=True, text=True, check=False
-        )
+    if api_container or restart_cmd:
+        if api_container:
+            restart = subprocess.run(
+                ["docker", "restart", api_container], capture_output=True, text=True, check=False
+            )
+            restart_evidence = {"container": api_container}
+        else:
+            restart = subprocess.run(
+                ["sh", "-c", restart_cmd], capture_output=True, text=True, check=False
+            )
+            restart_evidence = {"restart_cmd": restart_cmd}
         result.evidence["restart"] = {
-            "container": api_container,
+            **restart_evidence,
             "returncode": restart.returncode,
             "stderr_tail": restart.stderr[-400:],
         }
@@ -306,8 +318,9 @@ def stage_2_kill_restart(hub: Hub, api_container: Optional[str], admissions: Lis
         result.status = "limited"
         result.evidence["restart"] = {"skipped": True}
         result.limits.append(
-            "no --api-container handle provided; a real process restart was not exercised "
-            "in this run (receipts durability is still asserted by re-query below)"
+            "no --api-container or --restart-cmd handle provided; a real process restart "
+            "was not exercised in this run (receipts durability is still asserted by "
+            "re-query below)"
         )
 
     result.evidence["post_restart_receipts"] = hub.get(f"/api/heimdal/capture/receipts?{ids}")
@@ -392,7 +405,26 @@ def _admit_segment(hub: Hub, session_id: str, seq: int, media: bytes) -> Dict[st
     return out
 
 
-def stage_4_live_meeting(hub: Hub) -> StageResult:
+def _load_audio_fixtures(fixture_dir: Optional[str], prefix: str, count: int) -> Optional[Dict[int, bytes]]:
+    """Real speech fixtures for the meeting stages, when provided.
+
+    The live hub runs the real ASR engine, which (correctly) refuses
+    non-audio bytes — so an honest live run feeds real audio. Returns None
+    when the directory or any expected file is absent.
+    """
+    if not fixture_dir:
+        return None
+    base = Path(fixture_dir)
+    fixtures: Dict[int, bytes] = {}
+    for seq in range(count):
+        path = base / f"{prefix}-{seq}.m4a"
+        if not path.is_file():
+            return None
+        fixtures[seq] = path.read_bytes()
+    return fixtures
+
+
+def stage_4_live_meeting(hub: Hub, audio_fixtures: Optional[str] = None) -> StageResult:
     result = StageResult(stage=4, id="live_meeting_reconnect")
     session_id = f"cdlm10-{uuid.uuid4().hex[:12]}"
     opened = hub.post_json(
@@ -404,9 +436,14 @@ def stage_4_live_meeting(hub: Hub) -> StageResult:
         result.status = "fail"
         return result
 
-    segments = {
+    segments = _load_audio_fixtures(audio_fixtures, "seg", 6) or {
         seq: f"cdlm10 meeting segment {seq}: we decided item {seq}.".encode() for seq in range(6)
     }
+    if not _load_audio_fixtures(audio_fixtures, "seg", 6):
+        result.limits.append(
+            "no real audio fixtures provided; segment bytes are synthetic and the live "
+            "ASR engine will record failed derivations (structure still proven)"
+        )
     growth = []
     note_id = str(uuid.uuid4())
     note_text = "CDLM-10 verbatim note — must survive é å 中文, tabs\tand all."
@@ -473,14 +510,18 @@ def stage_4_live_meeting(hub: Hub) -> StageResult:
     return result
 
 
-def stage_5_gapped_close(hub: Hub, vault_root: Optional[Path]) -> StageResult:
+def stage_5_gapped_close(
+    hub: Hub, vault_root: Optional[Path], audio_fixtures: Optional[str] = None
+) -> StageResult:
     result = StageResult(stage=5, id="gapped_close_late_reconcile")
     session_id = f"cdlm10-gap-{uuid.uuid4().hex[:10]}"
     hub.post_json(
         "/api/heimdal/meeting/session",
         {"session_id": session_id, "device_id": "ipad-sim", "template_selection": {}},
     )
-    segs = {seq: f"cdlm10 gapped segment {seq} content.".encode() for seq in range(3)}
+    segs = _load_audio_fixtures(audio_fixtures, "gap", 3) or {
+        seq: f"cdlm10 gapped segment {seq} content.".encode() for seq in range(3)
+    }
     for seq in (0, 2):  # withhold 1
         _admit_segment(hub, session_id, seq, segs[seq])
     note_text = "gap-session verbatim user note."
@@ -734,11 +775,13 @@ def run(args: argparse.Namespace) -> int:
     results["multi_modality_round_trip"] = s1
     admitted = [a for a in s1.evidence.get("admissions", []) if a["status"] == 200]
     # regenerate media bytes references (kept in-process from stage 1)
-    results["kill_restart_chaos"] = stage_2_kill_restart(hub, args.api_container, admitted)
+    results["kill_restart_chaos"] = stage_2_kill_restart(
+        hub, args.api_container, admitted, restart_cmd=args.restart_cmd
+    )
     results["duplicate_injection"] = stage_3_duplicate_injection(hub, admitted)
-    results["live_meeting_reconnect"] = stage_4_live_meeting(hub)
+    results["live_meeting_reconnect"] = stage_4_live_meeting(hub, args.audio_fixtures)
     results["gapped_close_late_reconcile"] = stage_5_gapped_close(
-        hub, Path(args.vault_root) if args.vault_root else None
+        hub, Path(args.vault_root) if args.vault_root else None, args.audio_fixtures
     )
     results["legacy_lane_statement"] = stage_6_legacy_statement(
         hub, Path(args.watched_folder) if args.watched_folder else None
@@ -789,8 +832,18 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--hub-sha", default="unknown")
     parser.add_argument("--client-sha", default="unknown")
     parser.add_argument("--api-container", default=None, help="docker container name for the restart stage")
+    parser.add_argument(
+        "--restart-cmd",
+        default=None,
+        help="shell command that restarts the api process (alternative to --api-container)",
+    )
     parser.add_argument("--vault-root", default=None, help="test-channel vault root for artifact reads")
     parser.add_argument("--watched-folder", default=None, help="watched folder for the legacy-lane stage")
+    parser.add_argument(
+        "--audio-fixtures",
+        default=None,
+        help="directory of real speech fixtures (seg-0..5.m4a, gap-0..2.m4a) for the meeting stages",
+    )
     parser.add_argument("--out-dir", default="runtime/proof/cdlm10")
     parser.add_argument(
         "--plan",

--- a/scripts/cdlm_roundtrip_proof.py
+++ b/scripts/cdlm_roundtrip_proof.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""CDLM-10 (#4389): composed cross-device round-trip proof against the test channel.
+
+Specified by
+`docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/PROVE_CROSS_DEVICE_ROUND_TRIP_WITH_RECONNECT.md`.
+One re-runnable script drives the six stages of the vertical's composed proof
+through the hub's production HTTP surfaces — the exact contract the Bifrost
+client speaks (same endpoints, sidecar shapes, resend semantics) — plus
+hub-side verification queries, and emits named, durable evidence per stage:
+
+  1 multi_modality_round_trip   — four modalities admitted, receipted, enumerated
+  2 kill_restart_chaos          — api restart between admissions; no loss, no dup
+  3 duplicate_injection         — scripted double-POSTs; everything stays singular
+  4 live_meeting_reconnect      — projection grows; drop >=2 segments; reconnect
+                                  resends exactly the ledger-missing set; user
+                                  notes survive verbatim (hash-compared)
+  5 gapped_close_late_reconcile — needs_attention naming the hole; late admit;
+                                  re-finalization with lineage; 3-way separation
+  6 legacy_lane_statement       — the watched-folder contrast + which guarantees
+                                  apply to which lane
+
+Outputs (under --out-dir):
+  - round_trip_run_report.v1.json   (`cross_device_capture_live_meeting.round_trip_run_report.v1`)
+  - chaos_stage_evidence.v1.json    (`cross_device_capture_live_meeting.chaos_stage_evidence.v1`)
+  - run_report.md                   (the parent-issue receipt body)
+
+Honesty rules, non-negotiable: a stage that cannot run in this environment is
+reported `limited` with the named reason (e.g. the raw-store key still
+unprovisioned, no api container handle for a real restart, no vault root for
+artifact reads) — never silently skipped, never faked green. The four
+capability checklines (zero lost originals, zero duplicates, gap legibility,
+user-note verbatim survival) are explicit checked lines with inline evidence.
+
+Test channel only. Simulator/device truths stay with bifrost#21's walkthrough.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+RUN_REPORT_SCHEMA = "cross_device_capture_live_meeting.round_trip_run_report.v1"
+CHAOS_EVIDENCE_SCHEMA = "cross_device_capture_live_meeting.chaos_stage_evidence.v1"
+
+# Stage registry: the structure contract the AC test pins. Each stage names the
+# evidence keys its receipt must carry.
+STAGES: List[Dict[str, Any]] = [
+    {
+        "stage": 1,
+        "id": "multi_modality_round_trip",
+        "evidence": ["admissions", "receipt_query", "modality_count", "hash_matches"],
+    },
+    {
+        "stage": 2,
+        "id": "kill_restart_chaos",
+        "evidence": ["pre_restart_receipts", "restart", "post_restart_receipts", "resend_outcome"],
+    },
+    {
+        "stage": 3,
+        "id": "duplicate_injection",
+        "evidence": ["double_post_count", "idempotent_replays", "singularity"],
+    },
+    {
+        "stage": 4,
+        "id": "live_meeting_reconnect",
+        "evidence": [
+            "projection_growth",
+            "dropped_segments",
+            "ledger_missing_before_reconnect",
+            "resent_exactly_missing",
+            "revision_after_reconnect",
+            "user_note_hashes",
+        ],
+    },
+    {
+        "stage": 5,
+        "id": "gapped_close_late_reconcile",
+        "evidence": [
+            "close_needs_attention",
+            "late_admit",
+            "refinalization_lineage",
+            "artifact_separation",
+        ],
+    },
+    {
+        "stage": 6,
+        "id": "legacy_lane_statement",
+        "evidence": ["watched_folder_admission", "lane_guarantees"],
+    },
+]
+
+CHECKLINES = [
+    "zero_lost_originals",
+    "zero_duplicates",
+    "gap_legibility",
+    "user_note_verbatim_survival",
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class StageResult:
+    stage: int
+    id: str
+    status: str = "pass"  # pass | fail | limited
+    evidence: Dict[str, Any] = field(default_factory=dict)
+    limits: List[str] = field(default_factory=list)
+
+
+class Hub:
+    """Minimal client for the hub's production surfaces (stdlib only)."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def _request(
+        self, method: str, path: str, *, data: Optional[bytes] = None, headers: Optional[dict] = None
+    ) -> Dict[str, Any]:
+        req = urllib.request.Request(
+            self.base_url + path, data=data, headers=headers or {}, method=method
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return {"status": resp.status, "json": json.loads(resp.read().decode("utf-8"))}
+        except urllib.error.HTTPError as exc:
+            try:
+                body = json.loads(exc.read().decode("utf-8"))
+            except Exception:
+                body = {"raw": "unparseable"}
+            return {"status": exc.code, "json": body}
+
+    def get(self, path: str) -> Dict[str, Any]:
+        return self._request("GET", path)
+
+    def post_json(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request(
+            "POST",
+            path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def post_media(self, media: bytes, sidecar: Dict[str, Any], filename: str) -> Dict[str, Any]:
+        boundary = f"cdlm10-{uuid.uuid4().hex}"
+        parts = []
+        parts.append(
+            (
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="media"; filename="{filename}"\r\n'
+                "Content-Type: application/octet-stream\r\n\r\n"
+            ).encode("utf-8")
+            + media
+            + b"\r\n"
+        )
+        parts.append(
+            (
+                f"--{boundary}\r\n"
+                'Content-Disposition: form-data; name="sidecar"; filename="sidecar.json"\r\n'
+                "Content-Type: application/json\r\n\r\n"
+                + json.dumps(sidecar)
+                + "\r\n"
+            ).encode("utf-8")
+        )
+        parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+        body = b"".join(parts)
+        return self._request(
+            "POST",
+            "/api/heimdal/capture/media",
+            data=body,
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+
+
+def _sidecar(media: bytes, kind: str, device: str, **extra: Any) -> Dict[str, Any]:
+    return {
+        "capture_id": str(uuid.uuid4()),
+        "content_sha256": _sha256(media),
+        "kind": kind,
+        "captured_at": _now(),
+        "device_id": device,
+        "schema_version": 1,
+        **extra,
+    }
+
+
+def _admit(hub: Hub, media: bytes, sidecar: Dict[str, Any], name: str) -> Dict[str, Any]:
+    resp = hub.post_media(media, sidecar, name)
+    return {
+        "capture_id": sidecar["capture_id"],
+        "kind": sidecar["kind"],
+        "content_sha256": sidecar["content_sha256"],
+        "status": resp["status"],
+        "body": resp["json"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stages
+# ---------------------------------------------------------------------------
+
+
+def stage_1_multi_modality(hub: Hub) -> StageResult:
+    result = StageResult(stage=1, id="multi_modality_round_trip")
+    fixtures = [
+        ("audio", b"CDLM10 fixture audio memo bytes " + uuid.uuid4().bytes, "memo.m4a", "iphone-sim"),
+        ("image", b"\xff\xd8\xff CDLM10 fixture photo " + uuid.uuid4().bytes, "photo.jpg", "iphone-sim"),
+        (
+            "document",
+            b"%PDF-1.4 CDLM10 two-page receipt scan " + uuid.uuid4().bytes,
+            "receipt.pdf",
+            "ipad-sim",
+        ),
+        ("video", b"\x00\x00\x00 ftypmp42 CDLM10 clip " + uuid.uuid4().bytes, "clip.mp4", "ipad-sim"),
+    ]
+    admissions = []
+    for kind, media, name, device in fixtures:
+        sidecar = _sidecar(media, kind, device)
+        admission = _admit(hub, media, sidecar, name)
+        admission["_media"] = media  # in-process only; stripped before receipts
+        admissions.append(admission)
+    result.evidence["admissions"] = admissions
+    result.evidence["modality_count"] = len({a["kind"] for a in admissions})
+
+    ids = "&".join(f"capture_id={a['capture_id']}" for a in admissions)
+    query = hub.get(f"/api/heimdal/capture/receipts?{ids}")
+    result.evidence["receipt_query"] = query
+    hash_matches = []
+    outcomes = {r["capture_id"]: r for r in query["json"].get("receipts", [])} if query["status"] == 200 else {}
+    for adm in admissions:
+        answer = outcomes.get(adm["capture_id"], {})
+        hash_matches.append(
+            {
+                "capture_id": adm["capture_id"],
+                "admitted": adm["status"] == 200 and answer.get("outcome") == "admitted",
+                "hash_match": answer.get("content_sha256") == adm["content_sha256"],
+            }
+        )
+    result.evidence["hash_matches"] = hash_matches
+    if not all(m["admitted"] and m["hash_match"] for m in hash_matches):
+        failures = [a for a in admissions if a["status"] != 200]
+        if failures and any(
+            f["body"].get("detail", {}).get("error") == "raw_store_key_unavailable" for f in failures
+        ):
+            result.status = "fail"
+            result.limits.append(
+                "raw_store_key_unavailable: HEIMDAL_RAW_STORE_KEY is not provisioned to the "
+                "test-channel api process (operator Keychain step from #4422 outstanding)"
+            )
+        else:
+            result.status = "fail"
+    return result
+
+
+def stage_2_kill_restart(hub: Hub, api_container: Optional[str], admissions: List[Dict[str, Any]]) -> StageResult:
+    result = StageResult(stage=2, id="kill_restart_chaos")
+    if not admissions:
+        result.status = "limited"
+        result.limits.append("no stage-1 admissions to exercise (stage 1 did not pass)")
+        return result
+
+    ids = "&".join(f"capture_id={a['capture_id']}" for a in admissions)
+    result.evidence["pre_restart_receipts"] = hub.get(f"/api/heimdal/capture/receipts?{ids}")
+
+    if api_container:
+        restart = subprocess.run(
+            ["docker", "restart", api_container], capture_output=True, text=True, check=False
+        )
+        result.evidence["restart"] = {
+            "container": api_container,
+            "returncode": restart.returncode,
+            "stderr_tail": restart.stderr[-400:],
+        }
+        deadline = time.time() + 120
+        up = False
+        while time.time() < deadline:
+            try:
+                probe = hub.get("/api/health")
+                if probe["status"] in (200, 503):
+                    up = True
+                    break
+            except Exception:
+                pass
+            time.sleep(2)
+        result.evidence["restart"]["api_back_up"] = up
+        if not up:
+            result.status = "fail"
+            return result
+    else:
+        result.status = "limited"
+        result.evidence["restart"] = {"skipped": True}
+        result.limits.append(
+            "no --api-container handle provided; a real process restart was not exercised "
+            "in this run (receipts durability is still asserted by re-query below)"
+        )
+
+    result.evidence["post_restart_receipts"] = hub.get(f"/api/heimdal/capture/receipts?{ids}")
+    post = result.evidence["post_restart_receipts"]
+    survived = (
+        post["status"] == 200
+        and all(r.get("outcome") == "admitted" for r in post["json"].get("receipts", []))
+    )
+    # Resend the first original after restart: idempotent completion, no dup.
+    first = admissions[0]
+    resend = hub.post_media(
+        first["_media"],
+        {
+            "capture_id": first["capture_id"],
+            "content_sha256": first["content_sha256"],
+            "kind": first["kind"],
+            "captured_at": _now(),
+            "device_id": "iphone-sim",
+            "schema_version": 1,
+        },
+        "resend.bin",
+    )
+    result.evidence["resend_outcome"] = {
+        "status": resend["status"],
+        "idempotent_replay": resend["json"].get("idempotent_replay"),
+        "receipt_id": resend["json"].get("receipt_id"),
+        "same_receipt_id": resend["json"].get("receipt_id") == first["body"].get("receipt_id"),
+    }
+    if not survived or resend["status"] != 200 or not result.evidence["resend_outcome"]["same_receipt_id"]:
+        result.status = "fail"
+    return result
+
+
+def stage_3_duplicate_injection(hub: Hub, admissions: List[Dict[str, Any]]) -> StageResult:
+    result = StageResult(stage=3, id="duplicate_injection")
+    if not admissions:
+        result.status = "limited"
+        result.limits.append("no stage-1 admissions to double-post (stage 1 did not pass)")
+        return result
+    replays = []
+    for adm in admissions:
+        resp = hub.post_media(
+            adm["_media"],
+            {
+                "capture_id": adm["capture_id"],
+                "content_sha256": adm["content_sha256"],
+                "kind": adm["kind"],
+                "captured_at": _now(),
+                "device_id": "chaos-injector",
+                "schema_version": 1,
+            },
+            "dup.bin",
+        )
+        replays.append(
+            {
+                "capture_id": adm["capture_id"],
+                "status": resp["status"],
+                "idempotent_replay": resp["json"].get("idempotent_replay"),
+                "same_receipt_id": resp["json"].get("receipt_id") == adm["body"].get("receipt_id"),
+            }
+        )
+    result.evidence["double_post_count"] = len(replays)
+    result.evidence["idempotent_replays"] = replays
+    singular = all(r["status"] == 200 and r["idempotent_replay"] and r["same_receipt_id"] for r in replays)
+    ids = "&".join(f"capture_id={a['capture_id']}" for a in admissions)
+    query = hub.get(f"/api/heimdal/capture/receipts?{ids}")
+    receipt_ids = [r.get("receipt_id") for r in query["json"].get("receipts", [])]
+    result.evidence["singularity"] = {
+        "distinct_receipt_ids": len(set(receipt_ids)),
+        "expected": len(admissions),
+        "receipt_query_status": query["status"],
+    }
+    if not singular or len(set(receipt_ids)) != len(admissions):
+        result.status = "fail"
+    return result
+
+
+def _admit_segment(hub: Hub, session_id: str, seq: int, media: bytes) -> Dict[str, Any]:
+    sidecar = _sidecar(media, "audio", "ipad-sim", session_id=session_id, session_seq=seq)
+    out = _admit(hub, media, sidecar, f"seg-{seq}.m4a")
+    out["_media"] = media
+    return out
+
+
+def stage_4_live_meeting(hub: Hub) -> StageResult:
+    result = StageResult(stage=4, id="live_meeting_reconnect")
+    session_id = f"cdlm10-{uuid.uuid4().hex[:12]}"
+    opened = hub.post_json(
+        "/api/heimdal/meeting/session",
+        {"session_id": session_id, "device_id": "ipad-sim", "template_selection": {}},
+    )
+    result.evidence["session"] = {"session_id": session_id, "open_status": opened["status"]}
+    if opened["status"] != 200:
+        result.status = "fail"
+        return result
+
+    segments = {
+        seq: f"cdlm10 meeting segment {seq}: we decided item {seq}.".encode() for seq in range(6)
+    }
+    growth = []
+    note_id = str(uuid.uuid4())
+    note_text = "CDLM-10 verbatim note — must survive é å 中文, tabs\tand all."
+    # Live phase: send 0..2, note, observe projection growth.
+    for seq in (0, 1, 2):
+        _admit_segment(hub, session_id, seq, segments[seq])
+        proj = hub.get(f"/api/heimdal/meeting/{session_id}/projection")
+        growth.append(
+            {
+                "after_seq": seq,
+                "received": proj["json"].get("missing") is not None
+                and [row["seq"] for row in proj["json"].get("transcript", []) if row.get("kind") == "segment"],
+                "analysis_revision": proj["json"].get("analysis", {}).get("revision"),
+            }
+        )
+    note = hub.post_json(
+        f"/api/heimdal/meeting/{session_id}/user-note",
+        {"note_block_id": note_id, "revision": 1, "text": note_text, "editor_identity": "operator@ipad-sim"},
+    )
+    result.evidence["user_note_write"] = {"status": note["status"], "sha": note["json"].get("content_sha256")}
+
+    # Forced network drop over >=2 segments: 3 and 4 are never sent; 5 arrives.
+    _admit_segment(hub, session_id, 5, segments[5])
+    ledger = hub.get(f"/api/heimdal/meeting/{session_id}/segments")
+    missing_before = ledger["json"].get("missing")
+    result.evidence["dropped_segments"] = [3, 4]
+    result.evidence["ledger_missing_before_reconnect"] = missing_before
+    revision_before = hub.get(f"/api/heimdal/meeting/{session_id}/projection")["json"]["analysis"]["revision"]
+
+    # Reconnect: resend EXACTLY what the ledger names missing.
+    resent = []
+    for seq in missing_before or []:
+        out = _admit_segment(hub, session_id, seq, segments[seq])
+        resent.append({"seq": seq, "status": out["status"]})
+    result.evidence["resent_exactly_missing"] = {
+        "asked_for": missing_before,
+        "resent": [r["seq"] for r in resent],
+        "match": [r["seq"] for r in resent] == missing_before,
+    }
+    proj_after = hub.get(f"/api/heimdal/meeting/{session_id}/projection")["json"]
+    result.evidence["projection_growth"] = growth
+    result.evidence["revision_after_reconnect"] = {
+        "before": revision_before,
+        "after": proj_after["analysis"]["revision"],
+        "advanced": (proj_after["analysis"]["revision"] or 0) > (revision_before or 0),
+        "missing_now": proj_after.get("missing"),
+    }
+    note_rows = [b for b in proj_after.get("page_blocks", []) if b.get("block_id") == note_id]
+    registry_hash = _sha256(note_rows[0]["content"].encode("utf-8")) if note_rows else None
+    result.evidence["user_note_hashes"] = {
+        "written_sha256": _sha256(note_text.encode("utf-8")),
+        "registry_sha256": registry_hash,
+        "verbatim": registry_hash == _sha256(note_text.encode("utf-8")),
+    }
+    result.evidence["_session_id"] = session_id
+    result.evidence["_note"] = {"id": note_id, "text_sha": _sha256(note_text.encode("utf-8"))}
+    if not (
+        result.evidence["resent_exactly_missing"]["match"]
+        and result.evidence["revision_after_reconnect"]["advanced"]
+        and result.evidence["user_note_hashes"]["verbatim"]
+        and missing_before == [3, 4]
+    ):
+        result.status = "fail"
+    return result
+
+
+def stage_5_gapped_close(hub: Hub, vault_root: Optional[Path]) -> StageResult:
+    result = StageResult(stage=5, id="gapped_close_late_reconcile")
+    session_id = f"cdlm10-gap-{uuid.uuid4().hex[:10]}"
+    hub.post_json(
+        "/api/heimdal/meeting/session",
+        {"session_id": session_id, "device_id": "ipad-sim", "template_selection": {}},
+    )
+    segs = {seq: f"cdlm10 gapped segment {seq} content.".encode() for seq in range(3)}
+    for seq in (0, 2):  # withhold 1
+        _admit_segment(hub, session_id, seq, segs[seq])
+    note_text = "gap-session verbatim user note."
+    note_id = str(uuid.uuid4())
+    hub.post_json(
+        f"/api/heimdal/meeting/{session_id}/user-note",
+        {"note_block_id": note_id, "revision": 1, "text": note_text, "editor_identity": "operator@ipad-sim"},
+    )
+    closed = hub.post_json(f"/api/heimdal/meeting/{session_id}/close", {"final_seq_count": 3})
+    fin = closed["json"].get("finalization", {})
+    result.evidence["close_needs_attention"] = {
+        "status": closed["status"],
+        "finalization_status": fin.get("status"),
+        "completeness": fin.get("receipt", {}).get("completeness"),
+        "missing_seqs": fin.get("receipt", {}).get("missing_seqs"),
+        "skip_or_fail_reason": fin.get("reason") or fin.get("message"),
+    }
+    if fin.get("status") not in ("finalized", "replayed"):
+        result.status = "limited" if fin.get("reason") == "vault_root_unconfigured" else "fail"
+        if fin.get("reason") == "vault_root_unconfigured":
+            result.limits.append(
+                "finalization skipped: HEIMDAL_MEETING_VAULT_ROOT is not configured on the "
+                "test-channel api process; artifact materialization not exercised live"
+            )
+        return result
+
+    late = _admit_segment(hub, session_id, 1, segs[1])
+    proj = hub.get(f"/api/heimdal/meeting/{session_id}/projection")["json"]
+    refin = proj.get("finalization") or {}
+    first_receipt = fin.get("receipt", {})
+    result.evidence["late_admit"] = {"status": late["status"], "seq": 1}
+    result.evidence["refinalization_lineage"] = {
+        "first_state": first_receipt.get("finalization_state"),
+        "latest_state": refin.get("finalization_state"),
+        "supersedes": refin.get("supersedes"),
+        "lineage_ok": refin.get("supersedes") == first_receipt.get("finalization_state"),
+        "completeness_now": refin.get("completeness"),
+    }
+    separation: Dict[str, Any] = {"checked": False}
+    if vault_root is not None and refin.get("artifact_refs"):
+        refs = refin["artifact_refs"]
+        notes_path = vault_root / refs.get("user_notes", "")
+        transcript_path = vault_root / refs.get("transcript", "")
+        analysis_path = vault_root / refs.get("analysis", "")
+        try:
+            notes_body = notes_path.read_text(encoding="utf-8")
+            separation = {
+                "checked": True,
+                "three_distinct_files": len({str(p) for p in (notes_path, transcript_path, analysis_path)}) == 3
+                and transcript_path.is_file()
+                and analysis_path.is_file(),
+                "user_note_verbatim_in_artifact": note_text in notes_body,
+                "derived_text_absent_from_notes_artifact": "gapped segment" not in notes_body,
+            }
+        except OSError as exc:
+            separation = {"checked": False, "error": type(exc).__name__}
+    elif vault_root is None:
+        result.limits.append(
+            "no --vault-root provided; the three-way artifact separation was verified through "
+            "the finalization receipt refs only, not by reading artifact bytes"
+        )
+    result.evidence["artifact_separation"] = separation
+    if not result.evidence["refinalization_lineage"]["lineage_ok"] or (
+        result.evidence["close_needs_attention"]["missing_seqs"] != [1]
+    ):
+        result.status = "fail"
+    elif result.limits and result.status == "pass":
+        result.status = "limited"
+    return result
+
+
+def stage_6_legacy_statement(hub: Hub, watched_folder: Optional[Path]) -> StageResult:
+    result = StageResult(stage=6, id="legacy_lane_statement")
+    result.evidence["lane_guarantees"] = {
+        "outbox_lane": (
+            "governed HTTP admission; durable-acceptance receipts keyed by (capture_id, "
+            "content_sha256); receipt-gated retention on the client (CDLM-03); idempotent "
+            "resend; session/segment ledger, projections, ownership guard, finalization"
+        ),
+        "watched_folder_lane": (
+            "legacy Model-1 floor: admitted and receipted hub-side (content-hash keyed when no "
+            "sidecar capture_id), NO receipt-gated retention, no session semantics; deletion "
+            "behavior owned by the watcher (#4362 lineage)"
+        ),
+    }
+    if watched_folder is None:
+        result.status = "limited"
+        result.evidence["watched_folder_admission"] = {"skipped": True}
+        result.limits.append(
+            "no --watched-folder provided (watcher service not part of this run); the lane "
+            "contrast is stated, and the watched-folder round trip remains proven by HCAP-08 "
+            "(#3191), which owns that lane's proof"
+        )
+        return result
+    fixture = watched_folder / f"cdlm10-legacy-{uuid.uuid4().hex[:8]}.m4a"
+    payload = b"cdlm10 legacy watched-folder fixture " + uuid.uuid4().bytes
+    fixture.write_bytes(payload)
+    content_hash = _sha256(payload)
+    deadline = time.time() + 120
+    answer: Dict[str, Any] = {}
+    while time.time() < deadline:
+        query = hub.get(f"/api/heimdal/capture/receipts?capture_id={content_hash}")
+        receipts = query["json"].get("receipts", []) if query["status"] == 200 else []
+        if receipts and receipts[0].get("outcome") == "admitted":
+            answer = receipts[0]
+            break
+        time.sleep(3)
+    result.evidence["watched_folder_admission"] = {
+        "content_sha256": content_hash,
+        "receipt": answer or {"outcome": "not observed within 120s"},
+    }
+    if not answer:
+        result.status = "limited"
+        result.limits.append("watched-folder admission not observed within 120s")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+def build_checklines(results: Dict[str, StageResult]) -> List[Dict[str, Any]]:
+    s1 = results.get("multi_modality_round_trip")
+    s2 = results.get("kill_restart_chaos")
+    s3 = results.get("duplicate_injection")
+    s4 = results.get("live_meeting_reconnect")
+    s5 = results.get("gapped_close_late_reconcile")
+
+    def line(name: str, ok: Optional[bool], evidence: Any) -> Dict[str, Any]:
+        return {"checkline": name, "checked": bool(ok), "evidence": evidence}
+
+    lost = None
+    if s1 and s2:
+        lost = (
+            s1.status == "pass"
+            and all(m["admitted"] for m in s1.evidence.get("hash_matches", []))
+            and (
+                s2.status != "fail"
+                and all(
+                    r.get("outcome") == "admitted"
+                    for r in s2.evidence.get("post_restart_receipts", {}).get("json", {}).get("receipts", [])
+                )
+            )
+        )
+    dup = None
+    if s3:
+        dup = s3.status == "pass"
+    gaps = None
+    if s4 and s5:
+        gaps = (
+            s4.evidence.get("ledger_missing_before_reconnect") == [3, 4]
+            and s5.evidence.get("close_needs_attention", {}).get("missing_seqs") == [1]
+        )
+    verbatim = None
+    if s4:
+        verbatim = bool(s4.evidence.get("user_note_hashes", {}).get("verbatim"))
+        if s5 and s5.evidence.get("artifact_separation", {}).get("checked"):
+            verbatim = verbatim and s5.evidence["artifact_separation"]["user_note_verbatim_in_artifact"]
+
+    return [
+        line(
+            "zero_lost_originals",
+            lost,
+            {
+                "stage1_hash_matches": s1.evidence.get("hash_matches") if s1 else None,
+                "stage2_post_restart": (s2.evidence.get("post_restart_receipts", {}).get("json") if s2 else None),
+            },
+        ),
+        line("zero_duplicates", dup, s3.evidence.get("singularity") if s3 else None),
+        line(
+            "gap_legibility",
+            gaps,
+            {
+                "meeting_missing_pre_reconnect": s4.evidence.get("ledger_missing_before_reconnect") if s4 else None,
+                "gapped_close": s5.evidence.get("close_needs_attention") if s5 else None,
+            },
+        ),
+        line(
+            "user_note_verbatim_survival",
+            verbatim,
+            {
+                "hashes": s4.evidence.get("user_note_hashes") if s4 else None,
+                "artifact": s5.evidence.get("artifact_separation") if s5 else None,
+            },
+        ),
+    ]
+
+
+def render_markdown(report: Dict[str, Any]) -> str:
+    lines = [
+        "## CDLM-10 round-trip run report — `prove-cross-device-round-trip-with-reconnect`",
+        "",
+        f"- **Channel identity:** {report['channel']}",
+        f"- **Hub build SHA:** `{report['hub_sha']}`",
+        f"- **Client build SHA (bifrost):** `{report['client_sha']}`",
+        f"- **Run id / time:** `{report['run_id']}` / {report['ran_at']}",
+        f"- **Duplicate-injection count:** {report['duplicate_injection_count']}",
+        "",
+        "### Capability checklines",
+        "",
+    ]
+    for check in report["checklines"]:
+        mark = "x" if check["checked"] else " "
+        lines.append(f"- [{mark}] `{check['checkline']}`")
+    lines.append("")
+    lines.append("### Stages")
+    lines.append("")
+    lines.append("| # | Stage | Status | Limits |")
+    lines.append("| --- | --- | --- | --- |")
+    for stage in report["stages"]:
+        limits = "; ".join(stage["limits"]) or "—"
+        lines.append(f"| {stage['stage']} | `{stage['id']}` | **{stage['status']}** | {limits} |")
+    lines.append("")
+    lines.append(
+        "Full per-stage evidence (commands, responses, counts, hashes) is in the attached "
+        "receipt JSONs (`round_trip_run_report.v1.json`, `chaos_stage_evidence.v1.json`)."
+    )
+    lines.append("")
+    lines.append("### Simulator-only limits and the remaining human step")
+    lines.append("")
+    lines.append(
+        "This run drives the hub's production HTTP contract exactly as the Bifrost client "
+        "speaks it; on-device client behaviors (locked-screen capture, real calls, wrist "
+        "haptics, app-lifecycle kill/relaunch UI truths) are covered by CDLM-09's simulator "
+        "XCUITest receipts and remain **bifrost#21's device walkthrough** — the named, now "
+        "unblocked human step."
+    )
+    return "\n".join(lines)
+
+
+def _strip_private(value: Any) -> Any:
+    """Drop in-process-only keys (leading underscore, e.g. raw media bytes)
+    before anything is serialized into a durable receipt."""
+    if isinstance(value, dict):
+        return {k: _strip_private(v) for k, v in value.items() if not str(k).startswith("_")}
+    if isinstance(value, list):
+        return [_strip_private(v) for v in value]
+    return value
+
+
+def run(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hub = Hub(args.base_url)
+    run_id = f"cdlm10-{uuid.uuid4().hex[:10]}"
+
+    results: Dict[str, StageResult] = {}
+    s1 = stage_1_multi_modality(hub)
+    # Stage 2/3 need the raw bytes; stash them on the admission dicts.
+    results["multi_modality_round_trip"] = s1
+    admitted = [a for a in s1.evidence.get("admissions", []) if a["status"] == 200]
+    # regenerate media bytes references (kept in-process from stage 1)
+    results["kill_restart_chaos"] = stage_2_kill_restart(hub, args.api_container, admitted)
+    results["duplicate_injection"] = stage_3_duplicate_injection(hub, admitted)
+    results["live_meeting_reconnect"] = stage_4_live_meeting(hub)
+    results["gapped_close_late_reconcile"] = stage_5_gapped_close(
+        hub, Path(args.vault_root) if args.vault_root else None
+    )
+    results["legacy_lane_statement"] = stage_6_legacy_statement(
+        hub, Path(args.watched_folder) if args.watched_folder else None
+    )
+
+    checklines = build_checklines(results)
+    stages_payload = [
+        {
+            "stage": r.stage,
+            "id": r.id,
+            "status": r.status,
+            "evidence": _strip_private(r.evidence),
+            "limits": r.limits,
+        }
+        for r in sorted(results.values(), key=lambda r: r.stage)
+    ]
+    report = {
+        "schema": RUN_REPORT_SCHEMA,
+        "run_id": run_id,
+        "ran_at": _now(),
+        "channel": args.channel,
+        "base_url": args.base_url,
+        "hub_sha": args.hub_sha,
+        "client_sha": args.client_sha,
+        "duplicate_injection_count": results["duplicate_injection"].evidence.get("double_post_count", 0),
+        "checklines": checklines,
+        "stages": stages_payload,
+    }
+    chaos = {
+        "schema": CHAOS_EVIDENCE_SCHEMA,
+        "run_id": run_id,
+        "checklines": checklines,
+        "kill_restart": stages_payload[1],
+        "duplicate_injection": stages_payload[2],
+        "reconnect": stages_payload[3],
+    }
+    (out_dir / "round_trip_run_report.v1.json").write_text(json.dumps(report, indent=2))
+    (out_dir / "chaos_stage_evidence.v1.json").write_text(json.dumps(chaos, indent=2))
+    (out_dir / "run_report.md").write_text(render_markdown(report))
+    print(json.dumps({"run_id": run_id, "out_dir": str(out_dir), "stages": {s['id']: s['status'] for s in stages_payload}}, indent=2))
+    return 0 if all(s["status"] != "fail" for s in stages_payload) else 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base-url", default="http://127.0.0.1:8100", help="test-channel api base URL")
+    parser.add_argument("--channel", default="test")
+    parser.add_argument("--hub-sha", default="unknown")
+    parser.add_argument("--client-sha", default="unknown")
+    parser.add_argument("--api-container", default=None, help="docker container name for the restart stage")
+    parser.add_argument("--vault-root", default=None, help="test-channel vault root for artifact reads")
+    parser.add_argument("--watched-folder", default=None, help="watched folder for the legacy-lane stage")
+    parser.add_argument("--out-dir", default="runtime/proof/cdlm10")
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="print the stage/evidence contract as JSON and exit without any network access",
+    )
+    args = parser.parse_args(argv)
+    if args.plan:
+        print(
+            json.dumps(
+                {
+                    "schemas": [RUN_REPORT_SCHEMA, CHAOS_EVIDENCE_SCHEMA],
+                    "stages": STAGES,
+                    "checklines": CHECKLINES,
+                },
+                indent=2,
+            )
+        )
+        return 0
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/heimdal/test_cdlm_roundtrip_script.py
+++ b/tests/heimdal/test_cdlm_roundtrip_script.py
@@ -1,0 +1,120 @@
+"""CDLM-10 (#4389): proof-script structure and evidence contract.
+
+The live run against the test channel is the capability receipt (posted on the
+parent issue); this test pins the script's *contract*: it exists, is
+re-runnable, covers stages 1–6 with named evidence outputs, declares the two
+receipt schemas, and its honesty machinery (limited-status reporting, private
+in-process data stripped from durable receipts) is real.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.not_pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "cdlm_roundtrip_proof.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cdlm_roundtrip_proof", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Registered before exec so the script's dataclasses resolve their
+    # string annotations (PEP 563) against a real sys.modules entry.
+    sys.modules["cdlm_roundtrip_proof"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_script_stages_and_evidence_contract() -> None:
+    assert SCRIPT.is_file()
+    module = _load_module()
+
+    # The two durable receipt schemas the ACs name.
+    assert (
+        module.RUN_REPORT_SCHEMA
+        == "cross_device_capture_live_meeting.round_trip_run_report.v1"
+    )
+    assert (
+        module.CHAOS_EVIDENCE_SCHEMA
+        == "cross_device_capture_live_meeting.chaos_stage_evidence.v1"
+    )
+
+    # Stages 1–6 from the task spec, in order, each with named evidence keys.
+    stages = module.STAGES
+    assert [s["stage"] for s in stages] == [1, 2, 3, 4, 5, 6]
+    assert [s["id"] for s in stages] == [
+        "multi_modality_round_trip",
+        "kill_restart_chaos",
+        "duplicate_injection",
+        "live_meeting_reconnect",
+        "gapped_close_late_reconcile",
+        "legacy_lane_statement",
+    ]
+    for stage in stages:
+        assert stage["evidence"], stage["id"]
+        # And a real stage function backs each registry entry.
+        fn_prefix = f"stage_{stage['stage']}_"
+        assert any(
+            name.startswith(fn_prefix) for name in vars(module) if callable(getattr(module, name, None))
+        ), stage["id"]
+
+    # The four capability checklines are explicit.
+    assert module.CHECKLINES == [
+        "zero_lost_originals",
+        "zero_duplicates",
+        "gap_legibility",
+        "user_note_verbatim_survival",
+    ]
+
+    # Re-runnable and network-free in plan mode: the CLI contract holds.
+    plan = subprocess.run(
+        [sys.executable, str(SCRIPT), "--plan"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert plan.returncode == 0, plan.stderr
+    payload = json.loads(plan.stdout)
+    assert payload["schemas"] == [module.RUN_REPORT_SCHEMA, module.CHAOS_EVIDENCE_SCHEMA]
+    assert payload["stages"] == module.STAGES
+    assert payload["checklines"] == module.CHECKLINES
+
+    # Honesty machinery: private in-process values (raw media bytes) never
+    # reach a durable receipt, and the markdown renderer names the simulator
+    # limit + bifrost#21 as the remaining human step.
+    stripped = module._strip_private(
+        {"a": 1, "_media": b"secret-bytes", "nested": [{"_media": b"x", "keep": True}]}
+    )
+    assert stripped == {"a": 1, "nested": [{"keep": True}]}
+
+    markdown = module.render_markdown(
+        {
+            "channel": "test",
+            "hub_sha": "h" * 8,
+            "client_sha": "c" * 8,
+            "run_id": "cdlm10-test",
+            "ran_at": "2026-07-30T00:00:00Z",
+            "duplicate_injection_count": 4,
+            "checklines": [
+                {"checkline": name, "checked": True, "evidence": {}} for name in module.CHECKLINES
+            ],
+            "stages": [
+                {"stage": s["stage"], "id": s["id"], "status": "pass", "limits": []}
+                for s in module.STAGES
+            ],
+        }
+    )
+    assert "bifrost#21" in markdown
+    assert "device walkthrough" in markdown
+    for name in module.CHECKLINES:
+        assert f"`{name}`" in markdown


### PR DESCRIPTION
Governing-Issue: #4389

Fixes #4389

Final-Review-Rounds: 0

## Summary
Ships the CDLM-10 proof: `scripts/cdlm_roundtrip_proof.py`, a re-runnable six-stage composed proof against the test channel (multi-modality round trip, kill/restart chaos, duplicate injection, live meeting with reconnect, gapped close with late reconcile, legacy-lane statement) with named per-stage evidence, the four capability checklines, honest limited-status reporting, and the two durable receipt schemas (`round_trip_run_report.v1`, `chaos_stage_evidence.v1`). The structure contract is pinned by `tests/heimdal/test_cdlm_roundtrip_script.py::test_script_stages_and_evidence_contract`; README Supersessions now names bifrost#21's device walkthrough as the remaining human step. **The live run has been executed and its receipt is posted on the validation hub #4383**: all four capability checklines checked (zero lost originals, zero duplicates, gap legibility, user-note verbatim survival) over real Whisper ASR, a real SIGKILL process restart, the real `app_test` Postgres, and real vault artifacts; stages 1–5 pass, stage 6 honestly `limited` (watched-folder lane's proof stays owned by HCAP-08 #3191).

## Claim receipt
`pickup-claim-complete issue=4389 branch=feat/4389-cdlm-10-roundtrip-proof worktree=/Users/rasmus/worktrees/cdlm-10-4389 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4389 lease_id=lease-e67ff5fd holder=cdlm-hub-coordinator evidence=verified-dispatcher-lease`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the run report on #4383 is the capability receipt; a stale host-global deployment-lease finding from the run environment is reported operationally on the parent issue rather than as builder learning (foreign interrupted deploy, not a plan divergence of this slice).

## Notes
Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/heimdal/test_cdlm_roundtrip_script.py` — 1 passed (script/stage/evidence contract incl. plan-mode CLI, receipt schemas, privacy stripping, and the bifrost#21 statement in the rendered report).
- Live run `cdlm10-868e042e59` (see #4383): stages 1–5 pass, 6 limited; duplicate-injection count 4; hub SHA `95f5c3ee` (= merged main `b63d97ca` + this PR's proof-only additions), client SHA `297b6497` (bifrost#65 verified head).
- `ruff` clean; `mypy app` clean (833 files); docs_guard OK. Mechanical write class (proof script + test + doc statement); no runtime mechanism changed — light delivery path.
---