### PR TITLE
Add generation-bound targeted worktree cleanup

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -345,6 +345,11 @@ Enforcement surfaces:
   - `scripts/agent_workspace_cleanup.sh --report`
 - Safe cleanup apply (clean tree required):
   - `scripts/agent_workspace_cleanup.sh --apply --pr-state-file <path> --lease-file <path>`
+  - To reclaim exactly one completed worktree, add both `--target-worktree <absolute-path>` and
+    `--target-generation <32-hex-generation>`. Targeted apply limits mutations to that eligible
+    worktree and its associated local branch; it never acts on unrelated worktrees, branches,
+    remotes, stashes, or prune candidates. Missing, mismatched, or non-candidate selectors fail
+    closed before removal.
 - Register dedicated issue worktrees with `scripts/agent_worktree.py register`, renew them with
   `heartbeat`, and record `release` or `complete` when ownership ends. Cleanup is report-only by
   default. Apply may remove only a registered, expired, clean, unlocked worktree whose live

--- a/scripts/agent_workspace_cleanup.sh
+++ b/scripts/agent_workspace_cleanup.sh
@@ -9,6 +9,8 @@ STALE_DAYS=14
 CWD="$(pwd)"
 PR_STATE_FILE=""
 LEASE_FILE=""
+TARGET_WORKTREE=""
+TARGET_GENERATION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,6 +38,14 @@ while [[ $# -gt 0 ]]; do
       LEASE_FILE="$2"
       shift 2
       ;;
+    --target-worktree)
+      TARGET_WORKTREE="$2"
+      shift 2
+      ;;
+    --target-generation)
+      TARGET_GENERATION="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown arg: $1" >&2
       exit 2
@@ -46,6 +56,10 @@ done
 cd "$CWD"
 
 if [[ "$MODE" == "report" ]]; then
+  if [[ -n "$TARGET_WORKTREE" || -n "$TARGET_GENERATION" ]]; then
+    echo "Target selectors are only valid with --apply." >&2
+    exit 2
+  fi
   ARGS=(--cwd "$CWD")
   if [[ -n "$LEASE_FILE" ]]; then
     ARGS+=(--lease-file "$LEASE_FILE")
@@ -62,11 +76,22 @@ if [[ -z "$PR_STATE_FILE" || -z "$LEASE_FILE" ]]; then
   echo "Refusing cleanup: --apply requires --pr-state-file and --lease-file." >&2
   exit 1
 fi
+if [[ -n "$TARGET_WORKTREE" || -n "$TARGET_GENERATION" ]]; then
+  if [[ -z "$TARGET_WORKTREE" || -z "$TARGET_GENERATION" ]]; then
+    echo "Refusing cleanup: target cleanup requires --target-worktree and --target-generation." >&2
+    exit 1
+  fi
+fi
 
-python3 scripts/agent_worktree.py \
+ARGS=(
   --cwd "$CWD" \
   --lease-file "$LEASE_FILE" \
   janitor \
   --stale-after-days "$STALE_DAYS" \
   --mode apply \
   --pr-state-file "$PR_STATE_FILE"
+)
+if [[ -n "$TARGET_WORKTREE" ]]; then
+  ARGS+=(--target-worktree "$TARGET_WORKTREE" --target-generation "$TARGET_GENERATION")
+fi
+python3 scripts/agent_worktree.py "${ARGS[@]}"

--- a/scripts/agent_worktree.py
+++ b/scripts/agent_worktree.py
@@ -659,7 +659,15 @@ def janitor_apply(
     pr_states: dict[str, dict[str, Any]] | None,
     lease_path: Path,
     stale_after_days: int = 14,
+    target_worktree: Path | None = None,
+    target_generation: str | None = None,
 ) -> dict[str, Any]:
+    if (target_worktree is None) != (target_generation is None):
+        raise WorktreeLifecycleError(
+            "targeted cleanup requires both worktree path and lifecycle generation"
+        )
+    if target_generation is not None and not _valid_generation(target_generation):
+        raise WorktreeLifecycleError("targeted cleanup generation is invalid")
     path = _canonical(registry_path or _default_registry_path(cwd))
     if not path.exists():
         # Absence is not "nothing was ever registered": the registry is the only
