### PR TITLE
docs: correct stale HEIMDAL_RAW_STORE_KEY provisioning claims after #4422

### DIFF
--- a/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/ADMIT_MEDIA_WITH_DURABLE_RECEIPTS.md
+++ b/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/ADMIT_MEDIA_WITH_DURABLE_RECEIPTS.md
@@ -17,13 +17,17 @@ State: Delivered by hub issue #4384 (2026-07-30). `POST /api/heimdal/capture/med
 below proven by `tests/heimdal/test_media_ingress.py`; the event contract is recorded in
 `docs/EVENTS.md :: Heimdal governed media ingress + durable receipts`.
 
-Two things are deliberately **not** claimed by this slice. First, the api process needs
-`HEIMDAL_RAW_STORE_KEY` to encrypt into the raw store, and the host secret contract declares that
-secret for the `heimdal-capture-watch` consumer only — until it is provisioned to the api consumer,
-admission returns a named 500 `raw_store_key_unavailable` / `not_acknowledged` rather than a receipt
-(the pre-existing `POST /api/heimdal/screen/capture` shares that gap). Second, promotion of this lane
-into `docs/contracts/MIMER_CLIENT_CONTRACT.md` §4 (closing client-contract gap F5 for the media lane)
-remains parent-acceptance work on #4383.
+Two things were deliberately **not** claimed by this slice. First, the api process needs
+`HEIMDAL_RAW_STORE_KEY` to encrypt into the raw store, and at this slice's merge the host secret
+contract declared that secret for the `heimdal-capture-watch` consumer only, so admission returned a
+named 500 `raw_store_key_unavailable` / `not_acknowledged` rather than a receipt (the pre-existing
+`POST /api/heimdal/screen/capture` shared that gap). **That gap is now closed:** #4422 declared the
+api process as the `heimdal-api-ingress` consumer, wired the governed deploy wrapper and the `api`
+Compose service to deliver the key, and added an api startup preflight that reports both ingress
+lanes `unavailable` on `/api/status` before first use. Placing key material into each channel's
+Keychain item remains an operator step — see `docs/STATUS.md :: Runtime verification`. Second,
+promotion of this lane into `docs/contracts/MIMER_CLIENT_CONTRACT.md` §4 (closing client-contract gap
+F5 for the media lane) remains parent-acceptance work on #4383.
 
 ## Purpose
 

--- a/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/PROJECT_LIVE_TRANSCRIPT_AND_DEFAULT_ANALYSIS.md
+++ b/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/PROJECT_LIVE_TRANSCRIPT_AND_DEFAULT_ANALYSIS.md
@@ -18,8 +18,9 @@ through the shared engine seam `app.media.transcribe.run_asr`, and the six accep
 proven by `tests/heimdal/test_meeting_projection.py`. Projection tables ship in migration
 `b8d3f0a5c2e4` (Postgres/PDM) with a file-backed SQLite dev/test lane. The analysis engine in this
 slice is deterministic (`heimdal-meeting-analysis v1`, no LLM), so convergence is structural;
