### PR TITLE
Require linked successor artifacts on terminal LearningSignal dispositions

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -2831,6 +2831,15 @@ def release_lease(
 @click.option("--receipt-body", required=True)
 @click.option("--lifecycle-state", default=None)
 @click.option("--promotion-status", default=None)
+@click.option(
+    "--successor-ref",
+    multiple=True,
+    help=(
+        "JSON ref or shorthand ref_type:ref naming the successor artifact "
+        "(github_issue, github_pr, or promotion_intent). Required when a "
+        "LearningSignal transitions to superseded or discarded."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True)
 @click.pass_context
 def transition(
@@ -2845,6 +2854,7 @@ def transition(
     receipt_body: str,
     lifecycle_state: str | None,
     promotion_status: str | None,
+    successor_ref: tuple[str, ...],
     as_json: bool,
 ) -> None:
     try:
@@ -2859,6 +2869,7 @@ def transition(
             receipt_body=receipt_body,
             lifecycle_state=lifecycle_state,
             promotion_status=promotion_status,
+            successor_refs=_parse_refs(successor_ref) if successor_ref else None,
         )
     except BuilderOpsValidationError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/app/builderops/completeness_report.py
+++ b/app/builderops/completeness_report.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from app.builderops.epic_run_state import TERMINAL_LEARNING_EVALUATION_OUTCOMES
+from app.builderops.models import (
+    SUCCESSOR_REF_TYPES,
+    TERMINAL_SIGNAL_LIFECYCLE_STATES,
+)
 from app.builderops.store import SqliteBuilderOpsStore
 
 RETROSPECTIVE_EVENT_TYPE = "learning_retrospective"
@@ -33,6 +37,7 @@ def build_completeness_report(
             "complete": False,
             "unprocessed_learning_signals": [],
             "retrospective_receipts_missing_terminal_outcomes": [],
+            "terminal_signals_missing_successor_refs": [],
             "reevaluation_candidates_without_outcome": [],
             "stale_compatibility_entries": [],
             "receipt_body": "Completeness report unavailable: BuilderOps storage unavailable.",
@@ -67,6 +72,11 @@ def build_completeness_report(
         receipt for receipt in receipt_reports
         if receipt["missing_terminal_outcomes"]
     ]
+    missing_successors = [
+        _terminal_signal_summary(signal)
+        for signal in learning_signals
+        if _terminal_signal_missing_successor(signal)
+    ]
     unresolved_candidates = [
         _candidate_summary(candidate)
         for candidate in (reevaluation_candidates or [])
@@ -76,6 +86,7 @@ def build_completeness_report(
     complete = not (
         unprocessed
         or missing_terminal
+        or missing_successors
         or unresolved_candidates
         or stale_entries
         or not storage_state.get("available", False)
@@ -89,6 +100,7 @@ def build_completeness_report(
         "last_retrospective_receipt": _last_receipt_summary(retrospective_receipts),
         "unprocessed_learning_signals": unprocessed,
         "retrospective_receipts_missing_terminal_outcomes": missing_terminal,
+        "terminal_signals_missing_successor_refs": missing_successors,
         "reevaluation_candidates_without_outcome": unresolved_candidates,
         "stale_compatibility_entries": stale_entries,
         "terminal_outcomes": list(TERMINAL_LEARNING_EVALUATION_OUTCOMES),
@@ -96,6 +108,7 @@ def build_completeness_report(
             storage_state=storage_state,
             unprocessed=unprocessed,
             missing_terminal=missing_terminal,
+            missing_successors=missing_successors,
             unresolved_candidates=unresolved_candidates,
             stale_entries=stale_entries,
         ),
@@ -195,6 +208,24 @@ def _signal_summary(signal: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _terminal_signal_missing_successor(signal: Mapping[str, Any]) -> bool:
+    if signal.get("lifecycle_state") not in TERMINAL_SIGNAL_LIFECYCLE_STATES:
+        return False
+    successors = signal.get("successor_refs")
+    if not isinstance(successors, list) or not successors:
+        return True
+    return not any(
+        isinstance(ref, Mapping) and ref.get("ref_type") in SUCCESSOR_REF_TYPES
+        for ref in successors
+    )
+
+
+def _terminal_signal_summary(signal: Mapping[str, Any]) -> dict[str, Any]:
+    summary = _signal_summary(signal)
+    summary["lifecycle_state"] = signal.get("lifecycle_state")
+    return summary
+
+
 def _candidate_summary(candidate: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "id": candidate.get("id") or candidate.get("candidate_id"),
@@ -238,6 +269,7 @@ def _receipt_body(
     storage_state: Mapping[str, Any],
     unprocessed: list[dict[str, Any]],
     missing_terminal: list[dict[str, Any]],
+    missing_successors: list[dict[str, Any]],
     unresolved_candidates: list[dict[str, Any]],
     stale_entries: list[dict[str, Any]],
 ) -> str:
@@ -246,6 +278,7 @@ def _receipt_body(
     incomplete = (
         unprocessed
         or missing_terminal
+        or missing_successors
         or unresolved_candidates
         or stale_entries
     )
@@ -254,6 +287,7 @@ def _receipt_body(
         f"Completeness report {posture}: "
         f"unprocessed_learning_signals={len(unprocessed)}, "
         f"receipts_missing_terminal_outcomes={len(missing_terminal)}, "
+        f"terminal_signals_missing_successor_refs={len(missing_successors)}, "
         f"reevaluation_candidates_without_outcome={len(unresolved_candidates)}, "
         f"stale_compatibility_entries={len(stale_entries)}."
     )

--- a/app/builderops/models.py
+++ b/app/builderops/models.py
@@ -336,8 +336,16 @@ SOURCE_REF_LIST_FIELDS = frozenset({
     "last_verified_against",
     "shipped_refs",
     "source_refs",
+    "successor_refs",
     "target_refs",
 })
+
+# Terminal LearningSignal dispositions must name the artifact that enacted or
+# explicitly declined the divergence (issue #4267): a bare `superseded` or
+# `discarded` status transition with no linked successor artifact reads as
+# "handled" while the underlying defect stays unrepaired.
+TERMINAL_SIGNAL_LIFECYCLE_STATES = frozenset({"discarded", "superseded"})
+SUCCESSOR_REF_TYPES = frozenset({"github_issue", "github_pr", "promotion_intent"})
 
 
 class BuilderOpsValidationError(ValueError):
@@ -444,4 +452,38 @@ def normalize_record(record: Mapping[str, Any]) -> JsonDict:
         if field not in SOURCE_REF_LIST_FIELDS:
             validate_nonempty_list(data[field], field)
     validate_source_refs(data["source_refs"])
+    validate_terminal_signal_successor(data)
     return data
+
+
+def validate_terminal_signal_successor(record: Mapping[str, Any]) -> None:
+    """Require a linked successor artifact on terminal LearningSignal dispositions.
+
+    A `LearningSignal` reaching `superseded` or `discarded` must name, in
+    `successor_refs`, at least one Issue, PR, or PromotionIntent
+    (`ref_type` in ``SUCCESSOR_REF_TYPES``) that actually enacted or explicitly
+    declined the divergence. Enforced per
+    `docs/architecture/SBS_OPERATING_MODEL.md :: Builder Learning, Evaluation,
+    And TCD Governance Loop` (issue #4267).
+    """
+
+    if record.get("object_type") != "LearningSignal":
+        return
+    if record.get("lifecycle_state") not in TERMINAL_SIGNAL_LIFECYCLE_STATES:
+        return
+    successors = record.get("successor_refs")
+    if not isinstance(successors, list) or not successors:
+        raise BuilderOpsValidationError(
+            "LearningSignal terminal disposition "
+            f"'{record.get('lifecycle_state')}' requires successor_refs naming "
+            "the Issue, PR, or PromotionIntent that enacted or explicitly "
+            "declined the divergence"
+        )
+    validate_source_refs(successors, "successor_refs")
+    if not any(ref.get("ref_type") in SUCCESSOR_REF_TYPES for ref in successors):
+        allowed = ", ".join(sorted(SUCCESSOR_REF_TYPES))
+        raise BuilderOpsValidationError(
+            "LearningSignal terminal disposition "
+            f"'{record.get('lifecycle_state')}' requires at least one "
+            f"successor_refs entry with ref_type in: {allowed}"
+        )

--- a/app/builderops/store.py
+++ b/app/builderops/store.py
@@ -292,6 +292,7 @@ class SqliteBuilderOpsStore:
         receipt_body: str,
         lifecycle_state: str | None = None,
         promotion_status: str | None = None,
+        successor_refs: list[dict[str, Any]] | None = None,
         receipt_extra: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         if lifecycle_state is None and promotion_status is None:
@@ -304,6 +305,8 @@ class SqliteBuilderOpsStore:
         if not lease_id:
             raise BuilderOpsValidationError("lease_id must not be empty")
         validate_source_refs(source_refs)
+        if successor_refs is not None:
+            validate_source_refs(successor_refs, "successor_refs")
         actor_ref = normalize_actor(actor)
         request = {
             "operation": "transition_record_state",
@@ -317,6 +320,7 @@ class SqliteBuilderOpsStore:
             "receipt_body": receipt_body,
             "lifecycle_state": lifecycle_state,
             "promotion_status": promotion_status,
+            "successor_refs": successor_refs,
             "receipt_extra": dict(receipt_extra or {}),
         }
         request_hash = _request_hash(request)
@@ -352,6 +356,12 @@ class SqliteBuilderOpsStore:
                 updated["lifecycle_state"] = lifecycle_state
             if promotion_status is not None:
                 updated["promotion_status"] = promotion_status
+            if successor_refs is not None:
+                merged_successors = list(current.get("successor_refs", []))
+                for ref in successor_refs:
+                    if ref not in merged_successors:
+                        merged_successors.append(dict(ref))
+                updated["successor_refs"] = merged_successors
             new_state = {
                 "lifecycle_state": updated["lifecycle_state"],
                 "promotion_status": updated["promotion_status"],

--- a/docs/architecture/SBS_OPERATING_MODEL.md
+++ b/docs/architecture/SBS_OPERATING_MODEL.md
@@ -310,6 +310,22 @@ signal in scope must end as applied, already satisfied, issue created, promotion
 debt/fitness recorded, or discarded/superseded with a receipt. "Carry forward later" is not a
 terminal outcome unless represented by a bounded GitHub Issue or PromotionIntent.
 
+Terminal disposition linkage rule (#4267): a `LearningSignal` reaching a `superseded` or
+`discarded` terminal disposition must name, in its `successor_refs`, the linked successor artifact
+— the GitHub Issue, PR, or `PromotionIntent` — that actually enacted or explicitly declined the
+divergence. A bare status transition is not a terminal outcome: a signal marked handled without an
+enacting artifact creates false confidence that the divergence is tracked while the defect stays
+unrepaired (the 2026-06 `publish-pr` template gap re-derived from scratch by the #3927–#4162 audit
+and repaired only via #4187/#4192 is the motivating case). Another `LearningSignal` is not a valid
+successor — supersession by newer material still points at whatever artifact enacts or declines
+the repair. Mechanically enforced at the BuilderOps write path
+(`app/builderops/models.py::validate_terminal_signal_successor`, exercised by
+`app/builderops/store.py::transition_record_state`); legacy terminal records without a successor
+are machine-flaggable via the observe-only
+`python3 -m app.builderops builderops completeness-report check`
+(`terminal_signals_missing_successor_refs`). Verified by
+`tests/builderops/test_learning_signal_terminal_disposition.py`.
+
 Runtime/user memory contamination is a blocking failure mode. Failed prompts, quota/context failures,
 delivery receipts, BuilderOps records, TCD rationales, review comments, and skill retrospectives must
 not become HKA/MEM/user memory, runtime instructions, retrieval context, or product semantics unless

--- a/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
+++ b/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
@@ -347,10 +347,25 @@ a new owner-doc authority surface.
 
 The review repair loop connects blocking P0/P1 findings back to implementation.
 
+Severity-visible handoff (#4267): the handoff that starts this loop must make each finding's
+severity explicit to the implementing agent before repair starts, not leave it to the agent's own
+judgement. Concretely, the finding set handed to the implementing agent (packet, receipt, or
+message) must carry, per finding, the `severity` and `disposition` fields the gate already emits
+under `Outputs`; a handoff that strips or omits severity is malformed and must be regenerated
+before repair. The implementing agent's first act on receipt is to partition the findings by
+severity and repair only the P0/P1 subset. Fixing a P2 or P3 finding instead of applying its
+required disposition (defer-with-defect-evidence for P2, record-only for P3) is itself a defect in
+this loop: flag it — as a review finding on the repair receipt or a `LearningSignal` via
+`capture-learning` naming this contract — rather than letting it pass silently. This adds no
+review round and does not change the P2/P3 exclusion below; it makes the exclusion checkable at
+the moment of handoff.
+
 Required loop:
 
-1. Review gate emits blocking P0/P1 findings with actionable criteria.
-2. Implementation agent fixes only the scoped findings on the PR branch.
+1. Review gate emits blocking P0/P1 findings with actionable criteria, carrying each finding's
+   explicit severity and disposition into the handoff per the severity-visible handoff rule above.
+2. Implementation agent confirms the per-finding severities, then fixes only the scoped P0/P1
+   findings on the PR branch.
 3. Agent reruns the validation required by the issue and by the finding.
 4. Agent posts or records a repair receipt with changed files, validation
    evidence, and unresolved risk.

--- a/docs/development/DELIVERY_FEEDBACK_LOOP.md
+++ b/docs/development/DELIVERY_FEEDBACK_LOOP.md
@@ -197,7 +197,10 @@ terminal outcomes:
 - **debt_or_fitness_recorded** - a transition-debt row, fitness-rule backlog item, or rule update
   records the repeatable failure mode.
 - **discarded_or_superseded** - a `BuilderOpsReceipt` explains why the signal is obsolete, invalid,
-  or replaced by newer material.
+  or replaced by newer material, and the terminal `LearningSignal` names its linked successor
+  artifact (Issue/PR/PromotionIntent) in `successor_refs` per the terminal disposition linkage rule
+  in `docs/architecture/SBS_OPERATING_MODEL.md :: Builder Learning, Evaluation, And TCD Governance
+  Loop` (#4267).
 
 The closure receipt names the outcome for each processed signal. Proposal-only mode may still stop
 for human review, but once a pass is accepted for execution it must not leave claimed signals in an

--- a/tests/builderops/test_builderops_projections.py
+++ b/tests/builderops/test_builderops_projections.py
@@ -434,6 +434,7 @@ def test_learning_summary_keeps_terminal_learning_records(
         lifecycle_state="discarded",
         promotion_status="discarded",
         source_refs=[{"ref_type": "github_issue", "ref": "#4002"}],
+        successor_refs=[{"ref_type": "github_issue", "ref": "#4002"}],
         receipt_refs=["receipt_lrn_discarded_001"],
         created_by=_actor(),
     )
@@ -445,6 +446,7 @@ def test_learning_summary_keeps_terminal_learning_records(
         lifecycle_state="superseded",
         promotion_status="superseded",
         source_refs=[{"ref_type": "github_issue", "ref": "#4003"}],
+        successor_refs=[{"ref_type": "github_pr", "ref": "#4004"}],
         receipt_refs=["receipt_lrn_superseded_001"],
         created_by=_actor(),
     )
@@ -528,6 +530,7 @@ def test_write_projections_emits_expected_repo_markdown_files(
         lifecycle_state="discarded",
         promotion_status="discarded",
         source_refs=[{"ref_type": "github_issue", "ref": "#1506"}],
+        successor_refs=[{"ref_type": "github_issue", "ref": "#1506"}],
         receipt_refs=["receipt_lrn_projection_discarded_001"],
         created_by=_actor(),
     )
@@ -539,6 +542,7 @@ def test_write_projections_emits_expected_repo_markdown_files(
         lifecycle_state="superseded",
         promotion_status="superseded",
         source_refs=[{"ref_type": "github_issue", "ref": "#1507"}],
+        successor_refs=[{"ref_type": "github_pr", "ref": "#1519"}],
         receipt_refs=["receipt_lrn_projection_superseded_001"],
         created_by=_actor(),
     )

--- a/tests/builderops/test_learning_signal_terminal_disposition.py
+++ b/tests/builderops/test_learning_signal_terminal_disposition.py
@@ -1,0 +1,176 @@
+"""Terminal LearningSignal dispositions must name a linked successor artifact.
+
+Issue #4267: a `LearningSignal` marked `superseded` or `discarded` without a
+linked successor artifact (Issue, PR, or PromotionIntent) reads as "handled"
+while the underlying divergence stays unrepaired. These tests exercise the
+production write path (`SqliteBuilderOpsStore.transition_record_state` /
+`create_record`) rather than the validation helper in isolation, and the
+observe-only completeness report that flags legacy records.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.builderops.completeness_report import build_completeness_report
+from app.builderops.models import BuilderOpsValidationError
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+def _actor() -> dict[str, str]:
+    return {"actor_type": "agent", "id": "agent-4267"}
+
+
+def _source_ref(ref: str = "#4267") -> list[dict[str, str]]:
+    return [{"ref_type": "github_issue", "ref": ref, "authority_surface": "github"}]
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SqliteBuilderOpsStore:
+    s = SqliteBuilderOpsStore(tmp_path / "builderops.sqlite3")
+    s.initialize()
+    return s
+
+
+def _create_signal(store: SqliteBuilderOpsStore, signal_id: str) -> dict[str, object]:
+    return store.create_learning_signal(
+        id=signal_id,
+        summary="publish-pr templates omit the BuilderOps Routing section",
+        content="Templates in .codex/skills/publish-pr/SKILL.md fail pr-contract.",
+        signal_type="workflow_divergence",
+        idempotency_key=f"create:{signal_id}",
+        source_refs=_source_ref(),
+        created_by=_actor(),
+    )
+
+
+@pytest.mark.parametrize("terminal_state", ["superseded", "discarded"])
+def test_superseded_signal_requires_linked_successor_artifact(
+    store: SqliteBuilderOpsStore, terminal_state: str
+) -> None:
+    """The production transition path refuses a bare terminal disposition."""
+
+    signal = _create_signal(store, f"lrn_4267_{terminal_state}")
+    lease = store.acquire_lease(signal["id"], actor=_actor())
+
+    # Negative path: no successor artifact -> the transition fails loud and the
+    # record stays in its previous state.
+    with pytest.raises(BuilderOpsValidationError, match="successor_refs"):
+        store.transition_record_state(
+            signal["id"],
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key=f"transition:{signal['id']}:bare",
+            source_refs=_source_ref(),
+            summary="Mark signal handled",
+            action=terminal_state,
+            receipt_body="Bare status transition without a successor artifact.",
+            lifecycle_state=terminal_state,
+        )
+    unchanged = store.get_record(signal["id"])
+    assert unchanged is not None
+    assert unchanged["lifecycle_state"] == "active"
+
+    # Success path: the same transition with a successor artifact lands, and
+    # the record durably names what enacted the divergence.
+    result = store.transition_record_state(
+        signal["id"],
+        actor=_actor(),
+        lease_id=lease["lease_id"],
+        idempotency_key=f"transition:{signal['id']}:linked",
+        source_refs=_source_ref(),
+        summary="Mark signal handled with successor",
+        action=terminal_state,
+        receipt_body="Repair delivered by #4192 (fix for #4187).",
+        lifecycle_state=terminal_state,
+        successor_refs=[
+            {"ref_type": "github_pr", "ref": "#4192", "authority_surface": "github"},
+        ],
+    )
+    updated = result["record"]
+    assert updated["lifecycle_state"] == terminal_state
+    assert {"ref_type": "github_pr", "ref": "#4192", "authority_surface": "github"} in (
+        updated["successor_refs"]
+    )
+    persisted = store.get_record(signal["id"])
+    assert persisted is not None
+    assert persisted["successor_refs"] == updated["successor_refs"]
+
+
+def test_successor_refs_must_name_issue_pr_or_promotion_intent(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    """A successor pointing at another BuilderOps signal does not terminate one."""
+
+    signal = _create_signal(store, "lrn_4267_wrong_ref_type")
+    lease = store.acquire_lease(signal["id"], actor=_actor())
+
+    with pytest.raises(BuilderOpsValidationError, match="ref_type"):
+        store.transition_record_state(
+            signal["id"],
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key=f"transition:{signal['id']}:signal-ref",
+            source_refs=_source_ref(),
+            summary="Supersede with another signal",
+            action="superseded",
+            receipt_body="Replaced by a newer signal; no repair artifact linked.",
+            lifecycle_state="superseded",
+            successor_refs=[
+                {"ref_type": "builderops_object", "ref": "lrn_newer_signal"},
+            ],
+        )
+
+
+def test_signal_created_in_terminal_state_requires_successor(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    """Creation directly into a terminal state is held to the same contract."""
+
+    with pytest.raises(BuilderOpsValidationError, match="successor_refs"):
+        store.create_learning_signal(
+            id="lrn_4267_created_terminal",
+            summary="Pre-superseded signal",
+            content="Should not be creatable without a successor artifact.",
+            signal_type="workflow_divergence",
+            lifecycle_state="superseded",
+            idempotency_key="create:lrn_4267_created_terminal",
+            source_refs=_source_ref(),
+            created_by=_actor(),
+        )
+
+
+def test_completeness_report_flags_legacy_terminal_signal_without_successor() -> None:
+    """Legacy terminal records without a successor are machine-flaggable."""
+
+    legacy = {
+        "id": "lrn_20260602_legacy",
+        "object_type": "LearningSignal",
+        "lifecycle_state": "superseded",
+        "created_at": "2026-06-02T00:00:00Z",
+        "summary": "publish-pr templates omit BuilderOps Routing",
+        "signal_type": "workflow_divergence",
+    }
+    linked = {
+        "id": "lrn_20260602_linked",
+        "object_type": "LearningSignal",
+        "lifecycle_state": "superseded",
+        "created_at": "2026-06-02T00:00:00Z",
+        "summary": "Signal with linked successor",
+        "signal_type": "workflow_divergence",
+        "successor_refs": [
+            {"ref_type": "github_issue", "ref": "#4187"},
+        ],
+    }
+    report = build_completeness_report(
+        records=[legacy, linked],
+        storage={"available": True, "source": "fixture"},
+    )
+
+    flagged = report["terminal_signals_missing_successor_refs"]
+    assert [entry["id"] for entry in flagged] == ["lrn_20260602_legacy"]
+    assert flagged[0]["lifecycle_state"] == "superseded"
+    assert report["complete"] is False
+    assert "terminal_signals_missing_successor_refs=1" in report["receipt_body"]


### PR DESCRIPTION
Governing-Issue: #4267

Fixes #4267

Final-Review-Rounds: 0

## Summary
Closes the gap between a `LearningSignal` marked `superseded`/`discarded` and the divergence actually being repaired. The BuilderOps write path (`normalize_record`, enforced through `create_record` and `transition_record_state`) now refuses a LearningSignal reaching a terminal disposition unless `successor_refs` names at least one `github_issue`, `github_pr`, or `promotion_intent` ref — the artifact that enacted or explicitly declined the divergence. The CLI `transition` command gains `--successor-ref`. Legacy terminal rows stay readable (reads are non-normalizing) and are machine-flaggable via the observe-only `completeness-report check` (`terminal_signals_missing_successor_refs`). The Review Repair Loop gains the severity-visible handoff: per-finding `severity`/`disposition` must reach the implementing agent, only the P0/P1 subset is repaired, and fixing a P2/P3 instead of applying its disposition is itself a defect to flag — no new review round, P2/P3 exclusion unchanged.

## Verify targets (issue #4267 ACs)
- AC1: `docs/architecture/SBS_OPERATING_MODEL.md :: Builder Learning, Evaluation, And TCD Governance Loop` — new "Terminal disposition linkage rule (#4267)" paragraph.
- AC2: `tests/builderops/test_learning_signal_terminal_disposition.py::test_superseded_signal_requires_linked_successor_artifact` — exercises the production `transition_record_state` path, negative (bare transition rejected, record unchanged) and success (linked transition lands durably) for both `superseded` and `discarded`; plus wrong-ref-type, create-into-terminal, and legacy-detection tests.
- AC3: `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Review Repair Loop` — "Severity-visible handoff (#4267)" mechanism naming the concrete per-finding severity/disposition carry requirement and the fix-instead-of-defer defect rule.
- Consistency: `docs/development/DELIVERY_FEEDBACK_LOOP.md` `discarded_or_superseded` outcome links to the new rule.

## Constraints held
BuilderOps stays builder-plane (no Product/Runtime authority change); verification needs only the repo (tests run on a tmp store, completeness-report accepts fixture records); no new blocking review round for P2/P3.

## Risk gate
Declared risk surface: `state-machine` (BuilderOps record lifecycle). Mechanism convergence packet built (key `builderops-record-lifecycle/learning-signal-terminal-disposition`) and a fresh independent high-capability review of the local publishable SHA returned CLEAN, no P0/P1. Two P3 observations recorded, deliberately not fixed per this PR's own severity-disposition rule: (1) adding `successor_refs` to the transition request hash means a pre-upgrade idempotency-key retry conflicts (fail-closed) instead of replaying; (2) `ref_type` vocabulary drift exists in the subsystem (`github_pr` here vs `pull_request` in the retrospective ledger) — free-form field, rejection message names the allowed set.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: no plan divergence; the convergence receipt is carried in this PR body per the low-convergence receipt shape.

## Claim receipt
pickup-claim-complete issue=4267 branch=claude/issue-4267-learningsignal-supersession-gap worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a5856dfa1e2f3e742 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4267 lease_id=lease-531b6ee1 holder=claude-fable-worker-4267 evidence=verified-dispatcher-lease

## Notes
Validation: `ruff check app tests` clean; `pytest -q tests/builderops` 1092 passed (two pre-existing fixtures creating terminal signals without successors updated to conform); suggested validation `pytest -q tests/builderops/test_learning_signal_terminal_disposition.py` 5 passed; `pytest -q tests/architecture/test_builderops_store_boundary.py tests/architecture/test_builderops_migration_boundary.py` 6 passed; docs guard OK with `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1` — the changed `app/**` surface is builder-plane BuilderOps machinery, and the issue's owner docs (`SBS_OPERATING_MODEL.md`, `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md`) are updated in this PR; no Product/Runtime temporal doc (STATUS/ARCHITECTURE/...) is affected.
---
