### PR TITLE
Fail closed on dirty PRs and absent required checks in await_pr_checks

### DIFF
--- a/.codex/skills/_shared/CI_WAIT_CONTRACT.md
+++ b/.codex/skills/_shared/CI_WAIT_CONTRACT.md
@@ -41,6 +41,28 @@ drains GraphQL to zero and stalls every other agent's reads — a recurring, sys
    check-run name (ranked by `started_at`, falling back to run id) before green/red classification;
    `epic-run-state lifecycle-plan` reuses that shared latest-record selector for terminal dry-runs.
    A genuinely failed latest record still fails closed.
+8. **A dirty PR schedules no pull_request workflows — absence of a required check is never
+   success.** (#4605, LearningSignal `lrn_20260729154323_f134857a`, seen on PR #4354.) When a PR
+   is `mergeable_state=dirty`, GitHub cannot compute `refs/pull/<n>/merge`, so the repo's
+   `pull_request`-triggered workflows never schedule for that head — yet CodeQL can still attach
+   green check-runs from `refs/pull/<n>/head`. An all-green *short* check-run list is therefore
+   not evidence the required suite ran. In merge-gating mode (no `--sha`),
+   `scripts/await_pr_checks.sh` fails closed on both halves of this defect class:
+   - **Dirty PR (exit 6):** the PR's `mergeable_state` is read via REST before the wait and
+     re-asserted after it; `dirty` refuses immediately with a fix-conflicts-and-re-run message.
+     Transient `unknown` passes through (the presence rule below is the backstop while GitHub
+     recomputes mergeability).
+   - **Required-check presence (exit 7):** before reporting success, the expected required
+     contexts must be *present* on the head (deduped check-run names plus classic status
+     contexts). The expected set resolves in this order: (1) live branch-protection
+     `required_status_checks` contexts for the PR's base branch via REST when readable (the
+     endpoint needs admin; failure falls through), else (2) the documented per-base fallback set
+     from `docs/development/GITHUB_GOVERNANCE_SETUP.md` — base `stable`: `smoke`, `smoke-docker`,
+     `pr-contract`; any other base (the `main` default): `Unit tests (not pg)`. A late-attaching
+     required workflow keeps waiting inside the normal backoff; the absence only becomes terminal
+     at the deadline. Only the required set participates — absence of an arbitrary optional check
+     never fails the wait. `--sha` diagnostic mode skips both gates by design (it inspects a
+     pinned commit and is not a merge gate).
 
 ## Blessed path
 
