### PR TITLE
fix: pr-contract lint Check 10 catches regex-flag drift between JS/Python twins

### DIFF
--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -397,27 +397,54 @@ def _strip_js_line_comments(text: str) -> str:
     return "\n".join(re.sub(r"//.*$", "", line) for line in text.splitlines())
 
 
-_JS_REGEX_LITERAL_RE = re.compile(r"/((?:\\.|[^/\\\n])*)/[a-z]*")
+_JS_REGEX_LITERAL_RE = re.compile(r"/((?:\\.|[^/\\\n])*)/([a-z]*)")
+
+# JS regex flag letter -> Python `re` flag constant name. Only flags this
+# repo's twins actually use are mapped; this is deliberately not a general
+# regex-equivalence engine (issue #4342 Constraints). Letters with no Python
+# `re.compile` counterpart (JS `g`, `u`, `y`, `d`, ...) are ignored: they
+# change how `.match`/`.test` iterate or what `\d`/unicode mean in JS, not
+# what a single Python `re.compile(pattern, flags)` call can express.
+_JS_FLAG_TO_PYTHON = {
+    "i": "IGNORECASE",
+    "m": "MULTILINE",
+    "s": "DOTALL",
+}
 
 
-def _extract_js_regex_literals(block: str) -> list[str]:
-    """Extract regex-literal source text (unescaped `\\/` -> `/`), in order.
+def _js_flags_to_python_flag_names(js_flags: str) -> set[str]:
+    return {
+        _JS_FLAG_TO_PYTHON[letter] for letter in js_flags if letter in _JS_FLAG_TO_PYTHON
+    }
+
+
+def _extract_js_regex_literals(block: str) -> list[tuple[str, str]]:
+    """Extract regex-literal source text (unescaped `\\/` -> `/`) and flags, in order.
 
     Comments are stripped first so a `/`-containing path or URL in prose
