### PR TITLE
fix: deliver heimdal-capture-watch runtime env deterministically on every channel

### DIFF
--- a/app/cli/heimdal.py
+++ b/app/cli/heimdal.py
@@ -11,6 +11,7 @@ from app.heimdal.archive_capacity import build_archive_capacity_report
 from app.heimdal.capture_runtime import (
     CaptureRuntimeConfig,
     CaptureRuntimeConfigError,
+    resolve_config_for_supervised_run,
     run_capture_tick,
     run_forever,
 )
@@ -37,17 +38,19 @@ def heimdal_group() -> None:
     help="Optional safety: stop after N ticks (ignored with --once; defaults to run forever).",
 )
 def capture_watch(once: bool, max_ticks: int | None) -> None:
-    try:
-        cfg = CaptureRuntimeConfig.from_env()
-    except CaptureRuntimeConfigError as exc:
-        raise click.ClickException(str(exc)) from exc
-
-    click.echo(
-        "heimdal capture-watch: "
-        f"watch_dir={cfg.watch_dir} interval_seconds={cfg.interval_seconds}"
-    )
-
     if once:
+        # A manually-invoked diagnostic command: fail loud and exit
+        # immediately on a config error, matching Heimdal's posture
+        # everywhere else.
+        try:
+            cfg = CaptureRuntimeConfig.from_env()
+        except CaptureRuntimeConfigError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        click.echo(
+            "heimdal capture-watch: "
+            f"watch_dir={cfg.watch_dir} interval_seconds={cfg.interval_seconds}"
+        )
         result = run_capture_tick(cfg)
         if result is None:
             # `None` means the tick itself failed (e.g. the watch dir became
@@ -62,6 +65,16 @@ def capture_watch(once: bool, max_ticks: int | None) -> None:
         summary = {"admitted": len(result.admitted), "refused": len(result.refused)}
         click.echo(json.dumps(summary, ensure_ascii=False))
         return
+
+    # Supervised path (the compose service's default): see
+    # `resolve_config_for_supervised_run`'s docstring for why this must not
+    # exit immediately on a startup config error (#4362).
+    cfg = resolve_config_for_supervised_run()
+
+    click.echo(
+        "heimdal capture-watch: "
+        f"watch_dir={cfg.watch_dir} interval_seconds={cfg.interval_seconds}"
+    )
 
     try:
         ticks = run_forever(cfg, max_ticks=max_ticks)

--- a/app/heimdal/capture_runtime.py
+++ b/app/heimdal/capture_runtime.py
@@ -93,6 +93,54 @@ def run_capture_tick(cfg: CaptureRuntimeConfig) -> Optional[WatchCycleResult]:
         return None
 
 