@@ -64,6 +86,8 @@ failing **closed** on any fetch error (an unverifiable state never reports succe
 - `3` — Codex verdict is blocking (only with `--codex`)
 - `4` — Codex verdict unresolved (only with `--codex`) — resolve before merge
 - `5` — the PR head moved during the wait (when SHA is auto-resolved) — verified checks are stale; re-run
+- `6` — the PR is `mergeable_state=dirty`, so pull_request workflows will not schedule (merge-gating mode) — fix conflicts and re-run
+- `7` — expected required check contexts are absent from the head (merge-gating mode) — absence is not success; see Rule 8
 
 **The exit code is the gate — never let a pipeline eat it.** Do not run the script as `await_pr_checks.sh <PR> 2>&1 | tail -2` (or any `| grep`/`| tee` composition) when its exit code gates a merge: a pipeline's status is the *last* command's, so a failed check exits 0 through `tail` and an `&& gh pr merge` chain merges on red (seen: PR #2759). Run the script bare and capture `rc=$?` before any formatting, and key the merge on `$rc`. The same holds in background shells: the gate is the captured rc, never the visible output.
 
@@ -99,7 +123,9 @@ gh api "repos/$REPO/commits/$SHA/status" --jq '.state'
 gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
   --jq '.check_runs[] | select(.conclusion!=null and .conclusion!="success" and .conclusion!="skipped" and .conclusion!="neutral") | "\(.name): \(.conclusion)"'
 
-# Mergeability (REST, not GraphQL):
+# Mergeability (REST, not GraphQL). Run this FIRST when polling manually: `dirty` means
+# pull_request workflows never scheduled, so an all-green short check-run list is a false
+# green, not a pass (Rule 8):
 gh api "repos/$REPO/pulls/$PR" --jq '.mergeable, .mergeable_state'
 
 # Codex verdict — primary signal can be an emoji reaction or a review.

--- a/scripts/await_pr_checks.sh
+++ b/scripts/await_pr_checks.sh
@@ -14,7 +14,10 @@
 #   scripts/await_pr_checks.sh --help
 #
 # --sha pins a commit for inspection and is NOT a merge gate (PR head-drift is not verified). Omit
-# --sha for the merge-gating default: the head is auto-resolved and re-checked before success.
+# --sha for the merge-gating default: the head is auto-resolved and re-checked before success, the
+# PR must not be mergeable_state=dirty, and the expected required check contexts must be PRESENT
+# on the head before an all-green short list can count as success (#4605: a dirty PR schedules no
+# pull_request workflows, yet CodeQL can still attach green head-ref check-runs).
 #
 # Exit codes:
 #   0  CI check-runs + classic commit status all passed (with --codex, Codex also passed)
@@ -23,6 +26,8 @@
 #   3  Codex verdict is blocking         (only with --codex)
 #   4  Codex verdict unresolved — resolve per verification-and-closure before merge (only with --codex)
 #   5  PR head moved during the wait — verified checks are stale; re-run (when SHA is auto-resolved)
+#   6  PR is mergeable_state=dirty — pull_request workflows will not schedule; fix conflicts, re-run (merge-gating mode)
+#   7  required check contexts absent from the head — absence is NOT success (merge-gating mode)
 set -uo pipefail
 
 INITIAL_WAIT=180     # sleep before first check (~ CI p50; the `not pg` gate is the long pole)
@@ -67,18 +72,68 @@ REPO="${REPO_FLAG:-${GH_REPO:-}}"
 budget=$(gh api rate_limit --jq '"core=\(.resources.core.remaining) graphql=\(.resources.graphql.remaining)"' 2>/dev/null || echo "unknown")
 echo "repo=$REPO pr=$PR budget: $budget (this script uses REST core only)"
 
+# Dirty-PR fail-closed gate (#4605, LearningSignal lrn_20260729154323_f134857a, PR #4354): a
+# mergeable_state=dirty PR cannot compute refs/pull/<n>/merge, so the repo's pull_request
+# workflows NEVER schedule for it — while CodeQL can still attach green check-runs from
+# refs/pull/<n>/head. Waiting on such a head can only ever see unrelated green checks, so the
+# wait must refuse up front instead of reporting a false green. Merge-gating mode only.
+fail_if_dirty() {
+  if [ "$1" = "dirty" ]; then
+    echo "PR NOT MERGEABLE (mergeable_state=dirty): PR #$PR cannot compute its merge ref, so pull_request workflows will not schedule." >&2
+    echo "Head-ref check-runs (e.g. CodeQL) are NOT the required CI suite — refusing to wait toward a false green (CI_WAIT_CONTRACT.md :: Rules)." >&2
+    echo "Resolve the conflict (rebase onto the base branch, push) and re-run." >&2
+    exit 6
+  fi
+}
+
+BASE_REF=""
 if [ -z "$SHA" ]; then
-  SHA=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null) || true
+  pr_resp=$(gh api "repos/$REPO/pulls/$PR" 2>/dev/null) || true
+  SHA=$(printf '%s' "$pr_resp" | jq -r '.head.sha // empty' 2>/dev/null)
   [ -n "$SHA" ] || { echo "error: could not resolve head SHA for PR #$PR (REST)" >&2; exit 64; }
+  BASE_REF=$(printf '%s' "$pr_resp" | jq -r '.base.ref // empty' 2>/dev/null)
   SHA_FROM_PR=1
+  # mergeable_state=unknown is a transient compute state and passes through; the
+  # required-check presence gate below is the backstop while GitHub recomputes.
+  fail_if_dirty "$(printf '%s' "$pr_resp" | jq -r '.mergeable_state // "unknown"' 2>/dev/null)"
 fi
 echo "head=$SHA"
 if [ "$SHA_FROM_PR" -eq 0 ]; then
   # --sha pins a specific commit for inspection; it is deliberately NOT a merge gate, because the
   # PR head may differ from (or move away from) the pinned SHA, so a `--sha X && gh pr merge` would
-  # merge an unverified head. The merge-gating mode is the default (auto-resolved head + drift check).
+  # merge an unverified head. The merge-gating mode is the default (auto-resolved head + drift
+  # check + dirty-PR and required-check presence gates, which --sha mode deliberately skips).
   echo "note: --sha mode is diagnostic, NOT a merge gate (PR head-drift is not verified)." >&2
   echo "      For an autonomous merge gate, omit --sha so the head is resolved and re-checked." >&2
+fi
+
+# Required-check presence (#4605): success must mean "the required suite ran green", never "the
+# few checks that happened to attach are green". Resolution order for the expected set
+# (documented in CI_WAIT_CONTRACT.md :: Rules):
+#   1. Live branch-protection contexts for the PR's base branch (REST; needs admin — best effort).
+#   2. Documented fallback set per base branch from docs/development/GITHUB_GOVERNANCE_SETUP.md:
+#      stable -> smoke, smoke-docker, pr-contract; otherwise (main default) -> Unit tests (not pg).
+# This is the repo-required set, not "every optional check": absence of an arbitrary optional
+# check never fails the wait. Merge-gating mode only; --sha diagnostic mode skips it.
+REQUIRED_CHECKS=""
+REQUIRED_SOURCE=""
+if [ "$SHA_FROM_PR" -eq 1 ]; then
+  base="${BASE_REF:-main}"
+  prot=$(gh api "repos/$REPO/branches/$base/protection/required_status_checks" 2>/dev/null) || prot=""
+  if [ -n "$prot" ]; then
+    REQUIRED_CHECKS=$(printf '%s' "$prot" | jq -r '((.contexts // []) + [.checks // [] | .[].context]) | unique | .[]' 2>/dev/null)
+  fi
+  if [ -n "$REQUIRED_CHECKS" ]; then
+    REQUIRED_SOURCE="branch-protection:$base"
+  else
+    if [ "$base" = "stable" ]; then
+      REQUIRED_CHECKS=$(printf 'smoke\nsmoke-docker\npr-contract')
+    else
+      REQUIRED_CHECKS='Unit tests (not pg)'
+    fi
+    REQUIRED_SOURCE="documented-fallback:$base"
+  fi
+  echo "required checks ($REQUIRED_SOURCE): $(printf '%s\n' "$REQUIRED_CHECKS" | paste -sd ',' - | sed 's/,/, /g')"
 fi
 
 echo "waiting ${INITIAL_WAIT}s before first check (CI runs ~4-5 min; not polling through it)..."
@@ -104,7 +159,9 @@ DEDUPE_LATEST_PER_NAME='
 # a response we trust.
 deadline=$(( $(date +%s) + TIMEOUT - INITIAL_WAIT ))
 failed=""
+missing_required=""
 while :; do
+  missing_required=""
   resp=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" 2>/dev/null)
   rc=$?
   count=$(printf '%s' "$resp" | jq -r '.check_runs | length' 2>/dev/null)
@@ -134,11 +191,39 @@ while :; do
         if [ "${stotal:-0}" -gt 0 ] && [ "$sstate" != "success" ]; then
           failed="${failed:+$failed; }classic commit status=$sstate"
         fi
-        break
+        if [ -n "$failed" ]; then
+          break
+        fi
+        # Required-check presence gate (#4605, merge-gating mode only): an all-green short list is
+        # not success unless every expected required context is actually PRESENT on this head
+        # (check-run names + classic status contexts). A required workflow can attach late, so
+        # absence keeps waiting inside the budgeted backoff; it only becomes terminal (exit 7) at
+        # the deadline — never a silent fall-through to success.
+        if [ "$SHA_FROM_PR" -eq 1 ] && [ -n "$REQUIRED_CHECKS" ]; then
+          present=$( { printf '%s' "$resp" | jq -r "${DEDUPE_LATEST_PER_NAME} | .[].name" 2>/dev/null; \
+                       printf '%s' "$sresp" | jq -r '.statuses // [] | .[].context' 2>/dev/null; } )
+          missing_required=$(printf '%s\n' "$REQUIRED_CHECKS" | while IFS= read -r req; do
+            [ -n "$req" ] || continue
+            printf '%s\n' "$present" | grep -Fxq -- "$req" || printf '%s\n' "$req"
+          done)
+          if [ -n "$missing_required" ]; then
+            echo "required checks not attached to $SHA yet: $(printf '%s\n' "$missing_required" | paste -sd ',' - | sed 's/,/, /g'); waiting..."
+          else
+            break
+          fi
+        else
+          break
+        fi
       fi
     fi
   fi
   if [ "$(date +%s)" -ge "$deadline" ]; then
+    if [ -n "$missing_required" ]; then
+      echo "REQUIRED CHECKS MISSING on $SHA: $(printf '%s\n' "$missing_required" | paste -sd ',' - | sed 's/,/, /g') (expected set source: $REQUIRED_SOURCE)" >&2
+      echo "Absence of a required check is NOT success — the attached checks may be head-ref-only (e.g. CodeQL on a PR whose pull_request workflows never scheduled)." >&2
+      echo "Failing closed; see CI_WAIT_CONTRACT.md :: Rules (#4605)." >&2
+      exit 7
+    fi
     echo "TIMEOUT after ${TIMEOUT}s; checks not confirmed complete (last pending: ${pending:-unknown})" >&2
     exit 2
   fi
@@ -154,13 +239,17 @@ fi
 # Otherwise the green we just verified is for a stale commit, and an autonomous `&& gh pr merge`
 # would merge the new, unverified head. (Skipped when --sha pins an explicit commit.)
 if [ "$SHA_FROM_PR" -eq 1 ]; then
-  cur=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null)
+  cur_resp=$(gh api "repos/$REPO/pulls/$PR" 2>/dev/null) || true
+  cur=$(printf '%s' "$cur_resp" | jq -r '.head.sha // empty' 2>/dev/null)
   if [ -z "$cur" ]; then
     echo "ERROR: could not re-confirm PR head after the wait — failing closed" >&2; exit 2
   elif [ "$cur" != "$SHA" ]; then
     echo "PR HEAD MOVED during the wait: verified $SHA but head is now $cur — verified checks are stale; re-run" >&2
     exit 5
   fi
