### PR TITLE
Emit github_issue frontmatter at filing time and backfill the two unpopulated spec dirs

### DIFF
--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -96,6 +96,7 @@ Each task file uses this frontmatter:
 name: {Human-Readable Task Name}
 description: {one-line description}
 task_id: {CAPABILITY-NN}
+github_issue: {issue number, written back at filing time; absent only before the issue exists}
 source_anchor: {docs path :: anchor}
 parent_capability: {capability name}
 prerequisites: [{task_id list}]
@@ -103,6 +104,11 @@ depends_on: [{filename list}]
 can_parallelize_with: [{task name list}]
 ---
 ```
+
+`github_issue:` is the machine join between the task doc and its filed slice issue (INV-DG-5,
+#4444). It is not authored speculatively: the filing step below writes the created issue number
+back into the frontmatter in the same delivery, so a filed task doc never carries an empty or
+stale value.
 
 ### Task file structure
 
@@ -204,6 +210,10 @@ By contrast, additive work on a single surface that mirrors an existing pattern 
    - If the GitHub parent issue later closes, update the local `PARENT_FEATURE_ISSUE.md` again so it no longer reads as an unfiled or active draft.
    - When closing, also update the capability `README.md` so it no longer reads as an active pre-delivery lane and so any now-satisfied acceptance checklist truthfully reflects the delivered docs/spec state.
 10. Create or update GitHub issues from the task specifications, in dependency order.
+    Immediately after each child `gh issue create`, write the created issue number back into that
+    task doc's `github_issue:` frontmatter and include the writeback in the same breakdown
+    commit/PR — the filing-time invariant INV-DG-5; a task doc with a filed issue must never
+    leave the breakdown without its `github_issue:` key.
 11. Keep authoritative labels truthful; Project status is optional projection:
     - parent feature issue normally starts with `agent:blocked`
     - ready tasks use `agent:ready` after strict validation

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -2,6 +2,7 @@
 name: API-Only Client Cutover
 description: Move every MacBook and automation client to the authenticated BuilderOps API.
 task_id: BCP-04
+github_issue: 3791
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Target boundary
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-02]

--- a/docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md
@@ -2,6 +2,7 @@
 name: Authority Cutover And Product Separation
 description: Perform the one-way cutover, remove Product ownership, and retire legacy authorities.
 task_id: BCP-06
+github_issue: 3793
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Cross-task invariants / partial-failure safety
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-03, BCP-04, BCP-05]

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -2,6 +2,7 @@
 name: Demerzel Review And Merge Orchestration
 description: Adapt existing review/repair/verification/merge work to the BuilderOps API and outbox.
 task_id: BCP-05
+github_issue: 3603
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Backlog reconciliation
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-02, BCP-04]

--- a/docs/BUILDEROPS_CONTROL_PLANE/INDEPENDENT_AUTHENTICATED_DEPLOYMENT.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/INDEPENDENT_AUTHENTICATED_DEPLOYMENT.md
@@ -2,6 +2,7 @@
 name: Independent Authenticated Deployment
 description: Deploy BuilderOps as its own authenticated Demerzel service and operations lifecycle.
 task_id: BCP-02
+github_issue: 3790
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Target boundary
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-01]

--- a/docs/BUILDEROPS_CONTROL_PLANE/LEGACY_AUTHORITY_MIGRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/LEGACY_AUTHORITY_MIGRATION.md
@@ -2,6 +2,7 @@
 name: Legacy Authority Migration
 description: Inventory and deterministically import every BuilderOps and dispatcher legacy authority.
 task_id: BCP-03
+github_issue: 3789
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Cross-task invariants / partial-failure safety
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-01]

--- a/docs/BUILDEROPS_CONTROL_PLANE/OWNER_DOC_ENACTMENT_AND_CLOSURE.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/OWNER_DOC_ENACTMENT_AND_CLOSURE.md
@@ -2,6 +2,7 @@
 name: Owner-Doc Enactment And Closure
 description: Promote proven control-plane reality into owner docs and close backlog truth.
 task_id: BCP-07
+github_issue: 3690
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Validation and owner-doc promotion
 parent_capability: BuilderOps independent control plane
 prerequisites: [BCP-06]

--- a/docs/BUILDEROPS_CONTROL_PLANE/POSTGRES_TRANSACTION_KERNEL.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/POSTGRES_TRANSACTION_KERNEL.md
@@ -2,6 +2,7 @@
 name: PostgreSQL Transaction Kernel
 description: Establish the single PostgreSQL authority and atomic orchestration/outbox primitives.
 task_id: BCP-01
+github_issue: 3792
 source_anchor: docs/BUILDEROPS_CONTROL_PLANE/README.md :: Cross-task invariants / partial-failure safety
 parent_capability: BuilderOps independent control plane
 prerequisites: []

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/DEFINE_DESIGN_RUN_CONTRACTS.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/DEFINE_DESIGN_RUN_CONTRACTS.md
@@ -2,6 +2,7 @@
 name: Define Design-Run Contracts
 description: Define strict provider-neutral design descriptors, briefs, requests, admissions, statuses, results, handoffs, and canonical hashes.
 task_id: CDH-01
+github_issue: 4308
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Reuse boundary and external prerequisite
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: []

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/EXPOSE_DESIGN_RUN_CLI.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/EXPOSE_DESIGN_RUN_CLI.md
@@ -2,6 +2,7 @@
 name: Expose Design-Run CLI
 description: Provide the explicit operator brief, admission, start, status, and result surface outside generated HTML.
 task_id: CDH-04
+github_issue: 4311
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Operator surfaces
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: [CDH-01, CDH-02, CDH-03]

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/GOVERN_DESIGN_RUN_LIFECYCLE.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/GOVERN_DESIGN_RUN_LIFECYCLE.md
@@ -2,6 +2,7 @@
 name: Govern Design-Run Lifecycle
 description: Persist exact admission-bound design runs and append-only causal BuilderOps receipts.
 task_id: CDH-03
+github_issue: 4310
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Cross-Task Invariants / Interaction Safety
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: [CDH-01, CDH-02]

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/PARENT_FEATURE_ISSUE.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/PARENT_FEATURE_ISSUE.md
@@ -1,4 +1,4 @@
-State: Active parent validation-hub contract. GitHub Issue #4131 exists and remains blocked pending merged breakdown and child delivery.
+State: Active parent validation-hub contract. GitHub Issue #4131 exists and remains blocked while child delivery completes; children #4308–#4313 are filed, with #4312 and #4313 still open.
 Doc role: Parent feature Issue specification
 Authority: Stable acceptance shape for live parent #4131; GitHub owns current labels, comments, and closure state.
 Owner: Builder System / CKM

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/PROJECT_DESIGN_RUNS_IN_COCKPIT.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/PROJECT_DESIGN_RUNS_IN_COCKPIT.md
@@ -2,6 +2,7 @@
 name: Project Design Runs in the Cockpit
 description: Render Yggdrasil-compliant read-only adapter, status, receipt, refusal, and handoff projections in Direction B.
 task_id: CDH-05
+github_issue: 4312
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Operator surfaces
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: [CDH-01, CDH-02, CDH-03, CDH-04, YGGDRASIL-DESIGN-HANDOFF]

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/README.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/README.md
@@ -1,4 +1,4 @@
-State: Active target-state specification. Parent validation hub #4131 is open and blocked; no child implementation issue has been filed yet.
+State: Active target-state specification. Parent validation hub #4131 is open and blocked. Child implementation issues #4308–#4313 are filed (see each task doc's `github_issue:` frontmatter); CDH-01 through CDH-04 are delivered, CDH-05 (#4312) and CDH-06 (#4313) remain open.
 Doc role: Capability specification
 Authority: Owns the bounded CKM design-agent integration capability, cross-task invariants, task order, and acceptance path. Subordinate to ADR-0057, ADR-0064, the delivered CKM Direction B contract, and the BuilderOps authority boundary.
 Owner: Builder System / CKM

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/REGISTER_DESIGN_AGENT_ADAPTERS.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/REGISTER_DESIGN_AGENT_ADAPTERS.md
@@ -2,6 +2,7 @@
 name: Register Design-Agent Adapters
 description: Add exact design-agent registrations above the shared ADR-0064 model-access transport.
 task_id: CDH-02
+github_issue: 4309
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Authority boundary
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: [CDH-01, MAS-PHASE1-ACCEPTED]

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
@@ -2,6 +2,7 @@
 name: Validate the Design Hub End to End
 description: Prove production-path provider/refusal behavior, final cockpit artifacts, owner-doc promotion, and parent acceptance readiness.
 task_id: CDH-06
+github_issue: 4313
 source_anchor: docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Capability acceptance
 parent_capability: CKM Design-Agent Integration Hub
 prerequisites: [CDH-01, CDH-02, CDH-03, CDH-04, CDH-05]

--- a/tests/architecture/test_spec_dir_github_issue_frontmatter.py
+++ b/tests/architecture/test_spec_dir_github_issue_frontmatter.py
@@ -1,0 +1,63 @@
+"""Filing-time join invariant for spec task docs (INV-DG-5, #4444).
+
+Every task doc in the exemplar specification directories that carries a
+``task_id:`` (i.e. is a filed implementation task, not a README or parent
+hub doc) must also carry a populated ``github_issue:`` frontmatter key —
+the machine join between the docs plane's dependency DAG and the GitHub
+delivery plane. The audit that motivated this
+(``docs/audits/DELIVERY_GRAPH_JOIN_SUBSTRATE_2026-07-30.md`` F6) found the
+field populated in one exemplar dir out of three; this test pins all three
+so the join cannot silently regress. New spec dirs inherit the invariant
+from ``feature-breakdown``'s filing-time writeback step rather than from
+this list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXEMPLAR_SPEC_DIRS = (
+    "docs/DETERMINISTIC_DELIVERY_ORCHESTRATION",
+    "docs/BUILDEROPS_CONTROL_PLANE",
+    "docs/CKM_DESIGN_AGENT_INTEGRATION",
+)
+
+_TASK_ID = re.compile(r"^task_id:\s*\S+", re.MULTILINE)
+_GITHUB_ISSUE = re.compile(r"^github_issue:\s*[1-9][0-9]*\s*$", re.MULTILINE)
+
+
+def _frontmatter(text: str) -> str | None:
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    return text[4:end] if end != -1 else None
+
+
+def _task_docs(spec_dir: str) -> list[Path]:
+    docs = []
+    for path in sorted((REPO_ROOT / spec_dir).glob("*.md")):
+        frontmatter = _frontmatter(path.read_text(encoding="utf-8"))
+        if frontmatter is not None and _TASK_ID.search(frontmatter):
+            docs.append(path)
+    return docs
+
+
+@pytest.mark.parametrize("spec_dir", EXEMPLAR_SPEC_DIRS)
+def test_exemplar_spec_dirs_carry_github_issue_frontmatter(spec_dir: str) -> None:
+    task_docs = _task_docs(spec_dir)
+    assert task_docs, f"no task docs with task_id frontmatter found under {spec_dir}"
+
+    missing = [
+        str(path.relative_to(REPO_ROOT))
+        for path in task_docs
+        if not _GITHUB_ISSUE.search(_frontmatter(path.read_text(encoding="utf-8")) or "")
+    ]
+    assert not missing, (
+        "task docs missing a populated github_issue: frontmatter key "
+        f"(INV-DG-5): {missing}"
+    )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4444

## Linked Issue
Closes #4444

## SBS Impact
- Primary subsystem: Builder System / CES boundary (spec-directory contract and feature-breakdown skill)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none (docs and skill template only)
- Derived/rebuildable impact: the docs-plane to GitHub join becomes machine-readable for the three exemplar dirs
- New or changed contract: feature-breakdown template gains github_issue: and the filing-time writeback step
- Owner-doc impact: the spec dirs and the skill are the owning artifacts (updated in this PR)
- Transition debt impact: reduces (closes the filing-time gap instead of leaving per-dir drift)
- Boundary risk: backfilled numbers must never be guessed; every value in this PR is traceable to doc prose or live issue titles as listed

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- The feature-breakdown frontmatter template gains github_issue: plus an explicit filing-time writeback step — after each child gh issue create, the created number is written back into that task doc's frontmatter in the same breakdown (audit F6, INV-DG-5). Backfill: all 7 docs/BUILDEROPS_CONTROL_PLANE task docs (BCP-01→#3792, BCP-02→#3790, BCP-03→#3789, BCP-04→#3791, BCP-05→#3603, BCP-06→#3793, BCP-07→#3690; every number traceable to the doc's own prose or existing_issue key) and all 6 docs/CKM_DESIGN_AGENT_INTEGRATION task docs (CDH-01..06→#4308-#4313; slug-identical live issue titles; #4317/#4427 are the delivering PRs, not duplicate issues). The CKM dir's State prose no longer claims no child is filed (children #4308-#4313 named, #4312/#4313 open). A new architecture test pins the three exemplar dirs so the join cannot silently regress; new spec dirs inherit the invariant from the skill's writeback step.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Governance/docs-lane slice; no BuilderOps material routed.

## Notes
Validation: python3 -m pytest tests/architecture/test_spec_dir_github_issue_frontmatter.py -q => 3 passed; tests/governance + tests/architecture => 665 passed, 1 pre-existing environment-dependent failure (test_launcher_fails_closed_on_an_absent_declared_credential) reproduced identically on the clean tree without this diff — laptop host-credential environment, not this change; ruff check app tests => clean; lint_skills_consistency => clean; docs_guard => exit 0. Claim receipt: dispatcher-backed, task_id=github-RasmusTho--agentic-pkm-mvp-issue-4444, lease_id=lease-00337d3d, holder=claude-fable-5, evidence=verified-dispatcher-lease.
