### PR TITLE
Accept contract-legal non-behavioral Verify targets in readiness validation

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -79,8 +79,24 @@ Every Acceptance Criterion declares its verification inline with a `Verify:` mar
   `Verify: \`tests/<path>::<test_name>\`` and the test asserts `<guard>` is invoked from
   `<runtime entrypoint>`. A unit test of the guard function alone does not discharge an
   enforcement AC.
-- Non-behavioral AC → concrete observable target: doc writeback path plus anchor
-  (`Verify: doc writeback at \`docs/<path> :: <anchor>\``), roadmap diff, or runtime receipt.
+- Non-behavioral AC → concrete observable target, one of: doc writeback path plus anchor
+  (`Verify: doc writeback at \`docs/<path> :: <anchor>\``), roadmap diff
+  (`Verify: roadmap diff: \`docs/<path> :: <anchor>\``), runtime receipt
+  (`Verify: runtime receipt: <identity>.v<N>`), a bare repo anchor
+  (`Verify: \`<path> :: <anchor>\``), a diff-of-file target
+  (`Verify: diff of \`<repo path>\` <what the diff adds>`), or a marker-presence target
+  (`Verify: \`<literal>\` present in \`<repo path>\``). A durable repository path or anchor is
+  what makes the target concrete; prose without one is not a target.
+- A backticked canonical target may carry a trailing prose annotation on the same marker line
+  (an enforcement note, or "removed or rewritten as delivered."); the target stays the
+  backticked segment.
+- The `Verify:` marker opens its own (optionally bulleted) line per the body template. An
+  inline tail on the AC line (`- [ ] text. Verify: <target>`) also declares a marker when its
+  target is grammar-resolvable; any other mid-line mention inside AC prose is not a marker.
+- The machine grammar for these forms is
+  `app/builderops/issue_contract_validation.py :: is_resolvable_verify_target`;
+  `tests/governance/test_verify_target_contract_parity.py` keeps this section and the grammar
+  in parity.
 - An AC without a resolvable `Verify:` target is not executable; the Issue must not be
   `agent:ready` until the AC is refined or split.
 - Ready-label validation permits a behavioral `tests/...py::test_name` target to name a new test

--- a/app/builderops/issue_contract_validation.py
+++ b/app/builderops/issue_contract_validation.py
@@ -44,6 +44,11 @@ _RUNTIME_RECEIPT_TARGET = re.compile(
 )
 _PLACEHOLDER = re.compile(r"<[^>]+>")
 _AUTHORITY_TOKEN = re.compile(r"[A-Za-z0-9]+")
+_ANNOTATED_TARGET = re.compile(r"^`(?P<inner>[^`]+)` (?P<annotation>\S.*)$")
+_DIFF_OF_TARGET = re.compile(r"^diff of `(?P<path>[^`]+)`(?: \S.*)?$")
+_MARKER_PRESENCE_TARGET = re.compile(
+    r"^`(?P<literal>[^`]+)` present in `(?P<path>[^`]+)`(?:[,;]? \S.*)?$"
+)
 
 
 def _contains_vague_authority_token(value: str) -> bool:
@@ -100,12 +105,40 @@ def is_durable_repo_anchor(value: str) -> bool:
     )
 
 
+def _is_canonical_backticked_inner(inner: str) -> bool:
+    """Whether one unquoted segment is a standalone canonical target."""
+
+    test_target = _TEST_VERIFY_TARGET.fullmatch(inner)
+    if test_target is not None:
+        return is_durable_repo_path(test_target.group("path"))
+    if is_durable_repo_anchor(inner):
+        return True
+    repo_path, separator, selector = inner.partition("::")
+    return bool(separator and selector and is_durable_repo_path(repo_path))
+
+
 def is_resolvable_verify_target(value: str) -> bool:
     """Return whether one strict-contract ``Verify:`` target is resolvable."""
 
     target = value.strip()
     if not target or _PLACEHOLDER.search(target) is not None:
         return False
