### PR TITLE
fix: release abandoned host-global deployment lease on producer failure

### DIFF
--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2603,6 +2603,56 @@ def _finish_instance_state_deployment(
             )
 
 
+def _release_instance_state_deployment_lease(
+    *,
+    channel: str,
+    host_global_root: Path,
+    controller_pid: int,
+    controller_start_token: str,
+) -> dict[str, object]:
+    """Surrender an abandoned deployment's own host-global lease.
+
+    Called by the producer's own failure path between ``deployment-begin``
+    and ``deployment-finish``. This is a self-release: it only ever clears a
+    lease whose recorded channel and controller match the caller's own
+    identity, so it can never disturb a lease still owned by a live or
+    unrelated deployment, and it is a no-op once ``deployment-finish`` has
+    already cleared the lease it was guarding.
+    """
+
+    ownership_root = _assert_mount_root(host_global_root, "host-global")
+    controller = {"pid": controller_pid, "start_token": controller_start_token}
+    with _deployment_admission_locked(ownership_root):
+        lease_path = _deployment_lease_path(ownership_root)
+        if not lease_path.exists():
+            return {"released": False, "reason": "no-active-lease"}
+        try:
+            lease = _read_deployment_lease(ownership_root)
+        except InstanceStatePreflightError:
+            return {"released": False, "reason": "lease-unreadable"}
+        if lease.get("channel_id") != channel or lease.get("controller") != controller:
+            return {"released": False, "reason": "controller-mismatch"}
+        if lease.get("phase") == "cleanup":
+            result = lease.get("result")
+            if not (isinstance(result, dict) and result.get("channel") == channel):
+                return {"released": False, "reason": "cleanup-receipt-invalid"}
+            receipt = _complete_instance_state_deployment_cleanup(ownership_root)
+            return receipt | {"released": True, "reason": "already-in-cleanup"}
+        root_lease_path = _legacy_deployment_lease_path(ownership_root)
+        result: dict[str, object] = {
+            "channel": channel,
+            "restart_fence_cleared": True,
+            "aborted": True,
+        }
+        cleanup_lease = lease | {"phase": "cleanup", "result": result}
+        _replace_private_json(lease_path, cleanup_lease)
+        _replace_private_json(
+            root_lease_path, _compatibility_block_payload(cleanup_lease)
+        )
+        receipt = _complete_instance_state_deployment_cleanup(ownership_root)
+        return receipt | {"released": True, "reason": "abandoned-deployment"}
+
+
 def _fsync_directory(path: Path) -> None:
     descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
@@ -3358,6 +3408,11 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--backup-root", type=Path, required=True)
     finish.add_argument("--restore-root", type=Path)
     finish.add_argument("--quiescence-proof-path", type=Path, required=True)
+    release = subparsers.add_parser("deployment-release")
+    release.add_argument("--channel", required=True)
+    release.add_argument("--host-global-root", type=Path, required=True)
+    release.add_argument("--controller-pid", type=int, required=True)
+    release.add_argument("--controller-start-token", required=True)
     prove = subparsers.add_parser("deployment-prove")
     prove.add_argument("--channel", required=True)
     prove.add_argument("--host-global-root", type=Path, required=True)
@@ -3531,6 +3586,19 @@ def main(argv: list[str] | None = None) -> int:
                     backup_root=args.backup_root,
                     restore_root=args.restore_root,
                     quiescence_proof=proof,
