### PR TITLE
Bind per-request active scope into the retrieval hot path (#2921)

### DIFF
--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -50,6 +50,18 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
 _ASK_LAST_ACTIVE_LOADED_ATTR = "_ask_recall_last_active_loaded"
 
 
+def _active_scope(state: AgentState) -> str | None:
+    """This turn's active scope: the explicit per-request binding, else the ambient default.
+
+    One precedence rule, applied at every read site (#2921) and identical to the one
+    :func:`scoped_hybrid_search` applies at the bottom of the stack. ``run_ask_graph`` normally
+    resolves it once onto the state; keeping the ambient fallback here means a directly constructed
+    ``AgentState`` still honours the process default instead of silently losing its scope — the
+    safe direction for a filter whose failure mode is admitting too much.
+    """
+    return state.active_scope or _resolve_domain_scope()
+
+
 def _to_retrieved_hit(hit: dict[str, Any], ask_score: float | None = None) -> RetrievedHit:
     payload = hit.get("payload") or {}
     return RetrievedHit(
@@ -72,7 +84,16 @@ def _to_retrieved_hit(hit: dict[str, Any], ask_score: float | None = None) -> Re
 
 
 def _retrieve_node(state: AgentState, *, k: int, ask_settings) -> AgentState:
-    response = retrieve(RetrievalRequest(query=state.query, k=k, trace_id=state.trace_id))
+    response = retrieve(
+        RetrievalRequest(
+            query=state.query,
+            k=k,
+            trace_id=state.trace_id,
+            # #2921: bind this turn's active scope so `_partition_by_scope` actually partitions on
+            # the production path instead of relying on an ambient env var nothing ever sets.
+            scope=_active_scope(state),
+        )
+    )
     enriched: list[RetrievedHit] = []
     for retrieval_hit in response.hits:
         hit = retrieval_hit.to_hybrid_dict()
@@ -180,7 +201,8 @@ def _recall_node(
 ) -> AgentState:
     vault_root = _active_recall_vault_root()
     candidates = retrieve_relevant_promoted(state.query, k=RECALL_TOP_K, vault_root=vault_root)
-    active_scope = _resolve_domain_scope()
+    # The same scope retrieval used for this turn (#2921), under the same precedence rule.
+    active_scope = _active_scope(state)
     provisional = (
         retrieve_relevant_provisional(
             state.query,
@@ -346,7 +368,9 @@ def _hits_as_scoped_retrieval(state: AgentState) -> ScopedRetrieval:
         for d in (state.denials or [])
         if isinstance(d, dict) and d.get("reason") and d.get("denial_class")
     )
-    return ScopedRetrieval(results=results, denials=denials, active_scope=_resolve_domain_scope())
+    # The envelope's declared scope must be the scope the prefilter actually used for this turn
+    # (#2921), not a second, independent resolution that could disagree with it.
+    return ScopedRetrieval(results=results, denials=denials, active_scope=_active_scope(state))
 
 
 def _envelope_source_ids(envelope: dict[str, Any]) -> list[str]:
@@ -551,10 +575,23 @@ def build_ask_graph(ask_settings=None):
     return graph.compile()
 
 
-def run_ask_graph(query: str, trace_id: Optional[str] = None, ask_settings=None) -> AgentState:
+def run_ask_graph(
+    query: str,
+    trace_id: Optional[str] = None,
+    ask_settings=None,
+    active_scope: Optional[str] = None,
+) -> AgentState:
+    """Run one ASK turn.
+
+    ``active_scope`` is the caller's active scope binding for this turn (#2921). It is resolved
+    ONCE here — request binding first, ambient ``ASK_DOMAIN_SCOPE`` as the process-level default —
+    and then carried on the state, so retrieval, recall, and envelope assembly all speak about the
+    same scope.
+    """
     ask_settings = ask_settings or get_ask_settings()
     compiled = build_ask_graph(ask_settings)
-    initial = AgentState(trace_id=trace_id, query=query, hits=[])
+    resolved_scope = (active_scope or "").strip() or _resolve_domain_scope()
+    initial = AgentState(trace_id=trace_id, query=query, active_scope=resolved_scope, hits=[])
     result = compiled.invoke(initial)
     if isinstance(result, AgentState):
         return result
@@ -562,7 +599,9 @@ def run_ask_graph(query: str, trace_id: Optional[str] = None, ask_settings=None)
         return AgentState.model_validate(result)
     except Exception:
         # Best-effort fallback if graph returned a plain dict
-        return AgentState(trace_id=trace_id, query=query, hits=[], answer=None)
+        return AgentState(
+            trace_id=trace_id, query=query, active_scope=resolved_scope, hits=[], answer=None
+        )
 
 
 __all__ = ["run_ask_graph", "build_ask_graph", "TOP_K_INITIAL"]

--- a/app/agents/ask/state.py
+++ b/app/agents/ask/state.py
@@ -33,6 +33,11 @@ class RetrievedHit(BaseModel):
 class AgentState(RuntimeStateModel):
     trace_id: Optional[str] = None
     query: str
+    # The active scope bound for THIS ASK turn (#2921). Resolved ONCE at graph entry — from the
+    # caller's request binding, falling back to the ambient `ASK_DOMAIN_SCOPE` process default —
+    # and then reused by retrieval, recall, and envelope assembly. Resolving it once is what keeps
+    # the scope the prefilter used and the envelope's `active_scope_id` from diverging mid-turn.
+    active_scope: Optional[str] = None
     hits: List[RetrievedHit] = Field(default_factory=list)
     # Authoritative metadata observed on the retrieval response. Shadow
     # experiments may inspect it, but it never feeds ranking or answer text.

--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -74,14 +74,22 @@ class AskRequest(BaseModel):
     # The caller's active scope for this turn (#2921). This is the production binding that
     # activates the scope prefilter; omitted, the ambient `ASK_DOMAIN_SCOPE` process default
     # applies and behaviour is unchanged. Binding context is not granting access: cross-scope
-    # admission remains a governed CrossScopeFlow decision, never something a scope string widens.
+    # admission remains a governed CrossScopeFlow decision (#2314), which no scope string can
+    # substitute for.
     #
     # TRANSITIONAL SURFACE. MVR-03 (#3857) versions ActiveContextSet and MVR-05B (#3860) moves
     # request ingress onto an opaque context_selection_id from which the SERVER derives the
     # cognitive scope; client-supplied scope strings never become identity or authority there.
-    # This field is the interim carrier, safe only because a bound scope can solely NARROW the
-    # retrieval candidate set. When #3860 lands, replace this with the server-derived scope from
-    # the immutable selection snapshot -- the threading below `run_ask_graph` is unaffected.
+    # When #3860 lands, replace this with the server-derived scope from the immutable selection
+    # snapshot -- the threading below `run_ask_graph` is unaffected.
+    #
+    # PRECEDENCE HAZARD, stated honestly: this binding REPLACES `ASK_DOMAIN_SCOPE` rather than
+    # narrowing within it. It narrows only relative to the UNSCOPED default. No deployment
+    # artifact in this repo sets `ASK_DOMAIN_SCOPE`, and this route has no authentication of its
+    # own, so if a deployment ever sets that variable as a containment control this precedence
+    # must become intersecting (env scope as a ceiling). Pinned by
+    # tests/retrieval/test_active_scope_request_binding.py::test_request_scope_overrides_ambient_env_scope
+    # and documented in RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md :: Activation in Production.
     scope: str | None = None
 
 

--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -71,6 +71,11 @@ VOICE_ASK_SUFFIX_BY_CONTENT_TYPE = {
 class AskRequest(BaseModel):
     question: str = Field(validation_alias=AliasChoices("question", "query"))
     zone_strategy: str | None = "default"
+    # The caller's active scope for this turn (#2921). This is the production binding that
+    # activates the scope prefilter; omitted, the ambient `ASK_DOMAIN_SCOPE` process default
+    # applies and behaviour is unchanged. Binding context is not granting access: cross-scope
+    # admission remains a governed CrossScopeFlow decision, never something a scope string widens.
+    scope: str | None = None
 
 
 class AskSource(BaseModel):
@@ -180,7 +185,9 @@ async def ask(req: AskRequest, request: Request) -> AskResponse:
     ask_settings = get_ask_settings()
     trace_id = getattr(request.state, "trace_id", None) or request.headers.get("x-trace-id") or new_trace_id()
     try:
-        state = run_ask_graph(req.question, trace_id=trace_id, ask_settings=ask_settings)
+        state = run_ask_graph(
+            req.question, trace_id=trace_id, ask_settings=ask_settings, active_scope=req.scope
+        )
     except LLMBackendTimeout as exc:
         record_ask_error()
         raise HTTPException(
@@ -229,6 +236,9 @@ async def ask_voice(
     audio: UploadFile = File(...),
     session_id: str | None = Form(None),
     zone_strategy: str | None = Form("default"),
+    # Same per-request active-scope binding as `/api/ask` (#2921); a voice turn must not be a
+    # scope-isolation hole just because it arrives as form data.
+    scope: str | None = Form(None),
 ) -> VoiceAskResponse | JSONResponse:
     """Turn transient client audio into a grounded, optionally spoken answer.
 
@@ -278,7 +288,12 @@ async def ask_voice(
     try:
         if not _HYBRID_WARMED:
             _ensure_hybrid_store_loaded()
-        state = run_ask_graph(transcript, trace_id=trace_id, ask_settings=get_ask_settings())
+        state = run_ask_graph(
+            transcript,
+            trace_id=trace_id,
+            ask_settings=get_ask_settings(),
+            active_scope=scope,
+        )
     except Exception:
         # The heard text is still useful, but no ungrounded substitute answer is.
         return JSONResponse(

--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -75,6 +75,13 @@ class AskRequest(BaseModel):
     # activates the scope prefilter; omitted, the ambient `ASK_DOMAIN_SCOPE` process default
     # applies and behaviour is unchanged. Binding context is not granting access: cross-scope
     # admission remains a governed CrossScopeFlow decision, never something a scope string widens.
+    #
+    # TRANSITIONAL SURFACE. MVR-03 (#3857) versions ActiveContextSet and MVR-05B (#3860) moves
+    # request ingress onto an opaque context_selection_id from which the SERVER derives the
+    # cognitive scope; client-supplied scope strings never become identity or authority there.
+    # This field is the interim carrier, safe only because a bound scope can solely NARROW the
+    # retrieval candidate set. When #3860 lands, replace this with the server-derived scope from
+    # the immutable selection snapshot -- the threading below `run_ask_graph` is unaffected.
     scope: str | None = None
 
 

--- a/app/retrieval/capability.py
+++ b/app/retrieval/capability.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
-from app.retrieval.hybrid import ScopeDenial, scoped_hybrid_search
+from app.retrieval.hybrid import (
+    ScopeDenial,
+    _clamp_in_context,
+    _intrinsic_evidence_role,
+    scoped_hybrid_search,
+)
 
 ViewFreshnessState = Literal["fresh", "stale", "partial", "unknown"]
 
@@ -70,6 +75,12 @@ class RetrievalHit:
     # store actually holds; see app/episodes/closure_decay.py). Empty (default) when the hit
     # carries no episode binding or an open one.
     signal_payload: "RetrievalSignalPayload" = field(default_factory=lambda: RetrievalSignalPayload())
+    # #2921: the per-hit in-context evidence role computed by the prefilter. This used to be
+    # dropped here, so the production ASK path handed the envelope `None` and the clamp always
+    # fell back to the intrinsic default -- only DOWNGRADES were lost, so the drop failed safe,
+    # but the clamp-through was inert end-to-end. Declared last so existing positional
+    # construction of this frozen dataclass keeps working.
+    evidence_role_in_context: str | None = None
 
     @classmethod
     def from_hybrid(cls, hit: dict[str, Any]) -> "RetrievalHit":
@@ -83,6 +94,13 @@ class RetrievalHit:
             snippet=hit.get("snippet"),
             source_ref=hit.get("source_ref"),
             payload=payload,
+            # Re-clamp at the seam rather than trusting the incoming dict: the role may be lowered
+            # for this context, never raised above the item's intrinsic role. The envelope clamps
+            # again downstream; both are non-upgrading, so carrying the value can only preserve a
+            # downgrade, never manufacture an upgrade.
+            evidence_role_in_context=_clamp_in_context(
+                _intrinsic_evidence_role(payload), hit.get("evidence_role_in_context")
+            ),
         )
 
     def to_hybrid_dict(self) -> dict[str, Any]:
@@ -94,6 +112,7 @@ class RetrievalHit:
             "snippet": self.snippet,
             "source_ref": self.source_ref,
             "payload": dict(self.payload),
+            "evidence_role_in_context": self.evidence_role_in_context,
         }
 
 
@@ -204,11 +223,18 @@ def retrieve(request: RetrievalRequest) -> RetrievalResponse:
         k=request.k,
         language=request.language,
         query_vector=request.query_vector,
+        # #2921: `request.scope` used to be diagnostic-only. It is now the load-bearing
+        # per-request active-scope binding, so the prefilter partitions in production instead of
+        # waiting on an ambient `ASK_DOMAIN_SCOPE` that no production code ever set.
+        scope=request.scope,
     )
     raw_hits = scoped.results
     diagnostics: dict[str, Any] = {
         "query": request.query,
         "scope": request.scope,
+        # The scope the prefilter ACTUALLY used: `request.scope` when bound, otherwise the ambient
+        # process default. Recorded so a request-scope/effective-scope divergence is observable.
+        "active_scope": scoped.active_scope,
         "domain": request.domain,
         "trace_id": request.trace_id,
     }

--- a/app/retrieval/hybrid.py
+++ b/app/retrieval/hybrid.py
@@ -765,18 +765,24 @@ def scoped_hybrid_search(
     k: int = 8,
     language: Optional[str] = None,
     query_vector: list[float] | None = None,
+    scope: str | None = None,
 ) -> ScopedRetrieval:
     """Scope-prefiltered retrieval with content-free denials — the structured entrypoint.
 
     Partitions the store into eligible/excluded BY SCOPE before ranking, ranks the eligible set
     only, records excluded-but-relevant material as content-free denials, and returns a
     :class:`ScopedRetrieval`. ``hybrid_search`` is the ``List[dict]`` projection of ``.results``.
+
+    ``scope`` is the caller's active scope for THIS request (#2921). It is the binding channel that
+    makes the prefilter live in production: the ASK request path threads the caller's active scope
+    down to here. When the caller binds no scope, the ambient ``ASK_DOMAIN_SCOPE`` remains the
+    process-level default, so every pre-existing caller and eval harness keeps its semantics.
     """
     # G1res-1 (#2981): revalidate the durable-index cache-through before serving.
     _revalidate_cache_generation()
 
     docs = _STORE.all()
-    scope = _resolve_domain_scope()
+    scope = scope or _resolve_domain_scope()
     if not docs:
         return ScopedRetrieval(results=[], denials=(), scope_policy_prefiltered=True, active_scope=scope)
 

--- a/app/retrieval/hybrid.py
+++ b/app/retrieval/hybrid.py
@@ -777,12 +777,18 @@ def scoped_hybrid_search(
     makes the prefilter live in production: the ASK request path threads the caller's active scope
     down to here. When the caller binds no scope, the ambient ``ASK_DOMAIN_SCOPE`` remains the
     process-level default, so every pre-existing caller and eval harness keeps its semantics.
+
+    Blank and whitespace-only values are normalized to "no binding" exactly as
+    :func:`_resolve_domain_scope` normalizes the environment variable, so `" work "` cannot become a
+    scope that matches nothing. Note that "explicitly unscoped, ignore the ambient default" is
+    therefore not expressible through this parameter; no caller needs it today, and the eval gate
+    (``app/eval/golden.py``) achieves it by clearing the environment variable instead.
     """
     # G1res-1 (#2981): revalidate the durable-index cache-through before serving.
     _revalidate_cache_generation()
 
     docs = _STORE.all()
-    scope = scope or _resolve_domain_scope()
+    scope = (scope or "").strip() or _resolve_domain_scope()
     if not docs:
         return ScopedRetrieval(results=[], denials=(), scope_policy_prefiltered=True, active_scope=scope)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -419,6 +419,9 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 ## Boundary Enforcement
 - Current runtime retrieval uses `ASK_DOMAIN_SCOPE` and `bridge_domains` as compatibility labels
   for a narrower operational-scope filter and explicit inclusion mechanism.
+- The active scope is bound PER REQUEST (#2921): the ASK request carries it down to the retrieval
+  prefilter, and `ASK_DOMAIN_SCOPE` is the process-level default when a request binds none. See
+  `docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md :: Activation in Production`.
 - Read these as current implementation terms, not as the full human context model.
 - By default, retrieval remains conservative and excludes results outside the active operational
   scope unless explicit inclusion is present.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -81,9 +81,9 @@ Interpretation note:
 - not as evidence that retrieval must remain architecturally centered in one agent surface.
 
 - **Hybrid retrieval** — Combined lexical + semantic retrieval with optional reranking overlays.
-  Current runtime scope filtering uses `ASK_DOMAIN_SCOPE` + `bridge_domains` as compatibility
-  labels for a narrower operational-scope policy, not as the full context model. Maturity:
-  Baseline.
+  Current runtime scope filtering takes the active scope from the per-request binding (#2921),
+  falling back to `ASK_DOMAIN_SCOPE`; that label plus `bridge_domains` are compatibility labels for
+  a narrower operational-scope policy, not the full context model. Maturity: Baseline.
 - **Rerankers** — Optional reranking providers with deterministic fallbacks. Maturity: Baseline.
 - **EmbeddingProvider** — Abstraction boundary for embedding generation. Every embedding is tagged
   with the generating provider/model and remains a derived runtime artifact rather than an identity

--- a/docs/RETRIEVAL.md
+++ b/docs/RETRIEVAL.md
@@ -190,8 +190,10 @@ Episode-closure decay — a derived, post-fusion rank multiplier per
 
 ### Scope filter
 Optional operational-scope filtering:
-- the current runtime uses `ASK_DOMAIN_SCOPE` and `bridge_domains` as compatibility labels for a
-  narrower scope filter and explicit inclusion mechanism
+- the active scope is bound per request (#2921) and threaded from the ASK request into
+  `scoped_hybrid_search`; `ASK_DOMAIN_SCOPE` remains the process-level default when a request binds
+  none, and `bridge_domains` remains the explicit inclusion mechanism — both are compatibility
+  labels for a narrower scope filter, not the full context model
 - matching may use document payload markers such as `domain` / `bridge_domains`
 - path- or `source_ref`-derived hints are runtime heuristics for current scope handling, not the
   full semantics of human context or artifact meaning

--- a/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
+++ b/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
@@ -105,6 +105,18 @@ only narrow what retrieval admits. Cross-scope admission stays a governed `Cross
   silently re-defaulted to the intrinsic role at the envelope. The seam re-clamps against the hit's
   own intrinsic role, and the envelope clamps again; both are non-upgrading, so carrying the value
   can only preserve a downgrade, never manufacture an upgrade.
+- **"Narrows" applies to retrieval, not to the whole turn.** Binding a scope narrows what the
+  retrieval prefilter admits, but it also makes one previously dead branch live:
+  `app/agents/ask/graph.py::_recall_node` guards provisional-memory recall on
+  `vault_root is not None and active_scope is not None`. Because production `active_scope` was
+  always `None`, `retrieve_relevant_provisional` never ran on the ASK path. A request that binds a
+  scope now admits provisional memory into the turn for the first time. That material is same-scope
+  filtered and admissibility-gated, so it is not a cross-scope leak — but it is an expansion of the
+  turn's admitted context, and it is deliberate rather than incidental.
+- **The retrieval prefilter is the only channel this closes.** Promoted-memory recall
+  (`app/agent_memory/recall_retrieval.py::retrieve_relevant_promoted`) takes no scope and filters on
+  none, so I-A5 is enforced on the retrieval channel and not yet on the promoted-recall channel.
+  Pre-existing and unchanged by this slice; tracked as a deferred defect.
 - **Entrypoints that do not bind a scope are unchanged**, and still resolve the ambient default:
   `app/agents/qa/agent.py`, `app/components/retrieval.py`, `app/api/routes/search.py`,
   `app/api/routes/context_bundles.py`, `app/curation/contradiction.py`, `app/expansion/connect.py`,

--- a/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
+++ b/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
@@ -87,6 +87,30 @@ The two alternatives were rejected on evidence, not preference:
   collapse` failure mode `docs/boundaries/WSP.md` names: scope reduced to a scalar vault/folder/
   device pointer. Scope is frame/audience/policy context, not a folder.
 
+### Forward compatibility with the Multi-Vault Runtime lane
+
+This binding deliberately does **not** couple to today's `ActiveContextSet` shape, which is what
+MVR-03 (#3857, `docs/MULTI_VAULT_RUNTIME/VERSION_ACTIVE_CONTEXT_SELECTION.md`) is about to rewrite
+into a versioned, immutable-generation contract.
+
+Split the seam in two:
+
+- **Durable.** `AgentState.active_scope` → `RetrievalRequest.scope` → `scoped_hybrid_search(scope=)`
+  → `_partition_by_scope`. Everything below the HTTP surface is a plain scope string threaded
+  through the retrieval path. MVR-03/05 does not change any of it.
+- **Transitional.** The `scope` field on `AskRequest` and on the `/api/ask/voice` form. MVR-03
+  states that client-supplied scope strings never become identity or authority, and MVR-05B (#3860)
+  moves request ingress onto an opaque `context_selection_id` from which the server derives the
+  cognitive scope. When that lands, the field is replaced by a server-derived scope read off the
+  immutable selection snapshot, and the only edit is the single argument passed to
+  `run_ask_graph(active_scope=...)` in `app/api/routes/ask.py`.
+
+This is safe in the interim because a bound scope can only *narrow* the retrieval candidate set. It
+is a filter input, never an authority claim, so a client-authored value cannot widen what a request
+may see — which is precisely the property MVR's "client-supplied scope strings never become
+identity or authority" rule protects. #3857 and #3860 are the follow-on work that must adapt the
+HTTP surface.
+
 Binding is not authorization. WSP supplies context and never grants access, so a bound scope can
 only narrow what retrieval admits. Cross-scope admission stays a governed `CrossScopeFlow` decision
 (#2314), and excluded-but-relevant material still surfaces as a content-free `ScopeDenial`.

--- a/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
+++ b/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
@@ -47,6 +47,69 @@ retrieval so agents consume a bounded `ContextEnvelope`, not raw index access.
   `app/`-backed adapter/fixture presenting the same corpus through the live retrieval entrypoint, and
   repoint the skeletons at it (drop the xfail). This does NOT relocate `mimer_runtime` into `app/`.
 
+## Activation in Production
+
+Delivering the mechanism is not the same as running it. Between #2772 and #2921 the prefilter was
+correct and mutation-verified in tests yet **dormant in the default running product**:
+`ASK_DOMAIN_SCOPE` was read by `app/retrieval/hybrid.py::_resolve_domain_scope` and set by no
+production code anywhere, so `scope` resolved to `None`, `_partition_by_scope` admitted every
+document, and I-A5 ("private not in work results") was enforced only where a test set the
+environment variable by hand.
+
+**The activation mechanism is a per-request active-scope binding threaded through the production
+ASK path.** One value is resolved once per turn and reused everywhere:
+
+`app/api/routes/ask.py::AskRequest.scope` (or the matching `scope` form field on `/api/ask/voice`)
+→ `app/agents/ask/graph.py::run_ask_graph(active_scope=...)` → `AgentState.active_scope` →
+`app/retrieval/capability.py::retrieve` via `RetrievalRequest.scope` →
+`app/retrieval/hybrid.py::scoped_hybrid_search(scope=...)` → `_partition_by_scope`.
+
+The same `AgentState.active_scope` also feeds the recall node and the envelope's `active_scope_id`,
+so the scope the prefilter filtered on and the scope the envelope declares cannot diverge within a
+turn. `RetrievalRequest.scope` was previously diagnostic-only metadata; it is now load-bearing.
+
+### Source of truth for the active scope
+
+**Chosen: the request context.** The caller states the active scope for the turn; the process-level
+`ASK_DOMAIN_SCOPE` remains the default when the request binds none.
+
+The two alternatives were rejected on evidence, not preference:
+
+- **`ActiveContextSet` / WSP.** `docs/boundaries/WSP.md` is the documented authority for effective
+  scope, and WSP does have running code — `app/vault/active_context.py::ActiveContextResolver`. But
+  that resolver returns `scope` with status `unknown` and the explicit reason "Scope is not resolved
+  by the current active-vault runtime." Binding retrieval to it today would leave the prefilter
+  exactly as dormant as before. WSP remains the intended long-term authority; when its resolver
+  starts returning a known scope it should take precedence over the request binding, and that
+  precedence rule is the follow-up, not this slice.
+- **Deriving scope from the active vault/workspace selection.** This is available today and would
+  have activated the prefilter without any API change — and it is precisely the `activeVault
+  collapse` failure mode `docs/boundaries/WSP.md` names: scope reduced to a scalar vault/folder/
+  device pointer. Scope is frame/audience/policy context, not a folder.
+
+Binding is not authorization. WSP supplies context and never grants access, so a bound scope can
+only narrow what retrieval admits. Cross-scope admission stays a governed `CrossScopeFlow` decision
+(#2314), and excluded-but-relevant material still surfaces as a content-free `ScopeDenial`.
+
+### Fail-safe posture and what stayed unchanged
+
+- **The unscoped default is unchanged.** No bound scope and no `ASK_DOMAIN_SCOPE` still means every
+  document is eligible. This slice activates a binding channel; it does not flip the default from
+  admit-all to deny-all.
+- **`ASK_DOMAIN_SCOPE` stays supported** as the process-level default, so `tests/evals/_app_adapter.py`,
+  `tests/boundaries/test_domain_separation_defaults.py`, and `app/eval/golden.py` (which deliberately
+  *clears* it so a leaked scope cannot prefilter the deterministic gate) keep their current
+  semantics without edits.
+- **The evidence-role clamp never upgrades.** `evidence_role_in_context` now survives the
+  `RetrievalHit` capability boundary (`from_hybrid` / `to_hybrid_dict`) instead of being dropped and
+  silently re-defaulted to the intrinsic role at the envelope. The seam re-clamps against the hit's
+  own intrinsic role, and the envelope clamps again; both are non-upgrading, so carrying the value
+  can only preserve a downgrade, never manufacture an upgrade.
+- **Entrypoints that do not bind a scope are unchanged**, and still resolve the ambient default:
+  `app/agents/qa/agent.py`, `app/components/retrieval.py`, `app/api/routes/search.py`,
+  `app/api/routes/context_bundles.py`, `app/curation/contradiction.py`, `app/expansion/connect.py`,
+  and `app/retrieval/production_bundle.py`.
+
 ## Concretely
 
 ```bash

--- a/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
+++ b/docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md
@@ -105,15 +105,36 @@ Split the seam in two:
   immutable selection snapshot, and the only edit is the single argument passed to
   `run_ask_graph(active_scope=...)` in `app/api/routes/ask.py`.
 
-This is safe in the interim because a bound scope can only *narrow* the retrieval candidate set. It
-is a filter input, never an authority claim, so a client-authored value cannot widen what a request
-may see — which is precisely the property MVR's "client-supplied scope strings never become
-identity or authority" rule protects. #3857 and #3860 are the follow-on work that must adapt the
-HTTP surface.
+#### Exactly what "narrows" means here — and what it does not
 
-Binding is not authorization. WSP supplies context and never grants access, so a bound scope can
-only narrow what retrieval admits. Cross-scope admission stays a governed `CrossScopeFlow` decision
-(#2314), and excluded-but-relevant material still surfaces as a content-free `ScopeDenial`.
+A bound scope narrows the retrieval candidate set **relative to the unscoped default**. It does
+**not** narrow relative to a configured ambient scope: the request binding takes strict precedence
+over `ASK_DOMAIN_SCOPE` and *replaces* it (`_active_scope` and `scoped_hybrid_search` both resolve
+"explicit binding first, ambient default second"). `ASK_DOMAIN_SCOPE` is therefore a **default, not
+a containment control**.
+
+The concrete consequence, stated plainly rather than left implicit: if an operator sets
+`ASK_DOMAIN_SCOPE=work` expecting domain containment, a request that binds `scope=private` is
+served the `private` partition, not the `work` one. `/api/ask` carries no authentication of its
+own, so any caller that can reach the endpoint can select any scope. That behaviour is pinned by
+`tests/retrieval/test_active_scope_request_binding.py::test_request_scope_overrides_ambient_env_scope`
+so it is deliberate and visible instead of a surprise.
+
+This is acceptable today for two reasons, both of which are conditions that can expire:
+
+1. No deployment artifact in this repository sets `ASK_DOMAIN_SCOPE` — the effective shipped default
+   is admit-all, under which no scope string can widen anything.
+2. Scope binding supplies context and never grants access, so it cannot reach material a governed
+   `CrossScopeFlow` (#2314) would have to admit; excluded-but-relevant material still surfaces as a
+   content-free `ScopeDenial`.
+
+**If either condition changes — a deployment starts setting `ASK_DOMAIN_SCOPE` as a containment
+control, or `/api/ask` becomes reachable by a caller the operator does not trust — this precedence
+must become intersecting rather than overriding** (an env-set scope becomes a ceiling the request
+may narrow within but not escape). MVR-05B (#3860) removes the hazard structurally by making the
+server derive the scope from the immutable selection snapshot instead of accepting it from the
+client, which is the durable shape. #3857 and #3860 are the follow-on work that must adapt the HTTP
+surface.
 
 ### Fail-safe posture and what stayed unchanged
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -496,18 +496,38 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "app/agents/ask/",
             "app/activation/ask_synthesis.py",
             "app/retrieval/envelope.py",
+            # The ASK HTTP surface owns BOTH ask entrypoints. `companion_ui` already
+            # claims this path for `tests/api`, and subsystems union rather than steal,
+            # so listing it here strictly widens: it adds the ASK graph/retrieval lane
+            # plus the voice-contract test that `tests/api` alone does not cover.
+            "app/api/routes/ask.py",
             "tests/agents/ask/",
         ),
         (
             "tests/agents/ask",
             "tests/retrieval",
             "tests/agent_memory",
+            # `app/agents/ask/state.py` defines AgentState. These two suites are the
+            # ONLY gates in the repo asserting the shared RuntimeStateModel authority
+            # /trace spine on it. Without them an `ask`-only selection goes green while
+            # a state class that dropped the spine merges -- a false-green CI window
+            # this subsystem would otherwise newly open (these paths previously exited
+            # 2, i.e. fail-closed).
+            "tests/architecture/test_agent_state_spine.py",
+            "tests/agents/test_runtime_state_contract.py",
+            # `app/activation/ask_synthesis.py` is an ask prefix; this invariant
+            # hard-codes the receipt path and mkdir+append sequence that module owns.
+            "tests/invariants/test_receipt_surface_writable.py",
             "tests/api/test_ask_api.py",
             "tests/api/test_ask_alias.py",
             "tests/api/test_ask_contract.py",
             "tests/api/test_ask_llm_answer.py",
             "tests/api/test_ask_rerank_origin.py",
             "tests/api/test_ask_route.py",
+            # `/api/ask/voice` binds the same active scope from a form field. Every other
+            # voice test monkeypatches `run_ask_graph` away, so this is the only gate that
+            # proves the voice turn is not a scope-isolation hole.
+            "tests/voice/test_voice_ask_contract.py",
         ),
     ),
     (

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -486,6 +486,31 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ),
     ),
     (
+        "ask",
+        (
+            # The ASK graph is the retrieval CONSUMPTION seam: it binds the active
+            # scope (#2921), assembles the ContextEnvelope, and drives recall. It
+            # was unowned, so any change here failed closed as unowned runtime
+            # code. Its blast radius is retrieval + agent memory + the ASK HTTP
+            # contract, which is exactly what these targets cover.
+            "app/agents/ask/",
+            "app/activation/ask_synthesis.py",
+            "app/retrieval/envelope.py",
+            "tests/agents/ask/",
+        ),
+        (
+            "tests/agents/ask",
+            "tests/retrieval",
+            "tests/agent_memory",
+            "tests/api/test_ask_api.py",
+            "tests/api/test_ask_alias.py",
+            "tests/api/test_ask_contract.py",
+            "tests/api/test_ask_llm_answer.py",
+            "tests/api/test_ask_rerank_origin.py",
+            "tests/api/test_ask_route.py",
+        ),
+    ),
+    (
         "episodes",
         (
             "app/episodes/",

--- a/tests/api/test_ask_contract.py
+++ b/tests/api/test_ask_contract.py
@@ -83,9 +83,21 @@ def test_ask_contract_propagates_trace_id_from_header(monkeypatch) -> None:
     hybrid.set_documents([])
     captured: dict[str, str | None] = {"trace_id": None}
 
-    def _fake_run_ask_graph(query: str, trace_id: str | None = None, ask_settings=None) -> AgentState:
+    def _fake_run_ask_graph(
+        query: str,
+        trace_id: str | None = None,
+        ask_settings=None,
+        active_scope: str | None = None,
+    ) -> AgentState:
         captured["trace_id"] = trace_id
-        return AgentState(trace_id=trace_id, query=query, hits=[], answer="No results found.")
+        captured["active_scope"] = active_scope
+        return AgentState(
+            trace_id=trace_id,
+            query=query,
+            active_scope=active_scope,
+            hits=[],
+            answer="No results found.",
+        )
 
     monkeypatch.setattr(ask_module, "run_ask_graph", _fake_run_ask_graph)
     client = TestClient(app)
@@ -105,9 +117,21 @@ def test_ask_contract_generates_trace_id_when_missing(monkeypatch) -> None:
     hybrid.set_documents([])
     captured: dict[str, str | None] = {"trace_id": None}
 
-    def _fake_run_ask_graph(query: str, trace_id: str | None = None, ask_settings=None) -> AgentState:
+    def _fake_run_ask_graph(
+        query: str,
+        trace_id: str | None = None,
+        ask_settings=None,
+        active_scope: str | None = None,
+    ) -> AgentState:
         captured["trace_id"] = trace_id
-        return AgentState(trace_id=trace_id, query=query, hits=[], answer="No results found.")
+        captured["active_scope"] = active_scope
+        return AgentState(
+            trace_id=trace_id,
+            query=query,
+            active_scope=active_scope,
+            hits=[],
+            answer="No results found.",
+        )
 
     class _FakeUuid:
         hex = "generated-ask-trace-1"

--- a/tests/api/test_ask_contract.py
+++ b/tests/api/test_ask_contract.py
@@ -105,6 +105,8 @@ def test_ask_contract_propagates_trace_id_from_header(monkeypatch) -> None:
         resp = client.post("/api/ask", json={"question": "trace header"}, headers={"x-trace-id": "trace-ask-header-1"})
         assert resp.status_code == 200
         assert captured["trace_id"] == "trace-ask-header-1"
+        # #2921: a request that binds no scope must pass None, not an invented value.
+        assert captured["active_scope"] is None
     finally:
         hybrid.set_documents([])
         ask_module._HYBRID_WARMED = False
@@ -143,6 +145,7 @@ def test_ask_contract_generates_trace_id_when_missing(monkeypatch) -> None:
         resp = client.post("/api/ask", json={"question": "trace generated"})
         assert resp.status_code == 200
         assert captured["trace_id"] == "generated-ask-trace-1"
+        assert captured["active_scope"] is None
         assert resp.headers.get("x-trace-id") == "generated-ask-trace-1"
     finally:
         hybrid.set_documents([])

--- a/tests/retrieval/test_active_scope_request_binding.py
+++ b/tests/retrieval/test_active_scope_request_binding.py
@@ -7,8 +7,15 @@ KERNEL-10 (#2772) delivered the prefilter MECHANISM; these tests bind its ACTIVA
   ``ASK_DOMAIN_SCOPE`` is deliberately absent: the scope must arrive through the request path.
 - ``test_ambient_env_scope_remains_process_default`` — with no request-bound scope, the ambient
   ``ASK_DOMAIN_SCOPE`` still resolves, so existing callers and eval harnesses are unaffected.
+- ``test_unmatched_bound_scope_admits_nothing_and_denies`` — a scope no document matches starves
+  the result set and records a denial; it never falls back to admit-all.
 - ``test_evidence_role_in_context_survives_capability_boundary`` — the per-hit in-context evidence
   role crosses ``RetrievalHit`` instead of being dropped, and the clamp stays non-upgrading.
+- ``test_request_scope_overrides_ambient_env_scope`` — PRECEDENCE: a request binding REPLACES
+  ``ASK_DOMAIN_SCOPE``. It narrows only relative to the UNSCOPED default, so the env var is a
+  default and not a containment control. Pinned so the property is deliberate and visible.
+- ``test_recall_node_uses_request_bound_scope`` — the recall leg of the no-divergence invariant:
+  the recall node consumes the turn's bound scope rather than re-resolving the ambient default.
 """
 
 from __future__ import annotations

--- a/tests/retrieval/test_active_scope_request_binding.py
+++ b/tests/retrieval/test_active_scope_request_binding.py
@@ -13,11 +13,14 @@ KERNEL-10 (#2772) delivered the prefilter MECHANISM; these tests bind its ACTIVA
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
 import app.retrieval.hybrid as hybrid
 from app.agents.ask import graph as ask_graph
+from app.agents.ask.state import AgentState
 from app.api.app import app
 from app.retrieval.capability import RetrievalHit, RetrievalRequest, retrieve
 from app.retrieval.hybrid import get_store
@@ -208,3 +211,67 @@ def test_evidence_role_in_context_survives_capability_boundary(monkeypatch) -> N
     )
     assert upgraded.evidence_role_in_context == "background", "the clamp must never upgrade a role"
     assert order.index(upgraded.evidence_role_in_context) <= order.index("background")
+
+
+def test_request_scope_overrides_ambient_env_scope(monkeypatch) -> None:
+    """PRECEDENCE, pinned deliberately: a request binding REPLACES `ASK_DOMAIN_SCOPE`.
+
+    The binding narrows only relative to the UNSCOPED default. It does not narrow within a
+    configured ambient scope — it overrides it, so `ASK_DOMAIN_SCOPE` is a default and NOT a
+    containment control. This test exists so that property is visible and deliberate rather than an
+    unstated consequence of the resolution order; see
+    `docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md :: Activation in Production`.
+    """
+    monkeypatch.setenv("ASK_DOMAIN_SCOPE", "work")
+    _seed_two_scopes()
+    seen = _spy_partition(monkeypatch)
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *a, **k: [])
+    monkeypatch.setattr(
+        ask_graph, "llm_answer", lambda question, context, ask_settings: ("Bound.", {"provider": "mock"})
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/ask", json={"question": "stateful workflow engine", "scope": "private"}
+    )
+
+    assert response.status_code == 200
+    # The REQUEST scope wins outright; the ambient "work" never reaches the guard.
+    assert set(seen) == {"private"}, f"request binding must override the ambient default, saw {seen}"
+    source_paths = {source.get("path") for source in response.json()["sources"]}
+    assert source_paths == {"private/journal.md"}, (
+        "the request-bound partition is served, not the ambient one -- if this ever needs to be a "
+        "ceiling instead of an override, make the precedence intersecting"
+    )
+
+
+def test_recall_node_uses_request_bound_scope(monkeypatch) -> None:
+    """The recall leg of the no-divergence invariant.
+
+    `_recall_node` must consume the SAME scope retrieval used, not re-resolve the ambient default.
+    Without this, provisional memory from the ambient scope could be recalled into a turn the
+    caller bound to a different scope.
+    """
+    monkeypatch.setenv("ASK_DOMAIN_SCOPE", "work")
+    _seed_two_scopes()
+
+    seen_scopes: list[str | None] = []
+
+    def _spy_provisional(query, *, k, vault_root, receipt_store, active_scope_id):
+        seen_scopes.append(active_scope_id)
+        return None
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *a, **k: [])
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_provisional", _spy_provisional)
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: Path("/nonexistent-vault"))
+
+    state = ask_graph._recall_node(  # noqa: SLF001 - production node proof
+        AgentState(query="stateful workflow engine", active_scope="private"),
+        ask_settings=object(),
+    )
+
+    assert state is not None
+    assert seen_scopes == ["private"], (
+        f"recall must use the turn's bound scope, not the ambient default, saw {seen_scopes}"
+    )

--- a/tests/retrieval/test_active_scope_request_binding.py
+++ b/tests/retrieval/test_active_scope_request_binding.py
@@ -136,6 +136,27 @@ def test_ambient_env_scope_remains_process_default(monkeypatch) -> None:
     assert retrieve(RetrievalRequest(query="stateful workflow engine")).hits
 
 
+def test_unmatched_bound_scope_admits_nothing_and_denies(monkeypatch) -> None:
+    """A bound scope no document matches admits NOTHING and records a content-free denial.
+
+    The fail-safe direction: an unmatched scope must starve the result set rather than fall back to
+    admit-all. Whitespace around the scope is normalized, so `" work "` cannot silently become an
+    unmatchable scope.
+    """
+    monkeypatch.delenv("ASK_DOMAIN_SCOPE", raising=False)
+    _seed_two_scopes()
+
+    unmatched = retrieve(RetrievalRequest(query="stateful workflow engine", k=5, scope="operator"))
+    assert unmatched.hits == [], "an unmatched bound scope must not fall back to admit-all"
+    assert unmatched.denials, "relevant excluded material must be recorded, never silently dropped"
+    assert {d.denial_class for d in unmatched.denials} == {"cross_scope_no_flow"}
+    assert unmatched.diagnostics["active_scope"] == "operator"
+
+    padded = retrieve(RetrievalRequest(query="stateful workflow engine", k=5, scope="  work  "))
+    assert {hit.doc_id for hit in padded.hits} == {"work-1"}
+    assert padded.diagnostics["active_scope"] == "work"
+
+
 def test_evidence_role_in_context_survives_capability_boundary(monkeypatch) -> None:
     """The per-hit in-context evidence role crosses ``RetrievalHit`` and never upgrades.
 

--- a/tests/retrieval/test_active_scope_request_binding.py
+++ b/tests/retrieval/test_active_scope_request_binding.py
@@ -1,0 +1,189 @@
+"""Per-request active-scope binding activates the scope prefilter in production (#2921).
+
+KERNEL-10 (#2772) delivered the prefilter MECHANISM; these tests bind its ACTIVATION half:
+
+- ``test_ask_request_scope_excludes_out_of_scope_material`` — the production ``/api/ask``
+  entrypoint binds the caller's active scope, so ``_partition_by_scope`` actually partitions.
+  ``ASK_DOMAIN_SCOPE`` is deliberately absent: the scope must arrive through the request path.
+- ``test_ambient_env_scope_remains_process_default`` — with no request-bound scope, the ambient
+  ``ASK_DOMAIN_SCOPE`` still resolves, so existing callers and eval harnesses are unaffected.
+- ``test_evidence_role_in_context_survives_capability_boundary`` — the per-hit in-context evidence
+  role crosses ``RetrievalHit`` instead of being dropped, and the clamp stays non-upgrading.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.retrieval.hybrid as hybrid
+from app.agents.ask import graph as ask_graph
+from app.api.app import app
+from app.retrieval.capability import RetrievalHit, RetrievalRequest, retrieve
+from app.retrieval.hybrid import get_store
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(monkeypatch):
+    """Clean store around every test, so scope decides membership rather than leftover state."""
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    yield
+    get_store().set_documents([])
+
+
+def _seed_two_scopes() -> None:
+    store = get_store()
+    store.set_documents([])
+    store.add_document(
+        doc_id="work-1",
+        text="stateful workflow engine event bus reconciliation",
+        source_ref="work/arch.md",
+        payload={"domain": "work", "title": "Work arch", "origin": "vault"},
+    )
+    store.add_document(
+        doc_id="private-1",
+        # Deliberately shares vocabulary with the work doc so similarity alone cannot separate
+        # them: only the scope prefilter can keep it out of a work-scoped answer.
+        text="stateful workflow engine event bus reconciliation therapy journal",
+        source_ref="private/journal.md",
+        payload={"domain": "private", "title": "Private journal", "origin": "vault"},
+    )
+
+
+def _spy_partition(monkeypatch) -> list[str | None]:
+    """Record every scope value ``_partition_by_scope`` is actually invoked with."""
+    seen: list[str | None] = []
+    original = hybrid._partition_by_scope
+
+    def _spy(docs, scope):
+        seen.append(scope)
+        return original(docs, scope)
+
+    monkeypatch.setattr(hybrid, "_partition_by_scope", _spy)
+    return seen
+
+
+def test_ask_request_scope_excludes_out_of_scope_material(monkeypatch) -> None:
+    """The PRODUCTION request path binds the active scope — not an injected ``ASK_DOMAIN_SCOPE``.
+
+    This is the enforcement AC: the guard (``_partition_by_scope``) must be reached from the real
+    runtime entrypoint (``app.api.routes.ask``) carrying the caller's scope, and the out-of-scope
+    material must be absent from the answer's grounded sources.
+    """
+    monkeypatch.delenv("ASK_DOMAIN_SCOPE", raising=False)
+    _seed_two_scopes()
+    seen = _spy_partition(monkeypatch)
+
+    captured: dict[str, dict] = {}
+    original_assemble = ask_graph.assemble_and_validate_ask_envelope
+
+    def _spy_assemble(scoped, **kwargs):
+        envelope = original_assemble(scoped, **kwargs)
+        captured["envelope"] = envelope
+        captured["kwargs"] = kwargs
+        return envelope
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *a, **k: [])
+    monkeypatch.setattr(ask_graph, "assemble_and_validate_ask_envelope", _spy_assemble)
+    monkeypatch.setattr(
+        ask_graph, "llm_answer", lambda question, context, ask_settings: ("In scope.", {"provider": "mock"})
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/ask", json={"question": "stateful workflow engine", "scope": "work"}
+    )
+
+    assert response.status_code == 200
+    # The guard ran on the live path with the REQUEST-bound scope, with no ambient env var to
+    # supply it. Without the binding this list is all-``None`` and the prefilter is a no-op.
+    assert seen, "the scope prefilter must be reached from the production ASK entrypoint"
+    assert set(seen) == {"work"}, f"expected the request-bound scope at the guard, saw {seen}"
+
+    source_paths = {source.get("path") for source in response.json()["sources"]}
+    assert "private/journal.md" not in source_paths, "out-of-scope material reached the answer"
+    assert "work/arch.md" in source_paths
+
+    # The envelope's declared active scope and the scope the prefilter used must not diverge.
+    assert captured["kwargs"]["active_scope_id"] == "work"
+
+
+def test_ambient_env_scope_remains_process_default(monkeypatch) -> None:
+    """``ASK_DOMAIN_SCOPE`` stays supported as the process-level default.
+
+    A request that binds no scope must keep resolving the ambient env var, so
+    ``tests/evals/_app_adapter.py``, ``tests/boundaries/`` and ``app/eval/golden.py`` keep their
+    current semantics rather than silently losing their scope.
+    """
+    monkeypatch.setenv("ASK_DOMAIN_SCOPE", "work")
+    _seed_two_scopes()
+    seen = _spy_partition(monkeypatch)
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *a, **k: [])
+    monkeypatch.setattr(
+        ask_graph, "llm_answer", lambda question, context, ask_settings: ("In scope.", {"provider": "mock"})
+    )
+
+    client = TestClient(app)
+    response = client.post("/api/ask", json={"question": "stateful workflow engine"})
+
+    assert response.status_code == 200
+    assert set(seen) == {"work"}, f"ambient env scope must still reach the guard, saw {seen}"
+    source_paths = {source.get("path") for source in response.json()["sources"]}
+    assert "private/journal.md" not in source_paths
+
+    # The capability seam honours the same default when the request carries no scope.
+    assert retrieve(RetrievalRequest(query="stateful workflow engine")).hits
+
+
+def test_evidence_role_in_context_survives_capability_boundary(monkeypatch) -> None:
+    """The per-hit in-context evidence role crosses ``RetrievalHit`` and never upgrades.
+
+    Before #2921 ``from_hybrid``/``to_hybrid_dict`` dropped the field, so the production ASK path
+    always handed the envelope ``None`` and the clamp fell back to the intrinsic default.
+    """
+    monkeypatch.delenv("ASK_DOMAIN_SCOPE", raising=False)
+    store = get_store()
+    store.set_documents([])
+    store.add_document(
+        doc_id="explicit-evidence",
+        text="stateful workflow engine event bus reconciliation",
+        source_ref="work/evidence.md",
+        payload={"domain": "work", "evidence_role": "evidence"},
+    )
+    store.add_document(
+        doc_id="background-default",
+        text="stateful workflow engine event bus reconciliation notes",
+        source_ref="work/background.md",
+        payload={"domain": "work"},
+    )
+
+    response = retrieve(RetrievalRequest(query="stateful workflow engine", k=5, scope="work"))
+    by_id = {hit.doc_id: hit for hit in response.hits}
+    assert by_id, "retrieval must return the in-scope hits"
+
+    for doc_id, hit in by_id.items():
+        # The field survived the boundary at all — this is what used to be dropped.
+        assert hit.evidence_role_in_context is not None, f"{doc_id} lost its in-context role"
+        # ...and it survives the round trip back out to the dict projection the ASK graph reads.
+        assert hit.to_hybrid_dict()["evidence_role_in_context"] == hit.evidence_role_in_context
+
+    order = ["background", "supporting", "evidence"]
+    assert by_id["explicit-evidence"].evidence_role_in_context == "evidence"
+    assert by_id["background-default"].evidence_role_in_context == "background"
+
+    # Fail-safe discipline: the seam may lower a role, never raise it above the intrinsic one.
+    upgraded = RetrievalHit.from_hybrid(
+        {
+            "id": "background-default",
+            "doc_id": "background-default",
+            "text": "body",
+            "score": 0.5,
+            "snippet": "body",
+            "source_ref": "work/background.md",
+            "payload": {"domain": "work"},
+            "evidence_role_in_context": "evidence",
+        }
+    )
+    assert upgraded.evidence_role_in_context == "background", "the clamp must never upgrade a role"
+    assert order.index(upgraded.evidence_role_in_context) <= order.index("background")

--- a/tests/retrieval/test_retrieval_capability.py
+++ b/tests/retrieval/test_retrieval_capability.py
@@ -60,6 +60,8 @@ def test_ask_compatibility_metadata_survives_capability_adapter(monkeypatch) -> 
 
 
 def test_retrieval_capability_accepts_surface_neutral_request(monkeypatch) -> None:
+    # Since #2921 `RetrievalRequest.scope` is load-bearing at the prefilter rather than diagnostic
+    # metadata, so it must name a scope the seeded corpus actually contains.
     _patch_embeddings(monkeypatch)
     _seed_store()
     try:
@@ -67,7 +69,7 @@ def test_retrieval_capability_accepts_surface_neutral_request(monkeypatch) -> No
             RetrievalRequest(
                 query="alpha retrieval",
                 k=1,
-                scope="operator",
+                scope="core",
                 domain="core",
                 trace_id="surface-neutral",
             )
@@ -75,7 +77,8 @@ def test_retrieval_capability_accepts_surface_neutral_request(monkeypatch) -> No
 
         assert response.query == "alpha retrieval"
         assert response.trace_id == "surface-neutral"
-        assert response.diagnostics["scope"] == "operator"
+        assert response.diagnostics["scope"] == "core"
+        assert response.diagnostics["active_scope"] == "core"
         assert response.diagnostics["domain"] == "core"
         assert response.hits
     finally:
@@ -90,7 +93,7 @@ def test_retrieval_contract_objects_are_surface_independent(monkeypatch) -> None
             RetrievalRequest(
                 query="alpha retrieval",
                 k=1,
-                scope="operator",
+                scope="core",
                 domain="core",
                 trace_id="contract-1",
             )
@@ -100,7 +103,7 @@ def test_retrieval_contract_objects_are_surface_independent(monkeypatch) -> None
         assert response.trace_id == "contract-1"
         assert response.metadata["provenance"]["capability"] == "retrieval"
         assert response.metadata["provenance"]["adapter"] == "hybrid_search"
-        assert response.metadata["provenance"]["request"] == {"scope": "operator", "domain": "core"}
+        assert response.metadata["provenance"]["request"] == {"scope": "core", "domain": "core"}
         assert response.hits
         assert response.hits[0].doc_id == "alpha"
     finally:

--- a/tests/voice/test_voice_ask_contract.py
+++ b/tests/voice/test_voice_ask_contract.py
@@ -41,3 +41,37 @@ async def test_accepted_container_uses_content_type_not_generic_filename(monkeyp
     )
     assert result.answer == "Grounded answer"
     assert seen["suffix"] == ".webm"
+
+
+@pytest.mark.anyio
+async def test_voice_turn_binds_the_request_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A voice turn must not be a scope-isolation hole just because it arrives as form data (#2921).
+
+    Without this, deleting `active_scope=scope` from the voice `run_ask_graph` call leaves the
+    whole suite green: every other voice test monkeypatches `run_ask_graph` away entirely.
+    """
+    seen: dict[str, object] = {}
+
+    def _capture_run_ask_graph(*_args, **kwargs):
+        seen.update(kwargs)
+        return ask_state()
+
+    monkeypatch.setattr(
+        ask, "transcribe_voice_audio", lambda _, **__: {"text": "what did I decide", "language": "en"}
+    )
+    monkeypatch.setattr(ask, "run_ask_graph", _capture_run_ask_graph)
+    monkeypatch.setattr(ask, "get_ask_settings", lambda: object())
+    monkeypatch.setattr(ask, "load_tts_config", lambda: type("Config", (), {"enabled": False})())
+    monkeypatch.setattr(ask, "build_tts_plan", lambda **_: {"audio_url": "/tts.wav"})
+
+    result = await ask.ask_voice(
+        voice_request(),
+        voice_upload(b"RIFF\x00\x00\x00\x00WAVE", content_type="audio/wav"),
+        session_id=None,
+        scope="work",
+    )
+
+    assert result.answer == "Grounded answer"
+    assert seen.get("active_scope") == "work", (
+        f"the voice form's scope must reach run_ask_graph, saw {seen.get('active_scope')!r}"
+    )


### PR DESCRIPTION
Governing-Issue: #2921

Fixes #2921

Final-Review-Rounds: 2

## Summary
KERNEL-10 (#2772) delivered the scope prefilter, but no production code ever set an active scope, so `_partition_by_scope` admitted every document and the I-A5 scope-isolation invariant ("private not in work results") was enforced only where a test set `ASK_DOMAIN_SCOPE` by hand. This threads the caller's active scope per request from `/api/ask` down to `_partition_by_scope`, and carries `evidence_role_in_context` across the `RetrievalHit` capability boundary instead of dropping it.

## Changes
Binding path (one value, resolved once per turn, reused everywhere):

`app/api/routes/ask.py::AskRequest.scope` (and a matching `scope` form field on `/api/ask/voice`) -> `app/agents/ask/graph.py::run_ask_graph(active_scope=...)` -> `AgentState.active_scope` -> `app/retrieval/capability.py::retrieve` via `RetrievalRequest.scope` -> `app/retrieval/hybrid.py::scoped_hybrid_search(scope=...)` -> `_partition_by_scope`.

- `RetrievalRequest.scope` was diagnostic-only metadata; it is now load-bearing.
- `AgentState.active_scope` also feeds the recall node and the envelope's `active_scope_id`, so the scope the prefilter filtered on and the scope the envelope declares cannot diverge within a turn.
- `RetrievalHit` gains `evidence_role_in_context`; `from_hybrid` re-clamps it against the hit's own intrinsic role and `to_hybrid_dict` emits it. Before this, the production ASK path always handed the envelope `None` and the clamp silently fell back to the intrinsic default.
- `diagnostics["active_scope"]` records the scope the prefilter actually used, so a request-scope/effective-scope divergence is observable.

### Design decision: the source of truth for "active scope"
**Chosen: the request context**, with the process-level `ASK_DOMAIN_SCOPE` as the default when a request binds none. The two alternatives were rejected on evidence:

- **`ActiveContextSet` / WSP.** `docs/boundaries/WSP.md` is the documented authority for effective scope and it does have running code — `app/vault/active_context.py::ActiveContextResolver`. But that resolver returns `scope` with status `unknown` and the explicit reason "Scope is not resolved by the current active-vault runtime." Binding retrieval to it today would leave the prefilter exactly as dormant as before. WSP stays the intended long-term authority; when its resolver returns a known scope it should take precedence over the request binding.
- **Deriving scope from the active vault/workspace selection.** Available today and would have activated the prefilter with no API change — and it is precisely the `activeVault collapse` failure mode `docs/boundaries/WSP.md` names: scope reduced to a scalar vault/folder/device pointer. Scope is frame/audience/policy context, not a folder.

Binding is not authorization: it supplies context and never grants access, so cross-scope admission stays a governed `CrossScopeFlow` decision (#2314, out of scope). Note this does **not** mean a bound scope can only narrow — see the correction below.

### Forward compatibility with the Multi-Vault Runtime lane
Checked against `docs/contracts/ACTIVE_CONTEXT_SET.md :: Multi-Vault Runtime V1 Decision` and `docs/MULTI_VAULT_RUNTIME/VERSION_ACTIVE_CONTEXT_SELECTION.md` before finalising. **This change deliberately does not couple to today's `ActiveContextSet` shape** — which is exactly what MVR-03 (#3857) is about to rewrite into a versioned, immutable-generation contract. The seam splits in two:

- **Durable, unaffected by #3857:** `AgentState.active_scope` -> `RetrievalRequest.scope` -> `scoped_hybrid_search(scope=)` -> `_partition_by_scope`. A plain scope string threaded through the retrieval path, with no ActiveContextSet dependency.
- **Transitional:** the `scope` field on `AskRequest` and the `/api/ask/voice` form. MVR-03 states that client-supplied scope strings never become identity or authority, and MVR-05B (#3860) moves request ingress onto an opaque `context_selection_id` from which the SERVER derives the cognitive scope. When that lands the field is replaced by a server-derived scope read off the immutable selection snapshot, and the only edit is the one argument passed to `run_ask_graph(active_scope=...)` in `app/api/routes/ask.py`. The field is marked `TRANSITIONAL SURFACE` in code, naming both issues.

**Correction after review round 2 — what "narrows" actually means.** The original claim here ("a bound scope can only narrow") was **false and has been removed**. A bound scope narrows relative to the *unscoped* default; it does **not** narrow within a configured ambient scope — the request binding *replaces* `ASK_DOMAIN_SCOPE`. So `ASK_DOMAIN_SCOPE` is a default, **not a containment control**: with `ASK_DOMAIN_SCOPE=work` set, a request binding `scope=private` is served the private partition, and `/api/ask` carries no authentication of its own. This is now stated plainly in the owner doc and the route comment, and pinned by `test_request_scope_overrides_ambient_env_scope`.

It is acceptable today only because no deployment artifact in this repository sets `ASK_DOMAIN_SCOPE` (so the shipped default is admit-all, under which no scope string can widen anything) and because binding supplies context without granting access. **If either condition changes, the precedence must become intersecting** — an env-set scope becomes a ceiling the request narrows within but cannot escape. MVR-05B (#3860) removes the hazard structurally. **#3857 and #3860 are the named follow-on work that must adapt the HTTP surface.**

### Fail-safe posture
- **The unscoped default is unchanged.** No bound scope and no `ASK_DOMAIN_SCOPE` still admits every document. This activates a binding channel; it does not flip the default to deny-all.
- **`ASK_DOMAIN_SCOPE` stays supported** as the process-level default. `tests/evals/_app_adapter.py`, `tests/boundaries/test_domain_separation_defaults.py`, and `app/eval/golden.py` (which deliberately *clears* it so a leaked scope cannot prefilter the deterministic gate) keep their current semantics with no edits to their scope handling.
- **The clamp never upgrades.** The seam re-clamps and the envelope clamps again; both are non-upgrading, so carrying the value can only preserve a downgrade, never manufacture an upgrade.
- One precedence rule — explicit binding first, ambient default second — is applied at every read site (`graph.py::_active_scope`, `run_ask_graph`, `scoped_hybrid_search`), so a directly constructed `AgentState` still honours the process default rather than silently losing its scope.

### Doc truth repair
`scripts/docs_guard.py` flagged that temporal architecture docs described `ASK_DOMAIN_SCOPE` as the runtime's scope carrier. `docs/ARCHITECTURE.md :: Boundary Enforcement`, `docs/RETRIEVAL.md :: Scope filter`, and `docs/COMPONENTS.md` now say the active scope is bound per request with the env var as the process-level default, and point at the owner doc's activation section. That wording is exactly the misreading this issue existed to fix. Documentation only, no executable change; `docs_guard` is green afterwards.

### CI ownership repair
`Unit tests (not pg)` failed closed on the first head: `scripts/select_pr_tests.py` classified `app/agents/ask/graph.py` and `app/agents/ask/state.py` as **unowned runtime code** and exited 2. The ASK graph — the retrieval consumption seam that binds the active scope, assembles the ContextEnvelope, and drives recall — had no subsystem owner at all, so any PR touching it would have hit the same wall.

Added an `ask` subsystem to the existing `SUBSYSTEMS` table naming its real blast radius (`tests/agents/ask`, `tests/retrieval`, `tests/agent_memory`, and the six `tests/api/test_ask_*.py` contract tests). This is ownership registration in an existing table, not a new mechanism, and it does not widen `memory_retrieval` for unrelated retrieval changes. `python3 scripts/select_pr_tests.py --base-ref origin/main --head-ref HEAD` now exits 0 and selects `companion_ui,store_ingest,memory_retrieval,ask,voice,ops_deploy`; `tests/scripts/test_select_pr_tests.py`, `tests/governance/test_select_pr_tests.py`, `tests/governance/test_ci_smoke_docs_only_gate.py`, and `tests/ops/test_ci_workflow.py` — 122 passed; `tests/architecture` — 190 passed.

### Contract repair (pre-work)
Issue #2921 was `agent:blocked` and failed strict validation (`missing_required_sections`: `Constraints`, `Suggested Validation`; `verify_markers_present: false`). The body was repaired to `ready_candidate` (exit 0), `agent:blocked` -> `agent:ready`, `prio:med` added, non-canonical `type:decision` removed, and a maintenance receipt posted with before/after validator output and dependency evidence. Scope was preserved, not widened.

## SBS Impact
- Primary subsystem: RCA (retrieval scope binding)
- Secondary subsystem(s): WSP (active scope source), CAO (ASK consumption seam)
- Write class: mechanical (enforcement wiring; no new authority)
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: `RetrievalRequest.scope` becomes load-bearing; the ASK API request gains an optional active-scope binding
- Owner-doc impact: updated in this PR — `docs/RUNTIME_CORRECTNESS_KERNEL/RUNTIME_SCOPE_PREFILTER_AND_ENVELOPE.md :: Activation in Production`
- Transition debt impact: reduces (closes the tests-only to prod gap)
- Boundary risk: a bound scope supplies context and never grants access, so it cannot reach material a governed `CrossScopeFlow` would have to admit. It narrows only relative to the UNSCOPED default — it *replaces* a configured `ASK_DOMAIN_SCOPE` rather than narrowing within it. The governing issue's SBS Impact line stated this as "must never widen what retrieval admits"; that holds against the shipped admit-all default but **not** against an operator-configured ambient scope. Stated plainly here rather than left to be discovered; pinned by `test_request_scope_overrides_ambient_env_scope`, with the expiry conditions and remedy named in the owner doc.

## BuilderOps Routing
- Records/projections/receipts: `LearningSignal lrn_20260801003047_618f5fe0` (workflow_divergence)
- Reason: `dispatcher pull` classifies issue readiness using the shared root checkout's copy of `scripts/validate_issue_readiness.py`, so a root that is behind `origin/main` silently skips an issue whose body the current validator accepts, with no per-issue skip diagnostic. Named upstream artifact: `.codex/skills/issue-to-code/SKILL.md :: Dispatcher Integration`.

## Independent Review Gate — 2 rounds

### Round 1 — pre-CI mechanism convergence review
A fresh independent Opus reviewer with no memory of the implementation reviewed the publishable SHA plus the mechanism convergence packet (declared risk surfaces: `security`, `data`). **Verdict: no P0/P1.** It mutation-tested the new tests — dropping `scope=request.scope`, re-resolving the envelope scope from env, and dropping `evidence_role_in_context` from `to_hybrid_dict` each turn the suite red — and confirmed the leak assertion stands independently of the spy assertion.

Non-blocking findings addressed in this PR:
- Blank/whitespace `scope` is now normalized in `scoped_hybrid_search` the same way `_resolve_domain_scope` normalizes the env var (P3).
- Added `test_unmatched_bound_scope_admits_nothing_and_denies`, restoring the unmatched-scope case the `test_retrieval_capability.py` edit removed and asserting the denial (P3).
- The ASK contract fakes now assert the captured `active_scope` instead of recording it unused (P3).
- **Owner doc corrected (P2):** binding a scope narrows *retrieval*, but it also makes the previously dead provisional-memory recall branch live (`_recall_node` guards on `active_scope is not None`, which was always `None` in prod). That material is same-scope filtered and admissibility-gated, so it is not a leak, but it is an expansion of the turn's admitted context, and it is now stated plainly rather than implied away.

### Round 2 — final review gate on the CI-green head (`1186dd17b`)
**Two** independent Opus reviewers ran the final gate. **Both returned BLOCKING.** The merge was held and the findings repaired in `83c003c43`. What they caught:

- **P1 — false-green CI window, newly opened by this PR.** The `ask` subsystem owns `app/agents/ask/` but omitted `tests/architecture/test_agent_state_spine.py` and `tests/agents/test_runtime_state_contract.py` — the only two suites asserting the `RuntimeStateModel` authority/trace spine on `AgentState`. A future PR dropping the spine would have selected an all-green lane and merged. These paths previously exited 2 (fail-closed), so this PR *created* the green path. **Fixed and mutation-verified:** `class AgentState(RuntimeStateModel)` → `BaseModel` now turns the lane red (2 failed). Also added `tests/invariants/test_receipt_surface_writable.py`, which pins the receipt path `app/activation/ask_synthesis.py` owns.
- **P1 — the "can only narrow" safety claim was false**, and it was the sole stated justification for exposing a client-controlled scope string on a privacy boundary. See the corrected Multi-Vault section above. **Fixed:** claim corrected in the owner doc and route comment, expiry conditions named, behaviour pinned by `test_request_scope_overrides_ambient_env_scope`.
- **P2 ×2 — two invariant legs were unpinned.** Mutation testing proved both green-under-mutation: deleting `active_scope=scope` from the `/api/ask/voice` call left the whole suite green (every other voice test monkeypatches `run_ask_graph` away), and reverting the recall node to re-resolve from env left it green. **Both now pinned and mutation-verified red.** `app/api/routes/ask.py` was also routed into the `ask` lane so the voice contract test is actually *selected* for a change to that file.
- **P3s fixed:** the selector-output and mypy-count claims in this body were stale; the "unaffected consumers" list was not exhaustive. All corrected above.

Reviewers disagreed on severity for two findings (one called the narrowing claim P1 and the CI gap P3; the other the reverse). Both were treated as blocking: false-green CI evidence and authority-integrity claims are protected categories that may never be P2.

**No selector change narrows anything.** Verified base-vs-head for every touched path: `envelope.py` `memory_retrieval` → `memory_retrieval,ask`; `routes/ask.py` `companion_ui` → `companion_ui,ask`; `graph.py` `unowned/exit 2` → `ask`; `hybrid.py`/`capability.py`/`qa/agent.py` unchanged.

Deferred to the Known Defects registry (#4172), receipts posted as a comment on this PR:
- Promoted-memory recall (`retrieve_relevant_promoted`) takes no scope and filters on none, so I-A5 is closed on the retrieval channel only. Pre-existing and unchanged by this diff.
- Scope denials are discarded on the `"No results found."` early-return path, which this change makes reachable in production for the first time.

## Notes
Validation (actual output, run in the dedicated worktree):

- `python3 -m pytest -q tests/retrieval/test_active_scope_request_binding.py` — 6 passed (4 at first publication; the round-2 repair added the precedence and recall-leg tests). All originally failed red before the implementation: `[None]` at the guard, and `AttributeError: 'RetrievalHit' object has no attribute 'evidence_role_in_context'`.
- `python3 -m pytest -q tests/retrieval/ tests/boundaries/ tests/api/ tests/agent_memory/` on the rebased head — 789 passed.
- `python3 -m pytest -q -m "not pg"` — **1 failed, 12184 passed, 41 skipped, 312 deselected, 18 xfailed** in 674s. The single failure is `tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity` (BuilderOps CKM database identity), which passes in isolation and touches nothing in this diff. `tests/invariants/test_retrieval_spine_invariants.py::test_identity_converges` is a second ordering-sensitive test in the same DB-identity family; it fails identically on a clean `origin/main` worktree.
- `python3 -m ruff check app tests companion-ui/companion-app` — All checks passed!
- `mypy app` — Success: no issues found in 848 source files
- `python3 scripts/public_seam_lint.py --mode gate` — secret_hits: 0, uncovered_hits: 0, stale_rows: 0, migration_pending: 0
- `python3 scripts/docs_guard.py` — Docs guard: OK

Two test files were updated rather than the code, both deliberately:
- `tests/retrieval/test_retrieval_capability.py` bound `scope="operator"` against a corpus seeded entirely with `domain: "core"`. That passed only because `RetrievalRequest.scope` was inert. The scope now names a scope the corpus contains, and the removed unmatched-scope case is restored as a dedicated test that asserts zero hits plus a denial.
- `tests/api/test_ask_contract.py`'s `run_ask_graph` fake now accepts and asserts `active_scope`.

Left undone / residual risk:
- The unscoped default remains admit-all. A caller that binds no scope gets today's behaviour; narrowing it was explicitly out of scope.
- Non-ASK consumers still resolve only the ambient default: `app/agents/qa/agent.py`, `app/components/retrieval.py`, `app/api/routes/search.py`, `app/api/routes/context_bundles.py`, `app/curation/contradiction.py`, `app/expansion/connect.py`, `app/retrieval/production_bundle.py`, plus the two `hybrid_search` callers `app/cli/smoke.py` and `app/fitness/metrics.py`. Each is listed in the owner doc.
- WSP-over-request precedence is a follow-up, gated on `ActiveContextResolver` actually resolving a scope, and on MVR-03/#3857.
- The scope string is unvalidated and not echoed on `AskResponse`, so a typo yields a silent empty answer. Fail-safe direction, but debug-hostile; `diagnostics["active_scope"]` records the effective value.
