### PR TITLE
task: render the flaws band's unevaluated-predicate header on the cockpit surface

### DIFF
--- a/app/web/static/cockpit.js
+++ b/app/web/static/cockpit.js
@@ -153,6 +153,32 @@ function laneCardsMarkup(items) {
   return `${cards}<div class="thread-rows">${rows}</div>`;
 }
 
+// The flaws band's own honesty header (app/builderops/cockpit_chain.py
+// ::flaws_band_header): which flaw predicates this render could not evaluate
+// because their required source wasn't fresh (`not_evaluated`), and which
+// flaw types v1 never reads at all (`unread`) — distinct from and more
+// specific than the capability-wide `#unread-planes` list, which names
+// planes the whole surface never reads, not individual flaw predicates.
+function flawsHeaderMarkup(header) {
+  if (!header) return "";
+  const notEvaluated = header.not_evaluated || [];
+  const unread = header.unread || [];
+  let html = "";
+  if (notEvaluated.length) {
+    const items = notEvaluated
+      .map((entry) => `${esc(entry.predicate)} (${esc(entry.reason)})`)
+      .join(" · ");
+    html += `<p class="mono flaws-not-evaluated" style="color:var(--fg-3)">not evaluated this read (source not fresh): ${items}</p>`;
+  }
+  if (unread.length) {
+    const items = unread
+      .map((entry) => `${esc(entry.predicate)} (${esc(entry.plane)})`)
+      .join(" · ");
+    html += `<p class="mono flaws-unread" style="color:var(--fg-3)">flaw types v1 never reads: ${items}</p>`;
+  }
+  return html;
+}
+
 function bandMarkup(band) {
   const count = band.countable
     ? `<span class="band-count">${band.count}</span>`
@@ -160,6 +186,12 @@ function bandMarkup(band) {
   let bodyHtml = "";
   if (!band.countable) {
     bodyHtml = "";
+  } else if (band.key === "flawed") {
+    bodyHtml =
+      flawsHeaderMarkup(band.header) +
+      (band.items.length === 0
+        ? `<p class="mono" style="color:var(--fg-3)">0 — counted, not assumed</p>`
+        : `<div class="lane"><div class="lane-cards">${laneCardsMarkup(band.items)}</div></div>`);
   } else if (band.key === "done") {
     const cards = laneCardsMarkup(band.items);
     bodyHtml =

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -134,14 +134,13 @@ issue, which is where progress is checked off):
       changes repair that drift (scoping the dead-source check to exclude the one source that is
       supposed to be unconfigured here) rather than adding new wiring.
 - [x] Every plane the surface reads has fresh/stale/unavailable pill states with its own threshold
-- [ ] The five chain-derived states and the flaw predicates render from live data on the host, with
+- [x] The five chain-derived states and the flaw predicates render from live data on the host, with
       every unreadable predicate named as unread
-      — **partially true**: the chain-derived bands and flaw predicates do render from live data
-      (proven by `test_cockpit_journeys.py` and `test_cockpit_chain_states.py`), but the flaws
-      band's own `header.not_evaluated`/`header.unread` fields — distinct from the coarser
-      `unread_planes` list `cockpit.js` already renders — are not yet surfaced anywhere on the
-      served surface. Adding that rendering is beyond #4453's five lens/scale/print ACs — flagged
-      as a follow-up.
+      — the chain-derived bands and flaw predicates render from live data (proven by
+      `test_cockpit_journeys.py` and `test_cockpit_chain_states.py`); the flaws band's own
+      `header.not_evaluated`/`header.unread` fields — distinct from the coarser `unread_planes`
+      list `cockpit.js` also renders — are now surfaced on the served surface too (#4479,
+      `test_flaws_band_header_renders_not_evaluated_and_unread`).
 - [x] This README's task table, coordination constraints, and decision ledger reflect delivered
       reality (no stale "pending" rows)
 

--- a/tests/companion_ui/test_cockpit_journeys.py
+++ b/tests/companion_ui/test_cockpit_journeys.py
@@ -936,3 +936,50 @@ def test_print_hides_overflow_deferral_link(tmp_path: Path) -> None:
                 )
             finally:
                 browser.close()
+
+
+def test_flaws_band_header_renders_not_evaluated_and_unread(tmp_path: Path) -> None:
+    """The flaws band's own header (app/builderops/cockpit_chain.py
+    ::flaws_band_header) names which flaw predicates this render could not
+    evaluate because their required source wasn't fresh (``not_evaluated``),
+    and which flaw types v1 never reads at all (``unread``) — distinct from
+    and more specific than the capability-wide ``#unread-planes`` list, which
+    names planes the whole surface never reads, not individual flaw
+    predicates. #4479: the payload already carried this data; cockpit.js
+    never rendered it."""
+    db_path = _seeded_store(tmp_path)
+    deploy_dir = _deploy_receipts(tmp_path)
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                page.wait_for_selector(".card", timeout=5000)
+
+                flawed_band = page.locator("section.band").filter(
+                    has_text="What has flaws?"
+                )
+                assert flawed_band.count() == 1
+
+                # github-live is unconfigured in this offline harness (no
+                # COCKPIT_GITHUB_REPO), so every predicate requiring it is
+                # not evaluated on this render — named, not silently skipped.
+                not_evaluated = flawed_band.locator(".flaws-not-evaluated")
+                assert not_evaluated.count() == 1
+                not_evaluated_text = not_evaluated.inner_text()
+                assert "pr_ci_red_on_head_sha" in not_evaluated_text
+                assert "github-live" in not_evaluated_text
+
+                # The fixed unread set (planes v1 never reads at all).
+                unread = flawed_band.locator(".flaws-unread")
+                assert unread.count() == 1
+                unread_text = unread.inner_text()
+                assert "unpushed_local_worktree" in unread_text
+                assert "git working trees" in unread_text
+
+                # Distinct from the coarser capability-wide list, not a copy.
+                top_unread = page.locator("#unread-planes").inner_text()
+                assert "git" in top_unread
+                assert unread_text != top_unread
+            finally:
+                browser.close()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4479

## Linked Issue
Closes #4479

## SBS Impact
- Primary subsystem: Builder System / CES boundary (BuilderOps Cockpit surface)
- Secondary subsystem(s): none
- Write class: governance/docs/process (presentation-only render of already-computed data; no new source read, no persistence)
- Persistence impact: none
- Derived/rebuildable impact: none new
- New or changed contract: none
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces (closes the flagged #4453 follow-up)
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Render the flaws band's `header.not_evaluated`/`header.unread` fields on the served `/cockpit` surface, distinct from the coarser top-level `unread_planes` list; #4453's own capability acceptance criteria flagged this as an open follow-up.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 presentation fix with no BuilderOps record/projection/receipt implicated.

## Notes
Validation: `ruff check app tests companion-ui/companion-app` (pass); `node --check app/web/static/cockpit.js` (pass); `pytest tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_registry.py tests/api/test_cockpit_api.py -m "not pg"` (all pass, unaffected — backend unchanged). Manual visual verification: stood up a standalone harness replaying the existing `_seeded_store` fixture against the real served `cockpit.html`/`cockpit.js`/`cockpit.css` in the Claude Browser pane; screenshot + DOM read confirm both new lines render inside the flaws band, distinct from `#unread-planes`. The new Playwright regression test (`test_flaws_band_header_renders_not_evaluated_and_unread`) could not run locally — Playwright/Chromium isn't installed on this laptop — but `browser-runtime.yml` already runs the whole `test_cockpit_journeys.py` file post-merge per this repo's own convention (required PR check stays `"Unit tests (not pg)"`; browser journeys are never part of it). `scripts/docs_guard.py` flags this diff locally (any `app/**` change without a root `docs/{STATUS,ROADMAP,ARCHITECTURE,OPERATIONS,HUMAN-FLOWS,AGENT-FLOWS}.md` touch) but `ci-smoke.yaml` scopes that check to governance/docs-only PRs on purpose (see its own comment: running it unconditionally "would newly fail a large class of ordinary runtime PRs") — this PR's real owner-doc writeback is `docs/BUILDEROPS_COCKPIT/README.md`, the capability's own owner doc, which is included.