### PR TITLE
fix: exclude deploy controller's process group from native writer inventory

### DIFF
--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -32,6 +32,7 @@ DOMAINS = ("dev", "native", "prod", "test")
 COMPOSE_PROJECT_DOMAINS = {"pkm-dev": "dev", "pkm-prod": "prod", "pkm-test": "test"}
 COMPOSE_WRITER_SERVICES = {"api", "heimdal-capture-watch", "watcher", "worker"}
 LAUNCHER_SCRIPTS = {"deploy_channel.sh", "start_full_system.sh"}
+LAUNCHER_ROLES = {name.removesuffix(".sh") for name in LAUNCHER_SCRIPTS}
 TOKEN_RE = re.compile(r"^(?:linux|darwin|docker):[0-9a-f]{64}$")
 PYTHON_RE = re.compile(r"^python(?:3(?:\.\d+)*)?$")
 PF_KTHREAD = 0x00200000
@@ -1200,6 +1201,7 @@ def _native_writers(
     *,
     controller_pid: int,
     controller_start_token: str,
+    controller_pgid: int,
     linux_boot_id: str | None = None,
 ) -> list[dict[str, object]]:
     writers: list[dict[str, object]] = []
@@ -1211,6 +1213,17 @@ def _native_writers(
         if role is None:
             continue
         if process.pid == controller_pid and process.start_token == controller_start_token:
+            continue
+        # A running deployment forks subshells (e.g. `deploy_channel_compose()`
+        # runs its body in `( ... )`) that inherit the launcher argv but are not
+        # the controller pid itself. Those forks stay in the controller's own
+        # process group, so excluding launcher-role processes by process-group
+        # membership covers the controller's whole tree without exempting a
+        # foreign deployment, which runs in its own process group. Scope this
+        # to launcher roles only -- a non-launcher native writer (watcher,
+        # worker, uvicorn, celery, heimdal capture-watch) that happens to share
+        # a process group must still be reported.
+        if role in LAUNCHER_ROLES and process.pgid == controller_pgid:
             continue
         writers.append(
             {
@@ -1232,6 +1245,7 @@ def _snapshot(*, controller_pid: int, controller_start_token: str) -> dict[str, 
     for writer in _docker_writers() + _native_writers(
         controller_pid=controller_pid,
         controller_start_token=controller_start_token,
+        controller_pgid=controller.pgid,
         linux_boot_id=linux_boot_id,
     ):
         domain = str(writer.pop("domain"))

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -3122,6 +3122,11 @@ def test_linux_actual_harmless_process_with_empty_argv_is_enumerated(tmp_path) -
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux /proc contract")
 def test_linux_actual_empty_argv0_shell_launcher_blocks(tmp_path) -> None:
+    """An empty-argv0 launcher must still be detected -- when it is a foreign
+    process (its own process group), not a fork inside the controller's own
+    tree (Issue #4538: same-process-group launcher forks are excluded).
+    """
+
     env = {**os.environ, "PATH": _empty_docker_path(tmp_path)}
     controller_pid = os.getpid()
     token = _controller_token(controller_pid, env=env)
@@ -3132,6 +3137,7 @@ def test_linux_actual_empty_argv0_shell_launcher_blocks(tmp_path) -> None:
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=True,
     )
     assert process.stdout is not None
     assert process.stdout.read(1) == b"R"

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -2457,15 +2457,19 @@ def test_foreground_controller_inventory_helper_passes_without_self_observation(
     assert payload["snapshot_digests"][0] == payload["snapshot_digests"][1]
 
 
-@pytest.mark.parametrize("separate_session", [True, False])
-def test_actual_native_launcher_blocks_regardless_of_session_or_ancestry(
-    tmp_path, separate_session
-) -> None:
+def test_actual_native_launcher_in_foreign_process_group_blocks(tmp_path) -> None:
+    """A launcher started in its own session (a foreign process group) must
+    still be detected as a live native writer.
+
+    This is the case the guard exists to catch: a genuinely concurrent,
+    unrelated deployment that does not share the controller's process tree.
+    """
+
     env = {**os.environ, "PATH": _empty_docker_path(tmp_path)}
     controller_pid = os.getpid()
     token = _controller_token(controller_pid, env=env)
     launcher = _start_blocking_launcher(
-        _write_blocking_launcher(tmp_path), separate_session=separate_session
+        _write_blocking_launcher(tmp_path), separate_session=True
     )
     try:
         result, output = _run_quiescence_helper(
@@ -2479,6 +2483,33 @@ def test_actual_native_launcher_blocks_regardless_of_session_or_ancestry(
     assert result.returncode != 0
     assert result.stderr == "host-wide writer inventory is live or racing\n"
     assert not output.exists()
+
+
+def test_actual_native_launcher_in_controllers_process_group_is_not_a_writer(
+    tmp_path,
+) -> None:
+    """A launcher started inside the controller's own process group -- the
+    shape of a deploy script's own forked subshell -- must not be reported as
+    a native writer (Issue #4538).
+    """
+
+    env = {**os.environ, "PATH": _empty_docker_path(tmp_path)}
+    controller_pid = os.getpid()
+    token = _controller_token(controller_pid, env=env)
+    launcher = _start_blocking_launcher(
+        _write_blocking_launcher(tmp_path), separate_session=False
+    )
+    try:
+        result, output = _run_quiescence_helper(
+            tmp_path,
+            controller_pid=controller_pid,
+            controller_token=token,
+            env=env,
+        )
+    finally:
+        _stop_blocking_launcher(launcher)
+    assert result.returncode == 0, result.stderr
+    assert output.exists()
 
 
 def test_actual_launcher_appearing_between_real_probes_blocks_without_sleep(tmp_path) -> None:
@@ -2733,9 +2764,12 @@ def test_native_outbox_worker_blocks_quiescence_for_supported_python_aliases(
         lambda *, linux_boot_id: processes,
     )
 
+    unrelated_controller_pgid = 424242
+
     assert writer_inventory._native_writers(
         controller_pid=controller_pid,
         controller_start_token=controller_start_token,
+        controller_pgid=unrelated_controller_pgid,
         linux_boot_id="boot-fixture",
     ) == [
         {
@@ -2756,6 +2790,7 @@ def test_native_outbox_worker_blocks_quiescence_for_supported_python_aliases(
     assert writer_inventory._native_writers(
         controller_pid=controller_pid,
         controller_start_token=controller_start_token,
+        controller_pgid=unrelated_controller_pgid,
         linux_boot_id="boot-fixture",
     ) == []
 
@@ -3019,9 +3054,10 @@ def test_linux_snapshot_reads_boot_id_once(monkeypatch) -> None:
     )
     monkeypatch.setattr(writer_inventory, "_docker_writers", lambda: [])
 
-    def native_writers(*, controller_pid, controller_start_token, linux_boot_id):
+    def native_writers(*, controller_pid, controller_start_token, controller_pgid, linux_boot_id):
         assert controller_pid == pid
         assert controller_start_token == token
+        assert controller_pgid == pid
         assert linux_boot_id == "boot-fixture"
         return []
 

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -239,3 +239,230 @@ def test_parse_macos_ps_row_still_rejects_malformed_rows(row):
 
     with pytest.raises(InventoryError):
         writer_inventory._parse_macos_ps_row(row)
+
+
+# --- Issue #4538: a running deployment must not observe its own subshells ---
+
+CONTROLLER_PID = 900
+CONTROLLER_PGID = 900
+CONTROLLER_TOKEN = "linux:" + "a" * 64
+
+
+def _controller_record(argv=("deploy_channel.sh",)):
+    return writer_inventory.ProcessRecord(
+        pid=CONTROLLER_PID,
+        ppid=1,
+        pgid=CONTROLLER_PGID,
+        start_token=CONTROLLER_TOKEN,
+        argv=argv,
+    )
+
+
+def test_controller_subshell_is_not_a_native_writer(monkeypatch):
+    """A forked child of the controller that shares the controller's argv (the
+    shape of `deploy_channel_compose()`'s `( ... )` subshell) and process group
+    must not be reported as a native writer, even though it is not the
+    controller pid itself.
+    """
+
+    fork = writer_inventory.ProcessRecord(
+        pid=CONTROLLER_PID + 1,
+        ppid=CONTROLLER_PID,
+        pgid=CONTROLLER_PGID,
+        start_token="linux:" + "b" * 64,
+        argv=("/bin/bash", "scripts/deploy_channel.sh", "deploy"),
+    )
+    monkeypatch.setattr(
+        writer_inventory, "_native_processes", lambda *, linux_boot_id=None: [fork]
+    )
+
+    writers = writer_inventory._native_writers(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        controller_pgid=CONTROLLER_PGID,
+        linux_boot_id=None,
+    )
+
+    assert writers == []
+
+
+def test_foreign_deployment_is_still_detected(monkeypatch):
+    """A `deploy_channel` process outside the controller's process tree (its
+    own, distinct process group) must still be reported as a live writer.
+    """
+
+    foreign = writer_inventory.ProcessRecord(
+        pid=7777,
+        ppid=1,
+        pgid=7777,
+        start_token="linux:" + "c" * 64,
+        argv=("/bin/bash", "scripts/deploy_channel.sh", "deploy"),
+    )
+    monkeypatch.setattr(
+        writer_inventory, "_native_processes", lambda *, linux_boot_id=None: [foreign]
+    )
+
+    writers = writer_inventory._native_writers(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        controller_pgid=CONTROLLER_PGID,
+        linux_boot_id=None,
+    )
+
+    assert writers == [
+        {
+            "domain": "native",
+            "role": "deploy_channel",
+            "pid": 7777,
+            "start_token": "linux:" + "c" * 64,
+        }
+    ]
+
+
+def test_non_launcher_writer_sharing_controller_process_group_is_still_detected(
+    monkeypatch,
+):
+    """The process-group exclusion is scoped to launcher roles only. A
+    non-launcher native writer (watcher, worker, uvicorn, celery, heimdal
+    capture-watch) that happens to share the controller's process group must
+    still be reported -- the exclusion must not widen to any process merely
+    because it matches a writer role.
+    """
+
+    same_group_uvicorn = writer_inventory.ProcessRecord(
+        pid=CONTROLLER_PID + 2,
+        ppid=CONTROLLER_PID,
+        pgid=CONTROLLER_PGID,
+        start_token="linux:" + "e" * 64,
+        argv=("uvicorn", "app.api.app:app"),
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_native_processes",
+        lambda *, linux_boot_id=None: [same_group_uvicorn],
+    )
+
+    writers = writer_inventory._native_writers(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        controller_pgid=CONTROLLER_PGID,
+        linux_boot_id=None,
+    )
+
+    assert writers == [
+        {
+            "domain": "native",
+            "role": "uvicorn",
+            "pid": CONTROLLER_PID + 2,
+            "start_token": "linux:" + "e" * 64,
+        }
+    ]
+
+
+@pytest.fixture
+def _proof_stubs(monkeypatch):
+    """Stub the platform-specific probes `prove_quiescent` -> `_snapshot` calls."""
+
+    monkeypatch.setattr(writer_inventory, "_read_linux_boot_id", lambda: "boot-fixture")
+    monkeypatch.setattr(
+        writer_inventory,
+        "_record_for_pid",
+        lambda pid, *, linux_boot_id=None: _controller_record(),
+    )
+    monkeypatch.setattr(writer_inventory, "_docker_writers", lambda: [])
+
+
+def test_prove_quiescent_ignores_own_process_tree(monkeypatch, tmp_path, _proof_stubs):
+    """`prove_quiescent` must produce a proof when the only matching native
+    processes belong to the controller's own tree.
+    """
+
+    fork = writer_inventory.ProcessRecord(
+        pid=CONTROLLER_PID + 1,
+        ppid=CONTROLLER_PID,
+        pgid=CONTROLLER_PGID,
+        start_token="linux:" + "b" * 64,
+        argv=("/bin/bash", "scripts/deploy_channel.sh", "deploy"),
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_native_processes",
+        lambda *, linux_boot_id=None: [_controller_record(), fork],
+    )
+    output = tmp_path / "inventory.json"
+
+    writer_inventory.prove_quiescent(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        output=output,
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["inventory_complete"] is True
+    assert payload["domains"] == {"dev": [], "native": [], "prod": [], "test": []}
+
+
+def test_prove_quiescent_still_detects_native_writers(monkeypatch, tmp_path, _proof_stubs):
+    """`prove_quiescent` must still fail closed when a non-launcher native
+    writer is running in a foreign process group.
+    """
+
+    foreign_writer = writer_inventory.ProcessRecord(
+        pid=555,
+        ppid=1,
+        pgid=555,
+        start_token="linux:" + "d" * 64,
+        argv=("uvicorn", "app.api.app:app"),
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_native_processes",
+        lambda *, linux_boot_id=None: [_controller_record(), foreign_writer],
+    )
+    output = tmp_path / "inventory.json"
+
+    with pytest.raises(InventoryError, match="live or racing"):
+        writer_inventory.prove_quiescent(
+            controller_pid=CONTROLLER_PID,
+            controller_start_token=CONTROLLER_TOKEN,
+            output=output,
+        )
+
+    assert not output.exists()
+
+
+def test_prove_quiescent_is_deterministic_across_probes(monkeypatch, tmp_path, _proof_stubs):
+    """Repeated `prove_quiescent` invocations on identical host state must
+    return the same verdict.
+    """
+
+    fork = writer_inventory.ProcessRecord(
+        pid=CONTROLLER_PID + 1,
+        ppid=CONTROLLER_PID,
+        pgid=CONTROLLER_PGID,
+        start_token="linux:" + "b" * 64,
+        argv=("/bin/bash", "scripts/deploy_channel.sh", "deploy"),
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_native_processes",
+        lambda *, linux_boot_id=None: [_controller_record(), fork],
+    )
+    first_output = tmp_path / "inventory-1.json"
+    second_output = tmp_path / "inventory-2.json"
+
+    writer_inventory.prove_quiescent(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        output=first_output,
+    )
+    writer_inventory.prove_quiescent(
+        controller_pid=CONTROLLER_PID,
+        controller_start_token=CONTROLLER_TOKEN,
+        output=second_output,
+    )
+
+    first_payload = json.loads(first_output.read_text(encoding="utf-8"))
+    second_payload = json.loads(second_output.read_text(encoding="utf-8"))
+    assert first_payload["snapshot_digests"] == second_payload["snapshot_digests"]
+    assert first_payload["domains"] == second_payload["domains"]


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4538

## Linked Issue
Closes #4538

## SBS Impact
- Primary subsystem: Builder System -- release/deploy workflow
- Secondary subsystem(s): Product/Runtime instance-state ownership substrate, whose quiescence proof this gate produces
- Write class: mechanical
- Persistence impact: none -- the snapshot is derived
- Derived/rebuildable impact: the quiescence proof becomes reproducible for a single in-flight deployment
- New or changed contract: none -- restores the exclusion the code already intends
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: a genuinely concurrent second deployment, and every non-deployment native writer, must still be detected; the exclusion is scoped to launcher roles (deploy_channel, start_full_system) and does not widen to any process merely because it matches a writer role

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `_native_writers()` excluded only the exact controller pid+start_token, so a running deploy could observe its own forked launcher subshells (e.g. `deploy_channel_compose()`'s `( ... )`) as foreign `deploy_channel` writers and intermittently fail-close the quiescence guard on itself.
- The exclusion now also covers the controller's own process group, scoped to launcher roles (`deploy_channel`, `start_full_system`) only, so a genuinely concurrent foreign deployment (its own process group) and every non-launcher native writer (watcher, worker, uvicorn, celery, heimdal capture-watch) keep being detected unchanged.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Mechanical bug fix restoring intended exclusion behavior in a builder-system deploy script; no BuilderOps record type applies.

## Notes
Validation: `python -m pytest tests/ops/test_instance_state_writer_inventory.py tests/ops/test_instance_state_volume_contract.py tests/deploy/test_deploy_channel.py -q` (149 passed, 3 skipped); `ruff check scripts/instance_state_writer_inventory.py tests/ops/test_instance_state_writer_inventory.py tests/ops/test_instance_state_volume_contract.py` (clean); `python3 scripts/docs_guard.py` (OK).

Risk surface: concurrency (this is a fail-closed racing-writer guard). Ran `scripts/review_before_ci_gate.py --lane implementation --risk-surface concurrency` and obtained a fresh independent high-capability review of the local publishable SHA before validation, per the mandatory order for a declared high-risk surface. Reviewer verdict: APPROVE WITH NITS (non-blocking); the one actionable nit (scope the process-group exclusion to launcher roles only, not any writer role) was applied in this same change.

Local review gate (concurrency risk surface -> 2 consecutive passing rounds required): Round 1 and Round 2, both fresh independent Opus-level reviews at head `bc8e2ea7d361b454d0a4140174891b505c37e43c`, both PASS with no P0/P1 findings (posted on the PR). One P2 finding (pgid-exclusion coarser than a full ppid-chain walk; a narrow non-interactive concurrent-backgrounding topology could evade detection) was independently raised in both rounds and dispositioned via the Known Defects registry: KD-F5A09634F9B4 (issue #4172, https://github.com/RasmusTho/agentic-pkm-mvp/issues/4172#issuecomment-5156410607). No code change requested for this PR; deferred per this repo's P2 protocol.
