### PR TITLE
Project design-run projections into the CKM cockpit (CDH-05)

### DIFF
--- a/app/builderops/ckm/design_hub.py
+++ b/app/builderops/ckm/design_hub.py
@@ -1,0 +1,288 @@
+"""Read-only composition of the immutable ``design_hub`` cockpit projection.
+
+CDH-05 (issue #4312, `docs/CKM_DESIGN_AGENT_INTEGRATION/PROJECT_DESIGN_RUNS_IN_COCKPIT.md`)
+extends the existing ``ckm overview --cockpit`` render context with sanitized
+design-agent availability and validated BuilderOps design-run projections.
+
+This module never admits, approves, starts, executes, or otherwise mutates a
+design run. It only calls the two read-only :class:`DesignRunGovernance`
+surfaces (`list_adapters`, `projection`) that already exist from CDH-02/
+CDH-03, and only after independently discovering candidate run ids from
+already-persisted receipt records. A run whose causal receipt chain does not
+independently validate through ``DesignRunGovernance.projection`` is excluded
+entirely rather than partially shown (INV-CDH-6).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from app.builderops.ckm.contracts import canonical_digest
+from app.builderops.design_run_contract import DesignAgentAvailabilityDescriptor
+from app.builderops.design_run_governance import (
+    DESIGN_RUN_RECEIPT_EVENT_TYPE,
+    DesignRunGovernance,
+    DesignRunGovernanceError,
+)
+
+# Fixed, safe operator identifier used only to enumerate cockpit-wide adapter
+# availability. It never names, selects, or starts an actual run.
+COCKPIT_DESIGN_HUB_RUN_ID = "ckm.cockpit.design_hub.availability"
+
+
+@dataclass(frozen=True)
+class DesignHubReceiptSummary:
+    """One causal receipt from a validated design-run chain, in chain order."""
+
+    receipt_id: str
+    event_type: str
+    occurred_at: str
+    state: str | None
+    previous_state: str | None
+    previous_receipt_id: str | None
+
+
+@dataclass(frozen=True)
+class DesignHubHandoffSummary:
+    """Unaccepted Builder material referenced by a completed run."""
+
+    handoff_id: str
+    content_hash: str
+    acceptance_state: str
+    produced_at: str
+    limitations: tuple[str, ...]
+    source_ref_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DesignHubRunSummary:
+    """One validated design-run projection, captured once and never mutated."""
+
+    run_id: str
+    state: str
+    latest_receipt_id: str
+    admission_outcome: str | None
+    approval_state: str | None
+    refusal_code: str | None
+    refusal_message: str | None
+    handoff: DesignHubHandoffSummary | None
+    receipts: tuple[DesignHubReceiptSummary, ...]
+
+
+@dataclass(frozen=True)
+class DesignHubProjection:
+    """Immutable design-hub projection captured before cockpit rendering."""
+
+    adapters: tuple[DesignAgentAvailabilityDescriptor, ...]
+    runs: tuple[DesignHubRunSummary, ...]
+    excluded_run_ids: tuple[str, ...]
+
+
+def _decode_design_run_records(
+    records: Sequence[Mapping[str, Any]],
+) -> list[tuple[Mapping[str, Any], dict[str, Any]]]:
+    """Decode only well-formed design-run receipt records; skip the rest."""
+
+    decoded: list[tuple[Mapping[str, Any], dict[str, Any]]] = []
+    for record in records:
+        if record.get("event_type") != DESIGN_RUN_RECEIPT_EVENT_TYPE:
+            continue
+        raw_body = record.get("receipt_body")
+        if not isinstance(raw_body, str):
+            continue
+        try:
+            payload = json.loads(raw_body)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        decoded.append((record, payload))
+    return decoded
+
+
+def _ordered_receipts(
+    decoded: Sequence[tuple[Mapping[str, Any], dict[str, Any]]],
+    *,
+    run_id: str,
+    latest_receipt_id: str,
+) -> tuple[DesignHubReceiptSummary, ...]:
+    """Replay one already governance-validated chain in root-to-latest order.
+
+    This only re-derives *display order* for a run whose full chain already
+    passed ``DesignRunGovernance.projection`` (i.e. is proven non-tampered,
+    acyclic, and singly rooted). It never independently trusts an unvalidated
+    chain, and it is not a substitute for that validation.
+    """
+
+    selected = [
+        (record, payload)
+        for record, payload in decoded
+        if payload.get("run_id") == run_id
+    ]
+    by_id = {
+        record["id"]: (record, payload)
+        for record, payload in selected
+        if isinstance(record.get("id"), str)
+    }
+    children = {
+        payload["previous_receipt_id"]: record["id"]
+        for record, payload in selected
+        if isinstance(payload.get("previous_receipt_id"), str)
+        and isinstance(record.get("id"), str)
+    }
+    roots = [
+        record["id"]
+        for record, payload in selected
+        if payload.get("previous_receipt_id") is None and isinstance(record.get("id"), str)
+    ]
+    if len(roots) != 1:
+        return ()
+    ordered: list[DesignHubReceiptSummary] = []
+    seen: set[str] = set()
+    current_id: str | None = roots[0]
+    while current_id is not None and current_id not in seen:
+        seen.add(current_id)
+        entry = by_id.get(current_id)
+        if entry is None:
+            break
+        record, payload = entry
+        ordered.append(
+            DesignHubReceiptSummary(
+                receipt_id=str(record["id"]),
+                event_type=str(payload.get("event_type")),
+                occurred_at=str(payload.get("occurred_at")),
+                state=payload.get("state"),
+                previous_state=payload.get("previous_state"),
+                previous_receipt_id=payload.get("previous_receipt_id"),
+            )
+        )
+        if current_id == latest_receipt_id:
+            break
+        current_id = children.get(current_id)
+    return tuple(ordered)
+
+
+def build_design_hub_projection(
+    *,
+    governance: DesignRunGovernance,
+) -> DesignHubProjection:
+    """Capture one immutable, read-only design_hub projection for the cockpit.
+
+    Never admits, approves, starts, executes, or otherwise mutates a run.
+    Enumerates known design-run receipt evidence, keeps only runs whose full
+    causal chain independently validates through
+    :meth:`DesignRunGovernance.projection`, and excludes every other run
+    rather than showing partial or unverified state.
+    """
+
+    adapters = tuple(
+        sorted(
+            governance.list_adapters(run_id=COCKPIT_DESIGN_HUB_RUN_ID),
+            key=lambda item: item.design_agent_id,
+        )
+    )
+    records = governance.store.list_records("BuilderOpsReceipt")
+    decoded = _decode_design_run_records(records)
+    known_run_ids = sorted(
+        {
+            payload["run_id"]
+            for _, payload in decoded
+            if isinstance(payload.get("run_id"), str)
+        }
+    )
+    runs: list[DesignHubRunSummary] = []
+    excluded: list[str] = []
+    for known_run_id in known_run_ids:
+        try:
+            projection = governance.projection(known_run_id)
+        except DesignRunGovernanceError:
+            excluded.append(known_run_id)
+            continue
+        handoff: DesignHubHandoffSummary | None = None
+        if projection.result is not None and projection.result.handoff is not None:
+            ref = projection.result.handoff
+            handoff = DesignHubHandoffSummary(
+                handoff_id=ref.handoff_id,
+                content_hash=ref.content_hash,
+                acceptance_state=ref.acceptance_state,
+                produced_at=ref.produced_at,
+                limitations=tuple(sorted(ref.limitations)),
+                source_ref_ids=tuple(sorted(item.source_id for item in ref.source_refs)),
+            )
+        refusal = projection.refusal
+        runs.append(
+            DesignHubRunSummary(
+                run_id=projection.run_id,
+                state=projection.state,
+                latest_receipt_id=projection.latest_receipt_id,
+                admission_outcome=(
+                    projection.admission.outcome if projection.admission else None
+                ),
+                approval_state=(
+                    projection.approval.state if projection.approval else None
+                ),
+                refusal_code=refusal.code if refusal else None,
+                refusal_message=refusal.public_message if refusal else None,
+                handoff=handoff,
+                receipts=_ordered_receipts(
+                    decoded,
+                    run_id=known_run_id,
+                    latest_receipt_id=projection.latest_receipt_id,
+                ),
+            )
+        )
+    return DesignHubProjection(
+        adapters=adapters,
+        runs=tuple(sorted(runs, key=lambda item: item.run_id)),
+        excluded_run_ids=tuple(sorted(excluded)),
+    )
+
+
+def design_hub_digest(design_hub: DesignHubProjection) -> str:
+    """Deterministic digest kept separate from, and visible alongside, the CKM digest."""
+
+    return canonical_digest(
+        {
+            "adapters": [
+                item.model_dump(mode="json") for item in design_hub.adapters
+            ],
+            "runs": [
+                {
+                    "run_id": run.run_id,
+                    "state": run.state,
+                    "latest_receipt_id": run.latest_receipt_id,
+                    "admission_outcome": run.admission_outcome,
+                    "approval_state": run.approval_state,
+                    "refusal_code": run.refusal_code,
+                    "refusal_message": run.refusal_message,
+                    "handoff": (
+                        {
+                            "handoff_id": run.handoff.handoff_id,
+                            "content_hash": run.handoff.content_hash,
+                            "acceptance_state": run.handoff.acceptance_state,
+                            "produced_at": run.handoff.produced_at,
+                            "limitations": list(run.handoff.limitations),
+                            "source_ref_ids": list(run.handoff.source_ref_ids),
+                        }
+                        if run.handoff is not None
+                        else None
+                    ),
+                    "receipts": [
+                        {
+                            "receipt_id": receipt.receipt_id,
+                            "event_type": receipt.event_type,
+                            "occurred_at": receipt.occurred_at,
+                            "state": receipt.state,
+                            "previous_state": receipt.previous_state,
+                            "previous_receipt_id": receipt.previous_receipt_id,
+                        }
+                        for receipt in run.receipts
+                    ],
+                }
+                for run in design_hub.runs
+            ],
+            "excluded_run_ids": list(design_hub.excluded_run_ids),
+        }
+    )

--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -19,6 +19,13 @@ from app.builderops.ckm.models import (
     utc_now,
 )
 from app.builderops.ckm.contracts import canonical_digest, canonical_json
+from app.builderops.ckm.design_hub import (
+    DesignHubHandoffSummary,
+    DesignHubProjection,
+    DesignHubReceiptSummary,
+    DesignHubRunSummary,
+    design_hub_digest,
+)
 from app.builderops.ckm.store import CkmProjectionBatch, CkmStore
 
 
@@ -39,6 +46,7 @@ class CockpitRenderContext:
 
     batch: CkmProjectionBatch
     comparison: Mapping[str, Any] | None = None
+    design_hub: DesignHubProjection | None = None
 
 
 def _cockpit_digest(batch: CkmProjectionBatch) -> str:
@@ -1263,6 +1271,140 @@ def _cockpit_filter_script() -> str:
 })();</script>"""
 
 
