### PR TITLE
feat(builderops): add governed design-run CLI

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, cast
+from typing import Any, Callable, Iterable, Literal, Mapping, cast
 
 import click
 
@@ -61,6 +63,12 @@ from app.builderops.cutover_evidence import (
 from app.builderops.design_run_governance import (
     DesignRunGovernance,
     DesignRunGovernanceError,
+    DesignRunProjection,
+)
+from app.builderops.design_run_contract import (
+    CuratedDesignBrief,
+    is_safe_design_run_identifier,
+    parse_design_run_contract,
 )
 from app.builderops.evidence_bridge import (
     EvidenceBridgeError,
@@ -805,25 +813,391 @@ def inquiry() -> None:
 
 @builderops.group(
     "design-run",
-    help="Record authenticated local approval evidence for Builder design runs.",
+    help="Operate exact, governed Builder design runs outside the CKM cockpit.",
 )
 def design_run() -> None:
-    """Approval evidence only; execution and downstream writeback stay separate."""
+    """Explicit local control surface; CKM remains projection-only."""
 
 
 def _design_run_governance(
     ctx: click.Context,
     *,
     repo_root: Path,
+    store_mode: Literal["write", "read_only", "existing"] = "write",
 ) -> DesignRunGovernance:
     try:
+        if store_mode == "write":
+            store = _store(ctx)
+        else:
+            paths = _effective_paths(ctx)
+            if store_mode == "existing" and not paths.db_path.is_file():
+                raise DesignRunGovernanceError(
+                    "design-run evidence store does not exist"
+                )
+            store = SqliteBuilderOpsStore(paths.db_path)
         return DesignRunGovernance.from_declared_sources(
-            store=_store(ctx),
+            store=store,
             channel="dev",
             repo_root=repo_root,
         )
     except DesignRunGovernanceError as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+_DESIGN_RUN_CLI_REQUEST_VERSION = "builderops.design-run-cli-request.v1"
+_DESIGN_RUN_UTC_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+)
+_DESIGN_RUN_CLI_REQUEST_FIELDS = frozenset(
+    {
+        "adapter_id",
+        "brief",
+        "evaluated_at",
+        "request_id",
+        "requested_at",
+        "run_id",
+        "schema_version",
+    }
+)
+
+
+def _reject_duplicate_json_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ValueError("duplicate JSON key")
+        payload[key] = value
+    return payload
+
+
+def _load_design_run_cli_request(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_bytes(),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+        if not isinstance(payload, dict):
+            raise ValueError
+        if set(payload) != _DESIGN_RUN_CLI_REQUEST_FIELDS:
+            raise ValueError
+        if payload.get("schema_version") != _DESIGN_RUN_CLI_REQUEST_VERSION:
+            raise ValueError
+        for field in (
+            "adapter_id",
+            "evaluated_at",
+            "request_id",
+            "requested_at",
+            "run_id",
+        ):
+            if not isinstance(payload.get(field), str):
+                raise ValueError
+        for field in ("adapter_id", "request_id", "run_id"):
+            if not is_safe_design_run_identifier(payload[field]):
+                raise ValueError
+        for field in ("evaluated_at", "requested_at"):
+            timestamp = payload[field]
+            if not _DESIGN_RUN_UTC_TIMESTAMP.fullmatch(timestamp):
+                raise ValueError
+            datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+        raw_brief = payload["brief"]
+        if not isinstance(raw_brief, dict):
+            raise ValueError
+        brief = parse_design_run_contract(raw_brief)
+        if not isinstance(brief, CuratedDesignBrief):
+            raise ValueError
+        if brief.model_dump(mode="json") != raw_brief:
+            raise ValueError
+    except (OSError, TypeError, ValueError):
+        raise click.BadParameter(
+            "request-file must contain one exact canonical design-run CLI request"
+        ) from None
+    return {**payload, "brief": brief}
+
+
+def _load_design_run_brief(path: Path) -> CuratedDesignBrief:
+    try:
+        payload = json.loads(
+            path.read_bytes(),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+        if not isinstance(payload, dict):
+            raise ValueError
+        brief = parse_design_run_contract(payload)
+        if not isinstance(brief, CuratedDesignBrief):
+            raise ValueError
+        if brief.model_dump(mode="json") != payload:
+            raise ValueError
+    except (OSError, TypeError, ValueError):
+        raise click.BadParameter(
+            "brief-file must contain one canonical curated design brief"
+        ) from None
+    return brief
+
+
+def _design_run_cli_exception(exc: Exception) -> click.ClickException:
+    if isinstance(exc, DesignRunGovernanceError):
+        return click.ClickException(str(exc))
+    if isinstance(exc, (OSError, sqlite3.Error)):
+        return click.ClickException("design-run storage is unavailable")
+    return click.ClickException("design-run request was refused")
+
+
+def _design_run_preparation_payload(
+    *,
+    request: Any,
+    admission: Any,
+    persisted: bool,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "builderops.design-run-cli-output.v1",
+        "persisted": persisted,
+        "request": request.model_dump(mode="json"),
+        "request_hash": request.content_hash,
+        "admission": admission.model_dump(mode="json"),
+        "admission_hash": admission.content_hash,
+    }
+
+
+def _design_run_projection_payload(
+    projection: DesignRunProjection,
+) -> dict[str, Any]:
+    admission = projection.admission
+    approval = projection.approval
+    result = projection.result
+    return {
+        "schema_version": "builderops.design-run-cli-output.v1",
+        "run_id": projection.run_id,
+        "state": projection.state,
+        "latest_receipt_id": projection.latest_receipt_id,
+        "latest_receipt_hash": projection.latest_receipt_hash,
+        "admission": (
+            {
+                "admission_id": admission.admission_id,
+                "outcome": admission.outcome,
+                "request_ref": admission.request_ref.model_dump(mode="json"),
+            }
+            if admission is not None
+            else None
+        ),
+        "approval": (
+            {
+                "approval_id": approval.approval_id,
+                "state": approval.state,
+                "request_ref": approval.request_ref.model_dump(mode="json"),
+                "admission_ref": approval.admission_ref.model_dump(mode="json"),
+            }
+            if approval is not None
+            else None
+        ),
+        "result": result.model_dump(mode="json") if result is not None else None,
+        "refusal": (
+            projection.refusal.model_dump(mode="json")
+            if projection.refusal is not None
+            else None
+        ),
+    }
+
+
+@design_run.command(
+    "brief-build",
+    help="Validate and emit the bounded brief embedded in one canonical request file.",
+)
+@click.option(
+    "--request-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--json", "as_json", is_flag=True)
+def design_run_brief_build(request_file: Path, as_json: bool) -> None:
+    request = _load_design_run_cli_request(request_file)
+    brief = cast(CuratedDesignBrief, request["brief"])
+    _emit(
+        {
+            "schema_version": "builderops.design-run-cli-output.v1",
+            "brief": brief.model_dump(mode="json"),
+            "brief_hash": brief.content_hash,
+        },
+        as_json,
+    )
+
+
+@design_run.command(
+    "brief-inspect",
+    help="Validate and inspect one canonical bounded design brief.",
+)
+@click.option(
+    "--brief-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--json", "as_json", is_flag=True)
+def design_run_brief_inspect(brief_file: Path, as_json: bool) -> None:
+    brief = _load_design_run_brief(brief_file)
+    _emit(
+        {
+            "schema_version": "builderops.design-run-cli-output.v1",
+            "brief": brief.model_dump(mode="json"),
+            "brief_hash": brief.content_hash,
+        },
+        as_json,
+    )
+
+
+@design_run.command(
+    "agents",
+    help="List sanitized exact design-agent routes without selecting one.",
+)
+@click.option("--run-id", required=True)
+@click.option(
+    "--repo-root",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_agents(
+    ctx: click.Context,
+    run_id: str,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        descriptors = _design_run_governance(
+            ctx,
+            repo_root=repo_root,
+            store_mode="read_only",
+        ).list_adapters(run_id=run_id)
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(
+        {
+            "schema_version": "builderops.design-run-cli-output.v1",
+            "run_id": run_id,
+            "agents": [
+                descriptor.model_dump(mode="json")
+                for descriptor in descriptors
+            ],
+        },
+        as_json,
+    )
+
+
+def _prepare_design_run_from_cli(
+    ctx: click.Context,
+    *,
+    request_file: Path,
+    repo_root: Path,
+    persist: bool,
+) -> dict[str, Any]:
+    payload = _load_design_run_cli_request(request_file)
+    service = _design_run_governance(
+        ctx,
+        repo_root=repo_root,
+        store_mode="write" if persist else "read_only",
+    )
+    prepare = service.admit if persist else service.preview
+    request, admission = prepare(
+        run_id=payload["run_id"],
+        request_id=payload["request_id"],
+        brief=payload["brief"],
+        adapter_id=payload["adapter_id"],
+        requested_at=payload["requested_at"],
+        evaluated_at=payload["evaluated_at"],
+    )
+    return _design_run_preparation_payload(
+        request=request,
+        admission=admission,
+        persisted=persist,
+    )
+
+
+def _design_run_request_file_option(
+    function: Callable[..., Any],
+) -> Callable[..., Any]:
+    return click.option(
+        "--request-file",
+        required=True,
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    )(function)
+
+
+def _design_run_repo_root_option(
+    function: Callable[..., Any],
+) -> Callable[..., Any]:
+    return click.option(
+        "--repo-root",
+        required=True,
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+    )(function)
+
+
+@design_run.command(
+    "preview",
+    help="Evaluate exact admission read-only; write no receipt and call no provider.",
+)
+@_design_run_request_file_option
+@_design_run_repo_root_option
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_preview(
+    ctx: click.Context,
+    request_file: Path,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        payload = _prepare_design_run_from_cli(
+            ctx,
+            request_file=request_file,
+            repo_root=repo_root,
+            persist=False,
+        )
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(payload, as_json)
+
+
+@design_run.command(
+    "admit",
+    help="Persist the exact request and its deterministic admission.",
+)
+@_design_run_request_file_option
+@_design_run_repo_root_option
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_admit(
+    ctx: click.Context,
+    request_file: Path,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        payload = _prepare_design_run_from_cli(
+            ctx,
+            request_file=request_file,
+            repo_root=repo_root,
+            persist=True,
+        )
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(payload, as_json)
 
 
 @design_run.command(
@@ -852,14 +1226,26 @@ def design_run_approve(
         evidence = _design_run_governance(
             ctx,
             repo_root=repo_root,
+            store_mode="existing",
         ).approve(
             run_id=run_id,
             approval_id=approval_id,
             approved_at=approved_at,
         )
-    except (BuilderOpsValidationError, OSError, ValueError) as exc:
-        raise click.ClickException(str(exc)) from exc
-    _emit(evidence.model_dump(mode="json"), as_json)
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(
+        {
+            **evidence.model_dump(mode="json"),
+            "content_hash": evidence.content_hash,
+        },
+        as_json,
+    )
 
 
 @design_run.command(
@@ -888,14 +1274,149 @@ def design_run_revoke(
         evidence = _design_run_governance(
             ctx,
             repo_root=repo_root,
+            store_mode="existing",
         ).revoke(
             run_id=run_id,
             revocation_id=revocation_id,
             revoked_at=revoked_at,
         )
-    except (BuilderOpsValidationError, OSError, ValueError) as exc:
-        raise click.ClickException(str(exc)) from exc
-    _emit(evidence.model_dump(mode="json"), as_json)
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(
+        {
+            **evidence.model_dump(mode="json"),
+            "content_hash": evidence.content_hash,
+        },
+        as_json,
+    )
+
+
+@design_run.command(
+    "start",
+    help="Start only the exact durable request, admission, and approval named.",
+)
+@click.argument("run_id")
+@click.option("--request-id", required=True)
+@click.option("--request-hash", required=True)
+@click.option("--admission-id", required=True)
+@click.option("--admission-hash", required=True)
+@click.option("--approval-id", required=True)
+@click.option("--approval-hash", required=True)
+@click.option("--started-at", required=True)
+@click.option("--completed-at", required=True)
+@_design_run_repo_root_option
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_start(
+    ctx: click.Context,
+    run_id: str,
+    request_id: str,
+    request_hash: str,
+    admission_id: str,
+    admission_hash: str,
+    approval_id: str,
+    approval_hash: str,
+    started_at: str,
+    completed_at: str,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        result = _design_run_governance(
+            ctx,
+            repo_root=repo_root,
+            store_mode="existing",
+        ).execute_exact(
+            run_id=run_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            expected_request_id=request_id,
+            expected_request_hash=request_hash,
+            expected_admission_id=admission_id,
+            expected_admission_hash=admission_hash,
+            expected_approval_id=approval_id,
+            expected_approval_hash=approval_hash,
+        )
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(
+        {
+            "schema_version": "builderops.design-run-cli-output.v1",
+            "run_id": run_id,
+            "result": result.model_dump(mode="json"),
+        },
+        as_json,
+    )
+
+
+@design_run.command(
+    "status",
+    help="Derive current status only from the validated durable receipt chain.",
+)
+@click.argument("run_id")
+@_design_run_repo_root_option
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_status(
+    ctx: click.Context,
+    run_id: str,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        projection = _design_run_governance(
+            ctx,
+            repo_root=repo_root,
+            store_mode="existing",
+        ).projection(run_id)
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(_design_run_projection_payload(projection), as_json)
+
+
+@design_run.command(
+    "result",
+    help="Show validated terminal evidence without exposing adapter internals.",
+)
+@click.argument("run_id")
+@_design_run_repo_root_option
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def design_run_result(
+    ctx: click.Context,
+    run_id: str,
+    repo_root: Path,
+    as_json: bool,
+) -> None:
+    try:
+        projection = _design_run_governance(
+            ctx,
+            repo_root=repo_root,
+            store_mode="existing",
+        ).projection(run_id)
+    except (
+        BuilderOpsValidationError,
+        OSError,
+        sqlite3.Error,
+        ValueError,
+    ) as exc:
+        raise _design_run_cli_exception(exc) from exc
+    _emit(_design_run_projection_payload(projection), as_json)
 
 
 @inquiry.command("start", help="Persist an immutable inquiry question before model execution.")

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -823,18 +823,35 @@ def _design_run_governance(
     ctx: click.Context,
     *,
     repo_root: Path,
-    store_mode: Literal["write", "read_only", "existing"] = "write",
+    store_mode: Literal[
+        "write",
+        "read_only",
+        "existing_read",
+        "existing_write",
+    ] = "write",
 ) -> DesignRunGovernance:
     try:
         if store_mode == "write":
             store = _store(ctx)
         else:
             paths = _effective_paths(ctx)
-            if store_mode == "existing" and not paths.db_path.is_file():
+            if (
+                store_mode in {"existing_read", "existing_write"}
+                and not paths.db_path.is_file()
+            ):
                 raise DesignRunGovernanceError(
                     "design-run evidence store does not exist"
                 )
-            store = SqliteBuilderOpsStore(paths.db_path)
+            if store_mode == "existing_write":
+                store = SqliteBuilderOpsStore(
+                    paths.db_path,
+                    create_if_missing=False,
+                )
+            else:
+                store = SqliteBuilderOpsStore(
+                    paths.db_path,
+                    read_only=True,
+                )
         return DesignRunGovernance.from_declared_sources(
             store=store,
             channel="dev",
@@ -1226,7 +1243,7 @@ def design_run_approve(
         evidence = _design_run_governance(
             ctx,
             repo_root=repo_root,
-            store_mode="existing",
+            store_mode="existing_write",
         ).approve(
             run_id=run_id,
             approval_id=approval_id,
@@ -1274,7 +1291,7 @@ def design_run_revoke(
         evidence = _design_run_governance(
             ctx,
             repo_root=repo_root,
-            store_mode="existing",
+            store_mode="existing_write",
         ).revoke(
             run_id=run_id,
             revocation_id=revocation_id,
@@ -1305,8 +1322,8 @@ def design_run_revoke(
 @click.option("--request-hash", required=True)
 @click.option("--admission-id", required=True)
 @click.option("--admission-hash", required=True)
-@click.option("--approval-id", required=True)
-@click.option("--approval-hash", required=True)
+@click.option("--approval-id")
+@click.option("--approval-hash")
 @click.option("--started-at", required=True)
 @click.option("--completed-at", required=True)
 @_design_run_repo_root_option
@@ -1319,18 +1336,22 @@ def design_run_start(
     request_hash: str,
     admission_id: str,
     admission_hash: str,
-    approval_id: str,
-    approval_hash: str,
+    approval_id: str | None,
+    approval_hash: str | None,
     started_at: str,
     completed_at: str,
     repo_root: Path,
     as_json: bool,
 ) -> None:
+    if (approval_id is None) != (approval_hash is None):
+        raise click.UsageError(
+            "provide both --approval-id and --approval-hash, or neither"
+        )
     try:
         result = _design_run_governance(
             ctx,
             repo_root=repo_root,
-            store_mode="existing",
+            store_mode="existing_write",
         ).execute_exact(
             run_id=run_id,
             started_at=started_at,
@@ -1377,7 +1398,7 @@ def design_run_status(
         projection = _design_run_governance(
             ctx,
             repo_root=repo_root,
-            store_mode="existing",
+            store_mode="existing_read",
         ).projection(run_id)
     except (
         BuilderOpsValidationError,
@@ -1407,7 +1428,7 @@ def design_run_result(
         projection = _design_run_governance(
             ctx,
             repo_root=repo_root,
-            store_mode="existing",
+            store_mode="existing_read",
         ).projection(run_id)
     except (
         BuilderOpsValidationError,

--- a/app/builderops/design_agent_adapters.py
+++ b/app/builderops/design_agent_adapters.py
@@ -13,6 +13,7 @@ from typing import Any, Final, Literal
 
 from app.builderops.design_run_contract import (
     DesignAgentAvailabilityDescriptor,
+    DesignAgentDescriptor,
     DesignDeliverableKind,
     is_safe_design_run_identifier,
 )
@@ -194,6 +195,23 @@ class DesignAgentAdapterRegistry:
                 )
             descriptors.append(descriptor)
         return tuple(descriptors)
+
+    def contract_descriptor(
+        self,
+        design_agent_id: str,
+    ) -> DesignAgentDescriptor:
+        """Return the stable provider-neutral contract for one exact agent ID."""
+
+        role_profile_id = DESIGN_AGENT_ROLE_PROFILES.get(design_agent_id)
+        if role_profile_id is None:
+            raise UnknownDesignAgentError
+        return DesignAgentDescriptor(
+            descriptor_id=design_agent_id,
+            display_name=_DISPLAY_NAMES[design_agent_id],
+            role_profile_id=role_profile_id,
+            supported_deliverables=_SUPPORTED_DELIVERABLES,
+            descriptor_revision="v1",
+        )
 
     def select(
         self,

--- a/app/builderops/design_run_governance.py
+++ b/app/builderops/design_run_governance.py
@@ -614,6 +614,7 @@ class DesignRunGovernance:
             run_id=run_id,
             started_at=started_at,
             completed_at=completed_at,
+            require_exact_evidence=False,
             expected_request_id=None,
             expected_request_hash=None,
             expected_admission_id=None,
@@ -632,8 +633,8 @@ class DesignRunGovernance:
         expected_request_hash: str,
         expected_admission_id: str,
         expected_admission_hash: str,
-        expected_approval_id: str,
-        expected_approval_hash: str,
+        expected_approval_id: str | None,
+        expected_approval_hash: str | None,
     ) -> DesignRunResult:
         """Execute only when caller-named evidence is still the exact current chain."""
 
@@ -641,6 +642,7 @@ class DesignRunGovernance:
             run_id=run_id,
             started_at=started_at,
             completed_at=completed_at,
+            require_exact_evidence=True,
             expected_request_id=expected_request_id,
             expected_request_hash=expected_request_hash,
             expected_admission_id=expected_admission_id,
@@ -655,6 +657,7 @@ class DesignRunGovernance:
         run_id: str,
         started_at: str,
         completed_at: str,
+        require_exact_evidence: bool,
         expected_request_id: str | None = None,
         expected_request_hash: str | None = None,
         expected_admission_id: str | None = None,
@@ -671,6 +674,7 @@ class DesignRunGovernance:
             initial = self._load_chain(run_id)
             self._require_exact_start_evidence(
                 initial,
+                require_exact_evidence=require_exact_evidence,
                 expected_request_id=expected_request_id,
                 expected_request_hash=expected_request_hash,
                 expected_admission_id=expected_admission_id,
@@ -694,6 +698,7 @@ class DesignRunGovernance:
                 chain = self._load_chain(run_id)
                 self._require_exact_start_evidence(
                     chain,
+                    require_exact_evidence=require_exact_evidence,
                     expected_request_id=expected_request_id,
                     expected_request_hash=expected_request_hash,
                     expected_admission_id=expected_admission_id,
@@ -903,6 +908,7 @@ class DesignRunGovernance:
         self,
         chain: Sequence[_ReceiptNode],
         *,
+        require_exact_evidence: bool,
         expected_request_id: str | None,
         expected_request_hash: str | None,
         expected_admission_id: str | None,
@@ -912,36 +918,50 @@ class DesignRunGovernance:
     ) -> None:
         """Bind an operator start to the exact durable evidence it names."""
 
-        if expected_request_id is not None:
-            request = self._bundle(chain).request
+        if not require_exact_evidence:
+            return
+        request = self._bundle(chain).request
+        if (
+            expected_request_id is None
+            or expected_request_hash is None
+            or request.request_id != expected_request_id
+            or request.content_hash != expected_request_hash
+        ):
+            raise DesignRunGovernanceError(
+                "design-run start request identity mismatch"
+            )
+        admission = self._admission(chain)
+        if (
+            expected_admission_id is None
+            or expected_admission_hash is None
+            or admission is None
+            or admission.admission_id != expected_admission_id
+            or admission.content_hash != expected_admission_hash
+        ):
+            raise DesignRunGovernanceError(
+                "design-run start admission identity mismatch"
+            )
+        approval = self._latest_approval(chain)
+        if expected_approval_id is None:
             if (
-                request.request_id != expected_request_id
-                or request.content_hash != expected_request_hash
-            ):
-                raise DesignRunGovernanceError(
-                    "design-run start request identity mismatch"
-                )
-        if expected_admission_id is not None:
-            admission = self._admission(chain)
-            if (
-                admission is None
-                or admission.admission_id != expected_admission_id
-                or admission.content_hash != expected_admission_hash
-            ):
-                raise DesignRunGovernanceError(
-                    "design-run start admission identity mismatch"
-                )
-        if expected_approval_id is not None:
-            approval = self._latest_approval(chain)
-            if (
-                approval is None
-                or approval.approval_id != expected_approval_id
-                or approval.content_hash != expected_approval_hash
-                or approval.state != "approved"
+                expected_approval_hash is not None
+                or admission is None
+                or admission.outcome != "allow"
+                or approval is not None
             ):
                 raise DesignRunApprovalRequiredError(
                     "design-run start approval identity mismatch"
                 )
+        elif (
+            expected_approval_hash is None
+            or approval is None
+            or approval.approval_id != expected_approval_id
+            or approval.content_hash != expected_approval_hash
+            or approval.state != "approved"
+        ):
+            raise DesignRunApprovalRequiredError(
+                "design-run start approval identity mismatch"
+            )
 
     @staticmethod
     def _validate_returned_handoff(

--- a/app/builderops/design_run_governance.py
+++ b/app/builderops/design_run_governance.py
@@ -181,6 +181,17 @@ class DesignRunReceiptStore(Protocol):
 
 
 class DesignAgentRegistry(Protocol):
+    def descriptors(
+        self,
+        *,
+        run_id: str,
+    ) -> tuple[DesignAgentAvailabilityDescriptor, ...]: ...
+
+    def contract_descriptor(
+        self,
+        design_agent_id: str,
+    ) -> DesignAgentDescriptor: ...
+
     def select(
         self,
         design_agent_id: str,
@@ -385,6 +396,98 @@ class DesignRunGovernance:
             requested_at=requested_at,
         )
 
+    def list_adapters(
+        self,
+        *,
+        run_id: str,
+    ) -> tuple[DesignAgentAvailabilityDescriptor, ...]:
+        """Return sanitized exact-route availability without selecting a provider."""
+
+        self._require_run_id(run_id)
+        return self.registry.descriptors(run_id=run_id)
+
+    def preview(
+        self,
+        *,
+        run_id: str,
+        request_id: str,
+        brief: CuratedDesignBrief,
+        adapter_id: str,
+        requested_at: str,
+        evaluated_at: str,
+    ) -> tuple[DesignRunRequest, DesignRunAdmission]:
+        """Evaluate one exact request without persisting or executing it."""
+
+        request, adapter, bundle = self._prepare_request(
+            run_id=run_id,
+            request_id=request_id,
+            brief=brief,
+            adapter_id=adapter_id,
+            requested_at=requested_at,
+            evaluated_at=evaluated_at,
+        )
+        admission = self._evaluate_admission(
+            run_id=run_id,
+            bundle=bundle,
+            evaluated_at=evaluated_at,
+            repo_token_hash=self._trusted_repo_token_hash(brief),
+        )
+        return request, admission
+
+    def admit(
+        self,
+        *,
+        run_id: str,
+        request_id: str,
+        brief: CuratedDesignBrief,
+        adapter_id: str,
+        requested_at: str,
+        evaluated_at: str,
+    ) -> tuple[DesignRunRequest, DesignRunAdmission]:
+        """Persist one exact request and its deterministic admission."""
+
+        request, adapter, _bundle = self._prepare_request(
+            run_id=run_id,
+            request_id=request_id,
+            brief=brief,
+            adapter_id=adapter_id,
+            requested_at=requested_at,
+            evaluated_at=evaluated_at,
+        )
+        admission = self.submit(
+            run_id=run_id,
+            request=request,
+            brief=brief,
+            adapter=adapter,
+            evaluated_at=evaluated_at,
+        )
+        return request, admission
+
+    def _prepare_request(
+        self,
+        *,
+        run_id: str,
+        request_id: str,
+        brief: CuratedDesignBrief,
+        adapter_id: str,
+        requested_at: str,
+        evaluated_at: str,
+    ) -> tuple[DesignRunRequest, DesignAgentDescriptor, _RunBundle]:
+        self._require_run_id(run_id)
+        if evaluated_at < requested_at:
+            raise DesignRunGovernanceError(
+                "design-run admission time precedes its request"
+            )
+        adapter = self.registry.contract_descriptor(adapter_id)
+        request = self.build_request(
+            request_id=request_id,
+            brief=brief,
+            adapter=adapter,
+            requested_at=requested_at,
+        )
+        policy = load_design_run_policy(self.repo_root)
+        return request, adapter, _RunBundle(request, brief, adapter, policy)
+
     def submit(
         self,
         *,
@@ -507,6 +610,58 @@ class DesignRunGovernance:
     ) -> DesignRunResult:
         """Execute one exact approved adapter after a durable accepted-start fence."""
 
+        return self._execute(
+            run_id=run_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            expected_request_id=None,
+            expected_request_hash=None,
+            expected_admission_id=None,
+            expected_admission_hash=None,
+            expected_approval_id=None,
+            expected_approval_hash=None,
+        )
+
+    def execute_exact(
+        self,
+        *,
+        run_id: str,
+        started_at: str,
+        completed_at: str,
+        expected_request_id: str,
+        expected_request_hash: str,
+        expected_admission_id: str,
+        expected_admission_hash: str,
+        expected_approval_id: str,
+        expected_approval_hash: str,
+    ) -> DesignRunResult:
+        """Execute only when caller-named evidence is still the exact current chain."""
+
+        return self._execute(
+            run_id=run_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            expected_request_id=expected_request_id,
+            expected_request_hash=expected_request_hash,
+            expected_admission_id=expected_admission_id,
+            expected_admission_hash=expected_admission_hash,
+            expected_approval_id=expected_approval_id,
+            expected_approval_hash=expected_approval_hash,
+        )
+
+    def _execute(
+        self,
+        *,
+        run_id: str,
+        started_at: str,
+        completed_at: str,
+        expected_request_id: str | None = None,
+        expected_request_hash: str | None = None,
+        expected_admission_id: str | None = None,
+        expected_admission_hash: str | None = None,
+        expected_approval_id: str | None = None,
+        expected_approval_hash: str | None = None,
+    ) -> DesignRunResult:
         self._require_run_id(run_id)
         self._require_causal_execution_times(
             started_at=started_at,
@@ -514,6 +669,15 @@ class DesignRunGovernance:
         )
         with self._run_lock(run_id):
             initial = self._load_chain(run_id)
+            self._require_exact_start_evidence(
+                initial,
+                expected_request_id=expected_request_id,
+                expected_request_hash=expected_request_hash,
+                expected_admission_id=expected_admission_id,
+                expected_admission_hash=expected_admission_hash,
+                expected_approval_id=expected_approval_id,
+                expected_approval_hash=expected_approval_hash,
+            )
             existing_result = self._result(initial)
             if existing_result is not None:
                 return existing_result
@@ -528,6 +692,15 @@ class DesignRunGovernance:
             )
             try:
                 chain = self._load_chain(run_id)
+                self._require_exact_start_evidence(
+                    chain,
+                    expected_request_id=expected_request_id,
+                    expected_request_hash=expected_request_hash,
+                    expected_admission_id=expected_admission_id,
+                    expected_admission_hash=expected_admission_hash,
+                    expected_approval_id=expected_approval_id,
+                    expected_approval_hash=expected_approval_hash,
+                )
                 existing_result = self._result(chain)
                 if existing_result is not None:
                     return existing_result
@@ -726,6 +899,50 @@ class DesignRunGovernance:
                 if lease is not None:
                     self._release_run_lease(lease)
 
+    def _require_exact_start_evidence(
+        self,
+        chain: Sequence[_ReceiptNode],
+        *,
+        expected_request_id: str | None,
+        expected_request_hash: str | None,
+        expected_admission_id: str | None,
+        expected_admission_hash: str | None,
+        expected_approval_id: str | None,
+        expected_approval_hash: str | None,
+    ) -> None:
+        """Bind an operator start to the exact durable evidence it names."""
+
+        if expected_request_id is not None:
+            request = self._bundle(chain).request
+            if (
+                request.request_id != expected_request_id
+                or request.content_hash != expected_request_hash
+            ):
+                raise DesignRunGovernanceError(
+                    "design-run start request identity mismatch"
+                )
+        if expected_admission_id is not None:
+            admission = self._admission(chain)
+            if (
+                admission is None
+                or admission.admission_id != expected_admission_id
+                or admission.content_hash != expected_admission_hash
+            ):
+                raise DesignRunGovernanceError(
+                    "design-run start admission identity mismatch"
+                )
+        if expected_approval_id is not None:
+            approval = self._latest_approval(chain)
+            if (
+                approval is None
+                or approval.approval_id != expected_approval_id
+                or approval.content_hash != expected_approval_hash
+                or approval.state != "approved"
+            ):
+                raise DesignRunApprovalRequiredError(
+                    "design-run start approval identity mismatch"
+                )
+
     @staticmethod
     def _validate_returned_handoff(
         *,
@@ -855,6 +1072,10 @@ class DesignRunGovernance:
             )
             try:
                 chain = self._load_chain(run_id)
+                if self._current_state(chain) != "approval_pending":
+                    raise DesignRunApprovalRequiredError(
+                        "design-run approval mutation is no longer allowed"
+                    )
                 bundle = self._bundle(chain)
                 admission = self._required_admission(chain)
                 if admission.outcome != "approval_required":

--- a/app/builderops/store.py
+++ b/app/builderops/store.py
@@ -62,10 +62,17 @@ class SqliteBuilderOpsStore:
     migrations.
     """
 
-    def __init__(self, db_path: Path, *, read_only: bool = False) -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        read_only: bool = False,
+        create_if_missing: bool = True,
+    ) -> None:
         validate_db_path_outside_vault(Path(db_path))
         self._db_path = Path(db_path)
         self._read_only = read_only
+        self._create_if_missing = create_if_missing
 
     @property
     def db_path(self) -> Path:
@@ -75,6 +82,9 @@ class SqliteBuilderOpsStore:
         validate_db_path_outside_vault(self._db_path)
         if self._read_only:
             uri = f"{self._db_path.absolute().as_uri()}?mode=ro"
+            conn = sqlite3.connect(uri, uri=True)
+        elif not self._create_if_missing:
+            uri = f"{self._db_path.absolute().as_uri()}?mode=rw"
             conn = sqlite3.connect(uri, uri=True)
         else:
             self._db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/builderops/ckm/test_design_cockpit.py
+++ b/tests/builderops/ckm/test_design_cockpit.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.builderops.design_agent_adapters import DesignAgentAdapterRegistry
+from app.builderops.design_run_governance import DesignRunGovernance
+from app.builderops.model_access_resolver import BuilderModelAccessResolver
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+def test_ckm_calls_only_builder_system_design_adapter_port(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    policy_path = repo_root / "config/builderops/design_run_policy.json"
+    policy_path.parent.mkdir(parents=True)
+    source_policy = (
+        Path(__file__).parents[3]
+        / "config/builderops/design_run_policy.json"
+    )
+    policy_path.write_bytes(source_policy.read_bytes())
+    store = SqliteBuilderOpsStore(tmp_path / "builderops.sqlite3")
+    store.initialize()
+
+    service = DesignRunGovernance.from_declared_sources(
+        store=store,
+        channel="dev",
+        repo_root=repo_root,
+    )
+
+    assert isinstance(service.registry, DesignAgentAdapterRegistry)
+    assert isinstance(service.registry.resolver, BuilderModelAccessResolver)
+    assert service.registry.model_turn_adapters == {}
+    descriptors = service.list_adapters(run_id="run.production.zero-edge")
+    assert {item.design_agent_id for item in descriptors} == {
+        "claude-design-via-claude-code",
+        "codex",
+        "fable",
+    }
+    assert all(not item.available for item in descriptors)

--- a/tests/builderops/test_design_run_cli.py
+++ b/tests/builderops/test_design_run_cli.py
@@ -1,0 +1,798 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import app.builderops.cli as cli_module
+from app.builderops.cli import builderops
+from app.builderops.ckm.overview_html import (
+    CockpitRenderContext,
+    render_overview_html,
+)
+from app.builderops.ckm.store import CkmStore
+from app.builderops.design_agent_adapters import ResolvedDesignAgentAdapter
+from app.builderops.design_run_contract import (
+    DesignAgentAvailabilityDescriptor,
+    DesignAgentDescriptor,
+)
+from app.builderops.design_run_governance import DesignRunGovernance
+from app.builderops.store import SqliteBuilderOpsStore
+from llm_contract import AdapterResult
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+T0 = "2026-07-30T10:00:00Z"
+T1 = "2026-07-30T10:01:00Z"
+T2 = "2026-07-30T10:02:00Z"
+T3 = "2026-07-30T10:03:00Z"
+T4 = "2026-07-30T10:04:00Z"
+T5 = "2026-07-30T10:05:00Z"
+T6 = "2026-07-30T10:06:00Z"
+
+
+@dataclass
+class RecordingAdapter:
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    fail_with_sensitive_detail: bool = False
+    adapter_id: str = "test-codex"
+    provider: str = "test-provider"
+    model: str = "test-model"
+
+    def execute(self, request: Mapping[str, Any]) -> AdapterResult:
+        self.calls.append(dict(request))
+        if self.fail_with_sensitive_detail:
+            raise RuntimeError("Bearer top-secret from /Users/operator/private")
+        content = "bounded design output"
+        handoff = {
+            **dict(request["handoff_binding"]),
+            "content_hash": hashlib.sha256(content.encode()).hexdigest(),
+        }
+        return AdapterResult(
+            response_text=json.dumps(
+                {
+                    "schema_version": request[
+                        "handoff_output_schema_version"
+                    ],
+                    "artifact_content": content,
+                    "handoff": handoff,
+                },
+                sort_keys=True,
+            ),
+            provider_request_id="provider-request-not-persisted",
+        )
+
+
+@dataclass
+class RecordingRegistry:
+    adapter: RecordingAdapter
+    selections: list[tuple[str, str]] = field(default_factory=list)
+
+    def contract_descriptor(
+        self,
+        design_agent_id: str,
+    ) -> DesignAgentDescriptor:
+        if design_agent_id != "codex":
+            raise ValueError("unknown design agent")
+        return DesignAgentDescriptor(
+            descriptor_id="codex",
+            display_name="Codex",
+            role_profile_id="design.codex",
+            supported_deliverables=(
+                "content_review",
+                "interaction_specification",
+                "visual_handoff",
+            ),
+            descriptor_revision="v1",
+        )
+
+    def descriptors(
+        self,
+        *,
+        run_id: str,
+    ) -> tuple[DesignAgentAvailabilityDescriptor, ...]:
+        return (
+            DesignAgentAvailabilityDescriptor(
+                design_agent_id="codex",
+                display_name="Codex",
+                role_profile_id="design.codex",
+                supported_deliverables=(
+                    "content_review",
+                    "interaction_specification",
+                    "visual_handoff",
+                ),
+                available=True,
+                provider_identity="test-provider",
+                model_identity="test-model",
+                effective_identity="test-provider/test-model",
+                capabilities=("structured_output",),
+                resolution_group_id=f"design-run:{run_id}",
+            ),
+        )
+
+    def select(
+        self,
+        design_agent_id: str,
+        *,
+        run_id: str,
+    ) -> ResolvedDesignAgentAdapter:
+        self.selections.append((design_agent_id, run_id))
+        return ResolvedDesignAgentAdapter(
+            design_agent_id=design_agent_id,
+            descriptor=self.descriptors(run_id=run_id)[0],
+            model_turn_adapter=self.adapter,
+        )
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    policy_path = root / "config/builderops/design_run_policy.json"
+    policy_path.parent.mkdir(parents=True)
+    policy_path.write_text(
+        json.dumps(
+            {
+                "allowed_deliverables": [
+                    "content_review",
+                    "interaction_specification",
+                    "visual_handoff",
+                ],
+                "approval_required": True,
+                "contract_kind": "policy",
+                "max_attachment_refs": 8,
+                "max_source_refs": 16,
+                "profile_id": "design.policy.local",
+                "profile_version": "v1",
+                "schema_version": "builderops.design-run-contract.v1",
+                "visual_yggdrasil_receipt_required": True,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SqliteBuilderOpsStore:
+    selected = SqliteBuilderOpsStore(tmp_path / "builderops.sqlite3")
+    selected.initialize()
+    return selected
+
+
+def _service(
+    store: SqliteBuilderOpsStore,
+    repo_root: Path,
+    *,
+    fail_with_sensitive_detail: bool = False,
+) -> tuple[DesignRunGovernance, RecordingRegistry, RecordingAdapter]:
+    adapter = RecordingAdapter(
+        fail_with_sensitive_detail=fail_with_sensitive_detail
+    )
+    registry = RecordingRegistry(adapter)
+    return (
+        DesignRunGovernance(
+            store=store,
+            registry=registry,
+            repo_root=repo_root,
+            lease_ttl_seconds=30,
+        ),
+        registry,
+        adapter,
+    )
+
+
+def _brief_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "builderops.design-run-contract.v1",
+        "contract_kind": "brief",
+        "brief_id": "brief.cli.one",
+        "projection_id": "projection.cli.one",
+        "requested_deliverable": "interaction_specification",
+        "source_refs": [
+            {
+                "source_type": "github_issue",
+                "source_id": "github:RasmusTho/agentic-pkm-mvp#4311",
+                "content_hash": SHA_A,
+            }
+        ],
+        "attachment_refs": [
+            {
+                "attachment_id": "attachment.cli.one",
+                "media_type": "text/markdown",
+                "content_hash": SHA_B,
+            }
+        ],
+        "constraints": ["Use explicit evidence only."],
+        "yggdrasil_gate_receipt": None,
+        "non_visual_exemption": True,
+    }
+
+
+def _request_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "builderops.design-run-cli-request.v1",
+        "run_id": "run.cli.one",
+        "request_id": "request.cli.one",
+        "adapter_id": "codex",
+        "requested_at": T0,
+        "evaluated_at": T1,
+        "brief": _brief_payload(),
+    }
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _bind_service(
+    monkeypatch: pytest.MonkeyPatch,
+    service: DesignRunGovernance,
+) -> None:
+    monkeypatch.setattr(
+        cli_module,
+        "_design_run_governance",
+        lambda _ctx, *, repo_root, store_mode="write": service,
+    )
+
+
+def _invoke(
+    store: SqliteBuilderOpsStore,
+    *args: str,
+) -> Any:
+    return CliRunner().invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "design-run", *args],
+        catch_exceptions=False,
+    )
+
+
+def _admit_and_approve(
+    *,
+    store: SqliteBuilderOpsStore,
+    repo_root: Path,
+    request_file: Path,
+) -> dict[str, str]:
+    admitted = _invoke(
+        store,
+        "admit",
+        "--request-file",
+        str(request_file),
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert admitted.exit_code == 0, admitted.output
+    approved = _invoke(
+        store,
+        "approve",
+        "run.cli.one",
+        "--approval-id",
+        "approval.cli.one",
+        "--approved-at",
+        T2,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert approved.exit_code == 0, approved.output
+    admitted_payload = json.loads(admitted.output)
+    approved_payload = json.loads(approved.output)
+    return {
+        "request_id": admitted_payload["request"]["request_id"],
+        "request_hash": admitted_payload["request_hash"],
+        "admission_id": admitted_payload["admission"]["admission_id"],
+        "admission_hash": admitted_payload["admission_hash"],
+        "approval_id": approved_payload["approval_id"],
+        "approval_hash": approved_payload["content_hash"],
+    }
+
+
+def _exact_start_options(identities: Mapping[str, str]) -> list[str]:
+    return [
+        "--request-id",
+        identities["request_id"],
+        "--request-hash",
+        identities["request_hash"],
+        "--admission-id",
+        identities["admission_id"],
+        "--admission-hash",
+        identities["admission_hash"],
+        "--approval-id",
+        identities["approval_id"],
+        "--approval-hash",
+        identities["approval_hash"],
+    ]
+
+
+def test_cli_builds_only_explicit_bounded_briefs(
+    tmp_path: Path,
+    store: SqliteBuilderOpsStore,
+) -> None:
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+    first = _invoke(
+        store,
+        "brief-build",
+        "--request-file",
+        str(request_file),
+        "--json",
+    )
+    second = _invoke(
+        store,
+        "brief-build",
+        "--request-file",
+        str(request_file),
+        "--json",
+    )
+    assert first.exit_code == second.exit_code == 0
+    assert first.output == second.output
+    built = json.loads(first.output)
+    assert built["brief"]["source_refs"][0]["content_hash"] == SHA_A
+    assert built["brief"]["attachment_refs"][0]["content_hash"] == SHA_B
+
+    brief_file = _write_json(tmp_path / "brief.json", built["brief"])
+    inspected = _invoke(
+        store,
+        "brief-inspect",
+        "--brief-file",
+        str(brief_file),
+        "--json",
+    )
+    assert inspected.exit_code == 0
+    assert json.loads(inspected.output)["brief_hash"] == built["brief_hash"]
+
+    unbounded = _request_payload()
+    unbounded["brief"]["constraints"] = ["Use the whole repo."]
+    rejected = _invoke(
+        store,
+        "brief-build",
+        "--request-file",
+        str(_write_json(tmp_path / "unbounded.json", unbounded)),
+        "--json",
+    )
+    assert rejected.exit_code != 0
+    assert "canonical design-run CLI request" in rejected.output
+
+    missing_digest = _request_payload()
+    del missing_digest["brief"]["attachment_refs"][0]["content_hash"]
+    rejected_digest = _invoke(
+        store,
+        "brief-build",
+        "--request-file",
+        str(_write_json(tmp_path / "missing-digest.json", missing_digest)),
+        "--json",
+    )
+    assert rejected_digest.exit_code != 0
+
+    padded_cases = (
+        ("request-id", lambda payload: payload.__setitem__(
+            "request_id", " request.cli.one "
+        )),
+        ("brief-id", lambda payload: payload["brief"].__setitem__(
+            "brief_id", " brief.cli.one "
+        )),
+        ("source-id", lambda payload: payload["brief"]["source_refs"][0].__setitem__(
+            "source_id", " github:RasmusTho/agentic-pkm-mvp#4311 "
+        )),
+        ("constraint", lambda payload: payload["brief"].__setitem__(
+            "constraints", [" Use explicit evidence only. "]
+        )),
+    )
+    for name, mutate in padded_cases:
+        padded = _request_payload()
+        mutate(padded)
+        result = _invoke(
+            store,
+            "brief-build",
+            "--request-file",
+            str(_write_json(tmp_path / f"padded-{name}.json", padded)),
+            "--json",
+        )
+        assert result.exit_code != 0
+
+
+def test_cli_preview_precedes_exact_governed_start(
+    tmp_path: Path,
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, registry, adapter = _service(store, repo_root)
+    _bind_service(monkeypatch, service)
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+
+    preview = _invoke(
+        store,
+        "preview",
+        "--request-file",
+        str(request_file),
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert preview.exit_code == 0, preview.output
+    assert json.loads(preview.output)["persisted"] is False
+    assert store.list_records("BuilderOpsReceipt") == []
+    assert registry.selections == [] and adapter.calls == []
+
+    before_admission = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        "--request-id",
+        "request.cli.one",
+        "--request-hash",
+        "0" * 64,
+        "--admission-id",
+        "run.cli.one.admission",
+        "--admission-hash",
+        "0" * 64,
+        "--approval-id",
+        "approval.cli.one",
+        "--approval-hash",
+        "0" * 64,
+        "--started-at",
+        T3,
+        "--completed-at",
+        T4,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert before_admission.exit_code != 0
+    assert registry.selections == [] and adapter.calls == []
+
+    identities = _admit_and_approve(
+        store=store,
+        repo_root=repo_root,
+        request_file=request_file,
+    )
+    mismatched = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(
+            {**identities, "admission_id": "foreign.admission"}
+        ),
+        "--started-at",
+        T3,
+        "--completed-at",
+        T4,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert mismatched.exit_code != 0
+    assert registry.selections == [] and adapter.calls == []
+
+    started = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(identities),
+        "--started-at",
+        T3,
+        "--completed-at",
+        T4,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert started.exit_code == 0, started.output
+    assert json.loads(started.output)["result"]["final_status"] == "succeeded"
+    assert registry.selections == [("codex", "run.cli.one")]
+    assert len(adapter.calls) == 1
+    receipt_count = len(store.list_records("BuilderOpsReceipt"))
+    late_approval = _invoke(
+        store,
+        "approve",
+        "run.cli.one",
+        "--approval-id",
+        "approval.late.one",
+        "--approved-at",
+        T5,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert late_approval.exit_code != 0
+    assert len(store.list_records("BuilderOpsReceipt")) == receipt_count
+    assert service.projection("run.cli.one").state == "succeeded"
+
+
+def test_cli_approval_and_revocation_are_exact_and_actor_bound(
+    tmp_path: Path,
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, registry, adapter = _service(store, repo_root)
+    _bind_service(monkeypatch, service)
+    monkeypatch.setattr(
+        "app.builderops.design_run_governance._authenticated_local_principal",
+        lambda: "local-operator",
+    )
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+    admitted = _invoke(
+        store,
+        "admit",
+        "--request-file",
+        str(request_file),
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert admitted.exit_code == 0
+
+    help_result = _invoke(store, "approve", "--help")
+    assert "--actor" not in help_result.output
+    approved = _invoke(
+        store,
+        "approve",
+        "run.cli.one",
+        "--approval-id",
+        "approval.cli.one",
+        "--approved-at",
+        T2,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert approved.exit_code == 0, approved.output
+    approved_payload = json.loads(approved.output)
+    records = store.list_records("BuilderOpsReceipt")
+    assert records[-1]["actor"] == {
+        "actor_type": "human",
+        "id": "local-operator",
+    }
+
+    revoked = _invoke(
+        store,
+        "revoke",
+        "run.cli.one",
+        "--revocation-id",
+        "revocation.cli.one",
+        "--revoked-at",
+        T3,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert revoked.exit_code == 0
+    reapproved = _invoke(
+        store,
+        "approve",
+        "run.cli.one",
+        "--approval-id",
+        "approval.cli.one",
+        "--approved-at",
+        T4,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert reapproved.exit_code == 0, reapproved.output
+    reapproved_payload = json.loads(reapproved.output)
+    admitted_payload = json.loads(admitted.output)
+    stale_identities = {
+        "request_id": admitted_payload["request"]["request_id"],
+        "request_hash": admitted_payload["request_hash"],
+        "admission_id": admitted_payload["admission"]["admission_id"],
+        "admission_hash": admitted_payload["admission_hash"],
+        "approval_id": approved_payload["approval_id"],
+        "approval_hash": approved_payload["content_hash"],
+    }
+    assert (
+        reapproved_payload["content_hash"]
+        != stale_identities["approval_hash"]
+    )
+    refused = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(stale_identities),
+        "--started-at",
+        T5,
+        "--completed-at",
+        T6,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert refused.exit_code != 0
+    assert registry.selections == [] and adapter.calls == []
+
+
+def test_cli_status_and_result_are_receipt_derived_and_secret_safe(
+    tmp_path: Path,
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _registry, adapter = _service(
+        store,
+        repo_root,
+        fail_with_sensitive_detail=True,
+    )
+    _bind_service(monkeypatch, service)
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+    identities = _admit_and_approve(
+        store=store,
+        repo_root=repo_root,
+        request_file=request_file,
+    )
+    started = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(identities),
+        "--started-at",
+        T3,
+        "--completed-at",
+        T4,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert started.exit_code == 0, started.output
+    assert len(adapter.calls) == 1
+
+    for command in ("status", "result"):
+        observed = _invoke(
+            store,
+            command,
+            "run.cli.one",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        )
+        assert observed.exit_code == 0, observed.output
+        assert json.loads(observed.output)["state"] == "failed"
+        lowered = observed.output.lower()
+        assert "top-secret" not in lowered
+        assert "bearer" not in lowered
+        assert "/users/" not in lowered
+        assert "provider-request-not-persisted" not in lowered
+
+    latest = next(
+        record
+        for record in store.list_records("BuilderOpsReceipt")
+        if record.get("action") == "run_failed"
+        and record.get("event_type") == "design_run_event"
+    )
+    with sqlite3.connect(store.db_path) as conn:
+        row = conn.execute(
+            "SELECT payload FROM builderops_records WHERE id = ?",
+            (latest["id"],),
+        ).fetchone()
+        assert row is not None
+        payload = json.loads(row[0])
+        event = json.loads(payload["receipt_body"])
+        event["artifact_hash"] = "0" * 64
+        payload["receipt_body"] = json.dumps(event, sort_keys=True)
+        conn.execute(
+            "UPDATE builderops_records SET payload = ? WHERE id = ?",
+            (json.dumps(payload, sort_keys=True), latest["id"]),
+        )
+    tampered = _invoke(
+        store,
+        "status",
+        "run.cli.one",
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert tampered.exit_code != 0, tampered.output
+    assert '"state": "failed"' not in tampered.output
+
+
+def test_read_only_commands_do_not_create_storage_or_leak_host_paths(
+    tmp_path: Path,
+    repo_root: Path,
+) -> None:
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+    absent_db = tmp_path / "absent" / "builderops.sqlite3"
+    runner = CliRunner()
+
+    preview = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(absent_db),
+            "design-run",
+            "preview",
+            "--request-file",
+            str(request_file),
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert preview.exit_code == 0, preview.output
+    assert json.loads(preview.output)["persisted"] is False
+    assert not absent_db.exists()
+    assert not absent_db.parent.exists()
+
+    agents = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(absent_db),
+            "design-run",
+            "agents",
+            "--run-id",
+            "run.cli.one",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert agents.exit_code == 0, agents.output
+    assert not absent_db.exists()
+
+    marker = "private-secret-marker"
+    collision = tmp_path / marker
+    collision.write_text("not a directory", encoding="utf-8")
+    colliding_db = collision / "builderops.sqlite3"
+    colliding_preview = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(colliding_db),
+            "design-run",
+            "preview",
+            "--request-file",
+            str(request_file),
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert colliding_preview.exit_code == 0, colliding_preview.output
+    assert marker not in colliding_preview.output
+    status = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(colliding_db),
+            "design-run",
+            "status",
+            "run.cli.one",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert status.exit_code != 0
+    assert marker not in status.output
+    assert "design-run evidence store does not exist" in status.output
+
+
+def test_control_surface_stays_outside_static_cockpit(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "ckm.sqlite3")
+    store.ensure_schema()
+    rendered = render_overview_html(
+        store,
+        generated_at=T0,
+        cockpit=CockpitRenderContext(batch=store.load_projection_batch()),
+    )
+    lowered = rendered.lower()
+    assert "<form" not in lowered
+    assert "<button" not in lowered
+    assert "<textarea" not in lowered
+    assert "fetch(" not in lowered
+    assert "design-run start" not in lowered
+    assert "design-run approve" not in lowered
+    assert "design-run admit" not in lowered

--- a/tests/builderops/test_design_run_cli.py
+++ b/tests/builderops/test_design_run_cli.py
@@ -20,6 +20,7 @@ from app.builderops.ckm.overview_html import (
 from app.builderops.ckm.store import CkmStore
 from app.builderops.design_agent_adapters import ResolvedDesignAgentAdapter
 from app.builderops.design_run_contract import (
+    CuratedDesignBrief,
     DesignAgentAvailabilityDescriptor,
     DesignAgentDescriptor,
 )
@@ -297,7 +298,7 @@ def _admit_and_approve(
 
 
 def _exact_start_options(identities: Mapping[str, str]) -> list[str]:
-    return [
+    options = [
         "--request-id",
         identities["request_id"],
         "--request-hash",
@@ -306,11 +307,17 @@ def _exact_start_options(identities: Mapping[str, str]) -> list[str]:
         identities["admission_id"],
         "--admission-hash",
         identities["admission_hash"],
-        "--approval-id",
-        identities["approval_id"],
-        "--approval-hash",
-        identities["approval_hash"],
     ]
+    if "approval_id" in identities or "approval_hash" in identities:
+        options.extend(
+            [
+                "--approval-id",
+                identities["approval_id"],
+                "--approval-hash",
+                identities["approval_hash"],
+            ]
+        )
+    return options
 
 
 def test_cli_builds_only_explicit_bounded_briefs(
@@ -506,6 +513,116 @@ def test_cli_preview_precedes_exact_governed_start(
     assert late_approval.exit_code != 0
     assert len(store.list_records("BuilderOpsReceipt")) == receipt_count
     assert service.projection("run.cli.one").state == "succeeded"
+
+
+def test_cli_starts_approval_free_allow_and_rejects_one_sided_pair(
+    tmp_path: Path,
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy_path = repo_root / "config/builderops/design_run_policy.json"
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    policy["approval_required"] = False
+    policy_path.write_text(json.dumps(policy, sort_keys=True), encoding="utf-8")
+    service, registry, adapter = _service(store, repo_root)
+    _bind_service(monkeypatch, service)
+    request_file = _write_json(tmp_path / "request.json", _request_payload())
+
+    admitted = _invoke(
+        store,
+        "admit",
+        "--request-file",
+        str(request_file),
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert admitted.exit_code == 0, admitted.output
+    payload = json.loads(admitted.output)
+    assert payload["admission"]["outcome"] == "allow"
+    identities = {
+        "request_id": payload["request"]["request_id"],
+        "request_hash": payload["request_hash"],
+        "admission_id": payload["admission"]["admission_id"],
+        "admission_hash": payload["admission_hash"],
+    }
+
+    one_sided = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(identities),
+        "--approval-id",
+        "approval.must.not.be.one-sided",
+        "--started-at",
+        T2,
+        "--completed-at",
+        T3,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert one_sided.exit_code != 0
+    assert registry.selections == [] and adapter.calls == []
+
+    started = _invoke(
+        store,
+        "start",
+        "run.cli.one",
+        *_exact_start_options(identities),
+        "--started-at",
+        T2,
+        "--completed-at",
+        T3,
+        "--repo-root",
+        str(repo_root),
+        "--json",
+    )
+    assert started.exit_code == 0, started.output
+    assert json.loads(started.output)["result"]["final_status"] == "succeeded"
+    assert registry.selections == [("codex", "run.cli.one")]
+    assert len(adapter.calls) == 1
+
+
+def test_execute_exact_requires_runtime_request_and_admission_evidence(
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+) -> None:
+    service, registry, adapter = _service(store, repo_root)
+    brief = CuratedDesignBrief.model_validate_json(
+        json.dumps(_brief_payload(), sort_keys=True)
+    )
+    service.admit(
+        run_id="run.cli.one",
+        request_id="request.cli.one",
+        brief=brief,
+        adapter_id="codex",
+        requested_at=T0,
+        evaluated_at=T1,
+    )
+    service.approve(
+        run_id="run.cli.one",
+        approval_id="approval.cli.real",
+        approved_at=T2,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="request identity mismatch",
+    ):
+        service.execute_exact(
+            run_id="run.cli.one",
+            started_at=T3,
+            completed_at=T4,
+            expected_request_id=None,  # type: ignore[arg-type]
+            expected_request_hash=None,  # type: ignore[arg-type]
+            expected_admission_id=None,  # type: ignore[arg-type]
+            expected_admission_hash=None,  # type: ignore[arg-type]
+            expected_approval_id="approval.foreign",
+            expected_approval_hash="0" * 64,
+        )
+    assert registry.selections == [] and adapter.calls == []
 
 
 def test_cli_approval_and_revocation_are_exact_and_actor_bound(
@@ -778,6 +895,136 @@ def test_read_only_commands_do_not_create_storage_or_leak_host_paths(
     assert status.exit_code != 0
     assert marker not in status.output
     assert "design-run evidence store does not exist" in status.output
+
+
+def test_status_and_result_use_sqlite_mode_ro_and_never_recreate(
+    repo_root: Path,
+    store: SqliteBuilderOpsStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _registry, _adapter = _service(store, repo_root)
+    brief = CuratedDesignBrief.model_validate_json(
+        json.dumps(_brief_payload(), sort_keys=True)
+    )
+    service.admit(
+        run_id="run.cli.one",
+        request_id="request.cli.one",
+        brief=brief,
+        adapter_id="codex",
+        requested_at=T0,
+        evaluated_at=T1,
+    )
+    durable_bytes = store.db_path.read_bytes()
+
+    real_store = cli_module.SqliteBuilderOpsStore
+    read_only_flags: list[bool] = []
+
+    def recording_store(
+        path: Path,
+        *,
+        read_only: bool = False,
+    ) -> SqliteBuilderOpsStore:
+        read_only_flags.append(read_only)
+        return real_store(path, read_only=read_only)
+
+    monkeypatch.setattr(
+        cli_module,
+        "SqliteBuilderOpsStore",
+        recording_store,
+    )
+    runner = CliRunner()
+    status = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(store.db_path),
+            "design-run",
+            "status",
+            "run.cli.one",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert status.exit_code == 0, status.output
+    assert read_only_flags == [True]
+
+    def deleting_store(
+        path: Path,
+        *,
+        read_only: bool = False,
+    ) -> SqliteBuilderOpsStore:
+        assert read_only is True
+        Path(path).unlink()
+        return real_store(path, read_only=read_only)
+
+    monkeypatch.setattr(
+        cli_module,
+        "SqliteBuilderOpsStore",
+        deleting_store,
+    )
+    result = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(store.db_path),
+            "design-run",
+            "result",
+            "run.cli.one",
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "design-run storage is unavailable" in result.output
+    assert not store.db_path.exists()
+
+    store.db_path.write_bytes(durable_bytes)
+
+    def deleting_write_store(
+        path: Path,
+        *,
+        read_only: bool = False,
+        create_if_missing: bool = True,
+    ) -> SqliteBuilderOpsStore:
+        assert read_only is False
+        assert create_if_missing is False
+        Path(path).unlink()
+        return real_store(
+            path,
+            read_only=read_only,
+            create_if_missing=create_if_missing,
+        )
+
+    monkeypatch.setattr(
+        cli_module,
+        "SqliteBuilderOpsStore",
+        deleting_write_store,
+    )
+    approve = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(store.db_path),
+            "design-run",
+            "approve",
+            "run.cli.one",
+            "--approval-id",
+            "approval.cli.race",
+            "--approved-at",
+            T2,
+            "--repo-root",
+            str(repo_root),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert approve.exit_code != 0
+    assert "design-run storage is unavailable" in approve.output
+    assert not store.db_path.exists()
 
 
 def test_control_surface_stays_outside_static_cockpit(tmp_path: Path) -> None:

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,23 @@ import app.builderops.config as builderops_config
 from app.builderops.models import BuilderOpsLeaseError
 from app.builderops.store import SqliteBuilderOpsStore
 from app.builderops.cutover_evidence import build_receipt, write_receipt
+
+
+def test_noncreating_modes_refuse_missing_database(tmp_path: Path) -> None:
+    path = tmp_path / "missing" / "builderops.sqlite3"
+
+    with pytest.raises(sqlite3.OperationalError):
+        SqliteBuilderOpsStore(path, read_only=True).list_records()
+    assert not path.exists()
+    assert not path.parent.exists()
+
+    with pytest.raises(sqlite3.OperationalError):
+        SqliteBuilderOpsStore(
+            path,
+            create_if_missing=False,
+        ).list_records()
+    assert not path.exists()
+    assert not path.parent.exists()
 
 
 def test_default_store_leases_coordinate_across_cwd(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4311

## Linked Issue
Fixes #4311

## SBS Impact
- Primary subsystem: BuilderOps operator CLI
- Secondary subsystem(s): Design-run governance, shared model-access adapter port, and CKM non-execution boundary
- Write class: Single-operator local command surface over existing append-only design-run receipts
- Persistence impact: Only governed admit/approve/revoke/start operations write through the existing DesignRunGovernance service; no new table, object type, or receipt envelope
- Derived/rebuildable impact: Structured CLI status/result output is reconstructed from the validated durable receipt chain
- New or changed contract: Canonical CLI request file, read-only preview/listing, exact hash-bound start, and secret-safe status/result grammar
- Owner-doc impact: None until terminal parent acceptance
- Transition debt impact: Keeps all active controls outside generated CKM HTML
- Boundary risk: Caller cannot supply approval actor, bypass exact request/admission/approval hashes, invoke a provider from Click, or use CKM/Product/subscription authority

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add canonical bounded brief build/inspect, sanitized exact-agent listing, read-only preview, durable admit, OS-principal approval/revocation, exact start, status, and result commands.
- Bind start to current request, admission, and approval IDs plus canonical hashes at both execution fences; reject stale, reused, revoked, post-start, or terminal approval evidence before any adapter call.
- Keep read-only commands storage-neutral and all errors path/secret-safe while production remains provider-free with no credential, subscription, fallback, GitHub, Product, or cockpit control path.

## BuilderOps Routing
- Records/projections/receipts: Runtime design-run operations continue to use the existing BuilderOpsReceipt aggregate; this delivery creates no BuilderOps operational record or parallel authority.
- Reason: GitHub Issue #4311 and this PR are the repo-governed delivery authority. CKM remains projection/evidence only.

## Notes
Validation on 9d5ecda0bf62844d209b7d4796219f2f7f000f6b: all six governing Verify targets passed; 43 focused store/design-run contract/adapter/governance/CLI/cockpit tests passed; ruff check app tests passed; mypy app passed across 834 files; git diff --check passed. Final Review Round 1 on the previous head found two blocking P1s: approval-free allow admission was unreachable through the CLI, and nominal status/result reads opened SQLite in write/create mode. The repair makes approval evidence an all-or-none optional pair accepted only for the durable current allow decision, requires exact request/admission evidence in the public exact-execution path, separates existing read-only mode=ro from no-create writable mode=rw, and proves deletion races cannot recreate the database. A fresh independent Sol/high mechanism convergence review on the repair bytes returned PASS with zero remaining findings. No provider calls, credential operations, subscription-bridge changes, inquiry acceptance, GitHub mutation by CKM, or Product/runtime changes occurred.