### PR TITLE
ci: make the vaultwide panel verifier failure readable in smoke-docker

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -478,6 +478,14 @@ jobs:
           source scripts/lib/instance_ownership_host_state.sh
           prepare_instance_ownership_host_state_dir
           compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"
+          # #4463: single source of truth for the verifier's artifact paths. The
+          # diagnostic below used to read the script's workspace-relative tmp/
+          # defaults while the invocation overrode them to absolute /tmp paths,
+          # so a failing gate emitted no evidence at all. Declare once, and both
+          # the writer and the reader stay on the same paths. The run-id/attempt
+          # namespacing is deliberate: it stays precise under concurrent runs.
+          VAULTWIDE_PANEL_LOG_PATH="/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.log"
+          VAULTWIDE_PANEL_REPORT_PATH="/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.report"
           cleanup() {
             rc=$?
             trap - EXIT
@@ -485,11 +493,25 @@ jobs:
               echo "docker compose ps"
               docker compose $compose_files ps || true
               echo "verifier artifacts"
-              ls -1t tmp/verify_vaultwide_panel.*.report tmp/verify_vaultwide_panel.*.log 2>/dev/null | head -n 10 || true
-              latest_report=$(ls -1t tmp/verify_vaultwide_panel.*.report 2>/dev/null | head -n 1 || true)
-              latest_log=$(ls -1t tmp/verify_vaultwide_panel.*.log 2>/dev/null | head -n 1 || true)
-              if [ -n "${latest_report:-}" ]; then echo "=== REPORT (tail 200) ==="; tail -n 200 "$latest_report" || true; fi
-              if [ -n "${latest_log:-}" ]; then echo "=== LOG (tail 200) ==="; tail -n 200 "$latest_log" || true; fi
+              # No stderr suppression: when an artifact is absent, ls naming the
+              # missing path is itself the evidence.
+              ls -l "$VAULTWIDE_PANEL_REPORT_PATH" "$VAULTWIDE_PANEL_LOG_PATH" || true
+              if [ -s "$VAULTWIDE_PANEL_REPORT_PATH" ]; then
+                echo "=== REPORT $VAULTWIDE_PANEL_REPORT_PATH ==="
+                cat "$VAULTWIDE_PANEL_REPORT_PATH" || true
+              else
+                echo "VAULTWIDE_PANEL_VERIFIER_ARTIFACT_MISSING report=$VAULTWIDE_PANEL_REPORT_PATH"
+              fi
+              if [ -s "$VAULTWIDE_PANEL_LOG_PATH" ]; then
+                # The failing assertions are the point of the log, and they can
+                # sit far above its tail, so surface them before the tail.
+                echo "=== LOG FAILURES $VAULTWIDE_PANEL_LOG_PATH ==="
+                grep -F "FAIL: " "$VAULTWIDE_PANEL_LOG_PATH" || echo "(no FAIL: lines in verifier log)"
+                echo "=== LOG (tail 400) $VAULTWIDE_PANEL_LOG_PATH ==="
+                tail -n 400 "$VAULTWIDE_PANEL_LOG_PATH" || true
+              else
+                echo "VAULTWIDE_PANEL_VERIFIER_ARTIFACT_MISSING log=$VAULTWIDE_PANEL_LOG_PATH"
+              fi
               echo "migrate logs (tail=200)"
               docker compose $compose_files logs --no-color --tail=200 migrate || true
               echo "watcher logs (tail=200)"
@@ -508,8 +530,8 @@ jobs:
           prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"
 
           docker compose $compose_files up -d --build db api watcher worker
-          LOG_PATH="/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.log" \
-          REPORT_PATH="/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.report" \
+          LOG_PATH="$VAULTWIDE_PANEL_LOG_PATH" \
+          REPORT_PATH="$VAULTWIDE_PANEL_REPORT_PATH" \
           bash scripts/verify_vaultwide_panel.sh
 
       - name: Skip docker smoke for docs-only PR

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -30,6 +30,13 @@ def _contract_job_text() -> str:
     return workflow[workflow.index("contract-validation:") :]
 
 
+def _vaultwide_panel_verifier_step_text() -> str:
+    workflow = _smoke_text()
+    start = workflow.index('- name: "CI gate: vaultwide panel verifier"')
+    end = workflow.index("- name: Skip docker smoke for docs-only PR", start)
+    return workflow[start:end]
+
+
 def test_pr_ci_selects_subsystem_scoped_pytest_targets() -> None:
     # Moved from the retired ci.yml into ci-smoke.yaml (#3892); the PR unit
     # test lane must keep subsystem-scoped selection, the mandatory mypy
@@ -99,6 +106,87 @@ def test_smoke_docker_runs_for_stable_targeting_pull_requests() -> None:
     assert f"if: {ordinary_pull_request}" in workflow
     assert "Docker smoke is skipped only for ordinary pull requests." in workflow
     assert "types: [opened, synchronize, reopened, edited]" in workflow
+
+
+def test_vaultwide_panel_verifier_diagnostic_reads_runner_paths() -> None:
+    # #4463: the failure diagnostic read the verifier script's workspace-relative
+    # tmp/ defaults while the runner overrode LOG_PATH/REPORT_PATH to absolute
+    # /tmp paths namespaced by run id and attempt. The two never matched, so a
+    # failing gate printed the literal string "verifier artifacts" and nothing
+    # else. Both sides must resolve from one declaration.
+    step = _vaultwide_panel_verifier_step_text()
+
+    log_declaration = (
+        'VAULTWIDE_PANEL_LOG_PATH='
+        '"/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.log"'
+    )
+    report_declaration = (
+        'VAULTWIDE_PANEL_REPORT_PATH='
+        '"/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.report"'
+    )
+    assert step.count(log_declaration) == 1, (
+        "the verifier log path must be declared exactly once, keeping the "
+        "run-id/attempt namespacing"
+    )
+    assert step.count(report_declaration) == 1, (
+        "the verifier report path must be declared exactly once, keeping the "
+        "run-id/attempt namespacing"
+    )
+
+    # The runner writes through the declared paths...
+    assert 'LOG_PATH="$VAULTWIDE_PANEL_LOG_PATH"' in step
+    assert 'REPORT_PATH="$VAULTWIDE_PANEL_REPORT_PATH"' in step
+    assert "bash scripts/verify_vaultwide_panel.sh" in step
+
+    # ...and the failure diagnostic reads the same declared paths back.
+    assert 'cat "$VAULTWIDE_PANEL_REPORT_PATH"' in step
+    assert 'tail -n 400 "$VAULTWIDE_PANEL_LOG_PATH"' in step
+    assert 'grep -F "FAIL: " "$VAULTWIDE_PANEL_LOG_PATH"' in step
+
+    # The stale workspace-relative glob must be gone; it never matched what the
+    # runner wrote, which is exactly how the failure became unreadable.
+    assert "tmp/verify_vaultwide_panel.*" not in step
+
+
+def test_vaultwide_panel_verifier_diagnostic_fails_loud_on_missing_artifact() -> None:
+    # #4463: every `ls` in the old diagnostic was swallowed by
+    # `2>/dev/null || true`, so "no artifact found" and "artifact found and
+    # empty" were indistinguishable from a healthy silent step.
+    step = _vaultwide_panel_verifier_step_text()
+
+    marker = "VAULTWIDE_PANEL_VERIFIER_ARTIFACT_MISSING"
+    assert f'echo "{marker} report=$VAULTWIDE_PANEL_REPORT_PATH"' in step
+    assert f'echo "{marker} log=$VAULTWIDE_PANEL_LOG_PATH"' in step
+
+    # The artifact listing must not suppress its own stderr: the "No such file"
+    # line names the path that was expected and is itself the evidence.
+    listing = 'ls -l "$VAULTWIDE_PANEL_REPORT_PATH" "$VAULTWIDE_PANEL_LOG_PATH"'
+    assert listing in step
+    assert "2>/dev/null" not in step, (
+        "the verifier diagnostic must not discard stderr; a swallowed error is "
+        "how #4463 produced a red gate with no readable evidence"
+    )
+
+
+def test_vaultwide_panel_verifier_gate_remains_blocking() -> None:
+    # #4463 is bounded to legibility: the gate itself keeps failing the job and
+    # the verifier's assertions are untouched.
+    workflow = _smoke_text()
+    step = _vaultwide_panel_verifier_step_text()
+
+    assert '- name: "CI gate: vaultwide panel verifier"' in workflow
+    assert "continue-on-error" not in step
+
+    # The verifier runs bare, so its exit status is the step's exit status, and
+    # the cleanup trap re-raises the original status instead of masking it.
+    assert "bash scripts/verify_vaultwide_panel.sh ||" not in step
+    assert 'exit "$rc"' in step
+
+    verifier = (REPO_ROOT / "scripts" / "verify_vaultwide_panel.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'if [[ "$FAIL" -eq 0 ]]; then' in verifier
+    assert verifier.rstrip().endswith('_log "SUMMARY PASS=$PASS FAIL=$FAIL"\nexit 1')
 
 
 def test_dedicated_subsystem_workflows_have_path_filters_and_browser_runs_post_merge() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4463

## Linked Issue
Closes #4463

## SBS Impact
- Primary subsystem: Builder System / CI
- Secondary subsystem(s): none
- Write class: governance/docs/process — CI workflow observability only
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none; no gate weakened, added, or removed
- Owner-doc impact: none
- Transition debt impact: reduces D12 — a CI gate whose evidence cannot be read is exactly where builder signal vanishes from receipts
- Boundary risk: none — Builder System only; no Product/Runtime surface touched

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Declare the vaultwide panel verifier log/report paths once, above the cleanup trap, so the failure diagnostic and the verifier invocation resolve from the same declaration instead of drifting between workspace-relative `tmp/` defaults and absolute `/tmp` overrides.
- Stop suppressing the diagnostic stderr and emit the greppable `VAULTWIDE_PANEL_VERIFIER_ARTIFACT_MISSING` marker when an artifact is absent, so "found nothing" is no longer indistinguishable from silence.
- Print the report in full and the log `FAIL:` lines ahead of its tail, because a failing assertion can sit far above a 400-line tail.
- Keep the `${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}` namespacing, leave `scripts/verify_vaultwide_panel.sh` untouched, and keep the step blocking.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded CI observability repair with no plan divergence; the defect and its evidence are fully carried by issue #4463 and this diff.

## Notes
- Verification limit worth naming up front: `smoke-docker` runs only post-merge on `main`, on a `v*` tag, or on a PR whose base is `stable` (`if: github.event_name != 'pull_request' || github.base_ref == 'stable'`). This PR targets `main`, so its own CI skips the step. The fix proves itself on the first post-merge `main` run — which is also the run where the underlying verifier failure finally becomes readable.
- The diagnostic branches were executed locally, not merely asserted as strings: the cleanup block was extracted from the parsed workflow and run twice. With both artifacts absent it printed both `VAULTWIDE_PANEL_VERIFIER_ARTIFACT_MISSING` lines naming the exact expected paths and preserved exit 1. With a 503-line synthetic log it surfaced two `FAIL:` lines that a bare `tail -n 400` would have missed — which is why the `FAIL:` grep precedes the tail.
- Out of scope by contract: diagnosing or repairing whatever the verifier then reveals. That gets its own issue once the reason is visible.

## Validation
- `python3 -m pytest -q tests/ops/test_ci_workflow.py` → `21 passed`. The three acceptance tests were written first; `..._diagnostic_reads_runner_paths` and `..._diagnostic_fails_loud_on_missing_artifact` failed against the unchanged workflow, `..._gate_remains_blocking` passed from the start as the constraint guard it is.
- `ruff check app tests` → `All checks passed!`
- `bash tools/audit_smoke.sh` → `Audit ok`
- Precise affected set (every test that reads `ci-smoke.yaml`): `tests/ops/test_ci_workflow.py tests/ops/test_ci_smoke_workflow.py tests/governance/test_ci_smoke_docs_only_gate.py tests/governance/test_ci_test_environment.py tests/deploy/test_dockerfile_python_alignment.py` → `37 passed`.
- Wider net `tests/ops tests/governance tests/architecture` → `1 failed, 1376 passed, 5 skipped`. The one failure, `tests/governance/test_start_model_inquiry_skill.py::test_launcher_fails_closed_on_an_absent_declared_credential`, was reproduced identically on an `origin/main` worktree, so the base-vs-head delta is 0. It is a laptop Keychain/credential-host failure with no path to either changed file.
- The step script was extracted from the parsed YAML and passed `bash -n`; the workflow parses as YAML and the step carries no `continue-on-error`.