+  # The base can advance mid-wait and turn the PR dirty; green head checks would then gate a PR
+  # GitHub itself refuses to merge, so re-assert mergeability from the same re-fetch (#4605).
+  fail_if_dirty "$(printf '%s' "$cur_resp" | jq -r '.mergeable_state // "unknown"' 2>/dev/null)"
 fi
 echo "all required checks passed on $SHA"
 

--- a/tests/fixtures/await_pr_checks/head_only_unrelated_green.json
+++ b/tests/fixtures/await_pr_checks/head_only_unrelated_green.json
@@ -1,0 +1,21 @@
+{
+  "total_count": 2,
+  "check_runs": [
+    {
+      "id": 91000000001,
+      "name": "CodeQL",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-07-29T15:40:03Z",
+      "completed_at": "2026-07-29T15:41:12Z"
+    },
+    {
+      "id": 91000000002,
+      "name": "Analyze (python)",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-07-29T15:40:05Z",
+      "completed_at": "2026-07-29T15:43:27Z"
+    }
+  ]
+}

--- a/tests/fixtures/await_pr_checks/head_required_present_green.json
+++ b/tests/fixtures/await_pr_checks/head_required_present_green.json
@@ -1,0 +1,29 @@
+{
+  "total_count": 3,
+  "check_runs": [
+    {
+      "id": 92000000001,
+      "name": "CodeQL",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-07-29T15:40:03Z",
+      "completed_at": "2026-07-29T15:41:12Z"
+    },
+    {
+      "id": 92000000002,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-07-29T15:40:10Z",
+      "completed_at": "2026-07-29T15:52:44Z"
+    },
+    {
+      "id": 92000000003,
+      "name": "pr-contract",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-07-29T15:40:08Z",
+      "completed_at": "2026-07-29T15:40:31Z"
+    }
+  ]
+}

