### PR TITLE
fix: permit an ADR-0055-sanctioned native/channel vault root (#4517)

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -15,6 +15,7 @@ from app.instance.filesystem_identity import (
     same_filesystem_root,
 )
 from app.instance.ownership_ledger import (
+    LedgerCollisionError,
     LedgerError,
     LedgerSnapshot,
     LegacyOwner,
@@ -585,6 +586,10 @@ class InstanceStateBackup:
             payloads = self.ledger.capture_backup_artifacts(
                 capture_registry_artifacts=registry_store.capture_backup_artifacts,
             )
+        except LedgerCollisionError as exc:
+            raise InstanceStatePreflightError(
+                "backup registry/ledger ownership is not unambiguous"
+            ) from exc
         except (LedgerError, OSError, RegistryError) as exc:
             raise InstanceStatePreflightError(
                 "backup registry/ledger capture failed"

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1596,7 +1596,11 @@ class OwnershipLedger:
                     "release ownership transfer history is cyclic or disconnected"
                 )
 
-            live_bindings = binding_ids & set(current.leases)
+            live_bindings = {
+                binding_id
+                for binding_id, lease in current.leases.items()
+                if binding_id in binding_ids and lease.state == "active"
+            }
             retired_bindings = binding_ids & set(current.tombstones)
             if len(live_bindings) > 1:
                 raise LedgerCollisionError(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -28,6 +28,7 @@ from app.instance.filesystem_identity import (
 LEDGER_SCHEMA = "agentic-pkm.host-ownership-ledger.v1"
 KEY_SCHEMA = "agentic-pkm.host-ownership-key.v1"
 ROTATION_SCHEMA = "agentic-pkm.host-ownership-key-rotation.v1"
+_RELEASE_CHANNELS = frozenset({"dev", "prod", "test"})
 
 
 class LedgerError(RuntimeError):
@@ -1035,6 +1036,14 @@ class OwnershipLedger:
                 allow_same_channel_nested
                 and not exact
                 and lease.channel_id == candidate.channel_id
+            ):
+                continue
+            if (
+                lease.channel_id == "native"
+                and candidate.channel_id in _RELEASE_CHANNELS
+            ) or (
+                candidate.channel_id == "native"
+                and lease.channel_id in _RELEASE_CHANNELS
             ):
                 continue
             raise LedgerCollisionError("canonical content roots overlap across ownership domains")

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1119,6 +1119,7 @@ class OwnershipLedger:
                 transfer_lineage=tuple(transfer_lineage),
                 legacy_bootstrap_complete=current.legacy_bootstrap_complete,
             )
+            self._validate_snapshot(rotated, new_key)
             _atomic_private_json(
                 self.rotation_path,
                 {
@@ -1356,8 +1357,7 @@ class OwnershipLedger:
                 )
             ):
                 raise LedgerError("ownership ledger contains invalid transfer reservation")
-            normalized[transfer.source_binding_id] = transfer_lease
-            normalized[transfer.destination_binding_id] = OwnershipLease(
+            destination_lease = OwnershipLease(
                 channel_id=transfer.destination_channel_id,
                 vault_binding_id=transfer.destination_binding_id,
                 root_fingerprint=transfer.root_fingerprint,
@@ -1365,6 +1365,9 @@ class OwnershipLedger:
                 sealed_root=transfer.sealed_root,
                 state="transferring",
             )
+            self._authenticated_canonical_root(destination_lease, key)
+            normalized[transfer.source_binding_id] = transfer_lease
+            normalized[transfer.destination_binding_id] = destination_lease
         return list(normalized.values())
 
     def _authenticated_canonical_root(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1208,10 +1208,17 @@ class OwnershipLedger:
         current: LedgerSnapshot,
         key: _KeyMaterial,
     ) -> None:
-        if current.schema != LEDGER_SCHEMA:
+        if (
+            current.schema != LEDGER_SCHEMA
+            or type(current.generation) is not int
+            or type(current.key_id) is not str
+            or not current.key_id.strip()
+            or type(current.legacy_bootstrap_complete) is not bool
+        ):
             raise LedgerError("ownership ledger schema is invalid")
         leases = self._validated_component_leases(current, key)
         self._assert_native_release_component_cardinality(leases)
+        self._assert_release_transfer_topology(current, leases)
 
     def _validated_component_leases(
         self,
@@ -1457,6 +1464,173 @@ class OwnershipLedger:
                     "overlap component"
                 )
 
+    def _assert_release_transfer_topology(
+        self,
+        current: LedgerSnapshot,
+        leases: Sequence[OwnershipLease],
+    ) -> None:
+        """Reject release overlap unless it is one authenticated transfer path."""
+
+        overlap_graph: dict[int, set[int]] = {
+            index: set() for index in range(len(leases))
+        }
+        for index, left in enumerate(leases):
+            for right_index, right in enumerate(
+                leases[index + 1 :],
+                start=index + 1,
+            ):
+                if (
+                    left.root_fingerprint != right.root_fingerprint
+                    and left.root_fingerprint not in right.ancestor_fingerprints
+                    and right.root_fingerprint not in left.ancestor_fingerprints
+                ):
+                    continue
+                overlap_graph[index].add(right_index)
+                overlap_graph[right_index].add(index)
+
+        unseen = set(overlap_graph)
+        while unseen:
+            seed = unseen.pop()
+            component = {seed}
+            pending = [seed]
+            while pending:
+                index = pending.pop()
+                adjacent = overlap_graph[index] & unseen
+                unseen.difference_update(adjacent)
+                component.update(adjacent)
+                pending.extend(adjacent)
+
+            release_leases = [
+                leases[index]
+                for index in component
+                if leases[index].channel_id in _RELEASE_CHANNELS
+            ]
+            exact_roots: dict[tuple[str, str], str] = {}
+            for lease in release_leases:
+                exact_key = (lease.channel_id, lease.root_fingerprint)
+                existing_binding = exact_roots.get(exact_key)
+                if (
+                    existing_binding is not None
+                    and existing_binding != lease.vault_binding_id
+                ):
+                    raise LedgerCollisionError(
+                        "canonical content roots contain duplicate release bindings"
+                    )
+                exact_roots[exact_key] = lease.vault_binding_id
+
+            release_channels = {lease.channel_id for lease in release_leases}
+            if len(release_channels) <= 1:
+                continue
+
+            binding_ids = {lease.vault_binding_id for lease in release_leases}
+            edges: list[tuple[str, str]] = []
+            for item in current.transfer_lineage:
+                endpoints = {
+                    item.source_binding_id,
+                    item.destination_binding_id,
+                }
+                if not endpoints & binding_ids:
+                    continue
+                if not endpoints <= binding_ids:
+                    raise LedgerCollisionError(
+                        "release ownership transfer lineage crosses overlap components"
+                    )
+                edges.append(
+                    (item.source_binding_id, item.destination_binding_id)
+                )
+
+            current_edge: tuple[str, str] | None = None
+            if current.transfer is not None:
+                endpoints = {
+                    current.transfer.source_binding_id,
+                    current.transfer.destination_binding_id,
+                }
+                if endpoints & binding_ids:
+                    if not endpoints <= binding_ids:
+                        raise LedgerCollisionError(
+                            "release ownership transfer crosses overlap components"
+                        )
+                    current_edge = (
+                        current.transfer.source_binding_id,
+                        current.transfer.destination_binding_id,
+                    )
+                    edges.append(current_edge)
+
+            edge_nodes = {binding_id for edge in edges for binding_id in edge}
+            if edge_nodes != binding_ids or len(edges) != len(binding_ids) - 1:
+                raise LedgerCollisionError(
+                    "overlapping release bindings require one authenticated transfer path"
+                )
+
+            outgoing: dict[str, str] = {}
+            incoming: dict[str, str] = {}
+            for source_binding_id, destination_binding_id in edges:
+                if (
+                    source_binding_id == destination_binding_id
+                    or source_binding_id in outgoing
+                    or destination_binding_id in incoming
+                ):
+                    raise LedgerCollisionError(
+                        "release ownership transfer history is not a simple path"
+                    )
+                outgoing[source_binding_id] = destination_binding_id
+                incoming[destination_binding_id] = source_binding_id
+
+            starts = binding_ids - set(incoming)
+            terminals = binding_ids - set(outgoing)
+            if len(starts) != 1 or len(terminals) != 1:
+                raise LedgerCollisionError(
+                    "release ownership transfer history is cyclic or disconnected"
+                )
+            terminal = next(iter(terminals))
+            visited: set[str] = set()
+            cursor = next(iter(starts))
+            while cursor not in visited:
+                visited.add(cursor)
+                destination = outgoing.get(cursor)
+                if destination is None:
+                    break
+                cursor = destination
+            if visited != binding_ids or cursor != terminal:
+                raise LedgerCollisionError(
+                    "release ownership transfer history is cyclic or disconnected"
+                )
+
+            live_bindings = binding_ids & set(current.leases)
+            retired_bindings = binding_ids & set(current.tombstones)
+            if len(live_bindings) > 1:
+                raise LedgerCollisionError(
+                    "overlapping release transfer history has multiple live owners"
+                )
+            if current_edge is not None:
+                source_binding_id, destination_binding_id = current_edge
+                if (
+                    destination_binding_id != terminal
+                    or outgoing.get(source_binding_id) != destination_binding_id
+                    or live_bindings
+                    or not (
+                        binding_ids - {source_binding_id, destination_binding_id}
+                    )
+                    <= retired_bindings
+                ):
+                    raise LedgerCollisionError(
+                        "pending release transfer does not extend the terminal history"
+                    )
+                continue
+
+            if live_bindings:
+                if live_bindings != {terminal}:
+                    raise LedgerCollisionError(
+                        "release ownership transfer live owner is not terminal"
+                    )
+                required_retired = binding_ids - {terminal}
+            else:
+                required_retired = binding_ids
+            if not required_retired <= retired_bindings:
+                raise LedgerCollisionError(
+                    "release ownership transfer history is missing retained lineage"
+                )
+
     def _matches_root(self, lease: OwnershipLease, root: Path, key: _KeyMaterial) -> bool:
         return lease.root_fingerprint == self._lease_for_root(
             channel_id=lease.channel_id,
@@ -1628,10 +1802,21 @@ class OwnershipLedger:
         _assert_private_file(self.key_path)
         try:
             value = json.loads(self.key_path.read_text(encoding="utf-8"))
-            if value.get("schema") != KEY_SCHEMA:
+            if not isinstance(value, dict) or value.get("schema") != KEY_SCHEMA:
                 raise ValueError
-            secret = base64.b64decode(value["secret"], validate=True)
-            key = _KeyMaterial(str(value["key_id"]), int(value["generation"]), secret)
+            key_id = value.get("key_id")
+            generation = value.get("generation")
+            secret_value = value.get("secret")
+            if (
+                type(key_id) is not str
+                or not key_id.strip()
+                or type(generation) is not int
+                or generation < 1
+                or type(secret_value) is not str
+            ):
+                raise ValueError
+            secret = base64.b64decode(secret_value, validate=True)
+            key = _KeyMaterial(key_id, generation, secret)
         except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
             raise LedgerKeyError("protected ownership key is invalid") from exc
         if len(key.secret) != 32 or key.generation < 1:
@@ -1684,13 +1869,19 @@ class OwnershipLedger:
             transfer_lineage_raw = value.get("transfer_lineage", [])
             generation = value.get("generation")
             key_id = value.get("key_id")
+            legacy_bootstrap_complete = value.get(
+                "legacy_bootstrap_complete",
+                False,
+            )
             if (
                 not isinstance(leases_raw, dict)
                 or not isinstance(tombstones_raw, dict)
                 or not isinstance(transfer_lineage_raw, list)
                 or (transfer_raw is not None and not isinstance(transfer_raw, dict))
-                or not isinstance(generation, int)
-                or not isinstance(key_id, str)
+                or type(generation) is not int
+                or type(key_id) is not str
+                or not key_id.strip()
+                or type(legacy_bootstrap_complete) is not bool
                 or not all(
                     isinstance(binding, str) and isinstance(raw, dict)
                     for binding, raw in leases_raw.items()
@@ -1741,7 +1932,7 @@ class OwnershipLedger:
                 tombstones=tombstones,
                 transfer=transfer,
                 transfer_lineage=transfer_lineage,
-                legacy_bootstrap_complete=bool(value.get("legacy_bootstrap_complete", False)),
+                legacy_bootstrap_complete=legacy_bootstrap_complete,
             )
         except (AttributeError, ValueError, KeyError, TypeError) as exc:
             raise LedgerError("ownership ledger is invalid") from exc
@@ -1782,18 +1973,31 @@ class OwnershipLedger:
             ledger_value = journal["ledger"]
             if not isinstance(key_value, dict) or not isinstance(ledger_value, dict):
                 raise ValueError
-            secret = base64.b64decode(key_value["secret"], validate=True)
+            key_id = key_value.get("key_id")
+            key_generation = key_value.get("generation")
+            ledger_key_id = ledger_value.get("key_id")
+            ledger_generation = ledger_value.get("generation")
+            secret_value = key_value.get("secret")
             if (
                 key_value.get("schema") != KEY_SCHEMA
                 or ledger_value.get("schema") != LEDGER_SCHEMA
-                or key_value.get("key_id") != ledger_value.get("key_id")
-                or key_value.get("generation") != ledger_value.get("generation")
-                or len(secret) != 32
+                or type(key_id) is not str
+                or not key_id.strip()
+                or type(ledger_key_id) is not str
+                or type(key_generation) is not int
+                or key_generation < 1
+                or type(ledger_generation) is not int
+                or key_id != ledger_key_id
+                or key_generation != ledger_generation
+                or type(secret_value) is not str
             ):
                 raise ValueError
+            secret = base64.b64decode(secret_value, validate=True)
+            if len(secret) != 32:
+                raise ValueError
             recovered_key = _KeyMaterial(
-                str(key_value["key_id"]),
-                int(key_value["generation"]),
+                key_id,
+                key_generation,
                 secret,
             )
             self._snapshot_from_value(ledger_value, recovered_key)

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -374,9 +374,6 @@ class OwnershipLedger:
                 raise LedgerError(
                     "registry/ledger consistency cannot commit an in-progress transfer"
                 )
-            self._assert_native_release_component_cardinality(
-                self._component_leases(current)
-            )
 
             ledger_live_owners: set[tuple[str, str]] = set()
             ledger_live_roots: list[tuple[str, str, str]] = []
@@ -643,7 +640,7 @@ class OwnershipLedger:
             if (
                 lease is None
                 or lease.channel_id != channel_id
-                or not self._matches_root(lease, root, key)
+                or not self._matches_complete_root_identity(lease, root, key)
             ):
                 raise LedgerError(
                     "registered binding has no authenticated ownership reservation"
@@ -673,9 +670,17 @@ class OwnershipLedger:
             current = self._load_or_create_ledger_locked(key)
             existing = current.leases.get(vault_binding_id)
             if existing is not None:
-                if self._matches_root(existing, root, key):
+                if (
+                    existing.channel_id == channel_id
+                    and self._matches_complete_root_identity(existing, root, key)
+                ):
                     return existing
                 raise LedgerCollisionError("stable binding already owns a different physical root")
+            if vault_binding_id in current.tombstones or self._binding_id_is_historical(
+                current,
+                vault_binding_id,
+            ):
+                raise LedgerCollisionError("stable binding is retired, transferring, or historical")
             candidate = self._lease_for_root(
                 channel_id=channel_id,
                 vault_binding_id=vault_binding_id,
@@ -686,6 +691,7 @@ class OwnershipLedger:
             self._assert_no_collision(
                 current,
                 candidate,
+                key=key,
                 allow_same_channel_nested=allow_same_channel_nested,
             )
             leases = dict(current.leases)
@@ -723,8 +729,12 @@ class OwnershipLedger:
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
             lease = current.leases.get(vault_binding_id)
-            if lease is None:
+            if lease is None or lease.state != "active":
                 raise LedgerError("active ownership lease is missing")
+            if vault_binding_id in current.tombstones:
+                raise LedgerError(
+                    "immutable removal tombstone already records this binding epoch"
+                )
             retired = OwnershipLease(**(asdict(lease) | {"state": "retired"}))
             leases = dict(current.leases)
             del leases[vault_binding_id]
@@ -749,8 +759,23 @@ class OwnershipLedger:
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
             retired = current.tombstones.get(vault_binding_id)
-            if retired is None or not self._matches_root(retired, root, key):
+            if (
+                retired is None
+                or retired.channel_id != channel_id
+                or not self._matches_complete_root_identity(retired, root, key)
+            ):
                 raise LedgerCollisionError("root does not match immutable predecessor lineage")
+            existing = current.leases.get(vault_binding_id)
+            if existing is not None:
+                if (
+                    existing.state == "active"
+                    and existing.channel_id == channel_id
+                    and self._matches_complete_root_identity(existing, root, key)
+                ):
+                    return existing
+                raise LedgerCollisionError(
+                    "stable binding reactivation conflicts with existing authority"
+                )
             active = self._lease_for_root(
                 channel_id=channel_id,
                 vault_binding_id=vault_binding_id,
@@ -758,7 +783,12 @@ class OwnershipLedger:
                 key=key,
                 state="active",
             )
-            self._assert_no_collision(current, active, allow_same_channel_nested=True)
+            self._assert_no_collision(
+                current,
+                active,
+                key=key,
+                allow_same_channel_nested=True,
+            )
             leases = dict(current.leases)
             leases[vault_binding_id] = active
             self._write_ledger_locked(self._replace(current, leases=leases), key)
@@ -783,6 +813,8 @@ class OwnershipLedger:
             if current.transfer is not None:
                 if (
                     current.transfer.source_binding_id == source_binding_id
+                    and current.transfer.destination_channel_id
+                    == destination_channel_id
                     and current.transfer.destination_binding_id == destination_binding_id
                 ):
                     return current.transfer
@@ -790,6 +822,26 @@ class OwnershipLedger:
             source = current.leases.get(source_binding_id)
             if source is None or source.state != "active":
                 raise LedgerError("source lease is not active")
+            if source_binding_id == destination_binding_id:
+                raise LedgerCollisionError(
+                    "ownership transfer requires distinct stable bindings"
+                )
+            if source.channel_id == destination_channel_id:
+                raise LedgerCollisionError(
+                    "ownership transfer requires distinct channels"
+                )
+            if source_binding_id in current.tombstones:
+                raise LedgerCollisionError(
+                    "ownership transfer cannot overwrite immutable source lineage"
+                )
+            if (
+                destination_binding_id in current.leases
+                or destination_binding_id in current.tombstones
+                or self._binding_id_is_historical(current, destination_binding_id)
+            ):
+                raise LedgerCollisionError(
+                    "ownership transfer destination binding is already reserved"
+                )
             reservation = TransferReservation(
                 transfer_id=f"transfer-{uuid4()}",
                 source_channel_id=source.channel_id,
@@ -802,7 +854,50 @@ class OwnershipLedger:
             )
             leases = dict(current.leases)
             del leases[source_binding_id]
-            self._write_ledger_locked(self._replace(current, leases=leases, transfer=reservation), key)
+            pending = self._replace(current, leases=leases, transfer=reservation)
+            destination = OwnershipLease(
+                channel_id=reservation.destination_channel_id,
+                vault_binding_id=reservation.destination_binding_id,
+                root_fingerprint=reservation.root_fingerprint,
+                ancestor_fingerprints=reservation.ancestor_fingerprints,
+                sealed_root=reservation.sealed_root,
+                state="active",
+            )
+            source_tombstone = OwnershipLease(
+                channel_id=reservation.source_channel_id,
+                vault_binding_id=reservation.source_binding_id,
+                root_fingerprint=reservation.root_fingerprint,
+                ancestor_fingerprints=reservation.ancestor_fingerprints,
+                sealed_root=reservation.sealed_root,
+                state="retired",
+            )
+            terminal_leases = dict(leases)
+            terminal_leases[destination.vault_binding_id] = destination
+            terminal_tombstones = dict(current.tombstones)
+            terminal_tombstones[source_tombstone.vault_binding_id] = source_tombstone
+            terminal_lineage = current.transfer_lineage + (
+                OwnershipTransferLineage(
+                    transfer_id=reservation.transfer_id,
+                    source_channel_id=reservation.source_channel_id,
+                    source_binding_id=reservation.source_binding_id,
+                    destination_channel_id=reservation.destination_channel_id,
+                    destination_binding_id=reservation.destination_binding_id,
+                    root_fingerprint=reservation.root_fingerprint,
+                    ancestor_fingerprints=reservation.ancestor_fingerprints,
+                    sealed_root=reservation.sealed_root,
+                ),
+            )
+            self._validate_snapshot(
+                self._replace(
+                    current,
+                    leases=terminal_leases,
+                    tombstones=terminal_tombstones,
+                    transfer=None,
+                    transfer_lineage=terminal_lineage,
+                ),
+                key,
+            )
+            self._write_ledger_locked(pending, key)
             return reservation
 
     def activate_transfer(
@@ -817,6 +912,15 @@ class OwnershipLedger:
             transfer = current.transfer
             if transfer is None:
                 raise LedgerError("no transfer reservation is recoverable")
+            if (
+                transfer.source_binding_id in current.leases
+                or transfer.source_binding_id in current.tombstones
+                or transfer.destination_binding_id in current.leases
+                or transfer.destination_binding_id in current.tombstones
+            ):
+                raise LedgerCollisionError(
+                    "ownership transfer endpoints are no longer vacant"
+                )
             active = OwnershipLease(
                 channel_id=transfer.destination_channel_id,
                 vault_binding_id=transfer.destination_binding_id,
@@ -912,12 +1016,14 @@ class OwnershipLedger:
                     raise LedgerCollisionError(
                         "legacy owner binding is retired or transferring"
                     )
-                self._assert_no_collision(staged, candidate, allow_same_channel_nested=True)
+                self._assert_no_collision(
+                    staged,
+                    candidate,
+                    key=key,
+                    allow_same_channel_nested=True,
+                )
                 leases[candidate.vault_binding_id] = candidate
                 staged = self._replace(staged, leases=leases)
-            self._assert_native_release_component_cardinality(
-                self._component_leases(staged)
-            )
             staged = self._replace(staged, legacy_bootstrap_complete=True)
             if staged == current:
                 return current
@@ -940,9 +1046,6 @@ class OwnershipLedger:
                 )
             old_key = self._load_or_create_key_locked(allow_create=False)
             current = self._load_or_create_ledger_locked(old_key, allow_create=False)
-            self._assert_native_release_component_cardinality(
-                self._component_leases(current)
-            )
             live_roots = {
                 binding: Path(self._open_root(lease.sealed_root, old_key))
                 for binding, lease in current.leases.items()
@@ -1045,9 +1148,10 @@ class OwnershipLedger:
         current: LedgerSnapshot,
         candidate: OwnershipLease,
         *,
+        key: _KeyMaterial,
         allow_same_channel_nested: bool,
     ) -> None:
-        leases = self._component_leases(current)
+        leases = self._validated_component_leases(current, key)
         for lease in leases:
             exact = candidate.root_fingerprint == lease.root_fingerprint
             overlap = (
@@ -1079,30 +1183,236 @@ class OwnershipLedger:
         ] + [candidate]
         self._assert_native_release_component_cardinality(component_leases)
 
-    def _component_leases(
+    def _binding_id_is_historical(
         self,
         current: LedgerSnapshot,
+        vault_binding_id: str,
+    ) -> bool:
+        if current.transfer is not None:
+            if vault_binding_id in {
+                current.transfer.source_binding_id,
+                current.transfer.destination_binding_id,
+            }:
+                return True
+        return any(
+            vault_binding_id in {
+                item.source_binding_id,
+                item.destination_binding_id,
+            }
+            for item in current.transfer_lineage
+        )
+
+    def _validate_snapshot(
+        self,
+        current: LedgerSnapshot,
+        key: _KeyMaterial,
+    ) -> None:
+        if current.schema != LEDGER_SCHEMA:
+            raise LedgerError("ownership ledger schema is invalid")
+        leases = self._validated_component_leases(current, key)
+        self._assert_native_release_component_cardinality(leases)
+
+    def _validated_component_leases(
+        self,
+        current: LedgerSnapshot,
+        key: _KeyMaterial,
     ) -> list[OwnershipLease]:
-        leases = list(current.leases.values()) + list(current.tombstones.values())
+        normalized: dict[str, OwnershipLease] = {}
+        canonical_roots: dict[str, Path] = {}
+        lifecycle_roles: dict[str, set[str]] = {}
+
+        for role, records, allowed_states in (
+            ("lease", current.leases, {"pending", "active"}),
+            ("tombstone", current.tombstones, {"retired"}),
+        ):
+            for binding_id, lease in records.items():
+                if (
+                    not isinstance(binding_id, str)
+                    or not binding_id.strip()
+                    or binding_id != lease.vault_binding_id
+                    or lease.state not in allowed_states
+                ):
+                    raise LedgerError(
+                        "ownership ledger contains an invalid binding map or lifecycle role"
+                    )
+                canonical_root = self._authenticated_canonical_root(lease, key)
+                existing = normalized.get(binding_id)
+                if existing is not None and (
+                    existing.channel_id != lease.channel_id
+                    or existing.root_fingerprint != lease.root_fingerprint
+                    or existing.ancestor_fingerprints != lease.ancestor_fingerprints
+                    or canonical_roots[binding_id] != canonical_root
+                ):
+                    raise LedgerError(
+                        "ownership ledger contains divergent same-binding authority"
+                    )
+                lifecycle_roles.setdefault(binding_id, set()).add(role)
+                if existing is None or lease.state == "active":
+                    normalized[binding_id] = lease
+                    canonical_roots[binding_id] = canonical_root
+
+        for binding_id, roles in lifecycle_roles.items():
+            if len(roles) > 1 and (
+                roles != {"lease", "tombstone"}
+                or normalized[binding_id].state != "active"
+            ):
+                raise LedgerError(
+                    "ownership ledger contains incompatible same-binding lifecycle records"
+                )
+
+        transfer_source: OwnershipLease | None = None
+        if current.transfer is not None:
+            transfer_source = OwnershipLease(
+                channel_id=current.transfer.source_channel_id,
+                vault_binding_id=current.transfer.source_binding_id,
+                root_fingerprint=current.transfer.root_fingerprint,
+                ancestor_fingerprints=current.transfer.ancestor_fingerprints,
+                sealed_root=current.transfer.sealed_root,
+                state="transferring",
+            )
+
+        lineage_transfer_ids: set[str] = set()
+        lineage_identities: set[tuple[str, str, str, str, str]] = set()
+        for item in current.transfer_lineage:
+            identity = (
+                item.transfer_id,
+                item.source_channel_id,
+                item.source_binding_id,
+                item.destination_channel_id,
+                item.destination_binding_id,
+            )
+            source = current.tombstones.get(item.source_binding_id)
+            destination = current.leases.get(
+                item.destination_binding_id
+            ) or current.tombstones.get(item.destination_binding_id)
+            if (
+                destination is None
+                and transfer_source is not None
+                and transfer_source.vault_binding_id == item.destination_binding_id
+            ):
+                destination = transfer_source
+            lineage_lease = OwnershipLease(
+                channel_id=item.destination_channel_id,
+                vault_binding_id=item.destination_binding_id,
+                root_fingerprint=item.root_fingerprint,
+                ancestor_fingerprints=item.ancestor_fingerprints,
+                sealed_root=item.sealed_root,
+                state="lineage",
+            )
+            lineage_root = self._authenticated_canonical_root(lineage_lease, key)
+            if (
+                identity in lineage_identities
+                or item.transfer_id in lineage_transfer_ids
+                or any(
+                    not isinstance(value, str) or not value.strip()
+                    for value in identity
+                )
+                or item.source_channel_id == item.destination_channel_id
+                or item.source_binding_id == item.destination_binding_id
+                or source is None
+                or destination is None
+                or source.channel_id != item.source_channel_id
+                or destination.channel_id != item.destination_channel_id
+                or source.root_fingerprint != item.root_fingerprint
+                or destination.root_fingerprint != item.root_fingerprint
+                or source.ancestor_fingerprints != item.ancestor_fingerprints
+                or destination.ancestor_fingerprints != item.ancestor_fingerprints
+                or self._authenticated_canonical_root(source, key) != lineage_root
+                or self._authenticated_canonical_root(destination, key) != lineage_root
+            ):
+                raise LedgerError("ownership ledger contains invalid transfer lineage")
+            lineage_identities.add(identity)
+            lineage_transfer_ids.add(item.transfer_id)
+
         if current.transfer is not None:
             transfer = current.transfer
-            leases.append(
-                OwnershipLease(
-                    channel_id=transfer.destination_channel_id,
-                    vault_binding_id=transfer.destination_binding_id,
-                    root_fingerprint=transfer.root_fingerprint,
-                    ancestor_fingerprints=transfer.ancestor_fingerprints,
-                    sealed_root=transfer.sealed_root,
-                    state="transferring",
-                )
+            identity = (
+                transfer.transfer_id,
+                transfer.source_channel_id,
+                transfer.source_binding_id,
+                transfer.destination_channel_id,
+                transfer.destination_binding_id,
             )
-        return leases
+            if transfer_source is None:
+                raise LedgerError("ownership ledger contains invalid transfer reservation")
+            transfer_lease = transfer_source
+            self._authenticated_canonical_root(transfer_lease, key)
+            if (
+                any(
+                    not isinstance(value, str) or not value.strip()
+                    for value in identity
+                )
+                or transfer.transfer_id in lineage_transfer_ids
+                or transfer.source_channel_id == transfer.destination_channel_id
+                or transfer.source_binding_id == transfer.destination_binding_id
+                or transfer.source_binding_id in current.leases
+                or transfer.source_binding_id in current.tombstones
+                or transfer.destination_binding_id in current.leases
+                or transfer.destination_binding_id in current.tombstones
+                or any(
+                    transfer.destination_binding_id
+                    in {item.source_binding_id, item.destination_binding_id}
+                    for item in current.transfer_lineage
+                )
+            ):
+                raise LedgerError("ownership ledger contains invalid transfer reservation")
+            normalized[transfer.source_binding_id] = transfer_lease
+            normalized[transfer.destination_binding_id] = OwnershipLease(
+                channel_id=transfer.destination_channel_id,
+                vault_binding_id=transfer.destination_binding_id,
+                root_fingerprint=transfer.root_fingerprint,
+                ancestor_fingerprints=transfer.ancestor_fingerprints,
+                sealed_root=transfer.sealed_root,
+                state="transferring",
+            )
+        return list(normalized.values())
+
+    def _authenticated_canonical_root(
+        self,
+        lease: OwnershipLease,
+        key: _KeyMaterial,
+    ) -> Path:
+        if (
+            not isinstance(lease.channel_id, str)
+            or lease.channel_id not in _RELEASE_CHANNELS | {"native"}
+            or not isinstance(lease.vault_binding_id, str)
+            or not lease.vault_binding_id.strip()
+            or not isinstance(lease.sealed_root, str)
+            or not lease.sealed_root
+            or not self._valid_fingerprint(lease.root_fingerprint)
+            or not isinstance(lease.ancestor_fingerprints, tuple)
+            or not all(
+                self._valid_fingerprint(value)
+                for value in lease.ancestor_fingerprints
+            )
+        ):
+            raise LedgerError("ownership ledger contains invalid authenticated identity fields")
+        try:
+            root = Path(self._open_root(lease.sealed_root, key))
+            if not root.is_absolute():
+                raise ValueError
+            canonical_root = Path(os.path.abspath(os.path.normpath(str(root))))
+            if canonical_root != root:
+                raise ValueError
+            return canonical_root
+        except (LedgerError, OSError, UnicodeError, ValueError) as exc:
+            raise LedgerError("ownership ledger contains invalid authenticated root identity") from exc
+
+    @staticmethod
+    def _valid_fingerprint(value: object) -> bool:
+        return (
+            isinstance(value, str)
+            and len(value) == 64
+            and all(character in "0123456789abcdef" for character in value)
+        )
 
     def _assert_native_release_component_cardinality(
         self,
         leases: Sequence[OwnershipLease],
     ) -> None:
-        overlap_graph = {index: set() for index in range(len(leases))}
+        overlap_graph: dict[int, set[int]] = {
+            index: set() for index in range(len(leases))
+        }
         for index, left in enumerate(leases):
             for right_index, right in enumerate(
                 leases[index + 1 :],
@@ -1353,21 +1663,54 @@ class OwnershipLedger:
         _assert_private_file(self.path)
         try:
             value = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise LedgerError("ownership ledger is invalid") from exc
+        return self._snapshot_from_value(value, key)
+
+    def _snapshot_from_value(
+        self,
+        value: Mapping[str, object],
+        key: _KeyMaterial,
+    ) -> LedgerSnapshot:
+        try:
             if value.get("schema") != LEDGER_SCHEMA:
+                raise ValueError
+            leases_raw = value.get("leases", {})
+            tombstones_raw = value.get("tombstones", {})
+            transfer_raw = value.get("transfer")
+            transfer_lineage_raw = value.get("transfer_lineage", [])
+            generation = value.get("generation")
+            key_id = value.get("key_id")
+            if (
+                not isinstance(leases_raw, dict)
+                or not isinstance(tombstones_raw, dict)
+                or not isinstance(transfer_lineage_raw, list)
+                or (transfer_raw is not None and not isinstance(transfer_raw, dict))
+                or not isinstance(generation, int)
+                or not isinstance(key_id, str)
+                or not all(
+                    isinstance(binding, str) and isinstance(raw, dict)
+                    for binding, raw in leases_raw.items()
+                )
+                or not all(
+                    isinstance(binding, str) and isinstance(raw, dict)
+                    for binding, raw in tombstones_raw.items()
+                )
+                or not all(isinstance(raw, dict) for raw in transfer_lineage_raw)
+            ):
                 raise ValueError
             leases = {
                 binding: OwnershipLease(
                     **(raw | {"ancestor_fingerprints": tuple(raw["ancestor_fingerprints"])})
                 )
-                for binding, raw in value.get("leases", {}).items()
+                for binding, raw in leases_raw.items()
             }
             tombstones = {
                 binding: OwnershipLease(
                     **(raw | {"ancestor_fingerprints": tuple(raw["ancestor_fingerprints"])})
                 )
-                for binding, raw in value.get("tombstones", {}).items()
+                for binding, raw in tombstones_raw.items()
             }
-            transfer_raw = value.get("transfer")
             transfer = (
                 None
                 if transfer_raw is None
@@ -1385,27 +1728,29 @@ class OwnershipLedger:
                         | {"ancestor_fingerprints": tuple(raw["ancestor_fingerprints"])}
                     )
                 )
-                for raw in value.get("transfer_lineage", [])
+                for raw in transfer_lineage_raw
             )
             current = LedgerSnapshot(
                 schema=LEDGER_SCHEMA,
-                generation=int(value["generation"]),
-                key_id=str(value["key_id"]),
+                generation=generation,
+                key_id=key_id,
                 leases=leases,
                 tombstones=tombstones,
                 transfer=transfer,
                 transfer_lineage=transfer_lineage,
                 legacy_bootstrap_complete=bool(value.get("legacy_bootstrap_complete", False)),
             )
-        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        except (AttributeError, ValueError, KeyError, TypeError) as exc:
             raise LedgerError("ownership ledger is invalid") from exc
         if current.key_id != key.key_id or current.generation != key.generation:
             raise LedgerKeyError("ownership ledger/key generation mismatch")
+        self._validate_snapshot(current, key)
         return current
 
     def _write_ledger_locked(self, current: LedgerSnapshot, key: _KeyMaterial) -> None:
         if current.key_id != key.key_id or current.generation != key.generation:
             raise LedgerKeyError("cannot persist mixed ownership key generations")
+        self._validate_snapshot(current, key)
         _atomic_private_json(self.path, self._ledger_value(current))
 
     def _ledger_value(self, current: LedgerSnapshot) -> dict[str, object]:
@@ -1430,23 +1775,36 @@ class OwnershipLedger:
             journal = json.loads(self.rotation_path.read_text(encoding="utf-8"))
             if journal.get("schema") != ROTATION_SCHEMA:
                 raise ValueError
-            key = journal["key"]
-            ledger = journal["ledger"]
-            if not isinstance(key, dict) or not isinstance(ledger, dict):
+            key_value = journal["key"]
+            ledger_value = journal["ledger"]
+            if not isinstance(key_value, dict) or not isinstance(ledger_value, dict):
                 raise ValueError
-            secret = base64.b64decode(key["secret"], validate=True)
+            secret = base64.b64decode(key_value["secret"], validate=True)
             if (
-                key.get("schema") != KEY_SCHEMA
-                or ledger.get("schema") != LEDGER_SCHEMA
-                or key.get("key_id") != ledger.get("key_id")
-                or key.get("generation") != ledger.get("generation")
+                key_value.get("schema") != KEY_SCHEMA
+                or ledger_value.get("schema") != LEDGER_SCHEMA
+                or key_value.get("key_id") != ledger_value.get("key_id")
+                or key_value.get("generation") != ledger_value.get("generation")
                 or len(secret) != 32
             ):
                 raise ValueError
-        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+            recovered_key = _KeyMaterial(
+                str(key_value["key_id"]),
+                int(key_value["generation"]),
+                secret,
+            )
+            self._snapshot_from_value(ledger_value, recovered_key)
+        except (
+            OSError,
+            ValueError,
+            KeyError,
+            TypeError,
+            json.JSONDecodeError,
+            LedgerError,
+        ) as exc:
             raise LedgerKeyError("ownership key rotation journal is invalid") from exc
-        _atomic_private_json(self.key_path, key)
-        _atomic_private_json(self.path, ledger)
+        _atomic_private_json(self.key_path, key_value)
+        _atomic_private_json(self.path, ledger_value)
         self.rotation_path.unlink()
         _fsync_directory(self.root)
 

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1075,6 +1075,58 @@ class OwnershipLedger:
             ):
                 continue
             raise LedgerCollisionError("canonical content roots overlap across ownership domains")
+        component_leases = [
+            lease
+            for lease in leases
+            if lease.vault_binding_id != candidate.vault_binding_id
+        ] + [candidate]
+        self._assert_native_release_component_cardinality(component_leases)
+
+    def _assert_native_release_component_cardinality(
+        self,
+        leases: Sequence[OwnershipLease],
+    ) -> None:
+        overlap_graph = {index: set() for index in range(len(leases))}
+        for index, left in enumerate(leases):
+            for right_index, right in enumerate(
+                leases[index + 1 :],
+                start=index + 1,
+            ):
+                if (
+                    left.root_fingerprint != right.root_fingerprint
+                    and left.root_fingerprint not in right.ancestor_fingerprints
+                    and right.root_fingerprint not in left.ancestor_fingerprints
+                ):
+                    continue
+                overlap_graph[index].add(right_index)
+                overlap_graph[right_index].add(index)
+
+        unseen = set(overlap_graph)
+        while unseen:
+            seed = unseen.pop()
+            component = {seed}
+            pending = [seed]
+            while pending:
+                current = pending.pop()
+                adjacent = overlap_graph[current] & unseen
+                unseen.difference_update(adjacent)
+                component.update(adjacent)
+                pending.extend(adjacent)
+            native_owners = [
+                index for index in component if leases[index].channel_id == "native"
+            ]
+            release_owners = [
+                index
+                for index in component
+                if leases[index].channel_id in _RELEASE_CHANNELS
+            ]
+            if native_owners and release_owners and (
+                len(native_owners) != 1 or len(release_owners) != 1
+            ):
+                raise LedgerCollisionError(
+                    "canonical content roots form an ambiguous native/channel "
+                    "overlap component"
+                )
 
     def _matches_root(self, lease: OwnershipLease, root: Path, key: _KeyMaterial) -> bool:
         return lease.root_fingerprint == self._lease_for_root(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -374,6 +374,9 @@ class OwnershipLedger:
                 raise LedgerError(
                     "registry/ledger consistency cannot commit an in-progress transfer"
                 )
+            self._assert_native_release_component_cardinality(
+                self._component_leases(current)
+            )
 
             ledger_live_owners: set[tuple[str, str]] = set()
             ledger_live_roots: list[tuple[str, str, str]] = []
@@ -912,6 +915,9 @@ class OwnershipLedger:
                 self._assert_no_collision(staged, candidate, allow_same_channel_nested=True)
                 leases[candidate.vault_binding_id] = candidate
                 staged = self._replace(staged, leases=leases)
+            self._assert_native_release_component_cardinality(
+                self._component_leases(staged)
+            )
             staged = self._replace(staged, legacy_bootstrap_complete=True)
             if staged == current:
                 return current
@@ -934,6 +940,9 @@ class OwnershipLedger:
                 )
             old_key = self._load_or_create_key_locked(allow_create=False)
             current = self._load_or_create_ledger_locked(old_key, allow_create=False)
+            self._assert_native_release_component_cardinality(
+                self._component_leases(current)
+            )
             live_roots = {
                 binding: Path(self._open_root(lease.sealed_root, old_key))
                 for binding, lease in current.leases.items()
@@ -1038,19 +1047,7 @@ class OwnershipLedger:
         *,
         allow_same_channel_nested: bool,
     ) -> None:
-        leases = list(current.leases.values()) + list(current.tombstones.values())
-        if current.transfer is not None:
-            transfer = current.transfer
-            leases.append(
-                OwnershipLease(
-                    channel_id=transfer.destination_channel_id,
-                    vault_binding_id=transfer.destination_binding_id,
-                    root_fingerprint=transfer.root_fingerprint,
-                    ancestor_fingerprints=transfer.ancestor_fingerprints,
-                    sealed_root=transfer.sealed_root,
-                    state="transferring",
-                )
-            )
+        leases = self._component_leases(current)
         for lease in leases:
             exact = candidate.root_fingerprint == lease.root_fingerprint
             overlap = (
@@ -1081,6 +1078,25 @@ class OwnershipLedger:
             if lease.vault_binding_id != candidate.vault_binding_id
         ] + [candidate]
         self._assert_native_release_component_cardinality(component_leases)
+
+    def _component_leases(
+        self,
+        current: LedgerSnapshot,
+    ) -> list[OwnershipLease]:
+        leases = list(current.leases.values()) + list(current.tombstones.values())
+        if current.transfer is not None:
+            transfer = current.transfer
+            leases.append(
+                OwnershipLease(
+                    channel_id=transfer.destination_channel_id,
+                    vault_binding_id=transfer.destination_binding_id,
+                    root_fingerprint=transfer.root_fingerprint,
+                    ancestor_fingerprints=transfer.ancestor_fingerprints,
+                    sealed_root=transfer.sealed_root,
+                    state="transferring",
+                )
+            )
+        return leases
 
     def _assert_native_release_component_cardinality(
         self,

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -871,8 +871,6 @@ class OwnershipLedger:
         with self._locked():
             key = self._load_or_create_key_locked()
             current = self._load_or_create_ledger_locked(key)
-            if current.legacy_bootstrap_complete:
-                return current
             staged = current
             leases = dict(current.leases)
             for owner in owners:
@@ -883,10 +881,40 @@ class OwnershipLedger:
                     key=key,
                     state="active",
                 )
+                existing = leases.get(candidate.vault_binding_id)
+                if existing is not None:
+                    if (
+                        existing.channel_id != candidate.channel_id
+                        or not self._matches_complete_root_identity(
+                            existing,
+                            owner.root,
+                            key,
+                        )
+                    ):
+                        raise LedgerCollisionError(
+                            "legacy owner binding no longer identifies its active root"
+                        )
+                    if existing.state != "active":
+                        leases[candidate.vault_binding_id] = candidate
+                        staged = self._replace(staged, leases=leases)
+                    continue
+                if candidate.vault_binding_id in current.tombstones or (
+                    current.transfer is not None
+                    and candidate.vault_binding_id
+                    in {
+                        current.transfer.source_binding_id,
+                        current.transfer.destination_binding_id,
+                    }
+                ):
+                    raise LedgerCollisionError(
+                        "legacy owner binding is retired or transferring"
+                    )
                 self._assert_no_collision(staged, candidate, allow_same_channel_nested=True)
                 leases[candidate.vault_binding_id] = candidate
                 staged = self._replace(staged, leases=leases)
             staged = self._replace(staged, legacy_bootstrap_complete=True)
+            if staged == current:
+                return current
             self._write_ledger_locked(staged, key)
             return staged
 

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2516,6 +2516,7 @@ def _load_legacy_owner_inventory(
     registry: RegistrySnapshot,
     channel: str,
     quiescence_proof: DeploymentQuiescenceProof | None = None,
+    skip_unmaterialized: bool = False,
 ) -> list[LegacyOwner]:
     payload = _load_legacy_owner_inventory_payload(inventory_path)
     if quiescence_proof is not None:
@@ -2545,8 +2546,17 @@ def _load_legacy_owner_inventory(
         if not isinstance(item, dict):
             raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
         owner_channel = str(item.get("channel_id") or "").strip()
-        root = Path(str(item.get("root") or "")).expanduser().resolve(strict=False)
-        if not owner_channel or not root.is_dir():
+        raw_root = str(item.get("root") or "").strip()
+        if (
+            not owner_channel
+            or not raw_root
+            or not Path(raw_root).expanduser().is_absolute()
+        ):
+            raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
+        root = Path(raw_root).expanduser().resolve(strict=False)
+        if not root.is_dir():
+            if skip_unmaterialized:
+                continue
             raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
         binding_id = str(item.get("vault_binding_id") or "").strip()
         if owner_channel == channel:
@@ -2565,7 +2575,14 @@ def _load_legacy_owner_inventory(
         raise InstanceStatePreflightError("legacy-owner inventory repeats a binding identity")
     represented = {owner.vault_binding_id for owner in owners if owner.channel_id == channel}
     missing_bindings = set(registry.registrations) - represented
-    if missing_bindings:
+    materialized_missing_bindings = {
+        binding_id
+        for binding_id in missing_bindings
+        if Path(registry.registrations[binding_id].path).expanduser().is_dir()
+    }
+    if missing_bindings and (
+        not skip_unmaterialized or materialized_missing_bindings
+    ):
         raise InstanceStatePreflightError(
             "legacy-owner inventory omits a current-channel registration"
         )
@@ -2849,19 +2866,22 @@ def _finish_instance_state_deployment_locked(
         ledger_snapshot = ledger.require_existing()
     except LedgerError:
         ledger_snapshot = None
-    if ledger_snapshot is None or not ledger_snapshot.legacy_bootstrap_complete:
-        owners = _load_legacy_owner_inventory(
-            inventory_path,
-            registry=registry,
-            channel=channel,
-            quiescence_proof=quiescence_proof,
-        )
-        ledger_snapshot = ledger.bootstrap_legacy_owners(
-            owners,
-            inventory_complete=True,
-            writers_drained=True,
-            _capability=_STORAGE_MUTATION_CAPABILITY,
-        )
+    owners = _load_legacy_owner_inventory(
+        inventory_path,
+        registry=registry,
+        channel=channel,
+        quiescence_proof=quiescence_proof,
+        skip_unmaterialized=(
+            ledger_snapshot is not None
+            and ledger_snapshot.legacy_bootstrap_complete
+        ),
+    )
+    ledger_snapshot = ledger.bootstrap_legacy_owners(
+        owners,
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
     if scalar_roll_forward_merged:
         ledger.require_scalar_rollback_ready(
             channel_id=channel,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2542,22 +2542,32 @@ def _load_legacy_owner_inventory(
     if not isinstance(owner_payload, list):
         raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
     owners: list[LegacyOwner] = []
-    for item in owner_payload:
+    for index, item in enumerate(owner_payload):
         if not isinstance(item, dict):
-            raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
+            raise InstanceStatePreflightError(
+                "canonical global live-owner inventory is invalid: "
+                f"owners[{index}] is not an owner entry"
+            )
         owner_channel = str(item.get("channel_id") or "").strip()
         raw_root = str(item.get("root") or "").strip()
-        if (
-            not owner_channel
-            or not raw_root
-            or not Path(raw_root).expanduser().is_absolute()
-        ):
-            raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
+        if not owner_channel:
+            raise InstanceStatePreflightError(
+                "canonical global live-owner inventory is invalid: "
+                f"owners[{index}].channel_id is missing"
+            )
+        if not raw_root or not Path(raw_root).expanduser().is_absolute():
+            raise InstanceStatePreflightError(
+                "canonical global live-owner inventory is invalid: "
+                f"owners[{index}].root is missing or not absolute"
+            )
         root = Path(raw_root).expanduser().resolve(strict=False)
         if not root.is_dir():
             if skip_unmaterialized:
                 continue
-            raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
+            raise InstanceStatePreflightError(
+                "canonical global live-owner inventory is invalid: "
+                f"owners[{index}].root is not materialized"
+            )
         binding_id = str(item.get("vault_binding_id") or "").strip()
         if owner_channel == channel:
             for registration in registry.registrations.values():
@@ -2831,7 +2841,13 @@ def _finish_instance_state_deployment_locked(
     )
     had_populated_registry = has_registry_state and store.load().revision > 0
     if had_populated_registry and restore_root is None:
-        ledger.require_existing()
+        try:
+            ledger.require_existing()
+        except LedgerError as exc:
+            raise InstanceStatePreflightError(
+                "backup registry/ledger consistency verification failed during "
+                "ownership ledger preflight"
+            ) from exc
 
     source = Path(legacy_path).expanduser().resolve(strict=False)
     final_fingerprint: str | None = None
@@ -2862,20 +2878,32 @@ def _finish_instance_state_deployment_locked(
         store.load()
 
     registry = store.load()
-    try:
-        ledger_snapshot = ledger.require_existing()
-    except LedgerError:
+    if not ledger.path.exists() and not ledger.key_path.exists():
         ledger_snapshot = None
-    owners = _load_legacy_owner_inventory(
-        inventory_path,
-        registry=registry,
-        channel=channel,
-        quiescence_proof=quiescence_proof,
-        skip_unmaterialized=(
-            ledger_snapshot is not None
-            and ledger_snapshot.legacy_bootstrap_complete
-        ),
-    )
+    else:
+        try:
+            ledger_snapshot = ledger.require_existing()
+        except LedgerError as exc:
+            raise InstanceStatePreflightError(
+                "backup registry/ledger consistency verification failed during "
+                "ownership ledger preflight"
+            ) from exc
+    try:
+        owners = _load_legacy_owner_inventory(
+            inventory_path,
+            registry=registry,
+            channel=channel,
+            quiescence_proof=quiescence_proof,
+            skip_unmaterialized=(
+                ledger_snapshot is not None
+                and ledger_snapshot.legacy_bootstrap_complete
+            ),
+        )
+    except InstanceStatePreflightError as exc:
+        raise InstanceStatePreflightError(
+            "backup registry/ledger consistency verification failed: "
+            f"{exc}"
+        ) from exc
     ledger_snapshot = ledger.bootstrap_legacy_owners(
         owners,
         inventory_complete=True,

--- a/docs/CONCEPTS/VAULT_TOPOLOGY_CONTRACT.md
+++ b/docs/CONCEPTS/VAULT_TOPOLOGY_CONTRACT.md
@@ -65,8 +65,11 @@ source/authority/provenance/degradation requirements above.
 MVR-01B has shipped the non-authoritative topology-safety substrate: a durable per-channel registry
 store shared by every container consumer, a host-global canonical-root ownership ledger/key, and
 recoverable registration/transfer/removal lineage. That substrate prevents one physical content
-root (or an overlapping ancestor/descendant alias) from becoming active in different channel
-ownership domains, while preserving nested child-vault traversal boundaries within one channel.
+root (or an overlapping ancestor/descendant alias) from becoming active in two different release
+channels, while preserving nested child-vault traversal boundaries within one channel. One native
+runtime and one release channel may carry distinct authenticated bindings for the same or an
+overlapping vault root: ADR-0055 governs those concurrent writers at the write seam instead of
+making deployment reject their declared topology.
 It does not change the runtime topology authority decision: the registry is still dormant,
 production reads remain on the legacy scalar selection, and MVR-01C is the sole cutover owner.
 

--- a/docs/CONCEPTS/VAULT_TOPOLOGY_CONTRACT.md
+++ b/docs/CONCEPTS/VAULT_TOPOLOGY_CONTRACT.md
@@ -69,7 +69,9 @@ root (or an overlapping ancestor/descendant alias) from becoming active in two d
 channels, while preserving nested child-vault traversal boundaries within one channel. One native
 runtime and one release channel may carry distinct authenticated bindings for the same or an
 overlapping vault root: ADR-0055 governs those concurrent writers at the write seam instead of
-making deployment reject their declared topology.
+making deployment reject their declared topology. The exception is one overlap-connected owner-root
+pair, never a bridge to additional native or release roots; retained ownership lineage participates
+in that cardinality check.
 It does not change the runtime topology authority decision: the registry is still dormant,
 production reads remain on the legacy scalar selection, and MVR-01C is the sole cutover owner.
 

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -70,7 +70,8 @@ This slice promotes the existing seed without changing content-vault authority.
   bridge multiple owners through the exception. A completed legacy bootstrap is reconcilable only
   inside a freshly proved stopped deployment: newly materialized owners are added
   atomically, while binding reassignment, retired/transferring binding reuse, and forbidden
-  release-channel overlap fail without changing the ledger.
+  release-channel overlap fail without changing the ledger. Reconciliation, backup consistency,
+  and key rotation revalidate persisted component cardinality even when no binding changes.
   One channel/instance may register an initialized parent vault and initialized nested child as
   distinct bindings only when the existing nested-vault boundary contract is active: parent traversal
   prunes the child, each effect targets one explicit binding/lease, and neither registration aliases

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -67,7 +67,14 @@ This slice promotes the existing seed without changing content-vault authority.
   ADR-0055 declares them concurrent writers of the same vault. The exception remains narrow at the
   connected-component level: native plus release overlap contains exactly one owner
   root from each side, including retained tombstone and transfer ownership, so neither side can
-  bridge multiple owners through the exception. A completed legacy bootstrap is reconcilable only
+  bridge multiple owners through the exception. Cardinality counts authenticated stable bindings,
+  not lifecycle-record rows: an active lease and immutable retired tombstone for the same binding
+  normalize to one authority only when map/internal ID, channel, HMAC identity, ancestor chain, and
+  authenticated canonical root agree (their randomized sealed-root ciphertext may differ). Transfer
+  source and destination bindings stay distinct and both count, including while the recoverable
+  reservation is pending. The v1 tombstone map preserves one immutable removal epoch per binding;
+  after same-binding reactivation a second removal fails closed rather than overwriting that epoch,
+  until MVR-06B owns a versioned repeated-removal journal. A completed legacy bootstrap is reconcilable only
   inside a freshly proved stopped deployment: newly materialized owners are added
   atomically, while binding reassignment, retired/transferring binding reuse, and forbidden
   release-channel overlap fail without changing the ledger. Reconciliation, backup consistency,

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -64,8 +64,11 @@ This slice promotes the existing seed without changing content-vault authority.
   of ancestor/descendant overlap across two different release channels; `/vault` and
   `/vault/project` therefore cannot belong to different release channels. One `native` owner and one
   release channel may carry distinct authenticated bindings for equal or overlapping roots because
-  ADR-0055 declares them concurrent writers of the same vault. A completed legacy bootstrap remains
-  reconcilable only inside a freshly proved stopped deployment: newly materialized owners are added
+  ADR-0055 declares them concurrent writers of the same vault. The exception remains narrow at the
+  connected-component level: native plus release overlap contains exactly one owner
+  root from each side, including retained tombstone and transfer ownership, so neither side can
+  bridge multiple owners through the exception. A completed legacy bootstrap is reconcilable only
+  inside a freshly proved stopped deployment: newly materialized owners are added
   atomically, while binding reassignment, retired/transferring binding reuse, and forbidden
   release-channel overlap fail without changing the ledger.
   One channel/instance may register an initialized parent vault and initialized nested child as
@@ -403,7 +406,8 @@ new-schema state before fork/merge protection exists.
 - [ ] **MVR-01B:** Registering, relocating, or starting equal, ancestor, or descendant canonical
   content roots across two different release channels is rejected by the shared ownership ledger,
   including symlink and bind-mount aliases; one sanctioned native/channel pair may share or overlap
-  the vault root. A later stopped deployment reconciles a newly discovered native owner into an
+  the vault root, but an overlap-connected component with native plus release ownership must contain
+  exactly one owner root on each side, including tombstone and transfer ownership. A later stopped deployment reconciles a newly discovered native owner into an
   established ledger before backup verification, while forbidden collisions and binding-identity
   changes remain atomic failures. Injected crashes in reserve/commit/activate recover to at most one
   non-overlapping release-channel owner without exposing raw host paths.

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -72,13 +72,18 @@ This slice promotes the existing seed without changing content-vault authority.
   normalize to one authority only when map/internal ID, channel, HMAC identity, ancestor chain, and
   authenticated canonical root agree (their randomized sealed-root ciphertext may differ). Transfer
   source and destination bindings stay distinct and both count, including while the recoverable
-  reservation is pending. The v1 tombstone map preserves one immutable removal epoch per binding;
+  reservation is pending. Cross-release retained authority must form one authenticated directed,
+  acyclic transfer path with at most one live terminal binding; a pending reservation may extend
+  only that terminal, and missing, disconnected, branched, merged, cyclic, or interior-attached
+  history fails closed. The v1 tombstone map preserves one immutable removal epoch per binding;
   after same-binding reactivation a second removal fails closed rather than overwriting that epoch,
   until MVR-06B owns a versioned repeated-removal journal. A completed legacy bootstrap is reconcilable only
   inside a freshly proved stopped deployment: newly materialized owners are added
   atomically, while binding reassignment, retired/transferring binding reuse, and forbidden
   release-channel overlap fail without changing the ledger. Reconciliation, backup consistency,
-  and key rotation revalidate persisted component cardinality even when no binding changes.
+  and key rotation revalidate persisted component cardinality even when no binding changes. Ledger,
+  key, and rotation-journal generation/key/bootstrap authority fields require exact JSON types
+  before object construction or recovery; no truthy or numeric/string coercion is accepted.
   One channel/instance may register an initialized parent vault and initialized nested child as
   distinct bindings only when the existing nested-vault boundary contract is active: parent traversal
   prunes the child, each effect targets one explicit binding/lease, and neither registration aliases

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -60,9 +60,14 @@ This slice promotes the existing seed without changing content-vault authority.
   lifecycle preflight. It stores channel plus stable binding and HMAC fingerprints of the canonical
   filesystem identity and its canonical ancestor-identity chain, not raw paths. Canonicalization
   resolves symlinks, bind-mount aliases, and filesystem identity before comparison. Registration or
-  relocation under the global lock always rejects duplicate physical identity under different
-  bindings and rejects either direction of ancestor/descendant overlap across different channel/native
-  ownership domains; `/vault` and `/vault/project` therefore cannot belong to different channels.
+  relocation under the global lock always rejects duplicate physical identity and either direction
+  of ancestor/descendant overlap across two different release channels; `/vault` and
+  `/vault/project` therefore cannot belong to different release channels. One `native` owner and one
+  release channel may carry distinct authenticated bindings for equal or overlapping roots because
+  ADR-0055 declares them concurrent writers of the same vault. A completed legacy bootstrap remains
+  reconcilable only inside a freshly proved stopped deployment: newly materialized owners are added
+  atomically, while binding reassignment, retired/transferring binding reuse, and forbidden
+  release-channel overlap fail without changing the ledger.
   One channel/instance may register an initialized parent vault and initialized nested child as
   distinct bindings only when the existing nested-vault boundary contract is active: parent traversal
   prunes the child, each effect targets one explicit binding/lease, and neither registration aliases
@@ -396,10 +401,15 @@ new-schema state before fork/merge protection exists.
   reconstruction, never metadata-only restore).
   - Verify: `tests/ops/test_instance_state_volume_contract.py::test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restore`
 - [ ] **MVR-01B:** Registering, relocating, or starting equal, ancestor, or descendant canonical
-  content roots across different release-channel/native ownership domains is rejected by the shared ownership ledger, including
-  symlink and bind-mount aliases; injected crashes in reserve/commit/activate recover to at most one
-  non-overlapping active owner without exposing raw host paths.
+  content roots across two different release channels is rejected by the shared ownership ledger,
+  including symlink and bind-mount aliases; one sanctioned native/channel pair may share or overlap
+  the vault root. A later stopped deployment reconciles a newly discovered native owner into an
+  established ledger before backup verification, while forbidden collisions and binding-identity
+  changes remain atomic failures. Injected crashes in reserve/commit/activate recover to at most one
+  non-overlapping release-channel owner without exposing raw host paths.
   - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_overlapping_content_roots_cannot_be_active_in_two_channels`
+  - Verify: `tests/integration/test_vault_registry_channel_isolation.py::test_first_upgrade_allows_native_and_release_channel_shared_root`
+  - Verify: `tests/ops/test_instance_state_volume_contract.py::test_established_ledger_adopts_new_sanctioned_native_owner`
 - [ ] **MVR-01B:** One channel/instance can register an initialized parent vault and initialized
   nested child as distinct stable bindings; the production parent walker prunes the child, direct
   child selection remains usable, and duplicate-root aliases still coalesce or fail rather than

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -64,9 +64,11 @@ HMAC fingerprints of canonical filesystem identity plus its canonical ancestor-i
 two different release channels, including after symlink or bind-mount alias resolution. The narrow
 exception is one `native` owner paired with one release channel: ADR-0055 declares both runtimes as
 writers of the same vault, so their equal or overlapping roots may carry distinct authenticated
-bindings. One channel/instance may register initialized parent and child vaults only under the
-existing nested-vault boundary contract: parent traversal prunes the child and effects target one
-explicit binding. One CSPRNG-generated,
+bindings. The complete overlap-connected component must contain exactly those two owner roots;
+native cannot bridge multiple release owners, a release owner cannot bridge multiple native roots,
+and retained tombstone/transfer ownership counts in that component. One channel/instance may
+register initialized parent and child vaults only under the existing nested-vault boundary contract:
+parent traversal prunes the child and effects target one explicit binding. One CSPRNG-generated,
 host-global ledger key lives mode `0600` in private host app-data outside every channel volume and
 is mounted read-only into all channel/native consumers; generation, permissions, durable backup,
 and key ID are host-bootstrap truth. Missing, ephemeral, channel-specific, mismatched, or permissive
@@ -110,7 +112,8 @@ the wrapper marks the inventory drained and seeds every owner. A missing, change
 forbidden release-channel overlap fails closed rather than being silently omitted. On later
 deployments, the same stopped finalizer reconciles newly discovered, materialized owners into an
 established completed ledger before backup verification; binding reassignment, transfer/tombstone
-reuse, or a forbidden release-channel collision aborts atomically and leaves the fence in place. The fence prevents
+reuse, an over-cardinality native/channel component, or a forbidden release-channel collision aborts
+atomically and leaves the fence in place. The fence prevents
 upgraded consumers from restarting through a failed post-stop validation or import; a changed final
 fingerprint, missing inventory, missing established ledger/key, or unfenced finalizer also aborts.
 The independently durable legacy source is never deleted.

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -66,7 +66,11 @@ exception is one `native` owner paired with one release channel: ADR-0055 declar
 writers of the same vault, so their equal or overlapping roots may carry distinct authenticated
 bindings. The complete overlap-connected component must contain exactly those two owner roots;
 native cannot bridge multiple release owners, a release owner cannot bridge multiple native roots,
-and retained tombstone/transfer ownership counts in that component. One channel/instance may
+and retained tombstone/transfer ownership counts in that component. Lifecycle rows for one stable
+binding normalize once only after their authenticated channel/root identity agrees; independently
+sealed active and retired rows may therefore coexist. Transfer endpoints remain distinct. The v1
+tombstone slot is immutable, so a second removal after reactivation fails closed pending the MVR-06B
+versioned lifecycle journal. One channel/instance may
 register initialized parent and child vaults only under the existing nested-vault boundary contract:
 parent traversal prunes the child and effects target one explicit binding. One CSPRNG-generated,
 host-global ledger key lives mode `0600` in private host app-data outside every channel volume and

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -60,11 +60,13 @@ Per-channel registry isolation is not sufficient because current containers can 
 roots. A separate host-local **channel ownership ledger** is mounted consistently into every channel
 and native runtime. Under one global mode-`0600` lock it records `channel_id`, stable binding, and
 HMAC fingerprints of canonical filesystem identity plus its canonical ancestor-identity chain
-(never a raw host path). Duplicate physical identity under different bindings is always a conflict;
-ancestor/descendant overlap conflicts across different channel/native ownership domains, including
-after symlink or bind-mount alias resolution. One channel/instance may register initialized parent
-and child vaults only under the existing nested-vault boundary contract: parent traversal prunes the
-child and effects target one explicit binding. One CSPRNG-generated,
+(never a raw host path). Duplicate physical identity and ancestor/descendant overlap conflict across
+two different release channels, including after symlink or bind-mount alias resolution. The narrow
+exception is one `native` owner paired with one release channel: ADR-0055 declares both runtimes as
+writers of the same vault, so their equal or overlapping roots may carry distinct authenticated
+bindings. One channel/instance may register initialized parent and child vaults only under the
+existing nested-vault boundary contract: parent traversal prunes the child and effects target one
+explicit binding. One CSPRNG-generated,
 host-global ledger key lives mode `0600` in private host app-data outside every channel volume and
 is mounted read-only into all channel/native consumers; generation, permissions, durable backup,
 and key ID are host-bootstrap truth. Missing, ephemeral, channel-specific, mismatched, or permissive
@@ -73,8 +75,9 @@ re-fingerprints every canonical root, and atomically advances ledger plus key ge
 owner resumes; interrupted rotation recovers one complete generation and never compares mixed keys.
 Registration uses a recoverable pending→registry-commit→active reservation protocol; lifecycle start proves the
 active reservation still matches its channel and root. The same physical content root cannot be
-active in two dev/test/prod/native ownership domains simultaneously, and nested roots cannot straddle
-those domains. Relocation is implemented but capability-gated until MVR-06C proves every foreground
+active in two release-channel ownership domains simultaneously; the sanctioned native/channel pair
+above is the sole cross-domain exception. Relocation is implemented but capability-gated until
+MVR-06C proves every foreground
 and background consumer uses the matching shared/exclusive effect-lease order. Explicit transfer
 remains capability-gated until MVR-05C activates foreground read/write ownership fencing. It then
 uses a production-derived source-channel inventory to close foreground ingress, drain and stop every
@@ -88,8 +91,8 @@ The first MVR-01 rollout is a host-wide ownership migration, not a per-channel b
 any new reservation is accepted, deployment acquires a global bootstrap fence, blocks legacy
 selection/registry ingress, inventories every dev/test/prod Compose deployment and native runtime
 that can reach the host roots, and drains or stops all of their registry and lifecycle writers. It
-then rejects any pre-existing root collision and seeds one ledger generation with every legacy
-channel/native owner before opening claims. A seeded old channel may resume before its own upgrade
+then rejects any pre-existing root collision outside the sanctioned native/channel pair and seeds one
+ledger generation with every legacy channel/native owner before opening claims. A seeded old channel may resume before its own upgrade
 only on that fixed root behind mutation-denying ingress; a native or channel runtime that cannot be
 fenced remains stopped. Missing inventory, a racing writer, ambiguous ownership, or duplicate roots
 blocks every MVR-01 claim rather than letting an upgraded channel race an old image.
@@ -104,7 +107,10 @@ canonical channel/runtime env files, stopped or running Compose service config p
 the native scalar store, and the governed caller binding. Two identical probes create a private
 baseline; after lease-bound quiescence is proven, two more probes must reproduce it exactly before
 the wrapper marks the inventory drained and seeds every owner. A missing, changed, ambiguous, or
-cross-domain-overlapping source fails closed rather than being silently omitted. The fence prevents
+forbidden release-channel overlap fails closed rather than being silently omitted. On later
+deployments, the same stopped finalizer reconciles newly discovered, materialized owners into an
+established completed ledger before backup verification; binding reassignment, transfer/tombstone
+reuse, or a forbidden release-channel collision aborts atomically and leaves the fence in place. The fence prevents
 upgraded consumers from restarting through a failed post-stop validation or import; a changed final
 fingerprint, missing inventory, missing established ledger/key, or unfenced finalizer also aborts.
 The independently durable legacy source is never deleted.

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -113,7 +113,9 @@ forbidden release-channel overlap fails closed rather than being silently omitte
 deployments, the same stopped finalizer reconciles newly discovered, materialized owners into an
 established completed ledger before backup verification; binding reassignment, transfer/tombstone
 reuse, an over-cardinality native/channel component, or a forbidden release-channel collision aborts
-atomically and leaves the fence in place. The fence prevents
+atomically and leaves the fence in place. Reconciliation, backup consistency, and key rotation all
+revalidate the complete persisted component, so state written by an older implementation cannot
+pass as a no-op. The fence prevents
 upgraded consumers from restarting through a failed post-stop validation or import; a changed final
 fingerprint, missing inventory, missing established ledger/key, or unfenced finalizer also aborts.
 The independently durable legacy source is never deleted.

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -68,7 +68,11 @@ bindings. The complete overlap-connected component must contain exactly those tw
 native cannot bridge multiple release owners, a release owner cannot bridge multiple native roots,
 and retained tombstone/transfer ownership counts in that component. Lifecycle rows for one stable
 binding normalize once only after their authenticated channel/root identity agrees; independently
-sealed active and retired rows may therefore coexist. Transfer endpoints remain distinct. The v1
+sealed active and retired rows may therefore coexist. Transfer endpoints remain distinct.
+Cross-release retained authority is valid only as one authenticated directed, acyclic transfer
+path: every historical node precedes at most one successor, at most one live binding is the
+terminal node, and a pending reservation may only extend that terminal. Disconnected, branched,
+merged, cyclic, or interior-attached histories fail closed. The v1
 tombstone slot is immutable, so a second removal after reactivation fails closed pending the MVR-06B
 versioned lifecycle journal. One channel/instance may
 register initialized parent and child vaults only under the existing nested-vault boundary contract:
@@ -79,6 +83,8 @@ and key ID are host-bootstrap truth. Missing, ephemeral, channel-specific, misma
 key state blocks claims and lifecycle start. Key rotation holds the global fence, drains all owners,
 re-fingerprints every canonical root, and atomically advances ledger plus key generation before any
 owner resumes; interrupted rotation recovers one complete generation and never compares mixed keys.
+Ledger, key, and rotation-journal authority fields require their exact JSON boolean, integer, and
+string types before construction or recovery; truthy and numeric/string coercions are never authority.
 Registration uses a recoverable pending→registry-commit→active reservation protocol; lifecycle start proves the
 active reservation still matches its channel and root. The same physical content root cannot be
 active in two release-channel ownership domains simultaneously; the sanctioned native/channel pair

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -135,7 +135,10 @@ backup verification; binding reassignment, retired/transferring binding reuse, o
 release-channel collision aborts and leaves the fence in place. The native/channel exception is
 limited to one owner root on each side of a complete overlap-connected component, including retained
 tombstone/transfer ownership, so neither domain can bridge additional owners. Reconciliation,
-backup consistency, and key rotation revalidate that persisted component even on a no-op. It then optionally restores a
+backup consistency, and key rotation revalidate that persisted component even on a no-op.
+Authenticated active+retired rows for one stable binding count once; transfer endpoints remain
+distinct, and the immutable v1 tombstone slot refuses a second removal after reactivation instead of
+overwriting lineage. It then optionally restores a
 verified backup and creates the next registry/ledger/key backup. The fence is
 removed only after that sequence succeeds; consumer preflight rejects a missing mount, missing
 established state, incomplete owner bootstrap, or surviving fence without creating replacement

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -132,7 +132,9 @@ stopped the finalizer captures the final legacy scalar payload, imports or prese
 durable volume, verifies the private production-derived owner inventory, and seeds the shared ledger.
 On an established completed ledger it atomically reconciles any newly materialized owner before
 backup verification; binding reassignment, retired/transferring binding reuse, or a forbidden
-release-channel collision aborts and leaves the fence in place. It then optionally restores a
+release-channel collision aborts and leaves the fence in place. The native/channel exception is
+limited to one owner root on each side of a complete overlap-connected component, including retained
+tombstone/transfer ownership, so neither domain can bridge additional owners. It then optionally restores a
 verified backup and creates the next registry/ledger/key backup. The fence is
 removed only after that sequence succeeds; consumer preflight rejects a missing mount, missing
 established state, incomplete owner bootstrap, or surviving fence without creating replacement

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -129,8 +129,11 @@ release channels, fails closed before partial ledger seeding; a root shared betw
 channel is the topology `docs/adr/ADR-0055-vault-multiwriter-consistency-model.md` declares and does
 not fail closed. A post-stop failure leaves the fence in place. While
 stopped the finalizer captures the final legacy scalar payload, imports or preserves it on the
-durable volume, verifies the private production-derived owner inventory, seeds the shared ledger,
-optionally restores a verified backup, and creates the next registry/ledger/key backup. The fence is
+durable volume, verifies the private production-derived owner inventory, and seeds the shared ledger.
+On an established completed ledger it atomically reconciles any newly materialized owner before
+backup verification; binding reassignment, retired/transferring binding reuse, or a forbidden
+release-channel collision aborts and leaves the fence in place. It then optionally restores a
+verified backup and creates the next registry/ledger/key backup. The fence is
 removed only after that sequence succeeds; consumer preflight rejects a missing mount, missing
 established state, incomplete owner bootstrap, or surviving fence without creating replacement
 state. An explicitly selected rollback image that predates the runtime preflight module may pass

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -134,7 +134,8 @@ On an established completed ledger it atomically reconciles any newly materializ
 backup verification; binding reassignment, retired/transferring binding reuse, or a forbidden
 release-channel collision aborts and leaves the fence in place. The native/channel exception is
 limited to one owner root on each side of a complete overlap-connected component, including retained
-tombstone/transfer ownership, so neither domain can bridge additional owners. It then optionally restores a
+tombstone/transfer ownership, so neither domain can bridge additional owners. Reconciliation,
+backup consistency, and key rotation revalidate that persisted component even on a no-op. It then optionally restores a
 verified backup and creates the next registry/ledger/key backup. The fence is
 removed only after that sequence succeeds; consumer preflight rejects a missing mount, missing
 established state, incomplete owner bootstrap, or surviving fence without creating replacement

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -124,8 +124,10 @@ stores, the native scalar store, and the governed caller binding; two identical 
 required to create the private baseline. Before recreate it then installs the host lease and restart
 fence, stops API, worker, watcher, and Heimdal, probes dev/test/prod/native consumers twice, and
 durably proves quiescence. The owner producer must reproduce its baseline twice after that stop
-before marking it drained. A missing or racing source, or an equal/nested root across owner domains,
-fails closed before partial ledger seeding; a post-stop failure leaves the fence in place. While
+before marking it drained. A missing or racing source, or an equal/nested root across two different
+release channels, fails closed before partial ledger seeding; a root shared between `native` and one
+channel is the topology `docs/adr/ADR-0055-vault-multiwriter-consistency-model.md` declares and does
+not fail closed. A post-stop failure leaves the fence in place. While
 stopped the finalizer captures the final legacy scalar payload, imports or preserves it on the
 durable volume, verifies the private production-derived owner inventory, seeds the shared ledger,
 optionally restores a verified backup, and creates the next registry/ledger/key backup. The fence is

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -97,7 +97,8 @@ legacy-owner bootstrap, and reconciles newly materialized owners even when that 
 completed. Reconciliation preserves authenticated binding identity and is atomic with respect to
 forbidden release-channel collisions, tombstones, and transfers. The native/channel exception
 requires exactly one owner root from each side of the complete overlap-connected component; retained
-ownership participates, so an indirect bridge also fails closed. The finalizer then creates a
+ownership participates, so an indirect bridge also fails closed. Reconciliation and backup
+consistency revalidate persisted state even when the current inventory adds no owner. The finalizer then creates a
 verified registry/ledger/key backup and clears the fence.
 `INSTANCE_STATE_RESTORE_PATH`, when set, is verified and restored inside that stopped interval
 before finalization and consumer startup. Failure leaves the fence in place, so upgraded consumer

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -95,7 +95,9 @@ incomplete, non-private, or unvalidated inventory, captures the final legacy fin
 on first volume or preserves it beside an established dormant registry, calls the host-global
 legacy-owner bootstrap, and reconciles newly materialized owners even when that bootstrap previously
 completed. Reconciliation preserves authenticated binding identity and is atomic with respect to
-forbidden release-channel collisions, tombstones, and transfers. The finalizer then creates a
+forbidden release-channel collisions, tombstones, and transfers. The native/channel exception
+requires exactly one owner root from each side of the complete overlap-connected component; retained
+ownership participates, so an indirect bridge also fails closed. The finalizer then creates a
 verified registry/ledger/key backup and clears the fence.
 `INSTANCE_STATE_RESTORE_PATH`, when set, is verified and restored inside that stopped interval
 before finalization and consumer startup. Failure leaves the fence in place, so upgraded consumer

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -79,14 +79,17 @@ restart fence, stops API/worker/watcher/Heimdal, probes dev/test/prod/native con
 durably proves quiescence. Two new owner-source snapshots must reproduce the baseline exactly before
 the producer marks the inventory drained and copies it to
 `/app/instance-ownership/legacy-owner-inventory.json`; missing sources, config/store races, and
-equal or nested roots across owner domains abort without seeding a partial set. A failure at any
-stage after the lease/fence claim and before finalization — a live writer, a post-stop owner
-validation failure, or any other producer stage failure — surrenders that same-run producer's own
-host-global lease, public lease copy, and channel restart fence instead of stranding them; the
-release is scoped to the exact controller identity (pid plus start token) that claimed the lease, so
-it cannot disturb a lease still owned by a live or unrelated deployment, and a lease whose recorded
-controller process no longer exists is reclaimable by the next `deployment-begin` instead of fatal.
-The nonce-plus-inventory-digest proof
+equal or nested roots across two different release channels abort without seeding a partial set. A
+root shared between the `native` domain and one channel does not abort: per
+`docs/adr/ADR-0055-vault-multiwriter-consistency-model.md` the Mac runtime and a channel runtime are
+both declared writers of one vault, and their concurrent writes are resolved at write time rather
+than by refusing the deploy. A failure at any stage after the lease/fence claim and before
+finalization — a live writer, a post-stop owner validation failure, or any other producer stage
+failure — surrenders that same-run producer's own host-global lease, public lease copy, and channel
+restart fence instead of stranding them; the release is scoped to the exact controller identity (pid
+plus start token) that claimed the lease, so it cannot disturb a lease still owned by a live or
+unrelated deployment, and a lease whose recorded controller process no longer exists is reclaimable
+by the next `deployment-begin` instead of fatal. The nonce-plus-inventory-digest proof
 is required for restore, final export/preservation, and legacy bootstrap. The finalizer rejects an
 incomplete, non-private, or unvalidated inventory, captures the final legacy fingerprint, imports it
 on first volume or preserves it beside an established dormant registry, calls the host-global

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -93,7 +93,10 @@ by the next `deployment-begin` instead of fatal. The nonce-plus-inventory-digest
 is required for restore, final export/preservation, and legacy bootstrap. The finalizer rejects an
 incomplete, non-private, or unvalidated inventory, captures the final legacy fingerprint, imports it
 on first volume or preserves it beside an established dormant registry, calls the host-global
-legacy-owner bootstrap, creates a verified registry/ledger/key backup, and clears the fence.
+legacy-owner bootstrap, and reconciles newly materialized owners even when that bootstrap previously
+completed. Reconciliation preserves authenticated binding identity and is atomic with respect to
+forbidden release-channel collisions, tombstones, and transfers. The finalizer then creates a
+verified registry/ledger/key backup and clears the fence.
 `INSTANCE_STATE_RESTORE_PATH`, when set, is verified and restored inside that stopped interval
 before finalization and consumer startup. Failure leaves the fence in place, so upgraded consumer
 preflight refuses restart. Rollback to a previous image that predates `app.instance.runtime` is

--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -4,6 +4,37 @@
 The deployment wrapper runs this as one foreground process.  It owns both
 Docker and native enumeration, records no raw argv or host path, and emits a
 proof candidate only when two complete snapshots are identical and empty.
+
+Owner-root arrangements across domains
+--------------------------------------
+
+The legacy owner inventory enumerates vault owner roots across four domains:
+the three release channels (``dev``, ``test``, ``prod``) and ``native`` (the
+macOS app's ``app-local.md``).  It refuses only the arrangements that are
+genuinely ambiguous authority.  The rule follows from the writer set
+``docs/adr/ADR-0055-vault-multiwriter-consistency-model.md`` declares -- the Mac
+runtime, the human via Obsidian, iCloud sync, and the mobile clients -- not from
+any host, vault, or channel seen in the field:
+
+Permitted
+    ``native`` sharing a root with one release channel, whether the roots are
+    equal or one is an ancestor of the other in either direction.  The native
+    Mac runtime and a channel runtime writing one vault is the topology
+    ADR-0055 exists to govern, and it governs it *at write time* (atomic
+    writes, stale-detection, conflict staging).  Root identity is a statement
+    about ownership, not evidence that a writer is active.
+
+Forbidden
+    The same root, or ancestor/descendant overlap in either direction, claimed
+    by two *different release channels*.  ADR-0055 declares one Mac runtime,
+    not one per channel; ``docs/ENVIRONMENTS.md`` keeps channels isolated.  Two
+    channel runtimes on one vault is ambiguous authority no write-time
+    mechanism resolves, so it still aborts the deploy.
+
+This predicate is about ownership only.  The quiescence property -- that no
+writer is running during the deployment's stopped window -- is proved
+separately by :func:`prove_quiescent`, which requires two identical and empty
+process snapshots and is unaffected by which roots the domains own.
 """
 
 from __future__ import annotations
@@ -29,6 +60,9 @@ from typing import Sequence
 INVENTORY_SCHEMA = "agentic-pkm.host-deployment-quiescence.v2"
 LEGACY_OWNER_INVENTORY_SCHEMA = "agentic-pkm.legacy-owner-inventory.v1"
 DOMAINS = ("dev", "native", "prod", "test")
+# Owner-root overlap is fatal only between two of these; see the module
+# docstring for why a shared native/channel root is permitted instead.
+CHANNEL_DOMAINS = frozenset({"dev", "prod", "test"})
 COMPOSE_PROJECT_DOMAINS = {"pkm-dev": "dev", "pkm-prod": "prod", "pkm-test": "test"}
 COMPOSE_WRITER_SERVICES = {"api", "heimdal-capture-watch", "watcher", "worker"}
 LAUNCHER_SCRIPTS = {"deploy_channel.sh", "start_full_system.sh"}
@@ -959,6 +993,14 @@ def _normalize_legacy_owners(
             if left.channel_id == right.channel_id:
                 continue
             if (
+                left.channel_id not in CHANNEL_DOMAINS
+                or right.channel_id not in CHANNEL_DOMAINS
+            ):
+                # A native/channel pair. ADR-0055 declares both writers and
+                # resolves their collisions at write time, so a shared root is
+                # the designed topology rather than ambiguous authority.
+                continue
+            if (
                 left_primary == right_primary
                 or left_primary in right_ancestors
                 or right_primary in left_ancestors
@@ -968,8 +1010,10 @@ def _normalize_legacy_owners(
                     if left_primary == right_primary or left_primary in right_ancestors
                     else right_primary
                 )
+                # Both domains are release channels by the carve-out above, so
+                # the message names that narrower rule rather than "domains".
                 raise InventoryError(
-                    "legacy owner roots collide across domains: "
+                    "legacy owner roots collide across release channels: "
                     f"domain_a={left.channel_id} domain_b={right.channel_id} id={shared_id}"
                 )
     ordered = sorted(values, key=lambda item: (item[0].channel_id, item[0].root))

--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -29,7 +29,11 @@ Forbidden
     by two *different release channels*.  ADR-0055 declares one Mac runtime,
     not one per channel; ``docs/ENVIRONMENTS.md`` keeps channels isolated.  Two
     channel runtimes on one vault is ambiguous authority no write-time
-    mechanism resolves, so it still aborts the deploy.
+    mechanism resolves, so it still aborts the deploy.  The native exception
+    is one owner-root pair, not a bridge: an overlap-connected component that
+    contains native plus release ownership must contain exactly one owner from
+    each side.  A native parent with two release children, or a release parent
+    with two native children, is therefore also forbidden.
 
 This predicate is about ownership only.  The quiescence property -- that no
 writer is running during the deployment's stopped window -- is proved
@@ -988,8 +992,21 @@ def _normalize_legacy_owners(
         (record, primary, ancestors)
         for (_, primary), (record, ancestors) in normalized.items()
     ]
+    overlap_graph = {index: set() for index in range(len(values))}
     for index, (left, left_primary, left_ancestors) in enumerate(values):
-        for right, right_primary, right_ancestors in values[index + 1 :]:
+        for right_index, (right, right_primary, right_ancestors) in enumerate(
+            values[index + 1 :],
+            start=index + 1,
+        ):
+            overlap = (
+                left_primary == right_primary
+                or left_primary in right_ancestors
+                or right_primary in left_ancestors
+            )
+            if not overlap:
+                continue
+            overlap_graph[index].add(right_index)
+            overlap_graph[right_index].add(index)
             if left.channel_id == right.channel_id:
                 continue
             if (
@@ -1000,22 +1017,46 @@ def _normalize_legacy_owners(
                 # resolves their collisions at write time, so a shared root is
                 # the designed topology rather than ambiguous authority.
                 continue
-            if (
-                left_primary == right_primary
-                or left_primary in right_ancestors
-                or right_primary in left_ancestors
-            ):
-                shared_id = (
-                    left_primary
-                    if left_primary == right_primary or left_primary in right_ancestors
-                    else right_primary
-                )
-                # Both domains are release channels by the carve-out above, so
-                # the message names that narrower rule rather than "domains".
-                raise InventoryError(
-                    "legacy owner roots collide across release channels: "
-                    f"domain_a={left.channel_id} domain_b={right.channel_id} id={shared_id}"
-                )
+            shared_id = (
+                left_primary
+                if left_primary == right_primary or left_primary in right_ancestors
+                else right_primary
+            )
+            # Both domains are release channels by the carve-out above, so
+            # the message names that narrower rule rather than "domains".
+            raise InventoryError(
+                "legacy owner roots collide across release channels: "
+                f"domain_a={left.channel_id} domain_b={right.channel_id} id={shared_id}"
+            )
+
+    unseen = set(overlap_graph)
+    while unseen:
+        seed = unseen.pop()
+        component = {seed}
+        pending = [seed]
+        while pending:
+            current = pending.pop()
+            adjacent = overlap_graph[current] & unseen
+            unseen.difference_update(adjacent)
+            component.update(adjacent)
+            pending.extend(adjacent)
+        native_owners = [
+            index for index in component if values[index][0].channel_id == "native"
+        ]
+        release_owners = [
+            index
+            for index in component
+            if values[index][0].channel_id in CHANNEL_DOMAINS
+        ]
+        if native_owners and release_owners and (
+            len(native_owners) != 1 or len(release_owners) != 1
+        ):
+            component_id = min(values[index][1] for index in component)
+            raise InventoryError(
+                "legacy owner roots form an ambiguous native/channel overlap component: "
+                f"native_owners={len(native_owners)} "
+                f"release_owners={len(release_owners)} id={component_id}"
+            )
     ordered = sorted(values, key=lambda item: (item[0].channel_id, item[0].root))
     return (
         [item[0] for item in ordered],

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -838,6 +838,45 @@ def test_first_upgrade_seeds_all_legacy_channel_owners_before_claim(tmp_path) ->
         )
 
 
+@pytest.mark.parametrize("native_first", [True, False])
+def test_first_upgrade_allows_native_and_release_channel_shared_root(tmp_path, native_first) -> None:
+    host_global = tmp_path / "host-global"
+    root = tmp_path / "shared"
+    root.mkdir()
+    owners = [
+        LegacyOwner("native", "legacy-native", root),
+        LegacyOwner("prod", "legacy-prod", root),
+    ]
+    if not native_first:
+        owners.reverse()
+
+    snapshot = OwnershipLedger(host_global).bootstrap_legacy_owners(
+        owners,
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    assert {
+        lease.channel_id for lease in snapshot.leases.values()
+    } == {"native", "prod"}
+
+
+def test_first_upgrade_still_rejects_release_channel_shared_root(tmp_path) -> None:
+    root = tmp_path / "shared"
+    root.mkdir()
+    with pytest.raises(LedgerCollisionError, match="overlap"):
+        OwnershipLedger(tmp_path / "host-global").bootstrap_legacy_owners(
+            [
+                LegacyOwner("dev", "legacy-dev", root),
+                LegacyOwner("prod", "legacy-prod", root),
+            ],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+
 def test_env_only_bootstrap_atomically_enrolls_one_stable_binding_or_fails_closed(tmp_path) -> None:
     runtime = _runtime(tmp_path, "dev", tmp_path / "host-global")
     root = tmp_path / "vault"

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -1199,8 +1199,10 @@ def test_transfer_rejects_prospective_mixed_component_before_first_write(tmp_pat
     assert _ownership_artifact_bytes(ledger) == before
 
 
+@pytest.mark.parametrize("destination_channel", ["dev", "bogus"])
 def test_transfer_activation_revalidates_persisted_endpoints_without_mutation(
     tmp_path,
+    destination_channel,
 ) -> None:
     root = tmp_path / "root"
     root.mkdir()
@@ -1218,14 +1220,23 @@ def test_transfer_activation_revalidates_persisted_endpoints_without_mutation(
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
     payload = json.loads(ledger.path.read_text(encoding="utf-8"))
-    payload["transfer"]["destination_channel_id"] = "dev"
+    payload["transfer"]["destination_channel_id"] = destination_channel
     ledger.path.write_text(json.dumps(payload), encoding="utf-8")
     corrupted = _ownership_artifact_bytes(ledger)
 
-    with pytest.raises(LedgerError, match="invalid transfer reservation"):
-        ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
-
-    assert _ownership_artifact_bytes(ledger) == corrupted
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerError):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
 
 
 @pytest.mark.parametrize(
@@ -1355,6 +1366,51 @@ def test_rotation_recovery_authenticates_journal_before_replacing_state(tmp_path
         ledger.load()
 
     assert _ownership_artifact_bytes(ledger) == corrupted
+
+
+def test_rotation_validates_candidate_before_writing_journal_or_key(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.release_to_tombstone(
+        "binding-dev",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.reactivate(
+        "binding-dev",
+        channel_id="dev",
+        root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    snapshot = ledger.load()
+    protected = _ownership_artifact_bytes(ledger)
+    original_lease_for_root = ledger._lease_for_root
+
+    def divergent_rotated_tombstone(**kwargs):
+        lease = original_lease_for_root(**kwargs)
+        if lease.state == "retired" and lease.vault_binding_id == "binding-dev":
+            return replace(lease, channel_id="test")
+        return lease
+
+    monkeypatch.setattr(ledger, "_lease_for_root", divergent_rotated_tombstone)
+
+    with pytest.raises(LedgerError, match="divergent same-binding authority"):
+        ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert _ownership_artifact_bytes(ledger) == protected
+    assert ledger.load() == snapshot
 
 
 def test_persisted_ambiguous_overlap_fails_every_authority_gate(

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -1241,6 +1241,97 @@ def test_transfer_activation_revalidates_persisted_endpoints_without_mutation(
 
 @pytest.mark.parametrize(
     "corruption",
+    ["missing", "branch", "merge", "cycle", "interior_pending"],
+)
+def test_cross_release_history_requires_authenticated_transfer_lineage(
+    tmp_path,
+    corruption,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.begin_transfer(
+        source_binding_id="binding-dev",
+        destination_channel_id="test",
+        destination_binding_id="binding-test",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+    ledger.begin_transfer(
+        source_binding_id="binding-test",
+        destination_channel_id="prod",
+        destination_binding_id="binding-prod",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+    assert ledger.load().leases["binding-prod"].state == "active"
+
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    first, second = payload["transfer_lineage"]
+    if corruption == "missing":
+        payload["transfer_lineage"] = [second]
+    elif corruption == "branch":
+        second["source_channel_id"] = "dev"
+        second["source_binding_id"] = "binding-dev"
+    elif corruption == "merge":
+        first["destination_channel_id"] = "prod"
+        first["destination_binding_id"] = "binding-prod"
+    elif corruption == "cycle":
+        terminal = payload["leases"].pop("binding-prod")
+        terminal["state"] = "retired"
+        payload["tombstones"]["binding-prod"] = terminal
+        cycle = dict(second)
+        cycle.update(
+            {
+                "transfer_id": "transfer-cycle",
+                "source_channel_id": "prod",
+                "source_binding_id": "binding-prod",
+                "destination_channel_id": "dev",
+                "destination_binding_id": "binding-dev",
+            }
+        )
+        payload["transfer_lineage"].append(cycle)
+    else:
+        payload["tombstones"].pop("binding-test")
+        pending = dict(first)
+        pending.update(
+            {
+                "transfer_id": "transfer-interior",
+                "source_channel_id": "test",
+                "source_binding_id": "binding-test",
+                "destination_channel_id": "dev",
+                "destination_binding_id": "binding-next",
+            }
+        )
+        payload["transfer"] = pending
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.capture_backup_artifacts(
+            capture_registry_artifacts=lambda: {},
+        ),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerError):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
+
+
+@pytest.mark.parametrize(
+    "corruption",
     [
         "channel",
         "root_fingerprint",
@@ -1319,6 +1410,95 @@ def test_malformed_same_binding_authority_fails_every_consumer_without_mutation(
             tombstones={"binding-dev": root},
             transfer_lineage=(),
             global_live_owners=[LegacyOwner("dev", "binding-dev", root)],
+        ),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerError):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "ledger_bootstrap_string",
+        "ledger_bootstrap_number",
+        "ledger_generation_bool",
+        "ledger_generation_string",
+        "key_generation_bool",
+        "key_generation_string",
+        "key_id_number",
+        "journal_generation_bool",
+        "journal_generation_string",
+        "journal_key_id_number",
+    ],
+)
+def test_malformed_authority_scalars_fail_every_consumer_without_mutation(
+    tmp_path,
+    corruption,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    if corruption.startswith("journal_"):
+        with pytest.raises(RuntimeError, match="injected crash"):
+            ledger.rotate_key(
+                precondition=lambda _snapshot, _roots: None,
+                crash_after="key_commit",
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
+        journal = json.loads(ledger.rotation_path.read_text(encoding="utf-8"))
+        if corruption == "journal_generation_bool":
+            journal["key"]["generation"] = True
+            journal["ledger"]["generation"] = True
+        elif corruption == "journal_generation_string":
+            journal["key"]["generation"] = "2"
+            journal["ledger"]["generation"] = "2"
+        else:
+            journal["key"]["key_id"] = 7
+            journal["ledger"]["key_id"] = 7
+        ledger.rotation_path.write_text(json.dumps(journal), encoding="utf-8")
+    elif corruption.startswith("key_"):
+        key_payload = json.loads(ledger.key_path.read_text(encoding="utf-8"))
+        if corruption == "key_generation_bool":
+            key_payload["generation"] = True
+        elif corruption == "key_generation_string":
+            key_payload["generation"] = "1"
+        else:
+            key_payload["key_id"] = 7
+            ledger_payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+            ledger_payload["key_id"] = "7"
+            ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+        ledger.key_path.write_text(json.dumps(key_payload), encoding="utf-8")
+    else:
+        ledger_payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+        if corruption == "ledger_bootstrap_string":
+            ledger_payload["legacy_bootstrap_complete"] = "false"
+        elif corruption == "ledger_bootstrap_number":
+            ledger_payload["legacy_bootstrap_complete"] = 0
+        elif corruption == "ledger_generation_bool":
+            ledger_payload["generation"] = True
+        else:
+            ledger_payload["generation"] = "1"
+        ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.capture_backup_artifacts(
+            capture_registry_artifacts=lambda: {},
         ),
         lambda: ledger.rotate_key(
             precondition=lambda _snapshot, _roots: None,
@@ -1429,10 +1609,16 @@ def test_persisted_ambiguous_overlap_fails_every_authority_gate(
     ]
     ledger = OwnershipLedger(tmp_path / "host-global")
     component_guard = ledger._assert_native_release_component_cardinality
+    transfer_guard = ledger._assert_release_transfer_topology
     monkeypatch.setattr(
         ledger,
         "_assert_native_release_component_cardinality",
         lambda _leases: None,
+    )
+    monkeypatch.setattr(
+        ledger,
+        "_assert_release_transfer_topology",
+        lambda _current, _leases: None,
     )
     ledger.bootstrap_legacy_owners(
         owners,
@@ -1444,6 +1630,11 @@ def test_persisted_ambiguous_overlap_fails_every_authority_gate(
         ledger,
         "_assert_native_release_component_cardinality",
         component_guard,
+    )
+    monkeypatch.setattr(
+        ledger,
+        "_assert_release_transfer_topology",
+        transfer_guard,
     )
 
     with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
@@ -1466,6 +1657,53 @@ def test_persisted_ambiguous_overlap_fails_every_authority_gate(
             precondition=lambda _snapshot, _roots: None,
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
+
+
+def test_persisted_release_channel_overlap_fails_every_authority_gate(
+    tmp_path,
+) -> None:
+    root = tmp_path / "shared"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    prod = dict(payload["leases"]["binding-dev"])
+    prod["channel_id"] = "prod"
+    prod["vault_binding_id"] = "binding-prod"
+    payload["leases"]["binding-prod"] = prod
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.capture_backup_artifacts(
+            capture_registry_artifacts=lambda: {},
+        ),
+        lambda: ledger.require_registry_consistency(
+            channel_id="dev",
+            registrations={"binding-dev": root},
+            tombstones={},
+            transfer_lineage=(),
+            global_live_owners=[
+                LegacyOwner("dev", "binding-dev", root),
+                LegacyOwner("prod", "binding-prod", root),
+            ],
+        ),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerCollisionError, match="overlap"):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
 
 
 def test_first_upgrade_still_rejects_release_channel_shared_root(tmp_path) -> None:

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -877,6 +877,55 @@ def test_first_upgrade_still_rejects_release_channel_shared_root(tmp_path) -> No
         )
 
 
+def test_established_ledger_still_rejects_release_channel_shared_root(tmp_path) -> None:
+    root = tmp_path / "shared"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    seeded = ledger.bootstrap_legacy_owners(
+        [LegacyOwner("prod", "legacy-prod", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    with pytest.raises(LedgerCollisionError, match="overlap"):
+        ledger.bootstrap_legacy_owners(
+            [
+                LegacyOwner("prod", "legacy-prod", root),
+                LegacyOwner("dev", "legacy-dev", root),
+            ],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert ledger.load() == seeded
+
+
+def test_established_ledger_rejects_binding_identity_reassignment(tmp_path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    seeded = ledger.bootstrap_legacy_owners(
+        [LegacyOwner("prod", "legacy-prod", first)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    with pytest.raises(LedgerCollisionError, match="no longer identifies"):
+        ledger.bootstrap_legacy_owners(
+            [LegacyOwner("prod", "legacy-prod", second)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert ledger.load() == seeded
+
+
 def test_env_only_bootstrap_atomically_enrolls_one_stable_binding_or_fails_closed(tmp_path) -> None:
     runtime = _runtime(tmp_path, "dev", tmp_path / "host-global")
     root = tmp_path / "vault"

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -943,6 +943,61 @@ def test_native_channel_overlap_component_includes_retained_ownership_state(
     assert ledger.load() == before
 
 
+def test_persisted_ambiguous_overlap_fails_every_authority_gate(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    parent = tmp_path / "parent"
+    dev_root = parent / "dev"
+    prod_root = parent / "prod"
+    dev_root.mkdir(parents=True)
+    prod_root.mkdir()
+    owners = [
+        LegacyOwner("native", "legacy-native", parent),
+        LegacyOwner("dev", "legacy-dev", dev_root),
+        LegacyOwner("prod", "legacy-prod", prod_root),
+    ]
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    component_guard = ledger._assert_native_release_component_cardinality
+    monkeypatch.setattr(
+        ledger,
+        "_assert_native_release_component_cardinality",
+        lambda _leases: None,
+    )
+    ledger.bootstrap_legacy_owners(
+        owners,
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    monkeypatch.setattr(
+        ledger,
+        "_assert_native_release_component_cardinality",
+        component_guard,
+    )
+
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.bootstrap_legacy_owners(
+            owners,
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.require_registry_consistency(
+            channel_id="dev",
+            registrations={"legacy-dev": dev_root},
+            tombstones={},
+            transfer_lineage=(),
+            global_live_owners=owners,
+        )
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+
 def test_first_upgrade_still_rejects_release_channel_shared_root(tmp_path) -> None:
     root = tmp_path / "shared"
     root.mkdir()

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -72,6 +72,13 @@ def _runtime_state_bytes(
     }
 
 
+def _ownership_artifact_bytes(ledger: OwnershipLedger) -> dict[str, bytes | None]:
+    return {
+        path.name: path.read_bytes() if path.exists() else None
+        for path in (ledger.key_path, ledger.path, ledger.rotation_path)
+    }
+
+
 def _mechanically_register_nested_binding(
     runtime: InstanceRegistryRuntime, child_root: Path
 ) -> VaultRegistration:
@@ -909,38 +916,445 @@ def test_native_channel_overlap_component_includes_retained_ownership_state(
     first_child.mkdir(parents=True)
     second_child.mkdir()
     ledger = OwnershipLedger(tmp_path / "host-global")
-    ledger.bootstrap_legacy_owners(
-        [
-            LegacyOwner("native", "legacy-native", parent),
-            LegacyOwner("dev", "legacy-dev", first_child),
-        ],
-        inventory_complete=True,
-        writers_drained=True,
-        _capability=STORAGE_MUTATION_CAPABILITY,
-    )
     if retained_state == "tombstone":
+        ledger.bootstrap_legacy_owners(
+            [
+                LegacyOwner("native", "legacy-native", parent),
+                LegacyOwner("dev", "legacy-dev", first_child),
+            ],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
         ledger.release_to_tombstone(
             "legacy-dev",
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
+        candidate = LegacyOwner("prod", "legacy-prod", second_child)
     else:
+        ledger.bootstrap_legacy_owners(
+            [LegacyOwner("dev", "legacy-dev", first_child)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
         ledger.begin_transfer(
             source_binding_id="legacy-dev",
-            destination_channel_id="dev",
+            destination_channel_id="test",
             destination_binding_id="legacy-dev-destination",
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
+        candidate = LegacyOwner("native", "legacy-native", parent)
     before = ledger.load()
 
     with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
         ledger.bootstrap_legacy_owners(
-            [LegacyOwner("prod", "legacy-prod", second_child)],
+            [candidate],
             inventory_complete=True,
             writers_drained=True,
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
 
     assert ledger.load() == before
+
+
+def test_same_binding_reactivation_normalizes_every_authority_gate(tmp_path) -> None:
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    sibling = parent / "sibling"
+    child.mkdir(parents=True)
+    sibling.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    owners = [
+        LegacyOwner("native", "legacy-native", parent),
+        LegacyOwner("dev", "legacy-dev", child),
+    ]
+    ledger.bootstrap_legacy_owners(
+        owners,
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    retired = ledger.release_to_tombstone(
+        "legacy-dev",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    active = ledger.reactivate(
+        "legacy-dev",
+        channel_id="dev",
+        root=child,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    assert active.sealed_root != retired.sealed_root
+    assert ledger.require_existing().leases["legacy-dev"] == active
+    assert ledger.bootstrap_legacy_owners(
+        owners,
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    ).tombstones["legacy-dev"] == retired
+    ledger.require_scalar_rollback_ready(
+        channel_id="dev",
+        registrations={"legacy-dev": child},
+    )
+    captured = ledger.capture_backup_artifacts(capture_registry_artifacts=lambda: {})
+    assert set(captured) == {"ownership-ledger.json", "ownership-key.json"}
+    ledger.require_registry_consistency(
+        channel_id="dev",
+        registrations={"legacy-dev": child},
+        tombstones={"legacy-dev": child},
+        transfer_lineage=(),
+        global_live_owners=owners,
+    )
+
+    before_third_owner = _ownership_artifact_bytes(ledger)
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.bootstrap_legacy_owners(
+            [LegacyOwner("prod", "legacy-prod", sibling)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert _ownership_artifact_bytes(ledger) == before_third_owner
+
+    generation = ledger.load().generation
+    with pytest.raises(RuntimeError, match="injected crash"):
+        ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            crash_after="key_commit",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    recovered = ledger.load()
+    assert recovered.generation == generation + 1
+    assert recovered.leases["legacy-dev"].sealed_root != recovered.tombstones[
+        "legacy-dev"
+    ].sealed_root
+    ledger.require_registry_consistency(
+        channel_id="dev",
+        registrations={"legacy-dev": child},
+        tombstones={"legacy-dev": child},
+        transfer_lineage=(),
+        global_live_owners=owners,
+    )
+
+
+def test_stable_binding_lifecycle_refuses_identity_reuse_without_mutation(tmp_path) -> None:
+    root = tmp_path / "root"
+    other = tmp_path / "other"
+    root.mkdir()
+    other.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.release_to_tombstone(
+        "binding-dev",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    retired = _ownership_artifact_bytes(ledger)
+
+    for channel_id, candidate_root in (("test", root), ("dev", other)):
+        with pytest.raises(LedgerCollisionError, match="immutable predecessor"):
+            ledger.reactivate(
+                "binding-dev",
+                channel_id=channel_id,
+                root=candidate_root,
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
+        assert _ownership_artifact_bytes(ledger) == retired
+
+    with pytest.raises(LedgerCollisionError, match="retired, transferring, or historical"):
+        ledger.reserve(
+            channel_id="dev",
+            vault_binding_id="binding-dev",
+            root=root,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert _ownership_artifact_bytes(ledger) == retired
+
+    ledger.reactivate(
+        "binding-dev",
+        channel_id="dev",
+        root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    reactivated = _ownership_artifact_bytes(ledger)
+    with pytest.raises(LedgerError, match="immutable removal tombstone"):
+        ledger.release_to_tombstone(
+            "binding-dev",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert _ownership_artifact_bytes(ledger) == reactivated
+
+
+def test_transfer_validates_identity_retry_and_terminal_topology_before_write(
+    tmp_path,
+) -> None:
+    root = tmp_path / "root"
+    occupied_root = tmp_path / "occupied"
+    root.mkdir()
+    occupied_root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [
+            LegacyOwner("dev", "binding-dev", root),
+            LegacyOwner("prod", "binding-occupied", occupied_root),
+        ],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    before = _ownership_artifact_bytes(ledger)
+
+    invalid = (
+        ("binding-dev", "test", "binding-dev", "distinct stable bindings"),
+        ("binding-dev", "dev", "binding-new", "distinct channels"),
+        ("binding-dev", "test", "binding-occupied", "already reserved"),
+    )
+    for source, channel, destination, message in invalid:
+        with pytest.raises(LedgerCollisionError, match=message):
+            ledger.begin_transfer(
+                source_binding_id=source,
+                destination_channel_id=channel,
+                destination_binding_id=destination,
+                _capability=STORAGE_MUTATION_CAPABILITY,
+            )
+        assert _ownership_artifact_bytes(ledger) == before
+
+    reservation = ledger.begin_transfer(
+        source_binding_id="binding-dev",
+        destination_channel_id="test",
+        destination_binding_id="binding-test",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    assert ledger.begin_transfer(
+        source_binding_id="binding-dev",
+        destination_channel_id="test",
+        destination_binding_id="binding-test",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    ) == reservation
+    pending = _ownership_artifact_bytes(ledger)
+    with pytest.raises(LedgerError, match="another ownership transfer"):
+        ledger.begin_transfer(
+            source_binding_id="binding-dev",
+            destination_channel_id="prod",
+            destination_binding_id="binding-test",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert _ownership_artifact_bytes(ledger) == pending
+
+    active = ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+    assert active.vault_binding_id == "binding-test"
+    assert ledger.load().tombstones["binding-dev"].state == "retired"
+    completed = _ownership_artifact_bytes(ledger)
+    with pytest.raises(LedgerCollisionError, match="already reserved"):
+        ledger.begin_transfer(
+            source_binding_id="binding-test",
+            destination_channel_id="prod",
+            destination_binding_id="binding-dev",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert _ownership_artifact_bytes(ledger) == completed
+
+    chained = ledger.begin_transfer(
+        source_binding_id="binding-test",
+        destination_channel_id="prod",
+        destination_binding_id="binding-final",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    assert chained.source_binding_id == "binding-test"
+    assert ledger.activate_transfer(
+        _capability=STORAGE_MUTATION_CAPABILITY
+    ).vault_binding_id == "binding-final"
+
+
+def test_transfer_rejects_prospective_mixed_component_before_first_write(tmp_path) -> None:
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [
+            LegacyOwner("native", "binding-native", parent),
+            LegacyOwner("dev", "binding-dev", child),
+        ],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    before = _ownership_artifact_bytes(ledger)
+
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.begin_transfer(
+            source_binding_id="binding-dev",
+            destination_channel_id="test",
+            destination_binding_id="binding-test",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert _ownership_artifact_bytes(ledger) == before
+
+
+def test_transfer_activation_revalidates_persisted_endpoints_without_mutation(
+    tmp_path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.begin_transfer(
+        source_binding_id="binding-dev",
+        destination_channel_id="test",
+        destination_binding_id="binding-test",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    payload["transfer"]["destination_channel_id"] = "dev"
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    with pytest.raises(LedgerError, match="invalid transfer reservation"):
+        ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+
+    assert _ownership_artifact_bytes(ledger) == corrupted
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    [
+        "channel",
+        "root_fingerprint",
+        "ancestors",
+        "authenticated_plaintext_root",
+        "seal_authentication",
+        "map_binding_id",
+        "lifecycle_role",
+    ],
+)
+def test_malformed_same_binding_authority_fails_every_consumer_without_mutation(
+    tmp_path,
+    corruption,
+) -> None:
+    root = tmp_path / "root"
+    other = tmp_path / "other"
+    root.mkdir()
+    other.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.release_to_tombstone(
+        "binding-dev",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.reactivate(
+        "binding-dev",
+        channel_id="dev",
+        root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    retired = payload["tombstones"]["binding-dev"]
+    if corruption == "channel":
+        retired["channel_id"] = "test"
+    elif corruption == "root_fingerprint":
+        retired["root_fingerprint"] = "0" * 64
+    elif corruption == "ancestors":
+        retired["ancestor_fingerprints"][0] = "0" * 64
+    elif corruption == "authenticated_plaintext_root":
+        with ledger._locked():
+            key = ledger._load_or_create_key_locked(allow_create=False)
+            retired["sealed_root"] = ledger._seal_root(str(other.resolve()), key)
+    elif corruption == "seal_authentication":
+        retired["sealed_root"] = "not-an-authenticated-seal"
+    elif corruption == "map_binding_id":
+        payload["tombstones"]["other-binding"] = payload["tombstones"].pop(
+            "binding-dev"
+        )
+    else:
+        retired["state"] = "pending"
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.require_scalar_rollback_ready(
+            channel_id="dev",
+            registrations={"binding-dev": root},
+        ),
+        lambda: ledger.capture_backup_artifacts(capture_registry_artifacts=lambda: {}),
+        lambda: ledger.bootstrap_legacy_owners(
+            [LegacyOwner("dev", "binding-dev", root)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+        lambda: ledger.require_registry_consistency(
+            channel_id="dev",
+            registrations={"binding-dev": root},
+            tombstones={"binding-dev": root},
+            transfer_lineage=(),
+            global_live_owners=[LegacyOwner("dev", "binding-dev", root)],
+        ),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerError):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
+
+
+def test_rotation_recovery_authenticates_journal_before_replacing_state(tmp_path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.release_to_tombstone(
+        "binding-dev",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.reactivate(
+        "binding-dev",
+        channel_id="dev",
+        root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    with pytest.raises(RuntimeError, match="injected crash"):
+        ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            crash_after="key_commit",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    journal = json.loads(ledger.rotation_path.read_text(encoding="utf-8"))
+    journal["ledger"]["tombstones"]["binding-dev"]["channel_id"] = "test"
+    ledger.rotation_path.write_text(json.dumps(journal), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+
+    with pytest.raises(LedgerKeyError, match="rotation journal"):
+        ledger.load()
+
+    assert _ownership_artifact_bytes(ledger) == corrupted
 
 
 def test_persisted_ambiguous_overlap_fails_every_authority_gate(

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -1330,6 +1330,92 @@ def test_cross_release_history_requires_authenticated_transfer_lineage(
         assert _ownership_artifact_bytes(ledger) == corrupted
 
 
+def test_completed_transfer_pending_terminal_fails_every_authority_gate_without_mutation(
+    tmp_path,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [LegacyOwner("dev", "binding-dev", root)],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.begin_transfer(
+        source_binding_id="binding-dev",
+        destination_channel_id="test",
+        destination_binding_id="binding-test",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+    ledger.begin_transfer(
+        source_binding_id="binding-test",
+        destination_channel_id="prod",
+        destination_binding_id="binding-prod",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.activate_transfer(_capability=STORAGE_MUTATION_CAPABILITY)
+    assert ledger.load().leases["binding-prod"].state == "active"
+
+    runtime = _runtime(tmp_path, "prod", ledger.root)
+    runtime.registry.register(
+        VaultRegistration(
+            vault_binding_id="binding-prod",
+            ref=f"path:{root.resolve()}",
+            path=str(root.resolve()),
+            vault_id="terminal-live-authority",
+            local_instance_id="local-prod",
+            extensions={"status": "initialized", "contentEpoch": 1},
+        ),
+        expected_revision=0,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    payload["leases"]["binding-prod"]["state"] = "pending"
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+    corrupted = _ownership_artifact_bytes(ledger)
+    backup_callback_called = False
+
+    def capture_registry_artifacts() -> dict[str, bytes]:
+        nonlocal backup_callback_called
+        backup_callback_called = True
+        return {}
+
+    consumers = (
+        ledger.load,
+        ledger.require_existing,
+        lambda: ledger.capture_backup_artifacts(
+            capture_registry_artifacts=capture_registry_artifacts,
+        ),
+        lambda: runtime._require_established_ownership(runtime.registry.load()),
+        lambda: ledger.bootstrap_legacy_owners(
+            [LegacyOwner("prod", "binding-prod", root)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+        lambda: ledger.require_registry_consistency(
+            channel_id="prod",
+            registrations={"binding-prod": root},
+            tombstones={},
+            transfer_lineage=(),
+            global_live_owners=[LegacyOwner("prod", "binding-prod", root)],
+        ),
+        lambda: ledger.rotate_key(
+            precondition=lambda _snapshot, _roots: None,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        ),
+    )
+    for consume in consumers:
+        with pytest.raises(LedgerError):
+            consume()
+        assert _ownership_artifact_bytes(ledger) == corrupted
+
+    assert not backup_callback_called
+
+
 @pytest.mark.parametrize(
     "corruption",
     [

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -862,6 +862,87 @@ def test_first_upgrade_allows_native_and_release_channel_shared_root(tmp_path, n
     } == {"native", "prod"}
 
 
+@pytest.mark.parametrize("native_is_parent", [True, False])
+def test_legacy_bootstrap_rejects_ambiguous_native_channel_overlap_component(
+    tmp_path,
+    native_is_parent,
+) -> None:
+    parent = tmp_path / "parent"
+    first_child = parent / "first"
+    second_child = parent / "second"
+    first_child.mkdir(parents=True)
+    second_child.mkdir()
+    owners = (
+        [
+            LegacyOwner("native", "legacy-native", parent),
+            LegacyOwner("dev", "legacy-dev", first_child),
+            LegacyOwner("prod", "legacy-prod", second_child),
+        ]
+        if native_is_parent
+        else [
+            LegacyOwner("prod", "legacy-prod", parent),
+            LegacyOwner("native", "legacy-native-first", first_child),
+            LegacyOwner("native", "legacy-native-second", second_child),
+        ]
+    )
+    ledger = OwnershipLedger(tmp_path / "host-global")
+
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.bootstrap_legacy_owners(
+            owners,
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert ledger.load().leases == {}
+
+
+@pytest.mark.parametrize("retained_state", ["tombstone", "transfer"])
+def test_native_channel_overlap_component_includes_retained_ownership_state(
+    tmp_path,
+    retained_state,
+) -> None:
+    parent = tmp_path / "parent"
+    first_child = parent / "first"
+    second_child = parent / "second"
+    first_child.mkdir(parents=True)
+    second_child.mkdir()
+    ledger = OwnershipLedger(tmp_path / "host-global")
+    ledger.bootstrap_legacy_owners(
+        [
+            LegacyOwner("native", "legacy-native", parent),
+            LegacyOwner("dev", "legacy-dev", first_child),
+        ],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    if retained_state == "tombstone":
+        ledger.release_to_tombstone(
+            "legacy-dev",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    else:
+        ledger.begin_transfer(
+            source_binding_id="legacy-dev",
+            destination_channel_id="dev",
+            destination_binding_id="legacy-dev-destination",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    before = ledger.load()
+
+    with pytest.raises(LedgerCollisionError, match="ambiguous native/channel"):
+        ledger.bootstrap_legacy_owners(
+            [LegacyOwner("prod", "legacy-prod", second_child)],
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert ledger.load() == before
+
+
 def test_first_upgrade_still_rejects_release_channel_shared_root(tmp_path) -> None:
     root = tmp_path / "shared"
     root.mkdir()

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -3863,7 +3863,7 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
         rejected_backup = case_root / "rejected-backup"
         with pytest.raises(
             InstanceStatePreflightError,
-            match="registry/ledger consistency",
+            match=r"registry/ledger (?:capture|consistency)",
         ):
             InstanceStateBackup(layout, runtime.ledger).create(
                 rejected_backup,
@@ -3998,20 +3998,6 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
             )
             live_channel = "test"
             live_binding = destination_binding
-        if divergence == "cross-channel-self-lineage":
-            final_binding = f"final-{divergence}"
-            runtime.ledger.begin_transfer(
-                source_binding_id=destination_binding,
-                destination_channel_id="native",
-                destination_binding_id=final_binding,
-                _capability=STORAGE_MUTATION_CAPABILITY,
-            )
-            runtime.ledger.activate_transfer(
-                _capability=STORAGE_MUTATION_CAPABILITY,
-            )
-            live_channel = "native"
-            live_binding = final_binding
-
         complete_owners = _current_registry_owners(runtime) + [
             {
                 "channel_id": live_channel,
@@ -4062,7 +4048,7 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
 
         with pytest.raises(
             InstanceStatePreflightError,
-            match="registry/ledger consistency",
+            match=r"registry/ledger (?:capture|consistency)",
         ):
             InstanceStateBackup(layout, runtime.ledger).create(
                 case_root / "rejected-backup",
@@ -4114,19 +4100,6 @@ def test_backup_rejects_registry_ledger_divergence_bidirectionally(tmp_path) -> 
             )
             restore_live_channel = "test"
             restore_live_binding = restore_destination
-        if divergence == "cross-channel-self-lineage":
-            restore_final = f"restore-final-{divergence}"
-            restore_runtime.ledger.begin_transfer(
-                source_binding_id=restore_destination,
-                destination_channel_id="native",
-                destination_binding_id=restore_final,
-                _capability=STORAGE_MUTATION_CAPABILITY,
-            )
-            restore_runtime.ledger.activate_transfer(
-                _capability=STORAGE_MUTATION_CAPABILITY,
-            )
-            restore_live_channel = "native"
-            restore_live_binding = restore_final
         restore_complete_owners = _current_registry_owners(restore_runtime) + [
             {
                 "channel_id": restore_live_channel,

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -4702,6 +4702,52 @@ def _run_fenced_deployment(
     )
 
 
+def test_established_ledger_adopts_new_sanctioned_native_owner(tmp_path) -> None:
+    """A later native alias is reconciled before staged-backup verification."""
+
+    instance_state_root = tmp_path / "instance-state"
+    host_global_root = tmp_path / "host-global"
+    shared_root = tmp_path / "shared-vault"
+    instance_state_root.mkdir()
+    host_global_root.mkdir()
+    legacy_store = AppLocalSettingsStore(tmp_path / "legacy" / "app-local.md")
+    VaultManager(app_local_store=legacy_store).initialize_vault(
+        shared_root,
+        remember=True,
+    )
+    legacy_path = legacy_store.path
+    prod_owner = {"channel_id": "prod", "root": str(shared_root)}
+    native_owner = {"channel_id": "native", "root": str(shared_root)}
+
+    first = _run_fenced_deployment(
+        channel="prod",
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_payload=_legacy_owner_inventory_payload([prod_owner]),
+        backup_root=host_global_root / "backups" / "prod" / "latest",
+    )
+    assert first["restart_fence_cleared"] is True
+
+    second = _run_fenced_deployment(
+        channel="prod",
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_payload=_legacy_owner_inventory_payload([prod_owner, native_owner]),
+        backup_root=host_global_root / "backups" / "prod" / "latest",
+    )
+
+    assert second["restart_fence_cleared"] is True
+    ledger = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(instance_state_root, "prod"),
+        host_global_root,
+        initialize_layout=False,
+    ).ledger.load()
+    assert {lease.channel_id for lease in ledger.leases.values()} == {"native", "prod"}
+    assert not _deployment_fence_path(host_global_root, "prod").exists()
+
+
 def test_staged_backup_verification_succeeds_on_fresh_deployment(tmp_path) -> None:
     """#4371 AC1: staged-backup verification must not require the drained
     inventory's owner roots to be visible in the verifying process.

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -656,18 +656,38 @@ def test_forbidden_cross_domain_arrangements_are_named(owner_sources, tmp_path):
 
     shared = _vault(tmp_path, "vault")
     nested = _vault(tmp_path, "vault", "project")
+    sibling = _vault(tmp_path, "vault", "sibling")
+    native_one = _vault(tmp_path, "release-vault", "native-one")
+    native_two = _vault(tmp_path, "release-vault", "native-two")
+    release_parent = native_one.parent
 
     forbidden = {
         "two channels on one root": [("dev", shared), ("prod", shared)],
         "one channel nested under another": [("prod", shared), ("test", nested)],
         "ancestor direction reversed": [("test", nested), ("dev", shared)],
+        "native bridges two release channels": [
+            ("native", shared),
+            ("dev", nested),
+            ("prod", sibling),
+        ],
+        "release channel bridges two native roots": [
+            ("prod", release_parent),
+            ("native", native_one),
+            ("native", native_two),
+        ],
     }
 
     for label, owners in forbidden.items():
         owner_sources["owners"] = owners
         output = tmp_path / "forbidden-owners.json"
 
-        with pytest.raises(InventoryError, match="collide across release channels"):
+        with pytest.raises(
+            InventoryError,
+            match=(
+                "collide across release channels|"
+                "ambiguous native/channel overlap component"
+            ),
+        ):
             writer_inventory.produce_legacy_owners(
                 repo_root=REPO_ROOT, active_channel="dev", output=output
             )

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -21,11 +21,17 @@ identifier for it -- while still never emitting the raw host path.
 
 import json
 from pathlib import Path
+import shutil
 
 import pytest
 
 import scripts.instance_state_writer_inventory as writer_inventory
 from scripts.instance_state_writer_inventory import InventoryError
+from tests.deploy.test_deploy_channel import (
+    _deploy_events,
+    _deploy_harness,
+    _run_deploy,
+)
 
 CONTAINER_ID = "a" * 64
 
@@ -749,44 +755,41 @@ def test_active_writer_during_stopped_window_still_refuses(monkeypatch, tmp_path
     assert payload["domains"] == {domain: [] for domain in writer_inventory.DOMAINS}
 
 
-def test_deploy_proceeds_past_inventory_with_shared_native_root(owner_sources, tmp_path):
+def test_deploy_proceeds_past_inventory_with_shared_native_root(tmp_path):
     """`deploy_channel.sh deploy dev <sha>` must reach migrations and recreate."""
 
-    # The inventory really is the deploy's first gate: the wrapper runs this
-    # subcommand, and deploy_channel.sh runs the wrapper before migrations and
-    # service recreate. That ordering is why a refusal blocks every channel.
-    wrapper = (REPO_ROOT / "scripts" / "lib" / "instance_state_deployment.sh").read_text(
-        encoding="utf-8"
+    root, env, sha = _deploy_harness(tmp_path)
+    shutil.copy2(
+        REPO_ROOT / "scripts" / "instance_state_writer_inventory.py",
+        root / "scripts" / "instance_state_writer_inventory.py",
     )
-    assert "produce-legacy-owners" in wrapper
-
-    # Compare call sites, not the function definitions further up the file.
-    deploy = (REPO_ROOT / "scripts" / "deploy_channel.sh").read_text(encoding="utf-8")
-    inventory_at = deploy.index("prepare_instance_state_deployment compose")
-    migrate_at = deploy.index(
-        'run_postmutation_gate "migration execution failed" apply_changed_migrations'
-    )
-    recreate_at = deploy.index('run_postmutation_gate "service recreate/liveness gate failed"')
-    assert inventory_at < migrate_at
-    assert inventory_at < recreate_at
-
-    # The observed host arrangement: native and a channel on one iCloud vault.
     shared = _vault(tmp_path, "cloud-sync", "vault")
-    owner_sources["owners"] = [("native", shared), ("prod", shared)]
-    output = tmp_path / "legacy-owner-inventory.json"
-
-    # Exactly the argv scripts/lib/instance_state_deployment.sh builds.
-    exit_code = writer_inventory.main(
-        [
-            "produce-legacy-owners",
-            "--repo-root",
-            str(REPO_ROOT),
-            "--active-channel",
-            "dev",
-            "--output",
-            str(output),
-        ]
+    app_local = tmp_path / "app-local.md"
+    app_local.write_text(
+        "---\nknownVaults:\n  shared:\n" f"    path: {shared}\n---\n",
+        encoding="utf-8",
     )
+    env["DESIGN_HANDOFF_APP_LOCAL_SETTINGS"] = str(app_local)
+    env["VAULT_ROOT_PROD"] = str(shared)
 
-    assert exit_code == 0
-    assert json.loads(output.read_text(encoding="utf-8"))["inventory_complete"] is True
+    result = _run_deploy(root, env, sha, channel="dev")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    inventory_path = (
+        Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+        / "legacy-owner-inventory.json"
+    )
+    payload = json.loads(inventory_path.read_text(encoding="utf-8"))
+    assert {
+        (owner["channel_id"], owner["root"])
+        for owner in payload["owners"]
+    } >= {("native", str(shared)), ("prod", str(shared))}
+
+    events = _deploy_events(env)
+    assert any(
+        event.endswith(
+            "up -d --force-recreate api worker watcher "
+            "heimdal-capture-watch companion-ui"
+        )
+        for event in events
+    )

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -535,7 +535,7 @@ def test_collision_error_names_both_domains(tmp_path):
         writer_inventory.LegacyOwnerRecord("prod", str(shared_root), source="config_env"),
     ]
 
-    with pytest.raises(InventoryError, match="collide across domains") as excinfo:
+    with pytest.raises(InventoryError, match="collide across release channels") as excinfo:
         writer_inventory._normalize_legacy_owners(records)
 
     message = str(excinfo.value)
@@ -567,3 +567,206 @@ def test_inventory_errors_never_emit_raw_paths(tmp_path):
         )
 
     assert "not a mapping line" not in str(parse_excinfo.value)
+
+
+# --- Issue #4517: owner-root arrangements across domains --------------------
+
+REPO_ROOT = Path(writer_inventory.__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def owner_sources(monkeypatch):
+    """Drive the production owner inventory from an explicit owner set.
+
+    Only the two *source enumerators* are stubbed. Everything the deploy
+    wrapper actually calls -- the `produce-legacy-owners` entrypoint, the
+    two-snapshot stability check, normalization, the cross-domain predicate,
+    and the private receipt write -- runs for real.
+    """
+
+    state = {"owners": []}
+
+    monkeypatch.setattr(
+        writer_inventory, "_docker_legacy_owner_sources", lambda: ([], ["docker:stub"])
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_config_legacy_owner_sources",
+        lambda repo_root, *, active_channel: (
+            [
+                writer_inventory.LegacyOwnerRecord(domain, str(root), source="config_env")
+                for domain, root in state["owners"]
+            ],
+            ["config:stub"],
+        ),
+    )
+    return state
+
+
+def _vault(tmp_path, *parts):
+    root = tmp_path.joinpath(*parts)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def test_native_and_channel_may_share_a_vault_root(owner_sources, tmp_path):
+    """ADR-0055 declares the Mac runtime and a channel runtime as peer writers.
+
+    A vault root shared between `native` and one channel -- equal, or nested in
+    either direction -- is the designed topology, so the deploy's owner
+    inventory must produce its receipt instead of refusing.
+    """
+
+    shared = _vault(tmp_path, "vault")
+    nested = _vault(tmp_path, "vault", "project")
+
+    arrangements = {
+        "equal roots": [("native", shared), ("prod", shared)],
+        "channel nested under native": [("native", shared), ("dev", nested)],
+        "native nested under channel": [("test", shared), ("native", nested)],
+    }
+
+    for label, owners in arrangements.items():
+        owner_sources["owners"] = owners
+        output = tmp_path / f"owners-{len(label)}-{label[:4]}.json"
+
+        writer_inventory.produce_legacy_owners(
+            repo_root=REPO_ROOT, active_channel="dev", output=output
+        )
+
+        # Real-path assertion: the production entrypoint wrote its receipt, and
+        # both owners survived normalization rather than one being dropped.
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["schema"] == writer_inventory.LEGACY_OWNER_INVENTORY_SCHEMA, label
+        assert payload["inventory_complete"] is True, label
+        assert {owner["channel_id"] for owner in payload["owners"]} == {
+            domain for domain, _ in owners
+        }, label
+
+
+def test_forbidden_cross_domain_arrangements_are_named(owner_sources, tmp_path):
+    """The surviving refusal is two *release channels* on one root, and it is documented."""
+
+    docstring = writer_inventory.__doc__ or ""
+    assert "Permitted" in docstring
+    assert "Forbidden" in docstring
+    assert "release channels" in docstring
+    assert writer_inventory.CHANNEL_DOMAINS == frozenset({"dev", "prod", "test"})
+    assert "native" not in writer_inventory.CHANNEL_DOMAINS
+
+    shared = _vault(tmp_path, "vault")
+    nested = _vault(tmp_path, "vault", "project")
+
+    forbidden = {
+        "two channels on one root": [("dev", shared), ("prod", shared)],
+        "one channel nested under another": [("prod", shared), ("test", nested)],
+        "ancestor direction reversed": [("test", nested), ("dev", shared)],
+    }
+
+    for label, owners in forbidden.items():
+        owner_sources["owners"] = owners
+        output = tmp_path / "forbidden-owners.json"
+
+        with pytest.raises(InventoryError, match="collide across release channels"):
+            writer_inventory.produce_legacy_owners(
+                repo_root=REPO_ROOT, active_channel="dev", output=output
+            )
+
+        assert not output.exists(), label
+
+
+def test_active_writer_during_stopped_window_still_refuses(monkeypatch, tmp_path):
+    """Narrowing the ownership predicate must not touch the quiescence proof."""
+
+    controller_pid = 4242
+    controller_token = "darwin:" + "b" * 64
+
+    monkeypatch.setattr(
+        writer_inventory,
+        "_record_for_pid",
+        lambda pid, *, linux_boot_id=None: writer_inventory.ProcessRecord(
+            pid=controller_pid,
+            ppid=1,
+            pgid=controller_pid,
+            start_token=controller_token,
+            argv=("/bin/bash", "scripts/deploy_channel.sh", "deploy"),
+        ),
+    )
+    monkeypatch.setattr(
+        writer_inventory,
+        "_native_writers",
+        lambda **_kwargs: [],
+    )
+
+    live_writer = {
+        "domain": "dev",
+        "role": "watcher",
+        "pid": 99001,
+        "start_token": "docker:" + "c" * 64,
+    }
+    monkeypatch.setattr(writer_inventory, "_docker_writers", lambda: [dict(live_writer)])
+
+    output = tmp_path / "quiescence.json"
+    with pytest.raises(InventoryError, match="live or racing"):
+        writer_inventory.prove_quiescent(
+            controller_pid=controller_pid,
+            controller_start_token=controller_token,
+            output=output,
+        )
+
+    assert not output.exists()
+
+    # Control: with the writer drained the same call proves quiescence, so the
+    # refusal above is the live writer and not an unconditional failure.
+    monkeypatch.setattr(writer_inventory, "_docker_writers", lambda: [])
+    writer_inventory.prove_quiescent(
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+        output=output,
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["all_consumers_stopped"] is True
+    assert payload["domains"] == {domain: [] for domain in writer_inventory.DOMAINS}
+
+
+def test_deploy_proceeds_past_inventory_with_shared_native_root(owner_sources, tmp_path):
+    """`deploy_channel.sh deploy dev <sha>` must reach migrations and recreate."""
+
+    # The inventory really is the deploy's first gate: the wrapper runs this
+    # subcommand, and deploy_channel.sh runs the wrapper before migrations and
+    # service recreate. That ordering is why a refusal blocks every channel.
+    wrapper = (REPO_ROOT / "scripts" / "lib" / "instance_state_deployment.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "produce-legacy-owners" in wrapper
+
+    # Compare call sites, not the function definitions further up the file.
+    deploy = (REPO_ROOT / "scripts" / "deploy_channel.sh").read_text(encoding="utf-8")
+    inventory_at = deploy.index("prepare_instance_state_deployment compose")
+    migrate_at = deploy.index(
+        'run_postmutation_gate "migration execution failed" apply_changed_migrations'
+    )
+    recreate_at = deploy.index('run_postmutation_gate "service recreate/liveness gate failed"')
+    assert inventory_at < migrate_at
+    assert inventory_at < recreate_at
+
+    # The observed host arrangement: native and a channel on one iCloud vault.
+    shared = _vault(tmp_path, "cloud-sync", "vault")
+    owner_sources["owners"] = [("native", shared), ("prod", shared)]
+    output = tmp_path / "legacy-owner-inventory.json"
+
+    # Exactly the argv scripts/lib/instance_state_deployment.sh builds.
+    exit_code = writer_inventory.main(
+        [
+            "produce-legacy-owners",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--active-channel",
+            "dev",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["inventory_complete"] is True


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4517

## Linked Issue
Closes #4517

## SBS Impact
- Primary subsystem: Product/Runtime host deployment and host-global vault ownership ledger
- Secondary subsystem(s): native/release vault topology, instance-state backup/restore, scalar rollback, key rotation
- Write class: deployment admission and durable authority-state validation
- Persistence impact: v1 schema unchanged; stricter authenticated read/write validation and immutable one-epoch tombstone behavior
- Derived/rebuildable impact: none
- New or changed contract: native plus one release binding may overlap; cardinality counts authenticated stable bindings rather than lifecycle rows, and live terminal authority requires explicit `state == active`
- Owner-doc impact: current-state owner contracts updated in this PR
- Transition debt impact: reduces deploy outage risk and makes dormant transfer/removal limitations explicit
- Boundary risk: high-risk concurrency, data, credential-durability, and state-machine boundaries; protected by convergence review and current-SHA proof

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Permit the ADR-0055 native/release shared-root topology in stopped-deployment inventory while preserving release-channel collision and active-writer refusal.
- Reconcile established ownership ledgers, enforce authenticated stable-binding cardinality across active/tombstone and transfer lifecycle state, and fail closed across backup, rollback, runtime preflight, and key rotation.
- Preserve immutable tombstone lineage: same-binding reactivation normalizes one authority only after complete identity agreement; transfer endpoints remain distinct; completed cross-release lineage treats only an explicitly active terminal as live and rejects pending terminal state before any consumer mutation.

## BuilderOps Routing
- Records/projections/receipts: lrn_20260806120237_76b54cbc; lrn_20260806123356_b3f2f10c; lrn_20260806135817_329cb1a6; lrn_20260806155833_3fec1d17
- Reason: Preserved all prior active LearningSignals, the Issue-contract drift signal, and the final-round terminal-live-state convergence signal; no attempt counter was reset.

## Notes
Full delivery path is declared because this PR touches concurrency, data, credential durability, and an explicit authority state machine. Earlier exact-head proof on `19396c73a` passed 28 parameterized Verify cases, 356 affected tests with 3 skipped, static/docs/risk gates, CI, and Sol/xhigh final round 1; Sol/xhigh final round 2 then rejected the protected pending-terminal P1 in receipt #5207210233. That rejection and the exhausted 2+2 accounting remain binding.

The next complete convergence packet received a clean independent Sol/xhigh plan review before implementation (receipt #5207344745). Current repaired head `dc26c26ae3772a2c3370b329c0ce9076ee9c48df` received a clean independent Sol/xhigh publishable-SHA mechanism review, then passed 29 governing/protected Verify cases, the affected suite (357 passed, 3 skipped), Ruff, mypy, docs guard with its explicit non-temporal-owner override, and the review-before-CI gate (receipt #5207439729). Current-head CI and two consecutive clean final reviews remain required. Prior-head final reviews do not count toward this repaired SHA, so `Final-Review-Rounds` is reset to 0 for sequence truth only; repair-budget accounting was not reset.
