### PR TITLE
EROJ-01: commit entity-review operation and outbox visibility

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -704,6 +704,16 @@ jobs:
               - 'tests/index/test_provenance_stamp.py'
               - 'tests/indexer/test_outbox_roundtrip_pg.py'
               - 'tests/knowledge_acquisition/test_youtube_api_quota_pg.py'
+              # Entity-review operation journal (EROJ-01, #4350): every
+              # committed-visibility mechanism proof is pg-marked, so this
+              # lane is the PR-path check that can catch drift on it
+              # (`Unit tests (not pg)` deselects all of them by design).
+              - 'app/heimdal/entity_review_operation_journal.py'
+              - 'app/heimdal/entity_confirm.py'
+              - 'app/heimdal/entity_register.py'
+              - 'app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py'
+              - 'tests/heimdal/test_entity_review_operation_journal.py'
+              - 'tests/migrations/test_entity_review_operation_journal_schema_parity.py'
               - '.github/workflows/ci-smoke.yaml'
 
       - uses: actions/setup-python@v5
@@ -723,7 +733,7 @@ jobs:
         if: steps.changes.outputs.index_pg == 'true'
         run: python -c "import os, psycopg; psycopg.connect(os.environ['DATABASE_URL'], autocommit=True).execute('CREATE EXTENSION IF NOT EXISTS vector')"
 
-      - name: Run exact index and YouTube quota PG acceptance surface
+      - name: Run exact index, YouTube quota, and entity-review journal PG surface
         if: steps.changes.outputs.index_pg == 'true'
         shell: bash
         run: |
@@ -732,6 +742,8 @@ jobs:
             tests/index/test_provenance_stamp.py \
             tests/indexer/test_outbox_roundtrip_pg.py \
             tests/knowledge_acquisition/test_youtube_api_quota_pg.py \
+            tests/heimdal/test_entity_review_operation_journal.py \
+            tests/migrations/test_entity_review_operation_journal_schema_parity.py \
             --tb=short \
             | tee pytest-index-pg.log
 

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -235,6 +235,8 @@ jobs:
             tests/int/test_pg_backend.py \
             tests/api/test_status_store_pg.py \
             tests/indexer/test_outbox_roundtrip_pg.py \
+            tests/heimdal/test_entity_review_operation_journal.py \
+            tests/migrations/test_entity_review_operation_journal_schema_parity.py \
             -m "pg" \
             --tb=short \
             | tee tmp/nightly-pg-contracts.log

--- a/app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py
+++ b/app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py
@@ -1,0 +1,89 @@
+"""EROJ-01 (#4350): entity-review operation journal — committed visibility fence.
+
+Creates `entity_review_operations`, backing
+`app/heimdal/entity_review_operation_journal.py`: one row per deterministic
+entity-review merge operation (INV-EROJ-2 — the active vault identity, queue
+entry id, decision-list position, SHA-256 digest of the exact human-authored
+decision mapping, and the original `{from_id, into_id}` derive the id). The
+row commits BEFORE the first register note effect; its terminal
+`event_committed` state commits atomically with the operation's
+deterministically keyed `heimdal.register.entity.merged` outbox row; and a
+merge queue entry may leave `entities/review.md` `pending` only after a fresh
+connection observes both committed rows (INV-EROJ-3 — the #4253 stop-loss
+failure this table exists to close).
+
+The partial unique index enforces one *active* (non-cleared) operation per
+`(vault_identity, queue_entry_id)`: a changed decision mapping derives a
+different operation_id and its INSERT fails closed at the database
+(INV-EROJ-2/6) instead of minting a colliding second operation. `cleared`
+rows fall out of the index so a later re-queue of the same queue entry id can
+claim a fresh operation.
+
+Operational coordination evidence only (INV-EROJ-1): entity notes remain
+canonical identity truth and `entities/review.md` remains the human decision
+history; this table never decides that two entities are the same.
+
+Forward-only per the repo precedent: dropping this table would erase the only
+durable retry anchors for in-flight merge operations (an applied register
+effect whose event recovery depends on its committed operation row).
+
+The DDL below is byte-identical with the module's test-only autocreate shape;
+parity is asserted by
+tests/migrations/test_entity_review_operation_journal_schema_parity.py.
+
+Revision ID: e7a2b9c4d1f8
+Revises: d0f5b2c7e4a6
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# Alembic identifiers
+revision: str = "e7a2b9c4d1f8"
+down_revision: Union[str, None] = "d0f5b2c7e4a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Machine-readable classification for the promotion migration gate
+# (docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md;
+# app/release_channels/reversibility.py). Downgrade raises by design.
+reversibility: str = "forward-only"
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+CREATE TABLE IF NOT EXISTS entity_review_operations (
+    operation_id UUID PRIMARY KEY,
+    vault_identity TEXT NOT NULL,
+    queue_entry_id TEXT NOT NULL,
+    decision_position INTEGER NOT NULL,
+    decision_digest TEXT NOT NULL,
+    from_id TEXT NOT NULL,
+    into_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'claimed'
+        CONSTRAINT entity_review_operations_state_chk
+        CHECK (state IN ('claimed', 'event_committed', 'cleared')),
+    outbox_event_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+    )
+    op.execute(
+        """
+CREATE UNIQUE INDEX IF NOT EXISTS entity_review_operations_active_entry_idx
+    ON entity_review_operations (vault_identity, queue_entry_id)
+    WHERE state <> 'cleared'
+"""
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "EROJ-01 entity-review operation journal migration is forward-only; the "
+        "journal rows are the durable retry anchors for in-flight merge operations "
+        "(INV-EROJ-3) and are never dropped by downgrade."
+    )

--- a/app/heimdal/entity_confirm.py
+++ b/app/heimdal/entity_confirm.py
@@ -82,8 +82,13 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from app.heimdal.attribution_stage import RESOLUTION_UNRESOLVED, EntityMention
-from app.heimdal.entity_register import EntityRegister, EntityRegisterError
+from app.heimdal.entity_register import (
+    MERGE_EFFECTS_COMPLETE,
+    EntityRegister,
+    EntityRegisterError,
+)
 from app.heimdal.entity_review_operation_journal import (
+    STATE_EVENT_COMMITTED,
     EntityReviewOperationConflictError,
     EntityReviewOperationJournalError,
     EntityReviewOperationJournalPort,
@@ -359,12 +364,6 @@ class AppliedDecision:
     operation_id: str | None = None
 
 
-def _vault_identity(vault_root: Path) -> str:
-    """The active-vault identity an operation binds (INV-EROJ-2): the resolved
-    active-vault root this applicator was invoked for."""
-    return str(Path(vault_root).expanduser().resolve())
-
-
 def apply_human_review_decisions(
     vault_root: Path,
     *,
@@ -422,6 +421,21 @@ def apply_human_review_decisions(
     raised loudly as one aggregate `EntityConfirmError` after durable
     successes are recorded.
 
+    Resume is keyed on the ENTRY, not on re-deriving an id from the current
+    decision content: an active `event_committed` operation on a pending
+    entry is an already-authorized merge whose clear was interrupted, and it
+    is finished first (fence -> cleared -> entry removed, reported as the
+    applied merge) regardless of what the decision history now folds to --
+    consistent with the documented undo boundary, where a ruling appended
+    after hub application is an idempotent no-op, never a reversal. An active
+    `claimed` operation blocks a `reject` from clearing that entry (the
+    operation may already have register effects; ambiguity fails closed,
+    INV-EROJ-6) and makes a *changed* merge decision fail closed via the
+    identity conflict. An interrupted clear whose operation already reached
+    `cleared` (stop between the journal update and the note write) is
+    finished without claiming a new operation, so one merge can never emit a
+    second event through re-approval (partial-failure matrix row 4).
+
     Idempotent: a decision whose `queue_entry_id` is no longer in `pending`
     has already been applied (or never existed) and is skipped rather than
     re-merged -- re-running this function is always safe, and a re-run after
@@ -465,77 +479,156 @@ def apply_human_review_decisions(
             "(EROJ-01, INV-EROJ-3), so nothing was applied"
         )
 
-    vault_identity = _vault_identity(vault_root)
+    vault_identity = register.vault_identity
 
     for index, effective_decision in ordered_terminals:
         merged = False
         operation_id: str | None = None
-        if effective_decision.action == "merge":
-            assert (
-                effective_decision.from_id is not None
-                and effective_decision.into_id is not None
-            )
-            assert journal is not None  # guaranteed by the upfront check
-            try:
-                # Pre-claim validation: prove the merge is executable (or
-                # resumable) from current notes BEFORE binding an operation,
-                # so a typo'd decision never strands an active operation row.
-                register.merge_effect_state(
-                    effective_decision.from_id, effective_decision.into_id
+        queue_entry_id = effective_decision.queue_entry_id
+        try:
+            if journal is not None:
+                # Entry-keyed resume (review F1): an edited decision history
+                # derives a different operation id, so the in-flight row is
+                # reachable only through the entry itself.
+                active = journal.find_active_operation(
+                    vault_identity=vault_identity, queue_entry_id=queue_entry_id
                 )
-                # 1. Operation identity commits before the first register
-                #    effect (INV-EROJ-2; a changed mapping fails closed).
-                operation = journal.claim_operation(
-                    vault_identity=vault_identity,
-                    queue_entry_id=effective_decision.queue_entry_id,
-                    decision_position=index,
-                    decision_digest=decision_mapping_digest(raw_decisions[index]),
-                    from_id=effective_decision.from_id,
-                    into_id=effective_decision.into_id,
-                )
-                # 2. Resumable note effects (skips sides a crash already wrote).
-                register.ensure_merge_effects(
-                    effective_decision.from_id, effective_decision.into_id
-                )
-                # 3. Terminal journal state + exactly one event, atomically.
-                operation = journal.commit_merge_event(operation)
-                # 4. The fence: only a fresh transaction's read of the
-                #    committed journal + outbox rows authorizes the clear.
-                if not journal.verify_committed_visibility(operation):
-                    refused.append(
-                        (
-                            effective_decision.queue_entry_id,
-                            "committed visibility was not observed on a fresh "
-                            "transaction; the queue entry stays pending (INV-EROJ-3)",
+                if active is not None and active.state == STATE_EVENT_COMMITTED:
+                    # An already-authorized merge whose clear was interrupted:
+                    # finish it first. Whatever the history folds to now, the
+                    # durable outcome was recorded when its event committed --
+                    # a later ruling is an idempotent no-op per the undo
+                    # boundary, never a reversal.
+                    if not journal.verify_committed_visibility(active):
+                        refused.append(
+                            (
+                                queue_entry_id,
+                                "committed visibility was not observed on a fresh "
+                                "transaction for the in-flight operation "
+                                f"{active.operation_id}; the queue entry stays "
+                                "pending (INV-EROJ-3)",
+                            )
+                        )
+                        continue
+                    journal.mark_cleared(active)
+                    remaining_pending = [
+                        p
+                        for p in remaining_pending
+                        if p.get("queue_entry_id") != queue_entry_id
+                    ]
+                    applied.append(
+                        AppliedDecision(
+                            queue_entry_id=queue_entry_id,
+                            action="merge",
+                            merged=True,
+                            operation_id=active.operation_id,
                         )
                     )
                     continue
-                operation = journal.mark_cleared(operation)
-            except EntityReviewOperationSchemaMissingError:
-                # System misconfiguration, not a per-entry ambiguity: surface
-                # the migration guidance immediately.
-                raise
-            except (
-                EntityRegisterError,
-                EntityReviewOperationConflictError,
-                EntityReviewOperationJournalError,
-            ) as exc:
-                refused.append((effective_decision.queue_entry_id, str(exc)))
-                continue
-            merged = True
-            operation_id = operation.operation_id
-        # "reject": no register mutation -- the candidate stays unresolved/
-        # ambiguous, exactly as it was before queuing. "undo" never reaches
-        # this application loop because the fold represents it as no intent.
+                if active is not None and effective_decision.action != "merge":
+                    # Review F3: a reject must not clear an entry whose claimed
+                    # operation may already have register effects -- that would
+                    # silently divorce the human ruling from canonical notes.
+                    refused.append(
+                        (
+                            queue_entry_id,
+                            f"operation {active.operation_id} is still claimed for this "
+                            "entry; a reject cannot clear it and the entry stays "
+                            "pending (INV-EROJ-6)",
+                        )
+                    )
+                    continue
+
+            if effective_decision.action == "merge":
+                assert (
+                    effective_decision.from_id is not None
+                    and effective_decision.into_id is not None
+                )
+                assert journal is not None  # guaranteed by the upfront check
+                # Review F4 / matrix row 4: a stop between mark_cleared and
+                # the note write leaves the entry visible with its operation
+                # already cleared. Finishing that interrupted clear must not
+                # claim a new operation -- that path emits a second event for
+                # the same merge.
+                cleared_twin = journal.find_cleared_operation(
+                    vault_identity=vault_identity,
+                    queue_entry_id=queue_entry_id,
+                    from_id=effective_decision.from_id,
+                    into_id=effective_decision.into_id,
+                )
+                if (
+                    cleared_twin is not None
+                    and register.merge_effect_state(
+                        effective_decision.from_id, effective_decision.into_id
+                    )
+                    == MERGE_EFFECTS_COMPLETE
+                ):
+                    merged = True
+                    operation_id = cleared_twin.operation_id
+                else:
+                    # Pre-claim validation: prove the merge is executable (or
+                    # resumable) from current notes BEFORE binding an
+                    # operation, so a typo'd decision never strands an active
+                    # operation row.
+                    register.merge_effect_state(
+                        effective_decision.from_id, effective_decision.into_id
+                    )
+                    # 1. Operation identity commits before the first register
+                    #    effect (INV-EROJ-2; a changed mapping fails closed).
+                    operation = journal.claim_operation(
+                        vault_identity=vault_identity,
+                        queue_entry_id=queue_entry_id,
+                        decision_position=index,
+                        decision_digest=decision_mapping_digest(raw_decisions[index]),
+                        from_id=effective_decision.from_id,
+                        into_id=effective_decision.into_id,
+                    )
+                    # 2. Resumable note effects (skips sides a crash already
+                    #    wrote).
+                    register.ensure_merge_effects(
+                        effective_decision.from_id, effective_decision.into_id
+                    )
+                    # 3. Terminal journal state + exactly one event, atomically.
+                    operation = journal.commit_merge_event(operation)
+                    # 4. The fence: only a fresh transaction's read of the
+                    #    committed journal + outbox rows authorizes the clear.
+                    if not journal.verify_committed_visibility(operation):
+                        refused.append(
+                            (
+                                queue_entry_id,
+                                "committed visibility was not observed on a fresh "
+                                "transaction; the queue entry stays pending "
+                                "(INV-EROJ-3)",
+                            )
+                        )
+                        continue
+                    operation = journal.mark_cleared(operation)
+                    merged = True
+                    operation_id = operation.operation_id
+            # "reject": no register mutation -- the candidate stays
+            # unresolved/ambiguous, exactly as it was before queuing. "undo"
+            # never reaches this application loop because the fold represents
+            # it as no intent.
+        except EntityReviewOperationSchemaMissingError:
+            # System misconfiguration, not a per-entry ambiguity: surface the
+            # migration guidance immediately.
+            raise
+        except (
+            EntityRegisterError,
+            EntityReviewOperationConflictError,
+            EntityReviewOperationJournalError,
+        ) as exc:
+            refused.append((queue_entry_id, str(exc)))
+            continue
 
         remaining_pending = [
             p
             for p in remaining_pending
-            if p.get("queue_entry_id") != effective_decision.queue_entry_id
+            if p.get("queue_entry_id") != queue_entry_id
         ]
         applied.append(
             AppliedDecision(
-                queue_entry_id=effective_decision.queue_entry_id,
+                queue_entry_id=queue_entry_id,
                 action=effective_decision.action,
                 merged=merged,
                 operation_id=operation_id,

--- a/app/heimdal/entity_confirm.py
+++ b/app/heimdal/entity_confirm.py
@@ -83,6 +83,7 @@ from typing import Any, Mapping, Sequence
 
 from app.heimdal.attribution_stage import RESOLUTION_UNRESOLVED, EntityMention
 from app.heimdal.entity_register import (
+    LIFECYCLE_MERGED,
     MERGE_EFFECTS_COMPLETE,
     EntityRegister,
     EntityRegisterError,
@@ -425,16 +426,23 @@ def apply_human_review_decisions(
     decision content: an active `event_committed` operation on a pending
     entry is an already-authorized merge whose clear was interrupted, and it
     is finished first (fence -> cleared -> entry removed, reported as the
-    applied merge) regardless of what the decision history now folds to --
-    consistent with the documented undo boundary, where a ruling appended
-    after hub application is an idempotent no-op, never a reversal. An active
+    applied merge under its original operation id) -- the merge is
+    materialised and its event committed, so it is not reversible at this
+    layer. Because the documented undo boundary is defined on `pending` (the
+    only surface a client observes), a ruling that folded differently while
+    the entry was still pending is NEVER silently discarded: the completion
+    stands, and the divergence is raised loudly, naming the finished merge
+    and the ruling that was not applied (with `EntityRegister.split` as the
+    reversal path). The same loud notice covers a non-merge ruling clearing
+    an entry whose previously completed merge still stands. An active
     `claimed` operation blocks a `reject` from clearing that entry (the
     operation may already have register effects; ambiguity fails closed,
-    INV-EROJ-6) and makes a *changed* merge decision fail closed via the
-    identity conflict. An interrupted clear whose operation already reached
-    `cleared` (stop between the journal update and the note write) is
-    finished without claiming a new operation, so one merge can never emit a
-    second event through re-approval (partial-failure matrix row 4).
+    INV-EROJ-6; restoring the entry's original decision resumes it cleanly)
+    and makes a *changed* merge decision fail closed via the identity
+    conflict. An interrupted clear whose operation already reached `cleared`
+    (stop between the journal update and the note write) is finished without
+    claiming a new operation, so one merge can never emit a second event
+    through re-approval (partial-failure matrix row 4).
 
     Idempotent: a decision whose `queue_entry_id` is no longer in `pending`
     has already been applied (or never existed) and is skipped rather than
@@ -495,10 +503,8 @@ def apply_human_review_decisions(
                 )
                 if active is not None and active.state == STATE_EVENT_COMMITTED:
                     # An already-authorized merge whose clear was interrupted:
-                    # finish it first. Whatever the history folds to now, the
-                    # durable outcome was recorded when its event committed --
-                    # a later ruling is an idempotent no-op per the undo
-                    # boundary, never a reversal.
+                    # finish it first. The merge is materialised and its event
+                    # committed -- it is not reversible at this layer.
                     if not journal.verify_committed_visibility(active):
                         refused.append(
                             (
@@ -524,6 +530,34 @@ def apply_human_review_decisions(
                             operation_id=active.operation_id,
                         )
                     )
+                    if not (
+                        effective_decision.action == "merge"
+                        and effective_decision.from_id == active.from_id
+                        and effective_decision.into_id == active.into_id
+                    ):
+                        # Round-2 review blocker on #4350: completing the
+                        # committed operation is correct, but silently
+                        # discarding the human's later, different ruling is
+                        # not -- the journal must never appear to reinterpret
+                        # a decision (INV-EROJ-1). Say exactly what stood and
+                        # what was not applied.
+                        later_ruling = (
+                            f"merge into {effective_decision.into_id}"
+                            if effective_decision.action == "merge"
+                            else effective_decision.action
+                        )
+                        refused.append(
+                            (
+                                queue_entry_id,
+                                "an already-committed merge operation "
+                                f"{active.operation_id} ({active.from_id} -> "
+                                f"{active.into_id}) was finished and its entry "
+                                f"cleared; your later {later_ruling} was NOT "
+                                "applied. The merge is materialised and is not "
+                                "reversible at this layer -- see the undo "
+                                "boundary; use EntityRegister.split to reverse it.",
+                            )
+                        )
                     continue
                 if active is not None and effective_decision.action != "merge":
                     # Review F3: a reject must not clear an entry whose claimed
@@ -534,10 +568,38 @@ def apply_human_review_decisions(
                             queue_entry_id,
                             f"operation {active.operation_id} is still claimed for this "
                             "entry; a reject cannot clear it and the entry stays "
-                            "pending (INV-EROJ-6)",
+                            "pending (INV-EROJ-6). To recover, restore this entry's "
+                            "original decision in entities/review.md (the claimed "
+                            "operation then resumes cleanly), or wait for EROJ-02.",
                         )
                     )
                     continue
+                if effective_decision.action != "merge":
+                    # Round-2 review on #4350, cleared-window variant: the
+                    # entry may clear on this ruling, but a previously
+                    # completed merge that still stands must be named -- the
+                    # ruling does not reverse it.
+                    prior = journal.find_cleared_operation(
+                        vault_identity=vault_identity, queue_entry_id=queue_entry_id
+                    )
+                    if prior is not None:
+                        prior_source = register.get_entry(prior.from_id)
+                        if (
+                            prior_source is not None
+                            and prior_source.lifecycle == LIFECYCLE_MERGED
+                        ):
+                            refused.append(
+                                (
+                                    queue_entry_id,
+                                    f"entry cleared by {effective_decision.action}, but "
+                                    f"previously completed merge operation "
+                                    f"{prior.operation_id} ({prior.from_id} -> "
+                                    f"{prior.into_id}) remains materialised with its "
+                                    f"event committed; the {effective_decision.action} "
+                                    "does not reverse it -- use EntityRegister.split "
+                                    "to reverse it.",
+                                )
+                            )
 
             if effective_decision.action == "merge":
                 assert (
@@ -661,8 +723,9 @@ def apply_human_review_decisions(
         details = "; ".join(f"{queue_id}: {reason}" for queue_id, reason in refused)
         raise EntityConfirmError(
             "apply_human_review_decisions: "
-            f"{len(refused)} queue entr{'y' if len(refused) == 1 else 'ies'} refused and "
-            f"left pending with decision history unchanged -- {details}"
+            f"{len(refused)} queue entr{'y' if len(refused) == 1 else 'ies'} require "
+            f"operator attention (decision history is unchanged; each item states "
+            f"whether its entry stayed pending or was cleared) -- {details}"
         )
 
     return tuple(applied)

--- a/app/heimdal/entity_confirm.py
+++ b/app/heimdal/entity_confirm.py
@@ -82,7 +82,14 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from app.heimdal.attribution_stage import RESOLUTION_UNRESOLVED, EntityMention
-from app.heimdal.entity_register import EntityRegister
+from app.heimdal.entity_register import EntityRegister, EntityRegisterError
+from app.heimdal.entity_review_operation_journal import (
+    EntityReviewOperationConflictError,
+    EntityReviewOperationJournalError,
+    EntityReviewOperationJournalPort,
+    EntityReviewOperationSchemaMissingError,
+    decision_mapping_digest,
+)
 from app.heimdal.settings_notes import (
     DEFAULT_SETTINGS_DIR,
     ENTITY_REVIEW,
@@ -343,11 +350,19 @@ class ReviewDecision:
 @dataclass(frozen=True)
 class AppliedDecision:
     """Result of applying one `ReviewDecision`: which queue entry it
