### PR TITLE
fix: refuse divergent Keychain material across shared-domain host secrets

### DIFF
--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -322,13 +322,35 @@ def _secret_failure(*, secret: str, kind: str) -> HostSecretBootstrapError:
     )
 
 
-def _shared_domain_digest(value: str) -> bytes:
+def _shared_domain_comparable_bytes(kind: str, value: str) -> bytes:
+    """Normalize *value* to the bytes the cipher domain actually uses.
+
+    `raw-store-key` values are hex text that the raw store decodes with
+    `bytes.fromhex` before use as key material (`app/heimdal/raw_store.py`), so
+    two hex strings that differ only in case are the *same* key. Comparing the
+    raw text would flag that pair as diverged even though the domain agrees;
+    decode first so the equivalence check matches the cipher's own reading of
+    the value. A value that fails to decode is left as UTF-8 text — it is
+    already malformed for its declared kind and will fail
+    ``_validate_secret`` on its own path; this function only has to make sure
+    it does not COMPARE EQUAL to a well-formed sibling by accident, and text
+    bytes never collide with decoded key bytes here.
+    """
+    if kind == "raw-store-key":
+        try:
+            return bytes.fromhex(value)
+        except ValueError:
+            return value.encode("utf-8")
+    return value.encode("utf-8")
+
+
+def _shared_domain_digest(kind: str, value: str) -> bytes:
     """Non-reversible fingerprint used to compare shared-domain material.
 
     Never return, log, or persist this alongside the value it was derived
     from; it exists only to be compared against another digest in-process.
     """
