### PR TITLE
docs: owner-doc promotion for #4546 — T-ingest-api precondition names the WriteGuard gate

### DIFF
--- a/docs/architecture/formal-model.md
+++ b/docs/architecture/formal-model.md
@@ -116,10 +116,11 @@ T-review-decide [human, POST memory/review-queue/{id}/decision]  (app/api/routes
   two-phase: decision durable first, terminal flag only after materialization (blocked ⇒ re-pending)
 
 T-ingest-api [any caller, POST /ingest]  (app/api/routes/ingest.py:22)
-  pre:  well-formed payload — NOTHING ELSE (no WG, no vault check, no auth beyond app-level)
+  pre:  WG assert_writes_allowed("ingest.object_create") before any I/O (PR #4549; no bootstrap
+        escape) ∧ well-formed payload — no vault check, no auth beyond app-level
   post: evt(ingest.object.created) ONLY — despite its name, insert_object_and_outbox
         (app/services/outbox.py:247-264) writes no object row; P.objects materializes
-        asynchronously via T-materialize below            — see Divergence F-D
+        asynchronously via T-materialize below            — WG half delivered, see F-D
 
 T-materialize [worker → INGEST_OBJECT_CREATED]  (app/services/indexer.py:93)
   pre:  event delivered (at-least-once)


### PR DESCRIPTION
- [x] Docs authoring lane

Owner-doc promotion after PR #4549 merged (closed issue #4546): `docs/architecture/formal-model.md`'s transition catalog still claimed `T-ingest-api` requires "NOTHING ELSE (no WG)" and pointed to Divergence F-D as open, contradicting the delivered F-D entry and the shipped fail-closed guard at `POST /ingest`.

Corrected claims (lines 118–123): the precondition now names `WG assert_writes_allowed("ingest.object_create")` before any I/O with no bootstrap escape, and the stale open-divergence pointer now reads "WG half delivered, see F-D".

This satisfies the re-evaluation trigger for Known Defect `KD-B58AC0C36A7C` (registry #4172, from PR #4549 review finding r3698085342).

Refs #4546

Final-Review-Rounds: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)