### PR TITLE
fix: st_flags is authoritative for vault SQLite-scan datalessness (#4220)

### DIFF
--- a/app/builderops/vault_queue.py
+++ b/app/builderops/vault_queue.py
@@ -364,12 +364,17 @@ def _content_is_local(stat_result: os.stat_result) -> bool:
     metadata local. Opening such a file costs a network round-trip — measured
     at ~1.0-1.2 s per file, which is what made `vault validate` fail to
     terminate on the real shared vault (#4199). ``SF_DATALESS`` is the direct
-    macOS signal; zero allocated blocks against a non-zero logical size is the
-    portable fallback for the same state.
+    macOS signal, and where the platform exposes ``st_flags`` it is
+    authoritative for datalessness. Zero allocated blocks against a non-zero
+    logical size is only a *fallback* signal for platforms that expose no
+    ``st_flags`` at all: APFS transparent compression and some network mounts
+    report zero blocks for content that is entirely local, so this fallback
+    must never override an authoritative ``st_flags`` reading of "not
+    dataless".
     """
 
-    if getattr(stat_result, "st_flags", 0) & _SF_DATALESS:
-        return False
+    if hasattr(stat_result, "st_flags"):
+        return not (stat_result.st_flags & _SF_DATALESS)
     return not (stat_result.st_size > 0 and getattr(stat_result, "st_blocks", 1) == 0)
 
 

--- a/app/builderops/vault_queue.py
+++ b/app/builderops/vault_queue.py
@@ -373,8 +373,9 @@ def _content_is_local(stat_result: os.stat_result) -> bool:
     dataless".
     """
 
-    if hasattr(stat_result, "st_flags"):
-        return not (stat_result.st_flags & _SF_DATALESS)
+    flags: int | None = getattr(stat_result, "st_flags", None)
+    if flags is not None:
+        return not (flags & _SF_DATALESS)
     return not (stat_result.st_size > 0 and getattr(stat_result, "st_blocks", 1) == 0)
 
 

--- a/tests/builderops/test_builderops_paths.py
+++ b/tests/builderops/test_builderops_paths.py
@@ -342,6 +342,62 @@ def test_vault_validate_detects_extensionless_sqlite_without_full_scan(
     assert [path for path in opened if path.parent == notes] == []
 
 
+def test_zero_block_local_file_is_not_treated_as_evicted(tmp_path: Path) -> None:
+    """``st_blocks == 0`` alone must not mark a file as content-not-local.
+
+    APFS transparent compression (and some network mounts) report zero
+    allocated blocks for a file whose bytes are already on disk. Where the
+    platform exposes ``st_flags``, it is the authoritative dataless signal
+    (macOS ``SF_DATALESS``) and the ``st_blocks`` fallback must not override
+    it for a file that is not actually dataless.
+    """
+    from app.builderops import vault_queue
+
+    real = tmp_path / "compressed.bin"
+    real.write_bytes(b"SQLite format 3\x00" + b"\x00" * 16)
+    base = real.stat()
+
+    # Simulate a locally-materialized, transparently-compressed file: content
+    # is on this disk (no SF_DATALESS bit) but zero blocks are reported.
+    fake_local_compressed = os.stat_result(
+        (
+            base.st_mode,
+            base.st_ino,
+            base.st_dev,
+            base.st_nlink,
+            base.st_uid,
+            base.st_gid,
+            base.st_size,
+            base.st_atime,
+            base.st_mtime,
+            base.st_ctime,
+        ),
+        {"st_blocks": 0, "st_flags": 0},
+    )
+
+    assert vault_queue._content_is_local(fake_local_compressed) is True
+
+    # A genuinely dataless file (SF_DATALESS set) must still report as not
+    # local, regardless of st_blocks.
+    fake_evicted = os.stat_result(
+        (
+            base.st_mode,
+            base.st_ino,
+            base.st_dev,
+            base.st_nlink,
+            base.st_uid,
+            base.st_gid,
+            base.st_size,
+            base.st_atime,
+            base.st_mtime,
+            base.st_ctime,
+        ),
+        {"st_blocks": 0, "st_flags": vault_queue._SF_DATALESS},
+    )
+
+    assert vault_queue._content_is_local(fake_evicted) is False
+
+
 def test_vault_validate_still_opens_local_files_for_the_header_sniff(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/builderops/test_builderops_paths.py
+++ b/tests/builderops/test_builderops_paths.py
@@ -342,7 +342,7 @@ def test_vault_validate_detects_extensionless_sqlite_without_full_scan(
     assert [path for path in opened if path.parent == notes] == []
 
 
-def test_zero_block_local_file_is_not_treated_as_evicted(tmp_path: Path) -> None:
+def test_zero_block_local_file_is_not_treated_as_evicted() -> None:
     """``st_blocks == 0`` alone must not mark a file as content-not-local.
 
     APFS transparent compression (and some network mounts) report zero
@@ -350,52 +350,50 @@ def test_zero_block_local_file_is_not_treated_as_evicted(tmp_path: Path) -> None
     platform exposes ``st_flags``, it is the authoritative dataless signal
     (macOS ``SF_DATALESS``) and the ``st_blocks`` fallback must not override
     it for a file that is not actually dataless.
+
+    ``st_flags`` is a BSD/macOS-only field of the real C ``stat`` struct: a
+    Linux Python build's ``os.stat_result`` has no such attribute at all, and
+    silently drops it if injected via the extra-fields constructor argument.
+    So this test exercises ``_content_is_local`` (which only ever does
+    attribute access, never an isinstance check) against light duck-typed
+    stand-ins instead of a real ``os.stat_result``, to deterministically cover
+    every branch on every CI platform.
     """
+    from typing import cast
+
     from app.builderops import vault_queue
 
-    real = tmp_path / "compressed.bin"
-    real.write_bytes(b"SQLite format 3\x00" + b"\x00" * 16)
-    base = real.stat()
+    class _FakeStat:
+        def __init__(self, *, st_size: int, st_blocks: int, **extra: int) -> None:
+            self.st_size = st_size
+            self.st_blocks = st_blocks
+            for name, value in extra.items():
+                setattr(self, name, value)
 
-    # Simulate a locally-materialized, transparently-compressed file: content
-    # is on this disk (no SF_DATALESS bit) but zero blocks are reported.
-    fake_local_compressed = os.stat_result(
-        (
-            base.st_mode,
-            base.st_ino,
-            base.st_dev,
-            base.st_nlink,
-            base.st_uid,
-            base.st_gid,
-            base.st_size,
-            base.st_atime,
-            base.st_mtime,
-            base.st_ctime,
-        ),
-        {"st_blocks": 0, "st_flags": 0},
-    )
+    def _as_stat_result(fake: "_FakeStat") -> os.stat_result:
+        # `_content_is_local` only ever does attribute access on its
+        # argument, never an isinstance check, so a duck-typed stand-in
+        # exercises it faithfully; the cast below only satisfies mypy.
+        return cast("os.stat_result", fake)
 
-    assert vault_queue._content_is_local(fake_local_compressed) is True
+    # Locally-materialized, transparently-compressed file: content is on this
+    # disk (no SF_DATALESS bit) but zero blocks are reported. The platform
+    # exposes st_flags, so it is authoritative and must win over st_blocks.
+    fake_local_compressed = _FakeStat(st_size=32, st_blocks=0, st_flags=0)
+    assert vault_queue._content_is_local(_as_stat_result(fake_local_compressed)) is True
 
     # A genuinely dataless file (SF_DATALESS set) must still report as not
     # local, regardless of st_blocks.
-    fake_evicted = os.stat_result(
-        (
-            base.st_mode,
-            base.st_ino,
-            base.st_dev,
-            base.st_nlink,
-            base.st_uid,
-            base.st_gid,
-            base.st_size,
-            base.st_atime,
-            base.st_mtime,
-            base.st_ctime,
-        ),
-        {"st_blocks": 0, "st_flags": vault_queue._SF_DATALESS},
-    )
+    fake_evicted = _FakeStat(st_size=32, st_blocks=0, st_flags=vault_queue._SF_DATALESS)
+    assert vault_queue._content_is_local(_as_stat_result(fake_evicted)) is False
 
-    assert vault_queue._content_is_local(fake_evicted) is False
+    # Platforms that expose no st_flags at all fall back to the st_blocks
+    # heuristic, preserving pre-existing behavior there.
+    fake_no_flags_evicted = _FakeStat(st_size=32, st_blocks=0)
+    assert vault_queue._content_is_local(_as_stat_result(fake_no_flags_evicted)) is False
+
+    fake_no_flags_local = _FakeStat(st_size=32, st_blocks=1)
+    assert vault_queue._content_is_local(_as_stat_result(fake_no_flags_local)) is True
 
 
 def test_vault_validate_still_opens_local_files_for_the_header_sniff(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4220

## Linked Issue
Fixes #4220

## SBS Impact
- Primary subsystem: Builder System — BuilderOps shared vault validation
- Secondary subsystem(s): none
- Write class: read-only validation path
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: no — the confinement invariant is unchanged, only how datalessness is detected
- Owner-doc impact: none — the invariant doc's description of the narrowing stays true
- Transition debt impact: none
- Boundary risk: low — this tightens the scan rather than narrowing it

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `_content_is_local` in `app/builderops/vault_queue.py` no longer falls through to the `st_blocks == 0` heuristic when the platform exposes `st_flags`; `st_flags` is now authoritative for datalessness on platforms that expose it (macOS), and the `st_blocks` fallback is used only where `st_flags` is unavailable.
- Fixes the false-positive case where a locally-present, zero-block file (APFS transparent compression, some network mounts) was wrongly classified as remote and could skip the header sniff for an extension-less SQLite candidate whose size is not a 512-byte multiple.
- Added `tests/builderops/test_builderops_paths.py::test_zero_block_local_file_is_not_treated_as_evicted` (AC1), confirmed the existing `test_vault_validate_detects_extensionless_sqlite_without_full_scan` (AC2) and `test_vault_validate_reports_scan_stats_and_preserves_symlink_rejection` (AC3) still pass unchanged.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded bug-fix slice from an existing GitHub Issue; no BuilderOps operational record needed beyond the Issue/PR trail.

## Notes
- Validation: `pytest -q tests/builderops/test_builderops_paths.py tests/builderops/test_builderops_claims.py` (47 passed); `ruff check app tests` (all checks passed).
- Verify targets from the Issue:
  - AC1: `tests/builderops/test_builderops_paths.py::test_zero_block_local_file_is_not_treated_as_evicted`
  - AC2: `tests/builderops/test_builderops_paths.py::test_vault_validate_detects_extensionless_sqlite_without_full_scan`
  - AC3: `tests/builderops/test_builderops_paths.py::test_vault_validate_reports_scan_stats_and_preserves_symlink_rejection`
- Did not time `builderops vault validate` against the real synchronized vault (no access to it from this environment); the unit-level scan-cost tests above cover the same behavior deterministically.
