### PR TITLE
fix: stop Dockerfile COPYing the deleted repo-root sitecustomize.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,6 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # - companion-ui/companion-app/ the companion_ui package the companion-ui
 #                               service serves (working_dir + PYTHONPATH)
 # - alembic.ini                 root alembic entry (script_location=app/alembic)
-# - sitecustomize.py            import-time classifier persistence hook
 # - scripts/                    the two entrypoints compose executes
 #                               in-container (migrate + api services) PLUS the
 #                               scripts.<module> Python modules app/** imports
@@ -134,7 +133,7 @@ COPY vault/ ./vault/
 COPY docs/settings/ ./docs/settings/
 COPY docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md ./docs/EPISODE_RESOLUTION_ENGINE/stream_registry.md
 COPY companion-ui/companion-app/ ./companion-ui/companion-app/
-COPY alembic.ini sitecustomize.py ./
+COPY alembic.ini ./
 COPY scripts/start_api.sh scripts/run_migrations.sh \
      scripts/__init__.py scripts/yaml_roundtrip.py \
      scripts/validate_issue_readiness.py scripts/validate_source_anchors.py \


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4476

## Linked Issue
Closes #4476
Closes #4475

## SBS Impact
- Primary subsystem: Builder System (CI/release image build)
- Secondary subsystem(s): none
- Write class: mechanical (one-line Dockerfile fix)
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none
- Owner-doc impact: none
- Transition debt impact: reduces — restores a currently red, queue-wide CI signal
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
Commit `76767cb7` removed the repo-root `sitecustomize.py` but left `Dockerfile:137` still `COPY`ing it, so `Build SHA-tagged app image` fails on every PR branched from current `main`, independent of the PR's own diff. Drops the file from the `COPY` instruction and its now-dangling manifest comment at line 115.

Confirmed no other Dockerfile (`Dockerfile.builderops`, `Dockerfile.builderops-postgres`) references it, and `tests/deploy/test_dockerfile_hardening.py` / `tests/architecture/test_no_repo_sitecustomize.py` (13 tests) pass unchanged.

#4475 and #4476 independently filed the same finding (discovered separately while delivering #4452 and #4138); closing both here.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded mechanical fix; the issues and this PR are the durable evidence.

## Notes
Validation: `python3 -m pytest tests/deploy/test_dockerfile_hardening.py tests/architecture/test_no_repo_sitecustomize.py -q` → 13 passed. `Build SHA-tagged app image` on this PR's own head is the live proof.
