### PR TITLE
fix: fail-closed WriteGuard at POST /ingest (formal-model.md F-D)

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -4704,6 +4704,8 @@ def save_note_body(req: NoteSaveRequest) -> NoteSaveResponse | VaultSelectionReq
         # The health snapshot could not even be evaluated (e.g. a minimally
         # configured vault). The human-edit path fails open — this courtesy
         # data-safety net must never block the user from editing their own note.
+        # formal-model.md F-C: owner-decided to keep this fail-open (epic #2778
+        # chat decision, 2026-08-02) — not a pending decision, current behavior stands.
         pass
 
     safe_note_path = _validate_workspace_markdown_note_path(req.note_path)

--- a/app/api/routes/ingest.py
+++ b/app/api/routes/ingest.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Request
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
 from app.domain.state_axes import normalize_artifact_state_axes
@@ -6,8 +8,19 @@ from app.events.models import new_trace_id
 from app.events.types import INGEST_OBJECT_CREATED
 from app.observability.tracer import start_span
 from app.services.outbox import insert_object_and_outbox
+from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 
 router = APIRouter()
+
+# Named WriteGuard action for this seam (formal-model.md F-D, owner-decided on
+# epic #2778: this V-write seam gets the same fail-closed
+# ``assert_writes_allowed`` used at the other named seams, e.g. #2910's
+# knowledge write port and app/api/routes/capture.py's
+# ``companion.capture.append``). No bootstrap escape is registered for this
+# action, so a blocked/degraded runtime denies the write atomically instead of
+# reaching ``insert_object_and_outbox`` (I-A3 "WG at every V-write seam").
+_WRITE_GUARD_ACTION = "ingest.object_create"
+
 
 class IngestRequest(BaseModel):
     uuid: str
@@ -18,9 +31,33 @@ class IngestRequest(BaseModel):
     trust: Optional[str] = None
     source_ref: Optional[str] = None
 
+
+def _writeguard_blocked_detail(exc: WritesBlockedError) -> dict[str, Any]:
+    return {
+        "error": "writeguard_blocked",
+        "state": "blocked",
+        "message": str(exc),
+        "reason": exc.reason,
+    }
+
+
 @router.post("/ingest")
 async def ingest(req: IngestRequest, request: Request):
     trace_id = getattr(request.state, "trace_id", None) or new_trace_id()
+
+    # Policy — the guard is asserted at the seam itself, before any I/O, and
+    # fails closed: an evaluation error blocks the write like a denial does
+    # (formal-model.md gap 4, "fail-closed guards"). Ordering matches the
+    # other named seams (capture.py's /capture, companion.py's /note/save):
+    # guard first, so a blocked runtime never reaches the persistence call.
+    try:
+        DEFAULT_WRITE_GUARD.assert_writes_allowed(_WRITE_GUARD_ACTION)
+    except WritesBlockedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=_writeguard_blocked_detail(exc),
+        ) from exc
+
     with start_span("api.ingest", trace_id, {"path": "/ingest"}):
         payload = normalize_artifact_state_axes(req.model_dump(exclude_none=True), default_review_state="draft")
         # required_db=True (#4214 D2): this enqueue is the route's ONLY

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -51,6 +51,7 @@ promote public internet readiness.
 
 ## Health spine
 - HealthContract + WriteGuard + incident logging now form the deterministic spine for startup readiness; this snapshot is the baseline for initial go-live visibility.