+
+    # Non-behavioral concrete-observable forms and prose-annotated canonical
+    # targets carry more than one backtick segment, so they are matched
+    # before the single-segment unwrap below (#4464).
+    annotated = _ANNOTATED_TARGET.fullmatch(target)
+    if annotated is not None and _is_canonical_backticked_inner(
+        annotated.group("inner")
+    ):
+        return True
+    diff_target = _DIFF_OF_TARGET.fullmatch(target)
+    if diff_target is not None:
+        return is_durable_repo_path(diff_target.group("path"))
+    presence_target = _MARKER_PRESENCE_TARGET.fullmatch(target)
+    if presence_target is not None:
+        return is_durable_repo_path(presence_target.group("path"))
+
     unquoted_target = _strip_backtick_pair(target)
     if unquoted_target != target and "`" in unquoted_target:
         return False
@@ -114,6 +147,9 @@ def is_resolvable_verify_target(value: str) -> bool:
     test_target = _TEST_VERIFY_TARGET.fullmatch(target)
     if test_target is not None:
         return is_durable_repo_path(test_target.group("path"))
+
+    if is_durable_repo_anchor(target):
+        return True
 
     repo_path, separator, selector = target.partition("::")
     if separator and selector and is_durable_repo_path(repo_path):

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -317,7 +317,8 @@ Rules:
   file that the builder will add. Other file-based `Verify:` targets must resolve to existing
   repository files.
 - Enforcement ACs — behavioral ACs asserting a guard, gate, or invariant holds on the live runtime path — must point to a test that exercises the production call site, not the guard function in isolation. "Module exists and is unit-tested" does not discharge an enforcement AC; "invoked on the runtime path and asserted there" does.
-- Non-behavioral ACs point to a concrete observable target: doc writeback path plus anchor, roadmap diff, or runtime receipt.
+- Non-behavioral ACs point to a concrete observable target: doc writeback path plus anchor, roadmap diff, runtime receipt, a bare repo anchor (`` `<path> :: <anchor>` ``), a diff-of-file target (``diff of `<repo path>` <what the diff adds>``), or a marker-presence target (`` `<literal>` present in `<repo path>` ``). A durable repository path or anchor is what makes the target concrete.
+- A backticked canonical target may carry a trailing prose annotation on the same marker line (as the roadmap example above shows); the target stays the backticked segment. The `Verify:` marker opens its own line per the template; an inline tail on the AC line declares a marker only when its target is grammar-resolvable — any other mid-line mention inside AC prose is not a marker.
 - If an AC cannot carry a resolvable `Verify:` target, refine or split it before marking the Issue `agent:ready`.
 - `Suggested Validation` remains the section that lists the commands and procedures that execute the declared `Verify:` targets. ACs and Suggested Validation are coupled: commands exist to resolve the Verify targets, not to duplicate them.
 

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -184,8 +184,28 @@ def _summarize_item(item: str) -> str:
     return re.sub(r"\s+", " ", first_line)
 
 
+_ANNOTATED_TARGET = re.compile(r"^`(?P<inner>[^`]+)` \S.*$")
+_DIFF_OF_TARGET = re.compile(r"^diff of `(?P<path>[^`]+)`(?: \S.*)?$")
+_MARKER_PRESENCE_TARGET = re.compile(
+    r"^`[^`]+` present in `(?P<path>[^`]+)`(?:[,;]? \S.*)?$"
+)
+
+
 def _verify_file_path(target: str) -> str | None:
     canonical = target.strip()
+    # Mirror the grammar's multi-segment form order (#4464): an annotated
+    # backticked canonical target first, then diff-of-file, then
+    # marker-presence, before the single-segment unwrap.
+    annotated = _ANNOTATED_TARGET.fullmatch(canonical)
+    if annotated is not None and "::" in annotated.group("inner"):
+        canonical = f"`{annotated.group('inner')}`"
+    else:
+        diff_target = _DIFF_OF_TARGET.fullmatch(canonical)
+        if diff_target is not None:
+            return diff_target.group("path")
+        presence_target = _MARKER_PRESENCE_TARGET.fullmatch(canonical)
+        if presence_target is not None:
+            return presence_target.group("path")
     if canonical.startswith("`") and canonical.endswith("`"):
         canonical = canonical[1:-1]
     if canonical.startswith("runtime receipt: "):
@@ -197,6 +217,9 @@ def _verify_file_path(target: str) -> str | None:
                 canonical = canonical[1:-1]
             path, separator, _ = canonical.partition(" :: ")
             return path if separator else None
