### PR TITLE
Record a failed per-PR check-status read instead of swallowing it (#4471)

### DIFF
--- a/app/builderops/cockpit_chain.py
+++ b/app/builderops/cockpit_chain.py
@@ -449,6 +449,12 @@ def _pr_without_ci_on_head_sha(ctx: ThreadContext) -> dict[str, Any] | None:
         return None
     if ctx.github_snapshot.check_state_for(head_sha) is not None:
         return None
+    if ctx.github_snapshot.check_read_failed(head_sha):
+        # This predicate asserts something about GitHub ("no CI state on this
+        # SHA"). A failed read is not evidence for that claim, so the flaw is
+        # withheld rather than fired on evidence nobody has — the rung names
+        # the unread read instead (cockpit_registry, ci_sha).
+        return None
     run = ctx.verification_run
     if run and run.get("verified_head_sha") == head_sha:
         return None

--- a/app/builderops/cockpit_github_plane.py
+++ b/app/builderops/cockpit_github_plane.py
@@ -105,6 +105,10 @@ class GithubLiveSnapshot:
     pulls: dict[int, GithubPull] = field(default_factory=dict)
     checks: dict[str, str] = field(default_factory=dict)  # head_sha -> combined state
     branches: tuple[str, ...] = ()
+    # Head SHAs whose per-PR check-status read failed. Absence from `checks`
+    # otherwise means "this SHA has no checks recorded" — a claim about GitHub.
+    # A failed read is not that claim, and must not be able to impersonate it.
+    check_read_failures: frozenset[str] = frozenset()
 
     def issue_url(self, issue_number: int | None) -> str | None:
         if issue_number is None:
@@ -128,6 +132,16 @@ class GithubLiveSnapshot:
         if not head_sha:
             return None
         return self.checks.get(head_sha)
+
+    def check_read_failed(self, head_sha: str | None) -> bool:
+        """True when this SHA's check state could not be read at all.
+
+        Callers that treat a missing check state as evidence ("this PR has no
+        CI") must consult this first: unread is not the same claim as absent.
+        """
+        if not head_sha:
+            return False
+        return head_sha in self.check_read_failures
 
     def pulls_governing(self, issue_number: int) -> list[GithubPull]:
         return [
@@ -298,9 +312,11 @@ def default_github_reader(repo: str) -> GithubLiveSnapshot:
         )
 
     # Combined status per PR head SHA. One PR's check lookup failing does not
-    # refuse the whole plane — that SHA simply carries no recorded check
-    # state, same posture as a structurally-absent field elsewhere in v1.
+    # refuse the whole plane — but it is recorded as a failed read rather than
+    # dropped, because "we could not read this SHA's checks" and "this SHA has
+    # no checks" are different claims and only one of them is about GitHub.
     checks: dict[str, str] = {}
+    check_read_failures: set[str] = set()
     for pull in pulls.values():
         if not pull.head_sha:
             continue
@@ -309,6 +325,7 @@ def default_github_reader(repo: str) -> GithubLiveSnapshot:
                 ["api", f"repos/{owner}/{name}/commits/{pull.head_sha}/status"]
             )
         except GithubReadError:
+            check_read_failures.add(pull.head_sha)
             continue
         state = status_payload.get("state") if isinstance(status_payload, dict) else None
         if state:
@@ -331,6 +348,7 @@ def default_github_reader(repo: str) -> GithubLiveSnapshot:
         pulls=pulls,
         checks=checks,
         branches=branches,
+        check_read_failures=frozenset(check_read_failures),
     )
 
 

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -579,6 +579,21 @@ def _build_rungs(
                 stale_sources,
             )
         )
