### PR TITLE
Distinguish an opted-out cockpit source from a broken one (#4481)

### DIFF
--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -135,6 +135,12 @@ class _SourceRead:
     state: str  # "fresh" | "stale" | "empty" | "unavailable"
     last_successful_read: str | None
     detail: str
+    # EXT-8: an optional-by-design plane whose enabling config is simply absent
+    # is not a broken source. `configured` separates the two so the surface can
+    # render "never turned on" calmly while a genuinely dead source stays loud.
+    # It never affects `state`, which stays "unavailable" either way — an
+    # unconfigured plane still owns no countable facts.
+    configured: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -143,6 +149,7 @@ class _SourceRead:
             "last_successful_read": self.last_successful_read,
             "detail": self.detail,
             "stale_after_days": SOURCE_STALE_AFTER_DAYS,
+            "configured": self.configured,
         }
 
 
@@ -344,6 +351,13 @@ def _read_github_live(
     function (``fetch_github_live`` already catches every failure mode), and
     a failed/unconfigured read yields ``state="unavailable"`` — the refused
     claim, never a fabricated empty snapshot.
+
+    The two refusals are distinguished by ``configured`` (EXT-8), not by
+    ``state``: this plane is opt-in, so an absent ``repo`` means nobody asked
+    for it, while a present ``repo`` whose read fails is a real outage. The
+    flag mirrors ``fetch_github_live``'s own ``if not repo`` branch — the one
+    place that "no repo configured" refusal is produced — rather than matching
+    on its detail text.
     """
     result = fetch_github_live(repo, reader=reader)
     sources.add(
@@ -352,6 +366,7 @@ def _read_github_live(
             state=result.state,
             last_successful_read=result.last_successful_read,
             detail=result.detail,
+            configured=bool(repo),
         )
     )
     return result.snapshot

--- a/app/web/static/cockpit.css
+++ b/app/web/static/cockpit.css
@@ -45,6 +45,11 @@ body:has(#fq4:checked) #f4{display:flex}
 .src.stale{border-left-color:var(--amber)}.src.stale span{color:var(--amber)}
 .src.dead{border-left-color:var(--destructive);background:var(--destructive-muted)}.src.dead span{color:var(--destructive)}
 .src.dead b{color:var(--destructive)}
+/* EXT-8: opted out, not broken. Recedes rather than alarms — no destructive
+   colour, no amber, no raised background: the pill still names itself and its
+   reason, it just stops competing for attention it does not deserve. */
+.src.off{border-left-color:var(--border);background:transparent}
+.src.off b,.src.off span{color:var(--fg-3)}
 
 /* ---------- legend, always visible ---------- */
 .legend{display:grid;grid-template-columns:1.4fr 1fr 1fr;gap:var(--space-6);border:1px solid var(--border);background:var(--bg-surface);padding:var(--space-4) var(--space-5);margin-bottom:var(--space-8)}

--- a/app/web/static/cockpit.js
+++ b/app/web/static/cockpit.js
@@ -379,20 +379,38 @@ function renderFocus(payload) {
 }
 
 function sourceMarkup(source) {
-  const cls = source.state === "unavailable" ? " dead" : source.state === "stale" ? " stale" : "";
+  // EXT-8: an optional plane that was never turned on is unavailable but not
+  // broken. It gets its own calm class and says so in words — the loud
+  // `.src.dead` treatment is reserved for a source that was expected to work.
+  const optedOut = source.state === "unavailable" && source.configured === false;
+  const cls = optedOut
+    ? " off"
+    : source.state === "unavailable"
+      ? " dead"
+      : source.state === "stale"
+        ? " stale"
+        : "";
   const read = source.last_successful_read
     ? `read ${source.last_successful_read}`
-    : "no successful read";
+    : optedOut
+      ? "never enabled"
+      : "no successful read";
   return (
     `<div class="src${cls}"><b>${esc(source.name)}</b>` +
-    `<span>${esc(source.state)} · ${esc(read)}</span>` +
+    `<span>${esc(optedOut ? "not enabled" : source.state)} · ${esc(read)}</span>` +
     `<span>${esc(source.detail || "")}</span></div>`
   );
 }
 
 function render(payload) {
   const claimSection = document.getElementById("claim");
-  const anyDead = (payload.sources || []).some((s) => s.state === "unavailable");
+  // Only a source that was supposed to be readable counts toward the banner's
+  // amber. An opted-out optional plane (EXT-8) is a permanent, calm baseline;
+  // counting it would leave every deployed cockpit amber forever and drain the
+  // signal from a real outage.
+  const anyDead = (payload.sources || []).some(
+    (s) => s.state === "unavailable" && s.configured !== false
+  );
   claimSection.classList.toggle("bad", payload.claim.kind === "refused");
   claimSection.classList.toggle("warn", payload.claim.kind !== "refused" && anyDead);
   document.getElementById("claim-text").textContent = payload.claim.text;

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -50,7 +50,12 @@ pack is supporting input.
   `verification-runs` (SQLite read-only), `deploy-receipts`; unread planes named as unread. The
   third pill state, **stale** (EXT-3), arrived with BOPS-COCKPIT-04 (#4452): a source whose own
   watermark is older than `SOURCE_STALE_AFTER_DAYS` turns the rungs it backs amber and has the
-  counts it owns withdrawn rather than shown whole.
+  counts it owns withdrawn rather than shown whole. A read carries `configured` alongside `state`
+  (EXT-8, #4481): an optional-by-design plane whose enabling config is absent — `github-live` with
+  `COCKPIT_GITHUB_REPO` unset, the steady state on every host until #4484 — renders as *not
+  enabled* rather than dead and never contributes to the claim banner's amber, while a plane that
+  was configured and then failed still does both. `state` is unchanged in either case: an
+  unconfigured plane still owns no countable facts.
 - **Honest emptiness in three forms** — dated true emptiness; refused claims on dead sources
   ("cannot be counted", never zero); structural absence distinct from death.
 - **Two tiers in the done band** — "Ready for you to use" above "Tried by you" (empty by contract

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -163,6 +163,56 @@ def test_true_emptiness_is_dated_claim(tmp_path: Path) -> None:
     assert deploy_source["state"] == "empty"
 
 
+def test_unconfigured_github_source_marks_not_configured(tmp_path: Path) -> None:
+    """EXT-8: an opt-in plane nobody turned on is unavailable but configured=False.
+
+    ``state`` still says ``unavailable`` — the plane owns no countable facts
+    either way — but the payload now carries enough for the surface to tell
+    "never enabled" apart from "broken".
+    """
+    _, db_path = _make_store(tmp_path)
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=None,
+    )
+
+    github_source = next(
+        s for s in payload["sources"] if s["name"] == "github-live"
+    )
+    assert github_source["state"] == "unavailable"
+    assert github_source["configured"] is False
+
+    # Every other source is configured by construction: only a plane that is
+    # optional *and* unset may claim otherwise.
+    for source in payload["sources"]:
+        if source["name"] != "github-live":
+            assert source["configured"] is True
+
+
+def test_configured_github_failure_stays_configured(tmp_path: Path) -> None:
+    """A configured plane that fails is a real outage, and must stay loud."""
+    _, db_path = _make_store(tmp_path)
+
+    def failing_reader(repo: str):
+        raise RuntimeError("simulated read failure on a configured plane")
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo="RasmusTho/agentic-pkm-mvp",
+        github_reader=failing_reader,
+    )
+
+    github_source = next(
+        s for s in payload["sources"] if s["name"] == "github-live"
+    )
+    assert github_source["state"] == "unavailable"
+    assert github_source["configured"] is True
+    assert github_source["last_successful_read"] is None
+
+
 def test_rung_classification_machine_edges_only(tmp_path: Path) -> None:
     store, db_path = _make_store(tmp_path)
     repo = "RasmusTho/agentic-pkm-mvp"

--- a/tests/companion_ui/test_cockpit_journeys.py
+++ b/tests/companion_ui/test_cockpit_journeys.py
@@ -64,6 +64,7 @@ except ImportError:
     )
 
 from app.api.routes.cockpit import registry as _cockpit_registry_endpoint
+from app.builderops import cockpit_github_plane
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.store import SqliteStore
 
@@ -358,6 +359,7 @@ def _serve_cockpit(
     docs_root: Path | None = None,
     capabilities_yaml_path: Path | None = None,
     matrix_path: Path | None = None,
+    github_repo: str | None = None,
 ) -> Iterator[str]:
     env_keys = [
         "DISPATCHER_DB_PATH",
@@ -365,10 +367,18 @@ def _serve_cockpit(
         "COCKPIT_DOCS_ROOT",
         "COCKPIT_CAPABILITIES_YAML",
         "COCKPIT_TRACEABILITY_MATRIX",
+        # Held explicitly so an ambient COCKPIT_GITHUB_REPO on the runner
+        # cannot leak the opt-in live plane — and its network call — into a
+        # journey that never asked for it. Unset unless a test opts in.
+        "COCKPIT_GITHUB_REPO",
     ]
     env_before = {key: os.environ.get(key) for key in env_keys}
     os.environ["DISPATCHER_DB_PATH"] = str(db_path)
     os.environ["COCKPIT_DEPLOY_RECEIPT_DIR"] = str(deploy_receipt_dir)
+    if github_repo is None:
+        os.environ.pop("COCKPIT_GITHUB_REPO", None)
+    else:
+        os.environ["COCKPIT_GITHUB_REPO"] = github_repo
     if docs_root is not None:
         os.environ["COCKPIT_DOCS_ROOT"] = str(docs_root)
     if capabilities_yaml_path is not None:
@@ -489,15 +499,15 @@ def test_true_emptiness_is_dated_claim(tmp_path: Path) -> None:
                 # opt-in github-live plane (BOPS-COCKPIT-03, #4450) always
                 # reads "unavailable" here — a clean refusal of a source
                 # nobody asked for, not a degradation of the dispatcher-owned
-                # claim this test is actually about.
+                # claim this test is actually about. Since EXT-8 (#4481) that
+                # opted-out plane no longer ambers the banner either, so
+                # "warn" is asserted too: without it, the false-positive amber
+                # would mask a real regression in this computation.
                 claim_classes = (page.locator("#claim").get_attribute("class") or "").split()
                 assert "bad" not in claim_classes
+                assert "warn" not in claim_classes
 
-                dead_names = {
-                    text.split("\n", 1)[0]
-                    for text in page.locator(".src.dead").all_inner_texts()
-                }
-                assert dead_names <= {"github-live"}
+                assert page.locator(".src.dead").count() == 0
                 pill_texts = " ".join(page.locator(".src").all_inner_texts())
                 assert "dispatcher-store" in pill_texts
                 assert "verification-runs" in pill_texts
@@ -506,6 +516,114 @@ def test_true_emptiness_is_dated_claim(tmp_path: Path) -> None:
                 counts = page.locator(".band-count").all_inner_texts()
                 assert len(counts) == 5
                 assert all(count.strip() == "0" for count in counts)
+            finally:
+                browser.close()
+
+
+def test_unconfigured_source_pill_is_not_dead(tmp_path: Path) -> None:
+    """EXT-8 (#4481): a plane nobody turned on renders calm, and says why.
+
+    `github-live` is opt-in and no deployment sets COCKPIT_GITHUB_REPO, so the
+    unconfigured read is the permanent steady state on every deployed cockpit
+    — it must not wear the treatment reserved for a source that broke.
+    """
+    db_path = _empty_store(tmp_path)
+    deploy_dir = tmp_path / "deploys"
+
+    with _serve_cockpit(db_path=db_path, deploy_receipt_dir=deploy_dir) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                github_pill = page.locator(".src", has_text="github-live")
+                assert github_pill.count() == 1
+                classes = (github_pill.first.get_attribute("class") or "").split()
+                assert "off" in classes
+                assert "dead" not in classes
+
+                # It still names itself, in words, rather than going silent.
+                pill_text = github_pill.first.inner_text()
+                assert "not enabled" in pill_text
+                assert "COCKPIT_GITHUB_REPO" in pill_text
+
+                # Nothing else regressed into the dead treatment.
+                assert page.locator(".src.dead").count() == 0
+            finally:
+                browser.close()
+
+
+def test_claim_banner_ignores_unconfigured_optional_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The banner ambers for real failures only — never for an opted-out plane.
+
+    Three states, one computation: opted-out stays calm, a required source
+    that dies ambers, and an *optional* source that was configured and then
+    failed ambers too. Without the middle and last cases this test would pass
+    on a client that simply never ambers.
+    """
+    deploy_dir = tmp_path / "deploys"
+
+    # (1) Opted out: unavailable, but nobody asked for it. Calm.
+    with _serve_cockpit(
+        db_path=_empty_store(tmp_path / "calm"), deploy_receipt_dir=deploy_dir
+    ) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                classes = (page.locator("#claim").get_attribute("class") or "").split()
+                assert "warn" not in classes
+                assert "bad" not in classes
+            finally:
+                browser.close()
+
+    # (2) A required source that dies still ambers. A malformed deploy receipt
+    # is a read failure of a source the surface always reads — unlike a missing
+    # receipt, which is structural absence and stays "empty".
+    broken_deploys = tmp_path / "broken-deploys"
+    broken_deploys.mkdir()
+    (broken_deploys / "dev-latest.json").write_text("{not json", encoding="utf-8")
+
+    with _serve_cockpit(
+        db_path=_empty_store(tmp_path / "amber"), deploy_receipt_dir=broken_deploys
+    ) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                classes = (page.locator("#claim").get_attribute("class") or "").split()
+                assert "warn" in classes
+                dead_names = {
+                    text.split("\n", 1)[0]
+                    for text in page.locator(".src.dead").all_inner_texts()
+                }
+                assert "deploy-receipts" in dead_names
+            finally:
+                browser.close()
+
+    # (3) An *optional* plane that was configured and then failed is a real
+    # outage on a host that did opt in — still amber, still the dead pill.
+    # The failure is injected at the `gh` subprocess boundary so the whole
+    # production reader path runs with no network (module docstring rule).
+    def _refuse(args: list[str]):
+        raise cockpit_github_plane.GithubReadError("simulated read failure")
+
+    monkeypatch.setattr(cockpit_github_plane, "_run_gh", _refuse)
+
+    with _serve_cockpit(
+        db_path=_empty_store(tmp_path / "configured"),
+        deploy_receipt_dir=deploy_dir,
+        github_repo=_REPO,
+    ) as url:
+        with sync_playwright() as playwright:
+            browser, page = _open_page(playwright, url)
+            try:
+                classes = (page.locator("#claim").get_attribute("class") or "").split()
+                assert "warn" in classes
+                github_pill = page.locator(".src", has_text="github-live")
+                github_classes = (
+                    github_pill.first.get_attribute("class") or ""
+                ).split()
+                assert "dead" in github_classes
+                assert "off" not in github_classes
             finally:
                 browser.close()
 
@@ -543,14 +661,13 @@ def test_populated_bands_spine_freshness(tmp_path: Path) -> None:
                     assert name in pill_texts
                 # github-live is a separate, opt-in plane (BOPS-COCKPIT-03,
                 # #4450): unconfigured by default in this offline harness (no
-                # COCKPIT_GITHUB_REPO, no real network), so it alone is
-                # expected to read "unavailable" here — see the identical
-                # accounting in test_true_emptiness_is_dated_claim.
-                dead_names = {
-                    text.split("\n", 1)[0]
-                    for text in page.locator(".src.dead").all_inner_texts()
-                }
-                assert dead_names <= {"github-live"}
+                # COCKPIT_GITHUB_REPO, no real network), so it alone reads
+                # "unavailable" here — and since EXT-8 (#4481) it renders as
+                # opted-out rather than dead, and leaves the banner calm. See
+                # the identical accounting in test_true_emptiness_is_dated_claim.
+                assert page.locator(".src.dead").count() == 0
+                claim_classes = (page.locator("#claim").get_attribute("class") or "").split()
+                assert "warn" not in claim_classes
 
                 # Out-link on the delivered card carries the authority URL.
                 done_card = page.locator(".card.card-done").first


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4481

## Linked Issue
Fixes #4481

## SBS Impact
- Primary subsystem: Builder System (BuilderOps cockpit surface)
- Secondary subsystem(s): none
- Write class: none (read-time projection only)
- Persistence impact: none
- Derived/rebuildable impact: recomputed per render
- New or changed contract: additive `configured: bool` field on each entry of the registry payload's `sources` list; no existing field changes meaning
- Owner-doc impact: `docs/BUILDEROPS_COCKPIT/README.md` updated in this PR
- Transition debt impact: no effect
- Boundary risk: none — consumers reading `state`/`detail` are unaffected

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `_SourceRead` carries `configured` (default `True`), set `False` only for a plane that is optional by design and whose enabling config is absent — today only `github-live` with no repo configured. The flag mirrors `fetch_github_live`'s own `if not repo` branch rather than matching on its detail prose.
- `sourceMarkup` gives that case a calm `.src.off` treatment and the words "not enabled"; `render`'s `anyDead` skips it, so the claim banner is no longer permanently amber on every deployed cockpit. A configured-but-failing plane is unchanged: still `.src.dead`, still amber.
- `state` is untouched in both cases, so predicate evaluability, count withdrawal, and the `refused` (`.bad`) claim path are all unaffected — only the false-positive amber is removed.
- Journey harness hardening: `_serve_cockpit` now holds `COCKPIT_GITHUB_REPO` explicitly, so an ambient value on a runner cannot leak the opt-in live plane, and its network call, into a journey that never asked for it.

## Validation Run
- `pytest tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_docs_plane.py tests/api/test_cockpit_api.py -m "not pg"` → **35 passed**
- `pytest tests/architecture/test_builderops_store_boundary.py tests/architecture/test_sbs_fitness_rules.py tests/builderops/ckm/test_overview_html.py tests/builderops/test_design_run_cli.py tests/governance/test_verify_target_contract_parity.py tests/scripts/test_select_pr_tests.py tests/scripts/test_validate_issue_readiness.py tests/docs -m "not pg"` → **250 passed**
- `ruff check app tests companion-ui/companion-app` → **All checks passed**
- Client-side ACs: Playwright is not installed on this host, so the four `tests/companion_ui/test_cockpit_journeys.py` targets are verified by the post-merge browser lane, which is where `README.md :: Verification model` places browser journeys and where they are never a required PR check. To avoid handing that lane an unverified client change, `render` and `sourceMarkup` were additionally executed headlessly against two **real** `build_registry` payloads (opted-out, and configured-with-a-failing-reader, both built with the same arguments `app/api/routes/cockpit.py` passes): banner-not-warn, `.src.off` not `.src.dead`, "not enabled" copy, and the inverse assertions on the configured-failing payload all hold. That harness was a throwaway and is not part of the diff.

## BuilderOps Routing
- Records/projections/receipts: `LearningSignal lrn_20260731212129_e30c443c`
- Reason: #4481 wore `agent:ready` on GitHub but could not be claimed — `dispatcher pull` silently skips an issue that fails readiness validation, and its last AC carried two comma-separated backticked targets on one `Verify:` line, a shape outside `is_resolvable_verify_target`'s grammar. Splitting that AC in two made the issue syncable; the signal names the contract seam.

## Notes
- The AC's declared `Verify:` targets named `tests/builderops/test_cockpit_registry.py` for the two registry tests, so they live there rather than in the sibling `test_cockpit_github_plane.py` where the other `github_reader` injection tests sit.
- The issue body was repaired before pickup (one AC split into two, no scope change) because the original shape failed readiness validation and kept the task out of the dispatcher queue.
- `github-live` remains unreachable on every deployed channel — `gh` is not in the runtime image and no committed config sets `COCKPIT_GITHUB_REPO`. This PR makes that state honest; #4484 makes the plane enablable.
