### PR TITLE
fix(heimdal): give the governed media ingress lane its own consent scope (#4492)

### DIFF
--- a/app/alembic/versions/a9f3c2d7b6e1_heim_media_capture_consent_grant.py
+++ b/app/alembic/versions/a9f3c2d7b6e1_heim_media_capture_consent_grant.py
@@ -1,0 +1,121 @@
+"""HEIM (#4492): standing media-capture consent grant for the governed media ingress lane.
+
+Resolves Known Defect `KD-4E7228960927` (`KD-4384-MODALITY`) on #4172, under
+the owner ruling of 2026-07-30 recorded on that Issue: **one grant covering all
+four admitted kinds -- audio, image, video, document.**
+
+`POST /api/heimdal/capture/media` (`app/heimdal/media_ingress.py`, CDLM-01
+#4384) admitted every kind under the standing `self_record` grant seeded by
+`c4f7a1b2d9e3`, whose scope is `device+adapter:v1-voice-memo` and whose
+`capture_profile` names `speech` only. The consent block stamped onto a photo,
+video, or document raw record therefore referenced a grant whose descriptive
+profile did not cover it. This seeds the lane its own standing grant, following
+the per-lane precedent of `screen_capture.SCREEN_CAPTURE_SCOPE`.
+
+This is **provenance accuracy, not an enforcement change**: nothing on the
+admission path compares a modality against `capture_profile`
+(`admit_raw_evidence` resolves an active grant for the scope and
+`stamp_consent_block` copies `basis`/`granted_by`/`granted_at`/`third_party`/
+`grant_ref`). The field is stored, seeded, and surfaced read-only by
+`app/heimdal/consent_surface.py`. This migration adds no gate.
+
+Data-only: no DDL. The `heimdal_consent_grant` table, its indexes, and its
+HEIM-1 append-only trigger are all owned by `c4f7a1b2d9e3` and untouched here.
+The seed mirrors that migration's `self_record` seed exactly -- same idempotent
+`INSERT ... WHERE NOT EXISTS` shape, same v1-inert B-shaped defaults -- and is
+mirrored in-process by `app/heimdal/consent_ledger.py`
+(`_media_capture_seed_row`, seeded from `_MemoryConsentLedger._seed` and from
+the `STORE_SCHEMA_AUTOCREATE` branch of `_bootstrap_pg`). The producers are
+pinned together by
+`tests/migrations/test_heimdal_media_capture_grant_seed_parity.py`.
+
+Forward-only: `heimdal_consent_grant` is append-only (HEIM-1) and carries a
+database trigger rejecting UPDATE and DELETE, so a downgrade could not remove
+this row even if it wanted to. Revoking the grant is an appended revocation
+row, never a deletion.
+
+**Operator note for an existing deployment whose voice-memo grant was
+revoked.** Before this change both lanes resolved `SELF_RECORD_SCOPE`, so
+revoking `grant-self-record-v1` also stopped media ingress. This seed uses a
+*different* `grant_ref` that has never existed on that database, so the
+`WHERE NOT EXISTS` guard cannot match that revocation and the upgrade inserts
+an **active** media-capture grant: media ingress resumes admitting without a
+separate operator action. That is the intended consequence of separating the
+grants under the 2026-07-30 ruling, and `/api/status` shows the lane going
+live. `_heimdal/consent.md` will NOT show it: nothing in the shipped runtime
+calls `consent_surface.write_consent_readout`, so that note stays stale until
+something rebuilds it. An operator who revoked voice memos to stop *all*
+capture must also revoke `grant-media-capture-v1` after upgrading -- which is
+programmatic today, as no route or CLI grants or revokes.
+
+Revision ID: a9f3c2d7b6e1
+Revises: e7a2b9c4d1f8
+Create Date: 2026-08-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# Alembic identifiers
+revision: str = "a9f3c2d7b6e1"
+down_revision: Union[str, None] = "e7a2b9c4d1f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Machine-readable classification for the promotion migration gate
+# (docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md;
+# app/release_channels/reversibility.py). Downgrade raises by design.
+reversibility: str = "forward-only"
+
+# Mirrors app/heimdal/consent_ledger.py exactly (MEDIA_CAPTURE_GRANT_REF /
+# MEDIA_CAPTURE_BASIS / MEDIA_CAPTURE_SCOPE / MEDIA_CAPTURE_MODALITIES).
+_MEDIA_CAPTURE_GRANT_REF = "grant-media-capture-v1"
+_MEDIA_CAPTURE_BASIS = "self_record"
+_MEDIA_CAPTURE_SCOPE = "device+adapter:v1-media-ingress"
+_MEDIA_CAPTURE_CAPTURE_PROFILE = (
+    '{"modalities": ["audio", "image", "video", "document"], '
+    '"degradation_rules": ["third_party_speech"]}'
+)
+
+
+def upgrade() -> None:
+    # Idempotent: a rerun (bootstrap re-apply) must not duplicate the standing
+    # grant. Same guard shape as c4f7a1b2d9e3's self_record seed.
+    op.execute(
+        f"""
+        INSERT INTO heimdal_consent_grant (
+            id, grant_ref, basis, scope, granted_by, granted_at,
+            expiry, capture_profile, third_party_policy,
+            vad_gate, third_party, retention, erasure, revokes_grant_ref, payload
+        )
+        SELECT
+            gen_random_uuid(),
+            '{_MEDIA_CAPTURE_GRANT_REF}',
+            '{_MEDIA_CAPTURE_BASIS}',
+            '{_MEDIA_CAPTURE_SCOPE}',
+            'operator',
+            now(),
+            NULL,
+            '{_MEDIA_CAPTURE_CAPTURE_PROFILE}'::jsonb,
+            'degrade',
+            '{{"enabled": false}}'::jsonb,
+            '{{"policy": "degrade"}}'::jsonb,
+            '{{"hard_retention_days": null}}'::jsonb,
+            '{{"supported": false}}'::jsonb,
+            NULL,
+            '{{"note": "standing media-capture grant seeded by migration a9f3c2d7b6e1, owner ruling 2026-07-30 on #4172 (#4492)"}}'::jsonb
+        WHERE NOT EXISTS (
+            SELECT 1 FROM heimdal_consent_grant
+            WHERE grant_ref = '{_MEDIA_CAPTURE_GRANT_REF}'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "HEIM media-capture consent grant is forward-only; heimdal_consent_grant "
+        "is append-only (HEIM-1) and its trigger rejects DELETE. Revoke the grant "
+        "with an appended revocation row instead of removing the seed."
+    )

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -248,12 +248,14 @@ def _ingest_settings_at_startup() -> None:
 
 
 def _run_ingress_key_preflight() -> None:
-    """Detect a missing HEIMDAL_RAW_STORE_KEY before first use (#4422).
+    """Detect a missing ingress-lane precondition before first use (#4422, #4492).
 
-    Degrade-visibly, never fail-exit: the preflight records and logs the
-    ingress-lane availability (surfaced on /api/status) while every other API
-    function keeps serving; the request-time raw_store_key_unavailable
-    contract on the capture routes is unchanged.
+    Covers HEIMDAL_RAW_STORE_KEY for both governed ingress lanes and the media
+    lane's standing consent grant. Degrade-visibly, never fail-exit: the
+    preflight records and logs the ingress-lane availability (surfaced on
+    /api/status) while every other API function keeps serving; the request-time
+    raw_store_key_unavailable / consent_refused contracts on the capture routes
+    are unchanged.
     """
     try:
         from app.heimdal.ingress_preflight import run_ingress_preflight

--- a/app/heimdal/__init__.py
+++ b/app/heimdal/__init__.py
@@ -16,9 +16,13 @@ Mimer-side integration points that substrate hands off to:
 - `app/heimdal/consent_ledger.py` (#3042, Epic #3019 slice A5) -- the
   append-only consent-grant ledger + the HEIM-3 capture-time check
   (`admit_raw_evidence`, the one sanctioned signal->raw admission call),
-  seeded with the standing `self_record` grant (ADR-0049 §3 Posture A;
-  FABLE_COMPANION §6.1/§6.2; see
-  `docs/EVENTS.md :: Heimdal consent ledger v0 + capture-time check`).
+  seeded with one standing grant for each of the two self-record capture
+  lanes -- the voice-memo grant (ADR-0049 §3 Posture A;
+  FABLE_COMPANION §6.1/§6.2) and the media-capture grant naming every kind the
+  governed media ingress lane admits (#4492). Both carry basis `self_record`
+  and are told apart by `scope`. The screen-capture lane has no seeded grant;
+  see
+  `docs/EVENTS.md :: Heimdal consent ledger v0 + capture-time check`.
 - `app/heimdal/settings_notes.py` (#3034, Epic #3019 slice A14) is the
   writable `_heimdal/**` markdown control-surface substrate + schema
   (ADR-0049 §2 "markdown-first control surface"; `docs/HEIMDAL/

--- a/app/heimdal/consent_ledger.py
+++ b/app/heimdal/consent_ledger.py
@@ -20,6 +20,16 @@ Contract:
   deliberately recording is the grant" (FABLE_COMPANION §6.1 basis 1) -- so
   v1 capture is consented without per-memo ceremony, while still flowing
   through the same ledger + capture-time check every later posture uses.
+- **Standing media-capture grant (#4492).** One standing grant per capture
+  lane, not one shared grant: the governed media ingress lane
+  (`app.heimdal.media_ingress`) admits audio, image, video, and document, so
+  it carries its own scope and a `capture_profile` naming all four rather
+  than borrowing the voice-memo grant whose profile names `speech` only.
+  Seeded by migration `a9f3c2d7b6e1`. Per the owner ruling of 2026-07-30
+  (#4172), one grant covers all four admitted kinds. The two grants revoke
+  independently -- revoking voice memos no longer disables media ingress.
+  `capture_profile` stays **descriptive**: no admission path compares a
+  modality against it, so this is provenance accuracy, not a new gate.
 - **Capture-time check (HEIM-3), the one enforcement point.**
   :func:`admit_raw_evidence` is the *only* sanctioned signal->raw admission
   call. It resolves an active grant for a scope BEFORE returning an
@@ -50,9 +60,9 @@ Contract:
 Backend selection mirrors `app.heimdal.observation_log` (dual-backend,
 fail-loud resolution via `app.heimdal._backend.resolve_heimdal_backend`):
 ``STORE_BACKEND=memory`` (or no Postgres DSN configured) uses an in-process
-append-only list seeded with the same standing `self_record` grant the
-migration seeds for Postgres; a resolvable Postgres DSN uses the real
-`heimdal_consent_grant` table.
+append-only list seeded with the same standing grants the migrations seed for
+Postgres; a resolvable Postgres DSN uses the real `heimdal_consent_grant`
+table.
 
 Out of scope for this slice (per governing Issue #3042): the capture
 adapter itself, ASR, third-party voice detection, place/session grant
@@ -85,6 +95,27 @@ _MIGRATION_HINT = (
 SELF_RECORD_GRANT_REF = "grant-self-record-v1"
 SELF_RECORD_BASIS = "self_record"
 SELF_RECORD_SCOPE = "device+adapter:v1-voice-memo"
+
+# Standing grant for the governed media ingress lane (#4492, owner ruling
+# 2026-07-30 on #4172). The lane admits four kinds, so it gets its own scope
+# and a `capture_profile` that actually names them, instead of borrowing the
+# voice-memo grant whose profile names `speech` only -- the consent block
+# stamped onto a photo/video/document must reference a grant that covers it.
+# Same per-lane shape as `screen_capture.SCREEN_CAPTURE_SCOPE`.
+MEDIA_CAPTURE_GRANT_REF = "grant-media-capture-v1"
+# Same *basis* as the voice-memo grant: the reason consent exists is unchanged
+# ("the act of deliberately recording is the grant", FABLE_COMPANION §6.1
+# basis 1 -- an operator transferring their own device capture IS self-record).
+# Only the scope and the modality profile differ, so nothing downstream that
+# reads `consent.basis` changes meaning.
+MEDIA_CAPTURE_BASIS = "self_record"
+MEDIA_CAPTURE_SCOPE = "device+adapter:v1-media-ingress"
+# Every kind the governed media ingress lane admits. Held here rather than
+# imported from `app.heimdal.media_ingress` (which imports this module), and
+# pinned to `media_ingress.MEDIA_KINDS` by
+# `tests/heimdal/test_consent_ledger.py::test_media_capture_grant_is_seeded_and_names_every_admitted_kind`
+# so a fifth admitted kind cannot ship without extending this grant.
+MEDIA_CAPTURE_MODALITIES = ("audio", "image", "video", "document")
 
 # Consent event topics (values only -- app.events.types constants are owned
 # by sibling slice A4; referencing the string here does not redefine it).
@@ -166,36 +197,98 @@ def _default_b_shaped_fields() -> Dict[str, Dict[str, Any]]:
     }
 
 
-def _self_record_seed_row(sequence: int) -> ConsentGrant:
+def _standing_seed_row(
+    *,
+    grant_ref: str,
+    basis: str,
+    scope: str,
+    capture_profile: Dict[str, Any],
+    note: str,
+    sequence: int,
+) -> ConsentGrant:
+    """Build one standing grant row, mirroring its owning migration's seed exactly.
+
+    Shared by every standing grant so the memory backend and the
+    ``STORE_SCHEMA_AUTOCREATE`` Postgres bootstrap cannot drift apart in the
+    B-shaped defaults, the ``granted_by``, or the expiry posture.
+    """
     b_shaped = _default_b_shaped_fields()
     now = datetime.now(timezone.utc)
     return ConsentGrant(
         id=str(uuid4()),
-        grant_ref=SELF_RECORD_GRANT_REF,
-        basis=SELF_RECORD_BASIS,
-        scope=SELF_RECORD_SCOPE,
+        grant_ref=grant_ref,
+        basis=basis,
+        scope=scope,
         granted_by="operator",
         granted_at=now,
         expiry=None,
-        capture_profile={"modalities": ["speech"], "degradation_rules": ["third_party_speech"]},
+        capture_profile=dict(capture_profile),
         third_party_policy=_THIRD_PARTY_POLICY_DEFAULT,
         vad_gate=b_shaped["vad_gate"],
         third_party=b_shaped["third_party"],
         retention=b_shaped["retention"],
         erasure=b_shaped["erasure"],
         revokes_grant_ref=None,
-        payload={"note": "standing self_record grant (memory backend seed, mirrors migration c4f7a1b2d9e3)"},
+        payload={"note": note},
         created_at=now,
         sequence=sequence,
     )
 
 
+def _self_record_seed_row(sequence: int) -> ConsentGrant:
+    return _standing_seed_row(
+        grant_ref=SELF_RECORD_GRANT_REF,
+        basis=SELF_RECORD_BASIS,
+        scope=SELF_RECORD_SCOPE,
+        capture_profile={"modalities": ["speech"], "degradation_rules": ["third_party_speech"]},
+        note="standing self_record grant (memory backend seed, mirrors migration c4f7a1b2d9e3)",
+        sequence=sequence,
+    )
+
+
+def _media_capture_seed_row(sequence: int) -> ConsentGrant:
+    """The governed media ingress lane's standing grant (#4492).
+
+    ``degradation_rules`` keeps ``third_party_speech``: audio and video are
+    admitted kinds and can carry third-party speech, so the same §6.3
+    degradation posture applies here as on the voice-memo grant.
+    """
+    return _standing_seed_row(
+        grant_ref=MEDIA_CAPTURE_GRANT_REF,
+        basis=MEDIA_CAPTURE_BASIS,
+        scope=MEDIA_CAPTURE_SCOPE,
+        capture_profile={
+            "modalities": list(MEDIA_CAPTURE_MODALITIES),
+            "degradation_rules": ["third_party_speech"],
+        },
+        note=(
+            "standing media-capture grant (memory backend seed, mirrors migration "
+            "a9f3c2d7b6e1)"
+        ),
+        sequence=sequence,
+    )
+
+
+# Every standing grant the ledger seeds, in append order. Both in-process
+# producers (`_MemoryConsentLedger._seed` and the STORE_SCHEMA_AUTOCREATE
+# branch of `_bootstrap_pg`) iterate this one tuple, so adding a standing grant
+# cannot half-apply across them -- the invariant->producers rule
+# (`AGENTS.md :: Required rules`) in structural form. The Postgres production
+# producer is the owning migration; `tests/migrations/
+# test_heimdal_media_capture_grant_seed_parity.py` pins the two together.
+_STANDING_SEED_ROW_BUILDERS = (
+    (SELF_RECORD_GRANT_REF, _self_record_seed_row),
+    (MEDIA_CAPTURE_GRANT_REF, _media_capture_seed_row),
+)
+
+
 class _MemoryConsentLedger:
     """In-process append-only ledger. Test/dev backend; volatile by design.
 
-    Seeded with the standing `self_record` grant at construction, mirroring
-    the Postgres migration's seed row, so `STORE_BACKEND=memory` behaves
-    like a freshly-migrated database rather than an empty one.
+    Seeded with every standing grant at construction (`self_record` for the
+    voice-memo lane, media-capture for the governed media ingress lane),
+    mirroring the Postgres migrations' seed rows, so `STORE_BACKEND=memory`
+    behaves like a freshly-migrated database rather than an empty one.
     """
 
     def __init__(self) -> None:
@@ -205,9 +298,10 @@ class _MemoryConsentLedger:
 
     def _seed(self) -> None:
         with self._lock:
-            if any(r.grant_ref == SELF_RECORD_GRANT_REF and not r.is_revocation for r in self._rows):
-                return
-            self._rows.append(_self_record_seed_row(sequence=len(self._rows)))
+            for grant_ref, build_row in _STANDING_SEED_ROW_BUILDERS:
+                if any(r.grant_ref == grant_ref and not r.is_revocation for r in self._rows):
+                    continue
+                self._rows.append(build_row(len(self._rows)))
 
     def append(self, grant: ConsentGrant) -> ConsentGrant:
         with self._lock:
@@ -248,10 +342,11 @@ _MEMORY_LEDGER = _MemoryConsentLedger()
 def reset_memory_consent_ledger() -> None:
     """Test-only reset hook, mirroring the other memory-backend reset helpers.
 
-    Re-seeds the standing `self_record` grant after clearing, so a reset
-    ledger is still a *valid* freshly-migrated ledger, not an empty one that
-    would make every capture attempt (including the standing-grant tests)
-    spuriously refuse.
+    Re-seeds **every** standing grant after clearing, so a reset ledger is
+    still a *valid* freshly-migrated ledger, not an empty one that would make
+    every capture attempt (including the standing-grant tests) spuriously
+    refuse. A standing grant added to `_STANDING_SEED_ROW_BUILDERS` inherits
+    this automatically; one seeded outside it would silently lose the property.
     """
     _MEMORY_LEDGER.clear()
     _MEMORY_LEDGER._seed()
@@ -340,13 +435,17 @@ def _bootstrap_pg(conn: Any) -> None:
         FOR EACH ROW EXECUTE FUNCTION heimdal_consent_grant_reject_mutation()
         """
     )
-    # Seed the standing self_record grant (idempotent).
-    cur.execute(
-        f"SELECT 1 FROM {_TABLE} WHERE grant_ref = %s AND basis != 'revocation'",
-        (SELF_RECORD_GRANT_REF,),
-    )
-    if cur.fetchone() is None:
-        seed = _self_record_seed_row(sequence=0)
+    # Seed every standing grant (idempotent), from the same builder tuple the
+    # memory backend uses -- a standing grant cannot land in one in-process
+    # producer and not the other.
+    for grant_ref, build_row in _STANDING_SEED_ROW_BUILDERS:
+        cur.execute(
+            f"SELECT 1 FROM {_TABLE} WHERE grant_ref = %s AND basis != 'revocation'",
+            (grant_ref,),
+        )
+        if cur.fetchone() is not None:
+            continue
+        seed = build_row(0)
         cur.execute(
             f"""
             INSERT INTO {_TABLE} (
@@ -706,6 +805,10 @@ __all__ = [
     "ConsentGrant",
     "ConsentLedgerSchemaMissingError",
     "ConsentRefusedError",
+    "MEDIA_CAPTURE_BASIS",
+    "MEDIA_CAPTURE_GRANT_REF",
+    "MEDIA_CAPTURE_MODALITIES",
+    "MEDIA_CAPTURE_SCOPE",
     "SELF_RECORD_BASIS",
     "SELF_RECORD_GRANT_REF",
     "SELF_RECORD_SCOPE",

--- a/app/heimdal/consent_surface.py
+++ b/app/heimdal/consent_surface.py
@@ -27,9 +27,13 @@ Contract (binding for this slice):
   from, or worse override, the ledger (the named boundary risk: "the readout
   must not become a control that mutates consent independently of the
   ledger").
-- **v1 exercises only `self_record`.** The readout renders whatever grants
-  are active; v1's only populated basis is the standing `self_record` grant
-  (A5), so v1's `consent.md` reflects exactly that one grant.
+- **v1 exercises only the `self_record` basis.** The readout renders whatever
+  grants are active; v1's only populated basis is `self_record`. Since #4492
+  that basis has **two** standing grants -- the voice-memo grant
+  (`SELF_RECORD_SCOPE`) and the media-capture grant (`MEDIA_CAPTURE_SCOPE`) --
+  so v1's `consent.md` reflects both, distinguished by `scope` and
+  `grant_ref`, not by `basis`. A consumer that needs one specific lane's grant
+  must key on `scope`; a "the one self_record grant" read is wrong.
 - **B-shaped fields present-but-dormant (ADR-0049 §3).** The rendered readout
   always includes a `withhold_span_review` block and a `retention_erasure`
   block, both structurally present but inert in v1 (`enabled: False` /

--- a/app/heimdal/ingress_preflight.py
+++ b/app/heimdal/ingress_preflight.py
@@ -1,4 +1,4 @@
-"""Startup preflight for the governed ingress lanes' raw-store key (#4422).
+"""Startup preflight for the governed ingress lanes' runtime preconditions (#4422, #4492).
 
 The media (`POST /api/heimdal/capture/media`) and screen
 (`POST /api/heimdal/screen/capture`) ingress lanes encrypt through the raw
@@ -6,12 +6,32 @@ store, so they need ``HEIMDAL_RAW_STORE_KEY`` in the api process. Before this
 preflight, a missing key was invisible until the first upload returned the
 named 500 — a dead lane that looked calm (#4369's failure class).
 
+The media lane has a second precondition (#4492): its standing consent grant
+(`consent_ledger.MEDIA_CAPTURE_SCOPE`, seeded by migration `a9f3c2d7b6e1`).
+Without it every admission refuses with the named 409 `consent_refused`, which
+is the *same* invisible-dead-lane shape — a database that never ran the
+migration, or a lane whose grant was revoked, looks calm until the first
+upload. Checking it here is the `AGENTS.md :: Required rules`
+invariant→producers preflight for that seeded grant.
+
+The check is a read against the ledger and never grants, revokes, or repairs
+consent **in production**. One caveat worth naming: under
+``STORE_SCHEMA_AUTOCREATE=1`` (a test-fixture opt-in, `tests/conftest.py`) the
+Postgres ledger backend bootstraps its own schema and standing-grant seeds on
+construction — and `consent_ledger._backend()` constructs a fresh
+`_PgConsentLedger` per call — so in that environment resolving the grant can
+create the table and seed it, meaning the preflight cannot report
+`media_consent_grant_missing` for a missing table there. Production never sets
+that flag and takes `consent_ledger._assert_pg_schema` instead, so the read-only
+property holds on the path that matters.
+
 Posture is **degrade-visibly, never fail-exit**: the api process also serves
-search, ask, note-read, and text capture, so a missing key must not take the
-runtime down. The preflight runs once from the api lifespan, records a named
-result, logs loudly when the lanes are unavailable, and surfaces the lane
-state on ``/api/status`` — the request-time ``raw_store_key_unavailable``
-contract in the routes is unchanged and remains the per-request truth.
+search, ask, note-read, and text capture, so a missing precondition must not
+take the runtime down. The preflight runs once from the api lifespan, records a
+named result, logs loudly when a lane is unavailable, and surfaces the lane
+state on ``/api/status`` — the request-time ``raw_store_key_unavailable`` /
+``consent_refused`` contracts in the routes are unchanged and remain the
+per-request truth.
 
 Never logs, stores, or echoes key material — only availability.
 """
@@ -21,73 +41,127 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
+from app.heimdal.consent_ledger import MEDIA_CAPTURE_SCOPE, resolve_active_grant
 from app.heimdal.raw_store import RawStoreKeyMissingError, resolve_raw_store_key
 
 logger = logging.getLogger(__name__)
 
 LANE_MEDIA = "media_ingress"
 LANE_SCREEN = "screen_capture"
-_KEY_LANES = (LANE_MEDIA, LANE_SCREEN)
 
 STATE_AVAILABLE = "available"
 STATE_UNAVAILABLE = "unavailable"
 
+# Named detail classes. Never an exception message: a future error embedding
+# env material must not flow to the status surface.
+DETAIL_RAW_STORE_KEY_MISSING = "raw_store_key_missing"
+DETAIL_RAW_STORE_KEY_INVALID = "raw_store_key_invalid"
+DETAIL_MEDIA_CONSENT_GRANT_MISSING = "media_consent_grant_missing"
+DETAIL_MEDIA_CONSENT_LEDGER_UNREADABLE = "media_consent_ledger_unreadable"
+
 
 @dataclass(frozen=True)
 class IngressPreflightResult:
-    """One recorded preflight outcome (no key material, ever)."""
+    """One recorded preflight outcome (no key material, ever).
+
+    ``detail`` is a comma-joined list of named detail classes, empty when every
+    checked precondition holds. Two preconditions can fail at once, so it is
+    never a single cause.
+    """
 
     raw_store_key_available: bool
     lanes: Dict[str, str] = field(default_factory=dict)
     detail: str = ""
     checked_at: Optional[datetime] = None
+    media_consent_grant_available: bool = True
 
 
 _LAST_RESULT: Optional[IngressPreflightResult] = None
 
 
-def run_ingress_preflight() -> IngressPreflightResult:
-    """Check the raw-store key once and record the lane availability.
-
-    Called from the api lifespan startup. Never raises and never exits the
-    process: an unavailable key is a named, logged, surfaced degradation of
-    exactly the ingress lanes, not a runtime failure.
-    """
-    global _LAST_RESULT
+def _check_raw_store_key(details: List[str]) -> bool:
     try:
         resolve_raw_store_key()
-        available = True
-        detail = ""
+        return True
     except RawStoreKeyMissingError:
-        available = False
-        detail = "raw_store_key_missing"
+        details.append(DETAIL_RAW_STORE_KEY_MISSING)
     except Exception as exc:  # malformed key material etc. — same degradation
-        # Named class only, never the exception text: a future error embedding
-        # env material must not flow to the status surface.
-        available = False
-        detail = f"raw_store_key_invalid:{type(exc).__name__}"
+        details.append(f"{DETAIL_RAW_STORE_KEY_INVALID}:{type(exc).__name__}")
+    return False
 
-    state = STATE_AVAILABLE if available else STATE_UNAVAILABLE
+
+def _check_media_consent_grant(details: List[str]) -> bool:
+    """Whether the media lane's standing consent grant resolves right now.
+
+    A read-only ledger query. An unreadable ledger (no migration, DSN down) is
+    reported as its own named class rather than conflated with "revoked": the
+    operator remedies differ.
+    """
+    try:
+        grant = resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE)
+    except Exception as exc:
+        details.append(f"{DETAIL_MEDIA_CONSENT_LEDGER_UNREADABLE}:{type(exc).__name__}")
+        return False
+    if grant is None:
+        details.append(DETAIL_MEDIA_CONSENT_GRANT_MISSING)
+        return False
+    return True
+
+
+def run_ingress_preflight() -> IngressPreflightResult:
+    """Check every ingress-lane precondition once and record lane availability.
+
+    Called from the api lifespan startup. Never raises and never exits the
+    process: an unavailable precondition is a named, logged, surfaced
+    degradation of exactly the affected ingress lane, not a runtime failure.
+    """
+    global _LAST_RESULT
+    details: List[str] = []
+    key_available = _check_raw_store_key(details)
+    # The screen lane's `screen_always_on` scope carries no seeded grant, so
+    # this check is the media lane's alone.
+    media_grant_available = _check_media_consent_grant(details)
+
+    key_state = STATE_AVAILABLE if key_available else STATE_UNAVAILABLE
+    media_available = key_available and media_grant_available
     result = IngressPreflightResult(
-        raw_store_key_available=available,
-        lanes={lane: state for lane in _KEY_LANES},
-        detail=detail,
+        raw_store_key_available=key_available,
+        lanes={
+            LANE_MEDIA: STATE_AVAILABLE if media_available else STATE_UNAVAILABLE,
+            LANE_SCREEN: key_state,
+        },
+        detail=",".join(details),
         checked_at=datetime.now(timezone.utc),
+        media_consent_grant_available=media_grant_available,
     )
     _LAST_RESULT = result
-    if not available:
+    if not key_available:
         logger.error(
             "Heimdal ingress preflight: HEIMDAL_RAW_STORE_KEY is not available to "
             "this process — the media and screen ingress lanes will refuse every "
             "admission with the named raw_store_key_unavailable 500 until it is "
             "provisioned (host secret contract consumer 'heimdal-api-ingress'). All other API "
             "functions keep serving. Detail: %s",
-            detail,
+            result.detail,
         )
-    else:
-        logger.info("Heimdal ingress preflight: raw-store key available; ingress lanes ready.")
+    if not media_grant_available:
+        logger.error(
+            "Heimdal ingress preflight: no active consent grant for scope %r — the "
+            "media ingress lane will refuse every admission with the named 409 "
+            "consent_refused until the grant is present. Seeded by migration "
+            "a9f3c2d7b6e1; run 'alembic upgrade head' against this database, or "
+            "re-grant if it was revoked. All other API functions keep serving. "
+            "Detail: %s",
+            MEDIA_CAPTURE_SCOPE,
+            result.detail,
+        )
+    if key_available and media_grant_available:
+        logger.info(
+            "Heimdal ingress preflight: raw-store key and media consent grant "
+            "available; ingress lanes ready."
+        )
     return result
 
 
@@ -103,6 +177,10 @@ def reset_ingress_preflight() -> None:
 
 
 __all__ = [
+    "DETAIL_MEDIA_CONSENT_GRANT_MISSING",
+    "DETAIL_MEDIA_CONSENT_LEDGER_UNREADABLE",
+    "DETAIL_RAW_STORE_KEY_INVALID",
+    "DETAIL_RAW_STORE_KEY_MISSING",
     "LANE_MEDIA",
     "LANE_SCREEN",
     "STATE_AVAILABLE",

--- a/app/heimdal/ingress_preflight.py
+++ b/app/heimdal/ingress_preflight.py
@@ -72,10 +72,12 @@ class IngressPreflightResult:
     """
 
     raw_store_key_available: bool
+    # Required, not defaulted: an omitted precondition must not read as
+    # "available". Both preconditions are equally load-bearing for this lane.
+    media_consent_grant_available: bool
     lanes: Dict[str, str] = field(default_factory=dict)
     detail: str = ""
     checked_at: Optional[datetime] = None
-    media_consent_grant_available: bool = True
 
 
 _LAST_RESULT: Optional[IngressPreflightResult] = None
@@ -147,14 +149,27 @@ def run_ingress_preflight() -> IngressPreflightResult:
             result.detail,
         )
     if not media_grant_available:
+        # Two causes, two remedies — do not give the operator the wrong one.
+        if DETAIL_MEDIA_CONSENT_LEDGER_UNREADABLE in result.detail:
+            remedy = (
+                "the consent ledger could not be read at all: the "
+                "heimdal_consent_grant table is absent (migration c4f7a1b2d9e3 "
+                "never ran) or the database is unreachable. Check the DSN, then "
+                "run 'alembic upgrade head'"
+            )
+        else:
+            remedy = (
+                "no active grant covers the scope: most often this database has "
+                "not yet run migration a9f3c2d7b6e1 (run 'alembic upgrade head'); "
+                "otherwise the grant was revoked and must be re-granted"
+            )
         logger.error(
-            "Heimdal ingress preflight: no active consent grant for scope %r — the "
-            "media ingress lane will refuse every admission with the named 409 "
-            "consent_refused until the grant is present. Seeded by migration "
-            "a9f3c2d7b6e1; run 'alembic upgrade head' against this database, or "
-            "re-grant if it was revoked. All other API functions keep serving. "
+            "Heimdal ingress preflight: media ingress lane unavailable for scope "
+            "%r — every admission will refuse with the named 409 consent_refused "
+            "until this is resolved. %s. All other API functions keep serving. "
             "Detail: %s",
             MEDIA_CAPTURE_SCOPE,
+            remedy,
             result.detail,
         )
     if key_available and media_grant_available:

--- a/app/heimdal/media_ingress.py
+++ b/app/heimdal/media_ingress.py
@@ -62,7 +62,7 @@ from app.heimdal import (
     raw_store,
 )
 from app.heimdal.capture_adapter import SensorIdentity
-from app.heimdal.consent_ledger import admit_raw_evidence
+from app.heimdal.consent_ledger import MEDIA_CAPTURE_SCOPE, admit_raw_evidence
 from app.heimdal.media_receipts import MediaReceipt
 from app.heimdal.raw_read_gate import raw_ref_for
 from app.outbox.events import INDEX_OUTBOX_PATH
@@ -370,10 +370,13 @@ def admit_media_bytes(
 ) -> MediaAdmission:
     """Admit one media original and return its durable-acceptance receipt.
 
-    ``scope`` defaults to the standing self-record consent scope the voice-memo
-    lane already admits under (`capture_adapter.DEFAULT_CAPTURE_SCOPE`): an
-    operator transferring their own device captures *is* self-record, so this
-    lane needs no new grant. A caller may narrow it; no active grant for the
+    ``scope`` defaults to this lane's own standing consent scope
+    (`consent_ledger.MEDIA_CAPTURE_SCOPE`), whose seeded grant's
+    `capture_profile.modalities` names every kind in :data:`MEDIA_KINDS` -- so
+    the consent block stamped onto a photo, video, or document references a
+    grant that actually covers it. It borrowed the voice-memo lane's
+    speech-only `self_record` grant until #4492; the two now revoke
+    independently. A caller may still narrow it; no active grant for the
     resolved scope raises `ConsentRefusedError` (HEIM-3) before any bytes land.
 
     Raises the named refusals in the order the HTTP contract publishes them:
@@ -424,7 +427,7 @@ def admit_media_bytes(
     )
     capture_adapter._assert_sensor_registered(sensor)
 
-    resolved_scope = scope or capture_adapter.DEFAULT_CAPTURE_SCOPE
+    resolved_scope = scope or MEDIA_CAPTURE_SCOPE
     admitted = admit_raw_evidence(scope=resolved_scope)
 
     lineage: Dict[str, Any] = {

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -181,16 +181,20 @@ class IntegratedRuntimeCapabilityStatus(BaseModel):
 
 
 class HeimdalIngressStatus(BaseModel):
-    """Startup-preflight availability of the governed ingress lanes (#4422).
+    """Startup-preflight availability of the governed ingress lanes (#4422, #4492).
 
     Carries availability only — never key material. ``lanes`` maps
     media_ingress/screen_capture to "available" or "unavailable".
+    ``media_consent_grant_available`` is the media lane's second precondition
+    (its standing consent grant); ``detail`` is a comma-joined list of named
+    detail classes, because more than one precondition can fail at once.
     """
 
     raw_store_key_available: bool
     lanes: Dict[str, str] = Field(default_factory=dict)
     detail: str = ""
     checked_at: Optional[datetime] = None
+    media_consent_grant_available: bool = True
 
 
 class SystemStatus(BaseModel):

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -191,10 +191,12 @@ class HeimdalIngressStatus(BaseModel):
     """
 
     raw_store_key_available: bool
+    # Required, mirroring `IngressPreflightResult`: a defaulted `True` would let
+    # an omitted precondition render as available on the status surface.
+    media_consent_grant_available: bool
     lanes: Dict[str, str] = Field(default_factory=dict)
     detail: str = ""
     checked_at: Optional[datetime] = None
-    media_consent_grant_available: bool = True
 
 
 class SystemStatus(BaseModel):

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -1256,6 +1256,7 @@ def _get_heimdal_ingress_status():
         lanes=dict(result.lanes),
         detail=result.detail,
         checked_at=result.checked_at,
+        media_consent_grant_available=result.media_consent_grant_available,
     )
 
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -278,8 +278,14 @@ FABLE_COMPANION §6.1 basis 1, scope `device+adapter:v1-voice-memo`, migration
 They resolve and revoke independently, and are distinguished by `scope` /
 `grant_ref` — **not** by `basis`, which is `self_record` on both. Not every
 governed capture lane has a seeded grant: the screen-capture lane
-(`screen_capture.SCREEN_CAPTURE_SCOPE` = `screen_always_on`) has none, so
-screen capture is not consented by default. Grants are appended; a
+(`screen_capture.SCREEN_CAPTURE_SCOPE` = `screen_always_on`) has none, so a
+screen bundle admitting under **its own scope** is refused until an operator
+grants it. That is *not* the same as saying screen capture cannot be admitted:
+`ingest_screen_bundle` resolves its scope from the client-supplied bundle, so a
+client naming either seeded self-record scope is admitted today and the raw
+record is stamped with that other lane's `grant_ref`. That is a pre-existing
+defect tracked as #4497, not a property of this design; seeding a second
+always-active scope widens what such a client can name. Grants are appended; a
 revocation is a NEW row (`basis='revocation'`, `revokes_grant_ref` naming
 the lapsed grant) — never an edit of the grant it lapses, same HEIM-1
 discipline as `heimdal_observation_log`, enforced by an identical

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -269,9 +269,17 @@ Karakeep adapter and additive candidate behavior are not shipped by this docs/te
 specified by `docs/HEIMDAL/FABLE_COMPANION.md` §6.1/§6.2/§8 HEIM-3).
 
 An append-only ledger of consent grants and revocations (its own table,
-`heimdal_consent_grant`, migration `c4f7a1b2d9e3`), seeded with the standing
-`self_record` grant (v1 Posture A — "the act of deliberately recording is
-the grant", FABLE_COMPANION §6.1 basis 1). Grants are appended; a
+`heimdal_consent_grant`, migration `c4f7a1b2d9e3`), seeded with one standing
+grant for each of the two **self-record** capture lanes: the voice-memo grant
+(v1 Posture A — "the act of deliberately recording is the grant",
+FABLE_COMPANION §6.1 basis 1, scope `device+adapter:v1-voice-memo`, migration
+`c4f7a1b2d9e3`) and the media-capture grant for the governed media ingress lane
+(scope `device+adapter:v1-media-ingress`, migration `a9f3c2d7b6e1`, #4492).
+They resolve and revoke independently, and are distinguished by `scope` /
+`grant_ref` — **not** by `basis`, which is `self_record` on both. Not every
+governed capture lane has a seeded grant: the screen-capture lane
+(`screen_capture.SCREEN_CAPTURE_SCOPE` = `screen_always_on`) has none, so
+screen capture is not consented by default. Grants are appended; a
 revocation is a NEW row (`basis='revocation'`, `revokes_grant_ref` naming
 the lapsed grant) — never an edit of the grant it lapses, same HEIM-1
 discipline as `heimdal_observation_log`, enforced by an identical
@@ -619,14 +627,45 @@ Contract:
   receipt-aware retention interaction must land before that. Tracked as a deferred
   defect on the Known Defects registry (#4172, `KD-4384-RETENTION`), not claimed as
   solved here.
-- **Consent scope, stated honestly.** Every kind is admitted under the standing
-  self-record grant the voice-memo lane uses
-  (`consent_ledger.SELF_RECORD_SCOPE`), whose descriptive
-  `capture_profile.modalities` names `speech` only. No modality enforcement reads
-  that field today, so this is a provenance-accuracy gap rather than an
-  admission bypass; giving the media lane its own grant naming its modalities is
-  an owner decision, deferred on the Known Defects registry (#4172,
-  `KD-4384-MODALITY`).
+- **Consent scope names what the lane captures.** The lane admits under its own
+  standing grant (`consent_ledger.MEDIA_CAPTURE_SCOPE` =
+  `device+adapter:v1-media-ingress`, `grant_ref` `grant-media-capture-v1`,
+  seeded by migration `a9f3c2d7b6e1`), whose descriptive
+  `capture_profile.modalities` names all four admitted kinds — audio, image,
+  video, document — per the owner ruling of 2026-07-30 on #4172. So the consent
+  block stamped onto a photo, video, or document raw record references a grant
+  that actually covers it. It borrowed the voice-memo lane's speech-only
+  `self_record` grant until #4492 (`KD-4384-MODALITY`, now resolved). The two
+  grants are independent: revoking voice memos no longer disables media ingress,
+  and the watched-folder lane still admits under `SELF_RECORD_SCOPE`.
+  `capture_profile` remains **descriptive** — no admission path compares a
+  request's modality against it, so it is provenance, not a gate. The grant is a
+  runtime precondition: the startup preflight
+  (`app.heimdal.ingress_preflight`) reports `media_ingress` as `unavailable` on
+  `/api/status` when it is absent, rather than leaving a dead lane that looks
+  calm. Two named detail classes, because the operator remedies differ:
+  `media_consent_grant_missing` (the ledger is readable and no active grant
+  covers the scope — **most often a database that has not yet run
+  `a9f3c2d7b6e1`**, since the ledger *table* belongs to `c4f7a1b2d9e3`; also a
+  revoked or expired grant) and `media_consent_ledger_unreadable:<ErrorClass>`
+  (the ledger cannot be queried at all — the table is absent because
+  `c4f7a1b2d9e3` never ran, or the database is unreachable).
+  **Migrating a deployment whose voice-memo grant was revoked re-enables media
+  ingress.** Before #4492 both lanes resolved `SELF_RECORD_SCOPE`, so revoking
+  the voice-memo grant stopped media ingress too. `a9f3c2d7b6e1` seeds a
+  *different* `grant_ref` that has never existed on that database, so its
+  `WHERE NOT EXISTS` guard cannot match the revocation and the upgrade inserts
+  an **active** media-capture grant — media ingress starts admitting again
+  without a separate operator action. That is the intended consequence of
+  separating the grants under the 2026-07-30 ruling, and `/api/status` shows
+  the lane going live; note that `_heimdal/consent.md` will **not** reflect it,
+  because nothing in the shipped runtime calls
+  `consent_surface.write_consent_readout` — the note stays at whatever it last
+  showed until something rebuilds it. An operator who revoked voice memos in
+  order to stop *all* capture must revoke `grant-media-capture-v1` as well
+  after upgrading; that is programmatic today, since no route or CLI grants or
+  revokes. (A rerun of the migration after that revocation is a no-op — the
+  guard matches the existing row.)
 - **LAN/loopback/tailnet posture only.** Both routes refuse a peer outside
   loopback, RFC1918/ULA, link-local, or the tailnet CGNAT range with 403
   `public_ingress_refused`, judged on the immediate peer and never on

--- a/docs/HEIMDAL_CAPTURE_CLIENT/DEVICE_REGISTRATION_AND_CONSENT_SURFACE.md
+++ b/docs/HEIMDAL_CAPTURE_CLIENT/DEVICE_REGISTRATION_AND_CONSENT_SURFACE.md
@@ -33,6 +33,13 @@ truthfully (INV-B3-3).
   standing self-record grant as mirrored in `_heimdal/consent.md` (read the grant ref from the
   consent note's `grants`; if the consent note is missing/empty, the surface says so and offers
   registration with the ref left for the hub/human to bind — never a fabricated grant ref).
+  **Since #4492 `basis: self_record` no longer identifies a unique grant**: `consent.md` lists two
+  standing self-record grants, told apart by `scope` — `device+adapter:v1-voice-memo` (the
+  watched-folder/voice-memo lane) and `device+adapter:v1-media-ingress` (the governed media ingress
+  lane, `POST /api/heimdal/capture/media`). Select by `scope`, never by `basis` or by append order:
+  a device whose uploads go through the governed media lane is stamped `grant-media-capture-v1`, so
+  binding it to the voice-memo grant would make the device note disagree with the device's own raw
+  records.
 - **JC surface:** shows the standing grant (scope, granted_at, from the consent note — read-only,
   same note `ConsentLensView` reads), this device's registration state (note exists / fields),
   and an explicit statement of what capture means under Posture A (single-party, discrete,

--- a/docs/HEIMDAL_CAPTURE_CLIENT/DEVICE_REGISTRATION_AND_CONSENT_SURFACE.md
+++ b/docs/HEIMDAL_CAPTURE_CLIENT/DEVICE_REGISTRATION_AND_CONSENT_SURFACE.md
@@ -33,10 +33,14 @@ truthfully (INV-B3-3).
   standing self-record grant as mirrored in `_heimdal/consent.md` (read the grant ref from the
   consent note's `grants`; if the consent note is missing/empty, the surface says so and offers
   registration with the ref left for the hub/human to bind — never a fabricated grant ref).
-  **Since #4492 `basis: self_record` no longer identifies a unique grant**: `consent.md` lists two
+  **Since #4492 `basis: self_record` no longer identifies a unique grant**: the ledger holds two
   standing self-record grants, told apart by `scope` — `device+adapter:v1-voice-memo` (the
   watched-folder/voice-memo lane) and `device+adapter:v1-media-ingress` (the governed media ingress
-  lane, `POST /api/heimdal/capture/media`). Select by `scope`, never by `basis` or by append order:
+  lane, `POST /api/heimdal/capture/media`). A rendered `consent.md` therefore lists both — but note
+  that nothing in the shipped runtime calls `consent_surface.write_consent_readout`, so an on-disk
+  `consent.md` may predate the second grant entirely; treat a single-grant note as possibly stale
+  rather than as evidence that only one grant exists. Select by `scope`, never by `basis` or by
+  append order:
   a device whose uploads go through the governed media lane is stamped `grant-media-capture-v1`, so
   binding it to the voice-memo grant would make the device note disagree with the device's own raw
   records.

--- a/docs/HEIMDAL_CAPTURE_CLIENT/README.md
+++ b/docs/HEIMDAL_CAPTURE_CLIENT/README.md
@@ -24,15 +24,21 @@ Substrate facts this spec builds on (verified on hub `main` = `1ce3b013`):
 - **The hub transcribes.** ASR is the shared faster-whisper engine invoked inside Heimdal's trust
   boundary on the runtime host — local-only, fail-loud, no cloud fallback (ADR-0049 §3; the
   one-Whisper rule in `docs/HEIMDAL/FABLE_COMPANION.md`).
-- **Consent + device identity are vault notes.** The standing `self_record` grants live in the
-  consent ledger (mirrored to `_heimdal/consent.md`) — since #4492 there are two, one per
-  self-record capture lane, told apart by `scope` (`device+adapter:v1-voice-memo` and
-  `device+adapter:v1-media-ingress`), so `basis` alone no longer selects one; device identity/config is
+- **Consent + device identity are vault notes.** The standing `self_record` grant lives in the
+  consent ledger (mirrored to `_heimdal/consent.md`); device identity/config is
   `_heimdal/devices/{device_id}.md` (durable slice: `device_id`, `label`, `consent_grant_ref`
   human-editable; `capture_gap_log`, `last_known_snapshot` agent-authored).
 - **Watch constraint:** Tailscale does not run on watchOS and no sanctioned watchOS pattern
   exists for streaming mic audio (`CAPTURE_TRANSPORT_FEASIBILITY.md` Model 3, "do not build" +
   R-EXTERNAL). The sanctioned Watch path is file-based relay.
+
+Changed since that snapshot:
+
+- **Two standing `self_record` grants, not one (#4492).** The consent ledger now seeds one per
+  self-record capture lane — `device+adapter:v1-voice-memo` (this spec's watched-folder lane) and
+  `device+adapter:v1-media-ingress` (the governed media ingress lane) — so `basis: self_record` no
+  longer identifies a unique grant. Select by `scope`. See
+  `DEVICE_REGISTRATION_AND_CONSENT_SURFACE.md` for the binding rule.
 
 ## The ASR ruling (read before executing anything)
 

--- a/docs/HEIMDAL_CAPTURE_CLIENT/README.md
+++ b/docs/HEIMDAL_CAPTURE_CLIENT/README.md
@@ -24,8 +24,10 @@ Substrate facts this spec builds on (verified on hub `main` = `1ce3b013`):
 - **The hub transcribes.** ASR is the shared faster-whisper engine invoked inside Heimdal's trust
   boundary on the runtime host — local-only, fail-loud, no cloud fallback (ADR-0049 §3; the
   one-Whisper rule in `docs/HEIMDAL/FABLE_COMPANION.md`).
-- **Consent + device identity are vault notes.** The standing `self_record` grant lives in the
-  consent ledger (mirrored to `_heimdal/consent.md`); device identity/config is
+- **Consent + device identity are vault notes.** The standing `self_record` grants live in the
+  consent ledger (mirrored to `_heimdal/consent.md`) — since #4492 there are two, one per
+  self-record capture lane, told apart by `scope` (`device+adapter:v1-voice-memo` and
+  `device+adapter:v1-media-ingress`), so `basis` alone no longer selects one; device identity/config is
   `_heimdal/devices/{device_id}.md` (durable slice: `device_id`, `label`, `consent_grant_ref`
   human-editable; `capture_gap_log`, `last_known_snapshot` agent-authored).
 - **Watch constraint:** Tailscale does not run on watchOS and no sanctioned watchOS pattern

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -88,7 +88,22 @@ promote public internet readiness.
   request-time named 500 `raw_store_key_unavailable` / `not_acknowledged` contract is unchanged.
   The one remaining operator step is placing the actual key material into the Keychain item for
   the `heimdal-api-ingress` consumer per channel (`{channel}:heimdal-api-ingress:heimdal.raw-store-key`
-  under service `yggdrasil.host-secrets`). Contract detail
+  under service `yggdrasil.host-secrets`). **The lane now admits under its own consent grant
+  (#4492):** `device+adapter:v1-media-ingress` (`grant-media-capture-v1`, seeded by migration
+  `a9f3c2d7b6e1`), whose descriptive `capture_profile.modalities` names all four admitted kinds —
+  audio, image, video, document — per the owner ruling of 2026-07-30 on #4172, instead of borrowing
+  the voice-memo lane's speech-only `self_record` grant. The two grants revoke independently and the
+  watched-folder lane keeps admitting under the voice-memo grant; `capture_profile` stays
+  descriptive (no modality enforcement). The same startup preflight also resolves this grant and
+  reports `media_ingress` `unavailable` when it is absent, with detail `media_consent_grant_missing`
+  when the ledger is readable but no active grant covers the scope (most often a database that has
+  not yet run `a9f3c2d7b6e1` — the ledger table itself belongs to `c4f7a1b2d9e3`; also a revoked or
+  expired grant), or `media_consent_ledger_unreadable:<ErrorClass>` when the ledger cannot be
+  queried at all (table absent because `c4f7a1b2d9e3` never ran, or the database is unreachable).
+  Operator note: on a deployment whose voice-memo grant was revoked (which used to stop media
+  ingress too), applying the migration seeds an active media-capture grant and media ingress
+  resumes; revoke `grant-media-capture-v1` as well to keep it stopped — programmatic today, since
+  no CLI or route grants or revokes. Contract detail
   is owned by `docs/EVENTS.md :: Heimdal governed media ingress + durable receipts` and
   `docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/ADMIT_MEDIA_WITH_DURABLE_RECEIPTS.md`; promotion into
   `docs/contracts/MIMER_CLIENT_CONTRACT.md` §4 remains parent-acceptance work on #4383.

--- a/tests/heimdal/test_consent_ledger.py
+++ b/tests/heimdal/test_consent_ledger.py
@@ -27,6 +27,10 @@ import pytest
 
 from app.heimdal import consent_ledger
 from app.heimdal.consent_ledger import (
+    MEDIA_CAPTURE_BASIS,
+    MEDIA_CAPTURE_GRANT_REF,
+    MEDIA_CAPTURE_MODALITIES,
+    MEDIA_CAPTURE_SCOPE,
     SELF_RECORD_BASIS,
     SELF_RECORD_GRANT_REF,
     SELF_RECORD_SCOPE,
@@ -330,3 +334,91 @@ def test_list_active_grants_excludes_revocation_rows_themselves() -> None:
     # were themselves grants (basis == "revocation" is not a valid active grant).
     all_active = list_active_grants()
     assert all(g.basis != "revocation" for g in all_active)
+
+
+# --- #4492: the governed media ingress lane's own standing grant ---------------
+
+
+def test_media_capture_grant_is_seeded_and_names_every_admitted_kind() -> None:
+    """The media lane's standing grant is active by default and its descriptive
+    `capture_profile.modalities` names exactly the kinds the lane admits.
+
+    The set equality against `media_ingress.MEDIA_KINDS` is the load-bearing
+    half: `KD-4E7228960927` existed because the stamped grant named `speech`
+    while the lane admitted four kinds, so a fifth admitted kind added without
+    extending this grant would recreate the same provenance gap silently.
+    """
+    from app.heimdal.media_ingress import MEDIA_KINDS
+
+    grant = resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE)
+    assert grant is not None, "the media-capture grant must be seeded, not set up per test"
+    assert grant.grant_ref == MEDIA_CAPTURE_GRANT_REF
+    assert grant.basis == MEDIA_CAPTURE_BASIS
+    assert grant.scope == MEDIA_CAPTURE_SCOPE
+
+    modalities = grant.capture_profile["modalities"]
+    assert set(modalities) == set(MEDIA_KINDS), (
+        "the seeded grant's modalities must name exactly the admitted media kinds; "
+        f"grant={sorted(modalities)} lane={sorted(MEDIA_KINDS)}"
+    )
+    assert set(modalities) == set(MEDIA_CAPTURE_MODALITIES)
+    # The owner ruling of 2026-07-30 (#4172): one grant covering all four kinds.
+    assert set(modalities) == {"audio", "image", "video", "document"}
+    # Audio and video can carry third-party speech, so the §6.3 degradation
+    # posture is inherited rather than dropped.
+    assert grant.capture_profile["degradation_rules"] == ["third_party_speech"]
+
+
+def test_media_capture_and_self_record_are_separate_grants() -> None:
+    """Two standing grants, two scopes, revoked independently.
+
+    Before #4492 one grant covered both lanes, so revoking voice memos also
+    disabled media ingress. `list_active_grants` sees both, and a revocation of
+    either leaves the other resolvable.
+    """
+    assert MEDIA_CAPTURE_SCOPE != SELF_RECORD_SCOPE
+    assert MEDIA_CAPTURE_GRANT_REF != SELF_RECORD_GRANT_REF
+    seeded = {g.grant_ref for g in list_active_grants()}
+    assert {SELF_RECORD_GRANT_REF, MEDIA_CAPTURE_GRANT_REF} <= seeded
+
+    revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="operator")
+    assert resolve_active_grant(scope=SELF_RECORD_SCOPE) is None
+    still_active = resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE)
+    assert still_active is not None and still_active.grant_ref == MEDIA_CAPTURE_GRANT_REF
+
+    reset_memory_consent_ledger()
+
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="operator")
+    assert resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE) is None
+    voice_memo = resolve_active_grant(scope=SELF_RECORD_SCOPE)
+    assert voice_memo is not None and voice_memo.grant_ref == SELF_RECORD_GRANT_REF
+
+
+def test_reset_reseeds_every_standing_grant() -> None:
+    """`reset_memory_consent_ledger` restores a *valid freshly-migrated* ledger.
+
+    The property the reset hook exists for, now that there is more than one
+    standing grant: a reset ledger with only some of them would make the
+    un-reseeded lane spuriously refuse every capture.
+    """
+    revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="operator")
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="operator")
+    assert resolve_active_grant(scope=SELF_RECORD_SCOPE) is None
+    assert resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE) is None
+
+    reset_memory_consent_ledger()
+
+    assert {g.grant_ref for g in list_active_grants()} == {
+        SELF_RECORD_GRANT_REF,
+        MEDIA_CAPTURE_GRANT_REF,
+    }
+    for scope in (SELF_RECORD_SCOPE, MEDIA_CAPTURE_SCOPE):
+        assert resolve_active_grant(scope=scope) is not None
+
+
+def test_media_capture_grant_carries_the_b_shaped_dormant_shape() -> None:
+    """The new standing grant is B-shaped-but-dormant like every other grant
+    (ADR-0049 §3), so Posture B stays a grant change rather than a redesign."""
+    grant = resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE)
+    assert grant is not None
+    _assert_b_shaped_dormant(grant)

