### PR TITLE
fix: distinguish dangling active-vault reference from no-selection in default_signboard_root()

### DIFF
--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -64,6 +64,31 @@ class NoActiveVaultError(RuntimeError):
     is currently selected via the active-vault-selection mechanism."""
 
 
+class DanglingActiveVaultReferenceError(NoActiveVaultError):
+    """Raised when the active-vault reference names a path that no longer
+    exists on disk (``VaultContext.status == "missing"``).
+
+    Subclasses :class:`NoActiveVaultError` so an existing caller that only
+    catches the base class (the dispatcher CLI's ``export-signboard`` and
+    ``signboard-validate`` commands) keeps working without new plumbing,
+    while a caller that wants to distinguish the two cases can catch this
+    subclass first. #4223: a dangling reference is not the same fact as "no
+    vault was ever selected" — the message must not claim otherwise, and it
+    must name the dangling path so an operator can diagnose it. Mirrors the
+    established precedent in ``app/api/routes/companion.py``
+    (``_vault_selection_required_context``), which already distinguishes
+    ``status == "missing"`` from ``status == "none"``.
+    """
+
+    def __init__(self, active_vault_path: str) -> None:
+        self.active_vault_path = active_vault_path
+        super().__init__(
+            "the active vault reference points to a path that no longer "
+            f"exists: {active_vault_path!r}; open an existing vault or "
+            "select a different one"
+        )
+
+
 class SignboardStoreOwnershipError(RuntimeError):
     """Raised when a destructive board operation cannot prove the board belongs
     to the dispatcher store this process resolved."""
@@ -85,6 +110,8 @@ def default_signboard_root() -> Path:
         context = manager.load_last_active()
     if context.active_vault_path and context.status in {"selected", "uninitialized"}:
         return Path(context.active_vault_path).expanduser().resolve() / DEFAULT_SIGNBOARD_SUBPATH
+    if context.status == "missing" and context.active_vault_path:
+        raise DanglingActiveVaultReferenceError(context.active_vault_path)
     raise NoActiveVaultError(
         "no active vault is selected; pass an explicit path or select a vault first"
     )

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -785,7 +785,11 @@ python -m app.dispatcher export-signboard ~/BuilderOpsVault/agent-delivery --jso
 ```
 
 If no vault is currently selected and no explicit path is given, the command fails loud with a
-clear error instead of guessing a location.
+clear error instead of guessing a location. A genuinely never-selected reference (`status: none`)
+and a dangling one — a `lastActiveVaultRef` naming a path that no longer exists on disk
+(`status: missing`) — are reported distinctly (#4223): the dangling case names the missing path
+instead of claiming no vault was ever selected, matching the existing precedent in
+`app/api/routes/companion.py` for the same `VaultContext` status split.
 
 The exporter writes one Markdown file per dispatcher task under status columns:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -500,7 +500,12 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
   The projection remains read-only for coordination fields
   and has no write path for claim, lease, or lock state; dispatcher SQLite remains the authority for
   the legacy dispatcher/signboard claim lane per ADR-0010, while BCP-05 verification coordination
-  is the separately bounded BuilderOps API/PostgreSQL lane described above.
+  is the separately bounded BuilderOps API/PostgreSQL lane described above. `default_signboard_root()`
+  now distinguishes a dangling `lastActiveVaultRef` (`VaultContext.status == "missing"`, a
+  previously-selected vault whose path no longer exists on disk) from a genuinely never-selected
+  vault (`status == "none"`): the dangling case raises `DanglingActiveVaultReferenceError`, names the
+  missing path, and no longer claims "no active vault is selected" — matching the same status split
+  already established for `app/api/routes/companion.py`'s vault-selection-required responses (#4223).
 - Canvas co-authoring is materially implemented behind `CANVAS_ENABLED`: `canvas open` / `edit` /
   `close`, `/api/canvas/sessions*`, session-log persistence, and governance-bearing mutation routing
   are shipped; broader Chat cognition and hybrid Panel/Chat mutation remain separate follow-up work.

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -20,6 +20,7 @@ from app.dispatcher import signboard as signboard_module
 from app.dispatcher.signboard import (
     DEFAULT_SIGNBOARD_SUBPATH,
     STORE_STAMP_FILENAME,
+    DanglingActiveVaultReferenceError,
     NoActiveVaultError,
     SignboardStoreOwnershipError,
     default_signboard_root,
@@ -287,6 +288,53 @@ def test_default_signboard_root_raises_when_no_vault_selected(monkeypatch) -> No
 
     with pytest.raises(NoActiveVaultError):
         default_signboard_root()
+
+
+def test_default_signboard_root_reports_dangling_vault_reference_distinctly(
+    tmp_path, monkeypatch
+) -> None:
+    """A dangling ``lastActiveVaultRef`` (#4223) must not be reported as "no
+    active vault is selected" — that message is false here, and it drops the
+    dangling path an operator needs to diagnose the reference.
+    """
+
+    dead_path = str(tmp_path / "gone-vault")
+    context = VaultContext(status="missing", active_vault_path=dead_path)
+    monkeypatch.setattr(
+        signboard_module, "get_vault_manager", lambda: _StubVaultManager(context)
+    )
+
+    with pytest.raises(DanglingActiveVaultReferenceError) as excinfo:
+        default_signboard_root()
+
+    message = str(excinfo.value)
+    assert "no active vault is selected" not in message
+    assert dead_path in message
+    assert excinfo.value.active_vault_path == dead_path
+    # Subclasses NoActiveVaultError so existing callers that only catch the
+    # base class keep working without new plumbing.
+    assert isinstance(excinfo.value, NoActiveVaultError)
+
+
+def test_default_signboard_root_falls_back_to_missing_from_load_last_active(
+    monkeypatch,
+) -> None:
+    dead_path = "/tmp/does-not-exist-either"
+    loaded = VaultContext(status="missing", active_vault_path=dead_path)
+
+    class _NoneThenMissing(_StubVaultManager):
+        def __init__(self) -> None:
+            super().__init__(VaultContext(status="none"))
+
+        def load_last_active(self) -> VaultContext:
+            return loaded
+
+    monkeypatch.setattr(signboard_module, "get_vault_manager", _NoneThenMissing)
+
+    with pytest.raises(DanglingActiveVaultReferenceError) as excinfo:
+        default_signboard_root()
+
+    assert dead_path in str(excinfo.value)
 
 
 def test_cli_export_signboard_without_path_uses_default_vault(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4223

## Linked Issue
Closes #4223

## SBS Impact
- Primary subsystem: Product/Runtime System -- Signboard root resolution
- Secondary subsystem(s): none (the /signboard API route no longer calls default_signboard_root; see AC3 anchor-drift note)
- Write class: runtime error-reporting behavior, tests, owner-doc correction
- Persistence impact: none
- Derived/rebuildable impact: resolved Signboard root context remains derived from the active-vault reference
- New or changed contract: a dangling last-active vault reference now raises DanglingActiveVaultReferenceError naming the missing path instead of the generic no-selection message
- Owner-doc impact: docs/AGENT_ISSUE_DISPATCHER.md and docs/STATUS.md updated in this PR
- Transition debt impact: reduces operator ambiguity in the active-vault split-brain boundary
- Boundary risk: message names only the already-configured local reference path; discloses nothing new

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- default_signboard_root() now reports a dangling active-vault reference (status=missing) distinctly from a never-selected vault (status=none), naming the missing path instead of falsely claiming no vault was selected.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 message-fidelity bug fix; no BuilderOps record, projection, or receipt material was produced.

## Notes
Validation: pytest tests/dispatcher/test_signboard.py tests/api/test_signboard_api.py tests/governance/test_project_pickup_deprecation.py (71 passed); ruff check app tests companion-ui/companion-app (clean). AC3 anchor drift: the issue's Source Anchor app/api/routes/signboard.py::signboard_root() no longer calls default_signboard_root() at all -- since #4401 /api/signboard/board is served directly from the dispatcher store and carries no filesystem root (docs/AGENT_ISSUE_DISPATCHER.md :: Local visual Signboard). The fix and its tests are scoped to default_signboard_root() itself and its one remaining live caller, the legacy dispatcher CLI (export-signboard / signboard-validate).
