### PR TITLE
Stabilize CKM database identity regression

### DIFF
--- a/tests/builderops/ckm/test_query_plans.py
+++ b/tests/builderops/ckm/test_query_plans.py
@@ -181,27 +181,22 @@ def test_projection_batch_snapshot_prevents_concurrent_revision_mix(
 
 
 def test_projection_batch_refuses_mixed_database_identity(tmp_path: Path) -> None:
-    store, _, _, _ = _populated(tmp_path / "original")
-    replacement, _, _, _ = _populated(tmp_path / "replacement")
-    original = store._readonly_connect
-    replaced = False
+    store, _, _, _ = _populated(tmp_path)
+    original = store._db_file_identity
+    identity_reads = 0
 
-    def traced() -> sqlite3.Connection:
-        conn = original()
+    def changed_identity() -> tuple[int, int, int, int]:
+        nonlocal identity_reads
+        identity_reads += 1
+        identity = original()
+        if identity_reads == 2:
+            return (*identity[:3], identity[3] + 1)
+        return identity
 
-        def on_statement(statement: str) -> None:
-            nonlocal replaced
-            if replaced or not statement.startswith("SELECT * FROM ckm_capability"):
-                return
-            replaced = True
-            replacement.db_path.replace(store.db_path)
-
-        conn.set_trace_callback(on_statement)
-        return conn
-
-    store._readonly_connect = traced  # type: ignore[method-assign]
+    store._db_file_identity = changed_identity  # type: ignore[method-assign]
     with pytest.raises(CkmProjectionCaptureError) as refusal:
         store.load_projection_batch()
+    assert identity_reads == 2
     assert refusal.value.code == "mixed_epoch"
     assert "identity changed" in str(refusal.value)
 


### PR DESCRIPTION
Governing-Issue: #4618

Fixes #4618

Final-Review-Rounds: 0

## Summary
Replaces the filesystem-swap race with a deterministic second `_db_file_identity` result while continuing through `load_projection_batch`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded Tier 2 test-reliability repair; no operational record or owner-doc change is needed.

## Notes
Validation: targeted CKM plans (9 passed), mixed-epoch service test (1 passed), `ruff check app tests`, and `mypy app` passed. An unchanged full parallel baseline reproduced the test race as `sqlite3.OperationalError: disk I/O error`; post-change full-suite evidence is in progress.