@@ -672,6 +680,19 @@ def janitor_apply(
         raise WorktreeLifecycleError("worktree lifecycle registry is missing")
     _reconcile_removed_generations(cwd, path)
     records = _bind_live_generations(cwd, _locked_lifecycle_snapshot(path))
+    target_path: str | None = None
+    if target_worktree is not None:
+        target = _canonical(target_worktree)
+        record = records.get(str(target))
+        if (
+            not isinstance(record, dict)
+            or record.get("generation") != target_generation
+            or record.get("status") not in {"active", "released", "complete"}
+        ):
+            raise WorktreeLifecycleError(
+                "targeted cleanup lifecycle generation does not match"
+            )
+        target_path = str(target)
     return git_hygiene.janitor_apply(
         cwd,
         active_lease_loader=lambda: _load_active_lease_snapshot(lease_path),
@@ -683,6 +704,7 @@ def janitor_apply(
         stale_after_days=stale_after_days,
         pr_states=pr_states,
         lifecycle_records=records,
+        target_worktree=target_path,
     )
 
 
@@ -722,6 +744,8 @@ def main(argv: list[str] | None = None) -> int:
         operation.add_argument("--mode", choices=("report", "apply"), default="report")
         operation.add_argument("--stale-after-days", type=int, default=14)
         operation.add_argument("--pr-state-file")
+        operation.add_argument("--target-worktree")
+        operation.add_argument("--target-generation")
 
     args = parser.parse_args(argv)
     cwd = _canonical(Path(args.cwd))
@@ -763,6 +787,12 @@ def main(argv: list[str] | None = None) -> int:
                 registry_path=registry_path,
             )
         else:
+            if bool(args.target_worktree) != bool(args.target_generation):
+                raise WorktreeLifecycleError(
+                    "targeted cleanup requires both worktree path and lifecycle generation"
+                )
+            if args.mode == "report" and args.target_worktree:
+                raise WorktreeLifecycleError("target selectors are only valid for apply mode")
             pr_states = None
             if args.pr_state_file:
                 pr_states = json.loads(
@@ -783,6 +813,12 @@ def main(argv: list[str] | None = None) -> int:
                     pr_states=pr_states,
                     lease_path=lease_path,
                     stale_after_days=args.stale_after_days,
+                    target_worktree=(
+                        Path(args.target_worktree)
+                        if args.target_worktree is not None
+                        else None
+                    ),
+                    target_generation=args.target_generation,
                 )
             else:
                 active_leases = (

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1042,6 +1042,7 @@ def janitor_apply(
         [list[dict[str, Any]]], AbstractContextManager[Callable[[], None]]
     ]
     | None = None,
+    target_worktree: str | None = None,
 ) -> dict[str, Any]:
     actions: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -1165,6 +1166,52 @@ def janitor_apply(
         pr_states=pr_states,
         lifecycle_records=lifecycle_records,
     )
+
+    if target_worktree is not None:
+        target_path = str(Path(target_worktree).resolve(strict=False))
+        reclaimable = plan.get("reclaimable_worktrees", plan["candidates"]["worktrees"])
+        selected = [
+            worktree
+            for worktree in reclaimable
+            if str(Path(str(worktree.get("path", ""))).resolve(strict=False))
+            == target_path
+        ]
+        if len(selected) != 1:
+            return {
+                **plan,
+                "mode": "apply",
+                "targeted_cleanup": {"worktree": target_path},
+                "destructive_actions": actions,
+                "errors": [
+                    {
+                        "artifact": "worktree",
+                        "action": "select_target",
+                        "reason": "target_not_exactly_one_reclaimable_worktree",
+                        "path": target_path,
+                    }
+                ],
+                "ok": False,
+            }
+        # A targeted operation is intentionally narrower than the global janitor:
+        # preserve evidence and candidates belonging to other artifacts must not
+        # block it, but neither may they become eligible for mutation.
+        plan = {
+            **plan,
+            "candidates": {
+                **plan["candidates"],
+                "local_branches": [],
+                "worktrees": selected,
+                "orphaned_worktrees": [],
+                "remote_branches": [],
+                "remote_branches_requiring_rescue": [],
+                "old_stashes": [],
+            },
+            "reclaimable_worktrees": selected,
+            "orphaned_worktrees": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "preservation_receipts": [],
+            "targeted_cleanup": {"worktree": target_path},
+        }
 
     preservation_receipts = plan.get("preservation_receipts", [])
     if preservation_receipts:

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -233,6 +233,99 @@ def test_registration_generation_does_not_replay_after_worktree_recreation(
     )
 
 
+def test_targeted_janitor_apply_requires_matching_generation(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--initial-branch=main", repo], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "base.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "codex/target"], cwd=repo, check=True)
+    worktree = tmp_path / "target"
+    subprocess.run(["git", "worktree", "add", str(worktree), "codex/target"], cwd=repo, check=True)
+    registry_path = tmp_path / "agent-worktrees.json"
+    registration = agent_worktree.register_worktree(
+        repo, worktree=worktree, owner="owner", registry_path=registry_path
+    )
+    agent_worktree.complete_worktree(
+        repo, worktree=worktree, owner="owner", registry_path=registry_path
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(agent_worktree.WorktreeLifecycleError):
+        agent_worktree.janitor_apply(
+            repo,
+            registry_path=registry_path,
+            pr_states={},
+            lease_path=lease_path,
+            target_worktree=worktree,
+        )
+    with pytest.raises(agent_worktree.WorktreeLifecycleError):
+        agent_worktree.janitor_apply(
+            repo,
+            registry_path=registry_path,
+            pr_states={},
+            lease_path=lease_path,
+            target_worktree=worktree,
+            target_generation="b" * 32,
+        )
+    assert registration["generation"] != "b" * 32
+
+
+def test_targeted_janitor_apply_retires_selected_generation(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--initial-branch=main", repo], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "base.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "codex/target"], cwd=repo, check=True)
+    worktree = tmp_path / "target"
+    subprocess.run(["git", "worktree", "add", str(worktree), "codex/target"], cwd=repo, check=True)
+    registry_path = tmp_path / "agent-worktrees.json"
+    registration = agent_worktree.register_worktree(
+        repo, worktree=worktree, owner="owner", registry_path=registry_path
+    )
+    agent_worktree.complete_worktree(
+        repo, worktree=worktree, owner="owner", registry_path=registry_path
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def simulate_hygiene_apply(_cwd, **kwargs):
+        captured.update(kwargs)
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=worktree, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        with kwargs["lifecycle_authority_guard"](
+            [{"path": str(worktree), "branch": "codex/target", "head": head}]
+        ) as mark_succeeded:
+            mark_succeeded()
+        return {"ok": True}
+
+    monkeypatch.setattr(git_hygiene, "janitor_apply", simulate_hygiene_apply)
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=registration["generation"],
+    )
+
+    assert result["ok"] is True
+    assert captured["target_worktree"] == str(worktree.resolve())
+    record = agent_worktree.load_lifecycle_records(repo, registry_path=registry_path)[
+        str(worktree.resolve())
+    ]
+    assert record["status"] == "removed"
+    assert record["generation"] == registration["generation"]
+
+
 def test_bind_live_generations_skips_removal_tombstones(
     tmp_path,
     monkeypatch,

--- a/tests/scripts/test_git_hygiene_reclaim.py
+++ b/tests/scripts/test_git_hygiene_reclaim.py
@@ -219,6 +219,67 @@ def test_apply_uses_force_delete_for_pr_proven_non_ancestor_branch(
     )
 
 
+def test_targeted_janitor_apply_mutates_only_selected_worktree(
+    tmp_path, monkeypatch
+) -> None:
+    """Targeted apply must not inherit unrelated plan candidates."""
+    commands: list[list[str]] = []
+    target = tmp_path / "target"
+    other = tmp_path / "other"
+
+    def fake_run_git_result(args: list[str], _cwd: Path):
+        commands.append(args)
+        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+    def candidate(path: Path, branch: str) -> dict[str, str]:
+        return {
+            "path": str(path),
+            "branch": branch,
+            "head": branch,
+            "merge_proof": "merged_pr",
+        }
+
+    target_candidate = candidate(target, "codex/target")
+    other_candidate = candidate(other, "codex/other")
+    monkeypatch.setattr(git_hygiene, "run_git_result", fake_run_git_result)
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "candidates": {
+                "local_branches": [{"branch": "codex/unrelated"}],
+                "worktrees": [target_candidate, other_candidate],
+                "orphaned_worktrees": [],
+                "remote_branches": [{"branch": "codex/remote"}],
+                "remote_branches_requiring_rescue": [],
+                "old_stashes": [{"sha": "a" * 40}],
+            },
+            "reclaimable_worktrees": [target_candidate, other_candidate],
+            "orphaned_worktrees": [],
+            "prune_candidates": {"worktree": ["stale"], "remote": ["stale"]},
+            "preservation_receipts": [{"path": str(other), "reason": "unregistered"}],
+        },
+    )
+
+    report = git_hygiene.janitor_apply(
+        tmp_path,
+        pr_states={"codex/target": {"state": "MERGED"}},
+        active_lease_loader=lambda: [],
+        lifecycle_authority_guard=_allow_lifecycle_authority,
+        lifecycle_records={},
+        target_worktree=str(target),
+    )
+
+    assert report["ok"] is True
+    assert ["worktree", "remove", str(target)] in commands
+    assert ["branch", "-D", "codex/target"] in commands
+    assert not any(str(other) in command for command in commands)
+    assert not any(command[:2] == ["push", "origin"] for command in commands)
+    assert not any(command[:2] == ["stash", "drop"] for command in commands)
+    assert ["branch", "-d", "codex/unrelated"] not in commands
+
+
 def test_apply_real_git_reclaims_squash_merged_worktree_and_branch(tmp_path) -> None:
     """Real-git regression: a true squash-merge leaves the feature branch as a
     NON-ancestor of origin/main. With a merged PR proof, apply must remove the


### PR DESCRIPTION
Governing-Issue: #4521

Fixes #4521

Final-Review-Rounds: 0

## Summary
Adds paired worktree and generation selectors for a narrowly scoped cleanup apply. The selected worktree retains the existing fail-closed lifecycle and lease checks, while unrelated cleanup candidates cannot be mutated.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Builder System bug delivery had no plan divergence or BuilderOps authority crossing.

## Notes
Validation: pytest -q tests/ops/test_agent_worktree.py; pytest -q tests/scripts/test_git_hygiene_reclaim.py; ruff check scripts tests; mypy scripts/agent_worktree.py scripts/git_hygiene.py; python3 scripts/docs_guard.py; bash -n scripts/agent_workspace_cleanup.sh; review_before_ci_gate satisfied.