### PR TITLE
fix: BuilderOps PostgreSQL never listens on the container network

### DIFF
--- a/config/builderops/postgresql.conf
+++ b/config/builderops/postgresql.conf
@@ -1,3 +1,10 @@
+# Custom config_file bypasses the postgres image's usual listen_addresses='*'
+# handling, so it must be set explicitly here or the server falls back to its
+# compiled-in localhost default and no other container can connect. The
+# containing network (builderops-control-plane-internal) is internal: true,
+# so '*' is not host exposure.
+listen_addresses = '*'
+
 # BuilderOps recovery durability is asynchronous (ADR-0062 A1). Local commit
 # acknowledgement does not wait for this off-host archive pipeline.
 archive_mode = on

--- a/docker-compose.builderops.yml
+++ b/docker-compose.builderops.yml
@@ -40,7 +40,11 @@ services:
       - builderops_wal_encryption_key
     networks: [builderops-internal, builderops-recovery-egress]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U builderops_owner -d builderops"]
+      # Probing 127.0.0.1 would pass even under the buggy listen_addresses=localhost
+      # default, since loopback is reachable regardless. Probe the container's own
+      # builderops-internal network address so migrate/api/worker only see healthy
+      # once the server actually accepts connections from other containers.
+      test: ["CMD-SHELL", "pg_isready -h \"$(hostname -i)\" -U builderops_owner -d builderops"]
       interval: 5s
       timeout: 3s
       retries: 30

--- a/docs/BUILDEROPS_CONTROL_PLANE/INDEPENDENT_AUTHENTICATED_DEPLOYMENT.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/INDEPENDENT_AUTHENTICATED_DEPLOYMENT.md
@@ -125,6 +125,12 @@ trust/lifecycle unit and forbids Product Runtime ownership. It does not create a
   `pkm-*` stacks; no Product lifecycle event can stop, restart, or resource-starve the builder plane
   (ADR-0062 A2). A native host service is outside this task's selected deployment contract.
 - Do not cut production clients or expose the service as authority until BCP-03/04/05 gates pass.
+- PostgreSQL's custom `config_file` bypasses the official image's default `listen_addresses='*'`
+  handling, so `config/builderops/postgresql.conf` must set `listen_addresses = '*'` explicitly or
+  `migrate`/`api`/`worker` cannot connect at all. This is bounded by the `builderops-internal`
+  network's `internal: true` declaration, not host exposure; do not "harden" it back to a narrower
+  value without re-verifying the network is still internal-only, and do not publish a host port or
+  attach `db` to a non-internal network.
 
 ## Acceptance Criteria
 

--- a/tests/ops/test_builderops_compose_contract.py
+++ b/tests/ops/test_builderops_compose_contract.py
@@ -95,6 +95,20 @@ def test_builderops_compose_is_lifecycle_isolated() -> None:
     assert "runtime/dispatcher" not in text
 
 
+def test_builderops_postgres_listens_on_the_internal_network() -> None:
+    conf = (ROOT / "config/builderops/postgresql.conf").read_text(encoding="utf-8")
+    assert "listen_addresses = '*'" in conf
+    assert "internal: true" in conf
+
+
+def test_builderops_db_healthcheck_probes_the_container_network_address() -> None:
+    compose = _compose()
+    test_cmd = compose["services"]["db"]["healthcheck"]["test"][-1]
+    assert "127.0.0.1" not in test_cmd
+    assert "hostname -i" in test_cmd
+    assert "pg_isready" in test_cmd
+
+
 def test_builderops_image_has_a_dedicated_non_root_entrypoint() -> None:
     dockerfile = (ROOT / "Dockerfile.builderops").read_text(encoding="utf-8")
     assert "FROM python:3.12-slim" in dockerfile


### PR DESCRIPTION
## Summary
- `config/builderops/postgresql.conf` sets `listen_addresses = '*'` — the custom `config_file` bypasses the postgres image's usual default, so the server was falling back to compiled-in `localhost` and `migrate`/`api`/`worker` could never connect. Bounded by `builderops-control-plane-internal`'s `internal: true`, so this is not host exposure.
- `docker-compose.builderops.yml`'s `db` healthcheck now probes `pg_isready -h "$(hostname -i)"` instead of only the local socket, so a non-listening server can never satisfy `service_healthy`.
- `docs/BUILDEROPS_CONTROL_PLANE/INDEPENDENT_AUTHENTICATED_DEPLOYMENT.md :: Constraints` records the requirement so it isn't later "hardened" back into an outage.
- Regression tests added to `tests/ops/test_builderops_compose_contract.py`.

Governing-Issue: #4516
Fixes #4516

Final-Review-Rounds: 0

## Test plan
- [x] `pytest tests/ops/test_builderops_compose_contract.py -q` — 5 passed (2 new tests confirmed failing before the fix, passing after)
- [x] `ruff check app tests companion-ui/companion-app` — all checks passed
- [x] `pytest tests/ops -q` — 729 passed, 1 pre-existing unrelated failure (`test_builderops_backup_restore.py::test_recovered_epoch_fences_leases_and_executor_until_reconciliation`, confirmed failing identically on unmodified `main`), 4 skipped
- [x] `rg -n "listen_addresses" config/builderops/postgresql.conf`

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded code/config bug fix with owner-doc Constraints writeback in the same PR; no separate BuilderOps record, learning signal, or projection applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)