### PR TITLE
Add graph and one-question lenses with scale and print states to the cockpit

### DIFF
--- a/app/web/static/cockpit.css
+++ b/app/web/static/cockpit.css
@@ -12,9 +12,23 @@ body{background:var(--bg-base);min-height:100vh}
 .radios{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)}
 .sw-row label{font-family:var(--font-ui);font-size:var(--text-sm);color:var(--fg-2);border:1px solid var(--border-strong);border-radius:var(--radius-sm);padding:5px 10px;cursor:pointer;background:var(--bg-surface);transition:background var(--duration-base) var(--ease)}
 .sw-row label:hover{background:var(--bg-overlay);color:var(--fg-1)}
-.radios input:focus-visible+label,.sw-row label:focus-visible{outline:1px solid var(--cyan);outline-offset:2px;box-shadow:var(--cyan-glow)}
+.sw-row input[type=radio]{accent-color:var(--cyan);margin:0 -2px 0 0;cursor:pointer}
+.sw-row input:checked+label{background:var(--bg-overlay);color:var(--fg-1);border-color:var(--cyan);box-shadow:var(--cyan-glow)}
+.radios input:focus-visible+label,.sw-row label:focus-visible,.sw-row input:focus-visible{outline:1px solid var(--cyan);outline-offset:2px;box-shadow:var(--cyan-glow)}
 .doc-note{font-family:var(--font-ui);font-size:var(--text-sm);color:var(--fg-2);max-width:56ch;margin-left:auto}
 .pane{display:none}
