### PR TITLE
Scope launcher-test runtime env writes to tmp_path and guard the repo default

### DIFF
--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -32,6 +32,33 @@ if [ -z "$runtime_env_path" ]; then
     *) runtime_env_path="tmp/runtime.env" ;;
   esac
 fi
+
+# #4519 — fail-loud test isolation guard. pytest exports marker variables that
+# launcher subprocesses inherit; such a run must never write this repository's
+# own tmp/runtime.env or tmp-test/runtime.env, because a leaked test value
+# (e.g. VAULT_HOST_ROOT under a deleted pytest tmp_path) survives in operator
+# state and blocks every later channel deploy. Refuse loudly instead of
+# silently redirecting so the test author sees the missing RUNTIME_ENV_PATH.
+# Real operator invocations carry no pytest markers and are unaffected.
+if [ -n "${PYTEST_CURRENT_TEST:-}" ] || [ -n "${PYTEST_VERSION:-}" ]; then
+  _pytest_guard_target="$runtime_env_path"
+  case "$_pytest_guard_target" in
+    ./*) _pytest_guard_target="${_pytest_guard_target#./}" ;;
+  esac
+  case "$_pytest_guard_target" in
+    /*) ;;
+    *) _pytest_guard_target="$ROOT/$_pytest_guard_target" ;;
+  esac
+  case "$_pytest_guard_target" in
+    "$ROOT/tmp/runtime.env"|"$ROOT/tmp-test/runtime.env")
+      echo "export_runtime_env.sh: refusing to write $_pytest_guard_target from a pytest run (#4519)." >&2
+      echo "Set RUNTIME_ENV_PATH to a tmp_path-scoped file before invoking the launcher or this exporter from a test." >&2
+      exit 3
+      ;;
+  esac
+  unset _pytest_guard_target
+fi
+
 runtime_env_dir="$(dirname "$runtime_env_path")"
 mkdir -p "$runtime_env_dir"
 

--- a/tests/ops/test_start_full_runtime_health.py
+++ b/tests/ops/test_start_full_runtime_health.py
@@ -267,6 +267,13 @@ def _fake_inventory_python_bin(bin_dir: Path) -> None:
     )
 
 
+def _read_optional_bytes(path: Path) -> bytes | None:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
 def _runtime_env(tmp_path: Path, health: dict[str, object]) -> dict[str, str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -286,6 +293,7 @@ def _runtime_env(tmp_path: Path, health: dict[str, object]) -> dict[str, str]:
     for name in (
         "DESIGN_HANDOFF_APP_LOCAL_SETTINGS",
         "INSTANCE_LEGACY_OWNER_CONFIG_PATHS",
+        "RUNTIME_ENV_PATH",
         "VAULT_HOST_ROOT",
         "VAULT_ROOT_DEV",
         "VAULT_ROOT_PROD",
@@ -297,6 +305,12 @@ def _runtime_env(tmp_path: Path, health: dict[str, object]) -> dict[str, str]:
     env.update(
         {
             "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            # #4519 — scope the launcher's runtime env write to this test's
+            # tmp_path. export_runtime_env.sh derives its default output path
+            # from its own repo location, so without this override a launcher
+            # subprocess overwrites the repository's real tmp/runtime.env with
+            # pytest tmp paths that later dangle and block channel deploys.
+            "RUNTIME_ENV_PATH": str(tmp_path / "runtime.env"),
             "VAULT_ROOT": str(vault),
             "XDG_DATA_HOME": str(tmp_path / "xdg"),
             "DATABASE_URL": "postgresql://app:app@db:5432/app",
@@ -406,3 +420,146 @@ def test_runtime_verify_rejects_hard_health_failures(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert "required health ok=true not met" in result.stdout
     assert "API_READY=false" in result.stdout
+
+
+def test_launcher_tests_do_not_write_repo_runtime_env(tmp_path: Path) -> None:
+    """#4519 enforcement: a real launcher run leaves the repo's runtime env alone.
+
+    Runs the same prod launcher invocation whose temp vault path was found in
+    the host's real ``tmp/runtime.env`` and asserts against the real repo paths
+    afterwards — no mocked writer. The launcher must instead write the
+    ``tmp_path``-scoped file selected via ``RUNTIME_ENV_PATH``.
+    """
+    repo_runtime_env = REPO_ROOT / "tmp" / "runtime.env"
+    repo_test_runtime_env = REPO_ROOT / "tmp-test" / "runtime.env"
+    before = _read_optional_bytes(repo_runtime_env)
+    before_test = _read_optional_bytes(repo_test_runtime_env)
+
+    env = _runtime_env(tmp_path, _deferred_index_health())
+    env["COMPOSE_FILE"] = "docker-compose.yaml:docker-compose.prod.yml"
+    env["COMPOSE_PROJECT_NAME"] = "pkm-prod"
+    env["PKM_ENVIRONMENT"] = "prod"
+
+    result = run_runtime_start(
+        ["bash", "scripts/start_full_system.sh"],
+        cwd=REPO_ROOT,
+        env=env,
+        progress_path=Path(env["STARTUP_HARNESS_PROGRESS_PATH"]),
+        total_timeout=STARTUP_FIXTURE_TIMEOUT_SECONDS,
+    )
+
+    # Same launcher conclusion as the deferred-index prod rejection scenario;
+    # a launcher that failed before exporting the runtime env would make the
+    # invariance below vacuous, so prove the scoped write actually happened.
+    assert result.returncode == 1, result.stderr + result.stdout
+    scoped_runtime_env = tmp_path / "runtime.env"
+    assert scoped_runtime_env.exists(), result.stderr + result.stdout
+    scoped_content = scoped_runtime_env.read_text(encoding="utf-8")
+    assert f"VAULT_HOST_ROOT={tmp_path / 'vault'}" in scoped_content
+
+    # The repository's own operator state stayed byte-identical.
+    assert _read_optional_bytes(repo_runtime_env) == before
+    assert _read_optional_bytes(repo_test_runtime_env) == before_test
+
+
+def test_unscoped_runtime_env_write_is_refused_under_pytest(tmp_path: Path) -> None:
+    """#4519 guard: without RUNTIME_ENV_PATH, a pytest-driven export fails loud.
+
+    A future launcher test that forgets to scope its runtime env must be
+    refused before any write to the repository's real ``tmp/runtime.env`` —
+    not silently redirected.
+    """
+    repo_runtime_env = REPO_ROOT / "tmp" / "runtime.env"
+    repo_test_runtime_env = REPO_ROOT / "tmp-test" / "runtime.env"
+    before = _read_optional_bytes(repo_runtime_env)
+    before_test = _read_optional_bytes(repo_test_runtime_env)
+
+    env = _runtime_env(tmp_path, _deferred_index_health())
+    env.pop("RUNTIME_ENV_PATH", None)
+    env.pop("COMPOSE_PROJECT_NAME", None)
+    # The guard keys on the marker pytest itself exports to subprocesses; the
+    # harness env must still carry it for the guard to be reachable at all.
+    assert "PYTEST_CURRENT_TEST" in env
+
+    result = subprocess.run(
+        ["bash", "scripts/export_runtime_env.sh"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 3, result.stderr + result.stdout
+    assert "refusing to write" in result.stderr
+    assert "RUNTIME_ENV_PATH" in result.stderr
+    assert _read_optional_bytes(repo_runtime_env) == before
+    assert _read_optional_bytes(repo_test_runtime_env) == before_test
+
+
+def test_operator_invocation_still_writes_repo_runtime_env(tmp_path: Path) -> None:
+    """#4519 non-regression: a real operator invocation writes the repo default.
+
+    The exporter is copied into a tmp_path-scoped fake repo root so the
+    repo-relative default (``<root>/tmp/runtime.env``, derived from the
+    script's own location) can be exercised end-to-end without touching this
+    repository's real file. The pytest markers are removed from the child
+    environment exactly as an operator shell would lack them.
+    """
+    fake_root = tmp_path / "fake-repo"
+    (fake_root / "scripts" / "lib").mkdir(parents=True)
+    for rel in ("scripts/export_runtime_env.sh", "scripts/lib/load_env_defaults.sh"):
+        (fake_root / rel).write_bytes((REPO_ROOT / rel).read_bytes())
+
+    # The exporter's inline Python needs the interpreter that carries the app
+    # dependencies; expose it as `python3` the way an operator PATH would.
+    bin_dir = tmp_path / "operator-bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        f"""
+        #!/usr/bin/env bash
+        exec {sys.executable!s} "$@"
+        """,
+    )
+
+    vault = tmp_path / "operator-vault"
+    vault.mkdir()
+
+    env = os.environ.copy()
+    for name in (
+        "COMPOSE_PROJECT_NAME",
+        "NO_VAULT_MODE",
+        "PYTEST_CURRENT_TEST",
+        "PYTEST_VERSION",
+        "RUNTIME_ENV_PATH",
+        "VAULT_HOST_ROOT",
+        "WATCHER_RUNTIME_ENV_FILE",
+    ):
+        env.pop(name, None)
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "PYTHONPATH": str(REPO_ROOT),
+            "VAULT_ROOT": str(vault),
+            "DATABASE_URL": "postgresql://app:app@db:5432/app",
+            "DB_DSN": "postgresql://app:app@db:5432/app",
+            "LLM_PROVIDER": "mock",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(fake_root / "scripts" / "export_runtime_env.sh")],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    written = fake_root / "tmp" / "runtime.env"
+    assert written.exists(), result.stderr + result.stdout
+    content = written.read_text(encoding="utf-8")
+    assert f"VAULT_HOST_ROOT={vault}" in content
+    assert "VAULT_ROOT=/app/vault" in content

--- a/tests/quality_wave/test_bootstrap_start.py
+++ b/tests/quality_wave/test_bootstrap_start.py
@@ -82,7 +82,13 @@ class TestBootstrapStartContract:
                 capture_output=True,
                 text=True,
                 timeout=30,
-                env=_startup_env(PATH=f"{td}:{_SUBPROCESS_PATH}"),
+                # #4519 — scope the no-vault idle runtime-env write to the
+                # temp dir; this hermetic env carries no pytest markers, so
+                # the exporter's guard cannot catch an unscoped write here.
+                env=_startup_env(
+                    PATH=f"{td}:{_SUBPROCESS_PATH}",
+                    RUNTIME_ENV_PATH=str(Path(td) / "runtime.env"),
+                ),
             )
 
         combined = result.stdout + result.stderr
@@ -115,6 +121,7 @@ class TestBootstrapStartContract:
             text=True,
             env=_startup_env(
                 PATH=f"{tmp_path}:{_SUBPROCESS_PATH}",
+                RUNTIME_ENV_PATH=str(tmp_path / "runtime.env"),
                 START_FLIGHT_RECORDER="0",
                 VAULT_ROOT=str(missing_vault),
             ),
@@ -142,7 +149,13 @@ class TestBootstrapStartContract:
                 capture_output=True,
                 text=True,
                 timeout=20,
-                env=_startup_env(VAULT_ROOT=str(vault_dir)),
+                # #4519 — with real Docker this run reaches the runtime-env
+                # export; scope it so the real vault-bearing write lands in
+                # tmp_path, never in the repository's own tmp/runtime.env.
+                env=_startup_env(
+                    RUNTIME_ENV_PATH=str(tmp_path / "runtime.env"),
+                    VAULT_ROOT=str(vault_dir),
+                ),
             )
         except subprocess.TimeoutExpired as exc:
             stderr = "".join(part for part in [exc.stdout, exc.stderr] if part)

--- a/tests/runtime/test_start_full_system_no_vault.py
+++ b/tests/runtime/test_start_full_system_no_vault.py
@@ -39,6 +39,11 @@ def test_boots_idle_without_vault_root(tmp_path: Path) -> None:
     env = {
         "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
         "HOME": str(Path.home()),
+        # #4519 — the no-vault idle bring-up exports a minimal runtime env;
+        # scope that write to tmp_path so it cannot clobber the repository's
+        # real tmp/runtime.env (this hermetic env carries no pytest markers,
+        # so the exporter's guard cannot catch an unscoped write here).
+        "RUNTIME_ENV_PATH": str(tmp_path / "runtime.env"),
         # VAULT_ROOT intentionally absent -> no-vault idle posture.
     }
     result = subprocess.run(

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -189,6 +189,11 @@ exec {sys.executable!s} "$@"
             "PATH": f"{fake_bin}:{env.get('PATH', '')}",
             "HOME": str(Path.home()),
             "XDG_DATA_HOME": str(tmp_path / "xdg"),
+            # #4519 — this env inherits pytest's markers, so the launcher's
+            # runtime env write must be tmp_path-scoped or the exporter's
+            # repo-file guard refuses the run (and before that guard existed,
+            # the run overwrote the repository's real tmp/runtime.env).
+            "RUNTIME_ENV_PATH": str(tmp_path / "runtime.env"),
             "PKM_ENVIRONMENT": "prod",
             "START_MODE": "diagnostic",
             "START_FLIGHT_RECORDER": "0",


### PR DESCRIPTION
Governing-Issue: #4519

Fixes #4519

Final-Review-Rounds: 0

## Summary
Launcher tests no longer write the repository's real `tmp/runtime.env`: the affected tests point `scripts/export_runtime_env.sh` at a tmp_path-scoped file via the existing `RUNTIME_ENV_PATH` hook, and the exporter now refuses loudly (exit 3, stderr names `RUNTIME_ENV_PATH`) any pytest-marked invocation whose resolved target is the repo's own `tmp/runtime.env` or `tmp-test/runtime.env`. Real operator invocations carry no pytest markers and keep writing the repo default exactly as today.

## Claim receipt
pickup-claim-complete issue=4519 branch=issue-4519-launcher-runtime-env-isolation worktree=/private/tmp/issue-4519-runtime-env-1785655829 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4519 lease_id=lease-0610c664 holder=claude-fable-issue-4519 evidence=verified-dispatcher-lease

## Changes
- `scripts/export_runtime_env.sh` — fail-loud guard: when `PYTEST_CURRENT_TEST`/`PYTEST_VERSION` is present and the resolved output path is the script-root `tmp/runtime.env` or `tmp-test/runtime.env`, exit 3 before any write with remediation on stderr. `RUNTIME_ENV_PATH` semantics for operators unchanged; default write location for real invocations unchanged.
- `tests/ops/test_start_full_runtime_health.py` — `_runtime_env` now sets `RUNTIME_ENV_PATH=<tmp_path>/runtime.env`; adds the three governing tests (enforcement, refusal, operator non-regression). Existing launcher assertions untouched.
- `tests/runtime/test_start_full_system_version_marker.py` — the VCS-ref launcher run inherits pytest markers and was writing the repo file; scoped via `RUNTIME_ENV_PATH`.
- `tests/runtime/test_start_full_system_no_vault.py`, `tests/quality_wave/test_bootstrap_start.py` — hermetic no-vault idle runs build marker-free child envs (the guard cannot see them) and demonstrably wrote the repo file during blast-radius validation; scoped via `RUNTIME_ENV_PATH`.

## Acceptance criteria (all Verify targets green on head SHA)
- `test_launcher_tests_do_not_write_repo_runtime_env` — runs the real prod launcher subprocess, then asserts the repo `tmp/runtime.env`/`tmp-test/runtime.env` are byte-identical and that the tmp_path-scoped file received the actual write (enforcement, no mocked writer). PASS
- `test_unscoped_runtime_env_write_is_refused_under_pytest` — exporter without `RUNTIME_ENV_PATH` exits 3 with loud stderr, repo files untouched; shown failing (rc=0 + real write) before the guard existed. PASS
- `test_operator_invocation_still_writes_repo_runtime_env` — exporter copied into a tmp fake repo root, pytest markers removed: writes `<root>/tmp/runtime.env` with `VAULT_HOST_ROOT`/container `VAULT_ROOT` exactly as today. PASS
- `test_prod_start_full_rejects_deferred_index_rebuild` — assertions unchanged, still green. PASS

## Known limitation (stated in-test)
A test that constructs a fresh child env without pytest markers erases the guard's detection signal. The two existing tests of that shape are now explicitly scoped; the guard still catches every env-inheriting invocation, which is the incident class from the issue.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-issue Tier 2 bug slice; the dispatcher claim receipt above and this PR body carry the delivery evidence, and no BuilderOps record trigger applies.

## Notes
Delivery depth: single-issue Tier 2, light path (`Final-Review-Rounds: 0`), no TCD high-risk surface (risk-assessment complete, empty surface set; `scripts/review_before_ci_gate.py` satisfied).

Validation (isolated worktree, head SHA, rebased on origin/main):
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/ops/test_start_full_runtime_health.py` — 8 passed
- Blast-radius set (`tests/runtime/test_start_full_system_version_marker.py`, `tests/runtime/test_start_full_system_no_vault.py`, `tests/quality_wave/test_bootstrap_start.py`, `tests/ops/test_export_runtime_env.py`, `tests/scripts/test_start_script_runtime_env.py`, `tests/scripts/test_start_script_does_not_inject_scope.py`, `tests/ops/test_release_channel_startup_targets.py`, `tests/deploy/test_base_runtime_env_compose.py`, `tests/ops/test_start_system_outbox_contract.py`) — 98 passed, 1 skipped (pre-existing docker-gated skip)
- After the full run: no `tmp/runtime.env` or `tmp-test/runtime.env` exists in the checkout; `git status` shows only the five intended files
- `ruff check app tests companion-ui/companion-app` — clean
- `bash -n scripts/export_runtime_env.sh` — clean
- `mypy` not run: no `app/` files changed (diff is `scripts/*.sh` + `tests/**`)
- `scripts/docs_guard.py` temporal rule fires locally for any `scripts/**` change without owner-doc writeback; CI scopes that guard to governance/docs-only PRs by design, and the governing issue states owner-doc impact: none (test-harness isolation, operator contract unchanged)
---