+- `POST /ingest` now asserts `DEFAULT_WRITE_GUARD.assert_writes_allowed("ingest.object_create")` at the seam before any I/O, fail-closed like the other named WriteGuard seams (owner-decided epic #2778 F-D, `docs/architecture/formal-model.md :: 7. Divergences`); previously this seam was guardless.
 
 ## Runtime verification
 - `/api/health` reports watcher and worker heartbeat freshness plus the runtime DB/LLM probes so operators see deterministic health signals.

--- a/docs/architecture/formal-model.md
+++ b/docs/architecture/formal-model.md
@@ -305,7 +305,8 @@ audit kernel (`docs/audits/SYSTEM_REDESIGN_CORRECTNESS_KERNEL_2026-07-02.md` §2
 3. **Read purity (Q4):** no durable write on a GET/read path except registered heal transitions.
 4. **Fail-closed guards:** a WG evaluation error blocks the write. #2910 pins this for the three
    named write seams above (`test_raising_guard_blocks_write`); `note/save` deliberately fails open
-   today — divergence F-C, named exemption, owner decision pending on epic #2778.
+   today — divergence F-C, named exemption, **owner-decided: keep fail-open** (epic #2778 chat
+   decision, 2026-08-02).
 5. **Receipt-before-ack (T-capture shape)** as the general mutating-transition contract.
 
 **Gaps, registry → model:** none structural — the cross-scope/envelope invariants (#5–#9, #16,
@@ -375,12 +376,18 @@ domains. Flagged to CES as an extend-candidate, not enacted here.
   `DEFAULT_WRITE_GUARD.assert_writes_allowed("settings.compile.writeback")` before calling
   `write_note_from_absolute`; no event is still emitted (that gap is tracked separately under F-E's
   event-completeness class, not re-opened here).
-- **F-C · note/save WriteGuard fails open** (`app/api/routes/companion.py:4365-4369`, deliberate per comment).
-  Human-edit availability vs. gate integrity. **needs-owner-decision** — surfaced on epic #2778, still open.
-- **F-D · `POST /ingest` is guardless** (`app/api/routes/ingest.py:22`): no WG, no vault/selection check; any
-  well-formed payload becomes a P.objects row + event. Acceptable for a trusted-LAN dev seam,
-  undocumented as such. **needs-owner-decision** (document trust posture vs. add gate) — surfaced
-  on epic #2778, still open.
+- **F-C · note/save WriteGuard fails open** (`app/api/routes/companion.py`, deliberate per comment).
+  Human-edit availability vs. gate integrity. **owner-decided: keep fail-open** (epic #2778 chat
+  decision, 2026-08-02) — current behavior stands, no code change; a human typing in their own note
+  must never be blocked by an unevaluable health snapshot.
+- **F-D · `POST /ingest` was guardless — DELIVERED.** Previously (`app/api/routes/ingest.py:22`): no
+  WG, no vault/selection check; any well-formed payload became a P.objects row + event, acceptable
+  for a trusted-LAN dev seam but undocumented as such. **owner-decided: add guard** (epic #2778 chat
+  decision, 2026-08-02). `POST /ingest` now asserts
+  `DEFAULT_WRITE_GUARD.assert_writes_allowed("ingest.object_create")` at the seam before any I/O,
+  fail-closed like the other named write seams (no bootstrap escape registered for this action) —
+  see PR TBD (opened via publish-pr, links added at merge). Tests:
+  `tests/api/test_ingest_write_guard.py`.
 - **F-E · Mirror-write class (`emit_outbox=False`, no WG)** — eight call sites (C8) make the event
   log an incomplete journal. **fix-code as a class** via the event-completeness invariant
   (registered-mirror list or emitted events); reconciled with KERNEL-02/#2764 scope rather than a

--- a/docs/architecture/formal-model.md
+++ b/docs/architecture/formal-model.md
@@ -386,7 +386,7 @@ domains. Flagged to CES as an extend-candidate, not enacted here.
   decision, 2026-08-02). `POST /ingest` now asserts
   `DEFAULT_WRITE_GUARD.assert_writes_allowed("ingest.object_create")` at the seam before any I/O,
   fail-closed like the other named write seams (no bootstrap escape registered for this action) —
-  see PR TBD (opened via publish-pr, links added at merge). Tests:
+  see PR #4549. Tests:
   `tests/api/test_ingest_write_guard.py`.
 - **F-E · Mirror-write class (`emit_outbox=False`, no WG)** — eight call sites (C8) make the event
   log an incomplete journal. **fix-code as a class** via the event-completeness invariant

--- a/tests/api/test_ingest_write_guard.py
+++ b/tests/api/test_ingest_write_guard.py
@@ -1,0 +1,135 @@
+"""`POST /ingest` WriteGuard assertion (formal-model.md F-D, owner-decided on
+epic #2778).
+
+Before this change the seam was guardless: any well-formed payload became a
+``P.objects`` row + event regardless of runtime write-health state. This pins
+the same fail-closed ``assert_writes_allowed`` pattern used at the other
+named V-write seams (#2910 knowledge write port, ``app/api/routes/
+capture.py``'s ``/capture``): a blocked write-health state must deny the
+request atomically, before ``insert_object_and_outbox`` runs, and an
+authorized request must still succeed unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.api.routes import ingest as ingest_module
+from app.services import outbox as outbox_service
+from app.write_guard import WritesBlockedError
+
+pytestmark = pytest.mark.not_pg
+
+_BODY = {
+    "uuid": "00000000-0000-0000-0000-0000000004d4",
+    "title": "WriteGuard seam",
+    "review_state": "inbox",
+    "content": "body",
+}
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def execute(self, _sql: str, params: tuple[object, ...]) -> None:
+        self.calls.append(params)
+
+    def fetchone(self) -> tuple[str]:
+        return ("inserted-row",)
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.closed = False
+        self.cursor_instance = _Cursor()
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_ingest_blocks_the_write_when_writeguard_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked write-health state must deny /ingest before any persistence call."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    def _blocked(action: str) -> None:
+        raise WritesBlockedError(state="safe_mode", reason="test lock", action=action)
+
+    monkeypatch.setattr(
+        ingest_module.DEFAULT_WRITE_GUARD, "assert_writes_allowed", _blocked
+    )
+
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        ingest_module,
+        "insert_object_and_outbox",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "writeguard_blocked"
+    assert detail["state"] == "blocked"
+    assert detail["message"]
+    assert not calls, "a WriteGuard-blocked ingest must not reach the persistence call"
+
+
+def test_ingest_asserts_the_named_guard_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the action string the seam asserts, not only its observable effect."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    seen: list[str] = []
+    real_assert = ingest_module.DEFAULT_WRITE_GUARD.assert_writes_allowed
+
+    def _spy(action: str) -> None:
+        seen.append(action)
+        return real_assert(action)
+
+    monkeypatch.setattr(
+        ingest_module.DEFAULT_WRITE_GUARD, "assert_writes_allowed", _spy
+    )
+    conn = _Connection()
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 200
+    assert seen == [ingest_module._WRITE_GUARD_ACTION]
+
+
+def test_ingest_still_succeeds_when_writeguard_allows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard must not break the configured happy path (allowed write)."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    conn = _Connection()
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: conn)
+
+    client = TestClient(app)
+    response = client.post("/ingest", json=_BODY)
+
+    assert response.status_code == 200
+    assert response.json()["trace_id"]
+    assert conn.cursor_instance.calls, "an authorized ingest must still be persisted"


### PR DESCRIPTION
Governing-Issue: #4546
Fixes #4546

Validation: ruff check app tests; mypy app; python -m pytest tests/api/test_ingest_write_guard.py
tests/api/test_ingest_required_outbox.py tests/ingest -q (85 passed); python3 scripts/docs_guard.py
(OK); local review-before-CI gate run with --risk-surface auth and satisfied via an independent
fresh review (accept, no blocking issues).

Final-Review-Rounds: 1

## Summary
`POST /ingest` (`app/api/routes/ingest.py`) previously had no WriteGuard at all — any well-formed
payload became a `P.objects` row + event regardless of runtime write-health state
(formal-model.md F-D). This adds the same fail-closed `DEFAULT_WRITE_GUARD.assert_writes_allowed(
"ingest.object_create")` assertion used at the other three named seams, asserted before any I/O,
with no bootstrap escape registered — a blocked/degraded runtime now denies the write atomically.
Also resolves F-C's `needs-owner-decision` flag to owner-decided-keep-fail-open (no behavior
change; comment-only update in `app/api/routes/companion.py`'s `save_note_body`).

## Changes
- `app/api/routes/ingest.py` — new `DEFAULT_WRITE_GUARD.assert_writes_allowed("ingest.object_create")`
  guard before `insert_object_and_outbox`; `WritesBlockedError` maps to `409 writeguard_blocked`.
- `app/api/routes/companion.py` — comment-only: records F-C's resolved owner decision at the
  existing fail-open `except Exception: pass` block; no behavior change.
- `docs/architecture/formal-model.md` — F-D marked DELIVERED with the guard action name and test
  pointer; F-C marked owner-decided-keep-fail-open (both in `:: 7. Divergences found by this pass`
  and the gap-4 fail-closed-guards note).
- `docs/STATUS.md :: Health spine` — one-line note for the new gate (docs_guard temporal-owner
  requirement).
- `tests/api/test_ingest_write_guard.py` (new) — exercises the real HTTP route via `TestClient`:
  blocked guard returns 409 and never reaches `insert_object_and_outbox`; the exact action string
  asserted is pinned; an authorized request still succeeds and is actually persisted.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the decision provenance and delivery evidence live in the formal-model.md/STATUS.md
  writeback and this PR itself; no separate BuilderOps record was needed for a single bounded
  direct-repair change.

## Notes
Risk surface: auth (WriteGuard is an authority/write-gating mechanism) — ran the local
review-before-CI gate with `--risk-surface auth` and satisfied it via a fresh independent review
(verdict: accept, risk_level: low, no blocking issues; one non-blocking note about a placeholder
PR-link sentence, addressed in this body).

Delivery-vehicle note: this PR's patch is byte-identical to the one gated in the concurrent Fable
session's now-superseded PR #4548 (issue #4546). Per owner decision 2026-08-02
(https://github.com/RasmusTho/agentic-pkm-mvp/issues/4546#issuecomment-5156092630), this superset
PR is the governing delivery vehicle for #4546; #4548 was closed as superseded and its branch
deleted.
