### PR TITLE
Let the host-secret contract declare a secret optional (#4489)

### DIFF
--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -193,7 +193,12 @@ def _declared_secrets(
 def _validate_secret(kind: str, value: str) -> bool:
     if kind == "raw-store-key":
         return _RAW_STORE_KEY_PATTERN.fullmatch(value) is not None
-    if kind == "api-key":
+    # `token` shares the api-key grammar deliberately (#4489): both are opaque
+    # provider-issued bearer strings, and a second near-identical grammar would
+    # be a place for the two to drift apart rather than a real distinction. The
+    # kind exists at all because the contract derives it from the logical id's
+    # suffix, and `GITHUB_TOKEN` requires the logical id `github.token`.
+    if kind in {"api-key", "token"}:
         return (
             value == value.strip()
             and 20 <= len(value) <= 512
@@ -312,7 +317,16 @@ def _resolve_consumer_environment(
             try:
                 value = keychain_lookup(contract.keychain_service, account)
             except Exception as exc:
+                # An optional declaration tolerates *absence* only, and the
+                # lookup cannot distinguish "no such item" from any other
+                # failure, so an unresolvable optional secret simply does not
+                # bind. Its consumer runs without it; a required one still
+                # fails the whole bootstrap (#4489).
+                if contract.is_optional(secret):
+                    continue
                 raise _secret_failure(secret=secret, kind=kind) from exc
+            # Validation is deliberately outside that tolerance: a value that
+            # is present and wrong is a misconfiguration, never an opt-out.
             if not _validate_secret(kind, value):
                 raise _secret_failure(secret=secret, kind=kind)
             resolved[env_name] = value

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -548,6 +548,14 @@ def run_with_host_secrets(
     except HostSecretCredentialUnavailableError as exc:
         if not run_on_credential_unavailable:
             raise
+        # The handoff drops the WHOLE layer, not just the failed secret, so an
+        # optional secret must never be able to trigger it: that would let a
+        # misconfigured optional credential silently de-provision a *required*
+        # one declared for the same consumer (#4489). Only a required
+        # credential's unavailability is something a caller may opt into
+        # running without.
+        if selected_contract.is_optional(exc.credential_identity_ref):
+            raise
         # Model Inquiry owns the durable typed terminal receipt. This opt-in
         # handoff carries only the declared logical identifier, never a value,
         # and still launches without any provider credential binding.

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -80,7 +80,13 @@ def _temporary_signal_handlers(handler: SignalHandler) -> Iterator[None]:
 
 
 def _security_keychain_lookup(service: str, account: str) -> str:
-    if account.endswith(".api-key"):
+    # The framework path returns exact Keychain bytes; the `security` CLI below
+    # strips one trailing newline, which would let a stray-newline value pass a
+    # `value == value.strip()` grammar that was written to reject it (#4289).
+    # Every kind validated by that grammar must take the exact-bytes path — so
+    # `token` joins `api-key` here rather than inheriting the CLI's trimming
+    # (#4489).
+    if account.endswith(".api-key") or account.endswith(".token"):
         return _security_framework_keychain_lookup(service, account)
     try:
         result = subprocess.run(
@@ -286,7 +292,12 @@ def _read_runtime_secret_file(path: Path) -> str | None:
 
 
 def _secret_failure(*, secret: str, kind: str) -> HostSecretBootstrapError:
-    if kind == "api-key":
+    # The identifier-bearing variant names the logical id (never a value), which
+    # is what an operator needs to find the right Keychain item. `token` shares
+    # it for that reason; the only behavioral difference is the
+    # `run_on_credential_unavailable` opt-in, which no consumer granted a
+    # `token` secret uses (#4489).
+    if kind in {"api-key", "token"}:
         return HostSecretCredentialUnavailableError(secret)
     return HostSecretBootstrapError(
         "host secret bootstrap failed for declared consumer"

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -20,7 +20,10 @@ _CONTRACT_FIELDS = frozenset(
         "consumers",
     }
 )
-_SECRET_FIELDS = frozenset({"logical_id", "child_binding", "kind"})
+# `optional` is required on every declaration rather than defaulted (#4489):
+# the schema is closed at every level, and a secret whose absence is tolerated
+# is exactly the kind of thing that must be stated, not inferred from silence.
+_SECRET_FIELDS = frozenset({"logical_id", "child_binding", "kind", "optional"})
 _CONSUMER_FIELDS = frozenset({"consumer", "channels", "secrets", "role_requirements"})
 _KEYCHAIN_ACCOUNT_TEMPLATE = "{channel}:{consumer}:{secret}"
 _KEYCHAIN_SERVICE = "yggdrasil.host-secrets"
@@ -57,6 +60,10 @@ class HostSecretContract:
     allowed: frozenset[tuple[str, str, str]]
     secret_definitions: tuple[tuple[str, str, str], ...] = ()
     role_requirements: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
+    # Kept beside `secret_definitions` rather than widening it: several callers
+    # unpack that tuple positionally, and optionality is a property of the
+    # declaration, not of the identifier/binding/kind triple.
+    optional_secrets: frozenset[str] = frozenset()
 
     def require_declared(self, *, channel: str, consumer: str, secret: str) -> None:
         if (channel, consumer, secret) not in self.allowed:
@@ -81,6 +88,18 @@ class HostSecretContract:
         for logical_id, _child_binding, kind in self.secret_definitions:
             if logical_id == secret:
                 return kind
+        raise UndeclaredSecretConsumerError("undeclared host secret request")
+
+    def is_optional(self, secret: str) -> bool:
+        """Whether an *absent* declaration may be skipped rather than fail closed.
+
+        Optionality covers absence only. A declared secret that resolves to a
+        malformed value fails closed whether or not it is optional — see
+        ``host_secret_bootstrap._resolve_consumer_environment``.
+        """
+        for logical_id, _child_binding, _kind in self.secret_definitions:
+            if logical_id == secret:
+                return secret in self.optional_secrets
         raise UndeclaredSecretConsumerError("undeclared host secret request")
 
     def required_secrets_for_role(self, *, consumer: str, role: str) -> tuple[str, ...]:
@@ -142,21 +161,28 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
         error="invalid host secret channel declaration",
     )
     secret_definitions: list[tuple[str, str, str]] = []
+    optional_secrets: set[str] = set()
     for item in payload["secrets"]:
         if not isinstance(item, dict) or set(item) != _SECRET_FIELDS:
             raise ValueError("invalid host secret declaration")
         logical_id = item["logical_id"]
         child_binding = item["child_binding"]
         kind = item["kind"]
+        optional = item["optional"]
         if (
             not _is_identifier(logical_id, _LOGICAL_SECRET_PATTERN)
             or not _is_identifier(child_binding, _CHILD_BINDING_PATTERN)
             or not _is_identifier(kind, _KIND_PATTERN)
             or logical_id.rsplit(".", maxsplit=1)[1] != kind
             or child_binding != _expected_child_binding(logical_id)
+            # `type(...) is not bool` rather than isinstance: bool is a subclass
+            # of int, and a truthy 1 must not smuggle in an optional secret.
+            or type(optional) is not bool
         ):
             raise ValueError("invalid host secret identifier")
         secret_definitions.append((logical_id, child_binding, kind))
+        if optional:
+            optional_secrets.add(logical_id)
     logical_ids = [item[0] for item in secret_definitions]
     child_bindings = [item[1] for item in secret_definitions]
     if (
@@ -218,4 +244,5 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
         allowed=frozenset(allowed),
         secret_definitions=tuple(secret_definitions),
         role_requirements=tuple(role_requirements),
+        optional_secrets=frozenset(optional_secrets),
     )

--- a/config/secrets/host_secret_contract.json
+++ b/config/secrets/host_secret_contract.json
@@ -11,17 +11,26 @@
     {
       "logical_id": "heimdal.raw-store-key",
       "child_binding": "HEIMDAL_RAW_STORE_KEY",
-      "kind": "raw-store-key"
+      "kind": "raw-store-key",
+      "optional": false
     },
     {
       "logical_id": "openai.api-key",
       "child_binding": "OPENAI_API_KEY",
-      "kind": "api-key"
+      "kind": "api-key",
+      "optional": false
     },
     {
       "logical_id": "anthropic.api-key",
       "child_binding": "ANTHROPIC_API_KEY",
-      "kind": "api-key"
+      "kind": "api-key",
+      "optional": false
+    },
+    {
+      "logical_id": "github.token",
+      "child_binding": "GITHUB_TOKEN",
+      "kind": "token",
+      "optional": true
     }
   ],
   "consumers": [
@@ -33,7 +42,8 @@
         "prod"
       ],
       "secrets": [
-        "heimdal.raw-store-key"
+        "heimdal.raw-store-key",
+        "github.token"
       ],
       "role_requirements": {}
     },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -132,13 +132,15 @@ services:
       # ingress lanes can admit.
       #
       # This layer is also where the cockpit's `github-live` plane gets its
-      # credential (#4484): the in-container `gh` transport reads GITHUB_TOKEN
-      # (or GH_TOKEN) from the environment, so an operator enabling the plane on
-      # a channel supplies GITHUB_TOKEN through this same file rather than
-      # through any new mount, compose key, or secret mechanism. A repo-scoped
-      # read-only token is sufficient; the plane performs GET requests only and
-      # persists nothing. With the token absent the plane refuses cleanly, which
-      # is why no committed default is needed for it.
+      # credential (#4484, corrected by #4489): the in-container `gh` transport
+      # reads GITHUB_TOKEN from the environment. The file is bootstrap-owned, so
+      # the token arrives by provisioning the declared *optional* identifier
+      # `github.token` (consumer heimdal-api-ingress) in the Keychain — a
+      # hand-written env file on this handle is rebuilt over. Optional means an
+      # absent token never fails this consumer's bootstrap, so the media/screen
+      # ingress lanes above are unaffected on hosts that have none; a present
+      # but malformed token still fails closed. A repo-scoped read-only token is
+      # sufficient; the plane performs GET requests only and persists nothing.
       - path: ${HOST_SECRET_RUNTIME_ENV_FILE_API:-/dev/null}
         required: false
     user: "${LOCAL_UID:-0}:${LOCAL_GID:-0}"

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -35,7 +35,12 @@ ingress transport only; it is never a secret store or raw-audio archive.
    watched path only; it does not receive unrelated provider or deployment credentials. `dev`,
    `test`, and `prod` secrets remain distinct.
 3. **Fail closed.** A missing, malformed, or inaccessible required secret prevents the named process
-   from starting; it does not select a default, print the value, or silently weaken encryption.
+   from starting; it does not select a default, print the value, or silently weaken encryption. Since
+   #4489 "required" is a property the schema states rather than assumes: every declaration carries an
+   explicit `optional` boolean, and only a declaration marked `optional` may be *absent* without
+   failing its consumer. Optionality never covers a value that is present and malformed — that still
+   fails closed, for optional and required secrets alike — so this constraint is unweakened for every
+   secret that guards a shipped lane.
 4. **Key material stays outside the raw volume and database.** This preserves Heimdal's raw-store
    trust boundary.
 5. **No cloud secret service now.** 1Password Developer/CLI is a future migration option only when
@@ -43,13 +48,31 @@ ingress transport only; it is never a secret store or raw-audio archive.
 
 ### Declared identifier contract
 
-The value-free contract declares `heimdal.raw-store-key`, `openai.api-key`, and
-`anthropic.api-key`, their child bindings, and their validation kinds. The raw-store key is granted
-to `heimdal-capture-watch`; both model-provider identifiers are granted only to
-`builderops-model-inquiry`, with exact `fable` and `gpt_codex` role requirements. Every grant is
-declared for `dev`, `test`, and `prod` in `config/secrets/host_secret_contract.json`; no value or
-host path is stored in that file. This is the ADR-0064 declared-API-key scope. It declares the
-credential boundary but does not authorize provider selection, calls, CKM access, or fallback.
+The value-free contract declares `heimdal.raw-store-key`, `openai.api-key`, `anthropic.api-key`, and
+`github.token`, their child bindings, their validation kinds, and whether each is optional. The
+raw-store key is granted to `heimdal-capture-watch` and `heimdal-api-ingress`; both model-provider
+identifiers are granted only to `builderops-model-inquiry`, with exact `fable` and `gpt_codex` role
+requirements. Every grant is declared for `dev`, `test`, and `prod` in
+`config/secrets/host_secret_contract.json`; no value or host path is stored in that file. This is the
+ADR-0064 declared-API-key scope. It declares the credential boundary but does not authorize provider
+selection, calls, CKM access, or fallback.
+
+`github.token` (#4489) is the one **optional** declaration. It is granted to `heimdal-api-ingress`
+so the BuilderOps cockpit's `github-live` plane can read GitHub from inside the `api` container via
+`gh`, which reads `GITHUB_TOKEN` from its own environment. It must be optional because the
+bootstrap is fail-closed over every declared secret for a consumer: a required GitHub token would
+make a Keychain item mandatory on `dev`, `test`, **and** `prod`, and a host without one would lose
+the Heimdal media/screen ingress lanes that share this consumer's layer. Two properties follow, and
+both are deliberate:
+
+- **The grant is per-consumer, not per-channel.** A consumer's channels and its secrets are separate
+  flat lists, so `github.token` is declared on all three channels. It is inert wherever nothing is
+  provisioned and wherever no channel binds `COCKPIT_GITHUB_REPO` (today only `dev` does), so least
+  privilege holds in effect.
+- **The token inherits the layer's activation condition.** `deploy_channel_compose.sh` only wraps
+  compose with this consumer's bootstrap when `heimdal.raw-store-key` resolves, so a host without
+  that key materializes no layer and therefore receives no `GITHUB_TOKEN` either — provisioning the
+  token alone is not sufficient on the governed deploy path.
 
 The v1 Keychain service is pinned to the stable non-secret namespace
 `yggdrasil.host-secrets`, and its account is derived by percent-encoding each
@@ -58,9 +81,12 @@ tuples cannot collide and each channel resolves a distinct item. The loader acce
 grammar-valid, contract-declared identifiers. Identifier namespaces are length-bounded, require
 logical-id/validation-kind agreement, and derive each child binding from its logical identifier.
 Value-freedom is structural and semantic: the schema is closed at every level, duplicate keys fail,
-declarations carry no value field, and exact grants constrain every identifier. Identifier strings
-and the deliberately provider-agnostic `api-key` value validator are not required to have disjoint
-lexical languages.
+declarations carry no value field, and exact grants constrain every identifier. `optional` is a
+required field on every declaration for exactly this reason — an omitted field would be an implicit
+default in a schema that has none. Identifier strings and the deliberately provider-agnostic
+`api-key` value validator are not required to have disjoint lexical languages; `token` shares that
+validator rather than introducing a second near-identical grammar for the same shape of opaque
+bearer string.
 Contract JSON must use unique object keys; a duplicate declaration fails closed rather than allowing a
 value to be hidden behind a later canonical field.
 The delivered HSP-02 bootstrap resolves each consumer's allowlist into a temporary mode-0600 file.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -279,11 +279,15 @@ Companion docs:
   `HEIMDAL_RAW_STORE_KEY`. A repo-scoped read-only token suffices — the plane issues GET requests
   only and persists nothing.
 - Because `github.token` is declared `optional`, a host with no token still deploys normally and the
-  Heimdal ingress lanes are unaffected; the plane simply refuses. A token that is *present but
-  malformed* fails the bootstrap closed rather than being silently dropped. Note the coupling: this
-  layer is only materialized when `heimdal.raw-store-key` also resolves, so provisioning the GitHub
-  token alone is not sufficient on the governed deploy path. Identifier and account derivation:
-  `docs/LOCAL_SECRET_PROVISIONING/README.md :: Declared identifier contract`.
+  Heimdal ingress lanes are unaffected; the plane simply refuses.
+- **A token that is present but malformed fails the whole channel deploy.** Fail-closed here is
+  deliberate — a present-but-wrong credential is a misconfiguration, not an opt-out — but the cost is
+  that `docker compose` never runs, so no service starts, not just the cockpit. The error names the
+  logical id (`github.token`), never the value. Fix the Keychain item and re-run. The same has always
+  been true of a malformed `heimdal.raw-store-key`; tracked as deferred defect `KD-4489-malformed-declared-secret-aborts-channel-deploy` on #4172.
+- Note the coupling: this layer is only materialized when `heimdal.raw-store-key` also resolves, so
+  provisioning the GitHub token alone is not sufficient on the governed deploy path. Identifier and
+  account derivation: `docs/LOCAL_SECRET_PROVISIONING/README.md :: Declared identifier contract`.
 - Check it with `curl -s localhost:18001/api/cockpit/registry | jq '.sources[] |
   select(.name=="github-live")'`. Full path and rationale:
   `docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -271,10 +271,19 @@ Companion docs:
   `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`; `test` and `prod` deliberately leave it unset and
   render the source as *not enabled* rather than broken. Turning another channel on is a
   promotion-lane act, not a config default.
-- The token is host-supplied, never committed: put `GITHUB_TOKEN` on the `api` consumer's existing
-  host-secret env layer (`HOST_SECRET_RUNTIME_ENV_FILE_API`, the same layer that delivers
-  `HEIMDAL_RAW_STORE_KEY`). A repo-scoped read-only token suffices — the plane issues GET requests
-  only and persists nothing. Without a token the plane refuses cleanly; nothing else degrades.
+- The token is host-supplied, never committed. Provision it as the **Keychain item** for the declared
+  optional identifier `github.token` under consumer `heimdal-api-ingress` (#4489) — do not hand-write
+  an env file: on a governed `scripts/deploy_channel.sh` run the layer's file is bootstrap-owned and
+  rebuilt from declared identifiers only, so a hand-written value is discarded. The bootstrap then
+  materializes `GITHUB_TOKEN` onto `HOST_SECRET_RUNTIME_ENV_FILE_API`, the same layer that delivers
+  `HEIMDAL_RAW_STORE_KEY`. A repo-scoped read-only token suffices — the plane issues GET requests
+  only and persists nothing.
+- Because `github.token` is declared `optional`, a host with no token still deploys normally and the
+  Heimdal ingress lanes are unaffected; the plane simply refuses. A token that is *present but
+  malformed* fails the bootstrap closed rather than being silently dropped. Note the coupling: this
+  layer is only materialized when `heimdal.raw-store-key` also resolves, so provisioning the GitHub
+  token alone is not sufficient on the governed deploy path. Identifier and account derivation:
+  `docs/LOCAL_SECRET_PROVISIONING/README.md :: Declared identifier contract`.
 - Check it with `curl -s localhost:18001/api/cockpit/registry | jq '.sources[] |
   select(.name=="github-live")'`. Full path and rationale:
   `docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -145,8 +145,17 @@ _deploy_channel_needs_dev_capture_secret() {
 # secret contract cannot be loaded or does not declare the api consumer in this
 # environment (e.g. a harness root without config/secrets), the deploy proceeds
 # WITHOUT the layer — loudly — and the api startup preflight reports the
-# ingress lanes unavailable. A deploy never fails because this layer could not
-# be prepared.
+# ingress lanes unavailable.
+#
+# Scope of that promise (corrected #4489): it covers a layer that cannot be
+# *prepared* — absent contract, undeclared consumer, unprovisioned item. It does
+# NOT cover a declared secret whose Keychain item resolves to a MALFORMED value:
+# the bootstrap fails closed on that, so the wrap fails and the deploy aborts.
+# That was already true of a malformed heimdal.raw-store-key (the precheck below
+# only rejects an empty value) and is now also true of an optional secret such as
+# github.token. Fail-closed is the intended direction — a present-but-wrong
+# credential is a misconfiguration, not an opt-out — but the operator cost is a
+# whole-channel deploy failure, tracked as a deferred defect on #4172.
 _deploy_channel_api_ingress_bootstrap_available() {
   local channel="${1:?channel required}"
   local root="${2:?repo root required}"
@@ -345,9 +354,12 @@ deploy_channel_compose() {
       # (possibly nested) capture-watch bootstrap runs — that inner bootstrap
       # scrubs the shared HOST_SECRET_RUNTIME_ENV_FILE name from the child
       # environment, and the renamed handle is what the api service's
-      # env_file layer reads. The precheck above already proved the contract
-      # AND the Keychain item resolve, so a bootstrap failure here is a real
-      # fault, not the unprovisioned-key case (which skips the wrap). Runs
+      # env_file layer reads. The precheck above proved the contract loads and
+      # that heimdal.raw-store-key resolves non-empty — it does not validate
+      # that value, and does not look at the consumer's other declared secrets
+      # at all (#4489) — so a bootstrap failure here is a real fault
+      # (malformed value) rather than the unprovisioned-key case, which skips
+      # the wrap. Runs
       # from ${root} with ${root} on PYTHONPATH so the contract and app
       # package are this deploy's; every compose path in the command is
       # absolute or compose-file-relative, so the cd is inert for Compose.

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -155,7 +155,8 @@ _deploy_channel_needs_dev_capture_secret() {
 # only rejects an empty value) and is now also true of an optional secret such as
 # github.token. Fail-closed is the intended direction — a present-but-wrong
 # credential is a misconfiguration, not an opt-out — but the operator cost is a
-# whole-channel deploy failure, tracked as a deferred defect on #4172.
+# whole-channel deploy failure, tracked as deferred defect
+# KD-4489-malformed-declared-secret-aborts-channel-deploy on #4172.
 _deploy_channel_api_ingress_bootstrap_available() {
   local channel="${1:?channel required}"
   local root="${2:?repo root required}"

--- a/tests/builderops/inquiry_intent.py
+++ b/tests/builderops/inquiry_intent.py
@@ -141,6 +141,9 @@ def contract_with_role_targets(
                             .replace("-", "_")
                             .upper(),
                             "kind": secret.rsplit(".", maxsplit=1)[1],
+                            # Model-provider credentials are required: a role
+                            # cannot resolve without its declared key (#4489).
+                            "optional": False,
                         }
                     )
                     declared.add(secret)

--- a/tests/ops/test_cockpit_github_plane_enablement.py
+++ b/tests/ops/test_cockpit_github_plane_enablement.py
@@ -13,7 +13,8 @@ This file asserts the committed side of that path:
    `api` service, which is the service that serves the cockpit route;
 2. the token key the plane needs is documented on the `api` consumer's
    already-declared host-secret env layer, which is how a value reaches that
-   container without a new secret mechanism or compose surface; and
+   container without a new secret mechanism or compose surface — and, since
+   #4489, that the layer actually *delivers* it rather than only naming it; and
 3. the other channels stay unset, so the opt-in posture (and #4481's
    opted-out-vs-broken distinction) still holds where nobody asked for it.
 """
@@ -22,6 +23,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from app.ops.host_secret_bootstrap import materialize_consumer_environment
 from app.release_channels.channel_isolation_preflight import _load_compose
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -93,3 +95,44 @@ def test_other_channels_stay_opted_out_of_the_live_plane() -> None:
             "onto the live plane is an operational act owned by the promotion "
             "lane, not a side effect of making enablement possible (#4484)"
         )
+
+
+def test_api_host_secret_layer_delivers_the_github_token(tmp_path) -> None:
+    """#4489: the documented token key must actually arrive, not just be named.
+
+    #4484 documented `GITHUB_TOKEN` on the api consumer's host-secret layer, but
+    that layer's file is bootstrap-owned and rebuilt from the *declared*
+    identifiers only, so an operator-supplied value was discarded on every
+    governed deploy. This exercises the real production resolution path —
+    `materialize_consumer_environment` for the same `(channel, consumer)` pair
+    `scripts/lib/deploy_channel_compose.sh` wraps compose with — and asserts the
+    binding lands in the file the `api` service's `env_file` chain reads.
+    """
+    raw_key = "b" * 64
+    token = "ghp_" + ("t" * 36)
+
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":github.token"):
+            return token
+        if account.endswith(":heimdal.raw-store-key"):
+            return raw_key
+        raise AssertionError(f"undeclared account reached the lookup: {account}")
+
+    with materialize_consumer_environment(
+        channel="dev",
+        consumer="heimdal-api-ingress",
+        keychain_lookup=lookup,
+        directory=tmp_path,
+    ) as env_file:
+        delivered = dict(
+            line.split("=", 1)
+            for line in env_file.read_text(encoding="utf-8").splitlines()
+            if line
+        )
+
+    assert delivered.get(_TOKEN_KEY) == token, (
+        "the api consumer's host-secret layer must deliver GITHUB_TOKEN — it is "
+        "the credential the in-container gh transport reads (#4489)"
+    )
+    # The layer's existing duty is unchanged.
+    assert delivered["HEIMDAL_RAW_STORE_KEY"] == raw_key

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 import ctypes
+import json
 import os
 from pathlib import Path
 import signal
@@ -895,13 +896,34 @@ def _absent(*absent_suffixes: str) -> KeychainLookup:
 
 
 def test_absent_optional_secret_does_not_fail_the_consumer(tmp_path: Path) -> None:
+    contract = host_secret_bootstrap.load_host_secret_contract()
+    # Guard the *pairing*, not just the code path: without this declaration the
+    # assertions below would hold vacuously (nothing would ever look the secret
+    # up), so the test would keep passing against a revert of the mechanism.
+    contract.require_declared(
+        channel="dev", consumer="heimdal-api-ingress", secret="github.token"
+    )
+    assert contract.is_optional("github.token") is True
+
+    consulted: list[str] = []
+    absent = _absent(":github.token")
+
+    def lookup(service: str, account: str) -> str:
+        consulted.append(account)
+        return absent(service, account)
+
     with materialize_consumer_environment(
         channel="dev",
         consumer="heimdal-api-ingress",
-        keychain_lookup=_absent(":github.token"),
+        keychain_lookup=lookup,
         directory=tmp_path,
     ) as env_file:
         assert env_file.read_text(encoding="utf-8") == f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+
+    assert "dev:heimdal-api-ingress:github.token" in consulted, (
+        "the optional secret must actually be attempted and skipped, not simply "
+        "absent from the consumer's declared set"
+    )
 
 
 def test_malformed_optional_secret_fails_closed(tmp_path: Path) -> None:
@@ -939,10 +961,45 @@ def test_absent_required_secret_still_fails_closed(tmp_path: Path) -> None:
 
 
 def test_every_committed_secret_declares_its_optionality_explicitly() -> None:
-    """No implicit default: the closed schema stays closed."""
+    """No implicit default: the closed schema stays closed.
+
+    Asserting `isinstance(..., bool)` would be vacuous — `is_optional` returns a
+    membership test. The real guarantee is that the *loader* refuses a
+    declaration that omits `optional` or states it as anything but a JSON
+    boolean, so silence can never be read as "required" by accident.
+    """
     contract = host_secret_bootstrap.load_host_secret_contract()
-    for logical_id, _binding, _kind in contract.secret_definitions:
-        assert isinstance(contract.is_optional(logical_id), bool)
     # Everything that existed before #4489 stays required.
     for logical_id in ("heimdal.raw-store-key", "openai.api-key", "anthropic.api-key"):
         assert contract.is_optional(logical_id) is False
+    assert contract.is_optional("github.token") is True
+
+
+@pytest.mark.parametrize(
+    "optional_value",
+    [
+        pytest.param(..., id="omitted"),
+        pytest.param(1, id="truthy-int"),
+        pytest.param(0, id="falsy-int"),
+        pytest.param("true", id="string"),
+        pytest.param(None, id="null"),
+        pytest.param([], id="list"),
+    ],
+)
+def test_loader_rejects_a_declaration_without_an_explicit_boolean_optional(
+    tmp_path: Path, optional_value: object
+) -> None:
+    payload = json.loads(
+        (_REPO_ROOT / "config/secrets/host_secret_contract.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    if optional_value is ...:
+        del payload["secrets"][0]["optional"]
+    else:
+        payload["secrets"][0]["optional"] = optional_value
+    path = tmp_path / "host_secret_contract.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        host_secret_bootstrap.load_host_secret_contract(path)

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -948,6 +948,41 @@ def test_malformed_optional_secret_fails_closed(tmp_path: Path) -> None:
     assert list(tmp_path.iterdir()) == []
 
 
+def test_optional_secret_failure_never_unlocks_the_run_anyway_handoff(
+    tmp_path: Path,
+) -> None:
+    """An optional secret must not be able to drop a *required* one.
+
+    `run_on_credential_unavailable` launches the command with no layer at all.
+    If an optional secret could trigger it, a malformed `github.token` would
+    silently de-provision `heimdal.raw-store-key` for the same consumer — a
+    fail-*open*. No in-repo caller passes the flag for this consumer today;
+    this guards the CLI surface that allows it.
+    """
+    launched: list[list[str]] = []
+
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":github.token"):
+            return "short"  # present and malformed
+        return _RAW_KEY
+
+    with pytest.raises(HostSecretBootstrapError):
+        run_with_host_secrets(
+            channel="dev",
+            consumer="heimdal-api-ingress",
+            command=["must-not-start"],
+            keychain_lookup=lookup,
+            runner=lambda command, _env: launched.append(command) or 0,
+            directory=tmp_path,
+            run_on_credential_unavailable=True,
+        )
+
+    assert launched == [], (
+        "a malformed optional secret must not launch the command without the "
+        "layer that also carries the consumer's required secret"
+    )
+
+
 def test_absent_required_secret_still_fails_closed(tmp_path: Path) -> None:
     """#4489 must not weaken the guarantee protecting the ingress lanes."""
     with pytest.raises(HostSecretBootstrapError):
@@ -976,18 +1011,23 @@ def test_every_committed_secret_declares_its_optionality_explicitly() -> None:
 
 
 @pytest.mark.parametrize(
-    "optional_value",
+    ("optional_value", "expected"),
     [
-        pytest.param(..., id="omitted"),
-        pytest.param(1, id="truthy-int"),
-        pytest.param(0, id="falsy-int"),
-        pytest.param("true", id="string"),
-        pytest.param(None, id="null"),
-        pytest.param([], id="list"),
+        # An omitted key is caught by the closed field set; a present non-bool
+        # by the explicit type check. `match=` pins WHICH rule fires, so a
+        # revert cannot make these pass for the wrong reason (on a tree without
+        # `optional` in _SECRET_FIELDS the non-bool cases would otherwise be
+        # rejected as an unknown extra key).
+        pytest.param(..., "invalid host secret declaration", id="omitted"),
+        pytest.param(1, "invalid host secret identifier", id="truthy-int"),
+        pytest.param(0, "invalid host secret identifier", id="falsy-int"),
+        pytest.param("true", "invalid host secret identifier", id="string"),
+        pytest.param(None, "invalid host secret identifier", id="null"),
+        pytest.param([], "invalid host secret identifier", id="list"),
     ],
 )
 def test_loader_rejects_a_declaration_without_an_explicit_boolean_optional(
-    tmp_path: Path, optional_value: object
+    tmp_path: Path, optional_value: object, expected: str
 ) -> None:
     payload = json.loads(
         (_REPO_ROOT / "config/secrets/host_secret_contract.json").read_text(
@@ -1001,5 +1041,5 @@ def test_loader_rejects_a_declaration_without_an_explicit_boolean_optional(
     path = tmp_path / "host_secret_contract.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=expected):
         host_secret_bootstrap.load_host_secret_contract(path)

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -29,6 +29,7 @@ from app.ops.host_secret_bootstrap import (
 _RAW_KEY = "a" * 64
 _OPENAI_KEY = "openai-key-" + ("o" * 32)
 _ANTHROPIC_KEY = "anthropic-key-" + ("a" * 32)
+_GITHUB_TOKEN = "ghp_" + ("g" * 36)
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -858,3 +859,90 @@ deploy_channel_compose \\
         f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
     )
     assert not secret_file.exists()
+
+
+# --- Optional declared secrets (#4489) -------------------------------------
+#
+# The host-secret layer is fail-closed over *every* secret declared for a
+# consumer, which is why #4484 could not simply declare the cockpit's GitHub
+# token: doing so would make a Keychain item mandatory on dev, test, and prod,
+# and a host missing it would lose the Heimdal ingress lanes. `optional` makes
+# the required/optional distinction — which
+# `docs/LOCAL_SECRET_PROVISIONING/README.md :: Fixed constraints` #3 already
+# relies on in prose — something the schema can express. Optionality covers
+# *absence* only: a malformed value fails closed exactly as before.
+
+
+def _absent(*absent_suffixes: str) -> KeychainLookup:
+    """Keychain lookup where the named accounts are missing, others resolve."""
+
+    def lookup(_service: str, account: str) -> str:
+        for suffix in absent_suffixes:
+            if account.endswith(suffix):
+                # Mirrors _security_keychain_lookup's non-zero-exit path: the
+                # bootstrap cannot tell "no such item" from any other lookup
+                # failure, so absence surfaces as this exception.
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                )
+        if account.endswith(":heimdal.raw-store-key"):
+            return _RAW_KEY
+        if account.endswith(":github.token"):
+            return _GITHUB_TOKEN
+        pytest.fail(f"unexpected account lookup: {account}")
+
+    return lookup
+
+
+def test_absent_optional_secret_does_not_fail_the_consumer(tmp_path: Path) -> None:
+    with materialize_consumer_environment(
+        channel="dev",
+        consumer="heimdal-api-ingress",
+        keychain_lookup=_absent(":github.token"),
+        directory=tmp_path,
+    ) as env_file:
+        assert env_file.read_text(encoding="utf-8") == f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+
+
+def test_malformed_optional_secret_fails_closed(tmp_path: Path) -> None:
+    """Optionality covers absence, never a value that is present and wrong."""
+
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":github.token"):
+            return "short"  # present, but not a valid token value
+        return _RAW_KEY
+
+    with pytest.raises(HostSecretBootstrapError):
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-api-ingress",
+            keychain_lookup=lookup,
+            directory=tmp_path,
+        ):
+            pytest.fail("a malformed optional secret must not materialize a layer")
+
+    # Nothing was written: the whole consumer fails, so a partially-populated
+    # layer can never be handed to the child.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_absent_required_secret_still_fails_closed(tmp_path: Path) -> None:
+    """#4489 must not weaken the guarantee protecting the ingress lanes."""
+    with pytest.raises(HostSecretBootstrapError):
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-api-ingress",
+            keychain_lookup=_absent(":heimdal.raw-store-key"),
+            directory=tmp_path,
+        ):
+            pytest.fail("an absent required secret must not materialize a layer")
+
+
+def test_every_committed_secret_declares_its_optionality_explicitly() -> None:
+    """No implicit default: the closed schema stays closed."""
+    contract = host_secret_bootstrap.load_host_secret_contract()
+    for logical_id, _binding, _kind in contract.secret_definitions:
+        assert isinstance(contract.is_optional(logical_id), bool)
+    # Everything that existed before #4489 stays required.
+    for logical_id in ("heimdal.raw-store-key", "openai.api-key", "anthropic.api-key"):
+        assert contract.is_optional(logical_id) is False

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -193,23 +193,34 @@ def test_model_inquiry_secret_contract_is_exact_and_value_free() -> None:
             "logical_id": "heimdal.raw-store-key",
             "child_binding": "HEIMDAL_RAW_STORE_KEY",
             "kind": "raw-store-key",
+            "optional": False,
         },
         {
             "logical_id": "openai.api-key",
             "child_binding": "OPENAI_API_KEY",
             "kind": "api-key",
+            "optional": False,
         },
         {
             "logical_id": "anthropic.api-key",
             "child_binding": "ANTHROPIC_API_KEY",
             "kind": "api-key",
+            "optional": False,
+        },
+        # #4489: the cockpit's live GitHub read wants a token, but the api
+        # consumer's layer must keep materializing for hosts that have none.
+        {
+            "logical_id": "github.token",
+            "child_binding": "GITHUB_TOKEN",
+            "kind": "token",
+            "optional": True,
         },
     ]
     assert payload["consumers"] == [
         {
             "consumer": "heimdal-api-ingress",
             "channels": ["dev", "test", "prod"],
-            "secrets": ["heimdal.raw-store-key"],
+            "secrets": ["heimdal.raw-store-key", "github.token"],
             "role_requirements": {},
         },
         {


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4489

## Linked Issue
Closes #4489

## SBS Impact
- Primary subsystem: Product/Runtime System (host-secret provisioning for runtime consumers)
- Secondary subsystem(s): Builder System (the BuilderOps cockpit is the consumer that wants the key) — boundary work
- Write class: none (a secret value is materialized to a temporary mode-0600 file, as today)
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: yes — the host-secret contract schema gains a required per-declaration 'optional' boolean and a 'token' validation kind. Keychain service, account derivation, file mode, and child-environment scrubbing are unchanged.
- Owner-doc impact: updated in-PR: docs/LOCAL_SECRET_PROVISIONING/README.md and docs/OPERATIONS.md
- Transition debt impact: reduces (removes a documented-but-undeliverable operator path); D11 preserved, D12 preserved
- Boundary risk: the fail-closed guarantee protecting the Heimdal ingress lanes must not weaken. Preserved by construction: optionality is opt-in per declaration, every pre-existing secret is declared optional:false, malformed values fail closed regardless of optionality, and an optional secret cannot unlock the run-anyway handoff that would drop a required binding.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- The GITHUB_TOKEN path #4484 documented was discarded on every governed deploy: the api consumer's host-secret file is bootstrap-owned and rebuilt from declared identifiers only. Let the contract declare a secret optional, so github.token can be declared and delivered without making a Keychain item mandatory on every channel.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260731225545_8a878134; deferred defect KD-4489-malformed-declared-secret-aborts-channel-deploy on #4172
- Reason: Learning signal from the #4484 post-merge check that produced this issue, plus one P2 review finding routed to the rolling Known Defects registry with a deferred disposition.

## Notes
**Validation** (on the head SHA)
- Issue's Suggested Validation: 168 passed across `tests/ops/test_host_secret_bootstrap.py`, `test_host_secret_contract.py`, `test_cockpit_github_plane_enablement.py`, `tests/deploy/test_deploy_channel_script.py`, plus the model-inquiry adapter/skill suites that also load the contract.
- Full `select_pr_tests.py` lane for this diff (builder_system, runtime_health, ops): **4216 passed**, 3 skipped, 9 xfailed.
- `ruff check app tests companion-ui/companion-app` clean; `bash -n scripts/lib/deploy_channel_compose.sh` clean; `scripts/docs_guard.py` exit 0.

**Review gate — full path, 2 rounds**
Declared risk surfaces: `credential-durability`, `security`. A mechanism convergence packet (invariants, state/transition table, crash ordering, producers/consumers/recovery, test map) was built and reviewed by a fresh independent reviewer with no memory of the implementation.

- **Round 1** on `199940b45`: **pass**, no P0/P1. Four findings, three fixed in `c6b677dad`:
  - *P3 (fixed)* — `.token` accounts took the `security` CLI transport, which strips one trailing newline, so a stray-newline token would have passed the `value == value.strip()` grammar that #4289 added the exact-bytes framework path to enforce. Now routed through the framework path; the reviewer confirmed the suffix routing is provably in sync with the grammar (the loader enforces `logical_id.rsplit(".")[1] == kind`), and that no other account changed transport.
  - *P2 (partly fixed, remainder deferred)* — a malformed declared secret aborts the entire channel deploy, contradicting two comments in `deploy_channel_compose.sh` that promised the layer never fails a deploy. Comments corrected; the reviewer independently confirmed this was **already** true for a malformed `heimdal.raw-store-key` before this change (the precheck rejects only an *empty* value), so #4489 extends existing behavior rather than introducing it. The blast-radius fix needs per-secret degradation — a design change to the resolution contract — so it is deferred as `KD-4489-malformed-declared-secret-aborts-channel-deploy` on #4172.
  - *P3 (fixed)* — two tests guarded less than they claimed: the absent-optional case passed against a full revert (nothing looked the secret up), and the explicit-optionality case asserted a membership test returns a bool. Both now assert the real guarantee, plus a new parametrized loader-rejection test.
  - *P3 (deliberately not changed)* — `_clean_child_environment` scrubs `GITHUB_TOKEN` from every consumer's child, including `builderops-model-inquiry`, which is not granted it; `GH_TOKEN` is not scrubbed. The reviewer confirmed this is not exploitable (compose does not forward host env into containers) and that scrubbing `GH_TOKEN` too would make the model-inquiry case strictly worse. Left as-is.

- **Round 2** on `c6b677dad`: **pass**. It caught that *my own round-1 repair* widened a fail-open — naming the logical id for kind `token` also moved `github.token` into the `run_on_credential_unavailable` class, and that handoff drops the *whole* layer, so with the flag set a malformed optional token would have launched the command with the consumer's **required** `heimdal.raw-store-key` unbound (reviewer reproduced: `compose ran=True`). Latent, since no in-repo caller passes the flag for that consumer, but wrong-direction. Fixed in `804873880` by gating the handoff on the credential being required, with `test_optional_secret_failure_never_unlocks_the_run_anyway_handoff` as the guard. Remaining round-2 P3s (pin the loader-rejection reason with `match=`, state the deploy consequence in OPERATIONS.md, give the deferred defect a KD slug) are all fixed in the same commit.

**Why optional rather than the alternatives**
Declaring `github.token` as an ordinary required secret would have made a Keychain item mandatory on dev, test, and prod — a host missing it loses the Heimdal media/screen ingress lanes that share this consumer's layer. A separate consumer with its own compose handle needs a third nested bootstrap shim. Optionality makes a distinction the fixed constraints already relied on in prose ("a missing... **required** secret") something the schema can state. It is a required field on every declaration precisely so nothing is implied by silence.

**Fail-closed is unweakened.** Optionality covers *absence* only. The reviewer drove 11 hostile values (empty, whitespace, trailing newline, 513 chars, `None`, non-string, zero-width space, an env-file-injection candidate) through the real production path: every one raised and left no file behind. Resolution is all-or-nothing before any fd is opened, so a partial layer cannot reach a child.