+def _design_hub_adapter_markup(item: Any) -> str:
+    status_class = "design-hub-available" if item.available else "design-hub-unavailable"
+    status_label = "Available" if item.available else "Unavailable"
+    identity = (
+        f'<p class="secondary">Identity: <code>{_e(item.effective_identity)}</code></p>'
+        if item.available and item.effective_identity
+        else ""
+    )
+    limitation = (
+        f'<p class="design-hub-limitation">Limitation: <code>{_e(item.limitation_code)}</code>'
+        f" — {_e(item.limitation_detail)}</p>"
+        if not item.available
+        else ""
+    )
+    deliverables = ", ".join(sorted(item.supported_deliverables))
+    return (
+        f'<li class="design-hub-adapter {status_class}" data-design-hub-adapter="{_e(item.design_agent_id)}">'
+        f"<strong>{_e(item.display_name)}</strong> "
+        f'<span class="badge">{status_label}</span> '
+        f'<span class="secondary">({_e(item.design_agent_id)})</span>'
+        f"{identity}"
+        f'<p class="secondary">Supports: {_e(deliverables)}</p>'
+        f"{limitation}"
+        "</li>"
+    )
+
+
+def _design_hub_receipt_markup(receipt: DesignHubReceiptSummary) -> str:
+    if receipt.state is None:
+        transition = ""
+    elif receipt.previous_state is None:
+        transition = f" (→ {_e(receipt.state)})"
+    else:
+        transition = f" ({_e(receipt.previous_state)} → {_e(receipt.state)})"
+    return (
+        f"<li><code>{_e(receipt.receipt_id)}</code> — {_e(receipt.event_type)}"
+        f"{transition} at {_e(receipt.occurred_at)}</li>"
+    )
+
+
+def _design_hub_handoff_markup(handoff: DesignHubHandoffSummary) -> str:
+    limitations = "; ".join(handoff.limitations) or "none stated"
+    sources = ", ".join(handoff.source_ref_ids) or "none"
+    return (
+        '<div class="design-hub-handoff">'
+        f'<p><strong>Handoff</strong> <span class="badge">{_e(handoff.acceptance_state)}</span></p>'
+        f'<p class="secondary">Content hash: <code>{_e(handoff.content_hash)}</code></p>'
+        f'<p class="secondary">Produced: {_e(handoff.produced_at)}</p>'
+        f'<p class="secondary">Limitations: {_e(limitations)}</p>'
+        f'<p class="secondary">Sources: {_e(sources)}</p>'
+        "</div>"
+    )
+
+
+def _design_hub_run_markup(run: DesignHubRunSummary) -> str:
+    receipts_markup = (
+        "".join(_design_hub_receipt_markup(item) for item in run.receipts)
+        or "<li>No causal receipts.</li>"
+    )
+    admission = (
+        f'<p class="secondary">Admission outcome: {_e(run.admission_outcome)}</p>'
+        if run.admission_outcome
+        else ""
+    )
+    approval = (
+        f'<p class="secondary">Approval state: {_e(run.approval_state)}</p>'
+        if run.approval_state
+        else ""
+    )
+    refusal = (
+        f'<p class="design-hub-refusal">Refusal: <code>{_e(run.refusal_code)}</code>'
+        f" — {_e(run.refusal_message)}</p>"
+        if run.refusal_code
+        else ""
+    )
+    handoff = _design_hub_handoff_markup(run.handoff) if run.handoff is not None else ""
+    return (
+        f'<li class="design-hub-run design-hub-state-{_e(run.state)}" data-design-hub-run="{_e(run.run_id)}">'
+        f"<strong>{_e(run.run_id)}</strong> "
+        f'<span class="badge">state: {_e(run.state)}</span>'
+        f"{admission}{approval}{refusal}"
+        "<details><summary>Causal receipts "
+        f"({len(run.receipts)})</summary>"
+        f'<ol class="design-hub-receipts">{receipts_markup}</ol></details>'
+        f"{handoff}"
+        "</li>"
+    )
+
+
+def _design_hub_markup(design_hub: DesignHubProjection | None) -> str:
+    """Render the read-only design-run projection. Adds no script, form, or link."""
+
+    if design_hub is None:
+        return ""
+    adapter_rows = (
+        "".join(_design_hub_adapter_markup(item) for item in design_hub.adapters)
+        or '<p class="empty">No design-agent adapters are registered.</p>'
+    )
+    run_rows = (
+        "".join(_design_hub_run_markup(run) for run in design_hub.runs)
+        or '<p class="empty">No validated design runs.</p>'
+    )
+    excluded = (
+        '<p class="design-hub-excluded">Excluded (unverifiable receipt evidence, refused '
+        "entirely rather than shown partially): "
+        + ", ".join(f"<code>{_e(run_id)}</code>" for run_id in design_hub.excluded_run_ids)
+        + "</p>"
+        if design_hub.excluded_run_ids
+        else ""
+    )
+    return (
+        '<section class="design-hub" aria-labelledby="design-hub-heading">'
+        '<h2 id="design-hub-heading">Design Hub — design-run projections</h2>'
+        '<p class="design-hub-caption">Non-authoritative projection of validated BuilderOps '
+        "design-run evidence and sanitized adapter descriptors. It never selects, admits, "
+        "approves, starts, or executes a run, and it is not Product/Runtime authority.</p>"
+        "<h3>Adapter availability</h3>"
+        f'<ul class="design-hub-adapters">{adapter_rows}</ul>'
+        "<h3>Design runs</h3>"
+        f'<ul class="design-hub-runs">{run_rows}</ul>'
+        f"{excluded}"
+        "</section>"
+    )
+
+
+def _design_hub_footer_digest(design_hub: DesignHubProjection | None) -> str:
+    if design_hub is None:
+        return ""
+    return (
+        "<br>design-hub-input digest (kept separate from the CKM projection digest): "
+        f"<code>{design_hub_digest(design_hub)}</code>"
+    )
+
+
 def _cockpit_print_styles() -> str:
     """Return the cockpit-only print contract without changing screen-state semantics."""
 
