### PR TITLE
docs: add missing State: header to SEMANTIC_MARKDOWN_MERGE_DRIVER.md

### DIFF
--- a/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
+++ b/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
@@ -1,3 +1,5 @@
+State: Current-state contract for the `semanticmd` git merge driver; aligned with shipped behavior (#4505 routing narrowing, #4561 `%A` result write).
+
 # Semantic Markdown merge driver (`semanticmd`)
 
 Owner: Builder System (git tooling) / Product vault-sync (resolver logic).


### PR DESCRIPTION
## Direct Repair
Type: docs
Reason: `tests/architecture/test_docs_index.py::test_all_docs_have_state_or_are_exempt` fails on every full `Unit tests (not pg)` run because #4561 (commit 05c7e2196) added `docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md` without a `State:` header; the defect stayed latent on main because path filters skipped the job there, and it now blocks unrelated PRs (first observed red on PR #4563, a docs-only audit). Bounded two-line header addition, no content change.
Validation: `python3 -m pytest tests/architecture/test_docs_index.py::test_all_docs_have_state_or_are_exempt -q` — 1 passed (was failing with this exact file listed).
Issue required: no

Final-Review-Rounds: 0

## Summary
Adds the required `State:` line to the semanticmd merge-driver contract doc so the docs-state census passes again on full CI runs.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 direct docs repair; no BuilderOps material routed.

## Notes
Validation: focused failing test now green; no other surface touched.
---
🤖 Generated with [Claude Code](https://claude.com/claude-code)