### PR TITLE
Decouple staged-backup verification from live owner-root mounts

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -684,9 +684,14 @@ class InstanceStateBackup:
                     raise ValueError
         except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
             raise InstanceStatePreflightError("backup verification failed") from exc
+        # Restore is the mutating path: never skip a lease-less inventory
+        # owner here. Restore already requires materialized roots, so the
+        # candidate skip that keeps mount-blind backup creation green (#4371)
+        # would only mask a staged ledger that lost a live lease.
         staged_ledger, global_live_owners = self._verify_staged_backup(
             payloads=payloads,
             owner_payload=owner_payload,
+            skip_unadopted_owners=False,
         )
         manifest_key_id = manifest.get("ownership_key_id")
         manifest_generation = manifest.get("ownership_generation")
@@ -759,6 +764,7 @@ class InstanceStateBackup:
         payloads: Mapping[str, bytes],
         owner_payload: Mapping[str, object],
         require_materialized_owner_roots: bool = True,
+        skip_unadopted_owners: bool = True,
     ) -> tuple[LedgerSnapshot, tuple[LegacyOwner, ...]]:
         try:
             with tempfile.TemporaryDirectory(
@@ -786,6 +792,7 @@ class InstanceStateBackup:
                     require_materialized_owner_roots=(
                         require_materialized_owner_roots
                     ),
+                    skip_unadopted_owners=skip_unadopted_owners,
                 )
                 ledger = self._require_registry_ledger_consistency(
                     registry=registry,
@@ -796,10 +803,21 @@ class InstanceStateBackup:
                     ),
                 )
                 return ledger, global_live_owners
+        except InstanceStatePreflightError as exc:
+            # Surface the underlying cause in the top-level message (#4371):
+            # the chained traceback is not always visible in step output, and
+            # the generic fence text alone sends readers to the wrong
+            # subsystem.
+            raise InstanceStatePreflightError(
+                f"backup registry/ledger consistency verification failed: {exc};"
+                " keep the global fence until fenced re-key and ledger "
+                "reconstruction complete"
+            ) from exc
         except Exception as exc:
             raise InstanceStatePreflightError(
-                "backup registry/ledger consistency verification failed; keep the "
-                "global fence until fenced re-key and ledger reconstruction complete"
+                "backup registry/ledger consistency verification failed "
+                f"({type(exc).__name__}); keep the global fence until fenced "
+                "re-key and ledger reconstruction complete"
             ) from exc
 
     def _require_registry_ledger_consistency(
@@ -844,7 +862,7 @@ class InstanceStateBackup:
             )
         except LedgerError as exc:
             raise InstanceStatePreflightError(
-                "registry/ledger consistency verification failed"
+                f"registry/ledger consistency verification failed: {exc}"
             ) from exc
 
     def _global_live_owners(
@@ -854,37 +872,50 @@ class InstanceStateBackup:
         registry: RegistrySnapshot,
         ledger: OwnershipLedger,
         require_materialized_owner_roots: bool = True,
+        skip_unadopted_owners: bool = True,
     ) -> tuple[LegacyOwner, ...]:
         raw_owners = owner_payload.get("owners")
         if not isinstance(raw_owners, list):
             raise InstanceStatePreflightError(
-                "canonical global live-owner inventory is invalid"
+                "canonical global live-owner inventory is invalid: the drained "
+                "owner receipt carries no owners list"
             )
         owners: list[LegacyOwner] = []
-        for item in raw_owners:
+        for index, item in enumerate(raw_owners):
             if not isinstance(item, dict):
                 raise InstanceStatePreflightError(
-                    "canonical global live-owner inventory is invalid"
+                    "canonical global live-owner inventory is invalid: "
+                    f"owners[{index}] is not an owner entry"
                 )
             channel_id = str(item.get("channel_id") or "").strip()
