### PR TITLE
Register standing questions from captures and explicit intent (SQ-02)

### DIFF
--- a/app/components/llm/question_intent_classifier.py
+++ b/app/components/llm/question_intent_classifier.py
@@ -1,0 +1,244 @@
+"""Capture-intent classification for Standing Questions registration (SQ-02).
+
+Sibling of :mod:`app.components.llm.intent_classifier` — same pattern, different
+intent taxonomy. This cognition labels an ordinary capture's text as either
+``question_registration`` (the human said something like "find out whether X" /
+"jag undrar om X") or ``not_a_question_registration``, and extracts the question
+itself.
+
+It is LLM-backed through the shared constrained-completion utility
+(``app/components/llm/constrained.py``): the model is asked for schema-constrained
+JSON and the completion is **validated against the registered schema before any
+routing decision** (KERNEL-07, audit invariants I-A1/I-A2,
+``docs/RUNTIME_CORRECTNESS_KERNEL/STRUCTURED_INTENT_OUTPUT_WITH_UNKNOWN.md``). The
+raw completion function is injectable for tests; validation always runs below the
+injection point. Keyword heuristics are explicitly not the mechanism here — the
+governing spec forbids replacing the classifier with one.
+
+The cognition is **pure**: it reads the capture text and returns a typed label. It
+never writes to disk, never creates a Question note, and never stages a proposal.
+Registration is `app.standing_questions.registration`'s job, and even there a
+validated classification only ever becomes an unchecked suggested checkbox.
+
+Two explicit non-admitting outcomes, neither of which can register anything:
+
+- ``UNKNOWN`` when the provider fails, the backend is degraded, or the completion
+  does not validate. There is no silent action-capable default.
+- ``UNKNOWN`` when a *schema-valid* ``question_registration`` carries an
+  ``extracted_text`` that is not present verbatim in the capture. The Question
+  note's text must always be the human's own words (``REGISTER_QUESTIONS_FRICTION_FREE.md``
+  :: "never a paraphrase or summary the classifier invents"), so a fabricated or
+  paraphrased extraction is refused rather than proposed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from app.components.llm.constrained import (
+    CompletionFn,
+    ConstrainedCompletionError,
+    constrained_completion,
+    register_schema,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class QuestionIntentClass(str, Enum):
+    """Capture-intent classes, plus the explicit ``UNKNOWN`` failure class.
+
+    ``UNKNOWN`` is deliberately absent from the model-facing schema enum: it is
+    never a class the model may emit, only the local result of a refused or failed
+    validation. It authorizes nothing.
+    """
+
+    QUESTION_REGISTRATION = "question_registration"
+    NOT_A_QUESTION_REGISTRATION = "not_a_question_registration"
+    UNKNOWN = "unknown"
+
+
+#: Registered schema for the classification completion. The model must return
+#: exactly one JSON object of this shape; anything else is a validation failure
+#: and yields ``UNKNOWN``.
+QUESTION_INTENT_SCHEMA_REF = "standing_questions.capture_intent_classification.v1"
+
+_QUESTION_INTENT_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "intent_class": {
+            "enum": [
+                QuestionIntentClass.QUESTION_REGISTRATION.value,
+                QuestionIntentClass.NOT_A_QUESTION_REGISTRATION.value,
+            ]
+        },
+        "extracted_text": {"type": ["string", "null"]},
+        "rationale": {"type": ["string", "null"]},
+    },
+    "required": ["intent_class", "extracted_text"],
+}
+
+register_schema(QUESTION_INTENT_SCHEMA_REF, _QUESTION_INTENT_SCHEMA)
+
+
+@dataclass(frozen=True)
+class QuestionIntentClassification:
+    """Result of classifying one capture for question-registration intent.
+
+    ``extracted_text`` is set **iff** ``intent_class`` is ``QUESTION_REGISTRATION``,
+    and is then guaranteed to occur verbatim in the capture that was classified.
+    ``classified`` is ``False`` **iff** ``intent_class`` is ``UNKNOWN``.
+    """
+
+    intent_class: QuestionIntentClass
+    extracted_text: str | None = None
+    classified: bool = True
+    rationale: str | None = None
+    trace_id: str | None = None
+
+
+class QuestionIntentClassifierCognition:
+    """Classify a capture for question-registration intent.
+
+    The raw LLM completion is injectable via ``completion`` so tests can supply a
+    deterministic stub instead of a live provider. Schema validation runs inside
+    :func:`constrained_completion` on this side of the injection seam, so the
+    production ``classify()`` path always validates.
+    """
+
+    def __init__(self, *, completion: CompletionFn | None = None) -> None:
+        self._completion = completion
+
+    def classify(
+        self,
+        *,
+        capture_text: str,
+        trace_id: str | None = None,
+    ) -> QuestionIntentClassification:
+        """Return the capture-intent class (and verbatim question, if any).
+
+        Never raises on a degraded backend or invalid output: anything that does
+        not validate yields the explicit ``UNKNOWN`` classification
+        (``classified=False``) instead of a silent registration.
+        """
+        try:
+            payload = constrained_completion(
+                QUESTION_INTENT_SCHEMA_REF,
+                system=_SYSTEM_PROMPT,
+                user=_build_user_prompt(capture_text),
+                task_kind="decide",
+                trace_id=trace_id,
+                complete=self._completion,
+            )
+        except ConstrainedCompletionError as exc:
+            # Fail-loud observability: without this line a provider outage is
+            # indistinguishable from "the owner captured nothing worth registering".
+            logger.warning(
+                "capture-intent classification degraded to UNKNOWN (schema_ref=%s trace_id=%s): %s",
+                QUESTION_INTENT_SCHEMA_REF,
+                trace_id or "-",
+                exc.reason,
+            )
+            return _unknown(trace_id, reason=exc.reason)
+        return _from_validated(payload, capture_text=capture_text, trace_id=trace_id)
+
+
+# ---------------------------------------------------------------------------
+# Prompt + context
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT = (
+    "You are reading one capture the owner just made (a voice note, a clipping, a "
+    "quick note to self). Decide whether it contains an intent to register a "
+    "standing question — something the owner wants answered over time, phrased as "
+    '"find out whether X", "jag undrar om X", "should we X?", and so on. Return '
+    "ONLY a JSON object, no commentary:\n"
+    '{"intent_class": "<question_registration|not_a_question_registration>", '
+    '"extracted_text": "<the question, copied verbatim from the capture, or null>"}\n\n'
+    "Rules:\n"
+    "- extracted_text must be copied from the capture byte-for-byte. Never "
+    "rephrase it, translate it, tidy it, or turn a statement into a question; a "
+    "span that is not present verbatim in the capture is rejected and nothing is "
+    "registered.\n"
+    "- question_registration only when the owner is asking for something to be "
+    "found out, not merely mentioning a topic. Otherwise "
+    "not_a_question_registration with extracted_text null."
+)
+
+
+def _build_user_prompt(capture_text: str) -> str:
+    return f"Capture:\n{capture_text.strip()}"
+
+
+# ---------------------------------------------------------------------------
+# Validated-payload mapping
+# ---------------------------------------------------------------------------
+
+
+def _unknown(trace_id: str | None, *, reason: str) -> QuestionIntentClassification:
+    """Explicit UNKNOWN: the only failure result. Authorizes nothing."""
+    return QuestionIntentClassification(
+        intent_class=QuestionIntentClass.UNKNOWN,
+        extracted_text=None,
+        classified=False,
+        rationale=reason,
+        trace_id=trace_id,
+    )
+
+
+def _from_validated(
+    payload: dict[str, Any], *, capture_text: str, trace_id: str | None
+) -> QuestionIntentClassification:
+    """Map a schema-validated payload to a typed classification.
+
+    Only called with payloads that already validated against
+    :data:`QUESTION_INTENT_SCHEMA_REF`, so the enum construction cannot fail. The
+    verbatim check below is the second, non-schema gate: JSON Schema can prove the
+    shape of ``extracted_text`` but not that the model copied it rather than
+    invented it.
+    """
+    intent_class = QuestionIntentClass(payload["intent_class"])
+    rationale = _str_or_none(payload.get("rationale"))
+
+    if intent_class is not QuestionIntentClass.QUESTION_REGISTRATION:
+        return QuestionIntentClassification(
+            intent_class=intent_class,
+            extracted_text=None,
+            classified=True,
+            rationale=rationale,
+            trace_id=trace_id,
+        )
+
+    extracted = _str_or_none(payload.get("extracted_text"))
+    if extracted is None or extracted not in capture_text:
+        logger.warning(
+            "capture-intent classification refused a non-verbatim extraction "
+            "(schema_ref=%s trace_id=%s)",
+            QUESTION_INTENT_SCHEMA_REF,
+            trace_id or "-",
+        )
+        return _unknown(trace_id, reason="extracted_text is not verbatim in the capture")
+    return QuestionIntentClassification(
+        intent_class=QuestionIntentClass.QUESTION_REGISTRATION,
+        extracted_text=extracted,
+        classified=True,
+        rationale=rationale,
+        trace_id=trace_id,
+    )
+
+
+def _str_or_none(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+__all__ = [
+    "QUESTION_INTENT_SCHEMA_REF",
+    "QuestionIntentClass",
+    "QuestionIntentClassification",
+    "QuestionIntentClassifierCognition",
+]

--- a/app/standing_questions/registration.py
+++ b/app/standing_questions/registration.py
@@ -1,0 +1,351 @@
+"""Friction-free registration of standing questions (SQ-02).
+
+Two paths into the SQ-01 store, per
+``docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md``:
+
+- **Path (a) — capture intent.** :func:`propose_question_registration` classifies a
+  capture with the fenced capture-intent cognition and, on a validated
+  ``question_registration``, writes **one unchecked suggested checkbox** into the
+  capture note's own ``AI-åtgärder`` section through the existing PanelAgent
+  write-back (PA2-SUGGESTED-CHECKBOXES). It never creates a Question note.
+  :func:`confirm_question_registrations` is the other half: it reads the capture
+  note back and registers only the proposals a **human has checked**.
+- **Path (b) — explicit.** :func:`register_question_explicitly` writes straight
+  through the SQ-01 guarded seam. Taking the companion-UI action *is* the human
+  confirmation, so there is nothing to propose.
+
+Invariants held here (each covered by a test that fails when the guard is removed):
+
+- **The classifier can never bypass the checkbox.** There is no code path in this
+  module from a classification to :meth:`QuestionStore.create_question`. Path (a)'s
+  only write is an unchecked ``- [ ]`` line; the only function that creates a note
+  from a capture is :func:`confirm_question_registrations`, and it registers a
+  proposal only when :func:`~app.agents.panel.writeback.parse_action_line` reports
+  it checked.
+- **Question text is never fabricated.** The cognition already refuses a
+  non-verbatim extraction; confirmation re-checks the label against the live
+  capture text, so a hand-edited or tampered label cannot become a Question note
+  either. Path (b) stores the human's own words unchanged.
+- **Idempotent proposals and registrations.** The proposal is keyed by
+  ``sha256(capture_id, extracted_text)``, embedded in the checkbox label, so the
+  panel write-back's own dedupe makes re-classification a no-op. The Question note
+  minted on confirmation carries a UUIDv5 derived from the same key, so a repeated
+  confirmation lands on SQ-01's existing ``FileExistsError`` backstop instead of a
+  duplicate note.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.agents.panel.parser import is_ai_fence
+from app.agents.panel.writeback import parse_action_line
+from app.agents.panel_agent.runtime import _write_proposals_to_panel
+from app.components.llm.constrained import CompletionFn
+from app.components.llm.question_intent_classifier import (
+    QuestionIntentClass,
+    QuestionIntentClassification,
+    QuestionIntentClassifierCognition,
+)
+from app.knowledge.contracts import WriteReceipt
+from app.standing_questions.question_store import QuestionStore
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
+from scripts.yaml_roundtrip import load_frontmatter
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Named WriteGuard action for path (a)'s proposal write seam — auditable, not a
+#: silent absence of a guard. Dotted ``<module>.<verb>`` convention, mirroring
+#: ``curation.propose_write`` and SQ-01's ``standing_questions.write_note``.
+REGISTRATION_PROPOSE_WRITE_ACTION = "standing_questions.propose_registration"
+
+#: Swedish label prefix, matching the `AI-åtgärder` surface convention. It is also
+#: the selector confirmation uses to find this task's proposals among any other
+#: checkboxes on the capture note.
+REGISTRATION_LABEL_PREFIX = "Registrera stående fråga: "
+
+#: Stable namespace for the deterministic Question id minted on confirmation.
+#: Fixed forever: changing it would let an already-registered capture register a
+#: second time.
+_REGISTRATION_NAMESPACE = uuid.UUID("6f9a1c2e-4d3b-4a55-9c7e-2b8f1d0a7e34")
+
+
+@dataclass(frozen=True)
+class RegistrationProposalResult:
+    """Outcome of one path (a) classification pass over one capture note.
+
+    ``written`` is ``False`` both when nothing was proposed and when the proposal
+    was already present (the idempotent rerun), so a caller can distinguish "no
+    intent" from "already offered" through ``proposal_id``.
+    """
+
+    classification: QuestionIntentClassification
+    proposal_id: str | None = None
+    extracted_text: str | None = None
+    label: str | None = None
+    written: bool = False
+
+
+@dataclass(frozen=True)
+class RegistrationConfirmResult:
+    """Outcome of one confirmation pass over one capture note."""
+
+    created: tuple[dict[str, Any], ...] = ()
+    unchecked: int = 0
+    already_registered: int = 0
+    refused_non_verbatim: int = 0
+
+
+def capture_human_text(markdown: str) -> str:
+    """Return the capture with every ``%% AI:… %%`` panel block removed.
+
+    The panel is machine surface: it holds this task's own proposal lines and any
+    other agent's suggestions. Two things depend on excluding it, and both are
+    correctness rather than tidiness:
+
+    - the classifier is fenced on the human's actual capture, so a second pass
+      cannot "extract" a question out of a proposal an earlier pass wrote;
+    - the verbatim check has a fixed point. Checking against the whole file would
+      make any label trivially verbatim — the label is *in* the file — so a
+      hand-edited or tampered label would validate itself.
+    """
+    kept: list[str] = []
+    inside_panel = False
+    for line in markdown.splitlines():
+        if is_ai_fence(line):
+            inside_panel = not inside_panel
+            continue
+        if not inside_panel:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _capture_identity(capture_note_path: Path, vault_root: Path) -> str:
+    """Stable id for the source capture: its frontmatter uuid, else its path.
+
+    Mirrors ``app.curation.lint._note_identity``: a uuid is advisory lineage
+    metadata, never a processing gate, so a uuid-less capture still gets a stable
+    proposal key rather than being skipped.
+    """
+    try:
+        metadata, _body = load_frontmatter(capture_note_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        metadata = {}
+    note_uuid = metadata.get("uuid") if isinstance(metadata, dict) else None
+    if isinstance(note_uuid, str) and note_uuid.strip():
+        return note_uuid.strip()
+    try:
+        return f"path:{capture_note_path.resolve().relative_to(vault_root).as_posix()}"
+    except ValueError:
+        return f"path:{capture_note_path.name}"
+
+
+def _proposal_key(capture_id: str, extracted_text: str) -> str:
+    return f"{capture_id}::{extracted_text}"
+
+
+def proposal_id_for(capture_id: str, extracted_text: str) -> str:
+    """Idempotency key for a registration proposal (spec: ``hash(capture_id, text)``)."""
+    digest = hashlib.sha256(_proposal_key(capture_id, extracted_text).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _question_id_for(capture_id: str, extracted_text: str) -> str:
+    """Deterministic Question id, so a repeated confirmation cannot duplicate a note."""
+    return f"sq-{uuid.uuid5(_REGISTRATION_NAMESPACE, _proposal_key(capture_id, extracted_text))}"
+
+
+def _proposal_label(extracted_text: str, proposal_id: str) -> str:
+    """Self-contained checkbox label: the question plus its short proposal id.
+
+    The short id makes the label unique per (capture, question) pair, which is what
+    the panel write-back's own dedupe keys on — the same discipline
+    ``app.curation.proposal_writer`` uses for finding ids.
+    """
+    return f'{REGISTRATION_LABEL_PREFIX}"{extracted_text}" (förslag {proposal_id[:12]})'
+
+
+def _extracted_text_from_label(label: str) -> str | None:
+    """Recover the question from a proposal label, or ``None`` if it does not parse."""
+    if not label.startswith(REGISTRATION_LABEL_PREFIX):
+        return None
+    remainder = label[len(REGISTRATION_LABEL_PREFIX) :].strip()
+    if not remainder.startswith('"'):
+        return None
+    # rsplit on the trailing suffix so a question containing a quote still parses.
+    closing = remainder.rfind('" (förslag ')
+    if closing <= 0:
+        return None
+    return remainder[1:closing]
+
+
+def propose_question_registration(
+    *,
+    capture_note_path: Path | str,
+    vault_root: Path | str,
+    classifier: QuestionIntentClassifierCognition | None = None,
+    complete: CompletionFn | None = None,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    trace_id: str | None = None,
+) -> RegistrationProposalResult:
+    """Classify a capture and, if it registers a question, offer an unchecked checkbox.
+
+    This is path (a)'s production entrypoint. It **never** creates a Question note:
+    the only durable effect it can have is one unchecked ``- [ ]`` line on the
+    capture note itself.
+    """
+    resolved_root = Path(vault_root).expanduser().resolve()
+    capture_path = Path(capture_note_path).expanduser().resolve()
+    capture_text = capture_path.read_text(encoding="utf-8")
+    human_text = capture_human_text(capture_text)
+
+    cognition = classifier if classifier is not None else QuestionIntentClassifierCognition(
+        completion=complete
+    )
+    classification = cognition.classify(capture_text=human_text, trace_id=trace_id)
+    if classification.intent_class is not QuestionIntentClass.QUESTION_REGISTRATION:
+        # UNKNOWN and not_a_question_registration are both non-admitting: no
+        # proposal, no write, no note.
+        return RegistrationProposalResult(classification=classification)
+
+    extracted = classification.extracted_text
+    # The cognition only returns QUESTION_REGISTRATION with a verbatim extraction;
+    # re-checking it here keeps the guarantee local to the write path too, so an
+    # injected classifier cannot smuggle fabricated text past this seam.
+    if extracted is None or extracted not in human_text:
+        _LOGGER.warning(
+            "Refused a Standing Questions registration proposal whose text is not "
+            "verbatim in its capture: %s",
+            capture_path,
+        )
+        return RegistrationProposalResult(classification=classification)
+
+    capture_id = _capture_identity(capture_path, resolved_root)
+    proposal_id = proposal_id_for(capture_id, extracted)
+    label = _proposal_label(extracted, proposal_id)
+
+    # Guard at the seam, before any filesystem mutation.
+    write_guard.assert_writes_allowed(REGISTRATION_PROPOSE_WRITE_ACTION)
+    updated = _write_proposals_to_panel(capture_text, [(proposal_id, label)])
+    if updated == capture_text:
+        # Already proposed on an earlier pass — idempotent no-op, no write.
+        return RegistrationProposalResult(
+            classification=classification,
+            proposal_id=proposal_id,
+            extracted_text=extracted,
+            label=label,
+        )
+    capture_path.write_text(updated, encoding="utf-8")
+    return RegistrationProposalResult(
+        classification=classification,
+        proposal_id=proposal_id,
+        extracted_text=extracted,
+        label=label,
+        written=True,
+    )
+
+
+def confirm_question_registrations(
+    *,
+    capture_note_path: Path | str,
+    vault_root: Path | str,
+    scope: str,
+    store: QuestionStore | None = None,
+) -> RegistrationConfirmResult:
+    """Register every proposal the human has **checked** on this capture note.
+
+    An unchecked proposal is left exactly as it is. This is the only function in
+    this module that can turn a capture into a Question note, and it acts on the
+    checkbox state, never on a classification.
+    """
+    resolved_root = Path(vault_root).expanduser().resolve()
+    capture_path = Path(capture_note_path).expanduser().resolve()
+    capture_text = capture_path.read_text(encoding="utf-8")
+    human_text = capture_human_text(capture_text)
+    question_store = store if store is not None else QuestionStore(resolved_root)
+    capture_id = _capture_identity(capture_path, resolved_root)
+
+    created: list[dict[str, Any]] = []
+    unchecked = 0
+    already_registered = 0
+    refused_non_verbatim = 0
+
+    for line in capture_text.splitlines():
+        parsed = parse_action_line(line.strip())
+        if parsed is None or not parsed.label.startswith(REGISTRATION_LABEL_PREFIX):
+            continue
+        if not parsed.checked:
+            unchecked += 1
+            continue
+        extracted = _extracted_text_from_label(parsed.label)
+        # Re-check verbatimness against the live capture: the label is editable
+        # text in the human's vault, so a tampered or rewritten label must not be
+        # able to author a Question note.
+        if extracted is None or extracted not in human_text:
+            _LOGGER.warning(
+                "Refused a checked Standing Questions registration whose text is not "
+                "verbatim in its capture: %s",
+                capture_path,
+            )
+            refused_non_verbatim += 1
+            continue
+        try:
+            note, _receipt = question_store.create_question(
+                text=extracted,
+                scope=scope,
+                registered_via="capture_intent",
+                question_id=_question_id_for(capture_id, extracted),
+            )
+        except FileExistsError:
+            # Deterministic id + SQ-01's existing existence check = idempotency.
+            already_registered += 1
+            continue
+        created.append(note)
+
+    return RegistrationConfirmResult(
+        created=tuple(created),
+        unchecked=unchecked,
+        already_registered=already_registered,
+        refused_non_verbatim=refused_non_verbatim,
+    )
+
+
+def register_question_explicitly(
+    *,
+    text: str,
+    scope: str,
+    vault_root: Path | str,
+    store: QuestionStore | None = None,
+) -> tuple[dict[str, Any], WriteReceipt]:
+    """Path (b): register a question the human stated directly.
+
+    No proposal, no confirm step, no classifier — the human already confirmed by
+    taking the action, and ``text`` is their own words stored unchanged.
+    """
+    question_text = text.strip()
+    if not question_text:
+        raise ValueError("explicit registration requires non-empty question text")
+    resolved_root = Path(vault_root).expanduser().resolve()
+    question_store = store if store is not None else QuestionStore(resolved_root)
+    return question_store.create_question(
+        text=question_text,
+        scope=scope,
+        registered_via="explicit",
+    )
+
+
+__all__ = [
+    "REGISTRATION_LABEL_PREFIX",
+    "REGISTRATION_PROPOSE_WRITE_ACTION",
+    "RegistrationConfirmResult",
+    "RegistrationProposalResult",
+    "confirm_question_registrations",
+    "propose_question_registration",
+    "proposal_id_for",
+    "register_question_explicitly",
+]

--- a/docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md
+++ b/docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md
@@ -56,10 +56,13 @@ typing or pasting anything beyond the question itself.
 ## Concretely
 
 ```
-# Heimdal capture transcript: "Note to self, find out whether we should fully migrate to BGE-M3."
+# Heimdal capture transcript: "Note to self: should we fully migrate to BGE-M3? Find out before Q3."
 $ python -m app.cli captures classify-question-intent <capture_id> --json
-{"classified": true, "class": "question_registration", "extracted_text": "Should we fully migrate to BGE-M3?"}
-# → capture note gains: - [ ] Registrera stående fråga: "Should we fully migrate to BGE-M3?"
+{"classified": true, "class": "question_registration", "extracted_text": "should we fully migrate to BGE-M3?"}
+# → capture note gains: - [ ] Registrera stående fråga: "should we fully migrate to BGE-M3?"
+# The extraction is a verbatim span of the capture (point 3 below). A capture that only
+# *implies* a question, with no question the human actually uttered, is not registered —
+# the classifier may never compose the question text itself.
 # Human checks the box in Obsidian (or via Companion UI read-mode click) →
 $ python -m app.cli questions create --text "Should we fully migrate to BGE-M3?" --scope work --registered-via capture_intent
 → WriteReceipt(locator=vault://questions/sq-...)

--- a/tests/standing_questions/_registration_fixtures.py
+++ b/tests/standing_questions/_registration_fixtures.py
@@ -1,0 +1,117 @@
+"""Shared fixtures for the SQ-02 registration acceptance tests."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.standing_questions.question_store import QuestionStore
+from app.write_guard import WriteGuard
+
+CAPTURE_REL_PATH = "captures/2026-07-14-rostanteckning.md"
+EXTRACTED_QUESTION = "should we fully migrate to BGE-M3?"
+CAPTURE_BODY = f"""---
+uuid: capture-uuid-1
+kind: capture
+---
+
+# Röstanteckning 2026-07-14
+
+Note to self: {EXTRACTED_QUESTION} Find out before the Q3 planning round.
+
+%% AI:Start %%
+## AI-instruktion
+
+## AI-åtgärder
+%% AI:End %%
+"""
+
+NON_QUESTION_REL_PATH = "captures/2026-07-15-inkop.md"
+NON_QUESTION_BODY = """---
+uuid: capture-uuid-2
+kind: capture
+---
+
+# Inköp
+
+Bought oat milk and rye bread on the way home.
+
+%% AI:Start %%
+## AI-instruktion
+
+## AI-åtgärder
+%% AI:End %%
+"""
+
+
+def healthy_store(vault: Path) -> QuestionStore:
+    return QuestionStore(vault, write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}))
+
+
+def healthy_guard() -> WriteGuard:
+    return WriteGuard(snapshot_fn=lambda: {"state": "healthy"})
+
+
+def write_capture(
+    vault: Path,
+    relative_path: str = CAPTURE_REL_PATH,
+    body: str = CAPTURE_BODY,
+) -> Path:
+    path = vault / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return vault
+
+
+def completion_returning(raw: str | dict[str, Any]):
+    """Deterministic raw-completion stub that records every prompt it saw."""
+    payload = raw if isinstance(raw, str) else json.dumps(raw)
+    prompts: list[str] = []
+
+    def complete(
+        *,
+        system: str,
+        user: str,
+        trace_id: str | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        prompts.append(user)
+        return payload
+
+    complete.prompts = prompts  # type: ignore[attr-defined]
+    return complete
+
+
+def registration_payload(
+    extracted: str | None = EXTRACTED_QUESTION,
+    *,
+    intent_class: str = "question_registration",
+) -> dict[str, Any]:
+    return {
+        "intent_class": intent_class,
+        "extracted_text": extracted,
+        "rationale": "explicit note-to-self registration intent",
+    }
+
+
+def question_notes(vault: Path) -> list[Path]:
+    questions_dir = vault / "questions"
+    if not questions_dir.exists():
+        return []
+    return sorted(questions_dir.glob("sq-*.md"))
+
+
+def check_the_box(capture_path: Path, extracted_text: str) -> None:
+    """Simulate the human tapping the suggested checkbox in their editor."""
+    text = capture_path.read_text(encoding="utf-8")
+    needle = f'- [ ] Registrera stående fråga: "{extracted_text}"'
+    assert needle in text, "no unchecked registration proposal to check"
+    capture_path.write_text(
+        text.replace(needle, needle.replace("- [ ]", "- [x]", 1), 1), encoding="utf-8"
+    )

--- a/tests/standing_questions/test_question_intent_classifier.py
+++ b/tests/standing_questions/test_question_intent_classifier.py
@@ -1,0 +1,256 @@
+"""Capture-intent classification for Standing Questions registration (SQ-02).
+
+Covers `docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md` AC1-AC3 and
+AC8: the classifier is LLM-backed through the shared schema-constrained-completion
+utility, degrades to an explicit `UNKNOWN` that registers nothing, validates on the
+production entrypoint, and can never bypass the human checkbox-confirm step.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import string
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+import app.components.llm.constrained as constrained_module
+from app.components.llm.constrained import registered_schema
+from app.components.llm.question_intent_classifier import (
+    QUESTION_INTENT_SCHEMA_REF,
+    QuestionIntentClass,
+    QuestionIntentClassifierCognition,
+)
+from app.standing_questions.registration import propose_question_registration
+
+from tests.standing_questions._registration_fixtures import (
+    CAPTURE_BODY,
+    EXTRACTED_QUESTION,
+    NON_QUESTION_BODY,
+    NON_QUESTION_REL_PATH,
+    completion_returning,
+    healthy_guard,
+    make_vault,
+    question_notes,
+    registration_payload,
+    write_capture,
+)
+
+
+def _classify(raw: str | dict, capture_text: str = CAPTURE_BODY):
+    return QuestionIntentClassifierCognition(
+        completion=completion_returning(raw)
+    ).classify(capture_text=capture_text)
+
+
+# ---------------------------------------------------------------------------
+# AC1: explicit registration intent, verbatim extraction.
+# ---------------------------------------------------------------------------
+
+
+def test_capture_intent_classified_and_extracted() -> None:
+    result = _classify(registration_payload())
+
+    assert result.intent_class is QuestionIntentClass.QUESTION_REGISTRATION
+    assert result.classified is True
+    assert result.extracted_text == EXTRACTED_QUESTION
+    # Verbatim, never a paraphrase: the extraction must occur in the capture
+    # byte-for-byte, which is what makes the eventual Question note the human's
+    # own words rather than the classifier's.
+    assert result.extracted_text in CAPTURE_BODY
+
+
+def test_paraphrased_extraction_is_refused_not_registered() -> None:
+    """A schema-valid classification whose extraction is not verbatim in the capture
+    is downgraded to UNKNOWN -- the classifier may never invent question text."""
+    result = _classify(registration_payload("Should we adopt a different embedding model?"))
+
+    assert result.intent_class is QuestionIntentClass.UNKNOWN
+    assert result.classified is False
+    assert result.extracted_text is None
+
+
+# ---------------------------------------------------------------------------
+# AC2: non-registration intent and degraded backend never register.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_never_silently_registers(tmp_path: Path) -> None:
+    negative = _classify(
+        registration_payload(None, intent_class="not_a_question_registration"),
+        capture_text=NON_QUESTION_BODY,
+    )
+    assert negative.intent_class is QuestionIntentClass.NOT_A_QUESTION_REGISTRATION
+    assert negative.classified is True
+    assert negative.extracted_text is None
+
+    garbage = _classify("not json at all, just prose about migrating to BGE-M3")
+    assert garbage.intent_class is QuestionIntentClass.UNKNOWN
+    assert garbage.classified is False
+    assert garbage.extracted_text is None
+
+    def _degraded_backend(**_: object) -> str:
+        raise RuntimeError("classification backend unavailable")
+
+    degraded = QuestionIntentClassifierCognition(completion=_degraded_backend).classify(
+        capture_text=CAPTURE_BODY
+    )
+    assert degraded.intent_class is QuestionIntentClass.UNKNOWN
+    assert degraded.classified is False
+
+    # And neither non-admitting outcome may reach the store through path (a).
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault, NON_QUESTION_REL_PATH, NON_QUESTION_BODY)
+    before = capture.read_bytes()
+    for completion in (
+        completion_returning(
+            registration_payload(None, intent_class="not_a_question_registration")
+        ),
+        completion_returning("garbage"),
+        _degraded_backend,
+    ):
+        result = propose_question_registration(
+            capture_note_path=capture,
+            vault_root=vault,
+            complete=completion,
+            write_guard=healthy_guard(),
+        )
+        assert result.written is False
+        assert result.proposal_id is None
+    assert capture.read_bytes() == before
+    assert question_notes(vault) == []
+
+
+# ---------------------------------------------------------------------------
+# AC3 (enforcement): validation runs on the production classify() entrypoint.
+# ---------------------------------------------------------------------------
+
+
+def test_validation_invoked_from_production_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    validated: list[tuple[str, object]] = []
+    real_validate = constrained_module.validate_payload
+
+    def _spy(schema_ref: str, payload: object):
+        validated.append((schema_ref, payload))
+        return real_validate(schema_ref, payload)
+
+    monkeypatch.setattr(constrained_module, "validate_payload", _spy)
+
+    result = QuestionIntentClassifierCognition(
+        completion=completion_returning(registration_payload())
+    ).classify(capture_text=CAPTURE_BODY)
+
+    assert result.intent_class is QuestionIntentClass.QUESTION_REGISTRATION
+    assert [ref for ref, _payload in validated] == [QUESTION_INTENT_SCHEMA_REF]
+
+
+def test_schema_rejects_unknown_as_a_model_emittable_class() -> None:
+    """`UNKNOWN` is a local failure result, never something the model may claim."""
+    with pytest.raises(constrained_module.ConstrainedCompletionError):
+        constrained_module.validate_payload(
+            QUESTION_INTENT_SCHEMA_REF,
+            {"intent_class": "unknown", "extracted_text": None},
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC8 (fuzz): garbage classifier output never bypasses the checkbox.
+# ---------------------------------------------------------------------------
+
+
+def _garbage_outputs(rng: random.Random, count: int) -> list[str]:
+    """Adversarial garbage: noise, non-objects, near-miss enums, prose-wrapped JSON."""
+    near_misses = [
+        "QUESTION_REGISTRATION",
+        "question-registration",
+        "unknown",
+        "question_registration ",
+        "",
+        None,
+        1,
+        True,
+        ["question_registration"],
+    ]
+    outputs: list[str] = []
+    for _ in range(count):
+        pick = rng.randrange(7)
+        if pick == 0:
+            outputs.append("".join(rng.choices(string.printable, k=rng.randrange(0, 80))))
+        elif pick == 1:
+            outputs.append(json.dumps(rng.choice([None, True, 3.14, "question_registration", [1]])))
+        elif pick == 2:
+            outputs.append(
+                json.dumps(
+                    {
+                        "".join(rng.choices(string.ascii_lowercase, k=5)): rng.random()
+                        for _ in range(rng.randrange(0, 4))
+                    }
+                )
+            )
+        elif pick == 3:
+            outputs.append(
+                json.dumps(
+                    {
+                        "intent_class": rng.choice(near_misses),
+                        "extracted_text": rng.choice(near_misses),
+                    }
+                )
+            )
+        elif pick == 4:
+            outputs.append(
+                'Sure: {"intent_class": "question_registration", '
+                f'"extracted_text": "{EXTRACTED_QUESTION}"}} as requested.'
+            )
+        elif pick == 5:
+            outputs.append('{"intent_class": "question_registration", "extracted_te')
+        else:
+            # Schema-valid but fabricated extraction: the model invents text the
+            # capture never contained.
+            outputs.append(
+                json.dumps(
+                    {
+                        "intent_class": "question_registration",
+                        "extracted_text": "".join(
+                            rng.choices(string.ascii_letters + " ", k=rng.randrange(1, 40))
+                        ),
+                    }
+                )
+            )
+    return outputs
+
+
+def test_fuzz_classifier_never_bypasses_checkbox(tmp_path: Path) -> None:
+    rng = random.Random(3328)
+    schema = registered_schema(QUESTION_INTENT_SCHEMA_REF)
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    guard = healthy_guard()
+
+    for raw in _garbage_outputs(rng, 300):
+        result = propose_question_registration(
+            capture_note_path=capture,
+            vault_root=vault,
+            complete=completion_returning(raw),
+            write_guard=guard,
+        )
+        # A Question note is never created by path (a), whatever the model emits.
+        assert question_notes(vault) == []
+        text = capture.read_text(encoding="utf-8")
+        # Every registration line this path can ever write is unchecked.
+        assert "- [x]" not in text.lower()
+
+        if result.classification.intent_class is QuestionIntentClass.UNKNOWN:
+            assert result.classification.classified is False
+            assert result.written is False
+            continue
+        # Anything that classified must be provably schema-validated output.
+        payload = json.loads(raw)
+        jsonschema.validate(payload, schema)
+        assert result.classification.classified is True
+        if result.proposal_id is not None:
+            # A proposal is only ever a suggestion line on the capture note.
+            assert result.extracted_text is not None
+            assert result.extracted_text in CAPTURE_BODY
+            assert f'- [ ] Registrera stående fråga: "{result.extracted_text}"' in text

--- a/tests/standing_questions/test_register_capture_intent.py
+++ b/tests/standing_questions/test_register_capture_intent.py
@@ -1,0 +1,291 @@
+"""Path (a) -- capture-intent registration behind the human checkbox (SQ-02).
+
+Covers `docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md` AC4-AC6: a
+validated classification lands as an unchecked suggested checkbox and never as a
+directly created Question note; only the human checking it registers the question;
+re-classifying the same capture does not stack duplicate proposals.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.agents.panel.writeback import parse_action_line
+from app.components.llm.question_intent_classifier import (
+    QuestionIntentClass,
+    QuestionIntentClassification,
+)
+from app.standing_questions.registration import (
+    REGISTRATION_LABEL_PREFIX,
+    REGISTRATION_PROPOSE_WRITE_ACTION,
+    confirm_question_registrations,
+    propose_question_registration,
+)
+from app.write_guard import WriteGuard, WritesBlockedError
+
+from tests.standing_questions._registration_fixtures import (
+    CAPTURE_BODY,
+    EXTRACTED_QUESTION,
+    check_the_box,
+    completion_returning,
+    healthy_guard,
+    healthy_store,
+    make_vault,
+    question_notes,
+    registration_payload,
+    write_capture,
+)
+
+
+def _propose(vault: Path, capture: Path, payload=None):
+    return propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        complete=completion_returning(payload or registration_payload()),
+        write_guard=healthy_guard(),
+    )
+
+
+def _registration_lines(capture: Path) -> list[str]:
+    return [
+        line
+        for line in capture.read_text(encoding="utf-8").splitlines()
+        if REGISTRATION_LABEL_PREFIX in line
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AC4: proposal only, never a direct write.
+# ---------------------------------------------------------------------------
+
+
+def test_classification_lands_as_suggested_checkbox_not_direct_write(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+
+    result = _propose(vault, capture)
+
+    assert result.written is True
+    assert result.extracted_text == EXTRACTED_QUESTION
+    assert result.proposal_id is not None
+
+    lines = _registration_lines(capture)
+    assert len(lines) == 1
+    parsed = parse_action_line(lines[0])
+    assert parsed is not None
+    assert parsed.checked is False
+    assert parsed.label.startswith(REGISTRATION_LABEL_PREFIX)
+    assert EXTRACTED_QUESTION in parsed.label
+    # Panel proposal metadata is present, so the parser keeps the human gate armed.
+    assert parsed.option_id
+    assert parsed.action_id
+    assert parsed.proposal_marker is not None
+    # The proposal lands inside the note's AI-atgarder section, not appended loose.
+    text = capture.read_text(encoding="utf-8")
+    assert text.index("## AI-åtgärder") < text.index(REGISTRATION_LABEL_PREFIX)
+    assert text.index(REGISTRATION_LABEL_PREFIX) < text.index("%% AI:End %%")
+
+    # No Question note exists: only a human check may create one.
+    assert question_notes(vault) == []
+    assert not (vault / "questions").exists()
+
+
+def test_propose_refuses_fabricated_text_from_an_injected_classifier(tmp_path: Path) -> None:
+    """The write path re-checks verbatimness itself, so a classifier that claims a
+    validated registration for words the capture never held proposes nothing."""
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    before = capture.read_bytes()
+
+    class _FabricatingClassifier:
+        def classify(self, **_: object) -> QuestionIntentClassification:
+            return QuestionIntentClassification(
+                intent_class=QuestionIntentClass.QUESTION_REGISTRATION,
+                extracted_text="should we delete the whole vault?",
+                classified=True,
+            )
+
+    result = propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        classifier=_FabricatingClassifier(),  # type: ignore[arg-type]
+        write_guard=healthy_guard(),
+    )
+
+    assert result.written is False
+    assert result.proposal_id is None
+    assert capture.read_bytes() == before
+    assert question_notes(vault) == []
+
+
+def test_non_registration_class_never_proposes_even_with_an_extraction(tmp_path: Path) -> None:
+    """Only `question_registration` may propose. A non-admitting class that still
+    carries a verbatim extraction is refused on the class, not on the text."""
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    before = capture.read_bytes()
+
+    class _MislabelledClassifier:
+        def classify(self, **_: object) -> QuestionIntentClassification:
+            return QuestionIntentClassification(
+                intent_class=QuestionIntentClass.NOT_A_QUESTION_REGISTRATION,
+                extracted_text=EXTRACTED_QUESTION,
+                classified=True,
+            )
+
+    result = propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        classifier=_MislabelledClassifier(),  # type: ignore[arg-type]
+        write_guard=healthy_guard(),
+    )
+
+    assert result.written is False
+    assert result.proposal_id is None
+    assert capture.read_bytes() == before
+
+
+def test_proposal_lines_are_fenced_out_of_the_next_classification(tmp_path: Path) -> None:
+    """A later pass classifies the human's capture, not the panel this task wrote —
+    otherwise a proposal could bootstrap itself into looking like a fresh capture."""
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    _propose(vault, capture)
+
+    completion = completion_returning(registration_payload())
+    propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        complete=completion,
+        write_guard=healthy_guard(),
+    )
+
+    assert completion.prompts  # type: ignore[attr-defined]
+    for prompt in completion.prompts:  # type: ignore[attr-defined]
+        assert REGISTRATION_LABEL_PREFIX not in prompt
+        assert "%% AI:Start %%" not in prompt
+
+
+def test_proposal_write_is_writeguard_gated_by_named_action(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    before = capture.read_bytes()
+
+    with pytest.raises(WritesBlockedError, match=REGISTRATION_PROPOSE_WRITE_ACTION):
+        propose_question_registration(
+            capture_note_path=capture,
+            vault_root=vault,
+            complete=completion_returning(registration_payload()),
+            write_guard=WriteGuard(snapshot_fn=lambda: {"state": "safe_mode", "reason": "test"}),
+        )
+
+    assert capture.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# AC5: the human check is the only path to an open Question note.
+# ---------------------------------------------------------------------------
+
+
+def test_checkbox_confirmation_creates_open_question(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    store = healthy_store(vault)
+    _propose(vault, capture)
+
+    # Unchecked: nothing is registered, however often confirmation runs.
+    unchecked = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+    assert unchecked.created == ()
+    assert unchecked.unchecked == 1
+    assert question_notes(vault) == []
+
+    check_the_box(capture, EXTRACTED_QUESTION)
+    confirmed = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+
+    assert len(confirmed.created) == 1
+    notes = question_notes(vault)
+    assert len(notes) == 1
+    note = store.read_question(confirmed.created[0]["question_id"])
+    assert note["status"] == "open"
+    assert note["registered_via"] == "capture_intent"
+    assert note["text"] == EXTRACTED_QUESTION
+    assert note["text"] in CAPTURE_BODY
+    assert note["scope"] == "work"
+    assert note["evidence"] == []
+
+
+def test_confirmation_is_idempotent_on_repeat(tmp_path: Path) -> None:
+    """Re-running confirmation over an already-registered checked proposal creates
+    nothing new -- the deterministic question id makes SQ-01's store the backstop."""
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    store = healthy_store(vault)
+    _propose(vault, capture)
+    check_the_box(capture, EXTRACTED_QUESTION)
+
+    first = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+    second = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+
+    assert len(first.created) == 1
+    assert second.created == ()
+    assert second.already_registered == 1
+    assert len(question_notes(vault)) == 1
+
+
+def test_confirmation_refuses_a_tampered_non_verbatim_label(tmp_path: Path) -> None:
+    """A checkbox label edited to text the capture never contained is refused: the
+    Question note's text is always the human's own words from the capture."""
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    store = healthy_store(vault)
+    _propose(vault, capture)
+    check_the_box(capture, EXTRACTED_QUESTION)
+    # Tamper with the checkbox label only; the capture's own prose is untouched, so
+    # the label now claims words the human never captured.
+    tampered = "\n".join(
+        line.replace(EXTRACTED_QUESTION, "should we delete the whole vault?")
+        if REGISTRATION_LABEL_PREFIX in line
+        else line
+        for line in capture.read_text(encoding="utf-8").splitlines()
+    )
+    capture.write_text(tampered + "\n", encoding="utf-8")
+    assert EXTRACTED_QUESTION in capture.read_text(encoding="utf-8")
+
+    result = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+
+    assert result.created == ()
+    assert result.refused_non_verbatim == 1
+    assert question_notes(vault) == []
+
+
+# ---------------------------------------------------------------------------
+# AC6: repeated classification does not stack proposals.
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_classification_idempotent(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+
+    first = _propose(vault, capture)
+    after_first = capture.read_bytes()
+    second = _propose(vault, capture)
+
+    assert first.written is True
+    assert second.written is False
+    assert second.proposal_id == first.proposal_id
+    assert len(_registration_lines(capture)) == 1
+    # No write at all on the idempotent rerun.
+    assert capture.read_bytes() == after_first

--- a/tests/standing_questions/test_register_explicit.py
+++ b/tests/standing_questions/test_register_explicit.py
@@ -1,0 +1,73 @@
+"""Path (b) -- explicit companion-UI registration (SQ-02).
+
+Covers `docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md` AC7: taking the
+explicit registration action *is* the human confirmation, so it writes through the
+SQ-01 guarded seam directly with no proposal/confirm step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.standing_questions.registration import register_question_explicitly
+from app.write_guard import WriteGuard, WritesBlockedError
+
+from tests.standing_questions._registration_fixtures import (
+    healthy_store,
+    make_vault,
+    question_notes,
+)
+
+QUESTION = "What's our stance on cross-scope federation?"
+
+
+def test_explicit_registration_writes_directly(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    store = healthy_store(vault)
+
+    note, receipt = register_question_explicitly(
+        text=QUESTION, scope="work", vault_root=vault, store=store
+    )
+
+    assert len(question_notes(vault)) == 1
+    assert note["status"] == "open"
+    assert note["registered_via"] == "explicit"
+    # The human's own words, stored verbatim -- no classifier in this path at all.
+    assert note["text"] == QUESTION
+    assert note["scope"] == "work"
+    assert note["evidence"] == []
+    assert f"questions/{note['question_id']}.md" in str(receipt.locator)
+
+    stored = store.read_question(note["question_id"])
+    assert stored == note
+
+    # No proposal surface is created on this path: there is nothing to confirm.
+    assert list(vault.rglob("*.md")) == question_notes(vault)
+
+
+def test_explicit_registration_rejects_blank_text(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    store = healthy_store(vault)
+
+    with pytest.raises(ValueError):
+        register_question_explicitly(text="   ", scope="work", vault_root=vault, store=store)
+
+    assert question_notes(vault) == []
+
+
+def test_explicit_registration_is_writeguard_gated(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    from app.standing_questions.question_store import QuestionStore
+
+    blocked = QuestionStore(
+        vault, write_guard=WriteGuard(snapshot_fn=lambda: {"state": "safe_mode", "reason": "test"})
+    )
+
+    with pytest.raises(WritesBlockedError):
+        register_question_explicitly(
+            text=QUESTION, scope="work", vault_root=vault, store=blocked
+        )
+
+    assert question_notes(vault) == []


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #3328

## Linked Issue
Closes #3328

## SBS Impact
- Primary subsystem: CAO (capture-intent classification cognition)
- Secondary subsystem(s): HKA (registers into the Question note store), HIX (explicit companion-UI registration path), GOV (proposal/confirm discipline)
- Write class: path (a) proposal class — an unchecked suggested checkbox carries no authority until a human confirms it; path (b) mechanical durable, already-confirmed by construction
- Persistence impact: suggested checkboxes live in the existing capture note's `AI-åtgärder` section (no new artifact class); confirmed and explicit registrations create Question notes through SQ-01's unchanged schema and guarded seam
- Derived/rebuildable impact: none new — registered questions flow into the existing rebuildable `standing_questions` projection
- New or changed contract: new registered classification schema `standing_questions.capture_intent_classification.v1`; new named WriteGuard action `standing_questions.propose_registration` for the proposal write
- Owner-doc impact: `docs/STANDING_QUESTIONS/REGISTER_QUESTIONS_FRICTION_FREE.md :: Concretely` corrected so its example no longer contradicts the document's own verbatim-extraction rule; updated in this PR
- Transition debt impact: reduces
- Boundary risk: none new — no new egress, reusing the existing LLM provider routing. Authority impact is none: proposals carry no authority, and confirmation executes the existing checkbox-confirm loop rather than a new authority path. The classifier cannot reach `create_question` on any code path.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds the two SQ-02 registration paths: a schema-constrained capture-intent classifier whose validated output can only become an unchecked suggested checkbox on the source capture note, and an explicit registration path that writes straight through the SQ-01 guarded seam. No code path leads from a classification to a Question note -- only a human-checked box or the explicit action registers anything.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Normal bounded slice delivery; the one divergence found (a spec example contradicting its own normative rule) was repaired in this PR rather than deferred, so no LearningSignal was warranted.

## Notes
Tier 2 implementation slice, light delivery path (Final-Review-Rounds: 0). No TCD high-risk surface: no auth, migration, concurrency, credential-durability, payments, or new external egress -- the classifier reuses the existing `constrained_completion` seam, the proposal reuses the existing PanelAgent `AI-åtgärder` write-back, and the durable write reuses SQ-01's already-guarded store.

Validation actually run (local, on this branch):
- `ruff check app tests` -> All checks passed!
- `mypy app` -> Success: no issues found in 870 source files
- `pytest -q tests/standing_questions/` -> 158 passed (all 8 `Verify:` targets plus 8 added enforcement/edge tests)
- `RUN_INTEGRATED_RUNTIME_UAT=1 pytest -q -m "not pg" tests/uat` -> 10 passed (named by the Issue because this is a vault write-path change)
- `pytest -q -m "not pg"` (host-leased, `-n auto --dist=loadfile`, execution id `3328:b4c8a5f9b`) -> 12447 passed, 3 failed: `tests/expansion/test_connect_findings.py::test_default_retrieve_fn_resolves_through_live_capability`, `tests/builderops/ckm/test_query_plans.py::test_projection_batch_refuses_mixed_database_identity`, `tests/retrieval/test_conditional_rerank.py::test_containment_enforced_when_conditional_rerank_runs`. All three pass in isolation, and this is the third consecutive full-suite run on this host to produce a *different* small failure set from the same unchanged surfaces (see PR #4588's receipt), so it is worker/order dependence rather than a regression. Nothing in this diff is imported outside `tests/standing_questions/`. CI is the authority on the shared suite.

That suite ran on commit `b4c8a5f9b`, which this branch then rebased byte-identically onto `1324257b5`. The only incoming base change was BuilderOps LearningSignal disposition work (`app/builderops/**`, `tests/builderops/**`, three governance docs) with no source, dependency, contract, configuration, migration, test-selection, or toolchain overlap with this diff, so the evidence carries forward per `GOVERNANCE_PROPORTIONALITY.md :: Post-validation base-drift evidence reuse`. `ruff check app tests` and `pytest -q tests/standing_questions/` were re-run green on the rebased head; current-head CI remains the current-SHA gate.

Enforcement proof: every guard was mutation-checked -- removing the checkbox gate in confirmation, the confirm-side verbatim check, the propose-side verbatim check, the non-registration class gate, the proposal idempotency check, the panel-fencing of the classification input and verbatim baseline, the propose WriteGuard assertion, the classifier's verbatim refusal, or the classifier's UNKNOWN degrade each turns at least one test red.

Spec repair included: `REGISTER_QUESTIONS_FRICTION_FREE.md :: Concretely` illustrated an extraction ("Should we fully migrate to BGE-M3?") that was a rewrite of the capture ("...find out whether we should fully migrate to BGE-M3"), contradicting the same document's normative rule in point 3 that `text` is "a verbatim quote from their capture ... never a paraphrase or summary the classifier invents". The implementation follows the normative rule and the example is corrected in the same change.
