### PR TITLE
docs: owner-doc promotion for #4489

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,7 +78,10 @@ promote public internet readiness.
   `heimdal.raw-store-key` (`heimdal-api-ingress` in `config/secrets/host_secret_contract.json`,
   dev/test/prod); the governed deploy wrapper bootstraps its secret layer for every `up` that
   includes the api service (degrade-visibly — a missing Keychain item or contract never fails the
-  deploy) and the `api` Compose service consumes it via its own env-file handle, without changing
+  deploy; a Keychain item that resolves to a *malformed* value does fail it, since the bootstrap is
+  fail-closed on validation, and #4489 extended that to the optional `github.token` declared for the
+  same consumer — tracked as `KD-4489-malformed-declared-secret-aborts-channel-deploy` on #4172) and
+  the `api` Compose service consumes it via its own env-file handle, without changing
   how `heimdal-capture-watch` is provisioned. An api startup preflight detects a missing
   `HEIMDAL_RAW_STORE_KEY` before first use, logs it loudly, and reports the media and screen
   ingress lanes `unavailable` on `/api/status` while every other API function keeps serving; the


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Post-merge owner-doc promotion for #4489 (PR #4491). `docs/STATUS.md` claimed the api host-secret layer is degrade-visibly with no qualification — "a missing Keychain item or contract never fails the deploy". That is true for a layer that cannot be *prepared*, but a Keychain item that resolves to a **malformed** value does fail the deploy, because the bootstrap is fail-closed on validation.

## Changes
One sentence in `docs/STATUS.md` (the #4422 Heimdal key-provisioning paragraph) now separates the missing case from the malformed case and names the deferred defect.

#4491 already corrected the two equivalent claims in `scripts/lib/deploy_channel_compose.sh` and the operator guidance in `docs/OPERATIONS.md`; STATUS was the remaining surface asserting the unqualified form.

Note the malformed-value behavior is **not new**: an independent reviewer confirmed a malformed `heimdal.raw-store-key` already aborted the deploy before #4489, because the wrapper's precheck rejects only an *empty* value. #4489 extended the same behavior to the optional `github.token` declared for the same consumer, which is what made the unqualified wording worth correcting. The blast-radius fix itself is deferred as `KD-4489-malformed-declared-secret-aborts-channel-deploy` on #4172.

## Notes
Validation: `pytest tests/docs tests/governance -m "not pg" -q` -> 494 passed. Docs-only change; no code or test surface touched.
---