### PR TITLE
fix: persist known-defect stable key via explicit re-intake id

### DIFF
--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -72,7 +72,12 @@ The helper:
 - sends P0/P1 defects back to the normal bug-Issue path;
 - derives `KD-<12 uppercase hex>` deterministically from source identity and normalized symptom;
 - accepts `--defect-key <stable-key>` when later source SHAs or evidence wording should deduplicate
-  to the same defect;
+  to the same defect at the time of that intake call — the key itself is not persisted anywhere, so
+  it cannot be used to re-derive the id in a later, separate intake call;
+- accepts `--defect-id <KD-...>` to re-intake an existing entry explicitly: pass the id from the
+  original intake receipt (or a `lookup` call) and the id is used as-is, skipping derivation
+  entirely, so updated symptom/SHA/evidence text on the re-intake still converges on the same entry
+  without reconstructing `--defect-key`;
 - finds or creates and locks the single rolling registry Issue;
 - rejects unlocked or mislabeled registries and parses only exact first-line markers with the
   expected schema shape;

--- a/.codex/skills/bug-to-issue/scripts/known_defects.py
+++ b/.codex/skills/bug-to-issue/scripts/known_defects.py
@@ -162,6 +162,7 @@ class KnownDefect:
     workaround: str
     trigger: str
     defect_key: str | None = None
+    defect_id_override: str | None = None
 
     @classmethod
     def validated(
@@ -178,6 +179,7 @@ class KnownDefect:
         workaround: str,
         trigger: str,
         defect_key: str | None = None,
+        defect_id_override: str | None = None,
     ) -> "KnownDefect":
         repo = _validate_repo(repo)
         if source_pr <= 0:
@@ -217,6 +219,13 @@ class KnownDefect:
             if defect_key is not None
             else None
         )
+        normalized_override = None
+        if defect_id_override is not None:
+            normalized_override = " ".join(defect_id_override.split())
+            if not ENTRY_ID_RE.fullmatch(normalized_override):
+                raise KnownDefectsError(
+                    "defect_id_override must have form KD-<12 uppercase hex>"
+                )
         return cls(
             repo=repo,
             source_pr=source_pr,
@@ -229,10 +238,13 @@ class KnownDefect:
             workaround=_require_text("workaround", workaround),
             trigger=_require_text("trigger", trigger),
             defect_key=normalized_key,
+            defect_id_override=normalized_override,
         )
 
     @property
     def defect_id(self) -> str:
+        if self.defect_id_override is not None:
+            return self.defect_id_override
         if self.defect_key is not None:
             identity = {
                 "repo": self.repo.casefold(),
@@ -1877,6 +1889,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--defect-key",
         help="optional stable dedupe key when evidence wording or source SHA may evolve",
     )
+    intake.add_argument(
+        "--defect-id",
+        help=(
+            "optional explicit KD-<12 uppercase hex> id to re-intake an existing "
+            "entry (e.g. from a prior receipt or `lookup`) without re-deriving it "
+            "from --defect-key or source identity; skips derivation entirely"
+        ),
+    )
     intake.add_argument("--registry-issue", type=int)
 
     lookup = subparsers.add_parser("lookup", help="look up one deterministic defect id")
@@ -1930,6 +1950,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     workaround=args.workaround,
                     trigger=args.trigger,
                     defect_key=args.defect_key,