-    return hashlib.sha256(value.encode("utf-8")).digest()
+    return hashlib.sha256(_shared_domain_comparable_bytes(kind, value)).digest()
 
 
 def _check_shared_domain_agreement(
@@ -336,6 +358,7 @@ def _check_shared_domain_agreement(
     channel: str,
     consumer: str,
     secret: str,
+    kind: str,
     value: str,
     contract: HostSecretContract,
     keychain_lookup: KeychainLookup,
@@ -343,15 +366,18 @@ def _check_shared_domain_agreement(
     """Refuse rather than proceed when a sibling consumer's material differs.
 
     Only secrets declared `shared_key_domain` are checked. A sibling consumer
-    whose own material cannot be resolved (not yet provisioned, transient
-    lookup failure) is not itself evidence of divergence — that failure
-    belongs to the sibling's own bootstrap invocation — so it is skipped here
-    rather than failing this consumer closed. Only two resolvable values that
-    disagree count as divergence.
+    whose own material cannot be resolved (not yet provisioned, a lookup
+    failure the sibling's own bootstrap will surface on its own path) is not
+    itself evidence of divergence, so it is skipped here rather than failing
+    this consumer closed — narrowly, on the same typed failure every
+    `keychain_lookup` implementation in this module raises, so an unexpected
+    programming error (wrong callable signature, a decode bug) still fails
+    this consumer closed instead of silently disabling the check. Only two
+    resolvable values that disagree count as divergence.
     """
     if not contract.is_shared_key_domain(secret):
         return
-    own_digest = _shared_domain_digest(value)
+    own_digest = _shared_domain_digest(kind, value)
     for sibling_consumer in sorted(
         contract.consumers_declared_for(channel=channel, secret=secret)
     ):
@@ -362,9 +388,9 @@ def _check_shared_domain_agreement(
         )
         try:
             sibling_value = keychain_lookup(contract.keychain_service, sibling_account)
-        except Exception:
+        except HostSecretBootstrapError:
             continue
-        if not hmac.compare_digest(_shared_domain_digest(sibling_value), own_digest):
+        if not hmac.compare_digest(_shared_domain_digest(kind, sibling_value), own_digest):
             raise HostSecretSharedDomainDivergenceError(secret)
 
 
@@ -413,6 +439,7 @@ def _resolve_consumer_environment(
                 channel=channel,
                 consumer=consumer,
                 secret=secret,
+                kind=kind,
                 value=value,
                 contract=contract,
                 keychain_lookup=keychain_lookup,

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -6,6 +6,8 @@ import argparse
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 import ctypes
+import hashlib
+import hmac
 import os
 from pathlib import Path
 import re
@@ -52,6 +54,22 @@ class HostSecretBootstrapTerminated(HostSecretBootstrapError):
     def __init__(self, signum: int) -> None:
         super().__init__("host secret bootstrap terminated for declared consumer")
         self.signum = signum
+
+
+class HostSecretSharedDomainDivergenceError(HostSecretBootstrapError):
+    """Two declared consumers of a shared-domain secret resolved to different material.
+
+    Raised without either value, or anything derived from which a value could
+    be recovered — only the declared logical secret identifier, which is what
+    an operator needs to locate and re-provision the diverged Keychain items.
+    """
+
+    def __init__(self, shared_domain_secret_ref: str) -> None:
+        super().__init__(
+            "host secret bootstrap failed for declared consumer: shared-domain "
+            f"secret diverges across consumers: {shared_domain_secret_ref}"
+        )
+        self.shared_domain_secret_ref = shared_domain_secret_ref
 
 
 SignalHandler = Callable[[int, FrameType | None], None]
@@ -304,6 +322,52 @@ def _secret_failure(*, secret: str, kind: str) -> HostSecretBootstrapError:
     )
 
 
+def _shared_domain_digest(value: str) -> bytes:
+    """Non-reversible fingerprint used to compare shared-domain material.
+
+    Never return, log, or persist this alongside the value it was derived
+    from; it exists only to be compared against another digest in-process.
+    """
+    return hashlib.sha256(value.encode("utf-8")).digest()
+
+
+def _check_shared_domain_agreement(
+    *,
+    channel: str,
+    consumer: str,
+    secret: str,
+    value: str,
+    contract: HostSecretContract,
+    keychain_lookup: KeychainLookup,
+) -> None:
+    """Refuse rather than proceed when a sibling consumer's material differs.
+
+    Only secrets declared `shared_key_domain` are checked. A sibling consumer
+    whose own material cannot be resolved (not yet provisioned, transient
+    lookup failure) is not itself evidence of divergence — that failure
+    belongs to the sibling's own bootstrap invocation — so it is skipped here
+    rather than failing this consumer closed. Only two resolvable values that
+    disagree count as divergence.
+    """
+    if not contract.is_shared_key_domain(secret):
+        return
+    own_digest = _shared_domain_digest(value)
+    for sibling_consumer in sorted(
+        contract.consumers_declared_for(channel=channel, secret=secret)
+    ):
+        if sibling_consumer == consumer:
+            continue
+        sibling_account = contract.keychain_account(
+            channel=channel, consumer=sibling_consumer, secret=secret
+        )
+        try:
+            sibling_value = keychain_lookup(contract.keychain_service, sibling_account)
+        except Exception:
+            continue
+        if not hmac.compare_digest(_shared_domain_digest(sibling_value), own_digest):
+            raise HostSecretSharedDomainDivergenceError(secret)
+
+
 def _resolve_consumer_environment(
     *,
     channel: str,
@@ -340,6 +404,19 @@ def _resolve_consumer_environment(
             # is present and wrong is a misconfiguration, never an opt-out.
             if not _validate_secret(kind, value):
                 raise _secret_failure(secret=secret, kind=kind)
+            # A shared-domain secret backs one cipher domain fed by more than
+            # one consumer process (#4512): a value that is individually valid
+            # is still wrong if a sibling consumer holds different material,
+            # so refuse before this consumer's bootstrap can proceed into a
+            # split cipher domain.
+            _check_shared_domain_agreement(
+                channel=channel,
+                consumer=consumer,
+                secret=secret,
+                value=value,
+                contract=contract,
+                keychain_lookup=keychain_lookup,
+            )
             resolved[env_name] = value
     except HostSecretBootstrapError:
         raise

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -23,7 +23,13 @@ _CONTRACT_FIELDS = frozenset(
 # `optional` is required on every declaration rather than defaulted (#4489):
 # the schema is closed at every level, and a secret whose absence is tolerated
 # is exactly the kind of thing that must be stated, not inferred from silence.
-_SECRET_FIELDS = frozenset({"logical_id", "child_binding", "kind", "optional"})
+# `shared_key_domain` follows the same rule (#4512): whether every declared
+# consumer of a secret must resolve to identical material is a property of
+# the secret, and it must be stated explicitly rather than inferred from how
+# many consumers happen to declare it.
+_SECRET_FIELDS = frozenset(
+    {"logical_id", "child_binding", "kind", "optional", "shared_key_domain"}
+)
 _CONSUMER_FIELDS = frozenset({"consumer", "channels", "secrets", "role_requirements"})
 _KEYCHAIN_ACCOUNT_TEMPLATE = "{channel}:{consumer}:{secret}"
 _KEYCHAIN_SERVICE = "yggdrasil.host-secrets"
@@ -64,6 +70,10 @@ class HostSecretContract:
     # unpack that tuple positionally, and optionality is a property of the
     # declaration, not of the identifier/binding/kind triple.
     optional_secrets: frozenset[str] = frozenset()
+    # Secrets every declared consumer must resolve to identical material for
+    # (#4512). Kept beside `secret_definitions` for the same reason as
+    # `optional_secrets`.
+    shared_key_domain_secrets: frozenset[str] = frozenset()
 
     def require_declared(self, *, channel: str, consumer: str, secret: str) -> None:
         if (channel, consumer, secret) not in self.allowed:
@@ -101,6 +111,28 @@ class HostSecretContract:
             if logical_id == secret:
                 return secret in self.optional_secrets
         raise UndeclaredSecretConsumerError("undeclared host secret request")
+
+    def is_shared_key_domain(self, secret: str) -> bool:
+        """Whether every declared consumer of *secret* must hold identical material.
+
+        A shared-domain secret backs one cipher domain fed by more than one
+        consumer process; a value resolved by one consumer must match every
+        other declared consumer's value for the same channel, or the domain
+        has silently split. Non-shared-domain secrets (a per-consumer API key)
+        are declared independently per consumer with no such requirement.
+        """
+        for logical_id, _child_binding, _kind in self.secret_definitions:
+            if logical_id == secret:
+                return secret in self.shared_key_domain_secrets
+        raise UndeclaredSecretConsumerError("undeclared host secret request")
+
+    def consumers_declared_for(self, *, channel: str, secret: str) -> frozenset[str]:
+        """Every consumer declared for *secret* on *channel*."""
+        return frozenset(
+            declared_consumer
+            for declared_channel, declared_consumer, declared_secret in self.allowed
+            if declared_channel == channel and declared_secret == secret
+        )
 
     def required_secrets_for_role(self, *, consumer: str, role: str) -> tuple[str, ...]:
         for declared_consumer, declared_role, secrets in self.role_requirements:
@@ -162,6 +194,7 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
     )
     secret_definitions: list[tuple[str, str, str]] = []
     optional_secrets: set[str] = set()
+    shared_key_domain_secrets: set[str] = set()
     for item in payload["secrets"]:
         if not isinstance(item, dict) or set(item) != _SECRET_FIELDS:
             raise ValueError("invalid host secret declaration")
@@ -169,6 +202,7 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
         child_binding = item["child_binding"]
         kind = item["kind"]
         optional = item["optional"]
+        shared_key_domain = item["shared_key_domain"]
         if (
             not _is_identifier(logical_id, _LOGICAL_SECRET_PATTERN)
             or not _is_identifier(child_binding, _CHILD_BINDING_PATTERN)
@@ -176,13 +210,17 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
             or logical_id.rsplit(".", maxsplit=1)[1] != kind
             or child_binding != _expected_child_binding(logical_id)
             # `type(...) is not bool` rather than isinstance: bool is a subclass
-            # of int, and a truthy 1 must not smuggle in an optional secret.
+            # of int, and a truthy 1 must not smuggle in an optional or
+            # shared-domain secret.
             or type(optional) is not bool
+            or type(shared_key_domain) is not bool
         ):
             raise ValueError("invalid host secret identifier")
         secret_definitions.append((logical_id, child_binding, kind))
         if optional:
             optional_secrets.add(logical_id)
+        if shared_key_domain:
+            shared_key_domain_secrets.add(logical_id)
     logical_ids = [item[0] for item in secret_definitions]
     child_bindings = [item[1] for item in secret_definitions]
     if (
@@ -245,4 +283,5 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
         secret_definitions=tuple(secret_definitions),
         role_requirements=tuple(role_requirements),
         optional_secrets=frozenset(optional_secrets),
+        shared_key_domain_secrets=frozenset(shared_key_domain_secrets),
     )

--- a/config/secrets/host_secret_contract.json
+++ b/config/secrets/host_secret_contract.json
@@ -12,25 +12,29 @@
       "logical_id": "heimdal.raw-store-key",
       "child_binding": "HEIMDAL_RAW_STORE_KEY",
       "kind": "raw-store-key",
-      "optional": false
+      "optional": false,
+      "shared_key_domain": true
     },
     {
       "logical_id": "openai.api-key",
       "child_binding": "OPENAI_API_KEY",
       "kind": "api-key",
-      "optional": false
+      "optional": false,
+      "shared_key_domain": false
     },
     {
       "logical_id": "anthropic.api-key",
       "child_binding": "ANTHROPIC_API_KEY",
       "kind": "api-key",
-      "optional": false
+      "optional": false,
+      "shared_key_domain": false
     },
     {
       "logical_id": "github.token",
       "child_binding": "GITHUB_TOKEN",
       "kind": "token",
-      "optional": true
+      "optional": true,
+      "shared_key_domain": false
     }
   ],
   "consumers": [

--- a/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
@@ -35,6 +35,14 @@ history, repository file, issue, or receipt. HSP-02 will own non-interactive ret
 runtime material. A raw-store key is generated only when the governed preflight proves no encrypted
 records require an existing key; rotation is a separate migration, never a bootstrap retry.
 
+**Shared-domain secrets** (`shared_key_domain: true`, currently only `heimdal.raw-store-key`) feed one
+cipher domain from more than one consumer process — `heimdal-capture-watch` and `heimdal-api-ingress`
+both encrypt/decrypt the same raw-evidence records with it. When creating or re-provisioning that item
+on a channel, write the *identical* generated value to every declared consumer's account for that
+channel in the same operation. The bootstrap fail-closed check added in #4512 only detects a mismatch
+after the fact and refuses rather than proceeding into a split cipher domain; it cannot repair one, and
+a diverged domain that already produced records is out of scope for that check to fix.
+
 ## Acceptance criteria
 
 - [x] The contract lists every initial logical secret, consumer, and permitted channel without a

--- a/tests/builderops/inquiry_intent.py
+++ b/tests/builderops/inquiry_intent.py
@@ -144,6 +144,9 @@ def contract_with_role_targets(
                             # Model-provider credentials are required: a role
                             # cannot resolve without its declared key (#4489).
                             "optional": False,
+                            # Model-provider credentials resolve independently
+                            # per consumer, never shared-domain (#4512).
+                            "shared_key_domain": False,
                         }
                     )
                     declared.add(secret)

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -20,6 +20,7 @@ from app.ops.host_secret_bootstrap import (
     HOST_SECRET_RUNTIME_ENV_FILE,
     HostSecretBootstrapError,
     HostSecretBootstrapTerminated,
+    HostSecretSharedDomainDivergenceError,
     KeychainLookup,
     materialize_consumer_environment,
     load_runtime_secret_values,
@@ -53,11 +54,19 @@ def test_consumer_gets_only_allowlisted_values(tmp_path: Path) -> None:
     ) as env_file:
         assert env_file.read_text(encoding="utf-8") == f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
 
+    # heimdal.raw-store-key is shared-domain (#4512): resolving it for one
+    # consumer also looks up the other declared consumer's account on the same
+    # channel to compare digests, so both accounts are requested even though
+    # only the requested consumer's value is materialized.
     assert requested == [
         (
             "yggdrasil.host-secrets",
             "dev:heimdal-capture-watch:heimdal.raw-store-key",
-        )
+        ),
+        (
+            "yggdrasil.host-secrets",
+            "dev:heimdal-api-ingress:heimdal.raw-store-key",
+        ),
     ]
 
 
@@ -1050,3 +1059,148 @@ def test_loader_rejects_a_declaration_without_an_explicit_boolean_optional(
 
     with pytest.raises(ValueError, match=expected):
         host_secret_bootstrap.load_host_secret_contract(path)
+
+
+# --- Shared-domain divergence check (#4512) ---------------------------------
+#
+# `heimdal.raw-store-key` feeds one AES-256-GCM cipher domain from two
+# independently bootstrapped consumers (heimdal-capture-watch,
+# heimdal-api-ingress). Nothing previously required the two Keychain items to
+# hold the same value; these tests prove the production bootstrap entrypoint
+# (`run_with_host_secrets`, and `main` below it) refuses rather than
+# proceeding into a split cipher domain, that matching material bootstraps
+# byte-for-byte unchanged, and that the check never discloses either value.
+
+_SIBLING_RAW_KEY = "b" * 64
+
+
+def _divergent_raw_store_key_lookup(
+    *,
+    primary: str = _RAW_KEY,
+    sibling: str = _SIBLING_RAW_KEY,
+) -> KeychainLookup:
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":heimdal-api-ingress:heimdal.raw-store-key"):
+            return sibling
+        if account.endswith(":heimdal-capture-watch:heimdal.raw-store-key"):
+            return primary
+        pytest.fail(f"unexpected account lookup: {account}")
+
+    return lookup
+
+
+def test_divergent_shared_domain_secret_fails_loud(tmp_path: Path) -> None:
+    launched = False
+
+    def runner(_command: list[str], _env: dict[str, str]) -> int:
+        nonlocal launched
+        launched = True
+        return 0
+
+    with pytest.raises(HostSecretSharedDomainDivergenceError) as error:
+        run_with_host_secrets(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            command=["never-start"],
+            keychain_lookup=_divergent_raw_store_key_lookup(),
+            runner=runner,
+            directory=tmp_path,
+        )
+
+    assert not launched
+    message = str(error.value)
+    assert "heimdal.raw-store-key" in message
+    assert _RAW_KEY not in message
+    assert _SIBLING_RAW_KEY not in message
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_matching_shared_domain_secret_bootstraps_unchanged(tmp_path: Path) -> None:
+    """Identical material across both consumers bootstraps unchanged (#4489/#4512)."""
+    observed_path: Path | None = None
+
+    def runner(_command: list[str], env: dict[str, str]) -> int:
+        nonlocal observed_path
+        observed_path = Path(env["HOST_SECRET_RUNTIME_ENV_FILE"])
+        assert observed_path.read_text(encoding="utf-8") == f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+        return 0
+
+    result = run_with_host_secrets(
+        channel="dev",
+        consumer="heimdal-capture-watch",
+        command=["consumer"],
+        keychain_lookup=_divergent_raw_store_key_lookup(sibling=_RAW_KEY),
+        runner=runner,
+        directory=tmp_path,
+    )
+
+    assert result == 0
+    assert observed_path is not None and not observed_path.exists()
+
+
+def test_non_shared_domain_secret_with_two_consumers_skips_sibling_lookup(
+    tmp_path: Path,
+) -> None:
+    """`openai.api-key` is declared by two consumers but is not shared-domain.
+
+    `builderops-model-inquiry` and `builderops-ckm-semantic` both declare
+    `openai.api-key`, proving the sibling-lookup machinery is gated on
+    `shared_key_domain`, not merely on "more than one declared consumer".
+    """
+    requested_accounts: list[str] = []
+
+    def lookup(_service: str, account: str) -> str:
+        requested_accounts.append(account)
+        if account == "dev:builderops-ckm-semantic:openai.api-key":
+            return _OPENAI_KEY
+        pytest.fail(f"unexpected account lookup: {account}")
+
+    result = run_with_host_secrets(
+        channel="dev",
+        consumer="builderops-ckm-semantic",
+        command=["consumer"],
+        keychain_lookup=lookup,
+        runner=lambda _command, _env: 0,
+        directory=tmp_path,
+    )
+
+    assert result == 0
+    assert requested_accounts == ["dev:builderops-ckm-semantic:openai.api-key"]
+
+
+def test_shared_domain_check_never_logs_key_material(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # `main` resolves through the real default `_security_keychain_lookup`,
+    # bound as a parameter default at function-definition time, so patching
+    # the module attribute would not reach it. `raw-store-key` accounts take
+    # the `security` CLI subprocess path (never the framework path), so patch
+    # that call site instead — same technique already used by
+    # `test_capture_watch_uses_bootstrap_not_tracked_env` via a fake `security`
+    # binary, done here via `subprocess.run` directly to stay in-process.
+    lookup = _divergent_raw_store_key_lookup()
+
+    class _FakeCompletedProcess:
+        def __init__(self, stdout: str) -> None:
+            self.returncode = 0
+            self.stdout = stdout
+
+    def fake_run(command: list[str], **_kwargs: object) -> _FakeCompletedProcess:
+        account = command[command.index("-a") + 1]
+        return _FakeCompletedProcess(lookup("yggdrasil.host-secrets", account) + "\n")
+
+    monkeypatch.setattr(host_secret_bootstrap.subprocess, "run", fake_run)
+
+    exit_code = host_secret_bootstrap.main(
+        ["--channel", "dev", "--consumer", "heimdal-capture-watch", "--", "never-start"]
+    )
+
+    assert exit_code == 78
+    captured = capsys.readouterr()
+    for stream in (captured.out, captured.err):
+        assert _RAW_KEY not in stream
+        assert _SIBLING_RAW_KEY not in stream
+        assert "heimdal-capture-watch:heimdal.raw-store-key" not in stream
+        assert "heimdal-api-ingress:heimdal.raw-store-key" not in stream
+    assert "heimdal.raw-store-key" in captured.err

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -1138,6 +1138,100 @@ def test_matching_shared_domain_secret_bootstraps_unchanged(tmp_path: Path) -> N
     assert observed_path is not None and not observed_path.exists()
 
 
+def test_shared_domain_agreement_is_hex_case_insensitive(tmp_path: Path) -> None:
+    """Two hex-case spellings of the same raw-store key must not read as diverged.
+
+    `raw-store-key` values are decoded with `bytes.fromhex` before use
+    (`app/heimdal/raw_store.py`), so `"a" * 64` and `"A" * 64` are the same key
+    material. Comparing the raw text would false-positive here and brick both
+    consumers on an otherwise correctly provisioned host.
+    """
+    observed_path: Path | None = None
+
+    def runner(_command: list[str], env: dict[str, str]) -> int:
+        nonlocal observed_path
+        observed_path = Path(env["HOST_SECRET_RUNTIME_ENV_FILE"])
+        return 0
+
+    result = run_with_host_secrets(
+        channel="dev",
+        consumer="heimdal-capture-watch",
+        command=["consumer"],
+        keychain_lookup=_divergent_raw_store_key_lookup(sibling=_RAW_KEY.upper()),
+        runner=runner,
+        directory=tmp_path,
+    )
+
+    assert result == 0
+    assert observed_path is not None and not observed_path.exists()
+
+
+def test_sibling_lookup_programming_error_still_fails_closed(tmp_path: Path) -> None:
+    """The sibling-skip path only tolerates the typed bootstrap failure.
+
+    An unexpected error from a `keychain_lookup` implementation (a signature
+    mismatch, a decode bug) must not be swallowed as "sibling unresolvable" —
+    that would silently disable the divergence check. Only
+    `HostSecretBootstrapError`, the failure every in-repo `keychain_lookup`
+    raises for a genuinely unresolvable item, is tolerated; anything else
+    reaches the outer handler and fails this consumer closed.
+    """
+    launched = False
+
+    def runner(_command: list[str], _env: dict[str, str]) -> int:
+        nonlocal launched
+        launched = True
+        return 0
+
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":heimdal-api-ingress:heimdal.raw-store-key"):
+            raise TypeError("unexpected programming error, not a bootstrap failure")
+        return _RAW_KEY
+
+    with pytest.raises(HostSecretBootstrapError) as error:
+        run_with_host_secrets(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            command=["never-start"],
+            keychain_lookup=lookup,
+            runner=runner,
+            directory=tmp_path,
+        )
+
+    assert not isinstance(error.value, HostSecretSharedDomainDivergenceError)
+    assert not launched
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_sibling_lookup_bootstrap_failure_is_tolerated_as_skip(tmp_path: Path) -> None:
+    """A sibling's typed, unresolvable-item failure is skipped, not fatal."""
+    observed_path: Path | None = None
+
+    def runner(_command: list[str], env: dict[str, str]) -> int:
+        nonlocal observed_path
+        observed_path = Path(env["HOST_SECRET_RUNTIME_ENV_FILE"])
+        return 0
+
+    def lookup(_service: str, account: str) -> str:
+        if account.endswith(":heimdal-api-ingress:heimdal.raw-store-key"):
+            raise HostSecretBootstrapError(
+                "host secret bootstrap failed for declared consumer"
+            )
+        return _RAW_KEY
+
+    result = run_with_host_secrets(
+        channel="dev",
+        consumer="heimdal-capture-watch",
+        command=["consumer"],
+        keychain_lookup=lookup,
+        runner=runner,
+        directory=tmp_path,
+    )
+
+    assert result == 0
+    assert observed_path is not None and not observed_path.exists()
+
+
 def test_non_shared_domain_secret_with_two_consumers_skips_sibling_lookup(
     tmp_path: Path,
 ) -> None:

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -194,18 +194,23 @@ def test_model_inquiry_secret_contract_is_exact_and_value_free() -> None:
             "child_binding": "HEIMDAL_RAW_STORE_KEY",
             "kind": "raw-store-key",
             "optional": False,
+            # #4512: fed by two consumers (heimdal-capture-watch,
+            # heimdal-api-ingress) into one AES-256-GCM cipher domain.
+            "shared_key_domain": True,
         },
         {
             "logical_id": "openai.api-key",
             "child_binding": "OPENAI_API_KEY",
             "kind": "api-key",
             "optional": False,
+            "shared_key_domain": False,
         },
         {
             "logical_id": "anthropic.api-key",
             "child_binding": "ANTHROPIC_API_KEY",
             "kind": "api-key",
             "optional": False,
+            "shared_key_domain": False,
         },
         # #4489: the cockpit's live GitHub read wants a token, but the api
         # consumer's layer must keep materializing for hosts that have none.
@@ -214,6 +219,7 @@ def test_model_inquiry_secret_contract_is_exact_and_value_free() -> None:
             "child_binding": "GITHUB_TOKEN",
             "kind": "token",
             "optional": True,
+            "shared_key_domain": False,
         },
     ]
     assert payload["consumers"] == [
@@ -336,3 +342,50 @@ def test_api_consumer_declares_raw_store_key() -> None:
         )
     with pytest.raises(UndeclaredSecretConsumerError):
         contract.require_declared(channel="dev", consumer="heimdal-api-ingress", secret="openai.api-key")
