### PR TITLE
docs: seal the MVR-05A GOV-revocation seam instead of migrating an empty producer set

### DIFF
--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -401,9 +401,12 @@ Partial delivery remains fail-closed:
   ambiguous/conflicting rows quarantine. Issue 05D retires the compatibility translator only after
   native producer migration, and issue 06D cannot backfill a duplicate;
 - before issue 05A enables scalar vault-bound dispatch, every enabled GOV-revocation producer uses
-  the host-global ownership fence and matching exclusive binding lease. The 05A worker holds the
+  the host-global ownership fence and matching exclusive binding lease. That enabled set is closed by
+  inventory and is empty at 05A, so 05A discharges this by sealing the seam and proving the set
+  empty, not by migrating existing producers. The 05A worker holds the
   shared lease through dispatch/ack/receipt, so revocation cannot cross that effect window; 05B
-  extends the already-live fence to foreground read producers;
+  extends the already-live fence to foreground read producers and lands the first real producer
+  against the already-live seal;
 - after issue 06B, legacy choose/open and default set/clear continue to rebind only `compatibility`
   lifecycle intent with the same mutation-gate/pre-commit scan+buffer/quiesce → commit →
   post-commit old-root scan+buffer drain → resume transaction. Default clear re-runs the canonical

--- a/docs/MULTI_VAULT_RUNTIME/ROUTE_REQUESTS_THROUGH_ACTIVE_CONTEXT.md
+++ b/docs/MULTI_VAULT_RUNTIME/ROUTE_REQUESTS_THROUGH_ACTIVE_CONTEXT.md
@@ -158,10 +158,13 @@ not background lifecycles.
   independently safe `global` work. The worker releases the global fence after the stable snapshot
   but holds the shared lease through external dispatch, acknowledgement, and receipt; revocation,
   relocation, or removal therefore waits for an already-authorized effect or blocks it before effect.
-  Before 05A enables that dispatch, it migrates every already-enabled GOV revocation producer to
-  acquire the host-global ownership fence and the same binding's exclusive effect lease before
-  advancing the authorization epoch. Removal and relocation remain capability-not-ready, but an
-  enabled revocation can no longer cross the worker validation-to-dispatch window.
+  Before 05A enables that dispatch, it seals the GOV revocation seam: any enabled production path
+  must acquire the host-global ownership fence and the same binding's exclusive effect lease before
+  advancing the authorization epoch, and the enabled production set is closed by inventory. That set
+  is empty at 05A — the one production caller of the binding authorizer seeds binding facts and never
+  revokes — so the seal guards against the first producer landing unfenced rather than migrating
+  producers that already exist. Removal and relocation remain capability-not-ready, and no enabled
+  revocation can cross the worker validation-to-dispatch window.
   MVR-06 owns multi-binding dispatch and governed quarantine
   recovery; until it lands no ambiguous row can execute against an env-selected vault.
 - While every old DB/outbox producer is fenced and before any upgraded producer is enabled, classify
@@ -257,8 +260,9 @@ acceptance criteria prefixed with its ID:
 1. **MVR-05A — binding-keyed persistence cutover:** projection/outbox schema and backfill,
    idempotency classification, all-process mixed-version fence, minimum-runtime floor, duplicate-
    binding projection isolation, and an immediately shipped scalar-worker poll/ack compatibility
-   gate holding the per-binding shared effect lease through dispatch/ack/receipt plus migration of
-   every enabled GOV-revocation producer to the matching exclusive lease before dispatch activates,
+   gate holding the per-binding shared effect lease through dispatch/ack/receipt plus a sealed
+   GOV-revocation seam requiring the matching exclusive lease before dispatch activates, with the
+   enabled production producer set closed by inventory and empty on delivery,
    with a non-skippable
    real-PostgreSQL CI receipt and DB/deployment/release owner-doc
    writebacks.
@@ -424,11 +428,16 @@ un-revalidated read/write to cross its floor; independently safe explicit-global
   It holds the binding shared-effect lease from final validation through dispatch, acknowledgement,
   and receipt, so concurrent revocation/removal/relocation cannot complete across an effect window.
   - Verify: `tests/workers/test_multi_vault_partial_delivery_gate.py::test_mvr05a_scalar_worker_gates_migrated_rows_before_dispatch`
-- [ ] **MVR-05A:** Before vault-bound worker dispatch activates, every enabled GOV-revocation
-  production path takes the ownership fence and matching exclusive binding lease before advancing
-  authorization state; a revocation after worker validation either blocks dispatch or waits for the
-  authorized dispatch, acknowledgement, and receipt to finish. Removal/relocation stay dormant.
+- [ ] **MVR-05A:** Before vault-bound worker dispatch activates, the GOV-revocation seam is sealed:
+  no enabled production path may advance binding authorization state without first taking the
+  host-global ownership fence and the matching exclusive binding lease. The enabled production
+  producer set is closed by a checked-in inventory and is **empty on delivery** — production seeds
+  binding facts but never revokes — so this criterion is discharged by proving that set empty and by
+  the gate failing when a producer is added without the fence, not by migrating existing producers.
+  A revocation that does reach the seam after worker validation either blocks dispatch or waits for
+  the authorized dispatch, acknowledgement, and receipt to finish. Removal/relocation stay dormant.
   - Verify: `tests/workers/test_multi_vault_partial_delivery_gate.py::test_mvr05a_revocation_cannot_cross_worker_dispatch_effect_window`
