### PR TITLE
Attach provenance-cited evidence to open Standing Questions (SQ-03)

### DIFF
--- a/app/standing_questions/evidence_matching.py
+++ b/app/standing_questions/evidence_matching.py
@@ -1,0 +1,424 @@
+"""Match new ingest artifacts against open Question notes (SQ-03).
+
+This module is the production matching entrypoint named by
+``docs/STANDING_QUESTIONS/MATCH_EVIDENCE_TO_OPEN_QUESTIONS.md``. It consumes
+artifacts that already flowed through the existing ingest paths (Heimdal
+captures, KAP candidates, new/edited vault notes) and, for each
+``(open question, candidate artifact)`` pair that clears a cheap deterministic
+prefilter, asks a **fenced** schema-constrained completion whether the artifact
+is evidence for the question.
+
+Three disciplines carry the whole task and are enforced here rather than left to
+callers:
+
+- **The source artifact is never written to** (INV-SQ-B). The candidate capture,
+  KAP candidate, or note is opened read-only to build the association prompt and
+  is never opened for write on any code path — attach, below-threshold,
+  degraded, or excluded. Only the *question* side gains state, through the SQ-01
+  guarded seam (:class:`~app.standing_questions.question_store.QuestionStore`).
+  This is the one deliberate asymmetry against the Episode Resolution Engine's
+  ``episode_ref`` pattern, which stamps the artifact's own bundle.
+- **Scope is hard** (mirroring ``docs/MIMER_CAPABILITY_HARDENING/
+  EXPANSION_CONNECT_AND_CREATE.md :: 1.2``). A cross-scope pair is excluded
+  *before* the artifact's content is resolved, so no span of another scope can
+  reach the model, the log, or the evidence trail — a content-free denial. No
+  ``CrossScopeFlow`` grant class exists for this relation; cross-scope evidence
+  is capability-level out of scope, not deferred.
+- **LLM cognition, deterministic gate.** The model judges relatedness; code
+  decides attachment. A schema-validation failure or degraded backend yields no
+  link (``UNKNOWN``-equivalent per ``docs/RUNTIME_CORRECTNESS_KERNEL/
+  STRUCTURED_INTENT_OUTPUT_WITH_UNKNOWN.md``), never a fabricated or
+  default-attached one, and a quoted span that is not verbatim in the artifact
+  is refused rather than stored as a paraphrase.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from app.components.llm.constrained import (
+    CompletionFn,
+    ConstrainedCompletionError,
+    constrained_completion,
+    register_schema,
+)
+from app.standing_questions.projection import (
+    QuestionsDirectoryMissingError,
+    iter_question_notes,
+)
+from app.standing_questions.question_store import QuestionStore
+
+_LOGGER = logging.getLogger(__name__)
+
+VAULT_REF_PREFIX = "vault://"
+
+
+class ConfidenceClass(str, Enum):
+    """The association's uncertainty band, ranked by :data:`CONFIDENCE_CLASS_RANK`.
+
+    Deliberately a closed set: the deterministic gate can only rank classes it
+    knows, so a class the model invents is a schema violation (no link), never an
+    unranked value that falls through the floor comparison.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+#: Total order the threshold gate compares against. Kept next to the enum so a new
+#: class cannot be added without giving it a rank.
+CONFIDENCE_CLASS_RANK: dict[ConfidenceClass, int] = {
+    ConfidenceClass.LOW: 0,
+    ConfidenceClass.MEDIUM: 1,
+    ConfidenceClass.HIGH: 2,
+}
+
+#: **RQ-SQ2 — provisional.** The deterministic floor an association's confidence
+#: class must clear before a link attaches at all. This is the single source for
+#: that threshold; nothing else in the codebase may hard-code an attach cutoff.
+#: Starting posture is conservative per ``docs/STANDING_QUESTIONS/README.md ::
+#: Provisional thresholds (RQ-SQ1, RQ-SQ2)`` — under-attaching is preferred,
+#: because a missed link can still be found by a later, stronger-evidence pass
+#: while a wrongly attached one pollutes an evidence trail a human must then
+#: mentally discount. It is a tuning value to revisit once live data accumulates,
+#: not a pre-code gate.
+EVIDENCE_ATTACH_CONFIDENCE_FLOOR = ConfidenceClass.HIGH
+
+#: Registered schema for the fenced association judgment. ``relation_label`` is
+#: judged and logged but not persisted: the Question note's ``evidence`` entry
+#: shape is owned by SQ-01's ``schemas/question-note.schema.json`` and this task
+#: does not widen it.
+EVIDENCE_ASSOCIATION_SCHEMA_REF = "standing_questions.evidence_association.v1"
+
+_EVIDENCE_ASSOCIATION_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "related": {"type": "boolean"},
+        "confidence_class": {"enum": [member.value for member in ConfidenceClass]},
+        "relation_label": {"type": ["string", "null"]},
+        "supporting_span": {"type": "string"},
+    },
+    "required": ["related", "confidence_class", "supporting_span"],
+}
+
+register_schema(EVIDENCE_ASSOCIATION_SCHEMA_REF, _EVIDENCE_ASSOCIATION_SCHEMA)
+
+_SYSTEM_PROMPT = (
+    "You judge whether one artifact is evidence bearing on one open question. "
+    "You see only the question and the artifact; judge nothing else and assume "
+    "nothing about their origin. Return ONLY a JSON object, no commentary:\n"
+    '{"related": <true|false>, "confidence_class": "<low|medium|high>", '
+    '"relation_label": "<short phrase or null>", "supporting_span": "<verbatim '
+    'quote from the artifact, or empty string>"}\n\n'
+    "Rules:\n"
+    "- supporting_span must be copied verbatim from the artifact text. Never "
+    "paraphrase, translate, summarise, or repair it; a span that is not present "
+    "byte-for-byte in the artifact is rejected and the artifact is not linked.\n"
+    "- related: true only when the artifact bears on answering this question, "
+    "not merely when it shares vocabulary with it.\n"
+    "- confidence_class states your uncertainty about that judgment: high only "
+    "when the span itself makes the bearing plain."
+)
+
+
+@dataclass(frozen=True)
+class CandidateArtifact:
+    """One artifact from an existing ingest path, offered for matching.
+
+    This task adds no acquisition source: callers are the existing consumers
+    (Heimdal observation-log cursor, ``knowledge_acquisition.stage.completed``,
+    ``ingest.vault.changed`` / ``ingest.object.created``) and supply what they
+    already hold.
+
+    ``content`` is optional. A ``vault://`` ref is resolved read-only against the
+    vault root when content is not supplied inline; any other ref scheme must
+    carry its content, because this module has no other read path and will never
+    invent one.
+    """
+
+    artifact_ref: str
+    source_stream: str
+    scope: str
+    provenance_ref: str
+    content: str | None = None
+
+
+@dataclass(frozen=True)
+class EvidenceAssociation:
+    """A validated association judgment. Carries no authority by itself."""
+
+    related: bool
+    confidence_class: ConfidenceClass
+    supporting_span: str
+    relation_label: str | None = None
+
+    def clears_threshold(self) -> bool:
+        return (
+            CONFIDENCE_CLASS_RANK[self.confidence_class]
+            >= CONFIDENCE_CLASS_RANK[EVIDENCE_ATTACH_CONFIDENCE_FLOOR]
+        )
+
+
+@dataclass(frozen=True)
+class MatchTickSummary:
+    """Legible outcome counts for one matching tick.
+
+    Every pair the tick saw lands in exactly one bucket, so a link that did not
+    attach always has a named reason rather than disappearing silently.
+    """
+
+    evaluated_pairs: int = 0
+    attached: int = 0
+    unrelated: int = 0
+    below_threshold: int = 0
+    unverifiable_span: int = 0
+    duplicate_basis: int = 0
+    degraded: int = 0
+    excluded_cross_scope: int = 0
+    excluded_non_open: int = 0
+    unresolved_artifact: int = 0
+
+
+@dataclass
+class _Counters:
+    counts: dict[str, int] = field(default_factory=dict)
+
+    def bump(self, name: str, amount: int = 1) -> None:
+        self.counts[name] = self.counts.get(name, 0) + amount
+
+    def summary(self) -> MatchTickSummary:
+        return MatchTickSummary(**self.counts)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _open_questions(vault_root: Path, counters: _Counters) -> list[dict[str, Any]]:
+    """Return every ``open`` Question note, counting the terminal ones skipped.
+
+    A missing ``questions/`` directory is an empty tick rather than an error:
+    matching is a read-only consumer, so the projection's fail-loud posture — which
+    exists to stop a TRUNCATE from wiping a live projection — has nothing to protect
+    here.
+    """
+    try:
+        notes = iter_question_notes(vault_root)
+    except QuestionsDirectoryMissingError:
+        return []
+    open_notes: list[dict[str, Any]] = []
+    for _source_path, note in notes:
+        if note["status"] == "open":
+            open_notes.append(note)
+        else:
+            # INV-SQ-F: answered/closed are terminal for the engine. Only a human
+            # editing status back to `open` resumes matching.
+            counters.bump("excluded_non_open")
+    return open_notes
+
+
+def _resolve_content(vault_root: Path, candidate: CandidateArtifact) -> str | None:
+    """Read the artifact's text. Read-only by construction — there is no write path.
+
+    Returns ``None`` when the artifact cannot be resolved (for example a note
+    deleted between the ingest event and this tick), which yields no link.
+    """
+    if candidate.content is not None:
+        return candidate.content
+    if not candidate.artifact_ref.startswith(VAULT_REF_PREFIX):
+        _LOGGER.warning(
+            "Standing Questions matching cannot resolve artifact ref without inline content: %s",
+            candidate.artifact_ref,
+        )
+        return None
+    relative = candidate.artifact_ref[len(VAULT_REF_PREFIX) :]
+    path = (vault_root / relative).resolve()
+    if not path.is_relative_to(vault_root) or not path.is_file():
+        _LOGGER.warning(
+            "Standing Questions matching skipped unresolvable artifact: %s",
+            candidate.artifact_ref,
+        )
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _build_user_prompt(question_text: str, artifact_text: str) -> str:
+    """Fence the completion: the model sees the question and the artifact, nothing else.
+
+    No question id, scope, status, existing evidence, or sibling artifact is ever
+    included, so the judgment cannot be steered by state the model has no business
+    reasoning about.
+    """
+    return (
+        f"Open question:\n{question_text.strip()}\n\n"
+        f"Artifact text:\n{artifact_text.strip()}"
+    )
+
+
+def judge_association(
+    *,
+    question_text: str,
+    artifact_text: str,
+    complete: CompletionFn | None = None,
+    trace_id: str | None = None,
+) -> EvidenceAssociation | None:
+    """Run the fenced association judgment, or return ``None`` when degraded.
+
+    ``None`` is this task's ``UNKNOWN``: a provider failure or any completion that
+    does not validate against :data:`EVIDENCE_ASSOCIATION_SCHEMA_REF` yields no
+    judgment at all, which the caller can only turn into "no link".
+    """
+    try:
+        payload = constrained_completion(
+            EVIDENCE_ASSOCIATION_SCHEMA_REF,
+            system=_SYSTEM_PROMPT,
+            user=_build_user_prompt(question_text, artifact_text),
+            task_kind="decide",
+            trace_id=trace_id,
+            complete=complete,
+        )
+    except ConstrainedCompletionError as exc:
+        # Fail-loud observability: without this a backend outage is
+        # indistinguishable from "nothing matched today".
+        _LOGGER.warning(
+            "evidence association degraded to no-link (schema_ref=%s trace_id=%s): %s",
+            EVIDENCE_ASSOCIATION_SCHEMA_REF,
+            trace_id or "-",
+            exc.reason,
+        )
+        return None
+    relation_label = payload.get("relation_label")
+    return EvidenceAssociation(
+        related=bool(payload["related"]),
+        confidence_class=ConfidenceClass(payload["confidence_class"]),
+        supporting_span=payload["supporting_span"],
+        relation_label=relation_label if isinstance(relation_label, str) else None,
+    )
+
+
+def _existing_bases(note: dict[str, Any]) -> set[tuple[str, str]]:
+    return {
+        (entry["artifact_ref"], entry["quoted_span"]) for entry in note.get("evidence", [])
+    }
+
+
+def match_evidence_to_open_questions(
+    *,
+    vault_root: Path | str,
+    candidates: Iterable[CandidateArtifact],
+    store: QuestionStore | None = None,
+    complete: CompletionFn | None = None,
+    trace_id: str | None = None,
+) -> MatchTickSummary:
+    """Run one matching tick over ``candidates`` and return its outcome counts.
+
+    This is the production entrypoint every acceptance test asserts against. It
+    reads Question notes and artifacts, and writes **only** to the question side
+    through the SQ-01 guarded seam.
+    """
+    resolved_root = Path(vault_root).expanduser().resolve()
+    question_store = store if store is not None else QuestionStore(resolved_root)
+    candidate_list: Sequence[CandidateArtifact] = list(candidates)
+    counters = _Counters()
+
+    for note in _open_questions(resolved_root, counters):
+        question_id = note["question_id"]
+        seen_bases = _existing_bases(note)
+        new_entries: list[dict[str, Any]] = []
+
+        for candidate in candidate_list:
+            # Scope first, before any content is resolved: a cross-scope artifact's
+            # text must never be read, prompted, or logged (content-free denial).
+            if candidate.scope != note["scope"]:
+                counters.bump("excluded_cross_scope")
+                continue
+            artifact_text = _resolve_content(resolved_root, candidate)
+            if artifact_text is None:
+                counters.bump("unresolved_artifact")
+                continue
+
+            counters.bump("evaluated_pairs")
+            association = judge_association(
+                question_text=note["text"],
+                artifact_text=artifact_text,
+                complete=complete,
+                trace_id=trace_id,
+            )
+            if association is None:
+                counters.bump("degraded")
+                continue
+            if not association.related:
+                counters.bump("unrelated")
+                continue
+            # The deterministic gate (RQ-SQ2). The model's judgment alone never
+            # attaches anything.
+            if not association.clears_threshold():
+                counters.bump("below_threshold")
+                continue
+            span = association.supporting_span
+            # Verbatim or nothing: a span the artifact does not actually contain
+            # would put a fabricated quote into a human-legible evidence trail.
+            if not span.strip() or span not in artifact_text:
+                counters.bump("unverifiable_span")
+                continue
+            basis = (candidate.artifact_ref, span)
+            # Idempotency fold key is (question_id, artifact_ref) narrowed by the
+            # quoted basis: re-ticking never duplicates an identical-basis entry,
+            # while a later pass carrying a materially different span still may add
+            # one.
+            if basis in seen_bases:
+                counters.bump("duplicate_basis")
+                continue
+            seen_bases.add(basis)
+            new_entries.append(
+                {
+                    "artifact_ref": candidate.artifact_ref,
+                    "source_stream": candidate.source_stream,
+                    "matched_at": _utc_now(),
+                    "confidence_class": association.confidence_class.value,
+                    "provenance_ref": candidate.provenance_ref,
+                    "quoted_span": span,
+                }
+            )
+
+        if not new_entries:
+            continue
+        # Re-read immediately before the guarded append: a human may have closed the
+        # question mid-tick, and a closed question must never be resurrected by a
+        # race (INV-SQ-F partial failure).
+        current = question_store.read_question(question_id)
+        if current["status"] != "open":
+            counters.bump("excluded_non_open")
+            continue
+        question_store.update_system_fields(
+            question_id,
+            {
+                "evidence": [*current["evidence"], *new_entries],
+                "last_matched_at": _utc_now(),
+            },
+        )
+        counters.bump("attached", len(new_entries))
+
+    return counters.summary()
+
+
+__all__ = [
+    "CONFIDENCE_CLASS_RANK",
+    "EVIDENCE_ASSOCIATION_SCHEMA_REF",
+    "EVIDENCE_ATTACH_CONFIDENCE_FLOOR",
+    "CandidateArtifact",
+    "ConfidenceClass",
+    "EvidenceAssociation",
+    "MatchTickSummary",
+    "judge_association",
+    "match_evidence_to_open_questions",
+    "VAULT_REF_PREFIX",
+]

