### PR TITLE
Parse macOS ps command column as display text, not shell syntax

### DIFF
--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -16,7 +16,6 @@ import json
 import os
 import posixpath
 import re
-import shlex
 import stat
 import subprocess
 import sys
@@ -329,7 +328,14 @@ def _parse_macos_ps_row(line: str) -> ProcessRecord:
     pid_text, ppid_text, pgid_text, started, command = match.groups()
     try:
         dt.datetime.strptime(started, "%a %b %d %H:%M:%S %Y")
-        argv = tuple(shlex.split(command, posix=True))
+        # ps renders `command=` as argv joined with single spaces. It is display
+        # text, not shell syntax, so whitespace splitting is its faithful
+        # inverse. A shell lexer here both raises on any argument carrying an
+        # unbalanced quote — aborting the whole inventory over one unrelated
+        # process — and silently strips quote characters that are literal
+        # argument content. Only whitespace-free tokens are consumed downstream
+        # by _native_role.
+        argv = tuple(command.split())
         pid, ppid, pgid = int(pid_text), int(ppid_text), int(pgid_text)
     except (ValueError, TypeError) as exc:
         raise InventoryError("native process inventory row is malformed") from exc

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -1,10 +1,16 @@
-"""Regression tests for the legacy-owner source inventory (Issue #4423).
+"""Regression tests for the instance-state writer inventory.
 
