### PR TITLE
fix: name domain, source, and root identity in writer-inventory refusals

### DIFF
--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -59,6 +59,12 @@ class ProcessRecord:
 class LegacyOwnerRecord:
     channel_id: str
     root: str
+    # Which of this module's owner sources produced this record (docker_env,
+    # docker_app_local, config_env, config_app_local, process_env,
+    # native_app_local). Named so a refusal can identify *what* it refused
+    # without emitting a raw host path. Defaults to "unknown" only as a
+    # safety net; every live construction site below supplies a real value.
+    source: str = "unknown"
 
 
 def _digest_token(kind: str, *parts: object) -> str:
@@ -388,6 +394,19 @@ def _read_env_bytes(raw: bytes) -> dict[str, str]:
     return values
 
 
+class _AppLocalMalformed(RuntimeError):
+    """Internal marker carrying *why* app-local frontmatter parsing failed.
+
+    Never raised across the module boundary: `_parse_app_local_roots` catches
+    this and converts it into a domain/source-qualified `InventoryError`, so
+    the reason tags below never leak file content or paths on their own.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
 def _yaml_mapping_entry(raw: str) -> tuple[str, str]:
     quote = ""
     escaped = False
@@ -409,7 +428,7 @@ def _yaml_mapping_entry(raw: str) -> tuple[str, str]:
             continue
         if character == ":" and not quote and (index + 1 == len(raw) or raw[index + 1].isspace()):
             return raw[:index].strip(), raw[index + 1 :].strip()
-    raise InventoryError("legacy app-local owner source is invalid")
+    raise _AppLocalMalformed("mapping-missing-colon")
 
 
 def _yaml_scalar(raw: str) -> str:
@@ -420,22 +439,22 @@ def _yaml_scalar(raw: str) -> str:
         try:
             decoded = json.loads(value)
         except json.JSONDecodeError as exc:
-            raise InventoryError("legacy app-local owner source is invalid") from exc
+            raise _AppLocalMalformed("scalar-invalid-json") from exc
         if isinstance(decoded, str):
             return decoded
     if not value or value[0] in {"'", '"', "[", "{", "&", "*", "!", "|", ">"}:
-        raise InventoryError("legacy app-local owner source is invalid")
+        raise _AppLocalMalformed("scalar-invalid-syntax")
     return value
 
 
-def _parse_app_local_roots(raw: bytes) -> list[str]:
+def _parse_app_local_roots_body(raw: bytes) -> list[str]:
     try:
         text = raw.decode("utf-8")
         if not text.startswith("---\n") or "\n---\n" not in text[4:]:
             raise ValueError
         frontmatter_text = text[4:].split("\n---\n", 1)[0]
     except (UnicodeDecodeError, ValueError) as exc:
-        raise InventoryError("legacy app-local owner source is invalid") from exc
+        raise _AppLocalMalformed("frontmatter-malformed") from exc
     roots: list[str] = []
     known_seen = False
     in_known = False
@@ -446,14 +465,14 @@ def _parse_app_local_roots(raw: bytes) -> list[str]:
         nonlocal entry_open, entry_path
         if entry_open:
             if not entry_path:
-                raise InventoryError("legacy app-local owner source is invalid")
+                raise _AppLocalMalformed("entry-missing-path")
             roots.append(entry_path)
         entry_open = False
         entry_path = None
 
     for raw_line in frontmatter_text.splitlines():
         if "\t" in raw_line:
-            raise InventoryError("legacy app-local owner source is invalid")
+            raise _AppLocalMalformed("tab-indentation")
         content = raw_line.lstrip(" ")
         if not content or content.startswith("#"):
             continue
@@ -465,12 +484,12 @@ def _parse_app_local_roots(raw: bytes) -> list[str]:
             if _yaml_scalar(key_raw) != "knownVaults":
                 continue
             if known_seen:
-                raise InventoryError("legacy app-local owner source is invalid")
+                raise _AppLocalMalformed("duplicate-known-vaults-key")
             known_seen = True
             if value in {"{}", "{ }"}:
                 continue
             if value:
-                raise InventoryError("legacy app-local owner source is invalid")
+                raise _AppLocalMalformed("known-vaults-unexpected-value")
             in_known = True
             continue
         if not in_known:
@@ -480,20 +499,38 @@ def _parse_app_local_roots(raw: bytes) -> list[str]:
             key_raw, value = _yaml_mapping_entry(content)
             _yaml_scalar(key_raw)
             if value:
-                raise InventoryError("legacy app-local owner source is invalid")
+                raise _AppLocalMalformed("list-item-unexpected-value")
             entry_open = True
             continue
         if indent == 4 and entry_open:
             key_raw, value = _yaml_mapping_entry(content)
             if _yaml_scalar(key_raw) == "path":
                 if entry_path is not None:
-                    raise InventoryError("legacy app-local owner source is invalid")
+                    raise _AppLocalMalformed("duplicate-path-key")
                 entry_path = _yaml_scalar(value)
             continue
         if indent < 4 or not entry_open:
-            raise InventoryError("legacy app-local owner source is invalid")
+            raise _AppLocalMalformed("unexpected-indent")
     finish_entry()
     return roots
+
+
+def _parse_app_local_roots(raw: bytes, *, domain: str, source: str) -> list[str]:
+    """Parse app-local frontmatter, naming *what* failed without leaking content.
+
+    `domain` and `source` identify which of this module's four owner sources
+    produced the offending record; `reason` is a structural diagnosis of the
+    malformed frontmatter shape. Neither carries raw file content or a host
+    path, preserving the module's no-raw-path redaction posture.
+    """
+
+    try:
+        return _parse_app_local_roots_body(raw)
+    except _AppLocalMalformed as exc:
+        raise InventoryError(
+            "legacy app-local owner source is invalid: "
+            f"domain={domain} source={source} reason={exc.reason}"
+        ) from exc
 
 
 def _docker_copy_file(container_id: str, path: str) -> bytes | None:
@@ -651,7 +688,7 @@ def _docker_legacy_owner_sources() -> tuple[list[LegacyOwnerRecord], list[str]]:
         channel = COMPOSE_PROJECT_DOMAINS[str(project)]
         values = _env_list(config.get("Env"))
         for root in _roots_from_values(values, channel=channel, mounts=mounts):
-            owners.append(LegacyOwnerRecord(channel, str(root)))
+            owners.append(LegacyOwnerRecord(channel, str(root), source="docker_env"))
         store_path = values.get("DESIGN_HANDOFF_APP_LOCAL_SETTINGS", "").strip()
         if not store_path:
             store_path = (
@@ -665,11 +702,11 @@ def _docker_legacy_owner_sources() -> tuple[list[LegacyOwnerRecord], list[str]]:
             stores[store_key] = _docker_copy_file(container_id, store_path)
         raw_store = stores[store_key]
         if raw_store is not None:
-            for root in _parse_app_local_roots(raw_store):
+            for root in _parse_app_local_roots(raw_store, domain=channel, source="docker_app_local"):
                 translated = _translate_container_root(root, mounts)
                 if translated is None:
                     raise InventoryError("legacy app-local owner root has no host mount")
-                owners.append(LegacyOwnerRecord(channel, str(translated)))
+                owners.append(LegacyOwnerRecord(channel, str(translated), source="docker_app_local"))
         fingerprints.append(
             hashlib.sha256(
                 json.dumps(
@@ -800,7 +837,7 @@ def _config_legacy_owner_sources(
             continue
         values = _read_env_bytes(raw)
         for owner_root in _roots_from_values(values, channel=channel):
-            owners.append(LegacyOwnerRecord(channel, str(owner_root)))
+            owners.append(LegacyOwnerRecord(channel, str(owner_root), source="config_env"))
         runtime_ref = values.get("WATCHER_RUNTIME_ENV_FILE", "").strip()
         if runtime_ref:
             if "$" in runtime_ref:
@@ -823,8 +860,10 @@ def _config_legacy_owner_sources(
                 ).hexdigest()
             )
             owners.extend(
-                LegacyOwnerRecord(channel, root_path)
-                for root_path in _parse_app_local_roots(app_local_raw)
+                LegacyOwnerRecord(channel, root_path, source="config_app_local")
+                for root_path in _parse_app_local_roots(
+                    app_local_raw, domain=channel, source="config_app_local"
+                )
             )
     current_bindings: dict[str, dict[str, str]] = {
         active_channel: {
@@ -842,7 +881,7 @@ def _config_legacy_owner_sources(
     )
     for channel, values in current_bindings.items():
         owners.extend(
-            LegacyOwnerRecord(channel, str(path))
+            LegacyOwnerRecord(channel, str(path), source="process_env")
             for path in _roots_from_values(values, channel=channel)
         )
     native_app_local, native_required = _native_app_local_settings_path()
@@ -854,27 +893,42 @@ def _config_legacy_owner_sources(
     )
     if native_raw is not None:
         owners.extend(
-            LegacyOwnerRecord("native", root_path)
-            for root_path in _parse_app_local_roots(native_raw)
+            LegacyOwnerRecord("native", root_path, source="native_app_local")
+            for root_path in _parse_app_local_roots(
+                native_raw, domain="native", source="native_app_local"
+            )
         )
     return owners, sorted(fingerprints)
 
 
-def _owner_identity_material(root: Path) -> tuple[str, frozenset[str]]:
+def _owner_identity_material(root: Path, *, domain: str, source: str) -> tuple[str, frozenset[str]]:
     resolved = root.expanduser().resolve(strict=False)
+    # A stable digest of the resolved path, not the path itself: enough to
+    # correlate the same offending root across two runs of the inventory
+    # without emitting a raw host path in the refusal.
+    redacted_id = _digest_token("root", str(resolved))
     try:
         metadata = os.stat(resolved)
     except OSError as exc:
-        raise InventoryError("legacy owner root is missing or invalid") from exc
+        raise InventoryError(
+            "legacy owner root is missing or invalid: "
+            f"domain={domain} source={source} reason=vanished id={redacted_id}"
+        ) from exc
     if not stat.S_ISDIR(metadata.st_mode):
-        raise InventoryError("legacy owner root is missing or invalid")
+        raise InventoryError(
+            "legacy owner root is missing or invalid: "
+            f"domain={domain} source={source} reason=not-a-directory id={redacted_id}"
+        )
     primary = f"inode:{metadata.st_dev}:{metadata.st_ino}"
     ancestors: set[str] = set()
     for ancestor in resolved.parents:
         try:
             ancestor_metadata = os.stat(ancestor)
         except OSError as exc:
-            raise InventoryError("legacy owner ancestor identity is unavailable") from exc
+            raise InventoryError(
+                "legacy owner ancestor identity is unavailable: "
+                f"domain={domain} source={source} id={redacted_id}"
+            ) from exc
         ancestors.add(f"inode:{ancestor_metadata.st_dev}:{ancestor_metadata.st_ino}")
     return primary, frozenset(ancestors)
 
@@ -885,12 +939,16 @@ def _normalize_legacy_owners(
     normalized: dict[tuple[str, str], tuple[LegacyOwnerRecord, frozenset[str]]] = {}
     for record in records:
         if record.channel_id not in DOMAINS:
-            raise InventoryError("legacy owner domain is invalid")
+            raise InventoryError(
+                f"legacy owner domain is invalid: domain={record.channel_id} source={record.source}"
+            )
         root = Path(record.root).expanduser().resolve(strict=False)
-        primary, ancestors = _owner_identity_material(root)
+        primary, ancestors = _owner_identity_material(
+            root, domain=record.channel_id, source=record.source
+        )
         normalized.setdefault(
             (record.channel_id, primary),
-            (LegacyOwnerRecord(record.channel_id, str(root)), ancestors),
+            (LegacyOwnerRecord(record.channel_id, str(root), source=record.source), ancestors),
         )
     values = [
         (record, primary, ancestors)
@@ -905,7 +963,15 @@ def _normalize_legacy_owners(
                 or left_primary in right_ancestors
                 or right_primary in left_ancestors
             ):
-                raise InventoryError("legacy owner roots collide across domains")
+                shared_id = (
+                    left_primary
+                    if left_primary == right_primary or left_primary in right_ancestors
+                    else right_primary
+                )
+                raise InventoryError(
+                    "legacy owner roots collide across domains: "
+                    f"domain_a={left.channel_id} domain_b={right.channel_id} id={shared_id}"
+                )
     ordered = sorted(values, key=lambda item: (item[0].channel_id, item[0].root))
     return (
         [item[0] for item in ordered],
@@ -928,7 +994,11 @@ def _legacy_owner_snapshot(repo_root: Path, *, active_channel: str) -> dict[str,
         repo_root, active_channel=active_channel
     )
     owners, owner_identities = _normalize_legacy_owners(docker_owners + config_owners)
-    owner_rows = [record.__dict__ for record in owners]
+    # `source` is diagnostic-only context for InventoryError messages; keep the
+    # persisted receipt schema unchanged so existing consumers are unaffected.
+    owner_rows = [
+        {"channel_id": record.channel_id, "root": record.root} for record in owners
+    ]
     source_evidence = {
         "docker": docker_fingerprints,
         "config": config_fingerprints,

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -2404,8 +2404,10 @@ def test_legacy_owner_producer_reads_stopped_compose_config_and_scalar_store(
     owners, fingerprints = writer_inventory._docker_legacy_owner_sources()
 
     assert owners == [
-        writer_inventory.LegacyOwnerRecord("test", str(mounted.resolve())),
-        writer_inventory.LegacyOwnerRecord("test", str(selected.resolve())),
+        writer_inventory.LegacyOwnerRecord("test", str(mounted.resolve()), source="docker_env"),
+        writer_inventory.LegacyOwnerRecord(
+            "test", str(selected.resolve()), source="docker_app_local"
+        ),
     ]
     assert len(fingerprints) == 1
 
@@ -2422,7 +2424,9 @@ def test_legacy_owner_producer_parses_canonical_quoted_app_local_paths() -> None
         "---\n"
     ).encode()
 
-    assert writer_inventory._parse_app_local_roots(raw) == [
+    assert writer_inventory._parse_app_local_roots(
+        raw, domain="test", source="config_app_local"
+    ) == [
         "/Users/operator/Vault #1",
         "/Users/operator/Vault ☃",
     ]

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -11,6 +11,12 @@ Issue #4434: `ps`'s `command=` column is a display string — argv joined with
 single spaces — not shell syntax. Those tests pin the macOS row parser to that
 reading, so an ordinary quoted command line cannot abort the whole native
 inventory and thereby fail-close a deploy.
+
+Issue #4518: `InventoryError` refusals from the legacy-owner path named neither
+the offending root nor the domain that claimed it, which made a real refusal
+undiagnosable without monkeypatching the module. These tests pin every such
+refusal to carry a domain, a source, and (where a root is involved) a redacted
+identifier for it -- while still never emitting the raw host path.
 """
 
 import json
