### PR TITLE
fix: close select_pr_tests.py unowned fallthrough for CLAUDE.md/.codex/** combos

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -884,13 +884,27 @@ def _is_docs_only(paths: tuple[str, ...]) -> bool:
         # CLAUDE.md is the Claude compatibility entrypoint documented alongside
         # AGENTS.md (#4281); it must resolve here so a CLAUDE.md-only PR routes
         # to tests/architecture instead of falling through to unowned/full-suite.
-        and (path.startswith("docs/") or path in {"README.md", "AGENTS.md", "CLAUDE.md"})
+        # `.codex/` is included so a `.codex/**` path (e.g. `.codex/agents/*.toml`,
+        # `.codex/config.toml`) mixed with a `docs/**` path or `CLAUDE.md` still
+        # resolves here instead of falling through every SUBSYSTEMS prefix into
+        # `unowned` (#4335) -- a pure `.codex/**` diff still resolves via
+        # `_is_governance_only` first, since that branch is checked before this
+        # one in `select_tests`.
+        and (
+            path.startswith("docs/")
+            or path.startswith(".codex/")
+            or path in {"README.md", "AGENTS.md", "CLAUDE.md"}
+        )
         for path in non_test
     )
 
 
 def _is_governance_only(paths: tuple[str, ...]) -> bool:
-    governance_prefixes = (".github/", "docs/development/", "AGENTS.md", ".codex/")
+    # CLAUDE.md is added here symmetrically with AGENTS.md so
+    # `select_tests(["AGENTS.md", "CLAUDE.md"])` resolves the same way as
+    # `select_tests(["AGENTS.md"])` alone (both governance), instead of the
+    # combination silently falling through to the docs branch (#4335).
+    governance_prefixes = (".github/", "docs/development/", "AGENTS.md", "CLAUDE.md", ".codex/")
     non_test = _non_test_signal(paths, GOVERNANCE_TARGETS)
     return bool(non_test) and all(
         path.startswith(governance_prefixes) or path == "scripts/select_pr_tests.py"

--- a/tests/governance/test_ci_smoke_docs_only_gate.py
+++ b/tests/governance/test_ci_smoke_docs_only_gate.py
@@ -259,6 +259,15 @@ def test_pr_4275_shaped_diff_now_selects_architecture_and_ci_gate_coverage() -> 
     # tests/architecture and tests/ops/test_review_before_ci_gate.py, so the
     # architecture/CI-gate tests that actually assert on these paths still
     # would not have run.
+    #
+    # #4335 widened `_is_docs_only` to accept `.codex/**` (previously only a
+    # pure `.codex/skills/`+`docs/contracts/` mix routed through the
+    # `docs_authoring` subsystem loop; `docs/DOCS_INDEX.md` in this diff kept
+    # `_is_docs_only` False before that fix). This diff now classifies as
+    # docs-only up front, with `docs_authoring` still unioned in as a foreign
+    # subsystem match (#4336) since its targets are not a subset of
+    # `DOCS_TARGETS` -- a strict superset of the previous coverage, not a
+    # narrowing.
     pr_4275_diff = (
         ".codex/AGENTS.md",
         ".codex/skills/README.md",
@@ -272,9 +281,10 @@ def test_pr_4275_shaped_diff_now_selects_architecture_and_ci_gate_coverage() -> 
 
     assert selection.full_suite is False
     assert selection.unowned_paths == ()
-    assert selection.subsystems == ("docs_authoring",)
+    assert selection.subsystems == ("docs", "docs_authoring")
     assert "tests/governance" in selection.targets
     assert "tests/scripts" in selection.targets
     assert "tests/ops/test_ci_workflow.py" in selection.targets
     assert "tests/architecture" in selection.targets
     assert "tests/ops/test_review_before_ci_gate.py" in selection.targets
+    assert "tests/docs" in selection.targets

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -1263,3 +1263,57 @@ def test_cli_rejects_an_unowned_path() -> None:
     assert result.returncode == 2
     assert "subsystems=unowned" in result.stdout
     assert "unowned_paths=app/new_surface/example.py" in result.stdout
+
+
+def test_agent_surface_combinations_never_resolve_unowned() -> None:
+    """#4335: the whole {AGENTS.md, CLAUDE.md, .codex/**, docs/**} surface #4330
+    widened `ci-smoke.yaml`'s `code` paths-filter for must never fall through
+    every SUBSYSTEMS prefix into `unowned` (exit 2), no matter how its members
+    are combined on one PR."""
+    import itertools
+
+    universe = (
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".codex/AGENTS.md",
+        ".codex/skills/x/SKILL.md",
+        ".codex/agents/reviewer.toml",
+        ".codex/config.toml",
+        "docs/STATUS.md",
+        "docs/ARCHITECTURE.md",
+        "README.md",
+    )
+
+    for size in (1, 2, 3):
+        for combo in itertools.combinations(universe, size):
+            selection = select_tests(list(combo))
+            assert selection.subsystems != ("unowned",), combo
+            assert selection.unowned_paths == (), combo
+            assert selection.full_suite is False, combo
+
+
+def test_claude_md_is_symmetric_with_agents_md_in_governance_only() -> None:
+    agents_only = select_tests(["AGENTS.md"])
+    agents_and_claude = select_tests(["AGENTS.md", "CLAUDE.md"])
+
+    assert agents_only.subsystems == ("governance",)
+    assert agents_and_claude.subsystems == ("governance",)
+    assert agents_and_claude.reason == "governance-only PR"
+
+
+def test_docs_only_lane_selects_tests_governance() -> None:
+    selection = select_tests(["docs/ARCHITECTURE.md"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("docs",)
+    assert "tests/governance" in selection.targets
+
+
+def test_docs_plus_tests_governance_does_not_narrow_mixed_pr() -> None:
+    selection = select_tests(
+        ["docs/ARCHITECTURE.md", "tests/governance/test_project_pickup_deprecation.py"]
+    )
+
+    assert selection.full_suite is False
+    assert "builder_system" in selection.subsystems
+    assert "tests/governance/test_project_pickup_deprecation.py" in selection.targets


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4335

## Linked Issue
Fixes #4335

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: mechanical
- Persistence impact: none — git-tracked selector constants only
- Derived/rebuildable impact: none
- New or changed contract: none — closes gaps in the classification/coverage contract PR #4330 already introduced; adds no new gate or subsystem concept
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Closes the remaining Gap 1 from #4335: `_is_governance_only` now includes `CLAUDE.md` in its prefix tuple symmetrically with `AGENTS.md`, and `_is_docs_only` now accepts the `.codex/` prefix so a non-`skills/` `.codex/**` path (e.g. `.codex/agents/*.toml`, `.codex/config.toml`) mixed with a `docs/**` path or `CLAUDE.md` no longer falls through every `SUBSYSTEMS` prefix into `unowned` (exit 2).
- Gap 2 (`tests/governance` in `DOCS_TARGETS`) was already fixed by an earlier, unrelated PR (verified against current `origin/main` before implementing) — no change needed there.
- Added 4 regression tests matching the issue's Acceptance Criteria: `test_agent_surface_combinations_never_resolve_unowned` (brute-force 1-3 file combinations over the full `{AGENTS.md, CLAUDE.md, .codex/**, docs/**, README.md}` universe never resolve `unowned`), `test_claude_md_is_symmetric_with_agents_md_in_governance_only`, `test_docs_only_lane_selects_tests_governance`, `test_docs_plus_tests_governance_does_not_narrow_mixed_pr`.
- Updated one existing test (`test_pr_4275_shaped_diff_now_selects_architecture_and_ci_gate_coverage`) whose exact-tuple assertion no longer held: the widened `.codex/` prefix now correctly classifies that historical diff as `docs-only` up front (previously it fell through to the `docs_authoring` subsystem loop only). The `docs_authoring` subsystem is still unioned in as a foreign-subsystem match (#4336 mechanism), so this is a strict superset of prior coverage — a widening, not a narrowing.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: mechanical tuple/prefix fix to an existing selector script plus its own regression tests; no BuilderOps-tracked record type applies.

## Notes
- Verified before implementing (against rebased `origin/main`, includes #4336's merge) that Gap 2 was already resolved; only Gap 1 required a code change.
- Validation: `pytest -q tests/scripts/test_select_pr_tests.py tests/governance/test_ci_smoke_docs_only_gate.py` (99 passed); `ruff check app tests` (clean); `mypy app` (clean, 870 files); affected-subsystem suite `pytest -m "not pg and not alpha_llm and not alpha_llm_live and not panel_llm_e2e and not eval and not browser_runtime and not human_uat and not uat_integrated_runtime" tests/governance tests/scripts tests/ops/test_ci_workflow.py tests/architecture tests/ops/test_review_before_ci_gate.py tests/builderops tests/dispatcher tests/ops tests/deploy` (4053 passed, 3 skipped).
- No residual risk identified; this is a targeted tuple/prefix widening per the issue's Constraints (no `SUBSYSTEMS`/`GOVERNANCE_TARGETS`/`DOCS_TARGETS` widening, no full-suite escalation for any covered combination).
