### PR TITLE
Resume exact tombstoned cleanup branch step

### DIFF
--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -141,6 +141,13 @@ generation before branch deletion; restart reconciliation completes only a pendi
 never infers removal from an ordinary missing lifecycle record. Broad worktree-metadata pruning
 remains report-only.
 
+When a selected worktree has already been durably retired as an exact `removed` generation but its
+branch step did not complete, a later targeted apply may resume only that tombstone's bound local
+branch. It requires fresh external PR-state and lease snapshots, preserves every other janitor
+candidate, confirms the checkout remains absent, and holds the lifecycle lock through the branch
+deletion while rechecking the path, branch, and generation binding. Any replacement checkout,
+lifecycle drift, or active path/branch lease fails closed and leaves the branch intact.
+
 ## Enforcement intent
 
 - Issues are the canonical delivery task contract for implementation work.

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -143,8 +143,10 @@ remains report-only.
 
 When a selected worktree has already been durably retired as an exact `removed` generation but its
 branch step did not complete, a later targeted apply may resume only that tombstone's bound local
-branch. A non-ancestor branch additionally requires fresh external `MERGED` PR-state and lease snapshots, preserves every other janitor
-candidate, confirms the checkout remains absent, and holds the lifecycle lock through the branch
+branch. A non-ancestor branch additionally requires fresh external `MERGED` PR-state and lease
+snapshots; its current local branch head must exactly match the merged PR head during planning and
+again in the final locked deletion window. The retry preserves every other janitor candidate,
+confirms the checkout remains absent, and holds the lifecycle lock through the branch
 deletion while rechecking the path, branch, and generation binding. It atomically reserves the
 absent target path for that delete window, so another `git worktree add` cannot reuse it between
 revalidation and branch deletion. Any replacement checkout, lifecycle drift, or active path/branch

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -145,7 +145,7 @@ When a selected worktree has already been durably retired as an exact `removed` 
 branch step did not complete, a later targeted apply may resume only that tombstone's bound local
 branch. A non-ancestor branch additionally requires fresh external `MERGED` PR-state and lease
 snapshots; its current local branch head must exactly match the merged PR head during planning and
-again in the final locked deletion window. The retry preserves every other janitor candidate,
+again in the final locked deletion window, then uses a compare-and-delete ref update. The retry preserves every other janitor candidate,
 confirms the checkout remains absent, and holds the lifecycle lock through the branch
 deletion while rechecking the path, branch, and generation binding. It atomically reserves the
 absent target path for that delete window, so another `git worktree add` cannot reuse it between

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -143,10 +143,12 @@ remains report-only.
 
 When a selected worktree has already been durably retired as an exact `removed` generation but its
 branch step did not complete, a later targeted apply may resume only that tombstone's bound local
-branch. It requires fresh external PR-state and lease snapshots, preserves every other janitor
+branch. A non-ancestor branch additionally requires fresh external `MERGED` PR-state and lease snapshots, preserves every other janitor
 candidate, confirms the checkout remains absent, and holds the lifecycle lock through the branch
-deletion while rechecking the path, branch, and generation binding. Any replacement checkout,
-lifecycle drift, or active path/branch lease fails closed and leaves the branch intact.
+deletion while rechecking the path, branch, and generation binding. It atomically reserves the
+absent target path for that delete window, so another `git worktree add` cannot reuse it between
+revalidation and branch deletion. Any replacement checkout, lifecycle drift, or active path/branch
+lease fails closed and leaves the branch intact.
 
 ## Enforcement intent
 

