### PR TITLE
Preserve unavailable BuilderOps storage reporting

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -2089,7 +2089,7 @@ def completeness_report_check(
     learning_log_file: Path | None,
     as_json: bool,
 ) -> None:
-    records: list[Any]
+    records: list[Mapping[str, Any]] | None
     candidates: list[Mapping[str, Any]] = []
     if records_file is not None:
         payload = _load_json_value_file(records_file, field="records-file")
@@ -2097,7 +2097,7 @@ def completeness_report_check(
             records = payload
             storage = {"available": True, "source": str(records_file), "record_count": len(records)}
         elif isinstance(payload, dict) and isinstance(payload.get("records"), list):
-            records = cast(list[Any], payload["records"])
+            records = cast(list[Mapping[str, Any]], payload["records"])
             candidates = _completeness_report_candidates(payload)
             storage = {"available": True, "source": str(records_file), "record_count": len(records)}
         else:
@@ -2107,7 +2107,7 @@ def completeness_report_check(
         if db_path is None:
             db_path = load_paths().db_path
         loaded_records, storage = load_records_from_db(Path(db_path))
-        records = list(loaded_records or [])
+        records = cast(list[Mapping[str, Any]] | None, loaded_records)
 
     learning_log_text = (
         learning_log_file.read_text(encoding="utf-8")

--- a/tests/builderops/test_completeness_report.py
+++ b/tests/builderops/test_completeness_report.py
@@ -170,6 +170,9 @@ def test_completeness_report_cli_outputs_unavailable_storage(tmp_path: Path) -> 
     assert payload["storage"]["available"] is False
     assert payload["storage"]["reason"] == "missing_builderops_db"
     assert payload["mutations_performed"] is False
+    assert "unavailable" in payload["receipt_body"]
+    assert "last_retrospective_receipt" not in payload
+    assert "terminal_outcomes" not in payload
 
 
 def test_completeness_report_cli_reads_fixture_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #4321

Fixes #4321

Final-Review-Rounds: 0

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): OEF
- Write class: mechanical
- Persistence impact: none
- Derived/rebuildable impact: derived completeness report only
- New or changed contract: unavailable BuilderOps storage reporting
- Owner-doc impact: none
- Transition debt impact: reduces false-empty operational reporting
- Boundary risk: unavailable storage must not be represented as an empty healthy store

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary

Preserve the unavailable-storage sentinel from the BuilderOps database loader through the completeness-report CLI. The unavailable report remains distinct from an available empty record source.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Tier 2 Builder System bug fix; the GitHub Issue and PR are the durable delivery record, with no learning, freshness, roadmap, or promotion material produced.

## Notes
Validation: `python3 -m pytest -q tests/builderops/test_completeness_report.py` (7 passed); `ruff check app tests`; `mypy app`; `git diff --check`. Red test evidence: the strengthened unavailable-storage CLI assertion failed before the sentinel-preservation change.