--- a/docs/STANDING_QUESTIONS/README.md
+++ b/docs/STANDING_QUESTIONS/README.md
@@ -124,6 +124,9 @@ Episode Resolution Engine's own provisional-threshold discipline
   association's confidence class must clear to attach a link at all. Starting posture: conservative
   (under-attaching is preferred — a missed link can still be found by a later, stronger-evidence
   pass; a wrongly attached link pollutes the evidence trail a human must then mentally discount).
+  **Shipped as** `EVIDENCE_ATTACH_CONFIDENCE_FLOOR` in `app/standing_questions/evidence_matching.py`
+  — the single source for this threshold, currently `ConfidenceClass.HIGH`. It is **provisional**:
+  nothing else may hard-code an attach cutoff, and retuning it is a one-constant edit.
 
 Both are tuning research resolved after live data accumulates, exactly like RQ-E1/RQ3 in the Episode
 Resolution Engine — not a pre-code gate.

--- a/tests/standing_questions/test_evidence_matching.py
+++ b/tests/standing_questions/test_evidence_matching.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.standing_questions.evidence_matching import (
+    EVIDENCE_ASSOCIATION_SCHEMA_REF,
+    EVIDENCE_ATTACH_CONFIDENCE_FLOOR,
+    CandidateArtifact,
+    ConfidenceClass,
+    match_evidence_to_open_questions,
+)
+from app.standing_questions.question_store import (
+    QuestionStore,
+    parse_question_note,
+    serialize_question_note,
+)
+from app.write_guard import WriteGuard
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+QUESTION_TEXT = "How should the event outbox be sharded once a single writer saturates?"
+RELEVANT_BODY = (
+    "Outbox notes\n\n"
+    "We measured the single-writer ceiling at 1.2k events per second, so "
+    "sharding by aggregate id is the only option that keeps ordering per stream.\n"
+)
+RELEVANT_SPAN = "sharding by aggregate id is the only option that keeps ordering per stream"
+IRRELEVANT_BODY = "Grocery list\n\nOat milk, rye bread, and a new watering can for the balcony.\n"
+CROSS_SCOPE_MARKER = "balcony-irrigation-schedule-for-the-personal-scope"
+
+
+def _store(vault: Path) -> QuestionStore:
+    return QuestionStore(vault, write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}))
+
+
+def _write_artifact(vault: Path, relative_path: str, body: str) -> str:
+    path = vault / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return f"vault://{relative_path}"
+
+
+def _candidate(artifact_ref: str, *, scope: str = "work") -> CandidateArtifact:
+    return CandidateArtifact(
+        artifact_ref=artifact_ref,
+        source_stream="ingest.vault.changed",
+        scope=scope,
+        provenance_ref=f"outbox://ingest.vault.changed/{artifact_ref}",
+    )
+
+
+class _Association:
+    """Deterministic stand-in for the provider side of ``constrained_completion``.
+
+    Records every prompt it is asked to complete so a test can assert that a
+    filtered-out pair never reached the model at all.
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        # Keyed by a substring of the artifact content; the value is either a
+        # payload dict, a raw string, or an exception instance to raise.
+        self._responses = responses
+        self.prompts: list[str] = []
+
+    def __call__(
+        self,
+        *,
+        system: str,
+        user: str,
+        trace_id: str | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        self.prompts.append(user)
+        for marker, response in self._responses.items():
+            if marker in user:
+                if isinstance(response, Exception):
+                    raise response
+                if isinstance(response, str):
+                    return response
+                return json.dumps(response)
+        return json.dumps({"related": False, "confidence_class": "low", "supporting_span": ""})
+
+
+def _attached(span: str = RELEVANT_SPAN, confidence: str = "high") -> dict[str, Any]:
+    return {
+        "related": True,
+        "confidence_class": confidence,
+        "relation_label": "measures the ceiling this question is about",
+        "supporting_span": span,
+    }
+
+
+def _hash_tree(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_relevant_artifact_attaches_irrelevant_does_not(tmp_path: Path) -> None:
+    """AC1: a relevant fixture attaches with provenance and a verbatim span; an
+    irrelevant one does not."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+    irrelevant_ref = _write_artifact(vault, "notes/groceries.md", IRRELEVANT_BODY)
+    association = _Association({"single-writer ceiling": _attached()})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref), _candidate(irrelevant_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.evaluated_pairs == 2
+    assert summary.attached == 1
+    assert summary.unrelated == 1
+
+    evidence = store.read_question(note["question_id"])["evidence"]
+    assert len(evidence) == 1
+    entry = evidence[0]
+    assert entry["artifact_ref"] == relevant_ref
+    assert entry["source_stream"] == "ingest.vault.changed"
+    assert entry["provenance_ref"] == f"outbox://ingest.vault.changed/{relevant_ref}"
+    assert entry["confidence_class"] == ConfidenceClass.HIGH.value
+    # Verbatim, never paraphrased: the stored span must occur in the artifact byte-for-byte.
+    assert entry["quoted_span"] == RELEVANT_SPAN
+    assert entry["quoted_span"] in (vault / "notes/outbox-measurements.md").read_text(
+        encoding="utf-8"
+    )
+    assert entry["matched_at"].endswith("Z")
+
+
+def test_cross_scope_artifact_excluded_content_free(tmp_path: Path) -> None:
+    """AC2: a same-content, different-scope artifact is excluded before any content
+    is read or shown to the model."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+
+    foreign_ref = _write_artifact(
+        vault,
+        "notes/personal-outbox-measurements.md",
+        RELEVANT_BODY + CROSS_SCOPE_MARKER + "\n",
+    )
+    # A judgment that would attach if the pair were ever evaluated at all.
+    association = _Association({"single-writer ceiling": _attached()})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(foreign_ref, scope="personal")],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.excluded_cross_scope == 1
+    assert summary.evaluated_pairs == 0
+    assert summary.attached == 0
+    assert store.read_question(note["question_id"])["evidence"] == []
+    # Content-free denial: no prompt was built, so no span of the other scope's
+    # artifact could leak into the association call.
+    assert association.prompts == []
+
+
+def test_matching_never_writes_to_source_artifact(tmp_path: Path) -> None:
+    """AC3 (enforcement): no code path of the production matching entrypoint mutates a
+    source artifact -- attach, below-threshold, degraded, and cross-scope alike."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+
+    attaching_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+    below_ref = _write_artifact(vault, "notes/weak-signal.md", "A weak signal about outboxes.\n")
+    degraded_ref = _write_artifact(vault, "notes/degraded.md", "A backend outage artifact.\n")
+    foreign_ref = _write_artifact(vault, "notes/other-scope.md", RELEVANT_BODY)
+
+    association = _Association(
+        {
+            "single-writer ceiling": _attached(),
+            "weak signal": _attached(span="A weak signal about outboxes", confidence="medium"),
+            "backend outage": RuntimeError("association backend unavailable"),
+        }
+    )
+
+    artifacts_root = vault / "notes"
+    before = _hash_tree(artifacts_root)
+    question_before = (vault / "questions" / f"{note['question_id']}.md").read_bytes()
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[
+            _candidate(attaching_ref),
+            _candidate(below_ref),
+            _candidate(degraded_ref),
+            _candidate(foreign_ref, scope="personal"),
+        ],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.attached == 1
+    assert summary.below_threshold == 1
+    assert summary.degraded == 1
+    assert summary.excluded_cross_scope == 1
+    # The question side gained state; the evidence side is byte-identical.
+    assert (vault / "questions" / f"{note['question_id']}.md").read_bytes() != question_before
+    assert _hash_tree(artifacts_root) == before
+
+
+def test_below_threshold_judgment_does_not_attach(tmp_path: Path) -> None:
+    """AC4: `related: true` under the RQ-SQ2 floor does not attach, and the floor is a
+    single named constant documented as provisional."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+
+    association = _Association({"single-writer ceiling": _attached(confidence="medium")})
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.below_threshold == 1
+    assert summary.attached == 0
+    assert store.read_question(note["question_id"])["evidence"] == []
+    assert EVIDENCE_ATTACH_CONFIDENCE_FLOOR is ConfidenceClass.HIGH
+
+    # Doc writeback (AC4, non-behavioral half): the provisional-threshold section names
+    # the single-sourced constant, so the doc and the code cannot drift apart silently.
+    readme = (REPO_ROOT / "docs/STANDING_QUESTIONS/README.md").read_text(encoding="utf-8")
+    section = readme.split("## Provisional thresholds (RQ-SQ1, RQ-SQ2)")[1].split("\n## ")[0]
+    assert "EVIDENCE_ATTACH_CONFIDENCE_FLOOR" in section
+    assert "app/standing_questions/evidence_matching.py" in section
+    assert "provisional" in section.lower()
+
+
+def test_degraded_association_never_fabricates_link(tmp_path: Path) -> None:
+    """AC5: a provider failure or a schema-invalid completion yields no link."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+
+    outage_ref = _write_artifact(vault, "notes/outage.md", "A backend outage artifact.\n")
+    invalid_ref = _write_artifact(vault, "notes/invalid.md", "A schema violation artifact.\n")
+    prose_ref = _write_artifact(vault, "notes/prose.md", "A prose wrapped artifact.\n")
+
+    association = _Association(
+        {
+            "backend outage": RuntimeError("association backend unavailable"),
+            # `related` missing entirely: validates against nothing the gate may act on.
+            "schema violation": {"confidence_class": "high", "supporting_span": "whatever"},
+            "prose wrapped": 'Sure! Here is the JSON: {"related": true, '
+            '"confidence_class": "high", "supporting_span": "prose"}',
+        }
+    )
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(outage_ref), _candidate(invalid_ref), _candidate(prose_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.degraded == 3
+    assert summary.attached == 0
+    assert store.read_question(note["question_id"])["evidence"] == []
+
+
+def test_matching_never_attaches_an_unquotable_span(tmp_path: Path) -> None:
+    """A high-confidence judgment whose span is not verbatim in the artifact is refused
+    rather than stored as a paraphrase (CitationChecker discipline)."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+
+    association = _Association(
+        {"single-writer ceiling": _attached(span="they decided to shard by tenant id")}
+    )
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.unverifiable_span == 1
+    assert summary.attached == 0
+    assert store.read_question(note["question_id"])["evidence"] == []
+
+
+def test_matching_idempotent_per_pair(tmp_path: Path) -> None:
+    """AC6: re-ticking the same (question_id, artifact_ref) basis never duplicates."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+    association = _Association({"single-writer ceiling": _attached()})
+
+    first = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+    note_after_first = (vault / "questions" / f"{note['question_id']}.md").read_bytes()
+    second = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert first.attached == 1
+    assert second.attached == 0
+    assert second.duplicate_basis == 1
+    assert len(store.read_question(note["question_id"])["evidence"]) == 1
+    # No write at all on the idempotent re-tick.
+    assert (vault / "questions" / f"{note['question_id']}.md").read_bytes() == note_after_first
+
+
+def test_matching_skips_non_open_questions(tmp_path: Path) -> None:
+    """AC7 (INV-SQ-F): `answered`/`closed` are terminal for the engine."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    note_path = vault / "questions" / f"{note['question_id']}.md"
+    # `status` is human-owned, so the human-side transition is written directly, not
+    # through the engine seam (which refuses it).
+    human_edited = {**parse_question_note(note_path.read_text(encoding="utf-8")), "status": "answered"}
+    note_path.write_text(serialize_question_note(human_edited), encoding="utf-8")
+    before = note_path.read_bytes()
+
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+    association = _Association({"single-writer ceiling": _attached()})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.excluded_non_open == 1
+    assert summary.evaluated_pairs == 0
+    assert summary.attached == 0
+    assert association.prompts == []
+    assert note_path.read_bytes() == before
+    assert store.read_question(note["question_id"])["evidence"] == []
+
+
+def test_question_closed_mid_tick_is_never_resurrected(tmp_path: Path) -> None:
+    """INV-SQ-F partial failure: the write path re-checks status immediately before the
+    guarded append and drops the write if the human closed the question mid-tick."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    note_path = vault / "questions" / f"{note['question_id']}.md"
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+
+    def close_then_answer(
+        *,
+        system: str,
+        user: str,
+        trace_id: str | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        current = parse_question_note(note_path.read_text(encoding="utf-8"))
+        note_path.write_text(
+            serialize_question_note({**current, "status": "closed"}), encoding="utf-8"
+        )
+        return json.dumps(_attached())
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=close_then_answer,
+    )
+
+    assert summary.attached == 0
+    assert summary.excluded_non_open == 1
+    assert store.read_question(note["question_id"])["evidence"] == []
+
+
+def test_missing_questions_directory_is_a_no_op_tick(tmp_path: Path) -> None:
+    """A vault that never registered a question yields an empty tick, not a crash --
+    matching is a read-only consumer, so the projection's fail-loud posture (which
+    exists to prevent a TRUNCATE wipe) does not apply here."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    association = _Association({})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate("vault://notes/anything.md")],
+        complete=association,
+    )
+
+    assert summary.evaluated_pairs == 0
+    assert summary.attached == 0
+    assert association.prompts == []
+
+
+def test_association_schema_is_registered_and_rejects_unknown_confidence() -> None:
+    """The association contract is a registered, named schema; the model may not invent
+    a confidence class the deterministic gate does not rank."""
+    from app.components.llm.constrained import ConstrainedCompletionError, validate_payload
+
+    with pytest.raises(ConstrainedCompletionError):
+        validate_payload(
+            EVIDENCE_ASSOCIATION_SCHEMA_REF,
+            {"related": True, "confidence_class": "certain", "supporting_span": "x"},
+        )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #3326

## Linked Issue
Closes #3326

## SBS Impact
- Primary subsystem: CAO (evidence-association cognition)
- Secondary subsystem(s): SIP (provenance/evidence linking), HKA (writes into the Question note's evidence field), DRI (projection updates)
- Write class: proposal-adjacent mechanical (append-only evidence-log entries, no authority)
- Persistence impact: appends to the Question note's existing system-owned `evidence` field (SQ-01 schema, unchanged); no new note class
- Derived/rebuildable impact: evidence entries mirror into the existing `standing_questions` projection and rebuild from vault; nothing new is derived-only
- New or changed contract: new registered association schema `standing_questions.evidence_association.v1`; the Question-note schema is unchanged
- Owner-doc impact: `docs/STANDING_QUESTIONS/README.md :: Provisional thresholds (RQ-SQ1, RQ-SQ2)` now names the shipped RQ-SQ2 constant and its single source; updated in this PR
- Transition debt impact: reduces
- Boundary risk: none new -- no new egress and no new acquisition source; the association call reuses the existing constrained-completion seam and the write reuses SQ-01's guarded store. Authority impact is none: an evidence link is a tracked candidate relation, not a claim of truth, and the source artifact is read-only on every code path.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds the SQ-03 matching tick: artifacts from the existing ingest paths are checked against every open Question note, and a qualifying match appends a provenance-cited evidence entry to the note's system-owned evidence log through the SQ-01 guarded seam. The source artifact is never written to on any code path.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Normal bounded slice delivery with no plan divergence; no LearningSignal, receipt, or projection was produced.

## Notes
Tier 2 implementation slice, light delivery path (Final-Review-Rounds: 0). No TCD high-risk surface: no auth, migration, concurrency, credential-durability, payments, or new external egress -- the association call reuses the existing constrained-completion seam and the write reuses SQ-01's already-guarded store.

Validation actually run (local, on this branch):
- `ruff check app tests` -> All checks passed!
- `mypy app` -> Success: no issues found in 867 source files
- `pytest -q tests/standing_questions/` -> 140 passed (includes all 7 `Verify:` targets plus 4 added edge/enforcement tests)
- `pytest -q -m "not pg"`, host-leased, twice. Serial run: 12423 passed, 1 failed (`tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity`). Parallel run on the publishable SHA (`-n auto --dist=loadfile`, execution id `3326:abd0514e8`): 12423 passed, 3 failed (`tests/architecture/test_settings_single_location.py::test_no_new_settings_paths`, `tests/test_hybrid_search.py::test_hybrid_search_ranks_expected_doc`, `tests/retrieval/test_context_dimension_threading.py::test_scope_flows_through_retrieval_unchanged`). The two failure sets are disjoint and every named test passes in isolation, which is order/worker-dependence rather than a regression: this diff adds two new files that nothing outside `tests/standing_questions/` imports, plus one docs line, so it cannot statically reach BuilderOps CKM, settings-path scanning, hybrid search, or retrieval scope threading. CI is the authority on the shared suite.

Enforcement proof: every guard in the matching tick was mutation-checked -- removing the threshold gate, the scope prefilter, the verbatim-span check, the open-only filter, the idempotency fold key, the degraded-yields-no-link branch, or the pre-write status re-check each turns at least one test red.

`scripts/docs_guard.py` reports its temporal-owner-doc rule for this diff; that rule is scoped in CI to governance/docs-only PRs (`ci-smoke.yaml`, `heavy_smoke != 'true'`) and does not apply to an ordinary runtime PR.
