### PR TITLE
Add the Heimdal screen derivation stage: local-vision derivation, span coalescing, governed publish

### DIFF
--- a/app/heimdal/screen_context_providers.py
+++ b/app/heimdal/screen_context_providers.py
@@ -1,0 +1,160 @@
+"""Local context providers for the screen derivation stage (SCREEN-02, #3344).
+
+Specified by `docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md`
+:: What This Task Does step 2: the frontmost app/window is **provider #1**;
+others (active calendar event, the frontmost editor's git branch,
+playing media) plug in as declared providers "without changing the derivation
+contract".
+
+Two rules define this seam and are the reason it is a registry rather than a
+growing parameter list on the stage:
+
+- **Providers run host-side over the already-read bundle.** A provider is
+  handed the decoded frame bundle the gated raw read (HEIM-5) already
+  produced. None of them re-reads the screen, opens a new raw handle, or
+  reaches any network, so adding one adds no new evidence path and no new
+  egress surface to review.
+- **Providers enrich, they do not decide.** A contribution is context
+  (`facts`), surfaced mentions, and optionally the segmenter `dimensions` the
+  span coalescer keys on. A provider never publishes, never resolves a
+  canonical identity, and cannot change the observation payload contract --
+  which is what keeps "add a provider" a local change rather than a contract
+  change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple
+
+#: Provider #1 -- the frontmost app/window metadata captured with the frame.
+FRONTMOST_APP_PROVIDER = "frontmost_app"
+
+
+@dataclass(frozen=True)
+class FrameContext:
+    """What a provider may read: one already-gated frame bundle, nothing more."""
+
+    raw_ref: str
+    observed_at: str
+    bundle: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ContextContribution:
+    """One provider's contribution to a frame's derivation.
+
+    ``facts`` are short human-legible context lines (they reach both the local
+    model's prompt and the published markdown), ``mentions`` are surfaced
+    entity mentions (never canonical identities -- resolution is stamped
+    ``unresolved`` downstream, HEIM-6/HEIM-11), and ``dimensions`` are the
+    segmenter axes this provider is authoritative for (INV-SCREEN-E).
+    """
+
+    provider: str
+    facts: Tuple[str, ...] = ()
+    mentions: Tuple[Mapping[str, Any], ...] = ()
+    dimensions: Mapping[str, str] = field(default_factory=dict)
+
+
+ContextProvider = Callable[[FrameContext], Optional[ContextContribution]]
+
+
+def _bundle_value(bundle: Mapping[str, Any], key: str) -> str:
+    value = bundle.get(key)
+    return str(value).strip() if value is not None else ""
+
+
+def frontmost_app_provider(context: FrameContext) -> Optional[ContextContribution]:
+    """Provider #1: the frontmost app / window / capture scope of this frame.
+
+    These are the three metadata dimensions the client captures alongside the
+    pixels; the fourth segmenter dimension (the derived goal) comes from the
+    derivation itself, not from a provider.
+    """
+    app = _bundle_value(context.bundle, "app")
+    window = _bundle_value(context.bundle, "window")
+    scope = _bundle_value(context.bundle, "scope")
+
+    facts = []
+    mentions = []
+    if app:
+        facts.append(f"frontmost app: {app}")
+        mentions.append({"surface_form": app, "kind_hint": "app"})
+    if window:
+        facts.append(f"window: {window}")
+        mentions.append({"surface_form": window, "kind_hint": "document"})
+    if scope:
+        facts.append(f"capture scope: {scope}")
+
+    return ContextContribution(
+        provider=FRONTMOST_APP_PROVIDER,
+        facts=tuple(facts),
+        mentions=tuple(mentions),
+        dimensions={"app": app, "window": window, "scope": scope},
+    )
+
+
+def _default_registry() -> Dict[str, ContextProvider]:
+    return {FRONTMOST_APP_PROVIDER: frontmost_app_provider}
+
+
+_REGISTRY: Dict[str, ContextProvider] = _default_registry()
+
+
+def register_context_provider(name: str, provider: ContextProvider) -> None:
+    """Register one local context provider under a stable name.
+
+    Refuses a duplicate name loudly rather than silently replacing a
+    registered provider: two providers quietly sharing a name would make the
+    derived observation depend on import order.
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"context provider name must be a non-empty string, got {name!r}")
+    if not callable(provider):
+        raise TypeError(f"context provider {name!r} must be callable, got {type(provider)!r}")
+    if name in _REGISTRY:
+        raise ValueError(f"context provider {name!r} is already registered")
+    _REGISTRY[name] = provider
+
+
+def unregister_context_provider(name: str) -> None:
+    """Remove a registered provider (raises if it was never registered)."""
+    if name not in _REGISTRY:
+        raise KeyError(name)
+    del _REGISTRY[name]
+
+
+def registered_context_providers() -> Tuple[Tuple[str, ContextProvider], ...]:
+    """Every registered provider in registration order (deterministic)."""
+    return tuple(_REGISTRY.items())
+
+
+def reset_context_providers() -> None:
+    """Restore the built-in provider set (test/dev reset hook)."""
+    _REGISTRY.clear()
+    _REGISTRY.update(_default_registry())
+
+
+def collect_context(context: FrameContext) -> Tuple[ContextContribution, ...]:
+    """Run every registered provider over one frame, in registration order."""
+    contributions = []
+    for _, provider in registered_context_providers():
+        contribution = provider(context)
+        if contribution is not None:
+            contributions.append(contribution)
+    return tuple(contributions)
+
+
+__all__ = [
+    "ContextContribution",
+    "ContextProvider",
+    "FRONTMOST_APP_PROVIDER",
+    "FrameContext",
+    "collect_context",
+    "frontmost_app_provider",
+    "register_context_provider",
+    "registered_context_providers",
+    "reset_context_providers",
+    "unregister_context_provider",
+]

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -365,7 +365,10 @@ def resolve_local_vision_endpoint() -> str:
             "cannot be proven host-local (HEIM-12). No frame was transmitted."
         )
     if hostname in _LOOPBACK_HOSTNAMES or hostname in _declared_host_local_hostnames():
