### PR TITLE
docs: correct the design-hub panel opt-in flag contract in Direction B cockpit

### DIFF
--- a/docs/CKM_COCKPIT_DIRECTION_B/README.md
+++ b/docs/CKM_COCKPIT_DIRECTION_B/README.md
@@ -54,14 +54,18 @@ affordance can mutate CKM, GitHub, repo docs, Product/Runtime state, or BuilderO
 
 ## Delivered design-hub panel (dormant capability)
 
-Cockpit mode also renders a read-only design-hub panel supplied by the delivered
+Cockpit mode can also render a read-only design-hub panel supplied by the delivered
 [CKM Design-Agent Integration](../CKM_DESIGN_AGENT_INTEGRATION/README.md) capability (CDH-05,
-issue #4312, merged in PR #4493). The panel projects design-agent availability, design-run state,
-refusal codes, receipt chains, and handoff summaries. It obeys the same boundary as the rest of this
-page: inert, deterministic, no added script, form, link, or control, complete with JavaScript off,
-and incapable of starting, approving, or otherwise mutating a design run. The capability it projects
-ships dormant and fail-closed — no design run can execute, and every registered design agent renders
-as unavailable on every channel.
+issue #4312, merged in PR #4493), but only as an opt-in extension: the panel appears only when
+`ckm overview` is invoked with both `--design-hub` and `--repo-root` together with `--cockpit`. The
+default `ckm overview --cockpit` output (no `--design-hub`) omits the panel entirely, so an absent
+panel on its own does not indicate the receipt-corruption condition described in the bullet below.
+When rendered, the panel projects design-agent availability, design-run state, refusal codes,
+receipt chains, and handoff summaries. It obeys the same boundary as the rest of this page: inert,
+deterministic, no added script, form, link, or control, complete with JavaScript off, and incapable
+of starting, approving, or otherwise mutating a design run. The capability it projects ships dormant
+and fail-closed — no design run can execute, and every registered design agent renders as
+unavailable on every channel.
 
 Two limits bound how this panel may be read:
 


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Corrects the false design-hub panel usage claim identified by the #4131 terminal post-promotion audit ([issuecomment-5149692443](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4131#issuecomment-5149692443)), which is the authority for this change and its exact authorized scope (§7). `docs/CKM_COCKPIT_DIRECTION_B/README.md` previously stated that cockpit mode renders the design-hub panel; it does not by default. The panel is an opt-in extension requiring `--design-hub` together with `--repo-root` on top of `--cockpit`, and the shipped acceptance test (`tests/builderops/test_design_hub_acceptance.py`) already asserts the default `--cockpit` output omits it.

## Changes
- `docs/CKM_COCKPIT_DIRECTION_B/README.md` (`## Delivered design-hub panel (dormant capability)`): rewrote the opening sentence to state the `--design-hub` + `--repo-root` flag contract, that the default `--cockpit` output omits the panel, and that an absent panel therefore does not by itself indicate the receipt-corruption condition described in the following bullet. No other sentence, section, file, code, test, config, or acceptance criterion was touched, per the audit's hard scope authorization (§7) and the parent's five §9 restrictions (unchanged/unweakened).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring lane with no BuilderOps material routed.

## Notes
Validation actually run on the publishable SHA:
- `python3 scripts/docs_guard.py` -> `Docs guard: OK`
- `python3 -m pytest -q tests/architecture/test_docs_index.py` -> 4 passed
- `python3 scripts/public_seam_lint.py --mode gate` -> secret_hits: 0, uncovered_hits: 0, stale_rows: 0, migration_pending: 0
- `python3 -m pytest -q tests/builderops/test_design_hub_acceptance.py` -> 3 passed (the parent's own AC2 `Verify:` target file, unchanged, still asserts the corrected sentence's underlying fact)

This PR does not close, relabel, or tick any criterion on #4131. Closure awaits a fresh independent re-audit per the terminal audit's §7 discharge conditions.
---
