### PR TITLE
Add the Heimdal time-spend projection: rebuildable markdown rollup over screen spans

### DIFF
--- a/app/cli/heimdal.py
+++ b/app/cli/heimdal.py
@@ -8,6 +8,11 @@ from pathlib import Path
 import click
 
 from app.heimdal.archive_capacity import build_archive_capacity_report
+from app.heimdal.time_spend import (
+    TimeSpendProjectionError,
+    rebuild_time_spend,
+    time_spend_summary,
+)
 from app.heimdal.capture_runtime import (
     CaptureRuntimeConfig,
     CaptureRuntimeConfigError,
@@ -99,6 +104,45 @@ def capacity(vault_root: Path) -> None:
     try:
         receipt = build_archive_capacity_report(vault_root).as_dict()
     except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(json.dumps(receipt, ensure_ascii=False))
+
+
+@heimdal_group.command(
+    name="time-spend",
+    help=(
+        "Rebuildable time-spend rollup over screen span observations (SCREEN-05). "
+        "Without --rebuild, prints the JSON rollup summary. With --rebuild, "
+        "deterministically re-folds the observation stream from event zero and "
+        "(re)writes the weekly markdown projection note(s) through the governed "
+        "write path (derived class, never over a human note)."
+    ),
+)
+@click.option("--week", default=None, help="ISO week label (e.g. 2026-W28); defaults to all weeks observed.")
+@click.option("--rebuild", is_flag=True, help="Re-fold from event zero and write the markdown note(s).")
+@click.option(
+    "--vault-root",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+    default=None,
+    help="Vault to write the projection note(s) into (required with --rebuild).",
+)
+def time_spend(week: str | None, rebuild: bool, vault_root: Path | None) -> None:
+    if not rebuild:
+        click.echo(json.dumps(time_spend_summary(week), ensure_ascii=False))
+        return
+    if vault_root is None:
+        raise click.ClickException("--rebuild requires --vault-root to select the target vault")
+    from app.vault.manager import VaultContext
+
+    context = VaultContext(
+        status="selected",
+        active_vault_id="cli",
+        active_vault_name="cli",
+        active_vault_path=str(vault_root),
+    )
+    try:
+        receipt = rebuild_time_spend(vault_context=context, week=week)
+    except TimeSpendProjectionError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(json.dumps(receipt, ensure_ascii=False))
 

--- a/app/heimdal/time_spend.py
+++ b/app/heimdal/time_spend.py
@@ -1,0 +1,612 @@
+"""Heimdal time-spend projection: rebuildable markdown rollup over screen spans.
+
+SCREEN-05 (#3345), specified by
+`docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md`. The third
+downstream track from the screen stream: "analysis of what I spend my time
+on". Screen span observations (SCREEN-02, `app.heimdal.screen_derivation`)
+carry a real ``observed_at_start``/``observed_at_end`` window, the frontmost
+app, entity mentions, and a scope tag -- everything needed to answer "where
+did my time go?" without any manual tracking.
+
+Design contract (issue Acceptance Criteria + MACHINE_MIRROR_AND_DB_AUTHORITY_CONTRACT):
+
+- **Derived, rebuildable, never authority.** The rollup is a disposable lens
+  over the observation log. Every fold starts from event zero
+  (:func:`app.heimdal.observation_log.read_observations_from` at sequence 0)
+  -- there is deliberately NO consumer cursor and NO incremental state, so a
+  "rebuild" and an "incremental update" are the same deterministic re-fold
+  and can never drift apart. The rendered markdown carries no wall-clock
+  timestamp and no counter that the observations themselves do not imply:
+  same observations in, byte-identical projection out.
+- **Per-span identity, not per-episode.** Spans fold by ``observation_id``
+  (last revision wins by log ``sequence``; a winner named in another
+  winner's ``supersedes``/``revision_of`` chain is dropped as corrected).
+  This deliberately does NOT reuse the candidate projector's ``episode_id``
+  fold (`app.heimdal.candidate_projection.fold_observations`): known defect
+  ``KD-FBDBDAD4C052`` records that the episode fold collapses distinct
+  spans sharing one ``episode_id``, under-reporting distinct activities.
+  Reading the log directly with per-span identity is that defect's
+  documented workaround, and the reason this module never goes through the
+  candidate notes.
+- **Idle/locked gaps are excluded by construction.** The capture client
+  never samples idle/locked time (SCREEN-01), so gaps between spans simply
+  do not appear in any span window. The rollup sums span durations; it never
+  interpolates between spans. Per DERIVE_ACTIVITY_OBSERVATIONS.md, SCREEN-02
+  ships no max-gap bound, so this module makes no bounded-gap assumption
+  either -- a long coalesced span is summed exactly as published.
+- **Governed write, derived class, never over a human note.** The weekly
+  markdown note (``heimdal/time-spend/YYYY-Www.md``) is written through
+  ``WriteGuard`` + ``app.knowledge.write_ops.write_note_relative`` with the
+  derived posture (``requires_review: true``, ``source_authoritative:
+  false``, ``ai_generated: true``). An existing note at the target path is
+  overwritten ONLY when its frontmatter proves it is this module's own
+  derived projection; anything else (a human note, a foreign artifact, an
+  unparseable file) blocks the write loudly and leaves the file untouched.
+
+Attribution choices (deterministic, documented rather than configurable):
+
+- A span's whole duration lands on the day/week of its ``observed_at_start``
+  (spans are short coalesced windows; splitting across midnight would add
+  complexity without changing the answer materially).
+- The **project** axis reads entity mentions with ``kind_hint == "project"``;
+  a span mentioning several projects contributes its full duration to each
+  (a lens over attention, not a partition -- per-project sums may exceed
+  wall clock and the note says so). Spans with no project mention land on
+  ``(none)``.
+- The **scope** axis prefers the span dimension ``scope`` and falls back to
+  the payload ``scope_hint``.
+
+Named seams (not built here, per the source doc steps 3-4): the companion-UI
+lens is a later reader over these same notes/rollups, and the episode-level
+rollup (time per meeting/build/trip) is a future enrichment keyed on
+``episode_ref`` once ERE (SCREEN-04) lands -- this module ships fully from
+observations alone and does not depend on ERE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+from app.heimdal.observation_log import ObservationRow, read_observations_from
+from app.knowledge.write_ops import write_note_relative
+from app.vault.manager import VaultContext
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+#: The observation topic and modality this projection folds. Values mirror
+#: `app.heimdal.screen_derivation` (OBSERVATION_TOPIC / modality="screen");
+#: kept as local constants so the projection does not import the derivation
+#: stage's local-vision runtime dependencies just to read the log.
+SCREEN_OBSERVATION_TOPIC = "heimdal.observation.published"
+SCREEN_MODALITY = "screen"
+
+ARTIFACT_CLASS = "time_spend_projection"
+PROJECTION_CONSUMER = "heimdal.time_spend"
+DEFAULT_TIME_SPEND_DIR = "heimdal/time-spend"
+TIME_SPEND_WRITE_ACTION = "heimdal.time_spend.write"
+
+#: Bucket labels for spans missing an axis value. Parenthesized so they can
+#: never collide with a real slug/app/scope surface form.
+UNKNOWN_BUCKET = "(unknown)"
+NO_PROJECT_BUCKET = "(none)"
+
+
+class TimeSpendProjectionError(RuntimeError):
+    """Raised when the time-spend projection cannot run at all."""
+
+
+@dataclass(frozen=True)
+class TimeSpendSpan:
+    """One folded screen span, reduced to the rollup axes."""
+
+    observation_id: str
+    sequence: int
+    app: str
+    scope: str
+    projects: Tuple[str, ...]
+    day: str  # YYYY-MM-DD (UTC date of observed_at_start)
+    week: str  # ISO week label, e.g. 2026-W28
+    duration_seconds: float
+
+
+@dataclass(frozen=True)
+class TimeSpendRollup:
+    """The deterministic fold result over one observation stream read."""
+
+    spans: Tuple[TimeSpendSpan, ...]
+    #: Screen-span log rows considered (including revisions that later folded
+    #: away) -- the "rebuilt_from" provenance count.
+    source_row_count: int
+
+    def weeks(self) -> Tuple[str, ...]:
+        return tuple(sorted({span.week for span in self.spans}))
+
+    def spans_for_week(self, week: str) -> Tuple[TimeSpendSpan, ...]:
+        return tuple(span for span in self.spans if span.week == week)
+
+
+@dataclass(frozen=True)
+class TimeSpendWriteResult:
+    status: str  # "written" | "rebuilt" | "unchanged" | "blocked" | "no_observations"
+    week: str
+    artifact_path: Optional[str]
+    reason: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Folding: observation rows -> spans -> rollup
+# ---------------------------------------------------------------------------
+
+
+def _payload_of(row: ObservationRow) -> Mapping[str, Any]:
+    payload = row.envelope.get("payload")
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _as_moment(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _iso_week_label(day: date) -> str:
+    iso = day.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _is_screen_span(row: ObservationRow, payload: Mapping[str, Any]) -> bool:
+    if row.topic != SCREEN_OBSERVATION_TOPIC:
+        return False
+    return payload.get("modality") == SCREEN_MODALITY
+
+
+def _span_dimensions(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    structure = payload.get("content_structure")
+    if not isinstance(structure, Mapping):
+        return {}
+    span = structure.get("span")
+    if not isinstance(span, Mapping):
+        return {}
+    dimensions = span.get("dimensions")
+    return dimensions if isinstance(dimensions, Mapping) else {}
+
+
+def _projects_of(payload: Mapping[str, Any]) -> Tuple[str, ...]:
+    mentions = payload.get("entity_mentions")
+    if not isinstance(mentions, Sequence) or isinstance(mentions, (str, bytes)):
+        return (NO_PROJECT_BUCKET,)
+    projects = {
+        str(mention.get("surface_form")).strip()
+        for mention in mentions
+        if isinstance(mention, Mapping)
+        and mention.get("kind_hint") == "project"
+        and str(mention.get("surface_form") or "").strip()
+    }
+    if not projects:
+        return (NO_PROJECT_BUCKET,)
+    return tuple(sorted(projects))
+
+
+def _build_span(row: ObservationRow, payload: Mapping[str, Any]) -> Optional[TimeSpendSpan]:
+    start = _as_moment(payload.get("observed_at_start"))
+    end = _as_moment(payload.get("observed_at_end"))
+    if start is None or end is None:
+        # The publisher (INV-SCREEN-B) refuses incomplete windows; a row
+        # without one is not a span observation and cannot carry duration.
+        return None
+    duration = (end - start).total_seconds()
+    if duration < 0:
+        # Cannot be published by screen_derivation (backwards windows are
+        # refused); fold defensively rather than corrupt the sums.
+        return None
+    dimensions = _span_dimensions(payload)
+    app = str(dimensions.get("app") or "").strip() or UNKNOWN_BUCKET
+    scope = (
+        str(dimensions.get("scope") or "").strip()
+        or str(payload.get("scope_hint") or "").strip()
+        or UNKNOWN_BUCKET
+    )
+    observation_id = str(payload.get("observation_id") or "").strip() or row.id
+    start_day = (start.astimezone(timezone.utc) if start.tzinfo else start).date()
+    return TimeSpendSpan(
+        observation_id=observation_id,
+        sequence=row.sequence,
+        app=app,
+        scope=scope,
+        projects=_projects_of(payload),
+        day=start_day.isoformat(),
+        week=_iso_week_label(start_day),
+        duration_seconds=duration,
+    )
+
+
+def fold_time_spend(rows: Sequence[ObservationRow]) -> TimeSpendRollup:
+    """Fold observation rows into the time-spend rollup, deterministically.
+
+    Pure function of ``rows``: filters to screen spans, groups by
+    ``observation_id`` (per-span identity -- see the module docstring on
+    ``KD-FBDBDAD4C052``), lets the highest log ``sequence`` win within a
+    group (a revision republish of the same evidence), then drops winners
+    named in any other winner's ``supersedes``/``revision_of`` chain
+    (corrections). Output order is fixed by log sequence, so every
+    downstream sum runs in one deterministic order.
+    """
+    screen_rows: List[Tuple[ObservationRow, Mapping[str, Any]]] = []
+    for row in rows:
+        payload = _payload_of(row)
+        if _is_screen_span(row, payload):
+            screen_rows.append((row, payload))
+
+    winners: Dict[str, Tuple[ObservationRow, Mapping[str, Any]]] = {}
+    for row, payload in screen_rows:
+        observation_id = str(payload.get("observation_id") or "").strip() or row.id
+        current = winners.get(observation_id)
+        if current is None or row.sequence > current[0].sequence:
+            winners[observation_id] = (row, payload)
+
+    corrected: set[str] = set()
+    for row, payload in winners.values():
+        for field_name in ("supersedes", "revision_of"):
+            target = payload.get(field_name)
+            if isinstance(target, str) and target.strip():
+                corrected.add(target.strip())
+
+    spans: List[TimeSpendSpan] = []
+    for observation_id, (row, payload) in winners.items():
+        if observation_id in corrected:
+            continue
+        span = _build_span(row, payload)
+        if span is not None:
+            spans.append(span)
+    spans.sort(key=lambda span: span.sequence)
+
+    return TimeSpendRollup(spans=tuple(spans), source_row_count=len(screen_rows))
+
+
+# ---------------------------------------------------------------------------
+# Aggregation + rendering
+# ---------------------------------------------------------------------------
+
+
+def _sum_by(spans: Sequence[TimeSpendSpan], axis: str) -> Dict[str, float]:
+    totals: Dict[str, float] = {}
+    for span in spans:
+        if axis == "project":
+            for project in span.projects:
+                totals[project] = totals.get(project, 0.0) + span.duration_seconds
+            continue
+        key: str = getattr(span, axis)
+        totals[key] = totals.get(key, 0.0) + span.duration_seconds
+    return totals
+
+
+def rollup_axes(
+    spans: Sequence[TimeSpendSpan],
+) -> Dict[str, Dict[str, float]]:
+    """All five contract axes over the given spans (seconds per bucket)."""
+    return {
+        "by_app": _sum_by(spans, "app"),
+        "by_project": _sum_by(spans, "project"),
+        "by_scope": _sum_by(spans, "scope"),
+        "by_day": _sum_by(spans, "day"),
+        "by_week": _sum_by(spans, "week"),
+    }
+
+
+def format_duration(seconds: float) -> str:
+    """Deterministic human duration: 6h12m / 5m / 5m30s / 45s / 0s."""
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m{secs:02d}s" if secs else f"{minutes}m"
+    return f"{secs}s"
+
+
+def _sorted_buckets(totals: Mapping[str, float]) -> List[Tuple[str, float]]:
+    # Largest first; name breaks ties so the ordering is total.
+    return sorted(totals.items(), key=lambda item: (-item[1], item[0]))
+
+
+def _axis_table(title: str, totals: Mapping[str, float]) -> List[str]:
+    lines = [f"## {title}", "", "| Bucket | Time |", "| --- | --- |"]
+    for name, seconds in _sorted_buckets(totals):
+        lines.append(f"| {name} | {format_duration(seconds)} |")
+    lines.append("")
+    return lines
+
+
+def time_spend_note_path(week: str, *, time_spend_dir: str = DEFAULT_TIME_SPEND_DIR) -> str:
+    safe_dir = PurePosixPath(time_spend_dir.strip().strip("/"))
+    if any(part in ("..", "") for part in safe_dir.parts):
+        raise TimeSpendProjectionError(f"invalid time-spend directory: {time_spend_dir!r}")
+    return (safe_dir / f"{week}.md").as_posix()
+
+
+def render_time_spend_note(week: str, rollup: TimeSpendRollup) -> str:
+    """Render one week's markdown projection note.
+
+    Deterministic by construction: every value comes from the folded
+    observations (no wall-clock stamp, no run counter), buckets sort by
+    (duration desc, name asc), and days sort ascending -- same observations
+    in, byte-identical note out (AC2).
+    """
+    spans = rollup.spans_for_week(week)
+    axes = rollup_axes(spans)
+    total_seconds = sum(span.duration_seconds for span in spans)
+
+    frontmatter: Dict[str, Any] = {
+        "artifact_class": ARTIFACT_CLASS,
+        "lifecycle": "active",
+        "work_relation": "learn",
+        "projection": {
+            "consumer": PROJECTION_CONSUMER,
+            "week": week,
+            "span_count": len(spans),
+            "rebuilt_from": rollup.source_row_count,
+            "source": "heimdal.observation.published (modality=screen)",
+        },
+        "authority": {
+            "source_authoritative": False,
+            "ai_generated": True,
+            "requires_review": True,
+        },
+        "review_state": "draft",
+        "rebuildable": True,
+    }
+    yaml_block = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+
+    lines: List[str] = [
+        f"# Time spent -- {week}",
+        "",
+        f"Total observed screen time: **{format_duration(total_seconds)}** across "
+        f"{len(spans)} span(s), folded from {rollup.source_row_count} observation row(s). "
+        "Idle/locked time is excluded by construction (never sampled).",
+        "",
+    ]
+    lines.extend(_axis_table("By app", axes["by_app"]))
+    lines.extend(_axis_table("By project", axes["by_project"]))
+    lines.extend(_axis_table("By scope", axes["by_scope"]))
+    lines.extend(_axis_table("By day", dict(sorted(axes["by_day"].items()))))
+    lines.extend(
+        [
+            "---",
+            "",
+            "_This note is a derived, rebuildable projection over the Heimdal screen "
+            "observation stream -- a lens, never authority. It holds no state the "
+            "observations do not; regenerate it any time with "
+            f"`python -m app.cli heimdal time-spend --rebuild --week {week}`. "
+            "A span mentioning several projects counts fully toward each, so "
+            "per-project sums may exceed wall clock._",
+        ]
+    )
+    body = "\n".join(lines)
+    return f"---\n{yaml_block}\n---\n\n{body}\n"
+
+
+# ---------------------------------------------------------------------------
+# Governed write
+# ---------------------------------------------------------------------------
+
+
+def _vault_root(context: VaultContext) -> Path:
+    if not context.is_selected or context.active_vault_path is None:
+        raise TimeSpendProjectionError("time-spend projection requires a selected vault")
+    root = Path(context.active_vault_path).expanduser().resolve()
+    if not root.is_dir():
+        raise TimeSpendProjectionError(
+            "time-spend projection requires an existing vault directory"
+        )
+    return root
+
+
+def _is_own_projection(path: Path) -> bool:
+    """Whether the existing file is this module's own derived projection.
+
+    Anything that does not positively prove the derived posture -- a human
+    note, a foreign artifact class, a note claiming authority, an
+    unparseable file -- is NOT ours and must never be overwritten.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if not text.startswith("---\n"):
+        return False
+    end = text.find("\n---", 4)
+    if end < 0:
+        return False
+    try:
+        frontmatter = yaml.safe_load(text[4:end])
+    except yaml.YAMLError:
+        return False
+    if not isinstance(frontmatter, Mapping):
+        return False
+    if frontmatter.get("artifact_class") != ARTIFACT_CLASS:
+        return False
+    authority = frontmatter.get("authority")
+    return (
+        isinstance(authority, Mapping)
+        and authority.get("ai_generated") is True
+        and authority.get("source_authoritative") is False
+        and authority.get("requires_review") is True
+    )
+
+
+def write_time_spend_note(
+    week: str,
+    rollup: TimeSpendRollup,
+    *,
+    vault_context: VaultContext,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    time_spend_dir: str = DEFAULT_TIME_SPEND_DIR,
+) -> TimeSpendWriteResult:
+    """The governed vault-write call site for one week's projection note.
+
+    ``WriteGuard``-gated immediately before the write; a blocked write is a
+    loud, item-scoped result, never a silent drop. Overwrites ONLY its own
+    prior projection (rebuild = re-fold + rewrite, the note is disposable);
+    any other occupant of the path blocks the write and is left untouched.
+    """
+    vault_root = _vault_root(vault_context)
+    artifact_path = time_spend_note_path(week, time_spend_dir=time_spend_dir)
+    note_path = vault_root / artifact_path
+
+    content = render_time_spend_note(week, rollup)
+
+    if note_path.exists() or note_path.is_symlink():
+        if not _is_own_projection(note_path):
+            return TimeSpendWriteResult(
+                status="blocked",
+                week=week,
+                artifact_path=None,
+                reason=(
+                    f"path is occupied by a note that is not a {ARTIFACT_CLASS} "
+                    f"projection; refusing to overwrite: {artifact_path}"
+                ),
+            )
+        try:
+            if note_path.read_text(encoding="utf-8") == content:
+                return TimeSpendWriteResult(
+                    status="unchanged", week=week, artifact_path=artifact_path
+                )
+        except OSError:
+            pass
+        status = "rebuilt"
+    else:
+        status = "written"
+
+    try:
+        write_guard.assert_writes_allowed(TIME_SPEND_WRITE_ACTION)
+    except WritesBlockedError as exc:
+        return TimeSpendWriteResult(
+            status="blocked", week=week, artifact_path=None, reason=str(exc)
+        )
+
+    write_note_relative(
+        artifact_path,
+        content,
+        vault_root=vault_root,
+        action=TIME_SPEND_WRITE_ACTION,
+        write_guard=write_guard,
+    )
+    return TimeSpendWriteResult(status=status, week=week, artifact_path=artifact_path)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoints: fold-from-zero rebuild
+# ---------------------------------------------------------------------------
+
+
+def build_time_spend_rollup() -> TimeSpendRollup:
+    """Fold the full observation stream from event zero.
+
+    No cursor, no cache: the projection is stateless by design so a rebuild
+    can never disagree with an incremental update (they are the same fold).
+    """
+    return fold_time_spend(read_observations_from(0))
+
+
+def rebuild_time_spend(
+    *,
+    vault_context: VaultContext,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    week: Optional[str] = None,
+    time_spend_dir: str = DEFAULT_TIME_SPEND_DIR,
+) -> Dict[str, Any]:
+    """Re-fold the observation stream and (re)write the weekly markdown notes.
+
+    The production rebuild entrypoint (`heimdal time-spend --rebuild`).
+    Writes one note per ISO week present in the folded spans, or only
+    ``week`` when given. Returns a receipt mapping each targeted week to its
+    write status; a week with no observations reports ``no_observations``
+    and writes nothing.
+    """
+    rollup = build_time_spend_rollup()
+    targets = [week] if week is not None else list(rollup.weeks())
+
+    results: Dict[str, TimeSpendWriteResult] = {}
+    for target in targets:
+        if not rollup.spans_for_week(target):
+            results[target] = TimeSpendWriteResult(
+                status="no_observations", week=target, artifact_path=None
+            )
+            continue
+        results[target] = write_time_spend_note(
+            target,
+            rollup,
+            vault_context=vault_context,
+            write_guard=write_guard,
+            time_spend_dir=time_spend_dir,
+        )
+
+    return {
+        "rebuilt_from": rollup.source_row_count,
+        "span_count": len(rollup.spans),
+        "weeks": {
+            target: {
+                "status": result.status,
+                "artifact_path": result.artifact_path,
+                "reason": result.reason,
+            }
+            for target, result in results.items()
+        },
+    }
+
+
+def time_spend_summary(week: Optional[str] = None) -> Dict[str, Any]:
+    """Read-only JSON summary of the rollup (the ``--json`` CLI surface)."""
+    rollup = build_time_spend_rollup()
+    spans: Sequence[TimeSpendSpan]
+    if week is not None:
+        spans = rollup.spans_for_week(week)
+    else:
+        spans = rollup.spans
+    axes = rollup_axes(spans)
+    formatted = {
+        axis: {
+            name: format_duration(seconds)
+            for name, seconds in _sorted_buckets(totals)
+        }
+        for axis, totals in axes.items()
+    }
+    return {
+        "week": week,
+        "span_count": len(spans),
+        "rebuilt_from": rollup.source_row_count,
+        **formatted,
+    }
+
+
+__all__ = [
+    "ARTIFACT_CLASS",
+    "DEFAULT_TIME_SPEND_DIR",
+    "NO_PROJECT_BUCKET",
+    "PROJECTION_CONSUMER",
+    "SCREEN_MODALITY",
+    "SCREEN_OBSERVATION_TOPIC",
+    "TIME_SPEND_WRITE_ACTION",
+    "TimeSpendProjectionError",
+    "TimeSpendRollup",
+    "TimeSpendSpan",
+    "TimeSpendWriteResult",
+    "UNKNOWN_BUCKET",
+    "build_time_spend_rollup",
+    "fold_time_spend",
+    "format_duration",
+    "rebuild_time_spend",
+    "render_time_spend_note",
+    "rollup_axes",
+    "time_spend_note_path",
+    "time_spend_summary",
+    "write_time_spend_note",
+]

--- a/docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md
+++ b/docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md
@@ -40,12 +40,21 @@ projection** into the vault. It works **from observations alone** — no episode
 ## Concretely
 
 ```
-$ python -m app.cli heimdal time-spend --week 2026-W28 --json
-{"by_app": {"Obsidian": "6h12m", "Safari": "3h48m", "Terminal": "2h30m"},
- "by_scope": {"work": "9h40m", "private": "2h50m"}, "by_project": {"ERE spec": "4h05m"}, "rebuilt_from": 1442}
-$ python -m app.cli heimdal time-spend --rebuild --week 2026-W28   # deterministic re-fold from observations
-wrote heimdal/time-spend/2026-W28.md  (derived, requires_review, from 1442 observations)
+$ python -m app.cli heimdal time-spend --week 2026-W28
+{"week": "2026-W28", "span_count": 4, "rebuilt_from": 1442,
+ "by_app": {"Obsidian": "6h12m", "Safari": "3h48m", "Terminal": "2h30m"},
+ "by_project": {"ERE spec": "4h05m"}, "by_scope": {"work": "9h40m", "private": "2h50m"}, ...}
+$ python -m app.cli heimdal time-spend --rebuild --week 2026-W28 --vault-root /path/to/vault
+{"rebuilt_from": 1442, "span_count": 4,
+ "weeks": {"2026-W28": {"status": "written", "artifact_path": "heimdal/time-spend/2026-W28.md", ...}}}
 ```
+
+Shipped as `app/heimdal/time_spend.py` (SCREEN-05, #3345): the rebuild is always a full re-fold from
+event zero — there is no consumer cursor and no incremental state, so a rebuild and an "incremental
+update" are the same deterministic fold and can never drift apart. Spans fold by `observation_id`
+(per-span identity), deliberately not by the candidate projector's `episode_id` fold — known defect
+`KD-FBDBDAD4C052` records that the episode fold collapses distinct spans sharing one episode; reading
+the observation log directly is that defect's documented workaround.
 
 ## Why This Matters
 
@@ -57,14 +66,14 @@ event motor does.
 
 ## Acceptance Criteria
 
-- [ ] AC1: spans roll up by app / project / scope / day / week with correct duration sums (idle gaps
+- [x] AC1: spans roll up by app / project / scope / day / week with correct duration sums (idle gaps
       excluded). Verify: `tests/heimdal/test_time_spend_projection.py::test_rollup_by_all_axes`
-- [ ] AC2: the projection rebuilds deterministically from the observation stream — same observations in,
+- [x] AC2: the projection rebuilds deterministically from the observation stream — same observations in,
       same rollup out; the projection holds no state the observations do not. Verify: `tests/heimdal/test_time_spend_projection.py::test_time_spend_rebuilds_from_observations`
-- [ ] AC3: the markdown projection is written through the governed write path as derived /
+- [x] AC3: the markdown projection is written through the governed write path as derived /
       `requires_review` class, never overwriting a human-authored note. Verify: `tests/heimdal/test_time_spend_projection.py::test_projection_written_governed_derived_class`
-- [ ] AC4 (non-behavioral): the future companion-UI seam and the future episode-rollup enrichment are
-      named as seams, not built, and the task's independence from ERE is stated. Verify: doc writeback at `docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md :: What This Task Does` (steps 3-4)
+- [x] AC4 (non-behavioral): the future companion-UI seam and the future episode-rollup enrichment are
+      named as seams, not built, and the task's independence from ERE is stated. Verify: `docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md :: What This Task Does` (doc writeback, steps 3-4)
 
 ## How to Verify (Pre-Merge)
 
@@ -96,4 +105,4 @@ absent from the observations (AC2 enforces it). No in-memory user-facing state t
 
 ## Related GitHub Issues
 
-One issue: `[Heimdal Screen Stream] time-spend-projection: rebuildable markdown rollup by app/project/scope/day/week`. Blocked until SCREEN-02 merges (∥ SCREEN-03, SCREEN-06). **Sonnet-tier** (a rebuildable derived projection over an existing stream — bounded, mirrors existing projection patterns). See scratchpad draft.
+One issue: #3345 `[Heimdal Screen Stream] time-spend-projection: rebuildable markdown rollup by app/project/scope/day/week` — **delivered**. Its dependency SCREEN-02/#3344 merged first, as planned; every behavioral acceptance criterion above is checked against a passing named test, and the companion-UI / episode-rollup seams remain named-not-built (steps 3–4 above).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -45,6 +45,18 @@ records. It requires `_heimdal/settings.md` to declare a valid
 `retention_window_days`; missing policy fails loud. It neither reads raw
 payloads nor performs archive, retention, or storage lifecycle work.
 
+### Heimdal time-spend projection (SCREEN-05)
+
+Use `python -m app.cli heimdal time-spend [--week YYYY-Www]` to print the JSON
+time-spend rollup over screen span observations (by app/project/scope/day/week),
+and `python -m app.cli heimdal time-spend --rebuild --vault-root <vault>
+[--week YYYY-Www]` to deterministically re-fold the observation stream from
+event zero and (re)write the weekly markdown projection note(s) at
+`heimdal/time-spend/YYYY-Www.md`. The note is a derived, rebuildable projection
+(`requires_review`, never authority): rebuilding overwrites only its own prior
+projection and refuses to touch any other note at the path. A missing store
+backend fails loud (`STORE_BACKEND=memory` or a Postgres DSN is required).
+
 ## Version & Release Workflow
 - Run `python scripts/bump_version.py <new_version>` to update `settings.app_version`, core docs, and project memory (supporting `--dry-run`).
 - Commit the bump with `chore(version): bump to X.Y.Z`, then create an annotated tag using `python scripts/tag_release.py [--dry-run|--push]` (tags default to `v<version>`).

--- a/tests/heimdal/test_time_spend_projection.py
+++ b/tests/heimdal/test_time_spend_projection.py
@@ -1,0 +1,473 @@
+"""SCREEN-05 (#3345): the rebuildable time-spend projection over screen spans.
+
+Acceptance criteria under test (issue #3345 / PROJECT_TIME_SPEND_ANALYSIS.md):
+
+- AC1 ``test_rollup_by_all_axes``: spans roll up by app / project / scope /
+  day / week with correct duration sums; idle gaps (time between spans) are
+  never counted.
+- AC2 ``test_time_spend_rebuilds_from_observations``: the projection is a
+  deterministic pure fold of the observation stream -- same observations in,
+  byte-identical markdown out; an "incremental" rebuild after more
+  observations arrive equals a from-scratch rebuild over the same stream
+  (there is no hidden state to diverge).
+- AC3 ``test_projection_written_governed_derived_class``: the markdown note
+  is written through the governed WriteGuard path with the derived /
+  ``requires_review`` posture and never overwrites a human-authored note.
+
+Every publishing step goes through the production observation publish path
+(`assemble_observation_payload` + `publish_full_observation`, the exact call
+site `app.heimdal.screen_derivation._publish_span` uses), and every
+enforcement assertion drives the production rebuild entrypoint
+(`rebuild_time_spend`), not an isolated helper.
+
+Per-span identity (KD-FBDBDAD4C052): spans here deliberately share one
+``episode_id`` in several tests -- the rollup must keep them distinct, which
+is the recorded workaround for the candidate projector's episode fold defect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.heimdal.cursor_store import reset_memory_cursor_store
+from app.heimdal.observation_log import (
+    read_observations_from,
+    reset_memory_observation_log,
+)
+from app.heimdal.publish import (
+    assemble_observation_payload,
+    publish_full_observation,
+)
+from app.heimdal.time_spend import (
+    ARTIFACT_CLASS,
+    NO_PROJECT_BUCKET,
+    build_time_spend_rollup,
+    fold_time_spend,
+    format_duration,
+    rebuild_time_spend,
+    render_time_spend_note,
+    rollup_axes,
+    time_spend_note_path,
+)
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+
+pytestmark = pytest.mark.not_pg
+
+TOPIC = "heimdal.observation.published"
+
+
+@pytest.fixture(autouse=True)
+def _reset_heimdal_stores():
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    yield
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_name="Vault Test",
+        active_vault_path=str(root),
+    )
+
+
+def _allowing_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _blocking_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "safe_mode", "reason": "test-induced block"})
+
+
+def _span_payload(
+    *,
+    observation_id: str,
+    start: str,
+    end: str,
+    app: str = "Obsidian",
+    scope: str = "work",
+    projects: tuple[str, ...] = (),
+    episode_id: str = "screen-tick-shared",
+    supersedes: str | None = None,
+    content_identity: str = "sha256:" + "c" * 64,
+) -> dict:
+    """One screen span payload shaped exactly like `screen_derivation._publish_span`'s."""
+    mentions = [
+        {
+            "mention_id": f"screen:project:{project.lower().replace(' ', '-')}",
+            "surface_form": project,
+            "kind_hint": "project",
+            "resolution": "unresolved",
+        }
+        for project in projects
+    ]
+    return assemble_observation_payload(
+        observation_id=observation_id,
+        episode_id=episode_id,
+        observed_at_start=start,
+        observed_at_end=end,
+        clock_basis="device_metadata",
+        sequence=None,
+        supersedes=supersedes,
+        attributions=[
+            {
+                "mention_id": "operator",
+                "role": "recorder",
+                "resolution": "resolved",
+                "basis": "capture_context",
+            }
+        ],
+        entity_mentions=mentions,
+        modality="screen",
+        content=f"Working in {app}",
+        content_structure={
+            "span": {
+                "frame_count": 2,
+                "dimensions": {"app": app, "window": "doc", "scope": scope, "goal": "edit"},
+                "raw_refs": ["heimraw:frame-1"],
+            }
+        },
+        raw_ref="heimraw:frame-1",
+        confidence={
+            "attribution": {"score": 1.0, "calibration": "by_construction"},
+            "activity_summary": {"score": 0.8, "calibration": "heuristic"},
+        },
+        provenance={
+            "sensor": {"adapter": "macos_observer", "version": "v1", "machine": "mac-1"},
+            "capture_chain": ["macos_observer", "screen_capture_endpoint"],
+            "content_identity": content_identity,
+            "stage_versions": {"screen_derivation": "test-model@v1"},
+            "model_ref": "local/test-vision",
+            "raw_refs": ["heimraw:frame-1"],
+        },
+        sensitivity="private",
+        scope_hint=scope,
+        consent={
+            "basis": "self_record",
+            "granted_by": "operator",
+            "granted_at": "2026-01-01T00:00:00+00:00",
+            "third_party": "none",
+            "grant_ref": "grant-self-record-v1",
+        },
+    )
+
+
+def _publish(payload: dict, *, stage_versions: dict | None = None) -> None:
+    publish_full_observation(
+        topic=TOPIC,
+        payload=payload,
+        source="heimdal.screen_derivation",
+        stage_versions=stage_versions or payload["provenance"]["stage_versions"],
+    )
+
+
+def _publish_week_fixture() -> None:
+    """Four spans in 2026-W28 across two days, apps, scopes, projects.
+
+    All four share ONE episode_id (the KD-FBDBDAD4C052 shape) and carry a
+    2h idle gap between the first two spans that must never be counted.
+    """
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-a",
+            start="2026-07-06T09:00:00+00:00",
+            end="2026-07-06T09:30:00+00:00",  # 30m
+            app="Obsidian",
+            scope="work",
+            projects=("ERE spec",),
+            content_identity="sha256:" + "a" * 64,
+        )
+    )
+    # 2h idle/locked gap here: never sampled, so no span covers it.
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-b",
+            start="2026-07-06T11:30:00+00:00",
+            end="2026-07-06T11:45:00+00:00",  # 15m
+            app="Safari",
+            scope="private",
+            projects=(),
+            content_identity="sha256:" + "b" * 64,
+        )
+    )
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-c",
+            start="2026-07-07T10:00:00+00:00",
+            end="2026-07-07T11:00:00+00:00",  # 1h, next day
+            app="Obsidian",
+            scope="work",
+            projects=("ERE spec", "Heimdal"),
+            content_identity="sha256:" + "d" * 64,
+        )
+    )
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-d",
+            start="2026-07-07T12:00:00+00:00",
+            end="2026-07-07T12:05:30+00:00",  # 5m30s
+            app="Terminal",
+            scope="work",
+            projects=("Heimdal",),
+            content_identity="sha256:" + "e" * 64,
+        )
+    )
+
+
+# --- AC1: rollup by every axis, correct sums, idle gaps excluded --------------
+
+
+def test_rollup_by_all_axes():
+    _publish_week_fixture()
+
+    rollup = build_time_spend_rollup()
+    assert len(rollup.spans) == 4  # one per observation_id, despite the shared episode_id
+    axes = rollup_axes(rollup.spans)
+
+    assert axes["by_app"] == {
+        "Obsidian": 90 * 60.0,
+        "Safari": 15 * 60.0,
+        "Terminal": 330.0,
+    }
+    assert axes["by_scope"] == {
+        "work": 30 * 60.0 + 60 * 60.0 + 330.0,
+        "private": 15 * 60.0,
+    }
+    # A span mentioning two projects counts fully toward each.
+    assert axes["by_project"] == {
+        "ERE spec": 30 * 60.0 + 60 * 60.0,
+        "Heimdal": 60 * 60.0 + 330.0,
+        NO_PROJECT_BUCKET: 15 * 60.0,
+    }
+    assert axes["by_day"] == {
+        "2026-07-06": 45 * 60.0,
+        "2026-07-07": 60 * 60.0 + 330.0,
+    }
+    assert axes["by_week"] == {"2026-W28": 45 * 60.0 + 60 * 60.0 + 330.0}
+
+    # Idle gaps excluded: total is the sum of span windows, NOT the wall-clock
+    # extent of the observed period (which includes the 2h gap).
+    total = sum(span.duration_seconds for span in rollup.spans)
+    assert total == 45 * 60.0 + 60 * 60.0 + 330.0
+    wall_clock_extent = (11.75 - 9.0) * 3600  # first day alone spans 2h45m
+    assert total < wall_clock_extent + 24 * 3600  # sanity: nothing interpolated
+
+    assert format_duration(axes["by_week"]["2026-W28"]) == "1h50m"
+
+
+def test_revisions_and_corrections_do_not_double_count():
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-rev",
+            start="2026-07-06T09:00:00+00:00",
+            end="2026-07-06T09:30:00+00:00",
+            app="Obsidian",
+            content_identity="sha256:" + "a" * 64,
+        )
+    )
+    # A revision of the SAME evidence: same observation_id, new stage_versions
+    # -> a new log row that must fold onto the same span, not add 30m.
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-rev",
+            start="2026-07-06T09:00:00+00:00",
+            end="2026-07-06T09:30:00+00:00",
+            app="Obsidian",
+            content_identity="sha256:" + "a" * 64,
+        ),
+        stage_versions={"screen_derivation": "test-model@v2"},
+    )
+    # A correction that supersedes a distinct earlier observation id.
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-old",
+            start="2026-07-06T10:00:00+00:00",
+            end="2026-07-06T10:10:00+00:00",
+            app="Safari",
+            content_identity="sha256:" + "b" * 64,
+        )
+    )
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-corrected",
+            start="2026-07-06T10:00:00+00:00",
+            end="2026-07-06T10:12:00+00:00",
+            app="Safari",
+            supersedes="screen-obs-old",
+            content_identity="sha256:" + "d" * 64,
+        )
+    )
+
+    rollup = build_time_spend_rollup()
+    axes = rollup_axes(rollup.spans)
+    assert axes["by_app"] == {"Obsidian": 30 * 60.0, "Safari": 12 * 60.0}
+
+
+# --- AC2: deterministic rebuild from the observation stream alone -------------
+
+
+def test_time_spend_rebuilds_from_observations(tmp_path):
+    vault_a = _vault(tmp_path / "vault-a")
+    guard = _allowing_guard()
+    note_rel = time_spend_note_path("2026-W28")
+
+    # Incremental shape: two spans arrive, rebuild; two more arrive, rebuild.
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-a",
+            start="2026-07-06T09:00:00+00:00",
+            end="2026-07-06T09:30:00+00:00",
+            projects=("ERE spec",),
+            content_identity="sha256:" + "a" * 64,
+        )
+    )
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-b",
+            start="2026-07-06T11:30:00+00:00",
+            end="2026-07-06T11:45:00+00:00",
+            app="Safari",
+            scope="private",
+            content_identity="sha256:" + "b" * 64,
+        )
+    )
+    first = rebuild_time_spend(vault_context=vault_a, write_guard=guard)
+    assert first["weeks"]["2026-W28"]["status"] == "written"
+
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-c",
+            start="2026-07-07T10:00:00+00:00",
+            end="2026-07-07T11:00:00+00:00",
+            projects=("ERE spec", "Heimdal"),
+            content_identity="sha256:" + "d" * 64,
+        )
+    )
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-d",
+            start="2026-07-07T12:00:00+00:00",
+            end="2026-07-07T12:05:30+00:00",
+            app="Terminal",
+            projects=("Heimdal",),
+            content_identity="sha256:" + "e" * 64,
+        )
+    )
+    second = rebuild_time_spend(vault_context=vault_a, write_guard=guard)
+    assert second["weeks"]["2026-W28"]["status"] == "rebuilt"
+    incremental_bytes = (Path(vault_a.active_vault_path or "") / note_rel).read_text(
+        encoding="utf-8"
+    )
+
+    # From-scratch shape: a FRESH log receives the same four observations in
+    # one go; a fresh vault gets one rebuild. Same observations -> the
+    # projection must be byte-identical. No cursor, no run counter, no
+    # wall-clock stamp may leak in.
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    _publish_week_fixture()
+    vault_b = _vault(tmp_path / "vault-b")
+    scratch = rebuild_time_spend(vault_context=vault_b, write_guard=guard)
+    assert scratch["weeks"]["2026-W28"]["status"] == "written"
+    scratch_bytes = (Path(vault_b.active_vault_path or "") / note_rel).read_text(
+        encoding="utf-8"
+    )
+
+    assert scratch_bytes == incremental_bytes
+
+    # And the fold itself is a pure function: same rows, same rollup/markdown.
+    rows = read_observations_from(0)
+    assert render_time_spend_note("2026-W28", fold_time_spend(rows)) == render_time_spend_note(
+        "2026-W28", fold_time_spend(rows)
+    )
+
+    # Re-running with no new observations is a no-op, not a new artifact.
+    third = rebuild_time_spend(vault_context=vault_b, write_guard=guard)
+    assert third["weeks"]["2026-W28"]["status"] == "unchanged"
+
+
+# --- AC3: governed write, derived class, never over a human note --------------
+
+
+def test_projection_written_governed_derived_class(tmp_path):
+    _publish_week_fixture()
+    vault = _vault(tmp_path / "vault")
+    vault_root = Path(vault.active_vault_path or "")
+    note_rel = time_spend_note_path("2026-W28")
+    note_path = vault_root / note_rel
+
+    # A blocked WriteGuard stops the PRODUCTION rebuild path before any write.
+    blocked = rebuild_time_spend(vault_context=vault, write_guard=_blocking_guard())
+    assert blocked["weeks"]["2026-W28"]["status"] == "blocked"
+    assert not note_path.exists()
+
+    # An allowed write lands with the derived / requires_review posture.
+    written = rebuild_time_spend(vault_context=vault, write_guard=_allowing_guard())
+    assert written["weeks"]["2026-W28"]["status"] == "written"
+    content = note_path.read_text(encoding="utf-8")
+    assert f"artifact_class: {ARTIFACT_CLASS}" in content
+    assert "requires_review: true" in content
+    assert "source_authoritative: false" in content
+    assert "ai_generated: true" in content
+    assert "rebuildable: true" in content
+
+    # Rebuilding OVER its own projection is allowed (the note is disposable)...
+    _publish(
+        _span_payload(
+            observation_id="screen-obs-extra",
+            start="2026-07-08T09:00:00+00:00",
+            end="2026-07-08T09:10:00+00:00",
+            content_identity="sha256:" + "f" * 64,
+        )
+    )
+    rebuilt = rebuild_time_spend(vault_context=vault, write_guard=_allowing_guard())
+    assert rebuilt["weeks"]["2026-W28"]["status"] == "rebuilt"
+
+    # ...but a human-authored note at the target path is NEVER overwritten,
+    # even through the production rebuild entrypoint.
+    human_text = "# My own week notes\n\nHand-written; hands off.\n"
+    note_path.write_text(human_text, encoding="utf-8")
+    guarded = rebuild_time_spend(vault_context=vault, write_guard=_allowing_guard())
+    assert guarded["weeks"]["2026-W28"]["status"] == "blocked"
+    assert "refusing to overwrite" in (guarded["weeks"]["2026-W28"]["reason"] or "")
+    assert note_path.read_text(encoding="utf-8") == human_text
+
+    # A frontmatter-bearing note that claims authority is not ours either.
+    pretender = (
+        "---\nartifact_class: time_spend_projection\nauthority:\n"
+        "  ai_generated: false\n  source_authoritative: true\n  requires_review: false\n---\n\nbody\n"
+    )
+    note_path.write_text(pretender, encoding="utf-8")
+    guarded_again = rebuild_time_spend(vault_context=vault, write_guard=_allowing_guard())
+    assert guarded_again["weeks"]["2026-W28"]["status"] == "blocked"
+    assert note_path.read_text(encoding="utf-8") == pretender
+
+
+def test_rebuild_requires_selected_vault():
+    _publish_week_fixture()
+    from app.heimdal.time_spend import TimeSpendProjectionError
+
+    with pytest.raises(TimeSpendProjectionError):
+        rebuild_time_spend(
+            vault_context=VaultContext(status="uninitialized"),
+            write_guard=_allowing_guard(),
+        )
+
+
+def test_week_filter_and_missing_week(tmp_path):
+    _publish_week_fixture()
+    vault = _vault(tmp_path / "vault")
+    receipt = rebuild_time_spend(
+        vault_context=vault, write_guard=_allowing_guard(), week="2026-W29"
+    )
+    assert receipt["weeks"] == {
+        "2026-W29": {"status": "no_observations", "artifact_path": None, "reason": None}
+    }
+    assert not (Path(vault.active_vault_path or "") / time_spend_note_path("2026-W29")).exists()

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -817,6 +817,13 @@ WRITE_NOTE_RELATIVE_SITE_CLASSIFICATION: dict[tuple[str, str, int], str] = {
         "this call, in addition to the port's own guard; a blocked caller guard "
         "returns the item-scoped, re-runnable 'blocked' result."
     ),
