### PR TITLE
Guard POST /ingest with fail-closed WriteGuard at the V-write seam

### DIFF
--- a/app/api/routes/ingest.py
+++ b/app/api/routes/ingest.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Request
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
 from app.domain.state_axes import normalize_artifact_state_axes
@@ -6,8 +8,19 @@ from app.events.models import new_trace_id
 from app.events.types import INGEST_OBJECT_CREATED
 from app.observability.tracer import start_span
 from app.services.outbox import insert_object_and_outbox
+from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 
 router = APIRouter()
+
+# Named WriteGuard action for this seam (formal-model.md F-D, owner-decided on
+# epic #2778: this V-write seam gets the same fail-closed
+# ``assert_writes_allowed`` used at the other named seams, e.g. #2910's
+# knowledge write port and app/api/routes/capture.py's
+# ``companion.capture.append``). No bootstrap escape is registered for this
+# action, so a blocked/degraded runtime denies the write atomically instead of
+# reaching ``insert_object_and_outbox`` (I-A3 "WG at every V-write seam").
+_WRITE_GUARD_ACTION = "ingest.object_create"
+
 
 class IngestRequest(BaseModel):
     uuid: str
@@ -18,9 +31,33 @@ class IngestRequest(BaseModel):
     trust: Optional[str] = None
     source_ref: Optional[str] = None
 
+
+def _writeguard_blocked_detail(exc: WritesBlockedError) -> dict[str, Any]:
+    return {
+        "error": "writeguard_blocked",
+        "state": "blocked",
+        "message": str(exc),
+        "reason": exc.reason,
+    }
+
+
 @router.post("/ingest")
 async def ingest(req: IngestRequest, request: Request):
     trace_id = getattr(request.state, "trace_id", None) or new_trace_id()
+
+    # Policy — the guard is asserted at the seam itself, before any I/O, and
+    # fails closed: an evaluation error blocks the write like a denial does
+    # (formal-model.md gap 4, "fail-closed guards"). Ordering matches the
+    # other named seams (capture.py's /capture, companion.py's /note/save):
+    # guard first, so a blocked runtime never reaches the persistence call.
+    try:
+        DEFAULT_WRITE_GUARD.assert_writes_allowed(_WRITE_GUARD_ACTION)
+    except WritesBlockedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=_writeguard_blocked_detail(exc),
+        ) from exc
+
     with start_span("api.ingest", trace_id, {"path": "/ingest"}):
         payload = normalize_artifact_state_axes(req.model_dump(exclude_none=True), default_review_state="draft")
         # required_db=True (#4214 D2): this enqueue is the route's ONLY

--- a/tests/api/test_ingest_write_guard.py
+++ b/tests/api/test_ingest_write_guard.py
@@ -1,0 +1,135 @@
+"""`POST /ingest` WriteGuard assertion (formal-model.md F-D, owner-decided on
+epic #2778).
+
+Before this change the seam was guardless: any well-formed payload became a
+``P.objects`` row + event regardless of runtime write-health state. This pins
+the same fail-closed ``assert_writes_allowed`` pattern used at the other
+named V-write seams (#2910 knowledge write port, ``app/api/routes/
+capture.py``'s ``/capture``): a blocked write-health state must deny the
+request atomically, before ``insert_object_and_outbox`` runs, and an
+authorized request must still succeed unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.api.routes import ingest as ingest_module
+from app.services import outbox as outbox_service
+from app.write_guard import WritesBlockedError
+
+pytestmark = pytest.mark.not_pg
+
+_BODY = {
+    "uuid": "00000000-0000-0000-0000-0000000004d4",
+    "title": "WriteGuard seam",
+    "review_state": "inbox",
+    "content": "body",
+}
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+        self.calls.append(params)
+
+    def fetchone(self) -> tuple[str]:
+        return ("inserted-row",)
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.closed = False
+        self.cursor_instance = _Cursor()
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_ingest_blocks_the_write_when_writeguard_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked write-health state must deny /ingest before any persistence call."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    def _blocked(action: str) -> None:
+        raise WritesBlockedError(state="safe_mode", reason="test lock", action=action)
+
+    monkeypatch.setattr(
+        ingest_module.DEFAULT_WRITE_GUARD, "assert_writes_allowed", _blocked
+    )
+
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        ingest_module,
+        "insert_object_and_outbox",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "writeguard_blocked"
+    assert detail["state"] == "blocked"
+    assert detail["message"]
+    assert not calls, "a WriteGuard-blocked ingest must not reach the persistence call"
+
+
+def test_ingest_asserts_the_named_guard_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the action string the seam asserts, not only its observable effect."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    seen: list[str] = []
+    real_assert = ingest_module.DEFAULT_WRITE_GUARD.assert_writes_allowed
+
+    def _spy(action: str) -> None:
+        seen.append(action)
+        return real_assert(action)
+
+    monkeypatch.setattr(
+        ingest_module.DEFAULT_WRITE_GUARD, "assert_writes_allowed", _spy
+    )
+    conn = _Connection()
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 200
+    assert seen == [ingest_module._WRITE_GUARD_ACTION]
+
+
+def test_ingest_still_succeeds_when_writeguard_allows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard must not break the configured happy path (allowed write)."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    conn = _Connection()
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 200
+    assert response.json()["trace_id"]
+    assert conn.cursor_instance.calls, "an authorized ingest must still be persisted"


### PR DESCRIPTION
Governing-Issue: #4546

Fixes #4546

Final-Review-Rounds: 0

## Summary
Discharges the WG half of formal-model.md divergence F-D: `POST /ingest` now asserts the fail-closed `DEFAULT_WRITE_GUARD.assert_writes_allowed("ingest.object_create")` before any I/O, denying blocked write-health states atomically with 409 `writeguard_blocked` before `insert_object_and_outbox`, matching the pattern at the other named V-write seams (#2910 knowledge write port, `/capture`).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed.

## Notes
Validation: `tests/api/test_ingest_write_guard.py` 3/3 passed (not_pg, memory backend); `ruff check app tests` clean; `mypy app/api/routes/ingest.py` clean; `review_before_ci_gate.py` implementation lane, empty risk-surface set, status not_required.
---