### PR TITLE
Scope the cockpit live-GitHub join by repository (#4470)

### DIFF
--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -463,6 +463,34 @@ def _pr_number_from_linked(linked_pr: str | None) -> int | None:
         return None
 
 
+def _snapshot_for_task(
+    task: dict[str, Any],
+    github_snapshot: GithubLiveSnapshot | None,
+    github_repo: str | None,
+) -> GithubLiveSnapshot | None:
+    """The live snapshot, but only for a task in the repo that snapshot is of.
+
+    One live read covers exactly one repository (``COCKPIT_GITHUB_REPO``),
+    while the dispatcher store carries a ``repo`` per task. Issue and PR
+    numbers are only unique *within* a repository, so joining them across
+    repositories would let a task in repo B inherit rungs, out-links, and
+    flaw evidence from a same-numbered PR in repo A. The existing
+    verification-runs join is already keyed on ``(repo, pr_number)``; this
+    applies the same key to the live plane.
+
+    Gating here rather than inside each consumer is deliberate: every live
+    consumer — ``_resolve_pr``, the rung classifier, and every flaw predicate
+    reading ``github_snapshot`` — is covered by this one rule, so no future
+    predicate can be added on the unscoped path by omission.
+
+    Single-repo deployments (today's reality) see no behavior change: every
+    task's ``repo`` equals the configured one.
+    """
+    if github_snapshot is None or github_repo is None:
+        return github_snapshot
+    return github_snapshot if str(task.get("repo") or "") == github_repo else None
+
+
 def _resolve_pr(
     task: dict[str, Any],
     github_snapshot: GithubLiveSnapshot | None,
@@ -772,6 +800,7 @@ def _github_facts(
 def _build_unsynced_threads(
     tasks: list[dict[str, Any]] | None,
     github_snapshot: GithubLiveSnapshot | None,
+    github_repo: str | None = None,
 ) -> list[dict[str, Any]]:
     """PRs visible in GitHub with no matching dispatcher task.
 
@@ -792,6 +821,12 @@ def _build_unsynced_threads(
     known_pr_numbers: set[int] = set()
     known_issue_numbers: set[int] = set()
     for task in tasks or []:
+        # Only a task in the repo this snapshot describes can vouch for one of
+        # its PRs. Without this, a same-numbered task in another repository
+        # would suppress a genuinely-unsynced live PR as "already known" — the
+        # silent direction of the same collision `_snapshot_for_task` guards.
+        if _snapshot_for_task(task, github_snapshot, github_repo) is None:
+            continue
         pr_number = _pr_number_from_linked(task.get("linked_pr"))
         if pr_number is not None:
             known_pr_numbers.add(pr_number)
@@ -911,7 +946,11 @@ def build_registry(
             status = str(task.get("status") or "")
             try:
                 labels = _sync_labels(task.get("sync_state"))
-                _, live_pull = _resolve_pr(task, github_snapshot)
+                # Scoped once per task, then used everywhere below: position
+                # derivation, rungs, out-links, and flaw predicates all read
+                # the same repo-checked snapshot.
+                task_snapshot = _snapshot_for_task(task, github_snapshot, github_repo)
+                _, live_pull = _resolve_pr(task, task_snapshot)
                 position = derive_position(task, now=now, live_pull=live_pull)
                 if _NEEDS_HUMAN_LABEL in labels:
                     # An explicit human-routing label is the owner's own
@@ -939,7 +978,7 @@ def build_registry(
                     band,
                     position,
                     verification,
-                    github_snapshot,
+                    task_snapshot,
                     docs_snapshot,
                     stale_sources,
                     evaluated_predicates,
@@ -1058,7 +1097,9 @@ def build_registry(
         "unclassified": unclassified,
         "deployments": deployments,
         "github": _github_facts(sources, github_snapshot),
-        "unsynced_threads": _build_unsynced_threads(tasks, github_snapshot),
+        "unsynced_threads": _build_unsynced_threads(
+            tasks, github_snapshot, github_repo
+        ),
         "capability_lanes": {"countable": lanes is not None, "lanes": lanes},
         "docs_only_threads": unlinked_docs_threads(docs_snapshot),
         # The counts a stale source no longer backs. Named so the withdrawal

--- a/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
+++ b/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
@@ -26,7 +26,11 @@ freshness being the read instant and every failure degrading to a refused claim.
   `Governing-Issue`/closing keywords in PR bodies, check/CI state per PR head SHA, and the branch
   list (so the owner's "branch but no PR" deficiency becomes a computable predicate in
   BOPS-COCKPIT-04). Joined on issue number / PR number / SHA — the spine the audit proves
-  machine-keyed (INV-DG-1).
+  machine-keyed (INV-DG-1) — and scoped by repository (#4470): one live read covers one repo, while
+  the dispatcher store carries a `repo` per task, and those numbers are unique only *within* a
+  repository. A task outside the configured repo sees no live snapshot at all, so it can neither
+  inherit another repo's PR nor vouch for one as already-synced. Same key as the pre-existing
+  verification-runs join.
 - Registers `github-live` as a read source with `last_successful_read` = the call instant, removing
   it from `UNREAD_PLANES`. Per decision Q5: no cache that survives a reload; a failed or
   rate-limited read yields the refused-claim state for GitHub-owned facts, never stale data

--- a/tests/builderops/test_cockpit_github_plane.py
+++ b/tests/builderops/test_cockpit_github_plane.py
@@ -615,3 +615,116 @@ def test_default_github_reader_rejects_a_malformed_repo_slug() -> None:
         assert "owner/name" in str(exc)
     else:  # pragma: no cover - the call above must raise
         raise AssertionError("a slug with no '/' must be refused before any call")
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo join scoping (#4470)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_repo_issue_number_collision_does_not_cross_wire(tmp_path: Path) -> None:
+    """Issue and PR numbers are only unique within a repository.
+
+    One live read covers one repo. A dispatcher task in a *different* repo
+    that happens to share an issue number must not inherit that repo's PR —
+    and must not vouch for it either, which would silently suppress a
+    genuinely-unsynced live PR.
+    """
+    db_path, store = _make_store(tmp_path)
+    # A synthetic second repository: the scoping rule is about the repo
+    # dimension itself, so naming a real sibling repo here would add coupling
+    # and nothing else.
+    other_repo = "example-org/other-repo"
+
+    # Same issue number, two repositories. Only the first is the repo the live
+    # snapshot describes.
+    store.upsert_task(
+        _task(status="in_progress", issue_number=800, title="ours", repo=REPO)
+    )
+    store.upsert_task(
+        _task(status="in_progress", issue_number=800, title="theirs", repo=other_repo)
+    )
+    # A task in the other repo whose linked_pr collides with a live PR number.
+    store.upsert_task(
+        _task(
+            status="in_progress",
+            issue_number=801,
+            title="their pr number",
+            repo=other_repo,
+            linked_pr="91",
+        )
+    )
+
+    head_sha = "1" * 40
+
+    def fake_reader(repo: str) -> GithubLiveSnapshot:
+        assert repo == REPO
+        return GithubLiveSnapshot(
+            read_at=_now(),
+            issues={
+                800: GithubIssue(
+                    number=800,
+                    title="ours",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/issues/800",
+                )
+            },
+            pulls={
+                90: GithubPull(
+                    number=90,
+                    title="Fix #800",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/90",
+                    head_sha=head_sha,
+                    head_ref="fix-800",
+                    governing_issue=800,
+                ),
+                # Number 91 exists live in REPO and is tracked by nobody here;
+                # only the other repo's task carries linked_pr="91".
+                91: GithubPull(
+                    number=91,
+                    title="Unrelated live PR",
+                    state="open",
+                    html_url=f"https://github.com/{REPO}/pull/91",
+                    head_sha="2" * 40,
+                    head_ref="unrelated",
+                    governing_issue=None,
+                ),
+            },
+            checks={head_sha: "success"},
+            branches=("fix-800", "unrelated"),
+        )
+
+    payload = build_registry(
+        db_path=db_path,
+        deploy_receipt_dir=tmp_path / "deploys",
+        github_repo=REPO,
+        github_reader=fake_reader,
+    )
+
+    def _item(title: str) -> dict:
+        for band in payload["bands"]:
+            for item in band["items"]:
+                if item["title"] == title:
+                    return item
+        raise AssertionError(f"no item titled {title!r}")
+
+    # The in-repo task joins as before: live PR rung, live check, live out-link.
+    ours = _item("ours")
+    ours_rungs = {r["name"]: r for r in ours["rungs"]}
+    assert ours_rungs["pr"]["class"] == "proven"
+    assert "90" in ours_rungs["pr"]["value"]
+    assert ours_rungs["ci_sha"]["class"] == "proven"
+    assert ours["links"] == [f"https://github.com/{REPO}/pull/90"]
+
+    # The same-numbered task in another repo inherits none of it.
+    theirs = _item("theirs")
+    theirs_rungs = {r["name"]: r for r in theirs["rungs"]}
+    assert theirs_rungs["pr"]["class"] == "absent"
+    assert theirs_rungs["ci_sha"]["class"] == "absent"
+    assert f"https://github.com/{REPO}/pull/90" not in theirs["links"]
+
+    # And it cannot vouch for PR 91 either: that live PR is still unsynced.
+    unsynced_numbers = {t["pr_number"] for t in payload["unsynced_threads"]}
+    assert 91 in unsynced_numbers
+    assert 90 not in unsynced_numbers


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4470

## Linked Issue
Fixes #4470

## SBS Impact
- Primary subsystem: Builder System (cockpit registry join)
- Secondary subsystem(s): none
- Write class: none (projection)
- Persistence impact: none
- Derived/rebuildable impact: recomputed per render
- New or changed contract: none — bug-fix scoping, no new field or config
- Owner-doc impact: `docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md` updated in this PR
- Transition debt impact: reduces (closes a latent cross-repo join gap before it is ever exercised)
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `_snapshot_for_task` returns the live snapshot only for a task whose `repo` matches the repository that snapshot is of. Everything downstream — `_resolve_pr`, the rung classifier, the authority out-link, and every flaw predicate reading `github_snapshot` — is fed the scoped value.
- `_build_unsynced_threads` applies the same rule in the other direction, so a task in another repo cannot vouch for a live PR it merely shares a number with.
- Gated in one place rather than per consumer: that way a future predicate cannot land on the unscoped path by omission. This is the same `(repo, number)` key the verification-runs join in this file already uses.
- No new config surface; scoping uses the `repo` field the dispatcher store already carries.

## Validation Run
- `pytest tests/builderops/test_cockpit_registry.py tests/builderops/test_cockpit_github_plane.py tests/builderops/test_cockpit_chain_states.py tests/builderops/test_cockpit_docs_plane.py tests/api/test_cockpit_api.py tests/docs -m "not pg"` → **35 passed**
- `ruff check app tests companion-ui/companion-app` → **All checks passed**
- Test-first evidence: with `app/builderops/cockpit_registry.py` reverted to `origin/main`, `test_cross_repo_issue_number_collision_does_not_cross_wire` fails on `assert theirs_rungs["pr"]["class"] == "absent"` → `'proven'` — the other repo's task inheriting repo A's PR, which is exactly the defect. It passes with the change and the other 9 tests in the file stay green.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded slice delivered as specified with no plan divergence.

## Notes
- Single-repo deployments (today's reality) see zero behavior change, as the issue requires: every task's `repo` equals the configured one, so the gate is always open.
