### PR TITLE
Add dev/test Compose environment:-vs-env_file: clobber preflight (#4230)

### DIFF
--- a/app/release_channels/channel_isolation_preflight.py
+++ b/app/release_channels/channel_isolation_preflight.py
@@ -296,6 +296,55 @@ def _interpolate_env_file_path(
     return resolved
 
 
+def _interpolate_environment_value(
+    expr: str,
+    lookup: Callable[[str], str | None],
+) -> str | None:
+    """Interpolate a compose `environment:` scalar value the way compose does.
+
+    Same substitution grammar as :func:`_interpolate_env_file_path`
+    (``$VAR``, ``${VAR}``, ``${VAR-default}``, ``${VAR:-default}``), but a
+    different unresolvable rule: an env_file *path* expression that resolves
+    to an empty string is meaningless (no file to read), so that function
+    folds "empty" and "unresolvable" together. A Compose `environment:`
+    *value* has no such constraint — an empty string is exactly what
+    ``${VAR:-}`` produces against an unset shell variable, and detecting that
+    blank-override shape is the whole point of Issue #4230's check. Returns
+    ``None`` only for a genuinely unsupported expression form (e.g.
+    ``${VAR:?err}``, nested expressions) or a result that still contains
+    ``$`` — both truly unresolvable, unlike a legitimate empty string.
+    """
+    out: list[str] = []
+    pos = 0
+    for match in _ENV_FILE_VAR_PATTERN.finditer(expr):
+        out.append(expr[pos:match.start()])
+        pos = match.end()
+        if match.group("escaped"):
+            out.append("$")
+            continue
+        named = match.group("named")
+        if named is not None:
+            out.append(lookup(named) or "")
+            continue
+        braced = match.group("braced") or ""
+        if _BRACED_SIMPLE.match(braced):
+            out.append(lookup(braced) or "")
+            continue
+        default_match = _BRACED_DEFAULT.match(braced)
+        if default_match is None or "$" in default_match.group("default"):
+            return None  # unsupported expression form — unresolvable
+        value = lookup(default_match.group("name"))
+        if default_match.group("colon"):
+            out.append(value if value else default_match.group("default"))
+        else:
+            out.append(value if value is not None else default_match.group("default"))
+    out.append(expr[pos:])
+    resolved = "".join(out)
+    if "$" in resolved:
+        return None
+    return resolved
+
+
 def _service_env_file_layers(service_dict: dict[str, Any]) -> list[EnvFileLayer]:
     """Extract the env_file chain declared on one compose service dict."""
     raw = service_dict.get("env_file")
@@ -689,6 +738,111 @@ def _check_db_dsn(
                     ),
                 )
             )
