### PR TITLE
Give the cockpit live GitHub plane a real enablement path (#4484)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,14 @@ WORKDIR /app
 
 # ffmpeg stays in the RUNTIME stage: the capture/transcription path shells out
 # to it (faster-whisper/yt-dlp media handling). espeak-ng backs the local TTS
-# engines (piper phonemization).
+# engines (piper phonemization). gh backs the BuilderOps cockpit's `github-live`
+# plane: app/builderops/cockpit_github_plane.py :: _run_gh is the single
+# transport every live REST read passes through, and the `api` service that
+# serves /api/cockpit/registry runs from this image, so without the binary the
+# plane refuses on its first call in every channel (#4484). It is a plain
+# trixie/main package — no third-party apt source is added for it.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg espeak-ng \
+  && apt-get install -y --no-install-recommends ffmpeg espeak-ng gh \
   && rm -rf /var/lib/apt/lists/*
 
 # Installed third-party packages and their console scripts (uvicorn, alembic,

--- a/app/api/routes/cockpit.py
+++ b/app/api/routes/cockpit.py
@@ -34,8 +34,12 @@ def _github_repo() -> str | None:
     """Repo slug for the live GitHub read (BOPS-COCKPIT-03, #4450).
 
     Unset by default: the source then refuses cleanly rather than guessing a
-    repo. An operator enables the live plane by setting this alongside the
-    host's ``gh`` auth.
+    repo. The read runs in *this* process, so enabling a channel means binding
+    this key and a ``GITHUB_TOKEN`` for the in-container ``gh`` transport --
+    committed for dev in ``docker-compose.dev.yml``, token host-supplied on the
+    api consumer's host-secret env layer (#4484). See
+    ``docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: What makes that command
+    answer fresh (#4484)``.
     """
     return os.environ.get("COCKPIT_GITHUB_REPO") or None
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,17 @@ services:
       PKM_ENVIRONMENT: dev
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+      # Enables the BuilderOps cockpit's opt-in `github-live` plane on the dev
+      # channel only (#4484). Dev is the channel whose port is the plane's own
+      # stated acceptance form -- `localhost:18001/api/cockpit/registry`
+      # (docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: Concretely). test/prod
+      # deliberately leave the key unset, so their behavior stays byte-identical
+      # to the pre-#4484 refusal and the source renders *not enabled* rather
+      # than broken (EXT-8, #4481); turning another channel on is a promotion
+      # -lane act, not a side effect of making enablement possible. The read is
+      # read-only and persists nothing; the token it needs arrives separately on
+      # the api consumer's host-secret env layer (see docker-compose.yaml :: api).
+      COCKPIT_GITHUB_REPO: RasmusTho/agentic-pkm-mvp
       # Deliberately no VAULT_ROOT / VAULT_ROOT_DEV keys here (#3875, follow-up
       # to #3659/#3666 review thread PRRT_kwDOQEip6s6RRnQ2). Compose's service
       # `environment:` mapping always wins over `env_file:` for a given key,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -130,6 +130,15 @@ services:
       # from the capture-watch consumer's handle, which a nested bootstrap
       # scrubs). Delivers HEIMDAL_RAW_STORE_KEY so the shipped media/screen
       # ingress lanes can admit.
+      #
+      # This layer is also where the cockpit's `github-live` plane gets its
+      # credential (#4484): the in-container `gh` transport reads GITHUB_TOKEN
+      # (or GH_TOKEN) from the environment, so an operator enabling the plane on
+      # a channel supplies GITHUB_TOKEN through this same file rather than
+      # through any new mount, compose key, or secret mechanism. A repo-scoped
+      # read-only token is sufficient; the plane performs GET requests only and
+      # persists nothing. With the token absent the plane refuses cleanly, which
+      # is why no committed default is needed for it.
       - path: ${HOST_SECRET_RUNTIME_ENV_FILE_API:-/dev/null}
         required: false
     user: "${LOCAL_UID:-0}:${LOCAL_GID:-0}"

--- a/docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md
+++ b/docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md
@@ -141,6 +141,13 @@ sets `COCKPIT_GITHUB_REPO` anywhere, so `github-live`'s "unset by default" opt-i
 (`app/builderops/cockpit_github_plane.py`'s own docstring) is the permanent steady state on every
 host today, not an edge case.
 
+> Status since #4484: the "no repo-committed deployment config sets it anywhere" half of this
+> finding no longer holds — the runtime image ships the `gh` transport and `docker-compose.dev.yml`
+> commits the slug for the dev channel, so the unset state is now a per-channel choice (`test` and
+> `prod` keep it). EXT-8 is unaffected and more load-bearing for it: distinguishing opted-out from
+> broken is what lets an enabled channel's real failure read as a failure. See
+> `GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.
+
 ### EXT-8 — `configured` flag on per-source reads — ACCEPT cockpit-local; claim-banner warn scoped to it
 
 The two causes read identically today: (i) an optional plane was never turned on (a deliberate,

--- a/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
+++ b/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
@@ -47,9 +47,9 @@ freshness being the read instant and every failure degrading to a refused claim.
   that predicate asserts something about GitHub, and a failed read of ours is not evidence for it.
 - Every card gains its authority out-link (issue/PR URL) from the live read, independent of the
   sync mirror's structurally empty fields (audit F9) — rendered in the `out` button class.
-- Auth/binding: the token already available to the host environment (`gh` CLI credentials or
-  `GITHUB_TOKEN`); unauthenticated or missing-token environments degrade to the refused claim, and
-  tests must not require network.
+- Auth/binding: the token available to **the process that runs the read** — `gh` resolves
+  `GITHUB_TOKEN`/`GH_TOKEN` from its own environment. Unauthenticated or missing-token environments
+  degrade to the refused claim, and tests must not require network.
 
 ## Concretely
 
@@ -59,6 +59,29 @@ curl -s localhost:18001/api/cockpit/registry | jq '.sources[] | select(.name=="g
 
 Expected: `state: "fresh"` with the call's own instant — or `state: "unavailable"` with GitHub-owned
 counts refused, never zeroed, when the API is unreachable or rate-limited.
+
+### What makes that command answer `fresh` (#4484)
+
+The read runs **inside the `api` container**, not on the host, so the enablement path is three
+committed things plus one host-supplied value:
+
+1. **The transport exists in the image.** `Dockerfile`'s runtime stage installs `gh` alongside
+   `ffmpeg`/`espeak-ng` (a plain Debian trixie/main package; no third-party apt source). Before
+   #4484 it was absent, so `_run_gh` raised `gh CLI not found` on the first call in every channel
+   regardless of configuration.
+2. **The repo slug is committed for the dev channel.** `docker-compose.dev.yml :: api` sets
+   `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`. Dev is the channel this command names (18001).
+3. **`test` and `prod` deliberately leave it unset.** They stay byte-identical to the pre-#4484
+   refusal and render *not enabled* rather than broken (EXT-8, #4481). Turning another channel onto
+   the plane is a promotion-lane act.
+4. **The token is host-supplied.** `GITHUB_TOKEN` reaches the container on the `api` consumer's
+   already-declared host-secret env layer (`HOST_SECRET_RUNTIME_ENV_FILE_API` in
+   `docker-compose.yaml :: api`, #4422) — the same layer that delivers `HEIMDAL_RAW_STORE_KEY`. No
+   token is committed to the repo, and a repo-scoped read-only token is sufficient: the plane issues
+   GET requests only and persists nothing.
+
+With the slug set and the token absent, the plane is *configured but failing* — an honest outage,
+not an opt-out. With the slug unset, nobody asked for it and nothing is claimed either way.
 
 ## Why This Matters
 

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -52,10 +52,15 @@ pack is supporting input.
   watermark is older than `SOURCE_STALE_AFTER_DAYS` turns the rungs it backs amber and has the
   counts it owns withdrawn rather than shown whole. A read carries `configured` alongside `state`
   (EXT-8, #4481): an optional-by-design plane whose enabling config is absent — `github-live` with
-  `COCKPIT_GITHUB_REPO` unset, the steady state on every host until #4484 — renders as *not
-  enabled* rather than dead and never contributes to the claim banner's amber, while a plane that
-  was configured and then failed still does both. `state` is unchanged in either case: an
-  unconfigured plane still owns no countable facts.
+  `COCKPIT_GITHUB_REPO` unset — renders as *not enabled* rather than dead and never contributes to
+  the claim banner's amber, while a plane that was configured and then failed still does both.
+  `state` is unchanged in either case: an unconfigured plane still owns no countable facts. Since
+  #4484 that unset state is a per-channel choice rather than the only reachable state: the runtime
+  image ships the `gh` transport the plane reads through, and `docker-compose.dev.yml :: api`
+  commits the repo slug for the dev channel (18001) while `test`/`prod` stay unset. See
+  `GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)` for the full path,
+  including the host-supplied `GITHUB_TOKEN` that rides the `api` consumer's existing host-secret
+  env layer.
 - **Honest emptiness in three forms** — dated true emptiness; refused claims on dead sources
   ("cannot be counted", never zero); structural absence distinct from death.
 - **Two tiers in the done band** — "Ready for you to use" above "Tried by you" (empty by contract

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -262,6 +262,23 @@ Companion docs:
   Markdown read-back, mixed-language segments may route to different voices, and production
   deployment still depends on the Mac mini/local model health path.
 
+### BuilderOps cockpit live GitHub plane (#4484)
+- The cockpit's `github-live` source reads GitHub REST from **inside the `api` container** via the
+  `gh` CLI, which the runtime image installs (`Dockerfile`, runtime-stage apt layer) alongside
+  `ffmpeg`/`espeak-ng`. Before #4484 the binary was absent, so the plane refused on every channel
+  regardless of configuration.
+- The plane is opt-in per channel. `docker-compose.dev.yml :: api` binds
+  `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`; `test` and `prod` deliberately leave it unset and
+  render the source as *not enabled* rather than broken. Turning another channel on is a
+  promotion-lane act, not a config default.
+- The token is host-supplied, never committed: put `GITHUB_TOKEN` on the `api` consumer's existing
+  host-secret env layer (`HOST_SECRET_RUNTIME_ENV_FILE_API`, the same layer that delivers
+  `HEIMDAL_RAW_STORE_KEY`). A repo-scoped read-only token suffices — the plane issues GET requests
+  only and persists nothing. Without a token the plane refuses cleanly; nothing else degrades.
+- Check it with `curl -s localhost:18001/api/cockpit/registry | jq '.sources[] |
+  select(.name=="github-live")'`. Full path and rationale:
+  `docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.
+
 ### Karakeep managed source service (KMA-02)
 - `docker-compose.karakeep.yml` is the repo-owned deployment for the self-hosted Karakeep
   read-later source on the mac mini (Heimdal's external source dependency; ADR-0049 §1). It pins the

--- a/tests/api/test_cockpit_api.py
+++ b/tests/api/test_cockpit_api.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from app.api.app import app
+from app.builderops import cockpit_github_plane, cockpit_registry
+from app.builderops.cockpit_github_plane import GithubLiveResult
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -34,6 +36,72 @@ def test_registry_endpoint_and_page_served(tmp_path, monkeypatch) -> None:
     assert page.status_code == 200
     assert "Cockpit" in page.text
     assert "/static/cockpit.js" in page.text
+
+
+def _github_live_source(payload: dict) -> dict:
+    return next(
+        source for source in payload["sources"] if source["name"] == "github-live"
+    )
+
+
+def test_configured_repo_reaches_the_live_github_read(tmp_path, monkeypatch) -> None:
+    """#4484: a configured slug must survive the real route-to-transport path.
+
+    The assertion is on the production chain — route `_github_repo` ->
+    `build_registry` -> `_read_github_live` -> `fetch_github_live` — with only
+    the outermost read boundary substituted, so no network is performed. A
+    helper called in isolation would not prove the route passes the slug at
+    all, which is exactly the defect #4484 fixes.
+    """
+    monkeypatch.setenv("DISPATCHER_STATE_DIR", str(tmp_path / "dispatcher"))
+    monkeypatch.setenv("COCKPIT_DEPLOY_RECEIPT_DIR", str(tmp_path / "deploys"))
+    monkeypatch.setenv("COCKPIT_GITHUB_REPO", "RasmusTho/agentic-pkm-mvp")
+
+    seen: list[str | None] = []
+
+    def _record(repo: str | None, **kwargs):
+        seen.append(repo)
+        return GithubLiveResult(
+            snapshot=None,
+            state="unavailable",
+            last_successful_read=None,
+            detail="stubbed read boundary",
+        )
+
+    monkeypatch.setattr(cockpit_registry, "fetch_github_live", _record)
+
+    response = TestClient(app).get("/api/cockpit/registry")
+    assert response.status_code == 200
+
+    assert seen == ["RasmusTho/agentic-pkm-mvp"], (
+        "the /api/cockpit/registry route must reach the live GitHub read with "
+        "the configured slug; got: " + repr(seen)
+    )
+    # The plane was asked for, so its refusal is an outage rather than an
+    # opt-out (EXT-8, #4481).
+    assert _github_live_source(response.json())["configured"] is True
+
+
+def test_unset_repo_still_refuses_the_live_plane(tmp_path, monkeypatch) -> None:
+    """#4484 must not change the unconfigured path: no repo, no live read."""
+    monkeypatch.setenv("DISPATCHER_STATE_DIR", str(tmp_path / "dispatcher"))
+    monkeypatch.setenv("COCKPIT_DEPLOY_RECEIPT_DIR", str(tmp_path / "deploys"))
+    monkeypatch.delenv("COCKPIT_GITHUB_REPO", raising=False)
+
+    def _must_not_transport(repo: str) -> None:
+        raise AssertionError(f"no live read may be attempted for {repo!r}")
+
+    monkeypatch.setattr(
+        cockpit_github_plane, "default_github_reader", _must_not_transport
+    )
+
+    response = TestClient(app).get("/api/cockpit/registry")
+    assert response.status_code == 200
+
+    source = _github_live_source(response.json())
+    assert source["state"] == "unavailable"
+    assert source["configured"] is False
+    assert source["last_successful_read"] is None
 
 
 def test_token_sheet_parity_with_binding_source() -> None:

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -131,6 +131,28 @@ def test_runtime_stage_keeps_ffmpeg_and_compose_entrypoints() -> None:
     ), "image entrypoint/startup behavior must not change"
 
 
+def test_runtime_image_installs_gh_for_the_cockpit_live_plane() -> None:
+    """#4484: the cockpit's `github-live` plane shells out to `gh` in-container.
+
+    `app/builderops/cockpit_github_plane.py :: _run_gh` is the single transport
+    every live REST read passes through, and the `api` service that serves
+    `/api/cockpit/registry` runs from this image. Without the binary in the
+    RUNTIME stage the plane raises `GithubReadError("gh CLI not found ...")` on
+    its first call in every channel, so no configuration can enable it.
+    """
+    text = _dockerfile_text()
+    final_stage = text[text.rindex("FROM ") :]
+    install_lines = [
+        line for line in final_stage.splitlines() if "apt-get install" in line
+    ]
+    assert install_lines, "runtime (final) stage must have an apt-get install layer"
+    assert any(re.search(r"(?<![\w-])gh(?![\w-])", line) for line in install_lines), (
+        "runtime (final) stage must install the gh CLI: it is the only "
+        "transport the cockpit live GitHub plane has (#4484). Installed "
+        f"packages found: {install_lines}"
+    )
+
+
 def test_dockerignore_excludes_dev_only_surfaces() -> None:
     patterns = _dockerignore_patterns()
     for required in ("tests", "docs", ".git", "*.md", "ops", "scripts"):

--- a/tests/ops/test_cockpit_github_plane_enablement.py
+++ b/tests/ops/test_cockpit_github_plane_enablement.py
@@ -1,0 +1,95 @@
+"""Guard the committed enablement path of the cockpit live GitHub plane (#4484).
+
+The `github-live` source is opt-in: `app/api/routes/cockpit.py :: _github_repo`
+returns `None` unless `COCKPIT_GITHUB_REPO` is set, and `fetch_github_live`
+refuses before the transport is reached. Until #4484 no committed configuration
+set that key for any channel, so the plane's own stated acceptance form
+(`docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: Concretely` — a `fresh`
+source at `localhost:18001/api/cockpit/registry`) was not executable anywhere.
+
+This file asserts the committed side of that path:
+
+1. the dev channel (the 18001 acceptance form) binds the repo slug on the
+   `api` service, which is the service that serves the cockpit route;
+2. the token key the plane needs is documented on the `api` consumer's
+   already-declared host-secret env layer, which is how a value reaches that
+   container without a new secret mechanism or compose surface; and
+3. the other channels stay unset, so the opt-in posture (and #4481's
+   opted-out-vs-broken distinction) still holds where nobody asked for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.release_channels.channel_isolation_preflight import _load_compose
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASE_COMPOSE = _REPO_ROOT / "docker-compose.yaml"
+_DEV_COMPOSE = _REPO_ROOT / "docker-compose.dev.yml"
+_OPTED_OUT_COMPOSE = (
+    _REPO_ROOT / "docker-compose.test.yml",
+    _REPO_ROOT / "docker-compose.prod.yml",
+)
+
+_REPO_SLUG = "RasmusTho/agentic-pkm-mvp"
+_TOKEN_KEY = "GITHUB_TOKEN"
+_HOST_SECRET_HANDLE = "HOST_SECRET_RUNTIME_ENV_FILE_API"
+
+
+def _services(path: Path) -> dict:
+    # `_load_compose` tolerates compose's `!override` / `!reset` merge tags,
+    # which plain `yaml.safe_load` rejects in the channel overlays.
+    return _load_compose(path)["services"]
+
+
+def test_api_service_receives_cockpit_repo_and_token_key() -> None:
+    dev_api = _services(_DEV_COMPOSE)["api"]
+    assert dev_api["environment"]["COCKPIT_GITHUB_REPO"] == _REPO_SLUG, (
+        "the dev channel's api service must bind COCKPIT_GITHUB_REPO — it is "
+        "the channel whose port (18001) is the live plane's stated acceptance "
+        "form (docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: Concretely)"
+    )
+
+    # The token rides the api consumer's already-declared host-secret layer;
+    # this issue adds no new secret plumbing, so the committed artifact is the
+    # documented key name on that layer, next to the key it already delivers.
+    base_api = _services(_BASE_COMPOSE)["api"]
+    host_secret_layers = [
+        entry
+        for entry in base_api["env_file"]
+        if isinstance(entry, dict) and _HOST_SECRET_HANDLE in str(entry.get("path", ""))
+    ]
+    assert len(host_secret_layers) == 1, (
+        f"the api service must keep exactly one {_HOST_SECRET_HANDLE} env_file "
+        "layer (#4422); #4484 reuses it rather than adding a surface"
+    )
+
+    base_text = _BASE_COMPOSE.read_text(encoding="utf-8")
+    layer_comment = base_text[: base_text.index(f"${{{_HOST_SECRET_HANDLE}")]
+    layer_comment = layer_comment[layer_comment.rindex("# Governed host-secret") :]
+    assert "HEIMDAL_RAW_STORE_KEY" in layer_comment, (
+        "guard assumption: the layer's existing key is documented in its own "
+        "comment block, which is where the new key must be documented too"
+    )
+    assert _TOKEN_KEY in layer_comment, (
+        f"the api host-secret layer must document {_TOKEN_KEY} as the key the "
+        "cockpit live GitHub plane's gh transport reads (#4484), alongside the "
+        "key that layer already delivers"
+    )
+
+
+def test_other_channels_stay_opted_out_of_the_live_plane() -> None:
+    """The plane stays opt-in: only the enabled channel binds the slug.
+
+    With `COCKPIT_GITHUB_REPO` unset a channel's behavior is byte-identical to
+    the pre-#4484 refusal, and the source renders *not enabled* rather than
+    broken (EXT-8, #4481).
+    """
+    for path in _OPTED_OUT_COMPOSE:
+        api = _services(path).get("api", {})
+        assert "COCKPIT_GITHUB_REPO" not in (api.get("environment") or {}), (
+            f"{path.name} must not bind COCKPIT_GITHUB_REPO: turning a channel "
+            "onto the live plane is an operational act owned by the promotion "
+            "lane, not a side effect of making enablement possible (#4484)"
+        )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4484

## Linked Issue
Closes #4484

## SBS Impact
- Primary subsystem: Builder System (BuilderOps cockpit surface)
- Secondary subsystem(s): Runtime image and channel configuration (the cockpit route is served by the Product API app) — boundary work
- Write class: none (read-only REST; the cockpit persists nothing)
- Persistence impact: none
- Derived/rebuildable impact: all recomputed per render
- New or changed contract: none — the plane's opt-in posture, refusal contract, and pagination bounds are unchanged; this supplies only the dependency and the config the existing contract already names
- Owner-doc impact: updated in-PR: docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md, README.md, DESIGN_DECISIONS.md, docs/OPERATIONS.md
- Transition debt impact: reduces — closes the gap between a delivered capability's stated enablement path and the shipped runtime; D11 preserved (no stewardship authority concentrated in one skill/surface), D12 preserved (no learning/TCD capture surface touched)
- Boundary risk: the runtime image gains a builder-facing CLI dependency and the api container may carry a GitHub token. Accepted as proportional: the cockpit route already lives in the Product API app (crossed at #4438, not here), and the token rides the governed host-secret layer that consumer already declares.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- The cockpit's github-live plane had no enablement path on any deployed channel: the runtime image shipped no gh binary for its only transport, and no committed configuration bound COCKPIT_GITHUB_REPO for the api service. Install gh in the runtime stage, bind the repo slug for the dev channel only, and document the host-supplied GITHUB_TOKEN on the api consumer's already-declared host-secret env layer.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 slice: no BuilderOps record, projection, or receipt was produced or mutated.

## Notes
**Validation**
- `pytest tests/api/test_cockpit_api.py tests/ops/test_cockpit_github_plane_enablement.py tests/deploy/test_dockerfile_hardening.py tests/builderops/test_cockpit_github_plane.py -m "not pg" -q` -> 31 passed (the issue's Suggested Validation).
- Full `select_pr_tests.py` lane for this diff (companion_ui, runtime_health, ops, ops_deploy) -> 3822 passed, 10 skipped, 9 xfailed.
- `ruff check app tests companion-ui/companion-app` -> All checks passed!
- `python3 scripts/docs_guard.py` -> exit 0 after the `docs/OPERATIONS.md` writeback.
- Real-path proof for AC1 beyond the Dockerfile text guard: the exact apt layer was run against the pinned base digest — `gh version 2.46.0 (Debian 2.46.0-3)`, with `ffmpeg 7.1.5` and `espeak-ng 1.52.0` still installing. `gh` is a plain Debian trixie/main package, so no third-party apt source is added.

**Test-first note**
AC3/AC4 (`test_configured_repo_reaches_the_live_github_read`, `test_unset_repo_still_refuses_the_live_plane`) passed on first run against unchanged code — correctly so. The route→`build_registry`→`fetch_github_live` chain was already right; what was missing was the transport and the configuration. AC1 and AC2 both failed first (`gh` absent from the apt layer; `KeyError: 'COCKPIT_GITHUB_REPO'`) and now pass. AC3/AC4 stand as regression guards on the path the config now feeds.

**Scope decision worth a reviewer's eye**
The issue's Scope offered `config/runtime.defaults.env` *or* a per-channel overlay. The overlay was chosen: `runtime.defaults.env` is shared by every service and channel, so committing the slug there would put `test` and `prod` onto the live plane on their next restart — which the issue's own Constraint ("no channel is forced onto the live plane") forbids. `docker-compose.dev.yml` is the channel whose port (18001) is the plane's stated acceptance form, so it is the one channel the contract actually asks to be reachable. `test_other_channels_stay_opted_out_of_the_live_plane` guards that boundary.

**On the token and the declared-secret contract**
No entry was added to `config/secrets/host_secret_contract.json`. `app/ops/host_secret_bootstrap.py :: _resolve_consumer_environment` is fail-closed over *every* declared secret for a consumer, so declaring `github.token` for `heimdal-api-ingress` would break every api-channel deploy until the operator provisioned a Keychain item on all three channels — a new secret surface, which the issue's Constraints explicitly forbid. The committed artifact is therefore the documented key name on the layer that already exists, per the issue's Scope wording ("Document the required key name where the other keys delivered on that layer are documented"). Consequence a reviewer should weigh: on the `scripts/deploy_channel.sh` path the layer's file is bootstrap-owned, so an operator enabling dev supplies `GITHUB_TOKEN` through that layer's own mechanism rather than a side file. Until they do, the plane reads `configured: true, state: unavailable` — an honest outage, exactly the distinction #4481 delivered.

**Risk-surface attestation**
TCD risk assessment complete; declared surface set is empty. The external-API mechanism (`cockpit_github_plane.py`: pagination bounds, no retries, refusal-over-stale) is untouched and explicitly Out of Scope on the issue; no credential-handling code path changes. Light path, `Final-Review-Rounds: 0`.
