### PR TITLE
Machine-check the declared child-to-parent reference at issue readiness validation

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -50,6 +50,24 @@ data, or any artefact that is not reproducible from the checked-in repo plus pub
 body, linked PR, owner doc) before authoring the Issue that depends on it. If the material cannot be
 promoted, the Issue should not depend on it.
 
+## Child to parent reference
+
+A child slice governed by a parent feature issue declares that edge with exactly one line, on its
+own line in the body (conventionally at the end of `## Context`):
+
+```
+Parent: #<N>
+```
+
+Plain text, one parent, no bold or prose around the number — the line is machine-parsed
+(INV-DG-3). Orphan slices (no governing parent) carry no `Parent:` declaration at all.
+`scripts/validate_issue_readiness.py` fails readiness (`malformed_parent_reference`) when a
+declared reference — a `Parent:`-prefixed line carrying a `#<digits>` token — is not exactly this
+shape or appears more than once. Descriptive parent prose without an issue-number token is not a
+declaration. The parent→child direction is owned by the epic delivery ledger
+(`verification-and-closure :: Parent Issue Closure :: Structured child ledger (epic delivery
+ledger v1)`), not by this line.
+
 ## Verify: marker rule
 
 Every Acceptance Criterion declares its verification inline with a `Verify:` marker:

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -47,6 +47,7 @@ READINESS_CLASSES: tuple[str, ...] = (
     "missing_verify_markers",
     "missing_verify_file_paths",
     "malformed_acceptance_criteria",
+    "malformed_parent_reference",
     "ambiguous_intent",
     "authority_risk",
     "not_agentable",
@@ -298,6 +299,37 @@ def analyze_acceptance_criteria(section: str | None) -> AcceptanceCriteriaReport
     )
 
 
+_PARENT_CANONICAL = re.compile(r"^Parent: #[1-9][0-9]*$")
+_ISSUE_NUMBER_TOKEN = re.compile(r"#[0-9]+")
+
+
+def _parent_declaration_lines(body: str) -> list[str]:
+    """Lines that declare a child->parent reference (INV-DG-3).
+
+    The declaration grammar is a line starting with ``Parent:`` that carries an
+    issue-number token. Descriptive ``Parent:`` prose without a ``#<digits>``
+    token and legacy ``Parent feature issue: #N`` prose are not declarations,
+    so orphan slices and legacy bodies stay valid.
+    """
+    return [
+        stripped
+        for line in body.splitlines()
+        if (stripped := line.strip()).startswith("Parent:")
+        and _ISSUE_NUMBER_TOKEN.search(stripped)
+    ]
+
+
+def _parent_reference_problem(body: str) -> str | None:
+    declared = _parent_declaration_lines(body)
+    if not declared:
+        return None
+    if len(declared) > 1:
+        return "multiple parent declarations: " + "; ".join(declared)
+    if not _PARENT_CANONICAL.fullmatch(declared[0]):
+        return f"malformed parent declaration: {declared[0]}"
+    return None
+
+
 def _contains_any(patterns: Sequence[re.Pattern[str]], text: str) -> bool:
     return any(pattern.search(text) for pattern in patterns)
 
