### PR TITLE
Carry GitHub labels and issue URL in dispatcher sync_state

### DIFF
--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -360,11 +360,20 @@ def normalize_github_issue(
 
     updated_at = payload.get("updatedAt") or payload.get("updated_at") or now
 
+    # REST payloads carry both the API ``url`` and the browser ``html_url``;
+    # prefer the browser URL so Signboard cards link to the issue page.
+    # GraphQL-shaped payloads carry the browser URL as ``url``.
+    html_url = payload.get("html_url") or payload.get("url") or None
+
     sync_state = SyncState(
         last_pull_at=now,
         source_version=payload.get("updatedAt") or payload.get("updated_at"),
         sync_result="ok",
         sync_note=None,
+        extra={
+            "labels": labels,
+            "url": str(html_url) if html_url is not None else None,
+        },
     )
 
     return TaskRecord(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -494,6 +494,9 @@ When present, `sync_state` may include:
 - `source_version` (etag/hash/updated marker)
 - `sync_result` (`ok`, `stale`, `conflict`, `error`)
 - `sync_note` (string)
+- `labels` (list of GitHub label names, recorded on every pull since #4441)
+- `url` (the issue's browser `html_url`, or null; Signboard cards and the
+  `/api/signboard` board read these two keys for chips and links)
 
 MVP must remain testable without GitHub API access; sync-state is optional and never required for core queue/lease behavior.
 

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -885,3 +885,51 @@ def test_cli_export_signboard_prune_exits_nonzero_on_foreign_board(
 
     assert main(["export-signboard", str(board), "--prune-absent", "--json"]) == 1
     assert {path: path.read_bytes() for path in sorted(board.rglob("*.md"))} == before
+
+
+def test_render_task_shows_labels_and_url_from_synced_record() -> None:
+    """A record produced by the sync path renders label chips and the GitHub
+    link without hand-seeded sync_state (#4441)."""
+    from app.dispatcher.signboard import _render_task
+    from app.dispatcher.sync_github import normalize_github_issue
+
+    payload = {
+        "number": 4441,
+        "title": "Synced card",
+        "labels": [{"name": "type:task"}, {"name": "prio:med"}],
+        "url": "https://api.github.com/repos/RasmusTho/agentic-pkm-mvp/issues/4441",
+        "html_url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/4441",
+        "created_at": "2026-07-31T10:00:00Z",
+        "updated_at": "2026-07-31T10:00:00Z",
+    }
+    task = normalize_github_issue(payload, "RasmusTho/agentic-pkm-mvp")
+
+    card = _render_task(task)
+
+    assert 'labels: ["type:task", "prio:med"]' in card
+    assert 'github_url: "https://github.com/RasmusTho/agentic-pkm-mvp/issues/4441"' in card
+    assert "- GitHub: https://github.com/RasmusTho/agentic-pkm-mvp/issues/4441" in card
+
+
+def test_render_task_tolerates_sync_state_without_labels_or_url() -> None:
+    """Pre-#4441 rows without the new keys keep rendering unchanged."""
+    from app.dispatcher.models import TaskRecord
+    from app.dispatcher.signboard import _render_task
+
+    task = TaskRecord(
+        task_id="github-RasmusTho--agentic-pkm-mvp-issue-99",
+        issue_number=99,
+        title="Legacy row",
+        status="ready",
+        priority="med",
+        source_anchor_refs=["github:issue:99"],
+        created_at="2026-07-01T00:00:00+00:00",
+        updated_at="2026-07-01T00:00:00+00:00",
+        sync_state={"last_pull_at": "2026-07-01T00:00:00+00:00"},
+    )
+
+    card = _render_task(task)
+
+    assert 'github_url: ""' in card
+    assert "labels: []" in card
+    assert "- GitHub:" not in card

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -128,6 +128,43 @@ def test_pull_sync_adapter_interface() -> None:
 # AC: normalize_github_issue maps fields correctly
 # ---------------------------------------------------------------------------
 
+def test_sync_state_carries_labels_and_url() -> None:
+    """Every pull records the issue's label names and HTML URL in sync_state
+    so Signboard cards stop rendering structurally empty chips/links (#4441).
+
+    REST payloads carry both an API ``url`` and the browser ``html_url``;
+    the browser URL must win. GraphQL-shaped payloads carry only ``url``.
+    """
+    rest_payload = {
+        "number": 205,
+        "title": "REST-shaped issue",
+        "labels": [{"name": "prio:med"}, {"name": "agent:ready"}],
+        "url": "https://api.github.com/repos/RasmusTho/agentic-pkm-mvp/issues/205",
+        "html_url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/205",
+        "created_at": "2026-04-20T10:00:00Z",
+        "updated_at": "2026-04-21T12:00:00Z",
+    }
+    task = normalize_github_issue(rest_payload, REPO)
+    assert task.sync_state["labels"] == ["prio:med", "agent:ready"]
+    assert task.sync_state["url"] == "https://github.com/RasmusTho/agentic-pkm-mvp/issues/205"
+
+    graphql_payload = {
+        "number": 206,
+        "title": "GraphQL-shaped issue",
+        "labels": [{"name": "prio:low"}],
+        "url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/206",
+        "createdAt": "2026-04-20T10:00:00Z",
+        "updatedAt": "2026-04-21T12:00:00Z",
+    }
+    task = normalize_github_issue(graphql_payload, REPO)
+    assert task.sync_state["labels"] == ["prio:low"]
+    assert task.sync_state["url"] == "https://github.com/RasmusTho/agentic-pkm-mvp/issues/206"
+
+    bare = normalize_github_issue(SAMPLE_ISSUE_NO_LABELS, REPO)
+    assert bare.sync_state["labels"] == []
+    assert bare.sync_state["url"] is None
+
+
 def test_github_issue_task_id_single_source_format_pinned() -> None:
     """The repo-qualified task id has exactly one implementation with a pinned
     byte format, including the doubled ``--`` owner/repo separator that keeps


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4441

## Linked Issue
Closes #4441

## SBS Impact
- Primary subsystem: Builder System / CES boundary (dispatcher control plane and Signboard projection)
- Secondary subsystem(s): none
- Write class: derived
- Persistence impact: rebuildable (rows re-derive labels/url on next pull; no migration)
- Derived/rebuildable impact: existing rows gain the fields on next sync; absent fields tolerated
- New or changed contract: sync_state gains two populated keys the consumers already read (additive)
- Owner-doc impact: docs/AGENT_ISSUE_DISPATCHER.md sync-state field list updated in this PR
- Transition debt impact: reduces (production cards stop rendering structurally empty metadata)
- Boundary risk: sync_state stays derived evidence; priority/status derivation from labels unchanged

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- normalize_github_issue records the issue's GitHub label names and browser html_url in sync_state on every pull (audit F9). REST payloads carry both an API url and html_url — the browser URL wins; GraphQL-shaped payloads carry the browser URL as url; both shapes are covered. Signboard cards (_render_task) and the store-served /api/signboard board read exactly these keys, so synced records stop rendering structurally empty label chips and GitHub links. Pre-change rows without the keys keep rendering unchanged (pinned by test). The store upserts sync_state wholesale (no dict-equality reconciliation), so the added keys cannot break idempotency.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Tier 2 single-issue slice; no BuilderOps material routed.

## Notes
Validation: python3 -m pytest tests/dispatcher/test_sync_github.py tests/dispatcher/test_signboard.py -q => 85 passed (new: test_sync_state_carries_labels_and_url, test_render_task_shows_labels_and_url_from_synced_record, test_render_task_tolerates_sync_state_without_labels_or_url); tests/api/test_signboard_api.py => 12 passed (the other consumer surface); ruff check app tests => clean; mypy app => clean. Scope note: PR #4406 merged mid-session; this fix is sync-layer only as the issue anticipated, and the merged board route reads the same keys. Claim receipt: dispatcher-backed, task_id=github-RasmusTho--agentic-pkm-mvp-issue-4441, lease_id=lease-9f3ff11f, holder=claude-fable-5, evidence=verified-dispatcher-lease (task id derived through #4440's github_issue_task_id).