+    path, separator, spaced_rest = canonical.partition(" :: ")
+    if separator and spaced_rest:
+        return path
     path, separator, _ = canonical.partition("::")
     return path if separator else None
 
@@ -239,14 +262,29 @@ def _target_has_existing_file_path(target: str) -> bool:
     )
 
 
+# A `Verify:` marker is declared when it opens its own (optionally bulleted)
+# line per the body template, or when an inline tail (`- [ ] text. Verify:
+# <target>`) carries a grammar-resolvable target. A mid-line mention inside
+# AC prose whose tail is not a resolvable target is not a marker (#4464).
+_VERIFY_MARKER_ANY = re.compile(r"(?im)(?:^|\b)Verify:[ \t]*(.*)$")
+_VERIFY_LINE_LEAD = re.compile(r"[ \t]*(?:[-*][ \t]+)?(?:\[[ xX]\][ \t]+)?")
+
+
+def _declared_verify_targets(item: str) -> list[str]:
+    declared: list[str] = []
+    for match in _VERIFY_MARKER_ANY.finditer(item):
+        line_start = item.rfind("\n", 0, match.start()) + 1
+        lead = item[line_start : match.start()]
+        target = match.group(1).strip()
+        if _VERIFY_LINE_LEAD.fullmatch(lead) is not None:
+            declared.append(target)
+        elif is_resolvable_verify_target(target):
+            declared.append(target)
+    return declared
+
+
 def _has_concrete_verify_marker(item: str) -> bool:
-    targets = tuple(
-        match.group(1).strip()
-        for match in re.finditer(
-            r"(?im)(?:^|\b)Verify:[ \t]*(.*)$",
-            item,
-        )
-    )
+    targets = tuple(_declared_verify_targets(item))
     return (
         bool(targets)
         and len(set(targets)) == len(targets)
@@ -260,11 +298,7 @@ def _has_concrete_verify_marker(item: str) -> bool:
 
 
 def _verify_targets(item: str) -> list[str]:
-    return [
-        match.group(1).strip()
-        for match in re.finditer(r"(?im)(?:^|\b)Verify:\s*(.+)$", item)
-        if match.group(1).strip()
-    ]
+    return [target for target in _declared_verify_targets(item) if target]
 
 
 def _missing_verify_file_paths(item: str) -> list[str]:

--- a/tests/fixtures/issue_readiness/nonbehavioral_verify_targets.md
+++ b/tests/fixtures/issue_readiness/nonbehavioral_verify_targets.md
@@ -1,0 +1,42 @@
+## Context
+Cockpit journey coverage needs post-merge browser-lane wiring declared through
+non-behavioral concrete-observable targets (#4464 regression shapes from #4448).
+
+## Scope
+Wire journey tests into the post-merge browser lane and deselect them from the PR lane.
+
+## Source Anchors
+- `.codex/skills/_shared/ISSUE_CONTRACT.md :: Verify: marker rule`
+
+## SBS Impact
+- Primary subsystem: Builder System / CES boundary
+- Secondary subsystem(s): none
+- Write class: governance/docs/process
+- Persistence impact: none
+- Derived/rebuildable impact: CI artifact only
+- New or changed contract: none
+- Owner-doc impact: none
+- Transition debt impact: reduces
+- Boundary risk: none
+
+## Constraints
+- Do not mutate labels or Project status.
+
+## Acceptance Criteria
+- [ ] Dead-source journey drives the production route against an unreadable store.
+  - Verify: `tests/companion_ui/test_cockpit_journeys.py::test_dead_source_renders_refusal_not_calm` (enforcement: drives the production `/cockpit` route against an API process whose store path is unreadable)
+- [ ] Journey file wired into the post-merge browser lane as its own step.
+  - Verify: diff of `.github/workflows/browser-runtime.yml` adding a step running `tests/companion_ui/test_cockpit_journeys.py`
+- [ ] Journey module excluded from the required PR lane by the marker mechanism.
+  - Verify: `pytestmark = pytest.mark.browser_runtime` present in `tests/companion_ui/test_cockpit_journeys.py`, deselected by the PR marker expression in `scripts/select_pr_tests.py`
+- [ ] Delivery wording no longer lists the journey lane as pending.
+  - Verify: `docs/development/DEV_WORKFLOW.md :: Acceptance verifiability` removed or rewritten as delivered.
+
+## Out of Scope
+- PR-lane semantics changes.
+
+## Suggested Validation
+- `pytest -q tests/companion_ui/test_cockpit_journeys.py`
+
+## Source Docs
+- `.codex/skills/_shared/ISSUE_CONTRACT.md`

--- a/tests/governance/test_verify_target_contract_parity.py
+++ b/tests/governance/test_verify_target_contract_parity.py
@@ -1,0 +1,133 @@
+"""Classifier <-> contract parity for ``Verify:`` target grammar (#4464).
+
+`.codex/skills/_shared/ISSUE_CONTRACT.md :: Verify: marker rule` (skill-facing
+summary) and `docs/development/DEV_WORKFLOW.md :: Acceptance verifiability`
+(canonical long form) enumerate the accepted target forms. The strict grammar
+in `app.builderops.issue_contract_validation.is_resolvable_verify_target` must
+accept every enumerated form; a contract form the classifier rejects fails
+this test, so the two surfaces cannot drift silently again (#4448 fallback).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.builderops.issue_contract_validation import is_resolvable_verify_target
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ISSUE_CONTRACT = REPO_ROOT / ".codex/skills/_shared/ISSUE_CONTRACT.md"
+DEV_WORKFLOW = REPO_ROOT / "docs/development/DEV_WORKFLOW.md"
+
+# One concrete example per form the contract enumerates. The companion test
+# below asserts each form's identifying phrase is present in the contract
+# text, so removing or renaming a form in the docs breaks this table loudly.
+CONTRACT_FORM_EXAMPLES: dict[str, str] = {
+    "test pointer": (
+        "`tests/scripts/test_validate_issue_readiness.py::"
+        "test_fixture_classifications`"
+    ),
+    "doc writeback": (
+        "doc writeback at "
+        "`docs/development/DEV_WORKFLOW.md :: Acceptance verifiability`"
+    ),
+    "roadmap diff": "roadmap diff: `docs/ROADMAP.md :: DDO-03`",
+    "runtime receipt": "runtime receipt: delivery_receipt.v1",
+    "diff of file": (
+        "diff of `.github/workflows/browser-runtime.yml` adding a step "
+        "running `tests/companion_ui/test_cockpit_journeys.py`"
+    ),
+    "marker presence": (
+        "`pytestmark = pytest.mark.browser_runtime` present in "
+        "`tests/companion_ui/test_cockpit_journeys.py`, deselected by the "
+        "PR marker expression"
+    ),
+    "repo anchor": "`docs/development/DEV_WORKFLOW.md :: Acceptance verifiability`",
+    "annotated target": (
+        "`docs/ROADMAP.md :: DOMAIN-INGEST` removed or rewritten as delivered."
+    ),
+}
+
+FORM_PHRASE_IN_CONTRACT: dict[str, str] = {
+    "test pointer": "test pointer",
+    "doc writeback": "doc writeback at",
+    "roadmap diff": "roadmap diff",
+    "runtime receipt": "runtime receipt",
+    "diff of file": "diff of",
+    "marker presence": "present in",
+    "repo anchor": " :: ",
+    "annotated target": "trailing prose",
+}
+
+
+def _contract_text() -> str:
+    return (
+        ISSUE_CONTRACT.read_text(encoding="utf-8")
+        + DEV_WORKFLOW.read_text(encoding="utf-8")
+    )
+
+
+def test_contract_verify_forms_all_classify_ready() -> None:
+    rejected = {
+        form: example
+        for form, example in CONTRACT_FORM_EXAMPLES.items()
+        if not is_resolvable_verify_target(example)
+    }
+    assert rejected == {}, (
+        "contract-enumerated Verify forms rejected by the classifier "
+        f"grammar: {rejected}"
+    )
+
+
+def test_contract_text_enumerates_each_classifier_form() -> None:
+    text = _contract_text()
+    missing = {
+        form: phrase
+        for form, phrase in FORM_PHRASE_IN_CONTRACT.items()
+        if phrase not in text
+    }
+    assert missing == {}, (
+        "classifier-accepted forms no longer named in the contract docs: "
+        f"{missing}"
+    )
+
+
+def test_dev_workflow_canonical_example_targets_are_accepted() -> None:
+    """Every marker line in the fenced example under 'Acceptance
+    verifiability' must be accepted by the grammar."""
+    text = DEV_WORKFLOW.read_text(encoding="utf-8")
+    heading = text.find("## Acceptance verifiability")
+    assert heading != -1
+    # The fenced example embeds a `## Acceptance Criteria` heading, so slice
+    # from the section heading and take the first fence that follows it.
+    fence = re.search(r"```\n(.*?)```", text[heading:], re.DOTALL)
+    assert fence is not None, "expected a fenced example block in the section"
+    block = fence.group(1)
+    assert "Acceptance Criteria" in block
+    targets = [
+        match.group(1).strip()
+        for match in re.finditer(r"(?m)^\s*Verify:\s*(.+)$", block)
+    ]
+    assert targets, "expected Verify lines in the canonical example"
+    rejected = [t for t in targets if not is_resolvable_verify_target(t)]
+    assert rejected == [], (
+        f"canonical DEV_WORKFLOW example targets rejected by grammar: {rejected}"
+    )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "diff of `docs//broken.md` adding a step",
+        "diff of uncommitted local changes",
+        "`some marker` present in the deployed environment",
+        "diff of `<workflow file>` adding a step",
+        "`<marker>` present in `tests/scripts/test_validate_issue_readiness.py`",
+        "`docs/development/DEV_WORKFLOW.md :: later` removed as delivered.",
+        "manual QA",
+    ],
+)
+def test_grammar_still_rejects_unresolvable_targets(target: str) -> None:
+    assert not is_resolvable_verify_target(target)

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -195,6 +195,155 @@ def test_ready_issue_rejects_non_repo_relative_verify_file_path(verify_path: str
     assert report.readiness_classification == "missing_verify_file_paths"
 
 
+def test_diff_of_file_target_is_concrete() -> None:
+    """Contract-legal workflow-diff targets are concrete observables (#4464);
+    the #4448-shaped body classifies ready_candidate."""
+    body = (FIXTURE_DIR / "nonbehavioral_verify_targets.md").read_text(encoding="utf-8")
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_items == []
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_diff_of_file_target_requires_existing_file() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "`tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`",
+        "diff of `.github/workflows/does-not-exist.yml` adding a lane step",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+    assert report.acceptance_criteria.missing_verify_file_paths == [
+        ".github/workflows/does-not-exist.yml"
+    ]
+
+
+def test_marker_presence_target_is_concrete() -> None:
+    """A backticked literal asserted present in a durable repo file is a
+    concrete observable (#4464, #4448 AC shape)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "Verify: `tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`",
+        (
+            "Verify: `pytestmark = pytest.mark.browser_runtime` present in "
+            "`tests/companion_ui/test_cockpit_journeys.py`, deselected by the "
+            "PR marker expression in `scripts/select_pr_tests.py`"
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_trailing_prose_annotation_is_concrete() -> None:
+    """A backticked canonical target followed by explanatory prose stays
+    concrete, and path extraction carries no backtick residue (#4464)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "Verify: `tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`",
+        (
+            "Verify: `tests/scripts/test_validate_issue_readiness.py::"
+            "test_fixture_classifications` (enforcement: exercises the "
+            "production `classify_issue_body` call site)"
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_annotated_repo_anchor_target_is_concrete() -> None:
+    """The canonical DEV_WORKFLOW example form — a backticked repo anchor plus
+    'removed or rewritten as delivered.' — is concrete (#4464)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "Verify: `tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`",
+        (
+            "Verify: `docs/development/DEV_WORKFLOW.md :: Acceptance "
+            "verifiability` removed or rewritten as delivered."
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "diff of uncommitted local changes",
+        "`some marker` present in the deployed environment",
+        "`` present in `tests/scripts/test_validate_issue_readiness.py`",
+        "diff of `<workflow file>` adding a step",
+        "`<marker>` present in `tests/scripts/test_validate_issue_readiness.py`",
+    ],
+)
+def test_unresolvable_target_still_rejected(target: str) -> None:
+    """Extending the grammar (#4464) must not admit genuinely unresolvable
+    targets: no durable repo path, placeholder tokens, or prose-only claims."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "Verify: `tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`",
+        f"Verify: {target}",
+    )
+
+    report = classify_issue_body(body)
+
+    assert report.readiness_classification == "missing_verify_markers"
+    assert report.acceptance_criteria.missing_verify_items == [
+        "- [ ] The checker reports a ready candidate for canonical issue bodies."
+    ]
+
+
+def test_inline_tail_marker_with_resolvable_target_is_declared() -> None:
+    """The inline tail form (`- [ ] text. Verify: <target>`) used by the
+    model-inquiry proposal contract stays a declared marker (#4464)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        (
+            "- [ ] The checker reports a ready candidate for canonical issue bodies.\n"
+            "  - Verify: `tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`"
+        ),
+        (
+            "- [ ] The seam is deterministic. Verify: "
+            "`tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications`"
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_inline_marker_mention_in_prose_is_not_a_target() -> None:
+    """A mid-line mention inside AC prose whose tail is not a resolvable
+    target is not parsed as a marker declaration (#4464)."""
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "- [ ] The checker reports a ready candidate for canonical issue bodies.",
+        (
+            "- [ ] The checker accepts ACs whose prose mentions the "
+            "Verify: marker grammar without carrying a second target."
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
 @pytest.mark.parametrize("target", ["<test pointer>", "none", "n/a", "TBD"])
 def test_placeholder_verify_targets_are_not_concrete(target: str) -> None:
     body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4464

## Linked Issue
Closes #4464

## SBS Impact
- Primary subsystem: Builder System (issue readiness validation / dispatcher intake)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: readiness classifications and dispatcher task eligibility recomputed on next sync
- New or changed contract: Verify: target grammar aligned to ISSUE_CONTRACT; contract text now enumerates the accepted non-behavioral forms
- Owner-doc impact: updated in this PR (ISSUE_CONTRACT.md, DEV_WORKFLOW.md)
- Transition debt impact: reduces (removes a standing dispatcher-pull fallback cause)
- Boundary risk: classifier must not become laxer on genuinely unresolvable ACs; still-rejects coverage included

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Teach the readiness classifier the contract's non-behavioral Verify target forms (diff-of-file, marker-presence, bare/annotated repo anchors, trailing-prose annotations), fix marker-line vs prose-mention matching, and add a governance parity test binding the classifier grammar to ISSUE_CONTRACT/DEV_WORKFLOW.

## BuilderOps Routing
- Records/projections/receipts: dispatcher-backed pickup receipt on #4464 (task github-RasmusTho--agentic-pkm-mvp-issue-4464, lease lease-aedfcab7, holder fable-4464, evidence=verified-dispatcher-lease)
- Reason: Defect intake was routed as issue #4464 via bug-to-issue; no plan divergence, no LearningSignal needed.

## Notes
Validation:
- `python3 -m pytest tests/scripts/test_validate_issue_readiness.py tests/governance/test_verify_target_contract_parity.py tests/builderops/test_model_inquiry_promotion.py -q` -> 72 passed (new tests failed test-first against unchanged code, went green after the fix).
- Affected-subsystem set `python3 -m pytest tests/governance tests/builderops tests/scripts -q` -> green after the inline-tail marker rule was restored (first draft's strict line-anchoring broke the model-inquiry proposal contract's inline form; fixed before publication).
- Full `pytest -m "not pg"`: 11922 passed, 3 failed - all three failures reproduce identically on clean origin/main in this laptop environment (host-state: keychain launcher, SIGNBOARD_ROOT, provider env) and are unrelated to this change; the required clean-environment CI check is authoritative.
- `ruff check app tests companion-ui/companion-app` -> clean; `python3 scripts/docs_guard.py` -> OK; `scripts/review_before_ci_gate.py --lane implementation` -> satisfied (no TCD high-risk surface).
- Live sweep: all 52 open `agent:ready` issue bodies reclassified with the new code -> zero regressions; #3341, #3942, #4450, #4451 move from `missing_verify_file_paths` to `ready_candidate` with no body edits. #4448 now classifies `ready_candidate` after a separate mechanical Parent-line normalization (bold stripped per INV-DG-3, receipt comment on the issue). #4449 remains fallback-bound on the new-file doc-writeback contract question (follow-up flagged, out of scope here).

Delivery path: Tier 2 single-issue light path per `AGENTS.md :: Proportional delivery` (required CI green + self-verified Verify targets, Final-Review-Rounds: 0).