-    resolved and whether a register merge was performed."""
+    resolved, whether a register merge was performed, and (for merges) the
+    entity-review operation the merge was journaled under (EROJ-01)."""
 
     queue_entry_id: str
     action: str
     merged: bool
+    operation_id: str | None = None
+
+
+def _vault_identity(vault_root: Path) -> str:
+    """The active-vault identity an operation binds (INV-EROJ-2): the resolved
+    active-vault root this applicator was invoked for."""
+    return str(Path(vault_root).expanduser().resolve())
 
 
 def apply_human_review_decisions(
@@ -356,27 +371,60 @@ def apply_human_review_decisions(
     register: EntityRegister,
     settings_dir: str = DEFAULT_SETTINGS_DIR,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    journal: EntityReviewOperationJournalPort | None = None,
 ) -> tuple[AppliedDecision, ...]:
     """Fold and apply each pending entry's ordered `decisions` history.
 
     This is the confirmation mechanism itself: reading `decisions` off disk
     IS reading the human ruling -- there is no separate "confirm" API a UI
     calls that the note lacks (Constraints: "the ruling itself is a one-line
-    note edit ... the UI owns no capability the note lacks"). A `merge`
-    decision calls `register.merge(from_id, into_id)` -- A1's own mechanism,
-    reversible via `register.split()` (F5) -- never a bespoke mutation here.
-    A `reject` decision only clears the queue entry; the register is
-    untouched (no identity assertion is made for a declined candidate).
-    A following `undo` resets that queue entry to undecided before
-    application: no register mutation occurs, `pending` remains, and the
-    append-only `decisions` history is retained. A later merge/reject can
+    note edit ... the UI owns no capability the note lacks"). A Bifrost/iPad
+    record is only ever a proposal-bound review signal (INV-EROJ-1): this Hub
+    fold is what validates that a decision is bound to a displayed pending
+    proposal and canonicalizes an approval into an executable operation — a
+    client record alone is never replayed as a merge command.
+
+    A `merge` decision runs the EROJ-01 restart-safe sequence (#4350):
+
+    1. the exact human-authored decision mapping is bound into one
+       deterministic operation, committed by the journal **before** the first
+       register note write (`claim_operation`; a changed mapping for a
+       still-active entry fails closed);
+    2. the note effects are applied resumably through
+       `register.ensure_merge_effects` (A1's own mechanism — reversible via
+       `register.split()` (F5) — never a bespoke mutation here, and never
+       re-applied when a crash already wrote them);
+    3. the operation's `heimdal.register.entity.merged` event commits
+       atomically with the terminal journal state in a journal-owned
+       transaction (`commit_merge_event`);
+    4. the queue entry may leave `pending` only after a **fresh**
+       connection/transaction observes both the terminal journal state and
+       the matching committed outbox row (`verify_committed_visibility`,
+       INV-EROJ-3). Visibility on the writer's or a caller's own uncommitted
+       transaction never authorizes the clear — that same-connection read is
+       exactly how #4253 lost the merge event after the retry anchor was gone.
+
+    Merges therefore **require** `journal`; calling with merge intent and no
+    journal raises before anything is applied. A `reject` decision only
+    clears the queue entry and keeps its current semantics: the register and
+    journal are untouched (no identity assertion is made for a declined
+    candidate). A following `undo` resets that queue entry to undecided
+    before application: no register mutation occurs, `pending` remains, and
+    the append-only `decisions` history is retained. A later merge/reject can
     establish a new terminal intent. Once the hub has applied a decision and
     removed the pending entry, a later undo is an idempotent no-op rather
     than a register reversal.
 
+    Per-entry refusals (a changed decision digest, unprovable/evolved note
+    effects, a failed visibility fence) leave that entry `pending` with its
+    history byte-for-byte unchanged, do not block other entries, and are
+    raised loudly as one aggregate `EntityConfirmError` after durable
+    successes are recorded.
+
     Idempotent: a decision whose `queue_entry_id` is no longer in `pending`
     has already been applied (or never existed) and is skipped rather than
-    re-merged -- re-running this function is always safe.
+    re-merged -- re-running this function is always safe, and a re-run after
+    a crash resumes each in-flight operation at its journaled state.
     """
     note = _read_review_note(vault_root, settings_dir=settings_dir)
     pending = list(note.values.get("pending") or [])
@@ -385,6 +433,7 @@ def apply_human_review_decisions(
 
     pending_ids = {p.get("queue_entry_id") for p in pending}
     applied: list[AppliedDecision] = []
+    refused: list[tuple[str, str]] = []
     remaining_pending = list(pending)
 
     # Fold every pending queue entry to its final pre-application intent.
@@ -399,19 +448,81 @@ def apply_human_review_decisions(
             None if decision.action == "undo" else decision,
         )
 
-    for _, effective_decision in sorted(
-        terminal_by_queue_id.values(), key=lambda item: item[0]
-    ):
-        if effective_decision is None:
-            continue
+    ordered_terminals = [
+        (index, effective_decision)
+        for index, effective_decision in sorted(
+            terminal_by_queue_id.values(), key=lambda item: item[0]
+        )
+        if effective_decision is not None
+    ]
+
+    if journal is None and any(d.action == "merge" for _, d in ordered_terminals):
+        raise EntityConfirmError(
+            "apply_human_review_decisions: a merge decision is pending but no "
+            "entity-review operation journal was provided; a merge queue entry may "
+            "leave 'pending' only through the committed-visibility fence "
+            "(EROJ-01, INV-EROJ-3), so nothing was applied"
+        )
+
+    vault_identity = _vault_identity(vault_root)
+
+    for index, effective_decision in ordered_terminals:
         merged = False
+        operation_id: str | None = None
         if effective_decision.action == "merge":
             assert (
                 effective_decision.from_id is not None
                 and effective_decision.into_id is not None
             )
-            register.merge(effective_decision.from_id, effective_decision.into_id)
+            assert journal is not None  # guaranteed by the upfront check
+            try:
+                # Pre-claim validation: prove the merge is executable (or
+                # resumable) from current notes BEFORE binding an operation,
+                # so a typo'd decision never strands an active operation row.
+                register.merge_effect_state(
+                    effective_decision.from_id, effective_decision.into_id
+                )
+                # 1. Operation identity commits before the first register
+                #    effect (INV-EROJ-2; a changed mapping fails closed).
+                operation = journal.claim_operation(
+                    vault_identity=vault_identity,
+                    queue_entry_id=effective_decision.queue_entry_id,
+                    decision_position=index,
+                    decision_digest=decision_mapping_digest(raw_decisions[index]),
+                    from_id=effective_decision.from_id,
+                    into_id=effective_decision.into_id,
+                )
+                # 2. Resumable note effects (skips sides a crash already wrote).
+                register.ensure_merge_effects(
+                    effective_decision.from_id, effective_decision.into_id
+                )
+                # 3. Terminal journal state + exactly one event, atomically.
+                operation = journal.commit_merge_event(operation)
+                # 4. The fence: only a fresh transaction's read of the
+                #    committed journal + outbox rows authorizes the clear.
+                if not journal.verify_committed_visibility(operation):
+                    refused.append(
+                        (
+                            effective_decision.queue_entry_id,
+                            "committed visibility was not observed on a fresh "
+                            "transaction; the queue entry stays pending (INV-EROJ-3)",
+                        )
+                    )
+                    continue
+                operation = journal.mark_cleared(operation)
+            except EntityReviewOperationSchemaMissingError:
+                # System misconfiguration, not a per-entry ambiguity: surface
+                # the migration guidance immediately.
+                raise
+            except (
+                EntityRegisterError,
+                EntityReviewOperationConflictError,
+                EntityReviewOperationJournalError,
+            ) as exc:
+                refused.append((effective_decision.queue_entry_id, str(exc)))
+                continue
             merged = True
+            operation_id = operation.operation_id
         # "reject": no register mutation -- the candidate stays unresolved/
         # ambiguous, exactly as it was before queuing. "undo" never reaches
         # this application loop because the fold represents it as no intent.
@@ -426,6 +537,7 @@ def apply_human_review_decisions(
                 queue_entry_id=effective_decision.queue_entry_id,
                 action=effective_decision.action,
                 merged=merged,
+                operation_id=operation_id,
             )
         )
 
@@ -449,6 +561,14 @@ def apply_human_review_decisions(
             settings_dir=settings_dir,
             write_guard=write_guard,
             action=ENTITY_CONFIRM_WRITE_ACTION,
+        )
+
+    if refused:
+        details = "; ".join(f"{queue_id}: {reason}" for queue_id, reason in refused)
+        raise EntityConfirmError(
+            "apply_human_review_decisions: "
+            f"{len(refused)} queue entr{'y' if len(refused) == 1 else 'ies'} refused and "
+            f"left pending with decision history unchanged -- {details}"
         )
 
     return tuple(applied)

--- a/app/heimdal/entity_confirm.py
+++ b/app/heimdal/entity_confirm.py
@@ -378,11 +378,12 @@ def apply_human_review_decisions(
     This is the confirmation mechanism itself: reading `decisions` off disk
     IS reading the human ruling -- there is no separate "confirm" API a UI
     calls that the note lacks (Constraints: "the ruling itself is a one-line
-    note edit ... the UI owns no capability the note lacks"). A Bifrost/iPad
-    record is only ever a proposal-bound review signal (INV-EROJ-1): this Hub
-    fold is what validates that a decision is bound to a displayed pending
-    proposal and canonicalizes an approval into an executable operation — a
-    client record alone is never replayed as a merge command.
+    note edit ... the UI owns no capability the note lacks"). An iPad (or any
+    other client) record is only ever a proposal-bound review signal
+    (INV-EROJ-1): this Hub fold is what validates that a decision is bound to
+    a displayed pending proposal and canonicalizes an approval into an
+    executable operation — a client record alone is never replayed as a merge
+    command.
 
     A `merge` decision runs the EROJ-01 restart-safe sequence (#4350):
 

--- a/app/heimdal/entity_register.py
+++ b/app/heimdal/entity_register.py
@@ -276,9 +276,21 @@ class EntityRegister:
         if not vault_context.active_vault_path:
             raise EntityRegisterError("vault_context.active_vault_path is required")
         self._vault_root = Path(vault_context.active_vault_path).expanduser().resolve()
+        # Canonical vault identity for operational records bound to this
+        # register (EROJ-01, #4350): the vault-selection SoT id when the
+        # context carries one, else the resolved root path. A mount/symlink
+        # respelling of the same selected vault must NOT re-derive
+        # entity-review operation ids — that silently duplicates merge events
+        # instead of resuming (review F7 on #4350).
+        self._vault_identity = vault_context.active_vault_id or str(self._vault_root)
         self._write_guard = write_guard
         self._register_dir = register_dir
         self._conn = conn
+
+    @property
+    def vault_identity(self) -> str:
+        """Stable identity of the vault this register is bound to."""
+        return self._vault_identity
 
     # -- internal note IO ---------------------------------------------------
 
@@ -509,6 +521,18 @@ class EntityRegister:
             raise EntityRegisterError(f"merge_effect_state(): unknown into_id {into_id!r}")
         if from_id == into_id:
             raise EntityRegisterError("merge_effect_state(): from_id and into_id must differ")
+        if target.lifecycle == LIFECYCLE_MERGED:
+            # Target-evolution refusal (INV-EROJ-7, partial-failure matrix row
+            # 5): the human-decided target has itself been merged away, so this
+            # slice can neither begin a merge into it nor prove that resuming
+            # one recovers the original decision rather than rewriting it.
+            # EROJ-02's lineage proof owns that recovery; until then the
+            # decision history stays unchanged and the queue entry pending.
+            raise EntityRegisterError(
+                f"merge_effect_state(): into_id {into_id!r} is merged into "
+                f"{target.merged_into!r}; the target has evolved and this slice refuses "
+                "target-evolved application/recovery (EROJ-02)"
+            )
 
         target_claims_source = from_id in target.merged_from
         if source.lifecycle == LIFECYCLE_MERGED:

--- a/app/heimdal/entity_register.py
+++ b/app/heimdal/entity_register.py
@@ -92,6 +92,13 @@ LIFECYCLE_PROVISIONAL = "provisional"
 LIFECYCLE_CANONICAL = "canonical"
 LIFECYCLE_MERGED = "merged"
 
+# Note-effect states for one exact merge `(from_id -> into_id)` — the
+# resumable-application vocabulary of `merge_effect_state` /
+# `ensure_merge_effects` (EROJ-01, #4350).
+MERGE_EFFECTS_NONE = "none"
+MERGE_EFFECTS_SOURCE_ONLY = "source_only"
+MERGE_EFFECTS_COMPLETE = "complete"
+
 
 class EntityRegisterError(RuntimeError):
     """Raised for register contract violations (unknown id, bad merge, etc.)."""
@@ -448,6 +455,12 @@ class EntityRegister:
         the mutation once confirmation has already happened (matching §9-g
         "human-confirmed by default": the confirmation gate lives at the
         caller, this is the mechanism). Emits `heimdal.register.entity.merged`.
+
+        The entity-review applicator does NOT call this method: it applies the
+        same note effects through :meth:`ensure_merge_effects` (resumable, no
+        emission) and commits its `heimdal.register.entity.merged` event in the
+        entity-review operation journal's atomic transaction instead (EROJ-01,
+        #4350) so the event cannot exist without its committed operation row.
         """
         source = self._read_entry(from_id)
         target = self._read_entry(into_id)
@@ -462,19 +475,94 @@ class EntityRegister:
         if from_id == into_id:
             raise EntityRegisterError("merge(): from_id and into_id must differ")
 
-        merged_source = RegisterEntry(
-            entity_id=source.entity_id,
-            kind=source.kind,
-            label=source.label,
-            aliases=source.aliases,
-            lifecycle=LIFECYCLE_MERGED,
-            merged_into=into_id,
-            merged_from=source.merged_from,
-            split_from=source.split_from,
-            created=source.created,
-            updated=_now_iso(),
+        self.ensure_merge_effects(from_id, into_id)
+
+        self._emit(
+            HEIMDAL_REGISTER_ENTITY_MERGED,
+            entity_id=from_id,
+            fingerprint_scope=f"merge:{from_id}:{into_id}:{_now_iso()}",
+            payload={"from_id": from_id, "into_id": into_id},
         )
-        self._write_entry(merged_source)
+
+    def merge_effect_state(self, from_id: str, into_id: str) -> str:
+        """Read-only classification of the note effects for one exact merge.
+
+        EROJ-01 (#4350) resume support: after a crash mid-merge, the retry must
+        prove from current notes exactly which side of `(from_id -> into_id)`
+        was written. Returns one of :data:`MERGE_EFFECTS_NONE` (no effect yet),
+        :data:`MERGE_EFFECTS_SOURCE_ONLY` (redirect written, target complement
+        absent), or :data:`MERGE_EFFECTS_COMPLETE` (both sides present).
+
+        Fails closed (INV-EROJ-6) instead of guessing: unknown ids, a
+        self-merge, a source redirect pointing at a *different* target (the
+        original effect can no longer be proven from current notes — a
+        pre-existing merge, or post-effect target evolution whose lineage
+        proof is EROJ-02, out of scope here), or contradictory notes (an
+        unmerged source that the target already claims in `merged_from`) all
+        raise `EntityRegisterError`.
+        """
+        source = self._read_entry(from_id)
+        target = self._read_entry(into_id)
+        if source is None:
+            raise EntityRegisterError(f"merge_effect_state(): unknown from_id {from_id!r}")
+        if target is None:
+            raise EntityRegisterError(f"merge_effect_state(): unknown into_id {into_id!r}")
+        if from_id == into_id:
+            raise EntityRegisterError("merge_effect_state(): from_id and into_id must differ")
+
+        target_claims_source = from_id in target.merged_from
+        if source.lifecycle == LIFECYCLE_MERGED:
+            if source.merged_into != into_id:
+                raise EntityRegisterError(
+                    f"merge_effect_state(): {from_id!r} redirects to "
+                    f"{source.merged_into!r}, not {into_id!r}; the original effect cannot "
+                    "be proven from current notes and this slice refuses target-evolved "
+                    "recovery (EROJ-02)"
+                )
+            return MERGE_EFFECTS_COMPLETE if target_claims_source else MERGE_EFFECTS_SOURCE_ONLY
+        if target_claims_source:
+            raise EntityRegisterError(
+                f"merge_effect_state(): {into_id!r} claims {from_id!r} in merged_from but "
+                f"{from_id!r} carries no redirect; contradictory notes fail closed "
+                "(INV-EROJ-6)"
+            )
+        return MERGE_EFFECTS_NONE
+
+    def ensure_merge_effects(self, from_id: str, into_id: str) -> str:
+        """Idempotently apply the two note effects of one exact merge. No event.
+
+        The mechanism half of :meth:`merge`, made resumable for the
+        entity-review operation journal (EROJ-01, #4350): whichever of the
+        source-redirect and target-complement writes is missing for exactly
+        `(from_id -> into_id)` is applied; present effects are left untouched;
+        anything unprovable fails closed via :meth:`merge_effect_state`. Never
+        emits — the journal path commits its event atomically with the
+        operation row, and :meth:`merge` keeps its own emission.
+
+        Returns the pre-application :meth:`merge_effect_state` value.
+        """
+        state = self.merge_effect_state(from_id, into_id)
+        if state == MERGE_EFFECTS_COMPLETE:
+            return state
+
+        source = self._read_entry(from_id)
+        target = self._read_entry(into_id)
+        assert source is not None and target is not None  # proven by merge_effect_state
+
+        if state == MERGE_EFFECTS_NONE:
+            merged_source = RegisterEntry(
+                entity_id=source.entity_id,
+                kind=source.kind,
+                label=source.label,
+                aliases=source.aliases,
+                lifecycle=LIFECYCLE_MERGED,
+                merged_into=into_id,
+                merged_from=source.merged_from,
+                split_from=source.split_from,
+                created=source.created,
+                updated=_now_iso(),
+            )
+            self._write_entry(merged_source)
 
         # Fold the merged entity's aliases (and its own label, as an alias)
         # into the target so future resolve() calls against the old surface
@@ -495,13 +583,7 @@ class EntityRegister:
             updated=_now_iso(),
         )
         self._write_entry(updated_target)
-
-        self._emit(
-            HEIMDAL_REGISTER_ENTITY_MERGED,
-            entity_id=from_id,
-            fingerprint_scope=f"merge:{from_id}:{into_id}:{_now_iso()}",
-            payload={"from_id": from_id, "into_id": into_id},
-        )
+        return state
 
     def split(self, entity_id: str, partition_criteria: Mapping[str, Sequence[str]]) -> tuple[str, ...]:
         """`split(entity_id, partition_criteria)` — reversible un-merge (F5 gate).
@@ -687,6 +769,9 @@ __all__ = [
     "LIFECYCLE_PROVISIONAL",
     "LIFECYCLE_CANONICAL",
     "LIFECYCLE_MERGED",
+    "MERGE_EFFECTS_NONE",
+    "MERGE_EFFECTS_SOURCE_ONLY",
+    "MERGE_EFFECTS_COMPLETE",
     "entity_note_path",
     "render_entity_note",
 ]

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -1,0 +1,733 @@
+"""Entity-review operation journal — EROJ-01 (#4350, parent #4349).
+
+Specified by `docs/ENTITY_REVIEW_OPERATION_JOURNAL/COMMIT_OPERATION_AND_OUTBOX_VISIBILITY.md`
+and bound by INV-EROJ-1..9 in `docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md`.
+This module owns the narrow durable record that makes a human-confirmed
+entity-review merge restart-safe at the transaction boundary:
+
+- **One deterministic operation identity** (INV-EROJ-2): the active vault
+  identity, queue entry id, decision-list position, SHA-256 digest of the
+  exact human-authored decision mapping, and the original
+  ``{from_id, into_id}`` determine one ``operation_id``. An identical retry
+  selects the same row; a changed decision mapping for the same still-active
+  queue entry **fails closed** (`EntityReviewOperationConflictError`) instead
+  of minting a colliding second operation.
+- **Claim before effect**: the initial operation row is committed by
+  :meth:`EntityReviewOperationJournal.claim_operation` in a journal-owned
+  transaction *before* the first entity-register note write, so a crash
+  mid-effect resumes the same operation rather than starting a new one.
+- **Atomic terminal evidence**:
+  :meth:`EntityReviewOperationJournal.commit_merge_event` advances the
+  operation to ``event_committed`` and inserts exactly one
+  ``heimdal.register.entity.merged`` outbox row (deterministically keyed by
+  the operation) in **one** Postgres transaction — both commit or neither
+  does.
+- **Committed visibility as a fence** (INV-EROJ-3, the #4253 failure):
+  :meth:`EntityReviewOperationJournal.verify_committed_visibility` opens a
+  **fresh connection** and requires it to observe both the terminal journal
+  state and the matching committed outbox row. Visibility on the writer's or
+  a caller's own uncommitted transaction is never sufficient — Postgres lets
+  a transaction read its own uncommitted insert, and treating that read as
+  durability once cleared the only retry anchor from ``pending`` before a
+  rollback removed the event.
+
+Authority boundary (INV-EROJ-1): the journal records that the Hub executed a
+merge and whether its event is committed. It never decides that two entities
+are the same, never amends the human decision history, and never becomes
+identity truth — `entities/review.md` stays the decision history and
+`_heimdal/register/*.md` stays canonical identity. Postgres state here is
+operational coordination evidence only.
+
+States are **monotonic**: ``claimed`` -> ``event_committed`` -> ``cleared``.
+``cleared`` is recorded when the fence has passed and the pending clear is
+being applied; it is what allows a later re-queue of the same queue entry id
+to claim a fresh operation (the active-entry uniqueness below only covers
+non-cleared rows). Completion is never inferred from the absence of a
+``pending`` entry.
+
+Schema ownership (INV-EROJ-8): the ``entity_review_operations`` table is
+Alembic-owned (revision ``e7a2b9c4d1f8``) and **assert-only outside tests**
+— a Postgres runtime with the table missing raises
+:class:`EntityReviewOperationSchemaMissingError` with migration guidance.
+Test environments opt in to create-on-demand via ``STORE_SCHEMA_AUTOCREATE=1``
+(the KERNEL-04/#2766 fixture-flag precedent). Parity between the migration
+and this module's audited shape is asserted by
+``tests/migrations/test_entity_review_operation_journal_schema_parity.py``.
+
+Deliberately out of scope here (INV-EROJ-7, INV-EROJ-9): target-evolution
+lineage recovery (EROJ-02), globally unique split complements (EROJ-03), and
+any generic saga API, worker, event bus, graph, second outbox, or UI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid as uuid_module
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Mapping, Protocol
+
+from app.events.models import new_event
+from app.events.types import HEIMDAL_REGISTER_ENTITY_MERGED
+from app.services.outbox import write_outbox_event
+
+# ---------------------------------------------------------------------------
+# Identity derivation (INV-EROJ-2)
+# ---------------------------------------------------------------------------
+
+#: Fixed UUIDv5 namespace for deterministic entity-review operation ids.
+#: Changing this value changes every derived operation id and outbox event key
+#: and breaks resume/replay dedup — never rotate it.
+ENTITY_REVIEW_OPERATION_NAMESPACE = uuid_module.UUID("8c1f4b9e-5a37-4d2e-9f60-3b7a2c8d514e")
+
+#: Content-fingerprint label for the operation's deterministically keyed
+#: ``heimdal.register.entity.merged`` outbox event (KERNEL-02 derivation via
+#: ``app.services.outbox.derive_idempotency_key``): the source id is the
+#: operation id, so a retried emission of the same operation maps to the same
+#: outbox row while distinct operations never collide.
+OPERATION_EVENT_FINGERPRINT = "entity-review-operation"
+
+#: Envelope source for journal-committed merge events.
+OPERATION_EVENT_SOURCE = "heimdal.entity_review"
+
+STATE_CLAIMED = "claimed"
+STATE_EVENT_COMMITTED = "event_committed"
+STATE_CLEARED = "cleared"
+
+_STATES = (STATE_CLAIMED, STATE_EVENT_COMMITTED, STATE_CLEARED)
+
+JOURNAL_TABLE = "entity_review_operations"
+
+_MIGRATION_HINT = (
+    "entity_review_operations schema is migration-owned (EROJ-01, #4350): run "
+    "'alembic upgrade head' against this database. See "
+    "app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py and "
+    "docs/DB_SCHEMA.md :: Source Of Truth."
+)
+
+# The exact table shape (kept byte-identical with the Alembic revision
+# e7a2b9c4d1f8; parity is asserted by
+# tests/migrations/test_entity_review_operation_journal_schema_parity.py).
+_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS entity_review_operations (
+    operation_id UUID PRIMARY KEY,
+    vault_identity TEXT NOT NULL,
+    queue_entry_id TEXT NOT NULL,
+    decision_position INTEGER NOT NULL,
+    decision_digest TEXT NOT NULL,
+    from_id TEXT NOT NULL,
+    into_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'claimed'
+        CONSTRAINT entity_review_operations_state_chk
+        CHECK (state IN ('claimed', 'event_committed', 'cleared')),
+    outbox_event_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
+# One *active* (non-cleared) operation per (vault, queue entry): a changed
+# decision digest for a still-active queue entry derives a different
+# operation_id and this partial unique index makes the competing INSERT fail
+# closed at the database even under concurrent applicators (INV-EROJ-2/6).
+_ACTIVE_ENTRY_INDEX_DDL = """
+CREATE UNIQUE INDEX IF NOT EXISTS entity_review_operations_active_entry_idx
+    ON entity_review_operations (vault_identity, queue_entry_id)
+    WHERE state <> 'cleared'
+"""
+
+_COLUMNS = (
+    "operation_id",
+    "vault_identity",
+    "queue_entry_id",
+    "decision_position",
+    "decision_digest",
+    "from_id",
+    "into_id",
+    "state",
+    "outbox_event_id",
+    "created_at",
+    "updated_at",
+)
+
+_SELECT_COLUMNS = (
+    "operation_id, vault_identity, queue_entry_id, decision_position, "
+    "decision_digest, from_id, into_id, state, outbox_event_id"
+)
+
+
+class EntityReviewOperationJournalError(RuntimeError):
+    """Raised for entity-review operation journal contract violations."""
+
+
+class EntityReviewOperationConflictError(EntityReviewOperationJournalError):
+    """A different decision mapping is already bound to this active queue entry.
+
+    Fails closed (INV-EROJ-2 / INV-EROJ-6): the decision history and the
+    pending queue entry are left unchanged; no second operation is minted.
+    """
+
+
+class EntityReviewOperationSchemaMissingError(EntityReviewOperationJournalError):
+    """Migration-owned journal schema is absent in a Postgres-backed runtime."""
+
+
+def decision_mapping_digest(raw_mapping: Mapping[str, Any]) -> str:
+    """SHA-256 digest of the exact human-authored decision mapping.
+
+    Canonical JSON (sorted keys) over the raw mapping exactly as persisted in
+    `entities/review.md`'s append-only ``decisions`` history — including any
+    forward-compatible fields this code does not interpret — so *any* change
+    to the mapping changes the operation identity.
+    """
+    canonical = json.dumps(dict(raw_mapping), sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def derive_operation_id(
+    *,
+    vault_identity: str,
+    queue_entry_id: str,
+    decision_position: int,
+    decision_digest: str,
+    from_id: str,
+    into_id: str,
+) -> str:
+    """Derive the deterministic operation id from the INV-EROJ-2 tuple.
+
+    ``uuid5(namespace, sha256(vault \\x1f queue_entry \\x1f position \\x1f
+    digest \\x1f from \\x1f into))`` — an identical retry derives the same id;
+    a different decision mapping, position, pair, or vault cannot collide.
+    """
+    parts = {
+        "vault_identity": vault_identity,
+        "queue_entry_id": queue_entry_id,
+        "decision_digest": decision_digest,
+        "from_id": from_id,
+        "into_id": into_id,
+    }
+    for name, value in parts.items():
+        if not isinstance(value, str) or not value.strip():
+            raise EntityReviewOperationJournalError(
+                f"derive_operation_id requires a non-empty string {name!r}, got {value!r}"
+            )
+    if not isinstance(decision_position, int) or decision_position < 0:
+        raise EntityReviewOperationJournalError(
+            f"derive_operation_id requires a non-negative decision_position, got {decision_position!r}"
+        )
+    digest = hashlib.sha256(
+        "\x1f".join(
+            (
+                vault_identity,
+                queue_entry_id,
+                str(decision_position),
+                decision_digest,
+                from_id,
+                into_id,
+            )
+        ).encode("utf-8")
+    ).hexdigest()
+    return str(uuid_module.uuid5(ENTITY_REVIEW_OPERATION_NAMESPACE, digest))
+
+
+def derive_operation_event_id(operation_id: str) -> str:
+    """Deterministic outbox idempotency key for the operation's merged event."""
+    from app.services.outbox import derive_idempotency_key
+
+    return derive_idempotency_key(
+        HEIMDAL_REGISTER_ENTITY_MERGED, operation_id, OPERATION_EVENT_FINGERPRINT
+    )
+
+
+@dataclass(frozen=True)
+class OperationRecord:
+    """One committed row of the entity-review operation journal."""
+
+    operation_id: str
+    vault_identity: str
+    queue_entry_id: str
+    decision_position: int
+    decision_digest: str
+    from_id: str
+    into_id: str
+    state: str
+    outbox_event_id: str
+
+
+class EntityReviewOperationJournalPort(Protocol):
+    """The narrow journal surface `apply_human_review_decisions` depends on.
+
+    Production is :class:`EntityReviewOperationJournal` (Postgres). Tests may
+    substitute an in-process double for applicator-routing coverage, but the
+    committed-visibility fence itself is only proven against real Postgres
+    (`tests/heimdal/test_entity_review_operation_journal.py`, pg-marked).
+    """
+
+    def claim_operation(
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        decision_position: int,
+        decision_digest: str,
+        from_id: str,
+        into_id: str,
+    ) -> OperationRecord: ...
+
+    def commit_merge_event(self, operation: OperationRecord) -> OperationRecord: ...
+
+    def verify_committed_visibility(self, operation: OperationRecord) -> bool: ...
+
+    def mark_cleared(self, operation: OperationRecord) -> OperationRecord: ...
+
+
+# ---------------------------------------------------------------------------
+# Connection handling
+# ---------------------------------------------------------------------------
+
+
+def _schema_autocreate_enabled() -> bool:
+    return (os.environ.get("STORE_SCHEMA_AUTOCREATE") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _default_connection_factory() -> Any:
+    """Open one manual-commit psycopg connection from the canonical env DSN.
+
+    Manual commit is the whole point: every journal write is an explicit
+    journal-owned transaction, and :meth:`verify_committed_visibility` opens a
+    *separate* connection from the same factory so its reads can only see
+    committed state.
+    """
+    import psycopg
+
+    from app.db.dsn import resolve_dsn
+
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
+    if not url:
+        raise EntityReviewOperationJournalError(
+            "entity-review operation journal requires DATABASE_URL or DB_DSN"
+        )
+    return psycopg.connect(resolve_dsn(url))
+
+
+def _col(row: Any, index: int, key: str) -> Any:
+    if isinstance(row, dict):
+        return row[key]
+    return row[index]
+
+
+def _exec(conn: Any, sql: str, params: tuple[Any, ...] = ()) -> Any:
+    if hasattr(conn, "cursor"):
+        cur = conn.cursor()
+        cur.execute(sql, params)
+        return cur
+    return conn.execute(sql, params)
+
+
+def _is_unique_violation(exc: Exception) -> bool:
+    sqlstate = getattr(exc, "sqlstate", None)
+    if sqlstate is None:
+        diag = getattr(exc, "diag", None)
+        sqlstate = getattr(diag, "sqlstate", None)
+    return sqlstate == "23505"
+
+
+def ensure_journal_schema(conn: Any) -> None:
+    """Assert (or, under the test flag, create) the journal schema.
+
+    Assert-only outside tests: raises
+    :class:`EntityReviewOperationSchemaMissingError` with ``alembic upgrade
+    head`` guidance when the migration-owned table or a required column is
+    absent. With ``STORE_SCHEMA_AUTOCREATE=1`` (test fixtures only) the
+    audited shape is created on demand; the DDL here is what
+    ``tests/migrations/test_entity_review_operation_journal_schema_parity.py``
+    holds byte-parity with the Alembic revision.
+    """
+    if _schema_autocreate_enabled():
+        _exec(conn, _TABLE_DDL)
+        _exec(conn, _ACTIVE_ENTRY_INDEX_DDL)
+        conn.commit()
+        return
+    cur = _exec(conn, "SELECT to_regclass(%s) AS oid", (JOURNAL_TABLE,))
+    row = cur.fetchone() if hasattr(cur, "fetchone") else None
+    oid = _col(row, 0, "oid") if row is not None else None
+    if not oid:
+        raise EntityReviewOperationSchemaMissingError(
+            f"Missing table '{JOURNAL_TABLE}' in the configured Postgres. {_MIGRATION_HINT}"
+        )
+    cur = _exec(
+        conn,
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = %s",
+        (JOURNAL_TABLE,),
+    )
+    rows = cur.fetchall() if hasattr(cur, "fetchall") else []
+    present = {_col(r, 0, "column_name") for r in rows}
+    missing = [column for column in _COLUMNS if column not in present]
+    if missing:
+        raise EntityReviewOperationSchemaMissingError(
+            f"{JOURNAL_TABLE} table is missing column(s) {missing}. {_MIGRATION_HINT}"
+        )
+
+
+def bootstrap(conn: Any = None, *, connection_factory: Callable[[], Any] | None = None) -> None:
+    """Schema preflight entrypoint (assert-only outside tests).
+
+    Mirrors ``app.services.outbox.bootstrap``'s KERNEL-05 posture for this
+    table so fixtures and the schema-parity test share one producer.
+    """
+    close = False
+    if conn is None:
+        factory = connection_factory or _default_connection_factory
+        conn = factory()
+        close = True
+    try:
+        ensure_journal_schema(conn)
+    finally:
+        if close:
+            conn.close()
+
+
+class EntityReviewOperationJournal:
+    """Postgres-backed entity-review operation journal (EROJ-01).
+
+    Every method opens its own connection from ``connection_factory`` and
+    owns its transaction. No method ever accepts or reuses a caller's
+    connection: caller-transaction visibility is exactly the #4253 defect
+    this journal exists to fence out.
+    """
+
+    def __init__(self, *, connection_factory: Callable[[], Any] | None = None) -> None:
+        self._connection_factory = connection_factory or _default_connection_factory
+
+    # -- internal ------------------------------------------------------------
+
+    def _open(self) -> Any:
+        conn = self._connection_factory()
+        autocommit = getattr(conn, "autocommit", False)
+        if autocommit:
+            raise EntityReviewOperationJournalError(
+                "journal connections must be manual-commit; an autocommit "
+                "connection cannot express the atomic journal-owned transaction"
+            )
+        return conn
+
+    def _load_row(self, conn: Any, operation_id: str) -> OperationRecord | None:
+        cur = _exec(
+            conn,
+            f"SELECT {_SELECT_COLUMNS} FROM {JOURNAL_TABLE} WHERE operation_id = %s",
+            (operation_id,),
+        )
+        row = cur.fetchone() if hasattr(cur, "fetchone") else None
+        if row is None:
+            return None
+        record = OperationRecord(
+            operation_id=str(_col(row, 0, "operation_id")),
+            vault_identity=str(_col(row, 1, "vault_identity")),
+            queue_entry_id=str(_col(row, 2, "queue_entry_id")),
+            decision_position=int(_col(row, 3, "decision_position")),
+            decision_digest=str(_col(row, 4, "decision_digest")),
+            from_id=str(_col(row, 5, "from_id")),
+            into_id=str(_col(row, 6, "into_id")),
+            state=str(_col(row, 7, "state")),
+            outbox_event_id=str(_col(row, 8, "outbox_event_id")),
+        )
+        if record.state not in _STATES:
+            raise EntityReviewOperationJournalError(
+                f"operation {record.operation_id} has unknown state {record.state!r}; "
+                "refusing to proceed (INV-EROJ-6)"
+            )
+        return record
+
+    @staticmethod
+    def _validate_loaded(record: OperationRecord, expected: OperationRecord) -> OperationRecord:
+        immutable = (
+            "vault_identity",
+            "queue_entry_id",
+            "decision_position",
+            "decision_digest",
+            "from_id",
+            "into_id",
+            "outbox_event_id",
+        )
+        for field_name in immutable:
+            if getattr(record, field_name) != getattr(expected, field_name):
+                raise EntityReviewOperationJournalError(
+                    f"operation {record.operation_id} column {field_name!r} does not match "
+                    "its derivation inputs; journal row is malformed and the queue entry "
+                    "stays pending (INV-EROJ-6)"
+                )
+        return record
+
+    # -- API -----------------------------------------------------------------
+
+    def load_operation(self, operation_id: str) -> OperationRecord | None:
+        """Read one committed operation row on a fresh connection."""
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            return self._load_row(conn, operation_id)
+        finally:
+            conn.close()
+
+    def claim_operation(
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        decision_position: int,
+        decision_digest: str,
+        from_id: str,
+        into_id: str,
+    ) -> OperationRecord:
+        """Commit the initial operation row before the first register effect.
+
+        Idempotent for an identical retry (same derived id selects the same
+        row). A different decision mapping while another operation for this
+        ``(vault_identity, queue_entry_id)`` is still active fails closed
+        with :class:`EntityReviewOperationConflictError` — enforced both by
+        an explicit probe and by the partial unique index.
+        """
+        operation_id = derive_operation_id(
+            vault_identity=vault_identity,
+            queue_entry_id=queue_entry_id,
+            decision_position=decision_position,
+            decision_digest=decision_digest,
+            from_id=from_id,
+            into_id=into_id,
+        )
+        expected = OperationRecord(
+            operation_id=operation_id,
+            vault_identity=vault_identity,
+            queue_entry_id=queue_entry_id,
+            decision_position=decision_position,
+            decision_digest=decision_digest,
+            from_id=from_id,
+            into_id=into_id,
+            state=STATE_CLAIMED,
+            outbox_event_id=derive_operation_event_id(operation_id),
+        )
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            existing = self._load_row(conn, operation_id)
+            if existing is not None:
+                conn.rollback()
+                return self._validate_loaded(existing, expected)
+            cur = _exec(
+                conn,
+                f"SELECT operation_id FROM {JOURNAL_TABLE} "
+                "WHERE vault_identity = %s AND queue_entry_id = %s AND state <> %s",
+                (vault_identity, queue_entry_id, STATE_CLEARED),
+            )
+            active = cur.fetchall() if hasattr(cur, "fetchall") else []
+            conflicting = [
+                str(_col(r, 0, "operation_id"))
+                for r in active
+                if str(_col(r, 0, "operation_id")) != operation_id
+            ]
+            if conflicting:
+                conn.rollback()
+                raise EntityReviewOperationConflictError(
+                    f"queue entry {queue_entry_id!r} already has active operation "
+                    f"{conflicting[0]} bound to a different decision mapping; the changed "
+                    "decision fails closed and the entry stays pending (INV-EROJ-2/6)"
+                )
+            try:
+                _exec(
+                    conn,
+                    f"INSERT INTO {JOURNAL_TABLE} "
+                    "(operation_id, vault_identity, queue_entry_id, decision_position, "
+                    "decision_digest, from_id, into_id, state, outbox_event_id) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT (operation_id) DO NOTHING",
+                    (
+                        operation_id,
+                        vault_identity,
+                        queue_entry_id,
+                        decision_position,
+                        decision_digest,
+                        from_id,
+                        into_id,
+                        STATE_CLAIMED,
+                        expected.outbox_event_id,
+                    ),
+                )
+            except Exception as exc:
+                conn.rollback()
+                if _is_unique_violation(exc):
+                    raise EntityReviewOperationConflictError(
+                        f"queue entry {queue_entry_id!r} gained a concurrent active operation "
+                        "bound to a different decision mapping; failing closed (INV-EROJ-2/6)"
+                    ) from exc
+                raise
+            conn.commit()
+            committed = self._load_row(conn, operation_id)
+            if committed is None:
+                raise EntityReviewOperationJournalError(
+                    f"operation {operation_id} was not durable after claim commit"
+                )
+            return self._validate_loaded(committed, expected)
+        finally:
+            conn.close()
+
+    def commit_merge_event(self, operation: OperationRecord) -> OperationRecord:
+        """Atomically commit terminal journal state plus exactly one event.
+
+        One journal-owned Postgres transaction advances
+        ``claimed -> event_committed`` and inserts the operation's
+        deterministically keyed ``heimdal.register.entity.merged`` outbox row
+        carrying the original ``from_id``, original ``into_id``, and
+        ``operation_id`` (INV-EROJ-4). Both commit or neither does. Retrying
+        an already event-committed operation is a no-op: the atomic
+        transaction guarantees its event row is already durable.
+        """
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            cur = _exec(
+                conn,
+                f"UPDATE {JOURNAL_TABLE} SET state = %s, updated_at = now() "
+                "WHERE operation_id = %s AND state = %s",
+                (STATE_EVENT_COMMITTED, operation.operation_id, STATE_CLAIMED),
+            )
+            advanced = getattr(cur, "rowcount", 0) == 1
+            if not advanced:
+                conn.rollback()
+                current = self._load_row(conn, operation.operation_id)
+                if current is not None and current.state in (
+                    STATE_EVENT_COMMITTED,
+                    STATE_CLEARED,
+                ):
+                    return self._validate_loaded(current, operation)
+                raise EntityReviewOperationJournalError(
+                    f"operation {operation.operation_id} cannot commit its merge event from "
+                    f"state {current.state if current is not None else 'absent'!r}; "
+                    "failing closed (INV-EROJ-6)"
+                )
+            event = new_event(
+                event_type=HEIMDAL_REGISTER_ENTITY_MERGED,
+                payload={
+                    "from_id": operation.from_id,
+                    "into_id": operation.into_id,
+                    "operation_id": operation.operation_id,
+                },
+                source=OPERATION_EVENT_SOURCE,
+            )
+            write_outbox_event(event, conn=conn, idempotency_key=operation.outbox_event_id)
+            conn.commit()
+            return replace(operation, state=STATE_EVENT_COMMITTED)
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:  # pragma: no cover - close still runs
+                pass
+            raise
+        finally:
+            conn.close()
+
+    def verify_committed_visibility(self, operation: OperationRecord) -> bool:
+        """The fence (INV-EROJ-3): fresh-transaction proof of the commit.
+
+        Opens a **new** connection from the factory and returns True only when
+        that transaction observes (a) the journal row in a terminal
+        (``event_committed``/``cleared``) state with its immutable binding
+        intact and (b) the matching committed outbox row whose payload carries
+        the original ``from_id``, original ``into_id``, and ``operation_id``.
+        A row visible only to the writer's or a caller's uncommitted
+        transaction can never satisfy this read.
+        """
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            record = self._load_row(conn, operation.operation_id)
+            if record is None or record.state not in (STATE_EVENT_COMMITTED, STATE_CLEARED):
+                return False
+            self._validate_loaded(record, operation)
+            cur = _exec(
+                conn,
+                "SELECT topic, payload FROM outbox WHERE id = %s",
+                (record.outbox_event_id,),
+            )
+            row = cur.fetchone() if hasattr(cur, "fetchone") else None
+            if row is None:
+                return False
+            topic = str(_col(row, 0, "topic"))
+            raw_payload = _col(row, 1, "payload")
+            if topic != HEIMDAL_REGISTER_ENTITY_MERGED:
+                return False
+            envelope = raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload)
+            payload = envelope.get("payload") if isinstance(envelope, dict) else None
+            if not isinstance(payload, dict):
+                return False
+            return (
+                payload.get("from_id") == record.from_id
+                and payload.get("into_id") == record.into_id
+                and payload.get("operation_id") == record.operation_id
+            )
+        finally:
+            conn.close()
+
+    def mark_cleared(self, operation: OperationRecord) -> OperationRecord:
+        """Record that the fence passed and the pending clear is being applied.
+
+        Monotonic ``event_committed -> cleared``; idempotent when already
+        cleared. Any other state fails closed — clearing is only ever
+        authorized downstream of :meth:`verify_committed_visibility`.
+        """
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            cur = _exec(
+                conn,
+                f"UPDATE {JOURNAL_TABLE} SET state = %s, updated_at = now() "
+                "WHERE operation_id = %s AND state = %s",
+                (STATE_CLEARED, operation.operation_id, STATE_EVENT_COMMITTED),
+            )
+            if getattr(cur, "rowcount", 0) == 1:
+                conn.commit()
+                return replace(operation, state=STATE_CLEARED)
+            conn.rollback()
+            current = self._load_row(conn, operation.operation_id)
+            if current is not None and current.state == STATE_CLEARED:
+                return self._validate_loaded(current, operation)
+            raise EntityReviewOperationJournalError(
+                f"operation {operation.operation_id} cannot be marked cleared from state "
+                f"{current.state if current is not None else 'absent'!r}; "
+                "failing closed (INV-EROJ-6)"
+            )
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:  # pragma: no cover - close still runs
+                pass
+            raise
+        finally:
+            conn.close()
+
+
+__all__ = [
+    "ENTITY_REVIEW_OPERATION_NAMESPACE",
+    "JOURNAL_TABLE",
+    "OPERATION_EVENT_FINGERPRINT",
+    "OPERATION_EVENT_SOURCE",
+    "STATE_CLAIMED",
+    "STATE_CLEARED",
+    "STATE_EVENT_COMMITTED",
+    "EntityReviewOperationConflictError",
+    "EntityReviewOperationJournal",
+    "EntityReviewOperationJournalError",
+    "EntityReviewOperationJournalPort",
+    "EntityReviewOperationSchemaMissingError",
+    "OperationRecord",
+    "bootstrap",
+    "decision_mapping_digest",
+    "derive_operation_event_id",
+    "derive_operation_id",
+    "ensure_journal_schema",
+]

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -275,6 +275,14 @@ class EntityReviewOperationJournalPort(Protocol):
         into_id: str,
     ) -> OperationRecord: ...
 
+    def find_active_operation(
+        self, *, vault_identity: str, queue_entry_id: str
+    ) -> OperationRecord | None: ...
+
+    def find_cleared_operation(
+        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+    ) -> OperationRecord | None: ...
+
     def commit_merge_event(self, operation: OperationRecord) -> OperationRecord: ...
 
     def verify_committed_visibility(self, operation: OperationRecord) -> bool: ...
@@ -411,10 +419,13 @@ class EntityReviewOperationJournal:
         conn = self._connection_factory()
         autocommit = getattr(conn, "autocommit", False)
         if autocommit:
-            raise EntityReviewOperationJournalError(
-                "journal connections must be manual-commit; an autocommit "
-                "connection cannot express the atomic journal-owned transaction"
-            )
+            try:
+                conn.close()
+            finally:
+                raise EntityReviewOperationJournalError(
+                    "journal connections must be manual-commit; an autocommit "
+                    "connection cannot express the atomic journal-owned transaction"
+                )
         return conn
 
     def _load_row(self, conn: Any, operation_id: str) -> OperationRecord | None:
@@ -472,6 +483,70 @@ class EntityReviewOperationJournal:
         try:
             ensure_journal_schema(conn)
             return self._load_row(conn, operation_id)
+        finally:
+            conn.close()
+
+    def find_active_operation(
+        self, *, vault_identity: str, queue_entry_id: str
+    ) -> OperationRecord | None:
+        """The active (non-cleared) operation bound to this queue entry, if any.
+
+        Resume is keyed on the ENTRY, not on re-deriving an id from the current
+        decision content: after the decision history is edited mid-operation,
+        the current mapping derives a different id, and only this entry-keyed
+        read can still reach the in-flight row (review F1 on #4350). At most
+        one active row can exist (the partial unique index); more than one is
+        malformed and fails closed (INV-EROJ-6).
+        """
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            cur = _exec(
+                conn,
+                f"SELECT operation_id FROM {JOURNAL_TABLE} "
+                "WHERE vault_identity = %s AND queue_entry_id = %s AND state <> %s",
+                (vault_identity, queue_entry_id, STATE_CLEARED),
+            )
+            rows = cur.fetchall() if hasattr(cur, "fetchall") else []
+            if not rows:
+                return None
+            if len(rows) > 1:
+                raise EntityReviewOperationJournalError(
+                    f"queue entry {queue_entry_id!r} has {len(rows)} active operations; "
+                    "the journal is malformed and the entry stays pending (INV-EROJ-6)"
+                )
+            return self._load_row(conn, str(_col(rows[0], 0, "operation_id")))
+        finally:
+            conn.close()
+
+    def find_cleared_operation(
+        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+    ) -> OperationRecord | None:
+        """The most recent CLEARED operation for this entry and exact pair.
+
+        Guards matrix row 4's forbidden outcome (review F4 on #4350): a stop
+        between `mark_cleared` and the pending-note write leaves the entry
+        visible while its operation already released the active slot. A later
+        identical re-approval must finish the interrupted clear instead of
+        claiming a fresh operation and emitting a second event for the same
+        merge. Filtered by the exact original pair so a genuinely new merge of
+        a split-reverted pair (effects no longer present) never matches.
+        """
+        conn = self._open()
+        try:
+            ensure_journal_schema(conn)
+            cur = _exec(
+                conn,
+                f"SELECT operation_id FROM {JOURNAL_TABLE} "
+                "WHERE vault_identity = %s AND queue_entry_id = %s AND state = %s "
+                "AND from_id = %s AND into_id = %s "
+                "ORDER BY updated_at DESC, operation_id LIMIT 1",
+                (vault_identity, queue_entry_id, STATE_CLEARED, from_id, into_id),
+            )
+            row = cur.fetchone() if hasattr(cur, "fetchone") else None
+            if row is None:
+                return None
+            return self._load_row(conn, str(_col(row, 0, "operation_id")))
         finally:
             conn.close()
 

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -280,7 +280,12 @@ class EntityReviewOperationJournalPort(Protocol):
     ) -> OperationRecord | None: ...
 
     def find_cleared_operation(
-        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        from_id: str | None = None,
+        into_id: str | None = None,
     ) -> OperationRecord | None: ...
 
     def commit_merge_event(self, operation: OperationRecord) -> OperationRecord: ...
@@ -520,29 +525,43 @@ class EntityReviewOperationJournal:
             conn.close()
 
     def find_cleared_operation(
-        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        from_id: str | None = None,
+        into_id: str | None = None,
     ) -> OperationRecord | None:
-        """The most recent CLEARED operation for this entry and exact pair.
+        """The most recent CLEARED operation for this entry (optionally by pair).
 
         Guards matrix row 4's forbidden outcome (review F4 on #4350): a stop
         between `mark_cleared` and the pending-note write leaves the entry
         visible while its operation already released the active slot. A later
         identical re-approval must finish the interrupted clear instead of
         claiming a fresh operation and emitting a second event for the same
-        merge. Filtered by the exact original pair so a genuinely new merge of
-        a split-reverted pair (effects no longer present) never matches.
+        merge. With the exact original pair supplied, a genuinely new merge of
+        a split-reverted pair (effects no longer present) never matches. The
+        pair-less form supports the round-2 divergence diagnostic: a non-merge
+        ruling that clears an entry must be able to name a previously
+        completed merge that remains materialised for it.
         """
+        if (from_id is None) != (into_id is None):
+            raise EntityReviewOperationJournalError(
+                "find_cleared_operation requires both from_id and into_id, or neither"
+            )
         conn = self._open()
         try:
             ensure_journal_schema(conn)
-            cur = _exec(
-                conn,
+            sql = (
                 f"SELECT operation_id FROM {JOURNAL_TABLE} "
                 "WHERE vault_identity = %s AND queue_entry_id = %s AND state = %s "
-                "AND from_id = %s AND into_id = %s "
-                "ORDER BY updated_at DESC, operation_id LIMIT 1",
-                (vault_identity, queue_entry_id, STATE_CLEARED, from_id, into_id),
             )
+            params: tuple[Any, ...] = (vault_identity, queue_entry_id, STATE_CLEARED)
+            if from_id is not None and into_id is not None:
+                sql += "AND from_id = %s AND into_id = %s "
+                params = (*params, from_id, into_id)
+            sql += "ORDER BY updated_at DESC, operation_id LIMIT 1"
+            cur = _exec(conn, sql, params)
             row = cur.fetchone() if hasattr(cur, "fetchone") else None
             if row is None:
                 return None
@@ -611,7 +630,10 @@ class EntityReviewOperationJournal:
                 raise EntityReviewOperationConflictError(
                     f"queue entry {queue_entry_id!r} already has active operation "
                     f"{conflicting[0]} bound to a different decision mapping; the changed "
-                    "decision fails closed and the entry stays pending (INV-EROJ-2/6)"
+                    "decision fails closed and the entry stays pending (INV-EROJ-2/6). "
+                    "To recover, restore this entry's original decision in "
+                    "entities/review.md (the active operation then resumes cleanly), "
+                    "or wait for EROJ-02."
                 )
             try:
                 _exec(
@@ -638,7 +660,9 @@ class EntityReviewOperationJournal:
                 if _is_unique_violation(exc):
                     raise EntityReviewOperationConflictError(
                         f"queue entry {queue_entry_id!r} gained a concurrent active operation "
-                        "bound to a different decision mapping; failing closed (INV-EROJ-2/6)"
+                        "bound to a different decision mapping; failing closed (INV-EROJ-2/6). "
+                        "To recover, restore this entry's original decision in "
+                        "entities/review.md, or wait for EROJ-02."
                     ) from exc
                 raise
             conn.commit()

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -29,6 +29,21 @@ Last verified against: app/stores/pg.py + app/alembic/versions/c2766a04d001_kern
   fixtures opt in to create-on-demand via the same `STORE_SCHEMA_AUTOCREATE=1` flag KERNEL-04
   established. Schema parity between the migration and the audited `bootstrap()` shape is asserted by
   `tests/migrations/test_outbox_schema_parity.py`.
+- The **entity-review operation journal** table (`entity_review_operations`) is **migration-owned**
+  (EROJ-01, #4350): Alembic revision `e7a2b9c4d1f8` creates it, and
+  `app/heimdal/entity_review_operation_journal.py::ensure_journal_schema()` is assert-only outside
+  tests — a Postgres runtime with the table or a column missing raises
+  `EntityReviewOperationSchemaMissingError` with a "run `alembic upgrade head`" hint instead of
+  creating schema. Test fixtures opt in to create-on-demand via the same `STORE_SCHEMA_AUTOCREATE=1`
+  flag KERNEL-04 established. Schema parity between the migration and the module's audited shape is
+  asserted by `tests/migrations/test_entity_review_operation_journal_schema_parity.py`. One row per
+  deterministic entity-review merge operation: the row commits **before** the first register note
+  effect, its terminal `event_committed` state commits atomically with the operation's
+  `heimdal.register.entity.merged` outbox row, and a merge queue entry leaves
+  `entities/review.md` `pending` only after a **fresh** connection observes both committed rows
+  (INV-EROJ-3; see `docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md`). Operational coordination
+  evidence only — entity notes remain canonical identity truth. Target-evolution lineage recovery
+  (EROJ-02) and globally unique split complements (EROJ-03) are not delivered by this table.
 - The active legacy **`decisions`** writer schema is **migration-owned** (#3488): Alembic revision
   `e1d2c3b4a5f6` carries forward the table's creation, compatibility columns, generated UUID default,
   and nullable `object_id` / `ON DELETE SET NULL` FK. The neutral database seam
@@ -317,6 +332,36 @@ audited `app/services/outbox.py::bootstrap()` produced it; `bootstrap()` is asse
 Interpretation:
 - the outbox is the canonical runtime queue,
 - but the event payload is still an operational artifact layer rather than the whole domain model.
+
+## Entity-Review Operation Journal
+
+Migration-owned (EROJ-01, #4350): Alembic revision `e7a2b9c4d1f8` creates the table exactly as the
+audited `app/heimdal/entity_review_operation_journal.py` autocreate shape;
+`ensure_journal_schema()` is assert-only outside tests (`STORE_SCHEMA_AUTOCREATE=1` opts test
+fixtures into create-on-demand):
+- `entity_review_operations`
+  - `operation_id` (`uuid`, PK) — deterministic over the INV-EROJ-2 tuple (active vault identity,
+    queue entry id, decision-list position, SHA-256 digest of the exact human decision mapping,
+    original `from_id`, original `into_id`)
+  - `vault_identity` (`text`)
+  - `queue_entry_id` (`text`)
+  - `decision_position` (`integer`)
+  - `decision_digest` (`text`)
+  - `from_id` / `into_id` (`text`) — the original, immutable human-decided pair
+  - `state` (`text`, default `'claimed'`, CHECK `claimed | event_committed | cleared`, monotonic)
+  - `outbox_event_id` (`uuid`) — the operation's deterministic merged-event idempotency key
+  - `created_at` / `updated_at` (`timestamptz`, default `now()`)
+  - Indexes: `entity_review_operations_active_entry_idx` — partial UNIQUE on
+    `(vault_identity, queue_entry_id) WHERE state <> 'cleared'`, the fail-closed guard that a
+    changed decision mapping cannot mint a colliding second active operation
+
+Interpretation:
+- the journal is operational coordination evidence for restart-safe entity-review merges: the row
+  commits before the first register note effect, the terminal state commits atomically with the
+  `heimdal.register.entity.merged` outbox row, and only a fresh transaction's read of both
+  committed rows authorizes clearing the `entities/review.md` `pending` entry (INV-EROJ-3),
+- it never decides identity: `_heimdal/register/*.md` notes remain canonical identity truth and
+  `entities/review.md` remains the human decision history.
 
 ## Heimdal Observation Log (append-only, per-consumer cursor)
 

--- a/docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md
+++ b/docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md
@@ -1,11 +1,11 @@
-State: Filed target-state specification (parent #4349; serial children #4350–#4352) authored 2026-07-29; no runtime behavior is implemented by this directory.
+State: Target-state specification under serial delivery (parent #4349). EROJ-01 (#4350, committed operation identity + atomic event commit + fresh-visibility fence) is implemented; EROJ-02 (#4351) and EROJ-03 (#4352) are not yet implemented and their recovery guarantees are not claimed.
 Doc role: Specification directory (capability breakdown)
 Authority: Owns the bounded implementation order, cross-task recovery invariants, and acceptance path for crash-safe entity-review merge application. Subordinate to ADR-0049 and the Mimer entity-register contracts for semantic authority, `docs/EVENTS.md` for event authority, and the runtime correctness kernel for multi-store ordering.
 Owner: Product/Runtime — Mimer identity resolution, with PDM persistence and OEF outbox participation
 Temporal class: target-state delivery contract
 Review cadence: event-driven (filing, each child merge, terminal acceptance)
 Source of truth: this directory for task shape; the owner documents named above for current authority and shipped behavior
-Last reviewed: 2026-07-29
+Last reviewed: 2026-07-31
 
 # Entity-Review Operation Journal
 
@@ -143,7 +143,7 @@ recorded. No work in this chain is safe to parallelize.
       implementation PR that first changes each contract updates that owner in the same PR.
       Verify: doc writeback at `docs/DB_SCHEMA.md :: Source Of Truth`,
       `docs/EVENTS.md :: heimdal.register.entity.merged`,
-      `docs/MIMER_IPAD_THINKING_CANVAS/SIDE_BY_SIDE_ENTITY_CONFIRMATION_ON_IPAD.md :: Human flow`,
+      `docs/MIMER_IPAD_THINKING_CANVAS/SIDE_BY_SIDE_ENTITY_CONFIRMATION_ON_IPAD.md :: What This Task Does`,
       and `docs/STATUS.md :: Runtime verification`
 
 ## Acceptance and handoff path

--- a/docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md
+++ b/docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md
@@ -30,8 +30,9 @@ introduce a generic saga framework, graph store, event store, queue, service, or
 
 ## Classification and authority boundary
 
-**Change classification:** target-state / future-state work. This docs-only breakdown does not claim
-the journal, lineage fields, or complement identities are shipped.
+**Change classification:** target-state delivery contract under serial implementation. EROJ-01's
+journal and committed-visibility fence are shipped (#4350); the EROJ-02 lineage fields and EROJ-03
+complement identities are not shipped and are not claimed.
 
 **SBS classification:** Product/Runtime.
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -859,15 +859,32 @@ Payload fields (in addition to the envelope):
 
 ### `heimdal.register.entity.merged`
 
-Emitted by `EntityRegister.merge()` when a governed, human-confirmed merge folds one
-entity into another (`docs/HEIMDAL/FABLE_COMPANION.md` §3.2 op 3 / §9-g). Append-only
-(HEIM-1): the source entity's note is never deleted, only marked `lifecycle: merged` with
-a `merged_into` redirect; the target note's aliases are folded to include the source's
-label/aliases. Lineage/audit event, same non-dispatched posture as above.
+Emitted when a governed, human-confirmed merge folds one entity into another
+(`docs/HEIMDAL/FABLE_COMPANION.md` §3.2 op 3 / §9-g). Append-only (HEIM-1): the source
+entity's note is never deleted, only marked `lifecycle: merged` with a `merged_into`
+redirect; the target note's aliases are folded to include the source's label/aliases.
+Lineage/audit event, same non-dispatched posture as above. Two emitters:
+
+- **Entity-review merges** (the production human-review path, EROJ-01 #4350): emitted by the
+  entity-review operation journal (`app/heimdal/entity_review_operation_journal.py`), NOT by the
+  register. The event commits **atomically with the operation's terminal `event_committed` journal
+  state in one journal-owned Postgres transaction**, deterministically keyed by the operation id, so
+  the event cannot exist without its committed operation row (or be duplicated by a retry). The
+  `entities/review.md` `pending` entry may be cleared only after a **fresh** connection observes
+  both the terminal journal row and this committed event (INV-EROJ-3) — visibility on the writer's
+  or a caller's own uncommitted transaction never authorizes the clear. Source:
+  `heimdal.entity_review`. Recovery across later target evolution or splits is NOT claimed here
+  (EROJ-02/EROJ-03).
+- **Direct `EntityRegister.merge()` calls** (the A1 register API outside the review path): emitted
+  by the register immediately after the note writes, without an `operation_id`. Source:
+  `heimdal.entity_register`.
 
 Payload fields (in addition to the envelope):
-- `from_id` (`string`): the entity_id that was merged away.
-- `into_id` (`string`): the entity_id it was merged into.
+- `from_id` (`string`): the entity_id that was merged away — for entity-review merges, always the
+  **original** human-decided source, never a later-evolved endpoint (INV-EROJ-4).
+- `into_id` (`string`): the entity_id it was merged into — original, per the same rule.
+- `operation_id` (`string`, entity-review merges only): the deterministic entity-review operation
+  this merge was journaled under (see `docs/DB_SCHEMA.md` — `entity_review_operations`).
 
 ### `heimdal.register.entity.split`
 

--- a/docs/MIMER_IPAD_THINKING_CANVAS/SIDE_BY_SIDE_ENTITY_CONFIRMATION_ON_IPAD.md
+++ b/docs/MIMER_IPAD_THINKING_CANVAS/SIDE_BY_SIDE_ENTITY_CONFIRMATION_ON_IPAD.md
@@ -40,6 +40,15 @@ merge-execution authority.
   not the client signal, canonicalizes an approval into a merge operation.
 - The client never mutates `pending`, never edits or deletes prior review history, never writes the
   entity register notes, and never owns merge execution (Mimer-organ-owned, ADR-0049 §2).
+- **Delivered Hub-side transaction boundary (EROJ-01, #4350):** when the Hub folds an uncompensated
+  approval, it canonicalizes it into one durable entity-review operation
+  (`entity_review_operations`, deterministic over the exact decision mapping) **before** any
+  register mutation; the operation's `heimdal.register.entity.merged` event commits atomically with
+  its terminal journal state; and the `pending` entry is cleared only after a **fresh** database
+  transaction observes both committed rows. A client record alone is never replayed as a merge
+  command, and a changed decision mapping for a still-active operation fails closed with the entry
+  left pending. Recovery across later target merges/splits is not claimed by this boundary
+  (EROJ-02/EROJ-03).
 
 ## Undo boundary
 

--- a/tests/guard/test_no_direct_db_imports.py
+++ b/tests/guard/test_no_direct_db_imports.py
@@ -161,6 +161,14 @@ ALLOW_FILES = (
     # (heimdal_meeting_finalization_receipt) with a self-contained dual
     # sqlite/pg backend and fail-loud schema preflight.
     'app/heimdal/meeting_finalization.py',
+    # Entity-review operation journal (EROJ-01, #4350). Same bounded pattern
+    # as the meeting-finalization receipt store above: one dedicated
+    # migration-owned table (entity_review_operations) with journal-owned
+    # manual-commit transactions, direct DSN connection, and fail-loud schema
+    # preflight; no ORM layer to route through. The fresh-connection
+    # committed-visibility fence (INV-EROJ-3) requires this module to open
+    # its own independent connections, which is exactly this direct pattern.
+    'app/heimdal/entity_review_operation_journal.py',
     # YouTube Source Sync durable source registry (YSS-01, #3916). Same bounded
     # pattern as app/heimdal/cursor_store.py above: a dedicated table
     # (acquisition_source_registry) with a self-contained dual memory/pg

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -200,7 +200,12 @@ class _InMemoryJournal:
         return None
 
     def find_cleared_operation(
-        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        from_id: str | None = None,
+        into_id: str | None = None,
     ) -> OperationRecord | None:
         self.log.append(("find_cleared_operation", queue_entry_id))
         for record in self.operations.values():
@@ -208,8 +213,8 @@ class _InMemoryJournal:
                 record.vault_identity == vault_identity
                 and record.queue_entry_id == queue_entry_id
                 and record.state == STATE_CLEARED
-                and record.from_id == from_id
-                and record.into_id == into_id
+                and (from_id is None or record.from_id == from_id)
+                and (into_id is None or record.into_id == into_id)
             ):
                 return record
         return None

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -186,6 +186,34 @@ class _InMemoryJournal:
         self.log.append(("claim_operation", operation_id))
         return record
 
+    def find_active_operation(
+        self, *, vault_identity: str, queue_entry_id: str
+    ) -> OperationRecord | None:
+        self.log.append(("find_active_operation", queue_entry_id))
+        for record in self.operations.values():
+            if (
+                record.vault_identity == vault_identity
+                and record.queue_entry_id == queue_entry_id
+                and record.state != STATE_CLEARED
+            ):
+                return record
+        return None
+
+    def find_cleared_operation(
+        self, *, vault_identity: str, queue_entry_id: str, from_id: str, into_id: str
+    ) -> OperationRecord | None:
+        self.log.append(("find_cleared_operation", queue_entry_id))
+        for record in self.operations.values():
+            if (
+                record.vault_identity == vault_identity
+                and record.queue_entry_id == queue_entry_id
+                and record.state == STATE_CLEARED
+                and record.from_id == from_id
+                and record.into_id == into_id
+            ):
+                return record
+        return None
+
     def commit_merge_event(self, operation: OperationRecord) -> OperationRecord:
         record = self.operations[operation.operation_id]
         if record.state == STATE_CLAIMED:
@@ -770,16 +798,22 @@ def test_apply_merge_uses_committed_journal_before_pending_clear(tmp_path: Path)
         "the operation must commit before the first register effect"
     )
 
-    # Once the fence observes the committed evidence, the SAME operation
-    # clears — in the contract order claim -> effects -> commit -> verify ->
-    # clear, with the pending removal only after mark_cleared.
+    # Once the fence observes the committed evidence, the SAME in-flight
+    # operation is finished through the entry-keyed resume path: fence before
+    # mark_cleared, and no second event commit for an already-committed
+    # operation.
     journal.visibility = True
     log.clear()
     applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
     assert len(applied) == 1 and applied[0].merged is True
     assert pending_review_entries(vault_root) == ()
     methods = [name for name, _ in log]
-    assert methods.index("commit_merge_event") < methods.index("verify_committed_visibility")
+    assert "commit_merge_event" not in methods, (
+        "an already event-committed operation must resume, never re-commit"
+    )
+    assert methods.index("find_active_operation") < methods.index(
+        "verify_committed_visibility"
+    )
     assert methods.index("verify_committed_visibility") < methods.index("mark_cleared")
 
     # Reject keeps its current journal-free semantics on a fresh entry.
@@ -917,4 +951,66 @@ def test_client_approval_is_canonicalized_by_hub_before_merge_execution(
         "register mutation"
     )
     assert register.get_entry(source).merged_into == target
+    assert pending_review_entries(vault_root) == ()
+
+
+def test_invalid_merge_decision_never_strands_an_operation(tmp_path: Path) -> None:
+    """Review F6 (#4350): pre-claim validation ordering. A decision that
+    cannot be executed from current notes (typo'd entity id) is refused
+    BEFORE any operation is bound, so no active journal row is stranded and
+    a corrected decision can proceed normally afterwards."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    journal = _InMemoryJournal()
+    source = register.mint_canonical("Source")
+    target = register.mint_canonical("Target")
+    mention = _mention(
+        resolution=RESOLUTION_AMBIGUOUS, confidence=0.75, mention_id="mention:typo-1"
+    )
+    entry = queue_for_review(vault_root, mention, candidate_entity_ids=[source, target])
+    typo = ReviewDecision(
+        queue_entry_id=entry.queue_entry_id,
+        action="merge",
+        from_id=source,
+        into_id="ent:no-such-entity",
+    ).to_dict()
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={"pending": [entry.to_dict()], "decisions": [typo]},
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+
+    with pytest.raises(EntityConfirmError, match="unknown into_id"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert journal.operations == {}, (
+        "a refused pre-claim validation must not bind an operation row"
+    )
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [
+        entry.queue_entry_id
+    ]
+
+    # The corrected decision proceeds without any identity conflict.
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    corrected = ReviewDecision(
+        queue_entry_id=entry.queue_entry_id, action="merge", from_id=source, into_id=target
+    ).to_dict()
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                **note.values,
+                "decisions": [*list(note.values.get("decisions") or []), corrected],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].merged is True
     assert pending_review_entries(vault_root) == ()

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -812,7 +812,7 @@ def test_apply_merge_uses_committed_journal_before_pending_clear(tmp_path: Path)
 def test_client_approval_is_canonicalized_by_hub_before_merge_execution(
     tmp_path: Path,
 ) -> None:
-    """INV-EROJ-1: a Bifrost/iPad record is a proposal-bound review signal.
+    """INV-EROJ-1: an iPad client record is a proposal-bound review signal.
 
     The Hub fold validates that the signal is bound to a displayed pending
     proposal and canonicalizes the approval into a journaled operation BEFORE

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -25,6 +25,7 @@ read/write path, never a mock of either.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,15 @@ from app.heimdal.entity_register import (
     LIFECYCLE_CANONICAL,
     LIFECYCLE_MERGED,
     EntityRegister,
+)
+from app.heimdal.entity_review_operation_journal import (
+    STATE_CLAIMED,
+    STATE_CLEARED,
+    STATE_EVENT_COMMITTED,
+    EntityReviewOperationConflictError,
+    OperationRecord,
+    derive_operation_event_id,
+    derive_operation_id,
 )
 from app.heimdal.settings_notes import (
     DEFAULT_SETTINGS_DIR,
@@ -112,6 +122,105 @@ class FakeOutboxConn:
 
     def rows_for(self, topic: str) -> list[dict[str, Any]]:
         return [r for r in self.rows.values() if r["topic"] == topic]
+
+
+class _InMemoryJournal:
+    """In-process `EntityReviewOperationJournalPort` double for applicator
+    ROUTING coverage: honest deterministic identity, fail-closed digest
+    conflicts, and monotonic states — but no transaction physics. The
+    committed-visibility fence itself is only proven against real Postgres
+    (tests/heimdal/test_entity_review_operation_journal.py, pg-marked).
+
+    ``log`` records ("<journal method>", operation_id) in call order and may
+    be shared with `_LoggingRegister` to assert journal-vs-register ordering.
+    ``visibility`` simulates the fence outcome: False models "the fresh
+    transaction cannot observe the committed evidence"."""
+
+    def __init__(self, *, visibility: bool = True, log: list[tuple[str, str]] | None = None):
+        self.visibility = visibility
+        self.log = log if log is not None else []
+        self.operations: dict[str, OperationRecord] = {}
+
+    def claim_operation(
+        self,
+        *,
+        vault_identity: str,
+        queue_entry_id: str,
+        decision_position: int,
+        decision_digest: str,
+        from_id: str,
+        into_id: str,
+    ) -> OperationRecord:
+        operation_id = derive_operation_id(
+            vault_identity=vault_identity,
+            queue_entry_id=queue_entry_id,
+            decision_position=decision_position,
+            decision_digest=decision_digest,
+            from_id=from_id,
+            into_id=into_id,
+        )
+        record = self.operations.get(operation_id)
+        if record is None:
+            for other in self.operations.values():
+                if (
+                    other.vault_identity == vault_identity
+                    and other.queue_entry_id == queue_entry_id
+                    and other.state != STATE_CLEARED
+                ):
+                    raise EntityReviewOperationConflictError(
+                        f"queue entry {queue_entry_id!r} already has active operation "
+                        f"{other.operation_id}"
+                    )
+            record = OperationRecord(
+                operation_id=operation_id,
+                vault_identity=vault_identity,
+                queue_entry_id=queue_entry_id,
+                decision_position=decision_position,
+                decision_digest=decision_digest,
+                from_id=from_id,
+                into_id=into_id,
+                state=STATE_CLAIMED,
+                outbox_event_id=derive_operation_event_id(operation_id),
+            )
+            self.operations[operation_id] = record
+        self.log.append(("claim_operation", operation_id))
+        return record
+
+    def commit_merge_event(self, operation: OperationRecord) -> OperationRecord:
+        record = self.operations[operation.operation_id]
+        if record.state == STATE_CLAIMED:
+            record = replace(record, state=STATE_EVENT_COMMITTED)
+            self.operations[record.operation_id] = record
+        self.log.append(("commit_merge_event", record.operation_id))
+        return record
+
+    def verify_committed_visibility(self, operation: OperationRecord) -> bool:
+        self.log.append(("verify_committed_visibility", operation.operation_id))
+        record = self.operations.get(operation.operation_id)
+        return bool(
+            self.visibility
+            and record is not None
+            and record.state in (STATE_EVENT_COMMITTED, STATE_CLEARED)
+        )
+
+    def mark_cleared(self, operation: OperationRecord) -> OperationRecord:
+        record = replace(self.operations[operation.operation_id], state=STATE_CLEARED)
+        self.operations[record.operation_id] = record
+        self.log.append(("mark_cleared", record.operation_id))
+        return record
+
+
+class _LoggingRegister(EntityRegister):
+    """Real register that mirrors every note write into a shared call log so
+    tests can prove journal-before-register ordering."""
+
+    def __init__(self, *args: Any, log: list[tuple[str, str]], **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._log = log
+
+    def _write_entry(self, entry: Any) -> None:
+        self._log.append(("register_write", entry.entity_id))
+        super()._write_entry(entry)
 
 
 def _vault_root(tmp_path: Path) -> Path:
@@ -197,10 +306,12 @@ def test_merge_writes_redirect_and_is_reversible(tmp_path: Path) -> None:
     )
     write_settings_note(vault_root, note, settings_dir=DEFAULT_SETTINGS_DIR, write_guard=_allowing_guard())
 
-    applied = apply_human_review_decisions(vault_root, register=register)
+    journal = _InMemoryJournal()
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
     assert len(applied) == 1
     assert applied[0].merged is True
     assert applied[0].action == "merge"
+    assert applied[0].operation_id is not None
 
     # Redirect: the source note carries `merged_into` (append-only — HEIM-1).
     source_entry = register.get_entry(anna_gym)
@@ -218,7 +329,7 @@ def test_merge_writes_redirect_and_is_reversible(tmp_path: Path) -> None:
     assert pending_review_entries(vault_root) == ()
 
     # Idempotent: re-applying (no new decisions/pending) does nothing.
-    again = apply_human_review_decisions(vault_root, register=register)
+    again = apply_human_review_decisions(vault_root, register=register, journal=journal)
     assert again == ()
 
     # Reversible via split() (F5) — A1's own mechanism, not reimplemented.
@@ -387,7 +498,9 @@ def test_apply_human_review_decisions_applies_terminal_uncompensated_decision(
         write_guard=_allowing_guard(),
     )
 
-    applied = apply_human_review_decisions(vault_root, register=register)
+    applied = apply_human_review_decisions(
+        vault_root, register=register, journal=_InMemoryJournal()
+    )
 
     assert len(applied) == 1
     assert applied[0].action == terminal_action
@@ -582,3 +695,226 @@ def test_apply_human_review_decisions_no_note_yet_is_a_noop(tmp_path: Path) -> N
     vault_root = _vault_root(tmp_path)
     register = _register(vault_root)
     assert apply_human_review_decisions(vault_root, register=register) == ()
+
+
+# ---------------------------------------------------------------------------
+# EROJ-01 (#4350): the production applicator clears a merge only through the
+# committed-visibility fence; reject and pre-application undo are unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _queue_one_merge(
+    vault_root: Path, register: EntityRegister
+) -> tuple[str, str, str]:
+    source = register.mint_canonical("Source")
+    target = register.mint_canonical("Target")
+    mention = _mention(
+        resolution=RESOLUTION_AMBIGUOUS, confidence=0.75, mention_id="mention:fence-1"
+    )
+    entry = queue_for_review(vault_root, mention, candidate_entity_ids=[source, target])
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                "pending": [entry.to_dict()],
+                "decisions": [
+                    ReviewDecision(
+                        queue_entry_id=entry.queue_entry_id,
+                        action="merge",
+                        from_id=source,
+                        into_id=target,
+                    ).to_dict()
+                ],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    return entry.queue_entry_id, source, target
+
+
+def test_apply_merge_uses_committed_journal_before_pending_clear(tmp_path: Path) -> None:
+    vault_root = _vault_root(tmp_path)
+    log: list[tuple[str, str]] = []
+    register = _LoggingRegister(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-test",
+            active_vault_name="Vault Test",
+            active_vault_path=str(vault_root),
+        ),
+        write_guard=_allowing_guard(),
+        conn=FakeOutboxConn(),
+        log=log,
+    )
+    queue_entry_id, source, target = _queue_one_merge(vault_root, register)
+
+    # Without a journal, a merge decision cannot be applied at all: no
+    # register mutation, no pending clear, loud failure.
+    with pytest.raises(EntityConfirmError, match="committed-visibility fence"):
+        apply_human_review_decisions(vault_root, register=register)
+    assert register.get_entry(source).lifecycle == LIFECYCLE_CANONICAL
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+
+    # With a journal whose fence cannot observe the committed evidence, the
+    # queue entry MUST stay pending — same-writer belief is never durability.
+    journal = _InMemoryJournal(visibility=False, log=log)
+    log.clear()
+    with pytest.raises(EntityConfirmError, match="committed visibility"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+    methods = [name for name, _ in log]
+    assert "mark_cleared" not in methods, "an unobserved commit must never authorize a clear"
+    assert methods.index("claim_operation") < methods.index("register_write"), (
+        "the operation must commit before the first register effect"
+    )
+
+    # Once the fence observes the committed evidence, the SAME operation
+    # clears — in the contract order claim -> effects -> commit -> verify ->
+    # clear, with the pending removal only after mark_cleared.
+    journal.visibility = True
+    log.clear()
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].merged is True
+    assert pending_review_entries(vault_root) == ()
+    methods = [name for name, _ in log]
+    assert methods.index("commit_merge_event") < methods.index("verify_committed_visibility")
+    assert methods.index("verify_committed_visibility") < methods.index("mark_cleared")
+
+    # Reject keeps its current journal-free semantics on a fresh entry.
+    other = _mention(
+        resolution=RESOLUTION_AMBIGUOUS, confidence=0.7, mention_id="mention:fence-reject"
+    )
+    entry = queue_for_review(vault_root, other, candidate_entity_ids=[target])
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                **note.values,
+                "decisions": [
+                    *list(note.values.get("decisions") or []),
+                    ReviewDecision(queue_entry_id=entry.queue_entry_id, action="reject").to_dict(),
+                ],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    applied = apply_human_review_decisions(vault_root, register=register)
+    assert [a.action for a in applied] == ["reject"]
+    assert pending_review_entries(vault_root) == ()
+
+
+def test_client_approval_is_canonicalized_by_hub_before_merge_execution(
+    tmp_path: Path,
+) -> None:
+    """INV-EROJ-1: a Bifrost/iPad record is a proposal-bound review signal.
+
+    The Hub fold validates that the signal is bound to a displayed pending
+    proposal and canonicalizes the approval into a journaled operation BEFORE
+    any register mutation; a client record alone (unbound, or compensated by
+    a pre-application undo) is never replayed as a merge command."""
+    vault_root = _vault_root(tmp_path)
+    log: list[tuple[str, str]] = []
+    register = _LoggingRegister(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-test",
+            active_vault_name="Vault Test",
+            active_vault_path=str(vault_root),
+        ),
+        write_guard=_allowing_guard(),
+        conn=FakeOutboxConn(),
+        log=log,
+    )
+    journal = _InMemoryJournal(log=log)
+    source = register.mint_canonical("Source")
+    target = register.mint_canonical("Target")
+
+    # A client approval that is NOT bound to any displayed proposal (no such
+    # pending entry) is skipped outright: no operation, no register mutation.
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                "pending": [],
+                "decisions": [
+                    ReviewDecision(
+                        queue_entry_id="review:mention:not-displayed",
+                        action="merge",
+                        from_id=source,
+                        into_id=target,
+                    ).to_dict()
+                ],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    log.clear()
+    assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
+    assert log == [], "an unbound client record must not reach the journal or the register"
+    assert register.get_entry(source).lifecycle == LIFECYCLE_CANONICAL
+
+    # An approval compensated by a pre-application undo folds to undecided:
+    # still no operation and no register mutation, history retained.
+    mention = _mention(
+        resolution=RESOLUTION_AMBIGUOUS, confidence=0.75, mention_id="mention:approve-1"
+    )
+    entry = queue_for_review(vault_root, mention, candidate_entity_ids=[source, target])
+    approval = ReviewDecision(
+        queue_entry_id=entry.queue_entry_id, action="merge", from_id=source, into_id=target
+    ).to_dict()
+    undo = ReviewDecision(queue_entry_id=entry.queue_entry_id, action="undo").to_dict()
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={"pending": [entry.to_dict()], "decisions": [approval, undo]},
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    log.clear()
+    assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
+    assert log == []
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [
+        entry.queue_entry_id
+    ]
+
+    # A new uncompensated approval bound to the displayed proposal IS
+    # canonicalized: the Hub claims the operation BEFORE the first register
+    # mutation and only the Hub executes the merge.
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    re_approval = ReviewDecision(
+        queue_entry_id=entry.queue_entry_id, action="merge", from_id=source, into_id=target
+    ).to_dict()
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                **note.values,
+                "decisions": [*list(note.values.get("decisions") or []), re_approval],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    log.clear()
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].merged is True
+    methods = [name for name, _ in log]
+    assert "claim_operation" in methods and "register_write" in methods
+    assert methods.index("claim_operation") < methods.index("register_write"), (
+        "the Hub must canonicalize the approval into the operation before any "
+        "register mutation"
+    )
+    assert register.get_entry(source).merged_into == target
+    assert pending_review_entries(vault_root) == ()

--- a/tests/heimdal/test_entity_register.py
+++ b/tests/heimdal/test_entity_register.py
@@ -38,11 +38,15 @@ from app.events.types import (
 from app.heimdal.entity_register import (
     AmbiguousCandidates,
     ARTIFACT_CLASS,
+    MERGE_EFFECTS_COMPLETE,
+    MERGE_EFFECTS_NONE,
+    MERGE_EFFECTS_SOURCE_ONLY,
     EntityRegister,
     EntityRegisterError,
     KIND_PERSON,
     LIFECYCLE_CANONICAL,
     LIFECYCLE_MERGED,
+    RegisterEntry,
     ResolvedRef,
     UnresolvedProvisional,
     entity_note_path,
@@ -351,3 +355,143 @@ def test_mint_blocked_by_write_guard_is_loud(tmp_path: Path) -> None:
     vault_root = tmp_path / "vault"
     register_dir = vault_root / "_heimdal" / "register"
     assert not register_dir.exists() or not list(register_dir.glob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# EROJ-01 (#4350): resumable merge-effect helpers — classification, idempotent
+# completion, and every fail-closed branch (review F2/F6 on #4350).
+# ---------------------------------------------------------------------------
+
+
+class _EffectCrashRegister(EntityRegister):
+    """Real register whose Nth armed note write raises, for exact-boundary
+    crash construction; arming happens after fixture setup writes."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._fail_on: int | None = None
+        self._writes = 0
+
+    def arm(self, fail_on_write: int) -> None:
+        self._fail_on = fail_on_write
+        self._writes = 0
+
+    def disarm(self) -> None:
+        self._fail_on = None
+
+    def _write_entry(self, entry: Any) -> None:
+        if self._fail_on is not None:
+            self._writes += 1
+            if self._writes >= self._fail_on:
+                raise EntityRegisterError("simulated crash mid-merge")
+        super()._write_entry(entry)
+
+
+def _effect_register(tmp_path: Path) -> _EffectCrashRegister:
+    return _EffectCrashRegister(
+        vault_context=_vault(tmp_path / "vault"),
+        write_guard=_allowing_guard(),
+        conn=FakeOutboxConn(),
+    )
+
+
+def test_merge_effect_state_classifies_all_note_shapes(tmp_path: Path) -> None:
+    register = _effect_register(tmp_path)
+    a = register.mint_canonical("Alpha", aliases=["Al"])
+    b = register.mint_canonical("Beta")
+
+    assert register.merge_effect_state(a, b) == MERGE_EFFECTS_NONE
+
+    # Crash between the source-redirect write and the target-complement write.
+    register.arm(fail_on_write=2)
+    with pytest.raises(EntityRegisterError, match="simulated crash"):
+        register.ensure_merge_effects(a, b)
+    register.disarm()
+    assert register.merge_effect_state(a, b) == MERGE_EFFECTS_SOURCE_ONLY
+    assert register.get_entry(a).merged_into == b
+    assert a not in register.get_entry(b).merged_from
+
+    # Resume completes only the missing target side.
+    assert register.ensure_merge_effects(a, b) == MERGE_EFFECTS_SOURCE_ONLY
+    assert register.merge_effect_state(a, b) == MERGE_EFFECTS_COMPLETE
+    assert a in register.get_entry(b).merged_from
+    assert "Alpha" in register.get_entry(b).aliases
+
+    # Idempotent: a fully applied merge is left untouched.
+    assert register.ensure_merge_effects(a, b) == MERGE_EFFECTS_COMPLETE
+
+
+def test_merge_effect_helpers_fail_closed_on_unprovable_notes(tmp_path: Path) -> None:
+    register = _effect_register(tmp_path)
+    a = register.mint_canonical("Alpha")
+    b = register.mint_canonical("Beta")
+    c = register.mint_canonical("Gamma")
+
+    # Unknown ids and self-merge.
+    with pytest.raises(EntityRegisterError, match="unknown from_id"):
+        register.merge_effect_state("ent:ghost", b)
+    with pytest.raises(EntityRegisterError, match="unknown into_id"):
+        register.merge_effect_state(a, "ent:ghost")
+    with pytest.raises(EntityRegisterError, match="must differ"):
+        register.merge_effect_state(a, a)
+
+    # Foreign redirect: the source redirects to a different target than the
+    # operation's original pair — unprovable, refused (EROJ-02 territory).
+    register.merge(a, b)
+    with pytest.raises(EntityRegisterError, match="refuses target-evolved recovery"):
+        register.merge_effect_state(a, c)
+    with pytest.raises(EntityRegisterError, match="refuses target-evolved recovery"):
+        register.ensure_merge_effects(a, c)
+
+    # Contradictory notes: the target claims the source in merged_from while
+    # the source carries no redirect (constructed corruption) — fail closed.
+    source_entry = register.get_entry(a)
+    register._write_entry(  # simulate note corruption/hand-edit
+        RegisterEntry(
+            entity_id=source_entry.entity_id,
+            kind=source_entry.kind,
+            label=source_entry.label,
+            aliases=source_entry.aliases,
+            lifecycle=LIFECYCLE_CANONICAL,
+            merged_into=None,
+            merged_from=source_entry.merged_from,
+            split_from=source_entry.split_from,
+            created=source_entry.created,
+        )
+    )
+    with pytest.raises(EntityRegisterError, match="contradictory notes"):
+        register.merge_effect_state(a, b)
+
+
+def test_merge_into_evolved_target_is_refused(tmp_path: Path) -> None:
+    """Review F2 (#4350): INV-EROJ-7 / partial-failure matrix row 5. A target
+    that has itself been merged away refuses both fresh application and
+    resume — this slice cannot prove target-evolved recovery (EROJ-02)."""
+    register = _effect_register(tmp_path)
+    a = register.mint_canonical("Alpha")
+    b = register.mint_canonical("Beta")
+    c = register.mint_canonical("Gamma")
+
+    # Crash after the source redirect for a -> b, then b evolves into c.
+    register.arm(fail_on_write=2)
+    with pytest.raises(EntityRegisterError, match="simulated crash"):
+        register.ensure_merge_effects(a, b)
+    register.disarm()
+    register.merge(b, c)
+
+    # Resume of the half-applied a -> b merge is refused, loudly.
+    with pytest.raises(EntityRegisterError, match="target has evolved"):
+        register.merge_effect_state(a, b)
+    with pytest.raises(EntityRegisterError, match="target has evolved"):
+        register.ensure_merge_effects(a, b)
+    # The half-applied state was not silently completed.
+    assert a not in register.get_entry(c).merged_from
+    assert a not in register.get_entry(b).merged_from
+
+    # Fresh application into a merged-away target is refused the same way —
+    # a deliberate fail-closed behavior change to merge() (previously it
+    # silently merged into the dead identity).
+    d = register.mint_canonical("Delta")
+    with pytest.raises(EntityRegisterError, match="target has evolved"):
+        register.merge(d, b)
+    assert register.get_entry(d).lifecycle == LIFECYCLE_CANONICAL

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -758,13 +758,26 @@ def test_edited_history_after_refusal_converges_without_manual_repair(
         )
 
     # The retry converges: the in-flight operation is finished (fence ->
-    # cleared -> entry removed) under its ORIGINAL identity; the late ruling
-    # is a post-application no-op per the documented undo boundary.
+    # cleared -> entry removed) under its ORIGINAL identity. An identical
+    # re-approval is a silent success; a DIVERGENT later ruling still
+    # converges but must be reported loudly -- the completion stands and the
+    # discarded ruling is named (round-2 review blocker on #4350).
     journal = _journal(scratch_dsn)
-    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
-    assert len(applied) == 1
-    assert applied[0].merged is True
-    assert applied[0].operation_id == expected_id
+    if late_ruling == "reapprove":
+        applied = apply_human_review_decisions(
+            vault_root, register=register, journal=journal
+        )
+        assert len(applied) == 1
+        assert applied[0].merged is True
+        assert applied[0].operation_id == expected_id
+    else:
+        with pytest.raises(EntityConfirmError) as excinfo:
+            apply_human_review_decisions(vault_root, register=register, journal=journal)
+        message = str(excinfo.value)
+        assert "was finished and its entry cleared" in message
+        assert "your later reject was NOT applied" in message
+        assert expected_id in message
+        assert "EntityRegister.split" in message
     assert pending_review_entries(vault_root) == ()
     events = _merged_event_rows(scratch_dsn)
     assert len(events) == 1, "convergence must never mint a second merge event"
@@ -781,6 +794,112 @@ def test_edited_history_after_refusal_converges_without_manual_repair(
     assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
     # Append-only decision history survived every round byte-for-byte.
     assert _persisted_decisions(vault_root)[: len(decisions_before)] == decisions_before
+
+
+def test_divergent_reapproval_after_refusal_is_completed_loudly(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    """Round-2 review blocker (P1b) on #4350: the human's later terminal
+    ruling is a merge into a DIFFERENT candidate than the already-committed
+    operation. The committed merge is finished (it is materialised and
+    evented; refusing would re-create the round-1 brick), but the
+    substitution must be loud -- an indistinguishable success return is the
+    defect."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    other_candidate = register.mint_canonical("Anna Karlsson", aliases=["Anna K"])
+
+    refusing = _FenceRefusingJournal(
+        connection_factory=lambda: psycopg.connect(scratch_dsn), refuse_first=1
+    )
+    with pytest.raises(EntityConfirmError, match="committed visibility"):
+        apply_human_review_decisions(vault_root, register=register, journal=refusing)
+    expected_id = derive_operation_id(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+
+    # The human re-decides toward a different candidate while the entry is
+    # still pending.
+    _append_decisions(
+        vault_root,
+        ReviewDecision(queue_entry_id=queue_entry_id, action="undo").to_dict(),
+        ReviewDecision(
+            queue_entry_id=queue_entry_id,
+            action="merge",
+            from_id=from_id,
+            into_id=other_candidate,
+        ).to_dict(),
+    )
+
+    journal = _journal(scratch_dsn)
+    with pytest.raises(EntityConfirmError) as excinfo:
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    message = str(excinfo.value)
+    assert "was finished and its entry cleared" in message
+    assert f"your later merge into {other_candidate} was NOT applied" in message
+    assert expected_id in message and from_id in message and into_id in message
+    assert "EntityRegister.split" in message
+
+    # Durable truth: the ORIGINAL merge stands, exactly one event, entry
+    # cleared, no operation exists for the discarded ruling.
+    source_entry = register.get_entry(from_id)
+    assert source_entry is not None and source_entry.merged_into == into_id
+    other_entry = register.get_entry(other_candidate)
+    assert other_entry is not None and from_id not in other_entry.merged_from
+    assert pending_review_entries(vault_root) == ()
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1
+    assert events[0][1]["into_id"] == into_id
+    with psycopg.connect(scratch_dsn) as conn:
+        count = conn.execute(
+            "SELECT count(*) FROM entity_review_operations WHERE queue_entry_id = %s",
+            (queue_entry_id,),
+        ).fetchone()
+    assert count == (1,)
+
+
+def test_reject_over_cleared_operation_names_the_standing_merge(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    """Round-2 review, cleared-window variant on #4350: a reject that clears
+    an entry whose previously completed merge still stands must name that
+    standing merge -- it is applied as a reject, but never silently, because
+    the reject does not reverse the materialised, evented merge."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+
+    # Complete the operation journal-side, stopping before the note write.
+    operation = journal.claim_operation(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    register.ensure_merge_effects(from_id, into_id)
+    operation = journal.commit_merge_event(operation)
+    assert journal.verify_committed_visibility(operation) is True
+    journal.mark_cleared(operation)
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+
+    # The human rejects the still-visible entry.
+    _append_decisions(
+        vault_root,
+        ReviewDecision(queue_entry_id=queue_entry_id, action="undo").to_dict(),
+        ReviewDecision(queue_entry_id=queue_entry_id, action="reject").to_dict(),
+    )
+    with pytest.raises(EntityConfirmError) as excinfo:
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    message = str(excinfo.value)
+    assert "entry cleared by reject" in message
+    assert "remains materialised" in message
+    assert operation.operation_id in message
+    assert "EntityRegister.split" in message
+
+    # Durable truth: entry cleared, the merge stands, exactly one event.
+    assert pending_review_entries(vault_root) == ()
+    source_entry = register.get_entry(from_id)
+    assert source_entry is not None and source_entry.merged_into == into_id
+    assert len(_merged_event_rows(scratch_dsn)) == 1
 
 
 def test_reject_with_claimed_operation_refuses_and_preserves_pending(

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -1,0 +1,667 @@
+"""Entity-review operation journal proofs — EROJ-01 (#4350, parent #4349).
+
+Real-Postgres proofs of the committed-visibility mechanism specified by
+`docs/ENTITY_REVIEW_OPERATION_JOURNAL/COMMIT_OPERATION_AND_OUTBOX_VISIBILITY.md`:
+
+- `test_operation_identity_binds_exact_human_decision` — INV-EROJ-2: one
+  deterministic operation id per exact human decision; a changed mapping for
+  a still-active queue entry fails closed; a different vault never collides;
+  a cleared operation releases the queue entry id for a later re-queue.
+- `test_operation_claim_commits_before_first_register_effect` — the initial
+  journal row is durable (visible to a fresh connection) even when the very
+  first register note write crashes, and the retry resumes the SAME
+  operation.
+- `test_mid_effect_crash_resumes_and_completes_target_side` — partial-failure
+  matrix row 2: a source redirect without its target complement is completed
+  on resume, never treated as a complete merge and never re-applied.
+- `test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear`
+  — terminal journal state and exactly one deterministically keyed outbox
+  event commit atomically (both-or-neither), and a fresh transaction
+  observes the original `from_id`, original `into_id`, and `operation_id`.
+- `test_caller_transaction_rollback_cannot_clear_pending_or_hide_merge_event`
+  — the #4253 protected failure: an outbox insert visible only to the
+  caller's own uncommitted transaction never authorizes the pending clear;
+  after rollback the retry commits exactly one event and only then clears.
+- `test_effect_before_event_commit_recovers_one_durable_event` — a stop after
+  both register effects but before the event commit resumes the same
+  operation, emits exactly once, and preserves the append-only decision
+  mappings byte-for-byte.
+
+These tests run against a real Postgres by contract ("Run the
+rollback/visibility proof against Postgres rather than a fake connection"):
+cross-connection committed visibility is the mechanism under test and a fake
+connection cannot prove it. Applicator *routing* coverage that needs no real
+transaction lives non-pg in tests/heimdal/test_entity_confirm.py.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.heimdal import entity_review_operation_journal as journal_module
+from app.heimdal.attribution_stage import RESOLUTION_AMBIGUOUS, EntityMention
+from app.heimdal.entity_confirm import (
+    EntityConfirmError,
+    ReviewDecision,
+    apply_human_review_decisions,
+    pending_review_entries,
+    queue_for_review,
+)
+from app.heimdal.entity_register import (
+    LIFECYCLE_MERGED,
+    EntityRegister,
+    EntityRegisterError,
+)
+from app.heimdal.entity_review_operation_journal import (
+    STATE_CLAIMED,
+    STATE_CLEARED,
+    STATE_EVENT_COMMITTED,
+    EntityReviewOperationConflictError,
+    EntityReviewOperationJournal,
+    EntityReviewOperationJournalError,
+    OperationRecord,
+    derive_operation_id,
+)
+from app.heimdal.settings_notes import (
+    DEFAULT_SETTINGS_DIR,
+    ENTITY_REVIEW,
+    SettingsNote,
+    note_rel_path,
+    read_settings_note,
+    write_settings_note,
+)
+from app.services import outbox as outbox_module
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+
+pytestmark = pytest.mark.pg
+
+MERGED_TOPIC = "heimdal.register.entity.merged"
+
+
+# ---------------------------------------------------------------------------
+# Scratch database plumbing (per-test isolation on the configured Postgres)
+# ---------------------------------------------------------------------------
+
+
+def _admin_dsn() -> str:
+    from app.db.dsn import resolve_dsn
+
+    dsn = resolve_dsn()
+    if not dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    return dsn
+
+
+@pytest.fixture
+def scratch_dsn(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """One throwaway database with the journal + outbox schema installed."""
+    admin_dsn = _admin_dsn()
+    try:
+        probe = psycopg.connect(admin_dsn, connect_timeout=2)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    probe.close()
+
+    name = f"scratch_eroj01_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{name}"')
+    base, _, _ = admin_dsn.rpartition("/")
+    dsn = f"{base}/{name}"
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    with psycopg.connect(dsn) as conn:
+        journal_module.ensure_journal_schema(conn)
+    outbox_module.bootstrap()
+
+    yield dsn
+
+    try:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    except Exception:  # pragma: no cover - cleanup best effort
+        pass
+
+
+def _journal(dsn: str) -> EntityReviewOperationJournal:
+    return EntityReviewOperationJournal(connection_factory=lambda: psycopg.connect(dsn))
+
+
+def _merged_event_rows(dsn: str) -> list[tuple[str, dict[str, Any]]]:
+    """(id, inner payload) of committed merged-topic outbox rows, fresh conn."""
+    with psycopg.connect(dsn) as conn:
+        rows = conn.execute(
+            "SELECT id, payload FROM outbox WHERE topic = %s ORDER BY created_at",
+            (MERGED_TOPIC,),
+        ).fetchall()
+    result: list[tuple[str, dict[str, Any]]] = []
+    for row in rows:
+        envelope = row[1] if isinstance(row[1], dict) else json.loads(row[1])
+        result.append((str(row[0]), dict(envelope.get("payload") or {})))
+    return result
+
+
+def _journal_row(dsn: str, operation_id: str) -> tuple[str, str] | None:
+    """(state, outbox_event_id) as observed by an independent fresh connection."""
+    with psycopg.connect(dsn) as conn:
+        row = conn.execute(
+            "SELECT state, outbox_event_id FROM entity_review_operations "
+            "WHERE operation_id = %s",
+            (operation_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return (str(row[0]), str(row[1]))
+
+
+# ---------------------------------------------------------------------------
+# Vault / register fixtures (temp-vault convention from test_entity_confirm)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]):
+        self._rows = rows
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return list(self._rows)
+
+
+class _RegisterEmissionStub:
+    """In-memory sink for the register's own mint/split emissions so the real
+    DB outbox contains ONLY journal-committed rows and event counts are exact."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> _FakeCursor:
+        text = " ".join(sql.lower().split())
+        assert text.startswith("insert into outbox (id,"), text
+        row_id = params[0]
+        if row_id in self.rows:
+            return _FakeCursor([])
+        self.rows[row_id] = {"id": row_id, "topic": params[1], "payload": params[2]}
+        return _FakeCursor([(row_id,)])
+
+    def close(self) -> None:  # pragma: no cover - psycopg parity
+        pass
+
+
+class _CrashingRegister(EntityRegister):
+    """Real register whose Nth armed note write raises — a process stop at an
+    exact effect boundary, arming AFTER fixture setup writes."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.fail_on_write: int | None = None
+        self._armed_writes = 0
+
+    def arm(self, fail_on_write: int) -> None:
+        self.fail_on_write = fail_on_write
+        self._armed_writes = 0
+
+    def disarm(self) -> None:
+        self.fail_on_write = None
+
+    def _write_entry(self, entry: Any) -> None:
+        if self.fail_on_write is not None:
+            self._armed_writes += 1
+            if self._armed_writes >= self.fail_on_write:
+                raise EntityRegisterError(
+                    f"simulated crash before note write #{self._armed_writes}"
+                )
+        super()._write_entry(entry)
+
+
+def _vault_root(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _allowing_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _register(vault_root: Path, cls: type[EntityRegister] = EntityRegister) -> EntityRegister:
+    return cls(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-test",
+            active_vault_name="Vault Test",
+            active_vault_path=str(vault_root),
+        ),
+        write_guard=_allowing_guard(),
+        conn=_RegisterEmissionStub(),
+    )
+
+
+def _queue_merge_decision(
+    vault_root: Path, register: EntityRegister
+) -> tuple[str, str, str, dict[str, Any]]:
+    """Mint two entities, queue one mid-band mention, and write one human
+    merge decision. Returns (queue_entry_id, from_id, into_id, raw_decision)."""
+    source = register.mint_canonical("Anna fran gymmet", aliases=["Anna G"])
+    target = register.mint_canonical("Anna Svensson", aliases=["Anna"])
+    mention = EntityMention(
+        mention_id="mention:eroj-1",
+        surface_form="Anna",
+        resolution=RESOLUTION_AMBIGUOUS,
+        kind_hint="person",
+        confidence=0.75,
+    )
+    entry = queue_for_review(
+        vault_root,
+        mention,
+        candidate_entity_ids=[source, target],
+        write_guard=_allowing_guard(),
+    )
+    raw_decision = ReviewDecision(
+        queue_entry_id=entry.queue_entry_id,
+        action="merge",
+        from_id=source,
+        into_id=target,
+    ).to_dict()
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    write_settings_note(
+        vault_root,
+        SettingsNote(spec=ENTITY_REVIEW, values={**note.values, "decisions": [raw_decision]}),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+    return entry.queue_entry_id, source, target, raw_decision
+
+
+def _review_note_path(vault_root: Path) -> Path:
+    return vault_root / note_rel_path(ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+
+
+def _persisted_decisions(vault_root: Path) -> list[Any]:
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    return list(note.values.get("decisions") or [])
+
+
+def _claim_kwargs(
+    vault_root: Path, queue_entry_id: str, from_id: str, into_id: str, raw_decision: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "vault_identity": str(vault_root.resolve()),
+        "queue_entry_id": queue_entry_id,
+        "decision_position": 0,
+        "decision_digest": journal_module.decision_mapping_digest(raw_decision),
+        "from_id": from_id,
+        "into_id": into_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — deterministic identity, fail-closed digest binding (INV-EROJ-2)
+# ---------------------------------------------------------------------------
+
+
+def test_operation_identity_binds_exact_human_decision(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+    kwargs = _claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+
+    # Deterministic across retries: the derivation is a pure function of the
+    # INV-EROJ-2 tuple, and every varied component derives a different id.
+    baseline = derive_operation_id(**kwargs)
+    assert derive_operation_id(**kwargs) == baseline
+    assert derive_operation_id(**{**kwargs, "vault_identity": "/other/vault"}) != baseline
+    assert derive_operation_id(**{**kwargs, "queue_entry_id": "review:other"}) != baseline
+    assert derive_operation_id(**{**kwargs, "decision_position": 1}) != baseline
+    assert (
+        derive_operation_id(**{**kwargs, "decision_digest": "0" * 64}) != baseline
+    )
+    assert derive_operation_id(**{**kwargs, "from_id": into_id, "into_id": from_id}) != baseline
+
+    # An identical retry selects the same committed row.
+    first = journal.claim_operation(**kwargs)
+    again = journal.claim_operation(**kwargs)
+    assert first.operation_id == baseline == again.operation_id
+    assert first.state == STATE_CLAIMED
+    with psycopg.connect(scratch_dsn) as conn:
+        count = conn.execute(
+            "SELECT count(*) FROM entity_review_operations WHERE queue_entry_id = %s",
+            (queue_entry_id,),
+        ).fetchone()
+    assert count == (1,)
+
+    # A changed decision mapping for the same still-active queue entry fails
+    # closed instead of minting a colliding second operation.
+    edited = dict(raw_decision)
+    edited["audit_tag"] = "human-edited-after-claim"
+    changed = {
+        **kwargs,
+        "decision_position": 1,
+        "decision_digest": journal_module.decision_mapping_digest(edited),
+    }
+    with pytest.raises(EntityReviewOperationConflictError):
+        journal.claim_operation(**changed)
+    with psycopg.connect(scratch_dsn) as conn:
+        count = conn.execute(
+            "SELECT count(*) FROM entity_review_operations WHERE queue_entry_id = %s",
+            (queue_entry_id,),
+        ).fetchone()
+    assert count == (1,), "a conflicting claim must not create a second operation"
+
+    # A different vault cannot collide with this queue entry's operation.
+    other_vault = journal.claim_operation(**{**kwargs, "vault_identity": "/other/vault"})
+    assert other_vault.operation_id != baseline
+
+    # Once the original operation is fully cleared it releases the queue
+    # entry id: a genuinely new review of a re-queued entry may claim.
+    committed = journal.commit_merge_event(first)
+    assert journal.verify_committed_visibility(committed) is True
+    journal.mark_cleared(committed)
+    reclaimed = journal.claim_operation(**changed)
+    assert reclaimed.operation_id != baseline
+    assert reclaimed.state == STATE_CLAIMED
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — the initial journal row commits before the first register effect
+# ---------------------------------------------------------------------------
+
+
+def test_operation_claim_commits_before_first_register_effect(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root, _CrashingRegister)
+    assert isinstance(register, _CrashingRegister)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+    expected_id = derive_operation_id(
+        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    decisions_before = _persisted_decisions(vault_root)
+
+    # Crash at the very first register note write of the merge.
+    register.arm(fail_on_write=1)
+    with pytest.raises(EntityConfirmError, match="simulated crash"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+
+    # The operation row is already durable — an independent fresh connection
+    # observes it — while no register effect exists and pending is intact.
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_CLAIMED
+    source_entry = register.get_entry(from_id)
+    assert source_entry is not None and source_entry.lifecycle != LIFECYCLE_MERGED
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+    assert _merged_event_rows(scratch_dsn) == []
+
+    # The retry resumes the SAME operation and completes it exactly once.
+    register.disarm()
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1
+    assert applied[0].merged is True
+    assert applied[0].operation_id == expected_id
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_CLEARED
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1
+    assert pending_review_entries(vault_root) == ()
+    assert _persisted_decisions(vault_root) == decisions_before
+
+
+def test_mid_effect_crash_resumes_and_completes_target_side(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    """Partial-failure matrix row 2: source redirect written, complement absent."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root, _CrashingRegister)
+    assert isinstance(register, _CrashingRegister)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+    expected_id = derive_operation_id(
+        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+    )
+
+    # Crash between the source-redirect write and the target-complement write.
+    register.arm(fail_on_write=2)
+    with pytest.raises(EntityConfirmError, match="simulated crash"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+
+    source_entry = register.get_entry(from_id)
+    target_entry = register.get_entry(into_id)
+    assert source_entry is not None and source_entry.merged_into == into_id
+    assert target_entry is not None and from_id not in target_entry.merged_from
+    assert _merged_event_rows(scratch_dsn) == [], (
+        "a source redirect alone must never be treated as a complete merge"
+    )
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+
+    register.disarm()
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].operation_id == expected_id
+    target_entry = register.get_entry(into_id)
+    assert target_entry is not None and from_id in target_entry.merged_from
+    assert len(_merged_event_rows(scratch_dsn)) == 1
+    assert pending_review_entries(vault_root) == ()
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — atomic terminal commit, fresh-connection visibility
+# ---------------------------------------------------------------------------
+
+
+def test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear(
+    scratch_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+    operation = journal.claim_operation(
+        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    register.ensure_merge_effects(from_id, into_id)
+
+    # Atomicity, negative half: a failure inside the journal-owned transaction
+    # commits NEITHER the terminal state nor the event.
+    real_write = journal_module.write_outbox_event
+
+    def _boom(*args: Any, **kwargs: Any) -> str:
+        raise RuntimeError("simulated failure inside the journal-owned transaction")
+
+    monkeypatch.setattr(journal_module, "write_outbox_event", _boom)
+    with pytest.raises(RuntimeError, match="journal-owned transaction"):
+        journal.commit_merge_event(operation)
+    monkeypatch.setattr(journal_module, "write_outbox_event", real_write)
+    row = _journal_row(scratch_dsn, operation.operation_id)
+    assert row is not None and row[0] == STATE_CLAIMED
+    assert _merged_event_rows(scratch_dsn) == []
+
+    # Atomicity, positive half: one journal-owned transaction commits both,
+    # and an INDEPENDENT fresh connection observes the terminal journal state
+    # plus the matching outbox row with the original pair and operation id —
+    # all while the queue entry is still pending (clear comes only later).
+    committed = journal.commit_merge_event(operation)
+    assert committed.state == STATE_EVENT_COMMITTED
+    row = _journal_row(scratch_dsn, operation.operation_id)
+    assert row is not None and row[0] == STATE_EVENT_COMMITTED
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1
+    event_id, payload = events[0]
+    assert event_id == operation.outbox_event_id
+    assert payload["from_id"] == from_id
+    assert payload["into_id"] == into_id
+    assert payload["operation_id"] == operation.operation_id
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+
+    # Exactly one: an idempotent retry of the terminal commit adds nothing.
+    journal.commit_merge_event(operation)
+    assert len(_merged_event_rows(scratch_dsn)) == 1
+    assert journal.verify_committed_visibility(committed) is True
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — the #4253 failure: caller-transaction visibility never clears pending
+# ---------------------------------------------------------------------------
+
+
+class _CallerTransactionJournal(EntityReviewOperationJournal):
+    """The #4253 defect as a journal double: the 'commit' step writes the
+    outbox row on a CALLER-owned transaction it never commits, then reports
+    the operation as event-committed. Everything else (claim, the fence,
+    mark_cleared) is the real Postgres implementation — the fence must be
+    what stops this lie from clearing `pending`."""
+
+    def __init__(self, *, connection_factory: Any, caller_conn: Any) -> None:
+        super().__init__(connection_factory=connection_factory)
+        self.caller_conn = caller_conn
+
+    def commit_merge_event(self, operation: OperationRecord) -> OperationRecord:
+        from app.events.models import new_event
+
+        event = new_event(
+            event_type=MERGED_TOPIC,
+            payload={
+                "from_id": operation.from_id,
+                "into_id": operation.into_id,
+                "operation_id": operation.operation_id,
+            },
+            source="heimdal.entity_review",
+        )
+        outbox_module.write_outbox_event(
+            event, conn=self.caller_conn, idempotency_key=operation.outbox_event_id
+        )
+        # Same-transaction read-your-own-write: the caller can see the row...
+        seen = self.caller_conn.execute(
+            "SELECT count(*) FROM outbox WHERE id = %s", (operation.outbox_event_id,)
+        ).fetchone()
+        assert seen == (1,), "the caller transaction must see its own uncommitted insert"
+        # ...and on the #4253 path that visibility was treated as durability.
+        return replace(operation, state=STATE_EVENT_COMMITTED)
+
+
+def test_caller_transaction_rollback_cannot_clear_pending_or_hide_merge_event(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    decisions_before = _persisted_decisions(vault_root)
+
+    caller_conn = psycopg.connect(scratch_dsn)  # manual commit — a caller-owned txn
+    try:
+        broken = _CallerTransactionJournal(
+            connection_factory=lambda: psycopg.connect(scratch_dsn),
+            caller_conn=caller_conn,
+        )
+
+        # The applicator refuses the clear: the fresh-transaction fence cannot
+        # observe the uncommitted caller-side insert (nor a committed terminal
+        # journal state), so the queue entry MUST stay pending.
+        with pytest.raises(EntityConfirmError, match="committed visibility"):
+            apply_human_review_decisions(vault_root, register=register, journal=broken)
+        assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [
+            queue_entry_id
+        ], "same-connection visibility must never authorize a pending clear"
+        assert _persisted_decisions(vault_root) == decisions_before
+        assert _merged_event_rows(scratch_dsn) == [], (
+            "no committed merge event may exist yet"
+        )
+
+        # The caller rolls back: its event insert vanishes — this is exactly
+        # where #4253 lost the only merge event after pending was cleared.
+        caller_conn.rollback()
+        assert _merged_event_rows(scratch_dsn) == []
+    finally:
+        caller_conn.close()
+
+    # Because the retry anchor survived, the retry resumes the SAME operation
+    # through the real journal and commits exactly one visible merge event.
+    journal = _journal(scratch_dsn)
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].merged is True
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1
+    assert events[0][1]["from_id"] == from_id
+    assert events[0][1]["into_id"] == into_id
+    assert events[0][1]["operation_id"] == applied[0].operation_id
+    assert pending_review_entries(vault_root) == ()
+    assert _persisted_decisions(vault_root) == decisions_before
+
+
+# ---------------------------------------------------------------------------
+# AC 5 — stop after effects, before event commit: one durable event on resume
+# ---------------------------------------------------------------------------
+
+
+def test_effect_before_event_commit_recovers_one_durable_event(
+    scratch_dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+    note_bytes_before = _review_note_path(vault_root).read_bytes()
+    decisions_before = _persisted_decisions(vault_root)
+
+    # Stop AFTER both register effects but BEFORE the event commit.
+    real_commit = EntityReviewOperationJournal.commit_merge_event
+
+    def _crash(
+        self: EntityReviewOperationJournal, operation: OperationRecord
+    ) -> OperationRecord:
+        raise EntityReviewOperationJournalError("simulated stop before event commit")
+
+    monkeypatch.setattr(EntityReviewOperationJournal, "commit_merge_event", _crash)
+    with pytest.raises(EntityConfirmError, match="simulated stop"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    monkeypatch.setattr(EntityReviewOperationJournal, "commit_merge_event", real_commit)
+
+    # Both effects exist, no event, operation still claimed, review note
+    # byte-for-byte untouched (pending AND append-only decisions).
+    source_entry = register.get_entry(from_id)
+    target_entry = register.get_entry(into_id)
+    assert source_entry is not None and source_entry.merged_into == into_id
+    assert target_entry is not None and from_id in target_entry.merged_from
+    assert _merged_event_rows(scratch_dsn) == []
+    expected_id = derive_operation_id(
+        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_CLAIMED
+    assert _review_note_path(vault_root).read_bytes() == note_bytes_before
+
+    # Resume: the same operation validates the existing effects, commits
+    # exactly one event for the original pair, and only then clears pending.
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1
+    assert applied[0].operation_id == expected_id
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1
+    assert events[0][1] == {
+        "from_id": from_id,
+        "into_id": into_id,
+        "operation_id": expected_id,
+    }
+    assert pending_review_entries(vault_root) == ()
+    # The append-only human decision mappings survive byte-for-byte.
+    assert _persisted_decisions(vault_root) == decisions_before
+
+    # A later replay is a no-op: nothing pending, still exactly one event.
+    assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
+    assert len(_merged_event_rows(scratch_dsn)) == 1

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -296,10 +296,17 @@ def _persisted_decisions(vault_root: Path) -> list[Any]:
 
 
 def _claim_kwargs(
-    vault_root: Path, queue_entry_id: str, from_id: str, into_id: str, raw_decision: dict[str, Any]
+    register: EntityRegister,
+    queue_entry_id: str,
+    from_id: str,
+    into_id: str,
+    raw_decision: dict[str, Any],
 ) -> dict[str, Any]:
+    # The applicator binds the register's canonical vault identity (the
+    # vault-selection id, not a filesystem-path spelling — review F7 on
+    # #4350), so derived expectations must use the same identity.
     return {
-        "vault_identity": str(vault_root.resolve()),
+        "vault_identity": register.vault_identity,
         "queue_entry_id": queue_entry_id,
         "decision_position": 0,
         "decision_digest": journal_module.decision_mapping_digest(raw_decision),
@@ -320,7 +327,7 @@ def test_operation_identity_binds_exact_human_decision(
     register = _register(vault_root)
     queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
     journal = _journal(scratch_dsn)
-    kwargs = _claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+    kwargs = _claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
 
     # Deterministic across retries: the derivation is a pure function of the
     # INV-EROJ-2 tuple, and every varied component derives a different id.
@@ -392,7 +399,7 @@ def test_operation_claim_commits_before_first_register_effect(
     queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
     journal = _journal(scratch_dsn)
     expected_id = derive_operation_id(
-        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
     )
     decisions_before = _persisted_decisions(vault_root)
 
@@ -434,7 +441,7 @@ def test_mid_effect_crash_resumes_and_completes_target_side(
     queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
     journal = _journal(scratch_dsn)
     expected_id = derive_operation_id(
-        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
     )
 
     # Crash between the source-redirect write and the target-complement write.
@@ -473,7 +480,7 @@ def test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear(
     queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
     journal = _journal(scratch_dsn)
     operation = journal.claim_operation(
-        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
     )
     register.ensure_merge_effects(from_id, into_id)
 
@@ -640,7 +647,7 @@ def test_effect_before_event_commit_recovers_one_durable_event(
     assert target_entry is not None and from_id in target_entry.merged_from
     assert _merged_event_rows(scratch_dsn) == []
     expected_id = derive_operation_id(
-        **_claim_kwargs(vault_root, queue_entry_id, from_id, into_id, raw_decision)
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
     )
     row = _journal_row(scratch_dsn, expected_id)
     assert row is not None and row[0] == STATE_CLAIMED
@@ -665,3 +672,202 @@ def test_effect_before_event_commit_recovers_one_durable_event(
     # A later replay is a no-op: nothing pending, still exactly one event.
     assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
     assert len(_merged_event_rows(scratch_dsn)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Review F1/F3/F4 on #4350 — orphaned-operation convergence and the
+# second-event guard, reproduced and closed against real Postgres.
+# ---------------------------------------------------------------------------
+
+
+class _FenceRefusingJournal(EntityReviewOperationJournal):
+    """Real journal whose fence reports not-visible for the first N calls —
+    the deterministic way to park an operation in the designed refusal state
+    (`event_committed`, entry still pending) that review F1 starts from."""
+
+    def __init__(self, *, connection_factory: Any, refuse_first: int) -> None:
+        super().__init__(connection_factory=connection_factory)
+        self._refusals_left = refuse_first
+
+    def verify_committed_visibility(self, operation: OperationRecord) -> bool:
+        if self._refusals_left > 0:
+            self._refusals_left -= 1
+            return False
+        return super().verify_committed_visibility(operation)
+
+
+def _append_decisions(vault_root: Path, *decisions: dict[str, Any]) -> None:
+    note = read_settings_note(vault_root, ENTITY_REVIEW, settings_dir=DEFAULT_SETTINGS_DIR)
+    assert note is not None
+    write_settings_note(
+        vault_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                **note.values,
+                "decisions": [*list(note.values.get("decisions") or []), *decisions],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+
+
+@pytest.mark.parametrize("late_ruling", ["reapprove", "reject"])
+def test_edited_history_after_refusal_converges_without_manual_repair(
+    scratch_dsn: str, tmp_path: Path, late_ruling: str
+) -> None:
+    """Review F1 (#4350): an operation parked in the designed refusal state
+    (`event_committed`, entry pending) must converge through the entry-keyed
+    resume even after the human edits the decision history — never fail
+    closed forever on the re-derived identity."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    decisions_before = _persisted_decisions(vault_root)
+
+    refusing = _FenceRefusingJournal(
+        connection_factory=lambda: psycopg.connect(scratch_dsn), refuse_first=1
+    )
+    with pytest.raises(EntityConfirmError, match="committed visibility"):
+        apply_human_review_decisions(vault_root, register=register, journal=refusing)
+    expected_id = derive_operation_id(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_EVENT_COMMITTED
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+
+    # The human reacts to the still-pending entry by editing the history —
+    # the natural response, and the exact move that used to brick the entry.
+    if late_ruling == "reapprove":
+        _append_decisions(
+            vault_root,
+            ReviewDecision(queue_entry_id=queue_entry_id, action="undo").to_dict(),
+            ReviewDecision(
+                queue_entry_id=queue_entry_id,
+                action="merge",
+                from_id=from_id,
+                into_id=into_id,
+            ).to_dict(),
+        )
+    else:
+        _append_decisions(
+            vault_root,
+            ReviewDecision(queue_entry_id=queue_entry_id, action="reject").to_dict(),
+        )
+
+    # The retry converges: the in-flight operation is finished (fence ->
+    # cleared -> entry removed) under its ORIGINAL identity; the late ruling
+    # is a post-application no-op per the documented undo boundary.
+    journal = _journal(scratch_dsn)
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1
+    assert applied[0].merged is True
+    assert applied[0].operation_id == expected_id
+    assert pending_review_entries(vault_root) == ()
+    events = _merged_event_rows(scratch_dsn)
+    assert len(events) == 1, "convergence must never mint a second merge event"
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_CLEARED
+    with psycopg.connect(scratch_dsn) as conn:
+        count = conn.execute(
+            "SELECT count(*) FROM entity_review_operations WHERE queue_entry_id = %s",
+            (queue_entry_id,),
+        ).fetchone()
+    assert count == (1,), "no second operation may be minted for the edited history"
+
+    # The loop actually terminates: a further run is a clean no-op.
+    assert apply_human_review_decisions(vault_root, register=register, journal=journal) == ()
+    # Append-only decision history survived every round byte-for-byte.
+    assert _persisted_decisions(vault_root)[: len(decisions_before)] == decisions_before
+
+
+def test_reject_with_claimed_operation_refuses_and_preserves_pending(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    """Review F3 (#4350): a reject must not clear an entry whose claimed
+    operation is still in flight — its register effects may already exist,
+    and clearing would silently divorce the ruling from canonical notes."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root, _CrashingRegister)
+    assert isinstance(register, _CrashingRegister)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+
+    # Park a claimed operation with a real half-applied effect: crash between
+    # the source-redirect write and the target-complement write.
+    register.arm(fail_on_write=2)
+    with pytest.raises(EntityConfirmError, match="simulated crash"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    register.disarm()
+    expected_id = derive_operation_id(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    row = _journal_row(scratch_dsn, expected_id)
+    assert row is not None and row[0] == STATE_CLAIMED
+
+    # The human changes their mind to a reject while the operation is claimed.
+    _append_decisions(
+        vault_root,
+        ReviewDecision(queue_entry_id=queue_entry_id, action="undo").to_dict(),
+        ReviewDecision(queue_entry_id=queue_entry_id, action="reject").to_dict(),
+    )
+    with pytest.raises(EntityConfirmError, match="still claimed"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    # Nothing moved: entry pending, no event, effects exactly as the crash
+    # left them, ruling history intact.
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+    assert _merged_event_rows(scratch_dsn) == []
+    source_entry = register.get_entry(from_id)
+    assert source_entry is not None and source_entry.merged_into == into_id
+
+
+def test_interrupted_clear_never_emits_second_event_on_reapproval(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    """Review F4 (#4350): partial-failure matrix row 4's forbidden outcome. A
+    stop between `mark_cleared` and the pending-note write, followed by a
+    human undo + re-approval of the same merge, must finish the interrupted
+    clear — never claim a fresh operation and emit a second event."""
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(vault_root, register)
+    journal = _journal(scratch_dsn)
+
+    # Drive the operation to `cleared` entirely journal-side, stopping before
+    # the pending-note write — exactly the crash window under review.
+    operation = journal.claim_operation(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    register.ensure_merge_effects(from_id, into_id)
+    operation = journal.commit_merge_event(operation)
+    assert journal.verify_committed_visibility(operation) is True
+    journal.mark_cleared(operation)
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [queue_entry_id]
+    assert len(_merged_event_rows(scratch_dsn)) == 1
+
+    # Human sees the entry still pending, undoes, and re-approves the same
+    # merge — a new decision position, thus a new derived identity.
+    _append_decisions(
+        vault_root,
+        ReviewDecision(queue_entry_id=queue_entry_id, action="undo").to_dict(),
+        ReviewDecision(
+            queue_entry_id=queue_entry_id, action="merge", from_id=from_id, into_id=into_id
+        ).to_dict(),
+    )
+    applied = apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert len(applied) == 1 and applied[0].merged is True
+    assert applied[0].operation_id == operation.operation_id, (
+        "the interrupted clear must finish under the original operation"
+    )
+    assert pending_review_entries(vault_root) == ()
+    assert len(_merged_event_rows(scratch_dsn)) == 1, (
+        "matrix row 4 forbidden outcome: a second event was emitted"
+    )
+    with psycopg.connect(scratch_dsn) as conn:
+        count = conn.execute(
+            "SELECT count(*) FROM entity_review_operations WHERE queue_entry_id = %s",
+            (queue_entry_id,),
+        ).fetchone()
+    assert count == (1,), "no second operation may be claimed for the finished clear"

--- a/tests/migrations/test_entity_review_operation_journal_schema_parity.py
+++ b/tests/migrations/test_entity_review_operation_journal_schema_parity.py
@@ -1,0 +1,268 @@
+"""Entity-review operation journal schema parity (EROJ-01, #4350).
+
+The `entity_review_operations` table is migration-owned (Alembic revision
+`e7a2b9c4d1f8`) with assert-only runtime preflight, following the
+KERNEL-04/KERNEL-05 pattern (`tests/migrations/test_store_schema_parity.py`,
+`tests/migrations/test_outbox_schema_parity.py`). This module asserts
+INV-EROJ-8's producer set stays coherent:
+
+- `test_entity_review_operation_journal_schema_matches_head` — a fresh
+  `alembic upgrade head` produces exactly the audited shape the module's
+  test-only autocreate producer (`STORE_SCHEMA_AUTOCREATE=1`) creates,
+  including the state CHECK constraint and the partial unique
+  active-entry index.
+- `test_upgrade_idempotent_on_existing` — re-running migrations over an
+  environment that already carries the autocreated table is a no-op and
+  moves no data.
+- `test_missing_schema_fails_with_migration_guidance` — the runtime
+  assertion fails loud with `alembic upgrade head` guidance when the table
+  is absent and autocreate is off (stale-schema posture outside tests).
+
+Spec: docs/ENTITY_REVIEW_OPERATION_JOURNAL/COMMIT_OPERATION_AND_OUTBOX_VISIBILITY.md
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import psycopg
+import pytest
+
+pytestmark = pytest.mark.pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The head revision immediately before the journal table became owned.
+PRE_JOURNAL_HEAD = "d0f5b2c7e4a6"
+
+# The EROJ-01 journal-schema-owning revision. Pinned explicitly (not "head")
+# so later migrations adding DDL on top don't turn this into a moving target.
+JOURNAL_SCHEMA_HEAD = "e7a2b9c4d1f8"
+
+TABLE = "entity_review_operations"
+
+
+def _admin_dsn() -> str:
+    from app.db.dsn import resolve_dsn
+
+    dsn = resolve_dsn()
+    if not dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    return dsn
+
+
+def _scratch_dsn(admin_dsn: str, dbname: str) -> str:
+    base, _, _ = admin_dsn.rpartition("/")
+    return f"{base}/{dbname}"
+
+
+@pytest.fixture
+def scratch_db_factory(monkeypatch: pytest.MonkeyPatch):
+    """Create throwaway databases on the configured Postgres; drop them after."""
+    admin_dsn = _admin_dsn()
+    try:
+        probe = psycopg.connect(admin_dsn, connect_timeout=2)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    probe.close()
+
+    created: list[str] = []
+
+    def _create() -> str:
+        name = f"scratch_eroj01_{uuid.uuid4().hex[:12]}"
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'CREATE DATABASE "{name}"')
+        created.append(name)
+        dsn = _scratch_dsn(admin_dsn, name)
+        # An earlier migration declares `embedding VECTOR` unconditionally, so
+        # the extension must exist before `alembic upgrade` (mirrors
+        # tests/migrations/test_outbox_schema_parity.py).
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        return dsn
+
+    yield _create
+
+    for name in created:
+        try:
+            with psycopg.connect(admin_dsn, autocommit=True) as conn:
+                conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        except Exception:  # pragma: no cover - cleanup best effort
+            pass
+
+
+def _alembic_upgrade(dsn: str, monkeypatch: pytest.MonkeyPatch, revision: str = "head") -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    command.upgrade(cfg, revision)
+
+
+def _run_module_autocreate(dsn: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The module's test-only create-on-demand producer (STORE_SCHEMA_AUTOCREATE)."""
+    from app.heimdal import entity_review_operation_journal as journal_module
+
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    with psycopg.connect(dsn) as conn:
+        journal_module.ensure_journal_schema(conn)
+
+
+def _schema_snapshot(dsn: str) -> dict:
+    """Column/PK/index/check shape of the journal table, normalized."""
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT column_name, data_type, is_nullable,
+                       COALESCE(column_default, '') AS column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = %s
+                ORDER BY column_name
+                """,
+                (TABLE,),
+            )
+            columns = [tuple(row) for row in cur.fetchall()]
+            cur.execute(
+                """
+                SELECT kcu.column_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_name = kcu.constraint_name
+                 AND tc.table_schema = kcu.table_schema
+                WHERE tc.table_schema = 'public'
+                  AND tc.table_name = %s
+                  AND tc.constraint_type = 'PRIMARY KEY'
+                ORDER BY kcu.ordinal_position
+                """,
+                (TABLE,),
+            )
+            pk = [row[0] for row in cur.fetchall()]
+            cur.execute(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public' AND tablename = %s
+                ORDER BY indexname
+                """,
+                (TABLE,),
+            )
+            indexes = [tuple(row) for row in cur.fetchall()]
+            # Auto-generated NOT NULL check rows carry per-database OIDs in
+            # their names (`2200_<oid>_<n>_not_null`) and can never compare
+            # across databases; nullability is already covered by the columns
+            # snapshot, so keep only explicitly named CHECK constraints.
+            cur.execute(
+                """
+                SELECT cc.constraint_name, cc.check_clause
+                FROM information_schema.check_constraints cc
+                JOIN information_schema.table_constraints tc
+                  ON cc.constraint_name = tc.constraint_name
+                 AND cc.constraint_schema = tc.table_schema
+                WHERE tc.table_schema = 'public'
+                  AND tc.table_name = %s
+                  AND tc.constraint_type = 'CHECK'
+                  AND cc.constraint_name NOT LIKE '%%\\_not\\_null' ESCAPE '\\'
+                ORDER BY cc.constraint_name
+                """,
+                (TABLE,),
+            )
+            checks = [tuple(row) for row in cur.fetchall()]
+    return {"columns": columns, "pk": pk, "indexes": indexes, "checks": checks}
+
+
+def test_entity_review_operation_journal_schema_matches_head(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh-DB `alembic upgrade head` == the module's audited autocreate shape."""
+    migrated = scratch_db_factory()
+    autocreated = scratch_db_factory()
+
+    _alembic_upgrade(migrated, monkeypatch, "head")
+    _run_module_autocreate(autocreated, monkeypatch)
+
+    migrated_shape = _schema_snapshot(migrated)
+    autocreated_shape = _schema_snapshot(autocreated)
+
+    assert migrated_shape == autocreated_shape, (
+        "Alembic-produced entity_review_operations schema diverges from the module's "
+        "autocreate shape:\n"
+        f"alembic: {json.dumps(migrated_shape, indent=2, default=str)}\n"
+        f"autocreate: {json.dumps(autocreated_shape, indent=2, default=str)}"
+    )
+    assert migrated_shape["columns"], "journal table missing after alembic upgrade head"
+    assert any(
+        "state <> 'cleared'" in indexdef for _, indexdef in migrated_shape["indexes"]
+    ), "the partial unique active-entry index is missing"
+    assert migrated_shape["checks"], "the state CHECK constraint is missing"
+
+
+def test_upgrade_idempotent_on_existing(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing environments (pre-EROJ head + autocreated table) no-op with data kept."""
+    dsn = scratch_db_factory()
+
+    _alembic_upgrade(dsn, monkeypatch, PRE_JOURNAL_HEAD)
+    _run_module_autocreate(dsn, monkeypatch)
+
+    operation_id = uuid.uuid4()
+    with psycopg.connect(dsn) as conn:
+        conn.execute(
+            f"INSERT INTO {TABLE} (operation_id, vault_identity, queue_entry_id, "
+            "decision_position, decision_digest, from_id, into_id, state, outbox_event_id) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (
+                operation_id,
+                "/vault",
+                "review:mention:x",
+                0,
+                "d" * 64,
+                "ent:a",
+                "ent:b",
+                "claimed",
+                uuid.uuid4(),
+            ),
+        )
+        conn.commit()
+
+    before = _schema_snapshot(dsn)
+    _alembic_upgrade(dsn, monkeypatch, JOURNAL_SCHEMA_HEAD)
+    after = _schema_snapshot(dsn)
+
+    assert before == after, "Migration changed an existing environment's journal schema"
+    with psycopg.connect(dsn) as conn:
+        row = conn.execute(
+            f"SELECT count(*) FROM {TABLE} WHERE operation_id = %s", (operation_id,)
+        ).fetchone()
+    assert row == (1,), "Migration moved/destroyed existing journal data"
+
+
+def test_missing_schema_fails_with_migration_guidance(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Assert-only outside tests: stale schema directs to `alembic upgrade head`."""
+    from app.heimdal.entity_review_operation_journal import (
+        EntityReviewOperationJournal,
+        EntityReviewOperationSchemaMissingError,
+    )
+
+    dsn = scratch_db_factory()  # no journal table installed
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "0")
+    journal = EntityReviewOperationJournal(
+        connection_factory=lambda: psycopg.connect(dsn)
+    )
+    with pytest.raises(EntityReviewOperationSchemaMissingError, match="alembic upgrade head"):
+        journal.claim_operation(
+            vault_identity="/vault",
+            queue_entry_id="review:mention:x",
+            decision_position=0,
+            decision_digest="d" * 64,
+            from_id="ent:a",
+            into_id="ent:b",
+        )

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -61,6 +61,13 @@ def test_pr_index_pg_contracts_run_exact_acceptance_surface() -> None:
     assert "app/knowledge_acquisition/youtube_api_client.py" in job
     assert "app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py" in job
     assert "tests/knowledge_acquisition/test_youtube_api_quota_pg.py" in job
+    # Entity-review operation journal (EROJ-01, #4350): all its
+    # committed-visibility proofs are pg-marked, so this lane is the only
+    # PR-path check that can regress-test them.
+    assert "app/heimdal/entity_review_operation_journal.py" in job
+    assert "app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py" in job
+    assert "tests/heimdal/test_entity_review_operation_journal.py" in job
+    assert "tests/migrations/test_entity_review_operation_journal_schema_parity.py" in job
     assert '-m "pg"' in job
 
 


### PR DESCRIPTION
Governing-Issue: #4350

Fixes #4350

Refs #4349

Final-Review-Rounds: 1

## Summary

Delivers EROJ-01: a human-confirmed entity-review merge is now restart-safe at the transaction boundary. One migration-owned `entity_review_operations` journal row (deterministic over the INV-EROJ-2 tuple) commits before the first register note effect; the terminal journal state and exactly one deterministically keyed `heimdal.register.entity.merged` outbox event commit atomically in a journal-owned Postgres transaction; and `apply_human_review_decisions` may clear a merge entry from `pending` only after a fresh connection observes both committed rows (INV-EROJ-3). Same-transaction visibility never authorizes the clear — the protected data-loss failure that exhausted the prior attempt (#4253 stop-loss receipt) is structurally refused. This slice starts from the specification, not from the stopped implementation.

## Mechanism

- `app/heimdal/entity_review_operation_journal.py` (new): `EntityReviewOperationJournal` opens its own manual-commit connections from a connection factory and never accepts a caller's connection — the load-bearing property is that **the journal owns the commit**, so no caller's transaction boundary can ever be the boundary the fence reads across. `claim_operation` commits the operation before any effect; `commit_merge_event` advances `claimed -> event_committed` and inserts the operation's outbox row in one transaction (both-or-neither); `verify_committed_visibility` opens a separate fresh connection and requires it to observe the terminal journal row (immutable binding intact) plus the matching committed event payload (original `from_id`, original `into_id`, `operation_id`); `mark_cleared` records the authorized clear. States are monotonic; a `cleared` row releases the `(vault, queue entry)` slot for a later re-queue.
- **Entry-keyed resume (review F1) + divergence diagnostic (review round 2):** `find_active_operation(vault_identity, queue_entry_id)` reaches the in-flight row by the entry itself, never by re-deriving an id from the current decision content. An active `event_committed` operation is an already-authorized merge whose clear was interrupted; the applicator finishes it first (fence -> `mark_cleared` -> entry removed, reported under the original `operation_id`) — the merge is materialised and evented, so refusing would re-create the round-1 brick. Because the documented undo boundary is defined on `pending` (the only surface a client observes), a later ruling that folded differently while the entry was still pending is **never silently discarded**: the completion stands and the divergence raises loudly, naming the finished merge, the ruling that was not applied, and `EntityRegister.split` as the reversal path. The same loud notice fires when a non-merge ruling clears an entry whose previously completed (`cleared`-state) merge still stands. The diagnostic rides the existing aggregate-refusal raise (the function's one loud channel; durable state and the `applied` record are written before it) rather than a new return shape.
- **Interrupted-clear guard (review F4, matrix row 4):** `find_cleared_operation(vault, entry, pair)` detects a stop between `mark_cleared` and the pending-note write; an identical re-approval finishes the interrupted clear under the original operation instead of claiming a fresh one — one merge can never emit a second event through re-approval.
- `app/heimdal/entity_register.py`: `merge()`'s note-effect half is extracted into `merge_effect_state` / `ensure_merge_effects` (idempotent, resumable, never emits) so a crash mid-merge resumes exactly the missing side. **Target-evolution refusal (review F2, INV-EROJ-7):** a target that has itself been merged away refuses both fresh application and resume in every branch — this slice cannot prove target-evolved recovery; EROJ-02's lineage proof owns it. The register also exposes `vault_identity` (review F7): the canonical `VaultContext.active_vault_id` when set, else the resolved root — a mount/symlink respelling of the same selected vault no longer re-derives operation ids.
- `app/heimdal/entity_confirm.py`: the Hub fold validates a decision is bound to a displayed pending proposal and canonicalizes an approval into the journaled operation before any register mutation (INV-EROJ-1); merges require the journal; **a reject cannot clear an entry whose claimed operation is still in flight** (review F3 — its register effects may already exist; ambiguity fails closed); pre-claim validation refuses inexecutable decisions before binding an operation, so a typo'd decision never strands a row; per-entry refusals leave that entry pending with byte-identical history and raise one aggregate error after durable successes.
- `app/alembic/versions/e7a2b9c4d1f8_eroj01_entity_review_operations.py` (new, forward-only): table + partial unique index `(vault_identity, queue_entry_id) WHERE state <> 'cleared'` — a changed decision digest cannot mint a colliding second active operation even under concurrent applicators. Runtime preflight is assert-only outside tests with `alembic upgrade head` guidance; `STORE_SCHEMA_AUTOCREATE=1` remains the test-fixture producer, parity-locked to the migration.
- **CI lanes (review F5):** the pg-marked mechanism proofs are wired into the PR-path `pr-index-pg-contracts` lane (paths filter + file list in `.github/workflows/ci-smoke.yaml`, pinned by `tests/ops/test_ci_workflow.py`) and the nightly bounded PG lane (`integration-nightly.yaml`), so AC1-AC5/AC7 regress-test on drift instead of living only in local runs.

## Deliberate behavior changes to `EntityRegister.merge()` (direct callers)

Both are new fail-closed refusals, exercised via `ensure_merge_effects`:

1. Contradictory notes: the target already claims the source in `merged_from` while the source carries no redirect -> refused (previously unobservable half-state, now explicit).
2. Merged-away target: merging into an entity whose `lifecycle` is `merged` -> refused (previously completed silently into the dead identity; `resolve()` never surfaces merged candidates, so only hand-typed decisions could reach it).

## Mechanism convergence packet

**Invariants enforced:** INV-EROJ-1 (client record is review input only; Hub canonicalizes before mutation), INV-EROJ-2 (one immutable deterministic operation identity; changed mapping fails closed at probe + partial unique index), INV-EROJ-3 (fresh-transaction committed visibility before terminal clear), INV-EROJ-4 (event always carries the original pair + operation id; matrix row 4's second-event outcome guarded by the cleared-twin check), INV-EROJ-6 (unknown state, malformed row, digest drift, foreign redirect, contradictory notes, merged-away target all fail closed with pending intact), INV-EROJ-7 (target-evolved application/recovery refused in every branch, left to EROJ-02), INV-EROJ-8 (Alembic + runtime assertion + fixture producer + parity test + CI lane in this PR), INV-EROJ-9 (no saga API, worker, event bus, graph, second outbox, or UI — one table + one module).

**States and transitions:** `claimed -> event_committed -> cleared`, monotonic, guarded UPDATEs; rowcount-0 re-reads distinguish idempotent replay from fail-closed unknown states. `cleared` is written after the fence passes and before the note write; the cleared-twin check makes that window duplicate-proof and the entry-keyed resume makes the `event_committed` window edit-proof.

**Crash-ordering walk:** W1 crash inside claim txn -> rolled back, fresh claim. W2 after claim, before any note write -> resume same id (proof: `test_operation_claim_commits_before_first_register_effect`). W3 after source redirect, before target complement -> resume completes target side only (proof: `test_mid_effect_crash_resumes_and_completes_target_side`). W4/W5 after effects, before/inside event txn -> journal still `claimed`, zero events, note bytes untouched; resume commits exactly one (proofs: `test_effect_before_event_commit_recovers_one_durable_event`, negative half of `test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear`). W6 after event commit, before clear -> entry-keyed resume finishes under the original identity even after the human edits the history (proof: `test_edited_history_after_refusal_converges_without_manual_repair`, both re-approve and reject variants). W7 after `mark_cleared`, before note write -> the cleared-twin check finishes the clear without a second operation or event (proof: `test_interrupted_clear_never_emits_second_event_on_reapproval`). W8 after note write -> fold skips the absent entry.

**The #4253 failure specifically:** an outbox insert on a caller-owned transaction is visible to that transaction's own reads but the fence's fresh connection cannot see it and the journal was never advanced, so the clear is refused and `pending` (the retry anchor) survives; rollback then destroys only the caller-side insert, and the retry commits the one real event (proof: `test_caller_transaction_rollback_cannot_clear_pending_or_hide_merge_event`, real Postgres).

**Producers/consumers:** schema producers = Alembic revision `e7a2b9c4d1f8` + module autocreate under `STORE_SCHEMA_AUTOCREATE=1`, byte-parity asserted; the merged event gains `operation_id` and a `heimdal.entity_review` source for review-path merges — non-dispatched lineage topic, no registered JSON schema, no worker branch; direct `EntityRegister.merge()` emission unchanged.

**Locks/concurrency:** every journal method owns one short manual-commit transaction; concurrent commits serialize on the row lock with idempotent losers; concurrent conflicting claims serialize on the partial unique index (SQLSTATE 23505 -> fail closed). The review-note read-merge-write keeps the existing single-hub posture (ADR-0055 owns multi-writer semantics).

**Residual accepted corner (sanctioned, no data loss, loud, recoverable today):** an operation still in `claimed` whose decision history is edited before any retry keeps that entry fail-closed — identity conflict for a changed merge, explicit refusal for a reject, each message naming the recovery. Convergence, stated precisely: `event_committed` and `cleared` shapes converge by product action alone (with the divergence diagnostic when the later ruling differs); the `claimed` shape has no product-action convergence for a *changed* ruling, but **restoring the entry's original decision in `entities/review.md` recovers cleanly today** — the claimed operation resumes, one event, no repair outside the note. That recovery lives in the human's own note-authority surface; the iPad client cannot perform it (it never edits or deletes prior review history), which is the availability question EROJ-02 should own.

## Acceptance criteria -> proofs

All journal proofs ran green against a real throwaway PostgreSQL 17 cluster (UTF8, `initdb -E UTF8 --locale=C`), not a fake connection.

- AC1 identity binds exact decision, fails closed: `tests/heimdal/test_entity_review_operation_journal.py::test_operation_identity_binds_exact_human_decision`
- AC2 claim commits before first register effect: `...::test_operation_claim_commits_before_first_register_effect` (+ `...::test_mid_effect_crash_resumes_and_completes_target_side`)
- AC3 atomic terminal commit + fresh visibility: `...::test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear`
- AC4 caller-transaction rollback cannot clear pending or lose the event: `...::test_caller_transaction_rollback_cannot_clear_pending_or_hide_merge_event`
- AC5 stop after effects recovers one durable event, decisions byte-for-byte: `...::test_effect_before_event_commit_recovers_one_durable_event`
- AC6 applicator clears merges only through the fence; reject/undo semantics guarded: `tests/heimdal/test_entity_confirm.py::test_apply_merge_uses_committed_journal_before_pending_clear`, `...::test_client_approval_is_canonicalized_by_hub_before_merge_execution`, `...::test_invalid_merge_decision_never_strands_an_operation`
- AC7 Alembic-owned, assert-only, producers updated, stale schema guided: `tests/migrations/test_entity_review_operation_journal_schema_parity.py::test_entity_review_operation_journal_schema_matches_head` (+ idempotent-upgrade and missing-schema-guidance tests)
- AC8 owner contracts name the delivered boundary without claiming EROJ-02/03: see Owner-doc writeback
- Review-fix proofs: `...::test_edited_history_after_refusal_converges_without_manual_repair` (F1; the `[reject]` variant asserts the round-2 divergence diagnostic), `...::test_divergent_reapproval_after_refusal_is_completed_loudly` (round-2 blocker, P1b), `...::test_reject_over_cleared_operation_names_the_standing_merge` (round-2, cleared window), `...::test_reject_with_claimed_operation_refuses_and_preserves_pending` (F3), `...::test_interrupted_clear_never_emits_second_event_on_reapproval` (F4), `tests/heimdal/test_entity_register.py::test_merge_into_evolved_target_is_refused` (F2), `...::test_merge_effect_state_classifies_all_note_shapes` + `...::test_merge_effect_helpers_fail_closed_on_unprovable_notes` (F6)

## Validation

Local, on the publishable tree (macOS laptop; real Postgres = throwaway UTF8 postgresql@17 cluster):

- `pytest -q tests/heimdal/test_entity_review_operation_journal.py tests/heimdal/test_entity_confirm.py` (DATABASE_URL at the cluster): all passed — includes the rollback/visibility proof and the three review-fix reproductions against real Postgres
- `pytest -q tests/migrations/test_entity_review_operation_journal_schema_parity.py` (same cluster): 3 passed
- `pytest -q -m "not pg" tests/heimdal tests/migrations`: passed with zero regressions vs the base branch point (delta = exactly the new tests)
- Full `-m "not pg and not alpha_llm"` suite: 4 pre-existing-class failures at first run; the one implicating this PR (`tests/guard/test_no_direct_db_imports.py`) was fixed via the sanctioned `ALLOW_FILES` entry; the remaining 3 (deploy compose, model-inquiry launcher, YouTube client) share zero surface with this diff
- `ruff check app tests`: clean; `mypy app`: clean
- `scripts/public_seam_lint.py --mode gate`: 0 uncovered hits (no register rows added)
- `scripts/docs_guard.py`: exits 1 with "temporal code/config changed but no high-risk temporal docs were touched" — **expected and accepted**: the spec explicitly forbids updating `docs/STATUS.md` before full EROJ capability acceptance ("Do not update docs/STATUS.md to claim full capability acceptance yet"), and that step does not run on this PR's CI path
- `scripts/review_before_ci_gate.py --lane implementation` with risk surfaces `data migration concurrency state-machine`: satisfied; independent Tier-3 mechanism review rounds 1 and 2 completed. Round 1: F1-F9 addressed (F1-F6, F8, F9 implemented; F7 resolved to the canonical vault id; F2 resolved by implementing the refusal). Round 2: the F1 completion's silent override of a divergent later ruling is now a loud diagnostic in both the `event_committed` and `cleared` windows (proofs: `test_divergent_reapproval_after_refusal_is_completed_loudly`, `test_reject_over_cleared_operation_names_the_standing_merge`, and the updated `[reject]` convergence variant); the fence and concurrency posture survived re-attack unchanged

## Owner-doc writeback

- `docs/DB_SCHEMA.md :: Source Of Truth` + `## Entity-Review Operation Journal` section
- `docs/EVENTS.md :: heimdal.register.entity.merged` — two emitters, atomic journal commit, `operation_id`, EROJ-02/03 not claimed
- `docs/MIMER_IPAD_THINKING_CANVAS/SIDE_BY_SIDE_ENTITY_CONFIRMATION_ON_IPAD.md :: What This Task Does` — delivered Hub-side boundary
- `docs/ENTITY_REVIEW_OPERATION_JOURNAL/README.md` — stale `:: Human flow` anchor corrected to `:: What This Task Does`; State line and classification paragraph both updated to "EROJ-01 shipped; EROJ-02/03 not claimed" (review F9)

## SBS Impact

- Primary subsystem: Product/Runtime SIP / Mimer entity identity
- Secondary: PDM migration-owned operational state; OEF canonical DB outbox; GOV governed note writes; Builder CI lanes (pg proof wiring)
- Write class: authority-adjacent operational coordination
- Persistence impact: new durable Postgres journal table; entity notes remain canonical
- New or changed contract: deterministic entity-review operation identity and committed-visibility fence; fail-closed merge refusals for contradictory/evolved targets
- Boundary risk addressed: same-connection visibility can never authorize a queue clear

## BuilderOps Routing

- Records/projections/receipts: LearningSignal `lrn_20260730235456_f70f8ccc` (dispatcher pull false-green under the GitHub rate-limit kill switch, discovered at pickup); claim receipt github-comment:5137357858 (label-only fallback claim with kill-switch reason).
- Reason: one process divergence captured during pickup; implementation followed the issue contract, with review findings addressed in-PR.

## Notes

- Claim: `agent:ready` removed via `scripts/issue_pickup_claim.sh` in explicit `github-label-only-fallback` mode; durable claimant receipt github-comment:5137357858.
- Spec feedback for EROJ-02/EROJ-03 authoring is recorded in the hand-back report (claimed-state orphan recovery ownership; reconciling spec-vs-issue AC lists; the delivered three-state vocabulary and canonical vault identity as fixed baselines).