@@ -353,6 +385,8 @@ def classify_issue_body(
         classification = "missing_verify_markers"
     elif ac_report.missing_verify_file_paths:
         classification = "missing_verify_file_paths"
+    elif _parent_reference_problem(body) is not None:
+        classification = "malformed_parent_reference"
     elif _contains_any(AUTHORITY_RISK_PATTERNS, body):
         classification = "authority_risk"
         human_exception_required = True
@@ -425,6 +459,11 @@ def repair_guidance(
         return [
             "Rewrite `## Acceptance Criteria` as checkbox bullets (`- [ ] ...`).",
             "Give every acceptance criterion an inline `Verify:` marker naming a test, doc anchor, roadmap diff, or runtime receipt.",
+        ]
+    if classification == "malformed_parent_reference":
+        return [
+            "Declare the governing parent as exactly one canonical `Parent: #<N>` line (plain text, one parent, no bold or prose around the number).",
+            "Orphan slices carry no `Parent:` declaration at all; see `.codex/skills/_shared/ISSUE_CONTRACT.md :: Child to parent reference`.",
         ]
     if classification == "missing_verify_markers":
         missing_items = "; ".join(ac_report.missing_verify_items)

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -438,3 +438,46 @@ def test_cli_reads_issue_number_from_environment(tmp_path: Path) -> None:
     assert result.stdout == ""
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload["issue_number"] == 3212
+
+
+def test_declared_parent_reference_must_be_machine_parseable() -> None:
+    """A declared child->parent reference must be exactly one canonical
+    ``Parent: #<N>`` line (INV-DG-3, #4443)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+
+    canonical = body + "\nParent: #4447\n"
+    report = classify_issue_body(canonical, issue_number=1, labels=["type:task"])
+    assert report.readiness_classification == "ready_candidate"
+
+    for malformed_line in (
+        "Parent: **#4447**",
+        "Parent: #4447 and #4448",
+        "Parent: see #4447",
+    ):
+        report = classify_issue_body(
+            body + f"\n{malformed_line}\n", issue_number=1, labels=["type:task"]
+        )
+        assert report.readiness_classification == "malformed_parent_reference", malformed_line
+        assert any("Parent: #<N>" in item for item in report.repair_guidance)
+
+    duplicated = body + "\nParent: #4447\nParent: #4448\n"
+    report = classify_issue_body(duplicated, issue_number=1, labels=["type:task"])
+    assert report.readiness_classification == "malformed_parent_reference"
+
+
+def test_body_without_parent_reference_stays_ready() -> None:
+    """Orphan slices (no declared parent) remain valid, including legacy
+    prose like ``Parent feature issue: #N`` that is not the declaration
+    grammar (#4443)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+
+    report = classify_issue_body(body, issue_number=1, labels=["type:task"])
+    assert report.readiness_classification == "ready_candidate"
+
+    legacy_prose = body + "\nParent feature issue: #3325 (validation hub).\n"
+    report = classify_issue_body(legacy_prose, issue_number=1, labels=["type:task"])
+    assert report.readiness_classification == "ready_candidate"
+
+    descriptive_no_number = body + "\nParent: the governing validation hub for this track.\n"
+    report = classify_issue_body(descriptive_no_number, issue_number=1, labels=["type:task"])
+    assert report.readiness_classification == "ready_candidate"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4443

## Linked Issue
Closes #4443

## SBS Impact
- Primary subsystem: Builder System / CES boundary (issue-contract governance and readiness validation)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: issue contract names the child-to-parent line; validator gains a conditional shape check (no new REQUIRED_SECTION)
- Owner-doc impact: .codex/skills/_shared/ISSUE_CONTRACT.md updated in this PR
- Transition debt impact: reduces (an unchecked convention becomes a checked one)
- Boundary risk: the check stays conditional and offline; parentless slices remain valid; no GitHub resolution of the named parent

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- validate_issue_readiness.py now machine-checks the declared child-to-parent reference (audit F2, INV-DG-3): a line starting with Parent: that carries a #<digits> token is a declaration; exactly one canonical 'Parent: #<N>' line passes, while bold (Parent: **#N**), prose-around-the-number, and multiple declarations fail readiness with the new malformed_parent_reference class and targeted repair guidance. Orphan slices carry no declaration and stay valid; legacy 'Parent feature issue: #N' prose and Parent: prose without an issue-number token are deliberately outside the declaration grammar. ISSUE_CONTRACT.md gains the Child to parent reference section naming the convention, placement, and the downward-direction ownership (epic delivery ledger). Scope amendment recorded on #4443: classify_issue_body also runs at every dispatcher pull via _ready_validation_failure, so the three live agent:ready bodies carrying the bold variant (#4449-#4451) were normalized to 'Parent: #4447' (measured blast radius; post-normalization scan of all 52 ready issues reports zero malformed declarations).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Governance-lane slice; no BuilderOps material routed.

## Notes
Validation: python3 -m pytest tests/scripts/test_validate_issue_readiness.py -q => 44 passed (new: test_declared_parent_reference_must_be_machine_parseable, test_body_without_parent_reference_stays_ready); ruff check app tests + the script => clean; mypy app => clean; lint_skills_consistency => clean. docs_guard note: the temporal rule fails locally for any scripts/** diff without a docs/development pairing (validate_issue_readiness.py is not in GOVERNANCE_TEMPORAL_ENFORCEMENT); CI's docs_guard step does not run on this PR shape (scripts/tests are heavy_smoke), and adding the pairing is its own bounded change, not smuggled into this slice. Claim receipt: dispatcher-backed, task_id=github-RasmusTho--agentic-pkm-mvp-issue-4443, lease_id=lease-3054e232, holder=claude-fable-5, evidence=verified-dispatcher-lease.
