### PR TITLE
Set default response length for Claude sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,4 +11,12 @@ For specialist subagent roles, use `docs/development/BUILDER_SUBAGENT_ROLES.md`;
 
 Read scope for every citation in this chain is `.codex/skills/_shared/READ_SCOPE.md`: `FILE :: Section` means read that section only, a citation with no `::` is a whole-file read that must state its reason, and `docs/DOCS_INDEX.md` is grep-only.
 
+## Response length
+
+Answer short by default: lead with the outcome and what it means for the next step. Keep verification
+evidence — diff walkthroughs, comment tables, quoted receipts — out of the reply unless asked, or unless
+the decision cannot be understood without it. Durable evidence belongs in the receipt, Issue, or PR that
+already owns it, not restated in chat. Length must be earned by the task (a plan, a comparison, a
+multi-file change), not by how much material happens to be in context.
+
 This file is only a Claude compatibility entrypoint. If a Claude-specific workflow note is ever needed, keep it here and keep `AGENTS.md` authoritative.


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue

Issue-free governance-lane change; no governing issue exists.

## SBS Impact
- Primary subsystem: Builder System / agent instruction surfaces
- Secondary subsystem(s): none
- Write class: Builder System governance text
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none — `AGENTS.md` remains authoritative; this is a Claude-specific workflow note in the compatibility entrypoint, which `CLAUDE.md` already reserves space for
- Owner-doc impact: none
- Transition debt impact: none
- Boundary risk: none — reporting style only; it does not relax any lifecycle, receipt, or verification requirement, and durable evidence still lands in the receipt/Issue/PR that owns it

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Owner feedback after a post-merge owner-doc verification turn: the answer was "already done, nothing to fix", but the reply carried a receipt table, a diff walkthrough, and a quoted authority record.
- Adds a `## Response length` section to `CLAUDE.md` stating that chat replies lead with the outcome and keep verification evidence out unless asked, and that length is earned by the task rather than by context volume.
- Explicitly preserves the rule that durable evidence belongs in the receipt, Issue, or PR that owns it — this trims chat prose, not the audit trail.

## Notes
- Tier 1 per `docs/development/GOVERNANCE_PROPORTIONALITY.md`: governance-lane, docs-only, no product/runtime behavior. `## BuilderOps Routing` omitted; nothing was routed.
- One file, one section added. No code, tests, or contracts touched.