### PR TITLE
docs: repair the unsatisfiable design-hub capability-acceptance criterion

### DIFF
--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/README.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/README.md
@@ -164,10 +164,27 @@ earlier slices. CDH-05 may begin only after the Yggdrasil design-handoff gate pa
 
 ## Capability acceptance
 
+Registered design agents are partitioned into **headless-registered** routes (`codex`, `fable`) and
+**interactive-only** routes (`claude-design-via-claude-code`). The partition follows from
+INV-CDH-5A rather than exempting anything from it: an interactive-only route is hard-refused as
+`interactive_subscription_only` inside `DesignAgentAdapterRegistry` before any adapter lookup, so
+requiring a governed *success* for it would require the invariant to be broken. The two buckets must
+stay exhaustive and disjoint over `DESIGN_AGENT_IDS` — see `HEADLESS_CAPABLE_AGENT_IDS` and
+`INTERACTIVE_ONLY_AGENT_IDS` in `tests/builderops/test_design_hub_acceptance.py` — so a newly
+registered adapter lands on exactly one side and cannot escape the matrix by appearing in neither.
+
+This narrows what a success proves; it does not narrow the fail-closed guarantee. Every registered
+route that is not proven by a governed success must instead be proven by an exact,
+zero-provider-call, no-fallback refusal, and the shipped production posture grants no
+`builderops-design-run` secret, so the dormant registry must refuse every route including the
+headless-registered ones.
+
 - [ ] All six task Issues are closed with exact PR/SHA/Verify receipts on parent #4131.
   Verify: `runtime receipt: ckm_design_hub.child_ledger.v1`
-- [ ] The production path proves one governed success per registered adapter and distinct unknown,
-  unavailable, denied, pending, malformed, timed-out, and failed states with no fallback.
+- [ ] The production path proves one governed success per headless-registered adapter, an exact
+  zero-provider-call `interactive_subscription_only` refusal for every interactive-only registered
+  adapter, and distinct unknown, unavailable, denied, pending, malformed, timed-out, and failed
+  states with no fallback.
   Verify: `tests/builderops/test_design_hub_acceptance.py::test_design_hub_production_matrix_is_fail_closed`
 - [ ] Cockpit output remains projection-only, deterministic, JavaScript-off complete, printable,
   and incapable of starting a run.

--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
@@ -26,7 +26,10 @@ truth or closing the parent from the child.
 ## Concretely
 
 - Exercise no adapters, unknown/unavailable adapter, policy denial, approval pending, malformed
-  output, timeout, provider failure, and one governed success per registered adapter.
+  output, timeout, provider failure, one governed success per headless-registered adapter, and an
+  exact zero-provider-call `interactive_subscription_only` refusal for every interactive-only
+  registered adapter (see `README.md :: Capability acceptance` for why the partition is required by
+  INV-CDH-5A and does not relax the refusal requirement).
 - Exercise missing/stale/revoked/mismatched approval and missing/drifted Yggdrasil parity with zero
   provider calls.
 - Prove one provider call at most, no fallback, exact admission/approval binding, causal receipt


### PR DESCRIPTION
## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Docs-only. Both changed files are target-state specification surfaces under `docs/`; no code, test, contract, runtime behaviour, or shipped-reality claim changes.

## Linked Issue

No governing issue. This is finding F1c of the independent parent acceptance audit on #4131 (https://github.com/RasmusTho/agentic-pkm-mvp/issues/4131#issuecomment-5149425277), which explicitly rules the repair docs-only. Parent #4131 stays open and unaccepted; this PR authorizes no acceptance and no owner-doc promotion.

## SBS Impact
- Primary subsystem: Builder System / CKM (design-agent integration capability specification)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: restates one capability-acceptance criterion so it is satisfiable as written; the underlying refusal contract and INV-CDH-5A are unchanged
- Owner-doc impact: none — no current-state owner doc is touched, and none begins claiming design-agent support
- Transition debt impact: reduces
- Boundary risk: an acceptance criterion must not be loosened into something a dormant, fail-closed posture can pass vacuously; every registered route not proven by a governed success must still be proven by an exact zero-provider-call, no-fallback refusal

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `docs/CKM_DESIGN_AGENT_INTEGRATION/README.md :: Capability acceptance` demanded "one governed success per registered adapter". `DESIGN_AGENT_IDS` registers three agents and INV-CDH-5A makes `claude-design-via-claude-code` structurally headless-incapable — it is hard-refused as `interactive_subscription_only` inside `DesignAgentAdapterRegistry` before any adapter lookup — so the criterion could never be ticked. An unsatisfiable criterion must not be the thing that authorizes supported language.
- The criterion now states what is actually provable under the dormant provider posture: one governed success per headless-registered adapter (`codex`, `fable`), plus an exact zero-provider-call `interactive_subscription_only` refusal for every interactive-only registered adapter. This is the reading `test_design_hub_production_matrix_is_fail_closed` already proves on merged main.
- Added a preamble that names the partition as a consequence of INV-CDH-5A rather than an exemption from it, and requires the two buckets to stay exhaustive and disjoint over `DESIGN_AGENT_IDS` so a newly registered adapter cannot escape the matrix by appearing in neither bucket.
- Mirrored the same correction in `VALIDATE_DESIGN_HUB_END_TO_END.md :: Concretely`, which repeated the unsatisfiable phrasing.
- Nothing is ticked, no provider was provisioned, and no credential was read.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: docs-only specification wording repair; it creates no design run, receipt, or projection and changes no BuilderOps authority.

## Notes
- **Fail-closed is not weakened.** The narrowing applies only to what a governed *success* proves. The refusal requirement is unchanged and is now stated explicitly, including that the shipped production posture grants no `builderops-design-run` secret and therefore must refuse every route, headless-registered ones included.
- `docs/DOCS_INDEX.md` is deliberately untouched: the doc role, authority, owner, and reading order are unchanged, so no row update is triggered. The audit's non-blocking findings N2 (stale `Last reviewed:` dates) and N3 (stale DOCS_INDEX `State` prose) are left for the eventual owner-doc promotion PR, where the audit routed them.
- Validation: `python3 scripts/docs_guard.py` → `Docs guard: OK`; `python3 scripts/public_seam_lint.py --mode gate` → `secret_hits: 0 · uncovered_hits: 0 · stale_rows: 0 · migration_pending: 0`.
- The audit's other blocking findings are owned separately and are not in this PR: F1a by issue #4502, F1b by the updated `KD-7C4378C00F83` entry in registry #4172, and F2 by a correction comment on #4131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
