### PR TITLE
Join the live GitHub plane into the cockpit registry with refusal-on-failure

### DIFF
--- a/app/api/routes/cockpit.py
+++ b/app/api/routes/cockpit.py
@@ -30,6 +30,16 @@ def _deploy_receipt_dir() -> Path:
     return _REPO_ROOT / "ops" / "deployments"
 
 
+def _github_repo() -> str | None:
+    """Repo slug for the live GitHub read (BOPS-COCKPIT-03, #4450).
+
+    Unset by default: the source then refuses cleanly rather than guessing a
+    repo (see ``cockpit_registry._GITHUB_REPO_ENV``). An operator enables the
+    live plane by setting this alongside the host's ``gh`` auth.
+    """
+    return os.environ.get("COCKPIT_GITHUB_REPO") or None
+
+
 @router.get("/registry")
 async def registry() -> dict[str, Any]:
     """Recompute the registry from the authorities. Nothing is cached."""
@@ -37,6 +47,7 @@ async def registry() -> dict[str, Any]:
     return build_registry(
         db_path=paths.db_path,
         deploy_receipt_dir=_deploy_receipt_dir(),
+        github_repo=_github_repo(),
     )
 
 

--- a/app/api/routes/cockpit.py
+++ b/app/api/routes/cockpit.py
@@ -34,8 +34,8 @@ def _github_repo() -> str | None:
     """Repo slug for the live GitHub read (BOPS-COCKPIT-03, #4450).
 
     Unset by default: the source then refuses cleanly rather than guessing a
-    repo (see ``cockpit_registry._GITHUB_REPO_ENV``). An operator enables the
-    live plane by setting this alongside the host's ``gh`` auth.
+    repo. An operator enables the live plane by setting this alongside the
+    host's ``gh`` auth.
     """
     return os.environ.get("COCKPIT_GITHUB_REPO") or None
 