--- a/tests/scripts/test_await_pr_checks.py
+++ b/tests/scripts/test_await_pr_checks.py
@@ -1,0 +1,185 @@
+"""Fixture-level tests for scripts/await_pr_checks.sh merge-gating fail-closed rules (#4605).
+
+Defect class (LearningSignal lrn_20260729154323_f134857a, PR #4354): a `mergeable_state=dirty`
+PR cannot compute `refs/pull/<n>/merge`, so the repo's pull_request workflows never schedule.
+CodeQL can still attach green check-runs from `refs/pull/<n>/head`, leaving the waiter a short
+all-success check-run list that it previously reported as "all required checks passed".
+
+These tests stub `gh` on PATH so the real script (`scripts/await_pr_checks.sh`) runs unmodified
+in its merge-gating mode (no `--sha`) against canned REST payloads, and assert on the script's
+actual exit codes:
+
+- exit 6: the PR is `mergeable_state=dirty` — pull_request workflows will not schedule.
+- exit 7: expected required check contexts are absent from the head — absence is not success.
+
+The fake `gh` applies `--jq` expressions with the real `jq` binary (a hard dependency of the
+script itself), so the stub stays faithful for any REST call shape the script uses.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "await_pr_checks"
+SCRIPT = REPO_ROOT / "scripts" / "await_pr_checks.sh"
+
+FAKE_SHA = "9c1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e"
+
+# Serves canned REST payloads for every endpoint the script touches in merge-gating mode:
+# rate_limit, pulls/<pr> (head sha + base ref + mergeable_state), the branch-protection
+# required_status_checks endpoint, commits/<sha>/check-runs, and commits/<sha>/status.
+# `--jq` is applied with the real jq so both the pre-fix and post-fix script shapes work.
+FAKE_GH = """#!/usr/bin/env bash
+set -uo pipefail
+[ "${1:-}" = "api" ] || { echo "unhandled fake gh call: $*" >&2; exit 1; }
+path="$2"
+shift 2
+jq_expr=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jq) jq_expr="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+emit() {
+  if [ -n "$jq_expr" ]; then
+    printf '%s' "$1" | jq -r "$jq_expr"
+  else
+    printf '%s' "$1"
+  fi
+}
+case "$path" in
+  rate_limit)
+    emit '{"resources":{"core":{"remaining":4999},"graphql":{"remaining":4999}}}'
+    ;;
+  */branches/*/protection/required_status_checks)
+    if [ "${FAKE_PROTECTION_JSON:-}" = "" ]; then
+      # Mimic gh's non-admin/absent-protection behavior: error, no payload.
+      echo "gh: Not Found (HTTP 404)" >&2
+      exit 1
+    fi
+    emit "$FAKE_PROTECTION_JSON"
+    ;;
+  *check-runs*)
+    emit "$(cat "$FAKE_CHECK_RUNS_JSON")"
+    ;;
+  */status)
+    emit '{"state":"pending","total_count":0,"statuses":[]}'
+    ;;
+  */pulls/*)
+    emit "{\\"head\\":{\\"sha\\":\\"$FAKE_SHA\\"},\\"base\\":{\\"ref\\":\\"${FAKE_BASE_REF:-main}\\"},\\"mergeable_state\\":\\"${FAKE_MERGEABLE_STATE:-clean}\\"}"
+    ;;
+  *)
+    echo "unhandled fake gh api path: $path" >&2
+    exit 1
+    ;;
+esac
+"""
+
+
+def _make_fake_gh(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    gh_path = bin_dir / "gh"
+    gh_path.write_text(FAKE_GH, encoding="utf-8")
+    gh_path.chmod(gh_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run_merge_gating(
+    tmp_path: Path,
+    fixture_name: str,
+    *,
+    mergeable_state: str = "clean",
+    base_ref: str = "main",
+    protection_json: str = "",
+) -> subprocess.CompletedProcess[str]:
+    fake_bin_dir = _make_fake_gh(tmp_path)
+    fixture_path = FIXTURES_DIR / fixture_name
+    assert fixture_path.exists(), f"missing fixture: {fixture_path}"
+
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["FAKE_SHA"] = FAKE_SHA
+    env["FAKE_CHECK_RUNS_JSON"] = str(fixture_path)
+    env["FAKE_MERGEABLE_STATE"] = mergeable_state
+    env["FAKE_BASE_REF"] = base_ref
+    env["FAKE_PROTECTION_JSON"] = protection_json
+    env["GH_REPO"] = "RasmusTho/agentic-pkm-mvp"
+
+    # No --sha: this is the merge-gating mode the issue's fail-closed rules apply to.
+    # --timeout 0 makes the deadline immediate, so a missing-required outcome resolves on
+    # the first classification pass instead of sleeping through a >=60s backoff interval.
+    return subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "4321",
+            "--initial-wait",
+            "0",
+            "--interval",
+            "60",
+            "--timeout",
+            "0",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_dirty_pr_state_fails_before_false_green(tmp_path: Path) -> None:
+    """AC1: mergeable_state=dirty fails closed (exit 6) before any green report.
+
+    The head carries only unrelated green check-runs (the CodeQL-from-head shape of the
+    PR #4354 false green); the script must refuse before classifying them as the suite.
+    """
+    result = _run_merge_gating(
+        tmp_path, "head_only_unrelated_green.json", mergeable_state="dirty"
+    )
+    assert result.returncode == 6, result.stdout + result.stderr
+    assert "dirty" in result.stderr
+    assert "will not schedule" in result.stderr
+    assert "all required checks passed" not in result.stdout
+
+
+def test_missing_required_check_names_fail_closed(tmp_path: Path) -> None:
+    """AC2: a head with only unrelated green checks cannot pass — exit 7, naming the gap.
+
+    Branch protection is unreadable (404), so the documented fallback set for base `main`
+    applies: `Unit tests (not pg)`. It is absent from the head's contexts.
+    """
+    result = _run_merge_gating(tmp_path, "head_only_unrelated_green.json")
+    assert result.returncode == 7, result.stdout + result.stderr
+    assert "REQUIRED CHECKS MISSING" in result.stderr
+    assert "Unit tests (not pg)" in result.stderr
+    assert "all required checks passed" not in result.stdout
+
+
+def test_required_checks_present_green_still_passes(tmp_path: Path) -> None:
+    """Regression guard: a head carrying the required context green still exits 0."""
+    result = _run_merge_gating(tmp_path, "head_required_present_green.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "all required checks passed" in result.stdout
+
+
+def test_live_branch_protection_contexts_take_precedence(tmp_path: Path) -> None:
+    """Resolution order: readable branch-protection contexts override the documented fallback.
+
+    Live protection requires `smoke`, which the head lacks even though the fallback set's
+    `Unit tests (not pg)` is present and green — so the waiter must still fail closed.
+    """
+    result = _run_merge_gating(
+        tmp_path,
+        "head_required_present_green.json",
+        protection_json='{"contexts":["smoke"],"checks":[{"context":"smoke","app_id":15368}]}',
+    )
+    assert result.returncode == 7, result.stdout + result.stderr
+    assert "smoke" in result.stderr
+    assert "all required checks passed" not in result.stdout


### PR DESCRIPTION
Governing-Issue: #4605

Fixes #4605

Final-Review-Rounds: 0

## Summary
`scripts/await_pr_checks.sh` could report "all required checks passed" on a `mergeable_state=dirty` PR whose pull_request workflows never scheduled, because CodeQL still attaches green head-ref check-runs (defect class from PR #4354, LearningSignal `lrn_20260729154323_f134857a`). In merge-gating mode (no `--sha`) the waiter now fails closed, REST-only: `dirty` exits 6 before and after the wait, and the expected required check contexts must be present on the head before success — absence becomes exit 7 at the deadline, never a green report.

## Changes
- `scripts/await_pr_checks.sh`: reads `mergeable_state` and `base.ref` from the existing PR head-resolution fetch and refuses `dirty` (exit 6) up front and again at the post-wait head re-check; resolves the expected required set once per run — live branch-protection `required_status_checks` contexts for the base branch when readable, else the documented per-base fallback (`stable`: `smoke`, `smoke-docker`, `pr-contract`; otherwise `Unit tests (not pg)`) — and requires every member to be present among deduped check-run names plus classic status contexts before reporting success (missing => exit 7 at the deadline; late-attaching required workflows keep waiting inside the normal backoff). Only the required set participates: optional-check absence never fails the wait. `--sha` diagnostic mode deliberately skips both gates and stays a non-merge-gating inspection path. No new REST call inside the poll loop; shared-budget behavior is preserved.
- `.codex/skills/_shared/CI_WAIT_CONTRACT.md`: new Rule 8 documents the dirty-PR/no-workflow-scheduling failure mode, the required-check presence rule, and the required-set resolution order; exit codes 6/7 added to the blessed-path table; manual REST section now says to read mergeability first.
- `tests/scripts/test_await_pr_checks.py` (new) + two fixtures: runs the real script in merge-gating mode against a faithful fake `gh` (applies `--jq` with real jq) and asserts actual exit codes.

## Acceptance Criteria
- AC1 Verify: `tests/scripts/test_await_pr_checks.py::test_dirty_pr_state_fails_before_false_green` — passes (exit 6 on `mergeable_state=dirty` with only unrelated green head checks; written first and failed with exit 0 + "all required checks passed" against the unchanged script).
- AC2 Verify: `tests/scripts/test_await_pr_checks.py::test_missing_required_check_names_fail_closed` — passes (exit 7 naming `Unit tests (not pg)`; also written first and failed with a false green against the unchanged script).
- AC3 Verify: doc writeback at `.codex/skills/_shared/CI_WAIT_CONTRACT.md :: Rules` (Rule 8) — in this diff.

Additional guards: `test_required_checks_present_green_still_passes` (green path regression) and `test_live_branch_protection_contexts_take_precedence` (resolution order: live protection over documented fallback). Existing `--sha`-mode dedupe tests unchanged and passing.

## SBS Impact
Builder System / CES boundary; CI wait and verification workflow. Governance/dev-time only — no product/runtime behavior change. Strengthens merge gating by making absence of a required check distinct from success; GitHub Checks/branch-protection API reads only (REST). Owner doc updated in this PR (`CI_WAIT_CONTRACT.md`).

## BuilderOps Routing
- Records/projections/receipts: applies existing LearningSignal `builderops_object:lrn_20260729154323_f134857a` (this PR is the upstream repair that signal demanded); dispatcher claim receipt `task_id=github-RasmusTho--agentic-pkm-mvp-issue-4605 lease_id=lease-3e688bc2 holder=claude-w2a evidence=verified-dispatcher-lease`.
- Reason: no new BuilderOps record needed — the delivery closes the captured signal; no plan divergence occurred.

## Claim receipt
`pickup-claim-complete issue=4605 branch=fix/4605-ci-waiter-required-check-presence worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a963c87e9b8ff7e6c coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4605 lease_id=lease-3e688bc2 holder=claude-w2a evidence=verified-dispatcher-lease`

## Notes
Validation: `pytest -q tests/scripts/test_await_pr_checks.py tests/scripts/test_await_pr_checks_dedupe.py tests/dispatcher/test_poll_backoff.py` => 12 passed (on the rebased base 6952557d). Test-first proof: the two AC tests reproduced the false green (script exited 0 with "all required checks passed") before the fix. `bash -n` and `shellcheck scripts/await_pr_checks.sh` clean; `ruff check app tests scripts` and `ruff check app tests companion-ui/companion-app` all-clean; `python3 scripts/lint_skills_consistency.py` clean; `git diff --check` clean; `scripts/review_before_ci_gate.py --lane implementation` satisfied (governance surface, no high-risk TCD surface; risk assessment complete with empty risk-surface set). Local `scripts/docs_guard.py` reports its generic temporal code/docs pairing note for `scripts/**`; its CI step is scoped to docs-only PR shapes and the issue-designated owner doc is updated in this diff.
---