### PR TITLE
Join the docs/capability plane into the cockpit registry with honest weak edges

### DIFF
--- a/app/api/routes/cockpit.py
+++ b/app/api/routes/cockpit.py
@@ -40,6 +40,25 @@ def _github_repo() -> str | None:
     return os.environ.get("COCKPIT_GITHUB_REPO") or None
 
 
+def _docs_root() -> Path:
+    override = os.environ.get("COCKPIT_DOCS_ROOT")
+    return Path(override) if override else _REPO_ROOT / "docs"
+
+
+def _capabilities_yaml_path() -> Path:
+    override = os.environ.get("COCKPIT_CAPABILITIES_YAML")
+    if override:
+        return Path(override)
+    return _REPO_ROOT / "app" / "builderops" / "ckm" / "seed" / "capabilities.yaml"
+
+
+def _matrix_path() -> Path:
+    override = os.environ.get("COCKPIT_TRACEABILITY_MATRIX")
+    if override:
+        return Path(override)
+    return _REPO_ROOT / "docs" / "architecture" / "traceability-matrix.md"
+
+
 @router.get("/registry")
 async def registry() -> dict[str, Any]:
     """Recompute the registry from the authorities. Nothing is cached."""
@@ -48,6 +67,9 @@ async def registry() -> dict[str, Any]:
         db_path=paths.db_path,
         deploy_receipt_dir=_deploy_receipt_dir(),
         github_repo=_github_repo(),
+        docs_root=_docs_root(),
+        capabilities_yaml_path=_capabilities_yaml_path(),
+        matrix_path=_matrix_path(),
     )
 
 

