### PR TITLE
fix: correct issue-to-code SBS citation scope and READ_SCOPE gate list

### DIFF
--- a/.codex/skills/_shared/READ_SCOPE.md
+++ b/.codex/skills/_shared/READ_SCOPE.md
@@ -24,10 +24,28 @@ in one of two shapes, and the shape is the instruction.
 ## Why this is safe
 
 Reducing read scope removes a *read*, never a *check*. Every rule whose read is narrowed here is
-still enforced by a downstream pre-merge gate — CI (`pr-contract`, `Unit tests (not pg)`,
-`harness-selfverify`), `scripts/lint_skills_consistency.py`, `scripts/docs_guard.py`, the branch-truth
-gate, or the verification step in `verification-and-closure`. If a rule has no such gate, its read
-stays mandatory and unconditional.
+still enforced by a downstream pre-merge gate. What actually runs as an unconditional pre-merge check
+depends on the diff class:
+
+- On every PR, regardless of diff class: CI's `pr-contract` job, plus the `smoke` job's three
+  unconditional steps in `.github/workflows/ci-smoke.yaml` — `scripts/lint_skills_consistency.py`
+  ("Skills consistency lint"), "Doc integrity", and `tests/architecture/test_pr_hot_path_governance.py`
+  ("Hot path governance architecture test").
+- Only when the diff touches code paths matched by the `code` filter in `ci-smoke.yaml`: CI's
+  `Unit tests (not pg)` job (`pr-unit-tests-not-pg`); an instruction-file-only diff
+  (`.codex/**`, `AGENTS.md`, `CLAUDE.md`, `docs/**`) does not trip this filter, so this job's real
+  steps do not run against such a diff.
+- Only when the diff touches the release/promotion harness surface named in
+  `harness-selfverify.yml`'s `paths:` trigger (for example `tests/uat/**`, `app/ops/**`,
+  `.codex/skills/promote-to-test/**`) or via its cron/manual dispatch: the `harness-selfverify`
+  workflow.
+- Only via manual `workflow_dispatch` (`architecture-ci.yaml` has no `pull_request` trigger):
+  `scripts/docs_guard.py`.
+- The branch-truth gate and the verification step in `verification-and-closure` apply per their own
+  governing procedures.
+
+If a rule has no gate that actually fires for the diff class in front of you, its read stays
+mandatory and unconditional.
 
 The corollary is a maintenance rule: **before narrowing a citation, confirm the omitted content is
 either reproduced at the citation site or caught by an existing fail-loud gate.** Content that is

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -34,8 +34,14 @@ insufficient for the case in front of you.
 
 Before claiming an Issue or producing any implementation, answer the following. Stop as indicated if the answer is unresolvable.
 
-**System boundary** — classify the issue using
-`docs/architecture/SBS_OPERATING_MODEL.md :: Builder System Boundary And Work Classification`:
+**System boundary** — classify the issue using the categories below, inlined from
+`docs/architecture/SBS_OPERATING_MODEL.md :: Classification Procedure` (the tie-breaker below is the
+one rule from that subsection this skill does not otherwise reproduce). The parent heading's other
+subsections are already covered elsewhere: `:: Builder System SBS Impact Guidance` and
+`:: Builder System Artifact And Workflow Map` are cited separately and conditionally below (SBS
+Impact / Builder System branch only). Read `:: Builder-Agent Authority Model` or
+`:: Builder Learning, Evaluation, And TCD Governance Loop` only when the categories below are
+genuinely insufficient to classify the case in front of you:
 
 - Product/Runtime System work changes product behavior, runtime code, user-facing semantics,
   Product SBS contracts, durable human knowledge authority, machine memory, retrieval, execution,


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4296

## Linked Issue
Closes #4296

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): agent instruction chain
- Write class: governance/docs/process
- Persistence impact: none - git-tracked instruction artifacts only
- Derived/rebuildable impact: none
- New or changed contract: none - corrects an already-merged citation and gate list to match existing CI behavior
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Correct issue-to-code's SBS classification citation to a narrower Classification Procedure scope and correct READ_SCOPE.md's overstated pre-merge gate list for instruction-file-only diffs.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 governance-lane citation/gate-list correction; no BuilderOps record produced.

## Notes
Validation: python3 scripts/lint_skills_consistency.py (exit 0); pytest -q tests/governance/test_skills_consistency_lint.py (17 passed); python3 scripts/docs_guard.py (OK).