+    elif (
+        live_pull is not None
+        and github_snapshot is not None
+        and github_snapshot.check_read_failed(live_pull.head_sha)
+    ):
+        # The check state for this SHA was not read, which is not the same
+        # claim as "this SHA has no checks". Say so on the rung instead of
+        # letting a failed read wear the same bare `absent` as a real absence.
+        rungs.append(
+            _rung(
+                "ci_sha",
+                "absent",
+                f"{live_pull.head_sha[:12]} (check state unread: live read failed)",
+            )
+        )
     elif run:
         rungs.append(_rung("ci_sha", "absent", f"run {run.get('status', '?')}"))
     else:

--- a/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
+++ b/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
@@ -36,6 +36,11 @@ freshness being the read instant and every failure degrading to a refused claim.
 - Upgrades rung classes where live keys now exist: `pr` and `ci_sha` rungs become `proven` from
   live PR + check data; threads with a branch/PR but no dispatcher task appear rather than being
   invisible.
+- Per-SHA partial failure is recorded, not swallowed (#4471). One PR's check-status call failing
+  does not refuse the whole plane — the rest of the snapshot is still fresh — but the SHA lands in
+  `GithubLiveSnapshot.check_read_failures` rather than simply missing from `checks`. Downstream,
+  the `ci_sha` rung names the unread read and the "PR with no CI on head SHA" predicate withholds:
+  that predicate asserts something about GitHub, and a failed read of ours is not evidence for it.
 - Every card gains its authority out-link (issue/PR URL) from the live read, independent of the
   sync mirror's structurally empty fields (audit F9) — rendered in the `out` button class.
 - Auth/binding: the token already available to the host environment (`gh` CLI credentials or

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -61,7 +61,11 @@ pack is supporting input.
   a delivery with no verification receipt, a stale epic with open children. Each carries its own
   evidence keys; a predicate whose plane is not fresh is **named as unevaluated** in the flaws band
   header rather than reading as "no flaw", and predicates needing a plane this capability never
-  reads (git working trees, session records, issue comments) are named as unread there too. A
+  reads (git working trees, session records, issue comments) are named as unread there too. The
+  same rule holds one level down, per evidence rather than per plane (#4471): when a *fresh* plane
+  failed to read one specific fact — a per-PR check-status call that errored — the predicate that
+  would have asserted something about that fact withholds instead of firing, and the thread's
+  `ci_sha` rung names the unread read. Unread is never allowed to wear the shape of absent. A
   thread holds one position band and additionally appears in the flaws band — one identity, no
   copy drift. Within-band ordering is a four-tick reading signal only (EXT-7): it never crosses a
   band, never hides a card, and is never a selection input (ADR-0057 A1).

--- a/tests/builderops/test_cockpit_github_plane.py
+++ b/tests/builderops/test_cockpit_github_plane.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+from app.builderops import cockpit_github_plane
 from app.builderops.cockpit_github_plane import (
     GithubIssue,
     GithubLiveSnapshot,
@@ -452,3 +453,165 @@ def test_mirror_watermark_absent_when_sync_state_lacks_it(tmp_path: Path) -> Non
 
     item = _item_by_issue(payload, 401)
     assert item["mirror_watermark"] is None
+
+
+# ---------------------------------------------------------------------------
+# Per-PR check-status read failures, and the real reader (#4471)
+# ---------------------------------------------------------------------------
+
+
+def test_check_status_read_failure_is_distinguishable_from_no_checks(
+    tmp_path: Path,
+) -> None:
+    """A failed per-SHA check read must not impersonate "this SHA has no CI".
+
+    Both cases leave the SHA out of ``checks``. Only one of them is a claim
+    about GitHub; the other is a claim about our own read. The rung says which,
+    and the "PR without CI" flaw refuses to fire on evidence nobody has.
+    """
+    db_path, store = _make_store(tmp_path)
+    store.upsert_task(_task(status="in_progress", issue_number=610, title="unread ci"))
+    store.upsert_task(_task(status="in_progress", issue_number=620, title="no ci"))
+
+    unread_sha = "c" * 40
+    genuinely_bare_sha = "d" * 40
+
+    def _pull(number: int, issue: int, sha: str) -> GithubPull:
+        return GithubPull(
+            number=number,
+            title=f"Fix #{issue}",
+            state="open",
+            html_url=f"https://github.com/{REPO}/pull/{number}",
+            head_sha=sha,
+            head_ref=f"fix-{issue}",
+            governing_issue=issue,
+        )
+
+    def fake_reader(repo: str) -> GithubLiveSnapshot:
+        return GithubLiveSnapshot(
+            read_at=_now(),
+            issues={},
+            pulls={61: _pull(61, 610, unread_sha), 62: _pull(62, 620, genuinely_bare_sha)},
+            # Neither SHA is in `checks`. The difference is entirely in why.
+            checks={},
+            branches=("fix-610", "fix-620"),
+            check_read_failures=frozenset({unread_sha}),
+        )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=fake_reader,
+    )
+
+    unread_item = _item_by_issue(payload, 610)
+    unread_rung = {r["name"]: r for r in unread_item["rungs"]}["ci_sha"]
+    assert unread_rung["class"] == "absent"
+    assert unread_sha[:12] in unread_rung["value"]
+    assert "unread" in unread_rung["value"]
+
+    bare_item = _item_by_issue(payload, 620)
+    bare_rung = {r["name"]: r for r in bare_item["rungs"]}["ci_sha"]
+    assert bare_rung["class"] == "absent"
+    assert "unread" not in (bare_rung["value"] or "")
+
+    # The flaw is a claim about GitHub, so it fires only for the SHA we
+    # actually read — never for the one we failed to read.
+    def _flaw_names(item: dict) -> set[str]:
+        return {flaw["predicate"] for flaw in item.get("flaws", [])}
+
+    assert "pr_without_ci_on_head_sha" in _flaw_names(bare_item)
+    assert "pr_without_ci_on_head_sha" not in _flaw_names(unread_item)
+
+
+def test_default_github_reader_builds_snapshot_from_mocked_gh_calls(
+    monkeypatch,
+) -> None:
+    """Direct coverage of the reader that actually runs in production.
+
+    Every other test here injects a snapshot, so ``default_github_reader`` —
+    pagination, PR/issue separation, the per-SHA status loop, and its failure
+    handling — had none. The ``gh`` subprocess boundary is mocked, so this
+    still performs no network I/O.
+    """
+    good_sha = "e" * 40
+    failing_sha = "f" * 40
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args: list[str]):
+        calls.append(args)
+        endpoint = args[1]
+        if endpoint.endswith("/issues"):
+            return [
+                {
+                    "number": 700,
+                    "title": "a real issue",
+                    "state": "open",
+                    "html_url": f"https://github.com/{REPO}/issues/700",
+                },
+                # The raw /issues endpoint mixes PRs in; they must be dropped.
+                {
+                    "number": 701,
+                    "title": "a pr wearing an issue shape",
+                    "state": "open",
+                    "html_url": f"https://github.com/{REPO}/pull/701",
+                    "pull_request": {"url": "..."},
+                },
+            ]
+        if endpoint.endswith("/pulls"):
+            return [
+                {
+                    "number": 71,
+                    "title": "Fix the thing",
+                    "state": "open",
+                    "html_url": f"https://github.com/{REPO}/pull/71",
+                    "head": {"sha": good_sha, "ref": "fix-700"},
+                    "body": "Governing-Issue: #700",
+                },
+                {
+                    "number": 72,
+                    "title": "Another",
+                    "state": "open",
+                    "html_url": f"https://github.com/{REPO}/pull/72",
+                    "head": {"sha": failing_sha, "ref": "other"},
+                    "body": "no governing line here",
+                },
+            ]
+        if endpoint.endswith("/branches"):
+            return [{"name": "fix-700"}, {"name": "other"}]
+        if endpoint.endswith(f"/commits/{good_sha}/status"):
+            return {"state": "success"}
+        if endpoint.endswith(f"/commits/{failing_sha}/status"):
+            raise GithubReadError("simulated rate limit on one PR's checks")
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    monkeypatch.setattr(cockpit_github_plane, "_run_gh", fake_run_gh)
+
+    snapshot = cockpit_github_plane.default_github_reader(REPO)
+
+    assert set(snapshot.issues) == {700}
+    assert set(snapshot.pulls) == {71, 72}
+    assert snapshot.pulls[71].governing_issue == 700
+    assert snapshot.pulls[72].governing_issue is None
+    assert snapshot.branches == ("fix-700", "other")
+
+    # One PR's check read succeeded, the other failed. The failure is recorded
+    # rather than swallowed, and does not refuse the whole plane.
+    assert snapshot.checks == {good_sha: "success"}
+    assert snapshot.check_read_failures == frozenset({failing_sha})
+    assert snapshot.check_read_failed(failing_sha) is True
+    assert snapshot.check_read_failed(good_sha) is False
+
+    # REST only, never GraphQL (the shared budget dies on GraphQL first).
+    assert all(call[0] == "api" for call in calls)
+    assert not any("graphql" in " ".join(call) for call in calls)
+
+
+def test_default_github_reader_rejects_a_malformed_repo_slug() -> None:
+    try:
+        cockpit_github_plane.default_github_reader("not-a-slug")
+    except GithubReadError as exc:
+        assert "owner/name" in str(exc)
+    else:  # pragma: no cover - the call above must raise
+        raise AssertionError("a slug with no '/' must be refused before any call")


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4471

## Linked Issue
Fixes #4471

## SBS Impact
- Primary subsystem: Builder System (cockpit registry join)
- Secondary subsystem(s): none
- Write class: none (read-only REST)
- Persistence impact: none
- Derived/rebuildable impact: recomputed per render
- New or changed contract: additive `check_read_failures` field on `GithubLiveSnapshot` (defaults empty, so every existing construction site is unchanged)
- Owner-doc impact: `docs/BUILDEROPS_COCKPIT/README.md` and `GITHUB_LIVE_PLANE.md` updated in this PR
- Transition debt impact: reduces (closes an untested production code path and a silent-swallow seam)
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- A failed per-SHA check-status read is recorded in `GithubLiveSnapshot.check_read_failures` instead of being dropped by a bare `except ... continue`. Missing-from-`checks` no longer conflates "we could not read this" with "GitHub has no checks here".
- The `ci_sha` rung names the unread read rather than rendering the same bare `absent` a genuine absence gets.
- `_pr_without_ci_on_head_sha` withholds on an unread SHA. That predicate asserts something about GitHub; a failed read of ours is not evidence for it, and firing it was a false flaw the swallow made invisible.
- `default_github_reader` gets direct coverage — pagination, the PR-vs-issue split on the raw `/issues` endpoint, governing-issue parsing, the per-SHA status loop and its failure branch, and REST-never-GraphQL. The `gh` subprocess boundary is mocked, so no test performs network I/O.

## Validation Run
- `pytest tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_docs_plane.py tests/api/test_cockpit_api.py tests/docs tests/governance/test_verify_target_contract_parity.py -m "not pg"` → **47 passed**
- `ruff check app tests companion-ui/companion-app` → **All checks passed**

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded slice delivered as specified with no plan divergence; nothing upstream needs repair.

## Notes
- The predicate change goes one step past the issue's literal `ci_sha` wording. It is the same defect: the swallow made a *false* flaw ("PR has no CI on head SHA") fire on a SHA nobody read, so fixing only the rung would have left a known false claim on the surface. Scope is otherwise unchanged — `fetch_github_live`'s whole-snapshot failure path is untouched, as the issue requires.
- A third test (`test_default_github_reader_rejects_a_malformed_repo_slug`) was added beyond the two declared `Verify:` targets; it covers the reader's other unguarded entry condition and costs nothing.
