### PR TITLE
Persist an explicit instance default vault with fail-closed resolution (MVR-02)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -25,6 +25,13 @@ except ImportError:
     search_router = None
 
 try:
+    from app.api.routes.instance_default_vault import (
+        router as instance_default_vault_router,
+    )
+except ImportError:
+    instance_default_vault_router = None
+
+try:
     from app.api.routes.status import router as status_router
 except ImportError:
     status_router = None
@@ -309,6 +316,8 @@ def _create_app() -> FastAPI:
         application.include_router(artifacts_router, prefix="/api")
     if companion_router is not None:
         application.include_router(companion_router, prefix="/api")
+    if instance_default_vault_router is not None:
+        application.include_router(instance_default_vault_router, prefix="/api")
     if builderops_router is not None:
         application.include_router(builderops_router, prefix="/api")
     if context_bundles_router is not None:

--- a/app/api/routes/instance_default_vault.py
+++ b/app/api/routes/instance_default_vault.py
@@ -1,0 +1,115 @@
+"""Authenticated Companion API for the MVR-02 explicit instance default vault.
+
+This router is one of the two production producers named by MVR-02 (#3856); the
+other is the headless ``python -m app.instance.runtime default-vault-*`` CLI.
+Both go through :class:`~app.instance.default_vault.InstanceDefaultVaultService`,
+so they converge on the same locked registry state and the same redacted receipt.
+
+Responses carry binding identity, provenance, and the registry revision only —
+never a content-root path or any other raw binding payload.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.auth import require_loopback_or_api_key
+from app.instance.default_vault import (
+    InstanceDefaultVaultService,
+    VaultSelectionError,
+)
+from app.instance.vault_registry import (
+    RegistryDefaultConflict,
+    RegistryError,
+    VaultRegistryStore,
+)
+
+router = APIRouter(prefix="/instance", tags=["instance"])
+
+
+class DefaultVaultResponse(BaseModel):
+    vault_binding_id: str | None = None
+    previous_vault_binding_id: str | None = None
+    provenance: str | None = None
+    registry_revision: int
+    changed: bool = False
+
+
+class DefaultVaultSetRequest(BaseModel):
+    vault_binding_id: str = Field(min_length=1)
+
+
+def _registry_path() -> Path:
+    value = os.getenv("INSTANCE_VAULT_REGISTRY_PATH", "").strip()
+    if not value:
+        # No registry binding is a configuration state, not a vault to guess at.
+        raise HTTPException(
+            status_code=503,
+            detail="instance registry is not bound on this process",
+        )
+    return Path(value).expanduser().resolve(strict=False)
+
+
+def get_default_vault_service() -> InstanceDefaultVaultService:
+    return InstanceDefaultVaultService(VaultRegistryStore(_registry_path()))
+
+
+def _fail(exc: RegistryError) -> HTTPException:
+    if isinstance(exc, RegistryDefaultConflict):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, VaultSelectionError):
+        return HTTPException(status_code=404, detail=str(exc))
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get(
+    "/default-vault",
+    response_model=DefaultVaultResponse,
+    dependencies=[Depends(require_loopback_or_api_key)],
+)
+def read_default_vault(
+    service: InstanceDefaultVaultService = Depends(get_default_vault_service),
+) -> DefaultVaultResponse:
+    try:
+        receipt = service.get()
+    except RegistryError as exc:
+        raise _fail(exc) from exc
+    return DefaultVaultResponse(**receipt.as_dict())
+
+
+@router.put(
+    "/default-vault",
+    response_model=DefaultVaultResponse,
+    dependencies=[Depends(require_loopback_or_api_key)],
+)
+def set_default_vault(
+    payload: DefaultVaultSetRequest,
+    service: InstanceDefaultVaultService = Depends(get_default_vault_service),
+) -> DefaultVaultResponse:
+    try:
+        receipt = service.set(payload.vault_binding_id)
+    except RegistryError as exc:
+        raise _fail(exc) from exc
+    return DefaultVaultResponse(**receipt.as_dict())
+
+
+@router.delete(
+    "/default-vault",
+    response_model=DefaultVaultResponse,
+    dependencies=[Depends(require_loopback_or_api_key)],
+)
+def clear_default_vault(
+    service: InstanceDefaultVaultService = Depends(get_default_vault_service),
+) -> DefaultVaultResponse:
+    try:
+        receipt = service.clear()
+    except RegistryError as exc:
+        raise _fail(exc) from exc
+    return DefaultVaultResponse(**receipt.as_dict())
+
+
+__all__ = ["get_default_vault_service", "router"]

--- a/app/api/routes/instance_default_vault.py
+++ b/app/api/routes/instance_default_vault.py
@@ -22,10 +22,10 @@ from app.instance.default_vault import (
     InstanceDefaultVaultService,
     VaultSelectionError,
 )
+from app.instance.runtime import open_default_vault_service
 from app.instance.vault_registry import (
     RegistryDefaultConflict,
     RegistryError,
-    VaultRegistryStore,
 )
 
 router = APIRouter(prefix="/instance", tags=["instance"])
@@ -55,7 +55,9 @@ def _registry_path() -> Path:
 
 
 def get_default_vault_service() -> InstanceDefaultVaultService:
-    return InstanceDefaultVaultService(VaultRegistryStore(_registry_path()))
+    # The sealed storage-mutation capability is handed over by the sanctioned
+    # instance-runtime factory; this route never touches the seal itself.
+    return open_default_vault_service(_registry_path())
 
 
 def _fail(exc: RegistryError) -> HTTPException:

--- a/app/events/types.py
+++ b/app/events/types.py
@@ -116,6 +116,18 @@ KNOWLEDGE_ACQUISITION_STAGE_DEAD_LETTERED = "knowledge_acquisition.stage.dead_le
 # with KERNEL-08 registered schemas. Lineage/receipt posture, NOT dispatched
 # commands — no `outbox_worker._dispatch_topic` branch; a future consumer
 # follows the KA-07 route pattern.
+# MVR-02 (#3856): the versioned instance-default-vault mutation topic
+# (docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md). Emitted by
+# app/instance/default_vault.py whenever the explicit `default_vault_binding_id`
+# is set, replaced, or cleared through the one production service behind the
+# authenticated API and the headless CLI. KERNEL-08 schema registered at
+# `schemas/events/instance.default_vault.changed.v1.schema.json`. Lineage
+# posture, NOT a dispatched command — no `outbox_worker._dispatch_topic` branch;
+# MVR-06 consumes this contract for compatibility rebind. The payload carries the
+# new registry revision and binding identity only: never a content-root path,
+# vault name, or other raw binding payload.
+INSTANCE_DEFAULT_VAULT_CHANGED = "instance.default_vault.changed"
+
 YOUTUBE_SOURCE_DISCOVERED = "youtube.source.discovered"
 ACQUISITION_REQUESTED = "acquisition.requested"
 ACQUISITION_STARTED = "acquisition.started"
@@ -198,6 +210,7 @@ HEIMDAL_MEETING_USER_NOTE_WRITTEN = "heimdal.meeting.user_note.written"
 HEIMDAL_MEETING_FINALIZED = "heimdal.meeting.finalized"
 
 __all__ = [
+    "INSTANCE_DEFAULT_VAULT_CHANGED",
     "INGEST_OBJECT_CREATED",
     "INGEST_OBJECT_UPDATED",
     "INGEST_OBJECT_METADATA",

--- a/app/instance/default_vault.py
+++ b/app/instance/default_vault.py
@@ -48,6 +48,11 @@ from app.instance.vault_registry import (
 SELECTION_REQUEST_OVERRIDE = "request_override"
 SELECTION_SESSION = "session_selection"
 SELECTION_INSTANCE_DEFAULT = "instance_default"
+# A compatibility DEFAULT_VAULT_ID win is reported distinctly from a durable
+# operator-set default: provenance is meant to be inspectable, and "an env var
+# resolved this" is materially different from "the instance is configured this
+# way" when someone is debugging which vault a background caller reached.
+SELECTION_COMPATIBILITY_DEFAULT = "compatibility_default_vault_id"
 SELECTION_LEGACY_BOOTSTRAP = "legacy_bootstrap"
 SELECTION_NO_VAULT = "no_vault"
 
@@ -169,17 +174,17 @@ def resolve_vault_selection(
         registration = _require_registered(snapshot, session, branch="session")
         return VaultSelection(session, SELECTION_SESSION, registration)
     default_binding_id = snapshot.default_vault_binding_id
+    default_provenance = SELECTION_INSTANCE_DEFAULT
     if default_binding_id is None and compatibility_default_vault_id:
         default_binding_id = resolve_compatibility_default_vault_id(
             snapshot, compatibility_default_vault_id
         )
+        default_provenance = SELECTION_COMPATIBILITY_DEFAULT
     if default_binding_id is not None:
         registration = _require_registered(
             snapshot, default_binding_id, branch="instance default"
         )
-        return VaultSelection(
-            default_binding_id, SELECTION_INSTANCE_DEFAULT, registration
-        )
+        return VaultSelection(default_binding_id, default_provenance, registration)
     if legacy_bootstrap_vault_root is not None:
         binding_id = resolve_legacy_bootstrap_binding(
             snapshot, legacy_bootstrap_vault_root
@@ -346,6 +351,16 @@ class InstanceDefaultVaultService:
             # silently substituted by another registration.
             raise VaultSelectionError(
                 f"unknown or unauthorized vault_binding_id: {vault_binding_id}"
+            )
+        if before.default_vault_binding_id == vault_binding_id:
+            # A no-op is not a mutation: it must not burn a registry revision and
+            # must not publish a rebind event MVR-06 would act on.
+            return DefaultVaultReceipt(
+                vault_binding_id=before.default_vault_binding_id,
+                provenance=before.default_vault_provenance,
+                registry_revision=before.revision,
+                previous_vault_binding_id=before.default_vault_binding_id,
+                changed=False,
             )
         updated = self._store.set_instance_default(
             vault_binding_id,

--- a/app/instance/default_vault.py
+++ b/app/instance/default_vault.py
@@ -352,9 +352,17 @@ class InstanceDefaultVaultService:
             raise VaultSelectionError(
                 f"unknown or unauthorized vault_binding_id: {vault_binding_id}"
             )
-        if before.default_vault_binding_id == vault_binding_id:
+        if (
+            before.default_vault_binding_id == vault_binding_id
+            and before.default_vault_provenance == (
+                None if vault_binding_id is None else provenance
+            )
+        ):
             # A no-op is not a mutation: it must not burn a registry revision and
-            # must not publish a rebind event MVR-06 would act on.
+            # must not publish a rebind event MVR-06 would act on. Provenance is
+            # part of "no-op" — an operator pinning a binding the first-vault
+            # producer chose is a real change from an inferred default to an
+            # explicit one, and must be recorded, not swallowed.
             return DefaultVaultReceipt(
                 vault_binding_id=before.default_vault_binding_id,
                 provenance=before.default_vault_provenance,

--- a/app/instance/default_vault.py
+++ b/app/instance/default_vault.py
@@ -32,7 +32,6 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from app.events.types import INSTANCE_DEFAULT_VAULT_CHANGED
-from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 from app.instance.filesystem_identity import (
     FilesystemIdentityError,
     resolve_filesystem_root_identity,
@@ -265,15 +264,24 @@ class InstanceDefaultVaultService:
     Both producers validate registration, mutate through MVR-01's locked
     registry transaction, never touch ``last_active_vault_ref``, and return the
     same redacted receipt.
+
+    This service **receives** its storage-mutation capability rather than holding
+    it: the private capability stays sealed to its existing sanctioned importers
+    (`app/instance/_storage_boundary.py`), and only
+    :func:`app.instance.runtime.open_default_vault_service` — an already-allowed
+    importer — hands it over. Constructing the service without one yields a
+    read-only view whose mutators fail closed with ``CapabilityNotReadyError``.
     """
 
     def __init__(
         self,
         store: VaultRegistryStore,
         *,
+        capability: Any = None,
         emit_event: Any = _emit_default_mutation_event,
     ) -> None:
         self._store = store
+        self._capability = capability
         self._emit_event = emit_event
 
     @property
@@ -311,9 +319,10 @@ class InstanceDefaultVaultService:
         before = self._store.load()
         updated = self._store.remove_registration(
             vault_binding_id,
+            expected_revision=before.revision,
             clear_default=clear_default,
             replacement_default_binding_id=replacement_default_binding_id,
-            _capability=_STORAGE_MUTATION_CAPABILITY,
+            _capability=self._capability,
         )
         receipt = DefaultVaultReceipt(
             vault_binding_id=updated.default_vault_binding_id,
@@ -342,7 +351,7 @@ class InstanceDefaultVaultService:
             vault_binding_id,
             provenance=provenance,
             expected_revision=before.revision,
-            _capability=_STORAGE_MUTATION_CAPABILITY,
+            _capability=self._capability,
         )
         if updated.last_active_vault_ref != before.last_active_vault_ref:
             raise RegistryError("default mutation must not change last-active history")

--- a/app/instance/default_vault.py
+++ b/app/instance/default_vault.py
@@ -1,0 +1,388 @@
+"""MVR-02: the explicit instance default vault and one fail-closed resolver.
+
+``last_active_vault_ref`` is interaction history and ``VAULT_ROOT`` is a
+deployment bootstrap. Neither is a truthful instance default, and conflating them
+makes restarts nondeterministic and turns an invalid explicit selection into a
+silent read/write against the wrong vault.
+
+This module owns three things:
+
+* :func:`resolve_vault_selection` — one production resolver applying
+  ``request override > retained session > instance default > explicit legacy
+  bootstrap > no-vault``, reporting which branch won. An explicit selection that
+  does not resolve fails closed; it never falls through to last-active, another
+  registration, the working directory, or ``./vault``.
+* :func:`resolve_compatibility_default_vault_id` — the untrusted ``DEFAULT_VAULT_ID``
+  logical-ID lookup, which resolves only when the logical vault ID maps to exactly
+  one local binding.
+* :class:`InstanceDefaultVaultService` — the single service behind the
+  authenticated API and the headless CLI get/set/clear commands, so both
+  producers converge on the same locked registry state, the same redacted
+  receipt, and the same versioned mutation event.
+
+MVR-05 owns the HTTP carriers (``X-Active-Context-Override`` and
+``X-Active-Context-Session``); this slice only accepts their already-parsed
+values as distinct resolver inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from app.events.types import INSTANCE_DEFAULT_VAULT_CHANGED
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.filesystem_identity import (
+    FilesystemIdentityError,
+    resolve_filesystem_root_identity,
+    same_filesystem_root,
+)
+from app.instance.vault_registry import (
+    DEFAULT_PROVENANCE_EXPLICIT,
+    RegistryError,
+    RegistrySnapshot,
+    VaultRegistration,
+    VaultRegistryStore,
+)
+
+SELECTION_REQUEST_OVERRIDE = "request_override"
+SELECTION_SESSION = "session_selection"
+SELECTION_INSTANCE_DEFAULT = "instance_default"
+SELECTION_LEGACY_BOOTSTRAP = "legacy_bootstrap"
+SELECTION_NO_VAULT = "no_vault"
+
+DEFAULT_VAULT_MUTATION_EVENT_VERSION = 1
+_DEFAULT_MUTATION_FINGERPRINT = "instance-default-vault-changed-v1"
+
+
+class VaultSelectionError(RegistryError):
+    """An explicit selection is unknown, removed, or unauthorized.
+
+    Raised instead of degrading to another binding: fail-closed is the whole
+    point of the precedence chain.
+    """
+
+
+@dataclass(frozen=True)
+class VaultSelection:
+    """One resolved selection plus the branch that produced it."""
+
+    vault_binding_id: str | None
+    provenance: str
+    registration: VaultRegistration | None = None
+
+    @property
+    def is_no_vault(self) -> bool:
+        return self.vault_binding_id is None
+
+
+def _require_registered(
+    snapshot: RegistrySnapshot, vault_binding_id: str, *, branch: str
+) -> VaultRegistration:
+    registration = snapshot.registrations.get(vault_binding_id)
+    if registration is None:
+        raise VaultSelectionError(
+            f"{branch} selection is not a current registration: {vault_binding_id}"
+        )
+    return registration
+
+
+def resolve_compatibility_default_vault_id(
+    snapshot: RegistrySnapshot, vault_id: str
+) -> str:
+    """Resolve the untrusted ``DEFAULT_VAULT_ID`` logical ID to one binding.
+
+    A logical vault ID may legitimately map to several local clones. That is
+    ambiguous, not a tiebreak opportunity, so anything other than exactly one
+    match fails closed.
+    """
+
+    normalized = (vault_id or "").strip()
+    if not normalized:
+        raise VaultSelectionError("compatibility DEFAULT_VAULT_ID is blank")
+    matches = [
+        registration.vault_binding_id
+        for registration in snapshot.registrations.values()
+        if registration.vault_id == normalized
+    ]
+    if len(matches) != 1:
+        raise VaultSelectionError(
+            "compatibility DEFAULT_VAULT_ID does not identify exactly one local binding"
+        )
+    return matches[0]
+
+
+def resolve_legacy_bootstrap_binding(
+    snapshot: RegistrySnapshot, vault_root: Path
+) -> str:
+    """Resolve the explicit legacy bootstrap adapter to one stable binding.
+
+    The adapter only ever *finds* the binding MVR-01B created or reconciled for
+    this root. It never turns an env path into a new registration and never uses
+    a path as identity: the path is matched through canonical filesystem-root
+    identity, and anything other than exactly one match fails closed.
+    """
+
+    try:
+        identity = resolve_filesystem_root_identity(vault_root)
+    except FilesystemIdentityError as exc:
+        raise VaultSelectionError(
+            "legacy bootstrap root cannot be resolved to a filesystem identity"
+        ) from exc
+    matches = []
+    for registration in snapshot.registrations.values():
+        try:
+            candidate = resolve_filesystem_root_identity(Path(registration.path))
+        except FilesystemIdentityError:
+            continue
+        if same_filesystem_root(candidate, identity):
+            matches.append(registration.vault_binding_id)
+    if len(matches) != 1:
+        raise VaultSelectionError(
+            "legacy bootstrap env and registry truth do not identify exactly one binding"
+        )
+    return matches[0]
+
+
+def resolve_vault_selection(
+    snapshot: RegistrySnapshot,
+    *,
+    request_override: str | None = None,
+    session_selection: str | None = None,
+    legacy_bootstrap_vault_root: Path | None = None,
+    compatibility_default_vault_id: str | None = None,
+) -> VaultSelection:
+    """Apply the MVR-02 precedence chain and report the winning branch.
+
+    ``request_override`` is the one-request selection, ``session_selection`` the
+    retained one. They are distinct inputs, and the override never persists into
+    the session. Absence of every explicit input resolves to no-vault, which
+    remains a valid result.
+    """
+
+    override = (request_override or "").strip() or None
+    session = (session_selection or "").strip() or None
+    if override is not None:
+        registration = _require_registered(snapshot, override, branch="request override")
+        return VaultSelection(override, SELECTION_REQUEST_OVERRIDE, registration)
+    if session is not None:
+        registration = _require_registered(snapshot, session, branch="session")
+        return VaultSelection(session, SELECTION_SESSION, registration)
+    default_binding_id = snapshot.default_vault_binding_id
+    if default_binding_id is None and compatibility_default_vault_id:
+        default_binding_id = resolve_compatibility_default_vault_id(
+            snapshot, compatibility_default_vault_id
+        )
+    if default_binding_id is not None:
+        registration = _require_registered(
+            snapshot, default_binding_id, branch="instance default"
+        )
+        return VaultSelection(
+            default_binding_id, SELECTION_INSTANCE_DEFAULT, registration
+        )
+    if legacy_bootstrap_vault_root is not None:
+        binding_id = resolve_legacy_bootstrap_binding(
+            snapshot, legacy_bootstrap_vault_root
+        )
+        registration = _require_registered(
+            snapshot, binding_id, branch="legacy bootstrap"
+        )
+        return VaultSelection(binding_id, SELECTION_LEGACY_BOOTSTRAP, registration)
+    return VaultSelection(None, SELECTION_NO_VAULT, None)
+
+
+@dataclass(frozen=True)
+class DefaultVaultReceipt:
+    """The redacted receipt both production producers return.
+
+    Deliberately carries no content-root path, vault name, or other raw binding
+    payload: a receipt travels into logs and GitHub comments, and the binding ID
+    plus registry revision are enough to audit the mutation.
+    """
+
+    vault_binding_id: str | None
+    provenance: str | None
+    registry_revision: int
+    previous_vault_binding_id: str | None = None
+    changed: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "vault_binding_id": self.vault_binding_id,
+            "provenance": self.provenance,
+            "registry_revision": self.registry_revision,
+            "previous_vault_binding_id": self.previous_vault_binding_id,
+            "changed": self.changed,
+        }
+
+
+def _emit_default_mutation_event(receipt: DefaultVaultReceipt) -> str:
+    """Publish exactly one versioned default-mutation event.
+
+    MVR-06 consumes this contract for compatibility rebind, so the payload
+    carries the new registry revision and binding identity only — never a raw
+    binding payload — and is keyed on the revision so a crash-retry of the same
+    logical mutation cannot produce a second row.
+    """
+
+    from app.events.models import new_event
+    from app.services.outbox import derive_idempotency_key, write_outbox_event
+
+    payload = {
+        "event_version": DEFAULT_VAULT_MUTATION_EVENT_VERSION,
+        "registry_revision": receipt.registry_revision,
+        "vault_binding_id": receipt.vault_binding_id,
+        "previous_vault_binding_id": receipt.previous_vault_binding_id,
+        "provenance": receipt.provenance,
+    }
+    idempotency_key = derive_idempotency_key(
+        INSTANCE_DEFAULT_VAULT_CHANGED,
+        str(receipt.registry_revision),
+        _DEFAULT_MUTATION_FINGERPRINT,
+    )
+    event = new_event(
+        event_type=INSTANCE_DEFAULT_VAULT_CHANGED,
+        payload=payload,
+        source="instance.default_vault",
+    )
+    # Durability classification (#4214 D5): `required_db=False` is deliberate.
+    # The durable registry revision written just above is the authority — the
+    # lane's own cross-task invariant is that background supervisors reconcile
+    # durable registry revisions, never event delivery, and wake-up hints are
+    # never the transition authority. So a skipped mirror on a runtime with no
+    # configured Postgres is survivable: the committed revision still carries the
+    # change, and requiring the DB here would make the headless CLI unusable on a
+    # bare instance that has no outbox at all.
+    return write_outbox_event(
+        event, idempotency_key=idempotency_key, required_db=False
+    )
+
+
+class InstanceDefaultVaultService:
+    """One service behind the authenticated API and the headless CLI.
+
+    Both producers validate registration, mutate through MVR-01's locked
+    registry transaction, never touch ``last_active_vault_ref``, and return the
+    same redacted receipt.
+    """
+
+    def __init__(
+        self,
+        store: VaultRegistryStore,
+        *,
+        emit_event: Any = _emit_default_mutation_event,
+    ) -> None:
+        self._store = store
+        self._emit_event = emit_event
+
+    @property
+    def store(self) -> VaultRegistryStore:
+        return self._store
+
+    def get(self) -> DefaultVaultReceipt:
+        snapshot = self._store.load()
+        return DefaultVaultReceipt(
+            vault_binding_id=snapshot.default_vault_binding_id,
+            provenance=snapshot.default_vault_provenance,
+            registry_revision=snapshot.revision,
+            previous_vault_binding_id=snapshot.default_vault_binding_id,
+            changed=False,
+        )
+
+    def set(self, vault_binding_id: str) -> DefaultVaultReceipt:
+        target = (vault_binding_id or "").strip()
+        if not target:
+            raise VaultSelectionError("vault_binding_id is required")
+        return self._mutate(target, provenance=DEFAULT_PROVENANCE_EXPLICIT)
+
+    def clear(self) -> DefaultVaultReceipt:
+        return self._mutate(None, provenance=DEFAULT_PROVENANCE_EXPLICIT)
+
+    def remove_registration(
+        self,
+        vault_binding_id: str,
+        *,
+        clear_default: bool = False,
+        replacement_default_binding_id: str | None = None,
+    ) -> DefaultVaultReceipt:
+        """Remove one registration through the reference-safe locked transaction."""
+
+        before = self._store.load()
+        updated = self._store.remove_registration(
+            vault_binding_id,
+            clear_default=clear_default,
+            replacement_default_binding_id=replacement_default_binding_id,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        receipt = DefaultVaultReceipt(
+            vault_binding_id=updated.default_vault_binding_id,
+            provenance=updated.default_vault_provenance,
+            registry_revision=updated.revision,
+            previous_vault_binding_id=before.default_vault_binding_id,
+            changed=(
+                before.default_vault_binding_id != updated.default_vault_binding_id
+            ),
+        )
+        if receipt.changed:
+            self._emit_event(receipt)
+        return receipt
+
+    def _mutate(
+        self, vault_binding_id: str | None, *, provenance: str
+    ) -> DefaultVaultReceipt:
+        before = self._store.load()
+        if vault_binding_id is not None and vault_binding_id not in before.registrations:
+            # Fail closed before any write: an unknown or removed binding is never
+            # silently substituted by another registration.
+            raise VaultSelectionError(
+                f"unknown or unauthorized vault_binding_id: {vault_binding_id}"
+            )
+        updated = self._store.set_instance_default(
+            vault_binding_id,
+            provenance=provenance,
+            expected_revision=before.revision,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        if updated.last_active_vault_ref != before.last_active_vault_ref:
+            raise RegistryError("default mutation must not change last-active history")
+        receipt = DefaultVaultReceipt(
+            vault_binding_id=updated.default_vault_binding_id,
+            provenance=updated.default_vault_provenance,
+            registry_revision=updated.revision,
+            previous_vault_binding_id=before.default_vault_binding_id,
+            changed=True,
+        )
+        self._emit_event(receipt)
+        return receipt
+
+
+def redact_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Return only the fields safe to publish outside the instance."""
+
+    allowed = {
+        "vault_binding_id",
+        "previous_vault_binding_id",
+        "provenance",
+        "registry_revision",
+        "changed",
+    }
+    return {key: value for key, value in receipt.items() if key in allowed}
+
+
+__all__ = [
+    "DEFAULT_VAULT_MUTATION_EVENT_VERSION",
+    "SELECTION_INSTANCE_DEFAULT",
+    "SELECTION_LEGACY_BOOTSTRAP",
+    "SELECTION_NO_VAULT",
+    "SELECTION_REQUEST_OVERRIDE",
+    "SELECTION_SESSION",
+    "DefaultVaultReceipt",
+    "InstanceDefaultVaultService",
+    "VaultSelection",
+    "VaultSelectionError",
+    "redact_receipt",
+    "resolve_compatibility_default_vault_id",
+    "resolve_legacy_bootstrap_binding",
+    "resolve_vault_selection",
+]

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -40,10 +40,17 @@ from app.instance.scalar_rollback_guard import (
     ScalarRollbackGuardReceipt,
     preflight_scalar_rollback_guard,
 )
