### PR TITLE
Preserve ranking direction in conditional rerank fallback

### DIFF
--- a/app/retrieval/hook_adapter.py
+++ b/app/retrieval/hook_adapter.py
@@ -46,7 +46,10 @@ def _bm25_dominance_margin(query: str, items: List[Dict[str, Any]]) -> float | N
                 [len(query_terms & set(tokens)) / len(query_terms) for tokens in tokenized_docs],
                 dtype=np.float32,
             )
-            return float(abs(coverage[0] - coverage[1]))
+            # ``items`` is already ranked. Only the current top candidate's
+            # coverage can establish lexical dominance; a better runner-up
+            # must still reach the reranker.
+            return float(coverage[0] - coverage[1])
         # Every candidate scores identically -> no dominant top result.
         return 0.0
     norm = (raw - min_v) / (max_v - min_v)

--- a/tests/retrieval/test_conditional_rerank.py
+++ b/tests/retrieval/test_conditional_rerank.py
@@ -133,3 +133,23 @@ def test_conditional_gate_two_result_unique_match_does_not_collapse(
 
     assert maybe_rerank("alpha beta", items) == items
     assert calls == []
+
+
+def test_conditional_gate_reranks_when_lower_coverage_item_is_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A coverage fallback only establishes dominance for the ranked top result."""
+    monkeypatch.setenv("RETRIEVAL_RERANK", "conditional")
+    reset_retrieval_tuning_cache()
+    calls: list[list[dict]] = []
+    monkeypatch.setattr(
+        "app.retrieval.hook_adapter.apply_optional_rerank",
+        lambda _query, items: calls.append(list(items)) or list(reversed(items)),
+    )
+    items = [
+        {"id": "weak", "text": "unrelated gardening note", "score": 0.9},
+        {"id": "exact", "text": "alpha beta exact document", "score": 0.5},
+    ]
+
+    assert [item["id"] for item in maybe_rerank("alpha beta", items)] == ["exact", "weak"]
+    assert calls == [items]


### PR DESCRIPTION
Governing-Issue: #4319

Fixes #4319

Final-Review-Rounds: 0

## Summary
Preserves the ranked result direction in the two-result zero-IDF coverage fallback. A stronger runner-up now invokes the reranker instead of incorrectly suppressing it.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Tier 2 bug correction with no BuilderOps material or authority crossing.

## Notes
Validation: pytest -q tests/retrieval/test_conditional_rerank.py; ruff check app tests; mypy app
---