### PR TITLE
Prove Linux ACL preservation for atomic vault replacement

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -606,6 +606,12 @@ jobs:
             dev-requirements.txt
             pyproject.toml
 
+      - name: Install Linux ACL tools
+        if: steps.changes.outputs.code == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y acl
+
       - name: Install dependencies
         if: steps.changes.outputs.code == 'true'
         run: |

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -5,8 +5,8 @@ Owner: Builder-agent governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: code, workflow files, and repo-local skill docs
-Last reviewed: 2026-07-29
-Last verified against: `.github/workflows/ci-smoke.yaml`, `.github/workflows/issue-pr-governance.yml`, `tests/architecture/test_agent_skill_entrypoints.py`, `tests/architecture/test_dispatcher_skill_integration.py`, `docs/development/PR_HOT_PATH.md`, `docs/development/PR_ESCALATION_PATHS.md`, `docs/development/PARENT_ISSUE_CLOSURE.md`, `.codex/skills/issue-to-code/SKILL.md`, `.codex/skills/pr-integration/SKILL.md`, `.codex/skills/verification-and-closure/SKILL.md`, `scripts/select_pr_tests.py`, `scripts/docs_guard_logic.py`, `tests/ops/test_review_before_ci_gate.py`, `tests/governance/test_ci_smoke_docs_only_gate.py`
+Last reviewed: 2026-08-01
+Last verified against: `.github/workflows/ci-smoke.yaml`, `.github/workflows/issue-pr-governance.yml`, `tests/architecture/test_agent_skill_entrypoints.py`, `tests/architecture/test_dispatcher_skill_integration.py`, `docs/development/PR_HOT_PATH.md`, `docs/development/PR_ESCALATION_PATHS.md`, `docs/development/PARENT_ISSUE_CLOSURE.md`, `.codex/skills/issue-to-code/SKILL.md`, `.codex/skills/pr-integration/SKILL.md`, `.codex/skills/verification-and-closure/SKILL.md`, `scripts/select_pr_tests.py`, `scripts/docs_guard_logic.py`, `tests/knowledge/linux_acl.py`, `tests/knowledge/test_linux_acl_fixture.py`, `tests/ops/test_review_before_ci_gate.py`, `tests/governance/test_ci_smoke_docs_only_gate.py`
 
 # Test Strategy for the Hot Path
 
@@ -26,6 +26,14 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - Every `builder_system` match includes `tests/architecture/test_builderops_store_boundary.py` as an exact run target, not only as an ownership prefix. Ordinary `app/builderops/**` changes must execute the audited store-access guard so new direct-store sites cannot bypass it while their own subsystem tests remain green.
 - The neutral top-level `llm_contract/**` leaf is owned by the `model_access` selector. A kernel change runs its direct contract suite, the BuilderOps adapter/runner compatibility suites, and the exact neutral-kernel/import-boundary architecture guards.
 - Every `vault` match includes `tests/architecture/test_no_hardcoded_vault_layout.py` as an exact run target, not only as an ownership prefix. Ordinary `app/vault/**` changes must execute the vault-layout guard without widening the subsystem to all architecture tests.
+- A vault-file replacement may claim Linux ACL preservation only after the real named-user ACL
+  fixture in `tests/knowledge/test_linux_acl_fixture.py` passes. The fixture compares the complete
+  numeric access ACL before and after a same-directory staged atomic replacement; mode bits alone
+  are insufficient. `Unit tests (not pg)` installs Ubuntu's `acl` package before the selected suite,
+  and a Linux runner without working `getfacl`/`setfacl` support fails loud rather than skipping or
+  emulating the proof. Non-Linux local runs may skip because they do not implement the governed
+  Ubuntu platform semantics. This fixture is prerequisite evidence only; it does not claim that an
+  unpublished vault replacement mechanism is delivered.
 - Runtime-start harness tests that exercise `scripts/start_full_system.sh` and its process-cleanup behavior are owned by the `ops_deploy` selector, even when the touched files live under `tests/helpers/` or `tests/runtime/`.
 - Store and vault-ingest changes are owned by the `store_ingest` selection and run its focused
   `tests/stores`, `tests/ingest`, and architecture contracts in the ordinary `not pg` job. That job