-        return host
+        # Return the string that was actually validated, never the raw input:
+        # `OLLAMA_HOST=127.0.0.1:11434` (the scheme-less form Ollama's own docs
+        # use) must not validate one value and then transmit to another.
+        return candidate
 
     raise RawEgressRefusedError(
         f"Refusing to derive: vision endpoint host {hostname!r} is not loopback and is not "
@@ -407,11 +410,17 @@ def _iso_utc(value: Any) -> str:
 
 
 def _as_moment(value: str) -> Optional[datetime]:
-    """Parse an observed-at stamp, or None when it is not a parseable instant."""
+    """Parse an observed-at stamp, or None when it is not a parseable instant.
+
+    A naive stamp is read as UTC rather than returned naive: comparing a naive
+    against an aware datetime raises `TypeError`, which would crash a whole
+    tick instead of producing a governed refusal.
+    """
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        moment = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except (TypeError, ValueError):
         return None
+    return moment if moment.tzinfo is not None else moment.replace(tzinfo=timezone.utc)
 
 
 def _decode_frame_bundle(plaintext: bytes) -> Mapping[str, Any]:
@@ -528,8 +537,8 @@ def _invoke_local_vision(
     return _parse_vision_content(content)
 
 
-def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
-    """POST one already-validated host-local vision request.
+def local_vision_session() -> Any:
+    """Build the HTTP session used to reach the host-local vision model.
 
     ``trust_env`` is disabled deliberately: `requests` otherwise honours
     ``HTTP_PROXY``/``HTTPS_PROXY``/``ALL_PROXY`` from the environment, which
@@ -542,6 +551,12 @@ def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
 
     session = requests.Session()
     session.trust_env = False
+    return session
+
+
+def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
+    """POST one already-validated host-local vision request."""
+    session = local_vision_session()
     try:
         response = session.post(
             endpoint.rstrip("/") + "/api/chat",
@@ -889,16 +904,26 @@ def _span_key(dimensions: Mapping[str, str]) -> Tuple[Tuple[str, str], ...]:
 def _coalesces_into(previous: Mapping[str, str], current: Mapping[str, str]) -> bool:
     """Whether ``current`` continues ``previous``'s activity.
 
-    Unknown is never equal to unknown: if any dimension is empty on either side
-    (a client without Accessibility permission reports no window title; a failed
-    frontmost-app lookup reports no app; a model that names no goal), the frames
-    are NOT merged. Missing metadata degrades to over-segmentation -- a cheap
-    downstream re-cut -- never to one observation claiming a single activity
-    across an arbitrarily long window.
+    Two rules, in order:
+
+    1. every contributed dimension must match -- including axes a provider
+       declared itself, not just the four built-ins;
+    2. at least one dimension must actually be *known*. Unknown is not evidence
+       of sameness: a client without Accessibility permission reports no window
+       title, a failed frontmost-app lookup reports no app, and a model that
+       answers in plain text names no goal. All-unknown frames are never
+       merged, so missing metadata degrades to over-segmentation -- a cheap
+       downstream re-cut -- rather than one observation claiming a single
+       activity across an arbitrarily long window.
+
+    Rule 2 is deliberately "at least one", not "all": requiring every axis
+    would mean a single unknown dimension (a model that omits `goal`) switches
+    coalescing off entirely and floods the stream, which is the failure AC3's
+    merge direction exists to prevent.
     """
     if _span_key(previous) != _span_key(current):
         return False
-    return all(str(value).strip() for value in current.values())
+    return any(str(value).strip() for value in current.values())
 
 
 def _runs_backwards(open_end: str, candidate: str) -> bool:
@@ -931,8 +956,10 @@ def derive_activity_observations(
     batch (over-segmentation is the preferred direction -- SCREEN-04 can merge
     downstream, it cannot invent a boundary that was never recorded).
 
-    ``vision_runner`` is the injection seam for tests and for a host that
-    serves the local model differently; production callers omit it.
+    ``vision_runner`` is a **test injection seam**. An injected runner replaces
+    the whole model call, including :func:`resolve_local_vision_endpoint`, so
+    an injector owns its own egress boundary and this stage's host-local
+    guarantee does not extend to it. Production callers omit it.
     """
     if not isinstance(episode_id, str) or not episode_id.strip():
         raise ValueError(f"episode_id must be a non-empty string, got {episode_id!r}")

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -23,12 +23,24 @@ What this module owns (issue Acceptance Criteria):
   path in this module to degrade into -- that is the structural off-switch for
   the raw-pixel egress seam, and it is declared here as
   :data:`DECLARED_EGRESS` (HEIM-12: zero raw-class egress).
+- **The destination is validated, not just the provider name.** A census entry
+  proves a provider *name* is local; it cannot prove that the socket a
+  decrypted frame is about to be written to is on this machine.
+  :func:`resolve_local_vision_endpoint` closes that half: the resolved endpoint
+  must be loopback, or a hostname the operator explicitly declared host-local
+  (:data:`HOST_LOCAL_VISION_ALLOWLIST_ENV`), or the derivation is refused
+  (:class:`RawEgressRefusedError`) before the frame is attached to any request.
+  The request also runs with ``trust_env`` disabled, so an ambient proxy cannot
+  carry a loopback-addressed frame off the host.
 - **Span coalescing (INV-SCREEN-E).** Consecutive frames whose activity is
   unchanged collapse into one span observation with a real
   ``observed_at_start``/``observed_at_end``. A boundary is created on **any**
-  dimension shift -- frontmost app, window/document, capture scope, or derived
-  goal. Over-segmentation is the preferred direction: a spurious boundary is a
-  cheap downstream re-cut, a lost one is unrecoverable.
+  dimension shift -- frontmost app, window/document, capture scope, derived
+  goal, or an axis a context provider declares itself. Unknown never equals
+  unknown: an empty dimension forces a boundary rather than merging. Frames out
+  of capture order force a boundary too. Over-segmentation is the preferred
+  direction: a spurious boundary is a cheap downstream re-cut, a lost one is
+  unrecoverable.
 - **Provenance stamped in the same write, or no write (INV-SCREEN-B).** A span
   that derived text but cannot stamp complete provenance (machine-bearing
   sensor, capture chain, content identity from the read receipt, observed-at
@@ -56,9 +68,10 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from datetime import timezone
+from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 from app.components.settings.providers_loader import ProviderCensus, load_provider_census
 from app.heimdal.publish import assemble_observation_payload, publish_full_observation
@@ -147,6 +160,14 @@ class ScreenFrameUndecodableError(ValueError):
     """Raised when a gated read does not yield a decodable screen frame bundle."""
 
 
+class ContextDimensionConflictError(ValueError):
+    """Raised when two context providers claim the same segmenter dimension.
+
+    Silent last-writer-wins here would move a span boundary invisibly, so the
+    ambiguity is refused instead of resolved by registration order.
+    """
+
+
 @dataclass(frozen=True)
 class DerivationRoute:
     """The compiled model route for one derivation tick."""
@@ -173,6 +194,10 @@ class ScreenFrame:
     capture_chain: Tuple[str, ...]
     consent: Mapping[str, Any]
     scope_hint: Optional[str] = None
+    #: Which clock ``observed_at`` came from. ``inferred`` when the capture
+    #: carried no device clock and ingest time stood in for it -- timing
+    #: uncertainty is stated, never silently faked (HEIM-10).
+    clock_basis: str = "device_metadata"
 
 
 @dataclass(frozen=True)
@@ -222,7 +247,6 @@ class ScreenDerivationTick:
     observations_published: int
     coalesced: int
     spans: Tuple[ActivitySpan, ...]
-    raw_egress: str = "none"
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +305,78 @@ def resolve_derivation_route(*, census: Optional[ProviderCensus] = None) -> Deri
 
 
 # ---------------------------------------------------------------------------
+# Egress destination -- the other half of the local-only guarantee
+# ---------------------------------------------------------------------------
+
+#: Addresses that are host-local by construction.
+_LOOPBACK_HOSTNAMES = frozenset({"127.0.0.1", "::1", "localhost", "localhost.localdomain"})
+
+#: Operator declaration that a named, non-loopback endpoint is still inside the
+#: host trust boundary -- the container-network case (`http://ollama:11434` in
+#: this repo's own compose files). Comma-separated hostnames. Empty/unset means
+#: loopback only; this never widens silently, exactly like
+#: ``HEIMDAL_RAW_READ_ALLOWLIST``.
+HOST_LOCAL_VISION_ALLOWLIST_ENV = "HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS"
+
+
+class RawEgressRefusedError(RuntimeError):
+    """Raised when the resolved vision endpoint is not provably host-local.
+
+    HEIM-12 / :data:`DECLARED_EGRESS`: raw-class evidence never leaves the host
+    trust boundary. The provider census proves a provider *name* is
+    ``tier: local``; it cannot prove that the socket the stage is about to send
+    a decrypted frame to is on this machine. This is that second check, and it
+    fails closed -- refused before the frame is attached to any request.
+    """
+
+
+def _declared_host_local_hostnames() -> frozenset:
+    raw = os.getenv(HOST_LOCAL_VISION_ALLOWLIST_ENV, "")
+    return frozenset(item.strip().lower() for item in raw.split(",") if item.strip())
+
+
+def resolve_local_vision_endpoint() -> str:
+    """Resolve the local vision endpoint, refusing any non-host-local destination.
+
+    Reads only the Ollama-specific host variables -- deliberately not the
+    generic runtime chat env, which is provider-routable and could resolve to a
+    remote provider. The resolved address must then be loopback, or a hostname
+    the operator explicitly declared host-local via
+    :data:`HOST_LOCAL_VISION_ALLOWLIST_ENV`. Anything else raises
+    :class:`RawEgressRefusedError` before a frame is transmitted.
+    """
+    host = (
+        os.getenv("OLLAMA_BASE_URL", "").strip()
+        or os.getenv("OLLAMA_HOST", "").strip()
+        or os.getenv("OLLAMA_URL", "").strip()
+    )
+    if not host:
+        raise LocalVisionUnavailableError(
+            "No local model host configured (OLLAMA_BASE_URL, OLLAMA_HOST, or OLLAMA_URL). "
+            "Screen derivation is local-only -- there is no remote fallback; the frames stay "
+            "buffered until the local vision model is available."
+        )
+
+    candidate = host if "://" in host else f"http://{host}"
+    hostname = (urlparse(candidate).hostname or "").strip().lower()
+    if not hostname:
+        raise RawEgressRefusedError(
+            f"Refusing to derive: vision endpoint {host!r} names no resolvable host, so it "
+            "cannot be proven host-local (HEIM-12). No frame was transmitted."
+        )
+    if hostname in _LOOPBACK_HOSTNAMES or hostname in _declared_host_local_hostnames():
+        return host
+
+    raise RawEgressRefusedError(
+        f"Refusing to derive: vision endpoint host {hostname!r} is not loopback and is not "
+        f"declared host-local in {HOST_LOCAL_VISION_ALLOWLIST_ENV}. Raw screen frames never "
+        "leave the host trust boundary (HEIM-12, DECLARED_EGRESS raw_class_egress=false). "
+        "No frame was transmitted. Point the stage at a host-local model, or declare the "
+        "endpoint host-local explicitly if it really is inside this machine's boundary."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Frames
 # ---------------------------------------------------------------------------
 
@@ -294,20 +390,28 @@ def screen_frame_from_raw_record(record: Any, *, observed_at: Optional[str] = No
     dependency on the raw layer: the gate. ``observed_at`` defaults to the
     record's ingest time when the capture did not carry a device clock.
     """
-    resolved_observed_at = observed_at or _iso_utc(record.ingested_at)
     return ScreenFrame(
         raw_ref=raw_ref_for(record),
-        observed_at=resolved_observed_at,
+        observed_at=observed_at or _iso_utc(record.ingested_at),
         sensor=dict(record.sensor or {}),
         capture_chain=tuple(record.capture_chain or ()),
         consent=dict(record.consent or {}),
         scope_hint=str((record.payload or {}).get("scope") or "") or None,
+        clock_basis="device_metadata" if observed_at else "inferred",
     )
 
 
 def _iso_utc(value: Any) -> str:
     moment = value.astimezone(timezone.utc)
     return moment.isoformat().replace("+00:00", "Z")
+
+
+def _as_moment(value: str) -> Optional[datetime]:
+    """Parse an observed-at stamp, or None when it is not a parseable instant."""
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
 
 
 def _decode_frame_bundle(plaintext: bytes) -> Mapping[str, Any]:
@@ -342,13 +446,29 @@ def _decode_frame_bundle(plaintext: bytes) -> Mapping[str, Any]:
 def _merge_contributions(
     contributions: Sequence[ContextContribution],
 ) -> Tuple[Tuple[str, ...], List[Dict[str, Any]], Dict[str, str]]:
+    """Fold every provider's contribution, refusing a silent dimension overwrite.
+
+    Last-writer-wins on the segmenter dimensions would let a second provider
+    overwrite provider #1's axis and merge a real boundary away (INV-SCREEN-E,
+    the unrecoverable direction), so a collision is a loud error rather than a
+    quiet reassignment.
+    """
     facts: List[str] = []
     mentions: List[Dict[str, Any]] = []
     dimensions: Dict[str, str] = {}
+    claimed_by: Dict[str, str] = {}
     for contribution in contributions:
         facts.extend(contribution.facts)
         mentions.extend(dict(mention) for mention in contribution.mentions)
-        dimensions.update({key: str(value) for key, value in contribution.dimensions.items()})
+        for key, value in contribution.dimensions.items():
+            if key in claimed_by:
+                raise ContextDimensionConflictError(
+                    f"Context provider {contribution.provider!r} sets segmenter dimension "
+                    f"{key!r}, which {claimed_by[key]!r} already set. Two providers cannot own "
+                    "one dimension: the later write would silently move a span boundary."
+                )
+            claimed_by[key] = contribution.provider
+            dimensions[key] = str(value)
     return tuple(facts), mentions, dimensions
 
 
@@ -387,31 +507,18 @@ def _invoke_local_vision(
                 f"Local vision (injected runner) failed for model {request.model!r}: {exc}"
             ) from exc
 
-    host = (
-        os.getenv("OLLAMA_BASE_URL", "").strip()
-        or os.getenv("OLLAMA_HOST", "").strip()
-        or os.getenv("OLLAMA_URL", "").strip()
-    )
-    if not host:
-        raise LocalVisionUnavailableError(
-            "No local model host configured (OLLAMA_BASE_URL, OLLAMA_HOST, or OLLAMA_URL). "
-            "Screen derivation is local-only -- there is no remote fallback; the frames stay "
-            "buffered until the local vision model is available."
-        )
+    # Resolve AND validate the destination before the frame is touched: the
+    # census proves a provider *name* is local, it cannot prove a socket is.
+    endpoint = resolve_local_vision_endpoint()
 
+    message: Dict[str, Any] = {"role": "user", "content": request.prompt}
+    if request.image:
+        message["images"] = [request.image]
     try:
-        import requests  # type: ignore[import-untyped]
-
-        message: Dict[str, Any] = {"role": "user", "content": request.prompt}
-        if request.image:
-            message["images"] = [request.image]
-        response = requests.post(
-            host.rstrip("/") + "/api/chat",
-            json={"model": request.model, "messages": [message], "stream": False},
-            timeout=float(os.getenv("HEIMDAL_SCREEN_VISION_TIMEOUT", "120")),
+        content = _post_local_vision(
+            endpoint,
+            {"model": request.model, "messages": [message], "stream": False},
         )
-        response.raise_for_status()
-        content = response.json()["message"]["content"]
     except Exception as exc:
         raise LocalVisionUnavailableError(
             f"Local vision model {request.model!r} failed on the host: {exc}. Screen derivation "
@@ -419,6 +526,32 @@ def _invoke_local_vision(
         ) from exc
 
     return _parse_vision_content(content)
+
+
+def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
+    """POST one already-validated host-local vision request.
+
+    ``trust_env`` is disabled deliberately: `requests` otherwise honours
+    ``HTTP_PROXY``/``HTTPS_PROXY``/``ALL_PROXY`` from the environment, which
+    would let an ambient proxy carry a loopback-addressed raw frame off the
+    host after :func:`resolve_local_vision_endpoint` proved the address itself
+    host-local. Validating the address and then handing the request to an
+    env-configurable proxy would defeat the whole guarantee.
+    """
+    import requests  # type: ignore[import-untyped]
+
+    session = requests.Session()
+    session.trust_env = False
+    try:
+        response = session.post(
+            endpoint.rstrip("/") + "/api/chat",
+            json=dict(body),
+            timeout=float(os.getenv("HEIMDAL_SCREEN_VISION_TIMEOUT", "120")),
+        )
+        response.raise_for_status()
+        return response.json()["message"]["content"]
+    finally:
+        session.close()
 
 
 def _parse_vision_content(content: Any) -> Mapping[str, Any]:
@@ -538,17 +671,19 @@ def _render_content(span: ActivitySpan) -> str:
     return "\n".join(lines)
 
 
-def _observation_id(episode_id: str, span: ActivitySpan, content: str) -> str:
+def _observation_id(episode_id: str, span: ActivitySpan) -> str:
+    """Identity of one span, derived from the EVIDENCE it covers.
+
+    Deliberately not derived from the model's text: a local vision model
+    rewording its summary by one token on replay would otherwise mint a new,
+    unlinked identity and append a duplicate observation for the same frames
+    (double-counted time-spend downstream). Keyed on the covered frames'
+    content identities, a replay lands on the same ``observation_id``, so
+    differing model text becomes a genuine revision through the
+    ``stage_versions`` fingerprint instead of a second unrelated row.
+    """
     digest = hashlib.sha256(
-        "|".join(
-            [
-                episode_id,
-                span.observed_at_start,
-                span.observed_at_end,
-                json.dumps(dict(span.dimensions), sort_keys=True),
-                content,
-            ]
-        ).encode("utf-8")
+        "|".join([episode_id, *span.content_identities]).encode("utf-8")
     ).hexdigest()
     return f"screen-obs-{digest[:32]}"
 
@@ -589,13 +724,20 @@ def _assert_complete_provenance(provenance: Mapping[str, Any], span: ActivitySpa
         raise UnprovenancedObservationError(
             "Refusing to publish: the observed-at window is incomplete."
         )
+    start = _as_moment(span.observed_at_start)
+    end = _as_moment(span.observed_at_end)
+    if start is not None and end is not None and end < start:
+        raise UnprovenancedObservationError(
+            f"Refusing to publish: the observed-at window runs backwards "
+            f"({span.observed_at_start} -> {span.observed_at_end}). A span cannot end before "
+            "it began (HEIM-10 bitemporal honesty)."
+        )
 
 
 def _publish_span(
     span: ActivitySpan,
     *,
     episode_id: str,
-    sequence: int,
     route: DerivationRoute,
 ) -> bool:
     content = _render_content(span)
@@ -617,12 +759,18 @@ def _publish_span(
         if isinstance(mention.get("confidence"), (int, float))
     ]
     payload = assemble_observation_payload(
-        observation_id=_observation_id(episode_id, span, content),
+        observation_id=_observation_id(episode_id, span),
         episode_id=episode_id,
         observed_at_start=span.observed_at_start,
         observed_at_end=span.observed_at_end,
-        clock_basis="device_metadata",
-        sequence=sequence,
+        clock_basis=span.frame.clock_basis,
+        # Deliberately unset: the schema documents `sequence` as monotone
+        # WITHIN THE EPISODE, and this stage only ever sees one tick's batch.
+        # A tick-local counter would be a false claim, and because it is folded
+        # into the publish fingerprint it would also make a replayed span at a
+        # different batch index derive a fresh idempotency key and duplicate the
+        # row -- the exact failure the idempotency key exists to prevent.
+        sequence=None,
         attributions=[
             {
                 "mention_id": "operator",
@@ -727,8 +875,43 @@ class _OpenSpan:
         )
 
 
-def _span_key(dimensions: Mapping[str, str]) -> Tuple[str, ...]:
-    return tuple(str(dimensions.get(name, "")) for name in SPAN_DIMENSIONS)
+def _span_key(dimensions: Mapping[str, str]) -> Tuple[Tuple[str, str], ...]:
+    """Key a span on EVERY contributed dimension, not just the four built-ins.
+
+    A provider that declares an axis of its own (the registry explicitly invites
+    this) must be able to cut a span; ignoring its dimension would merge a real
+    boundary away. Extra dimensions can only ever add boundaries, which is the
+    preferred direction.
+    """
+    return tuple(sorted((str(key), str(value)) for key, value in dimensions.items()))
+
+
+def _coalesces_into(previous: Mapping[str, str], current: Mapping[str, str]) -> bool:
+    """Whether ``current`` continues ``previous``'s activity.
+
+    Unknown is never equal to unknown: if any dimension is empty on either side
+    (a client without Accessibility permission reports no window title; a failed
+    frontmost-app lookup reports no app; a model that names no goal), the frames
+    are NOT merged. Missing metadata degrades to over-segmentation -- a cheap
+    downstream re-cut -- never to one observation claiming a single activity
+    across an arbitrarily long window.
+    """
+    if _span_key(previous) != _span_key(current):
+        return False
+    return all(str(value).strip() for value in current.values())
+
+
+def _runs_backwards(open_end: str, candidate: str) -> bool:
+    """Whether extending a span with ``candidate`` would invert its window.
+
+    Frames are expected in capture order; an out-of-order frame forces a
+    boundary instead of publishing a span that ends before it began.
+    """
+    end = _as_moment(open_end)
+    moment = _as_moment(candidate)
+    if end is None or moment is None:
+        return False
+    return moment < end
 
 
 def derive_activity_observations(
@@ -759,7 +942,6 @@ def derive_activity_observations(
     spans: List[ActivitySpan] = []
     published = 0
     coalesced = 0
-    sequence = 0
     open_span: Optional[_OpenSpan] = None
 
     for frame in frames:
@@ -769,15 +951,18 @@ def derive_activity_observations(
             key=key,
             vision_runner=vision_runner,
         )
-        if open_span is not None and _span_key(open_span.dimensions) == _span_key(dimensions):
+        if (
+            open_span is not None
+            and _coalesces_into(open_span.dimensions, dimensions)
+            and not _runs_backwards(open_span.observed_at_end, frame.observed_at)
+        ):
             open_span.extend(frame, content_identity)
             coalesced += 1
             continue
         if open_span is not None:
             span = open_span.close()
             spans.append(span)
-            published += int(_publish_span(span, episode_id=episode_id, sequence=sequence, route=route))
-            sequence += 1
+            published += int(_publish_span(span, episode_id=episode_id, route=route))
         open_span = _OpenSpan(
             frame=frame,
             dimensions=dimensions,
@@ -790,7 +975,7 @@ def derive_activity_observations(
     if open_span is not None:
         span = open_span.close()
         spans.append(span)
-        published += int(_publish_span(span, episode_id=episode_id, sequence=sequence, route=route))
+        published += int(_publish_span(span, episode_id=episode_id, route=route))
 
     return ScreenDerivationTick(
         route=route,
@@ -803,7 +988,11 @@ def derive_activity_observations(
 
 __all__ = [
     "ActivitySpan",
+    "ContextDimensionConflictError",
     "DECLARED_EGRESS",
+    "HOST_LOCAL_VISION_ALLOWLIST_ENV",
+    "RawEgressRefusedError",
+    "resolve_local_vision_endpoint",
     "DerivationRoute",
     "DerivedActivity",
     "ENGINE_VERSION",

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -528,6 +528,10 @@ def _invoke_local_vision(
             endpoint,
             {"model": request.model, "messages": [message], "stream": False},
         )
+    except RawEgressRefusedError:
+        # An egress refusal is not a model outage and must never be laundered
+        # into one: it has to reach the operator as what it is.
+        raise
     except Exception as exc:
         raise LocalVisionUnavailableError(
             f"Local vision model {request.model!r} failed on the host: {exc}. Screen derivation "
@@ -555,14 +559,30 @@ def local_vision_session() -> Any:
 
 
 def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
-    """POST one already-validated host-local vision request."""
+    """POST one already-validated host-local vision request.
+
+    Every hop between this call and the socket must stay inside the validated
+    destination, so redirects are refused rather than followed: a 3xx from the
+    local endpoint would otherwise resend the frame body to a ``Location`` that
+    :func:`resolve_local_vision_endpoint` never saw -- the same escape the
+    proxy guard closes, one hop later. A local model has no legitimate reason
+    to redirect ``/api/chat`` elsewhere, so this is fail-loud, not a downgrade.
+    """
     session = local_vision_session()
     try:
         response = session.post(
             endpoint.rstrip("/") + "/api/chat",
             json=dict(body),
             timeout=float(os.getenv("HEIMDAL_SCREEN_VISION_TIMEOUT", "120")),
+            allow_redirects=False,
         )
+        if response.is_redirect or response.is_permanent_redirect:
+            raise RawEgressRefusedError(
+                f"Refusing to follow a redirect from the local vision endpoint "
+                f"{endpoint!r} to {response.headers.get('Location')!r}: the redirect target "
+                "was never validated as host-local, and following it would resend the raw "
+                "frame off the validated destination (HEIM-12)."
+            )
         response.raise_for_status()
         return response.json()["message"]["content"]
     finally:
@@ -639,6 +659,16 @@ def _derive_frame(
         dimensions=dict(dimensions),
     )
     activity = _normalize_activity(_invoke_local_vision(request, vision_runner=vision_runner))
+    # The derived goal is this stage's own contribution to the segmenter axes.
+    # It is held to the same one-writer-per-dimension rule as the providers:
+    # overwriting a provider's `goal` here would make the stage a silent third
+    # writer and could merge away a boundary the provider drew.
+    if "goal" in dimensions:
+        raise ContextDimensionConflictError(
+            "A context provider claims the 'goal' dimension, which the derivation stage itself "
+            "contributes from the local model. Rename the provider's axis: the later write would "
+            "silently move a span boundary."
+        )
     dimensions["goal"] = activity.goal
     return activity, dimensions, facts, provider_mentions, gated.receipt.content_identity
 

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -36,11 +36,13 @@ What this module owns (issue Acceptance Criteria):
   unchanged collapse into one span observation with a real
   ``observed_at_start``/``observed_at_end``. A boundary is created on **any**
   dimension shift -- frontmost app, window/document, capture scope, derived
-  goal, or an axis a context provider declares itself. Unknown never equals
-  unknown: an empty dimension forces a boundary rather than merging. Frames out
-  of capture order force a boundary too. Over-segmentation is the preferred
-  direction: a spurious boundary is a cheap downstream re-cut, a lost one is
-  unrecoverable.
+  goal, or an axis a context provider declares itself. Unknown is not evidence
+  of sameness: frames with NO known dimension never merge, so a blind client
+  over-segments instead of collapsing a long window into one observation (one
+  unknown axis does not switch coalescing off -- that would flood the stream).
+  Frames out of capture order force a boundary too. Over-segmentation is the
+  preferred direction: a spurious boundary is a cheap downstream re-cut, a lost
+  one is unrecoverable.
 - **Provenance stamped in the same write, or no write (INV-SCREEN-B).** A span
   that derived text but cannot stamp complete provenance (machine-bearing
   sensor, capture chain, content identity from the read receipt, observed-at

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -1,0 +1,826 @@
+"""Heimdal screen derivation stage -- frames become one governed activity observation.
+
+SCREEN-02 (#3344), specified by
+`docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md`. This is the
+in-seam derivation stage: the screen analog of the ASR stage
+(`app.heimdal.asr_stage`), and it follows that module's shape deliberately --
+gated raw read in, stage-local derivation, no second writer.
+
+What this module owns (issue Acceptance Criteria):
+
+- **Gated raw read only (HEIM-5).** Frames are resolved exclusively through
+  `app.heimdal.raw_read_gate.read_raw_record` with reader id
+  ``"screen_derivation"``; this module never touches the raw store, a
+  filesystem path, or a decryption key path of its own, so every frame read
+  leaves a receipt and an unallowlisted reader gets bytes from nowhere.
+- **Local-only model routing (RUNTIME_MODEL_POSTURE §1/§4.2).** Screen
+  derivation is an always-on loop, so its task kind
+  (:data:`TASK_KIND`) is structurally paid-ineligible.
+  :func:`resolve_derivation_route` is the compile step: it reads the declared
+  provider census and **rejects** any policy that assigns this task kind to a
+  paid provider (:class:`PaidRouteRejectedError`) before a single frame is
+  read. The resolved route is a local vision model. There is no cloud code
+  path in this module to degrade into -- that is the structural off-switch for
+  the raw-pixel egress seam, and it is declared here as
+  :data:`DECLARED_EGRESS` (HEIM-12: zero raw-class egress).
+- **Span coalescing (INV-SCREEN-E).** Consecutive frames whose activity is
+  unchanged collapse into one span observation with a real
+  ``observed_at_start``/``observed_at_end``. A boundary is created on **any**
+  dimension shift -- frontmost app, window/document, capture scope, or derived
+  goal. Over-segmentation is the preferred direction: a spurious boundary is a
+  cheap downstream re-cut, a lost one is unrecoverable.
+- **Provenance stamped in the same write, or no write (INV-SCREEN-B).** A span
+  that derived text but cannot stamp complete provenance (machine-bearing
+  sensor, capture chain, content identity from the read receipt, observed-at
+  window, `stage_versions` + `model_ref`) raises
+  :class:`UnprovenancedObservationError` and publishes nothing.
+- **Governed publish, reused not reimplemented.** Payloads are assembled and
+  published through `app.heimdal.publish.publish_full_observation` (schema
+  validated, ``content_hash`` stamped in the same durable write,
+  revision-aware idempotency key). The Mimer candidate projector consumes the
+  observation log on its own cursor -- this stage never writes a note.
+
+Out of scope for this slice: the capture endpoint and schema (SCREEN-01, which
+lands the frames this stage reads); the client (SCREEN-03); ERE consumption of
+the spans (SCREEN-04); the time-spend rollup (SCREEN-05); the control surface
+and the `screen_coalesce_*` sensitivity settings (SCREEN-06). Frame discard
+after a successful publish is bounded by SCREEN-01's retention buffer
+(`app.heimdal.retention.enforce_screen_frame_retention`), not re-implemented
+here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import timezone
+from types import MappingProxyType
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from app.components.settings.providers_loader import ProviderCensus, load_provider_census
+from app.heimdal.publish import assemble_observation_payload, publish_full_observation
+from app.heimdal.raw_read_gate import raw_ref_for, read_raw_record
+from app.heimdal.screen_context_providers import (
+    ContextContribution,
+    FrameContext,
+    collect_context,
+)
+
+#: The always-on task kind this stage routes under. Structurally
+#: ``paid_eligible: false`` (RUNTIME_MODEL_POSTURE §4.2 floor 1).
+TASK_KIND = "heimdal.screen_derivation"
+
+#: This stage's reader identity at the gated raw-read path (HEIM-5). Must be on
+#: ``HEIMDAL_RAW_READ_ALLOWLIST`` for any frame to be readable at all.
+READER_ID = "screen_derivation"
+
+#: The stage name used in ``provenance.stage_versions`` for replay lineage.
+STAGE_NAME = "screen_derivation"
+
+#: Bumped when this stage's own summarizing/coalescing logic changes in a way
+#: that would produce a materially different observation for the same frames
+#: and model -- folded into ``stage_versions`` alongside the model id so a
+#: replay after a stage change is legible as a distinct stage version.
+ENGINE_VERSION = "heimdal-screen-derivation-v1"
+
+#: The declared local vision route (census-declared, tier ``local``).
+LOCAL_VISION_PROVIDER = "ollama"
+LOCAL_VISION_MODEL = "llava:7b"
+
+OBSERVATION_TOPIC = "heimdal.observation.published"
+PUBLISH_SOURCE = "heimdal.screen_derivation"
+
+#: HEIM-12 `heim_declared_egress`: the structured, machine-checkable egress
+#: posture for this stage. Raw-class evidence (the frames themselves) never
+#: leaves the host trust boundary; the only destination the stage has is the
+#: host-local vision model it compiles a route to. Asserted by
+#: ``tests/invariants/test_heimdal_seam.py::test_declared_egress``.
+DECLARED_EGRESS: Mapping[str, Any] = MappingProxyType(
+    {
+        "stage": TASK_KIND,
+        "raw_class_egress": False,
+        "raw_classes": ("screen_frame",),
+        "destinations": ("host_local_vision_model",),
+        "basis": (
+            "docs/HEIMDAL/FABLE_COMPANION.md :: HEIM-12; "
+            "docs/MIMER_CAPABILITY_HARDENING/RUNTIME_MODEL_POSTURE.md :: 4.2"
+        ),
+    }
+)
+
+#: The four segmenter dimensions a span is keyed on (INV-SCREEN-E / SCREEN-04).
+SPAN_DIMENSIONS: Tuple[str, ...] = ("app", "window", "scope", "goal")
+
+
+class PaidRouteRejectedError(RuntimeError):
+    """Raised when a policy would assign this always-on task kind to a paid route.
+
+    The stage-invariant floor (RUNTIME_MODEL_POSTURE §4.2): no posture stage
+    makes an always-on loop cloud-routable. Fail at compile, not at 3 a.m. --
+    this is raised before any frame is read.
+    """
+
+
+class LocalVisionUnavailableError(RuntimeError):
+    """Raised when the local vision model cannot produce an activity summary.
+
+    Fail-loud, mirroring `app.heimdal.asr_stage.LocalAsrUnavailableError`:
+    there is no cloud fallback in this module to degrade into. A caller
+    leaves the frames buffered (SCREEN-01's retention bound still applies) and
+    surfaces the failure to the operator.
+    """
+
+
+class UnprovenancedObservationError(RuntimeError):
+    """Raised when a derived span cannot stamp complete provenance (INV-SCREEN-B).
+
+    The observation must outlive its frames, so an observation that cannot say
+    which machine, which capture chain, which raw evidence, and which stage
+    version produced it is never published.
+    """
+
+
+class ScreenFrameUndecodableError(ValueError):
+    """Raised when a gated read does not yield a decodable screen frame bundle."""
+
+
+@dataclass(frozen=True)
+class DerivationRoute:
+    """The compiled model route for one derivation tick."""
+
+    task_kind: str
+    provider: str
+    model: str
+    model_ref: str
+    tier: str
+    paid_eligible: bool
+
+
+@dataclass(frozen=True)
+class ScreenFrame:
+    """One durable frame handed to the stage: an opaque raw handle plus its governance metadata.
+
+    Deliberately carries no pixels and no path -- the bytes are reachable only
+    through the gated read this stage performs from ``raw_ref``.
+    """
+
+    raw_ref: str
+    observed_at: str
+    sensor: Mapping[str, str]
+    capture_chain: Tuple[str, ...]
+    consent: Mapping[str, Any]
+    scope_hint: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class VisionRequest:
+    """The exact request handed to the local vision model (and to a test runner)."""
+
+    model: str
+    prompt: str
+    image: Optional[str]
+    facts: Tuple[str, ...]
+    dimensions: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class DerivedActivity:
+    """One frame's derived activity: what the owner is doing, and how sure we are."""
+
+    summary: str
+    goal: str
+    mentions: Tuple[Mapping[str, Any], ...]
+    confidence: float
+    calibration: str
+
+
+@dataclass(frozen=True)
+class ActivitySpan:
+    """One coalesced run of consecutive frames sharing every segmenter dimension."""
+
+    dimensions: Mapping[str, str]
+    observed_at_start: str
+    observed_at_end: str
+    frame_count: int
+    raw_refs: Tuple[str, ...]
+    content_identities: Tuple[str, ...]
+    facts: Tuple[str, ...]
+    provider_mentions: Tuple[Mapping[str, Any], ...]
+    activity: DerivedActivity
+    frame: ScreenFrame
+
+
+@dataclass(frozen=True)
+class ScreenDerivationTick:
+    """The result of one derivation pass over a batch of frames."""
+
+    route: DerivationRoute
+    frames_read: int
+    observations_published: int
+    coalesced: int
+    spans: Tuple[ActivitySpan, ...]
+    raw_egress: str = "none"
+
+
+# ---------------------------------------------------------------------------
+# Model routing -- the always-on-local floor, compiled
+# ---------------------------------------------------------------------------
+
+
+def resolve_derivation_route(*, census: Optional[ProviderCensus] = None) -> DerivationRoute:
+    """Compile the model route for :data:`TASK_KIND`, or refuse.
+
+    The declared provider census is the single source for provider tiers and
+    per-task-kind paid eligibility (RUNTIME_MODEL_POSTURE §2). This function is
+    the compile step the floor calls for: a census in which ANY provider claims
+    this always-on task kind as paid-eligible is rejected
+    (:class:`PaidRouteRejectedError`), and the resolved provider must be
+    declared ``tier: local``. The concrete local vision model must be declared
+    in the census too, so the route is never an undeclared string.
+    """
+    resolved = census if census is not None else load_provider_census()
+
+    claimed_by = [
+        provider.id for provider in resolved.providers if TASK_KIND in provider.paid_eligible_task_kinds
+    ]
+    if claimed_by:
+        raise PaidRouteRejectedError(
+            f"Routing refused: task kind {TASK_KIND!r} is an always-on loop and is "
+            f"structurally paid-ineligible (RUNTIME_MODEL_POSTURE 4.2 floor 1), but the "
+            f"declared census marks it paid-eligible for {sorted(claimed_by)!r}. No posture "
+            "stage makes an always-on loop cloud-routable; fix the census, not the stage."
+        )
+
+    provider = resolved.provider(LOCAL_VISION_PROVIDER)
+    if provider.tier != "local":
+        raise PaidRouteRejectedError(
+            f"Routing refused: task kind {TASK_KIND!r} resolves to provider "
+            f"{LOCAL_VISION_PROVIDER!r}, which the census declares tier {provider.tier!r}, "
+            "not 'local'. Raw pixels never leave the host trust boundary (HEIM-12)."
+        )
+
+    model = next((item for item in provider.models if item.id == LOCAL_VISION_MODEL), None)
+    if model is None:
+        raise PaidRouteRejectedError(
+            f"Routing refused: local vision model {LOCAL_VISION_MODEL!r} is not declared for "
+            f"provider {LOCAL_VISION_PROVIDER!r} in the provider census. The route must name a "
+            "declared model, never an ad-hoc one."
+        )
+
+    return DerivationRoute(
+        task_kind=TASK_KIND,
+        provider=provider.id,
+        model=model.id,
+        model_ref=model.effective_identity,
+        tier=provider.tier,
+        paid_eligible=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frames
+# ---------------------------------------------------------------------------
+
+
+def screen_frame_from_raw_record(record: Any, *, observed_at: Optional[str] = None) -> ScreenFrame:
+    """Build this stage's frame handle from a durable raw record.
+
+    ``record`` is duck-typed against `app.heimdal.raw_store.RawRecord` (id,
+    ``content_identity``, ``capture_chain``, ``sensor``, ``consent``,
+    ``ingested_at``) rather than imported, so this module keeps exactly one
+    dependency on the raw layer: the gate. ``observed_at`` defaults to the
+    record's ingest time when the capture did not carry a device clock.
+    """
+    resolved_observed_at = observed_at or _iso_utc(record.ingested_at)
+    return ScreenFrame(
+        raw_ref=raw_ref_for(record),
+        observed_at=resolved_observed_at,
+        sensor=dict(record.sensor or {}),
+        capture_chain=tuple(record.capture_chain or ()),
+        consent=dict(record.consent or {}),
+        scope_hint=str((record.payload or {}).get("scope") or "") or None,
+    )
+
+
+def _iso_utc(value: Any) -> str:
+    moment = value.astimezone(timezone.utc)
+    return moment.isoformat().replace("+00:00", "Z")
+
+
+def _decode_frame_bundle(plaintext: bytes) -> Mapping[str, Any]:
+    """Decode one gated read into the frame bundle the client captured.
+
+    SCREEN-01 lands the client bundle as canonical JSON; the frontmost-app
+    metadata may sit at the top level or inside ``raw``. Anything that is not a
+    JSON object is refused loudly rather than derived from guesswork.
+    """
+    try:
+        decoded = json.loads(plaintext.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ScreenFrameUndecodableError(
+            f"Screen frame bundle is not decodable JSON: {exc}"
+        ) from exc
+    if not isinstance(decoded, dict):
+        raise ScreenFrameUndecodableError(
+            f"Screen frame bundle must be a JSON object, got {type(decoded).__name__}"
+        )
+    merged: Dict[str, Any] = dict(decoded)
+    nested = decoded.get("raw")
+    if isinstance(nested, dict):
+        merged.update(nested)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Derivation
+# ---------------------------------------------------------------------------
+
+
+def _merge_contributions(
+    contributions: Sequence[ContextContribution],
+) -> Tuple[Tuple[str, ...], List[Dict[str, Any]], Dict[str, str]]:
+    facts: List[str] = []
+    mentions: List[Dict[str, Any]] = []
+    dimensions: Dict[str, str] = {}
+    for contribution in contributions:
+        facts.extend(contribution.facts)
+        mentions.extend(dict(mention) for mention in contribution.mentions)
+        dimensions.update({key: str(value) for key, value in contribution.dimensions.items()})
+    return tuple(facts), mentions, dimensions
+
+
+def _build_prompt(facts: Sequence[str]) -> str:
+    lines = [
+        "Describe in one short sentence what the operator is doing on this screen.",
+        "Answer as JSON with keys: summary, goal, mentions, confidence.",
+        "Name apps, documents, projects, and URLs you can see as mentions.",
+    ]
+    if facts:
+        lines.append("Host context:")
+        lines.extend(f"- {fact}" for fact in facts)
+    return "\n".join(lines)
+
+
+def _invoke_local_vision(
+    request: VisionRequest,
+    *,
+    vision_runner: Optional[Callable[[VisionRequest], Mapping[str, Any]]],
+) -> Mapping[str, Any]:
+    """Call the host-local vision model; never anything off-host.
+
+    ``vision_runner`` is the test/injection seam (called directly). The
+    production path posts to the locally served model host resolved from
+    ``OLLAMA_BASE_URL`` / ``OLLAMA_HOST`` / ``OLLAMA_URL`` -- deliberately not
+    the generic runtime chat env, because that one is provider-routable and
+    could resolve off-host. Any failure raises
+    :class:`LocalVisionUnavailableError`; there is no except branch in this
+    module that reaches for a remote model.
+    """
+    if vision_runner is not None:
+        try:
+            return dict(vision_runner(request))
+        except Exception as exc:  # pragma: no cover - mirrors the production branch
+            raise LocalVisionUnavailableError(
+                f"Local vision (injected runner) failed for model {request.model!r}: {exc}"
+            ) from exc
+
+    host = (
+        os.getenv("OLLAMA_BASE_URL", "").strip()
+        or os.getenv("OLLAMA_HOST", "").strip()
+        or os.getenv("OLLAMA_URL", "").strip()
+    )
+    if not host:
+        raise LocalVisionUnavailableError(
+            "No local model host configured (OLLAMA_BASE_URL, OLLAMA_HOST, or OLLAMA_URL). "
+            "Screen derivation is local-only -- there is no remote fallback; the frames stay "
+            "buffered until the local vision model is available."
+        )
+
+    try:
+        import requests  # type: ignore[import-untyped]
+
+        message: Dict[str, Any] = {"role": "user", "content": request.prompt}
+        if request.image:
+            message["images"] = [request.image]
+        response = requests.post(
+            host.rstrip("/") + "/api/chat",
+            json={"model": request.model, "messages": [message], "stream": False},
+            timeout=float(os.getenv("HEIMDAL_SCREEN_VISION_TIMEOUT", "120")),
+        )
+        response.raise_for_status()
+        content = response.json()["message"]["content"]
+    except Exception as exc:
+        raise LocalVisionUnavailableError(
+            f"Local vision model {request.model!r} failed on the host: {exc}. Screen derivation "
+            "is local-only -- the frames stay buffered and the operator must be notified."
+        ) from exc
+
+    return _parse_vision_content(content)
+
+
+def _parse_vision_content(content: Any) -> Mapping[str, Any]:
+    """Read the model's reply, tolerating a plain-text answer."""
+    if isinstance(content, Mapping):
+        return dict(content)
+    text = str(content or "").strip()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {"summary": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"summary": text}
+
+
+def _normalize_activity(output: Mapping[str, Any]) -> DerivedActivity:
+    summary = str(output.get("summary") or "").strip()
+    if not summary:
+        raise LocalVisionUnavailableError(
+            "Local vision model returned no activity summary; nothing is derived and nothing "
+            "is published (never an empty observation)."
+        )
+    raw_mentions = output.get("mentions") or ()
+    mentions: List[Mapping[str, Any]] = []
+    if isinstance(raw_mentions, Sequence) and not isinstance(raw_mentions, (str, bytes)):
+        for mention in raw_mentions:
+            if isinstance(mention, Mapping) and str(mention.get("surface_form") or "").strip():
+                mentions.append(dict(mention))
+    score = output.get("confidence")
+    confidence = float(score) if isinstance(score, (int, float)) else 0.5
+    confidence = max(0.0, min(1.0, confidence))
+    return DerivedActivity(
+        summary=summary,
+        goal=str(output.get("goal") or "").strip(),
+        mentions=tuple(mentions),
+        # Never claim a calibrated score: a vision model's self-reported
+        # confidence is a heuristic (FABLE_COMPANION §2.1 / HEIM-6).
+        confidence=confidence,
+        calibration="heuristic",
+    )
+
+
+def _derive_frame(
+    frame: ScreenFrame,
+    *,
+    route: DerivationRoute,
+    key: Optional[bytes],
+    vision_runner: Optional[Callable[[VisionRequest], Mapping[str, Any]]],
+) -> Tuple[DerivedActivity, Dict[str, str], Tuple[str, ...], List[Dict[str, Any]], str]:
+    """Read one frame through the gate and derive its activity."""
+    gated = read_raw_record(
+        frame.raw_ref,
+        reader=READER_ID,
+        purpose="screen_derivation",
+        key=key,
+    )
+    bundle = _decode_frame_bundle(gated.plaintext)
+    contributions = collect_context(
+        FrameContext(raw_ref=frame.raw_ref, observed_at=frame.observed_at, bundle=bundle)
+    )
+    facts, provider_mentions, dimensions = _merge_contributions(contributions)
+
+    image = bundle.get("frame")
+    request = VisionRequest(
+        model=route.model,
+        prompt=_build_prompt(facts),
+        image=str(image) if image is not None else None,
+        facts=facts,
+        dimensions=dict(dimensions),
+    )
+    activity = _normalize_activity(_invoke_local_vision(request, vision_runner=vision_runner))
+    dimensions["goal"] = activity.goal
+    return activity, dimensions, facts, provider_mentions, gated.receipt.content_identity
+
+
+# ---------------------------------------------------------------------------
+# Publishing
+# ---------------------------------------------------------------------------
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-") or "unknown"
+
+
+def _entity_mentions(span: ActivitySpan) -> List[Dict[str, Any]]:
+    mentions: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for mention in (*span.activity.mentions, *span.provider_mentions):
+        surface = str(mention.get("surface_form") or "").strip()
+        if not surface:
+            continue
+        kind = str(mention.get("kind_hint") or "thing")
+        mention_id = f"screen:{_slug(kind)}:{_slug(surface)}"
+        if mention_id in seen:
+            continue
+        seen.add(mention_id)
+        mentions.append(
+            {
+                "mention_id": mention_id,
+                "surface_form": surface,
+                "kind_hint": kind,
+                # Derivation surfaces mentions; it never mints a canonical
+                # identity (HEIM-6/HEIM-11). Resolution is a later stage's job.
+                "resolution": "unresolved",
+            }
+        )
+    return mentions
+
+
+def _render_content(span: ActivitySpan) -> str:
+    """Markdown-first, minimized: one activity line plus its host context."""
+    lines = [span.activity.summary]
+    if span.facts:
+        lines.append("")
+        lines.extend(f"- {fact}" for fact in span.facts)
+    return "\n".join(lines)
+
+
+def _observation_id(episode_id: str, span: ActivitySpan, content: str) -> str:
+    digest = hashlib.sha256(
+        "|".join(
+            [
+                episode_id,
+                span.observed_at_start,
+                span.observed_at_end,
+                json.dumps(dict(span.dimensions), sort_keys=True),
+                content,
+            ]
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"screen-obs-{digest[:32]}"
+
+
+def _assert_complete_provenance(provenance: Mapping[str, Any], span: ActivitySpan) -> None:
+    """INV-SCREEN-B: refuse to publish an observation that cannot outlive its frames."""
+    sensor = provenance.get("sensor")
+    if not isinstance(sensor, Mapping):
+        raise UnprovenancedObservationError(
+            "Refusing to publish: provenance carries no sensor block; the observation could "
+            "not say which machine observed it."
+        )
+    for field_name in ("adapter", "version", "machine"):
+        if not str(sensor.get(field_name) or "").strip():
+            raise UnprovenancedObservationError(
+                f"Refusing to publish: provenance sensor is missing {field_name!r}; complete "
+                "provenance is stamped in the same write as the observation or not at all "
+                "(INV-SCREEN-B)."
+            )
+    if not provenance.get("capture_chain"):
+        raise UnprovenancedObservationError(
+            "Refusing to publish: provenance carries no capture_chain."
+        )
+    if not str(provenance.get("content_identity") or "").strip():
+        raise UnprovenancedObservationError(
+            "Refusing to publish: provenance carries no content_identity from the gated read."
+        )
+    if not str(provenance.get("model_ref") or "").strip():
+        raise UnprovenancedObservationError(
+            "Refusing to publish: provenance carries no model_ref for the derivation."
+        )
+    stage_versions = provenance.get("stage_versions")
+    if not isinstance(stage_versions, Mapping) or not stage_versions.get(STAGE_NAME):
+        raise UnprovenancedObservationError(
+            f"Refusing to publish: provenance carries no {STAGE_NAME!r} stage version."
+        )
+    if not span.observed_at_start or not span.observed_at_end:
+        raise UnprovenancedObservationError(
+            "Refusing to publish: the observed-at window is incomplete."
+        )
+
+
+def _publish_span(
+    span: ActivitySpan,
+    *,
+    episode_id: str,
+    sequence: int,
+    route: DerivationRoute,
+) -> bool:
+    content = _render_content(span)
+    stage_versions = {STAGE_NAME: f"{route.model}@{ENGINE_VERSION}"}
+    provenance: Dict[str, Any] = {
+        "sensor": dict(span.frame.sensor),
+        "capture_chain": list(span.frame.capture_chain),
+        "content_identity": span.content_identities[0] if span.content_identities else "",
+        "content_identities": list(span.content_identities),
+        "stage_versions": stage_versions,
+        "model_ref": route.model_ref,
+        "raw_refs": list(span.raw_refs),
+    }
+    _assert_complete_provenance(provenance, span)
+
+    mention_scores = [
+        float(mention["confidence"])
+        for mention in span.activity.mentions
+        if isinstance(mention.get("confidence"), (int, float))
+    ]
+    payload = assemble_observation_payload(
+        observation_id=_observation_id(episode_id, span, content),
+        episode_id=episode_id,
+        observed_at_start=span.observed_at_start,
+        observed_at_end=span.observed_at_end,
+        clock_basis="device_metadata",
+        sequence=sequence,
+        attributions=[
+            {
+                "mention_id": "operator",
+                "role": "recorder",
+                "resolution": "resolved",
+                "basis": "capture_context",
+            }
+        ],
+        entity_mentions=_entity_mentions(span),
+        modality="screen",
+        content=content,
+        content_structure={
+            "span": {
+                "frame_count": span.frame_count,
+                "dimensions": dict(span.dimensions),
+                "raw_refs": list(span.raw_refs),
+            }
+        },
+        raw_ref=span.raw_refs[0] if span.raw_refs else None,
+        confidence={
+            "attribution": {
+                "score": 1.0,
+                "calibration": "by_construction",
+                "method": "single_operator_capture",
+            },
+            "activity_summary": {
+                "score": span.activity.confidence,
+                "calibration": span.activity.calibration,
+                "method": "local_vision",
+                "model_ref": route.model_ref,
+            },
+            "entity_mention": {
+                "score": (sum(mention_scores) / len(mention_scores)) if mention_scores else 0.5,
+                "calibration": "heuristic",
+                "method": "local_vision",
+                "model_ref": route.model_ref,
+            },
+        },
+        provenance=provenance,
+        consent=dict(span.frame.consent),
+        sensitivity="private",
+        scope_hint=span.frame.scope_hint,
+    )
+    row = publish_full_observation(
+        topic=OBSERVATION_TOPIC,
+        payload=payload,
+        source=PUBLISH_SOURCE,
+        stage_versions=stage_versions,
+    )
+    return row is not None
+
+
+# ---------------------------------------------------------------------------
+# The stage entrypoint
+# ---------------------------------------------------------------------------
+
+
+class _OpenSpan:
+    """Mutable accumulator for the span currently being coalesced."""
+
+    def __init__(
+        self,
+        *,
+        frame: ScreenFrame,
+        dimensions: Mapping[str, str],
+        facts: Tuple[str, ...],
+        activity: DerivedActivity,
+        provider_mentions: Sequence[Mapping[str, Any]],
+        content_identity: str,
+    ) -> None:
+        self.frame = frame
+        self.dimensions = dict(dimensions)
+        self.facts = facts
+        self.activity = activity
+        self.provider_mentions = [dict(mention) for mention in provider_mentions]
+        self.observed_at_start = frame.observed_at
+        self.observed_at_end = frame.observed_at
+        self.raw_refs: List[str] = [frame.raw_ref]
+        self.content_identities: List[str] = [content_identity]
+
+    def extend(self, frame: ScreenFrame, content_identity: str) -> None:
+        self.observed_at_end = frame.observed_at
+        self.raw_refs.append(frame.raw_ref)
+        self.content_identities.append(content_identity)
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.raw_refs)
+
+    def close(self) -> ActivitySpan:
+        return ActivitySpan(
+            dimensions=dict(self.dimensions),
+            observed_at_start=self.observed_at_start,
+            observed_at_end=self.observed_at_end,
+            frame_count=self.frame_count,
+            raw_refs=tuple(self.raw_refs),
+            content_identities=tuple(self.content_identities),
+            facts=self.facts,
+            provider_mentions=tuple(self.provider_mentions),
+            activity=self.activity,
+            frame=self.frame,
+        )
+
+
+def _span_key(dimensions: Mapping[str, str]) -> Tuple[str, ...]:
+    return tuple(str(dimensions.get(name, "")) for name in SPAN_DIMENSIONS)
+
+
+def derive_activity_observations(
+    frames: Sequence[ScreenFrame],
+    *,
+    episode_id: str,
+    vision_runner: Optional[Callable[[VisionRequest], Mapping[str, Any]]] = None,
+    key: Optional[bytes] = None,
+) -> ScreenDerivationTick:
+    """Derive and publish activity observations for one batch of frames.
+
+    The production entrypoint. Compiles the local-only route first (so a paid
+    assignment fails before any raw byte is read), then, per frame: gated raw
+    read -> local context providers -> local vision model -> span coalescing.
+    A span is published through the governed path when the next frame shifts a
+    segmenter dimension, and the final open span is flushed at the end of the
+    batch (over-segmentation is the preferred direction -- SCREEN-04 can merge
+    downstream, it cannot invent a boundary that was never recorded).
+
+    ``vision_runner`` is the injection seam for tests and for a host that
+    serves the local model differently; production callers omit it.
+    """
+    if not isinstance(episode_id, str) or not episode_id.strip():
+        raise ValueError(f"episode_id must be a non-empty string, got {episode_id!r}")
+
+    route = resolve_derivation_route()
+
+    spans: List[ActivitySpan] = []
+    published = 0
+    coalesced = 0
+    sequence = 0
+    open_span: Optional[_OpenSpan] = None
+
+    for frame in frames:
+        activity, dimensions, facts, provider_mentions, content_identity = _derive_frame(
+            frame,
+            route=route,
+            key=key,
+            vision_runner=vision_runner,
+        )
+        if open_span is not None and _span_key(open_span.dimensions) == _span_key(dimensions):
+            open_span.extend(frame, content_identity)
+            coalesced += 1
+            continue
+        if open_span is not None:
+            span = open_span.close()
+            spans.append(span)
+            published += int(_publish_span(span, episode_id=episode_id, sequence=sequence, route=route))
+            sequence += 1
+        open_span = _OpenSpan(
+            frame=frame,
+            dimensions=dimensions,
+            facts=facts,
+            activity=activity,
+            provider_mentions=provider_mentions,
+            content_identity=content_identity,
+        )
+
+    if open_span is not None:
+        span = open_span.close()
+        spans.append(span)
+        published += int(_publish_span(span, episode_id=episode_id, sequence=sequence, route=route))
+
+    return ScreenDerivationTick(
+        route=route,
+        frames_read=len(frames),
+        observations_published=published,
+        coalesced=coalesced,
+        spans=tuple(spans),
+    )
+
+
+__all__ = [
+    "ActivitySpan",
+    "DECLARED_EGRESS",
+    "DerivationRoute",
+    "DerivedActivity",
+    "ENGINE_VERSION",
+    "LOCAL_VISION_MODEL",
+    "LOCAL_VISION_PROVIDER",
+    "LocalVisionUnavailableError",
+    "PaidRouteRejectedError",
+    "READER_ID",
+    "SPAN_DIMENSIONS",
+    "STAGE_NAME",
+    "ScreenDerivationTick",
+    "ScreenFrame",
+    "ScreenFrameUndecodableError",
+    "TASK_KIND",
+    "UnprovenancedObservationError",
+    "VisionRequest",
+    "derive_activity_observations",
+    "resolve_derivation_route",
+    "screen_frame_from_raw_record",
+]

--- a/app/heimdal/screen_derivation.py
+++ b/app/heimdal/screen_derivation.py
@@ -71,7 +71,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
-from urllib.parse import urlparse
 
 from app.components.settings.providers_loader import ProviderCensus, load_provider_census
 from app.heimdal.publish import assemble_observation_payload, publish_full_observation
@@ -335,6 +334,47 @@ def _declared_host_local_hostnames() -> frozenset:
     return frozenset(item.strip().lower() for item in raw.split(",") if item.strip())
 
 
+def _dialled_host(url: str) -> str:
+    """The host the HTTP client will actually dial, per the client's own parser.
+
+    Deliberately `urllib3`'s parser -- the one `requests` resolves connections
+    with -- and never a second, independent parse. Two parsers over one string
+    is how a validated destination and a dialled destination diverge: they
+    disagree on shapes like a backslash or an `@` in the authority, so one can
+    read `http://127.0.0.1:1\\@elsewhere` as loopback while the other dials
+    `elsewhere`. Whatever the client would dial is what gets checked, so no
+    such differential exists to exploit -- and a future parser change cannot
+    reopen the class, because there is only ever one parser.
+    """
+    from urllib3.util import parse_url  # type: ignore[import-untyped]
+
+    try:
+        host = (parse_url(url).host or "").strip().lower()
+    except Exception:
+        # An endpoint the client itself cannot parse is not provably local.
+        return ""
+    return host.strip("[]")
+
+
+def _assert_host_local_url(url: str) -> None:
+    """Refuse a URL whose dialled host is not provably host-local (HEIM-12)."""
+    host = _dialled_host(url)
+    if not host:
+        raise RawEgressRefusedError(
+            f"Refusing to derive: vision endpoint {url!r} names no host the client can "
+            "resolve, so it cannot be proven host-local (HEIM-12). No frame was transmitted."
+        )
+    if host in _LOOPBACK_HOSTNAMES or host in _declared_host_local_hostnames():
+        return
+    raise RawEgressRefusedError(
+        f"Refusing to derive: vision endpoint host {host!r} is not loopback and is not "
+        f"declared host-local in {HOST_LOCAL_VISION_ALLOWLIST_ENV}. Raw screen frames never "
+        "leave the host trust boundary (HEIM-12, DECLARED_EGRESS raw_class_egress=false). "
+        "No frame was transmitted. Point the stage at a host-local model, or declare the "
+        "endpoint host-local explicitly if it really is inside this machine's boundary."
+    )
+
+
 def resolve_local_vision_endpoint() -> str:
     """Resolve the local vision endpoint, refusing any non-host-local destination.
 
@@ -344,6 +384,13 @@ def resolve_local_vision_endpoint() -> str:
     the operator explicitly declared host-local via
     :data:`HOST_LOCAL_VISION_ALLOWLIST_ENV`. Anything else raises
     :class:`RawEgressRefusedError` before a frame is transmitted.
+
+    This is the early, fail-fast check: it refuses a misconfigured endpoint
+    before a frame is even read. It is deliberately NOT the only check --
+    :func:`_post_local_vision` re-asserts host-locality on the exact prepared
+    URL it is about to send, so validation and transmission cannot diverge.
+    Both read :func:`_dialled_host`, so this module has exactly one notion of
+    "the host".
     """
     host = (
         os.getenv("OLLAMA_BASE_URL", "").strip()
@@ -357,26 +404,11 @@ def resolve_local_vision_endpoint() -> str:
             "buffered until the local vision model is available."
         )
 
+    # `OLLAMA_HOST=127.0.0.1:11434` (the scheme-less form Ollama's own docs use)
+    # is normalized here so the value validated is the value transmitted.
     candidate = host if "://" in host else f"http://{host}"
-    hostname = (urlparse(candidate).hostname or "").strip().lower()
-    if not hostname:
-        raise RawEgressRefusedError(
-            f"Refusing to derive: vision endpoint {host!r} names no resolvable host, so it "
-            "cannot be proven host-local (HEIM-12). No frame was transmitted."
-        )
-    if hostname in _LOOPBACK_HOSTNAMES or hostname in _declared_host_local_hostnames():
-        # Return the string that was actually validated, never the raw input:
-        # `OLLAMA_HOST=127.0.0.1:11434` (the scheme-less form Ollama's own docs
-        # use) must not validate one value and then transmit to another.
-        return candidate
-
-    raise RawEgressRefusedError(
-        f"Refusing to derive: vision endpoint host {hostname!r} is not loopback and is not "
-        f"declared host-local in {HOST_LOCAL_VISION_ALLOWLIST_ENV}. Raw screen frames never "
-        "leave the host trust boundary (HEIM-12, DECLARED_EGRESS raw_class_egress=false). "
-        "No frame was transmitted. Point the stage at a host-local model, or declare the "
-        "endpoint host-local explicitly if it really is inside this machine's boundary."
-    )
+    _assert_host_local_url(candidate)
+    return candidate
 
 
 # ---------------------------------------------------------------------------
@@ -568,11 +600,21 @@ def _post_local_vision(endpoint: str, body: Mapping[str, Any]) -> Any:
     proxy guard closes, one hop later. A local model has no legitimate reason
     to redirect ``/api/chat`` elsewhere, so this is fail-loud, not a downgrade.
     """
+    import requests  # type: ignore[import-untyped]
+
     session = local_vision_session()
     try:
-        response = session.post(
-            endpoint.rstrip("/") + "/api/chat",
-            json=dict(body),
+        prepared = session.prepare_request(
+            requests.Request("POST", endpoint.rstrip("/") + "/api/chat", json=dict(body))
+        )
+        # THE authoritative gate: host-locality is asserted on the exact URL
+        # the client is about to dial, not on an earlier string some other
+        # parser once approved. Nothing can be interposed between this check
+        # and `send`, so a validated destination cannot drift into a dialled
+        # one -- which is the class of defect, not just its one instance.
+        _assert_host_local_url(prepared.url)
+        response = session.send(
+            prepared,
             timeout=float(os.getenv("HEIMDAL_SCREEN_VISION_TIMEOUT", "120")),
             allow_redirects=False,
         )
@@ -650,6 +692,16 @@ def _derive_frame(
     )
     facts, provider_mentions, dimensions = _merge_contributions(contributions)
 
+    # Checked BEFORE the model call, not after: the conflict is fully known
+    # from the providers alone, and refusing afterwards would transmit every
+    # frame in the batch first. Fail at compile, not at 3 a.m.
+    if "goal" in dimensions:
+        raise ContextDimensionConflictError(
+            "A context provider claims the 'goal' dimension, which the derivation stage itself "
+            "contributes from the local model. Rename the provider's axis: the later write would "
+            "silently move a span boundary."
+        )
+
     image = bundle.get("frame")
     request = VisionRequest(
         model=route.model,
@@ -659,16 +711,9 @@ def _derive_frame(
         dimensions=dict(dimensions),
     )
     activity = _normalize_activity(_invoke_local_vision(request, vision_runner=vision_runner))
-    # The derived goal is this stage's own contribution to the segmenter axes.
-    # It is held to the same one-writer-per-dimension rule as the providers:
-    # overwriting a provider's `goal` here would make the stage a silent third
-    # writer and could merge away a boundary the provider drew.
-    if "goal" in dimensions:
-        raise ContextDimensionConflictError(
-            "A context provider claims the 'goal' dimension, which the derivation stage itself "
-            "contributes from the local model. Rename the provider's axis: the later write would "
-            "silently move a span boundary."
-        )
+    # The derived goal is this stage's own contribution to the segmenter axes,
+    # held to the same one-writer-per-dimension rule the providers obey (the
+    # conflict was already refused above).
     dimensions["goal"] = activity.goal
     return activity, dimensions, facts, provider_mentions, gated.receipt.content_identity
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,11 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:app@db:5432/app}
       DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
       OLLAMA_BASE_URL: http://ollama:11434
+      # The screen-derivation stage refuses to send a raw frame to any
+      # endpoint it cannot prove is host-local. This compose network's
+      # `ollama` service is inside the host trust boundary, and this line
+      # is the operator declaring exactly that (HEIM-12).
+      HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS: ollama
     depends_on:
       ollama:
         condition: service_healthy
@@ -25,6 +30,11 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:app@db:5432/app}
       DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
       OLLAMA_BASE_URL: http://ollama:11434
+      # The screen-derivation stage refuses to send a raw frame to any
+      # endpoint it cannot prove is host-local. This compose network's
+      # `ollama` service is inside the host trust boundary, and this line
+      # is the operator declaring exactly that (HEIM-12).
+      HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS: ollama
     depends_on:
       ollama:
         condition: service_healthy

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -50,12 +50,15 @@ the span boundaries the event motor needs.
      this task kind as paid-eligible or when the resolved provider is not `tier: local`, so the refusal
      lands before a single frame is read;
    - *the destination*: a census entry proves a provider **name** is local, never that the socket a
-     decrypted frame is about to be written to is on this machine. `resolve_local_vision_endpoint`
-     closes that half — the endpoint must be loopback, or a hostname the operator explicitly declared
-     host-local in `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS` (the container-network case), or the
-     derivation is refused before the frame is attached to any request. The request also runs with
-     `trust_env` disabled so an ambient `HTTP_PROXY` cannot carry a loopback-addressed frame off the
-     host.
+     decrypted frame is about to be written to is on this machine. The endpoint must be loopback, or
+     a hostname the operator explicitly declared host-local in
+     `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS` (the container-network case), or the derivation is
+     refused before the frame is attached to any request. Three escapes off that validated
+     destination are closed explicitly, because each was found reachable in review: an ambient
+     `HTTP_PROXY` (the request runs with `trust_env` disabled), an HTTP **redirect** (refused, never
+     followed — a local model has no reason to redirect `/api/chat` elsewhere), and a **URL-parser
+     differential** (host-locality is asserted on the exact prepared URL the client will dial, using
+     the client's own parser, so a validated destination and a dialled destination cannot diverge).
 
    Enforced by `tests/invariants/test_heimdal_seam.py::test_declared_egress`, the §8-reserved home
    HEIM-12's static half now graduates into, plus

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -145,9 +145,17 @@ rejected).
 
 The derivation stage is a stateless tick over durable inputs (the raw store) and durable outputs (the
 observation log): a crash mid-tick loses no published observation (idempotency-keyed publish dedups on
-replay) and no raw frame (frames stay in the buffer until derived or aged out). An **open span**
-(activity still ongoing at crash) is reconstructed on the next tick from the buffered frames — nothing
-user-facing is lost. This is why frame discard is gated on successful publish, not on the tick starting.
+replay) and no raw frame (frames stay in the buffer until derived or aged out). This is why frame
+discard is gated on successful publish, not on the tick starting.
+
+**As delivered, a batch has no open span**: `derive_activity_observations` flushes its final span
+before returning, and `observation_id` is derived from the covered frames' content identities, so a
+re-derive of the *same* grouping dedups exactly. The consequence to know before building the tick
+driver (SCREEN-06): an activity still ongoing at the batch boundary is published as a closed span, and
+a later batch that groups those frames differently mints a different identity over overlapping frames
+rather than extending the earlier span. Carrying an open span across ticks — the reconstruction this
+section originally described — needs durable cross-tick span state and belongs with the tick driver,
+not here. SCREEN-04's segmenter can merge adjacent spans; that is the cheap direction.
 
 ## Related Docs
 

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -73,9 +73,11 @@ the span boundaries the event motor needs.
    - a context provider that declares a **segmenter axis of its own** cuts spans on it too, so the
      built-in four are a floor, not a ceiling; and two providers may not claim one axis (the later
      write would move a boundary invisibly, so it is refused);
-   - **unknown is not evidence of sameness**: frames with no known dimension at all (a client without
-     Accessibility permission) are never merged. One unknown axis does not switch coalescing off —
-     that would flood the stream — but an all-unknown frame always starts its own span;
+   - **unknown is not evidence of sameness**: a frame with *no* known dimension at all always starts
+     its own span, so a fully blind client over-segments rather than collapsing a long window into
+     one observation. One unknown axis does not switch coalescing off — that would flood the stream —
+     so a client that loses `app`/`window` but still reports `scope` (the partial-Accessibility case)
+     does still coalesce on what it knows;
    - a frame **out of capture order** forces a boundary instead of publishing a span that ends before
      it began.
 

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -43,11 +43,23 @@ the span boundaries the event motor needs.
    **Declared egress posture (HEIM-12), delivered:** this stage declares **zero raw egress** — raw-class
    evidence (`screen_frame`) never leaves the host trust boundary, and the stage's only model destination
    is the host-local vision model. The declaration is structured and machine-checkable
-   (`app/heimdal/screen_derivation.py :: DECLARED_EGRESS`), not prose: `resolve_derivation_route` refuses
-   to compile a route at all when the census claims this task kind as paid-eligible or when the resolved
-   provider is not `tier: local`, so the refusal lands before a single frame is read. Enforced by
-   `tests/invariants/test_heimdal_seam.py::test_declared_egress`, the §8-reserved home HEIM-12's static
-   half now graduates into.
+   (`app/heimdal/screen_derivation.py :: DECLARED_EGRESS`), not prose, and it is enforced on **both**
+   halves of the seam:
+
+   - *the provider*: `resolve_derivation_route` refuses to compile a route at all when the census claims
+     this task kind as paid-eligible or when the resolved provider is not `tier: local`, so the refusal
+     lands before a single frame is read;
+   - *the destination*: a census entry proves a provider **name** is local, never that the socket a
+     decrypted frame is about to be written to is on this machine. `resolve_local_vision_endpoint`
+     closes that half — the endpoint must be loopback, or a hostname the operator explicitly declared
+     host-local in `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS` (the container-network case), or the
+     derivation is refused before the frame is attached to any request. The request also runs with
+     `trust_env` disabled so an ambient `HTTP_PROXY` cannot carry a loopback-addressed frame off the
+     host.
+
+   Enforced by `tests/invariants/test_heimdal_seam.py::test_declared_egress`, the §8-reserved home
+   HEIM-12's static half now graduates into, plus
+   `tests/heimdal/test_screen_derivation_routing.py::test_raw_frames_refuse_a_destination_that_is_not_host_local`.
 4. **Coalesce into spans (INV-SCREEN-E).** Consecutive frames whose activity is unchanged collapse into
    one span observation with real `observed_at_start`/`observed_at_end` duration. A span boundary is
    created on **any** dimension shift — frontmost app, window/document, scope, or derived-goal change —

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -64,8 +64,21 @@ the span boundaries the event motor needs.
    one span observation with real `observed_at_start`/`observed_at_end` duration. A span boundary is
    created on **any** dimension shift — frontmost app, window/document, scope, or derived-goal change —
    because those are the ERE segmenter's five-dimension shifts (SCREEN-04). **Over-segmentation is
-   preferred** (merge is a cheap downstream re-cut; a lost boundary is unrecoverable). Coalescing
-   sensitivity is `screen_coalesce_*` (provisional constants, SCREEN-06-governed).
+   preferred** (merge is a cheap downstream re-cut; a lost boundary is unrecoverable). Three rules
+   enforce that preference in the delivered stage:
+
+   - a context provider that declares a **segmenter axis of its own** cuts spans on it too, so the
+     built-in four are a floor, not a ceiling; and two providers may not claim one axis (the later
+     write would move a boundary invisibly, so it is refused);
+   - **unknown is not evidence of sameness**: frames with no known dimension at all (a client without
+     Accessibility permission) are never merged. One unknown axis does not switch coalescing off —
+     that would flood the stream — but an all-unknown frame always starts its own span;
+   - a frame **out of capture order** forces a boundary instead of publishing a span that ends before
+     it began.
+
+   Coalescing sensitivity is `screen_coalesce_*` (provisional constants, SCREEN-06-governed); this
+   slice ships no max-gap bound, so two identical frames far apart still merge — SCREEN-05's
+   time-spend rollup should not assume a bounded gap until SCREEN-06 lands.
 5. **Publish markdown-first through the governed path.** The stage assembles the SCREEN-01 payload and
    publishes via the existing `heimdal.publish.publish_full_observation` (schema-validated,
    `content_hash` stamped in the same write, revision-aware idempotency key). The Mimer candidate

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -84,21 +84,21 @@ stream floods — the invariant test pins the boundary-preserving direction.
 
 ## Acceptance Criteria
 
-- [ ] AC1: a frame bundle + app metadata derives one activity observation with a textual summary,
+- [x] AC1: a frame bundle + app metadata derives one activity observation with a textual summary,
       entity mentions, and per-axis confidence, published through `publish_full_observation` (governed
       path, not a bespoke insert). Verify: `tests/heimdal/test_screen_derivation.py::test_bundle_derives_and_publishes_observation`
-- [ ] AC2 (enforcement): derivation reads raw only via the gated read path with a receipt, and the
+- [x] AC2 (enforcement): derivation reads raw only via the gated read path with a receipt, and the
       resolved model is local — asserted at the derivation call site: the router is invoked with the
       `heimdal.screen_derivation` task kind and a paid route is rejected. Verify: `tests/heimdal/test_screen_derivation_routing.py::test_screen_derivation_is_paid_ineligible_and_reads_raw_gated` (asserts `paid_eligible=false` rejection at the compiler + `read_raw_record` receipt at the production call site)
-- [ ] AC3: unchanged consecutive frames coalesce into one span with real start/end duration; a
+- [x] AC3: unchanged consecutive frames coalesce into one span with real start/end duration; a
       dimension shift (app/window/scope/goal) always creates a new span boundary — a merge across a
       shift fails the test. Verify: `tests/heimdal/test_screen_coalescing.py::test_span_boundaries_survive_on_dimension_shift`
-- [ ] AC4: provenance (machine + observed-at window + derivation `stage_versions`/`model_ref`) is
+- [x] AC4: provenance (machine + observed-at window + derivation `stage_versions`/`model_ref`) is
       stamped in the same durable write as the observation; a bundle that derives text but cannot stamp
       complete provenance refuses to publish (INV-SCREEN-B). Verify: `tests/heimdal/test_screen_derivation.py::test_unprovenanced_observation_refuses_publish`
-- [ ] AC5: local context providers are pluggable — adding a provider changes the derived summary/mentions
+- [x] AC5: local context providers are pluggable — adding a provider changes the derived summary/mentions
       without changing the observation contract or the derivation entrypoint signature. Verify: `tests/heimdal/test_screen_context_providers.py::test_provider_registry_extensible`
-- [ ] AC6 (non-behavioral): the declared egress posture for the screen-derivation stage names zero raw
+- [x] AC6 (non-behavioral): the declared egress posture for the screen-derivation stage names zero raw
       egress (HEIM-12). Verify: doc writeback at `docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md :: What This Task Does` (step 3) + `tests/invariants/test_heimdal_seam.py::test_declared_egress` extended with the screen stage
 
 ## How to Verify (Pre-Merge)
@@ -133,4 +133,4 @@ user-facing is lost. This is why frame discard is gated on successful publish, n
 
 ## Related GitHub Issues
 
-One issue: `[Heimdal Screen Stream] derive-activity-observations: local-vision derivation + span coalescing + governed publish`. Blocked until SCREEN-01 merges. Likely **opus-tier** (derivation-model routing, coalescing invariant, privacy seam). See scratchpad draft.
+One issue: #3344 `[Heimdal Screen Stream] derive-activity-observations: local-vision derivation + span coalescing + governed publish` — **delivered**. Its dependency SCREEN-01/#3343 merged first, as planned; every acceptance criterion above is checked against a passing named test. Delivered opus-tier (derivation-model routing, coalescing invariant, privacy seam).

--- a/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md
@@ -34,12 +34,20 @@ the span boundaries the event motor needs.
    providers without changing the derivation contract. Providers run host-side over the bundle; none
    re-reads the screen.
 3. **Model routing per RUNTIME_MODEL_POSTURE (the binding floor).** Screen derivation is an **always-on
-   loop** → its task kind is `paid_eligible: false` in the provider census; the routing compiler
-   **rejects** any paid assignment (RUNTIME_MODEL_POSTURE §1/§4.2). Derivation therefore resolves to a
-   **local vision model** (Ollama-servable). This is the structural off-switch for the raw-pixel egress
-   seam — cloud vision derivation is not reachable for this task kind without an owner reclassification
-   that contradicts the floor. The declared egress posture (HEIM-12) for this stage names **zero raw
-   egress**.
+   loop** → its task kind (`heimdal.screen_derivation`) is `paid_eligible: false` in the provider census;
+   the routing compiler **rejects** any paid assignment (RUNTIME_MODEL_POSTURE §1/§4.2). Derivation
+   therefore resolves to a **local vision model** (Ollama-servable, census-declared `ollama/llava:7b`).
+   This is the structural off-switch for the raw-pixel egress seam — cloud vision derivation is not
+   reachable for this task kind without an owner reclassification that contradicts the floor.
+
+   **Declared egress posture (HEIM-12), delivered:** this stage declares **zero raw egress** — raw-class
+   evidence (`screen_frame`) never leaves the host trust boundary, and the stage's only model destination
+   is the host-local vision model. The declaration is structured and machine-checkable
+   (`app/heimdal/screen_derivation.py :: DECLARED_EGRESS`), not prose: `resolve_derivation_route` refuses
+   to compile a route at all when the census claims this task kind as paid-eligible or when the resolved
+   provider is not `tier: local`, so the refusal lands before a single frame is read. Enforced by
+   `tests/invariants/test_heimdal_seam.py::test_declared_egress`, the §8-reserved home HEIM-12's static
+   half now graduates into.
 4. **Coalesce into spans (INV-SCREEN-E).** Consecutive frames whose activity is unchanged collapse into
    one span observation with real `observed_at_start`/`observed_at_end` duration. A span boundary is
    created on **any** dimension shift — frontmost app, window/document, scope, or derived-goal change —

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -149,6 +149,25 @@ Current runtime path:
 2. The worker consumes DB outbox rows and performs ingest/index, panel scan, and promotion work, preserving bounded retries for transient missing or unstable notes before giving up.
 3. Health, status, and metrics confirm whether that path is healthy.
 
+## Heimdal screen derivation: host-local model precondition
+
+The screen derivation stage (`app/heimdal/screen_derivation.py`, SCREEN-02) refuses to send a raw
+screen frame to any endpoint it cannot prove is inside this host's trust boundary (HEIM-12: zero
+raw-class egress). Two operator-visible consequences:
+
+- **Endpoint.** The stage reads `OLLAMA_BASE_URL` / `OLLAMA_HOST` / `OLLAMA_URL` and accepts only a
+  loopback address, or a hostname listed in `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS`. A
+  container-network service name is not loopback, so the compose stack declares it explicitly
+  (`docker-compose.prod.yml` sets `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS: ollama`). Setting that
+  variable is an operator assertion that the named host really is inside this machine's boundary.
+  Without it the stage refuses loudly rather than degrading — that refusal is the feature.
+- **Model.** The route resolves to the census-declared local vision model `ollama/llava:7b`
+  (`docs/settings/models/providers.yaml`). `scripts/cold_boot.sh` does **not** pull it, so the first
+  derivation run on a fresh host fails loud until `ollama pull llava:7b` has run.
+
+The stage has no tick driver yet (SCREEN-06 owns the control surface), so neither precondition
+affects the current runtime path until a caller exists.
+
 ## Canonical Local Test Bootstrap
 
 The repo-supported local runtime verification path is the local `test` bootstrap golden path.

--- a/docs/settings/models/providers.yaml
+++ b/docs/settings/models/providers.yaml
@@ -59,6 +59,12 @@ providers:
       - id: llama3.1:8b
         effective_identity: ollama/llama3.1:8b
         capabilities: {structured_output: true, system_prompt_channel: true}
+      # Local vision model for the always-on Heimdal screen-derivation stage
+      # (heimdal.screen_derivation, SCREEN-02). Declared here so that stage's
+      # route names a census-declared model instead of an ad-hoc string.
+      - id: llava:7b
+        effective_identity: ollama/llava:7b
+        capabilities: {}
       - id: nomic-embed-text:latest
         effective_identity: ollama/nomic-embed-text:latest
         capabilities: {}

--- a/tests/heimdal/_screen_derivation_fixtures.py
+++ b/tests/heimdal/_screen_derivation_fixtures.py
@@ -1,0 +1,113 @@
+"""Shared fixtures for the SCREEN-02 derivation tests (#3344).
+
+Every screen-derivation test needs the same durable setup: an in-memory
+Heimdal backend, a registered screen sensor, an active `screen_always_on`
+grant, and one or more real frame bundles landed through the SCREEN-01
+ingress (`app.heimdal.screen_capture.ingest_screen_bundle`) so the raw
+records the derivation stage reads are the ones production actually writes,
+not hand-built rows.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any, Dict
+
+from app.heimdal.capture_adapter import register_sensor
+from app.heimdal.consent_ledger import grant_consent, reset_memory_consent_ledger
+from app.heimdal.observation_log import reset_memory_observation_log
+from app.heimdal.raw_read_gate import reset_memory_raw_read_receipts
+from app.heimdal.raw_store import all_raw_records, reset_memory_raw_store
+from app.heimdal.screen_capture import SCREEN_CAPTURE_SCOPE, ingest_screen_bundle
+from app.heimdal.screen_context_providers import reset_context_providers
+from app.heimdal.screen_derivation import ScreenFrame, screen_frame_from_raw_record
+
+RAW_STORE_KEY = bytes.fromhex(secrets.token_hex(32))
+SENSOR_ADAPTER = "screen-test"
+SENSOR_VERSION = "v1"
+MACHINE = "mac-1"
+GRANT_REF = "screen-test-grant"
+
+
+def reset_screen_derivation_state(monkeypatch: Any) -> None:
+    """Reset every durable Heimdal surface this stage touches, then re-seed consent."""
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("HEIMDAL_RAW_STORE_KEY", RAW_STORE_KEY.hex())
+    monkeypatch.setenv("HEIMDAL_RAW_READ_ALLOWLIST", "screen_derivation")
+    reset_memory_raw_store()
+    reset_memory_consent_ledger()
+    reset_memory_observation_log()
+    reset_memory_raw_read_receipts()
+    reset_context_providers()
+    register_sensor(SENSOR_ADAPTER, SENSOR_VERSION)
+    grant_consent(
+        grant_ref=GRANT_REF,
+        scope=SCREEN_CAPTURE_SCOPE,
+        basis="screen_always_on",
+        granted_by="operator",
+    )
+
+
+def screen_bundle(
+    *,
+    frame: str,
+    app: str = "Obsidian",
+    window: str = "ERE spec.md",
+    scope: str = "work",
+    machine: str = MACHINE,
+) -> Dict[str, Any]:
+    """One SCREEN-01 raw-capture bundle carrying its frontmost-app metadata."""
+    return {
+        "bundle_shape": "raw_capture_bundle",
+        "sensor": {"adapter": SENSOR_ADAPTER, "version": SENSOR_VERSION, "machine": machine},
+        "capture_chain": ["macos_screen_observer", "screen_capture_post"],
+        "raw": {"frame": frame, "app": app, "window": window, "scope": scope},
+    }
+
+
+def land_frame(
+    *,
+    frame: str,
+    observed_at: str,
+    app: str = "Obsidian",
+    window: str = "ERE spec.md",
+    scope: str = "work",
+    machine: str = MACHINE,
+) -> ScreenFrame:
+    """Land one frame through the real SCREEN-01 ingress and return its stage handle."""
+    bundle = screen_bundle(frame=frame, app=app, window=window, scope=scope, machine=machine)
+    ingest_screen_bundle(bundle, key=RAW_STORE_KEY)
+    record = all_raw_records()[-1]
+    return screen_frame_from_raw_record(record, observed_at=observed_at)
+
+
+def stub_vision_runner(
+    *,
+    summary: str | None = None,
+    goal: str = "draft the ERE spec",
+    confidence: float = 0.72,
+) -> Any:
+    """A deterministic stand-in for the local vision model.
+
+    Shaped exactly like the production local-vision call's return value
+    (`summary`/`goal`/`mentions`/`confidence`), and it echoes the dimensions
+    the context providers contributed so a provider change is visible in the
+    derived text.
+    """
+    calls: list[Any] = []
+
+    def runner(request: Any) -> Dict[str, Any]:
+        calls.append(request)
+        dimensions = dict(request.dimensions)
+        text = summary or (
+            f"Editing {dimensions.get('window', 'something')} in {dimensions.get('app', 'an app')}"
+        )
+        return {
+            "summary": text,
+            "goal": goal,
+            "mentions": [{"surface_form": dimensions.get("app", "unknown"), "kind_hint": "app"}],
+            "confidence": confidence,
+        }
+
+    runner.calls = calls  # type: ignore[attr-defined]
+    return runner

--- a/tests/heimdal/test_invariants_heim.py
+++ b/tests/heimdal/test_invariants_heim.py
@@ -540,12 +540,19 @@ def test_heim_11_attribution_resolves_in_register() -> None:
 #   where feasible).
 # Future test path (§8): tests/invariants/test_heimdal_seam.py::test_declared_egress
 #
-# NOTE: today the capture adapter states its no-cloud-fallback posture only
+# NOTE: the capture adapter still states its no-cloud-fallback posture only
 # in prose docstrings (app/heimdal/capture_adapter.py), not as a structured,
-# machine-checkable declaration. §8 calls for `static_test` "at enactment";
-# that structured declaration does not exist yet, so BOTH halves here are
-# honestly reserved rather than claiming a static pass the code does not
-# yet back.
+# machine-checkable declaration -- so the skeleton below stays honestly
+# reserved for that adapter and for the network-boundary probe.
+#
+# PARTIALLY GRADUATED (#3344, SCREEN-02): the screen-derivation stage
+# (app/heimdal/screen_derivation.py :: DECLARED_EGRESS) is the first Heimdal
+# stage carrying the structured declaration §8 asks for, and its static half
+# lives in the reserved §8 home,
+# tests/invariants/test_heimdal_seam.py::test_declared_egress -- see
+# GRADUATED_HEIM_FUTURE_TEST_PATHS below. The two halves are disjoint: nothing
+# here claims a pass the code does not back, and nothing there re-asserts what
+# is still unbuilt.
 
 
 def test_heim_12_declared_egress() -> None:
@@ -710,6 +717,14 @@ DISCHARGED_HEIM_TEST_NAMES = {
     "HEIM-9": "test_heim_9_observed_content_is_not_instruction",
 }
 
+# Invariants whose §8-reserved test path has now been built for real, holding
+# the half of the invariant that IS enforced today. The interim skeleton below
+# keeps only the still-unbuilt half, so the two never overlap and neither can
+# report a false green for the other.
+GRADUATED_HEIM_FUTURE_TEST_PATHS = {
+    "HEIM-12": "tests/invariants/test_heimdal_seam.py::test_declared_egress",
+}
+
 # Invariants with a reserved-but-unbuilt runtime half in THIS module. Each
 # must actually raise (xfail) when its harness fn runs, proving the skeleton
 # does not silently report green ahead of the runtime.
@@ -758,14 +773,33 @@ def test_heim_1_to_14_skeletons_present() -> None:
 
 
 def test_reserved_future_test_paths_do_not_exist_yet() -> None:
-    """§8 reserves tests/invariants/test_heimdal_*.py as future homes; none of
-    those files exist yet. If one appears, its invariant should graduate out
-    of this interim module's xfail set, not be duplicated silently."""
-    for entry in HEIM_REGISTRY.values():
-        rel_path = entry["future_test_path"].split("::", 1)[0]
-        assert not (REPO_ROOT / rel_path).exists(), (
-            f"{rel_path} now exists -- the corresponding HEIM invariant should "
-            "graduate its runtime test out of this interim skeleton module"
+    """§8 reserves tests/invariants/test_heimdal_*.py::<test> as future homes.
+
+    The accounting is per reserved TEST, not per file: several invariants share
+    one reserved file (HEIM-4/5/12 all reserve test_heimdal_seam.py), so one of
+    them graduating must not silently discharge its neighbours. A reserved test
+    that has not been built must still be absent; a graduated one must be
+    declared in GRADUATED_HEIM_FUTURE_TEST_PATHS and actually be defined at its
+    §8-reserved path.
+    """
+    for heim_id, entry in HEIM_REGISTRY.items():
+        rel_path, _, test_name = entry["future_test_path"].partition("::")
+        built = REPO_ROOT / rel_path
+        source = built.read_text(encoding="utf-8") if built.is_file() else ""
+        defined = f"def {test_name}(" in source
+        graduated_path = GRADUATED_HEIM_FUTURE_TEST_PATHS.get(heim_id)
+        if graduated_path is not None:
+            assert graduated_path == entry["future_test_path"], (
+                f"{heim_id} graduated path must be its §8-reserved path"
+            )
+            assert defined, (
+                f"{heim_id} is declared graduated but {rel_path} does not define {test_name}"
+            )
+            continue
+        assert not defined, (
+            f"{rel_path} now defines {test_name} -- the corresponding HEIM invariant should "
+            "graduate its runtime test out of this interim skeleton module "
+            "and be declared in GRADUATED_HEIM_FUTURE_TEST_PATHS"
         )
 
 

--- a/tests/heimdal/test_screen_coalescing.py
+++ b/tests/heimdal/test_screen_coalescing.py
@@ -15,6 +15,11 @@ from typing import Any, Dict, List
 import pytest
 
 from app.heimdal.observation_log import read_observations_from
+from app.heimdal.screen_context_providers import (
+    ContextContribution,
+    FrameContext,
+    register_context_provider,
+)
 from app.heimdal.screen_derivation import derive_activity_observations
 from tests.heimdal._screen_derivation_fixtures import (
     RAW_STORE_KEY,
@@ -131,3 +136,57 @@ def test_span_boundaries_survive_on_dimension_shift(monkeypatch: pytest.MonkeyPa
         assert (
             shift_spans[0]["dimensions"][dimension] != shift_spans[1]["dimensions"][dimension]
         ), f"{dimension} was not recorded as the shifted dimension"
+
+    # --- a provider's own declared axis also cuts a span
+    reset_screen_derivation_state(monkeypatch)
+    documents = iter(["doc-a", "doc-b"])
+
+    def document_provider(context: FrameContext) -> ContextContribution:
+        return ContextContribution(
+            provider="document",
+            facts=(),
+            mentions=(),
+            dimensions={"document_id": next(documents)},
+        )
+
+    register_context_provider("document", document_provider)
+    provider_tick = derive_activity_observations(
+        [
+            land_frame(frame="doc-1", observed_at="2026-07-11T14:00:00Z"),
+            land_frame(frame="doc-2", observed_at="2026-07-11T14:01:00Z"),
+        ],
+        episode_id="screen-session-provider-axis",
+        vision_runner=_goal_runner(["same goal", "same goal"]),
+        key=RAW_STORE_KEY,
+    )
+    assert provider_tick.coalesced == 0, "a provider-declared dimension shift was merged away"
+    assert provider_tick.observations_published == 2
+
+    # --- unknown never equals unknown: missing metadata over-segments
+    reset_screen_derivation_state(monkeypatch)
+    blind_tick = derive_activity_observations(
+        [
+            land_frame(frame="blind-1", observed_at="2026-07-11T15:00:00Z", window=""),
+            land_frame(frame="blind-2", observed_at="2026-07-11T15:01:00Z", window=""),
+        ],
+        episode_id="screen-session-blind",
+        vision_runner=_goal_runner(["same goal", "same goal"]),
+        key=RAW_STORE_KEY,
+    )
+    assert blind_tick.coalesced == 0, "frames with an unknown dimension were merged as identical"
+    assert blind_tick.observations_published == 2
+
+    # --- an out-of-order frame forces a boundary, never an inverted window
+    reset_screen_derivation_state(monkeypatch)
+    backwards_tick = derive_activity_observations(
+        [
+            land_frame(frame="back-1", observed_at="2026-07-11T16:05:00Z"),
+            land_frame(frame="back-2", observed_at="2026-07-11T16:00:00Z"),
+        ],
+        episode_id="screen-session-backwards",
+        vision_runner=_goal_runner(["same goal", "same goal"]),
+        key=RAW_STORE_KEY,
+    )
+    assert backwards_tick.coalesced == 0
+    for span in _spans():
+        assert span["start"] <= span["end"], "published a span that ends before it begins"

--- a/tests/heimdal/test_screen_coalescing.py
+++ b/tests/heimdal/test_screen_coalescing.py
@@ -1,0 +1,133 @@
+"""SCREEN-02 coalescing: spans collapse, boundaries survive (#3344, INV-SCREEN-E).
+
+AC3. Unchanged consecutive frames collapse into ONE span with a real
+start/end duration; a shift in ANY of the four segmenter dimensions
+(frontmost app, window/document, scope, derived goal) always creates a new
+span boundary. Over-segmentation is the preferred failure direction: a merge
+across a shift must fail, because a lost boundary is unrecoverable downstream
+while a spurious one is a cheap re-cut.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from app.heimdal.observation_log import read_observations_from
+from app.heimdal.screen_derivation import derive_activity_observations
+from tests.heimdal._screen_derivation_fixtures import (
+    RAW_STORE_KEY,
+    land_frame,
+    reset_screen_derivation_state,
+)
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_screen_derivation_state(monkeypatch)
+
+
+def _goal_runner(goals: List[str]) -> Any:
+    """A vision runner that returns a scripted goal per successive frame."""
+    remaining = list(goals)
+
+    def runner(request: Any) -> Dict[str, Any]:
+        dimensions = dict(request.dimensions)
+        goal = remaining.pop(0) if remaining else "unchanged goal"
+        return {
+            "summary": f"Working in {dimensions.get('app', 'an app')}",
+            "goal": goal,
+            "mentions": [{"surface_form": dimensions.get("app", "unknown"), "kind_hint": "app"}],
+            "confidence": 0.6,
+        }
+
+    return runner
+
+
+def _spans() -> List[Dict[str, Any]]:
+    payloads = [dict(row.envelope["payload"]) for row in read_observations_from(0)]
+    return [
+        {
+            "start": payload["observed_at_start"],
+            "end": payload["observed_at_end"],
+            "frame_count": payload["content_structure"]["span"]["frame_count"],
+            "dimensions": payload["content_structure"]["span"]["dimensions"],
+        }
+        for payload in payloads
+    ]
+
+
+SHIFTS: List[tuple[str, Dict[str, Any], List[str]]] = [
+    ("app", {"app": "Safari"}, ["same goal", "same goal"]),
+    ("window", {"window": "OTHER.md"}, ["same goal", "same goal"]),
+    ("scope", {"scope": "private"}, ["same goal", "same goal"]),
+    ("goal", {}, ["draft the ERE spec", "review PR #3185"]),
+]
+
+
+def test_span_boundaries_survive_on_dimension_shift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shift in any single segmenter dimension is never merged away.
+
+    Success path (merge direction): three unchanged frames coalesce into one
+    span with a real start/end duration. Completeness path (split direction):
+    each of the four dimensions, shifted alone, produces two spans whose
+    boundary lands exactly on the shifted frame -- a merge across the shift
+    fails the test.
+    """
+    # --- merge direction: unchanged activity coalesces into ONE span
+    frames = [
+        land_frame(frame=f"steady-{index}", observed_at=f"2026-07-11T11:0{index}:00Z")
+        for index in range(3)
+    ]
+    tick = derive_activity_observations(
+        frames,
+        episode_id="screen-session-steady",
+        vision_runner=_goal_runner(["draft the ERE spec"] * 3),
+        key=RAW_STORE_KEY,
+    )
+    assert tick.frames_read == 3
+    assert tick.coalesced == 2
+    assert tick.observations_published == 1
+
+    spans = _spans()
+    assert len(spans) == 1
+    assert spans[0]["start"] == "2026-07-11T11:00:00Z"
+    assert spans[0]["end"] == "2026-07-11T11:02:00Z"
+    assert spans[0]["frame_count"] == 3
+
+    # --- split direction: every dimension shift keeps its boundary
+    for dimension, shifted_frame_kwargs, goals in SHIFTS:
+        reset_screen_derivation_state(monkeypatch)
+
+        first = land_frame(frame=f"{dimension}-1", observed_at="2026-07-11T12:00:00Z")
+        second = land_frame(
+            frame=f"{dimension}-2",
+            observed_at="2026-07-11T12:01:00Z",
+            **shifted_frame_kwargs,
+        )
+
+        shift_tick = derive_activity_observations(
+            [first, second],
+            episode_id=f"screen-session-{dimension}",
+            vision_runner=_goal_runner(goals),
+            key=RAW_STORE_KEY,
+        )
+
+        assert shift_tick.coalesced == 0, f"{dimension} shift was merged away"
+        assert shift_tick.observations_published == 2, f"{dimension} shift lost a boundary"
+
+        shift_spans = _spans()
+        assert len(shift_spans) == 2, f"{dimension} shift did not produce two spans"
+        assert shift_spans[0]["frame_count"] == 1 and shift_spans[1]["frame_count"] == 1
+        assert shift_spans[0]["start"] == "2026-07-11T12:00:00Z"
+        assert shift_spans[0]["end"] == "2026-07-11T12:00:00Z"
+        # The boundary is real: the second span starts at the shifted frame and
+        # no span reaches across the shift.
+        assert shift_spans[1]["start"] == "2026-07-11T12:01:00Z"
+        assert shift_spans[1]["end"] == "2026-07-11T12:01:00Z"
+        assert (
+            shift_spans[0]["dimensions"][dimension] != shift_spans[1]["dimensions"][dimension]
+        ), f"{dimension} was not recorded as the shifted dimension"

--- a/tests/heimdal/test_screen_coalescing.py
+++ b/tests/heimdal/test_screen_coalescing.py
@@ -162,19 +162,40 @@ def test_span_boundaries_survive_on_dimension_shift(monkeypatch: pytest.MonkeyPa
     assert provider_tick.coalesced == 0, "a provider-declared dimension shift was merged away"
     assert provider_tick.observations_published == 2
 
-    # --- unknown never equals unknown: missing metadata over-segments
+    # --- all-unknown never equals all-unknown: a blind client over-segments
+    # rather than collapsing an arbitrarily long window into one observation.
     reset_screen_derivation_state(monkeypatch)
     blind_tick = derive_activity_observations(
         [
-            land_frame(frame="blind-1", observed_at="2026-07-11T15:00:00Z", window=""),
-            land_frame(frame="blind-2", observed_at="2026-07-11T15:01:00Z", window=""),
+            land_frame(
+                frame="blind-1", observed_at="2026-07-11T15:00:00Z", app="", window="", scope=""
+            ),
+            land_frame(
+                frame="blind-2", observed_at="2026-07-11T15:01:00Z", app="", window="", scope=""
+            ),
         ],
         episode_id="screen-session-blind",
-        vision_runner=_goal_runner(["same goal", "same goal"]),
+        vision_runner=_goal_runner(["", ""]),
         key=RAW_STORE_KEY,
     )
-    assert blind_tick.coalesced == 0, "frames with an unknown dimension were merged as identical"
+    assert blind_tick.coalesced == 0, "frames with no known dimension were merged as identical"
     assert blind_tick.observations_published == 2
+
+    # ...but one unknown axis must NOT switch coalescing off: a model that
+    # answers without naming a goal still coalesces on the known dimensions,
+    # or the stream floods (the failure AC3's merge direction prevents).
+    reset_screen_derivation_state(monkeypatch)
+    partial_tick = derive_activity_observations(
+        [
+            land_frame(frame="partial-1", observed_at="2026-07-11T15:10:00Z"),
+            land_frame(frame="partial-2", observed_at="2026-07-11T15:11:00Z"),
+        ],
+        episode_id="screen-session-partial",
+        vision_runner=_goal_runner(["", ""]),
+        key=RAW_STORE_KEY,
+    )
+    assert partial_tick.coalesced == 1, "a missing goal switched coalescing off entirely"
+    assert partial_tick.observations_published == 1
 
     # --- an out-of-order frame forces a boundary, never an inverted window
     reset_screen_derivation_state(monkeypatch)

--- a/tests/heimdal/test_screen_context_providers.py
+++ b/tests/heimdal/test_screen_context_providers.py
@@ -135,6 +135,30 @@ def test_two_providers_cannot_claim_one_segmenter_dimension() -> None:
             vision_runner=stub_vision_runner(),
             key=RAW_STORE_KEY,
         )
+    unregister_context_provider("shadow")
+
+
+def test_the_stage_is_not_an_unguarded_third_writer_of_the_goal_axis() -> None:
+    """The stage's own `goal` contribution obeys the one-writer rule too.
+
+    The derived goal is a segmenter axis like any other. If a provider claims
+    `goal`, the stage overwriting it would silently move a span boundary --
+    the same defect the provider-vs-provider guard exists to prevent, with the
+    stage as the unguarded writer.
+    """
+
+    def goal_provider(context: FrameContext) -> ContextContribution:
+        return ContextContribution(provider="planner", dimensions={"goal": "provider goal"})
+
+    register_context_provider("planner", goal_provider)
+    frame = land_frame(frame="providers-goal-conflict", observed_at="2026-07-11T13:04:00Z")
+    with pytest.raises(ContextDimensionConflictError, match="goal"):
+        derive_activity_observations(
+            [frame],
+            episode_id="screen-session-providers",
+            vision_runner=stub_vision_runner(),
+            key=RAW_STORE_KEY,
+        )
 
 
 def test_frontmost_app_provider_supplies_the_segmenter_dimensions() -> None:

--- a/tests/heimdal/test_screen_context_providers.py
+++ b/tests/heimdal/test_screen_context_providers.py
@@ -24,7 +24,10 @@ from app.heimdal.screen_context_providers import (
     registered_context_providers,
     unregister_context_provider,
 )
-from app.heimdal.screen_derivation import derive_activity_observations
+from app.heimdal.screen_derivation import (
+    ContextDimensionConflictError,
+    derive_activity_observations,
+)
 from tests.heimdal._screen_derivation_fixtures import (
     RAW_STORE_KEY,
     land_frame,
@@ -109,6 +112,29 @@ def test_provider_registry_extensible() -> None:
 
     unregister_context_provider("git_branch")
     assert [name for name, _ in registered_context_providers()] == [FRONTMOST_APP_PROVIDER]
+
+
+def test_two_providers_cannot_claim_one_segmenter_dimension() -> None:
+    """A provider must not silently overwrite another's span dimension.
+
+    Last-writer-wins on `app`/`window`/`scope` would let a second provider move
+    a span boundary invisibly (INV-SCREEN-E, the unrecoverable direction), so
+    the collision is refused at derivation time rather than resolved by
+    registration order.
+    """
+
+    def shadow_provider(context: FrameContext) -> ContextContribution:
+        return ContextContribution(provider="shadow", dimensions={"app": "CONSTANT"})
+
+    register_context_provider("shadow", shadow_provider)
+    frame = land_frame(frame="providers-conflict", observed_at="2026-07-11T13:03:00Z")
+    with pytest.raises(ContextDimensionConflictError, match="app"):
+        derive_activity_observations(
+            [frame],
+            episode_id="screen-session-providers",
+            vision_runner=stub_vision_runner(),
+            key=RAW_STORE_KEY,
+        )
 
 
 def test_frontmost_app_provider_supplies_the_segmenter_dimensions() -> None:

--- a/tests/heimdal/test_screen_context_providers.py
+++ b/tests/heimdal/test_screen_context_providers.py
@@ -1,0 +1,139 @@
+"""SCREEN-02 local context providers are pluggable (#3344).
+
+AC5. The frontmost-app/window provider is provider #1; others (active
+calendar event, the frontmost editor's git branch, playing media) plug in as
+declared providers. Adding one must change the derived summary/mentions
+*without* changing the observation contract or the derivation entrypoint
+signature.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, List
+
+import pytest
+
+from app.events.topic_schema_registry import validate_topic_payload
+from app.heimdal.observation_log import read_observations_from
+from app.heimdal.screen_context_providers import (
+    FRONTMOST_APP_PROVIDER,
+    ContextContribution,
+    FrameContext,
+    register_context_provider,
+    registered_context_providers,
+    unregister_context_provider,
+)
+from app.heimdal.screen_derivation import derive_activity_observations
+from tests.heimdal._screen_derivation_fixtures import (
+    RAW_STORE_KEY,
+    land_frame,
+    reset_screen_derivation_state,
+    stub_vision_runner,
+)
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_screen_derivation_state(monkeypatch)
+
+
+def _git_branch_provider(context: FrameContext) -> ContextContribution:
+    """A second local provider: the frontmost editor's checked-out branch."""
+    branch = str(context.bundle.get("git_branch") or "feature/ere")
+    return ContextContribution(
+        provider="git_branch",
+        facts=(f"git branch: {branch}",),
+        mentions=({"surface_form": branch, "kind_hint": "git_branch"},),
+    )
+
+
+def _payload() -> Dict[str, Any]:
+    rows = read_observations_from(0)
+    return dict(rows[-1].envelope["payload"])
+
+
+def test_provider_registry_extensible() -> None:
+    """Success path: a new provider changes the derived text and mentions.
+
+    Completeness path: the derivation entrypoint signature and the published
+    observation contract are byte-for-byte unchanged by the added provider,
+    and the registry refuses a duplicate or non-callable registration.
+    """
+    baseline_signature = inspect.signature(derive_activity_observations)
+    assert [name for name, _ in registered_context_providers()] == [FRONTMOST_APP_PROVIDER]
+
+    first = land_frame(frame="providers-1", observed_at="2026-07-11T13:00:00Z")
+    derive_activity_observations(
+        [first],
+        episode_id="screen-session-providers",
+        vision_runner=stub_vision_runner(),
+        key=RAW_STORE_KEY,
+    )
+    before = _payload()
+    assert "git branch" not in str(before["content"])
+    assert all(m["kind_hint"] != "git_branch" for m in before["entity_mentions"])
+
+    # --- add a provider; same entrypoint call, richer derived observation
+    register_context_provider("git_branch", _git_branch_provider)
+    assert [name for name, _ in registered_context_providers()] == [
+        FRONTMOST_APP_PROVIDER,
+        "git_branch",
+    ]
+
+    second = land_frame(frame="providers-2", observed_at="2026-07-11T13:01:00Z")
+    derive_activity_observations(
+        [second],
+        episode_id="screen-session-providers",
+        vision_runner=stub_vision_runner(),
+        key=RAW_STORE_KEY,
+    )
+    after = _payload()
+
+    assert "git branch: feature/ere" in str(after["content"])
+    assert any(m["kind_hint"] == "git_branch" for m in after["entity_mentions"])
+    assert any(m["surface_form"] == "feature/ere" for m in after["entity_mentions"])
+
+    # --- contract unchanged: same entrypoint signature, same payload shape
+    assert inspect.signature(derive_activity_observations) == baseline_signature
+    assert set(after) == set(before)
+    validate_topic_payload("heimdal.observation.published", after)
+
+    # --- registry refuses ambiguous or unusable registrations
+    with pytest.raises(ValueError, match="already registered"):
+        register_context_provider("git_branch", _git_branch_provider)
+    with pytest.raises(TypeError):
+        register_context_provider("not_callable", "nope")  # type: ignore[arg-type]
+
+    unregister_context_provider("git_branch")
+    assert [name for name, _ in registered_context_providers()] == [FRONTMOST_APP_PROVIDER]
+
+
+def test_frontmost_app_provider_supplies_the_segmenter_dimensions() -> None:
+    """Provider #1 is what feeds the app/window/scope coalescing dimensions."""
+    frame = land_frame(
+        frame="providers-dimensions",
+        observed_at="2026-07-11T13:02:00Z",
+        app="Safari",
+        window="PR #3185",
+        scope="work",
+    )
+    requests: List[Any] = []
+
+    def runner(request: Any) -> Dict[str, Any]:
+        requests.append(request)
+        return {"summary": "Reviewing a pull request", "goal": "review", "confidence": 0.5}
+
+    derive_activity_observations(
+        [frame],
+        episode_id="screen-session-providers",
+        vision_runner=runner,
+        key=RAW_STORE_KEY,
+    )
+    assert requests
+    dimensions = dict(requests[0].dimensions)
+    assert dimensions["app"] == "Safari"
+    assert dimensions["window"] == "PR #3185"
+    assert dimensions["scope"] == "work"

--- a/tests/heimdal/test_screen_derivation.py
+++ b/tests/heimdal/test_screen_derivation.py
@@ -1,0 +1,167 @@
+"""SCREEN-02 derivation: one frame bundle -> one governed activity observation (#3344).
+
+AC1 (`test_bundle_derives_and_publishes_observation`) and AC4
+(`test_unprovenanced_observation_refuses_publish`). Both drive the production
+entrypoint `app.heimdal.screen_derivation.derive_activity_observations` over
+frames landed through the real SCREEN-01 ingress -- no hand-built raw rows and
+no bypass of the governed publish path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from app.heimdal import screen_derivation
+from app.heimdal.observation_log import count_observations, read_observations_from
+from app.heimdal.screen_derivation import (
+    UnprovenancedObservationError,
+    derive_activity_observations,
+)
+from tests.heimdal._screen_derivation_fixtures import (
+    MACHINE,
+    RAW_STORE_KEY,
+    SENSOR_ADAPTER,
+    SENSOR_VERSION,
+    land_frame,
+    reset_screen_derivation_state,
+    stub_vision_runner,
+)
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_screen_derivation_state(monkeypatch)
+
+
+def _payloads() -> List[Dict[str, Any]]:
+    return [dict(row.envelope["payload"]) for row in read_observations_from(0)]
+
+
+def test_bundle_derives_and_publishes_observation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1: frame bundle + app metadata -> one observation on the governed path.
+
+    Success path: the derived observation carries a textual activity summary,
+    entity mentions, and per-axis confidence, and it reaches the log *through*
+    `publish_full_observation` (spied at the production call site), not a
+    bespoke insert. Completeness path: re-deriving the identical frame is
+    idempotent -- the governed path dedups instead of double-publishing.
+    """
+    publishes: List[Dict[str, Any]] = []
+    real_publish = screen_derivation.publish_full_observation
+
+    def spy_publish(**kwargs: Any) -> Any:
+        publishes.append(dict(kwargs))
+        return real_publish(**kwargs)
+
+    monkeypatch.setattr(screen_derivation, "publish_full_observation", spy_publish)
+
+    frame = land_frame(frame="frame-a", observed_at="2026-07-11T08:00:00Z")
+    runner = stub_vision_runner()
+
+    tick = derive_activity_observations(
+        [frame],
+        episode_id="screen-session-1",
+        vision_runner=runner,
+        key=RAW_STORE_KEY,
+    )
+
+    assert tick.frames_read == 1
+    assert tick.observations_published == 1
+    assert tick.route.task_kind == "heimdal.screen_derivation"
+    assert tick.route.paid_eligible is False
+    assert tick.raw_egress == "none"
+
+    # The one publish went through the governed, schema-validating seam.
+    assert len(publishes) == 1
+    assert publishes[0]["topic"] == "heimdal.observation.published"
+    assert publishes[0]["source"] == "heimdal.screen_derivation"
+
+    assert count_observations() == 1
+    payload = _payloads()[0]
+    assert payload["modality"] == "screen"
+    assert payload["episode_id"] == "screen-session-1"
+    assert "Obsidian" in str(payload["content"])
+    assert payload["observed_at_start"] == "2026-07-11T08:00:00Z"
+    assert payload["observed_at_end"] == "2026-07-11T08:00:00Z"
+
+    # Entity mentions surfaced, and honestly unresolved (HEIM-6/HEIM-11:
+    # derivation surfaces mentions, it does not mint canonical identities).
+    mentions = payload["entity_mentions"]
+    assert mentions and {m["resolution"] for m in mentions} == {"unresolved"}
+    assert any(m["surface_form"] == "Obsidian" for m in mentions)
+
+    # Per-axis confidence, never a single scalar (FABLE_COMPANION §2).
+    confidence = payload["confidence"]
+    assert set(confidence) >= {"attribution", "activity_summary", "entity_mention"}
+    for axis in confidence.values():
+        assert 0.0 <= axis["score"] <= 1.0
+        assert axis["calibration"] in {"calibrated", "heuristic", "by_construction"}
+    assert confidence["activity_summary"]["model_ref"] == tick.route.model_ref
+
+    provenance = payload["provenance"]
+    assert provenance["sensor"] == {
+        "adapter": SENSOR_ADAPTER,
+        "version": SENSOR_VERSION,
+        "machine": MACHINE,
+    }
+    assert provenance["capture_chain"]
+    assert provenance["content_identity"]
+    assert provenance["content_hash"]
+    assert provenance["stage_versions"]["screen_derivation"].endswith(
+        screen_derivation.ENGINE_VERSION
+    )
+    assert provenance["model_ref"] == tick.route.model_ref
+    assert payload["consent"]["grant_ref"]
+
+    # Completeness: the same frame re-derived is idempotent on the governed path.
+    replay = derive_activity_observations(
+        [frame],
+        episode_id="screen-session-1",
+        vision_runner=stub_vision_runner(),
+        key=RAW_STORE_KEY,
+    )
+    assert replay.observations_published == 0
+    assert count_observations() == 1
+
+
+def test_unprovenanced_observation_refuses_publish() -> None:
+    """AC4 (INV-SCREEN-B): text derived, provenance incomplete -> no publish.
+
+    Negative path: a bundle whose sensor cannot name the machine derives its
+    activity text (the vision runner is called) but cannot stamp complete
+    provenance, so the stage refuses loudly and the observation log stays
+    empty -- never a partial write, never a silently unprovenanced row.
+    Completeness path: the same frame with a complete sensor publishes.
+    """
+    unprovenanced = land_frame(
+        frame="frame-unprovenanced",
+        observed_at="2026-07-11T09:00:00Z",
+        machine="",
+    )
+    runner = stub_vision_runner()
+
+    with pytest.raises(UnprovenancedObservationError, match="machine"):
+        derive_activity_observations(
+            [unprovenanced],
+            episode_id="screen-session-2",
+            vision_runner=runner,
+            key=RAW_STORE_KEY,
+        )
+
+    # The text WAS derived -- the refusal is about stamping, not about reading.
+    assert runner.calls
+    assert count_observations() == 0
+
+    complete = land_frame(frame="frame-provenanced", observed_at="2026-07-11T09:01:00Z")
+    tick = derive_activity_observations(
+        [complete],
+        episode_id="screen-session-2",
+        vision_runner=stub_vision_runner(),
+        key=RAW_STORE_KEY,
+    )
+    assert tick.observations_published == 1
+    assert count_observations() == 1

--- a/tests/heimdal/test_screen_derivation.py
+++ b/tests/heimdal/test_screen_derivation.py
@@ -73,7 +73,6 @@ def test_bundle_derives_and_publishes_observation(monkeypatch: pytest.MonkeyPatc
     assert tick.observations_published == 1
     assert tick.route.task_kind == "heimdal.screen_derivation"
     assert tick.route.paid_eligible is False
-    assert tick.raw_egress == "none"
 
     # The one publish went through the governed, schema-validating seam.
     assert len(publishes) == 1
@@ -126,6 +125,21 @@ def test_bundle_derives_and_publishes_observation(monkeypatch: pytest.MonkeyPatc
     )
     assert replay.observations_published == 0
     assert count_observations() == 1
+
+    # And the identity is anchored to the EVIDENCE, not to the model's wording:
+    # a replay whose local model rewords the summary must land on the same
+    # observation_id (a revision of the same frames), never a second unlinked
+    # observation that would double-count this activity downstream.
+    original_id = _payloads()[0]["observation_id"]
+    reworded = derive_activity_observations(
+        [frame],
+        episode_id="screen-session-1",
+        vision_runner=stub_vision_runner(summary="Writing in Obsidian, different wording"),
+        key=RAW_STORE_KEY,
+    )
+    assert reworded.observations_published == 1
+    ids = {payload["observation_id"] for payload in _payloads()}
+    assert ids == {original_id}, "replayed span must keep one evidence-derived identity"
 
 
 def test_unprovenanced_observation_refuses_publish() -> None:

--- a/tests/heimdal/test_screen_derivation_routing.py
+++ b/tests/heimdal/test_screen_derivation_routing.py
@@ -1,0 +1,139 @@
+"""SCREEN-02 enforcement: local-only routing + gated raw read at the call site (#3344).
+
+AC2. This asserts the two privacy-seam properties **at the production
+derivation call site** (`derive_activity_observations`), not on a helper in
+isolation:
+
+1. the route compiled for task kind `heimdal.screen_derivation` is
+   `paid_eligible: false` and resolves to a local-tier provider; a census that
+   declares the task kind paid-eligible is *rejected* by the compiler before
+   any raw byte is read (RUNTIME_MODEL_POSTURE §1/§4.2 always-on-local floor);
+2. raw evidence is reached only through the gated read path
+   (`app.heimdal.raw_read_gate.read_raw_record`), leaving one receipt per
+   frame -- and a reader that is not on the allowlist gets no bytes and no
+   observation (HEIM-5).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from app.components.settings.providers_loader import load_provider_census
+from app.heimdal import screen_derivation
+from app.heimdal.observation_log import count_observations
+from app.heimdal.raw_read_gate import RawReadRefusedError, all_raw_read_receipts
+from app.heimdal.screen_derivation import (
+    TASK_KIND,
+    PaidRouteRejectedError,
+    derive_activity_observations,
+    resolve_derivation_route,
+)
+from tests.heimdal._screen_derivation_fixtures import (
+    RAW_STORE_KEY,
+    land_frame,
+    reset_screen_derivation_state,
+    stub_vision_runner,
+)
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_screen_derivation_state(monkeypatch)
+
+
+def _census_with_paid_task_kind() -> Any:
+    """The shipped census, mutated so a paid provider claims this task kind."""
+    census = load_provider_census()
+    paid = next(provider for provider in census.providers if provider.tier == "paid")
+    paid.paid_eligible_task_kinds = [*paid.paid_eligible_task_kinds, TASK_KIND]
+    return census
+
+
+def test_screen_derivation_is_paid_ineligible_and_reads_raw_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = land_frame(frame="frame-routing", observed_at="2026-07-11T10:00:00Z")
+
+    # --- success path: production call site compiles a local route and reads gated
+    reads: List[dict] = []
+    real_read = screen_derivation.read_raw_record
+
+    def spy_read(raw_ref: str, **kwargs: Any) -> Any:
+        reads.append({"raw_ref": raw_ref, **kwargs})
+        return real_read(raw_ref, **kwargs)
+
+    monkeypatch.setattr(screen_derivation, "read_raw_record", spy_read)
+
+    tick = derive_activity_observations(
+        [frame],
+        episode_id="screen-session-routing",
+        vision_runner=stub_vision_runner(),
+        key=RAW_STORE_KEY,
+    )
+
+    assert tick.route.task_kind == TASK_KIND
+    assert tick.route.paid_eligible is False
+    assert tick.route.tier == "local"
+    assert tick.route.provider == "ollama"
+    assert tick.observations_published == 1
+
+    # The one raw read went through the gate, with this stage's reader identity.
+    assert len(reads) == 1
+    assert reads[0]["raw_ref"] == frame.raw_ref
+    assert reads[0]["reader"] == "screen_derivation"
+    assert reads[0]["purpose"] == "screen_derivation"
+
+    receipts = all_raw_read_receipts()
+    assert len(receipts) == 1
+    assert receipts[0].reader == "screen_derivation"
+    assert receipts[0].raw_ref == frame.raw_ref
+
+    # The shipped census itself keeps this always-on task kind paid-ineligible.
+    assert resolve_derivation_route().paid_eligible is False
+
+    # --- negative path 1: a paid assignment is rejected by the compiler, before any read
+    monkeypatch.setattr(screen_derivation, "load_provider_census", _census_with_paid_task_kind)
+    reads.clear()
+    before = count_observations()
+    with pytest.raises(PaidRouteRejectedError, match=TASK_KIND):
+        derive_activity_observations(
+            [land_frame(frame="frame-paid", observed_at="2026-07-11T10:01:00Z")],
+            episode_id="screen-session-routing",
+            vision_runner=stub_vision_runner(),
+            key=RAW_STORE_KEY,
+        )
+    assert reads == []
+    assert count_observations() == before
+    assert len(all_raw_read_receipts()) == 1
+
+    monkeypatch.setattr(screen_derivation, "load_provider_census", load_provider_census)
+
+    # --- negative path 2: no ungated raw path exists to fall back to (HEIM-5)
+    monkeypatch.setenv("HEIMDAL_RAW_READ_ALLOWLIST", "")
+    with pytest.raises(RawReadRefusedError):
+        derive_activity_observations(
+            [land_frame(frame="frame-refused", observed_at="2026-07-11T10:02:00Z")],
+            episode_id="screen-session-routing",
+            vision_runner=stub_vision_runner(),
+            key=RAW_STORE_KEY,
+        )
+    assert count_observations() == before
+    assert len(all_raw_read_receipts()) == 1
+
+
+def test_derivation_module_has_no_paid_provider_code_path() -> None:
+    """Completeness: the stage cannot degrade into a cloud route.
+
+    Mirrors the ASR stage's "there is no cloud code path in this module at all
+    to silently fall into" posture -- the module names no paid provider and
+    reaches no generic, env-routed LLM dispatcher.
+    """
+    source = screen_derivation.__file__
+    with open(source, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    for forbidden in ("openai", "anthropic", "deepseek", "app.llm.adapter", "app.services.llm"):
+        assert forbidden not in text, f"screen derivation must not reference {forbidden}"

--- a/tests/heimdal/test_screen_derivation_routing.py
+++ b/tests/heimdal/test_screen_derivation_routing.py
@@ -177,6 +177,57 @@ def test_raw_frames_refuse_a_destination_that_is_not_host_local(
     assert screen_derivation.resolve_local_vision_endpoint() == "http://ollama:11434"
 
 
+def test_local_vision_refuses_to_follow_a_redirect_off_the_validated_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validated destination must stay validated for every hop.
+
+    A 3xx from the local endpoint would otherwise make `requests` resend the
+    frame body to a `Location` the endpoint validator never saw -- the same
+    escape the proxy guard closes, one hop later. The request must not follow
+    it, and the refusal must surface as an egress refusal rather than be
+    laundered into a generic "model unavailable".
+    """
+
+    class _Redirect:
+        is_redirect = True
+        is_permanent_redirect = False
+        headers = {"Location": "https://vision.example.com/api/chat"}
+
+        def raise_for_status(self) -> None:  # pragma: no cover - never reached
+            raise AssertionError("redirect must be refused before raise_for_status")
+
+        def json(self) -> Any:  # pragma: no cover - never reached
+            raise AssertionError("redirect must be refused before the body is read")
+
+    sent: List[Any] = []
+
+    class _Session:
+        trust_env = True
+
+        def post(self, url: str, **kwargs: Any) -> Any:
+            sent.append(kwargs)
+            assert kwargs.get("allow_redirects") is False, "redirects must not be followed"
+            return _Redirect()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(screen_derivation, "local_vision_session", lambda: _Session())
+    for variable in ("OLLAMA_HOST", "OLLAMA_URL"):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+
+    with pytest.raises(screen_derivation.RawEgressRefusedError, match="redirect"):
+        derive_activity_observations(
+            [land_frame(frame="frame-redirect", observed_at="2026-07-11T10:20:00Z")],
+            episode_id="screen-session-redirect",
+            key=RAW_STORE_KEY,
+        )
+    assert len(sent) == 1, "exactly one request should have been attempted"
+    assert count_observations() == 0
+
+
 def test_local_vision_request_ignores_ambient_proxy_configuration() -> None:
     """A validated loopback address must not be re-routed by an ambient proxy.
 

--- a/tests/heimdal/test_screen_derivation_routing.py
+++ b/tests/heimdal/test_screen_derivation_routing.py
@@ -184,8 +184,7 @@ def test_local_vision_request_ignores_ambient_proxy_configuration() -> None:
     carry a loopback-addressed raw frame off the host after the address itself
     was proven host-local. The session must disable `trust_env`.
     """
-    source = Path(screen_derivation.__file__).read_text(encoding="utf-8")
-    assert "session.trust_env = False" in source
+    assert screen_derivation.local_vision_session().trust_env is False
 
 
 def test_derivation_module_has_no_paid_provider_code_path() -> None:

--- a/tests/heimdal/test_screen_derivation_routing.py
+++ b/tests/heimdal/test_screen_derivation_routing.py
@@ -16,6 +16,7 @@ isolation:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, List
 
 import pytest
@@ -125,6 +126,68 @@ def test_screen_derivation_is_paid_ineligible_and_reads_raw_gated(
     assert len(all_raw_read_receipts()) == 1
 
 
+def test_raw_frames_refuse_a_destination_that_is_not_host_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production egress path: the census proves a name, this proves a socket.
+
+    A `tier: local` census entry says nothing about where `OLLAMA_BASE_URL`
+    actually points. Success path: a loopback endpoint (and an explicitly
+    operator-declared host-local one) is accepted. Negative path: a remote
+    endpoint is refused *and no request is issued* -- the frame is never
+    transmitted, so `DECLARED_EGRESS[raw_class_egress] is False` stays true.
+    """
+    posts: List[Any] = []
+
+    def spy_post(endpoint: str, body: Any) -> str:
+        posts.append(endpoint)
+        return '{"summary": "Editing a note", "goal": "write", "confidence": 0.5}'
+
+    monkeypatch.setattr(screen_derivation, "_post_local_vision", spy_post)
+    for variable in ("OLLAMA_HOST", "OLLAMA_URL"):
+        monkeypatch.delenv(variable, raising=False)
+
+    # --- negative path: a remote destination is refused before any transmission
+    monkeypatch.setenv("OLLAMA_BASE_URL", "https://vision.example.com")
+    monkeypatch.delenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, raising=False)
+    with pytest.raises(screen_derivation.RawEgressRefusedError, match="vision.example.com"):
+        derive_activity_observations(
+            [land_frame(frame="frame-remote", observed_at="2026-07-11T10:10:00Z")],
+            episode_id="screen-session-egress",
+            key=RAW_STORE_KEY,
+        )
+    assert posts == [], "a frame was transmitted to a non-host-local destination"
+    assert count_observations() == 0
+
+    # --- success path: loopback is accepted and reaches the local model
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+    tick = derive_activity_observations(
+        [land_frame(frame="frame-loopback", observed_at="2026-07-11T10:11:00Z")],
+        episode_id="screen-session-egress",
+        key=RAW_STORE_KEY,
+    )
+    assert tick.observations_published == 1
+    assert posts == ["http://127.0.0.1:11434"]
+
+    # --- completeness: a container-network host is host-local only when declared
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama:11434")
+    with pytest.raises(screen_derivation.RawEgressRefusedError):
+        screen_derivation.resolve_local_vision_endpoint()
+    monkeypatch.setenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, "ollama")
+    assert screen_derivation.resolve_local_vision_endpoint() == "http://ollama:11434"
+
+
+def test_local_vision_request_ignores_ambient_proxy_configuration() -> None:
+    """A validated loopback address must not be re-routed by an ambient proxy.
+
+    `requests` honours HTTP_PROXY/HTTPS_PROXY/ALL_PROXY by default, which would
+    carry a loopback-addressed raw frame off the host after the address itself
+    was proven host-local. The session must disable `trust_env`.
+    """
+    source = Path(screen_derivation.__file__).read_text(encoding="utf-8")
+    assert "session.trust_env = False" in source
+
+
 def test_derivation_module_has_no_paid_provider_code_path() -> None:
     """Completeness: the stage cannot degrade into a cloud route.
 
@@ -132,8 +195,6 @@ def test_derivation_module_has_no_paid_provider_code_path() -> None:
     to silently fall into" posture -- the module names no paid provider and
     reaches no generic, env-routed LLM dispatcher.
     """
-    source = screen_derivation.__file__
-    with open(source, "r", encoding="utf-8") as handle:
-        text = handle.read()
+    text = Path(screen_derivation.__file__).read_text(encoding="utf-8")
     for forbidden in ("openai", "anthropic", "deepseek", "app.llm.adapter", "app.services.llm"):
         assert forbidden not in text, f"screen derivation must not reference {forbidden}"

--- a/tests/heimdal/test_screen_derivation_routing.py
+++ b/tests/heimdal/test_screen_derivation_routing.py
@@ -177,6 +177,133 @@ def test_raw_frames_refuse_a_destination_that_is_not_host_local(
     assert screen_derivation.resolve_local_vision_endpoint() == "http://ollama:11434"
 
 
+#: Endpoint shapes that have historically split one URL parser from another,
+#: or that merely look host-local. Which of these a given `urllib.parse` /
+#: `urllib3` version disagrees on is a moving target, so this asserts the
+#: invariant rather than any one parser's quirk.
+ADVERSARIAL_ENDPOINTS = [
+    # Backslash and bracket shapes split `urllib.parse` from `urllib3`. Which
+    # direction they split in is version-dependent -- on urllib3 2.5.0 /
+    # CPython 3.12, `http://evil.example.com\@127.0.0.1` reads as loopback to
+    # `urllib.parse` while `requests` dials `evil.example.com`, which is
+    # exactly the exploitable direction.
+    "http://evil.example.com\\@127.0.0.1",
+    "http://127.0.0.1:11434\\@evil.example.com",
+    "http://127.0.0.1\\evil.example.com",
+    "http://evil.example.com]@127.0.0.1",
+    "http://127.0.0.1:11434[@evil.example.com",
+    "http://127.0.0.1%evil.example.com",
+    "http://127.0.0.1:evil.example.com",
+    "http://127.0.0.1@evil.example.com",
+    "http://localhost#@evil.example.com",
+    "http://evil.example.com#@127.0.0.1",
+    "http://localhost.evil.example.com",
+    "http://127.0.0.1.evil.example.com",
+    "http://2130706433",
+    "http://0177.0.0.1",
+    "http://127.0.0.2",
+    "http://0.0.0.0",
+    "http://[::ffff:127.0.0.1]",
+    "//evil.example.com",
+    "http://evil.example.com/../127.0.0.1",
+]
+
+
+def test_the_validated_host_is_the_host_the_client_actually_dials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validation and transmission must read one parser, never two.
+
+    A validator that parses the endpoint with a different library than the HTTP
+    client uses can approve one destination while the frame goes to another --
+    silently, because the other end's response is consumed as the model's
+    answer and published as a governed observation. This asserts the invariant
+    that survives parser-version drift: for every adversarial shape, EITHER the
+    endpoint is refused, OR the host the client would actually dial is
+    host-local. There is no third outcome.
+    """
+    import requests
+    from urllib3.util import parse_url
+
+    for variable in ("OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_URL"):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.delenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, raising=False)
+
+    session = screen_derivation.local_vision_session()
+    for endpoint in ADVERSARIAL_ENDPOINTS:
+        monkeypatch.setenv("OLLAMA_BASE_URL", endpoint)
+        try:
+            resolved = screen_derivation.resolve_local_vision_endpoint()
+        except (
+            screen_derivation.RawEgressRefusedError,
+            screen_derivation.LocalVisionUnavailableError,
+        ):
+            continue
+        # Not refused -> the host the CLIENT will dial must be host-local.
+        # Deliberately re-derived here with urllib3 (what `requests` actually
+        # resolves with) rather than through the module's own helper: reading
+        # the module's parser would make this test agree with a wrong
+        # validator instead of catching it.
+        prepared = session.prepare_request(
+            requests.Request("POST", resolved.rstrip("/") + "/api/chat", json={})
+        )
+        try:
+            dialled = (parse_url(prepared.url).host or "").strip().lower().strip("[]")
+        except Exception:
+            continue  # the client itself cannot dial this; nothing is transmitted
+        assert dialled in screen_derivation._LOOPBACK_HOSTNAMES, (
+            f"endpoint {endpoint!r} was accepted but the client would dial {dialled!r}"
+        )
+
+
+def test_the_send_itself_refuses_a_destination_that_is_not_host_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate adjacent to the socket is load-bearing on its own.
+
+    `resolve_local_vision_endpoint` is the fail-fast check; this is the one
+    that cannot be bypassed, because it reads the exact prepared URL. Asserted
+    against `_post_local_vision` directly: even handed an endpoint that never
+    passed the early check, it must refuse before sending. That is what makes
+    the two checks defence in depth rather than one check written twice.
+    """
+    sent: List[Any] = []
+    real_session = screen_derivation.local_vision_session()
+
+    class _Session:
+        def prepare_request(self, request: Any) -> Any:
+            return real_session.prepare_request(request)
+
+        def send(self, prepared: Any, **kwargs: Any) -> Any:  # pragma: no cover - must not run
+            sent.append(prepared.url)
+            raise AssertionError("a frame was sent to an unvalidated destination")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(screen_derivation, "local_vision_session", lambda: _Session())
+    monkeypatch.delenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, raising=False)
+
+    with pytest.raises(screen_derivation.RawEgressRefusedError, match="evil.example.com"):
+        screen_derivation._post_local_vision(
+            "http://evil.example.com", {"model": "llava:7b", "messages": []}
+        )
+    assert sent == []
+
+
+def test_every_endpoint_variable_is_guarded_not_just_the_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All three endpoint variables are validated, not only `OLLAMA_BASE_URL`."""
+    for variable in ("OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_URL"):
+        for other in ("OLLAMA_BASE_URL", "OLLAMA_HOST", "OLLAMA_URL"):
+            monkeypatch.delenv(other, raising=False)
+        monkeypatch.delenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, raising=False)
+        monkeypatch.setenv(variable, "http://evil.example.com")
+        with pytest.raises(screen_derivation.RawEgressRefusedError):
+            screen_derivation.resolve_local_vision_endpoint()
+
+
 def test_local_vision_refuses_to_follow_a_redirect_off_the_validated_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -201,12 +328,16 @@ def test_local_vision_refuses_to_follow_a_redirect_off_the_validated_endpoint(
             raise AssertionError("redirect must be refused before the body is read")
 
     sent: List[Any] = []
+    real_session = screen_derivation.local_vision_session()
 
     class _Session:
         trust_env = True
 
-        def post(self, url: str, **kwargs: Any) -> Any:
-            sent.append(kwargs)
+        def prepare_request(self, request: Any) -> Any:
+            return real_session.prepare_request(request)
+
+        def send(self, prepared: Any, **kwargs: Any) -> Any:
+            sent.append(prepared.url)
             assert kwargs.get("allow_redirects") is False, "redirects must not be followed"
             return _Redirect()
 

--- a/tests/invariants/test_heimdal_seam.py
+++ b/tests/invariants/test_heimdal_seam.py
@@ -62,13 +62,27 @@ def test_declared_egress() -> None:
     assert "zero raw egress" in doc
 
 
-def test_declared_egress_matches_the_stage_module_posture() -> None:
-    """Completeness: the declaration is not a decorative constant.
+def test_declared_egress_matches_the_stage_module_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Completeness: the declaration is enforced against the actual destination.
 
-    The stage's only model destination is the local route it compiles, and the
-    module carries no second, undeclared destination.
+    `raw_class_egress: False` is only true if the endpoint the stage would
+    write a decrypted frame to is provably on this host. A census entry names a
+    provider; it cannot name a socket. This asserts the second check exists and
+    fails closed, so the constant is backed by enforcement rather than intent.
     """
-    assert screen_derivation.LOCAL_VISION_PROVIDER == "ollama"
     census = load_provider_census()
     assert census.provider(screen_derivation.LOCAL_VISION_PROVIDER).tier == "local"
     assert DECLARED_EGRESS["raw_classes"] == ("screen_frame",)
+
+    for variable in ("OLLAMA_HOST", "OLLAMA_URL"):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.delenv(screen_derivation.HOST_LOCAL_VISION_ALLOWLIST_ENV, raising=False)
+
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    assert screen_derivation.resolve_local_vision_endpoint() == "http://localhost:11434"
+
+    monkeypatch.setenv("OLLAMA_BASE_URL", "https://vision.example.com")
+    with pytest.raises(screen_derivation.RawEgressRefusedError):
+        screen_derivation.resolve_local_vision_endpoint()

--- a/tests/invariants/test_heimdal_seam.py
+++ b/tests/invariants/test_heimdal_seam.py
@@ -1,0 +1,74 @@
+"""HEIM-12 `heim_declared_egress` -- the seam's declared egress posture.
+
+The §8-reserved home for HEIM-12 (`docs/HEIMDAL/FABLE_COMPANION.md` §8,
+reserved by `tests/heimdal/test_invariants_heim.py`). SCREEN-02 (#3344) is the
+first Heimdal stage to carry a **structured, machine-checkable** egress
+declaration rather than prose in a docstring, so the static half of HEIM-12
+graduates here for that stage.
+
+Still reserved in the interim skeleton module, deliberately not claimed here:
+the per-adapter posture for the voice-memo capture adapter (prose-only today)
+and the future network-boundary probe. This file asserts exactly what is
+enforced now -- the screen-derivation stage declares zero raw-class egress,
+and the route its production call site compiles cannot leave the host.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.components.settings.providers_loader import load_provider_census
+from app.heimdal import screen_derivation
+from app.heimdal.screen_derivation import (
+    DECLARED_EGRESS,
+    TASK_KIND,
+    PaidRouteRejectedError,
+    resolve_derivation_route,
+)
+from tests.invariants._helpers import read_doc
+
+pytestmark = pytest.mark.not_pg
+
+_STAGE_DOC = "docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md"
+
+
+def test_declared_egress() -> None:
+    """The screen-derivation stage declares zero raw egress, structurally.
+
+    Success path: the declaration exists, names the stage, and names no raw
+    egress; the compiled route is local-tier and paid-ineligible. Negative
+    path: a census that makes the stage paid-eligible is rejected outright,
+    so there is no declared-but-reachable cloud destination for raw pixels.
+    """
+    assert DECLARED_EGRESS["stage"] == TASK_KIND
+    assert DECLARED_EGRESS["raw_class_egress"] is False
+    assert DECLARED_EGRESS["destinations"] == ("host_local_vision_model",)
+
+    route = resolve_derivation_route()
+    assert route.task_kind == TASK_KIND
+    assert route.paid_eligible is False
+    assert route.tier == "local"
+
+    # No paid route is reachable for this always-on task kind: declaring one
+    # in the census fails the compile rather than opening an egress path.
+    census = load_provider_census()
+    paid = next(provider for provider in census.providers if provider.tier == "paid")
+    paid.paid_eligible_task_kinds = [*paid.paid_eligible_task_kinds, TASK_KIND]
+    with pytest.raises(PaidRouteRejectedError):
+        resolve_derivation_route(census=census)
+
+    # The owner-facing stage doc states the same posture (AC6 doc writeback).
+    doc = read_doc(_STAGE_DOC)
+    assert "zero raw egress" in doc
+
+
+def test_declared_egress_matches_the_stage_module_posture() -> None:
+    """Completeness: the declaration is not a decorative constant.
+
+    The stage's only model destination is the local route it compiles, and the
+    module carries no second, undeclared destination.
+    """
+    assert screen_derivation.LOCAL_VISION_PROVIDER == "ollama"
+    census = load_provider_census()
+    assert census.provider(screen_derivation.LOCAL_VISION_PROVIDER).tier == "local"
+    assert DECLARED_EGRESS["raw_classes"] == ("screen_frame",)


### PR DESCRIPTION
Governing-Issue: #3344

Fixes #3344

Final-Review-Rounds: 2

## Summary
Adds the SCREEN-02 in-seam screen derivation stage (`app/heimdal/screen_derivation.py`): a frame
bundle is read through the gated raw-read path, combined with host-local context providers and a
local vision model into one textual activity observation (summary + entity mentions + per-axis
confidence), coalesced into spans, and published through the existing governed
`publish_full_observation` path. The privacy seam is enforced at the production call site rather
than described — on **both** halves: `resolve_derivation_route` compiles the route for the always-on
task kind `heimdal.screen_derivation` from the declared provider census and refuses any paid
assignment before a frame is read, and `resolve_local_vision_endpoint` refuses any destination that
is not provably host-local before a frame is attached to a request.

## Risk surfaces
security, data (privacy/egress seam over raw screen evidence; durable observation writes). Runtime
change on a declared high-risk TCD category, so the mechanism convergence gate ran before
publication — see `Review rounds` below.

## Review rounds
Full path (`Final-Review-Rounds: 2`). Five independent review passes ran; the egress mechanism
produced a blocker in three of them, each one hop further down the same path, so the mechanism
convergence gate governed the repairs rather than point-fixing.

- **Round 1 (pre-publication convergence): BLOCKED.** Two independent reviewers on the same SHA
  converged on three P1s: (a) the local-only guarantee was enforced on the census provider *name*,
  not on the socket — the stage POSTed the decrypted frame to whatever `OLLAMA_BASE_URL` contained,
  and this repo's own `docker-compose.prod.yml` sets that to a non-loopback host; (b) two ways a
  span boundary could be merged away (a provider overwriting another's dimension, a
  provider-declared axis ignored by the span key, empty-equals-empty); (c) `observation_id` derived
  from the model's free text, so a reworded replay appended a duplicate unlinked observation.
- **Round 2 (post-repair): PASS**, with P2/P3s — including one measured finding that the
  empty-dimension rule was *too* strict and switched coalescing off entirely when the model named
  no goal. Fixed.
- **Round 3 (local review gate on the published PR): BLOCKED.** `requests` follows redirects by
  default, so a 3xx from the validated endpoint resent the raw frame to an unvalidated `Location`.
  Reproduced by the reviewer against live servers.
- **Round 4 (convergence + current-SHA gate): BLOCKED.** A URL-parser differential: the validator
  read `urllib.parse` while `requests` dials with `urllib3`, and the two disagree on backslash and
  bracket shapes in the authority. Reproduced end-to-end — frame delivered to an unvalidated host
  with no refusal raised.
- **Round 5 (current-SHA gate): PASS** — six P3s, none blocking. The reviewer attacked the egress
  class directly (47 hand-picked adversarial URL shapes plus 10,750 fuzzed ones against a
  socket-level intercept, live 302/307/308 servers, `ALL_PROXY`): zero leaks. Three of its P3s were
  false statements I had written, and are fixed in the final commit: a stale coalescing rule in the
  module docstring and the owner doc, and a `docs_guard.py` "OK" in this body that came from a
  masked exit code (it exited 1 — the guard wanted a temporal-doc writeback, now provided in
  `docs/OPERATIONS.md`). That final commit changes no behavior: the AST of `screen_derivation.py`
  with docstrings stripped is identical to the reviewed SHA `1c008e8ed`.

The round-4 fix removes the *class* rather than the instance: there is now exactly one notion of
"the host" in the module, read from the client's own parser, and host-locality is asserted on the
exact prepared URL immediately before `send`, so a validated destination cannot drift into a
dialled one.

Every guard is mutation-verified — removing the endpoint validation, the send-time gate, the
redirect refusal, the un-laundered re-raise, the empty-dimension rule, the provider-conflict guard,
the goal-axis guard, or the evidence-derived `observation_id` each fails its own test. Swapping the
validator back to a second parser also fails.

## Changes
- `app/heimdal/screen_derivation.py` (new) — route compilation (always-on-local floor), host-local
  destination validation (single parser, asserted on the prepared URL; proxies and redirects
  refused), gated read, span coalescing, fail-closed provenance stamping, governed publish.
- `docs/OPERATIONS.md` — the operator-facing precondition: which endpoints the stage accepts, the
  declaration variable the compose stack sets, and that `llava:7b` is not pulled at cold boot.
- `app/heimdal/screen_context_providers.py` (new) — the pluggable local-context registry;
  frontmost-app/window is provider #1 and supplies three of the four built-in segmenter dimensions.
- `docker-compose.prod.yml` — declares the compose `ollama` service host-local. Per
  `AGENTS.md :: Required rules` (invariant → producers), a new runtime precondition must migrate
  every producer in the same change, or the stage would silently dark in prod.
- `docs/settings/models/providers.yaml` — declares the local vision model `ollama/llava:7b`.
- `docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md` — AC6 doc writeback in
  `:: What This Task Does` step 3 (declared egress posture, both halves), the step-4 coalescing rules,
  acceptance criteria ticked, stale "blocked until SCREEN-01 merges" wording rewritten.
- `tests/invariants/test_heimdal_seam.py` (new) — HEIM-12's §8-reserved home. The structured
  declaration is the first machine-checkable Heimdal egress posture, so HEIM-12's **static half**
  graduates here; the voice-memo adapter's posture and the network-boundary probe stay honestly
  reserved in `tests/heimdal/test_invariants_heim.py`.
- `tests/heimdal/test_invariants_heim.py` — the graduation guard is now per reserved *test* rather
  than per reserved *file*, because HEIM-4, HEIM-5, and HEIM-12 all reserve `test_heimdal_seam.py`
  and one graduating must not silently discharge its neighbours.

## SBS Impact
Product/Runtime work. Primary CAO (frame → activity text); secondary SIP (provenance/confidence
stamping), HKA (candidate notes, via the existing projector — untouched), GOV (gated raw read +
receipt). Writes durable observations only through the existing governed publish path; reads
`heimdal_raw_record` only through the gated path. Authority impact: none — observations stay
noncanonical evidence-candidates (HEIM-8). External boundary impact: none; declared egress is zero
raw egress (HEIM-12), now extended to the screen stage and enforced on the destination. Owner-doc
writeback: **resolved in this PR** (SBS §9 option 2) — the SCREEN-02 owner doc is updated in the same
change; no other owner doc changes behavior or contract here.

## Verify ledger
- `tests/heimdal/test_screen_derivation.py::test_bundle_derives_and_publishes_observation` — pass
- `tests/heimdal/test_screen_derivation_routing.py::test_screen_derivation_is_paid_ineligible_and_reads_raw_gated` — pass
- `tests/heimdal/test_screen_coalescing.py::test_span_boundaries_survive_on_dimension_shift` — pass
- `tests/heimdal/test_screen_derivation.py::test_unprovenanced_observation_refuses_publish` — pass
- `tests/heimdal/test_screen_context_providers.py::test_provider_registry_extensible` — pass
- AC6 doc writeback at `docs/HEIMDAL_SCREEN_STREAM/DERIVE_ACTIVITY_OBSERVATIONS.md :: What This Task Does` (step 3) + `tests/invariants/test_heimdal_seam.py::test_declared_egress` — present and pass

## Residual risk the final reviewer named (recorded, not fixed here)
- The guard asserts a **hostname**, not a resolved address: DNS can point an accepted name off-box,
  and `HEIMDAL_SCREEN_VISION_HOST_LOCAL_HOSTS` is a name-level trust grant that would be false under
  a remapped container network. Closing that needs post-resolution address checking.
- The class is closed by coupling to `requests`/`urllib3` internals, so swapping the HTTP client
  would reopen it in a way these tests would not catch.
- `vision_runner` remains an unguarded egress seam on the public entrypoint — safe today only
  because nothing calls the entrypoint. Worth a structural bar when SCREEN-06 adds the tick driver.
- Three further P3s (dead `scope_hint`, entity mentions from frames 2..N of a span discarded, and
  the gated read happening before the endpoint refusal) are recorded in the review comment.

## Known gaps (deliberate — in the Issue's Out of Scope, or noted for the next slice)
- No `python -m app.cli heimdal screen-derive` tick driver: the doc's `Concretely` block shows one,
  but no AC requires it and SCREEN-06 governs the control surface. `derive_activity_observations`
  is the entrypoint the ACs verify; it has no in-repo caller yet.
- `scripts/cold_boot.sh` provisions only the embedding model, so the census-declared `llava:7b` is
  not pulled at cold boot. Deliberately not added: it is a multi-GB pull for a stage with no tick
  driver yet, and the missing model fails loud rather than silently.
- No max-gap bound on coalescing (`screen_coalesce_*` is SCREEN-06-governed), so two identical
  frames far apart still merge into one span. Now stated explicitly in the owner doc so SCREEN-05's
  time-spend rollup does not assume a bounded gap.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260802115750_05a2754b`; deferred defect
  `KD-FBDBDAD4C052` on the Known Defects registry (#4172)
- Reason: pickup diverged — the Issue's AC6 carried two `Verify:` targets joined on one marker line,
  which strict readiness validation rejected as a missing file path (the named doc exists); the
  Issue body was repaired to one target per line with no AC content change, and the signal names
  `scripts/validate_issue_readiness.py` as the upstream artifact. The P2 from round 3 (two screen
  spans sharing one `episode_id` fold into a single candidate note in the existing projector) is
  deferred as `KD-FBDBDAD4C052` with a re-evaluation trigger bound to SCREEN-04/SCREEN-05.

## Notes
Validation:
- `ruff check app tests` — clean
- `mypy app` — clean (865 source files)
- the four named test files — pass
- `pytest -q -m "not pg"` under the repo host lease at head `1c008e8ed` — 12385 passed, 1 failed:
  `tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity`,
  a filesystem-race test that replaces a SQLite file mid-query. It passes in isolation and across
  its whole directory with these changes, shares no import path with this diff, and CI's own
  `Unit tests (not pg)` is green on this exact SHA. Classified unrelated by evidence.
- `python3 scripts/docs_guard.py` — exit 0 after the `docs/OPERATIONS.md` writeback (it exited 1
  before it: a new runtime precondition had no operator-facing home)
- `python3 scripts/public_seam_lint.py --mode gate` — clean
---