+    ("app/heimdal/time_spend.py", "write_time_spend_note", 1): (
+        "guarded_by_caller: write_time_spend_note asserts write_guard."
+        "assert_writes_allowed(TIME_SPEND_WRITE_ACTION) immediately before this "
+        "call (converting a blocked write into a loud, item-scoped, re-runnable "
+        "'blocked' result) and passes the same guard/action through to the "
+        "port's own guard (#3345, SCREEN-05 time-spend projection)."
+    ),
     ("app/heimdal/capture_note.py", "write_capture_note", 1): (
         "guarded_by_port: write_capture_note passes write_guard through to "
         "write_note_relative, which asserts write_guard.assert_writes_allowed"


### PR DESCRIPTION
Governing-Issue: #3345

Fixes #3345

Final-Review-Rounds: 0

## Summary
SCREEN-05: a rebuildable time-spend projection over the screen span observation stream. `app/heimdal/time_spend.py` folds spans by app/project/scope/day/week from the observation log at event zero — no consumer cursor and no incremental state, so a rebuild and an "incremental update" are the same deterministic fold (same observations in, byte-identical markdown out). The weekly note (`heimdal/time-spend/YYYY-Www.md`) writes through WriteGuard + `write_note_relative` with the derived/`requires_review` posture, overwrites only its own prior projection, and refuses any other occupant of the path. CLI: `python -m app.cli heimdal time-spend [--week] [--rebuild --vault-root]`.

Per-span identity: spans fold by `observation_id` (last revision wins; `supersedes`/`revision_of` corrections drop the corrected span), deliberately not the candidate projector's `episode_id` fold — known defect `KD-FBDBDAD4C052` records that fold collapsing distinct spans sharing one episode, and reading the log directly is its documented workaround. The companion-UI seam and the episode-rollup enrichment stay named-not-built; the projection is independent of ERE.

## Acceptance Criteria coverage
- AC1 rollup by all axes, idle gaps excluded: `tests/heimdal/test_time_spend_projection.py::test_rollup_by_all_axes` — pass
- AC2 deterministic rebuild from observations alone (incremental == from-scratch, byte-identical): `::test_time_spend_rebuilds_from_observations` — pass
- AC3 governed derived-class write via the production rebuild entrypoint, never over a human note: `::test_projection_written_governed_derived_class` — pass
- AC4 seams named, ERE independence stated: doc writeback in `docs/HEIMDAL_SCREEN_STREAM/PROJECT_TIME_SPEND_ANALYSIS.md :: What This Task Does` (steps 3–4) + delivered-state wording

## BuilderOps Routing
- Records/projections/receipts: KD-FBDBDAD4C052 re-evaluation receipt on the Known Defects registry (#4172) — SCREEN-05's trigger fired; this rollup consumes the observation log directly with per-span identity, so the defect does not affect it and stays deferred with SCREEN-04 as the remaining trigger. Issue #3345 maintenance receipt (stale `agent:blocked` repaired to `agent:ready` after verifying SCREEN-02/#3344 delivery; AC4 `Verify:` line reshaped to the annotated grammar form).
- Reason: no plan divergence beyond the pre-claim label/contract repair already receipted on the issue; no new LearningSignal (the Verify-line defect family is already signaled as `lrn_20260802115750_05a2754b`).

## Notes
Validation:
- `ruff check app tests` — clean
- `mypy app` — clean (867 source files)
- `pytest -q tests/heimdal/test_time_spend_projection.py` — 6 passed
- `pytest -q -m "not pg" tests/heimdal/` — 454 passed, 9 xfailed
- repo-wide `pytest -q -m "not pg"` under the `pytest-not-pg` host lease at head `65602d295` — running at publication time; result recorded before merge
- `scripts/docs_guard.py` — OK (OPERATIONS.md operator-surface writeback included)
- `scripts/review_before_ci_gate.py` (implementation lane, risk assessment complete, no high-risk surfaces) — satisfied
---