+                ),
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "deployment-release":
+        print(
+            json.dumps(
+                _release_instance_state_deployment_lease(
+                    channel=args.channel,
+                    host_global_root=args.host_global_root,
+                    controller_pid=args.controller_pid,
+                    controller_start_token=args.controller_start_token,
                 ),
                 sort_keys=True,
             )

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2635,8 +2635,11 @@ def _release_instance_state_deployment_lease(
         if lease.get("controller") != controller:
             return {"released": False, "reason": "controller-mismatch"}
         if lease.get("phase") == "cleanup":
-            result = lease.get("result")
-            if not (isinstance(result, dict) and result.get("channel") == channel):
+            existing_result = lease.get("result")
+            if not (
+                isinstance(existing_result, dict)
+                and existing_result.get("channel") == channel
+            ):
                 return {"released": False, "reason": "cleanup-receipt-invalid"}
             receipt = _complete_instance_state_deployment_cleanup(ownership_root)
             return receipt | {"released": True, "reason": "already-in-cleanup"}

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2630,7 +2630,9 @@ def _release_instance_state_deployment_lease(
             lease = _read_deployment_lease(ownership_root)
         except InstanceStatePreflightError:
             return {"released": False, "reason": "lease-unreadable"}
-        if lease.get("channel_id") != channel or lease.get("controller") != controller:
+        if lease.get("channel_id") != channel:
+            return {"released": False, "reason": "channel-mismatch"}
+        if lease.get("controller") != controller:
             return {"released": False, "reason": "controller-mismatch"}
         if lease.get("phase") == "cleanup":
             result = lease.get("result")

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -79,8 +79,14 @@ restart fence, stops API/worker/watcher/Heimdal, probes dev/test/prod/native con
 durably proves quiescence. Two new owner-source snapshots must reproduce the baseline exactly before
 the producer marks the inventory drained and copies it to
 `/app/instance-ownership/legacy-owner-inventory.json`; missing sources, config/store races, and
-equal or nested roots across owner domains abort without seeding a partial set. A live writer or a
-post-stop owner validation failure leaves the fence in place. The nonce-plus-inventory-digest proof
+equal or nested roots across owner domains abort without seeding a partial set. A failure at any
+stage after the lease/fence claim and before finalization — a live writer, a post-stop owner
+validation failure, or any other producer stage failure — surrenders that same-run producer's own
+host-global lease, public lease copy, and channel restart fence instead of stranding them; the
+release is scoped to the exact controller identity (pid plus start token) that claimed the lease, so
+it cannot disturb a lease still owned by a live or unrelated deployment, and a lease whose recorded
+controller process no longer exists is reclaimable by the next `deployment-begin` instead of fatal.
+The nonce-plus-inventory-digest proof
 is required for restore, final export/preservation, and legacy bootstrap. The finalizer rejects an
 incomplete, non-private, or unvalidated inventory, captures the final legacy fingerprint, imports it
 on first volume or preserves it beside an established dormant registry, calls the host-global

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -4,6 +4,34 @@ _instance_state_deployment_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
 source "${_instance_state_deployment_lib_dir}/instance_ownership_host_state.sh"
 unset _instance_state_deployment_lib_dir
 
+# Best-effort self-release of the host-global deployment lease this producer
+# claimed when it began. Called only on a failure path after that successful
+# claim and before a successful finalization, so an abandoned deployment does
+# not strand the lease, the public lease copy, and the channel restart fence
+# that block every later runtime consumer and deploy attempt. The release is
+# self-scoped: it only ever clears a lease whose recorded channel and
+# controller identity match the ones passed here, so it can never disturb a
+# lease still owned by another deployment. Its own failure is logged and
+# swallowed; the caller's original failure is always the reported outcome.
+_release_abandoned_instance_state_deployment_lease() {
+  local compose_function="$1"
+  local channel="$2"
+  local runtime_user="$3"
+  local controller_pid="$4"
+  local controller_start_token="$5"
+  if [ -z "${controller_start_token}" ]; then
+    return 0
+  fi
+  if ! "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
+    python -m app.instance.runtime deployment-release \
+      --channel "${channel}" \
+      --host-global-root /app/instance-ownership \
+      --controller-pid "${controller_pid}" \
+      --controller-start-token "${controller_start_token}"; then
+    echo "warning: failed to release the abandoned host-global deployment lease" >&2
+  fi
+}
+
 # MVR-01B deploy/start producer. The caller supplies its channel-aware compose
 # function so the same fenced sequence is used by pinned deploys and local
 # full-system starts.
@@ -103,6 +131,9 @@ prepare_instance_state_deployment() {
   if [ "${inventory_rc}" -ne 0 ]; then
     rm -f -- "${inventory_host_path}"
     rm -f -- "${owner_inventory_host_path}"
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
 
@@ -117,6 +148,9 @@ prepare_instance_state_deployment() {
   if [ "${inventory_rc}" -ne 0 ]; then
     rm -f -- "${inventory_host_path}"
     rm -f -- "${owner_inventory_host_path}"
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
@@ -125,6 +159,9 @@ prepare_instance_state_deployment() {
   rm -f -- "${inventory_host_path}"
   if [ "${inventory_rc}" -ne 0 ]; then
     rm -f -- "${owner_inventory_host_path}"
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
 
@@ -136,6 +173,9 @@ prepare_instance_state_deployment() {
   inventory_rc=$?
   if [ "${inventory_rc}" -ne 0 ]; then
     rm -f -- "${owner_inventory_host_path}"
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
 
@@ -151,6 +191,9 @@ prepare_instance_state_deployment() {
   inventory_rc=$?
   if [ "${inventory_rc}" -ne 0 ]; then
     rm -f -- "${owner_inventory_host_path}"
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
@@ -158,6 +201,9 @@ prepare_instance_state_deployment() {
   inventory_rc=$?
   rm -f -- "${owner_inventory_host_path}"
   if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
 
@@ -167,6 +213,9 @@ prepare_instance_state_deployment() {
   if [ -n "${MVR01C_ROLL_FORWARD_LEGACY_PATH:-}" ]; then
     if [ "${MVR01C_ROLL_FORWARD_LEGACY_PATH}" != "/app/scalar-rollback/app-local.md" ]; then
       echo "MVR-01C roll-forward source must be the governed scalar volume" >&2
+      _release_abandoned_instance_state_deployment_lease \
+        "${compose_function}" "${channel}" "${runtime_user}" \
+        "${controller_pid}" "${controller_start_token}"
       return 78
     fi
     "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
@@ -179,6 +228,9 @@ prepare_instance_state_deployment() {
         --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json
     inventory_rc=$?
     if [ "${inventory_rc}" -ne 0 ]; then
+      _release_abandoned_instance_state_deployment_lease \
+        "${compose_function}" "${channel}" "${runtime_user}" \
+        "${controller_pid}" "${controller_start_token}"
       return "${inventory_rc}"
     fi
   fi
@@ -190,6 +242,9 @@ prepare_instance_state_deployment() {
   if [ -n "${MVR01C_ROLLBACK_VAULT_BINDING_ID:-}" ] || [ -n "${MVR01C_ROLLBACK_VAULT_ROOT:-}" ]; then
     if [ -z "${MVR01C_ROLLBACK_VAULT_BINDING_ID:-}" ] || [ -z "${MVR01C_ROLLBACK_VAULT_ROOT:-}" ]; then
       echo "MVR-01C cutover requires both rollback binding and root" >&2
+      _release_abandoned_instance_state_deployment_lease \
+        "${compose_function}" "${channel}" "${runtime_user}" \
+        "${controller_pid}" "${controller_start_token}"
       return 78
     fi
     "${compose_function}" run --rm --no-deps -T \
@@ -209,6 +264,9 @@ prepare_instance_state_deployment() {
         --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json
     inventory_rc=$?
     if [ "${inventory_rc}" -ne 0 ]; then
+      _release_abandoned_instance_state_deployment_lease \
+        "${compose_function}" "${channel}" "${runtime_user}" \
+        "${controller_pid}" "${controller_start_token}"
       return "${inventory_rc}"
     fi
   fi

--- a/tests/ops/test_instance_state_deployment_lease.py
+++ b/tests/ops/test_instance_state_deployment_lease.py
@@ -117,6 +117,60 @@ def test_release_after_successful_finish_is_a_noop(tmp_path: Path) -> None:
     assert receipt["reason"] == "no-active-lease"
 
 
+def test_release_ignores_a_lease_owned_by_a_different_controller(tmp_path: Path) -> None:
+    """Release must never clear a lease it did not itself claim, even a live one."""
+
+    channel = "prod"
+    owner_pid = os.getpid()
+    owner_token = _controller_token(owner_pid)
+    _state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=owner_pid,
+        controller_start_token=owner_token,
+    )
+
+    receipt = _release_instance_state_deployment_lease(
+        channel=channel,
+        host_global_root=ownership,
+        controller_pid=999_999_998,
+        controller_start_token=f"linux:{'6' * 64}",
+    )
+
+    assert receipt["released"] is False
+    assert receipt["reason"] == "controller-mismatch"
+    assert _deployment_lease_path(ownership).exists()
+    assert _deployment_fence_path(ownership, channel).exists()
+    lease = json.loads(_deployment_lease_path(ownership).read_text(encoding="utf-8"))
+    assert lease["controller"] == {"pid": owner_pid, "start_token": owner_token}
+
+
+def test_release_ignores_a_lease_from_a_different_channel(tmp_path: Path) -> None:
+    """Release must never clear another channel's lease, even with a matching controller."""
+
+    channel = "prod"
+    controller_pid = os.getpid()
+    controller_token = _controller_token(controller_pid)
+    _state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    receipt = _release_instance_state_deployment_lease(
+        channel="test",
+        host_global_root=ownership,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    assert receipt["released"] is False
+    assert receipt["reason"] == "channel-mismatch"
+    assert _deployment_lease_path(ownership).exists()
+    assert _deployment_fence_path(ownership, channel).exists()
+
+
 def test_dead_controller_lease_is_reclaimable(tmp_path: Path) -> None:
     """AC: a lease whose controller process no longer exists is reclaimable."""
 

--- a/tests/ops/test_instance_state_deployment_lease.py
+++ b/tests/ops/test_instance_state_deployment_lease.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.instance.runtime import (
+    InstanceStatePreflightError,
+    RegistryError,
+    _any_deployment_lease_exists,
+    _begin_instance_state_deployment,
+    _deployment_fence_path,
+    _deployment_lease_path,
+    _legacy_deployment_lease_path,
+    _preflight_runtime,
+    _release_instance_state_deployment_lease,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRITER_INVENTORY_HELPER = REPO_ROOT / "scripts/instance_state_writer_inventory.py"
+
+
+def _controller_token(pid: int) -> str:
+    return subprocess.check_output(
+        [
+            sys.executable,
+            str(WRITER_INVENTORY_HELPER),
+            "controller-token",
+            "--pid",
+            str(pid),
+        ],
+        text=True,
+    ).strip()
+
+
+def _begin(
+    tmp_path: Path,
+    *,
+    channel: str,
+    controller_pid: int,
+    controller_start_token: str,
+) -> tuple[Path, Path, dict[str, object]]:
+    state = tmp_path / "state"
+    ownership = tmp_path / "ownership"
+    state.mkdir(exist_ok=True)
+    ownership.mkdir(exist_ok=True)
+    fence = _begin_instance_state_deployment(
+        channel=channel,
+        instance_state_root=state,
+        host_global_root=ownership,
+        legacy_path=tmp_path / "legacy.md",
+        controller_pid=controller_pid,
+        controller_start_token=controller_start_token,
+    )
+    return state, ownership, fence
+
+
+def test_failed_deployment_releases_host_global_lease(tmp_path: Path) -> None:
+    """AC: a deployment that fails between begin and finish leaves no residue."""
+
+    channel = "prod"
+    controller_pid = os.getpid()
+    controller_token = _controller_token(controller_pid)
+    _state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+    assert _deployment_lease_path(ownership).exists()
+    assert _deployment_fence_path(ownership, channel).exists()
+    assert _legacy_deployment_lease_path(ownership).exists()
+
+    receipt = _release_instance_state_deployment_lease(
+        channel=channel,
+        host_global_root=ownership,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    assert receipt["released"] is True
+    assert not _deployment_lease_path(ownership).exists()
+    assert not _deployment_fence_path(ownership, channel).exists()
+    assert not _legacy_deployment_lease_path(ownership).exists()
+    assert not _any_deployment_lease_exists(ownership)
+
+
+def test_release_after_successful_finish_is_a_noop(tmp_path: Path) -> None:
+    """A release attempt must not run after deployment-finish already cleared the lease."""
+
+    channel = "prod"
+    controller_pid = os.getpid()
+    controller_token = _controller_token(controller_pid)
+    _state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+    # Simulate deployment-finish already having cleared the lease and fence.
+    _deployment_lease_path(ownership).unlink()
+    _deployment_fence_path(ownership, channel).unlink()
+    _legacy_deployment_lease_path(ownership).unlink()
+
+    receipt = _release_instance_state_deployment_lease(
+        channel=channel,
+        host_global_root=ownership,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    assert receipt["released"] is False
+    assert receipt["reason"] == "no-active-lease"
+
+
+def test_dead_controller_lease_is_reclaimable(tmp_path: Path) -> None:
+    """AC: a lease whose controller process no longer exists is reclaimable."""
+
+    channel = "prod"
+    dead_pid = 999_999_998
+    dead_token = f"linux:{'3' * 64}"
+    state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=dead_pid,
+        controller_start_token=dead_token,
+    )
+
+    live_pid = os.getpid()
+    live_token = _controller_token(live_pid)
+    recovered = _begin_instance_state_deployment(
+        channel=channel,
+        instance_state_root=state,
+        host_global_root=ownership,
+        legacy_path=tmp_path / "legacy.md",
+        controller_pid=live_pid,
+        controller_start_token=live_token,
+    )
+
+    assert recovered["controller"] == {"pid": live_pid, "start_token": live_token}
+    lease = json.loads(_deployment_lease_path(ownership).read_text(encoding="utf-8"))
+    assert lease["controller"] == {"pid": live_pid, "start_token": live_token}
+
+
+def test_live_controller_lease_still_blocks(tmp_path: Path) -> None:
+    """AC: a live controller with a matching start token still blocks, via the
+    production begin path rather than the liveness helper alone."""
+
+    channel = "prod"
+    controller_pid = os.getpid()
+    controller_token = _controller_token(controller_pid)
+    state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    with pytest.raises(InstanceStatePreflightError, match="controller is active"):
+        _begin_instance_state_deployment(
+            channel=channel,
+            instance_state_root=state,
+            host_global_root=ownership,
+            legacy_path=tmp_path / "legacy.md",
+            controller_pid=999_999_998,
+            controller_start_token=f"linux:{'4' * 64}",
+        )
+
+
+def test_recycled_pid_is_not_treated_as_live(tmp_path: Path) -> None:
+    """AC: a recycled pid whose start token differs from the recorded lease is dead."""
+
+    channel = "prod"
+    recycled_pid = os.getpid()
+    stale_token = f"linux:{'5' * 64}"
+    state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=recycled_pid,
+        controller_start_token=stale_token,
+    )
+
+    live_token = _controller_token(recycled_pid)
+    assert live_token != stale_token
+    recovered = _begin_instance_state_deployment(
+        channel=channel,
+        instance_state_root=state,
+        host_global_root=ownership,
+        legacy_path=tmp_path / "legacy.md",
+        controller_pid=recycled_pid,
+        controller_start_token=live_token,
+    )
+
+    assert recovered["controller"] == {"pid": recycled_pid, "start_token": live_token}
+
+
+def test_runtime_consumer_unblocked_after_abandoned_deployment(tmp_path: Path) -> None:
+    """AC: a runtime consumer started after an abandoned deployment is not
+    blocked by residue from that deployment."""
+
+    channel = "prod"
+    controller_pid = os.getpid()
+    controller_token = _controller_token(controller_pid)
+    state, ownership, _fence = _begin(
+        tmp_path,
+        channel=channel,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    with pytest.raises(RegistryError, match="blocks every runtime consumer"):
+        _preflight_runtime(
+            channel=channel,
+            instance_state_root=state,
+            host_global_root=ownership,
+            consumer="api",
+        )
+
+    _release_instance_state_deployment_lease(
+        channel=channel,
+        host_global_root=ownership,
+        controller_pid=controller_pid,
+        controller_start_token=controller_token,
+    )
+
+    assert not _any_deployment_lease_exists(ownership)
+    assert not _deployment_fence_path(ownership, channel).exists()
+
+    # Residue is gone: the preflight now fails later in the chain (the
+    # registry producer was never initialized in this test), never on the
+    # lease/fence guards the abandoned deployment used to trip.
+    with pytest.raises(
+        InstanceStatePreflightError,
+        match="instance-state registry producer has not initialized",
+    ):
+        _preflight_runtime(
+            channel=channel,
+            instance_state_root=state,
+            host_global_root=ownership,
+            consumer="api",
+        )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4537

## Linked Issue
Closes #4537

## SBS Impact
- Primary subsystem: Builder System - release/deploy workflow
- Secondary subsystem(s): Product/Runtime instance-state ownership substrate
- Write class: authority-bearing
- Persistence impact: durable
- Derived/rebuildable impact: an abandoned deployment stops poisoning later deployments and later runtime starts
- New or changed contract: none
- Owner-doc impact: updated-in-PR
- Transition debt impact: reduces
- Boundary risk: a lease held by a live controller must remain fatal; reclaim/release must never be reachable by a racing second deployment; release is self-scoped to the caller's own controller identity

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Release the abandoned host-global deployment lease, public copy, and channel restart fence on producer failure between deployment-begin and deployment-finish, self-scoped to the caller's own controller identity.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 implementation PR; no BuilderOps record material (no plan divergence, no docs-freshness/roadmap finding) beyond the governing Issue itself.

## Notes
ruff check app tests companion-ui/companion-app: clean. shellcheck -x scripts/lib/instance_state_deployment.sh: no new findings. pytest tests/ops/test_instance_state_deployment_lease.py (8 passed), tests/ops/test_instance_state_volume_contract.py, tests/deploy/test_deploy_channel.py: 139 passed, 3 skipped. Independent fresh-subagent concurrency review on the local publishable SHA: clean PASS, no P0/P1; the two P2/P3 findings were fixed in a follow-up commit rather than deferred.
