### PR TITLE
fix: reserve tombstones when target parent is absent

### DIFF
--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -149,7 +149,8 @@ again in the final locked deletion window, then uses a compare-and-delete ref up
 preserves every other janitor candidate, confirms the checkout remains absent, and holds the
 lifecycle lock through the branch deletion while rechecking the path, branch, and generation
 binding. It atomically reserves the absent target path for that delete window, creating a missing
-parent directory only to place the temporary reservation and removing it again when empty. Another
+immediate parent directory only to place the temporary reservation and removing it again only when
+this guard created it. Another
 `git worktree add` therefore cannot reuse the target between revalidation and branch deletion. Any
 replacement checkout, lifecycle drift, or active path/branch lease fails closed and leaves the
 branch intact.

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -145,12 +145,14 @@ When a selected worktree has already been durably retired as an exact `removed` 
 branch step did not complete, a later targeted apply may resume only that tombstone's bound local
 branch. A non-ancestor branch additionally requires fresh external `MERGED` PR-state and lease
 snapshots; its current local branch head must exactly match the merged PR head during planning and
-again in the final locked deletion window, then uses a compare-and-delete ref update. The retry preserves every other janitor candidate,
-confirms the checkout remains absent, and holds the lifecycle lock through the branch
-deletion while rechecking the path, branch, and generation binding. It atomically reserves the
-absent target path for that delete window, so another `git worktree add` cannot reuse it between
-revalidation and branch deletion. Any replacement checkout, lifecycle drift, or active path/branch
-lease fails closed and leaves the branch intact.
+again in the final locked deletion window, then uses a compare-and-delete ref update. The retry
+preserves every other janitor candidate, confirms the checkout remains absent, and holds the
+lifecycle lock through the branch deletion while rechecking the path, branch, and generation
+binding. It atomically reserves the absent target path for that delete window, creating a missing
+parent directory only to place the temporary reservation and removing it again when empty. Another
+`git worktree add` therefore cannot reuse the target between revalidation and branch deletion. Any
+replacement checkout, lifecycle drift, or active path/branch lease fails closed and leaves the
+branch intact.
 
 ## Enforcement intent
 

--- a/scripts/agent_worktree.py
+++ b/scripts/agent_worktree.py
@@ -478,9 +478,13 @@ def _locked_removed_generation_branch_authority(
                 "cleanup target removed lifecycle authority changed"
             )
         reservation = canonical / ".agent-worktree-cleanup-reservation"
-        parent_was_absent = not canonical.parent.exists()
+        parent_created = False
         try:
-            canonical.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            try:
+                canonical.parent.mkdir(mode=0o700)
+                parent_created = True
+            except FileExistsError:
+                pass
             canonical.mkdir(mode=0o700)
             descriptor = os.open(
                 reservation,
@@ -509,7 +513,7 @@ def _locked_removed_generation_branch_authority(
                 raise WorktreeLifecycleError(
                     "cleanup target path reservation could not be released"
                 ) from exc
-            if parent_was_absent:
+            if parent_created:
                 try:
                     canonical.parent.rmdir()
                 except OSError:

--- a/scripts/agent_worktree.py
+++ b/scripts/agent_worktree.py
@@ -478,7 +478,9 @@ def _locked_removed_generation_branch_authority(
                 "cleanup target removed lifecycle authority changed"
             )
         reservation = canonical / ".agent-worktree-cleanup-reservation"
+        parent_was_absent = not canonical.parent.exists()
         try:
+            canonical.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
             canonical.mkdir(mode=0o700)
             descriptor = os.open(
                 reservation,
@@ -507,6 +509,11 @@ def _locked_removed_generation_branch_authority(
                 raise WorktreeLifecycleError(
                     "cleanup target path reservation could not be released"
                 ) from exc
+            if parent_was_absent:
+                try:
+                    canonical.parent.rmdir()
+                except OSError:
+                    pass
 
 
 def load_lifecycle_records(

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -657,6 +657,45 @@ def test_removed_generation_branch_authority_reserves_target_with_absent_parent(
     assert record["status"] == "removed"
 
 
+def test_removed_generation_branch_authority_preserves_racing_parent_creator(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    parent = tmp_path / "racing-parent"
+    worktree = parent / "target"
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    record = payload["worktrees"].pop(str((tmp_path / "target").resolve()))
+    record["path"] = str(worktree.resolve())
+    payload["worktrees"][str(worktree.resolve())] = record
+    agent_worktree._write_registry(registry_path, payload)
+    original_mkdir = Path.mkdir
+    parent_created = False
+
+    def create_parent_first(path: Path, *args, **kwargs) -> None:
+        nonlocal parent_created
+        if path == parent and not parent_created:
+            parent_created = True
+            original_mkdir(path, *args, **kwargs)
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", create_parent_first)
+
+    with agent_worktree._locked_removed_generation_branch_authority(
+        repo,
+        registry_path,
+        worktree=str(worktree),
+        branch=branch,
+        generation=generation,
+    ):
+        assert (worktree / ".agent-worktree-cleanup-reservation").is_file()
+
+    assert parent.exists()
+    assert not worktree.exists()
+
+
 def test_bind_live_generations_skips_removal_tombstones(
     tmp_path,
     monkeypatch,

--- a/tests/ops/test_agent_worktree.py
+++ b/tests/ops/test_agent_worktree.py
@@ -622,6 +622,41 @@ def test_removed_generation_branch_authority_reserves_target_path(tmp_path) -> N
     assert replacement_branch in git_hygiene._local_branches(repo)
 
 
+def test_removed_generation_branch_authority_reserves_target_with_absent_parent(
+    tmp_path,
+) -> None:
+    repo, worktree, registry_path, branch, generation = _init_repo_with_tombstoned_branch(
+        tmp_path
+    )
+    parent = tmp_path / "retired-parent"
+    worktree = parent / "target"
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    record = payload["worktrees"].pop(str((tmp_path / "target").resolve()))
+    record["path"] = str(worktree.resolve())
+    payload["worktrees"][str(worktree.resolve())] = record
+    agent_worktree._write_registry(registry_path, payload)
+    assert not parent.exists()
+
+    with agent_worktree._locked_removed_generation_branch_authority(
+        repo,
+        registry_path,
+        worktree=str(worktree),
+        branch=branch,
+        generation=generation,
+    ):
+        reservation = worktree / ".agent-worktree-cleanup-reservation"
+        assert reservation.is_file()
+        assert not (worktree / ".git").exists()
+
+    assert not worktree.exists()
+    assert not parent.exists()
+    record = agent_worktree.load_lifecycle_records(repo, registry_path=registry_path)[
+        str(worktree.resolve())
+    ]
+    assert record["generation"] == generation
+    assert record["status"] == "removed"
+
+
 def test_bind_live_generations_skips_removal_tombstones(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
Governing-Issue: #4534

Fixes #4534

## Summary

- Permit the exact tombstone reservation to create a missing parent directory only for its temporary marker.
- Preserve the absent target path and its removed lifecycle generation after cleanup.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded code repair; the Issue, PR, CI, and terminal cleanup output are the delivery evidence.

## Verification

- `pytest -q tests/ops/test_agent_worktree.py -k 'targeted_janitor_apply or removed_generation_branch_authority'`
- `pytest -q tests/scripts/test_git_hygiene_reclaim.py -k 'targeted or lifecycle or force_delete or force_branch_cleanup'`
- `ruff check app tests && mypy app`
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py`

Final-Review-Rounds: 1