+
+
+def test_raw_store_key_declares_shared_key_domain() -> None:
+    """#4512: heimdal.raw-store-key backs one cipher domain fed by two consumers.
+
+    Every declared consumer of `heimdal.raw-store-key` must resolve to
+    identical material, so it is marked shared-domain. The model-provider
+    secrets keep resolving independently per consumer and are not marked.
+    """
+    contract = load_host_secret_contract()
+
+    assert contract.is_shared_key_domain("heimdal.raw-store-key") is True
+    assert contract.is_shared_key_domain("openai.api-key") is False
+    assert contract.is_shared_key_domain("anthropic.api-key") is False
+    assert contract.is_shared_key_domain("github.token") is False
+    assert contract.consumers_declared_for(
+        channel="dev", secret="heimdal.raw-store-key"
+    ) == frozenset({"heimdal-capture-watch", "heimdal-api-ingress"})
+    with pytest.raises(UndeclaredSecretConsumerError):
+        contract.is_shared_key_domain("unrelated-key")
+
+
+@pytest.mark.parametrize(
+    ("shared_key_domain_value", "expected"),
+    [
+        pytest.param(..., "invalid host secret declaration", id="omitted"),
+        pytest.param(1, "invalid host secret identifier", id="truthy-int"),
+        pytest.param(0, "invalid host secret identifier", id="falsy-int"),
+        pytest.param("true", "invalid host secret identifier", id="string"),
+        pytest.param(None, "invalid host secret identifier", id="null"),
+    ],
+)
+def test_loader_rejects_a_declaration_without_an_explicit_boolean_shared_key_domain(
+    tmp_path: Path, shared_key_domain_value: object, expected: str
+) -> None:
+    payload = json.loads(
+        Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8")
+    )
+    if shared_key_domain_value is ...:
+        del payload["secrets"][0]["shared_key_domain"]
+    else:
+        payload["secrets"][0]["shared_key_domain"] = shared_key_domain_value
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected):
+        load_host_secret_contract(contract_path)