-            root = Path(str(item.get("root") or "")).expanduser().resolve(
-                strict=False
-            )
+            raw_root = str(item.get("root") or "").strip()
             binding_id = str(item.get("vault_binding_id") or "").strip()
-            if (
-                not channel_id
-                or (
-                    require_materialized_owner_roots
-                    and not root.is_dir()
-                )
-                or (
-                    not require_materialized_owner_roots
-                    and not binding_id
-                )
-            ):
+            if not channel_id:
                 raise InstanceStatePreflightError(
-                    "canonical global live-owner inventory is invalid"
+                    "canonical global live-owner inventory is invalid: "
+                    f"owners[{index}].channel_id is missing"
                 )
+            if not raw_root or not Path(raw_root).expanduser().is_absolute():
+                raise InstanceStatePreflightError(
+                    "canonical global live-owner inventory is invalid: "
+                    f"owners[{index}].root is missing or not absolute"
+                )
+            if not require_materialized_owner_roots and not binding_id:
+                raise InstanceStatePreflightError(
+                    "canonical global live-owner inventory is invalid: "
+                    f"owners[{index}].vault_binding_id is missing"
+                )
+            # Owner-root materialization is not re-checked here (#4371): the
+            # host-side inventory producer proved every root twice and the
+            # receipt is digest-bound to the deployment lease, while this
+            # verification may run in another mount namespace (the
+            # deployment-finish container). A root that is not locally
+            # visible resolves to canonical-path identity, whose fingerprints
+            # cannot match an inode-fingerprinted lease minted where the root
+            # was materialized — such an owner therefore resolves to no lease
+            # and is handled by the unadopted-candidate rule in
+            # resolve_live_owner_bindings below.
+            root = Path(raw_root).expanduser().resolve(strict=False)
             if (
                 require_materialized_owner_roots
                 and channel_id == self.layout.channel_id
@@ -898,10 +929,22 @@ class InstanceStateBackup:
                         break
             owners.append(LegacyOwner(channel_id, binding_id, root))
         try:
-            resolved = ledger.resolve_live_owner_bindings(owners)
+            # Config-derived inventories (materialized-roots mode) may name
+            # candidates the ledger never adopted after legacy bootstrap
+            # completed; when such a root is also invisible to this process,
+            # the verifier cannot adjudicate it and the ledger holds no lease
+            # for it, so it is excluded from lease consistency. A lease-less
+            # owner whose root is locally materialized stays fail-closed, and
+            # lease-only payloads always carry binding ids.
+            resolved = ledger.resolve_live_owner_bindings(
+                owners,
+                skip_unadopted=(
+                    skip_unadopted_owners and require_materialized_owner_roots
+                ),
+            )
         except LedgerError as exc:
             raise InstanceStatePreflightError(
-                "canonical global live-owner binding identity is invalid"
+                f"canonical global live-owner binding identity is invalid: {exc}"
             ) from exc
         if len({owner.vault_binding_id for owner in resolved}) != len(resolved):
             raise InstanceStatePreflightError(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -252,8 +252,23 @@ class OwnershipLedger:
     def resolve_live_owner_bindings(
         self,
         owners: Sequence[LegacyOwner],
+        *,
+        skip_unadopted: bool = False,
     ) -> tuple[LegacyOwner, ...]:
-        """Fill omitted owner binding IDs from the authenticated live ledger."""
+        """Fill omitted owner binding IDs from the authenticated live ledger.
+
+        With ``skip_unadopted``, an owner that carries no binding ID, matches
+        no active lease, **and whose root is not materialized in this
+        process's filesystem view** is treated as a config-derived candidate
+        the ledger never adopted (a root bound after legacy bootstrap
+        completed, seen from a verifier in another mount namespace). It holds
+        no lease, so it cannot participate in lease consistency and is
+        omitted from the result instead of failing resolution (#4371). A
+        lease-less owner whose root IS locally materialized stays fail-closed
+        — there the verifier can adjudicate, and a missing lease is
+        indistinguishable from a ledger that lost one. An ambiguous match
+        always fails.
+        """
 
         self._assert_existing_artifacts()
         with self._locked():
@@ -272,13 +287,22 @@ class OwnershipLedger:
                         and lease.state == "active"
                         and self._matches_complete_root_identity(lease, owner.root, key)
                     ]
+                    unmaterialized = not resolve_filesystem_root_identity(
+                        owner.root
+                    ).materialized
                 except FilesystemIdentityError as exc:
                     raise LedgerError(
                         "cannot resolve omitted live-owner binding identity"
                     ) from exc
-                if len(matches) != 1:
+                if len(matches) > 1:
                     raise LedgerError(
                         "omitted live-owner binding identity is not unambiguous"
+                    )
+                if not matches:
+                    if skip_unadopted and unmaterialized:
+                        continue
+                    raise LedgerError(
+                        "omitted live-owner binding matches no live lease"
                     )
                 resolved.append(
                     LegacyOwner(owner.channel_id, matches[0], owner.root)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -231,6 +231,7 @@ promote public internet readiness.
 
 ## CI & Test Markers
 - CI legs assert `docs/ARCHITECTURE.md` contains fitness guard statements, confirm CLI health smoke commands pass, and verify the worker logs show `worker starting`.
+- `CI Smoke`'s push-lane `smoke-docker >> "CI gate: vaultwide panel verifier"` no longer false-positives on `main` (#4371): staged-backup verification (`_verify_staged_backup` -> `_global_live_owners`) validates the drained owner inventory by shape and ledger consistency instead of requiring every owner root to be a live directory in the verifying container, its top-level error names the failing inventory field, and the `vault` PR-test selection runs `tests/ops/test_instance_state_volume_contract.py` so this surface has pre-merge signal.
 - CI no longer treats absent model-provider credentials as a passing live-provider check: the optional
   Panel LLM E2E job and credential-gated Codex docs-guardian path are removed. Reintroducing either
   requires a separately declared credential backend and explicit cost/egress posture; deterministic

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -48,6 +48,16 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
   `app/outbox/events.py` producer belongs to both `outbox_worker` and `memory_retrieval`, so its
   selection unions delivery-worker/event, indexer, and event-envelope contract coverage. Other
   `app/objects/**` and `app/outbox/**` paths remain unowned unless explicitly mapped.
+- The push-lane `CI gate: vaultwide panel verifier` step (`.github/workflows/ci-smoke.yaml ::
+  smoke-docker`) exercises the MVR-01B instance-state deployment producer against the composed
+  runtime only after merge. Its protected verification logic has pre-merge signal (#4371): every
+  `vault` subsystem match (`app/instance/**`) runs
+  `tests/ops/test_instance_state_volume_contract.py` as an exact target, including the staged-backup
+  regression tests (`test_staged_backup_verification_succeeds_on_fresh_deployment`,
+  `test_staged_backup_failure_surfaces_underlying_cause`,
+  `test_inconsistent_registry_ledger_still_fails_closed`), so a backup/ownership verification defect
+  fails the changing PR instead of first turning `main`'s post-merge smoke red. The docker-compose
+  integration itself (mounts, launcher sequence, seeded vault) remains post-merge-only coverage.
 - E2E tests under `tests/e2e/` run after merge and in the nightly suite, not on ordinary PRs. Opt-in classes (live LLM, browser, human UAT, eval) remain in their dedicated post-merge or nightly lanes.
 
 ## Check Levels

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -311,6 +311,12 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/agents/test_merge_resolver.py",
             "tests/agents/test_merge_resolver_repo_docs.py",
             "tests/cli/test_merge_driver.py",
+            # Pre-merge signal for the instance-state deployment surface that
+            # the push-lane `CI gate: vaultwide panel verifier` protects
+            # (#4371): a backup/ownership verification defect in
+            # `app/instance/**` must fail the changing PR instead of first
+            # turning `main`'s post-merge smoke red.
+            "tests/ops/test_instance_state_volume_contract.py",
         ),
     ),
     (

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -4,6 +4,7 @@ import fcntl
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -4660,3 +4661,268 @@ def test_prod_restore_rejects_foreign_channel_before_writing_target_state(tmp_pa
         if path.is_file()
     }
     assert after == before
+
+
+def _run_fenced_deployment(
+    *,
+    channel: str,
+    instance_state_root: Path,
+    host_global_root: Path,
+    legacy_path: Path,
+    inventory_payload: dict[str, object],
+    backup_root: Path,
+) -> dict[str, object]:
+    """Run one complete begin -> prove -> finish deployment on the production path."""
+
+    _begin_instance_state_deployment(
+        channel=channel,
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        controller_pid=os.getpid(),
+        controller_start_token=_controller_token(os.getpid()),
+    )
+    inventory_path = host_global_root / "legacy-owner-inventory.json"
+    inventory_path.write_text(json.dumps(inventory_payload), encoding="utf-8")
+    os.chmod(inventory_path, 0o600)
+    return _finish_instance_state_deployment(
+        channel=channel,
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_path=inventory_path,
+        backup_root=backup_root,
+        restore_root=None,
+        quiescence_proof=_prove_empty_quiescence(
+            channel=channel, host_global_root=host_global_root
+        ),
+    )
+
+
+def test_staged_backup_verification_succeeds_on_fresh_deployment(tmp_path) -> None:
+    """#4371 AC1: staged-backup verification must not require the drained
+    inventory's owner roots to be visible in the verifying process.
+
+    Mirrors the `CI Smoke` `smoke-docker` shape on `main`: an earlier
+    deployment completed legacy bootstrap against an empty owner inventory,
+    `docker compose down -v` recreated the channel's instance-state volume
+    while the host-global ownership root persisted, and a fresh deployment now
+    runs with a newly config-bound vault root that (a) holds no ledger lease
+    yet and (b) is outside the verifying container's mount namespace.
+    """
+
+    instance_state_root = tmp_path / "instance-state"
+    host_global_root = tmp_path / "host-global"
+    instance_state_root.mkdir()
+    host_global_root.mkdir()
+    legacy_path = tmp_path / "missing-legacy.md"
+
+    first = _run_fenced_deployment(
+        channel="dev",
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_payload=_legacy_owner_inventory_payload([]),
+        backup_root=host_global_root / "backups" / "dev" / "latest",
+    )
+    assert first["restart_fence_cleared"] is True
+
+    # The channel volume is recreated fresh; host-global ownership persists.
+    shutil.rmtree(instance_state_root)
+    instance_state_root.mkdir()
+
+    # Produce the inventory while the owner root is materialized (the host
+    # view), then remove it so the deployment-finish verification runs in a
+    # view that cannot see the owner root (the container view).
+    vault_root = tmp_path / "ci-vault"
+    vault_root.mkdir()
+    inventory_payload = _legacy_owner_inventory_payload(
+        [{"channel_id": "dev", "root": str(vault_root)}]
+    )
+    shutil.rmtree(vault_root)
+
+    second = _run_fenced_deployment(
+        channel="dev",
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_payload=inventory_payload,
+        backup_root=host_global_root / "backups" / "dev" / "latest",
+    )
+    assert second["restart_fence_cleared"] is True
+    backup_manifest = Path(str(second["backup_manifest"]))
+    assert backup_manifest.is_file()
+    assert not _deployment_fence_path(host_global_root, "dev").exists()
+
+    # The unadopted config candidate must not have minted ownership: backup
+    # verification tolerates it without weakening the ledger.
+    layout = InstanceStateLayout.for_channel(instance_state_root, "dev")
+    ledger_snapshot = InstanceRegistryRuntime.for_paths(
+        layout,
+        host_global_root,
+        initialize_layout=False,
+    ).ledger.load()
+    assert ledger_snapshot.legacy_bootstrap_complete is True
+    assert ledger_snapshot.leases == {}
+
+
+@pytest.mark.parametrize(
+    ("owner_entry", "expected_field"),
+    [
+        ({"channel_id": "", "root": "/somewhere/vault"}, "channel_id"),
+        ({"channel_id": "dev", "root": ""}, "root"),
+    ],
+)
+def test_staged_backup_failure_surfaces_underlying_cause(
+    tmp_path, owner_entry, expected_field
+) -> None:
+    """#4371 AC2: a rejected owner inventory must surface a message naming the
+    invalid inventory and the failing owner field, readable from the top-level
+    error without reconstructing the chained traceback."""
+
+    instance_state_root = tmp_path / "instance-state"
+    host_global_root = tmp_path / "host-global"
+    instance_state_root.mkdir()
+    host_global_root.mkdir()
+    legacy_path = tmp_path / "missing-legacy.md"
+
+    first = _run_fenced_deployment(
+        channel="dev",
+        instance_state_root=instance_state_root,
+        host_global_root=host_global_root,
+        legacy_path=legacy_path,
+        inventory_payload=_legacy_owner_inventory_payload([]),
+        backup_root=host_global_root / "backups" / "dev" / "latest",
+    )
+    assert first["restart_fence_cleared"] is True
+    shutil.rmtree(instance_state_root)
+    instance_state_root.mkdir()
+
+    with pytest.raises(InstanceStatePreflightError) as excinfo:
+        _run_fenced_deployment(
+            channel="dev",
+            instance_state_root=instance_state_root,
+            host_global_root=host_global_root,
+            legacy_path=legacy_path,
+            inventory_payload=_legacy_owner_inventory_payload([owner_entry]),
+            backup_root=host_global_root / "backups" / "dev" / "latest",
+        )
+    message = str(excinfo.value)
+    assert "backup registry/ledger consistency verification failed" in message
+    assert "canonical global live-owner inventory is invalid" in message
+    assert expected_field in message
+    # The failure must keep the restart fence installed.
+    assert _deployment_fence_path(host_global_root, "dev").is_file()
+
+
+def test_inconsistent_registry_ledger_still_fails_closed(tmp_path) -> None:
+    """#4371 AC3: narrowing the live-owner false positive must not weaken the
+    real backup/ownership consistency check on the production create() path."""
+
+    layout = InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host-global")
+    root = tmp_path / "vault"
+    root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=root,
+        watcher_vault_path=root,
+    )
+
+    # (a) The authenticated drained inventory claims a live owner binding the
+    # ledger does not hold: fail closed, and name the cause at top level.
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=layout,
+        host_global_root=runtime.ledger.root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(root),
+            },
+            {
+                "channel_id": "prod",
+                "vault_binding_id": "forged-live-owner",
+                "root": str(tmp_path / "forged-root"),
+            },
+        ],
+    )
+    with pytest.raises(InstanceStatePreflightError) as forged:
+        InstanceStateBackup(layout, runtime.ledger).create(
+            tmp_path / "backup",
+            quiescence_proof=proof,
+            owner_receipt_path=owner_receipt,
+        )
+    assert "backup registry/ledger consistency verification failed" in str(forged.value)
+    assert "one live lease per global owner" in str(forged.value)
+    assert not (tmp_path / "backup" / "manifest.json").exists()
+
+    # (b) A binding-less inventory owner whose root IS materialized in the
+    # verifying view but holds no ledger lease: the verifier can adjudicate
+    # it, and a missing lease is indistinguishable from a ledger that lost
+    # one, so the unadopted-candidate skip must not apply. This is the
+    # regression fence for the #4371 narrowing.
+    _clear_test_deployment_authority(
+        layout=layout, host_global_root=runtime.ledger.root
+    )
+    materialized_unadopted = tmp_path / "materialized-unadopted"
+    materialized_unadopted.mkdir()
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=layout,
+        host_global_root=runtime.ledger.root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(root),
+            },
+            {
+                "channel_id": "prod",
+                "root": str(materialized_unadopted),
+            },
+        ],
+    )
+    with pytest.raises(InstanceStatePreflightError) as unadopted:
+        InstanceStateBackup(layout, runtime.ledger).create(
+            tmp_path / "backup",
+            quiescence_proof=proof,
+            owner_receipt_path=owner_receipt,
+        )
+    assert "backup registry/ledger consistency verification failed" in str(unadopted.value)
+    assert "matches no live lease" in str(unadopted.value)
+    assert not (tmp_path / "backup" / "manifest.json").exists()
+
+    # (c) A registry registration without any ledger lease: fail closed.
+    _clear_test_deployment_authority(
+        layout=layout, host_global_root=runtime.ledger.root
+    )
+    runtime.registry.register(
+        VaultRegistration(
+            "binding-unleased",
+            f"path:{tmp_path / 'other-vault'}",
+            str(tmp_path / "other-vault"),
+        ),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=layout,
+        host_global_root=runtime.ledger.root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(root),
+            }
+        ],
+    )
+    with pytest.raises(InstanceStatePreflightError) as unleased:
+        InstanceStateBackup(layout, runtime.ledger).create(
+            tmp_path / "backup",
+            quiescence_proof=proof,
+            owner_receipt_path=owner_receipt,
+        )
+    assert "backup registry/ledger consistency verification failed" in str(unleased.value)
+    assert "one live lease per registration" in str(unleased.value)
+    assert not (tmp_path / "backup" / "manifest.json").exists()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4371