-    (e.g. `app/dispatcher/...`) is never mistaken for a regex literal.
+    (e.g. `app/dispatcher/...`) is never mistaken for a regex literal. Each
+    result is `(pattern, flag_letters)`, e.g. `("^foo$", "im")`.
     """
     stripped = _strip_js_line_comments(block)
     return [
-        match.group(1).replace("\\/", "/")
+        (match.group(1).replace("\\/", "/"), match.group(2))
         for match in _JS_REGEX_LITERAL_RE.finditer(stripped)
     ]
 
 
-def _extract_python_regex_pattern(text: str, name: str) -> str | None:
+def _extract_python_regex_pattern(text: str, name: str) -> tuple[str, set[str]] | None:
     match = re.search(
-        re.escape(name) + r"\s*=\s*re\.compile\(\s*\n?\s*r\"([^\"]*)\"", text
+        re.escape(name)
+        + r"\s*=\s*re\.compile\(\s*\n?\s*r\"([^\"]*)\""
+        + r"(?:\s*,\s*\n?\s*([^)]*?)\s*\n?\s*)?\)",
+        text,
     )
-    return match.group(1) if match else None
+    if match is None:
+        return None
+    pattern = match.group(1)
+    flags_expr = match.group(2) or ""
+    flag_names = set(re.findall(r"re\.([A-Z]+)", flags_expr))
+    return pattern, flag_names
 
 
 # Order matters: this is the exact order the corresponding regex literals
@@ -455,15 +482,24 @@ def _check_pr_contract_marker_block(
             f"`{start_marker}` and `{end_marker}`, found {len(js_literals)}"
         ]
     errors: list[str] = []
-    for name, js_pattern in zip(py_names, js_literals):
-        py_pattern = _extract_python_regex_pattern(contract_text, name)
-        if py_pattern is None:
+    for name, (js_pattern, js_flags) in zip(py_names, js_literals):
+        py_extracted = _extract_python_regex_pattern(contract_text, name)
+        if py_extracted is None:
             errors.append(f"{contract_rel}: could not locate regex constant `{name}`")
             continue
+        py_pattern, py_flag_names = py_extracted
         if py_pattern != js_pattern:
             errors.append(
                 f"{contract_rel}::{name} pattern ({py_pattern!r}) does not match "
                 f"{workflow_rel} regex between `{start_marker}`/`{end_marker}` ({js_pattern!r})"
+            )
+            continue
+        expected_flag_names = _js_flags_to_python_flag_names(js_flags)
+        if expected_flag_names != py_flag_names:
+            errors.append(
+                f"{contract_rel}::{name} flags ({sorted(py_flag_names)!r}) do not match "
+                f"{workflow_rel} regex flags `{js_flags!r}` between `{start_marker}`/`{end_marker}` "
+                f"(expected Python flags {sorted(expected_flag_names)!r})"
             )
     return errors
 

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -58,6 +58,31 @@ def test_final_review_rounds_check_executes_via_canonical_implementation() -> No
         assert js_result["declaredCount"] == py_result.declared_count, body
         assert js_result["validCount"] == py_result.valid_count, body
 
+    # Semantic assertion (issue #4342), not only JS-vs-Python agreement: `3`
+    # must actually be rejected by the real gate, not merely agreed-upon
+    # between the twins. Widening `[012]` -> `[0-9]` identically on both
+    # sides would still pass every assertion above.
+    assert resolve_pr_contract_final_review_rounds("Final-Review-Rounds: 3\n").satisfied is False
+
+
+def test_final_review_rounds_workflow_accepts_only_012() -> None:
+    """Semantic pin: the live workflow JS accepts exactly `{0, 1, 2}` (issue #4342).
+
+    Restores the pin PR #4331 deleted (`assert r"Final-Review-Rounds:[ \\t]*
+    [012][ \\t]*$" in workflow`). Asserts against the workflow's own JS text
+    directly via `_js_final_review_rounds`, independent of JS-vs-Python
+    equality, so a value set widened identically on both twins (e.g.
+    `[012]` -> `[0-9]`) still fails this test even though the twins would
+    still agree with each other.
+    """
+    for value in ("0", "1", "2"):
+        result = _js_final_review_rounds(f"Final-Review-Rounds: {value}\n")
+        assert result["satisfied"] is True, value
+
+    for value in ("3", "4", "5", "9", "-1", "01", "10"):
+        result = _js_final_review_rounds(f"Final-Review-Rounds: {value}\n")
+        assert result["satisfied"] is False, value
+
 
 def test_builderops_routing_stub_detection_matches_workflow_js() -> None:
     """Behavioral parity test for the `## BuilderOps Routing` filled-vs-stub check.

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -326,6 +326,56 @@ def test_lint_fails_when_pr_contract_validator_diverges_from_workflow(tmp_path: 
     ), errors
 
 
+def test_lint_fails_when_pr_contract_validator_flags_diverge_from_workflow(
+    tmp_path: Path,
+) -> None:
+    """Dropping a regex *flag* (not pattern text) on one side must fail the lint.
+
+    Reproduces the exact drift class from issue #4342: Check 10 previously
+    compared only regex pattern text and discarded the JS trailing flag
+    suffix / the Python flags argument entirely, so a flag-only divergence
+    (e.g. losing `re.IGNORECASE` from `TIER1_LANE_PATTERN` while the
+    workflow's JS `tier1LanePattern` stays `/im`) passed silently.
+    """
+    root = _seed_tree(tmp_path)
+
+    workflow = REPO_ROOT / ".github" / "workflows" / "issue-pr-governance.yml"
+    contract = REPO_ROOT / "app" / "dispatcher" / "verification_contract.py"
+
+    dest_workflows = root / ".github" / "workflows"
+    dest_workflows.mkdir(parents=True, exist_ok=True)
+    (dest_workflows / "issue-pr-governance.yml").write_text(
+        workflow.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    dest_app = root / "app" / "dispatcher"
+    dest_app.mkdir(parents=True, exist_ok=True)
+    (dest_app / "verification_contract.py").write_text(
+        contract.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    baseline_errors = run_lint(root)
+    assert not any("verification_contract.py" in e for e in baseline_errors), baseline_errors
+
+    # Drift the Python TIER1_LANE_PATTERN alone: drop `re.IGNORECASE`,
+    # leaving the workflow's JS `tier1LanePattern` at `/im` unchanged. The
+    # pattern text on both sides is still byte-identical.
+    drifted = contract.read_text(encoding="utf-8").replace(
+        'TIER1_LANE_PATTERN = re.compile(\n'
+        r'    r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b", re.IGNORECASE | re.MULTILINE'
+        "\n)",
+        'TIER1_LANE_PATTERN = re.compile(\n'
+        r'    r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b", re.MULTILINE'
+        "\n)",
+    )
+    assert drifted != contract.read_text(encoding="utf-8"), "fixture swap did not apply"
+    (dest_app / "verification_contract.py").write_text(drifted, encoding="utf-8")
+
+    errors = run_lint(root)
+    assert any(
+        "TIER1_LANE_PATTERN" in e and "flags" in e for e in errors
+    ), errors
+
+
 def test_planned_marker_allows_unknown_reference(tmp_path: Path) -> None:
     root = _seed_tree(tmp_path)
     skills_root = root / ".codex" / "skills"


### PR DESCRIPTION
Governing-Issue: #4342

Fixes #4342

Final-Review-Rounds: 0

## Summary
Check 10 (`check_pr_contract_validator_matches_workflow` in `scripts/lint_skills_consistency.py`) compared only regex pattern text between the workflow's JS regex literals and their Python twins in `app/dispatcher/verification_contract.py`, discarding the JS trailing flag suffix (`_JS_REGEX_LITERAL_RE` kept only `group(1)`) and the Python `re.compile(...)` flags argument entirely. A flag-only divergence (e.g. dropping `re.IGNORECASE` from `TIER1_LANE_PATTERN` while the workflow's JS `tier1LanePattern` stays `/im`) passed silently even though it changes real matching behavior. Also restores the `Final-Review-Rounds` `{0,1,2}` semantic pin PR #4331 deleted, and adds a direct semantic assertion for the existing `"Final-Review-Rounds: 3\n"` fixture.

## Changes
- `scripts/lint_skills_consistency.py`: `_extract_js_regex_literals` now returns `(pattern, flags)` tuples; `_extract_python_regex_pattern` now also extracts the `re.compile(...)` flags argument; `_check_pr_contract_marker_block` compares flags in addition to pattern text via a small JS-flag-letter -> Python-`re`-constant map (`i`/`m`/`s`; other JS-only letters like `g` have no Python `re.compile` counterpart and are ignored, per the issue's Constraints against a general regex-equivalence engine).
- `tests/governance/test_skills_consistency_lint.py`: adds `test_lint_fails_when_pr_contract_validator_flags_diverge_from_workflow`, reproducing the exact `TIER1_LANE_PATTERN`/`re.IGNORECASE` drift class from the issue and confirming it now fails the lint (verified locally to fail against the pre-fix lint code, pass against the fix).
- `tests/governance/test_issue_pr_governance.py`: adds `test_final_review_rounds_workflow_accepts_only_012` (semantic pin against the live workflow JS text, independent of JS-vs-Python equality) and a direct `satisfied is False` assertion for the `"Final-Review-Rounds: 3\n"` fixture in the existing canonical-implementation parity test.

Did not touch the live workflow JS regex flags (detection only, per the issue's Constraints).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 bounded lint/test fix; no BuilderOps record class applies (not a memory/receipt/registry artifact).

## Notes
Validation:
- `python3 scripts/lint_skills_consistency.py` — exit 0 on this branch (unchanged behavior on the real repo tree)
- `python3 -m pytest -q tests/governance/test_skills_consistency_lint.py tests/governance/test_issue_pr_governance.py` — 120 passed
- `python3 -m pytest -q tests/governance/` — 501 passed
- `ruff check app tests companion-ui/companion-app` — all checks passed
- `mypy scripts/lint_skills_consistency.py` — no issues found
- Regression proof: stashed the lint-script change and reran the new `test_lint_fails_when_pr_contract_validator_flags_diverge_from_workflow` test — it fails (`assert False`) against the pre-fix code, confirming the drift class from issue #4342's Context was previously undetected.

Related: #4341 (twin/JS line-terminator divergence) is a different mechanism against the same twins — no scope overlap; this PR touches only the lint script that guards the twins, not the twins' own semantics.
---