### PR DESCRIPTION
Governing-Issue: #4512

Fixes #4512

Final-Review-Rounds: 2

## Summary
`heimdal.raw-store-key` is declared for two independently bootstrapped consumers (`heimdal-capture-watch`, `heimdal-api-ingress`) that feed one AES-256-GCM cipher domain, but nothing previously verified their Keychain items held the same value. The host secret contract now declares which logical secrets are shared-domain (`heimdal.raw-store-key` marked, model-provider keys not), and the bootstrap entrypoint (`run_with_host_secrets` / `main`) cross-checks a non-reversible digest of the resolving consumer's value against every other declared consumer's value on the same channel, refusing with a value-free named error (`HostSecretSharedDomainDivergenceError`) rather than proceeding into a split cipher domain. A sibling whose own item is unresolvable (the typed `HostSecretBootstrapError` every in-repo `keychain_lookup` raises) is skipped, not treated as divergence; any other error still fails closed. Raw-store-key material is compared as decoded bytes so two hex-case spellings of the same key are not falsely flagged as diverged. Matching material bootstraps byte-for-byte unchanged; the account template, request-time api preflight posture, and non-shared secrets are untouched.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 single-issue slice; no BuilderOps record/projection surface was in scope.

## Notes
Validation:
- `ruff check app tests` — clean
- `python3 -m mypy app/ops/host_secret_bootstrap.py app/ops/host_secret_contract.py` — clean
- `python3 scripts/public_seam_lint.py --mode gate` — `secret_hits: 0`
- `python3 scripts/docs_guard.py` — OK
- `pytest -q tests/ops/test_host_secret_contract.py tests/ops/test_host_secret_bootstrap.py tests/builderops tests/deploy/test_deploy_channel_script.py` — 1206 passed
- `pytest -q tests/heimdal/test_media_ingress.py` — 1 unrelated pre-existing failure (`test_preflight_logs_the_remedy_matching_the_failing_precondition`, needs `STORE_BACKEND`/`DATABASE_URL` not configured in this sandbox; reproduces identically on `origin/main` with these changes stashed)

