### PR TITLE
Strip backticks from Verify path candidates

### DIFF
--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -217,7 +217,11 @@ def _verify_file_path(target: str) -> str | None:
             if canonical.startswith("`") and canonical.endswith("`"):
                 canonical = canonical[1:-1]
             path, separator, _ = canonical.partition(" :: ")
-            return path if separator else None
+            if not separator:
+                return None
+            if _is_joined_verify_target(target):
+                return path
+            return path.strip("`")
     path, separator, spaced_rest = canonical.partition(" :: ")
     if separator and spaced_rest:
         return path

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -111,6 +111,37 @@ def test_ready_issue_rejects_missing_non_behavioral_verify_file_path() -> None:
     assert "non-test file-based" in report.repair_guidance[0]
 
 
+def test_prose_prefixed_backticked_verify_path_resolves() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        (
+            "doc writeback at `docs/development/DEV_WORKFLOW.md :: "
+            "Acceptance verifiability` (step 3)"
+        ),
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "ready_candidate"
+    assert report.acceptance_criteria.missing_verify_file_paths == []
+
+
+def test_backticked_missing_verify_path_still_rejected() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace(
+        "tests/scripts/test_validate_issue_readiness.py::test_fixture_classifications",
+        "doc writeback at `docs/missing-readiness-guidance.md :: verify-rule` (step 3)",
+    )
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_verify_file_paths"
+    assert report.acceptance_criteria.missing_verify_file_paths == [
+        "docs/missing-readiness-guidance.md"
+    ]
+
+
 def test_joined_verify_targets_report_the_actual_cause() -> None:
     """A joined multi-target `Verify:` line gets a split hint, not just
     "file not found" for a file that exists (#3857, #3859)."""


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4562

## Linked Issue
Closes #4562

## SBS Impact
- Primary subsystem: Builder System / CES boundary readiness classification
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none; restores documented extraction behavior without changing grammar
- Owner-doc impact: none
- Transition debt impact: no effect
- Boundary risk: no Product/Runtime behavior, persistence, or owner-doc authority crosses the boundary

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Strip backticks from prose-prefixed Verify file-path candidates while preserving joined-target rejection.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was produced; implementation state is fully represented by the governing Issue and PR.

## Notes
Validation: ruff check app scripts tests; pytest -q tests/scripts/test_validate_issue_readiness.py (60 passed); pytest -q tests/governance (501 passed).