--- a/tests/heimdal/test_consent_surface.py
+++ b/tests/heimdal/test_consent_surface.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import pytest
 
 from app.heimdal.consent_ledger import (
+    MEDIA_CAPTURE_GRANT_REF,
+    MEDIA_CAPTURE_SCOPE,
     SELF_RECORD_BASIS,
     SELF_RECORD_GRANT_REF,
     SELF_RECORD_SCOPE,
@@ -75,17 +77,21 @@ def _grant_refs(values: dict) -> set[str]:
 
 
 def test_selfrecord_readout(tmp_path: Path) -> None:
-    """`consent.md` mirrors the standing `self_record` grant, driven by real
-    ledger state -- not a hardcoded string. Granting/revoking changes the
-    rendered readout, proving the readout is actually derived."""
+    """`consent.md` mirrors the standing grants, driven by real ledger state --
+    not a hardcoded string. Granting/revoking changes the rendered readout,
+    proving the readout is actually derived."""
     vault_root = _vault(tmp_path)
     guard = _allowing_guard()
 
-    # 1. With only the standing seeded self_record grant active, the readout
-    #    reflects exactly that one grant, faithfully (every field mirrored).
+    # 1. With the seeded standing grants active, the readout reflects exactly
+    #    those grants, faithfully (every field mirrored). Since #4492 there are
+    #    two: the voice-memo `self_record` grant and the media-capture grant.
     note = write_consent_readout(vault_root, write_guard=guard)
     assert note.values["grants"], "readout must include the standing self_record grant"
-    assert len(note.values["grants"]) == 1
+    # Cardinality as well as identity: a set comparison alone would not notice a
+    # duplicated seed row.
+    assert len(note.values["grants"]) == 2
+    assert _grant_refs(note.values) == {SELF_RECORD_GRANT_REF, MEDIA_CAPTURE_GRANT_REF}
     mirrored = note.values["grants"][0]
     assert mirrored["grant_ref"] == SELF_RECORD_GRANT_REF
     assert mirrored["basis"] == SELF_RECORD_BASIS
@@ -121,22 +127,36 @@ def test_selfrecord_readout(tmp_path: Path) -> None:
         granted_by="operator",
     )
     rebuilt = write_consent_readout(vault_root, write_guard=guard)