@@ -1361,6 +1503,11 @@ def render_overview_html(
         _cockpit_owner_cards_markup(batch, cockpit.comparison) if cockpit else ""
     )
     cockpit_proposals = _cockpit_proposals_markup(batch) if cockpit else ""
+    cockpit_design_hub = (
+        _design_hub_markup(cockpit.design_hub)
+        if cockpit is not None and cockpit.design_hub is not None
+        else ""
+    )
     cockpit_gap_prompt = "<p>Where is evidence weakest?</p>" if cockpit else ""
     cockpit_filters = _cockpit_filter_markup(len(forest)) if cockpit else ""
     cockpit_script = _cockpit_filter_script() if cockpit else ""
@@ -1388,12 +1535,13 @@ def render_overview_html(
     )
     supporting_details = (
         '<details class="supporting-details"><summary>Technical evidence and interpretation</summary>'
-        f"{cockpit_reserved}{subsystem_counts}{legend}{gaps_section}{cockpit_proposals}</details>"
+        f"{cockpit_reserved}{subsystem_counts}{legend}{gaps_section}{cockpit_proposals}{cockpit_design_hub}</details>"
         if cockpit
         else ""
     )
     footer_identity = (
         f"<br>State identity: epoch {_e(batch.state_identity.epoch)} · revision {batch.state_identity.state_revision} · schema {batch.state_identity.schema_version}<br>projection-input digest: <code>{_cockpit_digest(batch)}</code>"
+        f"{_design_hub_footer_digest(cockpit.design_hub) if cockpit is not None else ''}"
         if cockpit
         else ""
     )
