### PR TITLE
docs: name content_drift in signboard-validate finding list

### DIFF
--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -824,8 +824,10 @@ Run `python -m app.dispatcher signboard-validate [path] --json` to lint the gene
 changing either the board or dispatcher store. As with `export-signboard`, the path is optional and
 defaults to the active vault's `BuilderOpsVault/agent-delivery` root. Validation exits nonzero for
 malformed generated cards, duplicate generated cards, column/status drift, cards stale against the
-dispatcher store, unreadable generated-filename candidates, and a board stamped by a different
-dispatcher store; run `export-signboard` to repair valid generated-card drift. Human-authored files are outside this lint's jurisdiction.
+dispatcher store, a same-column generated card whose title, priority, claim, linked PR, or labels no
+longer match its dispatcher task (`content_drift`), unreadable generated-filename candidates, and a
+board stamped by a different dispatcher store; run `export-signboard` to repair valid generated-card
+drift. Human-authored files are outside this lint's jurisdiction.
 
 A plain `export-signboard` only rewrites cards for task IDs that still exist in the dispatcher
 store, so it cannot clear a card whose task ID has disappeared from the store — those accumulate as


### PR DESCRIPTION
## Direct Repair
Type: docs
Reason: #4324 (merged, PR #4594) added a content_drift finding to validate_signboard, and docs/AGENT_ISSUE_DISPATCHER.md's exact enumeration of the findings signboard-validate reports had gone stale relative to shipped behavior; this is a bounded, immediate one-line doc correction with no independent scope.
Validation: doc-only change; visually diffed against app/dispatcher/signboard.py::validate_signboard finding kinds.
Issue required: no

Final-Review-Rounds: 0

## Summary
Names the `content_drift` finding kind (same-column card whose title, priority, claim, linked PR, or labels drifted from its dispatcher task) in the `signboard-validate` finding-kind enumeration.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-only fix with no BuilderOps material routed.

## Notes
Validation: doc-only change, no code/tests affected.
---