### PR TITLE
docs: reflect netstring length-prefixed calendar ledger key format

### DIFF
--- a/app/episodes/engine_state.py
+++ b/app/episodes/engine_state.py
@@ -15,11 +15,14 @@ segments"):
 - ``open_segment:<scope>`` -- the accumulated situation-model state of one
   scope's currently-open (not yet proposed) segment
   (:mod:`app.episodes.segmenter`).
-- ``calendar_consumed_signal:<scope>:<signal_id>`` -- exact calendar signal
-  identities whose segments closed under the fixed-window calendar poller.
-  These rows outlive an open segment's deletion after closure, preventing a
-  later poll from replaying stale calendar evidence into a new segment while
-  preserving eligibility for changed identities.
+- ``calendar_consumed_signal:<len(scope)>:<scope>:<signal_id>`` -- exact
+  calendar signal identities whose segments closed under the fixed-window
+  calendar poller. ``scope`` is length-prefixed netstring-style
+  (:func:`app.episodes.segmenter._calendar_consumed_signal_key`) so an
+  embedded ``:`` in either ``scope`` or ``signal_id`` cannot shift the key
+  boundary. These rows outlive an open segment's deletion after closure,
+  preventing a later poll from replaying stale calendar evidence into a new
+  segment while preserving eligibility for changed identities.
 
 Quiescence-closure frontiers are NOT persisted here: the segmenter computes a
 per-scope observed frontier fresh from each tick's own consumed signals

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -363,9 +363,12 @@ there is no `STORE_SCHEMA_AUTOCREATE` opt-in here, test fixtures run the migrati
       `outbox` table's vault-activity topics (independent of `outbox.delivered_at`, which the
       worker dispatcher owns);
     - `open_segment:<scope>` — one scope's currently-open (not yet proposed) segment state.
-    - `calendar_consumed_signal:<scope>:<signal_id>` — a closed calendar signal's durable
-      fixed-window idempotency boundary. It prevents a later poll from replaying evidence after
-      the originating open segment was deleted; changed calendar identities remain distinct.
+    - `calendar_consumed_signal:<len(scope)>:<scope>:<signal_id>` — a closed calendar signal's
+      durable fixed-window idempotency boundary. `scope` is length-prefixed netstring-style
+      (`app/episodes/segmenter.py::_calendar_consumed_signal_key`) so an embedded `:` in either
+      `scope` or `signal_id` cannot shift the key boundary. It prevents a later poll from
+      replaying evidence after the originating open segment was deleted; changed calendar
+      identities remain distinct.
   - (No `stream_watermark` row family: the quiescence-closure frontier is a per-scope
     read position computed fresh from each tick's own consumed signals, not carried durably.)
   - `value` (`jsonb`, `NOT NULL`)


### PR DESCRIPTION
## Direct Repair
Type: docs
Reason: PR #4408's fix commit (5a5e5499) changed the calendar consumed-signal ledger key from a plain scope:signal_id join to a netstring-style length-prefixed encoding to avoid boundary collisions; app/episodes/engine_state.py's docstring and docs/DB_SCHEMA.md still illustrated the old unescaped key format. Corrects the illustrative key-shape prose to the actual current-state format, prose-only.
Validation: python3 scripts/docs_guard.py (pass); ruff check app/episodes/engine_state.py (pass); git diff --check (pass)
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): HKA documentation
- Write class: Owner-doc current-state writeback
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none
- Owner-doc impact: updated in this PR
- Transition debt impact: none
- Boundary risk: none; prose-only, zero behavior change

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Owner-doc promotion follow-up for #4318: update the two illustrative calendar_consumed_signal key-shape strings to the netstring length-prefixed format shipped in PR #4408.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Prose-only owner-doc correction; the merged PR #4408 and this direct-repair PR are the durable record.

## Notes
Follow-up to PR #4408 (related to #4318) post-merge-owner-doc pass; prose-only, zero behavior change.