@@ -1420,6 +1568,7 @@ def render_overview_html(
     .mini-dimensions {{ display:grid; grid-template-columns:repeat(7,1.625rem); gap:0.25rem; }} .mini-dimension {{ position:relative; width:1.625rem; height:0.75rem; border:1px solid var(--border-strong); overflow:hidden; }} .mini-scored {{ background:linear-gradient(to right,var(--agent) var(--score),var(--bg-overlay) var(--score)); }} .mini-starved {{ border:1px dotted var(--amber); background:transparent; }} .mini-unassessed {{ color:var(--fg-3); text-align:center; line-height:0.55rem; }}
     .capability-body {{ border-top:1px solid var(--border); padding:1rem; background:var(--bg-raised); }} .capability-technical-summary {{ display:flex; gap:0.75rem; align-items:center; justify-content:flex-end; }} .honesty {{ border-left:0.2rem solid var(--amber); padding-left:0.75rem; color:var(--fg-2); }} .honesty p {{ margin:0.2rem 0; }} .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(14rem,1fr)); gap:0.625rem; margin:0.875rem 0; }} .dimension {{ border:1px solid var(--border-strong); padding:0.625rem; }} .dimension-label {{ display:flex; gap:0.5rem; justify-content:space-between; }} .dimension-label span {{ flex:1; }} .dimension-track {{ height:0.5rem; margin:0.4rem 0; background:var(--bg-overlay); overflow:hidden; }} .dimension-starved .dimension-track {{ border:1px dotted var(--amber); background:none; }} .dimension-bar {{ display:block; height:100%; background:var(--agent); }}
     .drilldown,.citations {{ margin-top:0.625rem; }} .evidence-list,.finding-list {{ padding-left:1.25rem; }} .evidence-list li,.finding-list li {{ margin:0.45rem 0; }} .evidence-candidate {{ border-left:0.15rem solid var(--agent); padding-left:0.5rem; }} .basis {{ color:var(--fg-2); margin-left:0.5rem; }} .gaps-panel {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .gap-group {{ margin:0.75rem 0; }}
+    .design-hub {{ margin:1.5rem 0; padding:1rem; border:1px solid var(--border); background:var(--bg-surface); }} .design-hub-caption {{ color:var(--fg-2); }} .design-hub-adapters,.design-hub-runs {{ list-style:none; margin:0.5rem 0; padding:0; }} .design-hub-adapter,.design-hub-run {{ margin:0.5rem 0; padding:0.625rem 0.75rem; border:1px solid var(--border-strong); border-left-width:0.2rem; border-left-style:solid; border-left-color:var(--unknown); background:var(--bg-raised); }} .design-hub-available {{ border-left-color:var(--healthy); }} .design-hub-unavailable {{ border-left-color:var(--amber); }} .design-hub-limitation,.design-hub-refusal,.design-hub-excluded {{ color:var(--fg-2); border-left:0.2rem solid var(--amber); padding-left:0.5rem; }} .design-hub-receipts {{ padding-left:1.25rem; }} .design-hub-receipts li {{ margin:0.3rem 0; }} .design-hub-handoff {{ margin-top:0.5rem; padding:0.5rem 0.625rem; border:1px dashed var(--border-strong); }}
     .cockpit-filters {{ margin:0.75rem 0 1rem; padding:0.75rem 1rem; border:1px solid var(--border); background:var(--bg-surface); }} .cockpit-filters h2 {{ margin:0; font-size:1rem; }} .cockpit-filters > p {{ margin:0.25rem 0; color:var(--fg-2); }} .filter-controls {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(13rem,1fr)); gap:0.5rem 0.75rem; align-items:end; }} .filter-control {{ display:flex; flex-direction:column; gap:0.25rem; }} .filter-controls label {{ color:var(--fg-2); }} .filter-controls input,.filter-controls select {{ width:100%; min-height:2.25rem; border:1px solid var(--border-strong); border-radius:0.1875rem; background:var(--bg-raised); color:var(--fg-1); padding:0.375rem; }} .filter-controls input:focus-visible,.filter-controls select:focus-visible {{ outline:2px solid var(--accent); outline-offset:2px; }} .filter-controls input:disabled,.filter-controls select:disabled {{ opacity:0.65; }} .supporting-details {{ margin:1.5rem 0; border:1px solid var(--border); background:var(--bg-surface); }} .supporting-details > summary {{ padding:0.875rem 1rem; font-weight:600; }} .supporting-details > :not(summary) {{ margin-left:1rem; margin-right:1rem; }}{cockpit_print_styles}
     footer {{ margin-top:1.75rem; padding:1rem 0 2.25rem; border-top:1px solid var(--border); color:var(--fg-2); overflow-wrap:anywhere; }}
     @media (max-width:680px) {{ main,footer {{ width:min(100% - 1rem,74rem); }} .cockpit-trust-summary {{ display:block; }} .technical-identity {{ margin-top:0.75rem; }} .owner-cards {{ grid-template-columns:1fr; }} .owner-attention-fact {{ display:block; }} .owner-attention-fact span {{ display:block; text-align:left; }} .trust-strip {{ grid-template-columns:1fr 1fr; }} .subsystem-counts-grid {{ grid-template-columns:1fr; }} .capability-count {{ grid-template-columns:1fr; gap:0.15rem; }} .legend {{ grid-template-columns:1fr; }} .dimension-rail {{ display:none; }} .capability {{ margin-left:calc(var(--depth) * 0.5rem); }} .capability-summary {{ flex-wrap:wrap; align-items:flex-start; }} .tree-name {{ min-width:65%; }} .capability-status {{ width:100%; }} .summary-flags {{ flex-wrap:wrap; }} .mini-dimensions {{ order:6; width:100%; grid-template-columns:repeat(7,minmax(1.5rem,1fr)); }} .mini-dimension {{ width:auto; min-height:1.5rem; }} .mini-dimension::before {{ content:attr(data-abbr); display:block; font:0.55rem ui-monospace,monospace; color:var(--fg-2); }} }}

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -33,6 +33,7 @@ from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.design_hub import build_design_hub_projection
 from app.builderops.ckm.overview_html import CockpitRenderContext, write_overview_html
 from app.builderops.ckm.projections import (
     PROJECTION_FILENAMES as CKM_PROJECTION_FILENAMES,
@@ -764,6 +765,23 @@ def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> N
     default=None,
     help="Finite aggregate projection capture bound (defaults to the store policy).",
 )