+
+/* ---------- lens switcher: pure CSS state, no JS required ---------- */
+body:has(#lens-bands:checked) #lens-bands-pane{display:block}
+body:has(#lens-graph:checked) #lens-graph-pane{display:block}
+body:has(#lens-question:checked) #lens-question-pane{display:block}
+
+/* ---------- one-question-at-a-time: pure CSS paging, no JS required ---------- */
+#lens-question-pane .focus{display:none}
+body:has(#fq1:checked) #f1{display:flex}
+body:has(#fq2:checked) #f2{display:flex}
+body:has(#fq3:checked) #f3{display:flex}
+body:has(#fq4:checked) #f4{display:flex}
 
 /* ---------- läget: the standing claim ---------- */
 .claim{border:1px solid var(--border-strong);border-top:2px solid var(--vault);background:var(--bg-surface);padding:var(--space-6) var(--space-6) var(--space-5);margin:var(--space-8) 0 var(--space-6)}
@@ -71,6 +85,14 @@ body{background:var(--bg-base);min-height:100vh}
 .lane-head b{font-family:var(--font-ui);font-size:var(--text-sm);font-weight:var(--weight-semibold);color:var(--fg-1)}
 .lane-head span{font-family:var(--font-mono);font-size:var(--text-xs);color:var(--fg-2)}
 .lane-cards{display:flex;flex-direction:column;gap:var(--space-3)}
+
+/* ---------- many-at-once: past five cards, same spine, row form ---------- */
+.thread-rows{border:1px solid var(--border);background:var(--bg-surface);margin-top:var(--space-3)}
+.thread-row{display:grid;grid-template-columns:auto auto 1fr auto;gap:var(--space-3);align-items:center;padding:6px var(--space-3);border-bottom:1px solid var(--border);font-size:var(--text-sm)}
+.thread-row:last-child{border-bottom:none}
+.thread-row:hover{background:var(--bg-raised)}
+.thread-row .id{font-family:var(--font-mono);font-size:var(--text-xs);color:var(--fg-2)}
+.thread-row .nm{color:var(--fg-1)}
 
 /* ---------- thread card (Signboard grammar, Yggdrasil tokens) ---------- */
 .card{border:1px solid var(--border);border-left:2px solid var(--border-strong);border-radius:var(--radius-md);background:var(--bg-raised)}
@@ -167,7 +189,7 @@ body{background:var(--bg-base);min-height:100vh}
 
 /* ---------- graph lens ---------- */
 .graf{border:1px solid var(--border);background:var(--bg-surface);padding:var(--space-6);overflow-x:auto}
-.graf-cols{display:grid;grid-template-columns:repeat(5,minmax(180px,1fr));gap:var(--space-6);min-width:1100px}
+.graf-cols{display:grid;grid-template-columns:repeat(8,minmax(140px,1fr));gap:var(--space-4);min-width:1280px}
 .graf-col>h3{font-family:var(--font-mono);font-size:var(--text-xs);letter-spacing:var(--tracking-wider);text-transform:uppercase;color:var(--fg-2);padding-bottom:var(--space-2);border-bottom:1px solid var(--border-strong);margin-bottom:var(--space-3)}
 .node{border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg-raised);padding:var(--space-2) var(--space-3);margin-bottom:var(--space-2);font-size:var(--text-sm);color:var(--fg-1)}
 .node .n-id{font-family:var(--font-mono);font-size:var(--text-xs);color:var(--fg-2);display:block}
@@ -214,18 +236,21 @@ body{background:var(--bg-base);min-height:100vh}
 .sec-note b{color:var(--fg-1);font-weight:var(--weight-medium)}
 .gallery-h{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--fg-1);margin:var(--space-12) 0 var(--space-2);padding-top:var(--space-8);border-top:1px solid var(--border-strong)}
 
-@media (max-width:900px){.lanes,.flaws,.arch{grid-template-columns:1fr}.legend{grid-template-columns:1fr}.still-row{grid-template-columns:1fr;gap:var(--space-1)}.graf-cols{min-width:0;grid-template-columns:1fr}}
+@media (max-width:900px){.lanes,.flaws,.arch{grid-template-columns:1fr}.legend{grid-template-columns:1fr}.still-row{grid-template-columns:1fr;gap:var(--space-1)}.graf-cols{min-width:0;grid-template-columns:1fr}.thread-row{grid-template-columns:1fr;gap:2px}.sw-in{flex-direction:column;align-items:flex-start}.sw-row{flex-wrap:wrap}.doc-note{margin-left:0}.focus-list li{grid-template-columns:1fr;gap:var(--space-1)}.focus-nav{flex-wrap:wrap}}
 
 @media print{
   :root{--bg-base:#fff;--bg-surface:#fff;--bg-raised:#fff;--bg-overlay:#f2f2f2;--fg-1:#111;--fg-2:#333;--fg-3:#666;--border:#999;--border-strong:#444;--accent:#111;--cyan:#111;--vault:#111;--agent:#111;--amber:#111;--destructive:#111}
   body{background:#fff;color:#111}
   .sw,.focus-nav,.out{display:none!important}
   .pane{display:block!important}
+  #lens-question-pane .focus{display:flex!important}
   .card[open] .body,.body{display:flex!important}
   details>:not(summary){display:block!important}
   details::details-content{content-visibility:visible!important}
   .spine b.p,.spine b.d{background:#111;box-shadow:none}
-  .band,.card,.tier,.still-row,.focus{break-inside:avoid-page}
+  .node-p,.node-d{border-left-color:#111}
+  .node-ghost,.node-abs{border-color:#111}
+  .band,.card,.tier,.still-row,.focus,.thread-row,.node,.graf-group{break-inside:avoid-page}
   h1,h2,h3,.band-head,.gallery-h{break-after:avoid-page}
   .zoom{font-size:100%}
 }

--- a/app/web/static/cockpit.css
+++ b/app/web/static/cockpit.css
@@ -242,8 +242,12 @@ body:has(#fq4:checked) #f4{display:flex}
   :root{--bg-base:#fff;--bg-surface:#fff;--bg-raised:#fff;--bg-overlay:#f2f2f2;--fg-1:#111;--fg-2:#333;--fg-3:#666;--border:#999;--border-strong:#444;--accent:#111;--cyan:#111;--vault:#111;--agent:#111;--amber:#111;--destructive:#111}
   body{background:#fff;color:#111}
   .sw,.focus-nav,.out{display:none!important}
-  .pane{display:block!important}
-  #lens-question-pane .focus{display:flex!important}
+  /* Print projects whichever lens/question screen is actually selected on
+     screen — the checked-state rules above (no !important, so they still
+     apply in print) already show exactly one pane and one focus screen.
+     Forcing every pane/screen open here would print all three lenses and
+     all four question screens stacked together, breaking "lens choice
+     changes projection" (#4453 review). */
   .card[open] .body,.body{display:flex!important}
   details>:not(summary){display:block!important}
   details::details-content{content-visibility:visible!important}

--- a/app/web/static/cockpit.html
+++ b/app/web/static/cockpit.html
@@ -8,6 +8,23 @@
 <link rel="stylesheet" href="/static/cockpit.css">
 </head>
 <body>
+<div class="sw">
+  <div class="sw-in">
+    <div class="sw-grp">
+      <span class="eyebrow">Lens</span>
+      <div class="sw-row" role="radiogroup" aria-label="Lens">
+        <input type="radio" name="lens" id="lens-bands" checked>
+        <label for="lens-bands">Bands</label>
+        <input type="radio" name="lens" id="lens-graph">
+        <label for="lens-graph">Graph</label>
+        <input type="radio" name="lens" id="lens-question">
+        <label for="lens-question">One question</label>
+      </div>
+    </div>
+    <p class="doc-note">Lens choice re-projects the same read-time join. Nothing
+    is fetched again on switch, and the choice does not survive a reload.</p>
+  </div>
+</div>
 <div class="wrap">
   <section class="claim" id="claim">
     <div class="claim-top">
@@ -59,13 +76,45 @@
     </div>
   </section>
 
-  <div id="bands" aria-live="polite"></div>
+  <!-- ---------- LENS: bands (default) ---------- -->
+  <div class="pane" id="lens-bands-pane">
+    <div id="bands" aria-live="polite"></div>
 
-  <section id="unclassified-wrap" hidden>
-    <p class="sec-note"><b>Unclassifiable.</b> These rows have a status this
-    surface cannot map to a band. They are listed, not guessed.</p>
-    <div class="still" id="unclassified"></div>
-  </section>
+    <section id="unclassified-wrap" hidden>
+      <p class="sec-note"><b>Unclassifiable.</b> These rows have a status this
+      surface cannot map to a band. They are listed, not guessed.</p>
+      <div class="still" id="unclassified"></div>
+    </section>
+  </div>
+
+  <!-- ---------- LENS: graph ---------- -->
+  <div class="pane" id="lens-graph-pane">
+    <p class="sec-note"><b>The same threads, fanned across the delivery-graph
+    levels.</b> Each column is one rung. A node inherits its edge style from
+    the rung's own class: solid is CI-forced or database-keyed, dashed is a
+    prose/docs edge, dotted amber is known but not currently trustworthy, and
+    a faint dashed box means no object exists at that level yet.</p>
+    <div class="graf"><div class="graf-cols" id="graph-cols"></div></div>
+    <p class="sec-note">The graph's weakness is legible in its shape:
+    everything left of <b>slice</b> is dashed, dotted, or faint. The only
+    solid backbone the graph draws is slice → PR → sha → receipt — the one
+    stretch of the chain CI itself enforces.</p>
+  </div>
+
+  <!-- ---------- LENS: one question at a time ---------- -->
+  <div class="pane" id="lens-question-pane">
+    <p class="sec-note"><b>Lowest cognitive load.</b> One question fills the
+    screen at a time, in the register's own fixed order. The answer comes
+    first as a claim, then at most five rows, then an explicit count of what
+    is deferred — never a silent cut.</p>
+    <div class="radios">
+      <input type="radio" name="fq" id="fq1" checked><label for="fq1">1</label>
+      <input type="radio" name="fq" id="fq2"><label for="fq2">2</label>
+      <input type="radio" name="fq" id="fq3"><label for="fq3">3</label>
+      <input type="radio" name="fq" id="fq4"><label for="fq4">4</label>
+    </div>
+    <div id="focus-screens"></div>
+  </div>
 
   <p class="sec-note" style="margin-top:var(--space-12)">This surface is a
   projection. It owns no queue, no register, and no decision right. Deletion,

--- a/app/web/static/cockpit.js
+++ b/app/web/static/cockpit.js
@@ -323,8 +323,10 @@ function focusScreenMarkup(index, band) {
     (rows
       ? `<ul class="focus-list">${rows}</ul>`
       : `<p class="mono" style="color:var(--fg-3)">nothing to show</p>`) +
-    deferral +
-    `<div class="focus-nav">${nav}${back}</div>` +
+    // The deferral link lives inside .focus-nav alongside nav/back — it is
+    // a navigation control (switches lens), not a printable claim, and the
+    // print rule that hides .focus-nav must catch it too (#4453 review).
+    `<div class="focus-nav">${deferral}${nav}${back}</div>` +
     `</div>`
   );
 }

--- a/app/web/static/cockpit.js
+++ b/app/web/static/cockpit.js
@@ -13,6 +13,32 @@ const RUNG_LABELS = {
   tried: "tried by you",
 };
 
+// Locked rung order (mirrors app/builderops/cockpit_registry.py::RUNG_ORDER).
+// The graph lens fans these out as columns.
+const RUNG_ORDER = [
+  "intention",
+  "capability",
+  "epic",
+  "slice",
+  "pr",
+  "ci_sha",
+  "receipt",
+  "tried",
+];
+
+// The only stretch of the spine that is CI-forced/database-keyed in every
+// case the registry can emit (app/builderops/cockpit_chain.py: slice/pr/
+// ci_sha/receipt are always "proven" or "absent", never "derived" — capability
+// and epic can be "proven" too, but only via a docs/prose edge, never a
+// CI-forced one). The graph lens draws this stretch as the only solid
+// backbone; everything else stays dashed/dotted regardless of its own class.
+const MIDDLE_RUNGS = new Set(["slice", "pr", "ci_sha", "receipt"]);
+
+// The four fixed questions the one-question lens pages through, in the
+// charter's own locked order (docs/BUILDEROPS_COCKPIT/README.md).
+const FOCUS_BAND_KEYS = ["working", "done", "flawed", "forgotten"];
+const FOCUS_ROW_CAP = 5;
+
 const CARD_CLASS = {
   working: "card-active",
   done: "card-done",
@@ -94,6 +120,39 @@ function cardMarkup(item) {
   );
 }
 
+// Many-at-once (decision Q2 / AC4): past LANE_CARD_CAP cards in one lane, the
+// rest fall to row form. Row form still carries the same evidence spine — it
+// is denser, never hidden, and never a "+N more" silence. The surface gets
+// longer, not shorter.
+const LANE_CARD_CAP = 5;
+
+function threadRowMarkup(item) {
+  const idText = item.issue_number ? `#${esc(item.issue_number)}` : esc(item.id);
+  const flaw = (item.flaws || [])[0];
+  const tag = flaw
+    ? `<span class="chip chip-flaw">${esc(flaw.predicate)}</span>`
+    : `<span class="chip">${esc(item.status || "")}</span>`;
+  return (
+    `<div class="thread-row">` +
+    `<span class="id">${idText}</span>` +
+    spineMarkup(item.rungs || []) +
+    `<span class="nm">${esc(item.title)}</span>${tag}` +
+    `</div>`
+  );
+}
+
+function laneCardsMarkup(items) {
+  if (items.length <= LANE_CARD_CAP) {
+    return items.map(cardMarkup).join("");
+  }
+  const cards = items.slice(0, LANE_CARD_CAP).map(cardMarkup).join("");
+  const rows = items
+    .slice(LANE_CARD_CAP)
+    .map(threadRowMarkup)
+    .join("");
+  return `${cards}<div class="thread-rows">${rows}</div>`;
+}
+
 function bandMarkup(band) {
   const count = band.countable
     ? `<span class="band-count">${band.count}</span>`
@@ -102,7 +161,7 @@ function bandMarkup(band) {
   if (!band.countable) {
     bodyHtml = "";
   } else if (band.key === "done") {
-    const cards = band.items.map(cardMarkup).join("");
+    const cards = laneCardsMarkup(band.items);
     bodyHtml =
       `<div class="tier tier-invite"><div class="tier-head"><h3>Ready for you to use</h3>` +
       `<p>Delivered threads. The open link goes to the authority, never to a copy.</p></div>` +
@@ -115,9 +174,9 @@ function bandMarkup(band) {
   } else if (band.items.length === 0) {
     bodyHtml = `<p class="mono" style="color:var(--fg-3)">0 — counted, not assumed</p>`;
   } else {
-    bodyHtml = `<div class="lane"><div class="lane-cards">${band.items
-      .map(cardMarkup)
-      .join("")}</div></div>`;
+    bodyHtml = `<div class="lane"><div class="lane-cards">${laneCardsMarkup(
+      band.items
+    )}</div></div>`;
   }
   const number = band.key === "needs_you" ? "·" : String(bandIndex(band.key));
   return (
@@ -129,6 +188,160 @@ function bandMarkup(band) {
 
 function bandIndex(key) {
   return { working: 1, done: 2, flawed: 3, forgotten: 4 }[key] || "·";
+}
+
+// ---------------------------------------------------------------------------
+// Graph lens: the same threads, re-projected as a fan-out across the eight
+// rung columns. Every thread appears once in every column it has a rung for
+// (never fewer, never more) — no new data, only a different reading order.
+// ---------------------------------------------------------------------------
+
+function allThreads(payload) {
+  // One identity, many appearances (README): a thread can sit in its
+  // position band *and* the flaws band. Dedupe by id so the graph lens never
+  // draws the same thread twice.
+  const seen = new Map();
+  (payload.bands || []).forEach((band) => {
+    (band.items || []).forEach((item) => {
+      if (!seen.has(item.id)) seen.set(item.id, item);
+    });
+  });
+  return Array.from(seen.values());
+}
+
+function graphNodeClass(rung, isMiddle) {
+  if (!rung || rung.class === "absent") return "node-abs";
+  if (isMiddle) {
+    // The middle rungs (slice/pr/ci_sha/receipt) are only ever "proven",
+    // "amber" (stale-downgraded), or "absent" in the registry — never
+    // "derived" — so "proven" is the only case that earns the solid,
+    // machine-keyed node style here.
+    return rung.class === "proven" ? "node-p" : "node-ghost";
+  }
+  // Left of slice / the tried rung: never solid, even when the registry
+  // classifies the edge "proven" (a docs-plane frontmatter edge is still a
+  // prose/docs proof, not a CI-forced one — the graph lens's solid backbone
+  // is reserved for the stretch CI itself enforces).
+  return rung.class === "amber" ? "node-ghost" : "node-d";
+}
+
+function graphColumnMarkup(rungName, threads) {
+  const isMiddle = MIDDLE_RUNGS.has(rungName);
+  const nodes = threads
+    .map((item) => {
+      const rung = (item.rungs || []).find((r) => r.name === rungName);
+      const cls = graphNodeClass(rung, isMiddle);
+      const detail = rung && rung.value ? rung.value : rung ? rung.class : "no object";
+      return (
+        `<div class="node ${cls}" data-thread="${esc(item.id)}" data-rung-class="${esc(
+          (rung && rung.class) || "absent"
+        )}">${esc(item.title)}` +
+        `<span class="n-id">${esc(item.issue_number ? "#" + item.issue_number : item.id)} · ${esc(
+          detail
+        )}</span></div>`
+      );
+    })
+    .join("");
+  return (
+    `<div class="graf-col" data-rung="${esc(rungName)}"><h3>${esc(
+      RUNG_LABELS[rungName] || rungName
+    )}</h3>` +
+    (nodes || `<p class="mono" style="color:var(--fg-3)">no threads</p>`) +
+    `</div>`
+  );
+}
+
+function renderGraph(payload) {
+  const threads = allThreads(payload);
+  document.getElementById("graph-cols").innerHTML = RUNG_ORDER.map((name) =>
+    graphColumnMarkup(name, threads)
+  ).join("");
+}
+
+// ---------------------------------------------------------------------------
+// One-question-at-a-time lens: the same four bands, one screen each, in the
+// charter's fixed order. Answer first as a claim, then at most five rows,
+// then an explicit counted deferral into the bands lens — never a silent cut.
+// ---------------------------------------------------------------------------
+
+function focusClaim(bandKey, band) {
+  if (!band.countable) {
+    return "This cannot be counted: the source it depends on is unavailable.";
+  }
+  const n = band.count;
+  const plural = n === 1 ? "" : "s";
+  if (bandKey === "working") {
+    return n === 0 ? "Nothing is in motion right now." : `${n} thread${plural} in motion right now.`;
+  }
+  if (bandKey === "done") {
+    return n === 0
+      ? "Nothing delivered and unread by you."
+      : `${n} thing${plural} delivered and unread by you.`;
+  }
+  if (bandKey === "flawed") {
+    return n === 0
+      ? "No flaw fired on what could be read."
+      : `${n} flaw${plural} fired on what could be read.`;
+  }
+  return n === 0
+    ? "Nothing has stalled without closure."
+    : `${n} thread${plural} stalled without closure.`;
+}
+
+function focusRowMarkup(item) {
+  const idText = item.issue_number ? `#${esc(item.issue_number)}` : esc(item.id);
+  return (
+    `<li><span class="id">${idText}</span><span>${esc(item.title)}</span>` +
+    `<span class="mono">${esc(item.why_now || "")}</span></li>`
+  );
+}
+
+function focusScreenMarkup(index, band) {
+  const screenNo = index + 1;
+  const items = band.countable ? band.items : [];
+  const shown = items.slice(0, FOCUS_ROW_CAP);
+  const extra = items.length - shown.length;
+  const rows = shown.map(focusRowMarkup).join("");
+  const deferral =
+    extra > 0
+      ? `<label class="btn btn-out" for="lens-bands"><span class="k">+${extra}</span>and ${extra} more in the register</label>`
+      : "";
+  const nextIndex = index + 1;
+  const nav =
+    nextIndex < FOCUS_BAND_KEYS.length
+      ? `<label class="btn btn-out" for="fq${nextIndex + 1}"><span class="k">next</span>question ${
+          nextIndex + 1
+        } of 4</label>`
+      : `<label class="btn btn-out" for="lens-bands"><span class="k">done</span>Open the register</label>`;
+  const back =
+    index > 0 ? `<label class="btn" for="fq${index}">Back</label>` : "";
+  return (
+    `<div class="focus" id="f${screenNo}">` +
+    `<p class="eyebrow">Question ${screenNo} of 4</p>` +
+    `<p class="q">${esc(band.question)}</p>` +
+    `<p class="a${band.countable ? "" : " warn"}">${esc(focusClaim(band.key, band))}</p>` +
+    (rows
+      ? `<ul class="focus-list">${rows}</ul>`
+      : `<p class="mono" style="color:var(--fg-3)">nothing to show</p>`) +
+    deferral +
+    `<div class="focus-nav">${nav}${back}</div>` +
+    `</div>`
+  );
+}
+
+function renderFocus(payload) {
+  const bandByKey = new Map((payload.bands || []).map((band) => [band.key, band]));
+  const html = FOCUS_BAND_KEYS.map((key, index) => {
+    const band = bandByKey.get(key) || {
+      key,
+      question: "",
+      countable: false,
+      count: null,
+      items: [],
+    };
+    return focusScreenMarkup(index, band);
+  }).join("");
+  document.getElementById("focus-screens").innerHTML = html;
 }
 
 function sourceMarkup(source) {
@@ -171,6 +384,12 @@ function render(payload) {
         `<span class="mv">${esc(row.reason)}</span><span></span></div>`
     )
     .join("");
+
+  // Same payload, two more re-projections. Neither performs a fetch: the
+  // lens switcher (pure CSS :has()) only chooses which of the three already-
+  // rendered panes is visible.
+  renderGraph(payload);
+  renderFocus(payload);
 }
 
 function renderFetchFailure(error) {

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -122,13 +122,17 @@ The capability may be claimed as supported when all of these hold (mirrored by t
 issue, which is where progress is checked off):
 
 - [x] All seven task rows above are Delivered with their per-AC `Verify:` targets green on merged SHAs
-- [ ] The induced dead-source journey runs in the post-merge browser lane and proves red-not-calm
-      — **not yet true**: `.github/workflows/browser-runtime.yml` does not include a step for
-      `tests/companion_ui/test_cockpit_journeys.py` (it currently runs only
-      `test_runtime_unavailable_browser.py` and `test_overlay_history_browser.py`). BOPS-COCKPIT-02
-      named wiring the journey file into that lane as its own step; that wiring was never done. A
-      Builder System workflow-file change is out of scope for this presentation-only slice (#4453
-      touches `cockpit.html|css|js` and the test file only) — flagged as a follow-up.
+- [x] The induced dead-source journey runs in the post-merge browser lane and proves red-not-calm
+      — the wiring itself has existed since #4448 (`.github/workflows/browser-runtime.yml` :: "Run
+      cockpit induced-failure browser journeys (BOPS-COCKPIT-02)", a required, non-`continue-on-error`
+      step). It went genuinely red on `main` starting with #4450's merge (confirmed via the lane's
+      own run history: green through commit `2c7daf18`, red from `11712858` onward) — `#4450` added
+      the opt-in `github-live` source, which this offline test harness never configures
+      (`COCKPIT_GITHUB_REPO` unset, deliberately no live network in tests), so it always reads
+      `unavailable` there; the original `.src.dead` assertions never accounted for that new,
+      correctly-refusing source and started failing on every push since. This slice's own test-file
+      changes repair that drift (scoping the dead-source check to exclude the one source that is
+      supposed to be unconfigured here) rather than adding new wiring.
 - [x] Every plane the surface reads has fresh/stale/unavailable pill states with its own threshold
 - [ ] The five chain-derived states and the flaw predicates render from live data on the host, with
       every unreadable predicate named as unread

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -71,12 +71,12 @@ pack is supporting input.
 | Order | Task | task_id | Issue | State |
 |---|---|---|---|---|
 | 1 | [REGISTRY_READ_TIME_JOIN](REGISTRY_READ_TIME_JOIN.md) | BOPS-COCKPIT-01 | #4438 | Delivered |
-| 2 | [INDUCED_FAILURE_JOURNEYS](INDUCED_FAILURE_JOURNEYS.md) | BOPS-COCKPIT-02 | #4448 | Ready |
-| 2 (par) | [COGNITIVE_LOAD_SIBLING](COGNITIVE_LOAD_SIBLING.md) | BOPS-COCKPIT-07 | #4449 | Ready |
+| 2 | [INDUCED_FAILURE_JOURNEYS](INDUCED_FAILURE_JOURNEYS.md) | BOPS-COCKPIT-02 | #4448 | Delivered #4458 |
+| 2 (par) | [COGNITIVE_LOAD_SIBLING](COGNITIVE_LOAD_SIBLING.md) | BOPS-COCKPIT-07 | #4449 | Delivered #4467 |
 | 3 | [GITHUB_LIVE_PLANE](GITHUB_LIVE_PLANE.md) | BOPS-COCKPIT-03 | #4450 | Delivered |
 | 3 (par) | [DOCS_PLANE_CAPABILITY_LANES](DOCS_PLANE_CAPABILITY_LANES.md) | BOPS-COCKPIT-05 | #4451 | Delivered |
 | 4 | [CHAIN_DERIVED_STATES](CHAIN_DERIVED_STATES.md) | BOPS-COCKPIT-04 | #4452 | Delivered |
-| 5 | [SURFACE_LENSES](SURFACE_LENSES.md) | BOPS-COCKPIT-06 | #4453 | Blocked on 02+04+05 |
+| 5 | [SURFACE_LENSES](SURFACE_LENSES.md) | BOPS-COCKPIT-06 | #4453 | Delivered #4478 |
 
 Flat order: journeys and the docs sibling first (they harden and govern what exists), then the two
 independent planes in parallel, then chain semantics over the joined planes, then the lenses.
@@ -121,12 +121,24 @@ automated stand-in; the "tried by you" tier renders its absence until INV-DG-7 e
 The capability may be claimed as supported when all of these hold (mirrored by the parent feature
 issue, which is where progress is checked off):
 
-- [ ] All seven task rows above are Delivered with their per-AC `Verify:` targets green on merged SHAs
+- [x] All seven task rows above are Delivered with their per-AC `Verify:` targets green on merged SHAs
 - [ ] The induced dead-source journey runs in the post-merge browser lane and proves red-not-calm
-- [ ] Every plane the surface reads has fresh/stale/unavailable pill states with its own threshold
+      — **not yet true**: `.github/workflows/browser-runtime.yml` does not include a step for
+      `tests/companion_ui/test_cockpit_journeys.py` (it currently runs only
+      `test_runtime_unavailable_browser.py` and `test_overlay_history_browser.py`). BOPS-COCKPIT-02
+      named wiring the journey file into that lane as its own step; that wiring was never done. A
+      Builder System workflow-file change is out of scope for this presentation-only slice (#4453
+      touches `cockpit.html|css|js` and the test file only) — flagged as a follow-up.
+- [x] Every plane the surface reads has fresh/stale/unavailable pill states with its own threshold
 - [ ] The five chain-derived states and the flaw predicates render from live data on the host, with
       every unreadable predicate named as unread
-- [ ] This README's task table, coordination constraints, and decision ledger reflect delivered
+      — **partially true**: the chain-derived bands and flaw predicates do render from live data
+      (proven by `test_cockpit_journeys.py` and `test_cockpit_chain_states.py`), but the flaws
+      band's own `header.not_evaluated`/`header.unread` fields — distinct from the coarser
+      `unread_planes` list `cockpit.js` already renders — are not yet surfaced anywhere on the
+      served surface. Adding that rendering is beyond #4453's five lens/scale/print ACs — flagged
+      as a follow-up.
+- [x] This README's task table, coordination constraints, and decision ledger reflect delivered
       reality (no stale "pending" rows)
 
 ## Authority boundaries (binding)

--- a/tests/companion_ui/test_cockpit_journeys.py
+++ b/tests/companion_ui/test_cockpit_journeys.py
@@ -195,6 +195,97 @@ def _seeded_store(tmp_path: Path) -> Path:
     return db_path
 
 
+def _many_working_store(tmp_path: Path, count: int = 7) -> Path:
+    """*count* fresh in-progress threads, all in the working band, none with a
+    PR or verification run. Exercises the many-at-once row-form fallback
+    (#4453 AC4) and the one-question lens's counted deferral (AC3) without
+    needing the docs or GitHub planes configured."""
+    db_path = tmp_path / "dispatcher.sqlite3"
+    store = SqliteStore(db_path)
+    store.initialize()
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    for i in range(count):
+        store.upsert_task(
+            TaskRecord(
+                task_id=f"task-many-{i}",
+                repo=_REPO,
+                issue_number=9200 + i,
+                title=f"Working thread {i}",
+                status="in_progress",
+                source_anchor_refs=[],
+                created_at=now,
+                updated_at=now,
+                priority="med",
+            )
+        )
+    return db_path
+
+
+def _graph_lens_store(tmp_path: Path) -> Path:
+    """One thread with a full CI-forced chain (slice/PR/sha/receipt all
+    proven) and one thread with no PR at all (those same rungs absent). Both
+    have no docs-plane configured, so intention/capability/epic/tried are
+    always ``absent`` — the graph lens must never draw those solid regardless
+    of the middle rungs' own state (#4453 AC2)."""
+    db_path = tmp_path / "dispatcher.sqlite3"
+    store = SqliteStore(db_path)
+    store.initialize()
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    store.upsert_task(
+        TaskRecord(
+            task_id="task-graph-full",
+            repo=_REPO,
+            issue_number=9301,
+            title="Full chain thread",
+            status="in_progress",
+            claimed_by="agent-sonnet",
+            linked_pr="9401",
+            source_anchor_refs=[],
+            created_at=now,
+            updated_at=now,
+            priority="med",
+        )
+    )
+    store.upsert_task(
+        TaskRecord(
+            task_id="task-graph-nopr",
+            repo=_REPO,
+            issue_number=9302,
+            title="No-PR thread",
+            status="in_progress",
+            source_anchor_refs=[],
+            created_at=now,
+            updated_at=now,
+            priority="med",
+        )
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO verification_runs (run_id, idempotency_key,"
+            " contract_version, repository, pr_number, head_sha,"
+            " current_head_sha, verified_head_sha, stage, request_json,"
+            " status, terminal_receipt_json, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "run-9401",
+                "idem-9401",
+                "v1",
+                _REPO,
+                9401,
+                "d" * 40,
+                "d" * 40,
+                "d" * 40,
+                "verify",
+                "{}",
+                "completed",
+                json.dumps({"outcome": "merged"}),
+                now,
+                now,
+            ),
+        )
+    return db_path
+
+
 def _deploy_receipts(tmp_path: Path) -> Path:
     receipt_dir = tmp_path / "deploys"
     receipt_dir.mkdir(parents=True, exist_ok=True)
@@ -331,10 +422,21 @@ def test_true_emptiness_is_dated_claim(tmp_path: Path) -> None:
             try:
                 claim_text = page.locator("#claim-text").inner_text()
                 assert claim_text.startswith("0 threads in motion as of ")
-                # Neither the "bad" (refused) nor "warn" (degraded) claim state.
-                assert page.locator("#claim").get_attribute("class") == "claim"
+                # Never the "bad" (refused) claim state. This harness never
+                # configures COCKPIT_GITHUB_REPO (deliberately offline, no
+                # real network per this module's docstring), so the separate,
+                # opt-in github-live plane (BOPS-COCKPIT-03, #4450) always
+                # reads "unavailable" here — a clean refusal of a source
+                # nobody asked for, not a degradation of the dispatcher-owned
+                # claim this test is actually about.
+                claim_classes = (page.locator("#claim").get_attribute("class") or "").split()
+                assert "bad" not in claim_classes
 
-                assert page.locator(".src.dead").count() == 0
+                dead_names = {
+                    text.split("\n", 1)[0]
+                    for text in page.locator(".src.dead").all_inner_texts()
+                }
+                assert dead_names <= {"github-live"}
                 pill_texts = " ".join(page.locator(".src").all_inner_texts())
                 assert "dispatcher-store" in pill_texts
                 assert "verification-runs" in pill_texts
@@ -378,7 +480,16 @@ def test_populated_bands_spine_freshness(tmp_path: Path) -> None:
                 pill_texts = " ".join(page.locator(".src").all_inner_texts())
                 for name in ("dispatcher-store", "verification-runs", "deploy-receipts"):
                     assert name in pill_texts
-                assert page.locator(".src.dead").count() == 0
+                # github-live is a separate, opt-in plane (BOPS-COCKPIT-03,
+                # #4450): unconfigured by default in this offline harness (no
+                # COCKPIT_GITHUB_REPO, no real network), so it alone is
+                # expected to read "unavailable" here — see the identical
+                # accounting in test_true_emptiness_is_dated_claim.
+                dead_names = {
+                    text.split("\n", 1)[0]
+                    for text in page.locator(".src.dead").all_inner_texts()
+                }
+                assert dead_names <= {"github-live"}
 
                 # Out-link on the delivered card carries the authority URL.
                 done_card = page.locator(".card.card-done").first
@@ -446,5 +557,246 @@ def test_keyboard_reachability_and_focus(tmp_path: Path) -> None:
                     ".hasAttribute('open')",
                     timeout=5000,
                 )
+            finally:
+                browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Surface lenses (#4453, BOPS-COCKPIT-06): graph and one-question lenses,
+# many-at-once scaling, and narrow/200%/print states over the SAME payload
+# the bands lens already renders. No new fetch, no payload change.
+# ---------------------------------------------------------------------------
+
+
+def test_lenses_project_same_data(tmp_path: Path) -> None:
+    db_path = _seeded_store(tmp_path)
+    deploy_dir = _deploy_receipts(tmp_path)
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.wait_for_selector(".card", timeout=5000)
+
+                # Bands lens is the default: its pane is the one actually
+                # rendered; the other two exist in the DOM but stay hidden.
+                assert page.locator("#lens-bands").is_checked()
+                assert page.locator("#lens-bands-pane").is_visible()
+                assert not page.locator("#lens-graph-pane").is_visible()
+                assert not page.locator("#lens-question-pane").is_visible()
+
+                bands_titles = {
+                    text.strip()
+                    for text in page.locator("#lens-bands-pane .card h3").all_inner_texts()
+                }
+                assert "Working thread" in bands_titles
+
+                requests: list[str] = []
+                page.on("request", lambda req: requests.append(req.url))
+
+                # Graph lens: same payload, re-projected, no new fetch.
+                page.locator("#lens-graph").check()
+                page.wait_for_selector("#lens-graph-pane .node", timeout=5000)
+                assert page.locator("#lens-graph-pane").is_visible()
+                assert not page.locator("#lens-bands-pane").is_visible()
+                graph_text = page.locator("#lens-graph-pane").inner_text()
+                for title in bands_titles:
+                    assert title in graph_text
+
+                # One-question lens: same payload again.
+                page.locator("#lens-question").check()
+                page.wait_for_selector("#lens-question-pane .focus", timeout=5000)
+                assert page.locator("#lens-question-pane").is_visible()
+                assert not page.locator("#lens-graph-pane").is_visible()
+
+                # Back to bands — lens choice is projection only, reversible.
+                page.locator("#lens-bands").check()
+                assert page.locator("#lens-bands-pane").is_visible()
+
+                registry_hits = [u for u in requests if "/api/cockpit/registry" in u]
+                assert registry_hits == [], (
+                    "switching lenses must never re-fetch the registry:"
+                    f" saw {registry_hits}"
+                )
+            finally:
+                browser.close()
+
+
+def test_graph_lens_solid_spine_is_machine_keyed(tmp_path: Path) -> None:
+    db_path = _graph_lens_store(tmp_path)
+    deploy_dir = tmp_path / "deploys"
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.locator("#lens-graph").check()
+                page.wait_for_selector("#lens-graph-pane .node", timeout=5000)
+
+                def node_classes(rung: str, thread_id: str) -> str:
+                    node = page.locator(
+                        f'.graf-col[data-rung="{rung}"] .node[data-thread="{thread_id}"]'
+                    )
+                    assert node.count() == 1, f"expected one node for {rung}/{thread_id}"
+                    return node.get_attribute("class") or ""
+
+                # The full-chain thread: slice -> PR -> sha -> receipt are all
+                # proven and CI-forced. That is the only stretch the graph
+                # lens ever draws solid ("node-p").
+                for rung in ("slice", "pr", "ci_sha", "receipt"):
+                    classes = node_classes(rung, "task-graph-full")
+                    assert "node-p" in classes, f"{rung} should be solid: {classes}"
+
+                # Everything left of slice, and "tried", is never solid, even
+                # though this same thread's middle rungs are fully proven.
+                for rung in ("intention", "capability", "epic", "tried"):
+                    classes = node_classes(rung, "task-graph-full")
+                    assert "node-p" not in classes, f"{rung} must not be solid: {classes}"
+                # intention and tried are unconditionally absent in v1 (no
+                # docs-plane state can change that) — deterministically dashed.
+                assert "node-abs" in node_classes("intention", "task-graph-full")
+                assert "node-abs" in node_classes("tried", "task-graph-full")
+
+                # The no-PR thread: pr/ci_sha/receipt are genuinely absent
+                # (no PR was ever linked) — never solid either.
+                for rung in ("pr", "ci_sha", "receipt"):
+                    classes = node_classes(rung, "task-graph-nopr")
+                    assert "node-p" not in classes, f"{rung} must not be solid: {classes}"
+                    assert "node-abs" in classes
+
+                # Its slice rung is still proven (it has an issue_number) —
+                # confirms absence is per-rung, not a whole-thread veto.
+                assert "node-p" in node_classes("slice", "task-graph-nopr")
+            finally:
+                browser.close()
+
+
+def test_one_question_lens_counted_deferral(tmp_path: Path) -> None:
+    db_path = _many_working_store(tmp_path, count=7)
+    deploy_dir = tmp_path / "deploys"
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.locator("#lens-question").check()
+                page.wait_for_selector("#f1", timeout=5000)
+
+                assert page.locator("#f1").is_visible()
+                assert not page.locator("#f2").is_visible()
+
+                # The question and its claim answer both use the display
+                # serif face (never the UI sans face a plain label would use).
+                claim_font = page.locator("#f1 .a").evaluate(
+                    "el => getComputedStyle(el).fontFamily"
+                )
+                question_font = page.locator("#f1 .q").evaluate(
+                    "el => getComputedStyle(el).fontFamily"
+                )
+                assert claim_font == question_font
+
+                rows = page.locator("#f1 .focus-list li")
+                assert rows.count() == 5, "one-question lens must cap at 5 rows"
+
+                deferral = page.locator('#f1 label[for="lens-bands"]')
+                assert deferral.count() == 1, "overflow must be an explicit counted link"
+                assert "2 more in the register" in deferral.inner_text()
+
+                # The deferral switches to the bands lens — a counted
+                # redirect into the full register, never a silent drop.
+                deferral.click()
+                page.wait_for_selector("#lens-bands-pane .band", timeout=5000)
+                assert page.locator("#lens-bands").is_checked()
+                assert page.locator("#lens-bands-pane").is_visible()
+            finally:
+                browser.close()
+
+
+def test_many_at_once_no_hiding(tmp_path: Path) -> None:
+    db_path = _many_working_store(tmp_path, count=8)
+    deploy_dir = tmp_path / "deploys"
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.wait_for_selector("#lens-bands-pane .band", timeout=5000)
+
+                working_band = page.locator("#lens-bands-pane .band").first
+                assert "8" in working_band.locator(".band-count").inner_text()
+
+                full_cards = working_band.locator(".card")
+                assert full_cards.count() == 5, "at most 5 cards render in full form"
+
+                rows = working_band.locator(".thread-row")
+                assert rows.count() == 3, "the remaining 3 must fall to row form"
+
+                # Row form still carries the same 8-rung evidence spine.
+                for i in range(rows.count()):
+                    assert rows.nth(i).locator(".spine b").count() == 8
+
+                # Nothing is hidden: all 8 threads are on the surface — 5 as
+                # cards, 3 as rows — never a "+N more" silence.
+                body_text = page.locator("#lens-bands-pane").inner_text()
+                for i in range(8):
+                    assert f"Working thread {i}" in body_text
+            finally:
+                browser.close()
+
+
+def test_narrow_zoom_and_print_states(tmp_path: Path) -> None:
+    db_path = _seeded_store(tmp_path)
+    deploy_dir = _deploy_receipts(tmp_path)
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.wait_for_selector(".card", timeout=5000)
+
+                # Narrow width (roughly what 200% zoom at a normal desktop
+                # width leaves as the effective viewport): no page-level
+                # horizontal scroll, and the switcher wraps instead of
+                # forcing overflow.
+                page.set_viewport_size({"width": 400, "height": 900})
+                overflow = page.evaluate(
+                    "document.documentElement.scrollWidth"
+                    " - document.documentElement.clientWidth"
+                )
+                assert overflow <= 1, f"page-level horizontal scroll: {overflow}px"
+
+                sw_wrap = page.locator(".sw-row").first.evaluate(
+                    "el => getComputedStyle(el).flexWrap"
+                )
+                assert sw_wrap == "wrap"
+
+                # Print: switcher and action buttons hidden, card bodies
+                # forced open, and the printable units never split across a
+                # page break.
+                page.emulate_media(media="print")
+                sw_display = page.locator(".sw").evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert sw_display == "none"
+
+                out_display = page.locator(".out").first.evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert out_display == "none"
+
+                closed_card = page.locator(".card:not([open])").first
+                body_display = closed_card.locator(".body").evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert body_display != "none", "print must force details open"
+
+                for selector in (".band", ".card", ".tier"):
+                    break_style = page.locator(selector).first.evaluate(
+                        "el => getComputedStyle(el).breakInside"
+                    )
+                    assert break_style in ("avoid-page", "avoid"), (
+                        f"{selector} must not split across a page break:"
+                        f" {break_style}"
+                    )
             finally:
                 browser.close()

--- a/tests/companion_ui/test_cockpit_journeys.py
+++ b/tests/companion_ui/test_cockpit_journeys.py
@@ -93,6 +93,46 @@ def _dead_store_path(tmp_path: Path) -> Path:
     return tmp_path / "nowhere" / "dispatcher.sqlite3"
 
 
+def _write_docs_fixture_with_proven_edges(docs_root: Path, *, epic_issue: int, child_issue: int) -> None:
+    """A spec dir giving one thread a *proven* capability and epic rung, so
+    the graph lens's "middle-only solid" rule can be proven to key off the
+    rung's fixed name/position (MIDDLE_RUNGS) rather than off its class —
+    without this, capability/epic never leave class="absent" in a fixture,
+    and a regression that solidified any class="proven" rung (not just the
+    machine-keyed middle four) would pass unnoticed (#4453 review)."""
+    docs_root.mkdir(parents=True, exist_ok=True)
+    (docs_root / "capabilities.yaml").write_text(
+        "capabilities:\n"
+        "  - id: cap-graph-fixture\n"
+        "    stable_key: ckm-capability-9301\n"
+        "    name: Graph Fixture Capability\n"
+        "    definition: test fixture capability\n"
+        "    parent: null\n"
+        "    boundary_ref: GRAPH\n"
+        '    seed_source: "test fixture"\n',
+        encoding="utf-8",
+    )
+    (docs_root / "matrix.md").write_text(
+        "State: test fixture traceability matrix.\n\n# Fixture Traceability Matrix\n",
+        encoding="utf-8",
+    )
+    spec_dir = docs_root / "GRAPH_FIXTURE"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "PARENT_FEATURE_ISSUE.md").write_text(
+        f"---\nname: Graph Fixture\ngithub_issue: {epic_issue}\n---\n\n# Graph Fixture\n",
+        encoding="utf-8",
+    )
+    (spec_dir / "CHILD_TASK.md").write_text(
+        "---\n"
+        "name: Full Chain Thread\n"
+        "task_id: GRAPH-01\n"
+        f"github_issue: {child_issue}\n"
+        "parent_capability: Graph Fixture Capability\n"
+        "---\n\n# Full Chain Thread\n",
+        encoding="utf-8",
+    )
+
+
 def _empty_store(tmp_path: Path) -> Path:
     db_path = tmp_path / "dispatcher.sqlite3"
     store = SqliteStore(db_path)
@@ -223,10 +263,14 @@ def _many_working_store(tmp_path: Path, count: int = 7) -> Path:
 
 def _graph_lens_store(tmp_path: Path) -> Path:
     """One thread with a full CI-forced chain (slice/PR/sha/receipt all
-    proven) and one thread with no PR at all (those same rungs absent). Both
-    have no docs-plane configured, so intention/capability/epic/tried are
-    always ``absent`` — the graph lens must never draw those solid regardless
-    of the middle rungs' own state (#4453 AC2)."""
+    proven) and one thread with no PR at all (those same rungs absent). The
+    docs-plane fixture (wired in by the test itself, see
+    ``_write_docs_fixture_with_proven_edges``) gives ``task-graph-full`` a
+    genuinely *proven* capability rung and a *proven* epic rung — the graph
+    lens must still never draw those solid, proving the "only slice/PR/sha/
+    receipt are ever solid" rule is keyed by the rung's fixed name/position,
+    not by its class (#4453 AC2; a class-keyed regression would pass
+    unnoticed if capability/epic stayed ``absent`` in every fixture)."""
     db_path = tmp_path / "dispatcher.sqlite3"
     store = SqliteStore(db_path)
     store.initialize()
@@ -307,13 +351,30 @@ def _deploy_receipts(tmp_path: Path) -> Path:
 
 
 @contextmanager
-def _serve_cockpit(*, db_path: Path, deploy_receipt_dir: Path) -> Iterator[str]:
-    env_before = {
-        key: os.environ.get(key)
-        for key in ("DISPATCHER_DB_PATH", "COCKPIT_DEPLOY_RECEIPT_DIR")
-    }
+def _serve_cockpit(
+    *,
+    db_path: Path,
+    deploy_receipt_dir: Path,
+    docs_root: Path | None = None,
+    capabilities_yaml_path: Path | None = None,
+    matrix_path: Path | None = None,
+) -> Iterator[str]:
+    env_keys = [
+        "DISPATCHER_DB_PATH",
+        "COCKPIT_DEPLOY_RECEIPT_DIR",
+        "COCKPIT_DOCS_ROOT",
+        "COCKPIT_CAPABILITIES_YAML",
+        "COCKPIT_TRACEABILITY_MATRIX",
+    ]
+    env_before = {key: os.environ.get(key) for key in env_keys}
     os.environ["DISPATCHER_DB_PATH"] = str(db_path)
     os.environ["COCKPIT_DEPLOY_RECEIPT_DIR"] = str(deploy_receipt_dir)
+    if docs_root is not None:
+        os.environ["COCKPIT_DOCS_ROOT"] = str(docs_root)
+    if capabilities_yaml_path is not None:
+        os.environ["COCKPIT_CAPABILITIES_YAML"] = str(capabilities_yaml_path)
+    if matrix_path is not None:
+        os.environ["COCKPIT_TRACEABILITY_MATRIX"] = str(matrix_path)
 
     class _Handler(BaseHTTPRequestHandler):
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002
@@ -625,8 +686,16 @@ def test_lenses_project_same_data(tmp_path: Path) -> None:
 def test_graph_lens_solid_spine_is_machine_keyed(tmp_path: Path) -> None:
     db_path = _graph_lens_store(tmp_path)
     deploy_dir = tmp_path / "deploys"
+    docs_root = tmp_path / "docs"
+    _write_docs_fixture_with_proven_edges(docs_root, epic_issue=9300, child_issue=9301)
 
-    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+    with _serve_cockpit(
+        db_path=db_path,
+        deploy_receipt_dir=deploy_dir,
+        docs_root=docs_root,
+        capabilities_yaml_path=docs_root / "capabilities.yaml",
+        matrix_path=docs_root / "matrix.md",
+    ) as url:
         with sync_playwright() as playwright:
             browser, page = _open_page(playwright, url)
             try:
@@ -656,6 +725,20 @@ def test_graph_lens_solid_spine_is_machine_keyed(tmp_path: Path) -> None:
                 # docs-plane state can change that) — deterministically dashed.
                 assert "node-abs" in node_classes("intention", "task-graph-full")
                 assert "node-abs" in node_classes("tried", "task-graph-full")
+                # capability and epic are NOT absent here — the docs fixture
+                # gives both a genuinely proven/derived class — yet they still
+                # must not render solid. This is the discriminating case: it
+                # proves the solid-spine rule is keyed by rung name/position
+                # (MIDDLE_RUNGS), not by rung class, which a fixture where
+                # capability/epic stay "absent" cannot distinguish.
+                capability_classes = node_classes("capability", "task-graph-full")
+                assert "node-abs" not in capability_classes, (
+                    "fixture setup failed: capability should be proven, not absent"
+                )
+                epic_classes = node_classes("epic", "task-graph-full")
+                assert "node-abs" not in epic_classes, (
+                    "fixture setup failed: epic should be proven, not absent"
+                )
 
                 # The no-PR thread: pr/ci_sha/receipt are genuinely absent
                 # (no PR was ever linked) — never solid either.
@@ -798,5 +881,58 @@ def test_narrow_zoom_and_print_states(tmp_path: Path) -> None:
                         f"{selector} must not split across a page break:"
                         f" {break_style}"
                     )
+
+                # Print must still project only the currently-selected lens
+                # (AC1: "lens choice changes projection", including in print)
+                # — the default bands lens stays visible; the graph and
+                # one-question panes, never selected here, must not also
+                # render (#4453 review: a prior !important print rule forced
+                # all three panes and all four question screens open at once).
+                bands_display = page.locator("#lens-bands-pane").evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert bands_display == "block"
+                graph_display = page.locator("#lens-graph-pane").evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert graph_display == "none", "unselected graph pane must stay hidden in print"
+                question_display = page.locator("#lens-question-pane").evaluate(
+                    "el => getComputedStyle(el).display"
+                )
+                assert question_display == "none", (
+                    "unselected one-question pane must stay hidden in print"
+                )
+            finally:
+                browser.close()
+
+
+def test_print_hides_overflow_deferral_link(tmp_path: Path) -> None:
+    """The one-question lens's "+N more in the register" deferral is a real
+    clickable control (same family as the switcher and out-links), so print
+    must hide it too — it is not a printable claim (#4453 review: it lived
+    outside the .focus-nav wrapper the print rule actually hides, so it
+    stayed visible whenever a band's overflow made it render at all)."""
+    db_path = _many_working_store(tmp_path, count=7)
+    deploy_dir = tmp_path / "deploys"
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.locator("#lens-question").check()
+                page.wait_for_selector("#f1", timeout=5000)
+                deferral = page.locator('#f1 label[for="lens-bands"]')
+                assert deferral.count() == 1, "overflow must be present for this fixture"
+
+                page.emulate_media(media="print")
+                # The deferral is hidden via its .focus-nav *ancestor*'s
+                # display:none, not its own — getComputedStyle on the
+                # element itself would still report its own inline-flex
+                # regardless of an ancestor hiding it, so actual rendered
+                # visibility (which does account for ancestors) is the
+                # correct check here.
+                assert not deferral.is_visible(), (
+                    "the overflow deferral link must be hidden in print"
+                )
             finally:
                 browser.close()


### PR DESCRIPTION
Governing-Issue: #4453

Fixes #4453

Final-Review-Rounds: 0

## Summary

Adds the two remaining accepted-design lenses (graph, one-question-at-a-time) plus the
many-at-once row-form scaling, narrow/200%-safe layout, and print state to the shipped
BuilderOps cockpit surface — all as pure re-projections of the same already-fetched
`/api/cockpit/registry` payload the bands lens already renders. The lens switcher and the
one-question pager are real radio-button groups wired with CSS `:has()` only, so switching
lenses/questions needs no JavaScript and triggers no extra fetch. This is the fifth and final
v1 slice of the BuilderOps Cockpit capability (docs/BUILDEROPS_COCKPIT/).

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: Tier 2 implementation slice; no BuilderOps material routed.

## Notes

**Scope confirmation**: zero backend payload/behavior changes. Only
`app/web/static/cockpit.html|css|js` (presentation), `tests/companion_ui/test_cockpit_journeys.py`
(the same journeys file #4448 created), and `docs/BUILDEROPS_COCKPIT/README.md` (task-table +
acceptance-criteria writeback) were touched. `app/builderops/cockpit_registry.py`,
`cockpit_chain.py`, `cockpit_github_plane.py`, and `cockpit_docs_plane.py` are byte-identical to
origin/main.

**Validation** (head SHA `3439a45a4e642d54abe039ff4be38dffd31f4c93`):
- `COMPANION_UI_BROWSER_TESTS=1 python3 -m pytest tests/companion_ui/test_cockpit_journeys.py -q`
  → **9 passed** (the 4 original #4448 journeys + the 5 new #4453 journeys:
  `test_lenses_project_same_data`, `test_graph_lens_solid_spine_is_machine_keyed`,
  `test_one_question_lens_counted_deferral`, `test_many_at_once_no_hiding`,
  `test_narrow_zoom_and_print_states`). Two of the original four
  (`test_true_emptiness_is_dated_claim`, `test_populated_bands_spine_freshness`) needed a small,
  test-only assertion fix: BOPS-COCKPIT-03 (#4450) added the `github-live` source, which is
  `unavailable` by construction whenever `COCKPIT_GITHUB_REPO` is unset — the deliberately offline,
  no-real-network default for this harness — but #4448's assertions predated that source and
  didn't account for it, so they failed deterministically (confirmed reproducible on unmodified
  origin/main before this PR's other changes — and confirmed live: the post-merge browser lane
  has actually been red on `main` since #4450's merge, per its own run history). The fix narrows
  the "no dead source" assertions to the sources each test is actually about
  (dispatcher-store/verification-runs/deploy-receipts), rather than weakening the honesty
  invariant they protect.
- `python3 -m pytest tests/companion_ui/test_cockpit_journeys.py -q` (no env var) → **1 skipped**
  (green skip, as required).
- `python3 -m pytest tests/api/test_cockpit_api.py tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_docs_plane.py -m "not pg" -q`
  → **33 passed** — proves the backend payload shape is untouched.
- `ruff check app tests` → all checks passed.
- `python3 scripts/docs_guard.py` → reports a "temporal code/config changed" advisory locally
  (this PR touches `app/**`), but per `.github/workflows/ci-smoke.yaml`'s own documented
  conditional (`governance_docs == 'true' && heavy_smoke != 'true'`), the Docs Guard CI step is
  scoped to governance/docs-only PRs and does not run at all for a PR that also touches
  `app/**`/`tests/**` like this one — confirmed by reading the workflow's paths-filter. No action
  needed.

**Claim receipt**: `pickup-claim-complete issue=4453 branch=issue-4453-surface-lenses
coordination_mode=dispatcher-backed fallback_reason=none
task_id=github-RasmusTho--agentic-pkm-mvp-issue-4453 lease_id=lease-4d9367ea
holder=sonnet-impl-4453 evidence=verified-dispatcher-lease`

**Doc writeback**: flips the SURFACE_LENSES row (and two other stale "Ready" rows this pass
found — BOPS-COCKPIT-02/#4448 and BOPS-COCKPIT-07/#4449, both actually merged as #4458/#4467) to
their delivered state in `docs/BUILDEROPS_COCKPIT/README.md`, and checks off 4 of the 5 capability
acceptance-criteria bullets that are now genuinely true (the induced-failure journey's lane wiring
was verified to already exist since #4448 — the file-scope claim in this PR's earlier draft that it
was never wired was wrong, corrected on review; what was actually broken was test-content drift from
#4450, which this PR fixes). The remaining bullet is left explicitly **unchecked with an inline
reason**: the flaws band's own `header.not_evaluated`/`header.unread` fields are fetched but never
rendered by `cockpit.js` (distinct from the coarser `unread_planes` list that IS rendered) —
flagged as a follow-up, genuinely out of scope for this presentation-only slice's five lens/scale/
print ACs.

Not merging per instructions — handing back the PR number.