--- a/tests/knowledge/linux_acl.py
+++ b/tests/knowledge/linux_acl.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class LinuxNamedAclUnavailable(RuntimeError):
+    """The runner cannot create or inspect the required Linux named ACL."""
+
+
+@dataclass(frozen=True)
+class LinuxNamedAclFile:
+    path: Path
+    owner_uid: int
+    named_uid: int
+    access_acl: str
+
+
+def _require_linux() -> None:
+    if sys.platform != "linux":
+        raise LinuxNamedAclUnavailable(
+            "the named-ACL fixture requires Linux POSIX ACL semantics"
+        )
+
+
+def _acl_tool(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise LinuxNamedAclUnavailable(
+            f"Linux named-ACL fixture requires {name}; install the Ubuntu 'acl' package"
+        )
+    return executable
+
+
+def _run_acl_tool(
+    name: str,
+    *arguments: str,
+    input_bytes: bytes | None = None,
+) -> bytes:
+    _require_linux()
+    result = subprocess.run(
+        [_acl_tool(name), *arguments],
+        input=input_bytes,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        diagnostic = result.stderr.decode("utf-8", errors="replace").strip()
+        raise LinuxNamedAclUnavailable(
+            f"Linux named-ACL fixture could not run {name} "
+            f"(exit {result.returncode}): {diagnostic or 'no diagnostic emitted'}"
+        )
+    return result.stdout
+
+
+def read_linux_access_acl(path: Path) -> str:
+    acl = _run_acl_tool(
+        "getfacl",
+        "--absolute-names",
+        "--numeric",
+        "--omit-header",
+        "--access",
+        os.fspath(path),
+    )
+    return acl.decode("utf-8")
+
+
+def create_linux_named_acl_file(path: Path, *, content: bytes) -> LinuxNamedAclFile:
+    _require_linux()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(0o640)
+
+    target_stat = path.lstat()
+    if not stat.S_ISREG(target_stat.st_mode):
+        raise LinuxNamedAclUnavailable(
+            "Linux named-ACL fixture target must be a regular file"
+        )
+
+    owner_uid = target_stat.st_uid
+    named_uid = 65_534 if owner_uid != 65_534 else 65_533
+    _run_acl_tool(
+        "setfacl",
+        "--modify",
+        f"user:{named_uid}:r--",
+        os.fspath(path),
+    )
+    access_acl = read_linux_access_acl(path)
+    if f"user:{named_uid}:r--" not in access_acl.splitlines():
+        raise LinuxNamedAclUnavailable(
+            "setfacl completed but getfacl did not report the required named-user entry"
+        )
+    return LinuxNamedAclFile(
+        path=path,
+        owner_uid=owner_uid,
+        named_uid=named_uid,
+        access_acl=access_acl,
+    )
+
+
+def replace_with_staged_acl_copy(path: Path, *, content: bytes) -> int:
+    source_acl = read_linux_access_acl(path)
+    descriptor, staged_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".stage",
+        dir=path.parent,
+    )
+    staged = Path(staged_name)
+    try:
+        with os.fdopen(descriptor, "wb") as staged_file:
+            staged_file.write(content)
+            staged_file.flush()
+        _run_acl_tool(
+            "setfacl",
+            "--set-file=-",
+            os.fspath(staged),
+            input_bytes=source_acl.encode("utf-8"),
+        )
+        if read_linux_access_acl(staged) != source_acl:
+            raise LinuxNamedAclUnavailable(
+                "staged replacement did not reproduce the source access ACL exactly"
+            )
+        with staged.open("rb") as staged_file:
+            os.fsync(staged_file.fileno())
+        staged_inode = staged.stat().st_ino
+        os.replace(staged, path)
+        return staged_inode
+    finally:
+        staged.unlink(missing_ok=True)

--- a/tests/knowledge/test_linux_acl_fixture.py
+++ b/tests/knowledge/test_linux_acl_fixture.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.knowledge import linux_acl
+from tests.knowledge.linux_acl import (
+    LinuxNamedAclFile,
+    LinuxNamedAclUnavailable,
+    create_linux_named_acl_file,
+    read_linux_access_acl,
+    replace_with_staged_acl_copy,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="Linux POSIX ACL semantics are proved on the governed Ubuntu CI lane",
+)
+
+
+@pytest.fixture
+def linux_named_acl_file(tmp_path: Path) -> LinuxNamedAclFile:
+    target = tmp_path / "vault" / "Logs" / "steering.md"
+    try:
+        return create_linux_named_acl_file(target, content=b"before\n")
+    except LinuxNamedAclUnavailable as exc:
+        pytest.fail(str(exc), pytrace=False)
+
+
+def test_linux_named_acl_fixture_is_nontrivial(
+    linux_named_acl_file: LinuxNamedAclFile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = linux_named_acl_file
+
+    assert stat.S_ISREG(fixture.path.stat().st_mode)
+    assert fixture.owner_uid != fixture.named_uid
+    assert f"user:{fixture.named_uid}:r--" in fixture.access_acl.splitlines()
+    assert "mask::r--" in fixture.access_acl.splitlines()
+    assert read_linux_access_acl(fixture.path) == fixture.access_acl
+
+    monkeypatch.setattr(linux_acl.shutil, "which", lambda _name: None)
+    with pytest.raises(
+        LinuxNamedAclUnavailable,
+        match="install the Ubuntu 'acl' package",
+    ):
+        read_linux_access_acl(fixture.path)
+
+
+def test_atomic_replacement_fixture_preserves_named_acl(
+    linux_named_acl_file: LinuxNamedAclFile,
+) -> None:
+    fixture = linux_named_acl_file
+    original_inode = fixture.path.stat().st_ino
+
+    staged_inode = replace_with_staged_acl_copy(fixture.path, content=b"after\n")
+
+    assert fixture.path.read_bytes() == b"after\n"
+    assert fixture.path.stat().st_ino == staged_inode
+    assert fixture.path.stat().st_ino != original_inode
+    assert read_linux_access_acl(fixture.path) == fixture.access_acl
+    assert f"user:{fixture.named_uid}:r--" in fixture.access_acl.splitlines()

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -51,6 +51,22 @@ def test_pr_ci_selects_subsystem_scoped_pytest_targets() -> None:
     assert "tests/eval/test_classification_golden.py" in job
 
 
+def test_ci_smoke_installs_acl_tools_for_linux_acl_fixture() -> None:
+    job = _unit_tests_job_text()
+
+    install_start = job.index("- name: Install Linux ACL tools")
+    install_end = job.index("- name: Install dependencies", install_start)
+    selected_test_run = job.index("- name: Run not-pg unit tests")
+    install_step = job[install_start:install_end]
+
+    assert "runs-on: ubuntu-latest" in job
+    assert "steps.changes.outputs.code == 'true'" in install_step
+    assert "sudo apt-get update" in install_step
+    assert "sudo apt-get install -y acl" in install_step
+    assert "continue-on-error" not in install_step
+    assert install_start < selected_test_run
+
+
 def test_pr_index_pg_contracts_run_exact_acceptance_surface() -> None:
     workflow = _smoke_text()
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4529

## Linked Issue
Closes #4529

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): HKA, GOV
- Write class: governance/docs/process
- Persistence impact: none; validates durable vault-file metadata semantics only
- Derived/rebuildable impact: CI evidence is rebuildable from the fixture and workflow
- New or changed contract: Linux named-ACL proof is required before atomic vault replacement may claim exact ACL preservation
- Owner-doc impact: updated in docs/development/TEST_STRATEGY_HOT_PATH.md
- Transition debt impact: reduces the Linux platform-proof gap that blocks later follow-up work
- Boundary risk: CI must not represent mode-only, emulated, skipped-on-Linux, or non-Linux behavior as ACL preservation proof

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a reusable Linux named-user ACL fixture that proves exact access-ACL preservation across a same-directory staged atomic replacement.
- Install Ubuntu ACL tooling in the PR unit-test job and document the platform-proof requirement without changing any runtime replacement mechanism.

## BuilderOps Routing
- Records/projections/receipts: existing LearningSignal lrn_20260801092535_5a890297 (already applied by the governing Issue); no new record
- Reason: The governing Issue and existing LearningSignal fully represent this bounded fixture work; implementation and review found no new delivery divergence.

## Notes
Validation: Ubuntu 24.04 ACL proof 2 passed; focused pytest 22 passed and 2 non-Linux skips; targeted selector/governance pytest 25 passed; repo Ruff passed; mypy app passed; docs guard passed; workflow yamllint exited 0 with the pre-existing truthy warning. Mechanism convergence: Sol/xhigh ACCEPT with no P0-P3 findings. Base-drift receipt: reviewed SHA c0baad2ef, rebased SHA ed7e3d172, stable patch ID 3e78655eecb888ca56b69ca04e71c85c32c6053a; incoming range 0fadbe5af..b21c54e0f touched unrelated CDLM docs only; all five delivery blobs remained byte-identical.
---