### PR TITLE
Rename the CDH-06 AC4 acceptance target to state what it proves

### DIFF
--- a/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
+++ b/docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md
@@ -55,8 +55,11 @@ unit tests or if owner docs claim support before merged-main acceptance.
 - [ ] Final cockpit HTML is deterministic, JS-off complete, print-complete, and incapable of
   execution across every terminal/refusal state.
   Verify: `tests/builderops/ckm/test_design_cockpit.py::test_design_hub_projection_preserves_direction_b_authority`
-- [ ] All focused design-run, CKM, and model-inquiry regressions pass on the exact PR head.
-  Verify: `tests/builderops/test_design_hub_acceptance.py::test_focused_regression_suites_are_bound_to_pr_head`
+- [ ] The named focused design-run, CKM, and model-inquiry regression set is complete at the PR
+  head and every acceptance `Verify:` target resolves to a defined test. Head-bound pass evidence
+  for that set is the `Unit tests (not pg)` CI check run on the PR head plus the evidence pack, not
+  a literal recorded inside the test.
+  Verify: `tests/builderops/test_design_hub_acceptance.py::test_focused_regression_set_is_complete_and_verify_targets_resolve`
 - [ ] Local spec state and parent #4131 receive the exact final child, Yggdrasil, artifact,
   transition-debt, and conditional-acceptance handoff receipts without changing supported owner
   truth.

--- a/tests/builderops/test_design_hub_acceptance.py
+++ b/tests/builderops/test_design_hub_acceptance.py
@@ -1238,11 +1238,11 @@ ACCEPTANCE_VERIFY_TARGETS: tuple[tuple[str, str], ...] = (
     ),
     (
         "tests/builderops/test_design_hub_acceptance.py",
-        "test_focused_regression_suites_are_bound_to_pr_head",
+        "test_focused_regression_set_is_complete_and_verify_targets_resolve",
     ),
 )
 
-def test_focused_regression_suites_are_bound_to_pr_head() -> None:
+def test_focused_regression_set_is_complete_and_verify_targets_resolve() -> None:
     """Prove the named focused-regression set is complete and resolvable here.
 
     This test runs inside the same head-SHA CI lane that runs every suite named


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4502

## Linked Issue
Closes #4502

## SBS Impact
- Primary subsystem: Builder System (CKM design-hub acceptance evidence)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: resolvable name of the CDH-06 AC4 Verify: target; no runtime or behavioral contract change
- Owner-doc impact: updated in this PR (VALIDATE_DESIGN_HUB_END_TO_END.md AC4)
- Transition debt impact: reduces
- Boundary risk: rename must not weaken any existing assertion; no Builder acceptance evidence crosses into Product SBS or runtime MEM/HKA

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Rename the misnamed CDH-06 AC4 Verify: target and align its spec criterion. No assertion changes.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: naming and spec-truth repair only; no plan divergence, no new record type

## Notes
Repairs finding F1a from the independent parent acceptance audit on #4131. CDH-06 (#4313) is closed and cannot own the repair; #4502 is that owner and is deliberately filed without a `Parent:` declaration.

Three call sites, no assertion changes:
- `tests/builderops/test_design_hub_acceptance.py` — function renamed to `test_focused_regression_set_is_complete_and_verify_targets_resolve`.
- `tests/builderops/test_design_hub_acceptance.py` — self-referential `ACCEPTANCE_VERIFY_TARGETS` entry updated, so the suite still proves its own acceptance target resolves.
- `docs/CKM_DESIGN_AGENT_INTEGRATION/VALIDATE_DESIGN_HUB_END_TO_END.md :: Acceptance Criteria` — AC4 now states what the target proves and names the `Unit tests (not pg)` CI check on the PR head plus the evidence pack as the head-bound pass evidence.

No content-digest or head-SHA literal gate was reintroduced. No `app/builderops/**` behaviour, acceptance matrix, or other `Verify:` target changed. Parent #4131 was not edited, relabelled, or closed.

Red-then-green evidence: after renaming the function alone, the target failed on its own self-referential assertion (`tests/builderops/test_design_hub_acceptance.py does not define test_focused_regression_suites_are_bound_to_pr_head`); updating the tuple turned it green.

Validation on this head:
- `python3 -m pytest -q tests/builderops/test_design_hub_acceptance.py` — 3 passed
- `python3 -m pytest -q tests/builderops/ckm` — 327 passed
- `grep -rn "test_focused_regression_suites_are_bound_to_pr_head" --include='*.py' --include='*.md' .` — no matches
- `python3 scripts/docs_guard.py` — OK
- `ruff check app tests` — all checks passed
- `mypy app` — no issues in 851 source files

Pickup claim: `evidence=verified-dispatcher-lease`, `task_id=github-RasmusTho--agentic-pkm-mvp-issue-4502`, `lease_id=lease-9790cb38`, `holder=claude-code`, `coordination_mode=dispatcher-backed`.
