### PR TITLE
Repair main: static-page test-selection expectation matches declared co-ownership

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -230,19 +230,16 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # lives in tests/api (test_ask_contract).
             "app/middleware/",
             # Static assets are mounted and served by app/api/app.py; page
-            # handlers (/signboard, /cockpit) are API surface. builder_system
-            # co-owns this prefix for the Builder-state content it renders.
+            # handlers (/signboard, /cockpit) are API surface, asserted from
+            # tests/api (test_signboard_api reads signboard.html/.js), so a
+            # UI-copy change selects that coverage instead of failing closed
+            # as unowned. builder_system co-owns this prefix for the
+            # Builder-state content it renders.
             "app/web/",
             "api/",
             # FastAPI dependency providers (get_agent_repository / get_db)
             # consumed by app/api/routers/agent.py; exercised via tests/api.
             "app/deps.py",
-            # The static pages the API mounts at /static (app/api/app.py) and
-            # serves at /signboard. Their contracts are asserted from tests/api
-            # (test_signboard_api reads signboard.html and signboard.js), so a
-            # UI-copy change belongs here instead of failing closed as an
-            # unowned app/ path.
-            "app/web/",
             "tests/companion_ui/",
             "tests/api/",
             "tests/architecture/test_openapi_static_contract.py",

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -1077,18 +1077,23 @@ def test_bundle_schema_and_invariant_change_selects_episodes_coverage() -> None:
     assert "tests/invariants/test_episode_binding.py" in selection.targets
 
 def test_api_served_static_page_change_selects_api_coverage() -> None:
-    """The pages the API serves are API surface, not an unowned app/ path.
+    """The pages the API serves are co-owned surface, not an unowned app/ path.
 
     `app/api/app.py` mounts `app/web/static`, and tests/api asserts on the
     served HTML/JS directly, so a Signboard UI-copy change must select that
     coverage instead of failing closed (exit 2) as unowned runtime code.
+    builder_system co-owns the prefix because the static pages (signboard,
+    cockpit) render dispatcher/BuilderOps state whose regressions live in
+    tests/dispatcher and tests/builderops (#4439 + #4406 both declare this
+    co-ownership in the subsystem map).
     """
     selection = select_tests(["app/web/static/signboard.js"])
 
     assert selection.full_suite is False
-    assert selection.subsystems == ("companion_ui",)
+    assert selection.subsystems == ("builder_system", "companion_ui")
     assert selection.unowned_paths == ()
     assert "tests/api" in selection.targets
+    assert "tests/dispatcher" in selection.targets
 
 
 def test_builder_system_change_selects_its_own_regression_tests() -> None:


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Required check 'Unit tests (not pg)' is red on main: #4439 and #4406 merged concurrently with a semantic conflict — both declared app/web/ co-ownership (builder_system + companion_ui) in scripts/select_pr_tests.py comments, but #4406's new test asserts exclusive companion_ui ownership. Every open PR inherits the red required check until main is repaired; bounded two-file fix.
Validation: python3 -m pytest tests/scripts/test_select_pr_tests.py -q => 84 passed; ruff check app tests => clean
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System / CES boundary (PR test-selection machinery)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none (selector behavior unchanged; test expectation aligned with shipped mapping)
- Owner-doc impact: none
- Transition debt impact: reduces (unreddens main's required check)
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Align test_api_served_static_page_change_selects_api_coverage with the co-ownership both #4439 and #4406 documented: app/web/static changes select builder_system + companion_ui coverage (tests/api and tests/dispatcher both asserted). Drop the duplicate app/web/ entry #4406 added to the companion_ui prefix tuple, folding its test_signboard_api rationale into the surviving comment.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded direct repair of a red main; no BuilderOps material routed.

## Notes
Root cause: concurrent merges #4439 (app/web/ into builder_system) and #4406 (app/web/ into companion_ui + exclusivity test) — each PR's CI ran before the other landed. Failure first observed on PR #4445's required check; reproduced on origin/main directly.