--- a/scripts/agent_worktree.py
+++ b/scripts/agent_worktree.py
@@ -453,6 +453,44 @@ def _locked_lifecycle_authority(
             _write_registry(path, payload)
 
 
+@contextmanager
+def _locked_removed_generation_branch_authority(
+    cwd: Path,
+    path: Path,
+    *,
+    worktree: str,
+    branch: str,
+    generation: str,
+) -> Iterator[None]:
+    """Hold the exact tombstone authority through its resumed branch deletion."""
+
+    canonical = _canonical(Path(worktree))
+    with _registry_lock(path):
+        payload = _read_registry(path)
+        record = payload["worktrees"].get(str(canonical))
+        if (
+            not isinstance(record, dict)
+            or record.get("generation") != generation
+            or record.get("branch") != branch
+            or record.get("status") != "removed"
+        ):
+            raise WorktreeLifecycleError(
+                "cleanup target removed lifecycle authority changed"
+            )
+        if canonical.exists():
+            raise WorktreeLifecycleError("cleanup target worktree was recreated")
+        live_entries = git_hygiene._parse_worktrees(
+            git_hygiene.run_git(["worktree", "list", "--porcelain"], cwd)
+        )
+        if any(
+            entry.get("worktree")
+            and _canonical(Path(entry["worktree"])) == canonical
+            for entry in live_entries
+        ):
+            raise WorktreeLifecycleError("cleanup target worktree was recreated")
+        yield
+
+
 def load_lifecycle_records(
     cwd: Path,
     *,
@@ -681,18 +719,31 @@ def janitor_apply(
     _reconcile_removed_generations(cwd, path)
     records = _bind_live_generations(cwd, _locked_lifecycle_snapshot(path))
     target_path: str | None = None
+    target_branch: str | None = None
     if target_worktree is not None:
         target = _canonical(target_worktree)
         record = records.get(str(target))
         if (
             not isinstance(record, dict)
             or record.get("generation") != target_generation
-            or record.get("status") not in {"active", "released", "complete"}
         ):
             raise WorktreeLifecycleError(
                 "targeted cleanup lifecycle generation does not match"
             )
         target_path = str(target)
+        if record.get("status") == "removed":
+            branch = record.get("branch")
+            if not isinstance(branch, str) or not branch:
+                raise WorktreeLifecycleError(
+                    "targeted cleanup removed lifecycle binding is invalid"
+                )
+            if target.exists():
+                raise WorktreeLifecycleError("targeted cleanup worktree was recreated")
+            target_branch = branch
+        elif record.get("status") not in {"active", "released", "complete"}:
+            raise WorktreeLifecycleError(
+                "targeted cleanup lifecycle generation does not match"
+            )
     return git_hygiene.janitor_apply(
         cwd,
         active_lease_loader=lambda: _load_active_lease_snapshot(lease_path),
@@ -705,6 +756,20 @@ def janitor_apply(
         pr_states=pr_states,
         lifecycle_records=records,
         target_worktree=target_path,
+        target_branch=target_branch,
+        branch_lifecycle_authority_guard=(
+            (
+                lambda target: _locked_removed_generation_branch_authority(
+                    cwd,
+                    path,
+                    worktree=str(target["path"]),
+                    branch=str(target["branch"]),
+                    generation=target_generation,
+                )
+            )
+            if target_branch is not None
+            else None
+        ),
     )
 
 

--- a/scripts/agent_worktree.py
+++ b/scripts/agent_worktree.py
@@ -477,18 +477,36 @@ def _locked_removed_generation_branch_authority(
             raise WorktreeLifecycleError(
                 "cleanup target removed lifecycle authority changed"
             )
-        if canonical.exists():
-            raise WorktreeLifecycleError("cleanup target worktree was recreated")
-        live_entries = git_hygiene._parse_worktrees(
-            git_hygiene.run_git(["worktree", "list", "--porcelain"], cwd)
-        )
-        if any(
-            entry.get("worktree")
-            and _canonical(Path(entry["worktree"])) == canonical
-            for entry in live_entries
-        ):
-            raise WorktreeLifecycleError("cleanup target worktree was recreated")
-        yield
+        reservation = canonical / ".agent-worktree-cleanup-reservation"
+        try:
+            canonical.mkdir(mode=0o700)
+            descriptor = os.open(
+                reservation,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            os.close(descriptor)
+        except FileExistsError as exc:
+            raise WorktreeLifecycleError("cleanup target worktree was recreated") from exc
+        try:
+            live_entries = git_hygiene._parse_worktrees(
+                git_hygiene.run_git(["worktree", "list", "--porcelain"], cwd)
+            )
+            if any(
+                entry.get("worktree")
+                and _canonical(Path(entry["worktree"])) == canonical
+                for entry in live_entries
+            ):
+                raise WorktreeLifecycleError("cleanup target worktree was recreated")
+            yield
+        finally:
+            try:
+                reservation.unlink()
+                canonical.rmdir()
+            except OSError as exc:
+                raise WorktreeLifecycleError(
+                    "cleanup target path reservation could not be released"
+                ) from exc
 
 
 def load_lifecycle_records(

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1212,16 +1212,11 @@ def janitor_apply(
                 None,
             )
             pr_state = _pr_state(target_branch, pr_states).get("state")
-            if (
-                skipped_reason == "not_merged_to_origin_main"
-                and pr_state in {"MERGED", "CLOSED"}
-            ):
+            if skipped_reason == "not_merged_to_origin_main" and pr_state == "MERGED":
                 selected_branches = [
                     {
                         "branch": target_branch,
-                        "merge_proof": (
-                            "merged_pr" if pr_state == "MERGED" else "closed_pr"
-                        ),
+                        "merge_proof": "merged_pr",
                     }
                 ]
         if target_branch is None and len(selected) != 1:

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1408,6 +1408,32 @@ def janitor_apply(
             )
             return False
 
+    def branch_delete_args(branch: Mapping[str, Any]) -> list[str] | None:
+        """Return a ref-CAS delete for non-ancestor PR-proven branches.
+
+        `git branch -D` cannot bind the delete to the planned ref.  A conditional
+        `update-ref -d` does, so a branch advanced after planning is preserved.
+        """
+
+        branch_name = branch.get("branch")
+        merge_proof = branch.get("merge_proof")
+        if not isinstance(branch_name, str) or not branch_name:
+            raise ValueError("branch cleanup candidate is invalid")
+        if merge_proof not in {"merged_pr", "closed_pr"}:
+            return ["branch", "-d", branch_name]
+        expected_head = branch.get("merged_pr_head", branch.get("head"))
+        if not isinstance(expected_head, str) or not expected_head:
+            errors.append(
+                {
+                    "artifact": "local_branch",
+                    "action": "select_delete_ref",
+                    "reason": "conditional_branch_delete_head_required",
+                    "branch": branch_name,
+                }
+            )
+            return None
+        return ["update-ref", "-d", f"refs/heads/{branch_name}", expected_head]
+
     reclaimable = plan.get("reclaimable_worktrees", plan["candidates"]["worktrees"])
     cleanup_worktrees = [
         *plan.get(
@@ -1471,17 +1497,22 @@ def janitor_apply(
                     "errors": errors,
                     "ok": False,
                 }
-            # Squash/closed-PR-proven branches are not ancestors of origin/main,
-            # so `git branch -d` refuses them and the branch would be skipped
-            # forever. The merge_proof already establishes safe-to-delete, so use
-            # -D for merged_pr/closed_pr; keep the conservative -d for branches
-            # proven by ancestry.
-            delete_flag = (
-                "-D"
-                if worktree.get("merge_proof") in {"merged_pr", "closed_pr"}
-                else "-d"
-            )
-            apply_git(["branch", delete_flag, worktree["branch"]], {"artifact": "local_branch", "action": "delete_after_worktree_remove", "branch": worktree["branch"]})
+            delete_args = branch_delete_args(worktree)
+            if delete_args is None or not apply_git(
+                delete_args,
+                {
+                    "artifact": "local_branch",
+                    "action": "delete_after_worktree_remove",
+                    "branch": worktree["branch"],
+                },
+            ):
+                return {
+                    **plan,
+                    "mode": "apply",
+                    "destructive_actions": actions,
+                    "errors": errors,
+                    "ok": False,
+                }
     for branch in plan["candidates"]["local_branches"]:
         if authority_changed_for(
             path=target_worktree if branch.get("branch") == target_branch else None,
@@ -1497,17 +1528,9 @@ def janitor_apply(
         action = {"artifact": "local_branch", "action": "delete", **branch}
         if target_branch is not None and branch.get("branch") == target_branch:
             action["path"] = target_worktree
-            if not apply_with_branch_lifecycle_authority(
-                [
-                    "branch",
-                    (
-                        "-D"
-                        if branch.get("merge_proof") in {"merged_pr", "closed_pr"}
-                        else "-d"
-                    ),
-                    branch["branch"],
-                ],
-                action,
+            delete_args = branch_delete_args(branch)
+            if delete_args is None or not apply_with_branch_lifecycle_authority(
+                delete_args, action
             ):
                 return {
                     **plan,

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1367,6 +1367,10 @@ def janitor_apply(
             return apply_git(args, action)
         try:
             with branch_lifecycle_authority_guard(action):
+                if authority_changed_for(
+                    path=action.get("path"), branch=action.get("branch")
+                ):
+                    return False
                 return apply_git(args, action)
         except (OSError, RuntimeError, TypeError, ValueError, subprocess.SubprocessError):
             errors.append(

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1211,12 +1211,21 @@ def janitor_apply(
                 ),
                 None,
             )
-            pr_state = _pr_state(target_branch, pr_states).get("state")
-            if skipped_reason == "not_merged_to_origin_main" and pr_state == "MERGED":
+            pr = _pr_state(target_branch, pr_states)
+            pr_state = pr.get("state")
+            merged_head = pr.get("head_sha")
+            current_head = run_git(["rev-parse", target_branch], cwd)
+            if (
+                skipped_reason == "not_merged_to_origin_main"
+                and pr_state == "MERGED"
+                and isinstance(merged_head, str)
+                and merged_head == current_head
+            ):
                 selected_branches = [
                     {
                         "branch": target_branch,
                         "merge_proof": "merged_pr",
+                        "merged_pr_head": merged_head,
                     }
                 ]
         if target_branch is None and len(selected) != 1:
@@ -1371,6 +1380,21 @@ def janitor_apply(
                     path=action.get("path"), branch=action.get("branch")
                 ):
                     return False
+                merged_pr_head = action.get("merged_pr_head")
+                if merged_pr_head is not None:
+                    current_head = run_git(["rev-parse", str(action["branch"])], cwd)
+                    if current_head != merged_pr_head:
+                        errors.append(
+                            {
+                                "artifact": "local_branch",
+                                "action": "revalidate_merged_pr_head",
+                                "reason": "target_branch_head_changed",
+                                "branch": action["branch"],
+                                "expected_head": merged_pr_head,
+                                "current_head": current_head,
+                            }
+                        )
+                        return False
                 return apply_git(args, action)
         except (OSError, RuntimeError, TypeError, ValueError, subprocess.SubprocessError):
             errors.append(

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1043,6 +1043,11 @@ def janitor_apply(
     ]
     | None = None,
     target_worktree: str | None = None,
+    target_branch: str | None = None,
+    branch_lifecycle_authority_guard: Callable[
+        [dict[str, Any]], AbstractContextManager[None]
+    ]
+    | None = None,
 ) -> dict[str, Any]:
     actions: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -1096,6 +1101,21 @@ def janitor_apply(
                     "artifact": "worktree",
                     "action": "revalidate_lifecycle_registry",
                     "reason": "authoritative_lifecycle_revalidation_required",
+                }
+            ],
+        }
+    if target_branch is not None and (
+        target_worktree is None or branch_lifecycle_authority_guard is None
+    ):
+        return {
+            "mode": "apply",
+            "ok": False,
+            "destructive_actions": [],
+            "errors": [
+                {
+                    "artifact": "worktree",
+                    "action": "revalidate_lifecycle_registry",
+                    "reason": "targeted_branch_lifecycle_guard_required",
                 }
             ],
         }
@@ -1176,7 +1196,35 @@ def janitor_apply(
             if str(Path(str(worktree.get("path", ""))).resolve(strict=False))
             == target_path
         ]
-        if len(selected) != 1:
+        selected_branches = [
+            {**branch, "merge_proof": "ancestor_of_origin_main"}
+            for branch in plan["candidates"]["local_branches"]
+            if branch.get("branch") == target_branch
+        ]
+        if target_branch is not None and not selected_branches:
+            skipped_reason = next(
+                (
+                    item.get("reason")
+                    for item in plan["skipped"]
+                    if item.get("artifact") == "local_branch"
+                    and item.get("name") == target_branch
+                ),
+                None,
+            )
+            pr_state = _pr_state(target_branch, pr_states).get("state")
+            if (
+                skipped_reason == "not_merged_to_origin_main"
+                and pr_state in {"MERGED", "CLOSED"}
+            ):
+                selected_branches = [
+                    {
+                        "branch": target_branch,
+                        "merge_proof": (
+                            "merged_pr" if pr_state == "MERGED" else "closed_pr"
+                        ),
+                    }
+                ]
+        if target_branch is None and len(selected) != 1:
             return {
                 **plan,
                 "mode": "apply",
@@ -1192,6 +1240,23 @@ def janitor_apply(
                 ],
                 "ok": False,
             }
+        if target_branch is not None and len(selected_branches) != 1:
+            return {
+                **plan,
+                "mode": "apply",
+                "targeted_cleanup": {"worktree": target_path, "branch": target_branch},
+                "destructive_actions": actions,
+                "errors": [
+                    {
+                        "artifact": "local_branch",
+                        "action": "select_target",
+                        "reason": "target_not_exactly_one_reclaimable_tombstone_branch",
+                        "path": target_path,
+                        "branch": target_branch,
+                    }
+                ],
+                "ok": False,
+            }
         # A targeted operation is intentionally narrower than the global janitor:
         # preserve evidence and candidates belonging to other artifacts must not
         # block it, but neither may they become eligible for mutation.
@@ -1199,18 +1264,22 @@ def janitor_apply(
             **plan,
             "candidates": {
                 **plan["candidates"],
-                "local_branches": [],
-                "worktrees": selected,
+                "local_branches": selected_branches,
+                "worktrees": selected if target_branch is None else [],
                 "orphaned_worktrees": [],
                 "remote_branches": [],
                 "remote_branches_requiring_rescue": [],
                 "old_stashes": [],
             },
-            "reclaimable_worktrees": selected,
+            "reclaimable_worktrees": selected if target_branch is None else [],
             "orphaned_worktrees": [],
             "prune_candidates": {"worktree": [], "remote": []},
             "preservation_receipts": [],
-            "targeted_cleanup": {"worktree": target_path},
+            "targeted_cleanup": (
+                {"worktree": target_path, "branch": target_branch}
+                if target_branch is not None
+                else {"worktree": target_path}
+            ),
         }
 
     preservation_receipts = plan.get("preservation_receipts", [])
@@ -1295,6 +1364,27 @@ def janitor_apply(
             return False
         return True
 
+    def apply_with_branch_lifecycle_authority(
+        args: list[str],
+        action: dict[str, Any],
+    ) -> bool:
+        if branch_lifecycle_authority_guard is None:
+            return apply_git(args, action)
+        try:
+            with branch_lifecycle_authority_guard(action):
+                return apply_git(args, action)
+        except (OSError, RuntimeError, TypeError, ValueError, subprocess.SubprocessError):
+            errors.append(
+                {
+                    "artifact": "worktree",
+                    "action": "revalidate_lifecycle_registry",
+                    "reason": "targeted_branch_lifecycle_authority_changed",
+                    "path": action.get("path"),
+                    "branch": action.get("branch"),
+                }
+            )
+            return False
+
     reclaimable = plan.get("reclaimable_worktrees", plan["candidates"]["worktrees"])
     cleanup_worktrees = [
         *plan.get(
@@ -1370,7 +1460,10 @@ def janitor_apply(
             )
             apply_git(["branch", delete_flag, worktree["branch"]], {"artifact": "local_branch", "action": "delete_after_worktree_remove", "branch": worktree["branch"]})
     for branch in plan["candidates"]["local_branches"]:
-        if authority_changed_for(branch=branch.get("branch")):
+        if authority_changed_for(
+            path=target_worktree if branch.get("branch") == target_branch else None,
+            branch=branch.get("branch"),
+        ):
             return {
                 **plan,
                 "mode": "apply",
@@ -1378,7 +1471,30 @@ def janitor_apply(
                 "errors": errors,
                 "ok": False,
             }
-        apply_git(["branch", "-d", branch["branch"]], {"artifact": "local_branch", "action": "delete", **branch})
+        action = {"artifact": "local_branch", "action": "delete", **branch}
+        if target_branch is not None and branch.get("branch") == target_branch:
+            action["path"] = target_worktree
+            if not apply_with_branch_lifecycle_authority(
+                [
+                    "branch",
+                    (
+                        "-D"
+                        if branch.get("merge_proof") in {"merged_pr", "closed_pr"}
+                        else "-d"
+                    ),
+                    branch["branch"],
+                ],
+                action,
+            ):
+                return {
+                    **plan,
+                    "mode": "apply",
+                    "destructive_actions": actions,
+                    "errors": errors,
+                    "ok": False,
+                }
+        else:
+            apply_git(["branch", "-d", branch["branch"]], action)
     for remote in plan["candidates"]["remote_branches"]:
         if authority_changed_for(branch=remote.get("branch")):
             return {

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -5,7 +5,7 @@ import os
 import stat
 import subprocess
 import threading
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 import pytest
@@ -163,6 +163,10 @@ def _init_repo_with_tombstoned_branch(
     agent_worktree._mark_generation_removed(record, removed_at=2)
     agent_worktree._write_registry(registry_path, payload)
     return repo, worktree, registry_path, branch, registration["generation"]
+
+
+def _merged_pr_state(repo: Path, branch: str) -> dict[str, str]:
+    return {"state": "MERGED", "head_sha": git_hygiene.run_git(["rev-parse", branch], repo)}
 
 
 def test_registry_write_fsyncs_parent_directory_after_replace(
@@ -388,7 +392,7 @@ def test_targeted_janitor_apply_resumes_removed_generation_branch_cleanup(tmp_pa
     result = agent_worktree.janitor_apply(
         repo,
         registry_path=registry_path,
-        pr_states={branch: {"state": "MERGED"}},
+        pr_states={branch: _merged_pr_state(repo, branch)},
         lease_path=lease_path,
         target_worktree=worktree,
         target_generation=generation,
@@ -447,7 +451,7 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
     result = agent_worktree.janitor_apply(
         repo,
         registry_path=registry_path,
-        pr_states={branch: {"state": "MERGED"}},
+        pr_states={branch: _merged_pr_state(repo, branch)},
         lease_path=lease_path,
         target_worktree=worktree,
         target_generation=generation,
@@ -495,7 +499,12 @@ def test_targeted_janitor_apply_removed_generation_preserves_closed_unmerged_bra
     result = agent_worktree.janitor_apply(
         repo,
         registry_path=registry_path,
-        pr_states={branch: {"state": "CLOSED"}},
+        pr_states={
+            branch: {
+                "state": "CLOSED",
+                "head_sha": git_hygiene.run_git(["rev-parse", branch], repo),
+            }
+        },
         lease_path=lease_path,
         target_worktree=worktree,
         target_generation=generation,
@@ -506,6 +515,86 @@ def test_targeted_janitor_apply_removed_generation_preserves_closed_unmerged_bra
     assert result["errors"][0]["reason"] == (
         "target_not_exactly_one_reclaimable_tombstone_branch"
     )
+
+
+def test_targeted_janitor_apply_removed_generation_preserves_newer_local_commits(
+    tmp_path,
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    merged_pr = _merged_pr_state(repo, branch)
+    tree = git_hygiene.run_git(["rev-parse", f"{branch}^{{tree}}"], repo)
+    newer = git_hygiene.run_git(
+        ["commit-tree", tree, "-p", branch, "-m", "newer local commit"], repo
+    )
+    git_hygiene.run_git(["update-ref", f"refs/heads/{branch}", newer], repo)
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={branch: merged_pr},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=generation,
+    )
+
+    assert result["ok"] is False
+    assert branch in git_hygiene._local_branches(repo)
+    assert git_hygiene.run_git(["rev-parse", branch], repo) == newer
+
+
+def test_targeted_janitor_apply_revalidates_merged_head_inside_final_guard(
+    tmp_path, monkeypatch
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    merged_pr = _merged_pr_state(repo, branch)
+    tree = git_hygiene.run_git(["rev-parse", f"{branch}^{{tree}}"], repo)
+    newer = git_hygiene.run_git(
+        ["commit-tree", tree, "-p", branch, "-m", "newer local commit"], repo
+    )
+    original_guard = agent_worktree._locked_removed_generation_branch_authority
+
+    @contextmanager
+    def advance_branch_inside_guard(*args, **kwargs):
+        with original_guard(*args, **kwargs):
+            git_hygiene.run_git(["update-ref", f"refs/heads/{branch}", newer], repo)
+            yield
+
+    monkeypatch.setattr(
+        agent_worktree,
+        "_locked_removed_generation_branch_authority",
+        advance_branch_inside_guard,
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={branch: merged_pr},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=generation,
+    )
+
+    assert result["ok"] is False
+    assert branch in git_hygiene._local_branches(repo)
+    assert git_hygiene.run_git(["rev-parse", branch], repo) == newer
+    assert result["errors"] == [
+        {
+            "artifact": "local_branch",
+            "action": "revalidate_merged_pr_head",
+            "reason": "target_branch_head_changed",
+            "branch": branch,
+            "expected_head": merged_pr["head_sha"],
+            "current_head": newer,
+        }
+    ]
 
 
 def test_removed_generation_branch_authority_reserves_target_path(tmp_path) -> None:

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -409,7 +409,10 @@ def test_targeted_janitor_apply_resumes_removed_generation_branch_cleanup(tmp_pa
     assert record["status"] == "removed"
 
 
-@pytest.mark.parametrize("authority", ("path_lease", "branch_lease", "binding_change"))
+@pytest.mark.parametrize(
+    "authority",
+    ("path_lease", "branch_lease", "late_path_lease", "late_branch_lease", "binding_change"),
+)
 def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_change(
     tmp_path, monkeypatch, authority
 ) -> None:
@@ -425,6 +428,8 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
         calls += 1
         if calls == 1:
             return []
+        if authority.startswith("late_") and calls == 2:
+            return []
         if authority == "binding_change":
             payload = json.loads(registry_path.read_text(encoding="utf-8"))
             payload["worktrees"][str(worktree.resolve())]["branch"] = "codex/replaced"
@@ -432,7 +437,7 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
             return []
         resource_id = (
             f"worktree:{worktree.resolve()}"
-            if authority == "path_lease"
+            if authority in {"path_lease", "late_path_lease"}
             else f"branch:{branch}"
         )
         return [{"resource_id": resource_id, "expires_at": None}]
@@ -463,7 +468,7 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
     else:
         resource_id = (
             f"worktree:{worktree.resolve()}"
-            if authority == "path_lease"
+            if authority in {"path_lease", "late_path_lease"}
             else f"branch:{branch}"
         )
         assert result["errors"] == [

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -409,8 +409,9 @@ def test_targeted_janitor_apply_resumes_removed_generation_branch_cleanup(tmp_pa
     assert record["status"] == "removed"
 
 
+@pytest.mark.parametrize("authority", ("path_lease", "branch_lease", "binding_change"))
 def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_change(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, authority
 ) -> None:
     repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
         tmp_path
@@ -424,7 +425,17 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
         calls += 1
         if calls == 1:
             return []
-        return [{"resource_id": f"worktree:{worktree.resolve()}", "expires_at": None}]
+        if authority == "binding_change":
+            payload = json.loads(registry_path.read_text(encoding="utf-8"))
+            payload["worktrees"][str(worktree.resolve())]["branch"] = "codex/replaced"
+            agent_worktree._write_registry(registry_path, payload)
+            return []
+        resource_id = (
+            f"worktree:{worktree.resolve()}"
+            if authority == "path_lease"
+            else f"branch:{branch}"
+        )
+        return [{"resource_id": resource_id, "expires_at": None}]
 
     monkeypatch.setattr(agent_worktree, "_load_active_lease_snapshot", leases_after_plan)
 
@@ -439,16 +450,82 @@ def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_cha
 
     assert result["ok"] is False
     assert branch in git_hygiene._local_branches(repo)
-    assert result["errors"] == [
-        {
-            "artifact": "worktree",
-            "action": "preserve",
-            "reason": "lease_authority_changed",
-            "path": str(worktree.resolve()),
-            "branch": branch,
-            "active_leases": [f"worktree:{worktree.resolve()}"],
-        }
-    ]
+    if authority == "binding_change":
+        assert result["errors"] == [
+            {
+                "artifact": "worktree",
+                "action": "revalidate_lifecycle_registry",
+                "reason": "targeted_branch_lifecycle_authority_changed",
+                "path": str(worktree.resolve()),
+                "branch": branch,
+            }
+        ]
+    else:
+        resource_id = (
+            f"worktree:{worktree.resolve()}"
+            if authority == "path_lease"
+            else f"branch:{branch}"
+        )
+        assert result["errors"] == [
+            {
+                "artifact": "worktree",
+                "action": "preserve",
+                "reason": "lease_authority_changed",
+                "path": str(worktree.resolve()),
+                "branch": branch,
+                "active_leases": [resource_id],
+            }
+        ]
+
+
+def test_targeted_janitor_apply_removed_generation_preserves_closed_unmerged_branch(
+    tmp_path,
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={branch: {"state": "CLOSED"}},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=generation,
+    )
+
+    assert result["ok"] is False
+    assert branch in git_hygiene._local_branches(repo)
+    assert result["errors"][0]["reason"] == (
+        "target_not_exactly_one_reclaimable_tombstone_branch"
+    )
+
+
+def test_removed_generation_branch_authority_reserves_target_path(tmp_path) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    replacement_branch = "codex/replacement"
+    subprocess.run(["git", "branch", replacement_branch], cwd=repo, check=True)
+
+    with agent_worktree._locked_removed_generation_branch_authority(
+        repo,
+        registry_path,
+        worktree=str(worktree),
+        branch=branch,
+        generation=generation,
+    ):
+        replacement = subprocess.run(
+            ["git", "worktree", "add", str(worktree), replacement_branch],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        assert replacement.returncode != 0
+    assert not worktree.exists()
+    assert replacement_branch in git_hygiene._local_branches(repo)
 
 
 def test_bind_live_generations_skips_removal_tombstones(

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -113,6 +113,58 @@ def _worktree_porcelain(
     )
 
 
+def _init_repo_with_tombstoned_branch(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, str, str]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", remote],
+        check=True,
+    )
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--initial-branch=main", repo], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "base.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=repo, check=True)
+
+    branch = "codex/tombstoned-target"
+    subprocess.run(["git", "branch", branch], cwd=repo, check=True)
+    worktree = tmp_path / "target"
+    subprocess.run(["git", "worktree", "add", str(worktree), branch], cwd=repo, check=True)
+    (worktree / "feature.txt").write_text("feature\n", encoding="utf-8")
+    subprocess.run(["git", "add", "feature.txt"], cwd=worktree, check=True)
+    subprocess.run(["git", "commit", "-m", "feature"], cwd=worktree, check=True)
+    registry_path = tmp_path / "agent-worktrees.json"
+    registration = agent_worktree.register_worktree(
+        repo,
+        worktree=worktree,
+        owner="prior-owner",
+        ttl_seconds=1,
+        registry_path=registry_path,
+        now=0,
+    )
+    agent_worktree.complete_worktree(
+        repo,
+        worktree=worktree,
+        owner="prior-owner",
+        registry_path=registry_path,
+        now=1,
+    )
+    subprocess.run(["git", "merge", "--squash", branch], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "squash feature"], cwd=repo, check=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "worktree", "remove", str(worktree)], cwd=repo, check=True)
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    record = payload["worktrees"][str(worktree.resolve())]
+    agent_worktree._mark_generation_removed(record, removed_at=2)
+    agent_worktree._write_registry(registry_path, payload)
+    return repo, worktree, registry_path, branch, registration["generation"]
+
+
 def test_registry_write_fsyncs_parent_directory_after_replace(
     tmp_path,
     monkeypatch,
@@ -324,6 +376,79 @@ def test_targeted_janitor_apply_retires_selected_generation(tmp_path, monkeypatc
     ]
     assert record["status"] == "removed"
     assert record["generation"] == registration["generation"]
+
+
+def test_targeted_janitor_apply_resumes_removed_generation_branch_cleanup(tmp_path) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={branch: {"state": "MERGED"}},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=generation,
+    )
+
+    assert result["ok"] is True, result["errors"]
+    assert result["targeted_cleanup"] == {
+        "worktree": str(worktree.resolve()),
+        "branch": branch,
+    }
+    assert git_hygiene._is_ancestor(repo, branch, "origin/main") is False
+    assert not worktree.exists()
+    assert branch not in git_hygiene._local_branches(repo)
+    record = agent_worktree.load_lifecycle_records(repo, registry_path=registry_path)[
+        str(worktree.resolve())
+    ]
+    assert record["generation"] == generation
+    assert record["status"] == "removed"
+
+
+def test_targeted_janitor_apply_removed_generation_fails_closed_on_authority_change(
+    tmp_path, monkeypatch
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    lease_path = tmp_path / "leases.json"
+    lease_path.write_text("[]\n", encoding="utf-8")
+    calls = 0
+
+    def leases_after_plan(_path: Path) -> list[dict[str, object]]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return []
+        return [{"resource_id": f"worktree:{worktree.resolve()}", "expires_at": None}]
+
+    monkeypatch.setattr(agent_worktree, "_load_active_lease_snapshot", leases_after_plan)
+
+    result = agent_worktree.janitor_apply(
+        repo,
+        registry_path=registry_path,
+        pr_states={branch: {"state": "MERGED"}},
+        lease_path=lease_path,
+        target_worktree=worktree,
+        target_generation=generation,
+    )
+
+    assert result["ok"] is False
+    assert branch in git_hygiene._local_branches(repo)
+    assert result["errors"] == [
+        {
+            "artifact": "worktree",
+            "action": "preserve",
+            "reason": "lease_authority_changed",
+            "path": str(worktree.resolve()),
+            "branch": branch,
+            "active_leases": [f"worktree:{worktree.resolve()}"],
+        }
+    ]
 
 
 def test_bind_live_generations_skips_removal_tombstones(

--- a/tests/scripts/test_git_hygiene_reclaim.py
+++ b/tests/scripts/test_git_hygiene_reclaim.py
@@ -147,8 +147,8 @@ def test_apply_uses_force_delete_for_pr_proven_non_ancestor_branch(
     tmp_path, monkeypatch
 ) -> None:
     """A reclaimable worktree whose merge proof is a merged/closed PR (squash
-    merge -> not an ancestor) must be deleted with ``git branch -D``. ``-d`` would
-    be refused by git and leave the branch skipped forever."""
+    merge -> not an ancestor) needs a conditional ref delete. ``git branch -d``
+    would be refused and leave the branch skipped forever."""
     commands: list[list[str]] = []
 
     def fake_run_git_result(args: list[str], _cwd: Path):
@@ -175,11 +175,13 @@ def test_apply_uses_force_delete_for_pr_proven_non_ancestor_branch(
                     "path": str(tmp_path / "deliver-squashed"),
                     "branch": "deliver/squashed",
                     "merge_proof": "merged_pr",
+                    "head": "squashed-head",
                 },
                 {
                     "path": str(tmp_path / "docs-closed"),
                     "branch": "docs/closed",
                     "merge_proof": "closed_pr",
+                    "head": "closed-head",
                 },
                 {
                     "path": str(tmp_path / "deliver-ancestor"),
@@ -207,9 +209,10 @@ def test_apply_uses_force_delete_for_pr_proven_non_ancestor_branch(
     )
 
     assert report["ok"] is True
-    # Squash/closed-PR proofs get the force delete.
-    assert ["branch", "-D", "deliver/squashed"] in commands
-    assert ["branch", "-D", "docs/closed"] in commands
+    # Squash/closed-PR proofs use a compare-and-delete ref update so an advance
+    # after planning cannot delete newer work.
+    assert ["update-ref", "-d", "refs/heads/deliver/squashed", "squashed-head"] in commands
+    assert ["update-ref", "-d", "refs/heads/docs/closed", "closed-head"] in commands
     # Ancestor proof keeps the conservative -d (must NOT be force-deleted).
     assert ["branch", "-d", "deliver/ancestor"] in commands
     assert ["branch", "-D", "deliver/ancestor"] not in commands
@@ -273,7 +276,7 @@ def test_targeted_janitor_apply_mutates_only_selected_worktree(
 
     assert report["ok"] is True
     assert ["worktree", "remove", str(target)] in commands
-    assert ["branch", "-D", "codex/target"] in commands
+    assert ["update-ref", "-d", "refs/heads/codex/target", "codex/target"] in commands
     assert not any(str(other) in command for command in commands)
     assert not any(command[:2] == ["push", "origin"] for command in commands)
     assert not any(command[:2] == ["stash", "drop"] for command in commands)
@@ -334,6 +337,7 @@ def test_apply_real_git_reclaims_squash_merged_worktree_and_branch(tmp_path) -> 
             "expires_at": 0,
         }
     }
+    branch_head = git_hygiene.run_git(["rev-parse", "deliver/squashed"], repo)
     report = git_hygiene.janitor_apply(
         repo,
         pr_states={"deliver/squashed": {"state": "MERGED"}},
@@ -350,7 +354,14 @@ def test_apply_real_git_reclaims_squash_merged_worktree_and_branch(tmp_path) -> 
         action.get("artifact") == "local_branch"
         and action.get("action") == "delete_after_worktree_remove"
         and action.get("branch") == "deliver/squashed"
-        and action.get("command") == ["git", "branch", "-D", "deliver/squashed"]
+        and action.get("command")
+        == [
+            "git",
+            "update-ref",
+            "-d",
+            "refs/heads/deliver/squashed",
+            branch_head,
+        ]
         for action in report["destructive_actions"]
     )
 
@@ -368,7 +379,7 @@ def _init_repo_with_merged_branch(
 
     ``squash=True`` reproduces a GitHub squash merge (branch tip is NOT an
     ancestor of ``origin/main``, so the merge proof is ``merged_pr`` and the
-    apply path uses the irreversible ``git branch -D``). ``squash=False`` keeps
+    apply path uses a conditional ref delete). ``squash=False`` keeps
     the branch an ancestor, which is what makes it an ordinary local-branch
     cleanup candidate on a later restart.
     """
@@ -470,6 +481,75 @@ def test_branch_deletion_fails_closed_on_post_removal_worktree_path_lease(
         error.get("reason") == "lease_authority_changed"
         and error.get("branch") == "codex/candidate"
         and lease["resource_id"] in error.get("active_leases", [])
+        for error in report["errors"]
+    )
+
+
+def test_force_branch_cleanup_preserves_ref_advanced_after_worktree_removal(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """The conditional ref delete cannot erase a branch advanced after planning."""
+    repo = _init_repo_with_merged_branch(
+        tmp_path, branch="codex/candidate", squash=True
+    )
+    worktree = tmp_path / "candidate-wt"
+    subprocess.run(
+        ["git", "worktree", "add", str(worktree), "codex/candidate"],
+        cwd=repo,
+        check=True,
+    )
+    lifecycle_records = {
+        str(worktree.resolve()): {
+            "path": str(worktree.resolve()),
+            "branch": "codex/candidate",
+            "generation": GENERATION,
+            "owner": "prior-agent",
+            "status": "complete",
+            "registered_at": -20,
+            "heartbeat_at": -10,
+            "complete_at": 0,
+            "expires_at": 0,
+        }
+    }
+    planned_head = git_hygiene.run_git(["rev-parse", "codex/candidate"], repo)
+    tree = git_hygiene.run_git(["rev-parse", "codex/candidate^{tree}"], repo)
+    newer = git_hygiene.run_git(
+        ["commit-tree", tree, "-p", "codex/candidate", "-m", "newer commit"],
+        repo,
+    )
+    original_run_git_result = git_hygiene.run_git_result
+
+    def advance_ref_after_remove(args: list[str], cwd: Path):
+        result = original_run_git_result(args, cwd)
+        if args == ["worktree", "remove", str(worktree)] and result.returncode == 0:
+            git_hygiene.run_git(
+                ["update-ref", "refs/heads/codex/candidate", newer], repo
+            )
+        return result
+
+    monkeypatch.setattr(git_hygiene, "run_git_result", advance_ref_after_remove)
+    report = git_hygiene.janitor_apply(
+        repo,
+        pr_states={"codex/candidate": {"state": "MERGED"}},
+        active_lease_loader=lambda: [],
+        lifecycle_authority_guard=_allow_lifecycle_authority,
+        lifecycle_records=lifecycle_records,
+    )
+
+    assert report["ok"] is False
+    assert not worktree.exists()
+    assert git_hygiene.run_git(["rev-parse", "codex/candidate"], repo) == newer
+    assert any(
+        error.get("command")
+        == [
+            "git",
+            "update-ref",
+            "-d",
+            "refs/heads/codex/candidate",
+            planned_head,
+        ]
+        and error.get("returncode") != 0
         for error in report["errors"]
     )
 


### PR DESCRIPTION
Governing-Issue: #4525

Fixes #4525

Final-Review-Rounds: 1

## Summary

Resumes an exact removed lifecycle generation's bound local branch cleanup without recreating its worktree. The retry rechecks fresh lease authority and holds the lifecycle lock through deletion; it also supports PR-proven squash merges.

## BuilderOps Routing

- Records/projections/receipts: LearningSignal `lrn_20260801092027_a4d49cdc`
- Reason: The prior targeted-cleanup delivery exposed a concrete tombstone retry gap; the signal records the upstream workflow/documentation divergence.

## Notes

Validation: `pytest -q tests/ops/test_agent_worktree.py -k 'targeted_janitor_apply'`; `pytest -q tests/scripts/test_git_hygiene_reclaim.py -k 'targeted or lifecycle'`; `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py`; independent state-machine review accepted after the squash-merge correction. One final review round is required for the declared lifecycle state-machine surface.