+  - Verify: `tests/architecture/test_multi_vault_projection_inventory.py::test_enabled_gov_revocation_producers_are_fenced_or_absent`
 - [ ] **MVR-05C:** Production capture/governed-write paths require one explicit authorized target,
   reject an otherwise registered/owned/GOV-authorized target outside the immutable selected binding
   set (and any batch that is not a subset), and record vault/context provenance in their receipt.


### PR DESCRIPTION
## Lane

- [x] Docs authoring lane

Docs-only specification repair. No code, no runtime behaviour, no shipped contract changes — the
acceptance criterion being reworded was never implemented. Per `AGENTS.md :: Docs authoring lane`,
published without a governing Issue; `Refs #3859` below is evidence-only and closes nothing.

Refs #3859
Refs #2143

Final-Review-Rounds: 0

## What and why

MVR-05A's revocation acceptance criterion required taking the ownership fence and matching exclusive
binding lease on *"every enabled GOV-revocation production path"* before vault-bound worker dispatch
activates. **That set is empty.**

- `RegistryBindingAuthorizer.set_binding` (`app/governance/binding_authority.py:174`) has exactly one
  production caller: `app/instance/active_context_service.py:213`, inside `build_authorizer()`.
- It passes `binding_id`, `fact.binding_revision`, and `available=` — **never `revoked=`**.
- So `DENY_REVOKED` (`app/governance/binding_authority.py:222`) is unreachable in production.
  Revocation is constructed only by tests.
- Every other `revoked` symbol under `app/**` is an unrelated subsystem: BuilderOps design-run
  approvals, Heimdal consent, YouTube OAuth, and the MVR-03 principal-subject revocation at
  `app/instance/runtime.py:3268` — which revokes a *principal*, not a *vault binding*.

As written the AC asked to migrate producers that do not exist, and its verification would have had
to exercise a path production cannot reach. That is the `Invariant → producers` trap: the rule checks
producer *existence*, never reachability in the environment it runs in. It already cost MVR-03 three
consecutive review rounds on this exact producer chain, so leaving it in place was a predictable
repeat.

**Reworded to the reachable obligation with the same intent** — revocation cannot cross the worker
validation-to-dispatch window. 05A seals the seam so no enabled production path can advance binding
authorization state without the fence and exclusive lease, closes the enabled production set by
inventory, and proves that set empty. The gate gains its force by failing when the first producer is
added unfenced — 05B/06B work per this lane's own partial-delivery text — rather than by migrating
producers that are not there.

**Alternative considered and rejected:** give revocation a real production producer inside 05A. The
lane assigns foreground read producers to 05B and removal/relocation to 06B
(`docs/MULTI_VAULT_RUNTIME/README.md :: Cross-Task Invariants`), so inventing one here would take
scope from a later slice.

## Why all three sites move together

The Issue body copies its ACs from this specification, so editing one alone opens issue/spec drift.
This PR edits the specification AC, the lane README's partial-delivery clause, and the 05A
decomposition summary; the matching `#3859` body edit is applied in the same change window and is
recorded on the Issue.

## Files

| File | Change |
| --- | --- |
| `docs/MULTI_VAULT_RUNTIME/ROUTE_REQUESTS_THROUGH_ACTIVE_CONTEXT.md` | AC reworded; `What This Task Does` narrative and 05A decomposition summary aligned |
| `docs/MULTI_VAULT_RUNTIME/README.md` | partial-delivery clause states the set is closed by inventory and empty at 05A |

A second `Verify:` target is added for the inventory assertion, hung on the projection-inventory
module MVR-05A's AC-2 already introduces rather than a new module. Each target is on **its own
`Verify:` line** — the joined-with-` + ` form is what made this Issue unreadable to the contract
grammar in the first place (repaired separately; LearningSignal `lrn_20260801235940_88ae5d3f`).

## Validation

All run on head `e9907aa4a`, in a dedicated worktree off `origin/main`.

| Check | Result |
| --- | --- |
| `scripts/docs_guard.py` | `Docs guard: OK` (rc 0) |
| `scripts/public_seam_lint.py --mode gate` | `secret_hits: 0  uncovered_hits: 0  stale_rows: 0  migration_pending: 0` (rc 0) |
| `pytest tests/architecture/test_docs_index.py tests/governance/test_verify_target_contract_parity.py` | **16 passed** |
| `is_resolvable_verify_target` on both new targets | `True`, `True` |
| `validate_issue_readiness.py` on the reworded #3859 body | `ready_candidate`, 13 ACs, `missing_verify_file_paths: []` (rc 0) |

Docs-only, so no `ruff` / `mypy` / `not pg` suite: no file under `app/`, `tests/`, or
`companion-ui/companion-app/` is touched. `Final-Review-Rounds: 0` per `AGENTS.md :: Proportional
delivery` — Tier 1 docs/governance text, single lane, no high-risk surface, no runtime effect.

## Scope

Delivers **only** the AC-12 contract repair. It does **not** deliver MVR-05A (#3859), which remains
`agent:blocked` and unclaimed. #2143 stays the blocked validation hub — not claimed, not closed.
Nothing touched on #3860, #4524, or #4559.