@@ -466,3 +472,98 @@ def test_prove_quiescent_is_deterministic_across_probes(monkeypatch, tmp_path, _
     second_payload = json.loads(second_output.read_text(encoding="utf-8"))
     assert first_payload["snapshot_digests"] == second_payload["snapshot_digests"]
     assert first_payload["domains"] == second_payload["domains"]
+
+
+# --- Issue #4518: refusals name domain, source, and a redacted root identity -
+
+MALFORMED_APP_LOCAL_FRONTMATTER = b"---\nnot a mapping line\n---\n"
+
+
+def test_inventory_errors_name_domain_and_source():
+    """Every `InventoryError` this module raises must name which domain and
+    which of the four owner sources produced the offending record, so a real
+    refusal is diagnosable from the message alone.
+    """
+
+    with pytest.raises(InventoryError) as excinfo:
+        writer_inventory._parse_app_local_roots(
+            MALFORMED_APP_LOCAL_FRONTMATTER, domain="dev", source="config_app_local"
+        )
+
+    message = str(excinfo.value)
+    assert "domain=dev" in message
+    assert "source=config_app_local" in message
+
+
+def test_missing_and_non_directory_roots_are_distinguishable(tmp_path):
+    """A vanished root and a root that exists but is not a directory must
+    raise distinguishable reasons, not the same bare message.
+    """
+
+    vanished = tmp_path / "does-not-exist"
+    not_a_directory = tmp_path / "a-file"
+    not_a_directory.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(InventoryError) as vanished_excinfo:
+        writer_inventory._owner_identity_material(vanished, domain="dev", source="config_env")
+
+    with pytest.raises(InventoryError) as file_excinfo:
+        writer_inventory._owner_identity_material(
+            not_a_directory, domain="dev", source="config_env"
+        )
+
+    vanished_message = str(vanished_excinfo.value)
+    file_message = str(file_excinfo.value)
+    assert vanished_message != file_message
+    assert "reason=vanished" in vanished_message
+    assert "reason=not-a-directory" in file_message
+    for message in (vanished_message, file_message):
+        assert "domain=dev" in message
+        assert "source=config_env" in message
+
+
+def test_collision_error_names_both_domains(tmp_path):
+    """A cross-domain collision (two channels claiming the same host root, the
+    ADR-0055-adjacent shape this module refuses) must name both domains and a
+    redacted identifier for the shared root.
+    """
+
+    shared_root = tmp_path / "shared-vault"
+    shared_root.mkdir()
+    records = [
+        writer_inventory.LegacyOwnerRecord("dev", str(shared_root), source="config_env"),
+        writer_inventory.LegacyOwnerRecord("prod", str(shared_root), source="config_env"),
+    ]
+
+    with pytest.raises(InventoryError, match="collide across domains") as excinfo:
+        writer_inventory._normalize_legacy_owners(records)
+
+    message = str(excinfo.value)
+    assert "domain_a=dev" in message
+    assert "domain_b=prod" in message
+    assert "id=inode:" in message
+    assert str(shared_root) not in message
+
+
+def test_inventory_errors_never_emit_raw_paths(tmp_path):
+    """No emitted error, log line, or receipt may contain a raw host path,
+    vault name, or operator name. This asserts against the strings the
+    deploy path actually raises, not a redaction helper's return value.
+    """
+
+    vanished = tmp_path / "operator-name" / "does-not-exist"
+
+    with pytest.raises(InventoryError) as excinfo:
+        writer_inventory._owner_identity_material(vanished, domain="dev", source="config_env")
+
+    message = str(excinfo.value)
+    assert str(vanished) not in message
+    assert str(tmp_path) not in message
+    assert "operator-name" not in message
+
+    with pytest.raises(InventoryError) as parse_excinfo:
+        writer_inventory._parse_app_local_roots(
+            MALFORMED_APP_LOCAL_FRONTMATTER, domain="dev", source="native_app_local"
+        )
+
+    assert "not a mapping line" not in str(parse_excinfo.value)


### PR DESCRIPTION
Governing-Issue: #4518

Fixes #4518

Final-Review-Rounds: 0

## Summary
`scripts/instance_state_writer_inventory.py` raised bare, identical `InventoryError` messages across all "legacy owner root is missing or invalid", "legacy owner roots collide across domains", and "legacy app-local owner source is invalid" refusal sites, so diagnosing a real refusal required monkeypatching the module. Every such `InventoryError` now names the domain (`dev`/`test`/`prod`/`native`) and the owner source (`docker_env`, `docker_app_local`, `config_env`, `config_app_local`, `process_env`, `native_app_local`) that produced the offending record, plus a redacted stable digest (or shared inode identity, for the cross-domain collision) instead of the raw host path -- preserving the module's no-raw-path redaction posture. A vanished root and a non-directory root now raise distinguishable reasons.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 bug-fix slice with no BuilderOps material routed; diagnosability-only change to an existing script and its tests.

## Notes
Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/ops/test_instance_state_writer_inventory.py tests/ops/test_instance_state_volume_contract.py` (119 passed, 3 skipped)
- `python3 scripts/public_seam_lint.py --mode gate` -> `secret_hits: 0`
- `ruff check app tests`
- `mypy app`
- Confirmed the persisted legacy-owner receipt JSON schema (`owners` rows) is unchanged; `source` is diagnostic-only context threaded through `InventoryError` messages, not into the receipt.