-`generic-default@1` is the only shipped template. The `HEIMDAL_RAW_STORE_KEY` provisioning gap
-(KD-4384-RAWKEY, #4422) bounds live end-to-end derivation the same way it bounds admission.
+`generic-default@1` is the only shipped template. The `HEIMDAL_RAW_STORE_KEY` provisioning gap is
+closed in code (#4422); the residual operator Keychain step bounds live end-to-end derivation the
+same way it bounds admission — see `docs/STATUS.md :: Runtime verification`.
 
 ## Purpose
 

--- a/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/TRACK_MEETING_SESSIONS_AND_SEGMENT_GAPS.md
+++ b/docs/CROSS_DEVICE_CAPTURE_AND_LIVE_MEETING/TRACK_MEETING_SESSIONS_AND_SEGMENT_GAPS.md
@@ -18,8 +18,9 @@ admission hook wired into `app/heimdal/media_ingress.py` and the six acceptance 
 by `tests/heimdal/test_meeting_session_ledger.py`; the `heimdal.meeting.segment.late_admitted` event
 contract is recorded in `docs/EVENTS.md`. Ledger tables ship in migration `a7c2e9f4b1d3` (Postgres /
 PDM) with a file-backed SQLite lane for dev/test, so the restart criterion is proven against real
-durable storage. The `HEIMDAL_RAW_STORE_KEY` provisioning gap CDLM-01 states (KD-4384-RAWKEY) bounds
-live end-to-end use of the admission-fed segment path the same way it bounds CDLM-01.
+durable storage. The `HEIMDAL_RAW_STORE_KEY` provisioning gap CDLM-01 stated is closed in code
+(#4422); the residual operator Keychain step bounds live end-to-end use of the admission-fed segment
+path the same way it bounds CDLM-01 — see `docs/STATUS.md :: Runtime verification`.
 
 ## Purpose
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -602,13 +602,17 @@ Contract:
   rather than admitting evidence the operator believed was bounded.
 - **Operator precondition.** Admission encrypts through
   `app.heimdal.raw_store`, so `HEIMDAL_RAW_STORE_KEY` must be provisioned to the
-  process serving the API. Today `config/secrets/host_secret_contract.json`
-  declares that secret for the `heimdal-capture-watch` consumer only, so an api
-  process without it refuses every admission with 500
+  process serving the API. `config/secrets/host_secret_contract.json` declares
+  that secret for the `heimdal-api-ingress` consumer (the api process, which the
+  pre-existing `POST /api/heimdal/screen/capture` needs equally) alongside
+  `heimdal-capture-watch`, and the governed deploy wrapper delivers it (#4422).
+  An api process still without the key refuses every admission with 500
   `raw_store_key_unavailable` / `not_acknowledged` — named and remediable, never
-  a silent or ambiguous failure. Provisioning it to the api consumer (which the
-  pre-existing `POST /api/heimdal/screen/capture` needs equally) is a deferred
-  defect on the Known Defects registry (#4172, `KD-4384-RAWKEY`), not claimed here.
+  a silent or ambiguous failure — and an api startup preflight
+  (`app.heimdal.ingress_preflight`) reports the media and screen lanes
+  `unavailable` on `/api/status` before first use instead of letting a dead lane
+  look calm. Placing key material into each channel's Keychain item remains an
+  operator step; see `docs/STATUS.md :: Runtime verification`.
 - **Receipts are not retention-aware, stated honestly.**
   `app.heimdal.retention.enforce_hard_retention_bound` hard-deletes raw records
   past the retention window without consulting receipts, so a receipt can outlive

--- a/docs/contracts/MIMER_CLIENT_CONTRACT.md
+++ b/docs/contracts/MIMER_CLIENT_CONTRACT.md
@@ -176,9 +176,14 @@ only. The posture is enforced hub-side on the immediate peer and deliberately ig
 `X-Forwarded-For`, so a client behind a relay cannot present itself as local.
 
 **One operator precondition, stated honestly:** admission encrypts through the raw store, so the api
-process needs `HEIMDAL_RAW_STORE_KEY`. It is not yet provisioned to that consumer, so until it is,
-every admission answers `500 raw_store_key_unavailable` / `not_acknowledged` rather than a receipt.
-Tracked as `KD-4384-RAWKEY` on the Known Defects registry #4172.
+process needs `HEIMDAL_RAW_STORE_KEY`. Provisioning is delivered (#4422): the api process is a
+declared consumer of `heimdal.raw-store-key` (`heimdal-api-ingress`, dev/test/prod), the governed
+deploy wrapper materializes its secret layer, and an api startup preflight reports the ingress lanes
+`unavailable` on `/api/status` before first use rather than letting the lane look healthy. What
+remains is the operator step of placing key material into the Keychain item for that consumer per
+channel; until that is done for a channel, every admission there still answers
+`500 raw_store_key_unavailable` / `not_acknowledged` rather than a receipt. See
+`docs/STATUS.md :: Runtime verification`.
 
 ## 5. Direct-filesystem write transport (owner-permitted, 2026-07-07)
 


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary

#4422 (PR #4431) provisioned `HEIMDAL_RAW_STORE_KEY` to the api process and updated `docs/STATUS.md`. Five other docs were not updated and still describe the gap as open — two of them state something now flatly false. This is a current-state correction; no code, runtime behavior, contract, or secret wiring changes.

## Changes

| File | Was | Now |
|---|---|---|
| `docs/contracts/MIMER_CLIENT_CONTRACT.md` | "It is not yet provisioned to that consumer" | Delivered posture + the residual operator Keychain step |
| `docs/EVENTS.md` | contract "declares that secret for the `heimdal-capture-watch` consumer only" | Names the `heimdal-api-ingress` consumer and the startup preflight |
| `.../ADMIT_MEDIA_WITH_DURABLE_RECEIPTS.md` (CDLM-01 spec) | same false claim | Keeps its historical "not claimed by this slice" framing, records the gap as closed |
| `.../TRACK_MEETING_SESSIONS_AND_SEGMENT_GAPS.md` | dangling `KD-4384-RAWKEY` cite | Points at #4422 + `STATUS.md :: Runtime verification` |
| `.../PROJECT_LIVE_TRANSCRIPT_AND_DEFAULT_ANALYSIS.md` | dangling `KD-4384-RAWKEY` cite | same |

**`KD-4384-RAWKEY` never existed on the Known Defects registry.** #4172 carries 17 entries; only `KD-4384-MODALITY` matches that prefix. The defect went straight to a bounded Issue (#4422), so all four citations to it as a registry entry were dangling. They are replaced with the real `#4422` reference.

Every statement now points at `docs/STATUS.md :: Runtime verification` as the owner surface rather than restating the posture, so the next provisioning change has one place to update.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring lane; no BuilderOps material routed.

## Notes

Validation (all green on this head):
- `ruff check app tests companion-ui/companion-app`
- `mypy app` — 850 source files, no issues
- `python3 scripts/docs_guard.py` — OK
- `python3 scripts/public_seam_lint.py --mode gate` — `secret_hits: 0`, `uncovered_hits: 0`, `stale_rows: 0`
- Delivery re-verified against live config rather than the acceptance record: `tests/ops/test_host_secret_contract.py`, `tests/deploy/test_deploy_channel_script.py`, `tests/heimdal/test_media_ingress.py` — **104 passed**
- Branch-truth gate and `review_before_ci_gate.py --lane docs-authoring` both satisfied

INV-EF1: `MIMER_CLIENT_CONTRACT.md` is the only touched file containing "Bifrost" and already has a register row; no register change needed.

**Adjacency disclosure:** open PR #4498 (#4492, media consent scope) also edits `docs/EVENTS.md`, at the bullet immediately after this one (old line ~619 vs this change at ~603). Different change, no duplicated correction, no textual conflict expected — whichever merges second may need a trivial rebase.

No secret value, resolved path, or key material appears in this diff or this body.
---