+def resolve_config_for_supervised_run(
+    *,
+    sleep: Optional[Callable[[float], None]] = None,
+    retry_interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    max_attempts: Optional[int] = None,
+) -> CaptureRuntimeConfig:
+    """Resolve config for the supervised/looping entrypoint, retrying in place on failure.
+
+    The `--once` CLI path fails loud and exits immediately on a config error
+    -- correct for a manually-invoked diagnostic command. The supervised path
+    (the compose service's default, no `--once`) must not do the same: under
+    `restart: unless-stopped`, an immediate exit respawns the process faster
+    than the container healthcheck's interval/retries window can observe a
+    consistent failure, so `docker ps` keeps reporting the health status from
+    the last successful start instead of transitioning to unhealthy -- a
+    crash-loop hiding behind a healthy-looking healthcheck (#4362). Staying
+    resident and retrying lets the independent compose healthcheck (which
+    re-resolves this same config on its own schedule) accumulate real
+    failures and report unhealthy honestly.
+
+    `max_attempts=None` (the production default) retries forever. Tests pass
+    a small `max_attempts` with an injected `sleep` to run deterministically.
+
+    `sleep` defaults to `None` and resolves to `time.sleep` inside the loop
+    (rather than as a bound default parameter value) so a caller that never
+    passes `sleep` explicitly -- the CLI's supervised path -- still honors a
+    `unittest.mock.patch`/`monkeypatch.setattr` of this module's `time.sleep`
+    at test time; a default parameter value would capture the real
+    `time.sleep` once at import time and ignore any later patch.
+    """
+    attempt = 0
+    while True:
+        try:
+            return CaptureRuntimeConfig.from_env()
+        except CaptureRuntimeConfigError as exc:
+            attempt += 1
+            logger.error(
+                "heimdal capture-watch: config unresolved (attempt %d), retrying "
+                "in %.0fs: %s",
+                attempt,
+                retry_interval_seconds,
+                exc,
+            )
+            if max_attempts is not None and attempt >= max_attempts:
+                raise
+            (sleep or time.sleep)(retry_interval_seconds)
+
+
 def run_forever(
     cfg: CaptureRuntimeConfig,
     *,
@@ -123,5 +171,6 @@ __all__ = [
     "CaptureRuntimeConfig",
     "CaptureRuntimeConfigError",
     "run_capture_tick",
+    "resolve_config_for_supervised_run",
     "run_forever",
 ]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,16 +70,15 @@ services:
       # keys here so the governed env_file chain supplies the binding.
 
   heimdal-capture-watch:
-    # The governed dev deploy wrapper materializes this last layer from the
-    # declared Keychain consumer and removes it after Compose creates the
-    # container. The base interpolation key is reset so it cannot blank or
-    # override the bootstrap layer from a caller shell or runtime env file.
-    env_file: !override
-      - ./config/runtime.defaults.env
-      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
-        required: false
-      - path: ${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}
-        required: false
+    # The host-secret env_file layer (HOST_SECRET_RUNTIME_ENV_FILE) now lives
+    # in the base compose file (#4362) so every channel, not just dev, gets
+    # it deterministically -- no per-channel override needed here anymore.
+    # The governed deploy wrapper materializes that layer from the declared
+    # Keychain consumer and removes it after Compose creates the container.
+    # The `environment` reset below still guards against a stray
+    # HEIMDAL_RAW_STORE_KEY reaching this service through any other channel
+    # (`environment:` always wins over `env_file:`), so the bootstrap layer
+    # stays the only source.
     environment:
       LLM_PROVIDER: mock
       PKM_ENVIRONMENT: dev

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -104,6 +104,11 @@ services:
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
       LLM_PROVIDER: mock
+      # HEIMDAL_CAPTURE_WATCH_DIR is deliberately NOT set here (#4362):
+      # CAPTURE_GOVERNED_KEYS (tests/deploy/test_base_runtime_env_compose.py)
+      # must ride the env_file chain, not `environment:` (which would shadow
+      # it with CLI interpolation, #3885). The test-scoped default lives in
+      # scripts/export_runtime_env.sh's test-channel branch instead.
 
   companion-ui:
     ports: !override

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -443,6 +443,21 @@ services:
       - ./config/runtime.defaults.env
       - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
         required: false
+      # Governed host-secret layer for the declared `heimdal-capture-watch`
+      # consumer (#4362, following the `api` consumer's #4422 pattern below):
+      # host_secret_contract.json declares this consumer for every channel
+      # (dev/test/prod), but the layer used to be wired only in the dev
+      # compose overlay -- test and prod deploys never received
+      # HEIMDAL_RAW_STORE_KEY through the generated env at all, forcing an
+      # ad-hoc shell export at compose time. Living in the base file makes
+      # delivery deterministic across every channel without a per-overlay
+      # opt-in. The deploy wrapper (scripts/lib/deploy_channel_compose.sh)
+      # materializes this file from the Keychain and removes it after Compose
+      # creates the container; a channel that never runs the wrapper (e.g. a
+      # bare `docker compose up` outside the governed deploy path) simply
+      # resolves this path to `/dev/null` and the layer contributes nothing.
+      - path: ${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}
+        required: false
     volumes:
       - "/Users:/Users"
       - "/Volumes:/Volumes"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -100,8 +100,20 @@ promote public internet readiness.
   deploy; a Keychain item that resolves to a *malformed* value does fail it, since the bootstrap is
   fail-closed on validation, and #4489 extended that to the optional `github.token` declared for the
   same consumer — tracked as `KD-4489-malformed-declared-secret-aborts-channel-deploy` on #4172) and
-  the `api` Compose service consumes it via its own env-file handle, without changing
-  how `heimdal-capture-watch` is provisioned. An api startup preflight detects a missing
+  the `api` Compose service consumes it via its own env-file handle. **`heimdal-capture-watch`'s
+  own provisioning is now channel-independent too (#4362):** the `HOST_SECRET_RUNTIME_ENV_FILE`
+  env-file layer that delivers `HEIMDAL_RAW_STORE_KEY` to that service lives in the base Compose
+  file (previously only the dev overlay carried it, so `test`/`prod` deploys never received the
+  key through the generated runtime env at all), the deploy wrapper's bootstrap gate now fires
+  for that service on every channel (previously dev-only), and `scripts/export_runtime_env.sh`
+  forwards an operator-set `HEIMDAL_CAPTURE_WATCH_DIR`/`HEIMDAL_RAW_READ_ALLOWLIST` into the
+  generated runtime env instead of requiring an ad-hoc shell export at compose time; the test
+  channel gets a hardcoded test-scoped watch dir the same way the `WATCHER_STATE_DIR`-family
+  paths already are. The supervised CLI entrypoint (no `--once`) also no longer exits on a
+  startup config error — it retries in place so the container stays resident long enough for the
+  independent Compose healthcheck to actually observe and report a config-missing failure as
+  `unhealthy`, instead of racing a `restart: unless-stopped` crash-loop that hid behind a stale
+  `healthy` status. An api startup preflight detects a missing
   `HEIMDAL_RAW_STORE_KEY` before first use, logs it loudly, and reports the media and screen
   ingress lanes `unavailable` on `/api/status` while every other API function keeps serving; the
   request-time named 500 `raw_store_key_unavailable` / `not_acknowledged` contract is unchanged.

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -67,6 +67,18 @@ ENV
   if [ -n "${SIGNBOARD_ROOT:-}" ]; then
     printf "SIGNBOARD_ROOT=%s\n" "$SIGNBOARD_ROOT" >> "$runtime_env_path"
   fi
+  # heimdal-capture-watch is not gated by no-vault/idle mode (#4362): forward
+  # the operator's watch-dir/allowlist config here too, same rule as the
+  # vault-bound branch below -- only when explicitly set, never defaulted.
+  if [ -n "${HEIMDAL_CAPTURE_WATCH_DIR:-}" ]; then
+    printf "%s\n" "HEIMDAL_CAPTURE_WATCH_DIR=${HEIMDAL_CAPTURE_WATCH_DIR}" >> "$runtime_env_path"
+  fi
+  if [ -n "${HEIMDAL_RAW_READ_ALLOWLIST:-}" ]; then
+    printf "%s\n" "HEIMDAL_RAW_READ_ALLOWLIST=${HEIMDAL_RAW_READ_ALLOWLIST}" >> "$runtime_env_path"
+  fi
+  if [ -n "${HEIMDAL_CAPTURE_INTERVAL_SECONDS:-}" ]; then
+    printf "%s\n" "HEIMDAL_CAPTURE_INTERVAL_SECONDS=${HEIMDAL_CAPTURE_INTERVAL_SECONDS}" >> "$runtime_env_path"
+  fi
   echo "Exported no-vault idle runtime env -> $runtime_env_path"
   exit 0
 fi
@@ -304,6 +316,14 @@ if [ "$_is_test_channel" -eq 1 ]; then
   printf "%s\n" "WATCHER_HEARTBEAT_PATH=/app/tmp-test/watcher_heartbeat.json" >> "$runtime_env_path"
   printf "%s\n" "WORKER_HEARTBEAT_PATH=/app/tmp-test/worker_heartbeat.json" >> "$runtime_env_path"
   printf "%s\n" "WATCHER_STATE_PATH=/app/tmp-test/watcher_state.json" >> "$runtime_env_path"
+  # heimdal-capture-watch has no real capture client on the test channel, and
+  # an absent/empty HEIMDAL_CAPTURE_WATCH_DIR is a fail-loud config error
+  # (app.heimdal.capture_runtime.CaptureRuntimeConfig.from_env) -- exactly
+  # what crash-looped pkm-test-heimdal-capture-watch-1 for 72h+ (#4362).
+  # Hardcode a test-scoped folder under the same tmp-test artifact root the
+  # other test-channel paths above use, unconditionally, so the service
+  # always has somewhere valid to watch (it will simply stay empty).
+  printf "%s\n" "HEIMDAL_CAPTURE_WATCH_DIR=/app/tmp-test/heimdal-capture-inbox" >> "$runtime_env_path"
 else
   if [ -n "${WATCHER_STATE_DIR:-}" ]; then
     printf "%s\n" "WATCHER_STATE_DIR=${WATCHER_STATE_DIR}" >> "$runtime_env_path"
@@ -311,6 +331,26 @@ else
 
   if [ -n "${WATCHER_STOP_FILE:-}" ]; then
     printf "%s\n" "WATCHER_STOP_FILE=${WATCHER_STOP_FILE}" >> "$runtime_env_path"
+  fi
+
+  # heimdal-capture-watch's non-secret operator config (#4362): the watched
+  # folder and read-allowlist differ per device/channel and have no safe
+  # default outside the test channel (an empty/missing watch dir must fail
+  # loud, never fall back to a guessed path) -- forward only when the
+  # operator actually set them, mirroring WATCHER_STATE_DIR/STOP_FILE above,
+  # so the generated runtime env is the one deterministic delivery path for
+  # every non-test channel instead of requiring an ad-hoc shell export at
+  # compose time. HEIMDAL_RAW_STORE_KEY is deliberately NOT handled here --
+  # it is a Keychain-backed secret delivered through the host-secret
+  # bootstrap env_file layer, never through this generated file.
+  if [ -n "${HEIMDAL_CAPTURE_WATCH_DIR:-}" ]; then
+    printf "%s\n" "HEIMDAL_CAPTURE_WATCH_DIR=${HEIMDAL_CAPTURE_WATCH_DIR}" >> "$runtime_env_path"
+  fi
+  if [ -n "${HEIMDAL_RAW_READ_ALLOWLIST:-}" ]; then
+    printf "%s\n" "HEIMDAL_RAW_READ_ALLOWLIST=${HEIMDAL_RAW_READ_ALLOWLIST}" >> "$runtime_env_path"
+  fi
+  if [ -n "${HEIMDAL_CAPTURE_INTERVAL_SECONDS:-}" ]; then
+    printf "%s\n" "HEIMDAL_CAPTURE_INTERVAL_SECONDS=${HEIMDAL_CAPTURE_INTERVAL_SECONDS}" >> "$runtime_env_path"
   fi
 fi
 unset _is_test_channel

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -131,10 +131,14 @@ services:
 YAML
 }
 
-_deploy_channel_needs_dev_capture_secret() {
+# host_secret_contract.json declares the `heimdal-capture-watch` consumer for
+# every channel (dev/test/prod), not only dev (#4362 -- before this fix, this
+# helper was dev-only and test/prod deploys never wrapped the compose
+# invocation, so HEIMDAL_RAW_STORE_KEY never reached the service's env_file
+# chain on those channels no matter what the Keychain held).
+_deploy_channel_needs_capture_secret() {
   local channel="${1:?channel required}"
   shift
-  [ "${channel}" = "dev" ] || return 1
   [ "${1:-}" = "up" ] || return 1
   local arg
   for arg in "$@"; do
@@ -373,7 +377,7 @@ deploy_channel_compose() {
       "$@"
     )
 
-    if _deploy_channel_needs_dev_capture_secret "${channel}" "$@"; then
+    if _deploy_channel_needs_capture_secret "${channel}" "$@"; then
       compose_command=(
         "${PYTHON:-python3}" -m app.ops.host_secret_bootstrap
         --channel "${channel}"

--- a/tests/cli/test_heimdal_cli.py
+++ b/tests/cli/test_heimdal_cli.py
@@ -20,6 +20,7 @@ import pytest
 from click.testing import CliRunner
 
 from app.cli import cli
+from app.heimdal import capture_runtime
 from app.heimdal.consent_ledger import reset_memory_consent_ledger
 from app.heimdal.raw_store import all_raw_records, reset_memory_raw_store
 
@@ -104,3 +105,37 @@ def test_capture_watch_once_fails_loud_on_tick_failure(
         assert '"admitted": 0' not in result.output
     finally:
         watch_dir.chmod(0o755)
+
+
+def test_capture_watch_forever_mode_retries_instead_of_exiting_on_missing_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#4362: without `--once` (the compose service's default), a missing
+    HEIMDAL_CAPTURE_WATCH_DIR at startup must not exit the process -- that
+    defeats the container healthcheck under `restart: unless-stopped`
+    (crash-loop hides behind a stale healthy status instead of the
+    healthcheck ever observing a consistent failure). It must retry in
+    place and only proceed once config resolves."""
+    monkeypatch.delenv("HEIMDAL_CAPTURE_WATCH_DIR", raising=False)
+
+    sleep_calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        # Resolve on the second retry so the command can actually finish.
+        if len(sleep_calls) == 2:
+            monkeypatch.setenv("HEIMDAL_CAPTURE_WATCH_DIR", str(tmp_path))
+
+    monkeypatch.setattr(capture_runtime.time, "sleep", fake_sleep)
+
+    runner = CliRunner()
+    # max-ticks=0 with forever mode means run_forever executes zero ticks and
+    # returns immediately once config resolves -- this proves the command
+    # reached the looping path without exiting on the initial config error.
+    result = runner.invoke(
+        cli, ["heimdal", "capture-watch", "--max-ticks", "0"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(sleep_calls) >= 2
+    assert "stopped after 0 ticks" in result.output

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -981,8 +981,10 @@ def test_same_target_retry_preserves_rollback_anchor(tmp_path: Path) -> None:
 
 def test_api_service_receives_raw_store_key() -> None:
     """#4422: the deploy wrapper bootstraps the declared api consumer and the
-    api service consumes its materialized secret layer, without changing how
-    heimdal-capture-watch is provisioned."""
+    api service consumes its materialized secret layer. #4362 later made
+    heimdal-capture-watch's own provisioning channel-independent (see
+    ``test_capture_watch_secret_gate_fires_for_every_channel`` below); this
+    test only pins the api-consumer wiring, which #4362 did not change."""
     lib = (REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh").read_text(
         encoding="utf-8"
     )
@@ -1004,9 +1006,9 @@ def test_api_service_receives_raw_store_key() -> None:
     # shared handle would deliver the api consumer's layer to the
     # capture-watch service's env_file chain.
     assert "unset HOST_SECRET_RUNTIME_ENV_FILE;" in lib
-    # The capture-watch provisioning is unchanged.
+    # The capture-watch provisioning helper still exists and is still wired.
     assert "--consumer heimdal-capture-watch" in lib
-    assert "_deploy_channel_needs_dev_capture_secret" in lib
+    assert "_deploy_channel_needs_capture_secret" in lib
 
     syntax = subprocess.run(
         ["bash", "-n", str(REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh")],
@@ -1097,3 +1099,74 @@ def test_api_service_receives_raw_store_key() -> None:
         text=True,
     )
     assert run.stdout == "/tmp/api-layer.env|scrubbed", run.stderr
+
+
+def test_capture_watch_secret_gate_fires_for_every_channel() -> None:
+    """#4362: heimdal-capture-watch's host-secret bootstrap wrap must fire on
+    every channel host_secret_contract.json declares the consumer for
+    (dev/test/prod), not only dev.
+
+    Before this fix, `_deploy_channel_needs_dev_capture_secret` hardcoded
+    `[ "${channel}" = "dev" ] || return 1`, so a `test` or `prod` deploy never
+    wrapped the compose invocation and HEIMDAL_RAW_STORE_KEY never reached
+    the service's env_file chain there no matter what the Keychain held --
+    the operator had to export it ad-hoc at compose time instead (the bug
+    report's prod bring-up symptom).
+    """
+    lib = (REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "_deploy_channel_needs_capture_secret" in lib
+    assert "_deploy_channel_needs_dev_capture_secret" not in lib
+
+    probe = (
+        'source "$1"; shift; '
+        "if _deploy_channel_needs_capture_secret \"$@\"; then echo yes; else echo no; fi"
+    )
+    lib_path = str(REPO_ROOT / "scripts" / "lib" / "deploy_channel_compose.sh")
+
+    def gate(*args: str) -> str:
+        run = subprocess.run(
+            ["bash", "-c", probe, "_", lib_path, *args],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return run.stdout.strip().splitlines()[-1] if run.stdout.strip() else run.stderr
+
+    for channel in ("dev", "test", "prod"):
+        assert gate(channel, "up", "-d", "heimdal-capture-watch") == "yes", channel
+        assert (
+            gate(channel, "up", "-d", "api", "worker", "watcher", "heimdal-capture-watch")
+            == "yes"
+        ), channel
+    assert gate("test", "up", "-d", "api") == "no"
+    assert gate("prod", "logs") == "no"
+
+    syntax = subprocess.run(
+        ["bash", "-n", lib_path],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+def test_heimdal_capture_watch_host_secret_layer_lives_in_base_compose() -> None:
+    """#4362: the HOST_SECRET_RUNTIME_ENV_FILE env_file layer for
+    heimdal-capture-watch must live in the base compose file so every
+    channel inherits it deterministically, rather than only in the dev
+    overlay (which left test/prod without a delivery path for
+    HEIMDAL_RAW_STORE_KEY at all)."""
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8"))
+    env_files = compose["services"]["heimdal-capture-watch"]["env_file"]
+    host_secret_layers = [
+        entry
+        for entry in env_files
+        if isinstance(entry, dict)
+        and str(entry.get("path", "")) == "${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}"
+    ]
+    assert len(host_secret_layers) == 1
+    assert host_secret_layers[0].get("required") is False

--- a/tests/heimdal/test_capture_runtime.py
+++ b/tests/heimdal/test_capture_runtime.py
@@ -25,6 +25,7 @@ from app.heimdal.capture_runtime import (
     DEFAULT_INTERVAL_SECONDS,
     CaptureRuntimeConfig,
     CaptureRuntimeConfigError,
+    resolve_config_for_supervised_run,
     run_forever,
 )
 
@@ -94,3 +95,56 @@ def test_runtime_survives_tick_exception(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     assert ticks == 2
     assert call_count["n"] == 2
+
+
+def test_resolve_config_for_supervised_run_returns_immediately_when_valid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(capture_runtime.WATCH_DIR_ENV, str(tmp_path))
+
+    sleeps: list[float] = []
+    cfg = resolve_config_for_supervised_run(sleep=sleeps.append)
+
+    assert cfg.watch_dir == tmp_path
+    assert sleeps == []
+
+
+def test_resolve_config_for_supervised_run_retries_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#4362: a missing HEIMDAL_CAPTURE_WATCH_DIR at supervised-loop startup
+    must not raise (which would exit the process and, under `restart:
+    unless-stopped`, crash-loop faster than the container healthcheck's
+    interval/retries window can observe it). It must retry in place instead,
+    so the process stays resident long enough for the independent compose
+    healthcheck to actually run and report unhealthy honestly."""
+    monkeypatch.delenv(capture_runtime.WATCH_DIR_ENV, raising=False)
+
+    sleeps: list[float] = []
+    attempts = {"n": 0}
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        attempts["n"] += 1
+        if attempts["n"] == 2:
+            monkeypatch.setenv(capture_runtime.WATCH_DIR_ENV, str(tmp_path))
+
+    cfg = resolve_config_for_supervised_run(
+        sleep=fake_sleep, retry_interval_seconds=3.0
+    )
+
+    assert cfg.watch_dir == tmp_path
+    assert sleeps == [3.0, 3.0]
+
+
+def test_resolve_config_for_supervised_run_raises_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded-attempts mode (used by tests) still surfaces the error once
+    the attempt budget is exhausted, instead of retrying forever."""
+    monkeypatch.delenv(capture_runtime.WATCH_DIR_ENV, raising=False)
+
+    with pytest.raises(CaptureRuntimeConfigError):
+        resolve_config_for_supervised_run(
+            sleep=lambda _seconds: None, max_attempts=2
+        )

--- a/tests/ops/test_heimdal_capture_watch_compose.py
+++ b/tests/ops/test_heimdal_capture_watch_compose.py
@@ -27,7 +27,9 @@ exactly the way the real preflight guard does.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import subprocess
 
 from app.release_channels.channel_isolation_preflight import (
     CHANNEL_SERVICES,
@@ -46,6 +48,19 @@ _SERVICE = "heimdal-capture-watch"
 
 def _service(compose: Path, name: str = _SERVICE) -> dict:
     return _load_compose(compose)["services"][name]
+
+
+def _healthcheck_test_command() -> str:
+    """Extract the shell one-liner Docker actually runs for this healthcheck.
+
+    ``healthcheck.test`` is ``["CMD-SHELL", "<script>"]``; the script is what
+    the container's healthcheck executes on its own interval, independent of
+    the supervised process (#4362).
+    """
+    svc = _service(_BASE_COMPOSE)
+    test = svc["healthcheck"]["test"]
+    assert test[0] == "CMD-SHELL"
+    return test[1]
 
 
 def test_base_service_defined() -> None:
@@ -172,3 +187,54 @@ def test_deploy_script_health_gates_the_new_service() -> None:
         if ln.strip().startswith("capture_watch_gate") and "()" not in ln
     ]
     assert invoked, "capture_watch_gate is defined but never invoked in the deploy flow"
+
+
+def test_healthcheck_fails_honestly_on_missing_watch_dir() -> None:
+    """#4362: the healthcheck must fail (nonzero exit) when
+    HEIMDAL_CAPTURE_WATCH_DIR is absent -- the exact config-missing shape
+    that crash-looped pkm-test-heimdal-capture-watch-1 for 72h+. This proves
+    the healthcheck mechanism itself is honest; the CLI-level fix (see
+    tests/heimdal/test_capture_runtime.py ::
+    test_resolve_config_for_supervised_run_retries_instead_of_raising) is
+    what keeps the container resident long enough for Docker's
+    interval/retries window to actually observe this failure instead of
+    racing a crash-loop restart."""
+    env = os.environ.copy()
+    env.pop("HEIMDAL_CAPTURE_WATCH_DIR", None)
+    env.pop("HEIMDAL_RAW_STORE_KEY", None)
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+
+    result = subprocess.run(
+        ["sh", "-c", _healthcheck_test_command()],
+        cwd=_REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "HEIMDAL_CAPTURE_WATCH_DIR" in result.stderr
+
+
+def test_healthcheck_succeeds_when_config_is_present(tmp_path: Path) -> None:
+    """Counterpart to the failure case above: a fully-configured environment
+    must report healthy, so the honest-failure fix above is not just always
+    failing."""
+    watch_dir = tmp_path / "capture-inbox"
+    watch_dir.mkdir()
+    env = os.environ.copy()
+    env["HEIMDAL_CAPTURE_WATCH_DIR"] = str(watch_dir)
+    env["HEIMDAL_RAW_STORE_KEY"] = "a" * 64
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+
+    result = subprocess.run(
+        ["sh", "-c", _healthcheck_test_command()],
+        cwd=_REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -797,8 +797,15 @@ def _write_executable(path: Path, text: str) -> None:
 
 
 def test_capture_watch_uses_bootstrap_not_tracked_env(tmp_path: Path) -> None:
+    # #4362: the HOST_SECRET_RUNTIME_ENV_FILE env_file layer now lives in the
+    # base compose file so every channel inherits it deterministically, not
+    # only dev (see tests/deploy/test_deploy_channel_script.py ::
+    # test_heimdal_capture_watch_host_secret_layer_lives_in_base_compose).
+    # The dev overlay still guards against a stray HEIMDAL_RAW_STORE_KEY
+    # reaching the service through any other channel.
+    base_compose = (_REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
     dev_overlay = (_REPO_ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8")
-    assert "${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}" in dev_overlay
+    assert "${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}" in base_compose
     assert "HEIMDAL_RAW_STORE_KEY: !reset null" in dev_overlay
 
     bin_dir = tmp_path / "bin"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4362

## Linked Issue
Closes #4362

## SBS Impact
- Primary subsystem: Heimdal-Capture-Watch-Runtime-Delivery
- Secondary subsystem(s): Builder-System-Deploy-Wiring
- Write class: none
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: heimdal-capture-watch's HOST_SECRET_RUNTIME_ENV_FILE env_file layer now lives in base docker-compose.yaml (every channel), the deploy wrapper's capture-watch host-secret bootstrap gate now fires on every channel instead of dev-only, export_runtime_env.sh forwards operator-set HEIMDAL_CAPTURE_WATCH_DIR/HEIMDAL_RAW_READ_ALLOWLIST/HEIMDAL_CAPTURE_INTERVAL_SECONDS and emits a hardcoded test-channel HEIMDAL_CAPTURE_WATCH_DIR default, and app/cli/heimdal.py's supervised (non--once) path retries in place on a startup config error instead of exiting
- Owner-doc impact: docs/STATUS.md :: Runtime verification updated in this PR
- Transition debt impact: none
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- heimdal-capture-watch never received HEIMDAL_RAW_STORE_KEY on test/prod (the host-secret env_file layer and deploy-wrapper bootstrap gate were dev-only) and had no deterministic delivery path for HEIMDAL_CAPTURE_WATCH_DIR/HEIMDAL_RAW_READ_ALLOWLIST, which crash-looped the test channel for 72h+ behind a healthcheck that never got to observe the failure under restart:unless-stopped. Fixes the delivery wiring across all channels and makes the supervised CLI path retry in place on startup config errors so the healthcheck can report unhealthy honestly.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 bounded bug fix extending an already-shipped host-secret bootstrap pattern (#4422) to a second declared consumer/channel; no BuilderOps material routed.

## Notes
Validation: python3 -m pytest tests/deploy/ tests/ops/test_heimdal_capture_watch_compose.py tests/ops/test_export_runtime_env.py tests/ops/test_host_secret_bootstrap.py tests/heimdal/test_capture_runtime.py tests/cli/test_heimdal_cli.py tests/release_channels/ tests/scripts/ (620 passed); ruff check app tests (all checks passed); bash -n + shellcheck on scripts/export_runtime_env.sh and scripts/lib/deploy_channel_compose.sh (no new findings); python3 scripts/docs_guard.py (OK).