## Linked Issue
Closes #4371

## SBS Impact
- Primary subsystem: Builder System - CI, architecture fitness, and validation rails
- Secondary subsystem(s): Product/Runtime - instance-state and ownership substrate (app/instance/** backup verification)
- Write class: runtime bootstrap / CI
- Persistence impact: none: backup verification logic only; no schema, artifact, or durability change
- Derived/rebuildable impact: none
- New or changed contract: none intended; verification narrows a false positive without weakening registry/ledger consistency
- Owner-doc impact: docs/development/TEST_STRATEGY_HOT_PATH.md :: Current Protection Surface and docs/STATUS.md :: CI & Test Markers updated in this PR
- Transition debt impact: reduces: restores a push-lane gate that currently yields no signal
- Boundary risk: fix must not weaken backup/ownership verification; fail-closed behavior proven by test_inconsistent_registry_ledger_still_fails_closed

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Staged-backup verification (create()/restore() -> _verify_staged_backup -> _global_live_owners) no longer requires drained-inventory owner roots to be live directories in the verifying process, and config-derived owners the ledger never adopted after legacy bootstrap no longer fail lease consistency. The surfaced error names the invalid inventory field at top level, and the vault PR-test selection now runs tests/ops/test_instance_state_volume_contract.py so the protected surface has pre-merge signal.

## BuilderOps Routing
- Records/projections/receipts: docs/STATUS.md CI & Test Markers note; docs/development/TEST_STRATEGY_HOT_PATH.md Current Protection Surface writeback
- Reason: Doc writebacks carry the delivery truth; no BuilderOps vault records were produced for this bounded defect.

## Notes
Validation: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/ops/test_instance_state_volume_contract.py (101 passed, 3 skipped; includes the three #4371 Verify targets); tests/ops/test_scalar_rollback_guard.py + tests/scripts/test_select_pr_tests.py (102 passed); tests/integration/test_vault_registry_channel_isolation.py (37 passed); tests/instance (30 passed); tests/governance/test_ci_smoke_docs_only_gate.py + tests/ops/test_ci_workflow.py + tests/scripts/test_select_pr_tests.py (113 passed); ruff check app tests clean; mypy app clean; python3 scripts/docs_guard.py clean. Evidence redacted per issue constraints: variable names and boolean/path-class results only.