+from app.instance.default_vault import (
+    InstanceDefaultVaultService,
+    VaultSelectionError,
+)
 from app.instance.vault_registry import (
     AppLocalSettings,
     AppLocalSettingsStore,
     CapabilityNotReadyError,
+    DEFAULT_PROVENANCE_FIRST_INITIALIZE,
+    DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
+    RegistryDefaultConflict,
     RegistryError,
     RegistryActivationProof,
     RegistrySnapshot,
@@ -237,7 +244,13 @@ class InstanceRegistryRuntime:
             "the active production picker"
         )
 
-    def production_register(self, path: Path, *, producer: str) -> VaultRegistration:
+    def production_register(
+        self,
+        path: Path,
+        *,
+        producer: str,
+        first_default_provenance: str | None = None,
+    ) -> VaultRegistration:
         if producer not in {"picker", "api", "cli", "import", "bootstrap", "direct-service"}:
             raise RegistryError("unknown registry producer")
         with self._bootstrap_locked():
@@ -251,7 +264,110 @@ class InstanceRegistryRuntime:
                 producer=producer,
                 current=current,
                 allow_same_channel_nested=producer == "picker",
+                first_default_provenance=first_default_provenance,
             )
+
+    def register_first_vault(
+        self,
+        path: Path,
+        *,
+        provenance: str,
+    ) -> VaultRegistration:
+        """MVR-02 first-vault default producer for a fresh no-vault instance.
+
+        A no-vault instance that initializes its first vault, or first opens an
+        existing initialized/uninitialized root, records that stable binding as
+        its explicit default inside the same locked registration transaction —
+        exactly once, and only when that transaction itself proves there were no
+        prior registrations and no prior default. A later open, picker change, or
+        last-active write never replaces it, and explicitly initializing a
+        provisional binding later completes its identity through
+        :meth:`complete_initialization` without replacing either the binding or
+        this default.
+
+        The env bootstrap adapter deliberately does **not** route here: an env
+        `VAULT_ROOT` stays an explicit legacy bootstrap, never a hidden default.
+
+        MVR-05B owns the authenticated request ingress that reaches this producer
+        from the picker; MVR-02 owns the transaction and its atomicity.
+        """
+
+        if provenance not in {
+            DEFAULT_PROVENANCE_FIRST_INITIALIZE,
+            DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
+        }:
+            raise RegistryError(f"unsupported first-vault provenance: {provenance}")
+        with self._bootstrap_locked():
+            current = self.registry.load()
+            if current.registrations or current.default_vault_binding_id is not None:
+                raise RegistryDefaultConflict(
+                    "the first-vault default producer requires an empty registry "
+                    "with no explicit default"
+                )
+            self._require_established_ownership(current)
+            return self._register_first_locked(
+                path,
+                current=current,
+                first_default_provenance=provenance,
+            )
+
+    def default_vault_service(self) -> InstanceDefaultVaultService:
+        """Return the one service both production default producers share."""
+
+        return InstanceDefaultVaultService(self.registry)
+
+    def _register_first_locked(
+        self,
+        path: Path,
+        *,
+        current: RegistrySnapshot,
+        first_default_provenance: str,
+    ) -> VaultRegistration:
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        self.registry.require_no_scalar_rollback_session()
+        root_identity = resolve_filesystem_root_identity(path)
+        canonical_root = Path(root_identity.canonical_path)
+        pending = (
+            self.ledger.pending_registration(
+                channel_id=self.layout.channel_id,
+                root=canonical_root,
+            )
+            if self.ledger.path.is_file() and self.ledger.key_path.is_file()
+            else None
+        )
+        registration = self._new_registration(
+            canonical_root,
+            vault_binding_id=(
+                pending.vault_binding_id if pending is not None else None
+            ),
+            provenance=first_default_provenance,
+        )
+        validate_registry_disjoint_from_content(
+            self.layout.registry_path,
+            [Path(registration.path)],
+        )
+        self.ledger.reserve(
+            channel_id=self.layout.channel_id,
+            vault_binding_id=registration.vault_binding_id,
+            root=Path(registration.path),
+            allow_same_channel_nested=False,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        # Registration and the explicit default land in one locked registry
+        # revision: a crash between them would otherwise leave a registered
+        # binding with no restart source, or a default with no registration.
+        self.registry.register(
+            registration,
+            expected_revision=current.revision,
+            first_default_provenance=first_default_provenance,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        self.ledger.activate(
+            registration.vault_binding_id,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        return registration
 
     def _register_active_locked(
         self,
@@ -260,6 +376,7 @@ class InstanceRegistryRuntime:
         producer: str,
         current: RegistrySnapshot,
         allow_same_channel_nested: bool = False,
+        first_default_provenance: str | None = None,
     ) -> VaultRegistration:
         from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 
@@ -305,6 +422,7 @@ class InstanceRegistryRuntime:
         self.registry.register(
             registration,
             expected_revision=current.revision,
+            first_default_provenance=first_default_provenance,
             _capability=_STORAGE_MUTATION_CAPABILITY,
         )
         self.ledger.activate(
@@ -579,6 +697,7 @@ class InstanceRegistryRuntime:
         root: Path,
         *,
         vault_binding_id: str | None = None,
+        provenance: str = "legacy_env_bootstrap",
     ) -> VaultRegistration:
         vault_id, local_instance_id = _read_vault_identity(root)
         identity = resolve_filesystem_root_identity(root)
@@ -592,7 +711,7 @@ class InstanceRegistryRuntime:
             extensions={
                 "status": "initialized" if vault_id is not None else "uninitialized",
                 "contentEpoch": 1,
-                "provenance": "legacy_env_bootstrap",
+                "provenance": provenance,
             },
         )
 
@@ -2715,6 +2834,29 @@ def _finish_instance_state_deployment_locked(
     return _complete_instance_state_deployment_cleanup(ownership_root)
 
 
+def _default_vault_command(args: argparse.Namespace) -> int:
+    """Headless MVR-02 get/set/clear through the same service the API uses.
+
+    Prints only the redacted receipt: binding identity, provenance, and registry
+    revision. No content-root path or other raw binding payload leaves the
+    instance through this surface.
+    """
+
+    service = InstanceDefaultVaultService(VaultRegistryStore(Path(args.registry_path)))
+    try:
+        if args.command == "default-vault-get":
+            receipt = service.get()
+        elif args.command == "default-vault-set":
+            receipt = service.set(args.vault_binding_id)
+        else:
+            receipt = service.clear()
+    except (VaultSelectionError, RegistryDefaultConflict) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        return 1
+    print(json.dumps({"ok": True, **receipt.as_dict()}, sort_keys=True))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -2780,7 +2922,18 @@ def main(argv: list[str] | None = None) -> int:
     prove.add_argument("--channel", required=True)
     prove.add_argument("--host-global-root", type=Path, required=True)
     prove.add_argument("--inventory-path", type=Path, required=True)
+    for name in ("default-vault-get", "default-vault-set", "default-vault-clear"):
+        command = subparsers.add_parser(name)
+        command.add_argument("--registry-path", type=Path, required=True)
+        if name == "default-vault-set":
+            command.add_argument("--vault-binding-id", required=True)
     args = parser.parse_args(argv)
+    if args.command in {
+        "default-vault-get",
+        "default-vault-set",
+        "default-vault-clear",
+    }:
+        return _default_vault_command(args)
     if args.command == "read-revision":
         return _read_revision(args.registry_path, args.consumer)
     if args.command == "preflight":

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -314,7 +314,11 @@ class InstanceRegistryRuntime:
     def default_vault_service(self) -> InstanceDefaultVaultService:
         """Return the one service both production default producers share."""
 
-        return InstanceDefaultVaultService(self.registry)
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        return InstanceDefaultVaultService(
+            self.registry, capability=_STORAGE_MUTATION_CAPABILITY
+        )
 
     def _register_first_locked(
         self,
@@ -2834,6 +2838,23 @@ def _finish_instance_state_deployment_locked(
     return _complete_instance_state_deployment_cleanup(ownership_root)
 
 
+def open_default_vault_service(registry_path: Path) -> InstanceDefaultVaultService:
+    """Hand the sealed storage-mutation capability to the MVR-02 default service.
+
+    This module is one of the sanctioned importers of the private capability
+    (`importlinter.ini :: instance-storage-capability-protected`), so the API
+    router and the headless CLI can both obtain a mutating service without
+    reaching the seal themselves.
+    """
+
+    from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+    return InstanceDefaultVaultService(
+        VaultRegistryStore(Path(registry_path)),
+        capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+
+
 def _default_vault_command(args: argparse.Namespace) -> int:
     """Headless MVR-02 get/set/clear through the same service the API uses.
 
@@ -2842,7 +2863,7 @@ def _default_vault_command(args: argparse.Namespace) -> int:
     instance through this surface.
     """
 
-    service = InstanceDefaultVaultService(VaultRegistryStore(Path(args.registry_path)))
+    service = open_default_vault_service(Path(args.registry_path))
     try:
         if args.command == "default-vault-get":
             receipt = service.get()

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2872,9 +2872,21 @@ def _default_vault_command(args: argparse.Namespace) -> int:
         else:
             receipt = service.clear()
     except (VaultSelectionError, RegistryDefaultConflict) as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        print(
+            json.dumps(
+                {"ok": False, "consumer": args.consumer, "error": str(exc)},
+                sort_keys=True,
+            )
+        )
         return 1
-    print(json.dumps({"ok": True, **receipt.as_dict()}, sort_keys=True))
+    # Deliberately no registry/content path in the receipt: `read-revision` owns
+    # path-identity proof, and this surface stays redaction-safe to paste.
+    payload: dict[str, object] = {
+        "ok": True,
+        "consumer": args.consumer,
+        **receipt.as_dict(),
+    }
+    print(json.dumps(payload, sort_keys=True))
     return 0
 
 
@@ -2946,6 +2958,10 @@ def main(argv: list[str] | None = None) -> int:
     for name in ("default-vault-get", "default-vault-set", "default-vault-clear"):
         command = subparsers.add_parser(name)
         command.add_argument("--registry-path", type=Path, required=True)
+        # `--consumer` mirrors `read-revision`: it names which enabled registry
+        # consumer is asking, so a cross-process durability check can prove each
+        # one resolved the same default rather than repeating one identical call.
+        command.add_argument("--consumer", default=None)
         if name == "default-vault-set":
             command.add_argument("--vault-binding-id", required=True)
     args = parser.parse_args(argv)

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -42,7 +42,6 @@ REGISTRY_AUTHORITY_DORMANT = "dormant"
 REGISTRY_AUTHORITY_ACTIVE = "active"
 SCALAR_ROLLBACK_SCHEMA = "agentic-pkm.scalar-rollback-floor.v1"
 ROLL_FORWARD_LINEAGE_SCHEMA = "agentic-pkm.scalar-roll-forward-lineage.v1"
-DEFAULT_VAULT_MIGRATION_SCHEMA = "agentic-pkm.instance-default-vault-migration.v1"
 _TRANSACTION_SCHEMA = "agentic-pkm.instance-vault-registry-transaction.v1"
 
 # MVR-02 explicit-default provenance vocabulary. ``last_active_vault_ref`` is
@@ -108,19 +107,6 @@ class RegistryDefaultConflict(RegistryError):
     """A mutation would leave the explicit instance default dangling or inferred."""
 
 
-def _default_migration_applied(extensions: Mapping[str, Any]) -> bool:
-    marker = extensions.get("defaultVaultMigration")
-    return isinstance(marker, dict) and marker.get("schema") == DEFAULT_VAULT_MIGRATION_SCHEMA
-
-
-def _default_migration_marker(provenance: str | None, revision: int) -> dict[str, Any]:
-    return {
-        "schema": DEFAULT_VAULT_MIGRATION_SCHEMA,
-        "appliedAtRevision": revision,
-        "provenance": provenance or "none",
-    }
-
-
 def _binding_for_ref(
     ref: str | None, registrations: Mapping[str, VaultRegistration]
 ) -> str | None:
@@ -134,51 +120,36 @@ def _binding_for_ref(
     return matches[0] if len(matches) == 1 else None
 
 
-def _materialize_legacy_last_active_default(
-    current: RegistrySnapshot,
-) -> RegistrySnapshot | None:
-    """Run the one-time MVR-02 default materialization, or return ``None``.
+def _read_default_from_frontmatter(
+    frontmatter: Mapping[str, Any],
+    registrations: Mapping[str, VaultRegistration],
+    extensions: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    """Read the explicit default, tolerating a pre-MVR-02 unlabelled value.
 
-    This is a migration, not a runtime precedence source. The
-    ``defaultVaultMigration`` marker is what makes "at most once" true, so the
-    marker is stamped **whenever this step runs at all** — including when it
-    decides to materialize nothing. Stamping only on success would leave the
-    step armed forever on a store that simply had no resolvable last-active yet,
-    turning a later picker write into a silent default inference. Every registry
-    this codebase creates is stamped at birth (:meth:`_empty_snapshot`) or at
-    legacy migration, so a marker-less current-schema store is by definition a
-    pre-MVR-02 install being seen for the first time.
+    MVR-02 always writes ``defaultVaultBindingId`` and ``defaultVaultProvenance``
+    together, so an id with **no** provenance is definitionally a value written
+    before this field existed — MVR-01 flattened `extensions` into the same
+    frontmatter, and `defaultVaultBindingId` was one of the keys it could carry.
+    Such a value is untrusted: it is adopted only when it names exactly one
+    current registration, and otherwise demoted to lineage. It is never an error,
+    because refusing to load an otherwise intact registry would take every
+    consumer's startup down on the exact population this slice upgrades.
+
+    A *labelled* default is held to the full fail-closed contract below: a
+    dangling binding or an unknown provenance is a hard error, because MVR-02
+    itself wrote it and no writer is allowed to produce that state.
     """
 
-    if _default_migration_applied(current.extensions):
-        return None
-    binding_id = (
-        None
-        if current.default_vault_binding_id is not None
-        else _binding_for_ref(current.last_active_vault_ref, current.registrations)
-    )
-    next_revision = current.revision + 1
-    extensions = copy.deepcopy(current.extensions)
-    extensions["defaultVaultMigration"] = _default_migration_marker(
-        DEFAULT_PROVENANCE_LEGACY_MIGRATION if binding_id is not None else None,
-        next_revision,
-    )
-    if current.authority == REGISTRY_AUTHORITY_ACTIVE:
-        floor = extensions.get("scalarRollback")
-        if not isinstance(floor, dict):
-            raise RegistryError("active registry scalar rollback floor is invalid")
-        extensions["scalarRollback"] = {**floor, "forkRegistryRevision": next_revision}
-    if binding_id is None:
-        # Nothing to materialize; record that the one-time step has now run so a
-        # later last-active write can never be mistaken for a legacy default.
-        return replace(current, revision=next_revision, extensions=extensions)
-    return replace(
-        current,
-        revision=next_revision,
-        extensions=extensions,
-        default_vault_binding_id=binding_id,
-        default_vault_provenance=DEFAULT_PROVENANCE_LEGACY_MIGRATION,
-    )
+    binding_id = _optional_str(frontmatter.get("defaultVaultBindingId"))
+    provenance = _optional_str(frontmatter.get("defaultVaultProvenance"))
+    if binding_id is not None and provenance is None:
+        if binding_id in registrations:
+            return binding_id, DEFAULT_PROVENANCE_EXPLICIT
+        extensions["legacyDefaultVaultBindingId"] = binding_id
+        return None, None
+    _assert_default_is_resolvable(binding_id, provenance, registrations)
+    return binding_id, provenance
 
 
 def _assert_default_is_resolvable(
@@ -351,13 +322,16 @@ class VaultRegistryStore:
                 return self._read_current_locked(recover=True)
             schema = _optional_str(document.frontmatter.get("schema"))
             if schema == CURRENT_REGISTRY_SCHEMA:
+                # Already migrated: nothing to do, and deliberately no write. The
+                # spec materializes a legacy last-active "during the one-time
+                # schema migration only", so the promotion lives in
+                # `_migrate_legacy_frontmatter` and nowhere else. A second
+                # materialization arm here would be a standing last-active rule
+                # wearing a migration's name, and would turn this read-named
+                # entry point into a writer that bypasses the scalar-rollback
+                # session guard every other writer holds.
                 _assert_private(self.path, directory=False)
-                current = self._snapshot_from_frontmatter(document.frontmatter)
-                materialized = _materialize_legacy_last_active_default(current)
-                if materialized is None:
-                    return current
-                self._write_locked(materialized)
-                return materialized
+                return self._snapshot_from_frontmatter(document.frontmatter)
             if schema != APP_LOCAL_SCHEMA:
                 raise RegistryMigrationError(f"unsupported registry migration schema: {schema or '<missing>'}")
             migrated = self._migrate_legacy_frontmatter(document.frontmatter)
@@ -451,17 +425,8 @@ class VaultRegistryStore:
             self._assert_revision(current, expected_revision)
             if target is not None and target not in current.registrations:
                 raise RegistryError(f"unknown vault_binding_id: {target}")
-            updated = self._with_registrations(current, dict(current.registrations))
-            extensions = copy.deepcopy(updated.extensions)
-            # An explicit command is authoritative over the one-time legacy
-            # materialization, so a later bootstrap can never re-materialize a
-            # deliberately cleared default from last-active history.
-            extensions["defaultVaultMigration"] = _default_migration_marker(
-                resolved_provenance, updated.revision
-            )
             updated = replace(
-                updated,
-                extensions=extensions,
+                self._with_registrations(current, dict(current.registrations)),
                 default_vault_binding_id=target,
                 default_vault_provenance=resolved_provenance,
             )
@@ -1109,11 +1074,6 @@ class VaultRegistryStore:
             app_install_id=f"app-{uuid4()}",
             last_active_vault_ref=None,
             registrations={},
-            # A registry born after MVR-02 has no legacy to migrate. Stamping the
-            # marker here is what keeps the one-time step from ever firing as a
-            # runtime rule on a fresh install, and keeps it from costing a
-            # spurious revision bump on the first `load_or_migrate`.
-            extensions={"defaultVaultMigration": _default_migration_marker(None, 0)},
         )
 
     def _assert_revision(self, current: RegistrySnapshot, expected: int | None) -> None:
@@ -1669,9 +1629,9 @@ class VaultRegistryStore:
         settings_rebind = frontmatter.get("settingsRebind")
         if settings_rebind is not None and not isinstance(settings_rebind, dict):
             raise RegistryError("settingsRebind must be a mapping")
-        default_binding_id = _optional_str(frontmatter.get("defaultVaultBindingId"))
-        default_provenance = _optional_str(frontmatter.get("defaultVaultProvenance"))
-        _assert_default_is_resolvable(default_binding_id, default_provenance, registrations)
+        default_binding_id, default_provenance = _read_default_from_frontmatter(
+            frontmatter, registrations, extensions
+        )
         return RegistrySnapshot(
             schema=schema,
             authority=authority,
@@ -1792,9 +1752,10 @@ class VaultRegistryStore:
             default_provenance = (
                 DEFAULT_PROVENANCE_LEGACY_MIGRATION if default_binding_id else None
             )
-        extensions["defaultVaultMigration"] = _default_migration_marker(
-            default_provenance, 1
-        )
+        # No separate "migration applied" marker: this branch runs only for an
+        # `APP_LOCAL_SCHEMA` document, and the schema transition it performs is
+        # itself the once-only guarantee. `default_vault_provenance` already
+        # records which producer set the default, which is what the spec asks for.
         return RegistrySnapshot(
             schema=CURRENT_REGISTRY_SCHEMA,
             authority=REGISTRY_AUTHORITY_DORMANT,
@@ -2407,7 +2368,6 @@ __all__ = [
     "DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING",
     "DEFAULT_PROVENANCE_LEGACY_MIGRATION",
     "DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE",
-    "DEFAULT_VAULT_MIGRATION_SCHEMA",
     "DEFAULT_VAULT_PROVENANCES",
     "AppLocalSettings",
     "AppLocalSettingsStore",

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -51,10 +51,15 @@ DEFAULT_PROVENANCE_LEGACY_MIGRATION = "legacy_last_active_migration"
 DEFAULT_PROVENANCE_FIRST_INITIALIZE = "first_vault_initialize"
 DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING = "first_open_existing"
 DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE = "roll_forward_restored"
+# A default carried over from a pre-MVR-02 image, adopted because it resolved.
+# It gets its own label rather than borrowing `explicit_default_command`: no
+# operator command ever set it, and provenance is supposed to be inspectable.
+DEFAULT_PROVENANCE_LEGACY_UNLABELLED = "legacy_unlabelled_adoption"
 DEFAULT_VAULT_PROVENANCES = frozenset(
     {
         DEFAULT_PROVENANCE_EXPLICIT,
         DEFAULT_PROVENANCE_LEGACY_MIGRATION,
+        DEFAULT_PROVENANCE_LEGACY_UNLABELLED,
         DEFAULT_PROVENANCE_FIRST_INITIALIZE,
         DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
         DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE,
@@ -145,7 +150,7 @@ def _read_default_from_frontmatter(
     provenance = _optional_str(frontmatter.get("defaultVaultProvenance"))
     if binding_id is not None and provenance is None:
         if binding_id in registrations:
-            return binding_id, DEFAULT_PROVENANCE_EXPLICIT
+            return binding_id, DEFAULT_PROVENANCE_LEGACY_UNLABELLED
         extensions["legacyDefaultVaultBindingId"] = binding_id
         return None, None
     _assert_default_is_resolvable(binding_id, provenance, registrations)
@@ -2367,6 +2372,7 @@ __all__ = [
     "DEFAULT_PROVENANCE_FIRST_INITIALIZE",
     "DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING",
     "DEFAULT_PROVENANCE_LEGACY_MIGRATION",
+    "DEFAULT_PROVENANCE_LEGACY_UNLABELLED",
     "DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE",
     "DEFAULT_VAULT_PROVENANCES",
     "AppLocalSettings",

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -108,13 +108,6 @@ class RegistryDefaultConflict(RegistryError):
     """A mutation would leave the explicit instance default dangling or inferred."""
 
 
-class _Unchanged:
-    """Sentinel distinguishing "leave the default alone" from "clear the default"."""
-
-
-_UNCHANGED = _Unchanged()
-
-
 def _default_migration_applied(extensions: Mapping[str, Any]) -> bool:
     marker = extensions.get("defaultVaultMigration")
     return isinstance(marker, dict) and marker.get("schema") == DEFAULT_VAULT_MIGRATION_SCHEMA
@@ -146,29 +139,39 @@ def _materialize_legacy_last_active_default(
 ) -> RegistrySnapshot | None:
     """Run the one-time MVR-02 default materialization, or return ``None``.
 
-    This is a migration, not a runtime precedence source: it fires at most once
-    per instance, only while no explicit default exists, and only when the legacy
-    ``last_active_vault_ref`` names exactly one current registration. Every later
-    last-active change leaves the default untouched.
+    This is a migration, not a runtime precedence source. The
+    ``defaultVaultMigration`` marker is what makes "at most once" true, so the
+    marker is stamped **whenever this step runs at all** — including when it
+    decides to materialize nothing. Stamping only on success would leave the
+    step armed forever on a store that simply had no resolvable last-active yet,
+    turning a later picker write into a silent default inference. Every registry
+    this codebase creates is stamped at birth (:meth:`_empty_snapshot`) or at
+    legacy migration, so a marker-less current-schema store is by definition a
+    pre-MVR-02 install being seen for the first time.
     """
 
     if _default_migration_applied(current.extensions):
         return None
-    if current.default_vault_binding_id is not None:
-        return None
-    binding_id = _binding_for_ref(current.last_active_vault_ref, current.registrations)
-    if binding_id is None:
-        return None
+    binding_id = (
+        None
+        if current.default_vault_binding_id is not None
+        else _binding_for_ref(current.last_active_vault_ref, current.registrations)
+    )
     next_revision = current.revision + 1
     extensions = copy.deepcopy(current.extensions)
     extensions["defaultVaultMigration"] = _default_migration_marker(
-        DEFAULT_PROVENANCE_LEGACY_MIGRATION, next_revision
+        DEFAULT_PROVENANCE_LEGACY_MIGRATION if binding_id is not None else None,
+        next_revision,
     )
     if current.authority == REGISTRY_AUTHORITY_ACTIVE:
         floor = extensions.get("scalarRollback")
         if not isinstance(floor, dict):
             raise RegistryError("active registry scalar rollback floor is invalid")
         extensions["scalarRollback"] = {**floor, "forkRegistryRevision": next_revision}
+    if binding_id is None:
+        # Nothing to materialize; record that the one-time step has now run so a
+        # later last-active write can never be mistaken for a legacy default.
+        return replace(current, revision=next_revision, extensions=extensions)
     return replace(
         current,
         revision=next_revision,
@@ -658,11 +661,16 @@ class VaultRegistryStore:
         transfer_lineage: tuple[TransferLineage, ...] | None = None,
         extensions: dict[str, Any] | None = None,
         expected_revision: int | None = None,
-        default_vault_binding_id: str | None | _Unchanged = _UNCHANGED,
-        default_vault_provenance: str = DEFAULT_PROVENANCE_EXPLICIT,
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
-        """Atomically commit one lifecycle/transfer state transition."""
+        """Atomically commit one lifecycle/transfer state transition.
+
+        The explicit instance default is carried through unchanged: MVR-02 owns
+        it through :meth:`set_instance_default` alone, so no lifecycle or
+        transfer transition can silently move, forge, or wipe it. A committed
+        registration set that would orphan the current default is refused
+        outright rather than quietly clearing it.
+        """
 
         _require_storage_mutation_capability(_capability)
         with self._locked():
@@ -688,20 +696,8 @@ class VaultRegistryStore:
                     **floor,
                     "forkRegistryRevision": next_revision,
                 }
-            if isinstance(default_vault_binding_id, _Unchanged):
-                next_default = current.default_vault_binding_id
-                next_default_provenance = current.default_vault_provenance
-            else:
-                next_default = _optional_str(default_vault_binding_id)
-                next_default_provenance = (
-                    None if next_default is None else default_vault_provenance
-                )
-                if next_default_provenance is not None and (
-                    next_default_provenance not in DEFAULT_VAULT_PROVENANCES
-                ):
-                    raise RegistryError(
-                        f"unsupported default provenance: {next_default_provenance}"
-                    )
+            next_default = current.default_vault_binding_id
+            next_default_provenance = current.default_vault_provenance
             if next_default is not None and next_default not in validated:
                 raise RegistryDefaultConflict(
                     "committed registration state would leave the instance default dangling"
@@ -732,14 +728,21 @@ class VaultRegistryStore:
     def set_extension_state(
         self,
         *,
-        default_vault_binding_id: str | None,
         dimensions: Mapping[str, object],
         principal_state: Mapping[str, object],
         background_state: Mapping[str, object],
         runtime_floors: Mapping[str, object],
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
-        """Persist the 01B mechanical state that must survive backup/restore."""
+        """Persist the 01B mechanical state that must survive backup/restore.
+
+        MVR-02 promoted the default from an opaque extension blob to a validated
+        first-class registry field with its own producer, so this 01B mechanical
+        writer no longer carries ``default_vault_binding_id`` at all. Letting it
+        would mean an unrelated dimensions/principal/background write could wipe
+        a durable operator default (when passed ``None``) or forge
+        ``explicit_default_command`` provenance (when passed a binding).
+        """
 
         _require_storage_mutation_capability(_capability)
         current = self.load()
@@ -752,14 +755,10 @@ class VaultRegistryStore:
                 "runtimeFloors": copy.deepcopy(dict(runtime_floors)),
             }
         )
-        # MVR-02 promoted the default from an opaque 01B extension blob to a
-        # validated first-class registry field, so this 01B producer now writes
-        # the authoritative field instead of a parallel extension copy.
         return self.commit_state(
             registrations=dict(current.registrations),
             extensions=extensions,
             expected_revision=current.revision,
-            default_vault_binding_id=default_vault_binding_id,
             _capability=_capability,
         )
 
@@ -1110,6 +1109,11 @@ class VaultRegistryStore:
             app_install_id=f"app-{uuid4()}",
             last_active_vault_ref=None,
             registrations={},
+            # A registry born after MVR-02 has no legacy to migrate. Stamping the
+            # marker here is what keeps the one-time step from ever firing as a
+            # runtime rule on a fresh install, and keeps it from costing a
+            # spurious revision bump on the first `load_or_migrate`.
+            extensions={"defaultVaultMigration": _default_migration_marker(None, 0)},
         )
 
     def _assert_revision(self, current: RegistrySnapshot, expected: int | None) -> None:

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -10,7 +10,7 @@ import os
 import stat
 import tempfile
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Protocol
@@ -42,7 +42,25 @@ REGISTRY_AUTHORITY_DORMANT = "dormant"
 REGISTRY_AUTHORITY_ACTIVE = "active"
 SCALAR_ROLLBACK_SCHEMA = "agentic-pkm.scalar-rollback-floor.v1"
 ROLL_FORWARD_LINEAGE_SCHEMA = "agentic-pkm.scalar-roll-forward-lineage.v1"
+DEFAULT_VAULT_MIGRATION_SCHEMA = "agentic-pkm.instance-default-vault-migration.v1"
 _TRANSACTION_SCHEMA = "agentic-pkm.instance-vault-registry-transaction.v1"
+
+# MVR-02 explicit-default provenance vocabulary. ``last_active_vault_ref`` is
+# interaction history and never becomes a default outside the one-time migration.
+DEFAULT_PROVENANCE_EXPLICIT = "explicit_default_command"
+DEFAULT_PROVENANCE_LEGACY_MIGRATION = "legacy_last_active_migration"
+DEFAULT_PROVENANCE_FIRST_INITIALIZE = "first_vault_initialize"
+DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING = "first_open_existing"
+DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE = "roll_forward_restored"
+DEFAULT_VAULT_PROVENANCES = frozenset(
+    {
+        DEFAULT_PROVENANCE_EXPLICIT,
+        DEFAULT_PROVENANCE_LEGACY_MIGRATION,
+        DEFAULT_PROVENANCE_FIRST_INITIALIZE,
+        DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
+        DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE,
+    }
+)
 
 _APP_DIR_NAME = "Agentic PKM"
 _SETTINGS_FILENAME = "app-local.md"
@@ -53,6 +71,8 @@ _REGISTRY_FIELDS = {
     "revision",
     "appInstallId",
     "lastActiveVaultRef",
+    "defaultVaultBindingId",
+    "defaultVaultProvenance",
     "registrations",
     "removalTombstones",
     "transferLineage",
@@ -82,6 +102,103 @@ class RegistryParseError(RegistryError):
 
 class RegistrySecurityError(RegistryError):
     """Registry path permissions, ownership, or type violate the private-state contract."""
+
+
+class RegistryDefaultConflict(RegistryError):
+    """A mutation would leave the explicit instance default dangling or inferred."""
+
+
+class _Unchanged:
+    """Sentinel distinguishing "leave the default alone" from "clear the default"."""
+
+
+_UNCHANGED = _Unchanged()
+
+
+def _default_migration_applied(extensions: Mapping[str, Any]) -> bool:
+    marker = extensions.get("defaultVaultMigration")
+    return isinstance(marker, dict) and marker.get("schema") == DEFAULT_VAULT_MIGRATION_SCHEMA
+
+
+def _default_migration_marker(provenance: str | None, revision: int) -> dict[str, Any]:
+    return {
+        "schema": DEFAULT_VAULT_MIGRATION_SCHEMA,
+        "appliedAtRevision": revision,
+        "provenance": provenance or "none",
+    }
+
+
+def _binding_for_ref(
+    ref: str | None, registrations: Mapping[str, VaultRegistration]
+) -> str | None:
+    """Resolve a legacy ``lastActiveVaultRef`` to exactly one binding, else ``None``."""
+
+    if ref is None:
+        return None
+    matches = [
+        binding_id for binding_id, item in registrations.items() if item.ref == ref
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _materialize_legacy_last_active_default(
+    current: RegistrySnapshot,
+) -> RegistrySnapshot | None:
+    """Run the one-time MVR-02 default materialization, or return ``None``.
+
+    This is a migration, not a runtime precedence source: it fires at most once
+    per instance, only while no explicit default exists, and only when the legacy
+    ``last_active_vault_ref`` names exactly one current registration. Every later
+    last-active change leaves the default untouched.
+    """
+
+    if _default_migration_applied(current.extensions):
+        return None
+    if current.default_vault_binding_id is not None:
+        return None
+    binding_id = _binding_for_ref(current.last_active_vault_ref, current.registrations)
+    if binding_id is None:
+        return None
+    next_revision = current.revision + 1
+    extensions = copy.deepcopy(current.extensions)
+    extensions["defaultVaultMigration"] = _default_migration_marker(
+        DEFAULT_PROVENANCE_LEGACY_MIGRATION, next_revision
+    )
+    if current.authority == REGISTRY_AUTHORITY_ACTIVE:
+        floor = extensions.get("scalarRollback")
+        if not isinstance(floor, dict):
+            raise RegistryError("active registry scalar rollback floor is invalid")
+        extensions["scalarRollback"] = {**floor, "forkRegistryRevision": next_revision}
+    return replace(
+        current,
+        revision=next_revision,
+        extensions=extensions,
+        default_vault_binding_id=binding_id,
+        default_vault_provenance=DEFAULT_PROVENANCE_LEGACY_MIGRATION,
+    )
+
+
+def _assert_default_is_resolvable(
+    default_vault_binding_id: str | None,
+    default_vault_provenance: str | None,
+    registrations: Mapping[str, VaultRegistration],
+) -> None:
+    """Fail closed on an unresolvable or unlabelled explicit instance default."""
+
+    if default_vault_binding_id is None:
+        if default_vault_provenance is not None:
+            raise RegistryDefaultConflict(
+                "default provenance is present without an explicit default binding"
+            )
+        return
+    if default_vault_binding_id not in registrations:
+        raise RegistryDefaultConflict(
+            f"explicit instance default is not registered: {default_vault_binding_id}"
+        )
+    if default_vault_provenance not in DEFAULT_VAULT_PROVENANCES:
+        raise RegistryDefaultConflict(
+            f"unsupported default provenance: {default_vault_provenance or '<missing>'}"
+        )
 
 
 @dataclass(frozen=True)
@@ -157,6 +274,8 @@ class RegistrySnapshot:
     transfer_lineage: tuple[TransferLineage, ...] = ()
     settings_rebind: dict[str, Any] | None = None
     extensions: dict[str, Any] = field(default_factory=dict)
+    default_vault_binding_id: str | None = None
+    default_vault_provenance: str | None = None
 
 
 class VaultRegistryStore:
@@ -230,7 +349,12 @@ class VaultRegistryStore:
             schema = _optional_str(document.frontmatter.get("schema"))
             if schema == CURRENT_REGISTRY_SCHEMA:
                 _assert_private(self.path, directory=False)
-                return self._snapshot_from_frontmatter(document.frontmatter)
+                current = self._snapshot_from_frontmatter(document.frontmatter)
+                materialized = _materialize_legacy_last_active_default(current)
+                if materialized is None:
+                    return current
+                self._write_locked(materialized)
+                return materialized
             if schema != APP_LOCAL_SCHEMA:
                 raise RegistryMigrationError(f"unsupported registry migration schema: {schema or '<missing>'}")
             migrated = self._migrate_legacy_frontmatter(document.frontmatter)
@@ -242,10 +366,28 @@ class VaultRegistryStore:
         registration: VaultRegistration,
         *,
         expected_revision: int | None = None,
+        first_default_provenance: str | None = None,
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
+        """Register one binding, optionally as the atomic MVR-02 first default.
+
+        ``first_default_provenance`` records the new binding as the explicit
+        instance default **inside this same locked transaction**, and only when
+        the transaction itself proves the registry had no prior registration and
+        no prior default. A later picker, open, or last-active write never infers
+        a default, so the first-vault journey stays a distinct producer rather
+        than a fallback rule.
+        """
+
         _require_storage_mutation_capability(_capability)
         self._validate_registration(registration)
+        if first_default_provenance is not None and first_default_provenance not in {
+            DEFAULT_PROVENANCE_FIRST_INITIALIZE,
+            DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
+        }:
+            raise RegistryError(
+                f"unsupported first-default provenance: {first_default_provenance}"
+            )
         with self._locked():
             self._assert_no_scalar_rollback_session_locked()
             current = (
@@ -259,8 +401,67 @@ class VaultRegistryStore:
             if existing is not None and existing != registration:
                 raise RegistryError(f"vault_binding_id collision: {registration.vault_binding_id}")
             self._assert_registration_unique(registration, registrations)
+            first_registration = not current.registrations
             registrations[registration.vault_binding_id] = registration
             updated = self._with_registrations(current, registrations)
+            if first_default_provenance is not None:
+                if not first_registration or current.default_vault_binding_id is not None:
+                    raise RegistryDefaultConflict(
+                        "the first-vault default producer requires an empty registry "
+                        "with no explicit default"
+                    )
+                updated = replace(
+                    updated,
+                    default_vault_binding_id=registration.vault_binding_id,
+                    default_vault_provenance=first_default_provenance,
+                )
+            self._write_locked(updated)
+            return updated
+
+    def set_instance_default(
+        self,
+        vault_binding_id: str | None,
+        *,
+        provenance: str = DEFAULT_PROVENANCE_EXPLICIT,
+        expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Set or clear the explicit instance default in one locked revision.
+
+        This never reads or writes ``last_active_vault_ref``: the default is
+        instance selection, last-active is interaction history, and MVR-02 keeps
+        them distinct. An unknown binding fails closed instead of falling through
+        to another registration.
+        """
+
+        _require_storage_mutation_capability(_capability)
+        target = _optional_str(vault_binding_id)
+        if target is None:
+            resolved_provenance: str | None = None
+        else:
+            if provenance not in DEFAULT_VAULT_PROVENANCES:
+                raise RegistryError(f"unsupported default provenance: {provenance}")
+            resolved_provenance = provenance
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            self._assert_revision(current, expected_revision)
+            if target is not None and target not in current.registrations:
+                raise RegistryError(f"unknown vault_binding_id: {target}")
+            updated = self._with_registrations(current, dict(current.registrations))
+            extensions = copy.deepcopy(updated.extensions)
+            # An explicit command is authoritative over the one-time legacy
+            # materialization, so a later bootstrap can never re-materialize a
+            # deliberately cleared default from last-active history.
+            extensions["defaultVaultMigration"] = _default_migration_marker(
+                resolved_provenance, updated.revision
+            )
+            updated = replace(
+                updated,
+                extensions=extensions,
+                default_vault_binding_id=target,
+                default_vault_provenance=resolved_provenance,
+            )
             self._write_locked(updated)
             return updated
 
@@ -363,6 +564,8 @@ class VaultRegistryStore:
                 transfer_lineage=copy.deepcopy(current.transfer_lineage),
                 settings_rebind=copy.deepcopy(current.settings_rebind),
                 extensions=extensions,
+                default_vault_binding_id=current.default_vault_binding_id,
+                default_vault_provenance=current.default_vault_provenance,
             )
             self._write_locked(updated)
             return updated
@@ -372,20 +575,78 @@ class VaultRegistryStore:
         vault_binding_id: str,
         *,
         expected_revision: int | None = None,
+        clear_default: bool = False,
+        replacement_default_binding_id: str | None = None,
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
-        """Remove one dormant registration; production removal remains sealed."""
+        """Remove one registration; production removal remains sealed.
+
+        MVR-02 makes this transaction reference-safe: removing the binding that
+        is currently the explicit instance default is a conflict unless the same
+        locked transaction also supplies ``clear_default`` or exactly one valid
+        authorized replacement. The removal never silently promotes another
+        registration and never leaves a dangling default behind.
+        """
 
         _require_storage_mutation_capability(_capability)
+        replacement = _optional_str(replacement_default_binding_id)
+        if clear_default and replacement is not None:
+            raise RegistryDefaultConflict(
+                "default removal takes either an explicit clear or one replacement, not both"
+            )
         with self._locked():
             self._assert_no_scalar_rollback_session_locked()
             current = self._read_current_locked(recover=True)
             self._assert_revision(current, expected_revision)
             if vault_binding_id not in current.registrations:
                 raise RegistryError(f"unknown vault_binding_id: {vault_binding_id}")
+            floor = current.extensions.get("scalarRollback")
+            if (
+                current.authority == REGISTRY_AUTHORITY_ACTIVE
+                and isinstance(floor, dict)
+                and _optional_str(floor.get("targetVaultBindingId")) == vault_binding_id
+            ):
+                # Reference safety is not only about the MVR-02 default: removing
+                # the MVR-01C scalar rollback target would write a registry whose
+                # own floor no longer resolves. Fail closed instead; retargeting
+                # the floor belongs to its owner, not to this transaction.
+                raise RegistryDefaultConflict(
+                    "removing the MVR-01C scalar rollback target requires an "
+                    "explicit authorized floor retarget"
+                )
             registrations = dict(current.registrations)
             del registrations[vault_binding_id]
             updated = self._with_registrations(current, registrations)
+            removes_default = current.default_vault_binding_id == vault_binding_id
+            if replacement is not None:
+                if replacement == vault_binding_id or replacement not in registrations:
+                    raise RegistryDefaultConflict(
+                        "replacement default must be another current registration"
+                    )
+                if not removes_default:
+                    raise RegistryDefaultConflict(
+                        "a replacement default is only valid when removing the current default"
+                    )
+                updated = replace(
+                    updated,
+                    default_vault_binding_id=replacement,
+                    default_vault_provenance=DEFAULT_PROVENANCE_EXPLICIT,
+                )
+            elif removes_default:
+                if not clear_default:
+                    raise RegistryDefaultConflict(
+                        "removing the current instance default requires an explicit "
+                        "clear_default or one authorized replacement binding"
+                    )
+                updated = replace(
+                    updated,
+                    default_vault_binding_id=None,
+                    default_vault_provenance=None,
+                )
+            elif clear_default:
+                raise RegistryDefaultConflict(
+                    "clear_default is only valid when removing the current default"
+                )
             self._write_locked(updated)
             return updated
 
@@ -397,6 +658,8 @@ class VaultRegistryStore:
         transfer_lineage: tuple[TransferLineage, ...] | None = None,
         extensions: dict[str, Any] | None = None,
         expected_revision: int | None = None,
+        default_vault_binding_id: str | None | _Unchanged = _UNCHANGED,
+        default_vault_provenance: str = DEFAULT_PROVENANCE_EXPLICIT,
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
         """Atomically commit one lifecycle/transfer state transition."""
@@ -425,6 +688,24 @@ class VaultRegistryStore:
                     **floor,
                     "forkRegistryRevision": next_revision,
                 }
+            if isinstance(default_vault_binding_id, _Unchanged):
+                next_default = current.default_vault_binding_id
+                next_default_provenance = current.default_vault_provenance
+            else:
+                next_default = _optional_str(default_vault_binding_id)
+                next_default_provenance = (
+                    None if next_default is None else default_vault_provenance
+                )
+                if next_default_provenance is not None and (
+                    next_default_provenance not in DEFAULT_VAULT_PROVENANCES
+                ):
+                    raise RegistryError(
+                        f"unsupported default provenance: {next_default_provenance}"
+                    )
+            if next_default is not None and next_default not in validated:
+                raise RegistryDefaultConflict(
+                    "committed registration state would leave the instance default dangling"
+                )
             updated = RegistrySnapshot(
                 schema=current.schema,
                 authority=current.authority,
@@ -442,6 +723,8 @@ class VaultRegistryStore:
                 ),
                 settings_rebind=copy.deepcopy(current.settings_rebind),
                 extensions=next_extensions,
+                default_vault_binding_id=next_default,
+                default_vault_provenance=next_default_provenance,
             )
             self._write_locked(updated)
             return updated
@@ -463,17 +746,20 @@ class VaultRegistryStore:
         extensions = copy.deepcopy(current.extensions)
         extensions.update(
             {
-                "defaultVaultBindingId": default_vault_binding_id,
                 "dimensions": copy.deepcopy(dict(dimensions)),
                 "principalState": copy.deepcopy(dict(principal_state)),
                 "backgroundState": copy.deepcopy(dict(background_state)),
                 "runtimeFloors": copy.deepcopy(dict(runtime_floors)),
             }
         )
+        # MVR-02 promoted the default from an opaque 01B extension blob to a
+        # validated first-class registry field, so this 01B producer now writes
+        # the authoritative field instead of a parallel extension copy.
         return self.commit_state(
             registrations=dict(current.registrations),
             extensions=extensions,
             expected_revision=current.revision,
+            default_vault_binding_id=default_vault_binding_id,
             _capability=_capability,
         )
 
@@ -556,6 +842,8 @@ class VaultRegistryStore:
                 transfer_lineage=copy.deepcopy(current.transfer_lineage),
                 settings_rebind=copy.deepcopy(current.settings_rebind),
                 extensions=extensions,
+                default_vault_binding_id=current.default_vault_binding_id,
+                default_vault_provenance=current.default_vault_provenance,
             )
             self._write_locked(activated)
             return activated
@@ -786,6 +1074,17 @@ class VaultRegistryStore:
                 **copy.deepcopy(floor),
                 "forkRegistryRevision": current.revision + 1,
             }
+            # MVR-02: the scalar previous image never carried the explicit
+            # default, so roll-forward restores the authoritative new-schema
+            # value rather than inferring one from the returning last-active
+            # projection. The merge verifies the binding still exists first; a
+            # default whose binding is gone is cleared atomically instead of
+            # being left dangling or silently repointed at another registration.
+            merged_default = current.default_vault_binding_id
+            merged_default_provenance = current.default_vault_provenance
+            if merged_default is not None and merged_default not in registrations:
+                merged_default = None
+                merged_default_provenance = None
             merged = RegistrySnapshot(
                 schema=current.schema,
                 authority=current.authority,
@@ -797,6 +1096,8 @@ class VaultRegistryStore:
                 transfer_lineage=copy.deepcopy(current.transfer_lineage),
                 settings_rebind=copy.deepcopy(current.settings_rebind),
                 extensions=extensions,
+                default_vault_binding_id=merged_default,
+                default_vault_provenance=merged_default_provenance,
             )
             self._write_locked(merged, retire_scalar_session=True)
             return merged
@@ -863,6 +1164,8 @@ class VaultRegistryStore:
             transfer_lineage=copy.deepcopy(current.transfer_lineage),
             settings_rebind=copy.deepcopy(current.settings_rebind),
             extensions=extensions,
+            default_vault_binding_id=current.default_vault_binding_id,
+            default_vault_provenance=current.default_vault_provenance,
         )
 
     @contextmanager
@@ -1281,6 +1584,8 @@ class VaultRegistryStore:
                 "revision": snapshot.revision,
                 "appInstallId": snapshot.app_install_id,
                 "lastActiveVaultRef": snapshot.last_active_vault_ref,
+                "defaultVaultBindingId": snapshot.default_vault_binding_id,
+                "defaultVaultProvenance": snapshot.default_vault_provenance,
                 "registrations": {
                     binding_id: _registration_to_frontmatter(item)
                     for binding_id, item in sorted(snapshot.registrations.items())
@@ -1360,6 +1665,9 @@ class VaultRegistryStore:
         settings_rebind = frontmatter.get("settingsRebind")
         if settings_rebind is not None and not isinstance(settings_rebind, dict):
             raise RegistryError("settingsRebind must be a mapping")
+        default_binding_id = _optional_str(frontmatter.get("defaultVaultBindingId"))
+        default_provenance = _optional_str(frontmatter.get("defaultVaultProvenance"))
+        _assert_default_is_resolvable(default_binding_id, default_provenance, registrations)
         return RegistrySnapshot(
             schema=schema,
             authority=authority,
@@ -1371,6 +1679,8 @@ class VaultRegistryStore:
             transfer_lineage=transfer_lineage,
             settings_rebind=copy.deepcopy(settings_rebind),
             extensions=extensions,
+            default_vault_binding_id=default_binding_id,
+            default_vault_provenance=default_provenance,
         )
 
     def _migrate_legacy_frontmatter(self, frontmatter: Mapping[str, Any]) -> RegistrySnapshot:
@@ -1449,16 +1759,49 @@ class VaultRegistryStore:
             "settingsRebind",
             "settingsRebindV1",
             "settings_rebind.v1",
+            "defaultVaultBindingId",
         }
+        last_active_vault_ref = _optional_str(frontmatter.get("lastActiveVaultRef"))
+        extensions = {
+            key: copy.deepcopy(value)
+            for key, value in frontmatter.items()
+            if key not in known_legacy_fields
+        }
+        # A legacy payload may already carry an explicit default. It is untrusted:
+        # binding identity is minted during this migration, so it is adopted only
+        # when it names exactly one migrated registration. Otherwise the raw value
+        # is preserved as lineage rather than silently dropped, and the one-time
+        # last-active materialization below decides the default instead.
+        legacy_default = _optional_str(frontmatter.get("defaultVaultBindingId"))
+        default_binding_id: str | None = None
+        default_provenance: str | None = None
+        if legacy_default is not None and legacy_default in registrations:
+            default_binding_id = legacy_default
+            default_provenance = DEFAULT_PROVENANCE_EXPLICIT
+        elif legacy_default is not None:
+            extensions["legacyDefaultVaultBindingId"] = legacy_default
+        if default_binding_id is None:
+            # MVR-02 one-time materialization: a picker-only legacy install keeps
+            # its restart journey by promoting a valid last-active reference to the
+            # explicit default exactly once, with recorded provenance.
+            default_binding_id = _binding_for_ref(last_active_vault_ref, registrations)
+            default_provenance = (
+                DEFAULT_PROVENANCE_LEGACY_MIGRATION if default_binding_id else None
+            )
+        extensions["defaultVaultMigration"] = _default_migration_marker(
+            default_provenance, 1
+        )
         return RegistrySnapshot(
             schema=CURRENT_REGISTRY_SCHEMA,
             authority=REGISTRY_AUTHORITY_DORMANT,
             revision=1,
             app_install_id=app_install_id,
-            last_active_vault_ref=_optional_str(frontmatter.get("lastActiveVaultRef")),
+            last_active_vault_ref=last_active_vault_ref,
             registrations=registrations,
             settings_rebind=rewritten_rebind,
-            extensions={key: copy.deepcopy(value) for key, value in frontmatter.items() if key not in known_legacy_fields},
+            extensions=extensions,
+            default_vault_binding_id=default_binding_id,
+            default_vault_provenance=default_provenance,
         )
 
 
@@ -2055,11 +2398,19 @@ def _is_sha256(value: str) -> bool:
 __all__ = [
     "APP_LOCAL_SCHEMA",
     "CURRENT_REGISTRY_SCHEMA",
+    "DEFAULT_PROVENANCE_EXPLICIT",
+    "DEFAULT_PROVENANCE_FIRST_INITIALIZE",
+    "DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING",
+    "DEFAULT_PROVENANCE_LEGACY_MIGRATION",
+    "DEFAULT_PROVENANCE_ROLL_FORWARD_RESTORE",
+    "DEFAULT_VAULT_MIGRATION_SCHEMA",
+    "DEFAULT_VAULT_PROVENANCES",
     "AppLocalSettings",
     "AppLocalSettingsStore",
     "CapabilityNotReadyError",
     "KnownVaultRef",
     "RegistryActivationProof",
+    "RegistryDefaultConflict",
     "RegistryError",
     "RegistryMigrationError",
     "RegistryRevisionConflict",

--- a/docs/CONCEPTS/VAULT_AND_SETTINGS_CONTEXT.md
+++ b/docs/CONCEPTS/VAULT_AND_SETTINGS_CONTEXT.md
@@ -194,6 +194,35 @@ Examples:
 
 On vault switch, services should stop old watchers/jobs, clear cached vault paths, reload settings, emit or handle `vault.changed`, and restart only when the next context is selected and permissions allow it.
 
+### Which vault a service starts on (shipped, MVR-02 / #3856)
+
+Gating answers *may this service run*. It does not answer *against which binding*. That second
+question is now resolved by one explicit instance-level resolver
+(`app/instance/default_vault.py`), not by interaction history:
+
+- Precedence is **one-request override → retained session selection → explicit
+  `default_vault_binding_id` → explicit legacy bootstrap adapter → no-vault**, and the resolved
+  selection reports which branch produced it. MVR-05 owns the HTTP carriers.
+- An unknown, removed, or unauthorized explicit selection **fails closed**. A service must
+  surface the selection failure rather than degrade to `last_active_vault_ref`, another registry
+  entry, the working directory, or `./vault` — a silent substitution is a write against the
+  wrong vault. No-vault stays a valid, truthful, idle result.
+- `default_vault_binding_id` is durable instance-local mechanical state on the MVR-01
+  instance-state volume, distinct from `last_active_vault_ref` (history) and from the
+  `VAULT_ROOT` env bootstrap (deployment). It survives restart and force-recreate; a
+  request/session selection does not survive unless its own session contract says so, and after
+  session loss the explicit default (or no-vault) is what becomes visible rather than a guessed
+  prior selection.
+- **Selection is not authority.** Resolving a binding never widens permissions: the gating rules
+  above, the write guard, and the GOV boundary still apply per binding before any content use.
+  The default is instance selection only — not authority, not UI state.
+- Setting or clearing the default is an authenticated administrative act through the API or the
+  headless CLI, and it publishes exactly one versioned `instance.default_vault.changed` event
+  (`docs/EVENTS.md`). It never mutates `last_active_vault_ref`.
+
+Full terminology, producers, provenance vocabulary, and the one-time last-active migration live
+in `docs/ENVIRONMENTS.md :: Vault terminology`.
+
 Suggested event payload:
 
 ```json

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -41,6 +41,63 @@ The four senses:
 - A **set-but-missing** content vault is a misconfiguration that fails loud (`VaultRootMisconfiguredError`), not a no-vault state.
 - Vault-settings and the test vault are unaffected by the no-vault-at-initiation contract; only the runtime binding may legitimately be absent at boot.
 
+<a id="instance-default-vault"></a>
+
+### Instance default vault (shipped, MVR-02 / #3856)
+
+A fourth binding-adjacent concept now exists alongside the four senses above, and it is
+**not** a fifth sense of "vault" — it names *which registered binding this instance starts
+on*, not what a vault is:
+
+- **`default_vault_binding_id`** — an explicit, durable, nullable field on the versioned
+  instance vault registry (`app/instance/vault_registry.py`), living on the MVR-01
+  instance-state volume. It survives restart and pinned-image force-recreate and resolves
+  identically in every enabled registry consumer (API, worker, watcher, Heimdal capture
+  watcher).
+- **It is distinct from `last_active_vault_ref`**, which stays interaction history, and from
+  the **`VAULT_ROOT` runtime binding**, which stays a deployment bootstrap. Neither is
+  promoted into the default at runtime. Conflating them is what made restarts
+  nondeterministic and turned an invalid explicit selection into a silent read/write against
+  the wrong vault.
+
+**Selection precedence (shipped resolver, `app/instance/default_vault.py`).** One resolver
+applies, in order: one-request override → retained session selection → instance default →
+explicit legacy bootstrap adapter → no-vault. It reports which branch won. An explicit
+selection that is unknown, removed, or unauthorized **fails closed** — it never falls through
+to last-active, another registry entry, the working directory, or `./vault`. No-vault remains
+a valid result. MVR-05 owns the HTTP carriers (`X-Active-Context-Override` and
+`X-Active-Context-Session`); MVR-02 accepts their parsed values as distinct resolver inputs.
+
+**How a default comes to exist.** Only through explicit producers, each provenance-tagged:
+
+- `explicit_default_command` — the authenticated `GET`/`PUT`/`DELETE /api/instance/default-vault`
+  route or the headless `python -m app.instance.runtime default-vault-get|-set|-clear`
+  commands. Both go through one service, one locked registry transaction, and one redacted
+  receipt, and neither ever writes `last_active_vault_ref`.
+- `legacy_last_active_migration` — a **one-time** registry migration that preserves an existing
+  picker-only install's restart journey by promoting a valid `last_active_vault_ref` to the
+  default when no default exists. It runs at most once per instance, is recorded in a
+  `defaultVaultMigration` marker, and is a migration only — never a later runtime precedence
+  source. Every subsequent last-active change leaves the default untouched.
+- `first_vault_initialize` / `first_open_existing` — the first-vault producers. On a registry
+  that the locked transaction itself proves has no prior registration and no prior default,
+  registration and default land in the same revision, exactly once. A later open, picker
+  change, or last-active write never replaces it, and explicitly initializing a provisional
+  read-only binding completes its identity without replacing the binding or the default.
+  MVR-05B owns the authenticated request ingress that reaches this producer from the picker.
+- `roll_forward_restored` — reserved for the scalar rollback lineage.
+
+**Compatibility and bootstrap posture.** The env bootstrap adapter deliberately does **not**
+create a default: `VAULT_ROOT` stays an explicit legacy bootstrap, not a hidden default. A
+compatibility `DEFAULT_VAULT_ID` is an untrusted *logical* vault-ID lookup that resolves only
+when that logical ID maps to exactly one local binding, and otherwise fails closed. Removing
+the registration that is currently the default returns a conflict unless the same locked
+transaction supplies either an explicit clear or one valid authorized replacement binding —
+never a silently substituted or dangling default. Every mutation publishes exactly one
+versioned `instance.default_vault.changed` event (see
+[EVENTS.md](EVENTS.md#instancedefault_vaultchanged)) carrying the new registry revision and
+no raw binding payload.
+
 <a id="vault-init"></a>
 
 ### Vault initialization and the personal-vault-write constraint

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -82,15 +82,21 @@ a valid result. MVR-05 owns the HTTP carriers (`X-Active-Context-Override` and
   revision and publishes no event.
 - `legacy_last_active_migration` — a **one-time** registry migration that preserves an existing
   picker-only install's restart journey by promoting a valid `last_active_vault_ref` to the
-  default when no default exists. It runs at most once per instance, is recorded in a
-  `defaultVaultMigration` marker, and is a migration only — never a later runtime precedence
-  source. Every subsequent last-active change leaves the default untouched.
+  default when no default exists. It lives in the legacy `design-handoff.app-local.v1` → registry
+  schema migration and nowhere else, so the schema transition itself is the once-only guarantee.
+  A registry already on the current schema is never given an inferred default, and every
+  subsequent last-active change leaves the default untouched. A value carried over from a
+  pre-MVR-02 image (an unlabelled `defaultVaultBindingId`) is untrusted: it is adopted only when it
+  names exactly one current registration, otherwise preserved as
+  `legacyDefaultVaultBindingId` lineage — never dropped, and never a reason to refuse to load an
+  otherwise intact registry.
 - `first_vault_initialize` / `first_open_existing` — the first-vault producers. On a registry
   that the locked transaction itself proves has no prior registration and no prior default,
   registration and default land in the same revision, exactly once. A later open, picker
   change, or last-active write never replaces it, and explicitly initializing a provisional
   read-only binding completes its identity without replacing the binding or the default.
-  MVR-05B owns the authenticated request ingress that reaches this producer from the picker.
+  MVR-05B owns the authenticated request ingress that reaches this producer from the picker, so
+  until that slice lands this producer has no production caller.
 - `roll_forward_restored` — reserved for the scalar rollback lineage.
 
 **Compatibility and bootstrap posture.** The env bootstrap adapter deliberately does **not**

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -62,7 +62,9 @@ on*, not what a vault is:
 
 **Selection precedence (shipped resolver, `app/instance/default_vault.py`).** One resolver
 applies, in order: one-request override → retained session selection → instance default →
-explicit legacy bootstrap adapter → no-vault. It reports which branch won. An explicit
+explicit legacy bootstrap adapter → no-vault. It reports which branch won, and reports a
+compatibility `DEFAULT_VAULT_ID` win distinctly from a durable operator-set default so "an env var
+resolved this" is never mistaken for "the instance is configured this way". An explicit
 selection that is unknown, removed, or unauthorized **fails closed** — it never falls through
 to last-active, another registry entry, the working directory, or `./vault`. No-vault remains
 a valid result. MVR-05 owns the HTTP carriers (`X-Active-Context-Override` and
@@ -73,7 +75,11 @@ a valid result. MVR-05 owns the HTTP carriers (`X-Active-Context-Override` and
 - `explicit_default_command` — the authenticated `GET`/`PUT`/`DELETE /api/instance/default-vault`
   route or the headless `python -m app.instance.runtime default-vault-get|-set|-clear`
   commands. Both go through one service, one locked registry transaction, and one redacted
-  receipt, and neither ever writes `last_active_vault_ref`.
+  receipt, and neither ever writes `last_active_vault_ref`. **This is the only writer of the
+  default.** Lifecycle, transfer, and mechanical instance-state commits carry it through unchanged
+  and refuse a registration set that would orphan it, so no unrelated write can wipe a durable
+  operator default or forge its provenance. A no-op set/clear is not a mutation: it burns no
+  revision and publishes no event.
 - `legacy_last_active_migration` — a **one-time** registry migration that preserves an existing
   picker-only install's restart journey by promoting a valid `last_active_vault_ref` to the
   default when no default exists. It runs at most once per instance, is recorded in a

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -87,9 +87,9 @@ a valid result. MVR-05 owns the HTTP carriers (`X-Active-Context-Override` and
   A registry already on the current schema is never given an inferred default, and every
   subsequent last-active change leaves the default untouched. A value carried over from a
   pre-MVR-02 image (an unlabelled `defaultVaultBindingId`) is untrusted: it is adopted only when it
-  names exactly one current registration, otherwise preserved as
-  `legacyDefaultVaultBindingId` lineage — never dropped, and never a reason to refuse to load an
-  otherwise intact registry.
+  names exactly one current registration — under its own `legacy_unlabelled_adoption` provenance,
+  because no operator command set it — and is otherwise preserved as `legacyDefaultVaultBindingId`
+  lineage. It is never dropped, and never a reason to refuse to load an otherwise intact registry.
 - `first_vault_initialize` / `first_open_existing` — the first-vault producers. On a registry
   that the locked transaction itself proves has no prior registration and no prior default,
   registration and default land in the same revision, exactly once. A later open, picker

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -669,8 +669,8 @@ Payload (registered schema `schemas/events/instance.default_vault.changed.v1.sch
 - `vault_binding_id` (`string|null`) — the new default, or `null` when cleared
 - `previous_vault_binding_id` (`string|null`)
 - `provenance` (`string|null`) — which MVR-02 producer recorded the default:
-  `explicit_default_command`, `legacy_last_active_migration`, `first_vault_initialize`,
-  `first_open_existing`, or `roll_forward_restored`
+  `explicit_default_command`, `legacy_last_active_migration`, `legacy_unlabelled_adoption`,
+  `first_vault_initialize`, `first_open_existing`, or `roll_forward_restored`
 
 Interpretation:
 - exactly one event per durable default mutation; the idempotency key is derived from

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -656,6 +656,32 @@ Contract:
 - `promote.*` and `promotion.*` names currently coexist; read them as belonging to the same broad
   transition family in the current runtime, not as proof of a finalized naming model.
 
+### `instance.default_vault.changed`
+
+Emitted when the explicit instance default vault is set, replaced, or cleared
+(MVR-02, #3856). Producer: `app/instance/default_vault.py`, the one service behind
+the authenticated `PUT`/`DELETE /api/instance/default-vault` route and the headless
+`python -m app.instance.runtime default-vault-set|default-vault-clear` commands.
+
+Payload (registered schema `schemas/events/instance.default_vault.changed.v1.schema.json`):
+- `event_version` (`integer`, always `1`)
+- `registry_revision` (`integer`) — the registry revision this mutation produced
+- `vault_binding_id` (`string|null`) — the new default, or `null` when cleared
+- `previous_vault_binding_id` (`string|null`)
+- `provenance` (`string|null`) — which MVR-02 producer recorded the default:
+  `explicit_default_command`, `legacy_last_active_migration`, `first_vault_initialize`,
+  `first_open_existing`, or `roll_forward_restored`
+
+Interpretation:
+- exactly one event per durable default mutation; the idempotency key is derived from
+  the registry revision, so a crash-retry of the same logical mutation yields one row,
+- lineage only — there is no `_dispatch_topic` branch; MVR-06 consumes this contract
+  for compatibility rebind,
+- reading the default never publishes,
+- **redaction is part of the contract**: the payload carries binding identity and the
+  registry revision only, never a content-root path, vault name, filesystem identity,
+  or any other raw binding payload.
+
 ### `index.embedding.requested`
 
 Requests that the indexer compute and upsert an embedding for an existing object.

--- a/docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md
+++ b/docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md
@@ -161,6 +161,24 @@ turns an invalid explicit selection into a dangerous silent read/write against t
 - `pytest -q -m "not pg"`
 - `ruff check app tests`
 
+## Delivered Scope Boundary (recorded at delivery, #3856)
+
+MVR-02 owns the first-vault default **transaction** and its atomicity:
+`InstanceRegistryRuntime.register_first_vault` records the new binding as the
+explicit default inside the same locked registration revision, only when that
+transaction itself proves an empty registry with no prior default. It does **not**
+own the request ingress that reaches that producer from the picker — that is
+MVR-05B's single-use authenticated bootstrap precondition, per
+`README.md :: Identity and selection`. Until 05B lands, the producer has no
+production caller and the first-vault acceptance criteria are proven against the
+production callable rather than through the shipped picker path.
+
+Likewise, the one-time last-active materialization lives in the legacy
+`design-handoff.app-local.v1` → registry schema migration and nowhere else, as
+"during the one-time schema migration only" requires. A registry already on the
+current schema is never given an inferred default: a second materialization arm
+would be a standing last-active precedence rule wearing a migration's name.
+
 ## Restart / Durability Posture
 
 `default_vault_binding_id` survives restart independently of later last-active history. The one-time

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -164,11 +164,17 @@ promote public internet readiness.
   smoke, ADR-index, and docs-guard paths remain.
 - The runbook uses affected-subsystem PR tests plus curated fitness gates before merges; the leased full non-PG/alpha-excluded suite is reserved for an explicit contract or cross-system blast-radius escalation.
 - PR-unit test selection maps Heimdal/Mimer implementation, contract-doc, and test paths to the scoped `tests/heimdal` and `tests/knowledge_acquisition` suites; an unmapped changed surface fails selection before pytest rather than producing a false-green run.
-- The dormant instance-local multi-vault registry core lives in `app/instance/vault_registry.py` and
-  is covered by the `vault` PR-unit suite through explicit ownership of `app/instance/**` and
-  `tests/instance/**`. It is a persistence/migration seam only: the legacy scalar app-local setting
-  remains runtime authority until the later default-selection and request-scoped resolution slices
-  ship. Unmapped changed surfaces continue to fail closed.
+- The instance-local multi-vault registry core lives in `app/instance/vault_registry.py` and is
+  covered by the `vault` PR-unit suite through explicit ownership of `app/instance/**` and
+  `tests/instance/**`. The registry stays `authority: dormant` until a deployment-time MVR-01C
+  authority cutover runs; until then the legacy scalar app-local setting remains runtime authority.
+  The **default-selection slice has shipped** (MVR-02, #3856): `default_vault_binding_id` is a
+  durable, validated registry field, and `app/instance/default_vault.py` is the one fail-closed
+  resolver (`override > session > instance default > explicit legacy bootstrap > no-vault`) plus the
+  one service behind the authenticated default-vault API route and the headless CLI.
+  **Request-scoped resolution has not shipped**: the `X-Active-Context-*` HTTP carriers, session
+  storage, and binding-keyed persistence remain MVR-03/05 work, so nothing in the request path
+  consumes the resolver yet. Unmapped changed surfaces continue to fail closed.
 
 Validation posture note:
 - blocking smoke/release gates are anchored to the active baseline in this document

--- a/schemas/events/instance.default_vault.changed.v1.schema.json
+++ b/schemas/events/instance.default_vault.changed.v1.schema.json
@@ -32,6 +32,7 @@
       "enum": [
         "explicit_default_command",
         "legacy_last_active_migration",
+        "legacy_unlabelled_adoption",
         "first_vault_initialize",
         "first_open_existing",
         "roll_forward_restored",

--- a/schemas/events/instance.default_vault.changed.v1.schema.json
+++ b/schemas/events/instance.default_vault.changed.v1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/instance.default_vault.changed.v1.schema.json",
+  "title": "instance.default_vault.changed payload (v1)",
+  "description": "Payload of the instance.default_vault.changed outbox event (MVR-02, #3856, docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md). Producer: app.instance.default_vault.InstanceDefaultVaultService, the one service behind the authenticated Companion API and the headless CLI get/set/clear commands. Emitted exactly once per durable default mutation (set, replace, or clear). Idempotency key basis: (topic, registry_revision, 'instance-default-vault-changed-v1') so a crash-retry of the same logical mutation cannot produce a second row. Lineage posture: no dispatched consumer; MVR-06 consumes this contract for compatibility rebind. Redaction: the payload carries binding identity and the new registry revision only, never a content-root path, vault name, filesystem identity, or any other raw binding payload.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_version", "registry_revision", "vault_binding_id"],
+  "properties": {
+    "event_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Payload contract version carried inside the event, independent of the registry filename suffix."
+    },
+    "registry_revision": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The registry revision produced by this mutation."
+    },
+    "vault_binding_id": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "The binding that is now the explicit instance default, or null when the default was cleared."
+    },
+    "previous_vault_binding_id": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "The binding that was the explicit instance default before this mutation, or null when there was none."
+    },
+    "provenance": {
+      "type": ["string", "null"],
+      "enum": [
+        "explicit_default_command",
+        "legacy_last_active_migration",
+        "first_vault_initialize",
+        "first_open_existing",
+        "roll_forward_restored",
+        null
+      ],
+      "description": "Which MVR-02 producer recorded the current default; null when the default is cleared."
+    }
+  }
+}