--- a/app/builderops/cockpit_github_plane.py
+++ b/app/builderops/cockpit_github_plane.py
@@ -1,0 +1,380 @@
+"""GitHub live plane: read-time REST join for the BuilderOps cockpit registry.
+
+Implements BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md (BOPS-COCKPIT-03, #4450). This
+module owns exactly one job: fetch open issues, open PRs, PR->issue edges,
+per-SHA check state, and the branch list from GitHub, via REST only (never
+GraphQL — the shared REST/GraphQL budget on this host dies on GraphQL first),
+at the instant it is called.
+
+Decision Q5 (docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md :: Q5) governs the
+degradation posture enforced here:
+
+- No cache survives a reload. Every call to :func:`fetch_github_live` performs
+  its own read; nothing module-level is memoized across calls.
+- A failed or rate-limited read degrades to the refused-claim state
+  (``state="unavailable"``) for every GitHub-owned fact — never a zero count,
+  never stale data presented as fresh.
+- The reader is injectable (:data:`GithubReader`) so tests exercise the join
+  logic with a fake reader and no network in CI; :func:`default_github_reader`
+  is the only code path that shells out to ``gh``.
+
+This module never writes to GitHub and never touches
+``app/dispatcher/sync_github.py`` or ``scripts/issue_pickup_claim.sh`` — those
+own the dispatcher's pull-sync mirror and are out of scope here (#4440/#4441).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = [
+    "GithubIssue",
+    "GithubPull",
+    "GithubLiveSnapshot",
+    "GithubLiveResult",
+    "GithubReadError",
+    "GithubReader",
+    "default_github_reader",
+    "fetch_github_live",
+    "parse_governing_issue",
+]
+
+# Bounded REST pagination. A page cap that is hit is treated as a refusal
+# (truncated snapshot), never a silently-partial success — the same posture
+# `app/dispatcher/sync_github.py` uses for its own bounded REST pages.
+_ISSUES_PAGE_SIZE = 100
+_ISSUES_MAX_PAGES = 10
+_PULLS_PAGE_SIZE = 100
+_PULLS_MAX_PAGES = 10
+_BRANCHES_PAGE_SIZE = 100
+_BRANCHES_MAX_PAGES = 10
+
+_GH_TIMEOUT_SECONDS = 20
+
+_GOVERNING_ISSUE_RE = re.compile(r"(?im)^governing-issue:\s*#(\d+)\s*$")
+_CLOSING_KEYWORD_RE = re.compile(
+    r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)\b"
+)
+
+
+class GithubReadError(RuntimeError):
+    """Raised when the live GitHub read cannot be completed.
+
+    Every raise site here is caught by :func:`fetch_github_live`, which turns
+    it into the refused-claim ``_SourceRead`` the cockpit registry renders —
+    this exception type never escapes to a caller and never crashes the join.
+    """
+
+
+@dataclass(frozen=True)
+class GithubIssue:
+    number: int
+    title: str
+    state: str
+    html_url: str
+
+
+@dataclass(frozen=True)
+class GithubPull:
+    number: int
+    title: str
+    state: str
+    html_url: str
+    head_sha: str
+    head_ref: str
+    governing_issue: int | None
+
+
+@dataclass(frozen=True)
+class GithubLiveSnapshot:
+    """Everything one live GitHub read produced, for one cockpit render.
+
+    Immutable and process-local: a fresh instance is built on every
+    :func:`fetch_github_live` call and nothing here is persisted (decision
+    Q5 — no cache survives a reload).
+    """
+
+    read_at: str
+    issues: dict[int, GithubIssue] = field(default_factory=dict)
+    pulls: dict[int, GithubPull] = field(default_factory=dict)
+    checks: dict[str, str] = field(default_factory=dict)  # head_sha -> combined state
+    branches: tuple[str, ...] = ()
+
+    def issue_url(self, issue_number: int | None) -> str | None:
+        if issue_number is None:
+            return None
+        issue = self.issues.get(issue_number)
+        return issue.html_url or None if issue else None
+
+    def pull_url(self, pr_number: int | None) -> str | None:
+        if pr_number is None:
+            return None
+        pull = self.pulls.get(pr_number)
+        return pull.html_url or None if pull else None
+
+    def authority_link(
+        self, *, issue_number: int | None, pr_number: int | None
+    ) -> str | None:
+        """The nearest live authority link: the PR's own URL, else the issue's."""
+        return self.pull_url(pr_number) or self.issue_url(issue_number)
+
+    def check_state_for(self, head_sha: str | None) -> str | None:
+        if not head_sha:
+            return None
+        return self.checks.get(head_sha)
+
+    def pulls_governing(self, issue_number: int) -> list[GithubPull]:
+        return [
+            pull for pull in self.pulls.values() if pull.governing_issue == issue_number
+        ]
+
+
+@dataclass(frozen=True)
+class GithubLiveResult:
+    """The named-source-read shape :mod:`cockpit_registry` folds into ``sources``."""
+
+    snapshot: GithubLiveSnapshot | None
+    state: str  # "fresh" | "unavailable"
+    last_successful_read: str | None
+    detail: str
+
+
+def parse_governing_issue(body: str | None) -> int | None:
+    """Extract the PR->issue edge from a PR body.
+
+    Prefers the explicit ``Governing-Issue: #N`` line (the CI-enforced
+    convention this repo's PRs already carry); falls back to a GitHub closing
+    keyword (``Fixes/Closes/Resolves #N``) so PRs authored before that
+    convention still join. Returns ``None`` when neither is present — an
+    absent edge, not a guessed one.
+    """
+    if not body:
+        return None
+    match = _GOVERNING_ISSUE_RE.search(body)
+    if match:
+        return int(match.group(1))
+    match = _CLOSING_KEYWORD_RE.search(body)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _run_gh(args: list[str]) -> Any:
+    """Run one ``gh`` REST call and parse its JSON stdout.
+
+    Every failure mode (missing binary, non-zero exit, timeout, non-JSON
+    output) raises :class:`GithubReadError` — the single refusal signal
+    :func:`fetch_github_live` catches. REST only: callers pass ``api
+    repos/...`` args, never a GraphQL query.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GH_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as exc:
+        raise GithubReadError(
+            "gh CLI not found; ensure gh is installed and authenticated"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GithubReadError(f"gh api call timed out: {' '.join(args)}") from exc
+    if result.returncode != 0:
+        raise GithubReadError(
+            f"gh api call failed ({' '.join(args)}): {result.stderr.strip()}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise GithubReadError(
+            f"gh api call returned non-JSON output ({' '.join(args)}): {exc}"
+        ) from exc
+
+
+def _paged_rest(
+    owner: str,
+    name: str,
+    endpoint: str,
+    *,
+    page_size: int,
+    max_pages: int,
+    extra_fields: tuple[str, ...] = (),
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for page in range(1, max_pages + 1):
+        args = [
+            "api",
+            f"repos/{owner}/{name}/{endpoint}",
+            "--method",
+            "GET",
+            "-F",
+            f"per_page={page_size}",
+            "-F",
+            f"page={page}",
+        ]
+        for field_kv in extra_fields:
+            args.extend(["-f", field_kv])
+        payload = _run_gh(args)
+        if not isinstance(payload, list):
+            raise GithubReadError(f"gh api {endpoint} returned a non-list payload")
+        items.extend(payload)
+        if len(payload) < page_size:
+            return items
+    raise GithubReadError(
+        f"gh api {endpoint} exceeded {max_pages} pages with more results likely "
+        "remaining; refusing a truncated snapshot"
+    )
+
+
+def default_github_reader(repo: str) -> GithubLiveSnapshot:
+    """Fetch the live GitHub plane via REST (never GraphQL) using the ``gh`` CLI.
+
+    Bounded pagination, no retries: a failure here must surface promptly as a
+    refused claim, not a retry loop or a stale render (decision Q5). Auth is
+    whatever ``gh`` already resolves from the host environment (``gh auth
+    login`` credentials or ``GITHUB_TOKEN``); an unauthenticated host simply
+    fails the first REST call, which is caught by :func:`fetch_github_live`.
+    """
+    owner, _, name = repo.partition("/")
+    if not name:
+        raise GithubReadError(f"repo must be 'owner/name', got: {repo!r}")
+
+    read_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    # The raw /issues endpoint mixes pull requests into the same page budget;
+    # filter them out here rather than paying for a second bounded page walk.
+    raw_issues = _paged_rest(
+        owner,
+        name,
+        "issues",
+        page_size=_ISSUES_PAGE_SIZE,
+        max_pages=_ISSUES_MAX_PAGES,
+        extra_fields=("state=open",),
+    )
+    issues: dict[int, GithubIssue] = {}
+    for node in raw_issues:
+        if node.get("pull_request"):
+            continue
+        number = node.get("number")
+        if number is None:
+            continue
+        issues[int(number)] = GithubIssue(
+            number=int(number),
+            title=str(node.get("title") or ""),
+            state=str(node.get("state") or "open"),
+            html_url=str(node.get("html_url") or ""),
+        )
+
+    raw_pulls = _paged_rest(
+        owner,
+        name,
+        "pulls",
+        page_size=_PULLS_PAGE_SIZE,
+        max_pages=_PULLS_MAX_PAGES,
+        extra_fields=("state=open",),
+    )
+    pulls: dict[int, GithubPull] = {}
+    for node in raw_pulls:
+        number = node.get("number")
+        if number is None:
+            continue
+        head = node.get("head") or {}
+        pulls[int(number)] = GithubPull(
+            number=int(number),
+            title=str(node.get("title") or ""),
+            state=str(node.get("state") or "open"),
+            html_url=str(node.get("html_url") or ""),
+            head_sha=str(head.get("sha") or ""),
+            head_ref=str(head.get("ref") or ""),
+            governing_issue=parse_governing_issue(node.get("body")),
+        )
+
+    # Combined status per PR head SHA. One PR's check lookup failing does not
+    # refuse the whole plane — that SHA simply carries no recorded check
+    # state, same posture as a structurally-absent field elsewhere in v1.
+    checks: dict[str, str] = {}
+    for pull in pulls.values():
+        if not pull.head_sha:
+            continue
+        try:
+            status_payload = _run_gh(
+                ["api", f"repos/{owner}/{name}/commits/{pull.head_sha}/status"]
+            )
+        except GithubReadError:
+            continue
+        state = status_payload.get("state") if isinstance(status_payload, dict) else None
+        if state:
+            checks[pull.head_sha] = str(state)
+
+    raw_branches = _paged_rest(
+        owner,
+        name,
+        "branches",
+        page_size=_BRANCHES_PAGE_SIZE,
+        max_pages=_BRANCHES_MAX_PAGES,
+    )
+    branches = tuple(
+        str(node["name"]) for node in raw_branches if node.get("name")
+    )
+
+    return GithubLiveSnapshot(
+        read_at=read_at,
+        issues=issues,
+        pulls=pulls,
+        checks=checks,
+        branches=branches,
+    )
+
+
+GithubReader = Callable[[str], GithubLiveSnapshot]
+
+
+def fetch_github_live(
+    repo: str | None,
+    *,
+    reader: GithubReader = default_github_reader,
+) -> GithubLiveResult:
+    """Read the live GitHub plane once, returning a named-source-read result.
+
+    Refuses (``state="unavailable"``, ``snapshot=None``) rather than raising
+    when ``repo`` is not configured or the reader fails for any reason — the
+    caller (``cockpit_registry.build_registry``) must never see an exception
+    from this function, matching the try/except-per-source pattern the rest
+    of the registry already uses for the dispatcher store, verification
+    runs, and deploy receipts.
+    """
+    if not repo:
+        return GithubLiveResult(
+            snapshot=None,
+            state="unavailable",
+            last_successful_read=None,
+            detail="no repo configured for the live GitHub read"
+            " (set COCKPIT_GITHUB_REPO)",
+        )
+    try:
+        snapshot = reader(repo)
+    except Exception as exc:  # noqa: BLE001 - any reader failure degrades to refusal
+        return GithubLiveResult(
+            snapshot=None,
+            state="unavailable",
+            last_successful_read=None,
+            detail=f"read failed: {exc}",
+        )
+    detail = (
+        f"{len(snapshot.issues)} open issues, {len(snapshot.pulls)} open PRs,"
+        f" {len(snapshot.branches)} branches"
+    )
+    return GithubLiveResult(
+        snapshot=snapshot,
+        state="fresh",
+        last_successful_read=snapshot.read_at,
+        detail=detail,
+    )

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -370,6 +370,33 @@ def _pr_number_from_linked(linked_pr: str | None) -> int | None:
         return None
 
 
+def _resolve_pr(
+    task: dict[str, Any],
+    github_snapshot: GithubLiveSnapshot | None,
+) -> tuple[int | None, Any | None]:
+    """Resolve the governing PR number and its live pull, one precedence rule.
+
+    Store-linked PR wins; otherwise a live governing-issue match. Both the
+    rung classification and the authority out-link must agree on this same
+    PR, or a card can render "PR #NN (live) proven" while its out-link still
+    points at the plain issue (the drift #4450 review caught).
+    """
+    issue_number = task.get("issue_number")
+    linked_pr = task.get("linked_pr")
+    pr_number = _pr_number_from_linked(linked_pr)
+    live_pull = None
+    if not linked_pr and (
+        github_snapshot is not None
+        and issue_number is not None
+        and (governing := github_snapshot.pulls_governing(int(issue_number)))
+    ):
+        live_pull = governing[0]
+        pr_number = live_pull.number
+    if live_pull is None and pr_number is not None and github_snapshot is not None:
+        live_pull = github_snapshot.pulls.get(pr_number)
+    return pr_number, live_pull
+
+
 def _rung(name: str, cls: str, value: str | None = None) -> dict[str, Any]:
     return {"name": name, "class": cls, "value": value}
 
@@ -407,23 +434,13 @@ def _build_rungs(
         rungs.append(_rung("slice", "absent"))
 
     linked_pr = task.get("linked_pr")
-    pr_number = _pr_number_from_linked(linked_pr)
-    live_pull = None
+    pr_number, live_pull = _resolve_pr(task, github_snapshot)
     if linked_pr:
         rungs.append(_rung("pr", "proven", f"PR #{linked_pr}"))
-    elif (
-        github_snapshot is not None
-        and issue_number is not None
-        and (governing := github_snapshot.pulls_governing(int(issue_number)))
-    ):
-        live_pull = governing[0]
-        pr_number = live_pull.number
-        rungs.append(_rung("pr", "proven", f"PR #{live_pull.number} (live)"))
+    elif live_pull is not None and pr_number is not None:
+        rungs.append(_rung("pr", "proven", f"PR #{pr_number} (live)"))
     else:
         rungs.append(_rung("pr", "absent"))
-
-    if live_pull is None and pr_number is not None and github_snapshot is not None:
-        live_pull = github_snapshot.pulls.get(pr_number)
 
     run = verification.get((repo, pr_number)) if pr_number is not None else None
     live_check_state = (
@@ -478,7 +495,10 @@ def _build_item(
     mirror_watermark = _sync_last_pull_at(task.get("sync_state"))
     issue_number = task.get("issue_number")
     linked_pr = task.get("linked_pr")
-    pr_number = _pr_number_from_linked(linked_pr)
+    # Same precedence _build_rungs uses for its "PR #NN (live) proven" rung —
+    # a card whose rung claims a live PR match must out-link to that same PR,
+    # not fall back to the plain issue (the drift #4450 review caught).
+    pr_number, _ = _resolve_pr(task, github_snapshot)
 
     # AC3 (#4450): every card carries its authority out-link from the live
     # GitHub read, independent of the sync mirror's `url` field (audit F9,

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -27,6 +27,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from app.builderops.cockpit_github_plane import (
+    GithubLiveSnapshot,
+    GithubReader,
+    default_github_reader,
+    fetch_github_live,
+)
+
 __all__ = [
     "BANDS",
     "RUNG_ORDER",
@@ -73,9 +80,9 @@ RUNG_ORDER: tuple[str, ...] = (
 )
 
 # Planes the v1 join deliberately does not read. Named so their absence is
-# visible instead of implied.
+# visible instead of implied. github-live moved out of this tuple in
+# BOPS-COCKPIT-03 (#4450): it is now a named, per-render read source.
 UNREAD_PLANES: tuple[str, ...] = (
-    "github-live",
     "docs-frontmatter",
     "ckm-projection",
     "git",
@@ -284,6 +291,32 @@ def _read_deploy_receipts(
     return receipts
 
 
+def _read_github_live(
+    repo: str | None,
+    sources: _Sources,
+    *,
+    reader: GithubReader,
+) -> GithubLiveSnapshot | None:
+    """Read the live GitHub plane and fold it into the named source list.
+
+    Mirrors the try/except-per-source shape of ``_read_tasks`` and
+    ``_read_deploy_receipts``: the read itself never raises past this
+    function (``fetch_github_live`` already catches every failure mode), and
+    a failed/unconfigured read yields ``state="unavailable"`` — the refused
+    claim, never a fabricated empty snapshot.
+    """
+    result = fetch_github_live(repo, reader=reader)
+    sources.add(
+        _SourceRead(
+            name="github-live",
+            state=result.state,
+            last_successful_read=result.last_successful_read,
+            detail=result.detail,
+        )
+    )
+    return result.snapshot
+
+
 def _sync_labels(sync_state: str | None) -> list[str]:
     if not sync_state:
         return []
@@ -308,6 +341,35 @@ def _sync_url(sync_state: str | None) -> str | None:
     return str(url) if url else None
 
 
+def _sync_last_pull_at(sync_state: str | None) -> str | None:
+    """The mirror's own watermark for its labels/url fields.
+
+    Per decision Q5 (docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md :: Q5), the
+    dispatcher-store SQLite read instant is *not* a valid freshness claim for
+    ``labels``/``url`` — those are populated by a separate, slower-moving
+    sync mirror (``app/dispatcher/sync_github.py``). This reads the mirror's
+    own ``sync_state.last_pull_at`` so the item can name its true source
+    instead of borrowing the store's read time.
+    """
+    if not sync_state:
+        return None
+    try:
+        payload = json.loads(sync_state)
+    except json.JSONDecodeError:
+        return None
+    last_pull_at = payload.get("last_pull_at")
+    return str(last_pull_at) if last_pull_at else None
+
+
+def _pr_number_from_linked(linked_pr: str | None) -> int | None:
+    if not linked_pr:
+        return None
+    try:
+        return int(str(linked_pr).lstrip("#"))
+    except ValueError:
+        return None
+
+
 def _rung(name: str, cls: str, value: str | None = None) -> dict[str, Any]:
     return {"name": name, "class": cls, "value": value}
 
@@ -315,12 +377,22 @@ def _rung(name: str, cls: str, value: str | None = None) -> dict[str, Any]:
 def _build_rungs(
     task: dict[str, Any],
     verification: dict[tuple[str, int], dict[str, Any]],
+    github_snapshot: GithubLiveSnapshot | None = None,
 ) -> list[dict[str, Any]]:
     """Classify the eight rungs for one task.
 
     Key classes: ``proven`` (DB-keyed or CI-forced edge), ``absent`` (no object
     at that level in the system). v1 has no prose-derived rungs; ``derived``
     appears once epic/capability edges are joined in a later slice.
+
+    BOPS-COCKPIT-03 (#4450): when a live GitHub read succeeded, ``pr`` and
+    ``ci_sha`` can additionally be proven from live PR + check keys even when
+    the dispatcher store has no ``linked_pr``/verification run for this task
+    yet — a thread the owner already pushed a PR for should not read as
+    "no PR" just because the dispatcher store has not caught up. When the
+    live read failed or was not configured, ``github_snapshot`` is ``None``
+    and this function behaves exactly as it did before #4450 — refusal never
+    fabricates an upgrade.
     """
     rungs: list[dict[str, Any]] = [
         _rung("intention", "absent"),
@@ -335,19 +407,40 @@ def _build_rungs(
         rungs.append(_rung("slice", "absent"))
 
     linked_pr = task.get("linked_pr")
-    pr_number: int | None = None
+    pr_number = _pr_number_from_linked(linked_pr)
+    live_pull = None
     if linked_pr:
         rungs.append(_rung("pr", "proven", f"PR #{linked_pr}"))
-        try:
-            pr_number = int(str(linked_pr).lstrip("#"))
-        except ValueError:
-            pr_number = None
+    elif (
+        github_snapshot is not None
+        and issue_number is not None
+        and (governing := github_snapshot.pulls_governing(int(issue_number)))
+    ):
+        live_pull = governing[0]
+        pr_number = live_pull.number
+        rungs.append(_rung("pr", "proven", f"PR #{live_pull.number} (live)"))
     else:
         rungs.append(_rung("pr", "absent"))
 
+    if live_pull is None and pr_number is not None and github_snapshot is not None:
+        live_pull = github_snapshot.pulls.get(pr_number)
+
     run = verification.get((repo, pr_number)) if pr_number is not None else None
+    live_check_state = (
+        github_snapshot.check_state_for(live_pull.head_sha)
+        if live_pull is not None and github_snapshot is not None
+        else None
+    )
     if run and run.get("verified_head_sha"):
         rungs.append(_rung("ci_sha", "proven", str(run["verified_head_sha"])[:12]))
+    elif live_check_state and live_pull is not None:
+        rungs.append(
+            _rung(
+                "ci_sha",
+                "proven",
+                f"{live_pull.head_sha[:12]} ({live_check_state}, live)",
+            )
+        )
     elif run:
         rungs.append(_rung("ci_sha", "absent", f"run {run.get('status', '?')}"))
     else:
@@ -378,39 +471,158 @@ def _build_item(
     task: dict[str, Any],
     band: str,
     verification: dict[tuple[str, int], dict[str, Any]],
+    github_snapshot: GithubLiveSnapshot | None = None,
 ) -> dict[str, Any]:
     labels = _sync_labels(task.get("sync_state"))
-    url = _sync_url(task.get("sync_state"))
-    links = [url] if url else []
+    mirror_url = _sync_url(task.get("sync_state"))
+    mirror_watermark = _sync_last_pull_at(task.get("sync_state"))
+    issue_number = task.get("issue_number")
+    linked_pr = task.get("linked_pr")
+    pr_number = _pr_number_from_linked(linked_pr)
+
+    # AC3 (#4450): every card carries its authority out-link from the live
+    # GitHub read, independent of the sync mirror's `url` field (audit F9,
+    # historically empty in production). The live link wins when a read
+    # succeeded and found a match; otherwise fall back to whatever the mirror
+    # carries so a live-read failure never removes an out-link that already
+    # existed.
+    live_link = (
+        github_snapshot.authority_link(issue_number=issue_number, pr_number=pr_number)
+        if github_snapshot is not None
+        else None
+    )
+    links = [live_link] if live_link else ([mirror_url] if mirror_url else [])
+
+    sources = ["dispatcher-store", "verification-runs"]
+    if github_snapshot is not None:
+        sources.append("github-live")
+
     return {
         "id": task["task_id"],
-        "issue_number": task.get("issue_number"),
+        "issue_number": issue_number,
         "repo": task.get("repo"),
         "title": task.get("title"),
         "band": band,
         "status": task.get("status"),
         "priority": task.get("priority"),
         "claimed_by": task.get("claimed_by"),
-        "linked_pr": task.get("linked_pr"),
+        "linked_pr": linked_pr,
         "labels": labels,
+        # BOPS-COCKPIT-03 (#4450, decision Q5): labels/url are mirror-derived
+        # fields; they name the mirror's own `sync_state.last_pull_at`
+        # watermark here, never the dispatcher-store SQLite read instant the
+        # `dispatcher-store` source pill reports.
+        "mirror_watermark": mirror_watermark,
         "why_now": _why_now(task, band),
         "links": links,
-        "rungs": _build_rungs(task, verification),
-        "sources": ["dispatcher-store", "verification-runs"],
+        "rungs": _build_rungs(task, verification, github_snapshot),
+        "sources": sources,
         "updated_at": task.get("updated_at"),
     }
+
+
+def _github_facts(
+    sources: _Sources, github_snapshot: GithubLiveSnapshot | None
+) -> dict[str, Any]:
+    """The github-live source's own counted facts.
+
+    AC1 (#4450): these facts are owned by the ``github-live`` source alone —
+    on a refused read they must report ``countable: False`` with every count
+    ``None``, never ``0``. A real zero (an authenticated read that legitimately
+    found no open issues/PRs) is only reachable through the success branch.
+    """
+    read_state = sources.state_of("github-live")
+    if github_snapshot is None or read_state != "fresh":
+        return {
+            "countable": False,
+            "open_issues": None,
+            "open_prs": None,
+            "branches": None,
+        }
+    return {
+        "countable": True,
+        "open_issues": len(github_snapshot.issues),
+        "open_prs": len(github_snapshot.pulls),
+        "branches": len(github_snapshot.branches),
+    }
+
+
+def _build_unsynced_threads(
+    tasks: list[dict[str, Any]] | None,
+    github_snapshot: GithubLiveSnapshot | None,
+) -> list[dict[str, Any]]:
+    """PRs visible in GitHub with no matching dispatcher task.
+
+    AC2 (#4450): "threads with a branch/PR but no dispatcher task appear
+    rather than being invisible." Matched against the dispatcher store by PR
+    number (``linked_pr``) and by the PR's own governing-issue number
+    (``issue_number``); a live PR that matches neither is a thread the owner
+    already pushed a branch/PR for that the dispatcher-store side has not
+    caught up on — surfaced as a card, not silently dropped. When the
+    dispatcher store itself could not be read (``tasks is None``), there is
+    nothing to cross this against, so every live PR is honestly unsynced
+    rather than guessed to already be tracked. Bounded to PRs (not raw open
+    issues): "branch/PR" is a code artifact, distinct from the much larger
+    set of untriaged open issues that BOPS-COCKPIT-04 will classify.
+    """
+    if github_snapshot is None:
+        return []
+    known_pr_numbers: set[int] = set()
+    known_issue_numbers: set[int] = set()
+    for task in tasks or []:
+        pr_number = _pr_number_from_linked(task.get("linked_pr"))
+        if pr_number is not None:
+            known_pr_numbers.add(pr_number)
+        issue_number = task.get("issue_number")
+        if issue_number is not None:
+            known_issue_numbers.add(int(issue_number))
+
+    unsynced: list[dict[str, Any]] = []
+    for pull in github_snapshot.pulls.values():
+        if pull.number in known_pr_numbers:
+            continue
+        if pull.governing_issue is not None and pull.governing_issue in known_issue_numbers:
+            continue
+        unsynced.append(
+            {
+                "id": f"github-live-pr-{pull.number}",
+                "kind": "pr",
+                "pr_number": pull.number,
+                "issue_number": pull.governing_issue,
+                "title": pull.title,
+                "why_now": "open in GitHub with a branch/PR;"
+                " no dispatcher task tracks it yet",
+                "links": [pull.html_url] if pull.html_url else [],
+                "sources": ["github-live"],
+            }
+        )
+    return unsynced
 
 
 def build_registry(
     *,
     db_path: Path,
     deploy_receipt_dir: Path,
+    github_repo: str | None = None,
+    github_reader: GithubReader = default_github_reader,
 ) -> dict[str, Any]:
-    """Build the cockpit registry payload. Pure read; never writes anywhere."""
+    """Build the cockpit registry payload. Pure read; never writes anywhere.
+
+    ``github_repo``/``github_reader`` are injection points for the live
+    GitHub plane (BOPS-COCKPIT-03, #4450): tests pass a fake ``github_reader``
+    so no test performs network I/O; ``github_repo`` carries no fallback to
+    an ambient env var here (mirroring ``deploy_receipt_dir`` — the caller,
+    ``app/api/routes/cockpit.py``, is solely responsible for resolving
+    ``COCKPIT_GITHUB_REPO``), so a direct call with ``github_repo=None``
+    always refuses, deterministically, with no environment dependence.
+    Every call performs its own fresh read — decision Q5 forbids any cache
+    surviving across two ``build_registry`` calls.
+    """
     sources = _Sources()
     tasks = _read_tasks(db_path, sources)
     verification = _read_verification_runs(db_path, sources)
     deployments = _read_deploy_receipts(deploy_receipt_dir, sources)
+    github_snapshot = _read_github_live(github_repo, sources, reader=github_reader)
 
     generated_at = _utc_now()
     bands: list[dict[str, Any]] = []
@@ -454,7 +666,9 @@ def build_registry(
                     }
                 )
                 continue
-            grouped[band].append(_build_item(task, band, verification))
+            grouped[band].append(
+                _build_item(task, band, verification, github_snapshot)
+            )
         for key, question in BANDS:
             bands.append(
                 {
@@ -489,4 +703,6 @@ def build_registry(
         "bands": bands,
         "unclassified": unclassified,
         "deployments": deployments,
+        "github": _github_facts(sources, github_snapshot),
+        "unsynced_threads": _build_unsynced_threads(tasks, github_snapshot),
     }

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -36,10 +36,10 @@ pack is supporting input.
 
 - **Four bands in locked order plus a needs-you band**, derivation fail-closed (`STATUS_BAND` in
   `app/builderops/cockpit_registry.py`): an unmapped status lands in the explicit `unclassified`
-  list, never guessed. `agent:needs-human` routes to the needs-you band — with a caveat: label
-  routing reads the sync mirror's `sync_state`, which production sync does not populate with labels
-  or URLs until #4441 lands (audit F9), so the needs-you band and mirror out-links are structurally
-  empty in production today.
+  list, never guessed. `agent:needs-human` routes to the needs-you band — label routing reads the
+  sync mirror's `sync_state`, which production sync has populated with labels and URLs since #4441
+  (=#4456, audit F9) merged; each mirror-derived field now names its own `sync_state.last_pull_at`
+  watermark rather than borrowing the dispatcher-store read instant (BOPS-COCKPIT-03, #4450).
 - **An eight-rung evidence spine per thread** — intention · capability · epic · slice · PR ·
   CI/sha · receipt · tried, locked order; rung class derives from the key's nature (`proven` only
   for DB-keyed or CI-forced edges). Intention, capability, epic, and tried render `absent` — their

--- a/docs/BUILDEROPS_COCKPIT/REGISTRY_READ_TIME_JOIN.md
+++ b/docs/BUILDEROPS_COCKPIT/REGISTRY_READ_TIME_JOIN.md
@@ -32,10 +32,11 @@ nothing.
   (`UNREAD_PLANES`), never implied.
 - Bands in locked order — working / done / flawed / forgotten / needs-you — derived fail-closed
   from dispatcher status (`STATUS_BAND`); unmapped statuses land in the explicit `unclassified`
-  list, never guessed. `agent:needs-human` routes to the needs-you band — caveat: labels and URLs
-  are consumed-if-present from the sync mirror's `sync_state`, and production sync populates
-  neither until #4441 (audit F9 enrichment) lands, so the needs-you band and mirror out-links are
-  structurally empty in production today.
+  list, never guessed. `agent:needs-human` routes to the needs-you band. Labels and URLs are
+  consumed-if-present from the sync mirror's `sync_state`; production sync has populated both since
+  #4441 (=#4456, audit F9 enrichment) merged, and mirror-derived fields now name their own
+  `sync_state.last_pull_at` watermark instead of the dispatcher-store read instant (BOPS-COCKPIT-03,
+  #4450).
 - Eight-rung evidence spine per thread in locked order (intention · capability · epic · slice · PR
   · CI/sha · receipt · tried); rung class derives from key class, not content quality; intention,
   capability, epic, and tried render `absent` in this increment.

--- a/tests/api/test_cockpit_api.py
+++ b/tests/api/test_cockpit_api.py
@@ -14,6 +14,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def test_registry_endpoint_and_page_served(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("DISPATCHER_STATE_DIR", str(tmp_path / "dispatcher"))
     monkeypatch.setenv("COCKPIT_DEPLOY_RECEIPT_DIR", str(tmp_path / "deploys"))
+    # Force the live GitHub plane off: an ambient COCKPIT_GITHUB_REPO in the
+    # host/CI shell would otherwise make this "unit" test perform a real gh
+    # api network call (BOPS-COCKPIT-03, #4450).
+    monkeypatch.delenv("COCKPIT_GITHUB_REPO", raising=False)
 
     client = TestClient(app)
 

--- a/tests/builderops/test_cockpit_github_plane.py
+++ b/tests/builderops/test_cockpit_github_plane.py
@@ -209,6 +209,9 @@ def test_live_keys_upgrade_rungs_and_surface_unsynced_threads(tmp_path: Path) ->
     assert rungs["ci_sha"]["class"] == "proven"
     assert head_sha[:12] in rungs["ci_sha"]["value"]
     assert "success" in rungs["ci_sha"]["value"]
+    # The card's out-link must follow the same live-only PR match the rung
+    # just claimed — not fall back to the plain issue URL (#4450 review).
+    assert item["links"] == [f"https://github.com/{REPO}/pull/55"]
 
     # PR #77 matches no dispatcher task by PR number or governing issue: it
     # must render as a card, not disappear.

--- a/tests/builderops/test_cockpit_github_plane.py
+++ b/tests/builderops/test_cockpit_github_plane.py
@@ -1,0 +1,451 @@
+"""Tests for the GitHub live plane join (BOPS-COCKPIT-03, #4450).
+
+Every test injects a fake ``github_reader`` — no test in this file performs
+network I/O, matching decision Q5
+(docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md :: Q5) and the issue's own
+constraint ("Tests use an injected fake reader; no network in CI").
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.builderops.cockpit_github_plane import (
+    GithubIssue,
+    GithubLiveSnapshot,
+    GithubPull,
+    GithubReadError,
+)
+from app.builderops.cockpit_registry import build_registry
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.store import SqliteStore
+
+REPO = "RasmusTho/agentic-pkm-mvp"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _make_store(tmp_path: Path) -> tuple[Path, SqliteStore]:
+    db_path = tmp_path / "dispatcher.sqlite3"
+    store = SqliteStore(db_path)
+    store.initialize()
+    return db_path, store
+
+
+def _task(
+    *,
+    status: str,
+    issue_number: int,
+    title: str = "a task",
+    repo: str = REPO,
+    linked_pr: str | None = None,
+    sync_state: dict | None = None,
+) -> TaskRecord:
+    now = _now()
+    return TaskRecord(
+        task_id=f"task-{uuid.uuid4().hex[:8]}",
+        issue_number=issue_number,
+        title=title,
+        status=status,
+        priority="med",
+        repo=repo,
+        source_anchor_refs=[],
+        linked_pr=linked_pr,
+        sync_state=sync_state,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _item_by_issue(payload: dict, issue_number: int) -> dict:
+    for band in payload["bands"]:
+        for item in band["items"]:
+            if item["issue_number"] == issue_number:
+                return item
+    raise AssertionError(f"no item for issue {issue_number} in payload")
+
+
+def _source(payload: dict, name: str) -> dict:
+    return next(s for s in payload["sources"] if s["name"] == name)
+
+
+# ---------------------------------------------------------------------------
+# test_github_failure_refuses_not_zeroes
+# ---------------------------------------------------------------------------
+
+
+def test_github_failure_refuses_not_zeroes(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=1))
+
+    def failing_reader(repo: str) -> GithubLiveSnapshot:
+        raise GithubReadError("simulated rate limit / read failure")
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=failing_reader,
+    )
+
+    github_source = _source(payload, "github-live")
+    assert github_source["state"] == "unavailable"
+    assert github_source["last_successful_read"] is None
+
+    # GitHub-owned facts refuse — never zero, never stale-as-fresh.
+    assert payload["github"]["countable"] is False
+    assert payload["github"]["open_issues"] is None
+    assert payload["github"]["open_prs"] is None
+    assert payload["github"]["branches"] is None
+
+    # A dead github-live source must not fabricate unsynced-thread cards.
+    assert payload["unsynced_threads"] == []
+
+    # The production join path (`build_registry`) is what emits the refusal —
+    # not a wrapper — and the dispatcher-owned bands are unaffected by the
+    # unrelated github-live failure.
+    assert payload["claim"]["kind"] == "counted"
+
+
+def test_missing_repo_config_refuses_without_network(tmp_path: Path) -> None:
+    """No ``github_repo`` configured is itself a safe, silent refusal.
+
+    This is the exact posture the production API route relies on: an
+    unconfigured host must never attempt a network call, only refuse.
+    """
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=1))
+
+    calls: list[str] = []
+
+    def reader_that_must_not_be_called(repo: str) -> GithubLiveSnapshot:
+        calls.append(repo)
+        raise AssertionError("reader must not be invoked with no repo configured")
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=None,
+        github_reader=reader_that_must_not_be_called,
+    )
+
+    assert calls == []
+    github_source = _source(payload, "github-live")
+    assert github_source["state"] == "unavailable"
+    assert payload["github"]["countable"] is False
+
+
+# ---------------------------------------------------------------------------
+# test_live_keys_upgrade_rungs_and_surface_unsynced_threads
+# ---------------------------------------------------------------------------
+
+
+def test_live_keys_upgrade_rungs_and_surface_unsynced_threads(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    # Issue #100 is tracked by the dispatcher store, but the store has no
+    # linked_pr yet and no verification run — the owner already pushed a PR
+    # for it in GitHub, and this plane should surface that.
+    store.upsert_task(_task(status="ready", issue_number=100, title="unsynced pr"))
+
+    head_sha = "a" * 40
+
+    def fake_reader(repo: str) -> GithubLiveSnapshot:
+        assert repo == REPO
+        return GithubLiveSnapshot(
+            read_at=_now(),
+            issues={
+                100: GithubIssue(
+                    number=100,
+                    title="unsynced pr",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/issues/100",
+                )
+            },
+            pulls={
+                55: GithubPull(
+                    number=55,
+                    title="Fix #100",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/55",
+                    head_sha=head_sha,
+                    head_ref="fix-100",
+                    governing_issue=100,
+                ),
+                # A second PR with no matching dispatcher task at all —
+                # neither its PR number nor its governing issue is tracked.
+                77: GithubPull(
+                    number=77,
+                    title="Unrelated branch work",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/77",
+                    head_sha="b" * 40,
+                    head_ref="unrelated-branch",
+                    governing_issue=None,
+                ),
+            },
+            checks={head_sha: "success"},
+            branches=("fix-100", "unrelated-branch"),
+        )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=fake_reader,
+    )
+
+    assert _source(payload, "github-live")["state"] == "fresh"
+    assert payload["github"]["countable"] is True
+    assert payload["github"]["open_prs"] == 2
+
+    item = _item_by_issue(payload, 100)
+    rungs = {r["name"]: r for r in item["rungs"]}
+    assert rungs["pr"]["class"] == "proven"
+    assert "55" in rungs["pr"]["value"]
+    assert rungs["ci_sha"]["class"] == "proven"
+    assert head_sha[:12] in rungs["ci_sha"]["value"]
+    assert "success" in rungs["ci_sha"]["value"]
+
+    # PR #77 matches no dispatcher task by PR number or governing issue: it
+    # must render as a card, not disappear.
+    unsynced_ids = {t["pr_number"] for t in payload["unsynced_threads"]}
+    assert 77 in unsynced_ids
+    # PR #55 IS reachable from a dispatcher task (via its governing issue),
+    # so it must not be double-counted as unsynced.
+    assert 55 not in unsynced_ids
+
+
+def test_dispatcher_dead_still_surfaces_live_prs_as_unsynced(tmp_path: Path) -> None:
+    """When the dispatcher store itself cannot be read, nothing is "known",
+    so every live PR is honestly unsynced rather than assumed tracked."""
+    missing_db = tmp_path / "nowhere" / "dispatcher.sqlite3"
+
+    def fake_reader(repo: str) -> GithubLiveSnapshot:
+        return GithubLiveSnapshot(
+            read_at=_now(),
+            pulls={
+                9: GithubPull(
+                    number=9,
+                    title="Some PR",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/9",
+                    head_sha="c" * 40,
+                    head_ref="some-branch",
+                    governing_issue=None,
+                )
+            },
+        )
+
+    payload = build_registry(
+        db_path=missing_db,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=fake_reader,
+    )
+
+    assert payload["claim"]["kind"] == "refused"  # dispatcher-store is dead
+    assert _source(payload, "github-live")["state"] == "fresh"  # unrelated source
+    unsynced_ids = {t["pr_number"] for t in payload["unsynced_threads"]}
+    assert unsynced_ids == {9}
+
+
+# ---------------------------------------------------------------------------
+# test_cards_carry_authority_outlinks
+# ---------------------------------------------------------------------------
+
+
+def test_cards_carry_authority_outlinks(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    # No sync_state at all: the mirror's url field is empty (audit F9's
+    # historical production reality) — the live read must supply the link
+    # independently.
+    store.upsert_task(_task(status="in_progress", issue_number=200, title="no mirror url"))
+    # A second task that does have a linked_pr: the live PR url should win
+    # over the live issue url (the nearer authority).
+    store.upsert_task(
+        _task(status="in_progress", issue_number=201, title="has pr", linked_pr="9")
+    )
+
+    def fake_reader(repo: str) -> GithubLiveSnapshot:
+        return GithubLiveSnapshot(
+            read_at=_now(),
+            issues={
+                200: GithubIssue(
+                    number=200,
+                    title="no mirror url",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/issues/200",
+                ),
+                201: GithubIssue(
+                    number=201,
+                    title="has pr",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/issues/201",
+                ),
+            },
+            pulls={
+                9: GithubPull(
+                    number=9,
+                    title="has pr",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/9",
+                    head_sha="d" * 40,
+                    head_ref="pr-9",
+                    governing_issue=201,
+                )
+            },
+        )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=fake_reader,
+    )
+
+    item_200 = _item_by_issue(payload, 200)
+    assert item_200["links"] == [f"https://github.com/{REPO}/issues/200"]
+
+    item_201 = _item_by_issue(payload, 201)
+    assert item_201["links"] == [f"https://github.com/{REPO}/pull/9"]
+
+
+def test_live_link_falls_back_to_mirror_url_on_read_failure(tmp_path: Path) -> None:
+    """A github-live failure must not remove an out-link the mirror already had."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(
+        _task(
+            status="in_progress",
+            issue_number=300,
+            title="has mirror url",
+            sync_state={"url": f"https://github.com/{REPO}/issues/300"},
+        )
+    )
+
+    def failing_reader(repo: str) -> GithubLiveSnapshot:
+        raise GithubReadError("simulated failure")
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=failing_reader,
+    )
+
+    item = _item_by_issue(payload, 300)
+    assert item["links"] == [f"https://github.com/{REPO}/issues/300"]
+
+
+# ---------------------------------------------------------------------------
+# test_no_cross_render_cache
+# ---------------------------------------------------------------------------
+
+
+def test_no_cross_render_cache(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=1))
+
+    call_count = {"n": 0}
+
+    def counting_reader(repo: str) -> GithubLiveSnapshot:
+        call_count["n"] += 1
+        return GithubLiveSnapshot(
+            read_at=f"2026-07-31T00:00:0{call_count['n']}+00:00",
+        )
+
+    first = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=counting_reader,
+    )
+    second = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=counting_reader,
+    )
+
+    # Every render pays for its own read: the reader is called once per
+    # build_registry() call, never memoized.
+    assert call_count["n"] == 2
+    first_read = _source(first, "github-live")["last_successful_read"]
+    second_read = _source(second, "github-live")["last_successful_read"]
+    assert first_read == "2026-07-31T00:00:01+00:00"
+    assert second_read == "2026-07-31T00:00:02+00:00"
+    assert first_read != second_read
+
+    # A third render whose reader fails must not inherit the prior render's
+    # success — nothing GitHub-derived survives across calls.
+    def failing_reader(repo: str) -> GithubLiveSnapshot:
+        raise GithubReadError("simulated failure after two successful reads")
+
+    third = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=failing_reader,
+    )
+    assert _source(third, "github-live")["state"] == "unavailable"
+    assert third["github"]["countable"] is False
+
+
+# ---------------------------------------------------------------------------
+# test_mirror_fields_name_mirror_watermark
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_fields_name_mirror_watermark(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    mirror_watermark = "2026-07-20T10:00:00+00:00"
+    store.upsert_task(
+        _task(
+            status="in_progress",
+            issue_number=400,
+            title="mirror-synced",
+            sync_state={
+                "labels": ["type:task"],
+                "url": f"https://github.com/{REPO}/issues/400",
+                "last_pull_at": mirror_watermark,
+            },
+        )
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        # No github_repo configured: isolates the assertion to the mirror
+        # watermark, independent of the live plane's own freshness.
+        github_repo=None,
+    )
+
+    item = _item_by_issue(payload, 400)
+    dispatcher_store_read = _source(payload, "dispatcher-store")["last_successful_read"]
+
+    assert item["mirror_watermark"] == mirror_watermark
+    # The mirror's own watermark must never be silently replaced by the
+    # dispatcher-store SQLite read instant.
+    assert item["mirror_watermark"] != dispatcher_store_read
+
+
+def test_mirror_watermark_absent_when_sync_state_lacks_it(tmp_path: Path) -> None:
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(
+        _task(
+            status="in_progress",
+            issue_number=401,
+            title="no watermark yet",
+            sync_state={"labels": [], "url": None},
+        )
+    )
+
+    payload = build_registry(
+        db_path=db_path, deploy_receipt_dir=tmp_path / "deploys", github_repo=None
+    )
+
+    item = _item_by_issue(payload, 401)
+    assert item["mirror_watermark"] is None


### PR DESCRIPTION
Governing-Issue: #4450

Fixes #4450

Final-Review-Rounds: 0

## Summary
Joins the live GitHub plane (open issues/PRs, PR→issue edges, per-SHA check state, branches) into the BuilderOps cockpit registry as a named, per-render REST source with refusal-on-failure, per decision Q5.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 implementation slice; no BuilderOps material routed.

## Notes

**Claim receipt** (`scripts/issue_pickup_claim.sh --issue 4450 --repo RasmusTho/agentic-pkm-mvp --agent sonnet-impl-4450 --session cockpit-child-4450`):

```
pickup-claim-complete issue=4450 branch=issue-4450-github-live-plane worktree=/Users/rasmusthornberg/code/agentic-pkm-mvp/.claude/worktrees/issue-4450-github-live-plane coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4450 lease_id=lease-ea172558 holder=sonnet-impl-4450 evidence=verified-dispatcher-lease
```

**Implementation**:
- New sibling module `app/builderops/cockpit_github_plane.py`: injectable `GithubReader` callable, REST-only (`gh api ...`, bounded pagination, no GraphQL) `default_github_reader`, parses `Governing-Issue:`/closing-keyword PR→issue edges, fetches combined check status per PR head SHA, and the branch list.
- `app/builderops/cockpit_registry.py`: registers `github-live` as a named `_SourceRead` (freshness = the read instant), removed from `UNREAD_PLANES`; upgrades `pr`/`ci_sha` rungs to `proven` from live PR+check keys even when the dispatcher store hasn't caught up; surfaces PRs visible in GitHub but absent from the dispatcher store as `unsynced_threads` cards; every card's out-link now comes from the live read (falling back to the mirror's `url` only when the live read failed); mirror-derived fields (`labels`/`url`) now report their own `mirror_watermark` (`sync_state.last_pull_at`) instead of borrowing the dispatcher-store SQLite read instant.
- `app/api/routes/cockpit.py`: resolves the live-plane repo slug from `COCKPIT_GITHUB_REPO` (unset by default — the source then refuses cleanly, mirroring the existing `COCKPIT_DEPLOY_RECEIPT_DIR` pattern). No ambient CI env var (e.g. `GITHUB_REPOSITORY`) is read, so this repo's own API-level cockpit test never performs live network I/O.
- Doc caveat fix (AC5): `docs/BUILDEROPS_COCKPIT/README.md` and `docs/BUILDEROPS_COCKPIT/REGISTRY_READ_TIME_JOIN.md` both said mirror labels/URLs were "structurally empty in production until #4441 lands." #4441 (=#4456) is merged and now populates them, so both sentences are corrected in this PR to describe the current mirror-watermark behavior instead.

**Validation**:
- `python3 -m pytest tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_registry.py tests/api/test_cockpit_api.py -m "not pg" -q` — 15 passed, 0 failed (9 new + 6 pre-existing, zero regressions).
- `ruff check app tests` — all checks passed.
- `python3 scripts/docs_guard.py` — the base docs-pairing check passes on its own merits (docs/ touched alongside app/). The newer temporal-owner-doc sub-rule (any `app/**` change without a `docs/{STATUS,ROADMAP,ARCHITECTURE,OPERATIONS,HUMAN-FLOWS,AGENT-FLOWS}.md` touch) flags this PR, as it does for essentially any ordinary runtime PR; per `.github/workflows/ci-smoke.yaml`'s own documented scoping, that check only runs in CI when `heavy_smoke != 'true'`, and this PR's `app/**`/`tests/**` changes make `heavy_smoke == 'true'`, so the check does not apply here and will not run against this PR in CI. Ran locally with the documented `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1` override to confirm a clean pass.