+
+
+# ---------------------------------------------------------------------------
+# environment:-vs-env_file: blank-override clobber detection (Issue #4230)
+# ---------------------------------------------------------------------------
+
+def check_environment_env_file_clobber(
+    compose_path: Path,
+    channel: str,
+    base_compose_path: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    load_dotenv: bool = True,
+) -> PreflightResult:
+    """Detect a blank `environment:` override shadowing a non-empty env_file value.
+
+    Compose's `environment:` block always wins over `env_file:` for the same
+    key. When an overlay declares a key like ``${VAR:-}`` and the invoking
+    shell never populates ``VAR`` — deliberate, since
+    ``scripts/lib/deploy_channel_compose.sh`` never passes the governed
+    runtime env file as a Compose CLI ``--env-file`` (that would expose DSNs
+    to Compose interpolation, #3875) — the interpolated value is an empty
+    string, and it silently shadows whatever value the same key would
+    otherwise receive from the service's ``env_file`` chain. This is the
+    exact shape that crash-looped ``heimdal-capture-watch`` on every
+    dev-channel deploy until commit ``f95a6811`` deleted the offending
+    `environment:` entries (Issue #4230's "already fixed" instance).
+
+    This check is channel-agnostic: it does not validate which channel a
+    binding belongs to (that is ``check_compose_channel_isolation``'s job),
+    only whether an explicit override is blank while the same key's
+    ``env_file`` chain would otherwise supply a real value. It runs over
+    :data:`CHANNEL_SERVICES` (currently including ``heimdal-capture-watch``)
+    the same way the DSN-isolation check does.
+
+    Read-only: never mutates compose, pin, or env_file layers, requires no
+    Docker and no network — pure YAML plus env_file text, mirroring
+    :func:`check_compose_channel_isolation`'s design constraints.
+    """
+    compose_data = _load_compose(compose_path)
+    services = compose_data.get("services") or {}
+    compose_dir = compose_path.resolve().parent
+
+    lookup = _make_var_lookup(
+        os.environ if environ is None else environ,
+        _load_dotenv(compose_dir) if load_dotenv else {},
+    )
+
+    base_compose = base_compose_path or (compose_dir / BASE_COMPOSE_FILENAME)
+    base_services: dict[str, Any] | None = None
+    if base_compose.is_file():
+        base_services = _load_compose(base_compose).get("services") or {}
+
+    result = PreflightResult(channel=channel, compose_path=str(compose_path))
+
+    for svc_name in CHANNEL_SERVICES:
+        svc = services.get(svc_name) or {}
+        env = _service_env(svc)
+        if not env:
+            continue
+
+        overlay_layers = _service_env_file_layers(svc)
+        if base_services is None:
+            chain = [EnvFileLayer(path_expr=str(BASE_ENV_DEFAULTS_REL))]
+        else:
+            chain = _service_env_file_layers(base_services.get(svc_name) or {})
+        chain = chain + overlay_layers
+
+        for key, raw_value in env.items():
+            if raw_value is None or "$" not in raw_value:
+                # No shell-interpolation token: a literal explicit value
+                # (including a deliberate literal `""`, e.g. the test
+                # channel's fail-closed `WATCHER_VAULT_PATH: ""`) is an
+                # intentional authoring choice, not the shell-interpolation
+                # clobber shape this check targets.
+                continue
+            resolved_override = _interpolate_environment_value(raw_value, lookup)
+            if resolved_override != "":
+                # Non-blank, or unresolvable (unsupported expression form):
+                # neither is a proven blank-clobber.
+                continue
+
+            resolution = _resolve_key_through_chain(key, chain, compose_dir, lookup)
+            if resolution.error is not None or not resolution.value:
+                # Unverifiable or genuinely absent from the env_file chain
+                # too: no non-blank value is being shadowed.
+                continue
+
+            result.violations.append(
+                BindingViolation(
+                    service=svc_name,
+                    field=key,
+                    expected=(
+                        f"no blank `environment:` override for {key!r} — "
+                        "the env_file chain supplies a non-empty value that "
+                        "would otherwise apply"
+                    ),
+                    actual=(
+                        f"explicit environment override {raw_value!r} resolves "
+                        f"to an empty value, shadowing {resolution.value!r} "
+                        f"from env_file layer {resolution.source}"
+                    ),
+                )
+            )
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -586,6 +586,15 @@ alerted state pending the one-time key setup and the prod restore (#4282).
   the underlying processing failure first (this preflight never mutates the queue), then redeploy.
   Rollback is deliberately not gated. Full contract:
   `docs/HEALTH.md :: Outbox and dead-letter signals`.
+- A `dev` or `test` deploy (`scripts/deploy_channel.sh deploy <dev|test> <sha>`) refuses to proceed
+  — before pin or migration mutation — when a `CHANNEL_SERVICES` service's compose `environment:`
+  override resolves blank while its `env_file` chain would otherwise supply a non-empty value for
+  the same key (#4230; the shape that crash-looped `heimdal-capture-watch` before commit
+  `f95a6811`). The deploy log always carries a
+  `dev/test environment clobber preflight: ok|skipped:<reason>|blocked ...` status line; on a
+  block, remove the blank override so the value rides the `env_file` chain instead. This preflight
+  is read-only and is not applied to `prod` or to rollback. Full contract:
+  `docs/RELEASE_CHANNELS/README.md :: Environment:-vs-env_file: blank-override clobber invariant`.
 
 Operator triage order:
 1. Run `make verify-runtime`.

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -197,6 +197,14 @@ expressions, because Compose must still resolve and load the service's `env_file
 
 The guard is **read-only**: it reports and fail-closes; it never edits operator files. When it fails, the operator must correct the compose overlay to match the intended channel before proceeding.
 
+### Environment:-vs-env_file: blank-override clobber invariant (Issue #4230)
+
+Independent of the DSN/`PKM_ENVIRONMENT` isolation guard above, a service's compose `environment:` block always wins over its `env_file:` chain for the **same key**, whatever value it resolves to — including an accidental blank one. `scripts/lib/deploy_channel_compose.sh` deliberately never passes the governed runtime env file as a Compose CLI `--env-file` (that would expose DSNs to Compose interpolation, #3875), so an overlay entry shaped like `${VAR:-}` interpolates to an empty string against the invoking shell and **silently shadows** whatever value the same key would otherwise receive from the service's `env_file` chain. This crash-looped `heimdal-capture-watch` on every dev-channel deploy until commit `f95a6811` deleted the offending `environment:` entries.
+
+**Enforcement:** `app/release_channels/channel_isolation_preflight.py::check_environment_env_file_clobber` detects this shape for every `CHANNEL_SERVICES` service (channel-agnostic — it only compares an override's resolved value against the same key's env_file-chain value, not which channel a binding belongs to). A literal explicit value (including a deliberate literal `""`, e.g. the test channel's fail-closed `WATCHER_VAULT_PATH: ""`) is never flagged — only a value containing a shell-interpolation token (`$...`) that resolves to an empty string while the env_file chain would otherwise supply a non-empty value counts as a clobber.
+
+`scripts/dev_test_environment_clobber_preflight.py` wraps the check for `scripts/deploy_channel.sh`'s `dev` and `test` channel `deploy` actions, invoked before `write_pin` / migration execution — the same placement and read-only, deploy-only-by-contract posture as the pre-existing prod-only pending-retry preflight (`prod_pending_retry_preflight`, #3903). It is deliberately not wired to the prod channel or to `rollback`: prod already carries an analogous, DSN-scoped resolver call (`prod_pending_retry_preflight` / `app.release_channels.channel_isolation_preflight.resolve_effective_dsn`), and rollback must stay ungated so the prior stable ref is always recoverable ([Rollback contract](DEFINE_ROLLBACK_CONTRACT.md)).
+
 ## Promotion model
 
 This section records the **current** prod promotion model and how it relates to the **target** gated model below. It is the authoritative reconciliation of the channel table and Invariant 4 with what prod actually runs (Issue #2527; [ADR-0040](../adr/ADR-0040-prod-promotion-ref-main-interim.md)).

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -748,6 +748,56 @@ print(line)
   return 0
 }
 
+dev_test_environment_env_file_clobber_preflight() {
+  # Read-only dev/test deploy-only preflight (#4230): detect a CHANNEL_SERVICES
+  # service whose explicit `environment:` block resolves a key to an empty
+  # string while that service's env_file chain would otherwise supply a
+  # non-empty value for the same key -- the exact shape that crash-looped
+  # heimdal-capture-watch on every dev-channel deploy until commit f95a6811
+  # deleted the offending `environment:` entries (that instance is already
+  # fixed; this preflight guards the still-open general class). Runs before
+  # write_pin / migration execution, mirroring prod_pending_retry_preflight's
+  # placement and rationale: read-only, no Docker, no network, resolved
+  # entirely by app.release_channels.channel_isolation_preflight (the one
+  # purpose-built, tested Compose environment:-vs-env_file: resolver), never
+  # re-derived from pin/runtime-env files by hand. Deliberately NOT applied to
+  # rollback or the prod channel (prod's own DSN-scoped gate above is
+  # unaffected -- docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md).
+  local receipt_json rc=0
+  receipt_json="$(
+    "${PYTHON}" "${ROOT}/scripts/dev_test_environment_clobber_preflight.py" "${channel}"
+  )" || rc=$?
+
+  printf '%s' "${receipt_json}" | "${PYTHON}" -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    data = {}
+status = data.get("status") or "error"
+if status == "blocked":
+    line = (
+        "dev/test environment clobber preflight: blocked violation_count="
+        + str(data.get("violation_count"))
+    )
+elif status == "skipped":
+    line = "dev/test environment clobber preflight: skipped:" + str(data.get("reason") or "unknown")
+elif status == "ok":
+    line = "dev/test environment clobber preflight: ok"
+else:
+    line = "dev/test environment clobber preflight: " + str(status)
+print(line)
+'
+
+  if [ "${rc}" -ne 0 ]; then
+    echo "dev/test deploy blocked before pin or Compose mutation: a service environment: override would clobber a non-empty env_file value (heimdal-capture-watch clobber class, #4230)" >&2
+    printf '%s\n' "${receipt_json}" >&2
+    echo "guidance: remove the blank environment: override for the reported key(s) so the value rides the env_file chain instead (see docker-compose.yaml's heimdal-capture-watch comment for the pattern); this preflight is read-only and never mutates compose, pin, or env_file layers" >&2
+    return 1
+  fi
+  return 0
+}
+
 version_gate() {
   local version_json health_json version_sha health_sha rc=0
   version_json="$(curl -fsS --max-time 5 "http://127.0.0.1:${api_port}/version")" || rc=$?
@@ -956,6 +1006,13 @@ export INSTANCE_STATE_LEGACY_ROLLBACK
 # the prior stable ref is always recoverable (DEFINE_ROLLBACK_CONTRACT.md).
 if [ "${channel}" = "prod" ] && [ "${action}" = "deploy" ]; then
   prod_pending_retry_preflight || exit 87
+fi
+
+# Same deploy-only-by-contract posture as the prod gate above (#4230): dev and
+# test never previously ran any Compose environment:-vs-env_file: precedence
+# check before mutation.
+if { [ "${channel}" = "dev" ] || [ "${channel}" = "test" ]; } && [ "${action}" = "deploy" ]; then
+  dev_test_environment_env_file_clobber_preflight || exit 90
 fi
 
 ensure_prod_instance_state_volume

--- a/scripts/dev_test_environment_clobber_preflight.py
+++ b/scripts/dev_test_environment_clobber_preflight.py
@@ -1,0 +1,114 @@
+"""Read-only dev/test deploy preflight: detect a Compose `environment:`
+override that resolves blank while the same service's `env_file` chain would
+otherwise supply a non-empty value for that key (Issue #4230).
+
+Compose's `environment:` block always wins over `env_file:` for the same key.
+`scripts/lib/deploy_channel_compose.sh` deliberately never passes the
+governed runtime env file as a Compose CLI `--env-file` (that would expose
+DSNs to Compose interpolation, #3875), so an overlay entry shaped like
+`${VAR:-}` interpolates to an empty string against the invoking shell and
+silently shadows whatever value the same key would otherwise receive from the
+service's env_file chain. This is the exact shape that crash-looped
+`heimdal-capture-watch` on every dev-channel deploy until commit `f95a6811`
+deleted the offending `environment:` entries -- that instance is already
+fixed, but the deploy path ran zero check for the general class on the dev
+and test channels (prod already carries an analogous, DSN-scoped gate via
+`scripts/prod_deploy_retry_preflight.py`).
+
+This script asks `app.release_channels.channel_isolation_preflight` (the one
+purpose-built, tested Compose `environment:`-vs-`env_file:` resolver) whether
+the channel's real compose overlay currently has this shape, for every
+service in `CHANNEL_SERVICES` (`api`, `worker`, `watcher`,
+`heimdal-capture-watch`). Read-only: no Docker, no network, never mutates
+compose, pin, or env_file files.
+
+Exit codes:
+  0  no blank-override clobber found (including "channel has no overlay" --
+     an unsupported/unknown channel argument is a caller error, not this
+     preflight's job to adjudicate).
+  1  at least one blank-override clobber found; the caller
+     (`scripts/deploy_channel.sh`) must not proceed to pin write or
+     migration/Compose mutation.
+
+Usage: ``python scripts/dev_test_environment_clobber_preflight.py <dev|test>``.
+Prints one JSON receipt object to stdout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CHANNEL_OVERLAYS = {
+    "dev": "docker-compose.dev.yml",
+    "test": "docker-compose.test.yml",
+}
+
+
+def _repo_root() -> Path:
+    # This script is invoked by path (sys.path[0] is scripts/, not the repo
+    # root), so the repo root is added to sys.path explicitly before any
+    # `app.*` import.
+    root = Path(__file__).resolve().parents[1]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    return root
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1 or argv[0] not in _CHANNEL_OVERLAYS:
+        print(
+            f"usage: {Path(__file__).name} <{'|'.join(_CHANNEL_OVERLAYS)}>",
+            file=sys.stderr,
+        )
+        return 2
+
+    channel = argv[0]
+    root = _repo_root()
+
+    compose_path = root / _CHANNEL_OVERLAYS[channel]
+    if not compose_path.is_file():
+        # Fail open, not closed: an absent compose overlay is a setup/
+        # environment concern this preflight does not adjudicate (mirrors
+        # scripts/prod_deploy_retry_preflight.py's skipped:no_dsn posture for
+        # "resolution is impossible at all", not "a violation was found").
+        payload = {
+            "status": "skipped",
+            "channel": channel,
+            "reason": "compose_overlay_missing",
+        }
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    from app.release_channels.channel_isolation_preflight import (
+        check_environment_env_file_clobber,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, channel)
+
+    if result.ok:
+        payload = {"status": "ok", "channel": channel, "violation_count": 0}
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    payload = {
+        "status": "blocked",
+        "channel": channel,
+        "violation_count": len(result.violations),
+        "violations": [
+            {
+                "service": violation.service,
+                "field": violation.field,
+                "expected": violation.expected,
+                "actual": violation.actual,
+            }
+            for violation in result.violations
+        ],
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -111,6 +111,7 @@ def _deploy_harness(tmp_path: Path) -> tuple[Path, dict[str, str], str]:
         "config/secrets/host_secret_contract.json",
         "scripts/deploy_channel.sh",
         "scripts/companion_ui_postdeploy_smoke.sh",
+        "scripts/dev_test_environment_clobber_preflight.py",
         "scripts/lib/deploy_channel_compose.sh",
         "scripts/lib/instance_state_deployment.sh",
         "scripts/lib/instance_ownership_host_state.sh",
@@ -1828,3 +1829,132 @@ def test_prod_deploy_pending_retry_preflight_fails_open_without_dsn(
     assert result.returncode == 0, result.stdout + result.stderr
     assert "prod pending-retry preflight: skipped:no_dsn" in result.stdout
     assert (tmp_path / "docker-called").exists()
+
+
+# ---------------------------------------------------------------------------
+# Dev/test environment:-vs-env_file: clobber preflight (Issue #4230)
+# ---------------------------------------------------------------------------
+
+#: Reproduces the pre-f95a6811 heimdal-capture-watch shape: an
+#: `environment:` entry interpolating from an unset shell variable shadows
+#: the real value the same key would otherwise receive from the env_file
+#: chain.
+_HEIMDAL_CLOBBER_OVERLAY = """\
+services:
+  heimdal-capture-watch:
+    env_file:
+      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+        required: false
+    environment:
+      HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-}
+"""
+
+#: The fixed shape (commit f95a6811): no `environment:` override at all for
+#: the host-specific key -- it rides the env_file chain untouched.
+_HEIMDAL_FIXED_OVERLAY = """\
+services:
+  heimdal-capture-watch:
+    env_file:
+      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+        required: false
+"""
+
+
+def _configure_dev_test_environment_clobber_preflight(
+    root: Path,
+    env: dict[str, str],
+    tmp_path: Path,
+    *,
+    channel: str,
+    overlay_content: str,
+) -> None:
+    """Copy the real checker module into the fixture repo and write a
+    synthetic compose overlay reproducing (or not) the heimdal-capture-watch
+    clobber shape, so the real, unmodified
+    app.release_channels.channel_isolation_preflight resolves it exactly as
+    the production deploy path would.
+    """
+    overlay_filename = "docker-compose.dev.yml" if channel == "dev" else "docker-compose.test.yml"
+    dest = root / "app" / "release_channels" / "channel_isolation_preflight.py"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        REPO_ROOT / "app/release_channels/channel_isolation_preflight.py", dest
+    )
+    (root / overlay_filename).write_text(overlay_content, encoding="utf-8")
+    # The overlay's env_file chain merges with the base compose's -- absent a
+    # base docker-compose.yaml here, check_environment_env_file_clobber models
+    # the base layer as this single required file (Issue #1655's contract);
+    # it must exist (even empty) or the whole chain is unverifiable and the
+    # check would skip rather than detect the clobber.
+    (root / "config").mkdir(exist_ok=True)
+    (root / "config/runtime.defaults.env").write_text("", encoding="utf-8")
+    (root / "tmp").mkdir(exist_ok=True)
+    (root / "tmp/runtime.env").write_text(
+        "HEIMDAL_CAPTURE_WATCH_DIR=/real/capture/dir\n", encoding="utf-8"
+    )
+    # Ambient interpolation sources this preflight must resolve against must
+    # match what the real Compose invocation would see -- neither key is
+    # ever set by deploy_channel_compose.sh (#3875), so a stray host export
+    # must not leak into the subprocess and mask the clobber.
+    env.pop("HEIMDAL_CAPTURE_WATCH_DIR", None)
+    env.pop("WATCHER_RUNTIME_ENV_FILE", None)
+
+
+def test_dev_deploy_preflight_rejects_environment_override_clobbering_env_file(
+    tmp_path: Path,
+) -> None:
+    """AC1 (#4230): a dev-channel deploy fails loud, before pin write or
+    migration execution, when a CHANNEL_SERVICES service's `environment:`
+    override resolves blank while its env_file chain supplies a non-empty
+    value for the same key -- the exact shape that crash-looped
+    heimdal-capture-watch on every dev-channel deploy before commit
+    f95a6811 deleted the offending `environment:` entries.
+    """
+    root, env, sha = _deploy_harness(tmp_path)
+    _configure_dev_test_environment_clobber_preflight(
+        root, env, tmp_path, channel="dev", overlay_content=_HEIMDAL_CLOBBER_OVERLAY
+    )
+
+    result = _run_deploy(root, env, sha, channel="dev")
+
+    assert result.returncode != 0
+    assert "dev/test environment clobber preflight: blocked violation_count=1" in result.stdout
+    assert "heimdal-capture-watch" in result.stderr
+    assert "HEIMDAL_CAPTURE_WATCH_DIR" in result.stderr
+    # No pin mutation: the pin file is never created/written before the block.
+    assert not (root / "config/deploy/dev.env").exists()
+    assert not (root / "config/deploy/dev.previous.env").exists()
+    assert not (tmp_path / "docker-called").exists()
+
+
+def test_dev_deploy_preflight_passes_fixed_shape(tmp_path: Path) -> None:
+    """The post-f95a6811 shape (no blank `environment:` override) must not
+    be blocked -- a regression here would make every ordinary dev deploy
+    fail."""
+    root, env, sha = _deploy_harness(tmp_path)
+    _configure_dev_test_environment_clobber_preflight(
+        root, env, tmp_path, channel="dev", overlay_content=_HEIMDAL_FIXED_OVERLAY
+    )
+
+    result = _run_deploy(root, env, sha, channel="dev")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "dev/test environment clobber preflight: ok" in result.stdout
+
+
+def test_test_channel_deploy_preflight_rejects_environment_override_clobbering_env_file(
+    tmp_path: Path,
+) -> None:
+    """Mirrors the dev-channel AC for the test channel, confirming the guard
+    is wired to both non-prod channels, not just dev."""
+    root, env, sha = _deploy_harness(tmp_path)
+    _configure_dev_test_environment_clobber_preflight(
+        root, env, tmp_path, channel="test", overlay_content=_HEIMDAL_CLOBBER_OVERLAY
+    )
+
+    result = _run_deploy(root, env, sha, channel="test")
+
+    assert result.returncode != 0
+    assert "dev/test environment clobber preflight: blocked violation_count=1" in result.stdout
+    assert not (root / "config/deploy/test.env").exists()
+    assert not (tmp_path / "docker-called").exists()

--- a/tests/release_channels/test_channel_isolation_preflight.py
+++ b/tests/release_channels/test_channel_isolation_preflight.py
@@ -41,6 +41,7 @@ import pytest
 
 from app.release_channels.channel_isolation_preflight import (
     check_compose_channel_isolation,
+    check_environment_env_file_clobber,
     resolve_effective_dsn,
 )
 
@@ -52,6 +53,7 @@ from app.release_channels.channel_isolation_preflight import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEST_COMPOSE = REPO_ROOT / "docker-compose.test.yml"
 PROD_COMPOSE = REPO_ROOT / "docker-compose.prod.yml"
+DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
 
 #: Mirrors the channel-critical lines of config/runtime.defaults.env: the base
 #: compose env_file supplies prod 'app' DSNs to every app service by default.
@@ -1424,3 +1426,211 @@ def test_resolve_effective_dsn_against_real_prod_compose() -> None:
             f"expected literal default -- update scripts/prod_deploy_retry_preflight.py's "
             "host-translation assumptions if this default DSN's host:port ever changes"
         )
+
+
+# ---------------------------------------------------------------------------
+# check_environment_env_file_clobber (Issue #4230)
+# ---------------------------------------------------------------------------
+
+#: A minimal base compose declaring heimdal-capture-watch's env_file chain,
+#: mirroring the real docker-compose.yaml shape after commit f95a6811 (no
+#: `environment:` block for the service at all -- host-specific values ride
+#: the env_file chain only).
+_BASE_COMPOSE_HEIMDAL_SHAPE = """\
+services:
+  heimdal-capture-watch:
+    env_file:
+      - ./config/runtime.defaults.env
+      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+        required: false
+"""
+
+
+def _write_heimdal_base(tmp_path: Path) -> Path:
+    (tmp_path / "config").mkdir(exist_ok=True)
+    (tmp_path / "config" / "runtime.defaults.env").write_text("", encoding="utf-8")
+    p = tmp_path / "docker-compose.yaml"
+    p.write_text(_BASE_COMPOSE_HEIMDAL_SHAPE, encoding="utf-8")
+    return p
+
+
+def _write_heimdal_runtime_layer(tmp_path: Path, value: str) -> Path:
+    p = tmp_path / "tmp" / "runtime.env"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"HEIMDAL_CAPTURE_WATCH_DIR={value}\n", encoding="utf-8")
+    return p
+
+
+def test_pre_fix_heimdal_shape_is_rejected(tmp_path: Path) -> None:
+    """Reproduces the pre-f95a6811 heimdal-capture-watch clobber (Issue #4230).
+
+    An `environment:` entry shaped like `${VAR:-}` interpolates to an empty
+    string against an invoking shell that never sets VAR (deliberate --
+    scripts/lib/deploy_channel_compose.sh never passes the runtime env file as
+    a Compose CLI --env-file, #3875) and silently shadows the real value the
+    same key would otherwise receive from the service's env_file chain. The
+    check must fail closed on this shape.
+    """
+    _write_heimdal_base(tmp_path)
+    _write_heimdal_runtime_layer(tmp_path, "/real/capture/dir")
+    compose_path = _write_compose(
+        tmp_path,
+        """\
+        services:
+          heimdal-capture-watch:
+            env_file:
+              - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+                required: false
+            environment:
+              HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-}
+        """,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, "dev", environ={})
+
+    assert not result.ok, (
+        "Expected the preflight to FAIL on the pre-fix heimdal-capture-watch "
+        "environment:-vs-env_file: clobber shape, but it passed."
+    )
+    violating = {(v.service, v.field) for v in result.violations}
+    assert ("heimdal-capture-watch", "HEIMDAL_CAPTURE_WATCH_DIR") in violating
+    assert "/real/capture/dir" in result.summary()
+
+
+def test_deleted_environment_block_passes(tmp_path: Path) -> None:
+    """AC2: the post-f95a6811 shape (no `environment:` block at all for the
+    service) passes -- the fix already applied on main must not regress."""
+    _write_heimdal_base(tmp_path)
+    _write_heimdal_runtime_layer(tmp_path, "/real/capture/dir")
+    compose_path = _write_compose(
+        tmp_path,
+        """\
+        services:
+          heimdal-capture-watch:
+            env_file:
+              - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+                required: false
+        """,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, "dev", environ={})
+
+    assert result.ok, (
+        f"Expected the fixed shape (no environment: override) to pass, got:\n"
+        f"{result.summary()}"
+    )
+
+
+def test_literal_empty_string_override_is_not_flagged(tmp_path: Path) -> None:
+    """A deliberate literal `""` override (no shell-interpolation token) is an
+    intentional authoring choice, not the shell-interpolation clobber shape
+    this check targets -- mirrors docker-compose.test.yml's real
+    `WATCHER_VAULT_PATH: ""` fail-closed default. Must not be flagged even
+    when a same-named env_file layer carries a non-empty value.
+    """
+    (tmp_path / "config").mkdir(exist_ok=True)
+    (tmp_path / "config" / "runtime.defaults.env").write_text(
+        "WATCHER_VAULT_PATH=/app/vault\n", encoding="utf-8"
+    )
+    compose_path = _write_compose(
+        tmp_path,
+        """\
+        services:
+          watcher:
+            environment:
+              WATCHER_VAULT_PATH: ""
+        """,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, "test", environ={})
+
+    assert result.ok, (
+        f"Expected a literal empty-string override to be treated as intentional, "
+        f"got:\n{result.summary()}"
+    )
+
+
+def test_non_blank_override_is_not_flagged(tmp_path: Path) -> None:
+    """A resolved non-blank override is exactly what compose would bind the
+    service to -- it is never a clobber, whatever the env_file chain says."""
+    _write_heimdal_base(tmp_path)
+    _write_heimdal_runtime_layer(tmp_path, "/should/not/matter")
+    compose_path = _write_compose(
+        tmp_path,
+        """\
+        services:
+          heimdal-capture-watch:
+            env_file:
+              - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+                required: false
+            environment:
+              HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-/explicit/default}
+        """,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, "dev", environ={})
+
+    assert result.ok, f"Expected a non-blank override to pass, got:\n{result.summary()}"
+
+
+def test_blank_override_with_no_env_file_value_is_not_flagged(tmp_path: Path) -> None:
+    """A blank override is only a clobber when it actually shadows something.
+    When the env_file chain never defines the key either, there is nothing to
+    shadow -- the service simply starts without the binding, a separate
+    concern from this check."""
+    _write_heimdal_base(tmp_path)
+    compose_path = _write_compose(
+        tmp_path,
+        """\
+        services:
+          heimdal-capture-watch:
+            env_file:
+              - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+                required: false
+            environment:
+              HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-}
+        """,
+    )
+
+    result = check_environment_env_file_clobber(compose_path, "dev", environ={})
+
+    assert result.ok, (
+        f"Expected a blank override with no shadowed env_file value to pass, "
+        f"got:\n{result.summary()}"
+    )
+
+
+def test_real_dev_compose_passes_environment_clobber_preflight() -> None:
+    """Regression guard: the committed docker-compose.dev.yml must never
+    reintroduce the pre-f95a6811 heimdal-capture-watch clobber shape (or any
+    analogous shape for another CHANNEL_SERVICES key)."""
+    result = check_environment_env_file_clobber(DEV_COMPOSE, "dev", environ={})
+
+    assert result.ok, (
+        f"docker-compose.dev.yml has a blank environment: override shadowing "
+        f"a non-empty env_file value:\n{result.summary()}"
+    )
+
+
+def test_real_test_compose_passes_environment_clobber_preflight() -> None:
+    """Regression guard mirroring the dev-channel check above, for the test
+    channel's committed docker-compose.test.yml."""
+    result = check_environment_env_file_clobber(TEST_COMPOSE, "test", environ={})
+
+    assert result.ok, (
+        f"docker-compose.test.yml has a blank environment: override shadowing "
+        f"a non-empty env_file value:\n{result.summary()}"
+    )
+
+
+def test_real_prod_compose_passes_environment_clobber_preflight() -> None:
+    """Regression guard: prod's own docker-compose.prod.yml must stay free of
+    this class too, even though prod isn't wired to this preflight in
+    scripts/deploy_channel.sh (Constraints: this issue extends the dev/test
+    deploy path only, prod already carries an analogous, DSN-scoped gate)."""
+    result = check_environment_env_file_clobber(PROD_COMPOSE, "prod", environ={})
+
+    assert result.ok, (
+        f"docker-compose.prod.yml has a blank environment: override shadowing "
+        f"a non-empty env_file value:\n{result.summary()}"
+    )


### PR DESCRIPTION
Governing-Issue: #4230

Fixes #4230

Final-Review-Rounds: 0

## Summary
dev and test channel deploys ran zero check for a service `environment:` override resolving blank while its `env_file` chain supplies a non-empty value for the same key -- the exact shape that crash-looped `heimdal-capture-watch` until commit f95a6811 deleted the offending `environment:` entries (already fixed instance; this PR guards the still-open general class). Adds `channel_isolation_preflight.check_environment_env_file_clobber` (channel-agnostic, ignores literal explicit values so only the shell-interpolation clobber shape is flagged), wraps it in `scripts/dev_test_environment_clobber_preflight.py`, and wires it into `scripts/deploy_channel.sh` before pin write / migration execution for the `dev` and `test` deploy actions -- same placement and read-only posture as the existing prod-only `prod_pending_retry_preflight`. Not applied to `prod` (which already has an analogous, DSN-scoped gate) or to `rollback` (per the rollback contract).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 bounded slice PR; no BuilderOps record/projection/receipt surface was touched.

## Notes
Validation:
- `python3 -m pytest tests/deploy/test_deploy_channel.py tests/release_channels/ tests/scripts/test_prod_deploy_retry_preflight_constants_parity.py -q` -> 149 passed
- `ruff check app tests scripts/dev_test_environment_clobber_preflight.py companion-ui/companion-app` -> all checks passed
- `bash -n scripts/deploy_channel.sh` -> OK
- `python3 scripts/docs_guard.py` -> OK (docs/OPERATIONS.md and docs/RELEASE_CHANNELS/README.md updated in this change)
---