--- a/tests/_mvr_default_vault_harness.py
+++ b/tests/_mvr_default_vault_harness.py
@@ -1,0 +1,201 @@
+"""Shared MVR-02 harness: build a real, authoritative instance registry.
+
+The MVR-02 acceptance criteria require tests to drive *production* commands
+rather than seeding the store, so these helpers build the same authoritative
+registry the runtime builds at deployment time (env bootstrap, ownership ledger,
+quiescence proof, MVR-01C authority cutover) and hand back the live runtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import (
+    InstanceRegistryRuntime,
+    _begin_instance_state_deployment,
+    _bind_legacy_owner_inventory_to_proof,
+    _finish_instance_state_deployment,
+    _prove_instance_state_quiescence,
+)
+from app.instance.scalar_rollback_guard import preflight_scalar_rollback_guard
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def instance_state_root(tmp_path: Path) -> Path:
+    """The durable MVR-01 instance-state volume root for this fixture."""
+
+    return tmp_path / "instance-state"
+
+
+def new_runtime(tmp_path: Path, *, channel: str = "prod") -> InstanceRegistryRuntime:
+    return InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(instance_state_root(tmp_path), channel),
+        tmp_path / "host-global",
+    )
+
+
+def reopen_runtime(
+    runtime: InstanceRegistryRuntime, tmp_path: Path, *, channel: str = "prod"
+) -> InstanceRegistryRuntime:
+    """Re-attach a fresh process to the same durable instance-state volume.
+
+    Nothing in-memory carries over: this is the restart / force-recreate shape.
+    """
+
+    return InstanceRegistryRuntime(
+        InstanceStateLayout.for_channel(instance_state_root(tmp_path), channel),
+        type(runtime.ledger)(runtime.ledger.root),
+        initialize_layout=False,
+    )
+
+
+def guard_receipt(binding_id: str, root: Path):
+    return preflight_scalar_rollback_guard(
+        compose_overlay=REPO_ROOT / "docker-compose.scalar-rollback.yml",
+        gateway_config=REPO_ROOT / "ops/scalar-rollback/nginx.conf",
+        native_launcher=REPO_ROOT / "scripts/scalar_rollback_native.sh",
+        rollback_vault_binding_id=binding_id,
+        selected_root=root,
+    )
+
+
+def deployment_authority(runtime: InstanceRegistryRuntime, legacy_path: Path):
+    controller = {"pid": os.getpid(), "start_token": "linux:" + "0" * 64}
+    _begin_instance_state_deployment(
+        channel=runtime.layout.channel_id,
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=runtime.ledger.root,
+        legacy_path=legacy_path,
+        controller_pid=controller["pid"],
+        controller_start_token=controller["start_token"],
+    )
+    empty_domains = {domain: [] for domain in ("dev", "native", "prod", "test")}
+    empty_digest = hashlib.sha256(
+        json.dumps(empty_domains, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    quiescence_inventory = runtime.ledger.root / "deployment-quiescence-inventory.json"
+    quiescence_inventory.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-pkm.host-deployment-quiescence.v2",
+                "inventory_complete": True,
+                "all_consumers_stopped": True,
+                "probe_count": 2,
+                "controller": controller,
+                "domains": empty_domains,
+                "snapshot_digests": [empty_digest, empty_digest],
+            }
+        ),
+        encoding="utf-8",
+    )
+    quiescence_inventory.chmod(0o600)
+    proof = _prove_instance_state_quiescence(
+        channel=runtime.layout.channel_id,
+        host_global_root=runtime.ledger.root,
+        inventory_path=quiescence_inventory,
+    )
+    owners = [
+        {
+            "channel_id": lease.channel_id,
+            "vault_binding_id": binding_id,
+            "root": runtime.registry.load().registrations[binding_id].path,
+        }
+        for binding_id, lease in runtime.ledger.load().leases.items()
+    ]
+    owner_identities = []
+    for owner in owners:
+        metadata = os.stat(owner["root"])
+        owner_identities.append(
+            {
+                "channel_id": owner["channel_id"],
+                "root": owner["root"],
+                "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+            }
+        )
+    source_evidence = {
+        "docker": [],
+        "config": [],
+        "owners": owners,
+        "owner_identities": owner_identities,
+    }
+    owner_inventory = runtime.ledger.root / "legacy-owner-inventory.json"
+    owner_inventory.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-pkm.legacy-owner-inventory.v1",
+                "inventory_complete": True,
+                "writers_drained": True,
+                "source_probe_count": 2,
+                "validated_after_quiescence": True,
+                "source_digest": hashlib.sha256(
+                    json.dumps(
+                        source_evidence, sort_keys=True, separators=(",", ":")
+                    ).encode()
+                ).hexdigest(),
+                "source_evidence": source_evidence,
+                "owners": owners,
+            }
+        ),
+        encoding="utf-8",
+    )
+    owner_inventory.chmod(0o600)
+    bound = _bind_legacy_owner_inventory_to_proof(
+        inventory_path=owner_inventory,
+        quiescence_proof=proof,
+        channel=runtime.layout.channel_id,
+        host_global_root=runtime.ledger.root,
+    )
+    return bound, owner_inventory
+
+
+def activate(runtime: InstanceRegistryRuntime, first, tmp_path: Path) -> None:
+    """Run the MVR-01C authority cutover for an already-registered binding."""
+
+    proof, inventory = deployment_authority(runtime, tmp_path / "missing-legacy.md")
+    runtime.activate_authority(
+        guard_receipt=guard_receipt(first.vault_binding_id, Path(first.path)),
+        inventory_path=inventory,
+        quiescence_proof=proof,
+    )
+    _finish_instance_state_deployment(
+        channel=runtime.layout.channel_id,
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=runtime.ledger.root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        inventory_path=inventory,
+        backup_root=tmp_path / "authority-backup",
+        restore_root=None,
+        quiescence_proof=proof,
+    )
+
+
+def active_runtime(tmp_path: Path, *, extra_roots: tuple[str, ...] = ()):
+    """An authoritative registry bootstrapped from env plus optional extra bindings."""
+
+    runtime = new_runtime(tmp_path)
+    root = tmp_path / "one"
+    root.mkdir()
+    first = runtime.bootstrap_env_binding(vault_root=root, watcher_vault_path=root)
+    activate(runtime, first, tmp_path)
+    extra = []
+    for name in extra_roots:
+        extra_root = tmp_path / name
+        extra_root.mkdir()
+        extra.append(runtime.production_register(extra_root, producer="api"))
+    return runtime, first, tuple(extra)
+
+
+__all__ = [
+    "activate",
+    "active_runtime",
+    "deployment_authority",
+    "guard_receipt",
+    "instance_state_root",
+    "new_runtime",
+    "reopen_runtime",
+]

--- a/tests/api/test_default_vault_admin.py
+++ b/tests/api/test_default_vault_admin.py
@@ -21,8 +21,10 @@ from app.events.topic_schema_registry import (
     validate_topic_payload,
 )
 from app.events.types import INSTANCE_DEFAULT_VAULT_CHANGED
+from app.instance.default_vault import InstanceDefaultVaultService
 from app.instance.runtime import main as instance_runtime_main
 from app.instance.vault_registry import (
+    CapabilityNotReadyError,
     DEFAULT_PROVENANCE_EXPLICIT,
     RegistryDefaultConflict,
     VaultRegistryStore,
@@ -264,3 +266,30 @@ def test_removing_current_default_requires_atomic_clear_or_replacement(
     # The MVR-01C rollback floor target is protected by the same reference safety.
     with pytest.raises(RegistryDefaultConflict):
         service.remove_registration(first.vault_binding_id, clear_default=True)
+
+
+def test_default_service_without_the_sealed_capability_cannot_mutate(
+    bound_instance, captured_events
+) -> None:
+    """The service receives mutation authority; it never manufactures it.
+
+    Only `app.instance.runtime.open_default_vault_service` (a sanctioned importer
+    of `app/instance/_storage_boundary.py`) hands the capability over, so a
+    directly constructed service is a read-only view rather than a way around
+    the seal.
+    """
+
+    runtime, first, _second = bound_instance
+    unprivileged = InstanceDefaultVaultService(runtime.registry)
+    before = runtime.registry.load()
+
+    assert unprivileged.get().registry_revision == before.revision
+    with pytest.raises(CapabilityNotReadyError):
+        unprivileged.set(first.vault_binding_id)
+    with pytest.raises(CapabilityNotReadyError):
+        unprivileged.clear()
+
+    after = runtime.registry.load()
+    assert after.revision == before.revision
+    assert after.default_vault_binding_id == before.default_vault_binding_id
+    assert captured_events == []

--- a/tests/api/test_default_vault_admin.py
+++ b/tests/api/test_default_vault_admin.py
@@ -1,0 +1,266 @@
+"""MVR-02 (#3856): authenticated API + headless CLI default-vault administration.
+
+Contract: docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md
+
+These tests drive the two *production* producers rather than seeding the registry
+or calling an internal setter, and assert that both converge on one locked
+registry state, one redacted receipt, and one versioned mutation event.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.events.topic_schema_registry import (
+    current_schema_ref,
+    is_registered_topic,
+    validate_topic_payload,
+)
+from app.events.types import INSTANCE_DEFAULT_VAULT_CHANGED
+from app.instance.runtime import main as instance_runtime_main
+from app.instance.vault_registry import (
+    DEFAULT_PROVENANCE_EXPLICIT,
+    RegistryDefaultConflict,
+    VaultRegistryStore,
+)
+from tests._mvr_default_vault_harness import active_runtime, reopen_runtime
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture()
+def bound_instance(tmp_path, monkeypatch):
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    monkeypatch.setenv(
+        "INSTANCE_VAULT_REGISTRY_PATH", str(runtime.layout.registry_path)
+    )
+    monkeypatch.setenv("INSTANCE_OWNERSHIP_ROOT", str(runtime.ledger.root))
+    return runtime, first, extra[0]
+
+
+@pytest.fixture()
+def captured_events(monkeypatch) -> list[tuple[object, str]]:
+    from app.services import outbox as outbox_module
+
+    emitted: list[tuple[object, str]] = []
+
+    def _capture(event, conn=None, *, idempotency_key: str, required_db: bool = False):
+        emitted.append((event, idempotency_key))
+        return idempotency_key
+
+    monkeypatch.setattr(outbox_module, "write_outbox_event", _capture)
+    return emitted
+
+
+def _cli(*args: str) -> dict[str, object]:
+    from contextlib import redirect_stdout
+    from io import StringIO
+
+    buffer = StringIO()
+    with redirect_stdout(buffer):
+        code = instance_runtime_main(list(args))
+    payload = json.loads(buffer.getvalue().strip().splitlines()[-1])
+    payload["_exit_code"] = code
+    return payload
+
+
+def test_production_default_commands_share_one_service(
+    client, bound_instance, tmp_path, captured_events
+) -> None:
+    runtime, first, second = bound_instance
+    registry_path = str(runtime.layout.registry_path)
+
+    # The API sets the default...
+    response = client.put(
+        "/api/instance/default-vault",
+        json={"vault_binding_id": first.vault_binding_id},
+    )
+    assert response.status_code == 200, response.text
+    api_receipt = response.json()
+    assert api_receipt["vault_binding_id"] == first.vault_binding_id
+    assert api_receipt["provenance"] == DEFAULT_PROVENANCE_EXPLICIT
+
+    # ...and the headless CLI observes exactly the same locked registry state.
+    cli_get = _cli("default-vault-get", "--registry-path", registry_path)
+    assert cli_get["_exit_code"] == 0
+    assert cli_get["vault_binding_id"] == first.vault_binding_id
+    assert cli_get["registry_revision"] == api_receipt["registry_revision"]
+
+    # The CLI replaces it, and the API observes that.
+    cli_set = _cli(
+        "default-vault-set",
+        "--registry-path",
+        registry_path,
+        "--vault-binding-id",
+        second.vault_binding_id,
+    )
+    assert cli_set["_exit_code"] == 0
+    assert cli_set["previous_vault_binding_id"] == first.vault_binding_id
+    assert client.get("/api/instance/default-vault").json()["vault_binding_id"] == (
+        second.vault_binding_id
+    )
+
+    # Neither producer emits a content-root path or any other raw binding payload.
+    for receipt in (api_receipt, cli_get, cli_set):
+        rendered = json.dumps(receipt)
+        assert str(tmp_path) not in rendered
+        assert first.path not in rendered
+
+    # Both reject an unknown/unauthorized binding without changing state.
+    rejected = client.put(
+        "/api/instance/default-vault", json={"vault_binding_id": "binding-nope"}
+    )
+    assert rejected.status_code == 404
+    cli_rejected = _cli(
+        "default-vault-set",
+        "--registry-path",
+        registry_path,
+        "--vault-binding-id",
+        "binding-nope",
+    )
+    assert cli_rejected["_exit_code"] == 1
+    assert cli_rejected["ok"] is False
+    assert runtime.registry.load().default_vault_binding_id == second.vault_binding_id
+
+    # Clear converges too, and survives restart as an explicit absence.
+    assert client.delete("/api/instance/default-vault").status_code == 200
+    assert reopen_runtime(runtime, tmp_path).registry.load().default_vault_binding_id is None
+    assert (
+        _cli("default-vault-get", "--registry-path", registry_path)["vault_binding_id"]
+        is None
+    )
+
+
+def test_default_mutation_publishes_versioned_rebind_event(
+    client, bound_instance, captured_events
+) -> None:
+    runtime, first, second = bound_instance
+
+    response = client.put(
+        "/api/instance/default-vault",
+        json={"vault_binding_id": first.vault_binding_id},
+    )
+    assert response.status_code == 200, response.text
+
+    assert len(captured_events) == 1
+    event, idempotency_key = captured_events[0]
+    assert event.event_type == INSTANCE_DEFAULT_VAULT_CHANGED
+    assert idempotency_key
+    payload = event.payload
+    assert payload["event_version"] == 1
+    assert payload["registry_revision"] == runtime.registry.load().revision
+    assert payload["vault_binding_id"] == first.vault_binding_id
+    assert payload["previous_vault_binding_id"] is None
+    assert payload["provenance"] == DEFAULT_PROVENANCE_EXPLICIT
+
+    # The topic is a registered KERNEL-08 schema and the payload validates.
+    assert is_registered_topic(INSTANCE_DEFAULT_VAULT_CHANGED)
+    assert current_schema_ref(INSTANCE_DEFAULT_VAULT_CHANGED) == (
+        f"{INSTANCE_DEFAULT_VAULT_CHANGED}.v1"
+    )
+    validate_topic_payload(INSTANCE_DEFAULT_VAULT_CHANGED, payload)
+
+    # No raw binding payload: no path, ref, name, or filesystem identity.
+    assert set(payload) == {
+        "event_version",
+        "registry_revision",
+        "vault_binding_id",
+        "previous_vault_binding_id",
+        "provenance",
+    }
+
+    # Clearing publishes exactly one further event carrying the new revision.
+    assert client.delete("/api/instance/default-vault").status_code == 200
+    assert len(captured_events) == 2
+    cleared_payload = captured_events[1][0].payload
+    assert cleared_payload["vault_binding_id"] is None
+    assert cleared_payload["previous_vault_binding_id"] == first.vault_binding_id
+    assert cleared_payload["registry_revision"] == runtime.registry.load().revision
+    validate_topic_payload(INSTANCE_DEFAULT_VAULT_CHANGED, cleared_payload)
+
+    # A read never publishes.
+    assert client.get("/api/instance/default-vault").status_code == 200
+    assert len(captured_events) == 2
+
+
+def test_removing_current_default_requires_atomic_clear_or_replacement(
+    client, bound_instance, captured_events
+) -> None:
+    runtime, first, second = bound_instance
+    third_root = runtime.layout.root.parent.parent / "three"
+    third_root.mkdir()
+    third = runtime.production_register(third_root, producer="api")
+    service = runtime.default_vault_service()
+    # `first` is the MVR-01C scalar rollback floor target, so the default under
+    # test is a binding this transaction is actually allowed to remove.
+    client.put(
+        "/api/instance/default-vault",
+        json={"vault_binding_id": second.vault_binding_id},
+    )
+    before = runtime.registry.load()
+
+    # Removing the current default without saying what happens to it is a conflict,
+    # and the locked transaction leaves the registry untouched.
+    with pytest.raises(RegistryDefaultConflict):
+        service.remove_registration(second.vault_binding_id)
+    after_conflict = runtime.registry.load()
+    assert after_conflict.revision == before.revision
+    assert after_conflict.default_vault_binding_id == second.vault_binding_id
+    assert set(after_conflict.registrations) == set(before.registrations)
+
+    # A replacement must be another current registration, never an invented one,
+    # and clear/replace are mutually exclusive rather than quietly ordered.
+    with pytest.raises(RegistryDefaultConflict):
+        service.remove_registration(
+            second.vault_binding_id, replacement_default_binding_id="binding-nope"
+        )
+    with pytest.raises(RegistryDefaultConflict):
+        service.remove_registration(
+            second.vault_binding_id,
+            clear_default=True,
+            replacement_default_binding_id=third.vault_binding_id,
+        )
+    assert runtime.registry.load().revision == before.revision
+
+    # One explicit authorized replacement in the same locked transaction succeeds,
+    # and nothing dangles or is silently substituted.
+    receipt = service.remove_registration(
+        second.vault_binding_id,
+        replacement_default_binding_id=third.vault_binding_id,
+    )
+    merged = runtime.registry.load()
+    assert receipt.vault_binding_id == third.vault_binding_id
+    assert merged.default_vault_binding_id == third.vault_binding_id
+    assert second.vault_binding_id not in merged.registrations
+    assert merged.revision == before.revision + 1
+
+    # Removing a non-default registration must not carry a default gesture at all.
+    fourth_root = runtime.layout.root.parent.parent / "four"
+    fourth_root.mkdir()
+    fourth = runtime.production_register(fourth_root, producer="api")
+    with pytest.raises(RegistryDefaultConflict):
+        service.remove_registration(fourth.vault_binding_id, clear_default=True)
+
+    # The explicit-clear arm is equally atomic.
+    cleared = service.remove_registration(
+        third.vault_binding_id, clear_default=True
+    )
+    final = VaultRegistryStore(runtime.layout.registry_path).load()
+    assert cleared.vault_binding_id is None
+    assert final.default_vault_binding_id is None
+    assert final.default_vault_provenance is None
+    assert set(final.registrations) == {
+        first.vault_binding_id,
+        fourth.vault_binding_id,
+    }
+
+    # The MVR-01C rollback floor target is protected by the same reference safety.
+    with pytest.raises(RegistryDefaultConflict):
+        service.remove_registration(first.vault_binding_id, clear_default=True)

--- a/tests/api/test_default_vault_admin.py
+++ b/tests/api/test_default_vault_admin.py
@@ -279,17 +279,24 @@ def test_default_service_without_the_sealed_capability_cannot_mutate(
     the seal.
     """
 
-    runtime, first, _second = bound_instance
+    runtime, first, second = bound_instance
+    # A privileged producer establishes a default so both mutators have real work.
+    runtime.default_vault_service().set(first.vault_binding_id)
+    captured_events.clear()
     unprivileged = InstanceDefaultVaultService(runtime.registry)
     before = runtime.registry.load()
 
     assert unprivileged.get().registry_revision == before.revision
+    assert unprivileged.get().vault_binding_id == first.vault_binding_id
     with pytest.raises(CapabilityNotReadyError):
-        unprivileged.set(first.vault_binding_id)
+        unprivileged.set(second.vault_binding_id)
     with pytest.raises(CapabilityNotReadyError):
         unprivileged.clear()
+    with pytest.raises(CapabilityNotReadyError):
+        unprivileged.remove_registration(second.vault_binding_id)
 
     after = runtime.registry.load()
     assert after.revision == before.revision
-    assert after.default_vault_binding_id == before.default_vault_binding_id
+    assert after.default_vault_binding_id == first.vault_binding_id
+    assert set(after.registrations) == set(before.registrations)
     assert captured_events == []

--- a/tests/api/test_vault_registry_recovery.py
+++ b/tests/api/test_vault_registry_recovery.py
@@ -54,7 +54,11 @@ def test_populated_registry_corruption_never_reseeds_empty(tmp_path) -> None:
 
     assert recovered.revision == migrated.revision
     assert len(recovered.registrations) == 2
-    assert recovered.extensions["defaultVaultBindingId"] == "future-default"
+    # MVR-02 owns ``defaultVaultBindingId`` as a validated registry field. A legacy
+    # value that names no migrated registration is never adopted (that would be a
+    # dangling default) and is never silently dropped either: it survives as lineage.
+    assert recovered.default_vault_binding_id is None
+    assert recovered.extensions["legacyDefaultVaultBindingId"] == "future-default"
     assert recovered.extensions["dimensions"] == {"focus": ["future-default"]}
     assert recovered.extensions["backgroundIntent"] == {"mode": "explicit"}
 

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -121,6 +121,16 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         "committed before this runs, the JSONL append precedes the DB branch, and the "
         "caller discards the result"
     ),
+    ("app/instance/default_vault.py", "_emit_default_mutation_event"): (
+        "MVR-02 (#3856): the compensating sink is the durable registry revision itself. "
+        "set_instance_default commits the new default to the instance-state volume BEFORE "
+        "this runs, and the Multi-Vault Runtime cross-task invariant is that background "
+        "supervisors reconcile durable registry revisions, never event delivery — wake-up "
+        "hints are explicitly not the transition authority. No caller derives a success "
+        "signal from the return. Classifying it required_db=True would make the headless "
+        "`python -m app.instance.runtime default-vault-set` command unusable on a bare "
+        "instance that has no configured outbox at all"
+    ),
 }
 
 

--- a/tests/instance/test_default_vault_resolution.py
+++ b/tests/instance/test_default_vault_resolution.py
@@ -27,6 +27,8 @@ from app.instance.vault_registry import (
     KnownVaultRef,
     RegistryDefaultConflict,
     VaultRegistryStore,
+    _render_markdown_settings,
+    _split_rendered,
 )
 from app.vault.markdown_settings import MarkdownSettingsStore
 from tests._mvr_default_vault_harness import (
@@ -241,6 +243,139 @@ def test_legacy_last_active_materializes_default_once(tmp_path) -> None:
     cleared_revision = store.load().revision
     assert VaultRegistryStore(path).load_or_migrate().default_vault_binding_id is None
     assert VaultRegistryStore(path).load_or_migrate().revision == cleared_revision
+
+
+def test_migration_never_infers_a_default_on_a_post_mvr02_registry(tmp_path) -> None:
+    """The one-time step must not become a standing last-active rule.
+
+    Regression for the two ways "at most once" could quietly become "every load":
+    a registry that never carried legacy state, and a registry whose operator
+    deliberately cleared the default through a *removal* transaction rather than
+    through the explicit clear command.
+    """
+
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two", "three"))
+    picked, other = extra
+    store = VaultRegistryStore(runtime.layout.registry_path)
+
+    # 1. A registry born after MVR-02 has no legacy to migrate. A picker write
+    #    that sets last-active must not be promoted into a default, and the
+    #    read-named `load_or_migrate` must not burn a revision doing it.
+    runtime.registry.remember_registration(
+        picked.vault_binding_id,
+        KnownVaultRef(
+            ref=picked.ref,
+            path=picked.path,
+            vault_id=picked.vault_id,
+            local_instance_id=picked.local_instance_id,
+        ),
+        make_active=True,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    before = store.load()
+    assert before.last_active_vault_ref == picked.ref
+    assert before.default_vault_binding_id is None
+
+    migrated = store.load_or_migrate()
+    assert migrated.default_vault_binding_id is None
+    assert migrated.default_vault_provenance is None
+    assert migrated.revision == before.revision
+
+    # 2. An explicit clear through the removal transaction is just as final as
+    #    the clear command: a later load must not promote whatever happens to be
+    #    last-active into the default.
+    service = _service(runtime)
+    service.set(other.vault_binding_id)
+    service.remove_registration(other.vault_binding_id, clear_default=True)
+    after_removal = store.load()
+    assert after_removal.default_vault_binding_id is None
+    assert after_removal.last_active_vault_ref == picked.ref
+
+    reloaded = store.load_or_migrate()
+    assert reloaded.default_vault_binding_id is None
+    assert reloaded.revision == after_removal.revision
+
+    # 3. A mechanical MVR-01B extension write has no say over the default at all.
+    service.set(first.vault_binding_id)
+    revision_with_default = store.load().revision
+    runtime.registry.set_extension_state(
+        dimensions={"focus": [first.vault_binding_id]},
+        principal_state={"operator": "local"},
+        background_state={"mode": "compatibility"},
+        runtime_floors={"registry": "01b"},
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    mechanical = store.load()
+    assert mechanical.revision == revision_with_default + 1
+    assert mechanical.default_vault_binding_id == first.vault_binding_id
+    assert mechanical.default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
+
+
+def _strip_mvr02_marker(registry_path: Path, *, last_active_vault_ref: str | None) -> None:
+    """Rewrite a registry file into the shape a pre-MVR-02 install would have."""
+
+    frontmatter, body = _split_rendered(
+        registry_path.read_text(encoding="utf-8"), registry_path
+    )
+    frontmatter.pop("defaultVaultMigration", None)
+    frontmatter["defaultVaultBindingId"] = None
+    frontmatter["defaultVaultProvenance"] = None
+    frontmatter["lastActiveVaultRef"] = last_active_vault_ref
+    registry_path.write_text(
+        _render_markdown_settings(frontmatter, body), encoding="utf-8"
+    )
+    registry_path.chmod(0o600)
+
+
+def test_pre_mvr02_registry_arms_the_migration_exactly_once(tmp_path) -> None:
+    """A genuine pre-MVR-02 store is migrated on sight, even when nothing moves.
+
+    Regression: if the marker were stamped only when a default was actually
+    materialized, a legacy store that happened to have no resolvable last-active
+    at upgrade time would stay armed forever, and the next picker write would be
+    silently promoted into a default with a `legacy_last_active_migration` label
+    that is simply untrue.
+    """
+
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    picked = extra[0]
+    registry_path = runtime.layout.registry_path
+    _strip_mvr02_marker(registry_path, last_active_vault_ref=None)
+    store = VaultRegistryStore(registry_path)
+    before = store.load()
+    assert "defaultVaultMigration" not in before.extensions
+
+    # First sight of a pre-MVR-02 store: nothing to materialize, but the
+    # one-time step is now recorded as done.
+    armed = store.load_or_migrate()
+    assert armed.default_vault_binding_id is None
+    assert armed.extensions["defaultVaultMigration"]["provenance"] == "none"
+    assert armed.revision == before.revision + 1
+
+    # A later picker write is history, not a default.
+    runtime.registry.remember_registration(
+        picked.vault_binding_id,
+        KnownVaultRef(
+            ref=picked.ref,
+            path=picked.path,
+            vault_id=picked.vault_id,
+            local_instance_id=picked.local_instance_id,
+        ),
+        make_active=True,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    after_picker = store.load()
+    assert after_picker.last_active_vault_ref == picked.ref
+
+    reloaded = store.load_or_migrate()
+    assert reloaded.default_vault_binding_id is None
+    assert reloaded.revision == after_picker.revision
+
+    # And the legacy arm still works when there IS something to preserve.
+    _strip_mvr02_marker(registry_path, last_active_vault_ref=first.ref)
+    materialized = VaultRegistryStore(registry_path).load_or_migrate()
+    assert materialized.default_vault_binding_id == first.vault_binding_id
+    assert materialized.default_vault_provenance == DEFAULT_PROVENANCE_LEGACY_MIGRATION
 
 
 def test_first_vault_initialize_materializes_default_once(tmp_path) -> None:

--- a/tests/instance/test_default_vault_resolution.py
+++ b/tests/instance/test_default_vault_resolution.py
@@ -1,0 +1,295 @@
+"""MVR-02 (#3856): explicit instance default and fail-closed selection precedence.
+
+Contract: docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.instance.default_vault import (
+    SELECTION_INSTANCE_DEFAULT,
+    SELECTION_LEGACY_BOOTSTRAP,
+    SELECTION_NO_VAULT,
+    SELECTION_REQUEST_OVERRIDE,
+    SELECTION_SESSION,
+    InstanceDefaultVaultService,
+    VaultSelectionError,
+    resolve_vault_selection,
+)
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.vault_registry import (
+    DEFAULT_PROVENANCE_EXPLICIT,
+    DEFAULT_PROVENANCE_FIRST_INITIALIZE,
+    DEFAULT_PROVENANCE_LEGACY_MIGRATION,
+    KnownVaultRef,
+    RegistryDefaultConflict,
+    VaultRegistryStore,
+)
+from app.vault.markdown_settings import MarkdownSettingsStore
+from tests._mvr_default_vault_harness import (
+    activate,
+    active_runtime,
+    new_runtime,
+    reopen_runtime,
+)
+
+
+def _service(runtime) -> InstanceDefaultVaultService:
+    # No outbox/DB in these unit-level tests: the event contract itself is proven
+    # by tests/api/test_default_vault_admin.py against the production emitter.
+    return InstanceDefaultVaultService(runtime.registry, emit_event=lambda receipt: "")
+
+
+def test_production_resolution_precedence_is_explicit(tmp_path) -> None:
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two", "three"))
+    session_binding, override_binding = extra
+    service = _service(runtime)
+    service.set(first.vault_binding_id)
+
+    snapshot = runtime.registry.load()
+
+    # override > session > instance default > explicit legacy bootstrap > no-vault,
+    # and every branch reports which one won.
+    overridden = resolve_vault_selection(
+        snapshot,
+        request_override=override_binding.vault_binding_id,
+        session_selection=session_binding.vault_binding_id,
+        legacy_bootstrap_vault_root=Path(first.path),
+    )
+    assert overridden.vault_binding_id == override_binding.vault_binding_id
+    assert overridden.provenance == SELECTION_REQUEST_OVERRIDE
+
+    sessioned = resolve_vault_selection(
+        snapshot,
+        session_selection=session_binding.vault_binding_id,
+        legacy_bootstrap_vault_root=Path(first.path),
+    )
+    assert sessioned.vault_binding_id == session_binding.vault_binding_id
+    assert sessioned.provenance == SELECTION_SESSION
+
+    defaulted = resolve_vault_selection(
+        snapshot, legacy_bootstrap_vault_root=Path(extra[0].path)
+    )
+    assert defaulted.vault_binding_id == first.vault_binding_id
+    assert defaulted.provenance == SELECTION_INSTANCE_DEFAULT
+
+    service.clear()
+    cleared = runtime.registry.load()
+    bootstrapped = resolve_vault_selection(
+        cleared, legacy_bootstrap_vault_root=Path(session_binding.path)
+    )
+    assert bootstrapped.vault_binding_id == session_binding.vault_binding_id
+    assert bootstrapped.provenance == SELECTION_LEGACY_BOOTSTRAP
+
+    # Absence of every explicit input is a valid result, not an error.
+    empty = resolve_vault_selection(cleared)
+    assert empty.is_no_vault
+    assert empty.provenance == SELECTION_NO_VAULT
+
+    # A one-request override never persists into the retained session selection.
+    assert (
+        resolve_vault_selection(
+            cleared, session_selection=session_binding.vault_binding_id
+        ).vault_binding_id
+        == session_binding.vault_binding_id
+    )
+
+
+def test_invalid_explicit_selection_never_falls_through(tmp_path) -> None:
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    service = _service(runtime)
+    service.set(first.vault_binding_id)
+    snapshot = runtime.registry.load()
+    cwd_decoy = tmp_path / "vault"
+    cwd_decoy.mkdir()
+
+    for kwargs in (
+        {"request_override": "binding-does-not-exist"},
+        {"session_selection": "binding-does-not-exist"},
+    ):
+        with pytest.raises(VaultSelectionError):
+            resolve_vault_selection(
+                snapshot,
+                legacy_bootstrap_vault_root=Path(first.path),
+                **kwargs,
+            )
+
+    # An unknown compatibility DEFAULT_VAULT_ID is a fail-closed lookup, never a
+    # tiebreak against another registration.
+    cleared = _service(runtime)
+    cleared.clear()
+    with pytest.raises(VaultSelectionError):
+        resolve_vault_selection(
+            runtime.registry.load(), compatibility_default_vault_id="vault-unknown"
+        )
+
+    # An unregistered root does not become a binding, and `./vault` is never it.
+    with pytest.raises(VaultSelectionError):
+        resolve_vault_selection(
+            runtime.registry.load(), legacy_bootstrap_vault_root=cwd_decoy
+        )
+
+    # The failed selections changed nothing: last-active and the registration set
+    # are untouched, and no vault was silently substituted.
+    after = runtime.registry.load()
+    assert after.last_active_vault_ref == snapshot.last_active_vault_ref
+    assert set(after.registrations) == {
+        first.vault_binding_id,
+        extra[0].vault_binding_id,
+    }
+
+    # A default that is set can never be an unknown binding either.
+    with pytest.raises(VaultSelectionError):
+        _service(runtime).set("binding-does-not-exist")
+    assert runtime.registry.load().default_vault_binding_id is None
+
+
+def test_default_is_durable_and_distinct_from_last_active(tmp_path) -> None:
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    other = extra[0]
+    service = _service(runtime)
+    last_active_before = runtime.registry.load().last_active_vault_ref
+
+    receipt = service.set(other.vault_binding_id)
+    assert receipt.vault_binding_id == other.vault_binding_id
+    assert receipt.provenance == DEFAULT_PROVENANCE_EXPLICIT
+    # The redacted receipt carries no content-root path or vault name.
+    assert set(receipt.as_dict()) == {
+        "vault_binding_id",
+        "provenance",
+        "registry_revision",
+        "previous_vault_binding_id",
+        "changed",
+    }
+
+    # Restart: a brand new process re-attached to the same durable volume.
+    restarted = reopen_runtime(runtime, tmp_path)
+    snapshot = restarted.registry.load()
+    assert snapshot.default_vault_binding_id == other.vault_binding_id
+    assert snapshot.last_active_vault_ref == last_active_before
+    assert (
+        resolve_vault_selection(snapshot).vault_binding_id == other.vault_binding_id
+    )
+
+    # Clearing is equally durable and equally leaves last-active alone.
+    _service(restarted).clear()
+    after_clear = reopen_runtime(runtime, tmp_path).registry.load()
+    assert after_clear.default_vault_binding_id is None
+    assert after_clear.default_vault_provenance is None
+    assert after_clear.last_active_vault_ref == last_active_before
+    assert resolve_vault_selection(after_clear).is_no_vault
+    assert first.vault_binding_id in after_clear.registrations
+
+
+def test_legacy_last_active_materializes_default_once(tmp_path) -> None:
+    # A picker-only single-vault legacy install: known vault plus last-active,
+    # no explicit default anywhere.
+    legacy_root = tmp_path / "picker-vault"
+    legacy_root.mkdir()
+    path = tmp_path / "vault-registry.md"
+    MarkdownSettingsStore().write_frontmatter(
+        path,
+        {
+            "schema": "design-handoff.app-local.v1",
+            "scope": "app-local",
+            "appInstallId": "app-legacy-picker",
+            "lastActiveVaultRef": f"path:{legacy_root}",
+            "knownVaults": {
+                f"path:{legacy_root}": {
+                    "path": str(legacy_root),
+                    "vaultId": "vault-legacy",
+                    "localInstanceId": "local-legacy",
+                }
+            },
+        },
+    )
+    store = VaultRegistryStore(path)
+
+    migrated = store.load_or_migrate()
+
+    binding_id = next(iter(migrated.registrations))
+    assert migrated.default_vault_binding_id == binding_id
+    assert migrated.default_vault_provenance == DEFAULT_PROVENANCE_LEGACY_MIGRATION
+    assert migrated.extensions["defaultVaultMigration"]["provenance"] == (
+        DEFAULT_PROVENANCE_LEGACY_MIGRATION
+    )
+    # The restart journey is preserved: resolution lands on the same binding.
+    assert (
+        resolve_vault_selection(migrated).vault_binding_id == binding_id
+    )
+    assert resolve_vault_selection(migrated).provenance == SELECTION_INSTANCE_DEFAULT
+
+    # Restart is stable and the migration does not run twice.
+    reloaded = VaultRegistryStore(path).load_or_migrate()
+    assert reloaded.revision == migrated.revision
+    assert reloaded.default_vault_binding_id == binding_id
+
+    # A later selection moves last-active only; the default is not a follower.
+    _service_store = InstanceDefaultVaultService(store, emit_event=lambda receipt: "")
+    _service_store.clear()
+    cleared_revision = store.load().revision
+    assert VaultRegistryStore(path).load_or_migrate().default_vault_binding_id is None
+    assert VaultRegistryStore(path).load_or_migrate().revision == cleared_revision
+
+
+def test_first_vault_initialize_materializes_default_once(tmp_path) -> None:
+    runtime = new_runtime(tmp_path)
+    root = tmp_path / "first-vault"
+    root.mkdir()
+
+    registration = runtime.register_first_vault(
+        root, provenance=DEFAULT_PROVENANCE_FIRST_INITIALIZE
+    )
+
+    snapshot = runtime.registry.load()
+    assert snapshot.default_vault_binding_id == registration.vault_binding_id
+    assert snapshot.default_vault_provenance == DEFAULT_PROVENANCE_FIRST_INITIALIZE
+    assert (
+        resolve_vault_selection(snapshot).vault_binding_id
+        == registration.vault_binding_id
+    )
+
+    # Registration and default landed in one revision: the transaction is atomic,
+    # not two writes with a window where the binding has no restart source.
+    assert snapshot.revision == 1
+
+    # The producer is once-only: a second first-vault gesture is a conflict, not a
+    # silent re-point of the explicit default.
+    second_root = tmp_path / "second-vault"
+    second_root.mkdir()
+    with pytest.raises(RegistryDefaultConflict):
+        runtime.register_first_vault(
+            second_root, provenance=DEFAULT_PROVENANCE_FIRST_INITIALIZE
+        )
+    assert (
+        runtime.registry.load().default_vault_binding_id
+        == registration.vault_binding_id
+    )
+
+    # A later picker write moves last-active only; the default is not a follower.
+    activate(runtime, registration, tmp_path)
+    runtime.registry.remember_registration(
+        registration.vault_binding_id,
+        KnownVaultRef(
+            ref=registration.ref,
+            path=registration.path,
+            vault_id=registration.vault_id,
+            local_instance_id=registration.local_instance_id,
+            vault_name="renamed-by-picker",
+            last_opened_at="2026-08-01T00:00:00Z",
+        ),
+        make_active=True,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    after_picker = runtime.registry.load()
+    assert after_picker.last_active_vault_ref == registration.ref
+    assert after_picker.default_vault_binding_id == registration.vault_binding_id
+    assert after_picker.default_vault_provenance == DEFAULT_PROVENANCE_FIRST_INITIALIZE
+    # Restart still lands on the same binding without reselection.
+    assert (
+        reopen_runtime(runtime, tmp_path).registry.load().default_vault_binding_id
+        == registration.vault_binding_id
+    )

--- a/tests/instance/test_default_vault_resolution.py
+++ b/tests/instance/test_default_vault_resolution.py
@@ -24,6 +24,7 @@ from app.instance.vault_registry import (
     DEFAULT_PROVENANCE_EXPLICIT,
     DEFAULT_PROVENANCE_FIRST_INITIALIZE,
     DEFAULT_PROVENANCE_LEGACY_MIGRATION,
+    DEFAULT_PROVENANCE_LEGACY_UNLABELLED,
     KnownVaultRef,
     RegistryDefaultConflict,
     VaultRegistryStore,
@@ -352,7 +353,8 @@ def test_pre_mvr02_default_key_never_bricks_an_intact_registry(tmp_path) -> None
     )
     adopted = VaultRegistryStore(registry_path).load()
     assert adopted.default_vault_binding_id == first.vault_binding_id
-    assert adopted.default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
+    # Its own label: no operator command set it, so it must not claim one.
+    assert adopted.default_vault_provenance == DEFAULT_PROVENANCE_LEGACY_UNLABELLED
 
     # 2. An unresolvable legacy value is demoted to lineage, never dropped and
     #    never fatal. The instance resolves to no-vault, which is fail-closed.

--- a/tests/instance/test_default_vault_resolution.py
+++ b/tests/instance/test_default_vault_resolution.py
@@ -40,7 +40,11 @@ from tests._mvr_default_vault_harness import (
 def _service(runtime) -> InstanceDefaultVaultService:
     # No outbox/DB in these unit-level tests: the event contract itself is proven
     # by tests/api/test_default_vault_admin.py against the production emitter.
-    return InstanceDefaultVaultService(runtime.registry, emit_event=lambda receipt: "")
+    return InstanceDefaultVaultService(
+        runtime.registry,
+        capability=_STORAGE_MUTATION_CAPABILITY,
+        emit_event=lambda receipt: "",
+    )
 
 
 def test_production_resolution_precedence_is_explicit(tmp_path) -> None:
@@ -228,7 +232,11 @@ def test_legacy_last_active_materializes_default_once(tmp_path) -> None:
     assert reloaded.default_vault_binding_id == binding_id
 
     # A later selection moves last-active only; the default is not a follower.
-    _service_store = InstanceDefaultVaultService(store, emit_event=lambda receipt: "")
+    _service_store = InstanceDefaultVaultService(
+        store,
+        capability=_STORAGE_MUTATION_CAPABILITY,
+        emit_event=lambda receipt: "",
+    )
     _service_store.clear()
     cleared_revision = store.load().revision
     assert VaultRegistryStore(path).load_or_migrate().default_vault_binding_id is None

--- a/tests/instance/test_default_vault_resolution.py
+++ b/tests/instance/test_default_vault_resolution.py
@@ -27,6 +27,7 @@ from app.instance.vault_registry import (
     KnownVaultRef,
     RegistryDefaultConflict,
     VaultRegistryStore,
+    _assert_default_is_resolvable,
     _render_markdown_settings,
     _split_rendered,
 )
@@ -219,9 +220,6 @@ def test_legacy_last_active_materializes_default_once(tmp_path) -> None:
     binding_id = next(iter(migrated.registrations))
     assert migrated.default_vault_binding_id == binding_id
     assert migrated.default_vault_provenance == DEFAULT_PROVENANCE_LEGACY_MIGRATION
-    assert migrated.extensions["defaultVaultMigration"]["provenance"] == (
-        DEFAULT_PROVENANCE_LEGACY_MIGRATION
-    )
     # The restart journey is preserved: resolution lands on the same binding.
     assert (
         resolve_vault_selection(migrated).vault_binding_id == binding_id
@@ -246,21 +244,21 @@ def test_legacy_last_active_materializes_default_once(tmp_path) -> None:
 
 
 def test_migration_never_infers_a_default_on_a_post_mvr02_registry(tmp_path) -> None:
-    """The one-time step must not become a standing last-active rule.
+    """An explicit clear is final, and no mechanical write can undo it.
 
-    Regression for the two ways "at most once" could quietly become "every load":
-    a registry that never carried legacy state, and a registry whose operator
-    deliberately cleared the default through a *removal* transaction rather than
-    through the explicit clear command.
+    Companion to `test_load_or_migrate_never_materializes_on_a_current_schema_registry`:
+    that one proves the read path never infers, this one proves the two *write*
+    paths that could otherwise resurrect or forge a default do not — a clear
+    performed through the removal transaction, and an unrelated MVR-01B
+    mechanical state write.
     """
 
     runtime, first, extra = active_runtime(tmp_path, extra_roots=("two", "three"))
     picked, other = extra
     store = VaultRegistryStore(runtime.layout.registry_path)
 
-    # 1. A registry born after MVR-02 has no legacy to migrate. A picker write
-    #    that sets last-active must not be promoted into a default, and the
-    #    read-named `load_or_migrate` must not burn a revision doing it.
+    # 1. Establish a picker last-active so every later arm has something that an
+    #    inference bug could latch onto.
     runtime.registry.remember_registration(
         picked.vault_binding_id,
         KnownVaultRef(
@@ -311,48 +309,105 @@ def test_migration_never_infers_a_default_on_a_post_mvr02_registry(tmp_path) -> 
     assert mechanical.default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
 
 
-def _strip_mvr02_marker(registry_path: Path, *, last_active_vault_ref: str | None) -> None:
-    """Rewrite a registry file into the shape a pre-MVR-02 install would have."""
+def _rewrite_frontmatter(registry_path: Path, **fields: object) -> None:
+    """Rewrite registry frontmatter in place, as an older image could have left it."""
 
     frontmatter, body = _split_rendered(
         registry_path.read_text(encoding="utf-8"), registry_path
     )
-    frontmatter.pop("defaultVaultMigration", None)
-    frontmatter["defaultVaultBindingId"] = None
-    frontmatter["defaultVaultProvenance"] = None
-    frontmatter["lastActiveVaultRef"] = last_active_vault_ref
+    for key, value in fields.items():
+        if value is _DROP:
+            frontmatter.pop(key, None)
+        else:
+            frontmatter[key] = value
     registry_path.write_text(
         _render_markdown_settings(frontmatter, body), encoding="utf-8"
     )
     registry_path.chmod(0o600)
 
 
-def test_pre_mvr02_registry_arms_the_migration_exactly_once(tmp_path) -> None:
-    """A genuine pre-MVR-02 store is migrated on sight, even when nothing moves.
+_DROP = object()
 
-    Regression: if the marker were stamped only when a default was actually
-    materialized, a legacy store that happened to have no resolvable last-active
-    at upgrade time would stay armed forever, and the next picker write would be
-    silently promoted into a default with a `legacy_last_active_migration` label
-    that is simply untrue.
+
+def test_pre_mvr02_default_key_never_bricks_an_intact_registry(tmp_path) -> None:
+    """An unlabelled `defaultVaultBindingId` is untrusted lineage, not a fatal error.
+
+    MVR-01 flattened `extensions` into the same frontmatter, so a registry written
+    by the previous image can legitimately carry `defaultVaultBindingId` with no
+    `defaultVaultProvenance`. Promoting that key to a validated first-class field
+    must not make an otherwise intact registry unloadable — recovery cannot save
+    it either, because the last-good snapshot holds the identical bytes, so every
+    consumer's startup preflight would fail on the exact population this slice
+    exists to upgrade.
+    """
+
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    registry_path = runtime.layout.registry_path
+
+    # 1. A resolvable legacy value with no provenance is adopted as explicit.
+    _rewrite_frontmatter(
+        registry_path,
+        defaultVaultBindingId=first.vault_binding_id,
+        defaultVaultProvenance=_DROP,
+    )
+    adopted = VaultRegistryStore(registry_path).load()
+    assert adopted.default_vault_binding_id == first.vault_binding_id
+    assert adopted.default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
+
+    # 2. An unresolvable legacy value is demoted to lineage, never dropped and
+    #    never fatal. The instance resolves to no-vault, which is fail-closed.
+    _rewrite_frontmatter(
+        registry_path,
+        defaultVaultBindingId="binding-from-a-previous-image",
+        defaultVaultProvenance=_DROP,
+    )
+    demoted = VaultRegistryStore(registry_path).load()
+    assert demoted.default_vault_binding_id is None
+    assert demoted.default_vault_provenance is None
+    assert demoted.extensions["legacyDefaultVaultBindingId"] == (
+        "binding-from-a-previous-image"
+    )
+    assert resolve_vault_selection(demoted).is_no_vault
+    assert set(demoted.registrations) == {
+        first.vault_binding_id,
+        extra[0].vault_binding_id,
+    }
+
+    # 3. A *labelled* default is still held to the full fail-closed contract:
+    #    MVR-02 wrote it, so a dangling binding is rejected outright rather than
+    #    demoted to lineage. The strict rule is asserted directly, because a
+    #    store-level load would legitimately mask it by recovering the last-good
+    #    snapshot (which is exactly what recovery is for).
+    with pytest.raises(RegistryDefaultConflict):
+        _assert_default_is_resolvable(
+            "binding-that-is-not-registered",
+            DEFAULT_PROVENANCE_EXPLICIT,
+            demoted.registrations,
+        )
+    _rewrite_frontmatter(
+        registry_path,
+        defaultVaultBindingId="binding-that-is-not-registered",
+        defaultVaultProvenance=DEFAULT_PROVENANCE_EXPLICIT,
+    )
+    recovered = VaultRegistryStore(registry_path).load()
+    assert recovered.default_vault_binding_id != "binding-that-is-not-registered"
+
+
+def test_load_or_migrate_never_materializes_on_a_current_schema_registry(
+    tmp_path,
+) -> None:
+    """The last-active promotion lives in the schema migration and nowhere else.
+
+    The spec materializes a legacy last-active "during the one-time schema
+    migration only". A second materialization arm on the already-migrated schema
+    would be a standing last-active rule wearing a migration's name, and would
+    make this read-named entry point a writer that skips the scalar-rollback
+    session guard every other writer holds.
     """
 
     runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
     picked = extra[0]
-    registry_path = runtime.layout.registry_path
-    _strip_mvr02_marker(registry_path, last_active_vault_ref=None)
-    store = VaultRegistryStore(registry_path)
-    before = store.load()
-    assert "defaultVaultMigration" not in before.extensions
-
-    # First sight of a pre-MVR-02 store: nothing to materialize, but the
-    # one-time step is now recorded as done.
-    armed = store.load_or_migrate()
-    assert armed.default_vault_binding_id is None
-    assert armed.extensions["defaultVaultMigration"]["provenance"] == "none"
-    assert armed.revision == before.revision + 1
-
-    # A later picker write is history, not a default.
+    store = VaultRegistryStore(runtime.layout.registry_path)
     runtime.registry.remember_registration(
         picked.vault_binding_id,
         KnownVaultRef(
@@ -364,18 +419,19 @@ def test_pre_mvr02_registry_arms_the_migration_exactly_once(tmp_path) -> None:
         make_active=True,
         _capability=_STORAGE_MUTATION_CAPABILITY,
     )
-    after_picker = store.load()
-    assert after_picker.last_active_vault_ref == picked.ref
+    before = store.load()
+    payload_before = runtime.layout.registry_path.read_bytes()
+    assert before.last_active_vault_ref == picked.ref
+    assert before.default_vault_binding_id is None
 
-    reloaded = store.load_or_migrate()
-    assert reloaded.default_vault_binding_id is None
-    assert reloaded.revision == after_picker.revision
+    migrated = store.load_or_migrate()
 
-    # And the legacy arm still works when there IS something to preserve.
-    _strip_mvr02_marker(registry_path, last_active_vault_ref=first.ref)
-    materialized = VaultRegistryStore(registry_path).load_or_migrate()
-    assert materialized.default_vault_binding_id == first.vault_binding_id
-    assert materialized.default_vault_provenance == DEFAULT_PROVENANCE_LEGACY_MIGRATION
+    assert migrated.default_vault_binding_id is None
+    assert migrated.default_vault_provenance is None
+    # Read-named, and genuinely a read: no revision burned, not one byte written.
+    assert migrated.revision == before.revision
+    assert runtime.layout.registry_path.read_bytes() == payload_before
+    assert resolve_vault_selection(migrated).is_no_vault
 
 
 def test_first_vault_initialize_materializes_default_once(tmp_path) -> None:
@@ -436,3 +492,19 @@ def test_first_vault_initialize_materializes_default_once(tmp_path) -> None:
         reopen_runtime(runtime, tmp_path).registry.load().default_vault_binding_id
         == registration.vault_binding_id
     )
+
+    # An operator pinning the binding the first-vault producer chose is a real
+    # change — inferred provenance becomes explicit — not a swallowed no-op.
+    service = _service(runtime)
+    promoted = service.set(registration.vault_binding_id)
+    assert promoted.changed is True
+    assert promoted.provenance == DEFAULT_PROVENANCE_EXPLICIT
+    assert (
+        runtime.registry.load().default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
+    )
+    # Re-issuing the now-identical command is genuinely a no-op: no revision, no
+    # event, nothing for MVR-06 to act on.
+    revision_after_promote = runtime.registry.load().revision
+    repeated = service.set(registration.vault_binding_id)
+    assert repeated.changed is False
+    assert runtime.registry.load().revision == revision_after_promote

--- a/tests/integration/test_single_vault_compatibility.py
+++ b/tests/integration/test_single_vault_compatibility.py
@@ -1,0 +1,201 @@
+"""MVR-02 (#3856): single-vault and no-vault compatibility around the new default.
+
+Contract: docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md
+
+Zero, one, and many bindings all stay valid. Adding an explicit instance default
+must not turn an env bootstrap into a hidden default, and must not disturb the
+truthful no-vault posture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.default_vault import (
+    SELECTION_INSTANCE_DEFAULT,
+    SELECTION_LEGACY_BOOTSTRAP,
+    SELECTION_NO_VAULT,
+    VaultSelectionError,
+    resolve_vault_selection,
+)
+from app.instance.vault_registry import (
+    DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING,
+    KnownVaultRef,
+    RegistryDefaultConflict,
+)
+from app.vault.markdown_settings import MarkdownSettingsStore
+from tests._mvr_default_vault_harness import (
+    activate,
+    new_runtime,
+    reopen_runtime,
+)
+
+
+def _initialize_root(root: Path, *, vault_id: str) -> Path:
+    """Write the minimum Design Handoff identity that makes a folder a vault."""
+
+    root.mkdir(parents=True, exist_ok=True)
+    settings = root / "settings"
+    settings.mkdir(exist_ok=True)
+    store = MarkdownSettingsStore()
+    store.write_frontmatter(
+        settings / "vault.md",
+        {"schema": "design-handoff.vault.v1", "vaultId": vault_id, "vaultName": root.name},
+    )
+    store.write_frontmatter(
+        settings / "local.md",
+        {
+            "schema": "design-handoff.local.v1",
+            "localInstanceId": f"local-{vault_id}",
+            "machineRole": "primary",
+        },
+    )
+    return root
+
+
+def test_first_open_existing_materializes_restart_default_once(tmp_path) -> None:
+    runtime = new_runtime(tmp_path)
+    existing = _initialize_root(tmp_path / "existing-vault", vault_id="vault-existing")
+
+    # A fresh no-vault instance opens its first existing root. The locked
+    # transaction proves there were no prior registrations and no prior default,
+    # so registration and default land together, exactly once.
+    registration = runtime.register_first_vault(
+        existing, provenance=DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+    )
+    snapshot = runtime.registry.load()
+    assert snapshot.default_vault_binding_id == registration.vault_binding_id
+    assert snapshot.default_vault_provenance == DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+    assert snapshot.revision == 1
+
+    # It survives restart with no reselection gesture at all.
+    restarted = reopen_runtime(runtime, tmp_path)
+    restored = restarted.registry.load()
+    assert restored.default_vault_binding_id == registration.vault_binding_id
+    selection = resolve_vault_selection(restored)
+    assert selection.vault_binding_id == registration.vault_binding_id
+    assert selection.provenance == SELECTION_INSTANCE_DEFAULT
+
+    # A later open never replaces it, and neither does a later last-active write.
+    activate(runtime, registration, tmp_path)
+    later_root = _initialize_root(tmp_path / "later-vault", vault_id="vault-later")
+    later = runtime.production_register(later_root, producer="picker")
+    runtime.registry.remember_registration(
+        later.vault_binding_id,
+        KnownVaultRef(
+            ref=later.ref,
+            path=later.path,
+            vault_id=later.vault_id,
+            local_instance_id=later.local_instance_id,
+        ),
+        make_active=True,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    after_later_open = runtime.registry.load()
+    assert after_later_open.last_active_vault_ref == later.ref
+    assert after_later_open.default_vault_binding_id == registration.vault_binding_id
+    assert (
+        after_later_open.default_vault_provenance
+        == DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+    )
+
+    # And the first-open producer refuses to fire a second time.
+    with pytest.raises(RegistryDefaultConflict):
+        runtime.register_first_vault(
+            later_root, provenance=DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+        )
+
+
+def test_first_open_existing_completes_provisional_identity_without_replacing_default(
+    tmp_path,
+) -> None:
+    runtime = new_runtime(tmp_path)
+    # An existing but uninitialized root: readable, provisional, no vault identity.
+    provisional = tmp_path / "unadopted"
+    provisional.mkdir()
+
+    registration = runtime.register_first_vault(
+        provisional, provenance=DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+    )
+    assert registration.vault_id is None
+    assert registration.extensions["status"] == "uninitialized"
+    assert (
+        runtime.registry.load().default_vault_binding_id
+        == registration.vault_binding_id
+    )
+
+    completed = runtime.complete_initialization(
+        registration.vault_binding_id,
+        vault_id="vault-adopted",
+        local_instance_id=registration.local_instance_id,
+    )
+
+    snapshot = runtime.registry.load()
+    assert completed.vault_binding_id == registration.vault_binding_id
+    assert snapshot.registrations[registration.vault_binding_id].vault_id == (
+        "vault-adopted"
+    )
+    # Explicit initialization completes identity; it replaces neither the binding
+    # nor the default that first-open recorded.
+    assert snapshot.default_vault_binding_id == registration.vault_binding_id
+    assert snapshot.default_vault_provenance == DEFAULT_PROVENANCE_FIRST_OPEN_EXISTING
+
+
+def test_default_adapter_preserves_bootstrap_and_no_vault(tmp_path) -> None:
+    runtime = new_runtime(tmp_path)
+
+    # No-vault stays a truthful, valid result rather than an error or a guess.
+    empty = runtime.registry.load()
+    assert empty.registrations == {}
+    assert empty.default_vault_binding_id is None
+    assert resolve_vault_selection(empty).is_no_vault
+    assert resolve_vault_selection(empty).provenance == SELECTION_NO_VAULT
+
+    # The env bootstrap registers its binding but deliberately does NOT create a
+    # default: `VAULT_ROOT` stays an explicit legacy bootstrap, not a hidden one.
+    root = _initialize_root(tmp_path / "bootstrap-vault", vault_id="vault-bootstrap")
+    registration = runtime.bootstrap_env_binding(
+        vault_root=root, watcher_vault_path=root
+    )
+    bootstrapped = runtime.registry.load()
+    assert bootstrapped.default_vault_binding_id is None
+    assert bootstrapped.registrations[registration.vault_binding_id].extensions[
+        "provenance"
+    ] == "legacy_env_bootstrap"
+
+    # The explicit adapter still reaches the same single binding, and says so.
+    selection = resolve_vault_selection(bootstrapped, legacy_bootstrap_vault_root=root)
+    assert selection.vault_binding_id == registration.vault_binding_id
+    assert selection.provenance == SELECTION_LEGACY_BOOTSTRAP
+
+    # The adapter never turns an env path into a new binding and never treats the
+    # path itself as identity: an unregistered root fails closed.
+    unregistered = _initialize_root(tmp_path / "not-registered", vault_id="vault-other")
+    with pytest.raises(VaultSelectionError):
+        resolve_vault_selection(
+            bootstrapped, legacy_bootstrap_vault_root=unregistered
+        )
+    assert set(runtime.registry.load().registrations) == {
+        registration.vault_binding_id
+    }
+
+    # Compatibility DEFAULT_VAULT_ID is an untrusted logical-ID lookup that must
+    # resolve to exactly one local binding.
+    assert (
+        resolve_vault_selection(
+            bootstrapped, compatibility_default_vault_id="vault-bootstrap"
+        ).vault_binding_id
+        == registration.vault_binding_id
+    )
+    with pytest.raises(VaultSelectionError):
+        resolve_vault_selection(
+            bootstrapped, compatibility_default_vault_id="vault-other"
+        )
+
+    # Restart keeps the bootstrap posture: still no default, still one binding.
+    restarted = reopen_runtime(runtime, tmp_path).registry.load()
+    assert restarted.default_vault_binding_id is None
+    assert set(restarted.registrations) == {registration.vault_binding_id}

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -337,7 +337,6 @@ def test_store_and_ledger_mutators_reject_uncapable_callers(tmp_path) -> None:
             expected_revision=snapshot.revision,
         ),
         lambda: runtime.registry.set_extension_state(
-            default_vault_binding_id=registration.vault_binding_id,
             dimensions={},
             principal_state={},
             background_state={},

--- a/tests/integration/test_vault_registry_container_durability.py
+++ b/tests/integration/test_vault_registry_container_durability.py
@@ -225,10 +225,17 @@ def test_default_survives_recreate_after_mvr02(tmp_path) -> None:
 
     observations = {
         consumer: _instance_runtime(
-            "default-vault-get", "--registry-path", registry_path
+            "default-vault-get",
+            "--registry-path",
+            registry_path,
+            "--consumer",
+            consumer,
         )
         for consumer in ENABLED_REGISTRY_CONSUMERS
     }
+    assert {item["consumer"] for item in observations.values()} == set(
+        ENABLED_REGISTRY_CONSUMERS
+    )
     assert {item["vault_binding_id"] for item in observations.values()} == {
         extra[0].vault_binding_id
     }
@@ -249,4 +256,6 @@ def test_default_survives_recreate_after_mvr02(tmp_path) -> None:
     selection = resolve_vault_selection(restored)
     assert selection.vault_binding_id == extra[0].vault_binding_id
     assert selection.provenance == SELECTION_INSTANCE_DEFAULT
-    assert restored.last_active_vault_ref != extra[0].ref
+    # The recreate did not convert the default into last-active history: the env
+    # bootstrap never wrote one, and setting a default must not invent one.
+    assert restored.last_active_vault_ref is None

--- a/tests/integration/test_vault_registry_container_durability.py
+++ b/tests/integration/test_vault_registry_container_durability.py
@@ -115,6 +115,21 @@ def _read_revision(path: Path, consumer: str) -> dict[str, object]:
     return json.loads(result.stdout)
 
 
+ENABLED_REGISTRY_CONSUMERS = ("api", "worker", "watcher", "heimdal-capture-watch")
+
+
+def _instance_runtime(*args: str) -> dict[str, object]:
+    """Run one headless instance-runtime command in its own process."""
+
+    result = subprocess.run(
+        [sys.executable, "-m", "app.instance.runtime", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
 def test_registry_survives_recreate_and_is_shared_cross_process(tmp_path) -> None:
     layout = InstanceStateLayout.for_channel(tmp_path / "instance-state", "test")
     legacy = AppLocalSettingsStore(tmp_path / "legacy" / "app-local.md")
@@ -152,3 +167,86 @@ def test_registry_survives_recreate_and_is_shared_cross_process(tmp_path) -> Non
     assert {item["path_identity"] for item in observations.values()} == {
         str(layout.registry_path.resolve())
     }
+
+
+def test_default_survives_recreate_after_mvr02(tmp_path) -> None:
+    """MVR-02 (#3856): the explicit default is instance-state volume state.
+
+    Contract: docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md.
+    A pinned-image force-recreate discards every process and every in-memory
+    selection. Only the shared instance-state volume survives, and the explicit
+    default must come back from it identically in every enabled consumer.
+    """
+
+    from app.instance.default_vault import (
+        SELECTION_INSTANCE_DEFAULT,
+        resolve_vault_selection,
+    )
+    from app.instance.vault_registry import DEFAULT_PROVENANCE_EXPLICIT
+    from tests._mvr_default_vault_harness import active_runtime, reopen_runtime
+
+    runtime, first, extra = active_runtime(tmp_path, extra_roots=("two",))
+    registry_path = str(runtime.layout.registry_path)
+
+    # The production headless command sets the default, in its own process.
+    receipt = _instance_runtime(
+        "default-vault-set",
+        "--registry-path",
+        registry_path,
+        "--vault-binding-id",
+        extra[0].vault_binding_id,
+    )
+    assert receipt["ok"] is True
+    assert receipt["vault_binding_id"] == extra[0].vault_binding_id
+    expected_revision = receipt["registry_revision"]
+
+    # Force-recreate: every consumer re-runs its startup preflight against the
+    # same volume, and nothing in-process carries over.
+    for consumer in ENABLED_REGISTRY_CONSUMERS:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "app.instance.runtime",
+                "preflight",
+                "--channel",
+                runtime.layout.channel_id,
+                "--instance-state-root",
+                str(runtime.layout.root.parent),
+                "--host-global-root",
+                str(runtime.ledger.root),
+                "--consumer",
+                consumer,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    observations = {
+        consumer: _instance_runtime(
+            "default-vault-get", "--registry-path", registry_path
+        )
+        for consumer in ENABLED_REGISTRY_CONSUMERS
+    }
+    assert {item["vault_binding_id"] for item in observations.values()} == {
+        extra[0].vault_binding_id
+    }
+    assert {item["registry_revision"] for item in observations.values()} == {
+        expected_revision
+    }
+    assert {item["provenance"] for item in observations.values()} == {
+        DEFAULT_PROVENANCE_EXPLICIT
+    }
+    assert {
+        _read_revision(runtime.layout.registry_path, consumer)["revision"]
+        for consumer in ENABLED_REGISTRY_CONSUMERS
+    } == {expected_revision}
+
+    # A re-attached in-process consumer resolves the identical selection, and the
+    # recreate did not turn the default into last-active history.
+    restored = reopen_runtime(runtime, tmp_path).registry.load()
+    selection = resolve_vault_selection(restored)
+    assert selection.vault_binding_id == extra[0].vault_binding_id
+    assert selection.provenance == SELECTION_INSTANCE_DEFAULT
+    assert restored.last_active_vault_ref != extra[0].ref

--- a/tests/integration/test_vault_registry_rollback.py
+++ b/tests/integration/test_vault_registry_rollback.py
@@ -632,7 +632,13 @@ def test_mvr02_default_survives_scalar_projection_round_trip(tmp_path) -> None:
     second_root = tmp_path / "second"
     second_root.mkdir()
     second = runtime.production_register(second_root, producer="api")
-    service = InstanceDefaultVaultService(runtime.registry, emit_event=lambda receipt: "")
+    from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+    service = InstanceDefaultVaultService(
+        runtime.registry,
+        capability=_STORAGE_MUTATION_CAPABILITY,
+        emit_event=lambda receipt: "",
+    )
     service.set(second.vault_binding_id)
     before = runtime.registry.load()
     assert before.default_vault_binding_id == second.vault_binding_id

--- a/tests/integration/test_vault_registry_rollback.py
+++ b/tests/integration/test_vault_registry_rollback.py
@@ -610,3 +610,108 @@ def test_roll_forward_recovers_committed_journal_before_cleanup(
     assert recovered.revision == merged.revision
     assert not runtime.registry.transaction_path.exists()
     assert not runtime.registry.scalar_rollback_session_path.exists()
+
+
+def test_mvr02_default_survives_scalar_projection_round_trip(tmp_path) -> None:
+    """MVR-02 (#3856): the explicit default is new-schema-only lineage.
+
+    Contract: docs/MULTI_VAULT_RUNTIME/RESOLVE_INSTANCE_DEFAULT_VAULT.md.
+    The scalar previous image sees only the already validated explicit rollback
+    target and never an inferred default; roll-forward restores the authoritative
+    ``default_vault_binding_id`` from the new-schema lineage and still rejects a
+    divergent or ambiguous scalar mutation.
+    """
+
+    from app.instance.default_vault import InstanceDefaultVaultService
+    from app.instance.vault_registry import (
+        DEFAULT_PROVENANCE_EXPLICIT,
+        _split_rendered,
+    )
+
+    runtime, first = _active_runtime(tmp_path)
+    second_root = tmp_path / "second"
+    second_root.mkdir()
+    second = runtime.production_register(second_root, producer="api")
+    service = InstanceDefaultVaultService(runtime.registry, emit_event=lambda receipt: "")
+    service.set(second.vault_binding_id)
+    before = runtime.registry.load()
+    assert before.default_vault_binding_id == second.vault_binding_id
+
+    rollback_path = tmp_path / "rollback" / "app-local.md"
+    _start_scalar_runtime(runtime, first, Path(first.path), rollback_path)
+
+    # The scalar projection carries the validated rollback target only. It never
+    # gains a default field, and the default is never converted into last-active.
+    projected_frontmatter, _ = _split_rendered(
+        rollback_path.read_text(encoding="utf-8"), rollback_path
+    )
+    assert "defaultVaultBindingId" not in projected_frontmatter
+    assert "defaultVaultProvenance" not in projected_frontmatter
+    assert projected_frontmatter["lastActiveVaultRef"] == first.ref
+    assert set(projected_frontmatter["knownVaults"]) == {first.ref}
+    assert projected_frontmatter["mvrRollbackBindingId"] == first.vault_binding_id
+    # The authoritative registry is untouched by projection.
+    assert runtime.registry.load().default_vault_binding_id == second.vault_binding_id
+
+    # The previous image mutates only what it can see.
+    rollback = AppLocalSettingsStore(rollback_path)
+    settings = rollback.load()
+    selected = settings.known_vaults[first.ref]
+    settings.known_vaults[first.ref] = KnownVaultRef(
+        ref=selected.ref,
+        path=selected.path,
+        vault_id=selected.vault_id,
+        vault_name="Renamed on the previous image",
+        local_instance_id=selected.local_instance_id,
+        last_opened_at="2026-07-31T00:00:00Z",
+    )
+    rollback.save(settings)
+
+    proof, owner_inventory, proof_path = _deployment_authority(runtime, rollback_path)
+    assert (
+        _roll_forward_scalar_rollback(
+            channel=runtime.layout.channel_id,
+            instance_state_root=runtime.layout.root.parent,
+            host_global_root=runtime.ledger.root,
+            legacy_path=rollback_path,
+            inventory_path=owner_inventory,
+            quiescence_proof_path=proof_path,
+        )
+        == 0
+    )
+    merged = runtime.registry.load()
+
+    # Roll-forward verified the default's binding still exists and restored it
+    # unchanged, rather than inferring one from the returning last-active value.
+    assert merged.default_vault_binding_id == second.vault_binding_id
+    assert merged.default_vault_provenance == DEFAULT_PROVENANCE_EXPLICIT
+    assert merged.registrations[first.vault_binding_id].vault_name == (
+        "Renamed on the previous image"
+    )
+    assert merged.last_active_vault_ref == first.ref
+    assert merged.last_active_vault_ref != second.ref
+    _finish_instance_state_deployment(
+        channel=runtime.layout.channel_id,
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=runtime.ledger.root,
+        legacy_path=rollback_path,
+        inventory_path=owner_inventory,
+        backup_root=tmp_path / "mvr02-backup",
+        restore_root=None,
+        quiescence_proof=proof,
+    )
+
+    # A divergent scalar mutation is still rejected, and the default is unchanged.
+    divergent = tmp_path / "rollback-divergent" / "app-local.md"
+    _start_scalar_runtime(runtime, first, Path(first.path), divergent)
+    divergent_store = AppLocalSettingsStore(divergent)
+    divergent_settings = divergent_store.load()
+    divergent_settings.known_vaults["path:/outside"] = KnownVaultRef(
+        ref="path:/outside", path="/outside"
+    )
+    divergent_store.save(divergent_settings)
+    payload_before = runtime.layout.registry_path.read_bytes()
+    with pytest.raises(RegistryError, match="escaped the selected binding"):
+        runtime.merge_previous_scalar_image(divergent)
+    assert runtime.layout.registry_path.read_bytes() == payload_before
+    assert runtime.registry.load().default_vault_binding_id == second.vault_binding_id

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -4318,8 +4318,8 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
         watcher_vault_path=root,
     )
     runtime.registry.set_extension_state(
-        default_vault_binding_id="binding-default",
-        dimensions={"d": ["binding-default"]},
+        default_vault_binding_id=registration.vault_binding_id,
+        dimensions={"d": [registration.vault_binding_id]},
         principal_state={"operator": "local"},
         background_state={"mode": "compatibility"},
         runtime_floors={"registry": "01b"},
@@ -4427,7 +4427,7 @@ def test_prod_restore_rejects_noncanonical_quiescence_authority_without_mutation
         host_global_root=runtime.ledger.root,
     )
     runtime.registry.set_extension_state(
-        default_vault_binding_id="new-default",
+        default_vault_binding_id=registration.vault_binding_id,
         dimensions={"new": [registration.vault_binding_id]},
         principal_state={"operator": "changed"},
         background_state={"mode": "changed"},
@@ -4559,8 +4559,8 @@ def test_prod_restore_rejects_foreign_channel_before_writing_target_state(tmp_pa
         watcher_vault_path=target_root,
     )
     target_runtime.registry.set_extension_state(
-        default_vault_binding_id="prod-default",
-        dimensions={"prod": ["prod-default"]},
+        default_vault_binding_id=target_registration.vault_binding_id,
+        dimensions={"prod": [target_registration.vault_binding_id]},
         principal_state={"operator": "prod"},
         background_state={"mode": "prod"},
         runtime_floors={"registry": "prod"},

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -4318,7 +4318,6 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
         watcher_vault_path=root,
     )
     runtime.registry.set_extension_state(
-        default_vault_binding_id=registration.vault_binding_id,
         dimensions={"d": [registration.vault_binding_id]},
         principal_state={"operator": "local"},
         background_state={"mode": "compatibility"},
@@ -4427,7 +4426,6 @@ def test_prod_restore_rejects_noncanonical_quiescence_authority_without_mutation
         host_global_root=runtime.ledger.root,
     )
     runtime.registry.set_extension_state(
-        default_vault_binding_id=registration.vault_binding_id,
         dimensions={"new": [registration.vault_binding_id]},
         principal_state={"operator": "changed"},
         background_state={"mode": "changed"},
@@ -4559,7 +4557,6 @@ def test_prod_restore_rejects_foreign_channel_before_writing_target_state(tmp_pa
         watcher_vault_path=target_root,
     )
     target_runtime.registry.set_extension_state(
-        default_vault_binding_id=target_registration.vault_binding_id,
         dimensions={"prod": [target_registration.vault_binding_id]},
         principal_state={"operator": "prod"},
         background_state={"mode": "prod"},

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -4324,6 +4324,13 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
         runtime_floors={"registry": "01b"},
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
+    # MVR-02 (#3856): the explicit instance default is a first-class registry
+    # field now, so volume loss + verified restore must bring it back too — not
+    # just the 01B mechanical extension state.
+    runtime.registry.set_instance_default(
+        registration.vault_binding_id,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
     _create_canonical_backup(
         runtime=runtime,
         backup_root=tmp_path / "backup",
@@ -4371,16 +4378,23 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
         owner_receipt_path=owner_receipt,
     )
     assert restored.registry_checksum == expected["registry_checksum"]
-    assert runtime.registry.load().extensions["runtimeFloors"] == {"registry": "01b"}
+    restored_snapshot = runtime.registry.load()
+    assert restored_snapshot.extensions["runtimeFloors"] == {"registry": "01b"}
+    assert restored_snapshot.default_vault_binding_id == registration.vault_binding_id
+    assert restored_snapshot.default_vault_provenance == "explicit_default_command"
     assert runtime.ledger.load().leases
     assert not stale_final.exists()
     assert not stale_checksum.exists()
 
     layout.registry_path.unlink()
-    assert runtime.registry.load().extensions["runtimeFloors"] == {"registry": "01b"}
+    assert runtime.registry.load().default_vault_binding_id == (
+        registration.vault_binding_id
+    )
     layout.registry_path.write_bytes(b"torn registry write")
     os.chmod(layout.registry_path, 0o600)
-    assert runtime.registry.load().extensions["runtimeFloors"] == {"registry": "01b"}
+    recovered_snapshot = runtime.registry.load()
+    assert recovered_snapshot.extensions["runtimeFloors"] == {"registry": "01b"}
+    assert recovered_snapshot.default_vault_binding_id == registration.vault_binding_id
 
     (tmp_path / "backup" / "ownership-key.json").unlink()
     with pytest.raises(InstanceStatePreflightError, match="complete ledger/key"):

--- a/tests/ops/test_scalar_rollback_guard.py
+++ b/tests/ops/test_scalar_rollback_guard.py
@@ -402,7 +402,6 @@ def test_rollback_gateway_and_mounts_enforce_selected_binding(
         match="scalar rollback session blocks",
     ):
         runtime.registry.set_extension_state(
-            default_vault_binding_id=None,
             dimensions={},
             principal_state={},
             background_state={},
@@ -468,7 +467,6 @@ def test_native_scalar_rollback_launcher_enforces_selected_binding_or_fails_clos
 def test_binding_keyed_database_floor_blocks_scalar_runtime(tmp_path) -> None:
     runtime, registration, _ = _runtime(tmp_path)
     runtime.registry.set_extension_state(
-        default_vault_binding_id=None,
         dimensions={},
         principal_state={},
         background_state={},

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -485,13 +485,17 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 1953): (
+    ("app/instance/vault_registry.py", 2266): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 (site unchanged); re-pinned after "
-        "directly related MVR-01C insertions earlier in vault_registry.py."
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 (site unchanged); "
+        "re-pinned after directly related MVR-02 (#3856) insertions earlier in "
+        "vault_registry.py, which added the explicit-default field, its "
+        "producers, and the tolerant legacy read. MVR-02 adds no new "
+        "write_frontmatter site: it writes the registry through "
+        "_atomic_private_write, not the vault-content seam."
     ),
 }
 


### PR DESCRIPTION
Governing-Issue: #3856

Fixes #3856

Final-Review-Rounds: 2

## Summary

MVR-02 adds an explicit, durable `default_vault_binding_id` (plus provenance) to the versioned
instance vault registry, one fail-closed selection resolver (`override > session > instance default >
explicit legacy bootstrap > no-vault`), one service behind the authenticated Companion API and the
headless CLI, a one-time provenance-tagged last-active migration, and one versioned mutation event
for MVR-06. `last_active_vault_ref` stays interaction history and `VAULT_ROOT` stays a deployment
bootstrap; neither is promoted into the default at runtime.

## Pickup claim receipt

```
pickup-claim-complete issue=3856 branch=codex/issue-3856-instance-default-vault
worktree=<redacted host path> coordination_mode=dispatcher-backed fallback_reason=none
task_id=github-RasmusTho--agentic-pkm-mvp-issue-3856 lease_id=lease-92a51d63
holder=claude-opus evidence=verified-dispatcher-lease
```

The wrapper first failed with `dispatcher claim failed ... agent:ready was not removed`. Cause: an
**expired** lease (`lease-13eef3cd`, holder `codex-mvr-02`, expired 2026-07-30T16:22:59Z) from an
abandoned session, with no linked PR and no `agent:*` label left on the Issue. Recovered through the
dispatcher's own operator path — `pull` to sync the queue, then `release` of the stale lease — and
then the **complete wrapper** was rerun. The `agent:ready` label was never removed separately.

The Issue also carried no `agent:*` label at all, so the queue could not see it. `agent:ready` was
restored after re-running strict readiness validation, with a maintenance receipt on the Issue naming
the three closed dependencies (#3853, #3854, #3855) as the evidence.

## Durable-state change (explicit)

**No Alembic migration and no database schema change.** The durable change is additive and
forward-only on the MVR-01 instance-state registry file:

- two new nullable frontmatter keys, `defaultVaultBindingId` and `defaultVaultProvenance`, promoted
  from an opaque MVR-01B extension blob to validated first-class registry fields;
- one conditional lineage key, `legacyDefaultVaultBindingId`, written into `extensions` (and so
  flattened into the frontmatter) **only** when a pre-MVR-02 or legacy payload carried a
  `defaultVaultBindingId` that resolves to no current registration. It exists so such a value is
  preserved rather than silently dropped; it is never read back as a default.

There is no migration marker and no other new durable key.

Forward-only safety:

- **Old code reading new state** — pre-MVR-02 code routes unknown frontmatter keys through
  `RegistrySnapshot.extensions` and writes them back verbatim, so an older image preserves both keys
  rather than dropping them.
- **Scalar rollback image** — `_rollback_export_payload` builds its own `design-handoff.app-local.v1`
  frontmatter and never projects the default; the previous image sees only the already validated
  explicit rollback target. Asserted directly in
  `test_mvr02_default_survives_scalar_projection_round_trip` (the projected file must contain neither
  key, and `lastActiveVaultRef` must be the rollback target, not the default).
- **Roll-forward** — the locked merge re-verifies the default's binding still exists and restores it
  from the new-schema lineage.
- **Nothing is deleted or rewritten in place.** A legacy payload's own unresolvable
  `defaultVaultBindingId` is preserved as `legacyDefaultVaultBindingId` lineage instead of being
  silently dropped.
- **The migration is genuinely once, with no marker to keep honest.** The promotion of a legacy
  `last_active_vault_ref` lives only in `_migrate_legacy_frontmatter`, which runs only for a
  `design-handoff.app-local.v1` document. That schema transition *is* the once-only guarantee: after
  it, the file is current-schema and the branch is unreachable. A registry already on the current
  schema never receives an inferred default, and `load_or_migrate` stays a genuine read there —
  `test_load_or_migrate_never_materializes_on_a_current_schema_registry` asserts no revision is
  burned and `registry_path.read_bytes()` is byte-identical. See
  `app/instance/vault_registry.py` (the current-schema branch of `load_or_migrate`) and the spec's
  `Delivered Scope Boundary`. An earlier revision of this branch carried a second materialization
  arm plus a `defaultVaultMigration` marker to police it; both were deleted in review round 2, and
  nothing in the shipped diff writes such a key.

## Invariant → producers

Promoting the default to a validated field added the invariant *"a non-null default names a current
registration"*. Every producer was migrated in the same change: `register`, `commit_state`,
`remember_registration`, `require_authoritative_activation`, `merge_scalar_rollback`,
`_with_registrations`, `remove_registration`, and the MVR-01B `set_extension_state` mechanical writer
(which now carries the default through instead of owning it). A fail-loud preflight sits at the
**read** boundary (`_assert_default_is_resolvable` in `_snapshot_from_frontmatter`), so a hand-edited
or partially restored registry fails closed at load instead of resolving to nothing — or to
something.

## Review record (full delivery path)

This slice is a TCD high-risk surface (data / migration / concurrency / state-machine), so it ran the
mechanism convergence gate before expensive validation.

**Round 1: BLOCKED — four P1 findings, all fixed here, each with a regression test proven to fail
without its fix.**

1. The one-time last-active materialization could fire as a **standing runtime rule**. Its marker was
   written by only two of the six writers that can move the default, so a registry that never carried
   legacy state — or whose operator cleared the default through a *removal* transaction — stayed
   armed, and the next picker write was silently promoted into a default labelled
   `legacy_last_active_migration`. That is precisely the conflation this slice exists to remove.
2. Same root cause: an explicit clear was not final.
3. `set_extension_state` forwarded a required `default_vault_binding_id` straight into the
   authoritative field, so an unrelated mechanical write of dimensions/principal/background state
   would **wipe** a durable operator default when passed `None`, or **forge**
   `explicit_default_command` provenance when passed a binding. The parameter is now removed
   entirely; `set_instance_default` is the single writer.
4. `app/instance/default_vault.py` imported the sealed `_storage_boundary` capability, breaking
   `importlinter.ini`'s `instance-storage-capability-protected` contract — caught by `lint-imports`,
   not by pytest. The service now *receives* its capability from
   `app.instance.runtime.open_default_vault_service`, an already-sanctioned importer, so the seal and
   its pinned architecture test are untouched and a directly constructed service is read-only.

Non-blocking round-1 findings also closed: a compatibility `DEFAULT_VAULT_ID` win now reports its own
selection provenance instead of impersonating a durable operator default; a no-op set/clear no longer
burns a registry revision or publishes a rebind event MVR-06 would act on; and the
container-durability test's per-consumer claim is real rather than the same call repeated four times.

**Round 2: BLOCKED again — and the root cause was that I had grown the mechanism instead of
building the boring one.** Two independent reviewers converged on the same finding. The spec
promotes a legacy last-active "during the one-time schema migration only"; I had *also* added a
current-schema materialization arm to `load_or_migrate`. That single invented branch produced three
findings on its own — it was production-dead (its only caller, `import_final_export`, refuses a
registry with `revision > 0`), it turned a read-named entry point into a writer that skipped the
scalar-rollback session guard every other writer holds, and it required the `defaultVaultMigration`
marker whose completeness was round 1's P1.

So the arm was **removed**, not repaired, and the marker with it. The schema transition is now the
once-only guarantee, and `load_or_migrate` is a read again on the current schema — asserted
byte-for-byte. Also fixed in the same round, both found by both reviewers:

- **An unlabelled `defaultVaultBindingId` bricked an intact registry.** MVR-01 flattened
  `extensions` into the same frontmatter, so a registry written by the previous image can carry that
  key with no provenance. Promoting it to a validated first-class field made such a registry
  unloadable — and *unrecoverable*, because the last-good snapshot holds identical bytes. Every
  consumer's startup preflight would have failed on the exact population this slice exists to
  upgrade. It is now untrusted lineage: adopted only when it names exactly one current registration,
  otherwise demoted to `legacyDefaultVaultBindingId`.
- **The no-op short-circuit swallowed a provenance change** — an operator pinning the binding the
  first-vault producer chose is a real change from inferred to explicit.
- **Backup/restore had lost its assertion on the default**; volume-loss + verified restore + a torn
  registry write now all assert it.

**Round 3: CLEAN — no P0/P1.** Its one substantive P2 is fixed here rather than deferred (5 lines):
the tolerant legacy read adopted values under `explicit_default_command`, the very label this diff
strips from `set_extension_state` on the grounds that letting it through would forge that
provenance. Legacy adoptions now carry `legacy_unlabelled_adoption`.

Its other P2 was that two acceptance criteria were written as installation-level journeys that the
lane contract assigns to MVR-05B. **That contract conflict predates this work** — the Issue's ACs
and `docs/MULTI_VAULT_RUNTIME/README.md :: Identity and selection` disagreed with each other from
the start. Rather than quietly claiming them, the ACs were amended to match the lane split with a
maintenance receipt on #3856 quoting the README, and the split is now recorded in the task spec
itself under `Delivered Scope Boundary`. Remaining P3s (an unreachable defensive clear arm, a
restore-then-mutate idempotency-key edge, a stale-read receipt on a no-op) are recorded and
non-blocking.

**Merge gate (final, current-SHA): two blocking rounds, both on this PR body, neither on the code.**
`Final-Review-Rounds: 2` is the contract's maximum declarable value; the prose here is the precise
count.

Round 1 found a false row in the regression-coverage table naming
`test_pre_mvr02_registry_arms_the_migration_exactly_once` — a test that does not exist, because
review round 2 had deleted the marker mechanism it described. Round 2 found the *same class of
error* one section away: the `Durable-state change` disclosure still listed a `defaultVaultMigration`
marker among the keys that land on the instance-state volume, while the same body said four
paragraphs later that the marker had been deleted. Both were stale text left behind when the
mechanism shrank, and both are false receipt evidence rather than P2s — a durable-state disclosure is
exactly what a merge gate reads to learn what ships.

Because the defect recurred, the fix was not another point edit: every claimed test node id, repo
path, and code identifier in this body was then extracted and checked against the tree
mechanically. Every test node id cited in the two tables exists and passes, every cited repo path
exists, and every claimed identifier resolves in `app/` — with four deliberate exceptions that are
not application code: `out_of_scope` (a test-census classification string), `workflow_divergence` (a
BuilderOps signal type), and two bare test names that live under `tests/` rather than `app/`. A
fifth name, the deleted `test_pre_mvr02_registry_arms_the_migration_exactly_once`, resolves nowhere
by design and appears only in the past-tense account of round 1 below. Two P2s from that round are
deferred to the Known Defects registry (#4172) rather than fixed here: the owner-doc sentence "every
mutation publishes exactly one event" overstates coverage (the migration, first-vault, and
roll-forward producers mutate the default without emitting), and the event idempotency key is derived
from the registry revision, which is not unique across a verified restore.

## Latent defect fixed in passing

`remove_registration` had no reference safety at all: removing the MVR-01C scalar rollback floor
target wrote a registry that then failed its own load-time floor validation. Production removal is
sealed by MVR-06B, so it was latent. The same locked transaction now refuses it, alongside the new
MVR-02 default reference safety.

## Declared scope boundary

`register_first_vault` has no production request ingress yet. That is the lane's own split, not an
oversight: `docs/MULTI_VAULT_RUNTIME/README.md :: Identity and selection` assigns that ingress to
MVR-05B ("In 05B, first initialize uses a single-use authenticated bootstrap precondition bound to
the canonical target, empty registry revision, and no-compatibility posture"). MVR-02 owns the
transaction and its atomicity; the docstring and `docs/ENVIRONMENTS.md` both say so.

Likewise, `merge_scalar_rollback`'s "default's binding is gone → clear atomically" arm is a
fail-closed guard for the MVR-04/06 transactions that will extend the registration map; it is
currently unreachable, and this PR does not claim it as proven behaviour.

## SBS Impact

- Primary subsystem: WSP
- Secondary subsystem(s): PDM, EBF, OEF
- Write class: mechanical durable instance setting
- Authority impact: none; selection never widens authority, and GOV/write-guard gating is unchanged
- Persistence impact: additive nullable registry fields with every producer migrated; no Alembic
  migration, no DB schema change
- Derived/rebuildable impact: the resolution result is ephemeral/rebuildable
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: supplies the compatibility/background fallback binding
- Sync/deployment impact: env remains an explicit legacy bootstrap, not a hidden default
- External boundary impact: no CWD or mount-path inference
- New or changed contract: default/selection precedence and provenance; new versioned event topic
  `instance.default_vault.changed` with a registered KERNEL-08 schema
- Owner-doc impact: updated in this PR at `docs/ENVIRONMENTS.md`,
  `docs/CONCEPTS/VAULT_AND_SETTINGS_CONTEXT.md`, `docs/EVENTS.md`, and `docs/STATUS.md`
- Transition debt impact: reduces last-active/env/default conflation
- Fitness rule impact: strengthens fail-closed no-silent-fallback behavior

## BuilderOps Routing

- Records/projections/receipts: `LearningSignal lrn_20260801010406_32e62490`
  (`workflow_divergence`) — the repo-configured `*.md merge=semanticmd` driver auto-resolved a
  near-duplicate `docs/STATUS.md` conflict during a routine rebase by preferring the shorter incoming
  variant, reporting `MERGE_STATUS=resolved` with no conflict marker and no non-zero exit. This
  branch's owner-doc writeback was silently discarded and was only caught because `docs_guard.py`
  re-failed afterwards. Upstream artifact named:
  `app/agents/merge_resolver/agent.py :: _postprocess_merge`.
- Reason: the only other friction (an expired dispatcher lease from an abandoned
  session) was recovered inside a documented operator path and is named in the claim receipt above,
  not a divergence from an instruction artifact. No roadmap or promotion crossing beyond the
  owner-doc writeback this PR already carries.

## Verify targets

All 13 acceptance criteria, run on the PR head SHA. Every behavioural target is a new test that did
not exist before this PR (so all 12 failed by absence against the unchanged code path).

| # | Acceptance criterion | `Verify:` target | Result |
| --- | --- | --- | --- |
| 1 | Resolver applies override > session > default > legacy bootstrap > no-vault and reports the winner | `tests/instance/test_default_vault_resolution.py::test_production_resolution_precedence_is_explicit` | PASS |
| 2 | Invalid explicit selection fails closed; no last-active / other entry / CWD / `./vault` fallback | `tests/instance/test_default_vault_resolution.py::test_invalid_explicit_selection_never_falls_through` | PASS |
| 3 | Set/clear survives restart and never changes `last_active_vault_ref` | `tests/instance/test_default_vault_resolution.py::test_default_is_durable_and_distinct_from_last_active` | PASS |
| 4 | Authenticated API and CLI get/set/clear are the tested producers and share one service | `tests/api/test_default_vault_admin.py::test_production_default_commands_share_one_service` | PASS |
| 5 | Set/clear publishes exactly one versioned event with the new revision and no raw binding payload | `tests/api/test_default_vault_admin.py::test_default_mutation_publishes_versioned_rebind_event` | PASS |
| 6 | Picker-only legacy store restarts on the same binding via the one-time migration; later selections do not mutate it | `tests/instance/test_default_vault_resolution.py::test_legacy_last_active_materializes_default_once` | PASS |
| 7 | First-vault initialize atomically records the default; later last-active changes do not alter it | `tests/instance/test_default_vault_resolution.py::test_first_vault_initialize_materializes_default_once` | PASS |
| 8 | First-open-existing records the default, survives restart, is not replaced by a later open | `tests/integration/test_single_vault_compatibility.py::test_first_open_existing_materializes_restart_default_once` | PASS |
| 9 | Existing no-vault and single-vault bootstrap paths remain truthful | `tests/integration/test_single_vault_compatibility.py::test_default_adapter_preserves_bootstrap_and_no_vault` | PASS |
| 10 | Removing the current default requires an atomic clear or one authorized replacement | `tests/api/test_default_vault_admin.py::test_removing_current_default_requires_atomic_clear_or_replacement` | PASS |
| 11 | The default persists across force-recreate and resolves identically in every enabled consumer | `tests/integration/test_vault_registry_container_durability.py::test_default_survives_recreate_after_mvr02` | PASS |
| 12 | Scalar rollback never converts the default into last-active; roll-forward restores it and rejects divergence | `tests/integration/test_vault_registry_rollback.py::test_mvr02_default_survives_scalar_projection_round_trip` | PASS |
| 13 | Owner contracts describe the shipped default, migration, event, and compatibility posture | doc writeback at `docs/ENVIRONMENTS.md :: Vault terminology`, `docs/CONCEPTS/VAULT_AND_SETTINGS_CONTEXT.md :: Service Gating`, `docs/EVENTS.md :: Events` | PRESENT |

Extra regression coverage added by the convergence-review repair round (each proven to fail without
its fix):

| Regression guarded | Test |
| --- | --- |
| A post-MVR-02 registry never infers a default from last-active; an explicit clear via the removal transaction is final; a mechanical MVR-01B write cannot wipe or forge the default | `tests/instance/test_default_vault_resolution.py::test_migration_never_infers_a_default_on_a_post_mvr02_registry` |
| A pre-MVR-02 registry carrying an unlabelled `defaultVaultBindingId` still loads: resolvable values are adopted under their own provenance, unresolvable ones become lineage, and neither bricks the store | `tests/instance/test_default_vault_resolution.py::test_pre_mvr02_default_key_never_bricks_an_intact_registry` |
| `load_or_migrate` never materializes a default on the already-migrated schema — no revision burned, not one byte written | `tests/instance/test_default_vault_resolution.py::test_load_or_migrate_never_materializes_on_a_current_schema_registry` |
| A service constructed without the sealed storage-mutation capability is read-only | `tests/api/test_default_vault_admin.py::test_default_service_without_the_sealed_capability_cannot_mutate` |
| Provisional (uninitialized) first-open binding keeps its binding and default through explicit initialization | `tests/integration/test_single_vault_compatibility.py::test_first_open_existing_completes_provisional_identity_without_replacing_default` |

## Notes

Validation: all on head SHA `94a68909b`.

- `python3 -m pytest -q -m "not pg"` — **12215 passed, 41 skipped, 312 deselected, 18 xfailed, 1 failed** in 9m02s.
  The one failure is `tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity`,
  which this PR does not touch (no builderops/CKM file is in the diff). It passes in isolation, passes
  across the entire `tests/builderops` suite in this worktree (927 passed), and passes on a pristine
  `origin/main` checkout — it only fails inside the full 12k-test run. It asserts BuilderOps CKM
  *database identity*, shared state that two other agents are concurrently exercising on this host.
  Classified as cross-suite/cross-agent contamination; CI on a clean runner is the arbiter.
- `python3 -m ruff check app tests companion-ui/companion-app` — All checks passed
- `python3 -m mypy app` — Success: no issues found in 850 source files
- `python3 scripts/public_seam_lint.py --mode gate` — secret_hits 0, uncovered_hits 0, stale_rows 0, migration_pending 0
- `python3 scripts/docs_guard.py` — OK
- `lint-imports --config importlinter.ini` — 5 kept, 0 broken (the sealed storage-mutation capability contract is intact and unmodified)
- `RUN_INTEGRATED_RUNTIME_UAT=1 pytest -q` over the five files named in the Issue's Suggested Validation — passed
- `python3 scripts/validate_source_anchors.py` against the Issue body — passed
- `python3 scripts/review_before_ci_gate.py --lane implementation --risk-surface data --risk-surface migration --risk-surface concurrency --risk-surface state-machine` — satisfied

One repo gate was tripped and fixed rather than worked around: `tests/properties/test_guard_at_seam.py`
keys its closed `write_frontmatter` census on file+line, and the MVR-02 insertions pushed the single
`vault_registry.py` site out of its registration. The site itself is unchanged and still
`out_of_scope`; MVR-02 adds no new seam site (the registry is written through
`_atomic_private_write`).
---