-    assert _grant_refs(rebuilt.values) == {SELF_RECORD_GRANT_REF, "grant-session-extra-1"}
+    assert _grant_refs(rebuilt.values) == {
+        SELF_RECORD_GRANT_REF,
+        MEDIA_CAPTURE_GRANT_REF,
+        "grant-session-extra-1",
+    }
 
     # 5. Revoking the standing self_record grant and rebuilding removes it
     #    from the readout (mirrors the ledger's `list_active_grants`, which
     #    excludes revoked grants) -- further proof the readout is a live
-    #    mirror, not a cache of the first render.
+    #    mirror, not a cache of the first render. The media-capture grant is a
+    #    separate grant and is untouched by that revocation (#4492).
     revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="operator")
     after_revoke = write_consent_readout(vault_root, write_guard=guard)
-    assert _grant_refs(after_revoke.values) == {"grant-session-extra-1"}
+    assert _grant_refs(after_revoke.values) == {
+        MEDIA_CAPTURE_GRANT_REF,
+        "grant-session-extra-1",
+    }
     assert SELF_RECORD_GRANT_REF not in _grant_refs(after_revoke.values)
 
 
 def test_readout_reflects_no_active_grants() -> None:
     """Negative/completeness coverage: an empty ledger (nothing active)
-    renders an empty grants list, not an error or a stale default."""
+    renders an empty grants list, not an error or a stale default.
+
+    Every standing grant must be revoked to reach that state since #4492;
+    revoking only one leaves the other rendered, which is the point of them
+    being separate grants."""
     revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="operator")
+    assert _grant_refs(build_consent_readout_values()) == {MEDIA_CAPTURE_GRANT_REF}
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="operator")
     values = build_consent_readout_values()
     assert values["grants"] == []
 
@@ -149,7 +169,27 @@ def test_readout_orders_grants_by_ledger_append_order() -> None:
     grant_consent(grant_ref="grant-third", basis="session_optin", scope="device+adapter:s3", granted_by="operator")
     values = build_consent_readout_values()
     refs_in_order = [g["grant_ref"] for g in values["grants"]]
-    assert refs_in_order == [SELF_RECORD_GRANT_REF, "grant-second", "grant-third"]
+    assert refs_in_order == [
+        SELF_RECORD_GRANT_REF,
+        MEDIA_CAPTURE_GRANT_REF,
+        "grant-second",
+        "grant-third",
+    ]
+
+
+def test_readout_mirrors_the_media_capture_grants_modalities() -> None:
+    """The read-only surface renders the media lane's `capture_profile`
+    verbatim (#4492), so `consent.md` states what the lane may actually
+    capture instead of the borrowed speech-only profile."""
+    values = build_consent_readout_values()
+    media = next(g for g in values["grants"] if g["grant_ref"] == MEDIA_CAPTURE_GRANT_REF)
+    assert media["scope"] == MEDIA_CAPTURE_SCOPE
+    assert media["capture_profile"]["modalities"] == [
+        "audio",
+        "image",
+        "video",
+        "document",
+    ]
 
 
 def test_readout_is_read_mostly_not_an_independent_write_path() -> None:

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import logging
 import secrets
 from pathlib import Path
 from typing import Any
@@ -1326,6 +1327,46 @@ def test_startup_preflight_reports_an_unreadable_consent_ledger(
     )
     assert "ConsentLedgerSchemaMissingError" in recorded.detail
     assert ingress_preflight.DETAIL_MEDIA_CONSENT_GRANT_MISSING not in recorded.detail
+
+
+def test_preflight_logs_the_remedy_matching_the_failing_precondition(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#4492: the two detail classes have different operator remedies, so the
+    log must not hand the operator the wrong one.
+
+    The log line is what an operator actually reads when a lane goes dark; a
+    single shared remedy would send someone hunting for a revocation that does
+    not exist (or vice versa).
+    """
+    from app.heimdal import ingress_preflight
+
+    # 1. Unreadable ledger -> point at the *table*-owning migration and the DSN.
+    def _unreadable(**_kwargs: Any):
+        raise ConsentLedgerSchemaMissingError("Missing table 'heimdal_consent_grant'.")
+
+    monkeypatch.setattr(ingress_preflight, "resolve_active_grant", _unreadable)
+    ingress_preflight.reset_ingress_preflight()
+    with caplog.at_level(logging.ERROR, logger="app.heimdal.ingress_preflight"):
+        ingress_preflight.run_ingress_preflight()
+    unreadable_log = caplog.text
+    assert "could not be read at all" in unreadable_log
+    assert "c4f7a1b2d9e3" in unreadable_log, "must name the table-owning migration"
+    assert "re-granted" not in unreadable_log, "wrong remedy for an unreadable ledger"
+
+    # 2. Readable ledger, no active grant -> point at *this* slice's migration
+    #    and at re-granting.
+    monkeypatch.undo()
+    caplog.clear()
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
+    ingress_preflight.reset_ingress_preflight()
+    with caplog.at_level(logging.ERROR, logger="app.heimdal.ingress_preflight"):
+        ingress_preflight.run_ingress_preflight()
+    missing_log = caplog.text
+    assert "no active grant covers the scope" in missing_log
+    assert "a9f3c2d7b6e1" in missing_log, "must name the grant-seeding migration"
+    assert "re-granted" in missing_log
+    assert "could not be read at all" not in missing_log
 
 
 def test_admission_succeeds_when_key_provisioned(client: TestClient) -> None:

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -33,6 +33,7 @@ from app.api.app import app
 from app.heimdal import media_ingress, media_receipts
 from app.heimdal.capture_adapter import admit_capture_file
 from app.heimdal.consent_ledger import (
+    ConsentLedgerSchemaMissingError,
     ConsentRefusedError,
     MEDIA_CAPTURE_GRANT_REF,
     MEDIA_CAPTURE_SCOPE,
@@ -1291,6 +1292,40 @@ def test_startup_preflight_reports_missing_media_consent_grant(
         assert refused.json()["detail"]["state"] == "not_acknowledged"
         assert all_raw_records() == []
         assert all_media_receipts() == []
+
+
+def test_startup_preflight_reports_an_unreadable_consent_ledger(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#4492: a ledger that cannot be queried at all is its own named class.
+
+    This is the branch where a false `available` hurts most — an unmigrated or
+    unreachable database — and it must not be conflated with
+    `media_consent_grant_missing`, because the operator remedies differ
+    (`alembic upgrade head` for the missing *table* vs re-granting a revoked
+    grant). Raised from the real ledger read the preflight performs.
+    """
+    from app.heimdal import ingress_preflight
+
+    def _unreadable(**_kwargs: Any):
+        raise ConsentLedgerSchemaMissingError("Missing table 'heimdal_consent_grant'.")
+
+    monkeypatch.setattr(ingress_preflight, "resolve_active_grant", _unreadable)
+    ingress_preflight.reset_ingress_preflight()
+
+    recorded = ingress_preflight.run_ingress_preflight()
+    assert recorded.media_consent_grant_available is False
+    assert recorded.raw_store_key_available is True
+    assert recorded.lanes["media_ingress"] == "unavailable"
+    # The screen lane has no consent precondition of its own, so it stays up.
+    assert recorded.lanes["screen_capture"] == "available"
+    # Named class plus the concrete error type, and never the grant-missing
+    # class, which would send the operator hunting for a revocation.
+    assert recorded.detail.startswith(
+        ingress_preflight.DETAIL_MEDIA_CONSENT_LEDGER_UNREADABLE + ":"
+    )
+    assert "ConsentLedgerSchemaMissingError" in recorded.detail
+    assert ingress_preflight.DETAIL_MEDIA_CONSENT_GRANT_MISSING not in recorded.detail
 
 
 def test_admission_succeeds_when_key_provisioned(client: TestClient) -> None:

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -33,8 +33,12 @@ from app.api.app import app
 from app.heimdal import media_ingress, media_receipts
 from app.heimdal.capture_adapter import admit_capture_file
 from app.heimdal.consent_ledger import (
+    ConsentRefusedError,
+    MEDIA_CAPTURE_GRANT_REF,
+    MEDIA_CAPTURE_SCOPE,
     SELF_RECORD_GRANT_REF,
     reset_memory_consent_ledger,
+    resolve_active_grant,
     revoke_consent,
 )
 from app.heimdal.media_receipts import (
@@ -383,8 +387,14 @@ def test_one_capture_id_spans_both_lanes(client: TestClient, tmp_path: Path) -> 
 
 
 def test_consent_refusal_admits_nothing(client: TestClient) -> None:
-    """HEIM-3 is the one signal->raw gate, and its refusal is a named 409."""
-    revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="test-operator")
+    """HEIM-3 is the one signal->raw gate, and its refusal is a named 409.
+
+    Follows this lane's own consent scope since #4492: revoking the
+    media-capture grant is what refuses media ingress. Revoking the voice-memo
+    grant no longer does — that separation is
+    `test_media_and_voice_memo_grants_revoke_independently`.
+    """
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
 
     media = b"no-active-grant-covers-this"
     refused = _post_media(client, media, _sidecar(media))
@@ -394,6 +404,116 @@ def test_consent_refusal_admits_nothing(client: TestClient) -> None:
     assert detail["state"] == "not_acknowledged"
     assert all_raw_records() == []
     assert all_media_receipts() == []
+
+
+# ---------------------------------------------------------------------------
+# #4492: the lane's own consent scope, naming every admitted modality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["audio", "image", "video", "document"])
+def test_admitted_media_stamps_the_media_capture_grant(client: TestClient, kind: str) -> None:
+    """Every admitted kind is stamped with a grant whose profile names that kind.
+
+    This is the defect `KD-4E7228960927` recorded: a photo, video, or document
+    raw record carried a consent block pointing at the voice-memo grant, whose
+    `capture_profile.modalities` is `["speech"]`. Asserted on the durable raw
+    record written by the production route, not on the seam's return value.
+    """
+    media = f"admitted-{kind}-bytes".encode()
+    admitted = _post_media(client, media, _sidecar(media, kind=kind))
+    assert admitted.status_code == 200, admitted.text
+
+    records = all_raw_records()
+    assert len(records) == 1
+    consent = records[0].consent
+    assert consent["grant_ref"] == MEDIA_CAPTURE_GRANT_REF
+    assert consent["grant_ref"] != SELF_RECORD_GRANT_REF
+
+    # The grant the record points at actually covers what was captured.
+    grant = resolve_active_grant(scope=MEDIA_CAPTURE_SCOPE)
+    assert grant is not None and grant.grant_ref == consent["grant_ref"]
+    assert kind in grant.capture_profile["modalities"]
+
+
+def test_media_and_voice_memo_grants_revoke_independently(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Two lanes, two grants: revoking one must not disable the other.
+
+    Before #4492 both lanes resolved `SELF_RECORD_SCOPE`, so consenting to
+    voice memos also consented to photo/video/document ingress from any device
+    — and revoking voice memos silently killed media ingress.
+    """
+    # 1. Revoking the voice-memo grant leaves the governed media lane admitting.
+    revoke_consent(grant_ref=SELF_RECORD_GRANT_REF, revoked_by="test-operator")
+    media = b"media-ingress-survives-voice-memo-revocation"
+    admitted = _post_media(client, media, _sidecar(media))
+    assert admitted.status_code == 200, admitted.text
+    assert admitted.json()["outcome"] == "admitted"
+
+    # ...while the watched-folder lane, which still admits under the voice-memo
+    # grant, is correctly refused by that same revocation.
+    watch_dir = tmp_path / "watched-refused"
+    watch_dir.mkdir()
+    memo = watch_dir / "memo-after-revocation.m4a"
+    memo.write_bytes(b"a voice memo after the voice-memo grant was revoked")
+    with pytest.raises(ConsentRefusedError):
+        admit_capture_file(memo, key=_KEY, stability_delay=0.0)
+
+    # 2. The mirror image: revoking only the media grant leaves the
+    #    watched-folder lane admitting.
+    reset_memory_consent_ledger()
+    reset_memory_raw_store()
+    reset_memory_media_receipts()
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
+
+    watched = tmp_path / "watched-admitted"
+    watched.mkdir()
+    surviving = watched / "memo-survives.m4a"
+    surviving.write_bytes(b"a voice memo after the media grant was revoked")
+    result = admit_capture_file(surviving, key=_KEY, stability_delay=0.0)
+    assert result.created
+    assert result.record.consent["grant_ref"] == SELF_RECORD_GRANT_REF
+
+    refused_media = b"media-ingress-is-the-one-that-stops"
+    refused = _post_media(client, refused_media, _sidecar(refused_media))
+    assert refused.status_code == 409
+    assert refused.json()["detail"]["error"] == "consent_refused"
+
+
+def test_capture_profile_is_not_an_enforcement_gate(client: TestClient) -> None:
+    """`capture_profile` stays descriptive: no admission path reads it as a gate.
+
+    The defect was rated P2 rather than an authority-integrity P1 precisely
+    because nothing compares a modality against `capture_profile`, and #4492
+    must not quietly change that — introducing modality enforcement would be a
+    new gate with no contract demand behind it. Proven by narrowing the active
+    grant's profile to a modality the request does not use and asserting the
+    admission still succeeds.
+    """
+    from app.heimdal.consent_ledger import grant_consent
+
+    # A later grant on the same scope wins (last-appended-wins), so this is the
+    # profile the admission resolves — and it names nothing the request sends.
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
+    grant_consent(
+        grant_ref="grant-media-capture-narrowed-profile",
+        basis="self_record",
+        scope=MEDIA_CAPTURE_SCOPE,
+        granted_by="operator",
+        capture_profile={"modalities": ["semaphore"], "degradation_rules": []},
+    )
+
+    media = b"an image admitted under a profile that names only semaphore"
+    admitted = _post_media(client, media, _sidecar(media, kind="image"))
+    assert admitted.status_code == 200, (
+        "capture_profile must remain descriptive; a mismatch is a provenance "
+        "concern, not an admission gate this slice may introduce"
+    )
+    records = all_raw_records()
+    assert len(records) == 1
+    assert records[0].consent["grant_ref"] == "grant-media-capture-narrowed-profile"
 
 
 def test_unregistered_sensor_admits_nothing(
@@ -1120,6 +1240,59 @@ def test_startup_preflight_reports_ingress_unavailable_without_exiting(
         assert refused.json()["detail"]["state"] == "not_acknowledged"
 
 
+def test_startup_preflight_reports_missing_media_consent_grant(
+    client: TestClient,
+) -> None:
+    """#4492 enforcement: the media lane's standing consent grant is a runtime
+    precondition, so the api LIFESPAN preflight reports the lane unavailable
+    with a named detail before any request — not only on the first upload.
+
+    The raw-store key is present here, so the only failing precondition is the
+    grant: the screen lane must stay `available`, proving the check is scoped
+    to the media lane rather than degrading both.
+    """
+    from app.heimdal import ingress_preflight
+
+    revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
+    ingress_preflight.reset_ingress_preflight()
+    assert ingress_preflight.current_ingress_status() is None
+
+    # TestClient's context manager runs the real lifespan — the production
+    # startup path (`app/api/app.py :: lifespan`), not the helper in isolation.
+    with TestClient(app) as started:
+        recorded = ingress_preflight.current_ingress_status()
+        assert recorded is not None, "the lifespan must have run the preflight"
+        assert recorded.raw_store_key_available is True
+        assert recorded.media_consent_grant_available is False
+        assert recorded.lanes == {
+            "media_ingress": "unavailable",
+            "screen_capture": "available",
+        }
+        assert (
+            ingress_preflight.DETAIL_MEDIA_CONSENT_GRANT_MISSING in recorded.detail
+        )
+
+        # Surfaced on the status endpoint before any ingress request was made.
+        status = started.get("/api/status")
+        assert status.status_code == 200
+        ingress = status.json()["heimdal_ingress"]
+        assert ingress["media_consent_grant_available"] is False
+        assert ingress["lanes"]["media_ingress"] == "unavailable"
+        assert ingress["lanes"]["screen_capture"] == "available"
+
+        # Unrelated routes keep serving: degrade-visibly, never fail-exit.
+        assert started.get("/api/health").status_code in (200, 503)
+
+        # The request-time named contract is unchanged.
+        media = b"still refused bytes"
+        refused = _post_media(started, media, _sidecar(media))
+        assert refused.status_code == 409
+        assert refused.json()["detail"]["error"] == "consent_refused"
+        assert refused.json()["detail"]["state"] == "not_acknowledged"
+        assert all_raw_records() == []
+        assert all_media_receipts() == []
+
+
 def test_admission_succeeds_when_key_provisioned(client: TestClient) -> None:
     """#4422: with the key present, the preflight passes and admission returns
     a durable receipt through the production route."""
@@ -1130,6 +1303,8 @@ def test_admission_succeeds_when_key_provisioned(client: TestClient) -> None:
         recorded = ingress_preflight.current_ingress_status()
         assert recorded is not None
         assert recorded.raw_store_key_available is True
+        assert recorded.media_consent_grant_available is True
+        assert recorded.detail == ""
         assert recorded.lanes == {
             "media_ingress": "available",
             "screen_capture": "available",

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -1,0 +1,170 @@
+"""Producer parity for the standing media-capture consent grant (#4492).
+
+The grant is a **runtime precondition**: without it every governed media
+admission refuses with the named 409 `consent_refused`. `AGENTS.md ::
+Required rules` (invariant -> producers) therefore requires every producer of it
+to ship in the same change, and this test is what keeps them from drifting
+afterwards. The producers are:
+
+1. `app/alembic/versions/a9f3c2d7b6e1_heim_media_capture_consent_grant.py` --
+   the Postgres production seed;
+2. `app/heimdal/consent_ledger.py :: _media_capture_seed_row` -- the in-process
+   memory-backend seed (`_MemoryConsentLedger._seed`, and therefore
+   `reset_memory_consent_ledger`);
+3. the `STORE_SCHEMA_AUTOCREATE` branch of `consent_ledger._bootstrap_pg` --
+   the Postgres test-fixture seed, which builds its row from the same tuple as
+   (2).
+
+The migration's identity fields are asserted by parsing the migration source,
+so this runs without Postgres: a `pg`-only parity test would not run in the
+required `Unit tests (not pg)` job, which is exactly where drift needs to be
+caught. Schema parity for the underlying table is owned by `c4f7a1b2d9e3` and
+is not re-asserted here -- this migration is data-only.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from app.heimdal.consent_ledger import (
+    MEDIA_CAPTURE_BASIS,
+    MEDIA_CAPTURE_GRANT_REF,
+    MEDIA_CAPTURE_MODALITIES,
+    MEDIA_CAPTURE_SCOPE,
+    _media_capture_seed_row,
+    _STANDING_SEED_ROW_BUILDERS,
+)
+
+pytestmark = pytest.mark.not_pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = (
+    REPO_ROOT
+    / "app"
+    / "alembic"
+    / "versions"
+    / "a9f3c2d7b6e1_heim_media_capture_consent_grant.py"
+)
+
+
+def _migration_module_constants() -> dict[str, object]:
+    """Read the migration's module-level literals without importing alembic."""
+    tree = ast.parse(MIGRATION_PATH.read_text(encoding="utf-8"))
+    values: dict[str, object] = {}
+    for node in tree.body:
+        target = None
+        value = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target, value = node.target.id, node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            only = node.targets[0]
+            if isinstance(only, ast.Name):
+                target, value = only.id, node.value
+        if target is None or value is None:
+            continue
+        try:
+            values[target] = ast.literal_eval(value)
+        except ValueError:
+            continue
+    return values
+
+
+def _producer_sources() -> dict[str, str]:
+    """Exact source of each in-process seed producer, via the AST.
+
+    Returns `{"_MemoryConsentLedger._seed": ..., "_bootstrap_pg": ...}`. Each
+    value spans only that definition's own lines, so a mention of the shared
+    tuple *outside* the definition cannot be mistaken for use inside it.
+    """
+    path = REPO_ROOT / "app" / "heimdal" / "consent_ledger.py"
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "_MemoryConsentLedger":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "_seed":
+                    segment = ast.get_source_segment(source, item)
+                    assert segment is not None
+                    found["_MemoryConsentLedger._seed"] = segment
+        elif isinstance(node, ast.FunctionDef) and node.name == "_bootstrap_pg":
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            found["_bootstrap_pg"] = segment
+    assert set(found) == {"_MemoryConsentLedger._seed", "_bootstrap_pg"}, (
+        f"expected both in-process producers to be found, got {sorted(found)}"
+    )
+    return found
+
+
+def test_every_producer_seeds_the_same_media_capture_grant() -> None:
+    """The migration and the in-process seed agree on the grant's identity.
+
+    Identity is `grant_ref` + `basis` + `scope` + `capture_profile`: those are
+    what a consumer resolves and what gets stamped onto a raw record, so a
+    divergence between backends would mean the same deployment answers
+    differently about what the operator consented to.
+    """
+    constants = _migration_module_constants()
+    assert constants["revision"] == "a9f3c2d7b6e1"
+
+    assert constants["_MEDIA_CAPTURE_GRANT_REF"] == MEDIA_CAPTURE_GRANT_REF
+    assert constants["_MEDIA_CAPTURE_BASIS"] == MEDIA_CAPTURE_BASIS
+    assert constants["_MEDIA_CAPTURE_SCOPE"] == MEDIA_CAPTURE_SCOPE
+
+    migration_profile = json.loads(str(constants["_MEDIA_CAPTURE_CAPTURE_PROFILE"]))
+    memory_seed = _media_capture_seed_row(0)
+    assert migration_profile == memory_seed.capture_profile
+    assert migration_profile["modalities"] == list(MEDIA_CAPTURE_MODALITIES)
+
+    # The memory seed's own identity fields match the module constants too, so
+    # neither producer can be "fixed" by editing only the other.
+    assert memory_seed.grant_ref == MEDIA_CAPTURE_GRANT_REF
+    assert memory_seed.basis == MEDIA_CAPTURE_BASIS
+    assert memory_seed.scope == MEDIA_CAPTURE_SCOPE
+    assert memory_seed.granted_by == "operator"
+    assert memory_seed.expiry is None
+    assert memory_seed.revokes_grant_ref is None
+
+
+def test_migration_seed_is_idempotent_and_forward_only() -> None:
+    """A rerun must not duplicate the standing grant, and the row cannot be
+    un-seeded: `heimdal_consent_grant` is append-only (HEIM-1) with a trigger
+    rejecting DELETE, so a downgrade path would be a false promise."""
+    source = MIGRATION_PATH.read_text(encoding="utf-8")
+    constants = _migration_module_constants()
+
+    assert constants["reversibility"] == "forward-only"
+    assert re.search(r"def downgrade\(\)[\s\S]*raise RuntimeError", source), (
+        "downgrade must raise rather than silently no-op"
+    )
+    # Guarded insert, same shape as c4f7a1b2d9e3's self_record seed.
+    assert "WHERE NOT EXISTS" in source
+    assert "INSERT INTO heimdal_consent_grant" in source
+    # Data-only: the table, its indexes, and its append-only trigger belong to
+    # c4f7a1b2d9e3 and must not be redefined here.
+    for ddl in ("CREATE TABLE", "ALTER TABLE", "DROP TABLE", "CREATE TRIGGER"):
+        assert ddl not in source, f"{ddl} does not belong in a data-only seed migration"
+
+
+def test_in_process_producers_share_one_builder_tuple() -> None:
+    """`_MemoryConsentLedger._seed` and the `_bootstrap_pg` autocreate branch
+    both iterate `_STANDING_SEED_ROW_BUILDERS`, so a standing grant cannot land
+    in one in-process producer and not the other."""
+    builders = dict(_STANDING_SEED_ROW_BUILDERS)
+    assert MEDIA_CAPTURE_GRANT_REF in builders
+    assert builders[MEDIA_CAPTURE_GRANT_REF] is _media_capture_seed_row
+
+    # Extract each producer's source via the AST rather than a regex span: a
+    # regex bounded by "the next def" also swallows any comment sitting between
+    # the two definitions, which would let this assertion pass vacuously on a
+    # hardcoded producer that merely *mentions* the tuple nearby.
+    for name, body in _producer_sources().items():
+        assert "_STANDING_SEED_ROW_BUILDERS" in body, (
+            f"{name} must iterate the shared builder tuple, not a hardcoded grant list"
+        )

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -15,16 +15,26 @@ afterwards. The producers are:
    the Postgres test-fixture seed, which builds its row from the same tuple as
    (2).
 
-The migration's identity fields are asserted by parsing the migration source,
-so this runs without Postgres: a `pg`-only parity test would not run in the
-required `Unit tests (not pg)` job, which is exactly where drift needs to be
-caught. Schema parity for the underlying table is owned by `c4f7a1b2d9e3` and
+The migration is asserted by **running its real `upgrade()`** against a
+capturing `op` and reading the SQL it emits, so this needs no Postgres and
+therefore runs in the required `Unit tests (not pg)` job, which is where drift
+has to be caught. Checking only that the migration's module constants match the
+ledger's is not sufficient: the constants can be right while the
+`INSERT ... SELECT` binds them to the wrong columns or hardcodes a literal over
+one, and on an append-only, forward-only table the resulting row can never be
+removed. Schema parity for the underlying table is owned by `c4f7a1b2d9e3` and
 is not re-asserted here -- this migration is data-only.
+
+Not covered here: applying the migration to a real database. Nothing in
+`integration-nightly.yaml`'s bounded pg lane exercises the consent ledger
+either, so the emitted-SQL assertions below are the only automated guard on
+this seed.
 """
 
 from __future__ import annotations
 
 import ast
+import importlib.util
 import json
 import re
 from pathlib import Path
@@ -76,6 +86,87 @@ def _migration_module_constants() -> dict[str, object]:
         except ValueError:
             continue
     return values
+
+
+class _CapturingOp:
+    """Stands in for `alembic.op` so `upgrade()` can be run without a database."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def execute(self, sql: object) -> None:
+        self.statements.append(str(sql))
+
+
+def _rendered_upgrade_sql() -> str:
+    """The SQL the migration's real `upgrade()` emits.
+
+    Runs the actual function with a capturing `op`, rather than reasoning about
+    the source. Comparing the migration's module *constants* to the ledger's
+    constants is not enough: the constants can be correct while the
+    `INSERT … SELECT` binds them to the wrong columns, hardcodes a literal in
+    place of one, or misspells a value — none of which a constants-only
+    comparison can see.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "heimdal_media_capture_migration_under_test", MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    capturing = _CapturingOp()
+    module.op = capturing  # type: ignore[attr-defined]
+    module.upgrade()
+    assert len(capturing.statements) == 1, (
+        f"expected exactly one statement from upgrade(), got {len(capturing.statements)}"
+    )
+    return capturing.statements[0]
+
+
+def _split_sql_list(text: str) -> list[str]:
+    """Split a SQL comma list at depth 0, respecting parens and quoted literals.
+
+    The seed's JSON literals contain commas, so a naive `str.split(",")`
+    mis-aligns every column after `capture_profile`.
+    """
+    items: list[str] = []
+    depth = 0
+    in_quote = False
+    current: list[str] = []
+    for char in text:
+        if char == "'":
+            in_quote = not in_quote
+        elif not in_quote and char == "(":
+            depth += 1
+        elif not in_quote and char == ")":
+            depth -= 1
+        elif char == "," and depth == 0 and not in_quote:
+            items.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    tail = "".join(current).strip()
+    if tail:
+        items.append(tail)
+    return items
+
+
+def _seeded_columns() -> dict[str, str]:
+    """Map each INSERTed column name to the value expression bound to it."""
+    sql = _rendered_upgrade_sql()
+    match = re.search(
+        r"INSERT INTO heimdal_consent_grant\s*\((?P<cols>[^)]*)\)\s*"
+        r"SELECT\s*(?P<vals>.*?)\s*WHERE NOT EXISTS",
+        sql,
+        re.S,
+    )
+    assert match is not None, "could not parse the seed INSERT ... SELECT"
+    columns = [c.strip() for c in match.group("cols").split(",") if c.strip()]
+    values = _split_sql_list(match.group("vals"))
+    assert len(columns) == len(values), (
+        f"column/value arity mismatch: {len(columns)} columns vs {len(values)} values"
+    )
+    return dict(zip(columns, values))
 
 
 class _RecordingCursor:
@@ -133,10 +224,26 @@ def test_every_producer_seeds_the_same_media_capture_grant() -> None:
     assert constants["_MEDIA_CAPTURE_BASIS"] == MEDIA_CAPTURE_BASIS
     assert constants["_MEDIA_CAPTURE_SCOPE"] == MEDIA_CAPTURE_SCOPE
 
-    migration_profile = json.loads(str(constants["_MEDIA_CAPTURE_CAPTURE_PROFILE"]))
     memory_seed = _media_capture_seed_row(0)
-    assert migration_profile == memory_seed.capture_profile
-    assert migration_profile["modalities"] == list(MEDIA_CAPTURE_MODALITIES)
+
+    # Correct constants are not enough — assert the row the migration actually
+    # EMITS binds each of them to its declared column. A swapped basis/scope
+    # pair, a hardcoded profile, or a typo'd scope literal all leave the
+    # constants intact while seeding a grant that resolves for nothing; on an
+    # append-only, forward-only table that row can never be removed.
+    seeded = _seeded_columns()
+    assert seeded["grant_ref"] == f"'{MEDIA_CAPTURE_GRANT_REF}'"
+    assert seeded["basis"] == f"'{MEDIA_CAPTURE_BASIS}'"
+    assert seeded["scope"] == f"'{MEDIA_CAPTURE_SCOPE}'"
+    assert seeded["granted_by"] == "'operator'"
+    assert seeded["expiry"] == "NULL"
+    assert seeded["revokes_grant_ref"] == "NULL"
+
+    emitted_profile = json.loads(seeded["capture_profile"].removesuffix("::jsonb").strip("'"))
+    assert emitted_profile == memory_seed.capture_profile, (
+        "the migration must emit the same capture_profile the in-process seed builds"
+    )
+    assert emitted_profile["modalities"] == list(MEDIA_CAPTURE_MODALITIES)
 
     # The memory seed's own identity fields match the module constants too, so
     # neither producer can be "fixed" by editing only the other.

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -95,16 +95,18 @@ class _RecordingCursor:
     def fetchone(self) -> None:
         return None
 
-    def seeded_grant_refs(self) -> set[str]:
-        """The `grant_ref` of every row this bootstrap actually INSERTed.
+    def seeded_identities(self) -> set[tuple[str, str, str]]:
+        """`(grant_ref, basis, scope)` of every row this bootstrap INSERTed.
 
-        `grant_ref` is the second bound parameter of the seed INSERT, matching
-        the column order in `consent_ledger._bootstrap_pg`.
+        Positions 1/2/3 of the bound parameters, matching the column order in
+        `consent_ledger._bootstrap_pg`'s INSERT. All three, not `grant_ref`
+        alone: a producer that emitted the right ref under the wrong scope
+        would seed a grant no admission can resolve.
         """
         return {
-            params[1]
+            (params[1], params[2], params[3])
             for sql, params in self.executed
-            if "INSERT INTO" in sql and len(params) > 1
+            if "INSERT INTO" in sql and len(params) > 3
         }
 
 
@@ -114,34 +116,6 @@ class _RecordingConn:
 
     def cursor(self) -> _RecordingCursor:
         return self.cursor_obj
-
-
-def _producer_sources() -> dict[str, str]:
-    """Exact source of each in-process seed producer, via the AST.
-
-    Returns `{"_MemoryConsentLedger._seed": ..., "_bootstrap_pg": ...}`. Each
-    value spans only that definition's own lines, so a mention of the shared
-    tuple *outside* the definition cannot be mistaken for use inside it.
-    """
-    path = REPO_ROOT / "app" / "heimdal" / "consent_ledger.py"
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    found: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "_MemoryConsentLedger":
-            for item in node.body:
-                if isinstance(item, ast.FunctionDef) and item.name == "_seed":
-                    segment = ast.get_source_segment(source, item)
-                    assert segment is not None
-                    found["_MemoryConsentLedger._seed"] = segment
-        elif isinstance(node, ast.FunctionDef) and node.name == "_bootstrap_pg":
-            segment = ast.get_source_segment(source, node)
-            assert segment is not None
-            found["_bootstrap_pg"] = segment
-    assert set(found) == {"_MemoryConsentLedger._seed", "_bootstrap_pg"}, (
-        f"expected both in-process producers to be found, got {sorted(found)}"
-    )
-    return found
 
 
 def test_every_producer_seeds_the_same_media_capture_grant() -> None:
@@ -238,7 +212,11 @@ def test_in_process_producers_share_one_builder_tuple(
     monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
     conn = _RecordingConn()
     consent_ledger._bootstrap_pg(conn)
-    assert conn.cursor_obj.seeded_grant_refs() == {
+    seeded = conn.cursor_obj.seeded_identities()
+    assert {ref for ref, _basis, _scope in seeded} == {
         SELF_RECORD_GRANT_REF,
         MEDIA_CAPTURE_GRANT_REF,
     }, "the autocreate bootstrap must INSERT every standing grant"
+    # ...and under the right scope: a grant seeded against the wrong scope
+    # resolves for nothing, which no grant_ref-only assertion would catch.
+    assert (MEDIA_CAPTURE_GRANT_REF, MEDIA_CAPTURE_BASIS, MEDIA_CAPTURE_SCOPE) in seeded

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -239,11 +239,39 @@ def test_every_producer_seeds_the_same_media_capture_grant() -> None:
     assert seeded["expiry"] == "NULL"
     assert seeded["revokes_grant_ref"] == "NULL"
 
-    emitted_profile = json.loads(seeded["capture_profile"].removesuffix("::jsonb").strip("'"))
+    def _emitted_json(column: str) -> object:
+        return json.loads(seeded[column].removesuffix("::jsonb").strip("'"))
+
+    emitted_profile = _emitted_json("capture_profile")
     assert emitted_profile == memory_seed.capture_profile, (
         "the migration must emit the same capture_profile the in-process seed builds"
     )
     assert emitted_profile["modalities"] == list(MEDIA_CAPTURE_MODALITIES)
+
+    # The B-shaped consent-posture columns too, not just identity. The migration
+    # docstring promises "the same v1-inert B-shaped defaults"; without these,
+    # flipping `erasure.supported` to true, widening `third_party_policy` to
+    # 'allow', swapping vad_gate/third_party, or setting a retention bound each
+    # seeds a production row whose consent posture silently diverges from
+    # `_default_b_shaped_fields()` — and on an append-only, forward-only table
+    # that row cannot be corrected except by another migration.
+    assert seeded["third_party_policy"] == f"'{memory_seed.third_party_policy}'"
+    assert _emitted_json("vad_gate") == memory_seed.vad_gate
+    assert _emitted_json("third_party") == memory_seed.third_party
+    assert _emitted_json("retention") == memory_seed.retention
+    assert _emitted_json("erasure") == memory_seed.erasure
+    # The payload is provenance prose rather than posture, so only its shape is
+    # pinned — it must be an object carrying a note, not silently empty.
+    assert isinstance(_emitted_json("payload"), dict)
+    assert "note" in _emitted_json("payload")  # type: ignore[operator]
+
+    # Every column the INSERT declares is now asserted, so a later column can
+    # not be added to the seed without this test being extended too.
+    assert set(seeded) == {
+        "id", "grant_ref", "basis", "scope", "granted_by", "granted_at",
+        "expiry", "capture_profile", "third_party_policy", "vad_gate",
+        "third_party", "retention", "erasure", "revokes_grant_ref", "payload",
+    }
 
     # The memory seed's own identity fields match the module constants too, so
     # neither producer can be "fixed" by editing only the other.
@@ -273,9 +301,13 @@ def test_migration_seed_is_idempotent_and_forward_only() -> None:
     # media ingress would 409 forever. Substring-checking "WHERE NOT EXISTS"
     # alone does not catch that, so assert the subquery's predicate.
     assert "INSERT INTO heimdal_consent_grant" in source
+    # Anchored on the closing paren: a prefix match would accept an appended
+    # `OR TRUE` (guard always true -> the insert never fires while
+    # alembic_version still advances -> media ingress 409s forever) or
+    # `AND 1 = 0` (guard never true -> a duplicate grant on every rerun).
     guard = re.search(
         r"WHERE NOT EXISTS\s*\(\s*SELECT 1 FROM heimdal_consent_grant\s*"
-        r"WHERE grant_ref = '\{(?P<ref_const>\w+)\}'",
+        r"WHERE grant_ref = '\{(?P<ref_const>\w+)\}'\s*\)",
         source,
     )
     assert guard is not None, (

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -31,13 +31,17 @@ from pathlib import Path
 
 import pytest
 
+from app.heimdal import consent_ledger
 from app.heimdal.consent_ledger import (
     MEDIA_CAPTURE_BASIS,
     MEDIA_CAPTURE_GRANT_REF,
     MEDIA_CAPTURE_MODALITIES,
     MEDIA_CAPTURE_SCOPE,
+    SELF_RECORD_GRANT_REF,
     _media_capture_seed_row,
     _STANDING_SEED_ROW_BUILDERS,
+    list_active_grants,
+    reset_memory_consent_ledger,
 )
 
 pytestmark = pytest.mark.not_pg
@@ -72,6 +76,44 @@ def _migration_module_constants() -> dict[str, object]:
         except ValueError:
             continue
     return values
+
+
+class _RecordingCursor:
+    """Minimal DB-API cursor stand-in that records what was executed.
+
+    `fetchone()` returns None so every standing-grant existence probe reports
+    "not seeded yet" and the bootstrap takes its INSERT branch for each one —
+    which is the branch under test.
+    """
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple]] = []
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params or ()))
+
+    def fetchone(self) -> None:
+        return None
+
+    def seeded_grant_refs(self) -> set[str]:
+        """The `grant_ref` of every row this bootstrap actually INSERTed.
+
+        `grant_ref` is the second bound parameter of the seed INSERT, matching
+        the column order in `consent_ledger._bootstrap_pg`.
+        """
+        return {
+            params[1]
+            for sql, params in self.executed
+            if "INSERT INTO" in sql and len(params) > 1
+        }
+
+
+class _RecordingConn:
+    def __init__(self) -> None:
+        self.cursor_obj = _RecordingCursor()
+
+    def cursor(self) -> _RecordingCursor:
+        return self.cursor_obj
 
 
 def _producer_sources() -> dict[str, str]:
@@ -143,28 +185,60 @@ def test_migration_seed_is_idempotent_and_forward_only() -> None:
     assert re.search(r"def downgrade\(\)[\s\S]*raise RuntimeError", source), (
         "downgrade must raise rather than silently no-op"
     )
-    # Guarded insert, same shape as c4f7a1b2d9e3's self_record seed.
-    assert "WHERE NOT EXISTS" in source
+    # Guarded insert, same shape as c4f7a1b2d9e3's self_record seed. The guard
+    # must key on *this* migration's grant_ref: a guard naming any already-seeded
+    # ref (e.g. the self-record grant) is true on every database, so the insert
+    # would silently never happen, alembic_version would still advance, and
+    # media ingress would 409 forever. Substring-checking "WHERE NOT EXISTS"
+    # alone does not catch that, so assert the subquery's predicate.
     assert "INSERT INTO heimdal_consent_grant" in source
+    guard = re.search(
+        r"WHERE NOT EXISTS\s*\(\s*SELECT 1 FROM heimdal_consent_grant\s*"
+        r"WHERE grant_ref = '\{(?P<ref_const>\w+)\}'",
+        source,
+    )
+    assert guard is not None, (
+        "the seed must be guarded by NOT EXISTS on a grant_ref predicate"
+    )
+    assert constants[guard.group("ref_const")] == MEDIA_CAPTURE_GRANT_REF, (
+        "the idempotency guard must name this migration's own grant_ref; naming an "
+        "already-seeded ref makes the guard true everywhere and the insert dead"
+    )
     # Data-only: the table, its indexes, and its append-only trigger belong to
     # c4f7a1b2d9e3 and must not be redefined here.
     for ddl in ("CREATE TABLE", "ALTER TABLE", "DROP TABLE", "CREATE TRIGGER"):
         assert ddl not in source, f"{ddl} does not belong in a data-only seed migration"
 
 
-def test_in_process_producers_share_one_builder_tuple() -> None:
-    """`_MemoryConsentLedger._seed` and the `_bootstrap_pg` autocreate branch
-    both iterate `_STANDING_SEED_ROW_BUILDERS`, so a standing grant cannot land
-    in one in-process producer and not the other."""
+def test_in_process_producers_share_one_builder_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both in-process producers actually seed **both** standing grants.
+
+    Asserted **behaviorally**, by running each producer and reading what it
+    emitted — not by checking that its source mentions
+    `_STANDING_SEED_ROW_BUILDERS`. A source-text assertion cannot distinguish a
+    producer that iterates the shared tuple from one that iterates it and then
+    filters a grant back out (`if grant_ref != SELF_RECORD_GRANT_REF: continue`),
+    which is exactly the regression this test exists to catch.
+    """
     builders = dict(_STANDING_SEED_ROW_BUILDERS)
-    assert MEDIA_CAPTURE_GRANT_REF in builders
+    assert builders.keys() == {SELF_RECORD_GRANT_REF, MEDIA_CAPTURE_GRANT_REF}
     assert builders[MEDIA_CAPTURE_GRANT_REF] is _media_capture_seed_row
 
-    # Extract each producer's source via the AST rather than a regex span: a
-    # regex bounded by "the next def" also swallows any comment sitting between
-    # the two definitions, which would let this assertion pass vacuously on a
-    # hardcoded producer that merely *mentions* the tuple nearby.
-    for name, body in _producer_sources().items():
-        assert "_STANDING_SEED_ROW_BUILDERS" in body, (
-            f"{name} must iterate the shared builder tuple, not a hardcoded grant list"
-        )
+    # Producer 1: the memory backend. Drive the real reset hook and read the
+    # ledger's own active grants.
+    reset_memory_consent_ledger()
+    memory_refs = {grant.grant_ref for grant in list_active_grants()}
+    assert memory_refs == {SELF_RECORD_GRANT_REF, MEDIA_CAPTURE_GRANT_REF}
+
+    # Producer 2: the STORE_SCHEMA_AUTOCREATE Postgres bootstrap. Driven
+    # against a stub connection, so this needs no Postgres and therefore runs
+    # in the required `Unit tests (not pg)` job, where drift must be caught.
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    conn = _RecordingConn()
+    consent_ledger._bootstrap_pg(conn)
+    assert conn.cursor_obj.seeded_grant_refs() == {
+        SELF_RECORD_GRANT_REF,
+        MEDIA_CAPTURE_GRANT_REF,
+    }, "the autocreate bootstrap must INSERT every standing grant"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4492

## Linked Issue
Refs #4492

## SBS Impact
- Primary subsystem: GOV — governance, policy, authority & receipts (consent-grant authority and the provenance stamped onto every governed admission)
- Secondary subsystem(s): EBF (the governed media ingress boundary), PDM (a new migration-owned seeded row in the append-only consent ledger)
- Write class: authority-bearing
- Persistence impact: durable — one new append-only row in `heimdal_consent_grant`, seeded by migration `a9f3c2d7b6e1` in Postgres and by `_MemoryConsentLedger._seed()` in the memory backend
- Derived/rebuildable impact: `_heimdal/consent.md` (`app/heimdal/consent_surface.py`) renders one additional standing grant — a pure rebuild from the ledger, so no note migration is needed. `/api/status.heimdal_ingress` gains `media_consent_grant_available`.
- New or changed contract: `docs/EVENTS.md :: Heimdal governed media ingress + durable receipts` — the consent scope the lane admits under moves from `SELF_RECORD_SCOPE` to the lane's own `MEDIA_CAPTURE_SCOPE`. The published HTTP error contract is unchanged (409 `consent_refused` still names the same refusal).
- Owner-doc impact: Owner doc updated in this PR (`docs/EVENTS.md`, two sections).
- Transition debt impact: reduces — retires deferred registry entry `KD-4E7228960927` (`KD-4384-MODALITY`) on #4172.
- Boundary risk: the descriptive `capture_profile` must not become an enforcement gate. No admission path compares a request's modality against it, and `test_capture_profile_is_not_an_enforcement_gate` fails if one is introduced.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `POST /api/heimdal/capture/media` admitted all four media kinds under the standing self-record grant `SELF_RECORD_SCOPE` (`device+adapter:v1-voice-memo`), whose seeded `capture_profile` names `speech` only — so the consent block stamped onto a photo, video, or document raw record referenced a grant that did not name what was captured. The lane now admits under its own `MEDIA_CAPTURE_SCOPE` (`device+adapter:v1-media-ingress`, grant `grant-media-capture-v1`) whose `capture_profile.modalities` names audio, image, video, and document, following the per-lane precedent of `screen_capture.SCREEN_CAPTURE_SCOPE`.
- **Provenance accuracy, not enforcement.** Nothing on the admission path compares a modality against `capture_profile`, and this change adds no such comparison — which is why the defect was correctly rated P2 rather than an authority-integrity P1. Pinned by a test that admits an `image` under a grant profile naming only `semaphore` and asserts it still succeeds.
- **The two grants are now independent.** Revoking voice memos no longer disables media ingress, and revoking media capture no longer disables the watched-folder lane — which deliberately keeps admitting under `SELF_RECORD_SCOPE`.
- **Invariant → producers rule.** The seeded grant is a runtime precondition, so every producer ships here: migration `a9f3c2d7b6e1` (Postgres production), `_MemoryConsentLedger._seed()`, and the `STORE_SCHEMA_AUTOCREATE` branch of `_bootstrap_pg`. The two in-process producers now iterate one shared builder tuple so a standing grant cannot half-apply across them, and a non-pg parity test pins the migration's seeded literals to the module constants. `reset_memory_consent_ledger()` keeps its "a reset ledger is still a *valid* freshly-migrated ledger" property for both grants.
- **Fail-loud preflight.** The existing api-lifespan ingress preflight (#4422) now also resolves the grant and reports `media_ingress` as `unavailable` with detail `media_consent_grant_missing` on `/api/status` — same degrade-visibly, never-fail-exit posture — instead of leaving a dead lane that looks calm until the first upload. Read-only: it never grants, revokes, or repairs consent.

Resolves Known Defect `KD-4E7228960927` (`KD-4384-MODALITY`) on #4172, under the **owner ruling of 2026-07-30** recorded there ([comment](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4172#issuecomment-5129197938)): *one grant covering all four admitted kinds — audio, image, video, document.* The modality set is that ruling's, not this PR's.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: no plan divergence and no builder-workflow learning arose — the slice followed `bug-to-issue` → `issue-to-code` → `publish-pr` as routed. The two LearningSignals it *applies* (`lrn_20260730034737_efc97f71` mypy gate, `lrn_20260730034754_7dc2ddb6` mutation-verified repairs) are pre-existing and cited in the Issue's `Applies learning` section.

## Notes
- **Risk surfaces declared:** `security` (consent authority), `data`, `migration`. Not the light path: mechanism convergence packet built and independently reviewed before expensive validation. **`Final-Review-Rounds: 2`** — this changes a *runtime* surface on declared high-risk TCD categories, which per `verification-and-closure :: Re-triggering after a fix` requires two **consecutive** passing independent rounds, not one.
- **Review history:** convergence review (pre-expensive-validation) → CLEAN with 9×P3, all fixed rather than deferred. Independent review gate round 1 → **BLOCKING** (1×P1, 3×P2, 3×P3); repaired at `ebd06c59b` with a repair receipt on this PR; the reviewer's own four reproductions were re-run against the repairs and now fail as they should. Rounds toward the stop condition are counted from the first *passing* round.
- **Migration is data-only and forward-only.** No DDL — `heimdal_consent_grant`, its indexes, and its HEIM-1 append-only trigger all belong to `c4f7a1b2d9e3`. Idempotent `INSERT … WHERE NOT EXISTS`. `downgrade()` raises: the table's trigger rejects DELETE, so a reversible classification would be a false promise. Forward-only migrations require explicit operator acknowledgment in the promotion plan (`docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`).
- **Every repair ships with a mutation-verified test.** Twelve mutations were applied one at a time — each broke a property the change is responsible for, each was confirmed to fail the named test, each was reverted byte-exact, and the working tree was verified identical to the pre-mutation state afterwards. That harness earned its keep: a post-review repair to the producer-parity test (tightening a regex span) *still passed vacuously*, because a comment between the two definitions falls inside a `(?=\n    def )` lookahead. Replaced with `ast.get_source_segment` on the actual `FunctionDef` nodes and re-verified.
- **Validation: `ruff check app tests companion-ui/companion-app` clean; `mypy app` clean (849 files); `python3 scripts/docs_guard.py` OK; `python3 scripts/public_seam_lint.py --mode gate` clean (0 secret/uncovered/stale/migration-pending). 998 affected-surface tests pass (`tests/heimdal tests/migrations tests/observability tests/api tests/cli/test_heimdal_cli.py`).**
- **Full repo-wide non-pg suite: 12208 passed, 6 failed — none attributable to this change.** The migration makes `scripts/select_pr_tests.py` escalate to `full_suite=true`, so this was run under the host lease per `docs/development/DEV_WORKFLOW.md :: Validation baseline`. The same command was also run against the **unmodified merge base**: it fails **8**. Across three runs (change@`3e0d6e72` → 7 failed, base@`6a11e3a5` → 8 failed, change@`91eaa379` → 6 failed) exactly four fail every time *including on the base* — `tests/ops/test_instance_state_volume_contract.py` (×2), `tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity`, `tests/ops/test_start_full_runtime_health.py::test_dev_start_full_returns_zero_with_deferred_index_rebuild` — with a rotating tail around them. Two shell out to `scripts/start_full_system.sh` and die on a vault-mount rw probe / missing `tmp/worker_heartbeat.json`, i.e. host-global contention under `-n auto`. **Zero failures across all three runs touch `heimdal`, `consent`, `media`, `migrations`, `observability`, or `status`**, and all pass in isolation on both sides. This is pre-existing host flakiness, not a regression — but it is real and unpleasant, and worth a separate look.
- **A gate that was passing vacuously:** `scripts/docs_guard.py` reads the *committed* diff, so it reported OK while the work was still unstaged. On first commit it failed (exit 1) demanding a temporal-doc writeback, which is what the `docs/STATUS.md` paragraph in this PR resolves. Worth knowing if you run it before committing.
- **Independently reviewed before expensive validation** (mechanism convergence gate, `security`/`data`/`migration` surfaces): fresh high-capability reviewer, verdict CLEAN, no P0/P1/P2. Its nine P3 findings were all **fixed rather than deferred** — stale `consent_surface` docstring, "one grant per lane" over-generalizing past the un-seeded screen lane, an undocumented second preflight detail class, dead `_KEY_LANES`, an unqualified "read-only" claim that does not hold under `STORE_SCHEMA_AUTOCREATE=1`, the vacuous parity regex, a lost cardinality assertion, an ambiguous `basis: self_record` referent in the HCAP-04 device-registration spec, and the operator note below.
- **Operator note carried into the docs:** on a deployment where the voice-memo grant was revoked (which previously stopped media ingress too, since both lanes shared the scope), applying `a9f3c2d7b6e1` seeds a *different* `grant_ref` its `WHERE NOT EXISTS` guard cannot match — so the upgrade inserts an **active** media-capture grant and media ingress resumes. That is the intended consequence of separating the grants under the ruling, and it is visible in `_heimdal/consent.md` and `/api/status`, but an operator who revoked voice memos to stop *all* capture must also revoke `grant-media-capture-v1`. Stated in the migration docstring, `docs/EVENTS.md`, and `docs/STATUS.md`.
- **The review surfaced an adjacent pre-existing defect, filed as #4497 (`prio:high`), not fixed here.** `POST /api/heimdal/screen/capture` resolves its consent scope from the client-supplied request body (`admit_raw_evidence(scope=str(bundle.get("scope", SCREEN_CAPTURE_SCOPE)))`), so a screen client naming an always-active seeded scope is admitted with no `screen_always_on` grant. Reproduced end-to-end through the production route: default scope → 400 refused / 0 raw records (correct); naming `device+adapter:v1-voice-memo` → 200 admitted, stamped `grant-self-record-v1`; naming `device+adapter:v1-media-ingress` → 200 admitted, stamped `grant-media-capture-v1`. **Pre-existing since SCREEN-01 — this PR does not introduce it**, though it does add a second always-active nameable scope. Filed as a first-class bug rather than a deferred registry entry because a client selecting its own admitting grant is authority-integrity, which the severity contract protects from P2. Seeding a `screen_always_on` grant is explicitly out of that Issue's scope: that is an owner consent decision, the same class as the ruling this PR implements.
- **A second review round was spent on repairs, and it caught two inaccuracies the first round's repairs introduced** — both doc-only, both fixed: the preflight detail classes were attributed backwards (a database that has not run `a9f3c2d7b6e1` yields `media_consent_grant_missing`, not `..._unreadable`, because the ledger *table* belongs to `c4f7a1b2d9e3`), and a claim that the seed is "visible in `_heimdal/consent.md`" was false, since nothing in the shipped runtime calls `consent_surface.write_consent_readout`. Both were independently re-verified by grep before editing; the second became a warning rather than a deletion.
- **`harness-selfverify` was deliberately not extended.** `prepare-promotion :: Invariant → producers rule` says to add new runtime preconditions to that gate's coverage, but `AGENTS.md :: Required rules` scopes the rule to invariants the runtime **fail-exits** without; this one degrades visibly and never fail-exits. That workflow's path filter covers `app/ops/**`, `app/release_channels/**`, `tests/uat/**`, and bootstrap scripts — not `app/heimdal/**` — and the shared `migrate` one-shot in `docker-compose.yaml` is the producer for both the test channel and prod, needing no per-migration update. The precondition is already fail-loud via the startup preflight plus the non-pg parity test that the required `Unit tests (not pg)` job runs. Adding a job would be a new permanent governance mechanism without a contract demand (`AGENTS.md :: Proportional delivery`). Precedent: #4422/PR #4431 shipped this same lane's raw-store-key precondition with the same posture and touched neither surface.
- **Deliberately out of scope** (each would be a new gate or a new owner decision): modality enforcement against `capture_profile`; repointing the watched-folder lane; a seeded grant for the screen lane's `screen_always_on` scope (it has none today); per-device scoping or revocation-propagation semantics. Also untouched: `KD-4384-RAWKEY` (unprovisioned `HEIMDAL_RAW_STORE_KEY`) and `KD-4384-RETENTION`.
- **Known pre-existing gap this does not close:** the preflight records a point-in-time result at startup, so a grant revoked *after* startup leaves `/api/status` reporting `available` while requests correctly refuse with 409. That is the documented #4422 posture — the per-request contract is the truth — and is now stated in the module docstring rather than left implicit.
Verified-Closing-Issues: #4492