### PR TITLE
Extend semanticmd content-loss guard to vault notes

### DIFF
--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -1,7 +1,18 @@
+import re
 from typing import Any, Dict, List, Tuple
 
 from .graph import diff_conflict_loci, apply_decisions
 from .llm import judge_locus
+
+
+def _token_similarity(x: str, y: str) -> float:
+    t1 = set(re.findall(r"\w+", x.lower()))
+    t2 = set(re.findall(r"\w+", y.lower()))
+    if not t1 or not t2:
+        return 0.0
+    inter = len(t1 & t2)
+    denom = (len(t1) + len(t2)) / 2.0
+    return inter / denom
 
 
 def _extract_uuid(md: str) -> str | None:
@@ -69,16 +80,7 @@ def _postprocess_merge(merged, info, a, b):
     b_body = _body(b)
     merged_body = _body(merged)
 
-    def _sim(x:str,y:str)->float:
-        t1 = set(re.findall(r"\w+", x.lower()))
-        t2 = set(re.findall(r"\w+", y.lower()))
-        if not t1 or not t2:
-            return 0.0
-        inter = len(t1 & t2)
-        denom = (len(t1) + len(t2)) / 2.0
-        return inter / denom
-
-    sim = _sim(a_body, b_body)
+    sim = _token_similarity(a_body, b_body)
 
     # 1) Near-duplicate -> markera 'concise' i reason om olika längd
     r = (info or {}).get("reason","")
@@ -87,9 +89,12 @@ def _postprocess_merge(merged, info, a, b):
         info["reason"] = (r + ("; " if r else "")) + "prefer concise (near-duplicate)"
 
 
-    # 1b) Om merged == A (eller B) och den valda varianten är kortare -> uttryckligen motivera 'prefer concise'
+    # 1b) Om merged == A (eller B) och den valda varianten är kortare -> uttryckligen motivera
+    # 'prefer concise'. Gated on the same genuine near-duplicate threshold as (1): without it,
+    # this fires purely because the (always-default-to-A) chosen side happens to be shorter,
+    # mislabeling arbitrary content loss as an intentional "prefer concise" pick.
     r = (info or {}).get("reason","")
-    if "concise" not in r.lower():
+    if sim >= 0.85 and "concise" not in r.lower():
         if merged_body == a_body and len(a_body) < len(b_body):
             info = dict(info or {})
             info["reason"] = (r + ("; " if r else "")) + "prefer concise"
@@ -119,27 +124,35 @@ def _body(md: str) -> str:
     return md.strip()
 
 
