### PR TITLE
fix: canonicalize pr-contract twins for non-LF line terminators (#4341)

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -261,8 +261,9 @@ required `Final-Review-Rounds: 0` line and concrete `## BuilderOps Routing` defa
 `<...>` placeholders. Raise `Final-Review-Rounds` to `1` or `2` only when
 `AGENTS.md :: Proportional delivery` selects the full path. The exact shape both fields must satisfy
 is the canonical `app/dispatcher/verification_contract.py::resolve_pr_contract_final_review_rounds`
-and `::resolve_builderops_routing_status` (kept in proven parity with the `pr-contract` gate's own JS
-by `tests/governance/test_issue_pr_governance.py
+and `::resolve_builderops_routing_status` (proven equivalent to the `pr-contract` gate's own JS across
+every ECMAScript line terminator and the JS/Python whitespace-class edge cases, not merely on an
+LF-only corpus, per #4341) by `tests/governance/test_issue_pr_governance.py
 ::test_final_review_rounds_check_executes_via_canonical_implementation` and
 `::test_builderops_routing_stub_detection_matches_workflow_js`) — do not re-derive the rule from this
 prose. The `none` / reason defaults shown match what `scripts/pr_body_generator.py` emits
@@ -403,8 +404,10 @@ Pre-push PR-body contract gate:
   or `Reason:`).
 - The exact shape both checks above enforce is not restated here — it is the canonical
   `app/dispatcher/verification_contract.py::resolve_pr_contract_final_review_rounds` and
-  `::resolve_builderops_routing_status`, proven identical to the `pr-contract` gate's own JS by
-  `tests/governance/test_issue_pr_governance.py`. CI remains the enforcement point; this is a manual
+  `::resolve_builderops_routing_status`, proven equivalent to the `pr-contract` gate's own JS across
+  every ECMAScript line terminator and the JS/Python whitespace-class edge cases (not merely on an
+  LF-only corpus, per #4341) by `tests/governance/test_issue_pr_governance.py`. CI remains the
+  enforcement point; this is a manual
   pre-push read, not a substitute for it.
 
 Direct Repair block placement: prefer placing the `## Direct Repair` block as the first section of the PR body (before `## Summary`). The governance check accepts the block in any position — first, middle, or last — but first placement is preferred for reviewer clarity.

--- a/app/dispatcher/verification_contract.py
+++ b/app/dispatcher/verification_contract.py
@@ -61,7 +61,7 @@ def resolve_final_review_rounds(body: object) -> int | None:
     return int(matches[0])
 
 
-# --- pr-contract gate twins (issue #4272) -----------------------------------
+# --- pr-contract gate twins (issue #4272; line-terminator parity #4341) -----
 #
 # The two functions below are a distinct concern from resolve_final_review_rounds
 # above: that function resolves how many verified-merge review rounds the
@@ -69,14 +69,21 @@ def resolve_final_review_rounds(body: object) -> int | None:
 # there on purpose). The `pr-contract` CI gate instead only checks the PR
 # body's *shape* \u2014 exactly one Final-Review-Rounds declaration with a value of
 # 0, 1, or 2 \u2014 regardless of which path that value selects. These twins mirror
-# the workflow's own JS 1:1 (the `// final-review-rounds:start`/`:end` and
-# `// builderops-routing:start`/`:end` marker-delimited blocks in
-# .github/workflows/issue-pr-governance.yml), proven by
-# tests/governance/test_issue_pr_governance.py
+# the workflow's own JS shape checks (the `// final-review-rounds:start`/`:end`
+# and `// builderops-routing:start`/`:end` marker-delimited blocks in
+# .github/workflows/issue-pr-governance.yml), proven equivalent on a corpus
+# that now spans every ECMAScript `LineTerminator` (`\n`, `\r\n`, lone `\r`,
+# U+2028, U+2029) by tests/governance/test_issue_pr_governance.py
 # ::test_final_review_rounds_check_executes_via_canonical_implementation and
 # ::test_builderops_routing_stub_detection_matches_workflow_js, following the
 # same marker-extraction parity pattern as
-# ::test_javascript_and_python_authority_grammar_are_identical.
+# ::test_javascript_and_python_authority_grammar_are_identical. JS's `$`/`^`
+# under the `/m` flag, and its `.` without `/s`, treat all four LineTerminator
+# code points as line breaks; Python's `re.MULTILINE`/dot semantics only
+# recognize `\n`. `_canonicalize_pr_contract_line_terminators` below folds all
+# four into `\n` before either twin matches -- the same `\r\n` -> `\n` step
+# `resolve_final_review_rounds` already applies -- so declared/valid line
+# counts agree with the JS gate regardless of which terminator a PR body uses.
 
 PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN = re.compile(
     r"^Final-Review-Rounds:[ \t]*.*$", re.MULTILINE
@@ -84,6 +91,15 @@ PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN = re.compile(
 PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN = re.compile(
     r"^Final-Review-Rounds:[ \t]*[012][ \t]*$", re.MULTILINE
 )
+# Pattern text kept byte-identical to the workflow's `tier1LanePattern` JS
+# literal on purpose (`scripts/lint_skills_consistency.py` Check 10, issue
+# #4342, asserts textual/flag parity between this constant and the JS regex
+# literal). The `\s` divergence this issue fixes -- Python's Unicode-mode
+# `\s` matches the C0 "information separator" controls \x1c-\x1f that JS's
+# `\s` does not (`chr(0x1c).isspace()` is `True` in Python, `/\s/.test("\x1c")`
+# is `false` in JS) -- is therefore repaired by canonicalizing those controls
+# out of the input in `_canonicalize_pr_contract_line_terminators` below, not
+# by rewriting this pattern's source text.
 TIER1_LANE_PATTERN = re.compile(
     r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b", re.IGNORECASE | re.MULTILINE
 )
@@ -101,6 +117,39 @@ BUILDEROPS_ROUTING_REASON_PATTERN = re.compile(
 BUILDEROPS_ROUTING_PLACEHOLDER_PATTERN = re.compile(r"^<.*>$")
 
 
+# Python's Unicode-mode `\s` treats these four C0 "information separator"
+# controls as whitespace; JS's `\s` does not (issue #4341). Map them to NUL,
+# a byte that satisfies neither language's `\s` and cannot otherwise appear
+# in a GitHub PR body, so `TIER1_LANE_PATTERN`'s untouched `\s` (kept
+# byte-identical to the workflow's JS literal for Check 10) stops accepting
+# separators the JS gate rejects.
+_C0_INFORMATION_SEPARATORS = "\x1c\x1d\x1e\x1f"
+
+
+def _canonicalize_pr_contract_line_terminators(text: str) -> str:
+    """Normalize line-terminator and whitespace-class divergences from the JS gate.
+
+    JS `$`/`^` under `/m`, and JS `.` without `/s`, treat `\\r\\n`, lone `\\r`,
+    U+2028, and U+2029 as line breaks; Python's `re.MULTILINE`/dot semantics
+    only recognize `\\n`. Canonicalizing first (the same `\\r\\n` -> `\\n` step
+    `resolve_final_review_rounds` already applies) keeps the pr-contract gate
+    twins aligned with the workflow's own JS across all four terminators
+    (#4341), instead of `resolve_final_review_rounds`'s stricter fail-closed
+    rejection of non-LF/CRLF bodies, which is specific to that function's own
+    ceremony-round semantics and not shared by these shape-only twins. Also
+    neutralizes `_C0_INFORMATION_SEPARATORS` (see above) for the same reason.
+    """
+    text = (
+        text.replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\u2028", "\n")
+        .replace("\u2029", "\n")
+    )
+    for separator in _C0_INFORMATION_SEPARATORS:
+        text = text.replace(separator, "\x00")
+    return text
+
+
 @dataclass(frozen=True)
 class PrContractFinalReviewRounds:
     declared_count: int
@@ -115,7 +164,7 @@ def resolve_pr_contract_final_review_rounds(body: object) -> PrContractFinalRevi
     (the light-delivery-path declaration) and only asserts shape, never
     ceremony-round semantics.
     """
-    text = body if isinstance(body, str) else ""
+    text = _canonicalize_pr_contract_line_terminators(body if isinstance(body, str) else "")
     declared = PR_CONTRACT_FINAL_REVIEW_ROUNDS_ALL_LINES_PATTERN.findall(text)
     valid = PR_CONTRACT_FINAL_REVIEW_ROUNDS_VALID_LINE_PATTERN.findall(text)
     return PrContractFinalReviewRounds(
@@ -137,7 +186,7 @@ def resolve_builderops_routing_status(
     body: object, *, has_issue_authority: bool
 ) -> BuilderOpsRoutingStatus:
     """Twin of the `pr-contract` gate's `## BuilderOps Routing` filled-vs-stub check."""
-    text = body if isinstance(body, str) else ""
+    text = _canonicalize_pr_contract_line_terminators(body if isinstance(body, str) else "")
     is_tier1_lane = TIER1_LANE_PATTERN.search(text) is not None
     section_match = BUILDEROPS_ROUTING_SECTION_PATTERN.search(text)
     section = section_match.group(0) if section_match else ""

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -50,6 +50,14 @@ def test_final_review_rounds_check_executes_via_canonical_implementation() -> No
         "Final-Review-Rounds:0\n",
         "Final-Review-Rounds:  2  \n",
         "prose mentioning Final-Review-Rounds: 1 mid-line\n",
+        # Non-LF line terminators (issue #4341): JS `$`/`^` under `/m` treat
+        # every ECMAScript `LineTerminator` as a line break, not only `\n`.
+        "Final-Review-Rounds: 1\r\n",
+        "Final-Review-Rounds: 1\r",
+        "Final-Review-Rounds: 1 ",
+        "Final-Review-Rounds: 1 ",
+        "Final-Review-Rounds: 0\r\nFinal-Review-Rounds: 1\r\n",
+        "prose\r\nFinal-Review-Rounds: 2\r\nmore prose\r\n",
     ]
     for body in fixture_bodies:
         js_result = _js_final_review_rounds(body)
@@ -103,6 +111,16 @@ def test_builderops_routing_stub_detection_matches_workflow_js() -> None:
             "- Records/projections/receipts: x\n- Reason: y\n",
             True,
         ),
+        # \x1c-\x1f "information separator" controls (issue #4341): Python's
+        # Unicode-mode `\s` matches them, JS's `\s` does not, so a body using
+        # one as the checkbox/lane-name separator must NOT be treated as the
+        # Tier 1 lane the way a real space is.
+        ("- [x]\x1cGovernance lane\n", False),
+        ("-\x1f[x]\x1fDocs authoring lane\n", False),
+        # \r-terminated / CRLF lane declarations must still be recognized
+        # (line-terminator canonicalization, not the whitespace-class fix).
+        ("- [x] Governance lane\r\n", False),
+        ("- [x] Docs authoring lane\r", True),
     ]
     for body, has_issue_authority in fixture_cases:
         js_result = _js_builderops_routing(body, has_issue_authority)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4341

## Linked Issue
Closes #4341

## SBS Impact
- Primary subsystem: Builder System — pr-contract CI gate / publish-pr skill guidance
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: resolve_pr_contract_final_review_rounds/resolve_builderops_routing_status must agree with the JS gate under all four JS line terminators and reject the same \x1c-\x1f separators the JS gate rejects, not just on LF-only bodies
- Owner-doc impact: updated
- Transition debt impact: reduces — closes the latent trust gap before the deferred local-run CLI harness (#4272) is built on these twins
- Boundary risk: none — change confined to the twin functions, their tests, and skill prose; the live JS gate is untouched

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Canonicalize line terminators (CRLF/lone-CR/U+2028/U+2029) and the \x1c-\x1f whitespace-class divergence in the pr-contract gate's Python twins so they agree with the workflow's live JS across every ECMAScript LineTerminator, not only LF.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 bounded bug fix; no BuilderOps record class applies (not a memory/receipt/registry artifact).

## Notes
pytest -q tests/governance/ -> 501 passed; ruff check app tests companion-ui/companion-app -> all checks passed; mypy app -> no issues; python3 scripts/lint_skills_consistency.py -> exit 0 (Check 10 still passes: TIER1_LANE_PATTERN text kept byte-identical to the workflow JS literal); python3 scripts/docs_guard.py -> advisory only, no contract/settings surface touched.
