### PR TITLE
fix(heimdal): stop screen ingress from admitting under a client-chosen consent scope

### DIFF
--- a/app/heimdal/screen_capture.py
+++ b/app/heimdal/screen_capture.py
@@ -60,7 +60,10 @@ def ingest_screen_bundle(bundle: Mapping[str, Any], *, key: bytes | None = None)
         device=str(sensor_data.get("machine", "")),
     )
     _assert_sensor_registered(sensor)
-    admitted = admit_raw_evidence(scope=str(bundle.get("scope", SCREEN_CAPTURE_SCOPE)))
+    # The admitting scope is always the screen lane's own scope, never a
+    # value read from the client-supplied bundle: a screen client must not
+    # be able to name another lane's standing grant to admit its capture.
+    admitted = admit_raw_evidence(scope=SCREEN_CAPTURE_SCOPE)
 
     raw_payload = bundle.get("raw")
     if raw_payload is None:

--- a/tests/heimdal/test_screen_capture_endpoint.py
+++ b/tests/heimdal/test_screen_capture_endpoint.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import secrets
 
 import pytest
+from fastapi import HTTPException
 
 from app.heimdal.capture_adapter import register_sensor
-from app.heimdal.consent_ledger import grant_consent, reset_memory_consent_ledger
+from app.heimdal.consent_ledger import (
+    ConsentRefusedError,
+    MEDIA_CAPTURE_SCOPE,
+    SELF_RECORD_SCOPE,
+    grant_consent,
+    reset_memory_consent_ledger,
+)
 from app.heimdal.observation_log import count_observations, reset_memory_observation_log
 from app.heimdal.raw_store import all_raw_records, reset_memory_raw_store
 from app.heimdal import screen_capture
@@ -87,3 +94,55 @@ def test_both_bundle_shapes_accepted():
     derived["derived_observation"]["modality"] = "speech"
     with pytest.raises(ValueError, match="modality must be screen"):
         ingest_screen_bundle(derived, key=_KEY)
+
+
+def test_client_supplied_scope_cannot_select_another_lanes_grant():
+    """A screen client naming another lane's standing scope must not be admitted under it.
+
+    `reset_memory_consent_ledger` (invoked by the autouse fixture before this
+    test's own reset below) seeds the standing `SELF_RECORD_SCOPE` and
+    `MEDIA_CAPTURE_SCOPE` grants active by default -- the same two scopes the
+    Issue reproduces the defect against. This test drives the production
+    route so it also proves the route does not forward a client-controlled
+    `scope` field.
+    """
+    from app.api.routes.heimdal_screen import capture_screen_bundle
+
+    # Start from a ledger with no screen_always_on grant, but with the two
+    # other lanes' standing grants still seeded and active.
+    reset_memory_consent_ledger()
+    register_sensor("screen-test", "v1")
+
+    for foreign_scope in (SELF_RECORD_SCOPE, MEDIA_CAPTURE_SCOPE):
+        before = len(all_raw_records())
+        payload = bundle()
+        payload["scope"] = foreign_scope
+        with pytest.raises(HTTPException) as excinfo:
+            capture_screen_bundle(payload)
+        assert excinfo.value.status_code == 400
+        assert len(all_raw_records()) == before
+    assert count_observations() == 0
+
+
+def test_screen_bundle_admits_under_the_screen_grant():
+    """With an active screen_always_on grant, a normal bundle admits and is
+    stamped with that grant -- not a foreign one, even if named."""
+    from app.api.routes.heimdal_screen import capture_screen_bundle
+
+    payload = bundle()
+    payload["scope"] = MEDIA_CAPTURE_SCOPE  # a client-named foreign scope must be ignored
+    ack = capture_screen_bundle(payload)
+    assert ack["created"] and ack["record_id"]
+    records = all_raw_records()
+    assert len(records) == 1
+    assert records[0].consent["grant_ref"] == "screen-test-grant"
+
+
+def test_screen_capture_refused_without_a_screen_grant():
+    """With no screen_always_on grant, a default-scope bundle is still refused."""
+    reset_memory_consent_ledger()
+    register_sensor("screen-test", "v1")
+
+    with pytest.raises(ConsentRefusedError):
+        ingest_screen_bundle(bundle(), key=_KEY)
+    assert len(all_raw_records()) == 0


### PR DESCRIPTION
Governing-Issue: #4497

Fixes #4497

Final-Review-Rounds: 2

## Summary
`POST /api/heimdal/screen/capture` resolved its consent-admission scope from the client-supplied
request body (`bundle.get("scope", SCREEN_CAPTURE_SCOPE)`), so a screen client naming another
lane's always-active standing grant (`device+adapter:v1-voice-memo` or
`device+adapter:v1-media-ingress`) was admitted under that lane's `grant_ref` with no
`screen_always_on` grant of its own — a HEIM-3 structural-OFF-default violation and false
provenance on the stamped raw record. `ingest_screen_bundle` now always admits under the
server-side `SCREEN_CAPTURE_SCOPE` constant; no client-supplied field can select the admitting
scope. No `screen_always_on` grant is seeded (owner consent decision, out of scope per the Issue).

## Risk surfaces
security, auth (consent-gate admission scope selection). Runtime surface on a declared high-risk
TCD category, so two consecutive clean independent review rounds were run (not one):

- **Round 1** (pre-CI mechanism convergence, before expensive validation): fresh independent
  reviewer, verdict CLEAN. Confirmed the fix removes every path for a client-supplied scope to
  reach `admit_raw_evidence`, confirmed the new tests fail against the pre-fix code reproducing the
  Issue's exact false-provenance stamp, confirmed no scope creep.
- **Round 2** (post-CI-green, before merge): second fresh independent reviewer, verdict CLEAN.
  Independently re-derived the same result, re-ran the mutation check (reverting the fix reproduces
  `assert 'grant-media-capture-v1' == 'screen-test-grant'` — the Issue's exact symptom), reconfirmed
  proportionality and commit-message hygiene (no closing keyword in the commit body). Two
  non-blocking P3 notes recorded, no P0/P1.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 bounded bug-fix slice with no plan divergence; no BuilderOps material routed.

## Notes
Validation:
- `python3 -m pytest tests/heimdal/test_screen_capture_endpoint.py tests/heimdal/test_screen_observation_contract.py tests/heimdal/test_consent_ledger.py -m "not pg"` — 30 passed, 1 deselected
- `ruff check app tests companion-ui/companion-app` — clean
- `mypy app` — clean
- `python3 scripts/docs_guard.py` — OK
- `python3 scripts/public_seam_lint.py --mode gate` — clean (0 secret/uncovered/stale/migration-pending)
- CI: all required and repo-standard checks green on head SHA `f32f41155` (Unit tests (not pg), pr-contract, smoke, CodeQL, import-linter, contract-validation, Index PG contracts, evidence-pack)
---