### PR TITLE
Derive chain-position bands and flaw predicates in the cockpit registry

### DIFF
--- a/app/builderops/cockpit_chain.py
+++ b/app/builderops/cockpit_chain.py
@@ -1,0 +1,807 @@
+"""Chain-derived states for the BuilderOps cockpit registry.
+
+Implements BUILDEROPS_COCKPIT/CHAIN_DERIVED_STATES.md (BOPS-COCKPIT-04, #4452).
+
+The delivered v1 banding mapped dispatcher *status words* to bands. The owner's
+model is stronger: the five thread states are **positions in the process
+chain**, and deficiency types are **predicates derived over that chain** rather
+than an enumerated list a writer has to keep current.
+
+Two ideas carry the whole module:
+
+- **Chain position** — where a thread sits between backlog and delivery, derived
+  from typed fields on the joined planes (dispatcher status, movement
+  timestamps, lease expiry, live PR existence). Derivation is purely rule-based
+  and deterministic: no LLM call, no fuzzy classification, no heuristic over
+  free text. Two renders of the same planes produce byte-identical positions,
+  which is what makes this surface CI-testable at all.
+- **Flaw predicate** — a named, evidence-bearing statement that some link in the
+  chain is missing its next link or its verification. A predicate declares the
+  source planes it needs; when any of those is not fresh the predicate is *not
+  evaluated* and says so in the flaws band header, rather than firing on absent
+  evidence or being silently omitted.
+
+Honesty rules this module enforces (mirrors ``cockpit_registry`` itself):
+
+- Fail-closed positions: a thread whose position cannot be computed lands in the
+  registry's explicit ``unclassified`` list, never guessed into a band.
+- Forgotten is never age alone (decision Q1): the stall predicate is a
+  conjunction of an age threshold **and** the absence of movement in the
+  thread's own authority. Either conjunct alone leaves the thread in progress.
+- Dual band, single identity: a thread holds exactly one *position* band and
+  additionally appears in the flaws band when any predicate fires. The flaws
+  band holds the same object, never a copy.
+- Within-band ordering only (EXT-7): the risk meter is four discrete ticks, is
+  never a displayed scalar, never reorders across bands, and never hides or
+  demotes a card. Per ADR-0057 A1 a risk number is a signal to read, never a
+  selection or ranking input.
+
+Nothing here persists. Every value is recomputed from the joined planes on
+every ``build_registry`` call (decision Q5).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+__all__ = [
+    "CHAIN_POSITIONS",
+    "FLAW_PREDICATES",
+    "FORGOTTEN_STALL_DAYS",
+    "OPEN_STATUSES",
+    "POSITION_BAND",
+    "RISK_MAX_TICKS",
+    "RUNG_SOURCE",
+    "SOURCE_STALE_AFTER_DAYS",
+    "TERMINAL_STATUSES",
+    "TRIED_TIER_REASON",
+    "UNREAD_FLAW_PREDICATES",
+    "ChainPosition",
+    "ThreadContext",
+    "amber_if_stale",
+    "derive_position",
+    "evaluate_flaws",
+    "flaws_band_header",
+    "order_within_band",
+    "parse_timestamp",
+    "risk_meter",
+    "stale_source_names",
+    "why_now",
+]
+
+# --------------------------------------------------------------------------
+# Named thresholds
+# --------------------------------------------------------------------------
+
+# How long a thread's own authority must be silent before the *age* half of the
+# forgotten conjunct is satisfied. Two weeks is the scale at which a builder
+# thread stops being "in flight, quietly" and starts being genuinely dropped;
+# below it the forgotten band would fill with work that is simply between
+# sessions. Age alone never suffices — see :func:`derive_position`.
+FORGOTTEN_STALL_DAYS = 14
+
+# How old a source's own ``last_successful_read`` watermark may be before that
+# source is *stale* (EXT-3's accepted third pill state, enacted here for the
+# first time: #4450/#4451 shipped only fresh/empty/unavailable).
+#
+# Why seven days: three of the five sources are read at render time, so their
+# watermark is always "now" and this threshold can never fire for them. The one
+# source whose watermark is genuinely a content age is ``docs-frontmatter``,
+# whose watermark is the newest mtime among the spec files it read. Seven days
+# is the cadence at which this repo's spec directories actually move; a shorter
+# window would paint the docs plane amber on every render (noise, not honesty),
+# and a much longer one would let a genuinely abandoned spec tree keep claiming
+# freshness. This is a named threshold, not a configuration surface.
+SOURCE_STALE_AFTER_DAYS = 7
+
+# EXT-7, as accepted: four ticks maximum, amber up to three, destructive at
+# four. No scalar is ever displayed and the meter never selects.
+RISK_MAX_TICKS = 4
+
+# --------------------------------------------------------------------------
+# Chain positions
+# --------------------------------------------------------------------------
+
+# The chain positions this module can derive. ``tried_by_owner`` is reserved:
+# it is never derived, because the owner-acceptance receipt contract does not
+# exist yet (INV-DG-7, owner-gated). It is listed so its emptiness is a named
+# reservation rather than an omission.
+CHAIN_POSITIONS: tuple[str, ...] = (
+    "in_progress",
+    "delivered",
+    "tried_by_owner",
+    "forgotten",
+)
+
+# Position -> band key. ``tried_by_owner`` maps to no band: it is a *tier*
+# inside the done band (EXT-2 / decision Q3), rendered empty by contract.
+POSITION_BAND: dict[str, str] = {
+    "in_progress": "working",
+    "delivered": "done",
+    "forgotten": "forgotten",
+}
+
+TRIED_TIER_REASON = (
+    "reserved: no owner-acceptance receipt contract exists yet (INV-DG-7 is"
+    " owner-gated), so every delivered thread is delivered-never-tried by"
+    " construction. Visible absence, not a red mark."
+)
+
+# Dispatcher statuses that mean the chain reached its end in the register.
+TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "done"})
+
+# Dispatcher statuses that mean the thread still holds a position somewhere
+# between backlog and merge. ``ready``/``backlog`` are included deliberately:
+# the register's first question includes the queue, so an open unclaimed ready
+# issue is *in progress*, not forgotten, until it meets the stall condition.
+# ``blocked`` is included because a blocked thread still occupies a link in the
+# chain — what is wrong with it is a flaw predicate, not a different position.
+OPEN_STATUSES: frozenset[str] = frozenset(
+    {"backlog", "ready", "claimed", "in_progress", "review", "blocked"}
+)
+
+# Which named source produced each rung's value. Used to turn a rung amber when
+# the source behind it is stale — precisely, so a rung proven from a fresh
+# source is never ambered by an unrelated stale one.
+RUNG_SOURCE: dict[str, str | None] = {
+    "intention": None,
+    "capability": "docs-frontmatter",
+    "epic": "docs-frontmatter",
+    "slice": "dispatcher-store",
+    "pr": None,  # resolved per rung: dispatcher-store or github-live
+    "ci_sha": None,  # resolved per rung: verification-runs or github-live
+    "receipt": "verification-runs",
+    "tried": None,
+}
+
+# Deficiency predicates whose evidence lives on a plane this capability does
+# not read at all. Named in the flaws band header so their absence is visible
+# rather than implied — the same honesty idiom as ``UNREAD_PLANES``.
+UNREAD_FLAW_PREDICATES: tuple[dict[str, str], ...] = (
+    {
+        "predicate": "unpushed_local_worktree",
+        "plane": "git working trees",
+        "reason": "the cockpit reads no git working tree; a thread whose only"
+        " work is an uncommitted or unpushed local branch cannot be seen from"
+        " here",
+    },
+    {
+        "predicate": "unlanded_session_insight",
+        "plane": "session records",
+        "reason": "the cockpit reads no session record; insight that never"
+        " left an agent session cannot be seen from here",
+    },
+    {
+        "predicate": "closed_issue_without_owner_doc_receipt",
+        "plane": "issue comments",
+        "reason": "the cockpit does not fetch issue comments; the post-merge"
+        " owner-doc writeback receipt is a comment, so its absence cannot be"
+        " distinguished from an unread plane",
+    },
+)
+
+_BRANCH_ISSUE_TOKEN = "(?:^|[^0-9]){number}(?:[^0-9]|$)"
+_RED_CHECK_STATES: frozenset[str] = frozenset({"failure", "error"})
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp to an aware UTC datetime, or ``None``.
+
+    Returning ``None`` for anything unparseable is load-bearing: a position
+    whose stall test needs a timestamp it cannot read must fail closed into
+    ``unclassified``, never silently assume "now" (which would read as
+    "recently moved") or "epoch" (which would read as "forgotten").
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# Position derivation
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChainPosition:
+    """One thread's derived position, or an explicit refusal to derive one."""
+
+    position: str | None
+    evidence: dict[str, Any]
+    unresolved_reason: str | None = None
+
+    @property
+    def band(self) -> str | None:
+        if self.position is None:
+            return None
+        return POSITION_BAND.get(self.position)
+
+
+def _last_movement(task: dict[str, Any]) -> tuple[datetime | None, str | None]:
+    """The latest timestamp the dispatcher authority carries for this thread."""
+    best: datetime | None = None
+    best_text: str | None = None
+    for field in ("updated_at", "last_heartbeat_at"):
+        parsed = parse_timestamp(task.get(field))
+        if parsed is None:
+            continue
+        if best is None or parsed > best:
+            best = parsed
+            best_text = str(task.get(field))
+    return best, best_text
+
+
+def derive_position(
+    task: dict[str, Any],
+    *,
+    now: datetime,
+    live_pull: Any | None = None,
+) -> ChainPosition:
+    """Derive one thread's chain position. Deterministic, fail-closed.
+
+    Rule order:
+
+    1. A terminal dispatcher status is *delivered* — the chain reached its end
+       in the register. Whether that delivery carries a verification receipt is
+       a **flaw predicate**, not a gate on the position: gating it would hide
+       an unverified merge from the done band entirely, which is the opposite
+       of what the flaws band exists to show.
+    2. An open status is *in progress* unless the thread has stalled.
+    3. Stalled = aged past the threshold **and** no movement in the thread's own
+       authority (decision Q1). Both conjuncts are required; age alone would
+       turn the forgotten band into a seniority list.
+    4. Anything else is unresolvable and lands in ``unclassified`` — never
+       guessed into a band.
+    """
+    status = str(task.get("status") or "")
+    movement_at, movement_text = _last_movement(task)
+    open_pull = getattr(live_pull, "number", None)
+
+    if status in TERMINAL_STATUSES:
+        return ChainPosition(
+            position="delivered",
+            evidence={
+                "dispatcher_status": status,
+                "last_movement_at": movement_text,
+            },
+        )
+
+    if status not in OPEN_STATUSES:
+        return ChainPosition(
+            position=None,
+            evidence={"dispatcher_status": status},
+            unresolved_reason=(
+                f"status {status!r} maps to no chain position"
+                " (neither terminal nor open)"
+            ),
+        )
+
+    if open_pull is not None:
+        # An open PR is live movement in the thread's own authority, which
+        # settles the forgotten conjunct on its own: whatever the dispatcher
+        # timestamps say, this thread is not stalled. Deciding here means a
+        # thread with unreadable dispatcher timestamps is still resolvable
+        # from the live plane — fail-closed, not fail-blind.
+        return ChainPosition(
+            position="in_progress",
+            evidence={
+                "dispatcher_status": status,
+                "last_movement_at": movement_text,
+                "stall_threshold_days": FORGOTTEN_STALL_DAYS,
+                "aged_past_threshold": (
+                    None
+                    if movement_at is None
+                    else now - movement_at >= timedelta(days=FORGOTTEN_STALL_DAYS)
+                ),
+                "open_authority_work": open_pull,
+            },
+        )
+
+    if movement_at is None:
+        # The stall conjunct cannot be evaluated at all, so neither
+        # "in progress" nor "forgotten" can be claimed. Refuse.
+        return ChainPosition(
+            position=None,
+            evidence={
+                "dispatcher_status": status,
+                "updated_at": task.get("updated_at"),
+                "last_heartbeat_at": task.get("last_heartbeat_at"),
+            },
+            unresolved_reason=(
+                "open thread carries no readable movement timestamp, so the"
+                " forgotten stall test cannot be evaluated"
+            ),
+        )
+
+    aged = now - movement_at >= timedelta(days=FORGOTTEN_STALL_DAYS)
+    evidence = {
+        "dispatcher_status": status,
+        "last_movement_at": movement_text,
+        "stall_threshold_days": FORGOTTEN_STALL_DAYS,
+        "aged_past_threshold": aged,
+        "open_authority_work": None,
+    }
+
+    # Both conjuncts, always. The open-PR branch above already returned for
+    # every thread with live authority movement, so reaching here means there
+    # is none — age is the only remaining question, and it is never enough on
+    # its own to reach this line (decision Q1).
+    if aged:
+        return ChainPosition(position="forgotten", evidence=evidence)
+    return ChainPosition(position="in_progress", evidence=evidence)
+
+
+# --------------------------------------------------------------------------
+# Flaw predicates
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ThreadContext:
+    """Everything one flaw predicate may read about one thread.
+
+    Deliberately a plain value object over already-fetched snapshots: no
+    predicate performs I/O, so no predicate can fail a read or raise past
+    ``build_registry``.
+    """
+
+    task: dict[str, Any]
+    repo: str
+    issue_number: int | None
+    position: str | None
+    pr_number: int | None
+    live_pull: Any | None
+    verification_run: dict[str, Any] | None
+    github_snapshot: Any | None
+    docs_snapshot: Any | None
+    now: datetime
+
+    @property
+    def status(self) -> str:
+        return str(self.task.get("status") or "")
+
+
+def _flaw(name: str, text: str, evidence: dict[str, Any]) -> dict[str, Any]:
+    return {"predicate": name, "text": text, "evidence": evidence}
+
+
+def _branch_names_issue(branch: str, issue_number: int) -> bool:
+    """Does a branch name carry this issue number as a whole token?
+
+    Digit boundaries on both sides so ``issue-445`` never matches issue 4452
+    and ``issue-44520`` never matches 4452 either.
+    """
+    pattern = _BRANCH_ISSUE_TOKEN.format(number=issue_number)
+    return re.search(pattern, branch) is not None
+
+
+def _pushed_branch_without_pr(ctx: ThreadContext) -> dict[str, Any] | None:
+    if ctx.github_snapshot is None or ctx.issue_number is None:
+        return None
+    open_head_refs = {
+        pull.head_ref
+        for pull in ctx.github_snapshot.pulls.values()
+        if getattr(pull, "head_ref", None)
+    }
+    for branch in ctx.github_snapshot.branches:
+        if branch in open_head_refs:
+            continue
+        if not _branch_names_issue(branch, ctx.issue_number):
+            continue
+        return _flaw(
+            "pushed_branch_without_pr",
+            f"branch {branch!r} is pushed with no open PR",
+            {"branch": branch, "issue_number": ctx.issue_number},
+        )
+    return None
+
+
+def _pr_ci_red_on_head_sha(ctx: ThreadContext) -> dict[str, Any] | None:
+    if ctx.live_pull is None or ctx.github_snapshot is None:
+        return None
+    head_sha = str(getattr(ctx.live_pull, "head_sha", "") or "")
+    if not head_sha:
+        return None
+    state = ctx.github_snapshot.check_state_for(head_sha)
+    if state not in _RED_CHECK_STATES:
+        return None
+    return _flaw(
+        "pr_ci_red_on_head_sha",
+        f"PR #{ctx.live_pull.number} CI is {state} on head SHA {head_sha[:12]}",
+        {
+            "pr_number": ctx.live_pull.number,
+            "head_sha": head_sha,
+            "check_state": state,
+        },
+    )
+
+
+def _pr_without_ci_on_head_sha(ctx: ThreadContext) -> dict[str, Any] | None:
+    if ctx.live_pull is None or ctx.github_snapshot is None:
+        return None
+    head_sha = str(getattr(ctx.live_pull, "head_sha", "") or "")
+    if not head_sha:
+        return None
+    if ctx.github_snapshot.check_state_for(head_sha) is not None:
+        return None
+    run = ctx.verification_run
+    if run and run.get("verified_head_sha") == head_sha:
+        return None
+    return _flaw(
+        "pr_without_ci_on_head_sha",
+        f"PR #{ctx.live_pull.number} has no CI state on head SHA"
+        f" {head_sha[:12]}",
+        {"pr_number": ctx.live_pull.number, "head_sha": head_sha},
+    )
+
+
+def _delivered_without_verification_receipt(
+    ctx: ThreadContext,
+) -> dict[str, Any] | None:
+    if ctx.position != "delivered":
+        return None
+    run = ctx.verification_run
+    if run and run.get("terminal_receipt_json"):
+        return None
+    return _flaw(
+        "delivered_without_verification_receipt",
+        f"delivered ({ctx.status}) with no terminal verification receipt",
+        {
+            "issue_number": ctx.issue_number,
+            "pr_number": ctx.pr_number,
+            "dispatcher_status": ctx.status,
+        },
+    )
+
+
+def _expired_lease(ctx: ThreadContext) -> dict[str, Any] | None:
+    if ctx.position == "delivered":
+        # A finished thread's leftover lease is bookkeeping, not a flaw.
+        return None
+    expires_at = parse_timestamp(ctx.task.get("lease_expires_at"))
+    if expires_at is None or expires_at > ctx.now:
+        return None
+    holder = ctx.task.get("claimed_by")
+    return _flaw(
+        "expired_lease",
+        f"lease held by {holder or 'an unnamed agent'} expired at"
+        f" {ctx.task.get('lease_expires_at')}",
+        {
+            "lease_id": ctx.task.get("lease_id"),
+            "holder": holder,
+            "lease_expires_at": ctx.task.get("lease_expires_at"),
+        },
+    )
+
+
+def _stale_epic_with_open_children(ctx: ThreadContext) -> dict[str, Any] | None:
+    if (
+        ctx.docs_snapshot is None
+        or ctx.github_snapshot is None
+        or ctx.issue_number is None
+    ):
+        return None
+    spec_dir = next(
+        (
+            info
+            for info in ctx.docs_snapshot.spec_dirs.values()
+            if info.epic_issue == ctx.issue_number
+        ),
+        None,
+    )
+    if spec_dir is None:
+        return None
+    open_children = sorted(
+        doc.github_issue
+        for doc in ctx.docs_snapshot.task_docs
+        if doc.spec_dir == spec_dir.name
+        and doc.github_issue is not None
+        and doc.github_issue in ctx.github_snapshot.issues
+    )
+    if not open_children:
+        return None
+    movement_at, movement_text = _last_movement(ctx.task)
+    if movement_at is None:
+        return None
+    if ctx.now - movement_at < timedelta(days=FORGOTTEN_STALL_DAYS):
+        return None
+    return _flaw(
+        "stale_epic_with_open_children",
+        f"epic #{ctx.issue_number} has {len(open_children)} open children and"
+        f" no movement since {movement_text}",
+        {
+            "epic_issue": ctx.issue_number,
+            "spec_dir": spec_dir.name,
+            "open_children": open_children,
+            "last_movement_at": movement_text,
+            "stall_threshold_days": FORGOTTEN_STALL_DAYS,
+        },
+    )
+
+
+def _dispatcher_github_contradiction(ctx: ThreadContext) -> dict[str, Any] | None:
+    if ctx.github_snapshot is None or ctx.issue_number is None:
+        return None
+    if ctx.status not in TERMINAL_STATUSES:
+        return None
+    if ctx.issue_number not in ctx.github_snapshot.issues:
+        return None
+    return _flaw(
+        "dispatcher_github_contradiction",
+        f"dispatcher says {ctx.status} but GitHub issue"
+        f" #{ctx.issue_number} is still open",
+        {
+            "issue_number": ctx.issue_number,
+            "dispatcher_status": ctx.status,
+            "github_issue_state": "open",
+        },
+    )
+
+
+def _blocked_without_next_link(ctx: ThreadContext) -> dict[str, Any] | None:
+    reason = ctx.task.get("blocked_reason")
+    if ctx.status != "blocked" or not reason:
+        return None
+    return _flaw(
+        "blocked_without_next_link",
+        f"blocked: {reason}",
+        {"blocked_reason": str(reason), "dispatcher_status": ctx.status},
+    )
+
+
+# Ordered: the first predicate that fires supplies the card's ``why_now``, so
+# the order is "most directly names the missing link" first. Order is fixed so
+# two renders of the same planes produce the same phrasing.
+FLAW_PREDICATES: tuple[dict[str, Any], ...] = (
+    {
+        "name": "blocked_without_next_link",
+        "requires": ("dispatcher-store",),
+        "fn": _blocked_without_next_link,
+    },
+    {
+        "name": "dispatcher_github_contradiction",
+        "requires": ("dispatcher-store", "github-live"),
+        "fn": _dispatcher_github_contradiction,
+    },
+    {
+        "name": "expired_lease",
+        "requires": ("dispatcher-store",),
+        "fn": _expired_lease,
+    },
+    {
+        "name": "pr_ci_red_on_head_sha",
+        "requires": ("github-live",),
+        "fn": _pr_ci_red_on_head_sha,
+    },
+    {
+        "name": "pr_without_ci_on_head_sha",
+        "requires": ("github-live",),
+        "fn": _pr_without_ci_on_head_sha,
+    },
+    {
+        "name": "pushed_branch_without_pr",
+        "requires": ("github-live",),
+        "fn": _pushed_branch_without_pr,
+    },
+    {
+        "name": "delivered_without_verification_receipt",
+        "requires": ("dispatcher-store", "verification-runs"),
+        "fn": _delivered_without_verification_receipt,
+    },
+    {
+        "name": "stale_epic_with_open_children",
+        "requires": ("docs-frontmatter", "github-live"),
+        "fn": _stale_epic_with_open_children,
+    },
+)
+
+
+def evaluable_predicates(source_state: dict[str, str]) -> tuple[list[str], list[dict]]:
+    """Split the predicate set by whether its required planes are fresh.
+
+    A predicate whose plane is unavailable, stale, or structurally empty is not
+    evaluated *at all* — never fired on absent evidence, and never dropped
+    silently: the second return value is what the flaws band header names.
+    """
+    evaluated: list[str] = []
+    not_evaluated: list[dict[str, Any]] = []
+    for predicate in FLAW_PREDICATES:
+        missing = [
+            name
+            for name in predicate["requires"]
+            if source_state.get(name) != "fresh"
+        ]
+        if missing:
+            not_evaluated.append(
+                {
+                    "predicate": predicate["name"],
+                    "requires": list(predicate["requires"]),
+                    "reason": "required source(s) not fresh: "
+                    + ", ".join(
+                        f"{name} ({source_state.get(name, 'unavailable')})"
+                        for name in missing
+                    ),
+                }
+            )
+        else:
+            evaluated.append(predicate["name"])
+    return evaluated, not_evaluated
+
+
+def evaluate_flaws(
+    ctx: ThreadContext, evaluated_names: list[str]
+) -> list[dict[str, Any]]:
+    """Run every evaluable predicate against one thread, in fixed order.
+
+    Predicates are pure functions over already-fetched snapshots. They are
+    wrapped defensively anyway: a predicate that hits an unexpected shape must
+    degrade to "did not fire" rather than crash the whole registry build — the
+    same broad-except-degrades boundary every source read in this capability
+    uses.
+    """
+    allowed = set(evaluated_names)
+    flaws: list[dict[str, Any]] = []
+    for predicate in FLAW_PREDICATES:
+        if predicate["name"] not in allowed:
+            continue
+        try:
+            result = predicate["fn"](ctx)
+        except Exception:  # noqa: BLE001 - a predicate never crashes the build
+            continue
+        if result is not None:
+            flaws.append(result)
+    return flaws
+
+
+def flaws_band_header(
+    evaluated: list[str], not_evaluated: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """The flaws band's own header: what was checked, what was not, and why."""
+    return {
+        "evaluated": evaluated,
+        "not_evaluated": not_evaluated,
+        "unread": [dict(entry) for entry in UNREAD_FLAW_PREDICATES],
+        "rendered_elsewhere": [
+            {
+                "predicate": "delivered_never_tried",
+                "surface": "done band tried tier",
+                "reason": "delivered-never-tried is visible as the empty tried"
+                " tier, not as a red mark (EXT-2 / decision Q3; the #4438"
+                " delivered posture stays)",
+            }
+        ],
+    }
+
+
+# --------------------------------------------------------------------------
+# Within-band ordering (EXT-7) — never cross-band, never hides
+# --------------------------------------------------------------------------
+
+
+def risk_meter(flaws: list[dict[str, Any]]) -> dict[str, Any]:
+    """A four-tick reading signal, capped. Never a displayed scalar.
+
+    Per ADR-0057 A1 this is a signal to read, never a selection input: it
+    orders cards inside one band and does nothing else. Nothing in this module
+    filters, hides, or demotes a card by ticks.
+    """
+    ticks = min(len(flaws), RISK_MAX_TICKS)
+    if ticks == 0:
+        tone = None
+    elif ticks >= RISK_MAX_TICKS:
+        tone = "destructive"
+    else:
+        tone = "amber"
+    return {"ticks": ticks, "max_ticks": RISK_MAX_TICKS, "tone": tone}
+
+
+def order_within_band(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Order one band's cards. Returns every input card, never fewer.
+
+    Composed stable sorts give a total, deterministic order: risk ticks
+    descending, then most-recently-moved first, then task id. The function is
+    only ever handed the items of a single band, so it structurally cannot move
+    a card between bands.
+    """
+    ordered = list(items)
+    ordered.sort(key=lambda item: str(item.get("id") or ""))
+    ordered.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+    ordered.sort(
+        key=lambda item: int((item.get("risk_meter") or {}).get("ticks") or 0),
+        reverse=True,
+    )
+    return ordered
+
+
+# --------------------------------------------------------------------------
+# Stale sources
+# --------------------------------------------------------------------------
+
+
+def stale_source_names(
+    reads: list[Any], *, now: datetime | None = None
+) -> frozenset[str]:
+    """Names of fresh-but-old sources, and flip their state to ``stale``.
+
+    Only a source that claims ``fresh`` and carries a parseable watermark can
+    become stale; ``empty``/``unavailable`` already carry their own honest
+    meaning and are never rewritten. ``last_successful_read`` is left untouched
+    — the pill must keep naming the instant it actually read.
+    """
+    moment = now or datetime.now(timezone.utc)
+    cutoff = timedelta(days=SOURCE_STALE_AFTER_DAYS)
+    stale: set[str] = set()
+    for read in reads:
+        if read.state != "fresh":
+            continue
+        watermark = parse_timestamp(read.last_successful_read)
+        if watermark is None:
+            continue
+        if moment - watermark >= cutoff:
+            read.state = "stale"
+            stale.add(read.name)
+    return frozenset(stale)
+
+
+def amber_if_stale(
+    rung: dict[str, Any], source: str | None, stale_sources: frozenset[str]
+) -> dict[str, Any]:
+    """Downgrade a rung to amber when the source behind it went stale.
+
+    Only ever a downgrade: ``absent`` stays ``absent`` (a stale source cannot
+    conjure an object that does not exist), and a rung with no source behind it
+    is untouched.
+    """
+    if source is None or source not in stale_sources:
+        return rung
+    if rung.get("class") not in ("proven", "derived"):
+        return rung
+    downgraded = dict(rung)
+    downgraded["class"] = "amber"
+    downgraded["stale_source"] = source
+    return downgraded
+
+
+# --------------------------------------------------------------------------
+# why_now — the gate's own phrasing, never a score
+# --------------------------------------------------------------------------
+
+
+def why_now(
+    task: dict[str, Any],
+    position: ChainPosition,
+    band: str,
+    flaws: list[dict[str, Any]],
+) -> str:
+    """Which predicate fired, or which position the thread holds. Never a score.
+
+    When a flaw fired, its own phrasing wins: the most useful thing to say
+    about a thread with a missing link is the name of the missing link.
+    """
+    if flaws:
+        return flaws[0]["text"]
+    status = str(task.get("status") or "?")
+    if band == "needs_you":
+        return f"{status} · labelled for a human"
+    if position.position == "forgotten":
+        last_movement = position.evidence.get("last_movement_at") or "unknown"
+        return f"stalled without closure · no movement since {last_movement}"
+    if position.position == "delivered":
+        return f"{status} · delivered with a terminal verification receipt"
+    if task.get("claimed_by"):
+        return f"{status} · claimed by {task['claimed_by']}"
+    return status

--- a/app/builderops/cockpit_chain.py
+++ b/app/builderops/cockpit_chain.py
@@ -87,9 +87,12 @@ FORGOTTEN_STALL_DAYS = 14
 # source is *stale* (EXT-3's accepted third pill state, enacted here for the
 # first time: #4450/#4451 shipped only fresh/empty/unavailable).
 #
-# Why seven days: three of the five sources are read at render time, so their
-# watermark is always "now" and this threshold can never fire for them. The one
-# source whose watermark is genuinely a content age is ``docs-frontmatter``,
+# Why seven days: four of the five sources (dispatcher-store, verification-runs,
+# deploy-receipts, github-live) are read at render time, so their watermark is
+# always "now" and this threshold can never fire for them in production — the
+# github-live and verification-runs amber/withdrawn-count paths below are only
+# reachable through a test fixture that hand-constructs an old watermark. The
+# one source whose watermark is genuinely a content age is ``docs-frontmatter``,
 # whose watermark is the newest mtime among the spec files it read. Seven days
 # is the cadence at which this repo's spec directories actually move; a shorter
 # window would paint the docs plane amber on every render (noise, not honesty),
@@ -269,7 +272,15 @@ def derive_position(
     """
     status = str(task.get("status") or "")
     movement_at, movement_text = _last_movement(task)
-    open_pull = getattr(live_pull, "number", None)
+    # Only a genuinely open PR counts as live movement — a closed/merged
+    # pull sitting in the snapshot (a future reader may not filter by state
+    # the way the default one does) must not permanently exempt a thread
+    # from the forgotten-stall test.
+    open_pull = (
+        getattr(live_pull, "number", None)
+        if getattr(live_pull, "state", None) == "open"
+        else None
+    )
 
     if status in TERMINAL_STATUSES:
         return ChainPosition(
@@ -513,6 +524,12 @@ def _stale_epic_with_open_children(ctx: ThreadContext) -> dict[str, Any] | None:
         and doc.github_issue in ctx.github_snapshot.issues
     )
     if not open_children:
+        return None
+    # An open live PR against the epic itself is the same "live movement"
+    # signal derive_position already treats as settling the stall test —
+    # a card must not carry stale_epic_with_open_children while its own
+    # position rung says in_progress from that same open PR.
+    if getattr(ctx.live_pull, "state", None) == "open":
         return None
     movement_at, movement_text = _last_movement(ctx.task)
     if movement_at is None:
@@ -786,6 +803,7 @@ def why_now(
     position: ChainPosition,
     band: str,
     flaws: list[dict[str, Any]],
+    evaluated_predicates: list[str] | None = None,
 ) -> str:
     """Which predicate fired, or which position the thread holds. Never a score.
 
@@ -796,11 +814,23 @@ def why_now(
         return flaws[0]["text"]
     status = str(task.get("status") or "?")
     if band == "needs_you":
+        if position.unresolved_reason:
+            return f"{status} · labelled for a human · {position.unresolved_reason}"
         return f"{status} · labelled for a human"
     if position.position == "forgotten":
         last_movement = position.evidence.get("last_movement_at") or "unknown"
         return f"stalled without closure · no movement since {last_movement}"
     if position.position == "delivered":
+        # A missing receipt would have fired delivered_without_verification_receipt
+        # above; reaching here with that predicate genuinely unevaluated (its
+        # source was unavailable) means we cannot claim a receipt exists —
+        # claiming presence without evidence is the same overclaim class as
+        # showing a zero over a dead source.
+        if (
+            evaluated_predicates is not None
+            and "delivered_without_verification_receipt" not in evaluated_predicates
+        ):
+            return f"{status} · delivered, but the verification-runs source could not be read"
         return f"{status} · delivered with a terminal verification receipt"
     if task.get("claimed_by"):
         return f"{status} · claimed by {task['claimed_by']}"

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -7,15 +7,20 @@ nothing survives a reload.
 
 Honesty rules this module enforces (owner doc: docs/BUILDEROPS_COCKPIT/README.md):
 
-- Band derivation is fail-closed: a task whose status has no band mapping lands
-  in ``unclassified``, never silently in a band.
+- Band derivation is fail-closed: a thread whose **chain position** cannot be
+  computed lands in ``unclassified``, never silently in a band
+  (BOPS-COCKPIT-04, #4452 — this replaced the earlier status-word mapping).
 - A view that cannot name per-source freshness must not claim emptiness: when a
   source read fails, the claim is refused and bands owned by that source report
-  ``countable: false`` instead of zero.
+  ``countable: false`` instead of zero. A source that is readable but *stale*
+  turns its dependent rungs amber and has the counts it owns withdrawn.
 - Evidence rungs classify by key class, not content quality: only DB-keyed or
   CI-forced edges are ``proven``. Rungs with no machine-readable object in v1
   (intention, capability, epic, tried-by-owner) render ``absent`` — visible
   absence is the point.
+- One identity, many appearances: a thread holds exactly one position band and
+  additionally appears in the flaws band when a predicate fires. The flaws band
+  holds the same object, never a copy.
 """
 
 from __future__ import annotations
@@ -27,6 +32,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from app.builderops.cockpit_chain import (
+    RUNG_SOURCE,
+    SOURCE_STALE_AFTER_DAYS,
+    TRIED_TIER_REASON,
+    ThreadContext,
+    amber_if_stale,
+    derive_position,
+    evaluable_predicates,
+    evaluate_flaws,
+    flaws_band_header,
+    order_within_band,
+    risk_meter,
+    stale_source_names,
+    why_now,
+)
 from app.builderops.cockpit_docs_plane import (
     DocsPlaneSnapshot,
     build_lanes,
@@ -45,7 +65,6 @@ from app.builderops.cockpit_github_plane import (
 __all__ = [
     "BANDS",
     "RUNG_ORDER",
-    "STATUS_BAND",
     "UNREAD_PLANES",
     "build_registry",
 ]
@@ -60,19 +79,12 @@ BANDS: tuple[tuple[str, str], ...] = (
     ("needs_you", "Needs you"),
 )
 
-# Dispatcher status -> band. Fail-closed: anything absent from this table is
-# reported as unclassified, never guessed into a band.
-STATUS_BAND: dict[str, str] = {
-    "claimed": "working",
-    "in_progress": "working",
-    "review": "working",
-    "completed": "done",
-    "done": "done",
-    "blocked": "flawed",
-    "backlog": "forgotten",
-    "ready": "forgotten",
-}
-
+# Band membership is derived in `app/builderops/cockpit_chain.py` from the
+# thread's *chain position*, not from its dispatcher status word
+# (BOPS-COCKPIT-04, #4452). The status word is one input among several
+# (movement timestamps, lease expiry, live PR existence); the mapping table
+# that used to live here is gone, because "ready" is not "forgotten" — a fresh
+# unclaimed ready issue is in progress, and forgotten requires a stall.
 _NEEDS_HUMAN_LABEL = "agent:needs-human"
 
 # Locked rung order for the evidence spine.
@@ -93,9 +105,16 @@ RUNG_ORDER: tuple[str, ...] = (
 # (#4451): both are now named, per-render read sources. ckm-projection stays
 # unread by design (ADR-0057: CKM is a lens, never spine — it must never
 # become a fourth join input here).
+# BOPS-COCKPIT-04 (#4452) names two further planes it does not read, because
+# each carries a deficiency predicate the flaws band would otherwise appear to
+# cover: session records and issue comments (see
+# `cockpit_chain.UNREAD_FLAW_PREDICATES`, which names the predicate each one
+# blocks).
 UNREAD_PLANES: tuple[str, ...] = (
     "ckm-projection",
     "git",
+    "session-records",
+    "issue-comments",
 )
 
 _DEPLOY_CHANNELS: tuple[str, ...] = ("dev", "test", "prod")
@@ -107,8 +126,13 @@ def _utc_now() -> str:
 
 @dataclass
 class _SourceRead:
+    # "stale" is the third pill state EXT-3 accepted and #4452 enacts: a
+    # readable source whose own watermark is older than
+    # SOURCE_STALE_AFTER_DAYS. It is applied after every read completes (see
+    # `stale_source_names`), and never rewrites `last_successful_read` — the
+    # pill must keep naming the instant it actually read.
     name: str
-    state: str  # "fresh" | "empty" | "unavailable"
+    state: str  # "fresh" | "stale" | "empty" | "unavailable"
     last_successful_read: str | None
     detail: str
 
@@ -118,6 +142,7 @@ class _SourceRead:
             "state": self.state,
             "last_successful_read": self.last_successful_read,
             "detail": self.detail,
+            "stale_after_days": SOURCE_STALE_AFTER_DAYS,
         }
 
 
@@ -160,9 +185,14 @@ def _read_tasks(db_path: Path, sources: _Sources) -> list[dict[str, Any]] | None
         return None
     try:
         with _read_only_connection(db_path) as conn:
+            # lease_id / last_heartbeat_at joined in by BOPS-COCKPIT-04
+            # (#4452): the expired-lease flaw predicate needs the lease's own
+            # id as evidence, and the forgotten stall test needs the heartbeat
+            # as a second movement timestamp alongside updated_at.
             rows = conn.execute(
                 "SELECT task_id, issue_number, title, status, priority, repo,"
-                " claimed_by, lease_expires_at, linked_pr, blocked_reason,"
+                " claimed_by, lease_id, lease_expires_at, last_heartbeat_at,"
+                " linked_pr, blocked_reason,"
                 " sync_state, created_at, updated_at"
                 " FROM dispatcher_tasks WHERE status != '_meta'"
                 " ORDER BY updated_at DESC, created_at DESC"
@@ -454,6 +484,7 @@ def _build_rungs(
     verification: dict[tuple[str, int], dict[str, Any]],
     github_snapshot: GithubLiveSnapshot | None = None,
     docs_snapshot: DocsPlaneSnapshot | None = None,
+    stale_sources: frozenset[str] = frozenset(),
 ) -> list[dict[str, Any]]:
     """Classify the eight rungs for one task.
 
@@ -473,27 +504,52 @@ def _build_rungs(
     and this function behaves exactly as it did before #4450 — refusal never
     fabricates an upgrade. The same posture applies to ``docs_snapshot`` for
     the ``capability``/``epic`` rungs.
+
+    BOPS-COCKPIT-04 (#4452): ``stale_sources`` names sources that read
+    successfully but whose watermark is older than the staleness threshold.
+    Every rung is ambered against *the source that actually produced its
+    value* — a ``pr`` rung proven from the dispatcher store's own
+    ``linked_pr`` is not ambered by a stale live-GitHub read, and vice versa.
+    The downgrade is one-directional: ``absent`` never becomes anything else.
     """
     issue_number = task.get("issue_number")
     capability = classify_capability(issue_number, docs_snapshot)
     epic = classify_epic(issue_number, docs_snapshot)
     rungs: list[dict[str, Any]] = [
         _rung("intention", "absent"),
-        capability["rung"],
-        epic["rung"],
+        amber_if_stale(capability["rung"], RUNG_SOURCE["capability"], stale_sources),
+        amber_if_stale(epic["rung"], RUNG_SOURCE["epic"], stale_sources),
     ]
     repo = task.get("repo") or ""
     if issue_number:
-        rungs.append(_rung("slice", "proven", f"{repo}#{issue_number}"))
+        rungs.append(
+            amber_if_stale(
+                _rung("slice", "proven", f"{repo}#{issue_number}"),
+                RUNG_SOURCE["slice"],
+                stale_sources,
+            )
+        )
     else:
         rungs.append(_rung("slice", "absent"))
 
     linked_pr = task.get("linked_pr")
     pr_number, live_pull = _resolve_pr(task, github_snapshot)
     if linked_pr:
-        rungs.append(_rung("pr", "proven", f"PR #{linked_pr}"))
+        rungs.append(
+            amber_if_stale(
+                _rung("pr", "proven", f"PR #{linked_pr}"),
+                "dispatcher-store",
+                stale_sources,
+            )
+        )
     elif live_pull is not None and pr_number is not None:
-        rungs.append(_rung("pr", "proven", f"PR #{pr_number} (live)"))
+        rungs.append(
+            amber_if_stale(
+                _rung("pr", "proven", f"PR #{pr_number} (live)"),
+                "github-live",
+                stale_sources,
+            )
+        )
     else:
         rungs.append(_rung("pr", "absent"))
 
@@ -504,13 +560,23 @@ def _build_rungs(
         else None
     )
     if run and run.get("verified_head_sha"):
-        rungs.append(_rung("ci_sha", "proven", str(run["verified_head_sha"])[:12]))
+        rungs.append(
+            amber_if_stale(
+                _rung("ci_sha", "proven", str(run["verified_head_sha"])[:12]),
+                "verification-runs",
+                stale_sources,
+            )
+        )
     elif live_check_state and live_pull is not None:
         rungs.append(
-            _rung(
-                "ci_sha",
-                "proven",
-                f"{live_pull.head_sha[:12]} ({live_check_state}, live)",
+            amber_if_stale(
+                _rung(
+                    "ci_sha",
+                    "proven",
+                    f"{live_pull.head_sha[:12]} ({live_check_state}, live)",
+                ),
+                "github-live",
+                stale_sources,
             )
         )
     elif run:
@@ -519,7 +585,13 @@ def _build_rungs(
         rungs.append(_rung("ci_sha", "absent"))
 
     if run and run.get("terminal_receipt_json"):
-        rungs.append(_rung("receipt", "proven", str(run.get("updated_at") or "")))
+        rungs.append(
+            amber_if_stale(
+                _rung("receipt", "proven", str(run.get("updated_at") or "")),
+                RUNG_SOURCE["receipt"],
+                stale_sources,
+            )
+        )
     else:
         rungs.append(_rung("receipt", "absent"))
 
@@ -527,24 +599,16 @@ def _build_rungs(
     return rungs
 
 
-def _why_now(task: dict[str, Any], band: str) -> str:
-    """The gate's own wording, not a score."""
-    status = task.get("status") or "?"
-    if band == "flawed" and task.get("blocked_reason"):
-        return f"blocked: {task['blocked_reason']}"
-    if band == "working" and task.get("claimed_by"):
-        return f"{status} · claimed by {task['claimed_by']}"
-    if band == "forgotten":
-        return f"{status} since {task.get('updated_at') or 'unknown'}"
-    return status
-
-
 def _build_item(
     task: dict[str, Any],
     band: str,
+    position: Any,
     verification: dict[tuple[str, int], dict[str, Any]],
     github_snapshot: GithubLiveSnapshot | None = None,
     docs_snapshot: DocsPlaneSnapshot | None = None,
+    stale_sources: frozenset[str] = frozenset(),
+    evaluated_predicates: list[str] | None = None,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
     labels = _sync_labels(task.get("sync_state"))
     mirror_url = _sync_url(task.get("sync_state"))
@@ -554,7 +618,32 @@ def _build_item(
     # Same precedence _build_rungs uses for its "PR #NN (live) proven" rung —
     # a card whose rung claims a live PR match must out-link to that same PR,
     # not fall back to the plain issue (the drift #4450 review caught).
-    pr_number, _ = _resolve_pr(task, github_snapshot)
+    pr_number, live_pull = _resolve_pr(task, github_snapshot)
+
+    # BOPS-COCKPIT-04 (#4452): deficiency predicates over the joined planes.
+    # Every predicate is a pure function of already-fetched snapshots, so no
+    # predicate can perform I/O, fail a read, or raise past this call.
+    repo = task.get("repo") or ""
+    flaws = evaluate_flaws(
+        ThreadContext(
+            task=task,
+            repo=repo,
+            issue_number=issue_number,
+            position=position.position,
+            pr_number=pr_number,
+            live_pull=live_pull,
+            verification_run=(
+                verification.get((repo, pr_number)) if pr_number is not None else None
+            ),
+            github_snapshot=github_snapshot,
+            docs_snapshot=docs_snapshot,
+            now=now or datetime.now(timezone.utc),
+        ),
+        evaluated_predicates or [],
+    )
+    # The bands this one identity appears in: its position band always, plus
+    # the flaws band when a predicate fired. Same object, never a copy.
+    appears_in = [band] + (["flawed"] if flaws else [])
 
     # AC3 (#4450): every card carries its authority out-link from the live
     # GitHub read, independent of the sync mirror's `url` field (audit F9,
@@ -602,11 +691,20 @@ def _build_item(
         # watermark here, never the dispatcher-store SQLite read instant the
         # `dispatcher-store` source pill reports.
         "mirror_watermark": mirror_watermark,
-        "why_now": _why_now(task, band),
+        "why_now": why_now(task, position, band, flaws),
         "links": links,
-        "rungs": _build_rungs(task, verification, github_snapshot, docs_snapshot),
+        "rungs": _build_rungs(
+            task, verification, github_snapshot, docs_snapshot, stale_sources
+        ),
         "sources": sources,
         "capability_lane": capability_lane,
+        # Chain position (#4452): the derived position and the evidence that
+        # produced it, so the card can state *why* it sits where it sits.
+        "chain_position": position.position,
+        "position_evidence": position.evidence,
+        "bands": appears_in,
+        "flaws": flaws,
+        "risk_meter": risk_meter(flaws),
         "updated_at": task.get("updated_at"),
     }
 
@@ -725,6 +823,18 @@ def build_registry(
         docs_root, capabilities_yaml_path, matrix_path, sources
     )
 
+    now = datetime.now(timezone.utc)
+    # EXT-3's third pill state, enacted (#4452): flip readable-but-old sources
+    # to "stale" before anything reads their state. Everything downstream —
+    # rung colour, count withdrawal, predicate evaluability — keys off the
+    # post-flip state, so a stale source degrades consistently everywhere
+    # instead of ambering one surface and staying calm on another.
+    stale_sources = stale_source_names(sources.reads, now=now)
+    source_state = {read.name: read.state for read in sources.reads}
+    # A predicate whose plane is not fresh is not evaluated at all: never
+    # fired on absent evidence, never silently dropped. The header names it.
+    evaluated_predicates, not_evaluated_predicates = evaluable_predicates(source_state)
+
     generated_at = _utc_now()
     bands: list[dict[str, Any]] = []
     unclassified: list[dict[str, Any]] = []
@@ -734,15 +844,27 @@ def build_registry(
         # The band counts are owned by the dispatcher store. Without it the
         # only honest claim is a refusal — "cannot be counted", never zero.
         for key, question in BANDS:
-            bands.append(
-                {
-                    "key": key,
-                    "question": question,
-                    "countable": False,
-                    "count": None,
+            refused_band: dict[str, Any] = {
+                "key": key,
+                "question": question,
+                "countable": False,
+                "count": None,
+                "items": [],
+            }
+            # The flaws header and the tried tier are structural, not counts:
+            # they must still say what is unread and what is reserved even
+            # when nothing can be counted at all.
+            if key == "flawed":
+                refused_band["header"] = flaws_band_header(
+                    evaluated_predicates, not_evaluated_predicates
+                )
+            if key == "done":
+                refused_band["tried_tier"] = {
                     "items": [],
+                    "reserved": True,
+                    "reason": TRIED_TIER_REASON,
                 }
-            )
+            bands.append(refused_band)
         claim = {
             "kind": "refused",
             "text": "I cannot say what is in motion: the dispatcher store"
@@ -754,34 +876,84 @@ def build_registry(
         for task in tasks:
             status = str(task.get("status") or "")
             labels = _sync_labels(task.get("sync_state"))
+            _, live_pull = _resolve_pr(task, github_snapshot)
+            position = derive_position(task, now=now, live_pull=live_pull)
             if _NEEDS_HUMAN_LABEL in labels:
+                # An explicit human-routing label is the owner's own authority
+                # speaking, not a derived claim, so it is not subject to the
+                # fail-closed position rule: it routes even when the chain
+                # position itself is unresolvable (the card still carries
+                # `chain_position: null` and its reason).
                 band = "needs_you"
-            elif status in STATUS_BAND:
-                band = STATUS_BAND[status]
+            elif position.band is not None:
+                band = position.band
             else:
                 unclassified.append(
                     {
                         "id": task["task_id"],
                         "title": task.get("title"),
                         "status": status,
-                        "reason": f"status {status!r} has no band mapping",
+                        "reason": position.unresolved_reason
+                        or f"status {status!r} has no chain position",
                     }
                 )
                 continue
-            item = _build_item(task, band, verification, github_snapshot, docs_snapshot)
-            grouped[band].append(item)
-            all_items.append(item)
-        for key, question in BANDS:
-            bands.append(
-                {
-                    "key": key,
-                    "question": question,
-                    "countable": True,
-                    "count": len(grouped[key]),
-                    "items": grouped[key],
-                }
+            item = _build_item(
+                task,
+                band,
+                position,
+                verification,
+                github_snapshot,
+                docs_snapshot,
+                stale_sources,
+                evaluated_predicates,
+                now,
             )
-        total = sum(len(items) for items in grouped.values())
+            grouped[band].append(item)
+            # The flaws band is cross-cutting: a thread holds one position
+            # band and additionally appears here when a predicate fired. The
+            # *same object* goes in both lists — one identity, no copy drift.
+            if item["flaws"] and band != "flawed":
+                grouped["flawed"].append(item)
+            all_items.append(item)
+        # The band counts are owned by the dispatcher store, and the staleness
+        # rule deliberately does not reach them: `_read_tasks` stamps its
+        # watermark at the instant it reads, so `dispatcher-store` is either
+        # fresh or unavailable and can never be stale. That matters beyond
+        # bookkeeping — `countable: false` already means "no cards either" to
+        # the delivered surface (`app/web/static/cockpit.js` renders no body
+        # for an uncountable band), so emitting an uncountable band that still
+        # carries items would hide cards, which is exactly what "withdraw the
+        # count, never the card" forbids. Withdrawal therefore applies only to
+        # counts owned by sources with a non-instant watermark: the docs
+        # plane's lane grouping and the github-live facts.
+        for key, question in BANDS:
+            band_payload: dict[str, Any] = {
+                "key": key,
+                "question": question,
+                "countable": True,
+                "count": len(grouped[key]),
+                # EXT-7: ordering applies strictly within this band's own item
+                # list, so it structurally cannot move a card across bands.
+                "items": order_within_band(grouped[key]),
+            }
+            if key == "flawed":
+                band_payload["header"] = flaws_band_header(
+                    evaluated_predicates, not_evaluated_predicates
+                )
+            if key == "done":
+                # EXT-2 / decision Q3: the tried tier renders, is empty, and
+                # says why. Delivered-never-tried is visible here as absence,
+                # never as a red mark in the flaws band.
+                band_payload["tried_tier"] = {
+                    "items": [],
+                    "reserved": True,
+                    "reason": TRIED_TIER_REASON,
+                }
+            bands.append(band_payload)
+        # Distinct threads, not the sum of band memberships: a thread in both
+        # its position band and the flaws band is one thread, counted once.
+        total = len(all_items)
         if total == 0 and not unclassified:
             claim = {
                 "kind": "counted",
@@ -803,7 +975,28 @@ def build_registry(
     # (tasks is None) — in which case all_items is an artifact of nothing
     # being known, not a true empty set, so lanes must refuse too rather
     # than calmly reporting "0 lanes" next to the bands' own refusal above.
-    lanes = build_lanes(all_items, docs_snapshot) if tasks is not None else None
+    #
+    # #4452 adds a third: the docs plane read fine but is *stale*, so the lane
+    # grouping it owns is withdrawn rather than shown whole (EXT-3's stale-
+    # source rule). The lane cards themselves are not hidden — they simply
+    # stop being counted, which is what "withdraw the numbers that source
+    # owns" means.
+    lanes = (
+        build_lanes(all_items, docs_snapshot)
+        if tasks is not None and "docs-frontmatter" not in stale_sources
+        else None
+    )
+
+    # Only counts owned by a source that can actually go stale appear here —
+    # see the band-count comment above for why `dispatcher-store` is absent.
+    withdrawn_counts = [
+        {"source": name, "counts": counts}
+        for name, counts in (
+            ("github-live", ["github.open_issues", "github.open_prs", "github.branches"]),
+            ("docs-frontmatter", ["capability_lanes.lanes"]),
+        )
+        if name in stale_sources
+    ]
 
     return {
         "authority": "read_time_join",
@@ -818,4 +1011,19 @@ def build_registry(
         "unsynced_threads": _build_unsynced_threads(tasks, github_snapshot),
         "capability_lanes": {"countable": lanes is not None, "lanes": lanes},
         "docs_only_threads": unlinked_docs_threads(docs_snapshot),
+        # The counts a stale source no longer backs. Named so the withdrawal
+        # is visible on the surface instead of looking like a quiet zero.
+        "withdrawn_counts": withdrawn_counts,
+        # EXT-7's binding constraint, stated in the payload so a frontend
+        # cannot reinterpret the risk meter as a ranking (ADR-0057 A1).
+        "within_band_ordering": {
+            "applied": True,
+            "basis": "count of fired flaw predicates, capped at four ticks",
+            "never": [
+                "reordering across bands",
+                "hiding, capping, or demoting a card",
+                "selection, ranking, or filtering (ADR-0057 A1: a risk number"
+                " is a signal to read, never a selection input)",
+            ],
+        },
     }

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -691,7 +691,7 @@ def _build_item(
         # watermark here, never the dispatcher-store SQLite read instant the
         # `dispatcher-store` source pill reports.
         "mirror_watermark": mirror_watermark,
-        "why_now": why_now(task, position, band, flaws),
+        "why_now": why_now(task, position, band, flaws, evaluated_predicates),
         "links": links,
         "rungs": _build_rungs(
             task, verification, github_snapshot, docs_snapshot, stale_sources
@@ -702,6 +702,10 @@ def _build_item(
         # produced it, so the card can state *why* it sits where it sits.
         "chain_position": position.position,
         "position_evidence": position.evidence,
+        # Populated only when the position is unresolvable (e.g. a
+        # needs_you-labelled thread whose fail-closed position could not
+        # be derived) — the card's own stated reason, not just a null.
+        "position_unresolved_reason": position.unresolved_reason,
         "bands": appears_in,
         "flaws": flaws,
         "risk_meter": risk_meter(flaws),
@@ -875,40 +879,56 @@ def build_registry(
         grouped: dict[str, list[dict[str, Any]]] = {key: [] for key, _ in BANDS}
         for task in tasks:
             status = str(task.get("status") or "")
-            labels = _sync_labels(task.get("sync_state"))
-            _, live_pull = _resolve_pr(task, github_snapshot)
-            position = derive_position(task, now=now, live_pull=live_pull)
-            if _NEEDS_HUMAN_LABEL in labels:
-                # An explicit human-routing label is the owner's own authority
-                # speaking, not a derived claim, so it is not subject to the
-                # fail-closed position rule: it routes even when the chain
-                # position itself is unresolvable (the card still carries
-                # `chain_position: null` and its reason).
-                band = "needs_you"
-            elif position.band is not None:
-                band = position.band
-            else:
+            try:
+                labels = _sync_labels(task.get("sync_state"))
+                _, live_pull = _resolve_pr(task, github_snapshot)
+                position = derive_position(task, now=now, live_pull=live_pull)
+                if _NEEDS_HUMAN_LABEL in labels:
+                    # An explicit human-routing label is the owner's own
+                    # authority speaking, not a derived claim, so it is not
+                    # subject to the fail-closed position rule: it routes
+                    # even when the chain position itself is unresolvable
+                    # (the card still carries `chain_position: null` and
+                    # its reason).
+                    band = "needs_you"
+                elif position.band is not None:
+                    band = position.band
+                else:
+                    unclassified.append(
+                        {
+                            "id": task["task_id"],
+                            "title": task.get("title"),
+                            "status": status,
+                            "reason": position.unresolved_reason
+                            or f"status {status!r} has no chain position",
+                        }
+                    )
+                    continue
+                item = _build_item(
+                    task,
+                    band,
+                    position,
+                    verification,
+                    github_snapshot,
+                    docs_snapshot,
+                    stale_sources,
+                    evaluated_predicates,
+                    now,
+                )
+            except Exception as exc:  # noqa: BLE001 - one thread's derivation
+                # failure must never crash the whole render (the #4451-class
+                # bug this exact pattern exists to prevent, applied per task
+                # rather than per source): the thread renders as explicitly
+                # unclassified instead of taking bands/tasks/everything down.
                 unclassified.append(
                     {
-                        "id": task["task_id"],
+                        "id": task.get("task_id"),
                         "title": task.get("title"),
                         "status": status,
-                        "reason": position.unresolved_reason
-                        or f"status {status!r} has no chain position",
+                        "reason": f"chain-position derivation failed: {exc}",
                     }
                 )
                 continue
-            item = _build_item(
-                task,
-                band,
-                position,
-                verification,
-                github_snapshot,
-                docs_snapshot,
-                stale_sources,
-                evaluated_predicates,
-                now,
-            )
             grouped[band].append(item)
             # The flaws band is cross-cutting: a thread holds one position
             # band and additionally appears here when a predicate fired. The

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -34,8 +34,10 @@ pack is supporting input.
 
 ## What the delivered increment renders (#4438)
 
-- **Four bands in locked order plus a needs-you band**, derivation fail-closed (`STATUS_BAND` in
-  `app/builderops/cockpit_registry.py`): an unmapped status lands in the explicit `unclassified`
+- **Four bands in locked order plus a needs-you band**, derivation fail-closed. #4438 derived the
+  band from the dispatcher status word; BOPS-COCKPIT-04 (#4452) replaced that mapping with
+  **chain-position** derivation (`derive_position` in `app/builderops/cockpit_chain.py`) over the
+  joined planes: a thread whose position cannot be computed lands in the explicit `unclassified`
   list, never guessed. `agent:needs-human` routes to the needs-you band — label routing reads the
   sync mirror's `sync_state`, which production sync has populated with labels and URLs since #4441
   (=#4456, audit F9) merged; each mirror-derived field now names its own `sync_state.last_pull_at`
@@ -45,11 +47,24 @@ pack is supporting input.
   for DB-keyed or CI-forced edges). Intention, capability, epic, and tried render `absent` — their
   visible absence is the point.
 - **Per-source freshness** — pills with per-source `last_successful_read` for `dispatcher-store`,
-  `verification-runs` (SQLite read-only), `deploy-receipts`; unread planes named as unread.
+  `verification-runs` (SQLite read-only), `deploy-receipts`; unread planes named as unread. The
+  third pill state, **stale** (EXT-3), arrived with BOPS-COCKPIT-04 (#4452): a source whose own
+  watermark is older than `SOURCE_STALE_AFTER_DAYS` turns the rungs it backs amber and has the
+  counts it owns withdrawn rather than shown whole.
 - **Honest emptiness in three forms** — dated true emptiness; refused claims on dead sources
   ("cannot be counted", never zero); structural absence distinct from death.
 - **Two tiers in the done band** — "Ready for you to use" above "Tried by you" (empty by contract
   until INV-DG-7 has an owner-acceptance receipt contract).
+- **Flaw predicates with named evidence** (BOPS-COCKPIT-04, #4452) — deficiencies are derived
+  predicates over the joined planes, not an enumerated list: a blocked link, a dispatcher/GitHub
+  contradiction, an expired lease, red or absent CI on a PR head SHA, a pushed branch with no PR,
+  a delivery with no verification receipt, a stale epic with open children. Each carries its own
+  evidence keys; a predicate whose plane is not fresh is **named as unevaluated** in the flaws band
+  header rather than reading as "no flaw", and predicates needing a plane this capability never
+  reads (git working trees, session records, issue comments) are named as unread there too. A
+  thread holds one position band and additionally appears in the flaws band — one identity, no
+  copy drift. Within-band ordering is a four-tick reading signal only (EXT-7): it never crosses a
+  band, never hides a card, and is never a selection input (ADR-0057 A1).
 
 ## Implementation tasks and execution order
 
@@ -58,9 +73,9 @@ pack is supporting input.
 | 1 | [REGISTRY_READ_TIME_JOIN](REGISTRY_READ_TIME_JOIN.md) | BOPS-COCKPIT-01 | #4438 | Delivered |
 | 2 | [INDUCED_FAILURE_JOURNEYS](INDUCED_FAILURE_JOURNEYS.md) | BOPS-COCKPIT-02 | #4448 | Ready |
 | 2 (par) | [COGNITIVE_LOAD_SIBLING](COGNITIVE_LOAD_SIBLING.md) | BOPS-COCKPIT-07 | #4449 | Ready |
-| 3 | [GITHUB_LIVE_PLANE](GITHUB_LIVE_PLANE.md) | BOPS-COCKPIT-03 | #4450 | Ready |
-| 3 (par) | [DOCS_PLANE_CAPABILITY_LANES](DOCS_PLANE_CAPABILITY_LANES.md) | BOPS-COCKPIT-05 | #4451 | Ready |
-| 4 | [CHAIN_DERIVED_STATES](CHAIN_DERIVED_STATES.md) | BOPS-COCKPIT-04 | #4452 | Blocked on 03 |
+| 3 | [GITHUB_LIVE_PLANE](GITHUB_LIVE_PLANE.md) | BOPS-COCKPIT-03 | #4450 | Delivered |
+| 3 (par) | [DOCS_PLANE_CAPABILITY_LANES](DOCS_PLANE_CAPABILITY_LANES.md) | BOPS-COCKPIT-05 | #4451 | Delivered |
+| 4 | [CHAIN_DERIVED_STATES](CHAIN_DERIVED_STATES.md) | BOPS-COCKPIT-04 | #4452 | Delivered |
 | 5 | [SURFACE_LENSES](SURFACE_LENSES.md) | BOPS-COCKPIT-06 | #4453 | Blocked on 02+04+05 |
 
 Flat order: journeys and the docs sibling first (they harden and govern what exists), then the two

--- a/tests/builderops/test_cockpit_chain_states.py
+++ b/tests/builderops/test_cockpit_chain_states.py
@@ -288,6 +288,32 @@ def test_unresolvable_position_is_unclassified_not_guessed(tmp_path: Path) -> No
     assert _band(payload, "working")["count"] == 1
 
 
+def test_needs_human_card_states_its_unresolved_reason(tmp_path: Path) -> None:
+    """A needs_you-labelled thread whose chain position is unresolvable must
+    still carry ITS OWN reason on the card — the routing label bypasses the
+    fail-closed band rule, but it must not silently drop the "why null"
+    explanation the unclassified path would otherwise have surfaced."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(
+        _task(
+            status="mystery_status",
+            issue_number=940,
+            title="needs a human, unresolvable position",
+            sync_state={"labels": ["agent:needs-human"]},
+        )
+    )
+
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    item = _item_by_issue(payload, 940)
+    assert 940 in _issues_in(payload, "needs_you")
+    assert item["chain_position"] is None
+    assert item["position_unresolved_reason"] is not None
+    assert "mystery_status" in item["position_unresolved_reason"]
+    assert "mystery_status" in item["why_now"]
+    assert "labelled for a human" in item["why_now"]
+
+
 # ---------------------------------------------------------------------------
 # AC2 — every flaw predicate fires with named evidence
 # ---------------------------------------------------------------------------
@@ -563,6 +589,13 @@ def test_forgotten_needs_stall_not_age(tmp_path: Path) -> None:
             last_heartbeat_at=_iso(_now() - timedelta(hours=2)),
         )
     )
+    # E: old and silent, and its governing PR is CLOSED (dead, not live) —
+    # a closed pull sitting in the snapshot must never be treated as open
+    # authority movement, or a genuinely abandoned thread could never
+    # become forgotten just because a dead PR still matches its issue.
+    store.upsert_task(
+        _task(status="ready", issue_number=834, title="old, closed pr", updated_at=old)
+    )
 
     snapshot = _snapshot(
         pulls={
@@ -574,7 +607,16 @@ def test_forgotten_needs_stall_not_age(tmp_path: Path) -> None:
                 head_sha="f" * 40,
                 head_ref="pr-31",
                 governing_issue=831,
-            )
+            ),
+            32: GithubPull(
+                number=32,
+                title="Governing-Issue: #834",
+                state="closed",
+                html_url=f"https://github.com/{REPO}/pull/32",
+                head_sha="c" * 40,
+                head_ref="pr-32",
+                governing_issue=834,
+            ),
         },
         checks={"f" * 40: "success"},
     )
@@ -586,9 +628,14 @@ def test_forgotten_needs_stall_not_age(tmp_path: Path) -> None:
         github_reader=_reader(snapshot),
     )
 
-    # Only the thread that is both old *and* silent is forgotten.
-    assert _issues_in(payload, "forgotten") == {830}
+    # Only threads that are both old *and* silent are forgotten — a closed
+    # PR (E) does not exempt a thread the way an open one (B) does.
+    assert _issues_in(payload, "forgotten") == {830, 834}
     assert _issues_in(payload, "working") == {831, 832, 833}
+
+    closed_pr_thread = _item_by_issue(payload, 834)
+    assert closed_pr_thread["chain_position"] == "forgotten"
+    assert closed_pr_thread["position_evidence"]["open_authority_work"] is None
 
     # B is provably as old as A — age was present and deliberately insufficient.
     old_but_moving = _item_by_issue(payload, 831)
@@ -608,6 +655,62 @@ def test_forgotten_needs_stall_not_age(tmp_path: Path) -> None:
     # C is not aged; D's heartbeat is the dispatcher's own movement signal.
     assert _item_by_issue(payload, 832)["position_evidence"]["aged_past_threshold"] is False
     assert _item_by_issue(payload, 833)["position_evidence"]["aged_past_threshold"] is False
+
+
+def test_stale_epic_exempt_when_epic_has_open_pr(tmp_path: Path) -> None:
+    """`stale_epic_with_open_children` must agree with `derive_position` about
+    what counts as movement: an epic with a live open PR against it is not
+    stalled, even if its dispatcher row's own timestamps are old — a card
+    must never carry `chain_position: in_progress` (from the open PR) and
+    the "no movement in the window" flaw for the same reason at once."""
+    db_path, store = _make_store(tmp_path)
+    stale_stamp = _days_ago(FORGOTTEN_STALL_DAYS + 16)
+    store.upsert_task(
+        _task(
+            status="ready",
+            issue_number=907,
+            title="epic with a live pr",
+            updated_at=stale_stamp,
+        )
+    )
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root, epic_issue=907, child_issue=908, spec_dir_name="LIVE_EPIC")
+
+    snapshot = _snapshot(
+        issues={
+            908: GithubIssue(
+                number=908,
+                title="open child",
+                state="open",
+                html_url=f"https://github.com/{REPO}/issues/908",
+            ),
+        },
+        pulls={
+            90: GithubPull(
+                number=90,
+                title="Governing-Issue: #907",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/90",
+                head_sha="9" * 40,
+                head_ref="pr-90",
+                governing_issue=907,
+            )
+        },
+        checks={"9" * 40: "success"},
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(snapshot),
+        **_docs_kwargs(docs_root),
+    )
+
+    item = _item_by_issue(payload, 907)
+    assert item["chain_position"] == "in_progress"
+    assert "stale_epic_with_open_children" not in _flaw_names(item)
 
 
 # ---------------------------------------------------------------------------
@@ -851,6 +954,33 @@ def test_stale_source_ambers_rungs_and_withdraws_counts(tmp_path: Path) -> None:
     assert control_rungs["capability"]["class"] == "proven"
 
 
+def test_delivered_why_now_does_not_overclaim_unevaluated_receipt(tmp_path: Path) -> None:
+    """A delivered thread whose verification-runs source could not be read
+    must not claim "delivered with a terminal verification receipt" — that
+    claims evidence the render never actually saw, the same overclaim class
+    as showing a zero over a dead source."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="completed", issue_number=920, title="delivered"))
+
+    # Drop verification_runs entirely so the source degrades to unavailable
+    # while dispatcher-store itself stays perfectly readable.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE IF EXISTS verification_runs")
+
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    assert _source(payload, "verification-runs")["state"] == "empty"
+    header = _band(payload, "flawed")["header"]
+    assert any(
+        entry["predicate"] == "delivered_without_verification_receipt"
+        for entry in header["not_evaluated"]
+    )
+    item = _item_by_issue(payload, 920)
+    assert item["chain_position"] == "delivered"
+    assert "verification-runs source could not be read" in item["why_now"]
+    assert "terminal verification receipt" not in item["why_now"]
+
+
 # ---------------------------------------------------------------------------
 # Degradation boundary — the #4451 review class of defect
 # ---------------------------------------------------------------------------
@@ -915,3 +1045,37 @@ def test_new_reads_and_predicates_degrade_instead_of_crashing(tmp_path: Path) ->
     assert malformed_payload["claim"]["kind"] == "counted"
     assert _issues_in(malformed_payload, "working") == {970}
     assert _flaw_names(_item_by_issue(malformed_payload, 970)) == set()
+
+
+def test_one_threads_derivation_failure_does_not_crash_the_render(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A structural defense-in-depth guarantee, not just a happy-path proof:
+    if chain-position derivation itself ever raises for one thread (a bug in
+    a future edit to this module, not a source-read failure), the whole
+    render must still stand — that thread renders unclassified instead of
+    taking every other thread down with it."""
+    import app.builderops.cockpit_registry as cockpit_registry
+
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=950, title="poisoned"))
+    store.upsert_task(_task(status="ready", issue_number=951, title="healthy"))
+
+    real_derive_position = cockpit_registry.derive_position
+
+    def _poisoned_derive_position(task, **kwargs):
+        if task.get("issue_number") == 950:
+            raise RuntimeError("synthetic derivation bug")
+        return real_derive_position(task, **kwargs)
+
+    monkeypatch.setattr(cockpit_registry, "derive_position", _poisoned_derive_position)
+
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    assert payload["claim"]["kind"] == "counted"
+    unclassified = {entry["id"]: entry for entry in payload["unclassified"]}
+    assert len(unclassified) == 1
+    (reason,) = [entry["reason"] for entry in unclassified.values()]
+    assert "synthetic derivation bug" in reason
+    # The other thread is entirely unaffected.
+    assert _issues_in(payload, "working") == {951}

--- a/tests/builderops/test_cockpit_chain_states.py
+++ b/tests/builderops/test_cockpit_chain_states.py
@@ -1,0 +1,917 @@
+"""Tests for chain-derived states and flaw predicates (BOPS-COCKPIT-04, #4452).
+
+Every test drives the production join path (``build_registry``) end to end with
+injected plane fixtures — no test performs network or live-repo I/O, and no
+test asserts against a wrapper the production surface does not use.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.builderops.cockpit_chain import (
+    FLAW_PREDICATES,
+    FORGOTTEN_STALL_DAYS,
+    RISK_MAX_TICKS,
+    SOURCE_STALE_AFTER_DAYS,
+    UNREAD_FLAW_PREDICATES,
+)
+from app.builderops.cockpit_github_plane import (
+    GithubIssue,
+    GithubLiveSnapshot,
+    GithubPull,
+)
+from app.builderops.cockpit_registry import build_registry
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.store import SqliteStore
+
+REPO = "RasmusTho/agentic-pkm-mvp"
+
+
+# ---------------------------------------------------------------------------
+# fixtures / helpers (same conventions as the three prior slices' test files)
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat(timespec="microseconds")
+
+
+def _days_ago(days: float) -> str:
+    return _iso(_now() - timedelta(days=days))
+
+
+def _make_store(tmp_path: Path) -> tuple[Path, SqliteStore]:
+    db_path = tmp_path / "dispatcher.sqlite3"
+    store = SqliteStore(db_path)
+    store.initialize()
+    return db_path, store
+
+
+def _task(
+    *,
+    status: str,
+    issue_number: int,
+    title: str = "a task",
+    repo: str = REPO,
+    linked_pr: str | None = None,
+    blocked_reason: str | None = None,
+    claimed_by: str | None = None,
+    lease_id: str | None = None,
+    lease_expires_at: str | None = None,
+    last_heartbeat_at: str | None = None,
+    updated_at: str | None = None,
+    sync_state: dict | None = None,
+) -> TaskRecord:
+    stamp = updated_at or _iso(_now())
+    return TaskRecord(
+        task_id=f"task-{issue_number}-{uuid.uuid4().hex[:6]}",
+        issue_number=issue_number,
+        title=title,
+        status=status,
+        priority="med",
+        repo=repo,
+        source_anchor_refs=[],
+        linked_pr=linked_pr,
+        blocked_reason=blocked_reason,
+        claimed_by=claimed_by,
+        lease_id=lease_id,
+        lease_expires_at=lease_expires_at,
+        last_heartbeat_at=last_heartbeat_at,
+        sync_state=sync_state,
+        created_at=stamp,
+        updated_at=stamp,
+    )
+
+
+def _band(payload: dict, key: str) -> dict:
+    return next(band for band in payload["bands"] if band["key"] == key)
+
+
+def _items(payload: dict, key: str) -> list[dict]:
+    return _band(payload, key)["items"]
+
+
+def _issues_in(payload: dict, key: str) -> set[int]:
+    return {item["issue_number"] for item in _items(payload, key)}
+
+
+def _item_by_issue(payload: dict, issue_number: int) -> dict:
+    for band in payload["bands"]:
+        for item in band["items"]:
+            if item["issue_number"] == issue_number:
+                return item
+    raise AssertionError(f"no item for issue {issue_number} in payload")
+
+
+def _source(payload: dict, name: str) -> dict:
+    return next(s for s in payload["sources"] if s["name"] == name)
+
+
+def _flaw_names(item: dict) -> set[str]:
+    return {flaw["predicate"] for flaw in item["flaws"]}
+
+
+def _all_flaws(payload: dict) -> dict[str, dict]:
+    """Every fired flaw across the whole payload, keyed by predicate name."""
+    found: dict[str, dict] = {}
+    for item in _items(payload, "flawed"):
+        for flaw in item["flaws"]:
+            found[flaw["predicate"]] = flaw
+    return found
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+_CAPABILITIES_YAML = """capabilities:
+  - id: chain-fixture
+    name: Chain Fixture Capability
+    boundary_ref: CFX
+"""
+
+_MATRIX_MD = """| Area | Control boundaries | Implementation issues |
+|---|---|---|
+| Fixture | CFX | #9001 |
+"""
+
+
+def _write_docs_fixture(
+    docs_root: Path,
+    *,
+    epic_issue: int = 807,
+    child_issue: int = 808,
+    spec_dir_name: str = "CHAIN_FIXTURE",
+) -> None:
+    """A minimal spec directory with a *machine* epic edge and one child doc."""
+    _write(docs_root / "capabilities.yaml", _CAPABILITIES_YAML)
+    _write(docs_root / "matrix.md", _MATRIX_MD)
+    _write(
+        docs_root / spec_dir_name / "PARENT_FEATURE_ISSUE.md",
+        f"---\nname: Chain Fixture\ngithub_issue: {epic_issue}\n---\n\n"
+        "# Chain Fixture\n",
+    )
+    _write(
+        docs_root / spec_dir_name / "CHILD_TASK.md",
+        "---\n"
+        "name: Child Task\n"
+        "task_id: CFX-01\n"
+        f"github_issue: {child_issue}\n"
+        "parent_capability: Chain Fixture Capability\n"
+        "---\n\n# Child Task\n",
+    )
+
+
+def _docs_kwargs(docs_root: Path) -> dict:
+    return {
+        "docs_root": docs_root,
+        "capabilities_yaml_path": docs_root / "capabilities.yaml",
+        "matrix_path": docs_root / "matrix.md",
+    }
+
+
+def _snapshot(**kwargs) -> GithubLiveSnapshot:
+    kwargs.setdefault("read_at", _iso(_now()))
+    return GithubLiveSnapshot(**kwargs)
+
+
+def _reader(snapshot: GithubLiveSnapshot):
+    def _read(repo: str) -> GithubLiveSnapshot:
+        assert repo == REPO
+        return snapshot
+
+    return _read
+
+
+# ---------------------------------------------------------------------------
+# AC1 — fail-closed chain position
+# ---------------------------------------------------------------------------
+
+
+def test_unresolvable_position_is_unclassified_not_guessed(tmp_path: Path) -> None:
+    """A position that cannot be computed lands in ``unclassified``, never in a
+    band — and contradictory planes never rescue it into one.
+
+    The fixture is deliberately contradictory: GitHub reports live, open work
+    while the dispatcher record is either unmapped or carries an unreadable
+    movement timestamp. Fail-closed must not mean fail-blind, so the third
+    thread proves the opposite direction: when the live plane *does* settle the
+    stall question on its own, the position is resolved rather than refused.
+    """
+    db_path, store = _make_store(tmp_path)
+    # A: a status word that maps to no chain position at all.
+    store.upsert_task(_task(status="mystery_status", issue_number=901, title="unmapped"))
+    # B: an open status whose only movement timestamps are unreadable, and no
+    #    live PR to settle the stall question from the other side.
+    store.upsert_task(
+        _task(
+            status="ready",
+            issue_number=902,
+            title="unreadable movement",
+            updated_at="not-a-timestamp",
+        )
+    )
+    # C: the same unreadable timestamps, but an open live PR — resolvable.
+    store.upsert_task(
+        _task(
+            status="ready",
+            issue_number=903,
+            title="unreadable movement but live PR",
+            updated_at="not-a-timestamp",
+        )
+    )
+
+    snapshot = _snapshot(
+        issues={
+            number: GithubIssue(
+                number=number,
+                title="still open in GitHub",
+                state="open",
+                html_url=f"https://github.com/{REPO}/issues/{number}",
+            )
+            for number in (901, 902, 903)
+        },
+        pulls={
+            93: GithubPull(
+                number=93,
+                title="Governing-Issue: #903",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/93",
+                head_sha="a" * 40,
+                head_ref="pr-93",
+                governing_issue=903,
+            )
+        },
+        checks={"a" * 40: "success"},
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(snapshot),
+    )
+
+    unclassified = {entry["id"]: entry for entry in payload["unclassified"]}
+    assert len(unclassified) == 2
+
+    # Neither refused thread appears in any band — not even the flaws band,
+    # and not even though GitHub says both issues are open.
+    banded_issues = {
+        item["issue_number"] for band in payload["bands"] for item in band["items"]
+    }
+    assert 901 not in banded_issues
+    assert 902 not in banded_issues
+
+    reasons = " | ".join(entry["reason"] for entry in unclassified.values())
+    assert "mystery_status" in reasons
+    assert "stall test cannot be evaluated" in reasons
+
+    # Fail-closed is not fail-blind: the live plane alone resolves C.
+    item = _item_by_issue(payload, 903)
+    assert item["chain_position"] == "in_progress"
+    assert item["position_evidence"]["open_authority_work"] == 93
+    assert 903 in _issues_in(payload, "working")
+
+    # Band counts never absorb a refused thread.
+    assert _band(payload, "working")["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# AC2 — every flaw predicate fires with named evidence
+# ---------------------------------------------------------------------------
+
+
+def test_each_flaw_predicate_fires_with_evidence(tmp_path: Path) -> None:
+    """One fixture that reproduces every implemented predicate's real shape.
+
+    Also pins the two boundaries the issue draws around the predicate set:
+    ``delivered_never_tried`` is rendered as the done band's empty tried tier
+    and is *never* a red mark, and no predicate fires without the evidence keys
+    its consumer needs (PR number, SHA, lease id, ...).
+    """
+    db_path, store = _make_store(tmp_path)
+    stale_stamp = _days_ago(FORGOTTEN_STALL_DAYS + 16)
+
+    store.upsert_task(
+        _task(
+            status="blocked",
+            issue_number=801,
+            title="blocked",
+            blocked_reason="waiting on upstream",
+        )
+    )
+    store.upsert_task(_task(status="completed", issue_number=802, title="merged"))
+    store.upsert_task(
+        _task(
+            status="claimed",
+            issue_number=803,
+            title="abandoned mid-work",
+            claimed_by="agent-x",
+            lease_id="lease-803",
+            lease_expires_at=_days_ago(2),
+        )
+    )
+    store.upsert_task(
+        _task(status="review", issue_number=804, title="red ci", linked_pr="84")
+    )
+    store.upsert_task(
+        _task(status="review", issue_number=805, title="no ci", linked_pr="85")
+    )
+    store.upsert_task(_task(status="ready", issue_number=806, title="pushed branch"))
+    store.upsert_task(
+        _task(
+            status="ready",
+            issue_number=807,
+            title="stale epic",
+            updated_at=stale_stamp,
+        )
+    )
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root, epic_issue=807, child_issue=808)
+
+    red_sha = "d" * 40
+    quiet_sha = "e" * 40
+    snapshot = _snapshot(
+        issues={
+            # 802 is open in GitHub while the dispatcher says completed.
+            802: GithubIssue(
+                number=802,
+                title="merged",
+                state="open",
+                html_url=f"https://github.com/{REPO}/issues/802",
+            ),
+            # 808 is the epic's open child.
+            808: GithubIssue(
+                number=808,
+                title="open child",
+                state="open",
+                html_url=f"https://github.com/{REPO}/issues/808",
+            ),
+        },
+        pulls={
+            84: GithubPull(
+                number=84,
+                title="red ci",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/84",
+                head_sha=red_sha,
+                head_ref="fix-red",
+                governing_issue=804,
+            ),
+            85: GithubPull(
+                number=85,
+                title="no ci",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/85",
+                head_sha=quiet_sha,
+                head_ref="fix-quiet",
+                governing_issue=805,
+            ),
+        },
+        checks={red_sha: "failure"},
+        branches=("fix-red", "fix-quiet", "issue-806-wip"),
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(snapshot),
+        **_docs_kwargs(docs_root),
+    )
+
+    # Every predicate the module declares was evaluable on this fixture.
+    header = _band(payload, "flawed")["header"]
+    assert header["not_evaluated"] == []
+    assert set(header["evaluated"]) == {p["name"] for p in FLAW_PREDICATES}
+
+    fired = _all_flaws(payload)
+    assert set(fired) == {p["name"] for p in FLAW_PREDICATES}, (
+        "every declared predicate must fire on this fixture; missing: "
+        f"{set(p['name'] for p in FLAW_PREDICATES) - set(fired)}"
+    )
+
+    # -- named evidence keys, per predicate --------------------------------
+    assert fired["blocked_without_next_link"]["evidence"] == {
+        "blocked_reason": "waiting on upstream",
+        "dispatcher_status": "blocked",
+    }
+    assert fired["dispatcher_github_contradiction"]["evidence"] == {
+        "issue_number": 802,
+        "dispatcher_status": "completed",
+        "github_issue_state": "open",
+    }
+    assert fired["expired_lease"]["evidence"]["lease_id"] == "lease-803"
+    assert fired["expired_lease"]["evidence"]["holder"] == "agent-x"
+    assert fired["expired_lease"]["evidence"]["lease_expires_at"] is not None
+    assert fired["pr_ci_red_on_head_sha"]["evidence"] == {
+        "pr_number": 84,
+        "head_sha": red_sha,
+        "check_state": "failure",
+    }
+    assert fired["pr_without_ci_on_head_sha"]["evidence"] == {
+        "pr_number": 85,
+        "head_sha": quiet_sha,
+    }
+    assert fired["pushed_branch_without_pr"]["evidence"] == {
+        "branch": "issue-806-wip",
+        "issue_number": 806,
+    }
+    assert fired["delivered_without_verification_receipt"]["evidence"][
+        "issue_number"
+    ] == 802
+    epic_evidence = fired["stale_epic_with_open_children"]["evidence"]
+    assert epic_evidence["epic_issue"] == 807
+    assert epic_evidence["spec_dir"] == "CHAIN_FIXTURE"
+    assert epic_evidence["open_children"] == [808]
+
+    # A branch already carrying an open PR is never reported as PR-less.
+    assert _flaw_names(_item_by_issue(payload, 804)) == {"pr_ci_red_on_head_sha"}
+
+    # why_now is the predicate's own phrasing, never a number.
+    for item in _items(payload, "flawed"):
+        assert item["why_now"] == item["flaws"][0]["text"]
+        assert not item["why_now"].strip().replace(".", "").isdigit()
+
+    # -- delivered-never-tried: an empty tier, not a red mark ---------------
+    assert "delivered_never_tried" not in fired
+    tried_tier = _band(payload, "done")["tried_tier"]
+    assert tried_tier["items"] == []
+    assert tried_tier["reserved"] is True
+    assert "INV-DG-7" in tried_tier["reason"]
+    assert any(
+        entry["predicate"] == "delivered_never_tried"
+        for entry in header["rendered_elsewhere"]
+    )
+
+
+def test_predicates_not_evaluated_when_their_plane_is_absent(tmp_path: Path) -> None:
+    """A predicate whose plane is missing is named as unevaluated, not fired.
+
+    This is the honesty seam that keeps the flaws band from reading as "no
+    flaws" when it really means "we could not look".
+    """
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(
+        _task(status="blocked", issue_number=811, title="blocked", blocked_reason="x")
+    )
+
+    # No github plane, no docs plane configured.
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    header = _band(payload, "flawed")["header"]
+    unevaluated = {entry["predicate"] for entry in header["not_evaluated"]}
+    assert "pushed_branch_without_pr" in unevaluated
+    assert "stale_epic_with_open_children" in unevaluated
+    assert "dispatcher_github_contradiction" in unevaluated
+    for entry in header["not_evaluated"]:
+        assert "not fresh" in entry["reason"]
+        assert entry["requires"]
+
+    # The predicates that only need the dispatcher store still run.
+    assert "blocked_without_next_link" in header["evaluated"]
+    assert _flaw_names(_item_by_issue(payload, 811)) == {"blocked_without_next_link"}
+
+
+# ---------------------------------------------------------------------------
+# AC3 — one identity, two bands
+# ---------------------------------------------------------------------------
+
+
+def test_dual_band_single_identity(tmp_path: Path) -> None:
+    """A thread holds a working position *and* carries flaws: same id, same
+    spine, no copy drift — including after JSON serialisation, which is where
+    a cloned card would actually diverge on the wire."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(
+        _task(
+            status="blocked",
+            issue_number=820,
+            title="working and flawed",
+            blocked_reason="upstream contract missing",
+        )
+    )
+
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    working = _items(payload, "working")
+    flawed = _items(payload, "flawed")
+    assert len(working) == 1
+    assert len(flawed) == 1
+
+    wire = json.loads(json.dumps(payload))
+    working_card = _items(wire, "working")[0]
+    flawed_card = _items(wire, "flawed")[0]
+
+    # One identity.
+    assert working_card["id"] == flawed_card["id"]
+    # No copy drift: the two appearances are byte-identical on the wire.
+    assert working_card == flawed_card
+    # Same spine, rung for rung.
+    assert working_card["rungs"] == flawed_card["rungs"]
+    # The card names both bands it appears in; its position stays "working".
+    assert working_card["bands"] == ["working", "flawed"]
+    assert working_card["band"] == "working"
+    assert working_card["chain_position"] == "in_progress"
+
+    # One thread, counted once — band memberships are not summed.
+    assert payload["claim"]["text"].startswith("1 threads in motion")
+
+
+# ---------------------------------------------------------------------------
+# AC4 — forgotten needs a stall, never age alone
+# ---------------------------------------------------------------------------
+
+
+def test_forgotten_needs_stall_not_age(tmp_path: Path) -> None:
+    """Decision Q1: forgotten = age **and** no movement in the thread's own
+    authority. Each conjunct alone leaves the thread in progress, so the
+    forgotten band can never become a seniority list."""
+    db_path, store = _make_store(tmp_path)
+    old = _days_ago(FORGOTTEN_STALL_DAYS + 46)
+
+    # A: old and silent in every authority -> forgotten.
+    store.upsert_task(
+        _task(status="ready", issue_number=830, title="truly stalled", updated_at=old)
+    )
+    # B: exactly as old, but an open PR is live movement in GitHub.
+    store.upsert_task(
+        _task(status="ready", issue_number=831, title="old but moving", updated_at=old)
+    )
+    # C: no age at all.
+    store.upsert_task(_task(status="ready", issue_number=832, title="fresh"))
+    # D: old updated_at, but a recent dispatcher heartbeat.
+    store.upsert_task(
+        _task(
+            status="ready",
+            issue_number=833,
+            title="old row, live heartbeat",
+            updated_at=old,
+            last_heartbeat_at=_iso(_now() - timedelta(hours=2)),
+        )
+    )
+
+    snapshot = _snapshot(
+        pulls={
+            31: GithubPull(
+                number=31,
+                title="Governing-Issue: #831",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/31",
+                head_sha="f" * 40,
+                head_ref="pr-31",
+                governing_issue=831,
+            )
+        },
+        checks={"f" * 40: "success"},
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(snapshot),
+    )
+
+    # Only the thread that is both old *and* silent is forgotten.
+    assert _issues_in(payload, "forgotten") == {830}
+    assert _issues_in(payload, "working") == {831, 832, 833}
+
+    # B is provably as old as A — age was present and deliberately insufficient.
+    old_but_moving = _item_by_issue(payload, 831)
+    assert old_but_moving["chain_position"] == "in_progress"
+    assert old_but_moving["position_evidence"]["aged_past_threshold"] is True
+    assert old_but_moving["position_evidence"]["open_authority_work"] == 31
+
+    # A names both halves of the conjunct as its evidence.
+    stalled = _item_by_issue(payload, 830)
+    assert stalled["chain_position"] == "forgotten"
+    assert stalled["position_evidence"]["aged_past_threshold"] is True
+    assert stalled["position_evidence"]["open_authority_work"] is None
+    assert stalled["position_evidence"]["stall_threshold_days"] == FORGOTTEN_STALL_DAYS
+    # why_now is the gate's own phrasing, not an age number.
+    assert stalled["why_now"].startswith("stalled without closure")
+
+    # C is not aged; D's heartbeat is the dispatcher's own movement signal.
+    assert _item_by_issue(payload, 832)["position_evidence"]["aged_past_threshold"] is False
+    assert _item_by_issue(payload, 833)["position_evidence"]["aged_past_threshold"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC5 — ordering within a band only; never hides
+# ---------------------------------------------------------------------------
+
+
+def test_ordering_never_crosses_bands_or_hides(tmp_path: Path) -> None:
+    """EXT-7 / ADR-0057 A1: the risk meter orders inside one band, caps at four
+    ticks, and neither promotes a card into another band nor removes one."""
+    db_path, store = _make_store(tmp_path)
+    old = _days_ago(FORGOTTEN_STALL_DAYS + 6)
+
+    # working, four flaws: blocked + expired lease + PR without CI + a pushed
+    # branch with no PR of its own.
+    store.upsert_task(
+        _task(
+            status="blocked",
+            issue_number=950,
+            title="four flaws",
+            blocked_reason="needs a decision",
+            claimed_by="agent-y",
+            lease_id="lease-950",
+            lease_expires_at=_days_ago(3),
+            linked_pr="90",
+        )
+    )
+    # working, zero flaws.
+    store.upsert_task(_task(status="in_progress", issue_number=951, title="clean"))
+    # forgotten, one flaw — more flaws than the clean working card, and it must
+    # still stay in its own band.
+    store.upsert_task(
+        _task(
+            status="blocked",
+            issue_number=952,
+            title="forgotten and flawed",
+            blocked_reason="nobody picked this up",
+            updated_at=old,
+        )
+    )
+
+    snapshot = _snapshot(
+        pulls={
+            90: GithubPull(
+                number=90,
+                title="four flaws",
+                state="open",
+                html_url=f"https://github.com/{REPO}/pull/90",
+                head_sha="c" * 40,
+                head_ref="pr-90",
+                governing_issue=950,
+            )
+        },
+        branches=("pr-90", "issue-950-old-attempt"),
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(snapshot),
+    )
+
+    # -- nothing hidden: every stored thread is in exactly one position band --
+    position_bands = ("working", "done", "forgotten", "needs_you")
+    appearances: list[int] = []
+    for key in position_bands:
+        appearances.extend(_issues_in(payload, key))
+    assert sorted(appearances) == [950, 951, 952]
+    assert payload["unclassified"] == []
+
+    # -- the meter caps at four and turns destructive only at the cap --------
+    four_flaw = _item_by_issue(payload, 950)
+    assert len(four_flaw["flaws"]) >= RISK_MAX_TICKS
+    assert four_flaw["risk_meter"] == {
+        "ticks": RISK_MAX_TICKS,
+        "max_ticks": RISK_MAX_TICKS,
+        "tone": "destructive",
+    }
+    assert _item_by_issue(payload, 951)["risk_meter"]["tone"] is None
+    assert _item_by_issue(payload, 952)["risk_meter"]["tone"] == "amber"
+
+    # -- ordering is within-band: ticks are non-increasing inside each band --
+    for band in payload["bands"]:
+        ticks = [item["risk_meter"]["ticks"] for item in band["items"]]
+        assert ticks == sorted(ticks, reverse=True), band["key"]
+        assert band["count"] == len(band["items"])
+
+    # -- ordering never crosses a band: the 1-tick forgotten card is NOT
+    #    hoisted above the 0-tick working card into the working band ---------
+    assert _issues_in(payload, "working") == {950, 951}
+    assert _issues_in(payload, "forgotten") == {952}
+    assert [i["issue_number"] for i in _items(payload, "working")] == [950, 951]
+
+    # -- the contract is stated on the payload, so no frontend may reread the
+    #    meter as a ranking (ADR-0057 A1) ---------------------------------
+    ordering = payload["within_band_ordering"]
+    assert ordering["applied"] is True
+    joined = " ".join(ordering["never"]).lower()
+    assert "across bands" in joined
+    assert "hiding" in joined
+    assert "selection" in joined
+
+
+# ---------------------------------------------------------------------------
+# AC6 — unread flaw planes named in the flaws band header
+# ---------------------------------------------------------------------------
+
+
+def test_unread_flaw_planes_named(tmp_path: Path) -> None:
+    """Predicates whose plane this capability does not read at all are named in
+    the flaws band header — absence made visible, never silently omitted."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="in_progress", issue_number=960, title="a thread"))
+
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=tmp_path / "deploys")
+
+    header = _band(payload, "flawed")["header"]
+    named = {entry["predicate"]: entry for entry in header["unread"]}
+    assert named.keys() == {entry["predicate"] for entry in UNREAD_FLAW_PREDICATES}
+    assert named["unpushed_local_worktree"]["plane"] == "git working trees"
+    assert named["unlanded_session_insight"]["plane"] == "session records"
+    assert named["closed_issue_without_owner_doc_receipt"]["plane"] == "issue comments"
+    for entry in named.values():
+        assert entry["reason"]
+
+    # The planes behind those predicates are also named at payload level, so
+    # the surface's own "planes not read" line stays true.
+    assert {"git", "session-records", "issue-comments"} <= set(payload["unread_planes"])
+
+    # The header is structural: it must still name the unread planes when the
+    # dispatcher store is dead and nothing can be counted at all.
+    refused = build_registry(
+        db_path=tmp_path / "nowhere" / "dispatcher.sqlite3",
+        deploy_receipt_dir=tmp_path / "deploys",
+    )
+    assert refused["claim"]["kind"] == "refused"
+    refused_header = _band(refused, "flawed")["header"]
+    assert {entry["predicate"] for entry in refused_header["unread"]} == named.keys()
+    assert _band(refused, "done")["tried_tier"]["reserved"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC7 — stale source ambers rungs and withdraws the counts it owns
+# ---------------------------------------------------------------------------
+
+
+def test_stale_source_ambers_rungs_and_withdraws_counts(tmp_path: Path) -> None:
+    """EXT-3's third pill state, enacted: a source that read fine but is older
+    than the threshold turns its dependent rungs amber and has the counts it
+    owns withdrawn — while every card it backs still renders."""
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="in_progress", issue_number=808, title="child"))
+
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture(docs_root, epic_issue=807, child_issue=808)
+    # The docs plane's watermark is the newest mtime among the files it reads,
+    # so ageing the fixture is the real-world way this source goes stale.
+    stale_epoch = (_now() - timedelta(days=SOURCE_STALE_AFTER_DAYS + 23)).timestamp()
+    for path in docs_root.rglob("*"):
+        if path.is_file():
+            os.utime(path, (stale_epoch, stale_epoch))
+
+    stale_github = _snapshot(
+        read_at=_iso(_now() - timedelta(days=SOURCE_STALE_AFTER_DAYS + 9)),
+        issues={
+            808: GithubIssue(
+                number=808,
+                title="child",
+                state="open",
+                html_url=f"https://github.com/{REPO}/issues/808",
+            )
+        },
+    )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(stale_github),
+        **_docs_kwargs(docs_root),
+    )
+
+    # -- the pill states themselves ----------------------------------------
+    docs_source = _source(payload, "docs-frontmatter")
+    assert docs_source["state"] == "stale"
+    # A stale pill must keep naming the instant it actually read.
+    assert docs_source["last_successful_read"] is not None
+    assert docs_source["stale_after_days"] == SOURCE_STALE_AFTER_DAYS
+    assert _source(payload, "github-live")["state"] == "stale"
+    # A source read at render time can never be stale — and must not be
+    # collateral damage from an unrelated stale one.
+    assert _source(payload, "dispatcher-store")["state"] == "fresh"
+
+    # -- dependent rungs render amber, naming the source that went stale ----
+    item = _item_by_issue(payload, 808)
+    rungs = {rung["name"]: rung for rung in item["rungs"]}
+    assert rungs["capability"]["class"] == "amber"
+    assert rungs["capability"]["stale_source"] == "docs-frontmatter"
+    assert rungs["epic"]["class"] == "amber"
+    assert rungs["epic"]["stale_source"] == "docs-frontmatter"
+    # A rung proven from a *fresh* source is untouched by an unrelated stale one.
+    assert rungs["slice"]["class"] == "proven"
+    assert "stale_source" not in rungs["slice"]
+
+    # -- the counts those sources own are withdrawn, not shown whole --------
+    assert payload["capability_lanes"] == {"countable": False, "lanes": None}
+    assert payload["github"]["countable"] is False
+    assert payload["github"]["open_issues"] is None
+    withdrawn = {entry["source"] for entry in payload["withdrawn_counts"]}
+    assert withdrawn == {"github-live", "docs-frontmatter"}
+
+    # -- withdrawing a count never hides a card ----------------------------
+    assert _issues_in(payload, "working") == {808}
+    assert _band(payload, "working")["countable"] is True
+    assert _band(payload, "working")["count"] == 1
+
+    # -- predicates depending on a stale plane are not evaluated, not fired --
+    unevaluated = {
+        entry["predicate"] for entry in _band(payload, "flawed")["header"]["not_evaluated"]
+    }
+    assert "stale_epic_with_open_children" in unevaluated
+    assert "pushed_branch_without_pr" in unevaluated
+
+    # -- and a fresh-everything control run proves the threshold is what moved
+    fresh_epoch = _now().timestamp()
+    for path in docs_root.rglob("*"):
+        if path.is_file():
+            os.utime(path, (fresh_epoch, fresh_epoch))
+    control = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(_snapshot(issues=stale_github.issues)),
+        **_docs_kwargs(docs_root),
+    )
+    assert _source(control, "docs-frontmatter")["state"] == "fresh"
+    assert control["capability_lanes"]["countable"] is True
+    assert control["withdrawn_counts"] == []
+    control_rungs = {r["name"]: r for r in _item_by_issue(control, 808)["rungs"]}
+    assert control_rungs["capability"]["class"] == "proven"
+
+
+# ---------------------------------------------------------------------------
+# Degradation boundary — the #4451 review class of defect
+# ---------------------------------------------------------------------------
+
+
+def test_new_reads_and_predicates_degrade_instead_of_crashing(tmp_path: Path) -> None:
+    """Everything this slice added degrades to a refusal, never an exception.
+
+    Two real failure modes, not hypotheticals:
+
+    1. the extended ``dispatcher_tasks`` SELECT (``lease_id`` /
+       ``last_heartbeat_at``) meeting an older store that predates those
+       columns — SQLite raises ``OperationalError`` on the missing column;
+    2. a plane snapshot carrying an unexpected value shape, which a predicate
+       would otherwise propagate straight out of ``build_registry``.
+
+    Either must leave the whole registry standing, with the failure attributed
+    to the source that actually failed.
+    """
+    # -- 1. an older dispatcher store without the new columns ---------------
+    legacy_db = tmp_path / "legacy.sqlite3"
+    with sqlite3.connect(legacy_db) as conn:
+        conn.execute(
+            "CREATE TABLE dispatcher_tasks ("
+            " task_id TEXT PRIMARY KEY, issue_number INTEGER, title TEXT,"
+            " status TEXT, priority TEXT, repo TEXT, claimed_by TEXT,"
+            " lease_expires_at TEXT, linked_pr TEXT, blocked_reason TEXT,"
+            " sync_state TEXT, created_at TEXT, updated_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO dispatcher_tasks (task_id, issue_number, title, status,"
+            " priority, repo, created_at, updated_at)"
+            " VALUES ('t1', 1, 'legacy row', 'ready', 'med', ?, ?, ?)",
+            (REPO, _iso(_now()), _iso(_now())),
+        )
+
+    payload = build_registry(
+        db_path=legacy_db, deploy_receipt_dir=tmp_path / "deploys"
+    )
+    dispatcher_source = _source(payload, "dispatcher-store")
+    assert dispatcher_source["state"] == "unavailable"
+    assert "read failed" in dispatcher_source["detail"]
+    assert payload["claim"]["kind"] == "refused"
+    for band in payload["bands"]:
+        assert band["countable"] is False
+        assert band["count"] is None
+
+    # -- 2. a malformed snapshot shape inside a predicate --------------------
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="ready", issue_number=970, title="thread"))
+
+    # `branches` carrying a non-string makes the branch matcher raise TypeError.
+    malformed = _snapshot(branches=(None, "issue-970-wip"))
+
+    malformed_payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=_reader(malformed),
+    )
+    # The registry stands; the predicate simply did not fire.
+    assert malformed_payload["claim"]["kind"] == "counted"
+    assert _issues_in(malformed_payload, "working") == {970}
+    assert _flaw_names(_item_by_issue(malformed_payload, 970)) == set()

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -60,13 +60,28 @@ def _band(payload: dict, key: str) -> dict:
 
 
 def test_band_derivation_fail_closed(tmp_path: Path) -> None:
+    """Fail-closed banding, restated over chain position (#4452).
+
+    #4438 shipped a dispatcher-status-word mapping; BOPS-COCKPIT-04 replaced it
+    with chain-position derivation, so the *band counts* below moved while
+    every honesty contract this test guards stayed put:
+
+    - a fresh unclaimed ``ready`` issue is **in progress**, not forgotten (the
+      register's first question includes the queue); forgotten now requires a
+      stall, proven separately in ``test_forgotten_needs_stall_not_age``;
+    - ``blocked`` is an open chain position that *carries* a flaw rather than
+      being a band of its own, so it appears in working **and** flawed;
+    - ``completed`` with no verification receipt stays delivered and gains the
+      ``delivered_without_verification_receipt`` flaw — gating the position on
+      the receipt would hide an unverified merge from the done band entirely.
+    """
     store, db_path = _make_store(tmp_path)
     store.upsert_task(_task(status="in_progress", issue_number=1, title="working"))
     store.upsert_task(_task(status="completed", issue_number=2, title="done"))
     store.upsert_task(
         _task(status="blocked", issue_number=3, title="flawed", blocked_reason="upstream")
     )
-    store.upsert_task(_task(status="ready", issue_number=4, title="forgotten"))
+    store.upsert_task(_task(status="ready", issue_number=4, title="fresh queue item"))
     store.upsert_task(
         _task(
             status="blocked",
@@ -79,11 +94,16 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
 
     payload = _registry(db_path, tmp_path)
 
+    # Band order stays locked — the contract #4452 must not weaken.
     assert [band["key"] for band in payload["bands"]] == [key for key, _ in BANDS]
-    assert _band(payload, "working")["count"] == 1
+    # in_progress (#1), blocked (#3) and the fresh ready item (#4) all hold an
+    # open chain position.
+    assert _band(payload, "working")["count"] == 3
     assert _band(payload, "done")["count"] == 1
-    assert _band(payload, "flawed")["count"] == 1
-    assert _band(payload, "forgotten")["count"] == 1
+    # Two threads carry a flaw: #3 (blocked) and #2 (delivered, no receipt).
+    assert _band(payload, "flawed")["count"] == 2
+    # Nothing has stalled: no card is forgotten on age it does not have.
+    assert _band(payload, "forgotten")["count"] == 0
     # The needs-human label routes to the needs-you band even from a mapped status.
     assert _band(payload, "needs_you")["count"] == 1
     # The unknown status is listed, never guessed into a band.
@@ -91,8 +111,13 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
     assert payload["unclassified"][0]["status"] == "mystery_status"
     all_items = [item for band in payload["bands"] for item in band["items"]]
     assert all(item["status"] != "mystery_status" for item in all_items)
-    # The flawed item carries the gate's own wording.
-    flawed_item = _band(payload, "flawed")["items"][0]
+    # The claim counts distinct threads, not band memberships: the two
+    # dual-banded threads are each one thread, never two.
+    assert payload["claim"]["text"].startswith("5 threads in motion")
+    # The flawed item carries the gate's own wording — the predicate's phrasing.
+    flawed_item = next(
+        item for item in _band(payload, "flawed")["items"] if item["issue_number"] == 3
+    )
     assert flawed_item["why_now"] == "blocked: upstream"
 
 


### PR DESCRIPTION
Governing-Issue: #4452

Fixes #4452

Final-Review-Rounds: 0

## Summary

Replaces the cockpit registry's dispatcher status-word band mapping with **chain-position** derivation over the joined planes: a thread's band is now where it sits between backlog and delivery, derived deterministically from typed fields (status, movement timestamps, lease expiry, live PR existence) — no LLM call, no fuzzy classification, byte-reproducible across renders. Deficiencies become **flaw predicates**: named, evidence-bearing statements that some link is missing its next link or its verification, each declaring the source planes it needs so a predicate whose plane is not fresh is named as *unevaluated* rather than reading as "no flaw". A thread holds exactly one position band and additionally appears in the flaws band — the same object in both lists, one identity, no copy drift — and this PR also enacts EXT-3's stale pill state, whose consequence is amber rungs plus withdrawal of the counts that source owns.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: Tier 2 implementation slice; no BuilderOps material routed.

## Notes

### Validation

| Command | Result |
|---|---|
| `pytest tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_docs_plane.py tests/api/test_cockpit_api.py -m "not pg"` | **29 passed**, 0 failed |
| `pytest tests/architecture tests/companion_ui/test_cockpit_journeys.py tests/builderops -m "not pg"` | **1078 passed, 1 skipped**, 157 deselected (the skip is the Playwright journey file, which runs in the post-merge browser lane) |
| `ruff check app tests` | All checks passed |
| `python3 scripts/docs_guard.py` | **Docs guard: OK** (this PR touches `docs/BUILDEROPS_COCKPIT/README.md`, so the app-without-docs-touch condition does not arise; per the #4450/#4451 precedent and `ci-smoke.yaml`'s `heavy_smoke` scoping this check is not a blocker for app/tests-touching PRs) |
| `scripts/agent_workspace_preflight.sh` | exit 0 pre-commit and pre-push |
| `scripts/review_before_ci_gate.py --lane implementation` | `status: satisfied`, `ok: true` |

### Claim receipt

```
pickup-claim-complete issue=4452 branch=issue-4452-chain-derived-states
worktree=/Users/rasmusthornberg/code/agentic-pkm-mvp/.claude/worktrees/issue-4452-chain-derived-states
coordination_mode=github-label-only-fallback
fallback_reason=dispatcher pull skips issue 4452: strict readiness validation reports malformed_parent_reference for its 'Parent: **#4447**' line, so the task never enters the store
agent=opus-impl-4452 session=cockpit-child-4452 evidence=github-comment:5142239604
```

`dispatcher-backed` claiming was attempted twice (once before and once after `python3 -m app.dispatcher pull`, which reported `upserted: 41`). Issue #4452 is never admitted to the dispatcher store: `app/dispatcher/sync_github.py::_ready_validation_failure` classifies its body as `malformed_parent_reference`, so `agent:ready` is dropped at pull time and no task id exists to claim. Verified directly against the live issue payload. This is a pre-existing intake defect, not caused by this PR.

### Flaw predicates: implemented vs. named-as-unread

**Implemented (8), each with named evidence keys, each degrading to "not evaluated" when its required plane is not fresh:**

| Predicate | Evidence keys | Required planes |
|---|---|---|
| `blocked_without_next_link` | `blocked_reason`, `dispatcher_status` | dispatcher-store |
| `dispatcher_github_contradiction` | `issue_number`, `dispatcher_status`, `github_issue_state` | dispatcher-store, github-live |
| `expired_lease` | `lease_id`, `holder`, `lease_expires_at` | dispatcher-store |
| `pr_ci_red_on_head_sha` | `pr_number`, `head_sha`, `check_state` | github-live |
| `pr_without_ci_on_head_sha` | `pr_number`, `head_sha` | github-live |
| `pushed_branch_without_pr` | `branch`, `issue_number` | github-live |
| `delivered_without_verification_receipt` | `issue_number`, `pr_number`, `dispatcher_status` | dispatcher-store, verification-runs |
| `stale_epic_with_open_children` | `epic_issue`, `spec_dir`, `open_children`, `last_movement_at` | docs-frontmatter, github-live |

The issue's "PR untouched by CI **or** red on head SHA" is implemented as two predicates because the two halves carry different evidence and mean different things to a reader.

**Rendered elsewhere by contract (1):** `delivered_never_tried` is *not* a flaw. It is visible as the done band's empty `tried_tier` (EXT-2 / decision Q3), and the flaws band header names it under `rendered_elsewhere` so its omission from the red list is explicit rather than accidental.

**Named-as-unread (3)** — surfaced in the flaws band header's `unread` list, each with the plane it is missing:

| Predicate | Missing plane |
|---|---|
| `unpushed_local_worktree` | git working trees |
| `unlanded_session_insight` | session records |
| `closed_issue_without_owner_doc_receipt` | issue comments (the post-merge owner-doc writeback receipt is a comment this capability does not fetch) |

`session-records` and `issue-comments` were also added to the payload-level `unread_planes` so the surface's own "planes not read" line stays true.

### Staleness threshold: 7 days, and why

`SOURCE_STALE_AFTER_DAYS = 7`. Three of the five sources (`dispatcher-store`, `verification-runs`, `deploy-receipts`) stamp their watermark at the instant they read, so the threshold can never fire for them — they are fresh or unavailable, never stale. The one source whose watermark is genuinely a *content* age is `docs-frontmatter`, whose watermark is the newest mtime among the spec files it read. Seven days matches the cadence at which this repo's spec directories actually move: a shorter window would paint the docs plane amber on nearly every render (noise, not honesty), a much longer one would let a genuinely abandoned spec tree keep claiming freshness. `github-live` is included in the withdrawal map even though `default_github_reader` always stamps "now", because decision Q5 anticipates a future mirror-backed reader that would supply an older `read_at`.

### Deliberate design decisions worth a reviewer's eye

- **`delivered` is not gated on the verification receipt.** A merged thread with no receipt stays in the done band and fires `delivered_without_verification_receipt`. Gating the *position* on the receipt would remove an unverified merge from the done band entirely, which is the opposite of what the flaws band exists to show.
- **`blocked` is an open chain position, not a band.** It occupies a link between backlog and merge; what is wrong with it is the predicate. It therefore appears in `working` *and* `flawed`.
- **A live open PR resolves the position on its own.** It settles the forgotten conjunct without needing dispatcher timestamps, so a thread with unreadable timestamps is still resolvable from the live plane — fail-closed, not fail-blind.
- **Band counts are deliberately excluded from stale-withdrawal.** `dispatcher-store` is a render-time read and can never be stale; more importantly `countable: false` already means "render no cards" to the delivered surface (`app/web/static/cockpit.js`), so emitting an uncountable band that still carried items would *hide cards* — precisely what "withdraw the count, never the card" forbids. Withdrawal is scoped to `capability_lanes.lanes` and the `github` facts.

### One intentional test change

`tests/builderops/test_cockpit_registry.py::test_band_derivation_fail_closed` had its **band counts** updated; every honesty-contract assertion in it is unchanged and several were added. This is not a regression — it is the behaviour this issue exists to replace. Under the old status-word table a fresh unclaimed `ready` issue mapped to `forgotten`; the governing spec states the opposite ("an open ready slice issue, even unclaimed... stays here until it meets the forgotten stall condition"). The test now also pins that the claim counts *distinct threads*, so a dual-banded thread is never counted twice. All 28 other pre-existing tests across the three prior slices pass untouched.

### Degradation boundary (the #4451 review class of defect)

This slice adds **no new source read**. What it does add is covered explicitly:

- The extended `dispatcher_tasks` SELECT (`lease_id`, `last_heartbeat_at`) meeting an older store that predates those columns raises `sqlite3.OperationalError`, which the existing `sqlite3.Error` handler catches and degrades to a refused source. Proven by test against a real legacy-schema database, not assumed.
- Every flaw predicate runs behind a broad `except Exception` in `evaluate_flaws`, so a predicate meeting an unexpected value shape degrades to "did not fire" instead of escaping `build_registry`. Proven by test with a malformed snapshot.

Both live in `test_new_reads_and_predicates_degrade_instead_of_crashing`.