--- a/app/builderops/cockpit_docs_plane.py
+++ b/app/builderops/cockpit_docs_plane.py
@@ -1,0 +1,617 @@
+"""Docs/capability plane: read-time join for the BuilderOps cockpit registry.
+
+Implements BUILDEROPS_COCKPIT/DOCS_PLANE_CAPABILITY_LANES.md (BOPS-COCKPIT-05,
+#4451). The delivery graph's *shape* lives in the docs plane — specification
+directories, task-doc frontmatter (``task_id``, ``github_issue``,
+``depends_on``), and the machine-registered capability seed — while its
+*state* lives in GitHub (audit: docs/audits/DELIVERY_GRAPH_JOIN_SUBSTRATE_2026-07-30.md,
+findings F3/F5/F6). This module reads three named-in-spec sources at render
+time and joins them to whatever thread (dispatcher task / GitHub issue) the
+cockpit registry is already rendering:
+
+- ``app/builderops/ckm/seed/capabilities.yaml`` — capability keys and their
+  ``boundary_ref`` (a Level-2 control-boundary code, e.g. ``RCA``).
+- ``docs/architecture/traceability-matrix.md`` — a hand-authored table whose
+  ``Control boundaries`` column names a boundary and whose
+  ``Implementation issues`` column lists ``#NNNN`` issues it implements. This
+  is a *machine edge*: boundary -> capability -> issue, extracted verbatim.
+- spec-directory task-doc frontmatter under ``docs/*/`` (any directory
+  carrying a ``PARENT_FEATURE_ISSUE.md``, the parent-feature-spec pattern) —
+  each task doc's own ``github_issue:``/``parent_capability:`` fields are a
+  second machine edge, independent of the matrix.
+
+Honesty rules this module enforces (mirrors ``cockpit_github_plane.py``):
+
+- No cache survives a reload; every call to :func:`read_docs_plane` performs
+  its own filesystem read.
+- A failed or unreadable docs tree degrades to the refused-claim state
+  (``state="unavailable"``) — never an empty-but-fabricated lane set.
+- A thread with no machine edge in either source renders **freestanding**,
+  in its own lane, with an ``amber`` capability rung — never guessed under a
+  parent capability (decision: docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md :: Q4).
+- Rung classes distinguish *no object exists in the system at all*
+  (``absent`` — reserved for docs-plane-unconfigured or genuinely keyless
+  rungs such as ``intention``) from *the object exists but names no edge for
+  this thread* (``amber``, capability-only) and from *the only evidence is
+  prose, not a machine field* (``derived`` — epic rung only, per audit F2/F6).
+
+CKM stays a lens only (ADR-0057): this module never reads any CKM store, and
+nothing here may be swapped for a CKM read without visibly regressing
+ADR-0057 (the "CKM is a lens, never spine" cockpit test in
+``tests/builderops/test_cockpit_docs_plane.py::test_ckm_is_lens_never_spine``
+grep-guards this file for exactly that reason).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+__all__ = [
+    "CapabilityNode",
+    "SpecTaskDoc",
+    "SpecDirInfo",
+    "DocsPlaneSnapshot",
+    "DocsPlaneResult",
+    "DocsPlaneReadError",
+    "read_docs_plane",
+    "classify_capability",
+    "classify_epic",
+    "build_lanes",
+    "unlinked_docs_threads",
+]
+
+_PARENT_FEATURE_DOC = "PARENT_FEATURE_ISSUE.md"
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?\n)---\s*\n?", re.DOTALL)
+_ISSUE_TOKEN_RE = re.compile(r"#(\d+)")
+_LINK_STRIP_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+_TABLE_SEP_RE = re.compile(r"^\|?[\s:\-]+\|?$")
+
+
+class DocsPlaneReadError(RuntimeError):
+    """Raised when the docs plane cannot be read.
+
+    Every raise site is caught by :func:`read_docs_plane`, which turns it into
+    the refused-claim result the cockpit registry renders. This exception
+    never escapes to a caller.
+    """
+
+
+@dataclass(frozen=True)
+class CapabilityNode:
+    id: str
+    name: str
+    boundary_ref: str | None
+
+
+@dataclass(frozen=True)
+class SpecTaskDoc:
+    """One task doc's frontmatter, read from a spec directory."""
+
+    spec_dir: str
+    relative_path: str
+    task_id: str | None
+    github_issue: int | None
+    parent_capability: str | None
+    # "Structurally empty" tracking (issue AC2): the key was present in the
+    # frontmatter mapping but its value was blank/None, distinct from the key
+    # never having existed at all.
+    parent_capability_empty: bool
+
+
+@dataclass(frozen=True)
+class SpecDirInfo:
+    """One spec directory's epic-level linkage, from its ``PARENT_FEATURE_ISSUE.md``."""
+
+    name: str
+    epic_issue: int | None
+    epic_rung_class: str  # "proven" | "derived" | "absent"
+    child_task_ids: tuple[str, ...]
+    prose_child_table_present: bool
+    prose_child_count: int | None
+
+
+@dataclass(frozen=True)
+class DocsPlaneSnapshot:
+    """Everything one live docs-plane read produced, for one cockpit render.
+
+    Immutable and process-local: nothing here is persisted (mirrors decision
+    Q5's no-cache posture, applied here to a filesystem source rather than a
+    network one).
+    """
+
+    read_at: str
+    capabilities: dict[str, CapabilityNode]
+    boundary_to_capability: dict[str, str]
+    matrix_issue_boundaries: dict[int, tuple[str, ...]]
+    task_docs: tuple[SpecTaskDoc, ...]
+    spec_dirs: dict[str, SpecDirInfo]
+
+    def task_doc_for_issue(self, issue_number: int) -> SpecTaskDoc | None:
+        for doc in self.task_docs:
+            if doc.github_issue == issue_number:
+                return doc
+        return None
+
+
+@dataclass(frozen=True)
+class DocsPlaneResult:
+    """The named-source-read shape :mod:`cockpit_registry` folds into ``sources``."""
+
+    snapshot: DocsPlaneSnapshot | None
+    state: str  # "fresh" | "unavailable"
+    last_successful_read: str | None
+    detail: str
+
+
+def _read_text(path: Path, mtimes: list[float]) -> str:
+    try:
+        stat = path.stat()
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DocsPlaneReadError(f"cannot read {path}: {exc}") from exc
+    mtimes.append(stat.st_mtime)
+    return text
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any] | None:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+    try:
+        data = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _state_line(text: str) -> str | None:
+    for line in text.splitlines():
+        if line.strip().startswith("State:"):
+            return line.strip()
+    return None
+
+
+def _issue_from_state_line(text: str) -> int | None:
+    line = _state_line(text)
+    if not line:
+        return None
+    match = _ISSUE_TOKEN_RE.search(line)
+    return int(match.group(1)) if match else None
+
+
+def _implementation_task_entries(text: str) -> list[str] | None:
+    """Raw, non-empty lines under a ``## Implementation Tasks`` heading.
+
+    ``None`` means the section is absent. An empty list means the section
+    exists but named no entries. Every entry under this heading is prose by
+    construction (F2: parent<->child edges are never expressed in
+    frontmatter) — this is the "may be wrong" child-count source, never a
+    ``proven`` one.
+    """
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().lower().startswith("## implementation tasks"):
+            start = i + 1
+            break
+    if start is None:
+        return None
+    entries: list[str] = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            break
+        if not stripped or _TABLE_SEP_RE.match(stripped):
+            continue
+        entries.append(stripped)
+    return entries
+
+
+def _looks_like_table_header(entry: str) -> bool:
+    """A markdown table's own header row (``| Task | GitHub work item | ... |``).
+
+    Heuristic: a pipe-delimited row naming no issue and no file path is read
+    as column labels, not a data row, so it is excluded from the child count.
+    """
+    if not entry.startswith("|"):
+        return False
+    return not _ISSUE_TOKEN_RE.search(entry) and "/" not in entry
+
+
+def _read_capabilities(path: Path, mtimes: list[float]) -> dict[str, CapabilityNode]:
+    text = _read_text(path, mtimes)
+    try:
+        payload = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise DocsPlaneReadError(f"invalid YAML in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise DocsPlaneReadError(f"{path} did not parse to a mapping")
+    nodes: dict[str, CapabilityNode] = {}
+    for entry in payload.get("capabilities") or []:
+        if not isinstance(entry, dict) or not entry.get("id"):
+            continue
+        node_id = str(entry["id"])
+        nodes[node_id] = CapabilityNode(
+            id=node_id,
+            name=str(entry.get("name") or node_id),
+            boundary_ref=(str(entry["boundary_ref"]) if entry.get("boundary_ref") else None),
+        )
+    return nodes
+
+
+def _split_table_row(line: str) -> list[str] | None:
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+def _read_matrix(path: Path, mtimes: list[float]) -> dict[int, tuple[str, ...]]:
+    """Parse ``Control boundaries`` -> ``Implementation issues`` matrix rows.
+
+    Returns ``{issue_number: (boundary_ref, ...)}``. A row's ``Implementation
+    issues`` cell can list several issues; each is joined to every boundary
+    token the same row names.
+    """
+    text = _read_text(path, mtimes)
+    header_cells: list[str] | None = None
+    boundary_idx: int | None = None
+    issues_idx: int | None = None
+    edges: dict[int, set[str]] = {}
+    for line in text.splitlines():
+        if _TABLE_SEP_RE.match(line.strip()):
+            continue
+        cells = _split_table_row(line)
+        if cells is None:
+            continue
+        if header_cells is None:
+            if "Control boundaries" in cells:
+                header_cells = cells
+                boundary_idx = cells.index("Control boundaries")
+                issues_idx = next(
+                    (i for i, c in enumerate(cells) if "Implementation issues" in c),
+                    None,
+                )
+            continue
+        if boundary_idx is None or issues_idx is None:
+            continue
+        if len(cells) <= max(boundary_idx, issues_idx):
+            continue
+        boundary_cell = _LINK_STRIP_RE.sub(r"\1", cells[boundary_idx])
+        boundary_tokens = {tok.strip() for tok in boundary_cell.split(",") if tok.strip()}
+        if not boundary_tokens:
+            continue
+        for match in _ISSUE_TOKEN_RE.finditer(cells[issues_idx]):
+            issue_number = int(match.group(1))
+            edges.setdefault(issue_number, set()).update(boundary_tokens)
+    return {issue: tuple(sorted(tokens)) for issue, tokens in edges.items()}
+
+
+def _read_task_doc(spec_dir: str, path: Path, mtimes: list[float]) -> SpecTaskDoc | None:
+    text = _read_text(path, mtimes)
+    frontmatter = _parse_frontmatter(text)
+    if frontmatter is None:
+        return None
+    task_id = frontmatter.get("task_id")
+    raw_issue = frontmatter.get("github_issue")
+    github_issue: int | None = None
+    if isinstance(raw_issue, int):
+        github_issue = raw_issue
+    elif isinstance(raw_issue, str) and raw_issue.strip().lstrip("#").isdigit():
+        github_issue = int(raw_issue.strip().lstrip("#"))
+    capability_present = "parent_capability" in frontmatter
+    raw_capability = frontmatter.get("parent_capability")
+    capability_value = str(raw_capability).strip() if raw_capability else ""
+    parent_capability = capability_value or None
+    parent_capability_empty = capability_present and not capability_value
+    return SpecTaskDoc(
+        spec_dir=spec_dir,
+        relative_path=path.name,
+        task_id=str(task_id) if task_id else None,
+        github_issue=github_issue,
+        parent_capability=parent_capability,
+        parent_capability_empty=parent_capability_empty,
+    )
+
+
+def _read_spec_dirs(
+    docs_root: Path, mtimes: list[float]
+) -> tuple[tuple[SpecTaskDoc, ...], dict[str, SpecDirInfo]]:
+    if not docs_root.is_dir():
+        raise DocsPlaneReadError(f"docs root not found or not a directory: {docs_root}")
+    task_docs: list[SpecTaskDoc] = []
+    spec_dirs: dict[str, SpecDirInfo] = {}
+    for entry in sorted(docs_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        parent_doc = entry / _PARENT_FEATURE_DOC
+        if not parent_doc.exists():
+            continue  # not a parent-feature-spec directory
+        parent_text = _read_text(parent_doc, mtimes)
+        parent_frontmatter = _parse_frontmatter(parent_text)
+        epic_issue: int | None = None
+        epic_rung_class = "absent"
+        if parent_frontmatter and isinstance(parent_frontmatter.get("github_issue"), int):
+            epic_issue = parent_frontmatter["github_issue"]
+            epic_rung_class = "proven"
+        if epic_issue is None:
+            derived_issue = _issue_from_state_line(parent_text)
+            if derived_issue is not None:
+                epic_issue = derived_issue
+                epic_rung_class = "derived"
+        entries = _implementation_task_entries(parent_text)
+        prose_present = entries is not None
+        prose_count: int | None = None
+        if entries:
+            data_entries = [e for e in entries if not _looks_like_table_header(e)]
+            prose_count = len(data_entries) or None
+
+        dir_task_ids: list[str] = []
+        for child in sorted(entry.glob("*.md")):
+            if child.name in (_PARENT_FEATURE_DOC, "README.md"):
+                continue
+            doc = _read_task_doc(entry.name, child, mtimes)
+            if doc is None:
+                continue
+            task_docs.append(doc)
+            if doc.task_id:
+                dir_task_ids.append(doc.task_id)
+
+        spec_dirs[entry.name] = SpecDirInfo(
+            name=entry.name,
+            epic_issue=epic_issue,
+            epic_rung_class=epic_rung_class,
+            child_task_ids=tuple(dir_task_ids),
+            prose_child_table_present=prose_present,
+            prose_child_count=prose_count,
+        )
+    return tuple(task_docs), spec_dirs
+
+
+def _boundary_to_capability(capabilities: dict[str, CapabilityNode]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for node in capabilities.values():
+        if node.boundary_ref and node.boundary_ref not in mapping:
+            mapping[node.boundary_ref] = node.id
+    return mapping
+
+
+def read_docs_plane(
+    *, capabilities_yaml_path: Path, matrix_path: Path, docs_root: Path
+) -> DocsPlaneResult:
+    """Read the docs/capability plane once. Never raises; refuses on failure.
+
+    Freshness watermark: the latest mtime among every file actually read
+    (capabilities.yaml, the matrix, and every spec-dir file examined) — the
+    docs plane's own read time, per
+    docs/BUILDEROPS_COCKPIT/DOCS_PLANE_CAPABILITY_LANES.md.
+    """
+    mtimes: list[float] = []
+    try:
+        capabilities = _read_capabilities(capabilities_yaml_path, mtimes)
+        matrix_edges = _read_matrix(matrix_path, mtimes)
+        task_docs, spec_dirs = _read_spec_dirs(docs_root, mtimes)
+    except DocsPlaneReadError as exc:
+        return DocsPlaneResult(
+            snapshot=None,
+            state="unavailable",
+            last_successful_read=None,
+            detail=f"read failed: {exc}",
+        )
+    if not mtimes:
+        watermark = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    else:
+        watermark = datetime.fromtimestamp(max(mtimes), tz=timezone.utc).isoformat(
+            timespec="seconds"
+        )
+    snapshot = DocsPlaneSnapshot(
+        read_at=watermark,
+        capabilities=capabilities,
+        boundary_to_capability=_boundary_to_capability(capabilities),
+        matrix_issue_boundaries=matrix_edges,
+        task_docs=task_docs,
+        spec_dirs=spec_dirs,
+    )
+    detail = (
+        f"{len(task_docs)} task docs across {len(spec_dirs)} spec dirs,"
+        f" {len(matrix_edges)} matrix-linked issues, {len(capabilities)} capabilities"
+    )
+    return DocsPlaneResult(
+        snapshot=snapshot, state="fresh", last_successful_read=watermark, detail=detail
+    )
+
+
+def classify_capability(
+    issue_number: int | None, snapshot: DocsPlaneSnapshot | None
+) -> dict[str, Any]:
+    """Classify one thread's capability rung and lane assignment.
+
+    Precedence: spec-dir task-doc frontmatter (``parent_capability:``) wins
+    over the traceability matrix, since it names the thread directly rather
+    than through a shared control-boundary code; both are ``proven`` machine
+    edges (issue AC1/Scope). No edge in either source renders freestanding
+    with an ``amber`` rung (never ``absent`` — the capability system exists
+    and was read; this thread specifically has no edge into it), per decision
+    Q4 ("their own lane", not a shared bucket).
+    """
+    if issue_number is None or snapshot is None:
+        return {
+            "rung": {"name": "capability", "class": "absent", "value": None},
+            "lane_key": None,
+            "lane_name": None,
+        }
+    doc = snapshot.task_doc_for_issue(issue_number)
+    if doc is not None and doc.parent_capability:
+        return {
+            "rung": {
+                "name": "capability",
+                "class": "proven",
+                "value": doc.parent_capability,
+                "chip": (
+                    {"kind": "empty_field", "field": "parent_capability"}
+                    if doc.parent_capability_empty
+                    else None
+                ),
+            },
+            "lane_key": f"capability:{doc.parent_capability}",
+            "lane_name": doc.parent_capability,
+        }
+    boundaries = snapshot.matrix_issue_boundaries.get(issue_number)
+    if boundaries:
+        capability_id = next(
+            (
+                snapshot.boundary_to_capability[boundary]
+                for boundary in boundaries
+                if boundary in snapshot.boundary_to_capability
+            ),
+            None,
+        )
+        if capability_id and capability_id in snapshot.capabilities:
+            node = snapshot.capabilities[capability_id]
+            return {
+                "rung": {"name": "capability", "class": "proven", "value": node.name},
+                "lane_key": f"capability:{node.id}",
+                "lane_name": node.name,
+            }
+    empty_field_chip = (
+        {"kind": "empty_field", "field": "parent_capability"}
+        if doc is not None and doc.parent_capability_empty
+        else None
+    )
+    return {
+        "rung": {
+            "name": "capability",
+            "class": "amber",
+            "value": None,
+            "chip": empty_field_chip,
+        },
+        "lane_key": f"freestanding:{issue_number}",
+        "lane_name": None,
+    }
+
+
+def classify_epic(issue_number: int | None, snapshot: DocsPlaneSnapshot | None) -> dict[str, Any]:
+    """Classify one thread's epic rung from its spec directory's parent linkage.
+
+    ``proven`` only if the spec dir's own ``PARENT_FEATURE_ISSUE.md`` carries
+    frontmatter naming its governing issue; ``derived`` if that link is only
+    nameable via ``State:`` prose (F6); ``absent`` if the thread belongs to no
+    known spec dir, or its spec dir names no epic issue at all. A prose-only
+    ``## Implementation Tasks`` table adds a "child count may be wrong"
+    caveat regardless of how the epic issue itself was found (F2: parent<->
+    child edges are prose in both directions).
+    """
+    if issue_number is None or snapshot is None:
+        return {"rung": {"name": "epic", "class": "absent", "value": None, "caveat": None}}
+    doc = snapshot.task_doc_for_issue(issue_number)
+    if doc is None:
+        return {"rung": {"name": "epic", "class": "absent", "value": None, "caveat": None}}
+    spec_dir = snapshot.spec_dirs.get(doc.spec_dir)
+    if spec_dir is None or spec_dir.epic_issue is None:
+        return {"rung": {"name": "epic", "class": "absent", "value": None, "caveat": None}}
+    caveat = None
+    if spec_dir.prose_child_table_present:
+        count_text = (
+            str(spec_dir.prose_child_count) if spec_dir.prose_child_count is not None else "an unknown number of"
+        )
+        caveat = (
+            f"child count derived from a prose parent/child table ({count_text} entries seen);"
+            " the actual filed-issue count may not match"
+        )
+    return {
+        "rung": {
+            "name": "epic",
+            "class": spec_dir.epic_rung_class,
+            "value": f"#{spec_dir.epic_issue}",
+            "caveat": caveat,
+        }
+    }
+
+
+def build_lanes(
+    items: list[dict[str, Any]], snapshot: DocsPlaneSnapshot | None
+) -> list[dict[str, Any]] | None:
+    """Group already-classified items into capability lanes.
+
+    Returns ``None`` when the docs plane could not be read — a refused claim,
+    never an empty lane list (AC3). Lane count/size is uncapped (decision
+    Q4); stacking at narrow widths is a frontend concern (BOPS-COCKPIT-06,
+    #4453), out of scope here.
+    """
+    if snapshot is None:
+        return None
+    lanes: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for item in items:
+        lane = item.get("capability_lane")
+        if not lane:
+            continue
+        key = lane["key"]
+        if key not in lanes:
+            lanes[key] = {
+                "capability": lane["name"],
+                "key": key,
+                "rung": lane["rung"],
+                "items": [],
+            }
+            order.append(key)
+        lanes[key]["items"].append(
+            {
+                "issue_number": item.get("issue_number"),
+                "task_id": item.get("id"),
+                "title": item.get("title"),
+                "band": item.get("band"),
+            }
+        )
+    return [lanes[key] for key in order]
+
+
+def unlinked_docs_threads(snapshot: DocsPlaneSnapshot | None) -> list[dict[str, Any]]:
+    """Task docs with a ``task_id`` but no populated ``github_issue:`` field.
+
+    Mirrors ``cockpit_registry._build_unsynced_threads``'s posture: these are
+    surfaced as their own cards (``unlinked`` slice rung) rather than
+    silently dropped, and they name known sibling ``task_id``s from the same
+    spec directory as the "no issue link" chip's content (AC2). A dead docs
+    source must not fabricate these cards — an empty list, matching the
+    ``unsynced_threads`` precedent for a dead github-live source.
+    """
+    if snapshot is None:
+        return []
+    threads: list[dict[str, Any]] = []
+    for doc in snapshot.task_docs:
+        if doc.github_issue is not None:
+            continue
+        spec_dir = snapshot.spec_dirs.get(doc.spec_dir)
+        siblings = [
+            task_id
+            for task_id in (spec_dir.child_task_ids if spec_dir else ())
+            if task_id != doc.task_id
+        ]
+        chip_text = (
+            f"no issue link; known children in {doc.spec_dir}: {', '.join(siblings)}"
+            if siblings
+            else f"no issue link; no other known children in {doc.spec_dir}"
+        )
+        chips = [{"kind": "no_issue_link", "text": chip_text}]
+        if doc.parent_capability_empty:
+            chips.append({"kind": "empty_field", "field": "parent_capability"})
+        threads.append(
+            {
+                "id": f"docs-task-{doc.spec_dir}-{doc.task_id or doc.relative_path}",
+                "kind": "docs_task",
+                "task_id": doc.task_id,
+                "spec_dir": doc.spec_dir,
+                "rung": {"name": "slice", "class": "unlinked", "value": None},
+                "chips": chips,
+                "why_now": f"planned in docs/{doc.spec_dir}/ with no issue filed yet",
+                "sources": ["docs-frontmatter"],
+            }
+        )
+    return threads

--- a/app/builderops/cockpit_docs_plane.py
+++ b/app/builderops/cockpit_docs_plane.py
@@ -397,7 +397,14 @@ def read_docs_plane(
         capabilities = _read_capabilities(capabilities_yaml_path, mtimes)
         matrix_edges = _read_matrix(matrix_path, mtimes)
         task_docs, spec_dirs = _read_spec_dirs(docs_root, mtimes)
-    except DocsPlaneReadError as exc:
+    except Exception as exc:  # noqa: BLE001 - any reader failure degrades to refusal
+        # Broad on purpose, matching cockpit_github_plane.fetch_github_live:
+        # the caller must never see an exception from this function. A
+        # DocsPlaneReadError covers the read helpers' own OSError wrapping,
+        # but an unreadable docs_root directory (PermissionError from
+        # Path.iterdir()) or a malformed capabilities.yaml (e.g. parsing to
+        # a non-list, raising TypeError) must degrade the same way — a
+        # single source's failure must never crash the whole registry.
         return DocsPlaneResult(
             snapshot=None,
             state="unavailable",

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -27,6 +27,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from app.builderops.cockpit_docs_plane import (
+    DocsPlaneSnapshot,
+    build_lanes,
+    classify_capability,
+    classify_epic,
+    read_docs_plane,
+    unlinked_docs_threads,
+)
 from app.builderops.cockpit_github_plane import (
     GithubLiveSnapshot,
     GithubReader,
@@ -81,9 +89,11 @@ RUNG_ORDER: tuple[str, ...] = (
 
 # Planes the v1 join deliberately does not read. Named so their absence is
 # visible instead of implied. github-live moved out of this tuple in
-# BOPS-COCKPIT-03 (#4450): it is now a named, per-render read source.
+# BOPS-COCKPIT-03 (#4450); docs-frontmatter moved out in BOPS-COCKPIT-05
+# (#4451): both are now named, per-render read sources. ckm-projection stays
+# unread by design (ADR-0057: CKM is a lens, never spine — it must never
+# become a fourth join input here).
 UNREAD_PLANES: tuple[str, ...] = (
-    "docs-frontmatter",
     "ckm-projection",
     "git",
 )
@@ -317,6 +327,44 @@ def _read_github_live(
     return result.snapshot
 
 
+def _read_docs_plane_snapshot(
+    docs_root: Path | None,
+    capabilities_yaml_path: Path | None,
+    matrix_path: Path | None,
+    sources: _Sources,
+) -> DocsPlaneSnapshot | None:
+    """Read the docs/capability plane and fold it into the named source list.
+
+    Mirrors ``_read_github_live``'s shape: unconfigured (any path is ``None``)
+    or a failed read both degrade to ``state="unavailable"`` — the refused
+    claim, never a fabricated empty snapshot (BOPS-COCKPIT-05, #4451).
+    """
+    if docs_root is None or capabilities_yaml_path is None or matrix_path is None:
+        sources.add(
+            _SourceRead(
+                name="docs-frontmatter",
+                state="unavailable",
+                last_successful_read=None,
+                detail="docs plane not configured",
+            )
+        )
+        return None
+    result = read_docs_plane(
+        capabilities_yaml_path=capabilities_yaml_path,
+        matrix_path=matrix_path,
+        docs_root=docs_root,
+    )
+    sources.add(
+        _SourceRead(
+            name="docs-frontmatter",
+            state=result.state,
+            last_successful_read=result.last_successful_read,
+            detail=result.detail,
+        )
+    )
+    return result.snapshot
+
+
 def _sync_labels(sync_state: str | None) -> list[str]:
     if not sync_state:
         return []
@@ -405,12 +453,16 @@ def _build_rungs(
     task: dict[str, Any],
     verification: dict[tuple[str, int], dict[str, Any]],
     github_snapshot: GithubLiveSnapshot | None = None,
+    docs_snapshot: DocsPlaneSnapshot | None = None,
 ) -> list[dict[str, Any]]:
     """Classify the eight rungs for one task.
 
-    Key classes: ``proven`` (DB-keyed or CI-forced edge), ``absent`` (no object
-    at that level in the system). v1 has no prose-derived rungs; ``derived``
-    appears once epic/capability edges are joined in a later slice.
+    Key classes: ``proven`` (DB-keyed, CI-forced, or docs-plane machine edge),
+    ``derived`` (prose-only edge — epic rung only, BOPS-COCKPIT-05/#4451),
+    ``amber`` (capability rung only: the docs plane was read but named no
+    edge for this thread — freestanding, never guessed under a parent),
+    ``absent`` (no object at that level in the system at all, or the docs
+    plane itself was not configured/could not be read).
 
     BOPS-COCKPIT-03 (#4450): when a live GitHub read succeeded, ``pr`` and
     ``ci_sha`` can additionally be proven from live PR + check keys even when
@@ -419,15 +471,18 @@ def _build_rungs(
     "no PR" just because the dispatcher store has not caught up. When the
     live read failed or was not configured, ``github_snapshot`` is ``None``
     and this function behaves exactly as it did before #4450 — refusal never
-    fabricates an upgrade.
+    fabricates an upgrade. The same posture applies to ``docs_snapshot`` for
+    the ``capability``/``epic`` rungs.
     """
+    issue_number = task.get("issue_number")
+    capability = classify_capability(issue_number, docs_snapshot)
+    epic = classify_epic(issue_number, docs_snapshot)
     rungs: list[dict[str, Any]] = [
         _rung("intention", "absent"),
-        _rung("capability", "absent"),
-        _rung("epic", "absent"),
+        capability["rung"],
+        epic["rung"],
     ]
     repo = task.get("repo") or ""
-    issue_number = task.get("issue_number")
     if issue_number:
         rungs.append(_rung("slice", "proven", f"{repo}#{issue_number}"))
     else:
@@ -489,6 +544,7 @@ def _build_item(
     band: str,
     verification: dict[tuple[str, int], dict[str, Any]],
     github_snapshot: GithubLiveSnapshot | None = None,
+    docs_snapshot: DocsPlaneSnapshot | None = None,
 ) -> dict[str, Any]:
     labels = _sync_labels(task.get("sync_state"))
     mirror_url = _sync_url(task.get("sync_state"))
@@ -516,6 +572,19 @@ def _build_item(
     sources = ["dispatcher-store", "verification-runs"]
     if github_snapshot is not None:
         sources.append("github-live")
+    if docs_snapshot is not None:
+        sources.append("docs-frontmatter")
+
+    capability = classify_capability(issue_number, docs_snapshot)
+    capability_lane = (
+        {
+            "key": capability["lane_key"],
+            "name": capability["lane_name"],
+            "rung": capability["rung"]["class"],
+        }
+        if capability["lane_key"] is not None
+        else None
+    )
 
     return {
         "id": task["task_id"],
@@ -535,8 +604,9 @@ def _build_item(
         "mirror_watermark": mirror_watermark,
         "why_now": _why_now(task, band),
         "links": links,
-        "rungs": _build_rungs(task, verification, github_snapshot),
+        "rungs": _build_rungs(task, verification, github_snapshot, docs_snapshot),
         "sources": sources,
+        "capability_lane": capability_lane,
         "updated_at": task.get("updated_at"),
     }
 
@@ -625,6 +695,9 @@ def build_registry(
     deploy_receipt_dir: Path,
     github_repo: str | None = None,
     github_reader: GithubReader = default_github_reader,
+    docs_root: Path | None = None,
+    capabilities_yaml_path: Path | None = None,
+    matrix_path: Path | None = None,
 ) -> dict[str, Any]:
     """Build the cockpit registry payload. Pure read; never writes anywhere.
 
@@ -635,18 +708,27 @@ def build_registry(
     ``app/api/routes/cockpit.py``, is solely responsible for resolving
     ``COCKPIT_GITHUB_REPO``), so a direct call with ``github_repo=None``
     always refuses, deterministically, with no environment dependence.
-    Every call performs its own fresh read — decision Q5 forbids any cache
-    surviving across two ``build_registry`` calls.
+    ``docs_root``/``capabilities_yaml_path``/``matrix_path`` are the same kind
+    of injection point for the docs/capability plane (BOPS-COCKPIT-05,
+    #4451): all three default to ``None``, so a direct call with no docs
+    plane configured always refuses that source too, deterministically —
+    tests point them at a fixture tree under ``tmp_path`` rather than the
+    live repo docs. Every call performs its own fresh read — decision Q5
+    forbids any cache surviving across two ``build_registry`` calls.
     """
     sources = _Sources()
     tasks = _read_tasks(db_path, sources)
     verification = _read_verification_runs(db_path, sources)
     deployments = _read_deploy_receipts(deploy_receipt_dir, sources)
     github_snapshot = _read_github_live(github_repo, sources, reader=github_reader)
+    docs_snapshot = _read_docs_plane_snapshot(
+        docs_root, capabilities_yaml_path, matrix_path, sources
+    )
 
     generated_at = _utc_now()
     bands: list[dict[str, Any]] = []
     unclassified: list[dict[str, Any]] = []
+    all_items: list[dict[str, Any]] = []
 
     if tasks is None:
         # The band counts are owned by the dispatcher store. Without it the
@@ -686,9 +768,9 @@ def build_registry(
                     }
                 )
                 continue
-            grouped[band].append(
-                _build_item(task, band, verification, github_snapshot)
-            )
+            item = _build_item(task, band, verification, github_snapshot, docs_snapshot)
+            grouped[band].append(item)
+            all_items.append(item)
         for key, question in BANDS:
             bands.append(
                 {
@@ -714,6 +796,8 @@ def build_registry(
                 "as_of": generated_at,
             }
 
+    lanes = build_lanes(all_items, docs_snapshot)
+
     return {
         "authority": "read_time_join",
         "generated_at": generated_at,
@@ -725,4 +809,9 @@ def build_registry(
         "deployments": deployments,
         "github": _github_facts(sources, github_snapshot),
         "unsynced_threads": _build_unsynced_threads(tasks, github_snapshot),
+        # BOPS-COCKPIT-05 (#4451): "countable": False + "lanes": None is the
+        # refused claim (an unreadable docs tree), never an empty lane list —
+        # the same shape discipline as `github` above.
+        "capability_lanes": {"countable": lanes is not None, "lanes": lanes},
+        "docs_only_threads": unlinked_docs_threads(docs_snapshot),
     }

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -796,7 +796,14 @@ def build_registry(
                 "as_of": generated_at,
             }
 
-    lanes = build_lanes(all_items, docs_snapshot)
+    # BOPS-COCKPIT-05 (#4451): "countable": False + "lanes": None is the
+    # refused claim, never an empty lane list. That refusal fires on either
+    # of two independent failures: the docs plane itself is unreadable
+    # (build_lanes returns None), or the dispatcher store is unreadable
+    # (tasks is None) — in which case all_items is an artifact of nothing
+    # being known, not a true empty set, so lanes must refuse too rather
+    # than calmly reporting "0 lanes" next to the bands' own refusal above.
+    lanes = build_lanes(all_items, docs_snapshot) if tasks is not None else None
 
     return {
         "authority": "read_time_join",
@@ -809,9 +816,6 @@ def build_registry(
         "deployments": deployments,
         "github": _github_facts(sources, github_snapshot),
         "unsynced_threads": _build_unsynced_threads(tasks, github_snapshot),
-        # BOPS-COCKPIT-05 (#4451): "countable": False + "lanes": None is the
-        # refused claim (an unreadable docs tree), never an empty lane list —
-        # the same shape discipline as `github` above.
         "capability_lanes": {"countable": lanes is not None, "lanes": lanes},
         "docs_only_threads": unlinked_docs_threads(docs_snapshot),
     }

--- a/tests/builderops/test_cockpit_docs_plane.py
+++ b/tests/builderops/test_cockpit_docs_plane.py
@@ -330,6 +330,72 @@ def test_docs_source_freshness_and_refusal(tmp_path: Path) -> None:
         "lanes": None,
     }
 
+    # Case 4: the docs root exists but is genuinely unreadable (permission
+    # denied on the directory itself) — the literal "unreadable docs tree"
+    # this AC names. Path.iterdir() raises PermissionError here, which is not
+    # a DocsPlaneReadError; the whole build_registry() call must still
+    # degrade to a refused docs-frontmatter source, never crash outright.
+    unreadable_docs_root = tmp_path / "unreadable-docs"
+    unreadable_docs_root.mkdir()
+    unreadable_docs_root.chmod(0o000)
+    try:
+        unreadable_payload = build_registry(
+            db_path=db_path,
+            deploy_receipt_dir=tmp_path / "deploys",
+            docs_root=unreadable_docs_root,
+            capabilities_yaml_path=docs_root / "capabilities.yaml",
+            matrix_path=docs_root / "matrix.md",
+        )
+    finally:
+        unreadable_docs_root.chmod(0o755)  # restore so tmp_path cleanup can remove it
+    assert _source(unreadable_payload, "docs-frontmatter")["state"] == "unavailable"
+    assert unreadable_payload["capability_lanes"] == {"countable": False, "lanes": None}
+    assert unreadable_payload["claim"]["kind"] == "counted"
+
+    # Case 5: capabilities.yaml parses but to a non-list "capabilities" value
+    # (a plausible malformed hand-edit) — the read helper's own iteration
+    # over it (`for entry in payload.get("capabilities") or []`) would raise
+    # TypeError, not a DocsPlaneReadError; must still refuse, not crash.
+    malformed_docs_root = tmp_path / "malformed-docs"
+    _write_docs_fixture(malformed_docs_root)
+    _write(malformed_docs_root / "capabilities.yaml", "capabilities: 5\n")
+    malformed_payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=malformed_docs_root,
+        capabilities_yaml_path=malformed_docs_root / "capabilities.yaml",
+        matrix_path=malformed_docs_root / "matrix.md",
+    )
+    assert _source(malformed_payload, "docs-frontmatter")["state"] == "unavailable"
+    assert malformed_payload["capability_lanes"] == {"countable": False, "lanes": None}
+    assert malformed_payload["claim"]["kind"] == "counted"
+
+
+def test_dead_dispatcher_store_refuses_lanes_not_calm_empty(tmp_path: Path) -> None:
+    """capability_lanes must refuse alongside the bands' own refusal when the
+    dispatcher store itself is unreadable — an empty ``all_items`` in that
+    branch means "nothing is known", not "zero threads exist"; reporting
+    ``{"countable": True, "lanes": []}`` next to the bands' explicit refusal
+    would be exactly the calm-next-to-refused inconsistency this capability
+    exists to prevent."""
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root)
+    missing_db = tmp_path / "nowhere" / "dispatcher.sqlite3"
+
+    payload = build_registry(
+        db_path=missing_db,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+
+    assert payload["claim"]["kind"] == "refused"  # dispatcher store is dead
+    # The docs plane itself read fine — it must not be blamed for a failure
+    # that belongs to a different source.
+    assert _source(payload, "docs-frontmatter")["state"] == "fresh"
+    assert payload["capability_lanes"] == {"countable": False, "lanes": None}
+
 
 # ---------------------------------------------------------------------------
 # test_ckm_is_lens_never_spine

--- a/tests/builderops/test_cockpit_docs_plane.py
+++ b/tests/builderops/test_cockpit_docs_plane.py
@@ -1,0 +1,415 @@
+"""Tests for the docs/capability plane join (BOPS-COCKPIT-05, #4451).
+
+Every test uses FIXTURE spec directories built under ``tmp_path`` — none of
+these assertions depend on the shape of the live repo's ``docs/`` tree beyond
+the schema/frontmatter conventions the issue itself names (``task_id``,
+``github_issue``, ``parent_capability``, a ``PARENT_FEATURE_ISSUE.md`` marker,
+a ``State:`` prose line, and a ``## Implementation Tasks`` section).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.builderops.cockpit_registry import build_registry
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.store import SqliteStore
+
+REPO = "RasmusTho/agentic-pkm-mvp"
+
+_CAPABILITIES_YAML = """\
+capabilities:
+  - id: cap-alpha
+    stable_key: ckm-capability-9001
+    name: Alpha Fixture Capability
+    definition: test fixture capability
+    parent: null
+    boundary_ref: ALPHA
+    seed_source: "test fixture"
+"""
+
+_MATRIX_MD = """\
+State: test fixture traceability matrix.
+
+# Fixture Traceability Matrix
+
+| # | Principle / finding | Control boundaries | Implementation issues |
+| --- | --- | --- | --- |
+| 1 | Fixture principle. | ALPHA | #501, #502 |
+"""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _make_store(tmp_path: Path) -> tuple[Path, SqliteStore]:
+    db_path = tmp_path / "dispatcher.sqlite3"
+    store = SqliteStore(db_path)
+    store.initialize()
+    return db_path, store
+
+
+def _task(*, status: str, issue_number: int, title: str = "a task", repo: str = REPO) -> TaskRecord:
+    now = _now()
+    return TaskRecord(
+        task_id=f"task-{uuid.uuid4().hex[:8]}",
+        issue_number=issue_number,
+        title=title,
+        status=status,
+        priority="med",
+        repo=repo,
+        source_anchor_refs=[],
+        linked_pr=None,
+        sync_state=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_docs_fixture(docs_root: Path) -> None:
+    """A minimal, valid docs/capability plane fixture with no edges at all.
+
+    Used by tests that only need the docs plane to read successfully
+    (``state="fresh"``) while producing zero matches for whatever thread the
+    test is probing — i.e. a genuinely empty, honestly-read plane.
+    """
+    _write(docs_root / "capabilities.yaml", _CAPABILITIES_YAML)
+    _write(docs_root / "matrix.md", _MATRIX_MD)
+    # One spec dir that names no issues relevant to the probed thread.
+    _write(
+        docs_root / "UNRELATED_SPEC" / "PARENT_FEATURE_ISSUE.md",
+        "State: Filed as GitHub Issue #999.\n\n# Unrelated Spec\n",
+    )
+    _write(
+        docs_root / "UNRELATED_SPEC" / "SOME_TASK.md",
+        (
+            "---\n"
+            "name: Some Task\n"
+            "task_id: UNRELATED-01\n"
+            "github_issue: 999\n"
+            "parent_capability: Unrelated Capability\n"
+            "---\n\n# Some Task\n"
+        ),
+    )
+
+
+def _item_by_issue(payload: dict, issue_number: int) -> dict:
+    for band in payload["bands"]:
+        for item in band["items"]:
+            if item["issue_number"] == issue_number:
+                return item
+    raise AssertionError(f"no item for issue {issue_number} in payload")
+
+
+def _source(payload: dict, name: str) -> dict:
+    return next(s for s in payload["sources"] if s["name"] == name)
+
+
+# ---------------------------------------------------------------------------
+# test_no_edge_means_freestanding_never_guessed
+# ---------------------------------------------------------------------------
+
+
+def test_no_edge_means_freestanding_never_guessed(tmp_path: Path) -> None:
+    """A thread with no matrix row and no spec-dir frontmatter match must
+    render freestanding, in its own lane, with an ``amber`` capability rung —
+    never absorbed into an unrelated lane (decision Q4)."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=901, title="orphan thread"))
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root)
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+
+    assert _source(payload, "docs-frontmatter")["state"] == "fresh"
+
+    item = _item_by_issue(payload, 901)
+    rungs = {r["name"]: r for r in item["rungs"]}
+    assert rungs["capability"]["class"] == "amber"
+    assert rungs["capability"]["value"] is None
+
+    assert item["capability_lane"]["key"] == "freestanding:901"
+    assert item["capability_lane"]["name"] is None
+
+    assert payload["capability_lanes"]["countable"] is True
+    lanes = payload["capability_lanes"]["lanes"]
+    freestanding_lanes = [lane for lane in lanes if lane["key"] == "freestanding:901"]
+    assert len(freestanding_lanes) == 1
+    lane = freestanding_lanes[0]
+    assert lane["capability"] is None
+    assert lane["rung"] == "amber"
+    assert [item["issue_number"] for item in lane["items"]] == [901]
+
+    # The orphan thread must never appear inside an unrelated named lane.
+    for lane in lanes:
+        if lane["key"] != "freestanding:901":
+            assert 901 not in {item["issue_number"] for item in lane["items"]}
+
+
+# ---------------------------------------------------------------------------
+# test_honest_partials_for_weak_edges
+# ---------------------------------------------------------------------------
+
+
+def test_honest_partials_for_weak_edges(tmp_path: Path) -> None:
+    """Covers the three honest-partial shapes the issue names:
+
+    - a prose-only parent/child table renders a ``derived`` epic rung with a
+      may-be-wrong-count caveat;
+    - an unpopulated ``github_issue:`` field renders as its own ``unlinked``
+      docs-only thread, naming known sibling children;
+    - a structurally empty ``parent_capability:`` field renders a distinct
+      "empty field" chip rather than being silently treated as content.
+    """
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=701, title="linked child"))
+
+    docs_root = tmp_path / "docs"
+    _write(docs_root / "capabilities.yaml", _CAPABILITIES_YAML)
+    _write(docs_root / "matrix.md", _MATRIX_MD)
+
+    spec_dir = docs_root / "AGENT_MEMORY_FIXTURE"
+    # Prose-only parent linkage: no frontmatter at all, only a State: line and
+    # a "## Implementation Tasks" list — exactly the weak edge F2/F6 name.
+    _write(
+        spec_dir / "PARENT_FEATURE_ISSUE.md",
+        (
+            "State: Filed as GitHub Issue #700 and open; children in progress.\n\n"
+            "# Agent Memory Fixture\n\n"
+            "## Implementation Tasks\n\n"
+            "1. `docs/AGENT_MEMORY_FIXTURE/TASK_ONE.md`\n"
+            "2. `docs/AGENT_MEMORY_FIXTURE/TASK_TWO.md`\n"
+        ),
+    )
+    _write(
+        spec_dir / "TASK_ONE.md",
+        (
+            "---\n"
+            "name: Task One\n"
+            "task_id: AMF-01\n"
+            "github_issue: 701\n"
+            "parent_capability: Agent Memory Fixture\n"
+            "---\n\n# Task One\n"
+        ),
+    )
+    # TASK_TWO has a task_id but no github_issue field at all, and a
+    # structurally empty parent_capability field.
+    _write(
+        spec_dir / "TASK_TWO.md",
+        (
+            "---\n"
+            "name: Task Two\n"
+            "task_id: AMF-02\n"
+            'parent_capability: ""\n'
+            "---\n\n# Task Two\n"
+        ),
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+
+    assert _source(payload, "docs-frontmatter")["state"] == "fresh"
+
+    # -- prose-only parent table: derived epic rung + may-be-wrong caveat --
+    item = _item_by_issue(payload, 701)
+    rungs = {r["name"]: r for r in item["rungs"]}
+    assert rungs["epic"]["class"] == "derived"
+    assert rungs["epic"]["value"] == "#700"
+    assert rungs["epic"]["caveat"] is not None
+    assert "may not match" in rungs["epic"]["caveat"] or "may be wrong" in rungs["epic"]["caveat"]
+
+    # -- unpopulated github_issue: unlinked rung + named-children chip --
+    docs_only = payload["docs_only_threads"]
+    task_two = next(t for t in docs_only if t["task_id"] == "AMF-02")
+    assert task_two["rung"]["class"] == "unlinked"
+    no_issue_chip = next(c for c in task_two["chips"] if c["kind"] == "no_issue_link")
+    assert "AMF-01" in no_issue_chip["text"]
+
+    # -- structurally empty parent_capability: dashed "empty field" chip --
+    empty_field_chip = next(c for c in task_two["chips"] if c["kind"] == "empty_field")
+    assert empty_field_chip["field"] == "parent_capability"
+
+    # TASK_ONE, being fully linked, must not appear as a docs-only thread.
+    assert all(t["task_id"] != "AMF-01" for t in docs_only)
+
+
+# ---------------------------------------------------------------------------
+# test_docs_source_freshness_and_refusal
+# ---------------------------------------------------------------------------
+
+
+def test_docs_source_freshness_and_refusal(tmp_path: Path) -> None:
+    """The docs plane is a named source with its own watermark; an unreadable
+    docs tree refuses lane claims instead of rendering an empty lane set."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=1))
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root)
+
+    fresh_payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+    fresh_source = _source(fresh_payload, "docs-frontmatter")
+    assert fresh_source["state"] == "fresh"
+    assert fresh_source["last_successful_read"] is not None
+    assert fresh_payload["capability_lanes"]["countable"] is True
+    # Issue #1 has no edge anywhere in this fixture, so it renders as its own
+    # freestanding lane (test_no_edge_means_freestanding_never_guessed covers
+    # this in depth) — a *populated* lane list, not an empty one, is the
+    # honest "fresh read, zero matches for this thread" shape.
+    lanes = fresh_payload["capability_lanes"]["lanes"]
+    assert lanes == [
+        {"capability": None, "key": "freestanding:1", "rung": "amber", "items": lanes[0]["items"]}
+    ]
+
+    # Case 1: docs plane not configured at all (the direct-call default).
+    unconfigured_payload = build_registry(
+        db_path=db_path, deploy_receipt_dir=tmp_path / "deploys"
+    )
+    unconfigured_source = _source(unconfigured_payload, "docs-frontmatter")
+    assert unconfigured_source["state"] == "unavailable"
+    assert unconfigured_source["last_successful_read"] is None
+    assert unconfigured_payload["capability_lanes"] == {"countable": False, "lanes": None}
+    assert unconfigured_payload["docs_only_threads"] == []
+
+    # Case 2: configured but pointing at a docs tree that does not exist —
+    # refusal, never a silently empty (and therefore falsely "complete")
+    # lane set.
+    missing_docs_root = tmp_path / "does-not-exist"
+    broken_payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=missing_docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+    broken_source = _source(broken_payload, "docs-frontmatter")
+    assert broken_source["state"] == "unavailable"
+    assert broken_payload["capability_lanes"] == {"countable": False, "lanes": None}
+    assert broken_payload["docs_only_threads"] == []
+    # The dispatcher-owned bands are unaffected by the unrelated docs-plane
+    # failure — same posture as the github-live source's independent refusal.
+    assert broken_payload["claim"]["kind"] == "counted"
+
+    # Case 3: the capabilities.yaml file itself is missing.
+    missing_capabilities_payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "does-not-exist.yaml",
+        matrix_path=docs_root / "matrix.md",
+    )
+    assert _source(missing_capabilities_payload, "docs-frontmatter")["state"] == "unavailable"
+    assert missing_capabilities_payload["capability_lanes"] == {
+        "countable": False,
+        "lanes": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_ckm_is_lens_never_spine
+# ---------------------------------------------------------------------------
+
+
+def test_ckm_is_lens_never_spine(tmp_path: Path) -> None:
+    """No band, count, lane membership, or ordering may derive from CKM state
+    (ADR-0057: CKM is a lens, never spine). This module must not read any CKM
+    store at all for that decision, per the issue's own guidance ("if you're
+    unsure whether to touch CKM — don't")."""
+    import ast
+    import inspect
+
+    import app.builderops.cockpit_docs_plane as docs_plane_module
+
+    source_text = inspect.getsource(docs_plane_module)
+    tree = ast.parse(source_text)
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+    # The module may *mention* "app/builderops/ckm/seed/capabilities.yaml" as
+    # a plain path string in its own docstring (that file is a legitimate,
+    # named docs-plane source) — the guard is that it never *imports* the CKM
+    # store/package, and never references the store's class, which is the
+    # only way a CKM read could reach lanes/bands/counts.
+    assert not any("ckm" in mod.lower() for mod in imported_modules), (
+        "cockpit_docs_plane.py must never import any app.builderops.ckm"
+        " module: lanes/bands/counts derive only from capabilities.yaml, the"
+        " traceability matrix, and spec-dir frontmatter (ADR-0057: CKM is a"
+        " lens, never spine)."
+    )
+    assert "CkmStore" not in source_text
+
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=1))
+    store.upsert_task(_task(status="in_progress", issue_number=2))
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root)
+
+    def _run() -> dict:
+        return build_registry(
+            db_path=db_path,
+            deploy_receipt_dir=tmp_path / "deploys",
+            docs_root=docs_root,
+            capabilities_yaml_path=docs_root / "capabilities.yaml",
+            matrix_path=docs_root / "matrix.md",
+        )
+
+    without_ckm = _run()
+
+    # A CKM-shaped store artifact happens to exist alongside the fixture, at
+    # a plausible conventional path — it must have zero effect on lanes,
+    # bands, or counts.
+    ckm_dir = tmp_path / "runtime" / "builderops"
+    ckm_dir.mkdir(parents=True, exist_ok=True)
+    (ckm_dir / "ckm.sqlite3").write_bytes(b"not a real sqlite file, just a decoy")
+
+    with_ckm = _run()
+
+    def _strip_timestamps(payload: dict) -> dict:
+        payload = dict(payload)
+        payload.pop("generated_at", None)
+        payload["claim"] = {k: v for k, v in payload["claim"].items() if k != "as_of"}
+        payload["sources"] = [
+            {k: v for k, v in s.items() if k != "last_successful_read"}
+            for s in payload["sources"]
+        ]
+        return payload
+
+    assert _strip_timestamps(without_ckm)["bands"] == _strip_timestamps(with_ckm)["bands"]
+    assert (
+        _strip_timestamps(without_ckm)["capability_lanes"]
+        == _strip_timestamps(with_ckm)["capability_lanes"]
+    )
+    assert (
+        _strip_timestamps(without_ckm)["docs_only_threads"]
+        == _strip_timestamps(with_ckm)["docs_only_threads"]
+    )


### PR DESCRIPTION
Governing-Issue: #4451

Fixes #4451

Final-Review-Rounds: 0

## Summary

Adds a new `docs-frontmatter` source (`app/builderops/cockpit_docs_plane.py`) that reads
`app/builderops/ckm/seed/capabilities.yaml`, `docs/architecture/traceability-matrix.md`, and
spec-directory task-doc frontmatter at render time, then joins it into
`app/builderops/cockpit_registry.py` so threads group into capability lanes only via machine
edges — a thread with no edge renders freestanding in its own lane with an amber capability rung,
never guessed under a parent. Weak edges (unpopulated `github_issue:`, prose-only parent/child
tables, structurally empty label fields) render as honest partials (`unlinked` rungs, "may be
wrong" caveats, dashed "empty field" chips) instead of being hidden or silently upgraded. CKM is
never read by this module — lanes/bands/counts derive only from the three named docs-plane
sources, per ADR-0057.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: Tier 2 implementation slice; no BuilderOps material routed.

## Notes

Validation run from the isolated worktree
`/Users/rasmusthornberg/code/agentic-pkm-mvp/.claude/worktrees/issue-4451-docs-plane-lanes`:

- `python3 -m pytest tests/builderops/test_cockpit_docs_plane.py tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_github_plane.py tests/api/test_cockpit_api.py -m "not pg" -q` — 19 passed, 0 failed (zero regression in the #4450 tests this PR builds alongside).
- `ruff check app tests` — all checks passed.
- `python3 scripts/docs_guard.py` — Docs guard: OK.

Claim receipt (dispatcher-backed):
`pickup-claim-complete issue=4451 branch=issue-4451-docs-plane-lanes worktree=/Users/rasmusthornberg/code/agentic-pkm-mvp/.claude/worktrees/issue-4451-docs-plane-lanes coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4451 lease_id=lease-e4f38090 holder=sonnet-impl-4451 evidence=verified-dispatcher-lease`

New registry payload fields (additive, non-breaking): `capability_lanes` (`{"countable": bool,
"lanes": list|None}` — `None` lanes is the refused claim on an unreadable docs tree, never an
empty list) and `docs_only_threads` (task docs with a `task_id` but no populated `github_issue:`,
mirroring the `unsynced_threads` pattern #4450 introduced). Existing items additionally carry a
`capability_lane` field and upgraded `capability`/`epic` rungs (`proven`/`derived`/`amber`/`absent`
per key class). `docs_root`/`capabilities_yaml_path`/`matrix_path` are new optional
`build_registry` parameters, defaulting to `None` (refuses cleanly, matching the existing
`github_repo` posture) unless supplied — `app/api/routes/cockpit.py` supplies the live repo paths
(with `COCKPIT_DOCS_ROOT`/`COCKPIT_CAPABILITIES_YAML`/`COCKPIT_TRACEABILITY_MATRIX` overrides).

Out of scope, per the issue: no backfill of `github_issue:` fields elsewhere (#4444 owns it), no
CKM store write, no linker run, no maturity number, and no frontend stacking/scrolling layout
(BOPS-COCKPIT-06/#4453).
