### PR TITLE
fix: import canonical BuilderOps-routing twin in pr_hot_path_governance tests

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -219,6 +219,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # BuilderOps store-access inventory fitness. Keep this exact file
             # owned without widening builder_system to all architecture tests.
             "tests/architecture/test_builderops_store_boundary.py",
+            # pr-contract/BuilderOps-routing hot-path governance fitness
+            # (#4343): a pure change to this one test file has no non-test
+            # governance/docs path alongside it, so `_is_governance_only`
+            # (which requires real non-test signal) never fires and the PR
+            # fell through the SUBSYSTEMS loop into `unowned` (exit 2). Own
+            # this exact file the same way test_builderops_store_boundary.py
+            # is owned above, without widening builder_system to all
+            # architecture tests.
+            "tests/architecture/test_pr_hot_path_governance.py",
             # Isolated subprocess import wiring is a Builder test-harness
             # contract; own both the helper and its focused regression without
             # widening this subsystem to all helpers.
@@ -232,6 +241,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/dispatcher",
             "tests/governance",
             "tests/architecture/test_builderops_store_boundary.py",
+            "tests/architecture/test_pr_hot_path_governance.py",
         ),
     ),
     (

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -297,6 +297,8 @@ def test_owner_doc_policy_requires_pr_specific_child_and_open_parent_receipts() 
 
 import re as _re
 
+from app.dispatcher.verification_contract import resolve_builderops_routing_status
+
 
 _REQUIRED_FIELDS_PATTERNS = [
     _re.compile(r"(?:^|\n)Type:\s*(docs|governance|code)\s*(?:\n|$)", _re.IGNORECASE),
@@ -309,18 +311,15 @@ _DIRECT_REPAIR_REGEX = _re.compile(
     r"## Direct Repair[\s\S]*?(?=\n##\s|\n---)|## Direct Repair[\s\S]*",
     _re.IGNORECASE,
 )
-_BUILDEROPS_ROUTING_REGEX = _re.compile(
-    r"(?:^|\n)## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|(?:^|\n)## BuilderOps Routing[\s\S]*",
-    _re.IGNORECASE,
-)
-_BUILDEROPS_ROUTING_FIELDS = [
-    _re.compile(r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*(.*?)\s*(?:\n|$)", _re.IGNORECASE),
-    _re.compile(r"(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)", _re.IGNORECASE),
-]
 
 
 def _is_direct_repair(body: str) -> bool:
-    """Python port of the JavaScript `isDirectRepair` logic in issue-pr-governance.yml."""
+    """Python port of the JavaScript `isDirectRepair` logic in issue-pr-governance.yml.
+
+    No canonical `verification_contract` twin exists for this check yet (issue
+    #4343 out-of-scope note); this remains the file's own port until one is
+    added under a separate issue.
+    """
     m = _DIRECT_REPAIR_REGEX.search(body)
     if not m:
         return False
@@ -329,44 +328,35 @@ def _is_direct_repair(body: str) -> bool:
 
 
 def _has_builderops_routing(body: str) -> bool:
-    """Python port of the JavaScript `hasBuilderOpsRouting` logic."""
-    m = _BUILDEROPS_ROUTING_REGEX.search(body)
-    if not m:
-        return False
-    section = m.group(0)
-    for pattern in _BUILDEROPS_ROUTING_FIELDS:
-        match = pattern.search(section)
-        if not match:
-            return False
-        value = match.group(1).strip()
-        if not value or _re.fullmatch(r"<.*>", value):
-            return False
-    return True
+    """Thin wrapper over the canonical `verification_contract` twin.
 
-
-_TIER1_LANE_REGEX = _re.compile(
-    r"^\-\s+\[x\]\s+(?:Docs authoring|Governance) lane\b",
-    _re.IGNORECASE | _re.MULTILINE,
-)
+    `has_issue_authority` only affects `BuilderOpsRoutingStatus.satisfied`, not
+    `.has_builderops_routing`, so any fixed value is safe here.
+    """
+    return resolve_builderops_routing_status(
+        body, has_issue_authority=False
+    ).has_builderops_routing
 
 
 def _builderops_routing_satisfied(body: str) -> bool:
-    """Python port of the JavaScript `builderOpsRoutingSatisfied` logic.
+    """Thin wrapper over the canonical `verification_contract` twin.
 
     Tier 1 lane PRs (docs/development/GOVERNANCE_PROPORTIONALITY.md) may omit the
     BuilderOps Routing section entirely only when they are not issue-backed —
     absence means "none". A present but unfilled section is still rejected at
     every tier, and issue-backed PRs use the higher Tier 2+ requirement.
+
+    `has_issue_authority` mirrors this file's own long-standing Fixes/Closes/
+    Resolves detection (not the stricter `Governing-Issue:` line format that
+    `resolve_issue_authority` requires) so every existing fixture's expected
+    outcome is unchanged by this import swap.
     """
-    if _has_builderops_routing(body):
-        return True
-    section_present = bool(_BUILDEROPS_ROUTING_REGEX.search(body))
-    has_issue_link = _re.search(r"(Fixes|Closes|Resolves)\s+#\d+", body, _re.IGNORECASE)
-    return (
-        _TIER1_LANE_REGEX.search(body) is not None
-        and has_issue_link is None
-        and not section_present
+    has_issue_authority = bool(
+        _re.search(r"(Fixes|Closes|Resolves)\s+#\d+", body, _re.IGNORECASE)
     )
+    return resolve_builderops_routing_status(
+        body, has_issue_authority=has_issue_authority
+    ).satisfied
 
 
 _VALID_DIRECT_REPAIR_FIELDS = (
@@ -492,6 +482,30 @@ def test_tier1_lane_pr_may_omit_builderops_routing() -> None:
 
     docs_body = "- [x] Docs authoring lane\n\n## Summary\nDocs clarification."
     assert _builderops_routing_satisfied(docs_body), "Expected docs-lane PR without section to pass"
+
+
+def test_canonical_tier1_lane_import_detects_governance_removal(monkeypatch) -> None:
+    """Proves the import swap closes the blind spot named in issue #4343.
+
+    If "Governance" were dropped from the tier-1 lane rule in the canonical
+    `verification_contract.TIER1_LANE_PATTERN` (mirroring a hypothetical
+    matching regression in the workflow's own JS `tier1LanePattern`), this
+    file's `_builderops_routing_satisfied` must observe that change, because
+    it now calls the canonical twin instead of carrying its own untouched
+    local copy of the regex.
+    """
+    import app.dispatcher.verification_contract as verification_contract
+
+    narrowed_pattern = _re.compile(
+        r"^\-\s+\[x\]\s+Docs authoring lane\b", _re.IGNORECASE | _re.MULTILINE
+    )
+    monkeypatch.setattr(verification_contract, "TIER1_LANE_PATTERN", narrowed_pattern)
+
+    governance_body = "- [x] Governance lane\n\n## Summary\nSkill text fix."
+    assert not _builderops_routing_satisfied(governance_body), (
+        "Expected a canonical TIER1_LANE_PATTERN regression to be visible "
+        "through the imported twin instead of masked by a local copy"
+    )
 
 
 def test_tier1_lane_pr_with_unfilled_section_still_rejected() -> None:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -893,9 +893,12 @@ def test_mixed_docs_and_review_gate_test_keeps_ops_targets() -> None:
 def test_docs_plus_architecture_still_stays_governance_only_when_no_foreign_owner() -> None:
     # Sibling assertion to the mixed-PR cases above: an architecture test
     # with no individual subsystem carve-out (unlike
-    # test_builderops_store_boundary.py / test_no_hardcoded_vault_layout.py)
-    # must still resolve through the plain governance-only fast path.
-    selection = select_tests([".codex/skills/x/SKILL.md", "tests/architecture/test_pr_hot_path_governance.py"])
+    # test_builderops_store_boundary.py / test_no_hardcoded_vault_layout.py /
+    # test_pr_hot_path_governance.py, the last of which gained its own
+    # builder_system carve-out under #4343 so a pure change to that one file
+    # no longer fails closed as unowned) must still resolve through the plain
+    # governance-only fast path.
+    selection = select_tests([".codex/skills/x/SKILL.md", "tests/architecture/test_agent_skill_entrypoints.py"])
 
     assert selection.full_suite is False
     assert selection.subsystems == ("governance",)


### PR DESCRIPTION
Governing-Issue: #4343

Fixes #4343

Final-Review-Rounds: 0

## Summary
`tests/architecture/test_pr_hot_path_governance.py` carried its own private port of the `pr-contract` gate's BuilderOps-routing/tier-1-lane logic (`_TIER1_LANE_REGEX`, `_has_builderops_routing`, `_builderops_routing_satisfied`), untested against and invisible to the canonical `app.dispatcher.verification_contract.resolve_builderops_routing_status` twin. Replaced those private copies with thin wrappers over the canonical twin and added a regression test (`test_canonical_tier1_lane_import_detects_governance_removal`) that monkeypatches the canonical `TIER1_LANE_PATTERN` to prove a canonical-twin regression is now visible through this file's own tests instead of masked by a local copy. `_is_direct_repair` has no canonical twin yet in `verification_contract.py`; per the issue's own out-of-scope note it is left as the file's own port and named here as a follow-up gap, not invented under this issue.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 lane with no BuilderOps material routed; this is a bounded test-file implementation swap.

## Notes
Validation:
- `pytest -q tests/architecture/test_pr_hot_path_governance.py tests/governance/test_issue_pr_governance.py` (132 passed)
- `grep -n "_TIER1_LANE_REGEX\|_has_builderops_routing\|_builderops_routing_satisfied" tests/architecture/test_pr_hot_path_governance.py` — no remaining private-copy definitions, only thin wrappers
- `python3 scripts/lint_skills_consistency.py` (clean)
- `ruff check app tests companion-ui/companion-app` (All checks passed!)
---