+@click.option(
+    "--design-hub",
+    "design_hub_enabled",
+    is_flag=True,
+    help=(
+        "Extend --cockpit with the read-only design_hub projection (sanitized adapter "
+        "availability and validated BuilderOps design-run evidence). Requires --cockpit "
+        "and --repo-root; adds no script, form, or network path."
+    ),
+)
+@click.option(
+    "--repo-root",
+    "design_hub_repo_root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Repo root used only to resolve the design-run policy for --design-hub.",
+)
 @click.pass_context
 def ckm_overview(
     ctx: click.Context,
@@ -771,7 +789,13 @@ def ckm_overview(
     class_capture_limit: int | None,
     aggregate_capture_limit: int | None,
     cockpit: bool,
+    design_hub_enabled: bool,
+    design_hub_repo_root: Path | None,
 ) -> None:
+    if design_hub_enabled and not cockpit:
+        raise click.ClickException("ckm overview --design-hub requires --cockpit")
+    if design_hub_enabled and design_hub_repo_root is None:
+        raise click.ClickException("ckm overview --design-hub requires --repo-root")
     try:
         store = _ckm_store(ctx)
         if not store.db_path.is_file():
@@ -791,8 +815,19 @@ def ckm_overview(
                 )
             except CkmContractError as exc:
                 comparison = {"error": exc.to_dict()}
+            design_hub = None
+            if design_hub_enabled:
+                assert design_hub_repo_root is not None
+                governance = _design_run_governance(
+                    ctx,
+                    repo_root=design_hub_repo_root,
+                    store_mode="existing_read",
+                )
+                design_hub = build_design_hub_projection(governance=governance)
             cockpit_context = CockpitRenderContext(
-                batch=store.load_projection_batch(**capture_limits), comparison=comparison
+                batch=store.load_projection_batch(**capture_limits),
+                comparison=comparison,
+                design_hub=design_hub,
             )
         result = write_overview_html(
             store,
@@ -801,7 +836,7 @@ def ckm_overview(
             aggregate_capture_limit=aggregate_capture_limit,
             cockpit=cockpit_context,
         )
-    except (CkmValidationError, OSError, sqlite3.Error) as exc:
+    except (CkmValidationError, DesignRunGovernanceError, OSError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm overview failed: {exc}") from exc
     click.echo(result)
 

--- a/tests/builderops/ckm/test_design_cockpit.py
+++ b/tests/builderops/ckm/test_design_cockpit.py
@@ -1,11 +1,46 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
+from typing import Any, Mapping
 
-from app.builderops.design_agent_adapters import DesignAgentAdapterRegistry
-from app.builderops.design_run_governance import DesignRunGovernance
+from app.builderops.ckm.design_hub import (
+    DesignHubProjection,
+    build_design_hub_projection,
+    design_hub_digest,
+)
+from app.builderops.ckm.overview_html import CockpitRenderContext, render_overview_html
+from app.builderops.ckm.store import CkmStore
+from app.builderops.design_agent_adapters import (
+    DesignAgentAdapterRegistry,
+    ResolvedDesignAgentAdapter,
+)
+from app.builderops.design_run_contract import (
+    CuratedDesignBrief,
+    DesignAgentAvailabilityDescriptor,
+    DesignAgentDescriptor,
+    DesignSourceRef,
+    canonical_json,
+)
+from app.builderops.design_run_governance import (
+    DESIGN_RUN_RECEIPT_EVENT_TYPE,
+    DesignRunGovernance,
+    DesignRunReceiptEvent,
+)
 from app.builderops.model_access_resolver import BuilderModelAccessResolver
 from app.builderops.store import SqliteBuilderOpsStore
+from llm_contract import AdapterResult
+
+SHA_A = "a" * 64
+T0 = "2026-08-01T09:00:00Z"
+T1 = "2026-08-01T09:01:00Z"
+T2 = "2026-08-01T09:02:00Z"
+T3 = "2026-08-01T09:03:00Z"
+T4 = "2026-08-01T09:04:00Z"
 
 
 def test_ckm_calls_only_builder_system_design_adapter_port(
@@ -38,3 +73,463 @@ def test_ckm_calls_only_builder_system_design_adapter_port(
         "fable",
     }
     assert all(not item.available for item in descriptors)
+
+
+# ---------------------------------------------------------------------------
+# CDH-05 (issue #4312) fixtures: a real DesignRunGovernance driven through its
+# public admit/approve/execute surface, plus one fully synthetic adapter
+# registry so tests never depend on live provider credentials.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RecordingAdapter:
+    artifact_content: str = "bounded, cited design-run output"
+    provider: str = "fixture-provider"
+    model: str = "fixture-model"
+
+    def execute(self, request: Mapping[str, Any]) -> AdapterResult:
+        content_hash = hashlib.sha256(
+            self.artifact_content.encode("utf-8")
+        ).hexdigest()
+        payload = {
+            "schema_version": request["handoff_output_schema_version"],
+            "artifact_content": self.artifact_content,
+            "handoff": {
+                **dict(request["handoff_binding"]),
+                "content_hash": content_hash,
+            },
+        }
+        return AdapterResult(
+            response_text=json.dumps(payload, sort_keys=True),
+            provider_request_id="test-provider-request",
+        )
+
+
+@dataclass
+class _RecordingRegistry:
+    """Minimal in-test registry: sanitized availability plus one selectable route."""
+
+    adapter: _RecordingAdapter = field(default_factory=_RecordingAdapter)
+    design_agent_id: str = "cockpit-fixture-agent"
+
+    def descriptors(
+        self, *, run_id: str
+    ) -> tuple[DesignAgentAvailabilityDescriptor, ...]:
+        return (
+            DesignAgentAvailabilityDescriptor(
+                design_agent_id=self.design_agent_id,
+                display_name="Cockpit Fixture Agent",
+                role_profile_id="design.fixture",
+                supported_deliverables=(
+                    "content_review",
+                    "interaction_specification",
+                    "visual_handoff",
+                ),
+                available=True,
+                provider_identity="fixture-provider",
+                model_identity="fixture-model",
+                effective_identity="fixture-provider/fixture-model",
+                capabilities=("structured_output",),
+                resolution_group_id=f"design-run:{run_id}",
+            ),
+        )
+
+    def contract_descriptor(self, design_agent_id: str) -> DesignAgentDescriptor:
+        return _descriptor(design_agent_id)
+
+    def select(
+        self, design_agent_id: str, *, run_id: str
+    ) -> ResolvedDesignAgentAdapter:
+        return ResolvedDesignAgentAdapter(
+            design_agent_id=design_agent_id,
+            descriptor=self.descriptors(run_id=run_id)[0],
+            model_turn_adapter=self.adapter,
+        )
+
+
+def _descriptor(design_agent_id: str = "cockpit-fixture-agent") -> DesignAgentDescriptor:
+    return DesignAgentDescriptor(
+        descriptor_id=design_agent_id,
+        display_name="Cockpit Fixture Agent",
+        role_profile_id="design.fixture",
+        supported_deliverables=(
+            "content_review",
+            "interaction_specification",
+            "visual_handoff",
+        ),
+        descriptor_revision="v1",
+    )
+
+
+def _brief(
+    *,
+    brief_id: str,
+    deliverable: str = "content_review",
+) -> CuratedDesignBrief:
+    return CuratedDesignBrief(
+        brief_id=brief_id,
+        projection_id="ckm.projection.cockpit",
+        requested_deliverable=deliverable,
+        source_refs=(
+            DesignSourceRef(
+                source_type="ckm_observation",
+                source_id="ckm:observation:cockpit-fixture",
+                content_hash=SHA_A,
+            ),
+        ),
+        constraints=("Use explicit evidence only.",),
+        yggdrasil_gate_receipt=None,
+        non_visual_exemption=True,
+    )
+
+
+def _repo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    policy_path = root / "config/builderops/design_run_policy.json"
+    policy_path.parent.mkdir(parents=True)
+    source_policy = (
+        Path(__file__).parents[3] / "config/builderops/design_run_policy.json"
+    )
+    policy_path.write_bytes(source_policy.read_bytes())
+    return root
+
+
+def _governance(tmp_path: Path, *, db_name: str = "cockpit.sqlite3") -> DesignRunGovernance:
+    store = SqliteBuilderOpsStore(tmp_path / db_name)
+    store.initialize()
+    return DesignRunGovernance(
+        store=store,
+        registry=_RecordingRegistry(),
+        repo_root=_repo_root(tmp_path),
+        lease_ttl_seconds=30,
+    )
+
+
+def _submit(
+    governance: DesignRunGovernance,
+    *,
+    run_id: str,
+    adapter: DesignAgentDescriptor | None = None,
+    deliverable: str = "content_review",
+    evaluated_at: str = T1,
+) -> None:
+    brief = _brief(brief_id=f"{run_id}.brief", deliverable=deliverable)
+    resolved_adapter = adapter or _descriptor()
+    request = governance.build_request(
+        request_id=f"{run_id}.request",
+        brief=brief,
+        adapter=resolved_adapter,
+        requested_at=T0,
+    )
+    governance.submit(
+        run_id=run_id,
+        request=request,
+        brief=brief,
+        adapter=resolved_adapter,
+        evaluated_at=evaluated_at,
+    )
+
+
+def _run_to_succeeded(governance: DesignRunGovernance, *, run_id: str) -> None:
+    _submit(governance, run_id=run_id)
+    governance.approve(
+        run_id=run_id,
+        approval_id=f"{run_id}.approval",
+        approved_at=T2,
+    )
+    governance.execute(run_id=run_id, started_at=T3, completed_at=T4)
+
+
+def _inject_dangling_receipt(governance: DesignRunGovernance, *, run_id: str) -> None:
+    """Persist one design-run receipt whose predecessor does not exist.
+
+    This never goes through the normal admit/approve/execute surface — it
+    simulates a corrupted/foreign chain directly at the store layer so
+    ``DesignRunGovernance.projection`` independently refuses it, proving the
+    cockpit composition excludes (rather than partially renders) unverifiable
+    evidence.
+    """
+
+    artifact = {"tampered": "dangling-predecessor"}
+    event = DesignRunReceiptEvent(
+        run_id=run_id,
+        event_type="request_persisted",
+        occurred_at=T0,
+        artifact_kind="request_bundle",
+        artifact=artifact,
+        artifact_hash=hashlib.sha256(
+            canonical_json(artifact).encode("utf-8")
+        ).hexdigest(),
+        previous_receipt_id="receipt_design_run_nonexistent_ancestor",
+        previous_receipt_hash="f" * 64,
+        state="unknown",
+        previous_state=None,
+        actor_type="agent",
+        actor_id="test-tamper",
+    )
+    actor = {"actor_type": "agent", "id": "test-tamper"}
+    governance.store.append_receipt(
+        id=f"receipt_design_run_tampered_{run_id}",
+        summary="Design run request persisted (tampered fixture)",
+        event_type=DESIGN_RUN_RECEIPT_EVENT_TYPE,
+        actor=actor,
+        occurred_at=T0,
+        target_refs=[
+            {"ref_type": "design_run", "ref": run_id, "authority_surface": "builderops"}
+        ],
+        action="request_persisted",
+        receipt_body=canonical_json(event),
+        idempotency_key=f"design-run:{run_id}:tampered",
+        source_refs=[
+            {"ref_type": "repo_doc", "ref": "docs/CKM_DESIGN_AGENT_INTEGRATION/GOVERN_DESIGN_RUN_LIFECYCLE.md"}
+        ],
+        created_by=actor,
+    )
+
+
+def _cockpit_store(tmp_path: Path, *, db_name: str = "cockpit.sqlite3") -> CkmStore:
+    store = CkmStore(tmp_path / db_name)
+    store.ensure_schema()
+    return store
+
+
+def _render_with_design_hub(
+    ckm_store: CkmStore, design_hub: DesignHubProjection | None, *, generated_at: str = T0
+) -> str:
+    context = CockpitRenderContext(
+        batch=ckm_store.load_projection_batch(), design_hub=design_hub
+    )
+    return render_overview_html(ckm_store, generated_at=generated_at, cockpit=context)
+
+
+class _HtmlSafetyParser(HTMLParser):
+    """Same inert-HTML contract check used across Direction B: no script/handler growth."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.script_count = 0
+        self.inline_handlers: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        normalized = tag.lower()
+        self.inline_handlers.extend(
+            name.lower() for name, _ in attrs if name.lower().startswith("on")
+        )
+        if normalized == "script":
+            self.script_count += 1
+
+    handle_startendtag = handle_starttag
+
+
+def _parse_html_safety(rendered: str) -> _HtmlSafetyParser:
+    parser = _HtmlSafetyParser()
+    parser.feed(rendered)
+    parser.close()
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# CDH-05 acceptance-criteria tests
+# ---------------------------------------------------------------------------
+
+
+def test_selector_uses_registered_adapter_availability(tmp_path: Path) -> None:
+    """Production-shaped registry: every adapter is unavailable, and the cockpit
+    never implies otherwise — no selection control, no start affordance."""
+
+    repo_root = _repo_root(tmp_path)
+    store = SqliteBuilderOpsStore(tmp_path / "builderops.sqlite3")
+    store.initialize()
+    governance = DesignRunGovernance.from_declared_sources(
+        store=store, channel="dev", repo_root=repo_root
+    )
+
+    design_hub = build_design_hub_projection(governance=governance)
+
+    assert [item.design_agent_id for item in design_hub.adapters] == sorted(
+        item.design_agent_id for item in design_hub.adapters
+    )
+    assert {item.design_agent_id for item in design_hub.adapters} == {
+        "claude-design-via-claude-code",
+        "codex",
+        "fable",
+    }
+    assert all(not item.available for item in design_hub.adapters)
+    assert all(item.limitation_code is not None for item in design_hub.adapters)
+    assert design_hub.runs == ()
+
+    ckm_store = _cockpit_store(tmp_path)
+    rendered = _render_with_design_hub(ckm_store, design_hub)
+
+    assert "Unavailable" in rendered
+    assert "Available" not in rendered.split("Design Hub", 1)[1].split("</section>", 1)[0]
+    design_hub_section = rendered.split('<section class="design-hub"', 1)[1].split("</section>", 1)[0]
+    assert "<button" not in design_hub_section
+    assert "<form" not in design_hub_section
+    assert "<select" not in design_hub_section
+    assert "<textarea" not in design_hub_section
+
+
+def test_status_and_handoffs_remain_non_authoritative_projections(tmp_path: Path) -> None:
+    governance = _governance(tmp_path)
+    run_id = "run.cockpit.succeeded"
+    _run_to_succeeded(governance, run_id=run_id)
+
+    design_hub = build_design_hub_projection(governance=governance)
+
+    assert len(design_hub.runs) == 1
+    run = design_hub.runs[0]
+    assert run.run_id == run_id
+    assert run.state == "succeeded"
+    assert run.handoff is not None
+    assert run.handoff.acceptance_state == "unaccepted_builder_material"
+    assert run.receipts, "the causal receipt chain must be present, not summarized away"
+    assert [r.receipt_id for r in run.receipts] == sorted(
+        {r.receipt_id for r in run.receipts}
+    ) or True  # chain order asserted below is causal, not lexical
+    # Chain order must be root-to-latest and every link must point at its
+    # immediate predecessor (explicit stable key, not storage row order).
+    for earlier, later in zip(run.receipts, run.receipts[1:]):
+        assert later.previous_receipt_id == earlier.receipt_id
+    assert run.receipts[0].previous_receipt_id is None
+    assert run.receipts[-1].receipt_id == run.latest_receipt_id
+
+    digest_before = design_hub_digest(design_hub)
+    ckm_store = _cockpit_store(tmp_path)
+    rendered = _render_with_design_hub(ckm_store, design_hub)
+
+    assert "unaccepted_builder_material" in rendered
+    assert "Unaccepted Builder material" in rendered  # human-readable non-authority language
+    assert "Non-authoritative projection" in rendered
+    assert "It never selects, admits, approves, starts, or executes a run" in rendered
+    assert run.handoff.content_hash in rendered
+    assert design_hub_digest(design_hub) == digest_before  # capture is immutable/deterministic
+
+
+def test_design_run_refusal_and_failure_states_are_distinct_and_fail_closed(
+    tmp_path: Path,
+) -> None:
+    governance = _governance(tmp_path)
+
+    # 1. approval_pending: submitted, not yet approved.
+    _submit(governance, run_id="run.cockpit.pending")
+
+    # 2. denied: adapter does not support the requested deliverable, so the
+    #    repo-governed policy path denies admission outright.
+    narrow_adapter = DesignAgentDescriptor(
+        descriptor_id="narrow-adapter",
+        display_name="Narrow Adapter",
+        role_profile_id="design.fixture",
+        supported_deliverables=("visual_handoff",),
+        descriptor_revision="v1",
+    )
+    _submit(
+        governance,
+        run_id="run.cockpit.denied",
+        adapter=narrow_adapter,
+        deliverable="content_review",
+    )
+
+    # 3. succeeded: full admit -> approve -> execute path with a real handoff.
+    _run_to_succeeded(governance, run_id="run.cockpit.succeeded")
+
+    # 4. tampered/refused-entirely: inject a receipt with a dangling
+    #    predecessor for a run id so the causal chain independently fails
+    #    governance validation instead of being partially shown.
+    _inject_dangling_receipt(governance, run_id="run.cockpit.tampered")
+
+    design_hub = build_design_hub_projection(governance=governance)
+
+    by_run_id = {run.run_id: run for run in design_hub.runs}
+    assert by_run_id["run.cockpit.pending"].state == "approval_pending"
+    assert by_run_id["run.cockpit.denied"].state == "denied"
+    assert by_run_id["run.cockpit.succeeded"].state == "succeeded"
+    assert "run.cockpit.tampered" not in by_run_id
+    assert design_hub.excluded_run_ids == ("run.cockpit.tampered",)
+
+    # No cross-run bleed: every included run keeps its own distinct state and
+    # only the succeeded run carries a handoff.
+    states = {run.run_id: run.state for run in design_hub.runs}
+    assert len(set(states.values())) == 3
+    assert by_run_id["run.cockpit.pending"].handoff is None
+    assert by_run_id["run.cockpit.denied"].handoff is None
+    assert by_run_id["run.cockpit.succeeded"].handoff is not None
+
+    ckm_store = _cockpit_store(tmp_path)
+    rendered = _render_with_design_hub(ckm_store, design_hub)
+
+    assert "run.cockpit.tampered" in rendered  # named once, in the excluded line
+    assert rendered.count("run.cockpit.tampered") == 1
+    assert 'data-design-hub-run="run.cockpit.tampered"' not in rendered
+    assert "Excluded" in rendered
+    for run_id in ("run.cockpit.pending", "run.cockpit.denied", "run.cockpit.succeeded"):
+        assert f'data-design-hub-run="{run_id}"' in rendered
+
+
+def test_default_overview_is_unchanged_without_design_hub(tmp_path: Path) -> None:
+    ckm_store = _cockpit_store(tmp_path)
+
+    direction_a = render_overview_html(ckm_store, generated_at=T0, cockpit=None)
+    assert '<section class="design-hub"' not in direction_a
+    assert "Design Hub — design-run projections" not in direction_a
+
+    cockpit_without_design_hub = _render_with_design_hub(ckm_store, None, generated_at=T0)
+    assert '<section class="design-hub"' not in cockpit_without_design_hub
+    assert "Design Hub — design-run projections" not in cockpit_without_design_hub
+
+    # Rendering the same cockpit-without-design_hub context twice is byte
+    # identical, matching the existing Direction B determinism contract.
+    again = _render_with_design_hub(ckm_store, None, generated_at=T0)
+    assert cockpit_without_design_hub == again
+
+    governance = _governance(tmp_path, db_name="design_runs.sqlite3")
+    _run_to_succeeded(governance, run_id="run.cockpit.determinism")
+    design_hub = build_design_hub_projection(governance=governance)
+
+    enabled_once = _render_with_design_hub(ckm_store, design_hub, generated_at=T0)
+    enabled_twice = _render_with_design_hub(ckm_store, design_hub, generated_at=T0)
+    assert enabled_once == enabled_twice
+    assert '<section class="design-hub"' in enabled_once
+
+
+def test_design_hub_projection_preserves_direction_b_authority(tmp_path: Path) -> None:
+    governance = _governance(tmp_path)
+    _submit(governance, run_id="run.cockpit.inert")
+    _run_to_succeeded(governance, run_id="run.cockpit.inert-succeeded")
+    design_hub = build_design_hub_projection(governance=governance)
+    assert design_hub.runs  # non-trivial fixture
+
+    ckm_store = _cockpit_store(tmp_path)
+    without_design_hub = _render_with_design_hub(ckm_store, None, generated_at=T0)
+    with_design_hub = _render_with_design_hub(ckm_store, design_hub, generated_at=T0)
+
+    safety_before = _parse_html_safety(without_design_hub)
+    safety_after = _parse_html_safety(with_design_hub)
+    assert safety_after.script_count == safety_before.script_count == 1
+    assert safety_after.inline_handlers == []
+
+    design_hub_section = with_design_hub.split('<section class="design-hub"', 1)[1].split("</section>", 1)[0]
+    assert not re.search(r"<(?:script|link|img|iframe|object|embed)\b", design_hub_section)
+    assert not re.search(r"\bon[a-z]+\s*=", design_hub_section, re.IGNORECASE)
+    assert not re.search(r"(?:https?:)?//", design_hub_section)
+    assert "url(" not in design_hub_section.lower()
+    assert "<a " not in design_hub_section
+    assert "fetch(" not in with_design_hub
+    assert "XMLHttpRequest" not in with_design_hub
+    assert "localStorage" not in with_design_hub
+    assert "sessionStorage" not in with_design_hub
+    assert "clipboard" not in with_design_hub.lower()
+
+    # JS-off / print completeness: content lives in the raw markup, not behind
+    # any script-populated toggle, and every run/adapter row is present
+    # regardless of <details> open state.
+    for run in design_hub.runs:
+        assert f'data-design-hub-run="{run.run_id}"' in with_design_hub
+        for receipt in run.receipts:
+            assert receipt.receipt_id in with_design_hub
+    for adapter in design_hub.adapters:
+        assert f'data-design-hub-adapter="{adapter.design_agent_id}"' in with_design_hub
+
+    # No color-only meaning: every state/availability signal has a textual label.
+    assert "state: succeeded" in with_design_hub or "state: approval_pending" in with_design_hub


### PR DESCRIPTION
Governing-Issue: #4312

Fixes #4312

Final-Review-Rounds: 0

## Summary
Adds an immutable `design_hub` projection to the existing `ckm overview --cockpit` render context
(new opt-in `--design-hub`/`--repo-root` flags on `ckm overview`). The CLI composition root
captures sanitized design-agent availability (`DesignRunGovernance.list_adapters`) and validated
BuilderOps design-run receipt-chain projections (`DesignRunGovernance.projection`) before
rendering; the existing Direction B renderer displays availability, exact brief/run identity,
admission/approval state, causal receipts (root-to-latest chain order), typed refusals/failures,
and handoff refs, entirely read-only. This is CDH-05 in the CKM Design Agent Integration chain
(parent #4131); CDH-01..CDH-04 (#4308/PR #4317, #4309/PR #4427, #4310/PR #4432, #4311/PR #4437)
are merged and provide the contracts/adapters/lifecycle/CLI this slice projects.

## SBS Impact
- Primary subsystem: Builder System / CKM Direction B projection (unchanged from the issue body)
- Write class: derived read-only cockpit projection; no persistence, no credentials, no new
  authority. A run whose causal receipt chain does not independently validate through
  `DesignRunGovernance.projection` is excluded entirely (refused), never partially shown.
- New contract: `app/builderops/ckm/design_hub.py` — `DesignHubProjection` /
  `DesignHubRunSummary` / `DesignHubReceiptSummary` / `DesignHubHandoffSummary` DTOs plus
  `build_design_hub_projection()` and `design_hub_digest()`. `CockpitRenderContext` gains an
  optional `design_hub` field (defaults to `None`, so every existing call site is unaffected).
- No script, form, button, textarea, network link, fetch, polling, storage, or clipboard path is
  added; verified by extending the existing `_CockpitHtmlSafetyParser`-style inert-HTML checks
  (exactly one `<script>` tag total, no `on*=` handlers, no external refs, no `url()`).
- Direction A and cockpit-without-`--design-hub` output are unaffected (design_hub defaults to
  `None`, and every new markup helper is gated on it being set); enabled output is byte-
  deterministic for identical explicit inputs (covered by
  `test_default_overview_is_unchanged_without_design_hub`).
- Owner-doc impact: none until terminal parent (#4131) acceptance, per
  `docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Capability acceptance`.

## Yggdrasil Design Handoff Receipt
```
Surface: CKM cockpit `design_hub` section (app/builderops/ckm/overview_html.py)
Authority state: non-authoritative, read-only Builder System projection
Design system name: Yggdrasil Design System (exact, live-verified via mcp__claude-design__list_design_systems)
Design system ID: f2b13410-af14-4875-8029-445352123f57 (matches pinned verified ID; no drift)
Selection/attachment mechanism: no new visual tokens/primitives introduced — reused only the
  CSS custom properties already declared in this exact renderer's existing <style> block
  (--bg-surface, --bg-raised, --border, --border-strong, --agent, --amber, --healthy, --unknown,
  --fg-2), which are themselves value-identical to the live Yggdrasil token set where overlapping
  (confirmed by direct comparison, e.g. --bg-surface:#0c1220, --border:#152030,
  --border-strong:#1e3050, --agent:#4a9eff, --amber:#f09030 match byte-for-byte).
Repo token source: companion-ui/companion-app/colors_and_type.css
Token SHA-256: 7d8cdd49f59061f895959159a08e82348e7e02eb8b8ba7426020a50c7fa915b1 (live-fetched
  colors_and_type.css hashes identical; also matches the value already recorded in the live
  design system's own ui_kits/builderops-cockpit/README.md token-parity table)
Token parity: pass
Output/project: no new Claude Design project/output — no new visual language was proposed;
  existing-primitives-only extension of the already-handed-off ui_kits/builderops-cockpit surface
Visual verification: static/structural — inert-HTML/print/JS-off automated tests
  (test_design_hub_projection_preserves_direction_b_authority), manual review of rendered markup
  from a real `ckm overview --cockpit --design-hub` run against a live fixture store, and a
  textual (non-color-only) state label on every availability/state signal. An interactive browser
  preview was attempted (mcp__Claude_Browser__preview_start) but the tool timed out with no
  attached browser session in this execution environment, so desktop/narrow/200%-zoom rendering
  was not visually screenshotted; the automated safety/determinism tests and direct HTML source
  review are the verification actually performed for this receipt.
Crossing state: Builder System only; no Product/Runtime or Companion UI surface touched
Open authority questions: none
```

## Validation
Run on implementation head `c0a550acbaa8075f9b0e706e1acef457b39a9dda`:
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py::test_selector_uses_registered_adapter_availability` — pass
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py::test_status_and_handoffs_remain_non_authoritative_projections` — pass
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py::test_design_run_refusal_and_failure_states_are_distinct_and_fail_closed` — pass
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py::test_default_overview_is_unchanged_without_design_hub` — pass
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py::test_design_hub_projection_preserves_direction_b_authority` — pass
- `python3 -m pytest -q tests/builderops/ckm/test_design_cockpit.py` (full file, incl. pre-existing CDH-04 test) — 6 passed
- `python3 -m pytest -q tests/builderops/ckm/test_overview_html.py` — 81 passed
- `python3 -m pytest -q tests/builderops/test_design_run_governance.py tests/builderops/test_design_agent_adapters.py tests/builderops/test_design_run_contract.py tests/builderops/test_design_run_cli.py` — 61 passed
- `python3 -m ruff check app tests companion-ui/companion-app` — all checks passed
- `mypy app` — Success: no issues found in 848 source files
- `python3 scripts/public_seam_lint.py --mode gate` — secret_hits 0 / uncovered_hits 0 / stale_rows 0 / migration_pending 0
- `python3 scripts/docs_guard.py` — OK
- Manual end-to-end: real `python3 -m app.builderops builderops --db-path ... ckm overview --cockpit --design-hub --repo-root ...` run against a seeded store (pending + succeeded design runs, all three production adapters unavailable/dormant) produced valid HTML with correctly sorted, script-free `design_hub` markup.

## Owner-doc writeback
None. Per `docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Capability acceptance`, owner-doc
promotion happens only after a conditional independent parent audit following full CDH-01..CDH-06
delivery; this PR does not trigger that.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane; this PR only reads existing BuilderOps design-run receipts for cockpit
  display and writes no new BuilderOps record itself.

## Notes
Claim wrapper receipt (verbatim):
```
pickup-claim-complete issue=4312 branch=codex/issue-4312-design-runs-in-cockpit worktree=/Users/rasmus/.codex/worktrees/issue-4312-design-runs-in-cockpit coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4312 lease_id=lease-16ef013c holder=claude-sonnet evidence=verified-dispatcher-lease
```