Security-sensitive surface (Keychain/credential-durability), declared high-risk runtime TCD surface — two consecutive clean independent review rounds required:
- Ran the review-before-CI gate (`--risk-surface security --risk-surface credential-durability`) before pushing.
- **Round 1** (fresh independent reviewer, no implementation context): verdict clean (no P0/P1). Two P2s found: (a) raw-store-key digest compared raw text instead of decoded bytes, so two hex-case spellings of the same key would false-positive as diverged; (b) the sibling-lookup skip caught bare `Exception`, which could silently swallow an unexpected programming error instead of failing closed. Both were cheap, well-understood fixes, so they were applied in this PR rather than deferred to the Known Defects registry (reviewer's own recommendation for finding (a)): normalized raw-store-key material to decoded bytes before the digest, narrowed the skip to the typed `HostSecretBootstrapError`, and added four regression tests (hex-case equivalence, programming-error-still-fails-closed, typed-failure-still-skips, plus the pre-existing three). Full suite re-run after the fix: 1206 passed.
- **Round 2**: pending on the post-fix head SHA before merge, per the two-consecutive-clean-round requirement for this declared high-risk surface.

Deferred (non-blocking, informational P3s from round 1, no code change needed): `HostSecretContract.shared_key_domain_secrets` defaults to an empty frozenset on a directly-constructed contract (matches the pre-existing `optional_secrets` pattern; the production loader always requires the field explicitly); the shared-domain declaration's cross-consumer Keychain read is documented only in code comments and the operator runbook, not in the contract schema itself; one test patches `subprocess.run` at module scope for the duration of that test (restored by `monkeypatch`, blast radius wider than the assertion needs but sound).
---