### PR TITLE
Single-source the dispatcher task_id derivation used by sync and the pickup wrapper

### DIFF
--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -310,6 +310,18 @@ def _ready_validation_failure(payload: dict[str, Any]) -> str | None:
     )
 
 
+def github_issue_task_id(repo: str, issue_number: int) -> str:
+    """Single source for the repo-qualified dispatcher task id.
+
+    Every consumer that needs the ``github-<owner>--<repo>-issue-<N>`` id —
+    including ``scripts/issue_pickup_claim.sh`` — must derive it through this
+    function; a second spelling silently splits the dispatcher join key
+    (INV-DG-2). The owner/name separator is doubled (``--``) so repo names
+    that themselves contain ``-`` cannot collapse two repos onto one id.
+    """
+    return f"github-{repo.replace('/', '--')}-issue-{issue_number}"
+
+
 def normalize_github_issue(
     payload: dict[str, Any], repo: str, now: str | None = None
 ) -> TaskRecord:
@@ -319,15 +331,9 @@ def normalize_github_issue(
     raw GitHub issue dicts (real or mocked) plus the ``owner/name`` *repo* the
     issue came from.
 
-    ``task_id`` is repo-qualified so that issue numbers colliding across repos
-    (both repos can have an issue #21) map to distinct rows instead of silently
-    clobbering each other. The owner/name separator is doubled (``--``) rather
-    than reusing the single ``-`` GitHub repo names may themselves contain —
-    a single-hyphen encoding lets two different repos collapse to the same
-    string (``"org/foo-bar"`` and ``"org-foo/bar"`` both become
-    ``"org-foo-bar"``); doubling the separator keeps them distinct
-    (``"org--foo-bar"`` vs ``"org-foo--bar"``) for any repo name that doesn't
-    itself contain a literal ``--``.
+    ``task_id`` is repo-qualified via :func:`github_issue_task_id` so that
+    issue numbers colliding across repos (both repos can have an issue #21)
+    map to distinct rows instead of silently clobbering each other.
 
     Priority defaults to ``med`` when no recognised priority label is present.
     Status defaults to ``ready`` when no recognised status label is present.
@@ -336,7 +342,7 @@ def normalize_github_issue(
         now = datetime.now(timezone.utc).isoformat()
 
     number = payload["number"]
-    task_id = f"github-{repo.replace('/', '--')}-issue-{number}"
+    task_id = github_issue_task_id(repo, number)
 
     labels = _label_names(payload)
 

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -628,7 +628,10 @@ Implementation surface:
   dispatcher store in one call; each repo's issues upsert independently and aggregate into one JSON
   receipt under `repos`. Task IDs are repo-qualified (`github-<owner>--<repo>-issue-<n>`) so the same
   issue number in two different repos never collides, and stale-ready reconciliation is scoped per
-  repo so pulling one repo cannot reconcile another repo's tasks. `make dispatcher-init` and
+  repo so pulling one repo cannot reconcile another repo's tasks. The id has exactly one
+  implementation — `app/dispatcher/sync_github.py::github_issue_task_id` — and every consumer,
+  including the pickup wrapper's default `TASK_ID`, derives through it rather than respelling the
+  format (INV-DG-2, #4440). `make dispatcher-init` and
   `make dispatcher-sync` pull both `RasmusTho/agentic-pkm-mvp` and `RasmusTho/bifrost` (the two live
   Yggdrasil-ecosystem repos with an active `agent:ready` backlog today); `app.ops.builderops_startup`
   defaults to the same pair (`DEFAULT_REPOS`) when the full-stack launcher doesn't override `--repo`.

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -101,10 +101,31 @@ if [[ "$REPO" != */* ]]; then
   exit 2
 fi
 
-# Match app/dispatcher/sync_github.py::normalize_github_issue's repo-qualified
-# task_id scheme (doubled "--" separator, not a single "-", so that e.g.
-# "org/foo-bar" and "org-foo/bar" can't collapse to the same id).
-TASK_ID="${TASK_ID:-github-${REPO//\//--}-issue-$ISSUE_NUMBER}"
+# The default task id is derived from the single Python source
+# (app/dispatcher/sync_github.py::github_issue_task_id), so this wrapper can
+# never drift from the id `dispatcher pull` assigns (INV-DG-2). python3 is
+# already a hard dependency of every wrapper path via JSON parsing.
+if [[ -z "$TASK_ID" ]]; then
+  script_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if ! TASK_ID="$(
+    TASK_ID_REPO="$REPO" \
+    TASK_ID_ISSUE="$ISSUE_NUMBER" \
+    TASK_ID_REPO_ROOT="$script_repo_root" \
+    "$JSON_PYTHON_BIN" - <<'PY'
+import os
+import sys
+
+sys.path.insert(0, os.environ["TASK_ID_REPO_ROOT"])
+
+from app.dispatcher.sync_github import github_issue_task_id
+
+print(github_issue_task_id(os.environ["TASK_ID_REPO"], int(os.environ["TASK_ID_ISSUE"])))
+PY
+  )"; then
+    echo "could not derive task_id via app.dispatcher.sync_github.github_issue_task_id; pass --task-id explicitly" >&2
+    exit 2
+  fi
+fi
 
 detect_coordination_receipt() {
   local status_json

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -18,6 +18,7 @@ from app.dispatcher.sync_github import (
     GitHubIssueSource,
     PullSyncAdapter,
     get_sync_meta,
+    github_issue_task_id,
     normalize_github_issue,
     record_sync_failure,
     record_sync_success,
@@ -126,6 +127,20 @@ def test_pull_sync_adapter_interface() -> None:
 # ---------------------------------------------------------------------------
 # AC: normalize_github_issue maps fields correctly
 # ---------------------------------------------------------------------------
+
+def test_github_issue_task_id_single_source_format_pinned() -> None:
+    """The repo-qualified task id has exactly one implementation with a pinned
+    byte format, including the doubled ``--`` owner/repo separator that keeps
+    ``org/foo-bar`` and ``org-foo/bar`` distinct (INV-DG-2, #4440)."""
+    assert github_issue_task_id("org/foo-bar", 21) == "github-org--foo-bar-issue-21"
+    assert github_issue_task_id("org-foo/bar", 21) == "github-org-foo--bar-issue-21"
+    assert (
+        github_issue_task_id("RasmusTho/agentic-pkm-mvp", 4440)
+        == "github-RasmusTho--agentic-pkm-mvp-issue-4440"
+    )
+    task = normalize_github_issue({"number": 4440, "title": "t"}, "RasmusTho/agentic-pkm-mvp")
+    assert task.task_id == github_issue_task_id("RasmusTho/agentic-pkm-mvp", 4440)
+
 
 def test_normalize_github_issue_to_task() -> None:
     """normalize_github_issue converts sample GitHub payload to TaskRecord."""

--- a/tests/scripts/test_issue_pickup_claim.py
+++ b/tests/scripts/test_issue_pickup_claim.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
+
+from app.dispatcher.sync_github import github_issue_task_id
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -239,6 +242,78 @@ def test_default_task_id_is_repo_qualified_to_match_dispatcher_pull(tmp_path: Pa
     assert "task_id=github-RasmusTho--bifrost-issue-21" in result.stdout
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
     assert "dispatcher -m app.dispatcher claim github-RasmusTho--bifrost-issue-21" in commands
+
+
+def test_explicit_task_id_override_still_wins(tmp_path: Path) -> None:
+    """``--task-id`` bypasses the derived default so multi-repo edge cases keep
+    an escape hatch (#4440)."""
+    worktree, env = _make_harness(
+        tmp_path,
+        status_json=json.dumps(
+            {
+                "ok": True,
+                "db_exists": True,
+                "coordination_mode": "dispatcher-backed",
+                "fallback_reason": None,
+            }
+        ),
+        claim_json=json.dumps(
+            {
+                "ok": True,
+                "task": {
+                    "task_id": "custom-task-id-3301",
+                    "issue_number": 3301,
+                    "status": "claimed",
+                    "claimed_by": "codex-3301",
+                    "lease_id": "lease-3301",
+                },
+                "lease": {
+                    "lease_id": "lease-3301",
+                    "resource": "issue:3301",
+                    "holder": "codex-3301",
+                    "expires_at": "2099-07-10T01:00:00Z",
+                    "released_at": None,
+                },
+            }
+        ),
+    )
+
+    result = _run(worktree, env, "--task-id", "custom-task-id-3301")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "task_id=custom-task-id-3301" in result.stdout
+    commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert "dispatcher -m app.dispatcher claim custom-task-id-3301" in commands
+
+
+def test_default_task_id_derived_from_python_single_source(tmp_path: Path) -> None:
+    """The wrapper derives its default task id from
+    ``app.dispatcher.sync_github.github_issue_task_id`` and carries no
+    independent spelling of the format string (INV-DG-2, #4440)."""
+    script_text = SCRIPT.read_text(encoding="utf-8")
+    assert "github_issue_task_id" in script_text
+    assert re.search(r"github-.*-issue-", script_text) is None
+
+    worktree, env = _make_harness(
+        tmp_path,
+        status_json=json.dumps(
+            {
+                "ok": True,
+                "db_exists": True,
+                "coordination_mode": "dispatcher-backed",
+                "fallback_reason": None,
+            }
+        ),
+        claim_json=_dispatcher_claim(),
+    )
+
+    result = _run(worktree, env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected = github_issue_task_id("RasmusTho/agentic-pkm-mvp", 3301)
+    assert f"task_id={expected}" in result.stdout
+    commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert f"dispatcher -m app.dispatcher claim {expected}" in commands
 
 
 def test_dispatcher_availability_is_not_reported_as_acquired_claim(tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4440

## Linked Issue
Closes #4440

## SBS Impact
- Primary subsystem: Builder System / CES boundary (dispatcher control plane)
- Secondary subsystem(s): none
- Write class: mechanical
- Persistence impact: none (task_id bytes unchanged)
- Derived/rebuildable impact: dispatcher rows stay keyed by unchanged ids; nothing to migrate
- New or changed contract: none externally; one exported derivation helper internally
- Owner-doc impact: docs/AGENT_ISSUE_DISPATCHER.md updated in this PR
- Transition debt impact: reduces (removes a duplicated join-key spelling)
- Boundary risk: task_id byte format must not change; pinned by test_github_issue_task_id_single_source_format_pinned

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- github_issue_task_id() in app/dispatcher/sync_github.py is now the only implementation of the repo-qualified github-<owner>--<repo>-issue-<N> dispatcher task id (audit F8, INV-DG-2). normalize_github_issue uses it, and scripts/issue_pickup_claim.sh derives its default TASK_ID through it via the wrapper's JSON python instead of carrying an independent spelling. The frozen legacy-row SQL migration constant in app/dispatcher/store.py is intentionally untouched: it must keep reproducing the historical format.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Tier 2 single-issue slice; no BuilderOps material routed.

## Notes
Validation: python3 -m pytest tests/dispatcher/test_sync_github.py tests/scripts/test_issue_pickup_claim.py -q => 52 passed on the rebased head (new: test_github_issue_task_id_single_source_format_pinned, test_default_task_id_derived_from_python_single_source, test_explicit_task_id_override_still_wins). ruff check app tests => clean. mypy app => clean (836 files). AC3 override coverage: test_explicit_task_id_override_still_wins complements the AC-named test_default_task_id_is_repo_qualified_to_match_dispatcher_pull. Claim receipt: dispatcher-backed, task_id=github-RasmusTho--agentic-pkm-mvp-issue-4440, lease_id=lease-ca03a464, holder=claude-fable-5, evidence=verified-dispatcher-lease.