-`produce_legacy_owners` requires two consecutive snapshots of unchanged host state
-to be byte-identical. The per-container fingerprint embeds the `Mounts` array from
-`docker inspect`, and Docker does not guarantee that array's ordering. These tests
-pin the fingerprint to mount *content* rather than to Docker's arbitrary ordering,
-while keeping the guard's ability to detect a genuine change.
+Issue #4423: `produce_legacy_owners` requires two consecutive snapshots of
+unchanged host state to be byte-identical. The per-container fingerprint embeds
+the `Mounts` array from `docker inspect`, and Docker does not guarantee that
+array's ordering. Those tests pin the fingerprint to mount *content* rather than
+to Docker's arbitrary ordering, while keeping the guard's ability to detect a
+genuine change.
+
+Issue #4434: `ps`'s `command=` column is a display string — argv joined with
+single spaces — not shell syntax. Those tests pin the macOS row parser to that
+reading, so an ordinary quoted command line cannot abort the whole native
+inventory and thereby fail-close a deploy.
 """
 
 import json
@@ -145,3 +151,91 @@ def test_produce_legacy_owners_still_detects_real_race(
         )
 
     assert not output.exists()
+
+
+# --- Issue #4434: macOS ps row parsing --------------------------------------
+
+LSTART = "Thu Jul 30 16:59:37 2026"
+
+
+def _ps_row(command, pid=98262, ppid=98128, pgid=98262):
+    return f"{pid} {ppid} {pgid} {LSTART} {command}"
+
+
+def test_parse_macos_ps_row_accepts_unbalanced_quotes():
+    """An ordinary command line with an odd apostrophe count must still parse.
+
+    This is the exact shape that aborted a real deploy: one agent process whose
+    natural-language prompt contained three apostrophes.
+    """
+
+    command = "claude --flag You are the hub coordinator. Don't stop; it's fine"
+    record = writer_inventory._parse_macos_ps_row(_ps_row(command))
+
+    assert record.pid == 98262
+    assert record.argv[0] == "claude"
+    assert record.argv == tuple(command.split())
+
+
+def test_parse_macos_ps_row_preserves_literal_quotes():
+    """Quote characters are argument content here, not syntax to be consumed."""
+
+    command = "python -c print('hi') \"double\""
+    record = writer_inventory._parse_macos_ps_row(_ps_row(command))
+
+    assert "print('hi')" in record.argv
+    assert '"double"' in record.argv
+
+
+def test_enumerate_macos_survives_quoted_command_row(monkeypatch):
+    """One quoted row must not abort the whole native inventory."""
+
+    rows = [
+        _ps_row("/sbin/launchd", pid=1, ppid=0, pgid=1),
+        _ps_row("claude --flag it's a prompt", pid=98262),
+        _ps_row("python -m app.cli watcher run", pid=4242, ppid=1, pgid=4242),
+    ]
+
+    def fake_run_checked(command, *, label, env=None):
+        assert list(command)[:1] == ["ps"]
+        return "\n".join(rows) + "\n"
+
+    monkeypatch.setattr(writer_inventory, "_run_checked", fake_run_checked)
+
+    records = writer_inventory._enumerate_macos()
+
+    assert [record.pid for record in records] == [1, 98262, 4242]
+
+
+def test_native_role_classifies_known_writers():
+    """Whitespace splitting must not lose any writer shape the guard detects."""
+
+    cases = {
+        ("python", "-m", "app.cli", "watcher", "run"): "watcher",
+        ("python3", "-m", "app.cli", "heimdal", "capture-watch"): "heimdal-capture-watch",
+        ("python", "-m", "app.workers.outbox_worker"): "outbox-worker",
+        ("python", "-m", "uvicorn", "app.api.app:app"): "uvicorn",
+        ("python", "-m", "celery", "worker"): "celery",
+        ("/usr/bin/uvicorn", "app.api.app:app"): "uvicorn",
+        ("/bin/bash", "scripts/deploy_channel.sh", "deploy"): "deploy_channel",
+    }
+    for argv, expected in cases.items():
+        assert writer_inventory._native_role(argv) == expected, argv
+
+    assert writer_inventory._native_role(("claude", "--flag", "it's")) is None
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "not a ps row at all",
+        f"98262 98128 98262 {LSTART}",
+        f"0 1 1 {LSTART} /sbin/launchd",
+        "98262 98128 98262 Thu Jul 30 16:59:37 /sbin/launchd",
+    ],
+)
+def test_parse_macos_ps_row_still_rejects_malformed_rows(row):
+    """Structurally malformed rows must keep failing closed."""
+
+    with pytest.raises(InventoryError):
+        writer_inventory._parse_macos_ps_row(row)


### PR DESCRIPTION
Governing-Issue: #4434

Fixes #4434

Final-Review-Rounds: 1

## Summary

`ps` renders its `command=` column as argv joined with single spaces. That is display text, not shell syntax, so running `shlex.split` over it was a category error with two consequences: it raised on any process whose arguments carried an unbalanced quote, and it silently stripped quote characters that were literal argument content.

Because `_enumerate_macos` maps every row, one unrelated process aborted the whole native inventory and fail-closed the deploy. This splits on whitespace instead — the faithful inverse of how `ps` joins argv. The row regex, `lstart` validation, and rejection of empty argv or non-positive ids are unchanged, so structurally malformed rows still fail closed.

## Evidence

Measured on a real three-channel host: 1 of 678 processes triggered the raise — an agent process whose natural-language prompt contained three apostrophes — which was enough to block `dev`, `test`, and `prod` alike. With the fix, all 714 rows parse and the host correctly reports zero native writers.

**This also resolves the seven long-standing failures in `tests/ops/test_instance_state_volume_contract.py`**, which are red on unmodified `origin/main` with the identical `native process inventory row is malformed` message. Combined suite: 143 passed, 3 skipped, 0 failed — versus 7 failed before.

The independent reviewer ran a live end-to-end check against the real host, starting an actual `start_full_system.sh` and running `prove-quiescent` on both revisions:

| scenario | `origin/main` | this branch |
|---|---|---|
| launcher running | fails: `row is malformed` (accidental block) | **blocks**: `host-wide writer inventory is live or racing` |
| launcher + apostrophe in argv | fails: `row is malformed` | **blocks** correctly |
| nothing running (genuine quiescence) | fails: `row is malformed` | passes, proof written |

On `origin/main` the gate is a permanent deny on this host even with nothing running — it carries no information. With the fix it both blocks real writers and admits genuine quiescence.

## SBS Impact

- Primary subsystem: Builder System — release/deploy workflow (`deploy_channel.sh` host quiescence gate)
- Secondary subsystem(s): Product/Runtime instance-state ownership substrate, which this gate guards
- Write class: mechanical
- Persistence impact: none — the parsed record is derived, not durable
- Derived/rebuildable impact: native enumeration succeeds on hosts with ordinary quoted command lines
- New or changed contract: none — restores the enumeration the code already intends
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: native writer detection must not weaken; `_native_role` must classify the same shapes

## Independent review

Declared risk surface: `concurrency`. A mechanism convergence packet was built for mechanism key `native-process-inventory-parsing` and reviewed by a fresh independent reviewer against the local publishable SHA. Verdict: **CLEAN**, no P0/P1.

Central question — can this let a running native writer go undetected? Answered **no**, by execution. Across 662 live `ps` rows the reviewer compared `_native_role(shlex.split(cmd))` against `_native_role(cmd.split())`: 1 row raised under `shlex`, 14 tokenized differently (all quote-stripping by `shlex`), and **0 produced a different role**. All 13 reachable writer shapes classify identically. Inputs where `shlex` would detect and `split()` would miss require the argv element itself to contain literal quotes (`python -m 'app.cli' watcher run`), which the reviewer confirmed unreachable for a *running* writer — `python -m "'json'"` fails with `No module named 'json'`. Whitespace collapsing is a non-issue: `shlex.split` collapses runs of whitespace identically to `str.split()`.

Four non-blocking P3 findings are recorded rather than fixed:

- `test_native_role_classifies_known_writers` does not cover two `_native_role` branches (`argv[0]` is itself a launcher script, `:1119`; bare `celery` at `:1127`), nor `start_full_system.sh` membership or `PYTHON_RE`'s versioned form. The reviewer verified out-of-band that both uncovered branches behave identically old vs. new. Test-completeness debt, not a correctness defect — but the test's docstring does overstate what it proves.
- `test_enumerate_macos_survives_quoted_command_row` proves non-abort rather than full completeness: it does not assert the writer row is still *classified*.
- A **pre-existing** false-quiescence path: a launcher installed at a path containing a space renders as `bash /Users/me/my repo/scripts/start_full_system.sh`, so `_basename(argv[1])` becomes `my` and `_native_role` returns `None`. The reviewer confirmed old and new parsers produce byte-identical argv there and both return `None`, so this change does not create the hole. The narrow interaction worth naming: if such a writer *also* has an apostrophe in its command line, old code blocked the deploy by accident where new code proceeds on a false proof. Not reachable today — every configured worktree path is space-free — but it exists on `main` too and deserves its own issue.
- The new code comment slightly overclaims; the real property is that a writer's *observed* token must be whitespace-free.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded single-mechanism defect repair with no plan divergence; the convergence packet and independent review are recorded in this PR body.

## Notes

Validation:

- `tests/ops/test_instance_state_writer_inventory.py` — 12 passed. Test-first: the three behavioural tests failed against unchanged `origin/main`; the detection and malformed-rejection tests passed both before and after, so detection power was never in flux.
- `tests/ops/test_instance_state_volume_contract.py` + `tests/deploy/test_deploy_channel.py` — 131 passed, 3 skipped, **0 failed** (7 failed before this change). Independently reproduced by the reviewer in a detached `origin/main` worktree.
- `ruff check app tests companion-ui/companion-app scripts/instance_state_writer_inventory.py` — all checks passed. The now-unused `shlex` import was removed; no other reference exists in the file, and repo-wide `shlex` users import it themselves.
- `scripts/docs_guard.py` — passed with `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1`, declared explicitly. No documented behaviour or contract changed; the fix makes the code match the enumeration the docs already describe.

Base drift: rebased onto `origin/main` before commit; validation above was run on the rebased base (`c11645167`).

---