+                    defect_id_override=args.defect_id,
                 )
                 receipt = intake_defect(
                     defect,

--- a/tests/governance/test_known_defects_registry.py
+++ b/tests/governance/test_known_defects_registry.py
@@ -271,6 +271,106 @@ def test_explicit_defect_key_keeps_id_stable_across_new_evidence() -> None:
     assert first.defect_id == later.defect_id
 
 
+def test_defect_id_override_rejects_malformed_ids() -> None:
+    with pytest.raises(known_defects.KnownDefectsError, match="defect_id_override"):
+        _defect(defect_id_override="not-a-kd-id")
+
+
+def test_keyed_entry_reintake_converges_on_the_same_defect_id() -> None:
+    """A defect first created with --defect-key can be re-intaken later with
+    changed symptom/SHA/evidence and no operator-supplied key, and converges
+    on the same defect_id and the same single registry entry.
+
+    The operator recovers the stable id from the original intake receipt (or
+    a subsequent `lookup`), not by remembering the original key string.
+    """
+    gateway = FakeGateway()
+    original = _defect(defect_key="receipt-attempt-count")
+
+    created = known_defects.intake_defect(original, gateway)
+    assert created["status"] == "created"
+    remembered_defect_id = created["defect_id"]
+
+    # A later re-intake supplies only the remembered defect_id: no
+    # --defect-key, changed source_sha, symptom, and evidence.
+    reintake = known_defects.KnownDefect.validated(
+        repo="RasmusTho/agentic-pkm-mvp",
+        source_pr=4321,
+        source_sha="c" * 40,
+        review_url=(
+            "https://github.com/RasmusTho/agentic-pkm-mvp/"
+            "pull/4321#discussion_r456"
+        ),
+        symptom="Widened blast radius discovered during a later audit.",
+        evidence="A second reproduction with a different repro path.",
+        severity="P2",
+        impact="Operators may misread repair progress across more surfaces.",
+        workaround="Read the raw attempt events.",
+        trigger="Promote after a third occurrence or when this blocks closure.",
+        defect_key=None,
+        defect_id_override=remembered_defect_id,
+    )
+
+    assert reintake.defect_id == original.defect_id == remembered_defect_id
+
+    reintake_receipt = known_defects.intake_defect(reintake, gateway)
+
+    assert reintake_receipt["status"] == "duplicate"
+    assert reintake_receipt["defect_id"] == remembered_defect_id
+    assert reintake_receipt["registry_issue"] == created["registry_issue"]
+    # No second entry was created; the entry for this defect_id is still one
+    # single comment.
+    entry_comments = [
+        comment
+        for comment in gateway.comments[created["registry_issue"]]
+        if known_defects._entry_id_from_comment(comment.get("body") or "")
+        == remembered_defect_id
+    ]
+    assert len(entry_comments) == 1
+
+
+def test_preexisting_entries_still_resolve_after_key_persistence() -> None:
+    """An entry created before the defect_id_override fix (plain keyless
+    derivation) must keep resolving under lookup unchanged."""
+    gateway = FakeGateway()
+    preexisting = _defect()
+
+    created = known_defects.intake_defect(preexisting, gateway)
+    assert created["status"] == "created"
+
+    looked_up = known_defects.lookup_defect(preexisting.defect_id, gateway)
+
+    assert looked_up["status"] == "deferred"
+    assert looked_up["defect_id"] == preexisting.defect_id
+    assert looked_up["registry_issue"] == created["registry_issue"]
+
+
+def test_marker_roundtrips_through_render_and_parse() -> None:
+    keyless = _defect()
+    keyed = _defect(defect_key="receipt-attempt-count")
+    overridden = known_defects.KnownDefect.validated(
+        repo="RasmusTho/agentic-pkm-mvp",
+        source_pr=4321,
+        source_sha="d" * 40,
+        review_url=(
+            "https://github.com/RasmusTho/agentic-pkm-mvp/"
+            "pull/4321#discussion_r789"
+        ),
+        symptom="Later wording.",
+        evidence="Later evidence.",
+        severity="P2",
+        impact="Later impact.",
+        workaround="Later workaround.",
+        trigger="Later trigger.",
+        defect_id_override=keyed.defect_id,
+    )
+
+    for defect in (keyless, keyed, overridden):
+        rendered = defect.render_entry(phase="final")
+        parsed = known_defects._entry_marker_from_comment(rendered)
+        assert parsed == (defect.defect_id, "final")
+
+
 def test_review_url_host_is_canonicalized_before_schema_rendering() -> None:
     defect = _defect(
         review_url=(


### PR DESCRIPTION
Governing-Issue: #4504

Fixes #4504

Final-Review-Rounds: 0

## Summary
A `--defect-key`-created Known Defects entry could not be re-intaken because the key was never persisted; add an optional `--defect-id <KD-...>` re-intake path that skips id derivation entirely, so a later intake with changed symptom/SHA/evidence converges on the same entry using the id already returned by the original receipt or `lookup`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane, single bounded bug fix with no BuilderOps material to route.

## Notes
Validation:
- `python3 -m pytest -q tests/governance/test_known_defects_registry.py` (164 passed, including new `test_keyed_entry_reintake_converges_on_the_same_defect_id`, `test_preexisting_entries_still_resolve_after_key_persistence`, `test_marker_roundtrips_through_render_and_parse`)
- `python3 -m ruff check app tests` (clean)
- `python3 -m mypy app` (clean, 866 files)
- `python3 scripts/lint_skills_consistency.py` (clean)
- `python3 scripts/docs_guard.py` (OK)

Marker schema is unchanged, so all preexisting entries (including `KD-7C4378C00F83` and this run's own deferred `KD-44721F70FA2B` / `KD-F5A09634F9B4`) keep resolving under `lookup` without migration.
---