-def _has_vault_identity(a: str, b: str) -> bool:
-    # A vault note carries a stable `uuid:` frontmatter identity. Repository
-    # documentation (docs/**, README.md, AGENTS.md, .codex/skills/**, ...) never does.
-    # Only vault notes are safe for the near-duplicate / "prefer concise" heuristics.
-    return bool(_extract_uuid(a) or _extract_uuid(b))
+def _guard_content_loss(merged, info, a, b):
+    """Refuse to silently resolve a merge that discards one side's real content.
 
+    Issue #4505 added this fail-safe for repository documentation (no `uuid:`
+    frontmatter): the near-duplicate / "prefer concise" heuristic could pick one
+    side wholesale, report MERGE_STATUS=resolved, and exit 0 -- discarding the
+    other side's committed content with no conflict and no warning.
 
-def _guard_non_vault_content_loss(merged, info, a, b):
-    """Refuse to silently resolve a merge that discards one side's content when
-    neither input carries vault-note identity.
+    That guard originally exempted vault notes (`uuid:` frontmatter present) on
+    the assumption that vault-note merging is real semantic merging and therefore
+    safe. It is not: `judge_locus` is a stub that never returns a resolvable
+    per-locus decision, so `apply_decisions` always keeps OURS (%A) regardless of
+    what THEIRS contains, and still reports "resolved". Once the driver's %A-write
+    contract was fixed (#4561), that silent, always-keep-OURS "resolve" started
+    reaching the real working tree on every vault-note merge with a genuine,
+    non-trivial divergence -- see
+    tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped.
 
-    Issue #4505: applied to code-review-approved repository documentation (no
-    `uuid:` frontmatter), the near-duplicate / "prefer concise" heuristic can pick
-    one side wholesale, report MERGE_STATUS=resolved, and exit 0 -- discarding the
-    other side's committed content with no conflict and no warning. A conservative
-    conflict is always acceptable; discarding a side without signalling is not.
+    The only two mechanisms this resolver has that actually preserve the
+    discarded side's real content are: an exact match (nothing to lose), and the
+    markdown-link-carryover heuristic below (which literally appends THEIRS'
+    missing links into the merged text). A genuine near-duplicate pick is also
+    trusted, since by definition there is negligible information to lose. Any
+    other divergence is not provably safe and must raise a conflict instead of
+    silently discarding a side -- the same conservative default #4505 already
+    established, now applied uniformly instead of only to non-vault content.
     """
     info = dict(info or {})
     if info.get("status") != "resolved":
-        return merged, info
-    if _has_vault_identity(a, b):
         return merged, info
 
     a_body = _body(a)
@@ -149,10 +162,17 @@ def _guard_non_vault_content_loss(merged, info, a, b):
         return merged, info
 
     reason = info.get("reason", "")
+    if "carried links" in reason.lower():
+        # The missing-link-carryover heuristic already reconciled the divergence.
+        return merged, info
+    if _token_similarity(a_body, b_body) >= 0.85:
+        # Genuine near-duplicate: negligible content to lose either way.
+        return merged, info
+
     info["status"] = "conflict"
     info["reason"] = (
         (reason + "; " if reason else "")
-        + "no vault-note identity (no uuid: frontmatter) and content diverges; "
+        + "content diverges without a verified-safe resolution; "
         "refusing to silently discard a side, raising a conflict instead"
     )
     return merged, info
@@ -161,4 +181,4 @@ def _guard_non_vault_content_loss(merged, info, a, b):
 def merge_note_from_blobs(base: str, a: str, b: str):
     merged, info = _orig_merge_note_from_blobs(base, a, b)
     merged, info = _postprocess_merge(merged, info, a, b)
-    return _guard_non_vault_content_loss(merged, info, a, b)
+    return _guard_content_loss(merged, info, a, b)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,6 +49,18 @@ promote public internet readiness.
 - Prod promotion model fix (#2656): AC1 and AC3 are done, while AC2 remains operator-gated pending operator receipt and sibling-doc reconciliation.
 - Delivery wave follow-on receipts: GraphQL exhaustion fix #2686, watcher settings receipts #2678, nested-vault boundary enforcement #2689, and deployment environment-separation spec #2692 are merged and reflected in the current shipped baseline.
 
+2026-08-03 fix writeback:
+- `semanticmd` merge driver's content-loss guard now applies to vault notes too (#4603):
+  delivering #4505 surfaced that its non-vault-only scoping assumed vault-note merging performs
+  real semantic judgment; it does not (`judge_locus` is a stub, so `apply_decisions` always keeps
+  OURS). Once #4561 made the driver actually write `resolved` results to `%A`, a genuine two-sided
+  vault-note edit became a clean, silent `git rebase`/`git merge` that permanently dropped one
+  side's content while reporting success. `app/agents/merge_resolver/agent.py::merge_note_from_blobs`
+  now refuses `status=resolved` for any diverging bodies (vault or not) unless an exact match, the
+  markdown-link-carryover heuristic, or a genuine near-duplicate pick (token similarity `>= 0.85`)
+  accounts for the divergence; a length-based "prefer concise" mislabeling that fired regardless of
+  real similarity is also fixed. See `docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md`.
+
 2026-08-02 fix writeback:
 - `semanticmd` merge driver no longer routes repository documentation (#4505): `.gitattributes`
   narrows `merge=semanticmd` off `docs/**`, `/README.md`, `/AGENTS.md`, `/CLAUDE.md`,

--- a/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
+++ b/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
@@ -1,4 +1,4 @@
-State: Current-state contract for the `semanticmd` git merge driver; aligned with shipped behavior (#4505 routing narrowing, #4561 `%A` result write).
+State: Current-state contract for the `semanticmd` git merge driver; aligned with shipped behavior (#4505 routing narrowing, #4561 `%A` result write, #4603 content-loss guard generalized to vault notes).
 
 # Semantic Markdown merge driver (`semanticmd`)
 
@@ -31,15 +31,35 @@ devices under `vault/**`.
 Path narrowing alone cannot cover every present or future repository doc
 outside the pinned paths above (nested `README.md` files, generated docs,
 etc.), so `merge_note_from_blobs` itself refuses to report `status=resolved`
-when **both** the vault-note identity is absent (no `uuid:` frontmatter on
-either side) **and** the two sides' bodies actually diverge. In that case it
-returns `status=conflict`, which the driver (`app/cli/merge_driver.py`) turns
-into a non-zero exit code — git then raises a normal conflict on that path
-instead of silently discarding one side's committed content.
+when the two sides' bodies actually diverge and no verified-safe resolution
+mechanism accounts for the divergence. In that case it returns
+`status=conflict`, which the driver (`app/cli/merge_driver.py`) turns into a
+non-zero exit code — git then raises a normal conflict on that path instead of
+silently discarding one side's committed content.
 
-This backstop does not change behavior for any input that carries `uuid:`
-frontmatter on either side; the vault-note near-duplicate/"prefer concise"
-path is unchanged.
+This guard applies uniformly to every input, including vault notes (`uuid:`
+frontmatter present). It was originally scoped to non-vault-note input only,
+on the assumption that vault-note merging performs real semantic judgment and
+is therefore safe. It does not: `judge_locus`
+(`app/agents/merge_resolver/llm.py`) is a stub that returns an LLM prompt pack,
+not a resolved decision, so `apply_decisions` always keeps OURS (%A)
+regardless of what THEIRS contains and still reports "resolved". Once #4561
+made the driver actually write that "resolved" result to `%A`, a real vault
+note merge with a genuine two-sided divergence became a clean, silent rebase
+that permanently drops one side's edit. See
+`tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped`
+for the regression coverage.
+
+Two mechanisms are trusted to resolve a divergence without raising a conflict,
+because they provably do not discard real content: an exact body match
+(nothing to lose), the markdown-link-carryover heuristic (THEIRS' missing
+links are appended into the merged text), and a genuine near-duplicate pick
+(token similarity `>= 0.85`, i.e. negligible information difference either
+way). Any other divergence — including ordinary distinct-prose additions on
+both sides — raises a conflict rather than silently picking a side. Real
+per-locus semantic merging (an actual LLM judgment wired into `judge_locus`)
+is not implemented; until it is, vault-note auto-resolve is limited to the
+three mechanisms above.
 
 ## History
 
@@ -49,6 +69,13 @@ routine rebases (exit 0, `MERGE_STATUS=resolved`), including one case where
 the discarded content was a correction that got reverted back to the
 incorrect prose. See `tests/agents/test_merge_resolver_repo_docs.py` for the
 regression coverage.
+
+Filed and fixed under GitHub issue #4603: delivering #4505 surfaced that its
+non-vault-only guard scoping rested on a false premise (vault-note merging
+"working" as real semantic merge). A real git-driver-level repro proved vault
+notes hit the identical silent-drop defect once #4561 made the `%A` write
+land. See the "Resolver-level backstop" section above and
+`tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped`.
 
 ## `%A` file-write contract (fixed by #4496)
 

--- a/tests/cli/test_merge_driver.py
+++ b/tests/cli/test_merge_driver.py
@@ -283,3 +283,97 @@ ours body, no link
     assert "https://example.com/incoming" in merged_on_disk
     assert "MERGE_STATUS" not in merged_on_disk
     assert "MERGE_REASON" not in merged_on_disk
+
+
+def test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped(tmp_path: Path):
+    # Same production wiring as the test above (real `git rebase`, not run_merge()
+    # directly), but with a vault note (uuid: frontmatter present) whose two sides
+    # each add distinct plain prose -- no markdown link, no large length skew, no
+    # near-duplicate phrasing. The resolver's per-locus judge (`judge_locus`) is a
+    # stub that never returns a real "decision", so `apply_decisions` silently
+    # keeps OURS and `merge_note_from_blobs` still reports status="resolved".
+    # git's %A-write contract (fixed in #4561) then faithfully commits that
+    # incomplete result: a clean, silent rebase that permanently drops one side's
+    # real edit with no conflict and no warning.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    for k, v in {
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }.items():
+        env[k] = v
+
+    _git(["init", "-q"], repo, env)
+    _git(["config", "commit.gpgsign", "false"], repo, env)
+    _git(["config", "merge.semanticmd.name", "Semantic Markdown merge (test)"], repo, env)
+    _git(
+        ["config", "merge.semanticmd.driver", f"{sys.executable} -m app.cli.merge_driver %O %A %B"],
+        repo, env,
+    )
+    (repo / ".gitattributes").write_text("*.md merge=semanticmd\n", encoding="utf-8")
+
+    note = repo / "n.md"
+    base_body = """---
+uuid: u-rebase-drop
+kind: concept
+review_state: reviewed
+---
+# T
+shared base line
+"""
+    note.write_text(base_body, encoding="utf-8")
+    _git(["add", "."], repo, env)
+    _git(["commit", "-q", "-m", "base"], repo, env)
+    main_branch = _git(["branch", "--show-current"], repo, env).stdout.strip()
+
+    _git(["checkout", "-q", "-b", "theirs"], repo, env)
+    theirs_body = """---
+uuid: u-rebase-drop
+kind: concept
+review_state: reviewed
+---
+# T
+shared base line
+theirs distinct addition about deployment timing
+"""
+    note.write_text(theirs_body, encoding="utf-8")
+    _git(["commit", "-q", "-am", "theirs edit"], repo, env)
+
+    _git(["checkout", "-q", main_branch], repo, env)
+    ours_body = """---
+uuid: u-rebase-drop
+kind: concept
+review_state: reviewed
+---
+# T
+shared base line
+ours distinct addition about retry budget
+"""
+    note.write_text(ours_body, encoding="utf-8")
+    _git(["commit", "-q", "-am", "ours edit"], repo, env)
+
+    rebase = subprocess.run(
+        ["git", "rebase", "theirs"],
+        cwd=repo, env=env, capture_output=True, text=True,
+    )
+
+    if rebase.returncode != 0:
+        # A hard conflict is an acceptable, safe outcome -- it is silent success
+        # (clean rebase + exit 0) that discards a real edit that is the defect.
+        subprocess.run(["git", "rebase", "--abort"], cwd=repo, env=env, capture_output=True)
+        return
+
+    merged_on_disk = note.read_text(encoding="utf-8")
+    log = _git(["log", "--oneline", "--all"], repo, env).stdout
+    assert "ours distinct addition about retry budget" in merged_on_disk, (
+        "clean rebase silently dropped the ours-side edit despite exit 0:\n"
+        f"stdout={rebase.stdout!r} stderr={rebase.stderr!r}\n"
+        f"working tree:\n{merged_on_disk}\nlog:\n{log}"
+    )
+    assert "theirs distinct addition about deployment timing" in merged_on_disk, (
+        "clean rebase silently dropped the theirs-side edit despite exit 0:\n"
+        f"working tree:\n{merged_on_disk}\nlog:\n{log}"
+    )

--- a/tests/fixtures/merge/nd_rambly.md
+++ b/tests/fixtures/merge/nd_rambly.md
@@ -4,4 +4,4 @@ kind: concept
 review_state: reviewed
 ---
 # Note
-This is a much longer, repetitive and somewhat rambling version of the same idea that repeats itself and adds little.
+Concise phrasing of the idea, the idea, the idea, the idea, concise phrasing of the idea, concise phrasing of the idea, concise phrasing of the idea.


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4603

## Linked Issue
Closes #4603

## SBS Impact
- Primary subsystem: Product vault-sync (semantic merge resolver)
- Secondary subsystem(s): Builder System git tooling
- Write class: authority-bearing
- Persistence impact: durable
- Derived/rebuildable impact: none
- New or changed contract: merge_note_from_blobs raises status=conflict for any diverging bodies unless exact match, link-carryover, or genuine near-duplicate (sim>=0.85) accounts for it
- Owner-doc impact: updated
- Transition debt impact: reduces
- Boundary risk: none

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Generalize the #4505 semanticmd content-loss guard to vault notes: judge_locus is a stub that never resolves a real per-locus decision, so a genuinely diverging vault note was silently resolved to OURS and, once #4561 fixed the %A write, that silent drop reached the real working tree on a clean git rebase/merge.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1/2 single-issue light-path PR; no BuilderOps material routed beyond the issue itself.

## Notes
python3 -m pytest tests/cli/test_merge_driver.py tests/agents/test_merge_resolver.py tests/agents/test_merge_resolver_repo_docs.py tests/smoke/test_merge_smoke.py tests/agents/test_apply_decisions_compose.py -q (18 passed); ruff check app tests (all checks passed); scripts/docs_guard.py OK
