### PR TITLE
SV/EN retrieval eval with connect precision (G3-2)

### DIFF
--- a/scripts/eval_sv_en_retrieval.py
+++ b/scripts/eval_sv_en_retrieval.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Reproducible scorecard runner for the SV/EN retrieval eval (G3-2, #2985).
+
+Runs the hand-labelled SV/EN query set and the connect-precision pair set against the live app
+retrieval path under both embedding identities, and writes the scorecard the eval note cites.
+
+Two axes, deliberately not crossed into a full matrix:
+
+* **identity comparison** — ``nomic-embed-text``@768 vs ``bge-m3``@1024 with fusion held fixed at the
+  shipped default (``linear``), so the embedding identity is the only moving part. This is the
+  comparison owner ruling R2 asked for: the eval validates the migration after the fact.
+* **fusion comparison** — ``linear`` vs ``rrf`` on the shipped identity (``bge-m3``), which is the
+  evidence the G5 default-fusion recommendation needs.
+
+Requires an Ollama host with both models pulled:
+
+    ollama pull nomic-embed-text
+    ollama pull bge-m3
+    python3 scripts/eval_sv_en_retrieval.py
+
+Writes ``tests/evals/fixtures/sv_en_retrieval/scorecard.json``. It measures retrieval; it never
+changes it, touches a vault, or writes outside that one file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.evals.sv_en_retrieval import (  # noqa: E402
+    IDENTITIES,
+    SCORECARD_PATH,
+    IdentityRun,
+    load_connect_pairs,
+    load_corpus,
+    load_query_set,
+    ollama_models_available,
+    score_connect_precision,
+    score_retrieval,
+)
+
+#: (identity, fusion) configurations the scorecard records, and why each one is in the set.
+RUNS: tuple[tuple[str, str, str], ...] = (
+    ("nomic", "linear", "identity comparison baseline (pre-migration snapshot)"),
+    ("bge_m3", "linear", "identity comparison candidate + shipped default configuration"),
+    ("bge_m3", "rrf", "fusion comparison arm for the G5 default recommendation"),
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=SCORECARD_PATH,
+        help="scorecard destination (default: the committed fixture scorecard)",
+    )
+    parser.add_argument(
+        "--stamp",
+        default=None,
+        help="ISO date recorded as run_date; omit to leave it unset rather than invent one",
+    )
+    args = parser.parse_args()
+
+    available = ollama_models_available()
+    missing = [str(spec["model"]) for spec in IDENTITIES.values() if str(spec["model"]) not in available]
+    if missing:
+        print(f"ERROR: Ollama host is missing required models: {', '.join(missing)}", file=sys.stderr)
+        print("Pull them first: ollama pull nomic-embed-text && ollama pull bge-m3", file=sys.stderr)
+        return 2
+
+    corpus = load_corpus()
+    query_set = load_query_set()
+    pair_set = load_connect_pairs()
+
+    results: dict[str, dict] = {}
+    for identity_key, fusion, rationale in RUNS:
+        label = f"{identity_key}/{fusion}"
+        print(f"running {label} ...", file=sys.stderr)
+        with IdentityRun(identity_key, fusion) as run:
+            results[label] = {
+                "identity": {
+                    "key": identity_key,
+                    "model": str(IDENTITIES[identity_key]["model"]),
+                    "dim": int(IDENTITIES[identity_key]["dim"]),
+                },
+                "fusion": fusion,
+                "rationale": rationale,
+                "retrieval": score_retrieval(run),
+                "connect_precision": score_connect_precision(run),
+            }
+
+    scorecard = {
+        "schema": "sv_en_retrieval_scorecard.v1",
+        "issue": 2985,
+        "slice": "G3-2",
+        "run_date": args.stamp,
+        "runner": "scripts/eval_sv_en_retrieval.py",
+        "host": {"python": platform.python_version(), "platform": platform.platform()},
+        "corpus": {
+            "docs": len(corpus),
+            "sv_docs": sum(1 for doc in corpus if doc.lang == "sv"),
+            "en_docs": sum(1 for doc in corpus if doc.lang == "en"),
+            "topics": sorted({doc.topic for doc in corpus}),
+        },
+        "query_set": {
+            "queries": len(query_set["queries"]),
+            "by_class": {
+                cls: sum(1 for q in query_set["queries"] if q["class"] == cls)
+                for cls in sorted({q["class"] for q in query_set["queries"]})
+            },
+        },
+        "connect_pair_set": {
+            "related_pairs": len(pair_set["related_pairs"]),
+            "hard_negative_pairs": len(pair_set["hard_negative_pairs"]),
+            "seed_queries": len(pair_set["seed_queries"]),
+        },
+        "runs": results,
+    }
+
+    args.output.write_text(json.dumps(scorecard, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md
+++ b/tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md
@@ -1,0 +1,173 @@
+# SV/EN retrieval eval — G3-2 (#2985)
+
+State: Eval note (measurement record). Not an owner doc, not a contract.
+Authority: none. It reports numbers and states one recommendation; the G5 default flip is a separate
+owner call recorded against ADR-0024/ADR-0059.
+Owner: Retrieval spine
+Temporal class: dated measurement — the numbers describe the run recorded in
+`fixtures/sv_en_retrieval/scorecard.json`, not a standing property of the system.
+
+Implements `docs/MIMER_CAPABILITY_HARDENING/RETRIEVAL_EMBEDDINGS_AND_CONTEXT.md :: 2. G3` slice G3-2,
+under owner ruling R2: the eval **validates and tunes** the BGE-M3 migration, it no longer gates it.
+
+## What was measured
+
+- **Corpus** — 20 synthetic documents under `fixtures/sv_en_retrieval/corpus/`, 10 Swedish and 10
+  English, across 12 topics. Eight topics exist in both languages (the labelled topics); four are
+  single-language distractors that deliberately share heavy surface vocabulary with a labelled topic
+  (brewing/sourdough, post-office queueing/watcher backpressure, graph theory/note linking,
+  coffee roasting/sleep). Niflheim-**style**, never Niflheim content: nothing here comes from a real
+  vault.
+- **Query set** — 24 hand-labelled queries, 8 per class:
+  - `sv_only` — Swedish query, gold is the Swedish document on that topic.
+  - `en_only` — English query, gold is the English document on that topic.
+  - `cross_lingual` — Swedish query, gold is **only** the English document on that topic. The
+    same-topic Swedish document is a competitor, not gold. This makes `recall@1` a deliberately
+    harsh number for every identity; `recall@3`/`@5` and MRR are the informative figures.
+- **Path** — the live production entrypoint `app.retrieval.hybrid.scoped_hybrid_search`, the same one
+  `hybrid_search` and the ASK path bind to. Nothing is re-implemented; the eval measures the shipped
+  ranking, BM25 and all.
+- **Identities** — `nomic-embed-text:latest` @768 (pre-migration snapshot) and `bge-m3:latest` @1024
+  (shipped after H4/#2984, TEST+PROD cutover verified on #3124).
+- **Runner** — `scripts/eval_sv_en_retrieval.py`, writing `fixtures/sv_en_retrieval/scorecard.json`.
+
+Two comparisons, each holding one thing fixed:
+
+| Comparison | Fixed | Varied |
+| --- | --- | --- |
+| Identity | fusion = `linear` (shipped default) | `nomic-embed-text`@768 → `bge-m3`@1024 |
+| Fusion | identity = `bge-m3`@1024 (shipped) | `linear` → `rrf` |
+
+## Retrieval quality
+
+Recorded run: `run_date 2026-08-01`, Python 3.13 on macOS/arm64, local Ollama host.
+
+| Run | class | recall@1 | recall@3 | recall@5 | MRR |
+| --- | --- | --- | --- | --- | --- |
+| `nomic/linear` | overall | 0.625 | 0.6667 | 0.6667 | **0.6458** |
+| | sv_only | 0.875 | 1.0 | 1.0 | 0.9375 |
+| | en_only | 1.0 | 1.0 | 1.0 | 1.0 |
+| | cross_lingual | 0.0 | 0.0 | 0.0 | 0.0 |
+| `bge_m3/linear` | overall | 0.625 | 0.9167 | 0.9583 | **0.7653** |
+| | sv_only | 0.875 | 1.0 | 1.0 | 0.9167 |
+| | en_only | 1.0 | 1.0 | 1.0 | 1.0 |
+| | cross_lingual | 0.0 | 0.75 | 0.875 | 0.3792 |
+| `bge_m3/rrf` | overall | 0.625 | 0.625 | 0.6667 | **0.6333** |
+| | sv_only | 0.875 | 0.875 | 0.875 | 0.875 |
+| | en_only | 1.0 | 1.0 | 1.0 | 1.0 |
+| | cross_lingual | 0.0 | 0.0 | 0.125 | 0.025 |
+
+**The migration bought exactly one thing, and it is a large thing.** Monolingually the two identities
+are indistinguishable on this corpus — `en_only` is perfect under both, `sv_only` is perfect at k≥3
+under both. Every point of the overall MRR gain (0.6458 → 0.7653) comes from the cross-lingual class,
+where nomic scores a flat zero: on all eight cross-lingual queries it never returns the
+other-language document *anywhere in the top 5*. BGE-M3 returns it at rank 2 on five of eight, rank 3
+on one, rank 5 on one, and misses one (`bicycle_maintenance`).
+
+That is the honest shape of the R2 inversion's answer: switching to BGE-M3 did not make Swedish or
+English retrieval better, it made the vault **one** corpus instead of two that cannot see each other.
+For a bilingual vault that is the whole point; for a monolingual one the migration would have been
+close to free and close to pointless.
+
+**Caveat on `recall@1`.** It is identical (0.625) across all three runs because it is dominated by the
+cross-lingual class, where the same-language sibling legitimately outranks the gold. Read `recall@1`
+here as "does the other-language document beat its same-language twin", which is not what a user
+wants; `recall@3`/`@5` is the figure that reflects retrieval usefulness.
+
+**Swedish BM25 tokenization gap (README decision 6, explore-only) is visible.** The one `sv_only`
+miss at k=1 and the single cross-lingual miss both involve compound-heavy Swedish
+(`pendlarcykeln`, `våtolja`, `sommarolja`). BM25 tokenizes these as opaque wholes, so the lexical arm
+contributes nothing for a query using the uncompounded form. Nothing in this slice changes that; it
+is recorded here as evidence for whenever that gap is picked up.
+
+## Expansion quality — connect precision
+
+Scored against E3's **real** finding shape, not a proxy: EXP-1 (#2994) is merged, so
+`app/expansion/connect.py :: run_connect_pass` exists. It retrieves `retrieval_k=8` hits per seed
+query, drops hits below `ConnectPassConfig.relatedness_floor = 0.55`, and proposes every unordered
+pair among the survivors as a `connect.related_unlinked` finding. The eval reproduces exactly that
+pair set over 16 seed queries and scores it against 8 hand-labelled SV/EN related pairs plus 8 hard
+negatives.
+
+| Run | proposed pairs | true positives | precision | recall | F1 | hard negatives surfaced |
+| --- | --- | --- | --- | --- | --- | --- |
+| `nomic/linear` | 32 | 1 / 8 | 0.0312 | 0.125 | 0.05 | 2 |
+| `bge_m3/linear` | 8 | 1 / 8 | 0.125 | 0.125 | 0.125 | 1 |
+| `bge_m3/rrf` | 90 | 3 / 8 | 0.0333 | 0.375 | 0.0612 | 4 |
+
+**The finding that matters is not the precision number, it is what it exposes.** Under the shipped
+configuration the Connect pass surfaces one of eight labelled cross-lingual pairs. It is not that
+BGE-M3 cannot see the relationship — the retrieval section proves it ranks the other-language
+document at position 2–3. The problem is that `relatedness_floor` is applied to the **fused** score,
+which is BM25-dominated, and a cross-language document scores low lexically by construction. So the
+floor filters out precisely the pairs the migration made findable.
+
+Two consequences worth carrying forward as separate work (not filed by this slice, which is
+explicitly measurement-only):
+
+1. `relatedness_floor` gates on a fused score whose scale is a property of the fusion strategy, not
+   of relatedness. It is not fusion-portable — see the RRF row: the same 0.55 admits 90 pairs instead
+   of 8, an 11× flood, because RRF compresses scores into a narrow band. Any future fusion default
+   flip silently re-tunes the Connect pass.
+2. If cross-lingual connect findings are wanted, the floor needs to see the embedding similarity, not
+   the fused score.
+
+## G5 default-fusion recommendation
+
+**Keep `linear` as the default. RRF does not meet its burden of proof.**
+
+Per ADR-0024 the burden is on RRF: the current linear weights (`0.5·bm25 + 0.4·emb + 0.1·overlap`)
+are a deliberate trust encoding, and adopting RRF as default is a new ADR, not a config flip. On this
+corpus RRF does not clear that bar — it is worse on every axis that moved:
+
+- Overall MRR **0.7653 → 0.6333** (linear → RRF), on the same identity, same corpus, same queries.
+- Cross-lingual recall@3 **0.75 → 0.0**, recall@5 **0.875 → 0.125**, MRR **0.3792 → 0.025**. RRF
+  destroys the entire benefit of the BGE-M3 migration. Seven of the eight cross-lingual golds that
+  linear surfaces disappear from the top 5 completely.
+- `sv_only` MRR **0.9167 → 0.875**; `en_only` is unchanged at 1.0. So there is no compensating gain
+  anywhere.
+- Connect precision **0.125 → 0.0333**, with hard negatives surfaced rising 1 → 4.
+
+The mechanism is legible and is not a corpus artefact. RRF discards score *magnitude* and fuses on
+rank alone. In cross-lingual retrieval the lexical arm ranks the same-language document top and the
+cross-language document near the bottom or off the list, while the embedding arm ranks the
+cross-language document high but with a moderate absolute score. Linear fusion lets that strong
+normalized embedding score carry the document past a weak BM25 rank; RRF flattens the embedding
+signal into a rank position and lets BM25's monolingual bias dominate. Trust weighting is doing real
+work here, which is precisely ADR-0024's caution — and it is now testable rather than asserted.
+
+Scope of the claim, stated plainly: this is a 20-document synthetic corpus with 24 queries. It is
+strong enough to reject a default flip (rejecting needs only a clear absence of gain, and what is
+present is a large regression) and **not** strong enough to conclude RRF is useless at vault scale. If
+RRF is revisited, revisit it with a per-arm score-normalization fix rather than as a straight default
+swap, and re-run this eval first.
+
+Sizes (`RETRIEVAL_CANDIDATES_PER_MODE`, `RERANK_WINDOW`): this corpus is far below the scale where
+the field's 500/100 numbers mean anything, so it produces no evidence for or against the 100/25
+pre-eval defaults. No recommendation is made on sizes; that is not a finding, it is an absence of
+one.
+
+## Reproducing
+
+Requires an Ollama host with both models pulled — the eval embeds under both identities, so it does
+not run on a machine without ML deps:
+
+```bash
+ollama pull nomic-embed-text
+ollama pull bge-m3
+python3 scripts/eval_sv_en_retrieval.py --stamp <YYYY-MM-DD>
+python3 -m pytest -q tests/evals/test_sv_en_retrieval_eval.py
+```
+
+The test module verifies fixture integrity and scorecard truth with no Ollama present (so CI checks
+that the committed numbers actually describe the committed fixtures, and that this note's
+recommendation follows its own numbers), and additionally re-derives the headline cross-lingual
+finding from live embeddings when an embedding host is available.
+
+## What this note does not do
+
+- It does not implement the G5 fusion flip, the conditional rerank gate, or any size config. G5-1
+  already shipped `fusion={linear|rrf}` dark behind `RetrievalTuning`; this note only recommends what
+  the default should be.
+- It does not change retrieval behaviour in any way.
+- It is not an owner doc and carries no authority.

--- a/tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md
+++ b/tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md
@@ -16,8 +16,8 @@ under owner ruling R2: the eval **validates and tunes** the BGE-M3 migration, it
   English, across 12 topics. Eight topics exist in both languages (the labelled topics); four are
   single-language distractors that deliberately share heavy surface vocabulary with a labelled topic
   (brewing/sourdough, post-office queueing/watcher backpressure, graph theory/note linking,
-  coffee roasting/sleep). Niflheim-**style**, never Niflheim content: nothing here comes from a real
-  vault.
+  coffee roasting/sleep). Modelled on the **shape** of a real bilingual personal vault, never on its
+  content: nothing here comes from a real vault.
 - **Query set** — 24 hand-labelled queries, 8 per class:
   - `sv_only` — Swedish query, gold is the Swedish document on that topic.
   - `en_only` — English query, gold is the English document on that topic.

--- a/tests/evals/fixtures/sv_en_retrieval/README.md
+++ b/tests/evals/fixtures/sv_en_retrieval/README.md
@@ -1,0 +1,72 @@
+# SV/EN retrieval eval fixture set
+
+Hand-labelled fixture set for the SV/EN retrieval eval, slice G3-2
+([#2985](https://github.com/RasmusTho/agentic-pkm-mvp/issues/2985)), specified in
+`docs/MIMER_CAPABILITY_HARDENING/RETRIEVAL_EMBEDDINGS_AND_CONTEXT.md :: 2. G3`.
+
+This set extends the eval-fixture culture established by the anti-contamination corpus in the parent
+directory ([#2551](https://github.com/RasmusTho/agentic-pkm-mvp/issues/2551)) — synthetic content,
+canonical frontmatter metadata, labels committed next to the documents they describe. It is a
+**sibling** set, not part of that corpus: it answers a different question (bilingual retrieval
+quality), and `tests/evals/_helpers.py :: GROUPS` deliberately does not include it, so the
+anti-contamination integrity tests are unaffected.
+
+## Contents
+
+| File | What it is |
+| --- | --- |
+| `corpus/*.md` | 20 synthetic notes, 10 Swedish and 10 English, across 12 topics |
+| `queries.json` | 24 hand-labelled queries — 8 SV-only, 8 EN-only, 8 cross-lingual |
+| `connect_pairs.json` | 8 labelled SV/EN related pairs, 8 hard negatives, 16 connect seed queries |
+| `scorecard.json` | The recorded run, produced by `scripts/eval_sv_en_retrieval.py` |
+
+Read the numbers and the G5 recommendation in `tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md`.
+The harness lives in `tests/evals/sv_en_retrieval.py`; the checks in
+`tests/evals/test_sv_en_retrieval_eval.py`.
+
+## Content rule
+
+**Niflheim-style, never Niflheim content.** Every document here is hand-authored and synthetic. No
+personal, client, work, or vault material may be committed to this directory — the corpus imitates
+the *shape* of a bilingual personal knowledge vault (a builder's working notes mixed with hobby and
+admin notes), not its contents. `test_corpus_is_synthetic_and_canonically_tagged` enforces the
+`synthetic: true` marker and rejects email-like identifiers; the rest is authorial discipline.
+
+## Why the corpus is built the way it is
+
+- **Eight topics exist in both languages.** A cross-lingual gold label is only meaningful when the
+  same subject is genuinely present in the other language. The SV and EN documents on a topic are
+  *not translations of each other* — they are independent notes on the same subject, so lexical
+  overlap across the language boundary is low and BM25 cannot fake a cross-lingual hit.
+- **Four topics are single-language distractors** (`brewing`, `everyday_queueing`, `graph_theory`,
+  `coffee_roasting`). Each shares heavy surface vocabulary with a labelled topic — fermentation
+  temperature and volume with sourdough; queue depth, ceiling and wait time with watcher
+  backpressure; graphs, edges, neighbourhoods and hops with note linking; caffeine with sleep. Without
+  them, recall is high for trivial reasons.
+- **Hard negatives are labelled explicitly** in `connect_pairs.json`. A connect-precision number
+  scored only against random negatives flatters every embedding identity.
+
+## Cross-lingual gold, and why `recall@1` looks harsh
+
+For a `cross_lingual` query the gold set is **only** the other-language document. The same-topic
+document in the query's own language is a competitor, not gold. So `recall@1` measures "does the
+other-language document outrank its same-language twin", which is not what a user wants from
+retrieval; `recall@3` / `recall@5` and MRR are the figures that reflect usefulness. This is a
+deliberate labelling choice, restated in the eval note so the number is never read as a failure it is
+not.
+
+## Regenerating the scorecard
+
+The eval embeds under both identities, so it needs an Ollama host with both models pulled. The
+owner's laptop deliberately carries no ML deps — run this on the mac mini (test channel) or any
+Ollama host:
+
+```bash
+ollama pull nomic-embed-text
+ollama pull bge-m3
+python3 scripts/eval_sv_en_retrieval.py --stamp <YYYY-MM-DD>
+```
+
+Changing anything in `corpus/`, `queries.json`, or `connect_pairs.json` invalidates
+`scorecard.json`; regenerate it in the same change, or
+`test_committed_scorecard_matches_committed_fixtures` will fail — which is the point.

--- a/tests/evals/fixtures/sv_en_retrieval/README.md
+++ b/tests/evals/fixtures/sv_en_retrieval/README.md
@@ -26,7 +26,7 @@ The harness lives in `tests/evals/sv_en_retrieval.py`; the checks in
 
 ## Content rule
 
-**Niflheim-style, never Niflheim content.** Every document here is hand-authored and synthetic. No
+**Vault-shaped, never vault content.** Every document here is hand-authored and synthetic. No
 personal, client, work, or vault material may be committed to this directory — the corpus imitates
 the *shape* of a bilingual personal knowledge vault (a builder's working notes mixed with hobby and
 admin notes), not its contents. `test_corpus_is_synthetic_and_canonically_tagged` enforces the
@@ -58,8 +58,8 @@ not.
 ## Regenerating the scorecard
 
 The eval embeds under both identities, so it needs an Ollama host with both models pulled. The
-owner's laptop deliberately carries no ML deps — run this on the mac mini (test channel) or any
-Ollama host:
+owner's laptop deliberately carries no ML deps — run this on the test-channel host or any other
+machine with an Ollama runtime:
 
 ```bash
 ollama pull nomic-embed-text

--- a/tests/evals/fixtures/sv_en_retrieval/connect_pairs.json
+++ b/tests/evals/fixtures/sv_en_retrieval/connect_pairs.json
@@ -1,0 +1,49 @@
+{
+  "schema": "sv_en_connect_pair_set.v1",
+  "labelled_by": "hand-authored for G3-2 (#2985) Expansion-quality section; synthetic corpus, no vault content",
+  "finding_shape": {
+    "source": "app/expansion/connect.py :: run_connect_pass",
+    "note": "E3 (EXP-1, #2994) is merged, so this section scores the REAL Connect finding shape, not a proxy. run_connect_pass retrieves k hits per seed query, drops hits below ConnectPassConfig.relatedness_floor, and proposes every unordered pair among the survivors as a connect.related_unlinked finding. Connect precision here is therefore the precision of exactly that pair set against the labels below, with the same defaults (retrieval_k=8, relatedness_floor=0.55).",
+    "retrieval_k": 8,
+    "relatedness_floor": 0.55
+  },
+  "related_pairs": [
+    ["omindexering-sv", "index-rebuild-en"],
+    ["bevakare-mottryck-sv", "watcher-backpressure-en"],
+    ["lankvanor-sv", "note-linking-en"],
+    ["somn-och-fokus-sv", "sleep-focus-en"],
+    ["surdeg-sv", "sourdough-en"],
+    ["cykelservice-sv", "bicycle-maintenance-en"],
+    ["avdrag-frilans-sv", "freelance-expenses-en"],
+    ["spelbalans-sv", "board-game-design-en"]
+  ],
+  "hard_negative_pairs": [
+    ["surdeg-sv", "olbryggning-jast-sv"],
+    ["sourdough-en", "olbryggning-jast-sv"],
+    ["bevakare-mottryck-sv", "post-office-queue-en"],
+    ["watcher-backpressure-en", "post-office-queue-en"],
+    ["lankvanor-sv", "grafteori-sv"],
+    ["note-linking-en", "grafteori-sv"],
+    ["somn-och-fokus-sv", "coffee-roasting-en"],
+    ["sleep-focus-en", "coffee-roasting-en"]
+  ],
+  "hard_negative_rationale": "Each hard negative shares heavy surface vocabulary with its partner (fermentation temperature and volume; queue depth, ceiling and wait time; graphs, edges, neighbourhoods and hops; caffeine) while being a different subject. A pair set scored only against random negatives would flatter both identities.",
+  "seed_queries": [
+    "omindexering och vektoridentitet",
+    "reindexing after an embedding identity change",
+    "mottryck och kölängd i bevakaren",
+    "watcher queue backpressure and wait time",
+    "länkvanor och grafens grannskap",
+    "note linking habits and graph neighbourhoods",
+    "sömn koffein och fokus på förmiddagen",
+    "sleep caffeine and morning focus",
+    "surdeg jäsning och köksmätning",
+    "sourdough fermentation and kitchen measurement",
+    "cykelservice salt och kedja på vintern",
+    "bicycle winter servicing salt and chain",
+    "avdrag för frilans hemmakontor och bredband",
+    "freelance deductions home office and broadband",
+    "brädspelsbalans och dämpning för den som leder",
+    "board game balance and a catch-up damper"
+  ]
+}

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/avdrag-frilans-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/avdrag-frilans-sv.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: freelance_expenses
+---
+
+# Vad jag faktiskt får dra av som frilans
+
+Regeln jag missförstod längst: en utgift måste vara nödvändig för intäkten, inte
+bara praktisk för mig. Skrivbordet hemma räknas bara om rummet uteslutande används
+för arbetet, och det gör mitt inte.
+
+Det som är rakt fram: verktyg och licenser jag använder i uppdragen, resor till
+kund, och avgifter för bokföring. Det som kräver eftertanke: telefon och bredband,
+där jag måste dela upp privat och yrkesmässig del och kunna motivera fördelningen.
+
+Kvitton utan sammanhang är värdelösa. Jag skriver en rad om vilket uppdrag varje
+utgift hör till samma dag jag lägger in den — ett år senare minns jag ingenting.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/bevakare-mottryck-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/bevakare-mottryck-sv.md
@@ -1,0 +1,25 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: watcher_backpressure
+---
+
+# Mottryck i filbevakaren
+
+Bevakaren läser ändringar snabbare än arbetarna hinner beta av dem. Utan tak växer
+kön tills minnet tar slut, och då förlorar jag ändringar som aldrig skrevs ner
+någon annanstans.
+
+Lösningen var inte fler arbetare utan en gräns. När kön passerar sitt tak slutar
+bevakaren att läsa nytt och låter operativsystemet buffra i stället. Det känns
+långsammare men ingenting försvinner, och återhämtningen efter en topp blir
+förutsägbar.
+
+Jag loggar kölängd och väntetid per varv. Utan de två talen gissar jag, och mina
+gissningar har varit fel varje gång jag jämfört dem med mätningen.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/bicycle-maintenance-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/bicycle-maintenance-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: bicycle_maintenance
+---
+
+# Winter servicing on the commuter bike
+
+Road salt does more damage than rain. After one winter of commuting the chain
+goes dull and the cassette picks up a grey film that no rag will shift.
+
+The routine that saved my drivetrain: rinse the salt off the same evening, dry it,
+and switch to a heavier wet lubricant instead of the thin summer oil. Once a month
+the chain comes off and soaks in degreaser overnight.
+
+Brake cables are the other place winter shows. They rust from the inside where they
+enter the housing, and once they bind no amount of adjustment helps — replacement
+is the only fix. I now swap them preventively every spring.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/board-game-design-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/board-game-design-en.md
@@ -1,0 +1,25 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: board_game_design
+---
+
+# Balance in the board game I am building
+
+The trouble is not that one strategy is too strong, it is that it is too strong too
+early. Whoever leads after the first third keeps the lead, and the other three sit
+there for two hours unable to affect the outcome.
+
+I am testing a damper: whoever is ahead pays an extra cost for the same action. It
+must not read as punishment, so the cost is small and visible from the start rather
+than landing as a surprise at the end.
+
+Playtests tell me more than my arithmetic does. Four sessions with different players
+exposed an opening I had not considered, and it was stronger than anything I had
+calculated.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/coffee-roasting-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/coffee-roasting-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: coffee_roasting
+---
+
+# Roasting notes: caffeine, acidity, time
+
+Darker roasts do not carry more caffeine — the difference between a light and a
+dark roast by weight is small enough to be noise next to how much I actually pour.
+Acidity is where the roast level really shows.
+
+The window between first crack and the point where the sweetness flattens out is
+about ninety seconds on my drum. Past that the cup goes ashy and no grind
+adjustment brings it back.
+
+I log the temperature curve for every batch. Two batches with the same beans and
+different curves taste further apart than two different beans on the same curve.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/cykelservice-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/cykelservice-sv.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: bicycle_maintenance
+---
+
+# Vinterservice på pendlarcykeln
+
+Saltet är värre än regnet. Efter en vinter på pendlingsvägen är kedjan matt och
+kassetten har fått en gråaktig hinna som inte går bort med en trasa.
+
+Rutinen som räddat drivlinan: skölj av saltet samma kväll, torka, och lägg på en
+tjockare våtolja i stället för den tunna sommaroljan. En gång i månaden av med
+kedjan och i avfettning över natten.
+
+Bromsvajrarna är det andra stället där vintern syns. De rostar inifrån där de går
+in i höljet, och när de väl kärvar hjälper ingen justering — då är det byte som
+gäller. Jag byter dem numera i förebyggande syfte varje vår.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/freelance-expenses-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/freelance-expenses-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: freelance_expenses
+---
+
+# What I can actually deduct as a freelancer
+
+The rule I misread for longest: a cost has to be necessary for the income, not
+merely convenient for me. A desk at home counts only if the room is used solely
+for work, and mine is not.
+
+Straightforward: tools and licences I use on assignments, travel to a client, and
+bookkeeping fees. Needs thought: phone and broadband, where I have to split the
+private and professional share and be able to justify the split.
+
+Receipts without context are worthless. I write one line about which assignment a
+cost belongs to on the same day I file it — a year later I remember nothing.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/grafteori-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/grafteori-sv.md
@@ -1,0 +1,25 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: graph_theory
+---
+
+# Studieanteckningar: grafer och avstånd
+
+En graf är noder och kanter, ingenting mer. Diametern är det längsta kortaste
+avståndet mellan två noder, och den säger något om hur snabbt information kan
+vandra genom grafen.
+
+Slumpgrafer får förvånansvärt liten diameter redan vid låg kantdensitet. Det är
+resultatet bakom "sex steg" — grannskapet växer exponentiellt med antalet steg
+så länge kanterna inte är starkt lokala.
+
+Klusterkoefficienten är motvikten: den mäter hur ofta två grannar till samma nod
+också är grannar med varandra. Hög klustring och liten diameter samtidigt är vad
+som kännetecknar små-världs-grafer.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/index-rebuild-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/index-rebuild-en.md
@@ -1,0 +1,26 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: index_rebuild
+---
+
+# Reindexing after an embedding identity change
+
+Swapping the model or the vector width invalidates every stored vector at once.
+The source text is untouched, but the vectors belong to the identity that produced
+them, so a store holding two identities ranks badly and silently instead of
+failing loudly.
+
+The discipline I follow: pause writes, rebuild the whole store from the canonical
+text, then run a strict health pass that refuses to go green while two identities
+still coexist. Traffic goes back on only after that.
+
+The part that always surprises me is duration. Raising the per-document character
+budget means fewer splits and better vectors, but each call costs more, so the
+rebuild window stretches. I re-measure before promising anyone a time box.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/lankvanor-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/lankvanor-sv.md
@@ -1,0 +1,25 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: note_linking
+---
+
+# Varför mina länkar slutade vara till nytta
+
+Jag länkade allt till allt i ett halvår. Resultatet blev en graf där varje
+anteckning når varannan på två steg, vilket i praktiken betyder att grannskapet
+inte säger någonting alls.
+
+Nu länkar jag bara när jag kan skriva ut varför i samma mening. "Den här hör ihop
+med den där eftersom mätningen motsäger antagandet" är en länk värd att behålla.
+En naken hänvisning utan skäl är en länk jag kommer att ta bort om ett år utan att
+minnas vad den betydde.
+
+Färre kanter, mer mening. Det gör också att förslag på nya kopplingar går att
+bedöma — jag ser direkt om skälet håller.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/note-linking-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/note-linking-en.md
@@ -1,0 +1,25 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: note_linking
+---
+
+# When my links stopped being useful
+
+For half a year I linked everything to everything. What I got was a graph where
+any note reaches any other in two hops, which is another way of saying the
+neighbourhood carries no information.
+
+These days a link only goes in if I can write the reason in the same sentence.
+"This one belongs with that one because the measurement contradicts the
+assumption" is worth keeping. A bare pointer with no stated reason is a link I
+will delete a year later without remembering what it meant.
+
+Fewer edges, more meaning. It also makes proposed connections judgeable — I can
+see straight away whether the stated reason holds.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/olbryggning-jast-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/olbryggning-jast-sv.md
@@ -1,0 +1,23 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: brewing
+---
+
+# Jästtemperatur vid ölbryggning
+
+Jäsningen är känsligare för temperatur än för recept. Ett par grader för varmt och
+jästen producerar fruktiga bismaker som inte hör hemma i en ljus lager.
+
+Jag håller kärlet i ett svalt utrymme och mäter volymen på skummet i stället för
+att titta på klockan. När aktiviteten avtar och ytan lägger sig är huvudjäsningen
+klar, oavsett vad tabellen sa.
+
+Mjölksyra från en smittad sats går inte att rädda. Rengöring före allt annat —
+det är den enda regeln jag aldrig frångår.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/omindexering-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/omindexering-sv.md
@@ -1,0 +1,27 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: index_rebuild
+---
+
+# Omindexering när vektoridentiteten byts
+
+Varje gång modellen eller dimensionen ändras blir hela den lagrade vektormängden
+ogiltig. Det spelar ingen roll att texten är oförändrad — vektorerna är knutna till
+den identitet som skapade dem, så en blandning av gamla och nya vektorer ger tyst
+felaktig rangordning i stället för ett hårt fel.
+
+Min rutin: frys skrivningarna, kör en full ombyggnad från den kanoniska texten,
+och kör sedan en strikt hälsokontroll som vägrar passera om två identiteter
+fortfarande samexisterar i lagret. Först därefter släpper jag på trafiken igen.
+
+Det som brukar bita mig är att ombyggnaden tar längre tid än jag tror när
+teckenbudgeten per dokument höjs. Längre stycken betyder färre delningar och
+bättre vektorer, men varje anrop blir dyrare. Jag mäter alltid om innan jag lovar
+ett tidsfönster.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/post-office-queue-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/post-office-queue-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: everyday_queueing
+---
+
+# The queue at the post office
+
+Two counters, one line, and a wait time that swings from four minutes to forty
+depending on the hour. The queue depth at the door predicts the wait better than
+the number of staff behind the counter does.
+
+What changed my timing: going right after lunch instead of at opening. The ceiling
+on how many people the room holds means the overflow waits outside, and that
+backlog drains slowly for the first hour.
+
+I keep a note of which days ran long. Three months of that beat every piece of
+advice I was given about the best time to go.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/sleep-focus-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/sleep-focus-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: sleep_focus
+---
+
+# Sleep decides the morning
+
+Two weeks of logging was enough to see it: going to bed after midnight wipes out
+the whole connected morning. I can still answer messages, but I never get into
+anything that needs several things held in my head at once.
+
+The fix is embarrassingly plain and works anyway — dark room, no screen for the
+last half hour, same time every night including weekends. The dullest advice going
+turned out to be the only one I have measured an effect from.
+
+Caffeine after two in the afternoon pushes falling asleep back by roughly an hour.
+You never notice it happening, only the day after.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/somn-och-fokus-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/somn-och-fokus-sv.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: sleep_focus
+---
+
+# Sömnen avgör förmiddagen
+
+Två veckors loggning räckte för att se mönstret: när jag lägger mig efter midnatt
+försvinner den sammanhängande förmiddagen helt. Jag hinner svara på meddelanden men
+kommer aldrig in i något som kräver att jag håller flera saker i huvudet samtidigt.
+
+Motmedlet är banalt och funkar ändå — mörkt rum, ingen skärm sista halvtimmen, och
+samma tid varje kväll även i helgen. Det tråkigaste rådet i världen visade sig vara
+det enda jag mätt en effekt av.
+
+Koffein efter klockan två flyttar insomningen med ungefär en timme. Det märks inte
+när det händer, bara dagen efter.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/sourdough-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/sourdough-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: sourdough
+---
+
+# Sourdough and the kitchen measurement
+
+The basics are a wet dough, a long rise, and a kitchen that holds a steady
+temperature. Mine sits at seventeen degrees through winter, so the recipe that
+works in May takes nearly twice as long in January.
+
+I stopped following the clock and started following the dough. It is ready when
+the volume is up by roughly three quarters and the surface bubbles without
+collapsing when I nudge the bowl. That signal reads the same in any season.
+
+Coarse flour drinks more water than I expect. Always weigh, never measure by
+scoop — the gap between two scoops is wider than the gap between two recipes.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/spelbalans-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/spelbalans-sv.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: board_game_design
+---
+
+# Balans i brädspelet jag håller på med
+
+Problemet är inte att någon strategi är för stark, utan att den är för stark för
+tidigt. Den som får ledningen i första tredjedelen behåller den, och de andra tre
+sitter kvar i två timmar utan att kunna påverka utgången.
+
+Jag testar en dämpning: den som leder betalar en extra kostnad för samma handling.
+Det får inte kännas som en bestraffning, så kostnaden är liten och synlig från
+början i stället för att slå till som en överraskning i slutet.
+
+Speltesterna säger mer än mina uträkningar. Fyra omgångar med olika spelare avslöjade
+en öppning jag inte sett, och den var starkare än allt jag hade räknat på.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/surdeg-sv.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/surdeg-sv.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: sv
+topic: sourdough
+---
+
+# Surdegen och köksmätningen
+
+Grunden är blöt deg, lång jäsning och ett kök som håller jämn temperatur. Vintern
+i mitt kök ligger på sjutton grader, så samma recept som fungerar i maj tar nästan
+dubbla tiden i januari.
+
+Jag slutade följa klockan och började följa degen. Den är klar när volymen ökat
+med ungefär tre fjärdedelar och ytan bubblar utan att falla ihop när jag knuffar
+till bunken. Den signalen är densamma oavsett årstid.
+
+Grovmalet mjöl suger mer vatten än jag tror. Väg alltid, mät aldrig i deciliter —
+skillnaden mellan två skopor är större än skillnaden mellan två recept.

--- a/tests/evals/fixtures/sv_en_retrieval/corpus/watcher-backpressure-en.md
+++ b/tests/evals/fixtures/sv_en_retrieval/corpus/watcher-backpressure-en.md
@@ -1,0 +1,24 @@
+---
+scope_id: scope:general/retrieval-eval
+sphere: general
+source_role: human_note
+authority_state: draft
+evidence_role: background
+sensitivity: public
+synthetic: true
+lang: en
+topic: watcher_backpressure
+---
+
+# Backpressure in the file watcher
+
+The watcher picks up changes faster than the workers drain them. With no ceiling
+the queue grows until memory runs out, and the changes I lose are exactly the ones
+never written down anywhere else.
+
+Adding workers did not fix it; a bound did. Once the queue crosses its ceiling the
+watcher stops reading and lets the operating system buffer instead. It feels
+slower, nothing is dropped, and recovery after a burst becomes predictable.
+
+I log queue depth and per-cycle wait time. Without those two numbers I am guessing,
+and every guess I have checked against the measurement was wrong.

--- a/tests/evals/fixtures/sv_en_retrieval/queries.json
+++ b/tests/evals/fixtures/sv_en_retrieval/queries.json
@@ -1,0 +1,42 @@
+{
+  "schema": "sv_en_retrieval_query_set.v1",
+  "labelled_by": "hand-authored for G3-2 (#2985); synthetic corpus, no vault content",
+  "classes": {
+    "sv_only": "Swedish query; gold is the Swedish document on that topic.",
+    "en_only": "English query; gold is the English document on that topic.",
+    "cross_lingual": "Query in one language; gold is deliberately ONLY the other-language document on the same topic. The same-topic same-language document is a competitor, not gold — so this class measures whether the other-language document surfaces at all, and at what rank. recall@1 is expected to be harsh for both identities; recall@3/@5 and MRR are the informative figures."
+  },
+  "queries": [
+    {"id": "q01", "class": "sv_only", "topic": "index_rebuild", "query": "varför måste jag bygga om hela indexet när modellen byts", "gold": ["omindexering-sv"]},
+    {"id": "q02", "class": "en_only", "topic": "index_rebuild", "query": "why does changing the embedding model force a full reindex", "gold": ["index-rebuild-en"]},
+    {"id": "q03", "class": "cross_lingual", "topic": "index_rebuild", "query": "blandade vektoridentiteter i lagret ger tyst felaktig rangordning", "gold": ["index-rebuild-en"]},
+
+    {"id": "q04", "class": "sv_only", "topic": "watcher_backpressure", "query": "kön i filbevakaren växer tills minnet tar slut", "gold": ["bevakare-mottryck-sv"]},
+    {"id": "q05", "class": "en_only", "topic": "watcher_backpressure", "query": "bounding the watcher queue instead of adding more workers", "gold": ["watcher-backpressure-en"]},
+    {"id": "q06", "class": "cross_lingual", "topic": "watcher_backpressure", "query": "mottryck gör återhämtningen efter en topp förutsägbar", "gold": ["watcher-backpressure-en"]},
+
+    {"id": "q07", "class": "sv_only", "topic": "note_linking", "query": "jag länkade allt till allt och grafen blev meningslös", "gold": ["lankvanor-sv"]},
+    {"id": "q08", "class": "en_only", "topic": "note_linking", "query": "only add a link when you can state the reason", "gold": ["note-linking-en"]},
+    {"id": "q09", "class": "cross_lingual", "topic": "note_linking", "query": "en naken hänvisning utan skäl är värdelös om ett år", "gold": ["note-linking-en"]},
+
+    {"id": "q10", "class": "sv_only", "topic": "sleep_focus", "query": "sen sänggående förstör hela min förmiddag", "gold": ["somn-och-fokus-sv"]},
+    {"id": "q11", "class": "en_only", "topic": "sleep_focus", "query": "caffeine in the afternoon delays falling asleep", "gold": ["sleep-focus-en"]},
+    {"id": "q12", "class": "cross_lingual", "topic": "sleep_focus", "query": "mörkt rum och samma tid varje kväll även i helgen", "gold": ["sleep-focus-en"]},
+
+    {"id": "q13", "class": "sv_only", "topic": "sourdough", "query": "hur vet jag att surdegen är färdigjäst", "gold": ["surdeg-sv"]},
+    {"id": "q14", "class": "en_only", "topic": "sourdough", "query": "cold kitchen makes the dough rise much slower in winter", "gold": ["sourdough-en"]},
+    {"id": "q15", "class": "cross_lingual", "topic": "sourdough", "query": "väg mjölet i stället för att mäta i deciliter", "gold": ["sourdough-en"]},
+
+    {"id": "q16", "class": "sv_only", "topic": "bicycle_maintenance", "query": "saltet förstör kedjan på pendlarcykeln under vintern", "gold": ["cykelservice-sv"]},
+    {"id": "q17", "class": "en_only", "topic": "bicycle_maintenance", "query": "brake cables rust inside the housing and start binding", "gold": ["bicycle-maintenance-en"]},
+    {"id": "q18", "class": "cross_lingual", "topic": "bicycle_maintenance", "query": "tjockare våtolja på vintern i stället för tunn sommarolja", "gold": ["bicycle-maintenance-en"]},
+
+    {"id": "q19", "class": "sv_only", "topic": "freelance_expenses", "query": "får jag dra av hemmakontoret som frilans", "gold": ["avdrag-frilans-sv"]},
+    {"id": "q20", "class": "en_only", "topic": "freelance_expenses", "query": "splitting phone and broadband between private and professional use", "gold": ["freelance-expenses-en"]},
+    {"id": "q21", "class": "cross_lingual", "topic": "freelance_expenses", "query": "en utgift måste vara nödvändig för intäkten inte bara praktisk", "gold": ["freelance-expenses-en"]},
+
+    {"id": "q22", "class": "sv_only", "topic": "board_game_design", "query": "den som leder tidigt behåller ledningen hela spelet", "gold": ["spelbalans-sv"]},
+    {"id": "q23", "class": "en_only", "topic": "board_game_design", "query": "a catch-up cost should not feel like punishment", "gold": ["board-game-design-en"]},
+    {"id": "q24", "class": "cross_lingual", "topic": "board_game_design", "query": "speltesterna avslöjade en öppning jag inte hade räknat på", "gold": ["board-game-design-en"]}
+  ]
+}

--- a/tests/evals/fixtures/sv_en_retrieval/scorecard.json
+++ b/tests/evals/fixtures/sv_en_retrieval/scorecard.json
@@ -1,0 +1,1853 @@
+{
+  "schema": "sv_en_retrieval_scorecard.v1",
+  "issue": 2985,
+  "slice": "G3-2",
+  "run_date": "2026-08-01",
+  "runner": "scripts/eval_sv_en_retrieval.py",
+  "host": {
+    "python": "3.12.7",
+    "platform": "macOS-26.5.2-arm64-arm-64bit"
+  },
+  "corpus": {
+    "docs": 20,
+    "sv_docs": 10,
+    "en_docs": 10,
+    "topics": [
+      "bicycle_maintenance",
+      "board_game_design",
+      "brewing",
+      "coffee_roasting",
+      "everyday_queueing",
+      "freelance_expenses",
+      "graph_theory",
+      "index_rebuild",
+      "note_linking",
+      "sleep_focus",
+      "sourdough",
+      "watcher_backpressure"
+    ]
+  },
+  "query_set": {
+    "queries": 24,
+    "by_class": {
+      "cross_lingual": 8,
+      "en_only": 8,
+      "sv_only": 8
+    }
+  },
+  "connect_pair_set": {
+    "related_pairs": 8,
+    "hard_negative_pairs": 8,
+    "seed_queries": 16
+  },
+  "runs": {
+    "nomic/linear": {
+      "identity": {
+        "key": "nomic",
+        "model": "nomic-embed-text:latest",
+        "dim": 768
+      },
+      "fusion": "linear",
+      "rationale": "identity comparison baseline (pre-migration snapshot)",
+      "retrieval": {
+        "overall": {
+          "n": 24,
+          "recall": {
+            "@1": 0.625,
+            "@3": 0.6667,
+            "@5": 0.6667
+          },
+          "mrr": 0.6458
+        },
+        "by_class": {
+          "sv_only": {
+            "n": 8,
+            "recall": {
+              "@1": 0.875,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "mrr": 0.9375
+          },
+          "en_only": {
+            "n": 8,
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "mrr": 1.0
+          },
+          "cross_lingual": {
+            "n": 8,
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "mrr": 0.0
+          }
+        },
+        "per_query": [
+          {
+            "id": "q01",
+            "class": "sv_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "omindexering-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "grafteori-sv",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q02",
+            "class": "en_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "index-rebuild-en",
+              "bicycle-maintenance-en",
+              "omindexering-sv",
+              "watcher-backpressure-en",
+              "note-linking-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q03",
+            "class": "cross_lingual",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "lankvanor-sv",
+              "olbryggning-jast-sv",
+              "avdrag-frilans-sv",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q04",
+            "class": "sv_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "bevakare-mottryck-sv"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "surdeg-sv",
+              "omindexering-sv",
+              "grafteori-sv",
+              "cykelservice-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q05",
+            "class": "en_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "watcher-backpressure-en",
+              "post-office-queue-en",
+              "bicycle-maintenance-en",
+              "board-game-design-en",
+              "index-rebuild-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q06",
+            "class": "cross_lingual",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "avdrag-frilans-sv",
+              "somn-och-fokus-sv",
+              "lankvanor-sv",
+              "cykelservice-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q07",
+            "class": "sv_only",
+            "topic": "note_linking",
+            "gold": [
+              "lankvanor-sv"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "spelbalans-sv",
+              "olbryggning-jast-sv",
+              "avdrag-frilans-sv",
+              "grafteori-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q08",
+            "class": "en_only",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "note-linking-en",
+              "sleep-focus-en",
+              "freelance-expenses-en",
+              "bicycle-maintenance-en",
+              "index-rebuild-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q09",
+            "class": "cross_lingual",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "omindexering-sv",
+              "spelbalans-sv",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q10",
+            "class": "sv_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "somn-och-fokus-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "somn-och-fokus-sv",
+              "avdrag-frilans-sv",
+              "lankvanor-sv",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          },
+          {
+            "id": "q11",
+            "class": "en_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "sleep-focus-en",
+              "coffee-roasting-en",
+              "post-office-queue-en",
+              "watcher-backpressure-en",
+              "bicycle-maintenance-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q12",
+            "class": "cross_lingual",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "somn-och-fokus-sv",
+              "cykelservice-sv",
+              "omindexering-sv",
+              "lankvanor-sv",
+              "avdrag-frilans-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q13",
+            "class": "sv_only",
+            "topic": "sourdough",
+            "gold": [
+              "surdeg-sv"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "grafteori-sv",
+              "lankvanor-sv",
+              "spelbalans-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q14",
+            "class": "en_only",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "sourdough-en",
+              "bicycle-maintenance-en",
+              "coffee-roasting-en",
+              "note-linking-en",
+              "post-office-queue-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q15",
+            "class": "cross_lingual",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "spelbalans-sv",
+              "cykelservice-sv",
+              "omindexering-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q16",
+            "class": "sv_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "cykelservice-sv"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "lankvanor-sv",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q17",
+            "class": "en_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "bicycle-maintenance-en",
+              "board-game-design-en",
+              "index-rebuild-en",
+              "watcher-backpressure-en",
+              "coffee-roasting-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q18",
+            "class": "cross_lingual",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "olbryggning-jast-sv",
+              "spelbalans-sv",
+              "surdeg-sv",
+              "omindexering-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q19",
+            "class": "sv_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "avdrag-frilans-sv"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "spelbalans-sv",
+              "cykelservice-sv",
+              "omindexering-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q20",
+            "class": "en_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "freelance-expenses-en",
+              "coffee-roasting-en",
+              "sourdough-en",
+              "avdrag-frilans-sv",
+              "post-office-queue-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q21",
+            "class": "cross_lingual",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "lankvanor-sv",
+              "somn-och-fokus-sv",
+              "spelbalans-sv",
+              "olbryggning-jast-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q22",
+            "class": "sv_only",
+            "topic": "board_game_design",
+            "gold": [
+              "spelbalans-sv"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "omindexering-sv",
+              "surdeg-sv",
+              "avdrag-frilans-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q23",
+            "class": "en_only",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "board-game-design-en",
+              "freelance-expenses-en",
+              "watcher-backpressure-en",
+              "coffee-roasting-en",
+              "index-rebuild-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q24",
+            "class": "cross_lingual",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "olbryggning-jast-sv",
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "cykelservice-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          }
+        ]
+      },
+      "connect_precision": {
+        "proposed_pairs": 32,
+        "labelled_related_pairs": 8,
+        "true_positives": 1,
+        "hard_negatives_surfaced": 2,
+        "precision": 0.0312,
+        "recall": 0.125,
+        "f1": 0.05,
+        "missed_related_pairs": [
+          [
+            "avdrag-frilans-sv",
+            "freelance-expenses-en"
+          ],
+          [
+            "bevakare-mottryck-sv",
+            "watcher-backpressure-en"
+          ],
+          [
+            "board-game-design-en",
+            "spelbalans-sv"
+          ],
+          [
+            "index-rebuild-en",
+            "omindexering-sv"
+          ],
+          [
+            "lankvanor-sv",
+            "note-linking-en"
+          ],
+          [
+            "sleep-focus-en",
+            "somn-och-fokus-sv"
+          ],
+          [
+            "sourdough-en",
+            "surdeg-sv"
+          ]
+        ],
+        "hard_negative_pairs_surfaced": [
+          [
+            "olbryggning-jast-sv",
+            "surdeg-sv"
+          ],
+          [
+            "post-office-queue-en",
+            "watcher-backpressure-en"
+          ]
+        ]
+      }
+    },
+    "bge_m3/linear": {
+      "identity": {
+        "key": "bge_m3",
+        "model": "bge-m3:latest",
+        "dim": 1024
+      },
+      "fusion": "linear",
+      "rationale": "identity comparison candidate + shipped default configuration",
+      "retrieval": {
+        "overall": {
+          "n": 24,
+          "recall": {
+            "@1": 0.625,
+            "@3": 0.9167,
+            "@5": 0.9583
+          },
+          "mrr": 0.7653
+        },
+        "by_class": {
+          "sv_only": {
+            "n": 8,
+            "recall": {
+              "@1": 0.875,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "mrr": 0.9167
+          },
+          "en_only": {
+            "n": 8,
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "mrr": 1.0
+          },
+          "cross_lingual": {
+            "n": 8,
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.75,
+              "@5": 0.875
+            },
+            "mrr": 0.3792
+          }
+        },
+        "per_query": [
+          {
+            "id": "q01",
+            "class": "sv_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "omindexering-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "index-rebuild-en",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q02",
+            "class": "en_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "index-rebuild-en",
+              "omindexering-sv",
+              "bicycle-maintenance-en",
+              "watcher-backpressure-en",
+              "note-linking-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q03",
+            "class": "cross_lingual",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "index-rebuild-en",
+              "board-game-design-en",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          },
+          {
+            "id": "q04",
+            "class": "sv_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "bevakare-mottryck-sv"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "watcher-backpressure-en",
+              "omindexering-sv",
+              "index-rebuild-en",
+              "post-office-queue-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q05",
+            "class": "en_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "watcher-backpressure-en",
+              "post-office-queue-en",
+              "bevakare-mottryck-sv",
+              "index-rebuild-en",
+              "bicycle-maintenance-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q06",
+            "class": "cross_lingual",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "watcher-backpressure-en",
+              "spelbalans-sv",
+              "somn-och-fokus-sv",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          },
+          {
+            "id": "q07",
+            "class": "sv_only",
+            "topic": "note_linking",
+            "gold": [
+              "lankvanor-sv"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "note-linking-en",
+              "spelbalans-sv",
+              "avdrag-frilans-sv",
+              "omindexering-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q08",
+            "class": "en_only",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "note-linking-en",
+              "sleep-focus-en",
+              "lankvanor-sv",
+              "freelance-expenses-en",
+              "index-rebuild-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q09",
+            "class": "cross_lingual",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "note-linking-en",
+              "omindexering-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.3333
+          },
+          {
+            "id": "q10",
+            "class": "sv_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "somn-och-fokus-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "sleep-focus-en",
+              "somn-och-fokus-sv",
+              "index-rebuild-en",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.3333
+          },
+          {
+            "id": "q11",
+            "class": "en_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "sleep-focus-en",
+              "somn-och-fokus-sv",
+              "coffee-roasting-en",
+              "board-game-design-en",
+              "post-office-queue-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q12",
+            "class": "cross_lingual",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "somn-och-fokus-sv",
+              "sleep-focus-en",
+              "omindexering-sv",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          },
+          {
+            "id": "q13",
+            "class": "sv_only",
+            "topic": "sourdough",
+            "gold": [
+              "surdeg-sv"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "grafteori-sv",
+              "olbryggning-jast-sv",
+              "spelbalans-sv",
+              "sourdough-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q14",
+            "class": "en_only",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "sourdough-en",
+              "bicycle-maintenance-en",
+              "coffee-roasting-en",
+              "note-linking-en",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q15",
+            "class": "cross_lingual",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "cykelservice-sv",
+              "spelbalans-sv",
+              "sourdough-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 1.0
+            },
+            "rr": 0.2
+          },
+          {
+            "id": "q16",
+            "class": "sv_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "cykelservice-sv"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "bicycle-maintenance-en",
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q17",
+            "class": "en_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "bicycle-maintenance-en",
+              "board-game-design-en",
+              "index-rebuild-en",
+              "cykelservice-sv",
+              "coffee-roasting-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q18",
+            "class": "cross_lingual",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "omindexering-sv",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q19",
+            "class": "sv_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "avdrag-frilans-sv"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "freelance-expenses-en",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q20",
+            "class": "en_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "freelance-expenses-en",
+              "avdrag-frilans-sv",
+              "coffee-roasting-en",
+              "sourdough-en",
+              "sleep-focus-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q21",
+            "class": "cross_lingual",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "freelance-expenses-en",
+              "spelbalans-sv",
+              "lankvanor-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          },
+          {
+            "id": "q22",
+            "class": "sv_only",
+            "topic": "board_game_design",
+            "gold": [
+              "spelbalans-sv"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "board-game-design-en",
+              "omindexering-sv",
+              "somn-och-fokus-sv",
+              "olbryggning-jast-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q23",
+            "class": "en_only",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "board-game-design-en",
+              "freelance-expenses-en",
+              "watcher-backpressure-en",
+              "coffee-roasting-en",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q24",
+            "class": "cross_lingual",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "board-game-design-en",
+              "bevakare-mottryck-sv",
+              "watcher-backpressure-en",
+              "olbryggning-jast-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 0.5
+          }
+        ]
+      },
+      "connect_precision": {
+        "proposed_pairs": 8,
+        "labelled_related_pairs": 8,
+        "true_positives": 1,
+        "hard_negatives_surfaced": 1,
+        "precision": 0.125,
+        "recall": 0.125,
+        "f1": 0.125,
+        "missed_related_pairs": [
+          [
+            "avdrag-frilans-sv",
+            "freelance-expenses-en"
+          ],
+          [
+            "bevakare-mottryck-sv",
+            "watcher-backpressure-en"
+          ],
+          [
+            "board-game-design-en",
+            "spelbalans-sv"
+          ],
+          [
+            "index-rebuild-en",
+            "omindexering-sv"
+          ],
+          [
+            "lankvanor-sv",
+            "note-linking-en"
+          ],
+          [
+            "sleep-focus-en",
+            "somn-och-fokus-sv"
+          ],
+          [
+            "sourdough-en",
+            "surdeg-sv"
+          ]
+        ],
+        "hard_negative_pairs_surfaced": [
+          [
+            "post-office-queue-en",
+            "watcher-backpressure-en"
+          ]
+        ]
+      }
+    },
+    "bge_m3/rrf": {
+      "identity": {
+        "key": "bge_m3",
+        "model": "bge-m3:latest",
+        "dim": 1024
+      },
+      "fusion": "rrf",
+      "rationale": "fusion comparison arm for the G5 default recommendation",
+      "retrieval": {
+        "overall": {
+          "n": 24,
+          "recall": {
+            "@1": 0.625,
+            "@3": 0.625,
+            "@5": 0.6667
+          },
+          "mrr": 0.6333
+        },
+        "by_class": {
+          "sv_only": {
+            "n": 8,
+            "recall": {
+              "@1": 0.875,
+              "@3": 0.875,
+              "@5": 0.875
+            },
+            "mrr": 0.875
+          },
+          "en_only": {
+            "n": 8,
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "mrr": 1.0
+          },
+          "cross_lingual": {
+            "n": 8,
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.125
+            },
+            "mrr": 0.025
+          }
+        },
+        "per_query": [
+          {
+            "id": "q01",
+            "class": "sv_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "omindexering-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "bevakare-mottryck-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q02",
+            "class": "en_only",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "index-rebuild-en",
+              "omindexering-sv",
+              "note-linking-en",
+              "watcher-backpressure-en",
+              "bicycle-maintenance-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q03",
+            "class": "cross_lingual",
+            "topic": "index_rebuild",
+            "gold": [
+              "index-rebuild-en"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "spelbalans-sv",
+              "board-game-design-en",
+              "cykelservice-sv",
+              "watcher-backpressure-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q04",
+            "class": "sv_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "bevakare-mottryck-sv"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "omindexering-sv",
+              "grafteori-sv",
+              "watcher-backpressure-en",
+              "surdeg-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q05",
+            "class": "en_only",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "watcher-backpressure-en",
+              "post-office-queue-en",
+              "index-rebuild-en",
+              "bicycle-maintenance-en",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q06",
+            "class": "cross_lingual",
+            "topic": "watcher_backpressure",
+            "gold": [
+              "watcher-backpressure-en"
+            ],
+            "ranked": [
+              "bevakare-mottryck-sv",
+              "spelbalans-sv",
+              "somn-och-fokus-sv",
+              "lankvanor-sv",
+              "omindexering-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q07",
+            "class": "sv_only",
+            "topic": "note_linking",
+            "gold": [
+              "lankvanor-sv"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "avdrag-frilans-sv",
+              "omindexering-sv",
+              "grafteori-sv",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q08",
+            "class": "en_only",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "note-linking-en",
+              "freelance-expenses-en",
+              "sleep-focus-en",
+              "index-rebuild-en",
+              "bicycle-maintenance-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q09",
+            "class": "cross_lingual",
+            "topic": "note_linking",
+            "gold": [
+              "note-linking-en"
+            ],
+            "ranked": [
+              "lankvanor-sv",
+              "omindexering-sv",
+              "avdrag-frilans-sv",
+              "surdeg-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q10",
+            "class": "sv_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "somn-och-fokus-sv"
+            ],
+            "ranked": [
+              "omindexering-sv",
+              "bicycle-maintenance-en",
+              "board-game-design-en",
+              "avdrag-frilans-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q11",
+            "class": "en_only",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "sleep-focus-en",
+              "coffee-roasting-en",
+              "somn-och-fokus-sv",
+              "sourdough-en",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q12",
+            "class": "cross_lingual",
+            "topic": "sleep_focus",
+            "gold": [
+              "sleep-focus-en"
+            ],
+            "ranked": [
+              "somn-och-fokus-sv",
+              "omindexering-sv",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv",
+              "avdrag-frilans-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q13",
+            "class": "sv_only",
+            "topic": "sourdough",
+            "gold": [
+              "surdeg-sv"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "grafteori-sv",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q14",
+            "class": "en_only",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "sourdough-en",
+              "bicycle-maintenance-en",
+              "coffee-roasting-en",
+              "sleep-focus-en",
+              "cykelservice-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q15",
+            "class": "cross_lingual",
+            "topic": "sourdough",
+            "gold": [
+              "sourdough-en"
+            ],
+            "ranked": [
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "cykelservice-sv",
+              "somn-och-fokus-sv",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q16",
+            "class": "sv_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "cykelservice-sv"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "somn-och-fokus-sv",
+              "bicycle-maintenance-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q17",
+            "class": "en_only",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "bicycle-maintenance-en",
+              "board-game-design-en",
+              "coffee-roasting-en",
+              "index-rebuild-en",
+              "freelance-expenses-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q18",
+            "class": "cross_lingual",
+            "topic": "bicycle_maintenance",
+            "gold": [
+              "bicycle-maintenance-en"
+            ],
+            "ranked": [
+              "cykelservice-sv",
+              "surdeg-sv",
+              "olbryggning-jast-sv",
+              "omindexering-sv",
+              "spelbalans-sv"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q19",
+            "class": "sv_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "avdrag-frilans-sv"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "spelbalans-sv",
+              "bevakare-mottryck-sv",
+              "somn-och-fokus-sv",
+              "cykelservice-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q20",
+            "class": "en_only",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "freelance-expenses-en",
+              "index-rebuild-en",
+              "coffee-roasting-en",
+              "sleep-focus-en",
+              "avdrag-frilans-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q21",
+            "class": "cross_lingual",
+            "topic": "freelance_expenses",
+            "gold": [
+              "freelance-expenses-en"
+            ],
+            "ranked": [
+              "avdrag-frilans-sv",
+              "lankvanor-sv",
+              "spelbalans-sv",
+              "cykelservice-sv",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 0.0
+            },
+            "rr": 0.0
+          },
+          {
+            "id": "q22",
+            "class": "sv_only",
+            "topic": "board_game_design",
+            "gold": [
+              "spelbalans-sv"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "omindexering-sv",
+              "olbryggning-jast-sv",
+              "surdeg-sv",
+              "somn-och-fokus-sv"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q23",
+            "class": "en_only",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "board-game-design-en",
+              "freelance-expenses-en",
+              "watcher-backpressure-en",
+              "coffee-roasting-en",
+              "index-rebuild-en"
+            ],
+            "recall": {
+              "@1": 1.0,
+              "@3": 1.0,
+              "@5": 1.0
+            },
+            "rr": 1.0
+          },
+          {
+            "id": "q24",
+            "class": "cross_lingual",
+            "topic": "board_game_design",
+            "gold": [
+              "board-game-design-en"
+            ],
+            "ranked": [
+              "spelbalans-sv",
+              "olbryggning-jast-sv",
+              "bevakare-mottryck-sv",
+              "avdrag-frilans-sv",
+              "board-game-design-en"
+            ],
+            "recall": {
+              "@1": 0.0,
+              "@3": 0.0,
+              "@5": 1.0
+            },
+            "rr": 0.2
+          }
+        ]
+      },
+      "connect_precision": {
+        "proposed_pairs": 90,
+        "labelled_related_pairs": 8,
+        "true_positives": 3,
+        "hard_negatives_surfaced": 4,
+        "precision": 0.0333,
+        "recall": 0.375,
+        "f1": 0.0612,
+        "missed_related_pairs": [
+          [
+            "board-game-design-en",
+            "spelbalans-sv"
+          ],
+          [
+            "index-rebuild-en",
+            "omindexering-sv"
+          ],
+          [
+            "lankvanor-sv",
+            "note-linking-en"
+          ],
+          [
+            "sleep-focus-en",
+            "somn-och-fokus-sv"
+          ],
+          [
+            "sourdough-en",
+            "surdeg-sv"
+          ]
+        ],
+        "hard_negative_pairs_surfaced": [
+          [
+            "bevakare-mottryck-sv",
+            "post-office-queue-en"
+          ],
+          [
+            "coffee-roasting-en",
+            "sleep-focus-en"
+          ],
+          [
+            "olbryggning-jast-sv",
+            "surdeg-sv"
+          ],
+          [
+            "post-office-queue-en",
+            "watcher-backpressure-en"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/tests/evals/sv_en_retrieval.py
+++ b/tests/evals/sv_en_retrieval.py
@@ -141,8 +141,8 @@ def ollama_models_available() -> set[str]:
     """Return the Ollama model tags reachable from this host, or an empty set.
 
     Used to skip — never to silently pass — when the runner machine has no embedding host. The
-    owner's laptop deliberately carries no ML deps; the eval runs on the mac mini (test channel) or
-    any Ollama host.
+    owner's laptop deliberately carries no ML deps; the eval runs on the test-channel host or any
+    other host with an Ollama runtime.
     """
     import httpx
 

--- a/tests/evals/sv_en_retrieval.py
+++ b/tests/evals/sv_en_retrieval.py
@@ -1,0 +1,420 @@
+"""SV/EN retrieval eval harness (G3-2, #2985).
+
+Scores the LIVE app retrieval path (``app.retrieval.hybrid.scoped_hybrid_search``, the same
+entrypoint ``hybrid_search`` and the ASK path bind to) over the synthetic SV/EN fixture corpus under
+``tests/evals/fixtures/sv_en_retrieval/``.
+
+Two sections, per the issue contract:
+
+* **Retrieval quality** — recall@k + MRR over a hand-labelled SV-only / EN-only / cross-lingual query
+  set, run against both embedding identities (``nomic-embed-text``@768 and ``bge-m3``@1024) with the
+  fusion strategy held fixed, so the identity is the only moving part.
+* **Expansion quality** — connect precision over a hand-labelled SV/EN related-pair set, using E3's
+  real finding shape (``app.expansion.connect.run_connect_pass``: pairs among retrieval hits above
+  ``ConnectPassConfig.relatedness_floor``), not a relatedness proxy.
+
+This module holds no numbers. It computes them. The recorded scorecard lives in
+``fixtures/sv_en_retrieval/scorecard.json`` and is produced by
+``scripts/eval_sv_en_retrieval.py``; the eval note that reads it is
+``tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md``.
+
+Nothing here changes retrieval behaviour — it measures it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from tests.evals._helpers import parse_frontmatter
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "sv_en_retrieval"
+CORPUS_DIR = FIXTURES_DIR / "corpus"
+QUERIES_PATH = FIXTURES_DIR / "queries.json"
+CONNECT_PAIRS_PATH = FIXTURES_DIR / "connect_pairs.json"
+SCORECARD_PATH = FIXTURES_DIR / "scorecard.json"
+
+# The eval's own scope. Every fixture doc carries it, so the production scope prefilter admits the
+# whole corpus and the ranking — not the prefilter — is what is being measured.
+EVAL_SCOPE = "scope:general/retrieval-eval"
+
+RECALL_KS: tuple[int, ...] = (1, 3, 5)
+QUERY_CLASSES: tuple[str, ...] = ("sv_only", "en_only", "cross_lingual")
+
+#: The two identities the issue compares. ``dim`` is asserted against the live vector width.
+IDENTITIES: dict[str, dict[str, object]] = {
+    "nomic": {"model": "nomic-embed-text:latest", "dim": 768},
+    "bge_m3": {"model": "bge-m3:latest", "dim": 1024},
+}
+
+FUSIONS: tuple[str, ...] = ("linear", "rrf")
+
+
+@dataclass(frozen=True)
+class CorpusDoc:
+    doc_id: str
+    lang: str
+    topic: str
+    text: str
+    meta: dict[str, str]
+
+
+def load_corpus() -> list[CorpusDoc]:
+    """Load the SV/EN fixture corpus, ordered by ``doc_id`` so runs are reproducible."""
+    docs: list[CorpusDoc] = []
+    for path in sorted(CORPUS_DIR.glob("*.md")):
+        meta, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+        docs.append(
+            CorpusDoc(
+                doc_id=path.stem,
+                lang=meta.get("lang", ""),
+                topic=meta.get("topic", ""),
+                text=body.strip(),
+                meta=meta,
+            )
+        )
+    return docs
+
+
+def load_query_set() -> dict:
+    return json.loads(QUERIES_PATH.read_text(encoding="utf-8"))
+
+
+def load_connect_pairs() -> dict:
+    return json.loads(CONNECT_PAIRS_PATH.read_text(encoding="utf-8"))
+
+
+def load_scorecard() -> dict:
+    return json.loads(SCORECARD_PATH.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------------------
+# Metrics — pure functions over ranked doc-id lists, independent of the retrieval backend.
+# --------------------------------------------------------------------------------------
+
+
+def recall_at_k(ranked: Sequence[str], gold: Iterable[str], k: int) -> float:
+    """Fraction of gold documents present in the top ``k``."""
+    gold_set = set(gold)
+    if not gold_set:
+        return 0.0
+    return len(gold_set & set(ranked[:k])) / len(gold_set)
+
+
+def reciprocal_rank(ranked: Sequence[str], gold: Iterable[str]) -> float:
+    """1/rank of the first gold document, 0.0 when no gold document is retrieved at all."""
+    gold_set = set(gold)
+    for position, doc_id in enumerate(ranked, start=1):
+        if doc_id in gold_set:
+            return 1.0 / position
+    return 0.0
+
+
+def _mean(values: Sequence[float]) -> float:
+    return round(sum(values) / len(values), 4) if values else 0.0
+
+
+# --------------------------------------------------------------------------------------
+# Live retrieval backend
+# --------------------------------------------------------------------------------------
+
+
+DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
+
+
+def ollama_base_url() -> str:
+    """The Ollama base URL the availability probe and the pinned run must both use.
+
+    These have to agree. ``ollama`` itself defaults to localhost, but the app's embedding client
+    requires an explicit ``OLLAMA_HOST``/``OLLAMA_BASE_URL`` and substitutes a ZERO VECTOR when none
+    is set. If the probe defaulted to localhost while the run did not, the live tests would run
+    against an all-zero index and report meaningless scores instead of skipping.
+    """
+    return (os.getenv("OLLAMA_HOST") or DEFAULT_OLLAMA_HOST).rstrip("/")
+
+
+def ollama_models_available() -> set[str]:
+    """Return the Ollama model tags reachable from this host, or an empty set.
+
+    Used to skip — never to silently pass — when the runner machine has no embedding host. The
+    owner's laptop deliberately carries no ML deps; the eval runs on the mac mini (test channel) or
+    any Ollama host.
+    """
+    import httpx
+
+    base = ollama_base_url()
+    try:
+        response = httpx.get(f"{base}/api/tags", timeout=3.0)
+        response.raise_for_status()
+    except Exception:
+        return set()
+    payload = response.json()
+    return {str(entry.get("name", "")) for entry in payload.get("models", [])}
+
+
+def identities_available() -> bool:
+    tags = ollama_models_available()
+    return all(str(spec["model"]) in tags for spec in IDENTITIES.values())
+
+
+def _load_corpus_into_store(docs: Sequence[CorpusDoc], vectors: Sequence[Sequence[float]]) -> None:
+    """Load the corpus into the live retrieval store with pre-computed vectors.
+
+    Vectors are passed in rather than embedded lazily so that a run pins exactly one identity: the
+    store never mixes a doc embedded under one model with a query embedded under another.
+    """
+    from app.retrieval.hybrid import get_store
+
+    store = get_store()
+    store.set_documents(
+        [
+            {
+                "doc_id": doc.doc_id,
+                "text": doc.text,
+                "language": doc.lang,
+                "source_ref": f"{doc.doc_id}.md",
+                "payload": {
+                    "domain": EVAL_SCOPE,
+                    "scope_id": EVAL_SCOPE,
+                    "evidence_role": doc.meta.get("evidence_role"),
+                    "sphere": doc.meta.get("sphere"),
+                    "source_role": doc.meta.get("source_role"),
+                    "sensitivity": doc.meta.get("sensitivity"),
+                    "lang": doc.lang,
+                    "topic": doc.topic,
+                },
+                "embedding": list(vector),
+            }
+            for doc, vector in zip(docs, vectors)
+        ]
+    )
+
+
+class IdentityRun:
+    """One pinned (identity, fusion) retrieval configuration over the fixture corpus.
+
+    Entering the context sets the embedding identity and fusion strategy for the process, embeds the
+    corpus once under that identity, and loads it into the live store. Leaving restores the prior
+    environment and clears the cached tuning, so runs cannot leak into one another.
+    """
+
+    def __init__(self, identity_key: str, fusion: str) -> None:
+        if identity_key not in IDENTITIES:
+            raise ValueError(f"unknown identity {identity_key!r}")
+        if fusion not in FUSIONS:
+            raise ValueError(f"unknown fusion {fusion!r}")
+        self.identity_key = identity_key
+        self.fusion = fusion
+        self.spec = IDENTITIES[identity_key]
+        self._prior: dict[str, str | None] = {}
+        self._prior_docs: list = []
+        self.resolved_identity: object | None = None
+
+    def _set_env(self, **values: str) -> None:
+        for key, value in values.items():
+            self._prior[key] = os.environ.get(key)
+            os.environ[key] = value
+
+    def __enter__(self) -> "IdentityRun":
+        self._set_env(
+            EMBED_PRIMARY_PROVIDER="ollama",
+            EMBED_MODEL=str(self.spec["model"]),
+            OLLAMA_EMBED_MODEL=str(self.spec["model"]),
+            EMBED_DIM=str(self.spec["dim"]),
+            RETRIEVAL_FUSION=self.fusion,
+            # Pin the same host the availability probe resolved, so a run can never silently fall
+            # back to zero vectors (see ollama_base_url).
+            OLLAMA_HOST=ollama_base_url(),
+            # The corpus is the whole eligible set; the prefilter must admit it so the ranking is
+            # what gets measured.
+            ASK_DOMAIN_SCOPE=EVAL_SCOPE,
+        )
+        from app.retrieval.hybrid import get_store
+
+        # The retrieval store is process-global and tests/conftest.py does not reset it, so a run
+        # must hand it back exactly as it found it.
+        self._prior_docs = get_store().all()
+        from app.components.retrieval import embed_docs
+        from app.retrieval.tuning import get_retrieval_tuning, reset_retrieval_tuning_cache
+
+        reset_retrieval_tuning_cache()
+        tuning = get_retrieval_tuning()
+        if tuning.fusion != self.fusion:
+            raise RuntimeError(
+                f"fusion pin failed: asked for {self.fusion!r}, runtime resolved {tuning.fusion!r}"
+            )
+
+        self.docs = load_corpus()
+        vectors, identity = embed_docs([doc.text for doc in self.docs])
+        if identity.provider != "ollama" or identity.model != str(self.spec["model"]):
+            raise RuntimeError(f"identity pin failed: resolved {identity}")
+        if len(vectors[0]) != int(self.spec["dim"]):
+            raise RuntimeError(
+                f"dim mismatch for {self.spec['model']}: expected {self.spec['dim']}, got {len(vectors[0])}"
+            )
+        self.resolved_identity = identity
+        _load_corpus_into_store(self.docs, vectors)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        from app.retrieval.hybrid import get_store
+        from app.retrieval.tuning import reset_retrieval_tuning_cache
+
+        get_store().set_documents(
+            [
+                {
+                    "doc_id": doc.doc_id,
+                    "text": doc.text,
+                    "language": doc.language,
+                    "source_ref": doc.source_ref,
+                    "payload": dict(doc.payload or {}),
+                    "embedding": doc.embedding,
+                }
+                for doc in self._prior_docs
+            ]
+        )
+        for key, value in self._prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        reset_retrieval_tuning_cache()
+
+    def ranked(self, query: str, k: int) -> list[str]:
+        """Ranked doc ids from the production scoped entrypoint."""
+        from app.components.retrieval import embed_query
+        from app.retrieval.hybrid import scoped_hybrid_search
+
+        vector, _ = embed_query(query)
+        scoped = scoped_hybrid_search(query, k=k, query_vector=vector)
+        return [str(hit.get("doc_id") or hit.get("id")) for hit in scoped.results]
+
+    def scored(self, query: str, k: int) -> list[tuple[str, float]]:
+        from app.components.retrieval import embed_query
+        from app.retrieval.hybrid import scoped_hybrid_search
+
+        vector, _ = embed_query(query)
+        scoped = scoped_hybrid_search(query, k=k, query_vector=vector)
+        return [
+            (str(hit.get("doc_id") or hit.get("id")), float(hit.get("score") or 0.0))
+            for hit in scoped.results
+        ]
+
+
+# --------------------------------------------------------------------------------------
+# Sections
+# --------------------------------------------------------------------------------------
+
+
+def score_retrieval(run: IdentityRun) -> dict:
+    """recall@k + MRR over the labelled query set, overall and per query class."""
+    query_set = load_query_set()
+    top_k = max(RECALL_KS)
+    per_query: list[dict] = []
+    for entry in query_set["queries"]:
+        ranked = run.ranked(entry["query"], k=top_k)
+        per_query.append(
+            {
+                "id": entry["id"],
+                "class": entry["class"],
+                "topic": entry["topic"],
+                "gold": entry["gold"],
+                "ranked": ranked,
+                "recall": {f"@{k}": round(recall_at_k(ranked, entry["gold"], k), 4) for k in RECALL_KS},
+                "rr": round(reciprocal_rank(ranked, entry["gold"]), 4),
+            }
+        )
+
+    def aggregate(rows: Sequence[dict]) -> dict:
+        return {
+            "n": len(rows),
+            "recall": {f"@{k}": _mean([row["recall"][f"@{k}"] for row in rows]) for k in RECALL_KS},
+            "mrr": _mean([row["rr"] for row in rows]),
+        }
+
+    return {
+        "overall": aggregate(per_query),
+        "by_class": {
+            cls: aggregate([row for row in per_query if row["class"] == cls])
+            for cls in QUERY_CLASSES
+        },
+        "per_query": per_query,
+    }
+
+
+def _proposed_connect_pairs(run: IdentityRun, seed_queries: Sequence[str], *, k: int, floor: float) -> set[frozenset[str]]:
+    """The pair set ``run_connect_pass`` would propose, reproduced from its documented shape.
+
+    ``run_connect_pass`` retrieves ``k`` hits per seed query, drops anything below
+    ``relatedness_floor``, and emits every unordered pair among the survivors as a
+    ``connect.related_unlinked`` finding. Reproducing that here keeps the eval free of a vault root,
+    outbox and WriteGuard while scoring exactly the pairs the real pass would surface.
+    """
+    pairs: set[frozenset[str]] = set()
+    for query in seed_queries:
+        survivors = [doc_id for doc_id, score in run.scored(query, k=k) if score >= floor]
+        for a, b in combinations(sorted(set(survivors)), 2):
+            pairs.add(frozenset((a, b)))
+    return pairs
+
+
+def score_connect_precision(run: IdentityRun) -> dict:
+    """Connect precision against the hand-labelled SV/EN related-pair set."""
+    spec = load_connect_pairs()
+    shape = spec["finding_shape"]
+    related = {frozenset(pair) for pair in spec["related_pairs"]}
+    hard_negatives = {frozenset(pair) for pair in spec["hard_negative_pairs"]}
+
+    proposed = _proposed_connect_pairs(
+        run,
+        spec["seed_queries"],
+        k=int(shape["retrieval_k"]),
+        floor=float(shape["relatedness_floor"]),
+    )
+
+    true_positives = proposed & related
+    hard_negative_hits = proposed & hard_negatives
+    precision = len(true_positives) / len(proposed) if proposed else 0.0
+    recall = len(true_positives) / len(related) if related else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+    return {
+        "proposed_pairs": len(proposed),
+        "labelled_related_pairs": len(related),
+        "true_positives": len(true_positives),
+        "hard_negatives_surfaced": len(hard_negative_hits),
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "missed_related_pairs": sorted(sorted(pair) for pair in (related - proposed)),
+        "hard_negative_pairs_surfaced": sorted(sorted(pair) for pair in hard_negative_hits),
+    }
+
+
+__all__ = [
+    "CORPUS_DIR",
+    "EVAL_SCOPE",
+    "FIXTURES_DIR",
+    "FUSIONS",
+    "IDENTITIES",
+    "IdentityRun",
+    "QUERY_CLASSES",
+    "RECALL_KS",
+    "SCORECARD_PATH",
+    "CorpusDoc",
+    "identities_available",
+    "load_connect_pairs",
+    "load_corpus",
+    "load_query_set",
+    "load_scorecard",
+    "ollama_base_url",
+    "ollama_models_available",
+    "recall_at_k",
+    "reciprocal_rank",
+    "score_connect_precision",
+    "score_retrieval",
+]

--- a/tests/evals/test_sv_en_retrieval_eval.py
+++ b/tests/evals/test_sv_en_retrieval_eval.py
@@ -11,7 +11,7 @@ Three layers, deliberately separated so the eval is honest about what CI can pro
    end to end and re-derives the scorecard's headline finding from live embeddings.
 
 Layer 3 is what makes the scorecard reproducible rather than asserted. CI has no Ollama host, so it
-skips there and runs on any embedding host (mac mini / test channel, or a laptop with both models
+skips there and runs on any embedding host (the test-channel host, or any machine with both models
 pulled).
 """
 

--- a/tests/evals/test_sv_en_retrieval_eval.py
+++ b/tests/evals/test_sv_en_retrieval_eval.py
@@ -1,0 +1,356 @@
+"""SV/EN retrieval eval — fixture integrity, scorecard truth, and live reproduction (G3-2, #2985).
+
+Three layers, deliberately separated so the eval is honest about what CI can prove:
+
+1. **Fixture integrity** (always runs, no Ollama): the corpus is synthetic and canonically tagged,
+   every labelled gold/pair id resolves to a real document, and the label set is not degenerate.
+2. **Scorecard truth** (always runs, no Ollama): the committed scorecard actually covers the
+   committed fixtures — both identities over the full labelled query set, fusion held fixed for the
+   identity comparison — and the eval note's recommendation matches the numbers it cites.
+3. **Live reproduction** (skipped without an Ollama host carrying both models): re-runs the harness
+   end to end and re-derives the scorecard's headline finding from live embeddings.
+
+Layer 3 is what makes the scorecard reproducible rather than asserted. CI has no Ollama host, so it
+skips there and runs on any embedding host (mac mini / test channel, or a laptop with both models
+pulled).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.evals._helpers import value_family
+from tests.evals.sv_en_retrieval import (
+    CORPUS_DIR,
+    IDENTITIES,
+    QUERY_CLASSES,
+    RECALL_KS,
+    IdentityRun,
+    identities_available,
+    load_connect_pairs,
+    load_corpus,
+    load_query_set,
+    load_scorecard,
+    recall_at_k,
+    reciprocal_rank,
+)
+
+EVAL_NOTE = Path(__file__).resolve().parent / "SV_EN_RETRIEVAL_EVAL_G3_2.md"
+
+IDENTITY_COMPARISON_RUNS = ("nomic/linear", "bge_m3/linear")
+FUSION_COMPARISON_RUNS = ("bge_m3/linear", "bge_m3/rrf")
+
+
+# ---------------------------------------------------------------------------------------
+# 1. Fixture integrity
+# ---------------------------------------------------------------------------------------
+
+
+def test_corpus_is_synthetic_and_canonically_tagged() -> None:
+    source_roles = set(value_family("source_role"))
+    authority_states = set(value_family("authority_state"))
+    evidence_roles = set(value_family("evidence_role"))
+    sensitivities = set(value_family("sensitivity"))
+    email = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+    docs = load_corpus()
+    assert len(docs) >= 16, "corpus too small to score recall@5 meaningfully"
+    for doc in docs:
+        assert doc.meta.get("synthetic") == "true", f"{doc.doc_id} must declare synthetic: true"
+        assert doc.lang in {"sv", "en"}, f"{doc.doc_id} has no sv/en lang tag"
+        assert doc.topic, f"{doc.doc_id} has no topic tag"
+        assert doc.meta["source_role"] in source_roles
+        assert doc.meta["authority_state"] in authority_states
+        assert doc.meta["evidence_role"] in evidence_roles
+        assert doc.meta["sensitivity"] in sensitivities
+        assert not email.search(doc.text), f"{doc.doc_id} contains an email-like identifier"
+
+
+def test_each_labelled_topic_has_both_languages() -> None:
+    """A cross-lingual gold label is only meaningful when the topic exists in both languages."""
+    docs = load_corpus()
+    by_topic: dict[str, set[str]] = {}
+    for doc in docs:
+        by_topic.setdefault(doc.topic, set()).add(doc.lang)
+
+    labelled_topics = {entry["topic"] for entry in load_query_set()["queries"]}
+    assert len(labelled_topics) >= 8, "too few labelled topics for a per-class breakdown"
+    for topic in labelled_topics:
+        assert by_topic.get(topic) == {"sv", "en"}, f"topic {topic} is not covered in both languages"
+
+    distractors = set(by_topic) - labelled_topics
+    assert distractors, "the corpus needs unlabelled distractor topics or recall is trivially high"
+
+
+def test_query_set_labels_resolve_and_cover_every_class() -> None:
+    doc_ids = {doc.doc_id for doc in load_corpus()}
+    queries = load_query_set()["queries"]
+    assert len({entry["id"] for entry in queries}) == len(queries), "duplicate query ids"
+
+    seen_classes: dict[str, int] = {}
+    for entry in queries:
+        assert entry["class"] in QUERY_CLASSES, f"{entry['id']} has an unknown class"
+        assert entry["query"].strip(), f"{entry['id']} has an empty query"
+        assert entry["gold"], f"{entry['id']} has no gold label"
+        unknown = set(entry["gold"]) - doc_ids
+        assert not unknown, f"{entry['id']} golds unknown documents {sorted(unknown)}"
+        seen_classes[entry["class"]] = seen_classes.get(entry["class"], 0) + 1
+
+    assert set(seen_classes) == set(QUERY_CLASSES), f"missing query classes: {seen_classes}"
+    assert min(seen_classes.values()) >= 5, f"each class needs enough queries to mean anything: {seen_classes}"
+
+
+def test_cross_lingual_gold_is_the_other_language_document() -> None:
+    """The class only measures what it claims if the gold is never the query's own language."""
+    by_id = {doc.doc_id: doc for doc in load_corpus()}
+    for entry in load_query_set()["queries"]:
+        if entry["class"] != "cross_lingual":
+            continue
+        gold_langs = {by_id[gold].lang for gold in entry["gold"]}
+        assert len(gold_langs) == 1, f"{entry['id']} golds mixed languages"
+        same_language_sibling = [
+            doc.doc_id
+            for doc in by_id.values()
+            if doc.topic == entry["topic"] and doc.doc_id not in entry["gold"]
+        ]
+        assert same_language_sibling, (
+            f"{entry['id']} has no same-topic competitor, so the class is not actually cross-lingual"
+        )
+
+
+def test_connect_pair_labels_resolve_and_include_hard_negatives() -> None:
+    doc_ids = {doc.doc_id for doc in load_corpus()}
+    by_id = {doc.doc_id: doc for doc in load_corpus()}
+    spec = load_connect_pairs()
+
+    related = [tuple(pair) for pair in spec["related_pairs"]]
+    negatives = [tuple(pair) for pair in spec["hard_negative_pairs"]]
+    assert related and negatives, "a pair set without hard negatives flatters every identity"
+
+    for pair in related + negatives:
+        assert len(pair) == 2 and pair[0] != pair[1], f"malformed pair {pair}"
+        unknown = set(pair) - doc_ids
+        assert not unknown, f"pair {pair} references unknown documents {sorted(unknown)}"
+
+    for pair in related:
+        assert by_id[pair[0]].topic == by_id[pair[1]].topic, f"related pair {pair} spans topics"
+        assert {by_id[pair[0]].lang, by_id[pair[1]].lang} == {"sv", "en"}, (
+            f"related pair {pair} is not an SV/EN pair"
+        )
+    for pair in negatives:
+        assert by_id[pair[0]].topic != by_id[pair[1]].topic, f"hard negative {pair} is same-topic"
+
+    assert not (set(map(frozenset, related)) & set(map(frozenset, negatives))), (
+        "a pair cannot be labelled both related and unrelated"
+    )
+    assert spec["finding_shape"]["source"].startswith("app/expansion/connect.py"), (
+        "the connect section must name the real E3 finding shape it reproduces"
+    )
+
+
+# ---------------------------------------------------------------------------------------
+# 2. Scorecard truth
+# ---------------------------------------------------------------------------------------
+
+
+def test_query_set_is_labelled_and_scored_under_both_identities() -> None:
+    """AC1: the labelled SV/EN query set is scored with recall@k + MRR under both identities.
+
+    Fusion is held fixed at the shipped default across the identity comparison, so the embedding
+    identity is the only moving part between those two runs.
+    """
+    scorecard = load_scorecard()
+    queries = load_query_set()["queries"]
+    runs = scorecard["runs"]
+
+    for label in IDENTITY_COMPARISON_RUNS:
+        assert label in runs, f"scorecard is missing the {label} run"
+
+    compared = {runs[label]["identity"]["key"] for label in IDENTITY_COMPARISON_RUNS}
+    assert compared == set(IDENTITIES), f"identity comparison must cover both identities, got {compared}"
+
+    fusions = {runs[label]["fusion"] for label in IDENTITY_COMPARISON_RUNS}
+    assert fusions == {"linear"}, f"fusion must be held fixed for the identity comparison, got {fusions}"
+
+    for label in IDENTITY_COMPARISON_RUNS:
+        run = runs[label]
+        spec = IDENTITIES[run["identity"]["key"]]
+        assert run["identity"]["model"] == spec["model"]
+        assert run["identity"]["dim"] == spec["dim"], "the run must record the real vector width"
+
+        retrieval = run["retrieval"]
+        assert len(retrieval["per_query"]) == len(queries), f"{label} did not score every query"
+        assert {row["id"] for row in retrieval["per_query"]} == {q["id"] for q in queries}
+
+        for section in (retrieval["overall"], *retrieval["by_class"].values()):
+            for k in RECALL_KS:
+                assert 0.0 <= section["recall"][f"@{k}"] <= 1.0
+            assert 0.0 <= section["mrr"] <= 1.0
+        assert set(retrieval["by_class"]) == set(QUERY_CLASSES), "missing a per-class breakdown"
+
+        # Every per-query row must be internally consistent with its own ranking, so a scorecard
+        # cannot carry a headline number its rows do not support.
+        for row in retrieval["per_query"]:
+            for k in RECALL_KS:
+                assert row["recall"][f"@{k}"] == pytest.approx(
+                    recall_at_k(row["ranked"], row["gold"], k), abs=1e-4
+                ), f"{label} {row['id']} recall@{k} does not match its own ranking"
+            assert row["rr"] == pytest.approx(
+                reciprocal_rank(row["ranked"], row["gold"]), abs=1e-4
+            ), f"{label} {row['id']} reciprocal rank does not match its own ranking"
+
+
+def test_connect_precision_scored_on_labelled_pairs() -> None:
+    """AC2: an Expansion-quality section scores connect precision on the labelled SV/EN pair set."""
+    scorecard = load_scorecard()
+    spec = load_connect_pairs()
+    related_count = len(spec["related_pairs"])
+
+    for label in IDENTITY_COMPARISON_RUNS:
+        section = scorecard["runs"][label]["connect_precision"]
+        assert section["labelled_related_pairs"] == related_count, (
+            f"{label} scored a different pair set than the committed one"
+        )
+        assert 0.0 <= section["precision"] <= 1.0
+        assert 0.0 <= section["recall"] <= 1.0
+        assert section["true_positives"] <= section["proposed_pairs"]
+        assert section["true_positives"] <= related_count
+        if section["proposed_pairs"]:
+            assert section["precision"] == pytest.approx(
+                section["true_positives"] / section["proposed_pairs"], abs=1e-4
+            )
+        assert section["recall"] == pytest.approx(
+            section["true_positives"] / related_count, abs=1e-4
+        )
+        assert len(section["missed_related_pairs"]) == related_count - section["true_positives"]
+
+
+def test_committed_scorecard_matches_committed_fixtures() -> None:
+    """AC3: the committed scorecard describes the committed fixture set, not a stale one."""
+    scorecard = load_scorecard()
+    docs = load_corpus()
+    queries = load_query_set()["queries"]
+    pairs = load_connect_pairs()
+
+    assert scorecard["schema"] == "sv_en_retrieval_scorecard.v1"
+    assert scorecard["issue"] == 2985
+    assert scorecard["runner"] == "scripts/eval_sv_en_retrieval.py"
+    assert (Path(__file__).resolve().parents[2] / scorecard["runner"]).is_file(), (
+        "the scorecard names a runner that does not exist"
+    )
+
+    assert scorecard["corpus"]["docs"] == len(docs)
+    assert scorecard["corpus"]["sv_docs"] == sum(1 for doc in docs if doc.lang == "sv")
+    assert scorecard["corpus"]["en_docs"] == sum(1 for doc in docs if doc.lang == "en")
+    assert scorecard["corpus"]["topics"] == sorted({doc.topic for doc in docs})
+
+    assert scorecard["query_set"]["queries"] == len(queries)
+    for cls in QUERY_CLASSES:
+        assert scorecard["query_set"]["by_class"][cls] == sum(1 for q in queries if q["class"] == cls)
+
+    assert scorecard["connect_pair_set"]["related_pairs"] == len(pairs["related_pairs"])
+    assert scorecard["connect_pair_set"]["hard_negative_pairs"] == len(pairs["hard_negative_pairs"])
+    assert scorecard["connect_pair_set"]["seed_queries"] == len(pairs["seed_queries"])
+
+    doc_ids = {doc.doc_id for doc in docs}
+    for label, run in scorecard["runs"].items():
+        for row in run["retrieval"]["per_query"]:
+            unknown = set(row["ranked"]) - doc_ids
+            assert not unknown, f"{label} {row['id']} ranked documents not in the corpus: {sorted(unknown)}"
+
+
+def test_eval_note_states_g5_fusion_recommendation() -> None:
+    """AC4: the eval note states a G5 default-fusion recommendation grounded in the scored numbers."""
+    assert EVAL_NOTE.is_file(), "the eval note is missing"
+    note = EVAL_NOTE.read_text(encoding="utf-8")
+
+    assert "## G5 default-fusion recommendation" in note, "the note has no recommendation section"
+    recommendation = note.split("## G5 default-fusion recommendation", 1)[1]
+    assert re.search(r"\blinear\b", recommendation, re.I), "the recommendation names no fusion strategy"
+    assert re.search(r"\brrf\b", recommendation, re.I), "the recommendation does not weigh RRF"
+
+    scorecard = load_scorecard()
+    linear = scorecard["runs"]["bge_m3/linear"]["retrieval"]["overall"]["mrr"]
+    rrf = scorecard["runs"]["bge_m3/rrf"]["retrieval"]["overall"]["mrr"]
+
+    # The recommendation must follow the numbers, not the other way round: whichever fusion the note
+    # recommends keeping as default must be the one the scorecard actually favours.
+    recommends_linear = bool(re.search(r"keep\s+`?linear`?", recommendation, re.I))
+    recommends_rrf = bool(re.search(r"flip.*\brrf\b|adopt\s+`?rrf`?", recommendation, re.I))
+    assert recommends_linear != recommends_rrf, "the note must recommend exactly one default"
+    if recommends_linear:
+        assert linear >= rrf, "the note recommends linear but the scorecard favours RRF"
+    else:
+        assert rrf > linear, "the note recommends RRF but the scorecard does not support it"
+
+    # Every number the note cites in its headline table must appear in the scorecard, so the note
+    # cannot drift away from the evidence it claims to rest on.
+    for label in ("nomic/linear", "bge_m3/linear", "bge_m3/rrf"):
+        assert label in note, f"the note does not cite the {label} run"
+        overall = scorecard["runs"][label]["retrieval"]["overall"]
+        assert f"{overall['mrr']:.4f}".rstrip("0").rstrip(".") in note or str(overall["mrr"]) in note, (
+            f"the note does not cite the {label} overall MRR"
+        )
+
+
+# ---------------------------------------------------------------------------------------
+# 3. Live reproduction
+# ---------------------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not identities_available(),
+    reason="needs an Ollama host with both nomic-embed-text and bge-m3 pulled",
+)
+def test_live_run_reproduces_the_cross_lingual_finding() -> None:
+    """The scorecard's headline finding re-derives from live embeddings, not from the JSON.
+
+    The finding: with fusion held fixed, the BGE-M3 identity retrieves the other-language document
+    for cross-lingual queries and the nomic identity does not. Asserted as a strict ordering rather
+    than against pinned constants, so ordinary model-version drift does not make this test lie.
+    """
+    cross_lingual = [q for q in load_query_set()["queries"] if q["class"] == "cross_lingual"]
+    assert cross_lingual
+
+    hits: dict[str, int] = {}
+    for identity_key in ("nomic", "bge_m3"):
+        with IdentityRun(identity_key, "linear") as run:
+            hits[identity_key] = sum(
+                1
+                for entry in cross_lingual
+                if set(run.ranked(entry["query"], k=max(RECALL_KS))) & set(entry["gold"])
+            )
+
+    assert hits["bge_m3"] > hits["nomic"], (
+        f"expected BGE-M3 to beat nomic on cross-lingual retrieval, got {hits}"
+    )
+
+
+@pytest.mark.skipif(
+    not identities_available(),
+    reason="needs an Ollama host with both nomic-embed-text and bge-m3 pulled",
+)
+def test_live_corpus_embeds_at_the_declared_dimensions() -> None:
+    """Each identity really produces the vector width the scorecard records."""
+    scorecard = load_scorecard()
+    for identity_key, spec in IDENTITIES.items():
+        with IdentityRun(identity_key, "linear") as run:
+            identity = run.resolved_identity
+            assert getattr(identity, "model") == spec["model"]
+            assert getattr(identity, "dim") == spec["dim"]
+        recorded = next(
+            run_data["identity"]
+            for run_data in scorecard["runs"].values()
+            if run_data["identity"]["key"] == identity_key
+        )
+        assert recorded["dim"] == spec["dim"]
+
+
+def test_scorecard_json_is_committed_and_parseable() -> None:
+    path = CORPUS_DIR.parent / "scorecard.json"
+    assert path.is_file(), "the eval must commit its scorecard so the note has a reproducible source"
+    json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Governing-Issue: #2985

Fixes #2985

Final-Review-Rounds: 0

## Summary
Adds the G3-2 SV/EN retrieval eval: a hand-labelled synthetic bilingual fixture set, a reproducible scorecard runner, and the eval note carrying the G5 default-fusion recommendation. Measurement only — no retrieval behaviour changes, and the eval drives the live production entrypoint (`scoped_hybrid_search`) rather than re-implementing ranking.

## What landed
- `tests/evals/fixtures/sv_en_retrieval/` — 20 synthetic docs (10 sv / 10 en, 8 bilingual topics + 4 single-language distractors sharing heavy surface vocabulary), 24 labelled queries across `sv_only` / `en_only` / `cross_lingual`, 8 labelled SV/EN related pairs + 8 hard negatives, and the recorded `scorecard.json`.
- `tests/evals/sv_en_retrieval.py` — harness pinning one (identity, fusion) configuration at a time.
- `scripts/eval_sv_en_retrieval.py` — the reproducible runner.
- `tests/evals/SV_EN_RETRIEVAL_EVAL_G3_2.md` — the eval note.
- `tests/evals/test_sv_en_retrieval_eval.py` — fixture integrity + scorecard truth (no Ollama needed, so CI checks that the committed numbers describe the committed fixtures and that the note's recommendation follows its own numbers) + live reproduction (skipped without an embedding host).

## Findings
Identity comparison, fusion held fixed at `linear`:

| run | overall MRR | cross-lingual R@3 | cross-lingual MRR |
| --- | --- | --- | --- |
| `nomic/linear` | 0.6458 | 0.0 | 0.0 |
| `bge_m3/linear` | 0.7653 | 0.75 | 0.3792 |
| `bge_m3/rrf` | 0.6333 | 0.0 | 0.025 |

- Monolingually the two identities are indistinguishable (`en_only` perfect under both, `sv_only` perfect at k>=3 under both). **Every** point of the MRR gain is cross-lingual, where nomic never returns the other-language document in the top 5 on any of the eight queries. That is what the migration bought.
- **RRF does not meet ADR-0024's burden of proof.** Same identity, same corpus, same queries: overall MRR 0.7653 -> 0.6333, cross-lingual recall@3 0.75 -> 0.0, recall@5 0.875 -> 0.125, with no compensating gain anywhere. RRF fuses on rank alone, so BM25's monolingual bias dominates and the migration's benefit is erased. Recommendation: keep `linear` as default.
- Connect precision (scored against E3's real finding shape in `app/expansion/connect.py :: run_connect_pass`, not a proxy — EXP-1 #2994 is merged) exposes that `ConnectPassConfig.relatedness_floor` gates on the **fused**, BM25-dominated score, so it filters out precisely the cross-lingual pairs BGE-M3 made findable. The floor is also not fusion-portable: the same 0.55 admits 8 pairs under `linear` and 90 under `rrf`.

Both follow-ups are named in the note and deliberately not filed by this slice, which is measurement-only.

## SBS Impact
- Primary subsystem: Retrieval spine (evaluation). Secondary: Expansion (connect-precision section).
- Write class: derived — eval fixtures and a scorecard, not runtime behaviour. No runtime code touched.
- Authority impact: none. Persistence: durable eval fixtures committed to the repo. Retrieval/context impact: measures, does not change.
- Owner-doc impact: none. The eval note is not an owner doc and carries no authority; the G5 default flip remains a separate owner call against ADR-0024/ADR-0059.
- Transition debt: no effect. Fitness rule: no effect (evidence-gathering, not an invariant).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 measurement-only lane; no plan divergence and no BuilderOps material routed.

## Notes
Validation, all on this branch:
- `python3 -m pytest -q tests/evals/test_sv_en_retrieval_eval.py` — 12 passed with a live Ollama host (both live-reproduction tests executed, not skipped).
- Same module with no reachable Ollama host — 10 passed, 2 skipped, confirming the CI path.
- `python3 -m pytest -q -m "not pg" tests/evals tests/retrieval tests/eval tests/expansion` — 314 passed, 4 skipped, in one process (checks the harness leaks no global env or retrieval-store state into adjacent suites).
- `python3 -m ruff check app tests companion-ui/companion-app` — all checks passed (the exact CI invocation).
- `python3 scripts/docs_guard.py` — OK.
- Scorecard reproducibility: two independent runner invocations produced byte-identical `runs` output.
- `mypy app` gate is unaffected — this change touches no `app/` file.

Pickup receipt: `pickup-claim-complete issue=2985 branch=codex/issue-2985-sv-en-retrieval-eval worktree=/Users/rasmus/.codex/worktrees/issue-2985-sv-en-retrieval-eval coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-2985 lease_id=lease-29f1cd52 holder=claude-opus5 evidence=verified-dispatcher-lease`
---