### PR TITLE
Refuse a production DSN in the pg test lane (#4573)

### DIFF
--- a/.github/workflows/architecture-ci.yaml
+++ b/.github/workflows/architecture-ci.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: app
-          POSTGRES_DB: app
+          POSTGRES_DB: app_test
         ports:
           - 5432:5432
         options: >-
@@ -38,7 +38,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://app:app@localhost:5432/app
+      DATABASE_URL: postgresql://app:app@localhost:5432/app_test
       PYTHONPATH: ${{ github.workspace }}
       TRACE_LOG_PATH: /tmp/trace.jsonl
     steps:

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -714,7 +714,7 @@ jobs:
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: app
-          POSTGRES_DB: app
+          POSTGRES_DB: app_test
         ports:
           - 5432:5432
         options: >-
@@ -723,8 +723,8 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://app:app@localhost:5432/app
-      DB_DSN: postgresql://app:app@localhost:5432/app
+      DATABASE_URL: postgresql://app:app@localhost:5432/app_test
+      DB_DSN: postgresql://app:app@localhost:5432/app_test
       PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/companion-ui/companion-app
       STORE_BACKEND: pg
       LLM_PROVIDER: mock

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -180,7 +180,7 @@ jobs:
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: app
-          POSTGRES_DB: app
+          POSTGRES_DB: app_test
         ports:
           - 5432:5432
         options: >-
@@ -189,7 +189,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql+psycopg://app:app@localhost:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@localhost:5432/app_test
       PYTHONPATH: ${{ github.workspace }}
       STORE_BACKEND: pg
       LLM_PROVIDER: mock
@@ -268,7 +268,7 @@ jobs:
         env:
           POSTGRES_USER: app
           POSTGRES_PASSWORD: app
-          POSTGRES_DB: app
+          POSTGRES_DB: app_test
         ports:
           - 5432:5432
         options: >-
@@ -277,7 +277,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://app:app@localhost:5432/app
+      DATABASE_URL: postgresql://app:app@localhost:5432/app_test
       PYTHONPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4

--- a/app/db/dsn.py
+++ b/app/db/dsn.py
@@ -34,13 +34,20 @@ def _keyword_conninfo_parts(conninfo: str) -> t.Optional[dict[str, str]]:
         return {}
 
     parts: dict[str, str] = {}
-    for field in fields:
-        if "=" not in field:
+    index = 0
+    while index < len(fields):
+        field = fields[index]
+        if "=" in field:
+            key, value = field.split("=", 1)
+        elif index + 2 < len(fields) and fields[index + 1] == "=":
+            key, value = field, fields[index + 2]
+            index += 2
+        else:
             return {}
-        key, value = field.split("=", 1)
         if not key:
             return {}
         parts[key.lower()] = value
+        index += 1
     return parts
 
 
@@ -78,17 +85,22 @@ def looks_like_prod_dsn(conninfo: t.Optional[str] = None) -> bool:
         return True
 
     try:
-        from urllib.parse import urlsplit  # noqa: PLC0415
+        from urllib.parse import parse_qs, urlsplit  # noqa: PLC0415
 
         parts = urlsplit(url)
     except Exception:
         return False
 
     db_name = (parts.path or "").lstrip("/").split("?", 1)[0]
-    if db_name == "app":
+    query = parse_qs(parts.query, keep_blank_values=True)
+    effective_db_name = (query.get("dbname", [db_name])[-1] or db_name).strip()
+    if effective_db_name == "app":
         return True
 
     try:
+        effective_port = query.get("port", [None])[-1]
+        if effective_port is not None:
+            return int(effective_port) == 15432
         if parts.port == 15432:
             return True
     except ValueError:

--- a/app/db/dsn.py
+++ b/app/db/dsn.py
@@ -34,20 +34,13 @@ def _keyword_conninfo_parts(conninfo: str) -> t.Optional[dict[str, str]]:
         return {}
 
     parts: dict[str, str] = {}
-    index = 0
-    while index < len(fields):
-        field = fields[index]
-        if "=" in field:
-            key, value = field.split("=", 1)
-        elif index + 2 < len(fields) and fields[index + 1] == "=":
-            key, value = field, fields[index + 2]
-            index += 2
-        else:
+    for field in fields:
+        if "=" not in field:
             return {}
+        key, value = field.split("=", 1)
         if not key:
             return {}
         parts[key.lower()] = value
-        index += 1
     return parts
 
 
@@ -85,22 +78,17 @@ def looks_like_prod_dsn(conninfo: t.Optional[str] = None) -> bool:
         return True
 
     try:
-        from urllib.parse import parse_qs, urlsplit  # noqa: PLC0415
+        from urllib.parse import urlsplit  # noqa: PLC0415
 
         parts = urlsplit(url)
     except Exception:
         return False
 
     db_name = (parts.path or "").lstrip("/").split("?", 1)[0]
-    query = parse_qs(parts.query, keep_blank_values=True)
-    effective_db_name = (query.get("dbname", [db_name])[-1] or db_name).strip()
-    if effective_db_name == "app":
+    if db_name == "app":
         return True
 
     try:
-        effective_port = query.get("port", [None])[-1]
-        if effective_port is not None:
-            return int(effective_port) == 15432
         if parts.port == 15432:
             return True
     except ValueError:

--- a/conftest.py
+++ b/conftest.py
@@ -69,11 +69,10 @@ def _sanitize_external_env(
     monkeypatch.setenv("LLM_EMBED_MODEL", "mock-embed")
 
     # pg-marked tests must see the environment-provided DATABASE_URL (CI
-    # service container, local dev DB); stripping it here made every pg test
-    # in CI fall through to the machine-local 127.0.0.1:15432 default in
-    # tests/conftest.py::default_pg_dsn_for_pg_tests and skip or fail
-    # (#2818). Same guard pattern as
-    # tests/conftest.py::force_memory_store_for_non_pg.
+    # service container, local scratch DB); stripping it here made every pg
+    # test in CI skip or fail (#2818). There is no fallback to strip through
+    # any more — the pg lane is explicit-or-nothing (#4573). Same guard pattern
+    # as tests/conftest.py::force_memory_store_for_non_pg.
     if request.node.get_closest_marker("pg") is None:
         monkeypatch.setenv("STORE_BACKEND", "memory")
         monkeypatch.delenv("DATABASE_URL", raising=False)

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -92,15 +92,19 @@ The gate checks **four** ways this repo can name a database, not just the obviou
 | Writer | Reached through | Checked |
 |---|---|---|
 | `DATABASE_URL` / `DB_DSN` | `app/db/dsn.py :: resolve_dsn` | always |
-| `PKM_DB_HOST` / `PKM_DB_PORT` / `PKM_DB_NAME_*` / `POSTGRES_*` | `app/config/database.py :: resolve_runtime_database_url` → `app/db/db.py :: conn_rw` | when loopback + production |
-| `PGHOST` / `PGPORT` / `PGDATABASE` | libpq's own defaults, whenever an empty conninfo is passed | when loopback + production |
+| `PKM_DB_HOST` / `PKM_DB_PORT` / `PKM_DB_NAME_*` / `POSTGRES_*` | `app/config/database.py :: resolve_runtime_database_url` → `app/db/db.py :: conn_rw` | always when explicitly configured |
+| `PGHOST` / `PGPORT` / `PGDATABASE` | libpq's own defaults, whenever an empty conninfo is passed | always when a TCP host is configured |
 | `BUILDEROPS_DATABASE_URL` | the control plane's own `CREATE SCHEMA` path | always |
 
 The second and third are the reason `DATABASE_URL` alone is not sufficient: a run with
 `PKM_DB_HOST=127.0.0.1 PKM_DB_PORT=15432` and no `DATABASE_URL` reaches production through
-`conn_rw()` while the documented pair still looks unconfigured. Those two are scoped to loopback
-addresses so the compose-internal `@db:5432/app` fallback — prod-shaped but reachable only from
-inside the compose network — does not abort ordinary runs.
+`conn_rw()` while the documented pair still looks unconfigured. Each writer is checked independently:
+a safe primary DSN cannot hide a production runtime or ambient libpq target. The unconditional
+compose-internal fallback is ignored only when no runtime writer was explicitly configured.
+
+Collection authorization stays consumer-specific. `DATABASE_URL` / `DB_DSN` authorizes the ordinary
+`pg` lane; `BUILDEROPS_DATABASE_URL` authorizes only control-plane tests that consume it. Runtime and
+ambient libpq variables never globally unskip destructive tests that consume the documented pair.
 
 The refusal is deliberately placed before imports rather than after collection: several test modules
 probe Postgres at import time (`tests/stores/test_capabilities_matrix.py` evaluates `pg_available()`

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -93,7 +93,8 @@ The gate checks **four** ways this repo can name a database, not just the obviou
 |---|---|---|
 | `DATABASE_URL` / `DB_DSN` | `app/db/dsn.py :: resolve_dsn` | always |
 | `PKM_DB_HOST` / `PKM_DB_PORT` / `PKM_DB_NAME_*` / `POSTGRES_*` | `app/config/database.py :: resolve_runtime_database_url` → `app/db/db.py :: conn_rw` | always when explicitly configured |
-| `PGHOST` / `PGPORT` / `PGDATABASE` | libpq's own defaults, whenever an empty conninfo is passed | always when a TCP host is configured |
+| `PGHOST` / `PGHOSTADDR` / `PGPORT` / `PGDATABASE` / `PGUSER` | libpq's own defaults, whenever an empty conninfo is passed | always when any target field is explicitly configured |
+| `PGSERVICE` / `PGSERVICEFILE` | libpq service indirection | fail closed whenever either is configured because its effective target cannot be inspected safely before imports |
 | `BUILDEROPS_DATABASE_URL` | the control plane's own `CREATE SCHEMA` path | always |
 
 The second and third are the reason `DATABASE_URL` alone is not sufficient: a run with
@@ -103,8 +104,9 @@ a safe primary DSN cannot hide a production runtime or ambient libpq target. The
 compose-internal fallback is ignored only when no runtime writer was explicitly configured.
 
 Collection authorization stays consumer-specific. `DATABASE_URL` / `DB_DSN` authorizes the ordinary
-`pg` lane; `BUILDEROPS_DATABASE_URL` authorizes only control-plane tests that consume it. Runtime and
-ambient libpq variables never globally unskip destructive tests that consume the documented pair.
+`pg` lane; `BUILDEROPS_DATABASE_URL` authorizes only the control-plane tests and BuilderOps recovery
+test that consume it. Runtime and ambient libpq variables never globally unskip destructive tests
+that consume the documented pair.
 
 The refusal is deliberately placed before imports rather than after collection: several test modules
 probe Postgres at import time (`tests/stores/test_capabilities_matrix.py` evaluates `pg_available()`

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -88,8 +88,9 @@ refuses to guess:
   DSN whose database name is exactly `app` or whose port is the prod-published `15432`.
 
 The same classification runs again at all three psycopg connection entry points during pytest. That
-side-effect-boundary guard covers values a test mutates or assembles after `pytest_configure`, including
-runtime defaults, local-socket libpq targets, and service indirection. The AST census under
+side-effect-boundary guard classifies positional conninfo together with libpq keyword parameters, so
+late overrides cannot hide a production target. It also refuses implicit or explicit local-socket
+targets and service indirection, whose server cannot be proven safe. The AST census under
 `tests/architecture/` deliberately checks only hard-coded defaults; it is not a Python dataflow analyzer.
 
 The gate checks **four** ways this repo can name a database, not just the obvious one:

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -87,6 +87,11 @@ refuses to guess:
   before the first test module is imported**, so nothing opens a connection. That classifier flags a
   DSN whose database name is exactly `app` or whose port is the prod-published `15432`.
 
+The same classification runs again at all three psycopg connection entry points during pytest. That
+side-effect-boundary guard covers values a test mutates or assembles after `pytest_configure`, including
+runtime defaults, local-socket libpq targets, and service indirection. The AST census under
+`tests/architecture/` deliberately checks only hard-coded defaults; it is not a Python dataflow analyzer.
+
 The gate checks **four** ways this repo can name a database, not just the obvious one:
 
 | Writer | Reached through | Checked |

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -75,6 +75,54 @@ Practical rule:
 - Settings/runtime contract changes:
   - `python -m app.cli settings-validate --json`
 
+### Pointing the PG lane at a scratch database
+
+The `pg` lane has **no default database** (#4573). It runs destructive DDL, `TRUNCATE`, and
+`CREATE DATABASE` / `DROP DATABASE` against whatever `DATABASE_URL` / `DB_DSN` resolves to, so it
+refuses to guess:
+
+- Nothing configured → every `pg`-marked test **skips**, with a terminal banner naming what to set.
+  A skipped PG lane is never silent, including under `pytest-xdist` (`make smoke`, `CI Smoke`).
+- A DSN that `app/db/dsn.py :: looks_like_prod_dsn` flags → the run **aborts in `pytest_configure`,
+  before the first test module is imported**, so nothing opens a connection. That classifier flags a
+  DSN whose database name is exactly `app` or whose port is the prod-published `15432`.
+
+The gate checks **four** ways this repo can name a database, not just the obvious one:
+
+| Writer | Reached through | Checked |
+|---|---|---|
+| `DATABASE_URL` / `DB_DSN` | `app/db/dsn.py :: resolve_dsn` | always |
+| `PKM_DB_HOST` / `PKM_DB_PORT` / `PKM_DB_NAME_*` / `POSTGRES_*` | `app/config/database.py :: resolve_runtime_database_url` → `app/db/db.py :: conn_rw` | when loopback + production |
+| `PGHOST` / `PGPORT` / `PGDATABASE` | libpq's own defaults, whenever an empty conninfo is passed | when loopback + production |
+| `BUILDEROPS_DATABASE_URL` | the control plane's own `CREATE SCHEMA` path | always |
+
+The second and third are the reason `DATABASE_URL` alone is not sufficient: a run with
+`PKM_DB_HOST=127.0.0.1 PKM_DB_PORT=15432` and no `DATABASE_URL` reaches production through
+`conn_rw()` while the documented pair still looks unconfigured. Those two are scoped to loopback
+addresses so the compose-internal `@db:5432/app` fallback — prod-shaped but reachable only from
+inside the compose network — does not abort ordinary runs.
+
+The refusal is deliberately placed before imports rather than after collection: several test modules
+probe Postgres at import time (`tests/stores/test_capabilities_matrix.py` evaluates `pg_available()`
+inside a `skipif`), and every import happens after collection begins. A collection-time check
+refuses only *after* the suite has already dialled the server. The consequence is that the check
+reads the environment, not the selected test set: a run whose marker expression happens to exclude
+`pg` still aborts if a prod-looking DSN is exported, unless the expression contains the literal
+`not pg`, which makes `tests/conftest.py` drop both variables up front. Unset the variable, or use
+`-m "not pg"`, when you want that run to proceed.
+
+Name a non-production target explicitly:
+
+```bash
+DATABASE_URL=postgresql://app:app@127.0.0.1:15434/app_test python3 -m pytest -q -m pg
+```
+
+Per `docs/ENVIRONMENTS.md`, `dev` publishes `15433` / `app_dev` and `test` publishes `15434` /
+`app_test`; `15432` / `app` is production and is exactly what the guard exists to refuse. The
+scratch-database factories under `tests/migrations/**` derive their admin DSN from the same
+resolution, so this one setting also decides where `CREATE DATABASE` lands. CI supplies its own
+`app_test` service DSN and is unaffected.
+
 Escalate to the repo-wide non-PG suite only when the governing Issue/owner document names it or the
 change has cross-system blast radius that focused subsystem tests cannot cover:
 

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -97,6 +97,10 @@ The gate checks **four** ways this repo can name a database, not just the obviou
 | `PGSERVICE` / `PGSERVICEFILE` | libpq service indirection | fail closed whenever either is configured because its effective target cannot be inspected safely before imports |
 | `BUILDEROPS_DATABASE_URL` | the control plane's own `CREATE SCHEMA` path | always |
 
+Service indirection is fail-closed whether selected through `PGSERVICE` / `PGSERVICEFILE` or embedded
+as a `service` option in an explicit conninfo/URI: the service file can supply a target the pre-import
+guard cannot inspect safely.
+
 The second and third are the reason `DATABASE_URL` alone is not sufficient: a run with
 `PKM_DB_HOST=127.0.0.1 PKM_DB_PORT=15432` and no `DATABASE_URL` reaches production through
 `conn_rw()` while the documented pair still looks unconfigured. Each writer is checked independently:

--- a/tests/api/test_ask_warm_load_pg.py
+++ b/tests/api/test_ask_warm_load_pg.py
@@ -23,7 +23,7 @@ def test_ask_warm_loads_pg_store(monkeypatch) -> None:
     if not pg_available():
         pytest.skip("Postgres backend not available")
 
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or "postgresql://app:app@127.0.0.1:15432/app")
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setenv("LLM_PROVIDER", "mock")
     monkeypatch.setenv("EMBED_DIM", "8")

--- a/tests/api/test_status_store_pg.py
+++ b/tests/api/test_status_store_pg.py
@@ -15,7 +15,7 @@ def test_status_counts_pg_objects(monkeypatch) -> None:
     if not pg_available():
         pytest.skip("Postgres backend not available")
 
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or "postgresql://app:app@127.0.0.1:15432/app")
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     reset_store_backends()
     store = get_object_store()

--- a/tests/architecture/test_no_prod_dsn_defaults.py
+++ b/tests/architecture/test_no_prod_dsn_defaults.py
@@ -100,8 +100,23 @@ def test_no_test_default_resolves_to_a_prod_dsn() -> None:
 _DSN_ENV_VARS = {"DATABASE_URL", "DB_DSN", "BUILDEROPS_DATABASE_URL"}
 # The runtime gate in tests/conftest.py checks four writer families; the census
 # must not be narrower, or `injected-prod` stays open through the ones it omits.
-_DSN_HOST_VARS = {"PKM_DB_HOST", "PGHOST", "PGHOSTADDR"}
-_DSN_PORT_VARS = {"PKM_DB_PORT", "PGPORT"}
+_RUNTIME_WRITER_VARS = {
+    "PKM_DB_HOST",
+    "PKM_DB_PORT",
+    "PKM_DB_NAME_DEV",
+    "PKM_DB_NAME_TEST",
+    "PKM_DB_NAME_PROD",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+}
+_RUNTIME_SELECTOR_VARS = {"PKM_ENVIRONMENT", "PKM_SETTINGS_PROFILE"}
+_AMBIENT_WRITER_VARS = {
+    "PGHOST",
+    "PGHOSTADDR",
+    "PGPORT",
+    "PGDATABASE",
+    "PGUSER",
+}
 _DSN_SERVICE_VARS = {"PGSERVICE", "PGSERVICEFILE"}
 
 # Loopback plus the prod-published port: the address a production container on
@@ -164,32 +179,84 @@ def _is_os_environ(node: ast.AST) -> bool:
     return isinstance(node, ast.Name) and node.id == "environ"
 
 
-def _flag_host_port_dict(
-    lineno: int, pairs: list[tuple[ast.AST, ast.AST]], bound: dict[str, str], hits: list
+def _record_writer_env(
+    lineno: int,
+    key: str | None,
+    value: str | None,
+    seen: dict[str, str],
+    hits: list[tuple[int, str]],
 ) -> None:
-    """A dict literal naming host+port directly, e.g. env overrides in a call."""
+    """Classify one late environment mutation through its writer family."""
 
-    seen: dict[str, str] = {}
-    for key_node, value_node in pairs:
-        key = _resolve_str(key_node, bound)
-        value = _resolve_str(value_node, bound)
-        if key is None or value is None:
-            continue
-        if key in _DSN_SERVICE_VARS and value:
+    if key is None or value is None:
+        return
+    if key in _DSN_SERVICE_VARS:
+        seen[key] = value
+        if value:
             hits.append((lineno, f"{key}=<configured service indirection>"))
-            continue
-        if key in _DSN_HOST_VARS:
-            seen["host"] = value
-        elif key in _DSN_PORT_VARS:
-            seen["port"] = value
-        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE", "PGUSER"}:
-            seen["db"] = value
-    if seen.get("host") in _REACHABLE_PROD_HOSTS:
-        port, db = seen.get("port", ""), seen.get("db", "")
-        if port == str(_PROD_PUBLISHED_PORT) or (
-            port in ("", str(_DEFAULT_POSTGRES_PORT)) and db == "app"
+        return
+    if key not in _RUNTIME_WRITER_VARS | _RUNTIME_SELECTOR_VARS | _AMBIENT_WRITER_VARS:
+        return
+    seen[key] = value
+
+    runtime_named = any(seen.get(name) for name in _RUNTIME_WRITER_VARS)
+    runtime_host = seen.get("PKM_DB_HOST", "db")
+    if runtime_named and runtime_host in _REACHABLE_PROD_HOSTS:
+        environment = seen.get("PKM_ENVIRONMENT", "").strip().lower()
+        profile = seen.get("PKM_SETTINGS_PROFILE", "").strip().lower()
+        if environment == "test":
+            runtime_db = seen.get("PKM_DB_NAME_TEST", "app_test")
+        elif environment == "dev" or (not environment and profile == "lab"):
+            runtime_db = seen.get("PKM_DB_NAME_DEV", "app_dev")
+        else:
+            runtime_db = seen.get("PKM_DB_NAME_PROD", "app")
+        runtime_port = seen.get("PKM_DB_PORT", str(_DEFAULT_POSTGRES_PORT))
+        if runtime_port == str(_PROD_PUBLISHED_PORT) or (
+            runtime_port == str(_DEFAULT_POSTGRES_PORT) and runtime_db == "app"
         ):
-            hits.append((lineno, f"{seen['host']}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}"))
+            hits.append((lineno, f"{runtime_host}:{runtime_port}/{runtime_db}"))
+
+    ambient_named = any(seen.get(name) for name in _AMBIENT_WRITER_VARS)
+    if not ambient_named:
+        return
+    ambient_hosts = [
+        part.strip()
+        for name in ("PGHOST", "PGHOSTADDR")
+        for part in seen.get(name, "").split(",")
+        if part.strip()
+    ]
+    # No host means libpq's local socket. A named non-loopback host remains a
+    # legal unreachable sentinel for tests that exercise error paths.
+    if ambient_hosts and not any(host in _REACHABLE_PROD_HOSTS for host in ambient_hosts):
+        return
+    ambient_ports = [
+        part.strip() for part in seen.get("PGPORT", "").split(",") if part.strip()
+    ] or [str(_DEFAULT_POSTGRES_PORT)]
+    ambient_db = seen.get("PGDATABASE", "") or seen.get("PGUSER", "")
+    if str(_PROD_PUBLISHED_PORT) in ambient_ports or (
+        str(_DEFAULT_POSTGRES_PORT) in ambient_ports and ambient_db == "app"
+    ):
+        host_label = ",".join(ambient_hosts) or "<local socket>"
+        hits.append((lineno, f"{host_label}:{','.join(ambient_ports)}/{ambient_db or '?'}"))
+
+
+def _flag_writer_dict(
+    lineno: int,
+    pairs: list[tuple[ast.AST, ast.AST]],
+    bound: dict[str, str],
+    seen: dict[str, str],
+    hits: list[tuple[int, str]],
+) -> None:
+    """Classify a dict literal of late environment overrides."""
+
+    for key_node, value_node in pairs:
+        _record_writer_env(
+            lineno,
+            _resolve_str(key_node, bound),
+            _resolve_str(value_node, bound),
+            seen,
+            hits,
+        )
 
 
 def _module_string_constants(tree: ast.AST) -> dict[str, str]:
@@ -247,7 +314,7 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
 
     bound = _module_string_constants(tree)
     hits: list[tuple[int, str]] = []
-    host_port: dict[int, dict[str, str]] = {}
+    writer_env: dict[str, str] = {}
 
     def flag(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
         key = _resolve_str(key_node, bound)
@@ -258,33 +325,15 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
             hits.append((lineno, value))
 
     def flag_pair(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
-        """`PKM_DB_HOST`/`PGHOST` + the prod port name a target without a URL."""
+        """Feed every named writer through one family-aware classifier."""
 
-        key = _resolve_str(key_node, bound)
-        value = _resolve_str(value_node, bound)
-        if value is None:
-            return
-        if key in _DSN_SERVICE_VARS and value:
-            hits.append((lineno, f"{key}=<configured service indirection>"))
-            return
-        if key in _DSN_HOST_VARS:
-            host_port.setdefault(0, {})["host"] = value
-        elif key in _DSN_PORT_VARS:
-            host_port.setdefault(0, {})["port"] = value
-        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE", "PGUSER"}:
-            host_port.setdefault(0, {})["db"] = value
-        else:
-            return
-        seen = host_port[0]
-        if seen.get("host") in _REACHABLE_PROD_HOSTS:
-            port = seen.get("port", "")
-            db = seen.get("db", "")
-            if port == str(_PROD_PUBLISHED_PORT) or (
-                port in ("", str(_DEFAULT_POSTGRES_PORT)) and db == "app"
-            ):
-                hits.append(
-                    (lineno, f"{seen.get('host')}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}")
-                )
+        _record_writer_env(
+            lineno,
+            _resolve_str(key_node, bound),
+            _resolve_str(value_node, bound),
+            writer_env,
+            hits,
+        )
 
     for node in ast.walk(tree):
         # monkeypatch.setenv("DATABASE_URL", "...")
@@ -302,7 +351,7 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
                 ]
                 for k, v in pairs:
                     flag(node.lineno, k, v)
-                _flag_host_port_dict(node.lineno, pairs, bound, hits)
+                _flag_writer_dict(node.lineno, pairs, bound, writer_env, hits)
 
         # os.environ["DATABASE_URL"] = "..."
         if isinstance(node, ast.Assign) and isinstance(
@@ -444,3 +493,25 @@ def test_census_recognises_late_ambient_writer_shapes() -> None:
         '    monkeypatch.setenv("PGDATABASE", "app_test")\n'
     )
     assert not _injected_reachable_prod_dsns(scratch)
+
+
+def test_census_resolves_late_writer_defaults_by_family() -> None:
+    runtime_prod_default = ast.parse(
+        "def test_it(monkeypatch):\n" '    monkeypatch.setenv("PKM_DB_HOST", "127.0.0.1")\n'
+    )
+    assert _injected_reachable_prod_dsns(runtime_prod_default)
+
+    runtime_test_default = ast.parse(
+        "def test_it(monkeypatch):\n"
+        '    monkeypatch.setenv("PKM_ENVIRONMENT", "test")\n'
+        '    monkeypatch.setenv("PKM_DB_HOST", "127.0.0.1")\n'
+    )
+    assert not _injected_reachable_prod_dsns(runtime_test_default)
+
+    local_socket_database = ast.parse(
+        "def test_it(monkeypatch):\n" '    monkeypatch.setenv("PGDATABASE", "app")\n'
+    )
+    assert _injected_reachable_prod_dsns(local_socket_database)
+
+    local_socket_user_default = ast.parse("import os\n" 'os.environ["PGUSER"] = "app"\n')
+    assert _injected_reachable_prod_dsns(local_socket_user_default)

--- a/tests/architecture/test_no_prod_dsn_defaults.py
+++ b/tests/architecture/test_no_prod_dsn_defaults.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from app.db.dsn import looks_like_prod_dsn
+from psycopg.conninfo import conninfo_to_dict
+
+from app.db.dsn import resolve_dsn
+from tests.conftest import _looks_like_prod_test_dsn
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,12 +34,18 @@ _ENV_LOOKUPS = {"getenv", "get"}
 
 
 def _is_prod_dsn_constant(node: ast.AST) -> bool:
-    return (
-        isinstance(node, ast.Constant)
-        and isinstance(node.value, str)
-        and node.value.startswith("postgresql")
-        and looks_like_prod_dsn(node.value)
-    )
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return False
+    return _parsed_conninfo(node.value) is not None and _looks_like_prod_test_dsn(node.value)
+
+
+def _parsed_conninfo(value: str) -> dict[str, str] | None:
+    """Return valid libpq conninfo, including keyword and URI forms."""
+
+    try:
+        return conninfo_to_dict(resolve_dsn(value))
+    except Exception:
+        return None
 
 
 def _default_position_offenders(tree: ast.AST) -> list[tuple[int, str]]:
@@ -114,23 +123,36 @@ def _is_reachable_prod_dsn(value: str) -> bool:
     code paths without a server.
     """
 
-    if not value.startswith("postgresql") or not looks_like_prod_dsn(value):
+    parsed = _parsed_conninfo(value)
+    if parsed is None or not _looks_like_prod_test_dsn(value):
         return False
-    from urllib.parse import urlsplit
 
-    try:
-        parts = urlsplit(value)
-        if parts.hostname not in _REACHABLE_PROD_HOSTS:
-            return False
-        database = (parts.path or "").lstrip("/").split("?", 1)[0]
-        if parts.port == _PROD_PUBLISHED_PORT:
-            return True
-        # Database `app` on the default port is a locally installed production
-        # database. Any other port on loopback (1, 15433, 15434, …) is either a
-        # deliberately-dead sentinel or a non-prod channel.
-        return parts.port == _DEFAULT_POSTGRES_PORT and database == "app"
-    except ValueError:
+    # A service file can name any host/port/database after pytest_configure,
+    # where the runtime pre-import guard can no longer inspect it.
+    if str(parsed.get("service", "") or "").strip():
+        return True
+
+    hosts = [
+        part.strip()
+        for key in ("host", "hostaddr")
+        for part in str(parsed.get(key, "") or "").split(",")
+        if part.strip()
+    ]
+    # No host means libpq's local Unix socket, which can still reach a locally
+    # installed production database.
+    if hosts and not any(host in _REACHABLE_PROD_HOSTS for host in hosts):
         return False
+
+    ports = [
+        part.strip() for part in str(parsed.get("port", "") or "").split(",") if part.strip()
+    ] or [str(_DEFAULT_POSTGRES_PORT)]
+    database = str(parsed.get("dbname", "") or "").strip()
+    if str(_PROD_PUBLISHED_PORT) in ports:
+        return True
+    # Database `app` on the default port is a locally installed production
+    # database. Any other port (1, 15433, 15434, …) is a deliberately-dead
+    # sentinel or a non-prod channel.
+    return str(_DEFAULT_POSTGRES_PORT) in ports and database == "app"
 
 
 def _is_os_environ(node: ast.AST) -> bool:
@@ -253,7 +275,9 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
             if port == str(_PROD_PUBLISHED_PORT) or (
                 port in ("", str(_DEFAULT_POSTGRES_PORT)) and db == "app"
             ):
-                hits.append((lineno, f"{seen.get('host')}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}"))
+                hits.append(
+                    (lineno, f"{seen.get('host')}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}")
+                )
 
     for node in ast.walk(tree):
         # monkeypatch.setenv("DATABASE_URL", "...")
@@ -266,13 +290,17 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
             # `dict.update` takes ONE positional argument; gating this on two
             # made the branch unreachable.
             elif name == "update" and isinstance(node.args[0], ast.Dict):
-                pairs = [(k, v) for k, v in zip(node.args[0].keys, node.args[0].values) if k is not None]
+                pairs = [
+                    (k, v) for k, v in zip(node.args[0].keys, node.args[0].values) if k is not None
+                ]
                 for k, v in pairs:
                     flag(node.lineno, k, v)
                 _flag_host_port_dict(node.lineno, pairs, bound, hits)
 
         # os.environ["DATABASE_URL"] = "..."
-        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.Constant, ast.Name, ast.BinOp, ast.JoinedStr)):
+        if isinstance(node, ast.Assign) and isinstance(
+            node.value, (ast.Constant, ast.Name, ast.BinOp, ast.JoinedStr)
+        ):
             for target in node.targets:
                 if isinstance(target, ast.Subscript) and _is_os_environ(target.value):
                     flag(node.lineno, target.slice, node.value)
@@ -316,7 +344,9 @@ def test_reachable_prod_classifier_is_neither_too_wide_nor_too_narrow() -> None:
     assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:1/app")
     # Locally installed production on the default port is still production.
     assert _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app")
+    assert _is_reachable_prod_dsn("host=127.0.0.1 port=15432 dbname=app")
     assert not _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app_test")
+    assert not _is_reachable_prod_dsn("host=127.0.0.1 port=15434 dbname=app_test")
     # Non-prod channels stay legal.
     assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:15434/app_test")
 
@@ -334,11 +364,7 @@ def test_conftest_carries_no_prod_dsn_at_all() -> None:
     # String constants only: the prose comment explaining *why* the default was
     # removed is documentation, not a target.
     tree = ast.parse(source, filename="tests/conftest.py")
-    prod_constants = [
-        node.value
-        for node in ast.walk(tree)
-        if _is_prod_dsn_constant(node)
-    ]
+    prod_constants = [node.value for node in ast.walk(tree) if _is_prod_dsn_constant(node)]
     assert not prod_constants, prod_constants
 
 
@@ -362,3 +388,24 @@ def test_census_recognises_each_default_position() -> None:
     # Assertion data and guard fixtures are not defaults and must stay allowed.
     inert = f'EXPECTED = "{prod}"\nassert resolved == "{prod}"\n'
     assert not _default_position_offenders(ast.parse(inert))
+
+    keyword_prod = "host=127.0.0.1 port=15432 dbname=app"
+    keyword_hits = _default_position_offenders(
+        ast.parse(f'import os\nos.getenv("DATABASE_URL", "{keyword_prod}")\n')
+    )
+    assert [reason for _, reason in keyword_hits] == ["env-lookup default"]
+
+
+def test_census_recognises_injected_keyword_conninfo() -> None:
+    prod = "host=127.0.0.1 port=15432 dbname=app"
+    scratch = "host=127.0.0.1 port=15434 dbname=app_test"
+
+    prod_tree = ast.parse(
+        f'def test_it(monkeypatch):\n    monkeypatch.setenv("DATABASE_URL", "{prod}")\n'
+    )
+    assert _injected_reachable_prod_dsns(prod_tree) == [(2, prod)]
+
+    scratch_tree = ast.parse(
+        f'def test_it(monkeypatch):\n    monkeypatch.setenv("DATABASE_URL", "{scratch}")\n'
+    )
+    assert not _injected_reachable_prod_dsns(scratch_tree)

--- a/tests/architecture/test_no_prod_dsn_defaults.py
+++ b/tests/architecture/test_no_prod_dsn_defaults.py
@@ -1,15 +1,14 @@
 """No test default may resolve to a production DSN (#4573).
 
-`app.db.dsn.looks_like_prod_dsn` is the repo's definition of "this address is
-production": database name exactly `app`, or the prod-published port 15432. A
-test harness that hard-codes such a DSN *as a fallback* hands the pg lane —
-destructive DDL, TRUNCATE, CREATE/DROP DATABASE — a production target whenever
-the environment forgets to name one.
+`tests/conftest.py` enforces the dynamic guarantee twice: before imports for
+inherited configuration, and again at every psycopg connection entry point for
+late or dynamically assembled values. This AST census has one deliberately
+smaller job: prevent a production-looking literal from returning as a default.
 
-The census is deliberately about **default position**, not about the string
-appearing at all: plenty of tests legitimately quote a prod-shaped DSN as
-assertion data or as input to a guard they are proving. What must not exist is a
-literal that *takes effect* when nothing else is configured:
+The census is about **default position**, not about the string appearing at
+all. Tests legitimately quote prod-shaped DSNs as assertion data and guard
+inputs. What must not exist is a literal that takes effect when configuration
+is absent:
 
     os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
     resolve_dsn() or "postgresql://app:app@127.0.0.1:15432/app"
@@ -33,12 +32,6 @@ TESTS_ROOT = REPO_ROOT / "tests"
 _ENV_LOOKUPS = {"getenv", "get"}
 
 
-def _is_prod_dsn_constant(node: ast.AST) -> bool:
-    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
-        return False
-    return _parsed_conninfo(node.value) is not None and _looks_like_prod_test_dsn(node.value)
-
-
 def _parsed_conninfo(value: str) -> dict[str, str] | None:
     """Return valid libpq conninfo, including keyword and URI forms."""
 
@@ -46,6 +39,12 @@ def _parsed_conninfo(value: str) -> dict[str, str] | None:
         return conninfo_to_dict(resolve_dsn(value))
     except Exception:
         return None
+
+
+def _is_prod_dsn_constant(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return False
+    return _parsed_conninfo(node.value) is not None and _looks_like_prod_test_dsn(node.value)
 
 
 def _default_position_offenders(tree: ast.AST) -> list[tuple[int, str]]:
@@ -71,7 +70,10 @@ def _default_position_offenders(tree: ast.AST) -> list[tuple[int, str]]:
         # def f(dsn="<dsn>") / lambda dsn="<dsn>"
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             args = node.args
-            for default in [*args.defaults, *(d for d in args.kw_defaults if d is not None)]:
+            for default in [
+                *args.defaults,
+                *(item for item in args.kw_defaults if item is not None),
+            ]:
                 if _is_prod_dsn_constant(default):
                     hits.append((node.lineno, "parameter default"))
 
@@ -79,7 +81,7 @@ def _default_position_offenders(tree: ast.AST) -> list[tuple[int, str]]:
 
 
 def _python_sources() -> list[Path]:
-    return sorted(p for p in TESTS_ROOT.rglob("*.py") if p.is_file())
+    return sorted(path for path in TESTS_ROOT.rglob("*.py") if path.is_file())
 
 
 def test_no_test_default_resolves_to_a_prod_dsn() -> None:
@@ -97,328 +99,13 @@ def test_no_test_default_resolves_to_a_prod_dsn() -> None:
     )
 
 
-_DSN_ENV_VARS = {"DATABASE_URL", "DB_DSN", "BUILDEROPS_DATABASE_URL"}
-# The runtime gate in tests/conftest.py checks four writer families; the census
-# must not be narrower, or `injected-prod` stays open through the ones it omits.
-_RUNTIME_WRITER_VARS = {
-    "PKM_DB_HOST",
-    "PKM_DB_PORT",
-    "PKM_DB_NAME_DEV",
-    "PKM_DB_NAME_TEST",
-    "PKM_DB_NAME_PROD",
-    "POSTGRES_USER",
-    "POSTGRES_PASSWORD",
-}
-_RUNTIME_SELECTOR_VARS = {"PKM_ENVIRONMENT", "PKM_SETTINGS_PROFILE"}
-_AMBIENT_WRITER_VARS = {
-    "PGHOST",
-    "PGHOSTADDR",
-    "PGPORT",
-    "PGDATABASE",
-    "PGUSER",
-}
-_DSN_SERVICE_VARS = {"PGSERVICE", "PGSERVICEFILE"}
-
-# Loopback plus the prod-published port: the address a production container on
-# the developer's own machine actually answers on. Unreachable prod-*shaped*
-# sentinels (`db:5432` compose-internal, `configured.example`, `127.0.0.1:1`)
-# are deliberately allowed — they exist to prove code paths without a server.
-_REACHABLE_PROD_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
-_PROD_PUBLISHED_PORT = 15432
-_DEFAULT_POSTGRES_PORT = 5432
-
-
-def _is_reachable_prod_dsn(value: str) -> bool:
-    """Prod-classified AND at an address this host could actually answer on.
-
-    Loopback is the discriminator. Both of `looks_like_prod_dsn`'s criteria
-    count once the host is loopback: port 15432 is what the prod container
-    publishes, and database `app` on the default 5432 is a locally installed
-    production database. Non-loopback prod-shaped DSNs (`db:5432` compose
-    internal, `configured.example`, TEST-NET) stay legal — they exist to drive
-    code paths without a server.
-    """
-
-    parsed = _parsed_conninfo(value)
-    if parsed is None or not _looks_like_prod_test_dsn(value):
-        return False
-
-    # A service file can name any host/port/database after pytest_configure,
-    # where the runtime pre-import guard can no longer inspect it.
-    if str(parsed.get("service", "") or "").strip():
-        return True
-
-    hosts = [
-        part.strip()
-        for key in ("host", "hostaddr")
-        for part in str(parsed.get(key, "") or "").split(",")
-        if part.strip()
-    ]
-    # No host means libpq's local Unix socket, which can still reach a locally
-    # installed production database.
-    if hosts and not any(host in _REACHABLE_PROD_HOSTS for host in hosts):
-        return False
-
-    ports = [
-        part.strip() for part in str(parsed.get("port", "") or "").split(",") if part.strip()
-    ] or [str(_DEFAULT_POSTGRES_PORT)]
-    database = str(parsed.get("dbname", "") or "").strip()
-    if str(_PROD_PUBLISHED_PORT) in ports:
-        return True
-    # Database `app` on the default port is a locally installed production
-    # database. Any other port (1, 15433, 15434, …) is a deliberately-dead
-    # sentinel or a non-prod channel.
-    return str(_DEFAULT_POSTGRES_PORT) in ports and database == "app"
-
-
-def _is_os_environ(node: ast.AST) -> bool:
-    """`os.environ` / `environ`, so an unrelated dict subscript is not flagged."""
-
-    if isinstance(node, ast.Attribute):
-        return node.attr == "environ"
-    return isinstance(node, ast.Name) and node.id == "environ"
-
-
-def _record_writer_env(
-    lineno: int,
-    key: str | None,
-    value: str | None,
-    seen: dict[str, str],
-    hits: list[tuple[int, str]],
-) -> None:
-    """Classify one late environment mutation through its writer family."""
-
-    if key is None or value is None:
-        return
-    if key in _DSN_SERVICE_VARS:
-        seen[key] = value
-        if value:
-            hits.append((lineno, f"{key}=<configured service indirection>"))
-        return
-    if key not in _RUNTIME_WRITER_VARS | _RUNTIME_SELECTOR_VARS | _AMBIENT_WRITER_VARS:
-        return
-    seen[key] = value
-
-    runtime_named = any(seen.get(name) for name in _RUNTIME_WRITER_VARS)
-    runtime_host = seen.get("PKM_DB_HOST", "db")
-    if runtime_named and runtime_host in _REACHABLE_PROD_HOSTS:
-        environment = seen.get("PKM_ENVIRONMENT", "").strip().lower()
-        profile = seen.get("PKM_SETTINGS_PROFILE", "").strip().lower()
-        if environment == "test":
-            runtime_db = seen.get("PKM_DB_NAME_TEST", "app_test")
-        elif environment == "dev" or (not environment and profile == "lab"):
-            runtime_db = seen.get("PKM_DB_NAME_DEV", "app_dev")
-        else:
-            runtime_db = seen.get("PKM_DB_NAME_PROD", "app")
-        runtime_port = seen.get("PKM_DB_PORT", str(_DEFAULT_POSTGRES_PORT))
-        if runtime_port == str(_PROD_PUBLISHED_PORT) or (
-            runtime_port == str(_DEFAULT_POSTGRES_PORT) and runtime_db == "app"
-        ):
-            hits.append((lineno, f"{runtime_host}:{runtime_port}/{runtime_db}"))
-
-    ambient_named = any(seen.get(name) for name in _AMBIENT_WRITER_VARS)
-    if not ambient_named:
-        return
-    ambient_hosts = [
-        part.strip()
-        for name in ("PGHOST", "PGHOSTADDR")
-        for part in seen.get(name, "").split(",")
-        if part.strip()
-    ]
-    # No host means libpq's local socket. A named non-loopback host remains a
-    # legal unreachable sentinel for tests that exercise error paths.
-    if ambient_hosts and not any(host in _REACHABLE_PROD_HOSTS for host in ambient_hosts):
-        return
-    ambient_ports = [
-        part.strip() for part in seen.get("PGPORT", "").split(",") if part.strip()
-    ] or [str(_DEFAULT_POSTGRES_PORT)]
-    ambient_db = seen.get("PGDATABASE", "") or seen.get("PGUSER", "")
-    if str(_PROD_PUBLISHED_PORT) in ambient_ports or (
-        str(_DEFAULT_POSTGRES_PORT) in ambient_ports and ambient_db == "app"
-    ):
-        host_label = ",".join(ambient_hosts) or "<local socket>"
-        hits.append((lineno, f"{host_label}:{','.join(ambient_ports)}/{ambient_db or '?'}"))
-
-
-def _flag_writer_dict(
-    lineno: int,
-    pairs: list[tuple[ast.AST, ast.AST]],
-    bound: dict[str, str],
-    seen: dict[str, str],
-    hits: list[tuple[int, str]],
-) -> None:
-    """Classify a dict literal of late environment overrides."""
-
-    for key_node, value_node in pairs:
-        _record_writer_env(
-            lineno,
-            _resolve_str(key_node, bound),
-            _resolve_str(value_node, bound),
-            seen,
-            hits,
-        )
-
-
-def _module_string_constants(tree: ast.AST) -> dict[str, str]:
-    """Module-level `NAME = "..."` bindings, so a named constant is not a hole."""
-
-    bound: dict[str, str] = {}
-    for node in getattr(tree, "body", []):
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str):
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        bound[target.id] = node.value.value
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str) and isinstance(node.target, ast.Name):
-                bound[node.target.id] = node.value.value
-    return bound
-
-
-def _resolve_str(node: ast.AST, bound: dict[str, str]) -> str | None:
-    """A string value knowable statically: literal, named constant, or concat."""
-
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    if isinstance(node, ast.Name):
-        return bound.get(node.id)
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
-        left = _resolve_str(node.left, bound)
-        right = _resolve_str(node.right, bound)
-        return None if left is None or right is None else left + right
-    if isinstance(node, ast.JoinedStr):  # f-string with only literal parts
-        out = []
-        for value in node.values:
-            resolved = _resolve_str(value, bound)
-            if resolved is None:
-                return None
-            out.append(resolved)
-        return "".join(out)
-    if isinstance(node, ast.FormattedValue):
-        return _resolve_str(node.value, bound)
-    return None
-
-
-def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
-    """Statements that put a live production address into a DSN env var.
-
-    Covers `monkeypatch.setenv(...)`, `os.environ[...] = ...`, and
-    `os.environ.update({...})`, with values given as a literal, a module-level
-    constant, a concatenation, or a literal f-string.
-
-    This is a safety net, not a proof: a value assembled at runtime, read from a
-    file, or passed through a helper this census cannot follow will not be seen.
-    The runtime gate in tests/conftest.py is the guarantee; this exists to catch
-    the shape that already bit once (#4573).
-    """
-
-    bound = _module_string_constants(tree)
-    hits: list[tuple[int, str]] = []
-    writer_env: dict[str, str] = {}
-
-    def flag(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
-        key = _resolve_str(key_node, bound)
-        if key not in _DSN_ENV_VARS:
-            return
-        value = _resolve_str(value_node, bound)
-        if value and _is_reachable_prod_dsn(value):
-            hits.append((lineno, value))
-
-    def flag_pair(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
-        """Feed every named writer through one family-aware classifier."""
-
-        _record_writer_env(
-            lineno,
-            _resolve_str(key_node, bound),
-            _resolve_str(value_node, bound),
-            writer_env,
-            hits,
-        )
-
-    for node in ast.walk(tree):
-        # monkeypatch.setenv("DATABASE_URL", "...")
-        if isinstance(node, ast.Call) and node.args:
-            func = node.func
-            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
-            if name == "setenv" and len(node.args) >= 2:
-                flag(node.lineno, node.args[0], node.args[1])
-                flag_pair(node.lineno, node.args[0], node.args[1])
-            # `dict.update` takes ONE positional argument; gating this on two
-            # made the branch unreachable.
-            elif name == "update" and isinstance(node.args[0], ast.Dict):
-                pairs = [
-                    (k, v) for k, v in zip(node.args[0].keys, node.args[0].values) if k is not None
-                ]
-                for k, v in pairs:
-                    flag(node.lineno, k, v)
-                _flag_writer_dict(node.lineno, pairs, bound, writer_env, hits)
-
-        # os.environ["DATABASE_URL"] = "..."
-        if isinstance(node, ast.Assign) and isinstance(
-            node.value, (ast.Constant, ast.Name, ast.BinOp, ast.JoinedStr)
-        ):
-            for target in node.targets:
-                if isinstance(target, ast.Subscript) and _is_os_environ(target.value):
-                    flag(node.lineno, target.slice, node.value)
-                    flag_pair(node.lineno, target.slice, node.value)
-
-    return sorted(set(hits))
-
-
-def test_no_test_injects_a_reachable_prod_dsn_into_the_environment() -> None:
-    """A prod DSN installed at runtime is not inert, even in a non-pg test.
-
-    `pytest_configure` cannot see this one: the value arrives via `monkeypatch`
-    after the session is configured. It bit for real — `tests/stores/
-    test_backend_auto_detection.py` set the live prod DSN, and that module's
-    autouse teardown runs `reset_store_backends()` -> `truncate_pg_tables()`
-    *before* monkeypatch restores the environment, issuing DELETE against
-    production on any host publishing it on 15432 (#4573).
-    """
-
-    offenders: dict[str, list[tuple[int, str]]] = {}
-    for path in _python_sources():
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        hits = _injected_reachable_prod_dsns(tree)
-        if hits:
-            offenders[str(path.relative_to(REPO_ROOT))] = hits
-
-    assert not offenders, (
-        "tests inject a reachable production DSN into the environment: "
-        f"{offenders}. Use an unreachable sentinel or the test-channel address "
-        "(127.0.0.1:15434/app_test) — a live prod address in os.environ is one "
-        "stray teardown away from writing to production (#4573)."
-    )
-
-
-def test_reachable_prod_classifier_is_neither_too_wide_nor_too_narrow() -> None:
-    assert _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:15432/app")
-    assert _is_reachable_prod_dsn("postgresql+psycopg://app:app@localhost:15432/scratch")
-
-    # Unreachable sentinels stay legal.
-    assert not _is_reachable_prod_dsn("postgresql://app:app@db:5432/app")
-    assert not _is_reachable_prod_dsn("postgresql://configured.example/app")
-    assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:1/app")
-    # Locally installed production on the default port is still production.
-    assert _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app")
-    assert _is_reachable_prod_dsn("host=127.0.0.1 port=15432 dbname=app")
-    assert not _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app_test")
-    assert not _is_reachable_prod_dsn("host=127.0.0.1 port=15434 dbname=app_test")
-    # Non-prod channels stay legal.
-    assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:15434/app_test")
-
-
 def test_conftest_carries_no_prod_dsn_at_all() -> None:
-    """The shared harness is stricter than the census: no prod DSN, anywhere.
-
-    `tests/conftest.py` applies to every test in the repo, so a prod DSN there
-    is never inert regardless of the syntactic position it sits in.
-    """
+    """The shared harness is stricter than the census: no prod DSN, anywhere."""
 
     source = (TESTS_ROOT / "conftest.py").read_text(encoding="utf-8")
     assert "default_pg_dsn_for_pg_tests" not in source
 
-    # String constants only: the prose comment explaining *why* the default was
+    # String constants only: the prose comment explaining why the default was
     # removed is documentation, not a target.
     tree = ast.parse(source, filename="tests/conftest.py")
     prod_constants = [node.value for node in ast.walk(tree) if _is_prod_dsn_constant(node)]
@@ -426,7 +113,7 @@ def test_conftest_carries_no_prod_dsn_at_all() -> None:
 
 
 def test_census_recognises_each_default_position() -> None:
-    """Guard the guard: every shape the census claims to catch must actually trip it."""
+    """Guard the guard: every claimed default shape must actually trip it."""
 
     prod = "postgresql://app:app@127.0.0.1:15432/app"
     scratch = "postgresql://app:app@127.0.0.1:15434/app_test"
@@ -451,67 +138,3 @@ def test_census_recognises_each_default_position() -> None:
         ast.parse(f'import os\nos.getenv("DATABASE_URL", "{keyword_prod}")\n')
     )
     assert [reason for _, reason in keyword_hits] == ["env-lookup default"]
-
-
-def test_census_recognises_injected_keyword_conninfo() -> None:
-    prod = "host=127.0.0.1 port=15432 dbname=app"
-    scratch = "host=127.0.0.1 port=15434 dbname=app_test"
-
-    prod_tree = ast.parse(
-        f'def test_it(monkeypatch):\n    monkeypatch.setenv("DATABASE_URL", "{prod}")\n'
-    )
-    assert _injected_reachable_prod_dsns(prod_tree) == [(2, prod)]
-
-    scratch_tree = ast.parse(
-        f'def test_it(monkeypatch):\n    monkeypatch.setenv("DATABASE_URL", "{scratch}")\n'
-    )
-    assert not _injected_reachable_prod_dsns(scratch_tree)
-
-
-def test_census_recognises_late_ambient_writer_shapes() -> None:
-    monkeypatch_hostaddr = ast.parse(
-        "def test_it(monkeypatch):\n"
-        '    monkeypatch.setenv("PGHOSTADDR", "127.0.0.1")\n'
-        '    monkeypatch.setenv("PGPORT", "15432")\n'
-    )
-    assert _injected_reachable_prod_dsns(monkeypatch_hostaddr)
-
-    raw_environ = ast.parse(
-        "import os\n" 'os.environ["PGHOST"] = "127.0.0.1"\n' 'os.environ["PGPORT"] = "15432"\n'
-    )
-    assert _injected_reachable_prod_dsns(raw_environ)
-
-    service_file = ast.parse(
-        "import os\n" 'os.environ["PGSERVICEFILE"] = "/tmp/hidden-service.conf"\n'
-    )
-    assert _injected_reachable_prod_dsns(service_file)
-
-    scratch = ast.parse(
-        "def test_it(monkeypatch):\n"
-        '    monkeypatch.setenv("PGHOSTADDR", "127.0.0.1")\n'
-        '    monkeypatch.setenv("PGPORT", "15434")\n'
-        '    monkeypatch.setenv("PGDATABASE", "app_test")\n'
-    )
-    assert not _injected_reachable_prod_dsns(scratch)
-
-
-def test_census_resolves_late_writer_defaults_by_family() -> None:
-    runtime_prod_default = ast.parse(
-        "def test_it(monkeypatch):\n" '    monkeypatch.setenv("PKM_DB_HOST", "127.0.0.1")\n'
-    )
-    assert _injected_reachable_prod_dsns(runtime_prod_default)
-
-    runtime_test_default = ast.parse(
-        "def test_it(monkeypatch):\n"
-        '    monkeypatch.setenv("PKM_ENVIRONMENT", "test")\n'
-        '    monkeypatch.setenv("PKM_DB_HOST", "127.0.0.1")\n'
-    )
-    assert not _injected_reachable_prod_dsns(runtime_test_default)
-
-    local_socket_database = ast.parse(
-        "def test_it(monkeypatch):\n" '    monkeypatch.setenv("PGDATABASE", "app")\n'
-    )
-    assert _injected_reachable_prod_dsns(local_socket_database)
-
-    local_socket_user_default = ast.parse("import os\n" 'os.environ["PGUSER"] = "app"\n')
-    assert _injected_reachable_prod_dsns(local_socket_user_default)

--- a/tests/architecture/test_no_prod_dsn_defaults.py
+++ b/tests/architecture/test_no_prod_dsn_defaults.py
@@ -1,0 +1,364 @@
+"""No test default may resolve to a production DSN (#4573).
+
+`app.db.dsn.looks_like_prod_dsn` is the repo's definition of "this address is
+production": database name exactly `app`, or the prod-published port 15432. A
+test harness that hard-codes such a DSN *as a fallback* hands the pg lane —
+destructive DDL, TRUNCATE, CREATE/DROP DATABASE — a production target whenever
+the environment forgets to name one.
+
+The census is deliberately about **default position**, not about the string
+appearing at all: plenty of tests legitimately quote a prod-shaped DSN as
+assertion data or as input to a guard they are proving. What must not exist is a
+literal that *takes effect* when nothing else is configured:
+
+    os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    resolve_dsn() or "postgresql://app:app@127.0.0.1:15432/app"
+    def connect(dsn: str = "postgresql://app:app@127.0.0.1:15432/app"): ...
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from app.db.dsn import looks_like_prod_dsn
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+_ENV_LOOKUPS = {"getenv", "get"}
+
+
+def _is_prod_dsn_constant(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.startswith("postgresql")
+        and looks_like_prod_dsn(node.value)
+    )
+
+
+def _default_position_offenders(tree: ast.AST) -> list[tuple[int, str]]:
+    """Prod-DSN constants sitting where they would take effect as a fallback."""
+
+    hits: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        # os.getenv("X", "<dsn>") / os.environ.get("X", "<dsn>")
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in _ENV_LOOKUPS and len(node.args) >= 2:
+                if _is_prod_dsn_constant(node.args[1]):
+                    hits.append((node.lineno, "env-lookup default"))
+
+        # <something> or "<dsn>"
+        if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+            for value in node.values:
+                if _is_prod_dsn_constant(value):
+                    hits.append((node.lineno, "`or` fallback"))
+
+        # def f(dsn="<dsn>") / lambda dsn="<dsn>"
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            args = node.args
+            for default in [*args.defaults, *(d for d in args.kw_defaults if d is not None)]:
+                if _is_prod_dsn_constant(default):
+                    hits.append((node.lineno, "parameter default"))
+
+    return sorted(set(hits))
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in TESTS_ROOT.rglob("*.py") if p.is_file())
+
+
+def test_no_test_default_resolves_to_a_prod_dsn() -> None:
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        hits = _default_position_offenders(tree)
+        if hits:
+            offenders[str(path.relative_to(REPO_ROOT))] = hits
+
+    assert not offenders, (
+        "production-looking DSN literals in default position under tests/: "
+        f"{offenders}. The pg lane must be pointed at a scratch database "
+        "explicitly (DATABASE_URL/DB_DSN); it has no default target (#4573)."
+    )
+
+
+_DSN_ENV_VARS = {"DATABASE_URL", "DB_DSN", "BUILDEROPS_DATABASE_URL"}
+# The runtime gate in tests/conftest.py checks four writer families; the census
+# must not be narrower, or `injected-prod` stays open through the ones it omits.
+_DSN_HOST_VARS = {"PKM_DB_HOST", "PGHOST"}
+_DSN_PORT_VARS = {"PKM_DB_PORT", "PGPORT"}
+
+# Loopback plus the prod-published port: the address a production container on
+# the developer's own machine actually answers on. Unreachable prod-*shaped*
+# sentinels (`db:5432` compose-internal, `configured.example`, `127.0.0.1:1`)
+# are deliberately allowed — they exist to prove code paths without a server.
+_REACHABLE_PROD_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
+_PROD_PUBLISHED_PORT = 15432
+_DEFAULT_POSTGRES_PORT = 5432
+
+
+def _is_reachable_prod_dsn(value: str) -> bool:
+    """Prod-classified AND at an address this host could actually answer on.
+
+    Loopback is the discriminator. Both of `looks_like_prod_dsn`'s criteria
+    count once the host is loopback: port 15432 is what the prod container
+    publishes, and database `app` on the default 5432 is a locally installed
+    production database. Non-loopback prod-shaped DSNs (`db:5432` compose
+    internal, `configured.example`, TEST-NET) stay legal — they exist to drive
+    code paths without a server.
+    """
+
+    if not value.startswith("postgresql") or not looks_like_prod_dsn(value):
+        return False
+    from urllib.parse import urlsplit
+
+    try:
+        parts = urlsplit(value)
+        if parts.hostname not in _REACHABLE_PROD_HOSTS:
+            return False
+        database = (parts.path or "").lstrip("/").split("?", 1)[0]
+        if parts.port == _PROD_PUBLISHED_PORT:
+            return True
+        # Database `app` on the default port is a locally installed production
+        # database. Any other port on loopback (1, 15433, 15434, …) is either a
+        # deliberately-dead sentinel or a non-prod channel.
+        return parts.port == _DEFAULT_POSTGRES_PORT and database == "app"
+    except ValueError:
+        return False
+
+
+def _is_os_environ(node: ast.AST) -> bool:
+    """`os.environ` / `environ`, so an unrelated dict subscript is not flagged."""
+
+    if isinstance(node, ast.Attribute):
+        return node.attr == "environ"
+    return isinstance(node, ast.Name) and node.id == "environ"
+
+
+def _flag_host_port_dict(
+    lineno: int, pairs: list[tuple[ast.AST, ast.AST]], bound: dict[str, str], hits: list
+) -> None:
+    """A dict literal naming host+port directly, e.g. env overrides in a call."""
+
+    seen: dict[str, str] = {}
+    for key_node, value_node in pairs:
+        key = _resolve_str(key_node, bound)
+        value = _resolve_str(value_node, bound)
+        if key is None or value is None:
+            continue
+        if key in _DSN_HOST_VARS:
+            seen["host"] = value
+        elif key in _DSN_PORT_VARS:
+            seen["port"] = value
+        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE"}:
+            seen["db"] = value
+    if seen.get("host") in _REACHABLE_PROD_HOSTS:
+        port, db = seen.get("port", ""), seen.get("db", "")
+        if port == str(_PROD_PUBLISHED_PORT) or (
+            port in ("", str(_DEFAULT_POSTGRES_PORT)) and db == "app"
+        ):
+            hits.append((lineno, f"{seen['host']}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}"))
+
+
+def _module_string_constants(tree: ast.AST) -> dict[str, str]:
+    """Module-level `NAME = "..."` bindings, so a named constant is not a hole."""
+
+    bound: dict[str, str] = {}
+    for node in getattr(tree, "body", []):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        bound[target.id] = node.value.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str) and isinstance(node.target, ast.Name):
+                bound[node.target.id] = node.value.value
+    return bound
+
+
+def _resolve_str(node: ast.AST, bound: dict[str, str]) -> str | None:
+    """A string value knowable statically: literal, named constant, or concat."""
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return bound.get(node.id)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _resolve_str(node.left, bound)
+        right = _resolve_str(node.right, bound)
+        return None if left is None or right is None else left + right
+    if isinstance(node, ast.JoinedStr):  # f-string with only literal parts
+        out = []
+        for value in node.values:
+            resolved = _resolve_str(value, bound)
+            if resolved is None:
+                return None
+            out.append(resolved)
+        return "".join(out)
+    if isinstance(node, ast.FormattedValue):
+        return _resolve_str(node.value, bound)
+    return None
+
+
+def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
+    """Statements that put a live production address into a DSN env var.
+
+    Covers `monkeypatch.setenv(...)`, `os.environ[...] = ...`, and
+    `os.environ.update({...})`, with values given as a literal, a module-level
+    constant, a concatenation, or a literal f-string.
+
+    This is a safety net, not a proof: a value assembled at runtime, read from a
+    file, or passed through a helper this census cannot follow will not be seen.
+    The runtime gate in tests/conftest.py is the guarantee; this exists to catch
+    the shape that already bit once (#4573).
+    """
+
+    bound = _module_string_constants(tree)
+    hits: list[tuple[int, str]] = []
+    host_port: dict[int, dict[str, str]] = {}
+
+    def flag(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
+        key = _resolve_str(key_node, bound)
+        if key not in _DSN_ENV_VARS:
+            return
+        value = _resolve_str(value_node, bound)
+        if value and _is_reachable_prod_dsn(value):
+            hits.append((lineno, value))
+
+    def flag_pair(lineno: int, key_node: ast.AST, value_node: ast.AST) -> None:
+        """`PKM_DB_HOST`/`PGHOST` + the prod port name a target without a URL."""
+
+        key = _resolve_str(key_node, bound)
+        value = _resolve_str(value_node, bound)
+        if value is None:
+            return
+        if key in _DSN_HOST_VARS:
+            host_port.setdefault(0, {})["host"] = value
+        elif key in _DSN_PORT_VARS:
+            host_port.setdefault(0, {})["port"] = value
+        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE"}:
+            host_port.setdefault(0, {})["db"] = value
+        else:
+            return
+        seen = host_port[0]
+        if seen.get("host") in _REACHABLE_PROD_HOSTS:
+            port = seen.get("port", "")
+            db = seen.get("db", "")
+            if port == str(_PROD_PUBLISHED_PORT) or (
+                port in ("", str(_DEFAULT_POSTGRES_PORT)) and db == "app"
+            ):
+                hits.append((lineno, f"{seen.get('host')}:{port or _DEFAULT_POSTGRES_PORT}/{db or '?'}"))
+
+    for node in ast.walk(tree):
+        # monkeypatch.setenv("DATABASE_URL", "...")
+        if isinstance(node, ast.Call) and node.args:
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name == "setenv" and len(node.args) >= 2:
+                flag(node.lineno, node.args[0], node.args[1])
+                flag_pair(node.lineno, node.args[0], node.args[1])
+            # `dict.update` takes ONE positional argument; gating this on two
+            # made the branch unreachable.
+            elif name == "update" and isinstance(node.args[0], ast.Dict):
+                pairs = [(k, v) for k, v in zip(node.args[0].keys, node.args[0].values) if k is not None]
+                for k, v in pairs:
+                    flag(node.lineno, k, v)
+                _flag_host_port_dict(node.lineno, pairs, bound, hits)
+
+        # os.environ["DATABASE_URL"] = "..."
+        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.Constant, ast.Name, ast.BinOp, ast.JoinedStr)):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript) and _is_os_environ(target.value):
+                    flag(node.lineno, target.slice, node.value)
+
+    return sorted(set(hits))
+
+
+def test_no_test_injects_a_reachable_prod_dsn_into_the_environment() -> None:
+    """A prod DSN installed at runtime is not inert, even in a non-pg test.
+
+    `pytest_configure` cannot see this one: the value arrives via `monkeypatch`
+    after the session is configured. It bit for real — `tests/stores/
+    test_backend_auto_detection.py` set the live prod DSN, and that module's
+    autouse teardown runs `reset_store_backends()` -> `truncate_pg_tables()`
+    *before* monkeypatch restores the environment, issuing DELETE against
+    production on any host publishing it on 15432 (#4573).
+    """
+
+    offenders: dict[str, list[tuple[int, str]]] = {}
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        hits = _injected_reachable_prod_dsns(tree)
+        if hits:
+            offenders[str(path.relative_to(REPO_ROOT))] = hits
+
+    assert not offenders, (
+        "tests inject a reachable production DSN into the environment: "
+        f"{offenders}. Use an unreachable sentinel or the test-channel address "
+        "(127.0.0.1:15434/app_test) — a live prod address in os.environ is one "
+        "stray teardown away from writing to production (#4573)."
+    )
+
+
+def test_reachable_prod_classifier_is_neither_too_wide_nor_too_narrow() -> None:
+    assert _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:15432/app")
+    assert _is_reachable_prod_dsn("postgresql+psycopg://app:app@localhost:15432/scratch")
+
+    # Unreachable sentinels stay legal.
+    assert not _is_reachable_prod_dsn("postgresql://app:app@db:5432/app")
+    assert not _is_reachable_prod_dsn("postgresql://configured.example/app")
+    assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:1/app")
+    # Locally installed production on the default port is still production.
+    assert _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app")
+    assert not _is_reachable_prod_dsn("postgresql://app:app@localhost:5432/app_test")
+    # Non-prod channels stay legal.
+    assert not _is_reachable_prod_dsn("postgresql://app:app@127.0.0.1:15434/app_test")
+
+
+def test_conftest_carries_no_prod_dsn_at_all() -> None:
+    """The shared harness is stricter than the census: no prod DSN, anywhere.
+
+    `tests/conftest.py` applies to every test in the repo, so a prod DSN there
+    is never inert regardless of the syntactic position it sits in.
+    """
+
+    source = (TESTS_ROOT / "conftest.py").read_text(encoding="utf-8")
+    assert "default_pg_dsn_for_pg_tests" not in source
+
+    # String constants only: the prose comment explaining *why* the default was
+    # removed is documentation, not a target.
+    tree = ast.parse(source, filename="tests/conftest.py")
+    prod_constants = [
+        node.value
+        for node in ast.walk(tree)
+        if _is_prod_dsn_constant(node)
+    ]
+    assert not prod_constants, prod_constants
+
+
+def test_census_recognises_each_default_position() -> None:
+    """Guard the guard: every shape the census claims to catch must actually trip it."""
+
+    prod = "postgresql://app:app@127.0.0.1:15432/app"
+    scratch = "postgresql://app:app@127.0.0.1:15434/app_test"
+
+    for template, label in (
+        ('import os\nos.getenv("DATABASE_URL", "{dsn}")\n', "env-lookup default"),
+        ('resolve_dsn() or "{dsn}"\n', "`or` fallback"),
+        ('def connect(dsn: str = "{dsn}") -> None: ...\n', "parameter default"),
+    ):
+        prod_hits = _default_position_offenders(ast.parse(template.format(dsn=prod)))
+        assert [reason for _, reason in prod_hits] == [label], (template, prod_hits)
+
+        scratch_hits = _default_position_offenders(ast.parse(template.format(dsn=scratch)))
+        assert not scratch_hits, (template, scratch_hits)
+
+    # Assertion data and guard fixtures are not defaults and must stay allowed.
+    inert = f'EXPECTED = "{prod}"\nassert resolved == "{prod}"\n'
+    assert not _default_position_offenders(ast.parse(inert))

--- a/tests/architecture/test_no_prod_dsn_defaults.py
+++ b/tests/architecture/test_no_prod_dsn_defaults.py
@@ -100,8 +100,9 @@ def test_no_test_default_resolves_to_a_prod_dsn() -> None:
 _DSN_ENV_VARS = {"DATABASE_URL", "DB_DSN", "BUILDEROPS_DATABASE_URL"}
 # The runtime gate in tests/conftest.py checks four writer families; the census
 # must not be narrower, or `injected-prod` stays open through the ones it omits.
-_DSN_HOST_VARS = {"PKM_DB_HOST", "PGHOST"}
+_DSN_HOST_VARS = {"PKM_DB_HOST", "PGHOST", "PGHOSTADDR"}
 _DSN_PORT_VARS = {"PKM_DB_PORT", "PGPORT"}
+_DSN_SERVICE_VARS = {"PGSERVICE", "PGSERVICEFILE"}
 
 # Loopback plus the prod-published port: the address a production container on
 # the developer's own machine actually answers on. Unreachable prod-*shaped*
@@ -174,11 +175,14 @@ def _flag_host_port_dict(
         value = _resolve_str(value_node, bound)
         if key is None or value is None:
             continue
+        if key in _DSN_SERVICE_VARS and value:
+            hits.append((lineno, f"{key}=<configured service indirection>"))
+            continue
         if key in _DSN_HOST_VARS:
             seen["host"] = value
         elif key in _DSN_PORT_VARS:
             seen["port"] = value
-        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE"}:
+        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE", "PGUSER"}:
             seen["db"] = value
     if seen.get("host") in _REACHABLE_PROD_HOSTS:
         port, db = seen.get("port", ""), seen.get("db", "")
@@ -260,11 +264,14 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
         value = _resolve_str(value_node, bound)
         if value is None:
             return
+        if key in _DSN_SERVICE_VARS and value:
+            hits.append((lineno, f"{key}=<configured service indirection>"))
+            return
         if key in _DSN_HOST_VARS:
             host_port.setdefault(0, {})["host"] = value
         elif key in _DSN_PORT_VARS:
             host_port.setdefault(0, {})["port"] = value
-        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE"}:
+        elif key in {"PKM_DB_NAME_PROD", "PGDATABASE", "PGUSER"}:
             host_port.setdefault(0, {})["db"] = value
         else:
             return
@@ -304,6 +311,7 @@ def _injected_reachable_prod_dsns(tree: ast.AST) -> list[tuple[int, str]]:
             for target in node.targets:
                 if isinstance(target, ast.Subscript) and _is_os_environ(target.value):
                     flag(node.lineno, target.slice, node.value)
+                    flag_pair(node.lineno, target.slice, node.value)
 
     return sorted(set(hits))
 
@@ -409,3 +417,30 @@ def test_census_recognises_injected_keyword_conninfo() -> None:
         f'def test_it(monkeypatch):\n    monkeypatch.setenv("DATABASE_URL", "{scratch}")\n'
     )
     assert not _injected_reachable_prod_dsns(scratch_tree)
+
+
+def test_census_recognises_late_ambient_writer_shapes() -> None:
+    monkeypatch_hostaddr = ast.parse(
+        "def test_it(monkeypatch):\n"
+        '    monkeypatch.setenv("PGHOSTADDR", "127.0.0.1")\n'
+        '    monkeypatch.setenv("PGPORT", "15432")\n'
+    )
+    assert _injected_reachable_prod_dsns(monkeypatch_hostaddr)
+
+    raw_environ = ast.parse(
+        "import os\n" 'os.environ["PGHOST"] = "127.0.0.1"\n' 'os.environ["PGPORT"] = "15432"\n'
+    )
+    assert _injected_reachable_prod_dsns(raw_environ)
+
+    service_file = ast.parse(
+        "import os\n" 'os.environ["PGSERVICEFILE"] = "/tmp/hidden-service.conf"\n'
+    )
+    assert _injected_reachable_prod_dsns(service_file)
+
+    scratch = ast.parse(
+        "def test_it(monkeypatch):\n"
+        '    monkeypatch.setenv("PGHOSTADDR", "127.0.0.1")\n'
+        '    monkeypatch.setenv("PGPORT", "15434")\n'
+        '    monkeypatch.setenv("PGDATABASE", "app_test")\n'
+    )
+    assert not _injected_reachable_prod_dsns(scratch)

--- a/tests/architecture/test_test_env_isolation.py
+++ b/tests/architecture/test_test_env_isolation.py
@@ -8,9 +8,8 @@ patch in #2091.
 
 Tests must set process env only via pytest's ``monkeypatch`` fixture (function
 scoped, auto-restored) or the autouse fixtures in ``tests/conftest.py``
-(``force_memory_store_for_non_pg`` / ``default_pg_dsn_for_pg_tests`` /
-``default_vault_layout_env``). This guard pins the files remediated under #2101 so
-they cannot regress to raw mutation.
+(``force_memory_store_for_non_pg`` / ``default_vault_layout_env``). This guard
+pins the files remediated under #2101 so they cannot regress to raw mutation.
 """
 
 from __future__ import annotations

--- a/tests/builderops/control_plane/conftest.py
+++ b/tests/builderops/control_plane/conftest.py
@@ -13,7 +13,22 @@ from app.builderops.control_plane import AuthorityEnvelope, PostgresBuilderOpsSt
 
 
 def _base_dsn() -> str:
-    return os.getenv("BUILDEROPS_DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    """The control-plane database, named explicitly or not at all (#4573).
+
+    This used to fall back to the production DSN, so an unset environment
+    pointed schema creation at prod. The pg lane's guard in tests/conftest.py
+    refuses a prod-looking value for either variable.
+    """
+
+    from app.db.dsn import resolve_dsn
+
+    dsn = os.getenv("BUILDEROPS_DATABASE_URL", "").strip() or resolve_dsn()
+    if not dsn:
+        pytest.skip(
+            "no control-plane database configured: set BUILDEROPS_DATABASE_URL "
+            "(or DATABASE_URL) to an explicit non-production Postgres"
+        )
+    return dsn
 
 
 def _schema_dsn(dsn: str, schema: str) -> str:

--- a/tests/cli/test_index_doctor_mixed.py
+++ b/tests/cli/test_index_doctor_mixed.py
@@ -9,7 +9,6 @@ Requires a live Postgres backend; skipped when unavailable.
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import asdict
 from uuid import uuid4
 
@@ -32,7 +31,7 @@ GEMINI = EmbeddingIdentity(provider="gemini", model="gemini-embedding-001", dim=
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/cli/test_index_rebuild_cli.py
+++ b/tests/cli/test_index_rebuild_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -208,7 +207,7 @@ def test_index_rebuild_sets_pg_meta(monkeypatch) -> None:
 
     reset_store_backends()
     legacy_store._MEMORY_STORE.clear()
-    dsn = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    dsn = resolve_dsn()
     monkeypatch.setenv("DATABASE_URL", dsn)
     monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setenv("LLM_PROVIDER", "mock")
@@ -245,7 +244,7 @@ def test_index_rebuild_resets_missing_meta(monkeypatch) -> None:
 
     reset_store_backends()
     legacy_store._MEMORY_STORE.clear()
-    dsn = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    dsn = resolve_dsn()
     monkeypatch.setenv("DATABASE_URL", dsn)
     monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setenv("LLM_PROVIDER", "mock")

--- a/tests/cli/test_index_reconcile.py
+++ b/tests/cli/test_index_reconcile.py
@@ -15,7 +15,6 @@ Requires a live Postgres backend; skipped when unavailable.
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import asdict
 from uuid import uuid4
 
@@ -39,7 +38,7 @@ FALLBACK = EmbeddingIdentity(provider="gemini", model="gemini-embedding-001", di
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/cli/test_store_stats_pg.py
+++ b/tests/cli/test_store_stats_pg.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 
 import pytest
 from click.testing import CliRunner
 
 from app.cli import cli
+from app.db.dsn import resolve_dsn
 from app.stores import reset_store_backends
 from app.stores.pg import pg_available
 
@@ -17,14 +17,12 @@ def test_store_stats_pg(monkeypatch) -> None:
         pytest.skip("Postgres backend not available")
 
     monkeypatch.setenv("STORE_BACKEND", "pg")
-    # Respect an env-provided DATABASE_URL (CI service container, local dev DB);
-    # the 15432 literal is only an unset-fallback, mirroring
-    # tests/conftest.py::default_pg_dsn_for_pg_tests. Hardcoding this DSN
-    # unconditionally overrode CI's service DSN and broke the test (#2937).
-    monkeypatch.setenv(
-        "DATABASE_URL",
-        os.environ.get("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"),
-    )
+    # Use whatever the run was pointed at — CI service container, local scratch
+    # DB — and nothing otherwise. Hardcoding a DSN here once overrode CI's
+    # service DSN and broke the test (#2937); the unset-fallback that replaced
+    # it resolved to production (#4573). The pg lane guarantees an explicit,
+    # non-prod DATABASE_URL by the time this runs.
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     reset_store_backends()
 
     runner = CliRunner()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -444,12 +444,24 @@ def _guard_pg_connection_target(
 
     host = str(effective.get("host", "") or "").strip()
     hostaddr = str(effective.get("hostaddr", "") or "").strip()
-    hosts = [part.strip() for part in host.split(",") if part.strip()]
-    implicit_or_socket_target = (
-        not host and not hostaddr
-    ) or any(part.startswith("/") or part.startswith("@") for part in hosts)
+    hosts = host.split(",") if host else []
+    hostaddrs = hostaddr.split(",") if hostaddr else []
 
-    if implicit_or_socket_target or _looks_like_prod_test_dsn(target):
+    # Empty members are significant in libpq multi-host lists: a position with
+    # neither host nor hostaddr selects the platform default (a Unix socket on
+    # Unix). Keep list positions aligned instead of filtering empty strings.
+    mismatched_lists = bool(hosts and hostaddrs and len(hosts) != len(hostaddrs))
+    implicit_or_socket_target = not hosts and not hostaddrs
+    for index in range(max(len(hosts), len(hostaddrs))):
+        candidate_host = hosts[index].strip() if index < len(hosts) else ""
+        candidate_hostaddr = hostaddrs[index].strip() if index < len(hostaddrs) else ""
+        if candidate_host.startswith(("/", "@")) or (
+            not candidate_host and not candidate_hostaddr
+        ):
+            implicit_or_socket_target = True
+            break
+
+    if mismatched_lists or implicit_or_socket_target or _looks_like_prod_test_dsn(target):
         raise pytest.UsageError(_prod_dsn_abort_message(variable="psycopg connection target"))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -331,6 +331,13 @@ def _looks_like_prod_test_dsn(dsn: str) -> bool:
         # for a destructive test lane.
         return True
 
+    # A libpq service can supply host, port, database, and credentials from an
+    # external file. Its effective target is not visible in conninfo, so a
+    # destructive lane must treat service indirection as unsafe rather than
+    # accepting an apparently harmless explicit DSN.
+    if str(effective.get("service", "") or "").strip():
+        return True
+
     dbname = str(effective.get("dbname", "") or "").strip()
     ports = str(effective.get("port", "") or "").split(",")
     return dbname == "app" or any(port.strip() == "15432" for port in ports)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -160,19 +161,6 @@ def force_memory_store_for_non_pg(request: pytest.FixtureRequest, monkeypatch: p
 
 
 @pytest.fixture(autouse=True)
-def default_pg_dsn_for_pg_tests(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
-    """Provide the standard local Postgres DSN for pg-marked tests when unset."""
-
-    if (
-        request.node.get_closest_marker("pg") is not None
-        and os.getenv("DATABASE_URL") is None
-        and os.getenv("DB_DSN") is None
-    ):
-        monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
-    yield monkeypatch
-
-
-@pytest.fixture(autouse=True)
 def store_schema_autocreate_for_pg_tests(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
     """Explicit create-on-demand opt-in for pg-marked tests (KERNEL-04, #2766).
 
@@ -284,3 +272,234 @@ def pytest_configure(config) -> None:
             "pytest-timeout (see dev-requirements.txt) or remove the --timeout "
             "flag. Refusing to run unguarded — see #2259."
         )
+
+    # Must run here, before the first test module is imported (#4573).
+    _refuse_prod_dsn_before_any_import()
+
+
+# --------------------------------------------------------------------------
+# pg-lane database resolution guard (#4573)
+#
+# The pg lane runs destructive DDL, TRUNCATE, and CREATE/DROP DATABASE against
+# whatever DATABASE_URL/DB_DSN resolves to. It used to carry an autouse default
+# of `postgresql://app:app@127.0.0.1:15432/app` — a DSN the repo's own
+# `app.db.dsn.looks_like_prod_dsn` classifies as production on both criteria —
+# so a bare `pytest -m pg` targeted prod. The resolution contract is now
+# explicit-or-nothing.
+#
+# The prod refusal lives in `pytest_configure`, NOT in a collection hook. Test
+# modules run connection probes at import time (`tests/stores/
+# test_capabilities_matrix.py` evaluates `pg_available()` in a `skipif`, which
+# opens a real connection), and every import happens *after* collection starts.
+# A collection-time check therefore refuses only after the suite has already
+# dialled production. `pytest_configure` runs before the first test module is
+# imported, and it does not depend on which items were collected — so it also
+# behaves under pytest-xdist, where the controller never collects.
+#
+# Every scratch-database factory under tests/ derives its admin DSN from
+# `app.db.dsn.resolve_dsn()`, i.e. from exactly the environment checked here, so
+# this single gate also stops CREATE/DROP DATABASE against a prod server.
+# --------------------------------------------------------------------------
+
+_PG_LANE_SCRATCH_HINT = (
+    "DATABASE_URL=postgresql://app:app@127.0.0.1:15434/app_test"
+)
+
+_PG_DSN_UNSET_REASON = (
+    "no database configured for the pg lane: set DATABASE_URL or DB_DSN to an "
+    "explicit non-production Postgres before running pg-marked tests, e.g. "
+    f"{_PG_LANE_SCRATCH_HINT}. This lane has no default target on purpose "
+    "(#4573) — it runs destructive DDL, TRUNCATE, and CREATE/DROP DATABASE."
+)
+
+
+def _redact_dsn(dsn: str) -> str:
+    """Drop any password from a DSN so guard messages stay printable.
+
+    Covers every shape `app.db.dsn.looks_like_prod_dsn` accepts: libpq keyword
+    form (``host=... password=...``, tokenised with `shlex` exactly as that
+    module does, so a quoted password is not half-echoed), URL userinfo
+    (``postgresql://user:pw@host/db``), and a password passed as a URL query
+    parameter (``...?password=...``), which the userinfo branch alone missed.
+    """
+
+    if "://" not in dsn and "=" in dsn:
+        try:
+            fields = shlex.split(dsn)
+        except ValueError:
+            return "<unparseable conninfo redacted>"
+        parts = []
+        for field in fields:
+            key, sep, _ = field.partition("=")
+            parts.append(f"{key}=***" if sep and key.lower() == "password" else field)
+        return " ".join(parts)
+
+    scheme, sep, rest = dsn.partition("://")
+    if not sep:
+        # Schemeless and keyword-less. `looks_like_prod_dsn` classifies this as
+        # prod (app/db/dsn.py: `if "://" not in url: return True`), so it can
+        # reach the abort message; a `user:pw@host` shape must not survive.
+        if "@" in dsn:
+            userinfo, _, hostpart = dsn.rpartition("@")
+            user, has_password, _ = userinfo.partition(":")
+            if has_password:
+                return f"{user}:***@{hostpart}"
+        return dsn
+
+    rest, query_sep, query = rest.partition("?")
+    if query:
+        redacted_query = "&".join(
+            f"{p.split('=', 1)[0]}=***"
+            if p.split("=", 1)[0].lower() in {"password", "passfile"} and "=" in p
+            else p
+            for p in query.split("&")
+        )
+        query = redacted_query
+
+    if "@" in rest:
+        userinfo, _, hostpart = rest.rpartition("@")
+        user, has_password, _ = userinfo.partition(":")
+        if has_password:
+            rest = f"{user}:***@{hostpart}"
+
+    return f"{scheme}://{rest}{query_sep}{query}"
+
+
+def _prod_dsn_abort_message(dsn: str, *, variable: str = "DATABASE_URL/DB_DSN") -> str:
+    return (
+        f"Refusing to run pg-marked tests: {variable} resolves to a "
+        f"production-looking database ({_redact_dsn(dsn)}). "
+        "app.db.dsn.looks_like_prod_dsn flags a DSN whose database name is "
+        "exactly 'app' or whose port is the prod-published 15432. The pg lane "
+        "runs destructive DDL, TRUNCATE, and CREATE/DROP DATABASE against the "
+        f"resolved server. Point it at a scratch database, e.g. "
+        f"{_PG_LANE_SCRATCH_HINT} (#4573)."
+    )
+
+
+_REACHABLE_PROD_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
+
+
+def _points_at_a_reachable_prod_server(dsn: str) -> bool:
+    """Prod-classified *and* at an address this host can actually answer on.
+
+    Used only for the second resolver below, where the built-in fallback is the
+    compose-internal `…@db:5432/app`. That address is prod-shaped but reachable
+    only from inside the compose network, so treating it as a refusal would
+    abort ordinary runs. A loopback prod address is the real hazard.
+    """
+
+    from urllib.parse import urlsplit
+
+    from app.db.dsn import looks_like_prod_dsn, resolve_dsn
+
+    if not looks_like_prod_dsn(dsn):
+        return False
+    try:
+        parts = urlsplit(resolve_dsn(dsn))
+        return parts.hostname in _REACHABLE_PROD_HOSTS
+    except ValueError:
+        return True
+
+
+def _refuse_prod_dsn_before_any_import() -> None:
+    """Abort the session if any configured DSN points at production.
+
+    Three writers, not one. `DATABASE_URL`/`DB_DSN` is the documented pair, but
+    `app/config/database.py :: resolve_runtime_database_url` is a *second*
+    resolver behind `app/db/db.py :: conn_rw`, fed by `PKM_DB_HOST`,
+    `PKM_DB_PORT`, `PKM_DB_NAME_*` and `POSTGRES_*`. A run with
+    `PKM_DB_HOST=127.0.0.1 PKM_DB_PORT=15432` and no `DATABASE_URL` reaches
+    production through `conn_rw()` while the first pair looks unconfigured.
+    `BUILDEROPS_DATABASE_URL` is a third, with its own CREATE SCHEMA path.
+    """
+
+    from app.config.database import explicit_runtime_database_url
+    from app.db.dsn import looks_like_prod_dsn, resolve_dsn
+
+    control_plane = os.getenv("BUILDEROPS_DATABASE_URL", "").strip()
+    if control_plane and looks_like_prod_dsn(control_plane):
+        raise pytest.UsageError(
+            _prod_dsn_abort_message(control_plane, variable="BUILDEROPS_DATABASE_URL")
+        )
+
+    dsn = resolve_dsn()
+    if dsn and looks_like_prod_dsn(dsn):
+        raise pytest.UsageError(_prod_dsn_abort_message(dsn))
+
+    runtime_dsn = explicit_runtime_database_url(os.environ)
+    if runtime_dsn and _points_at_a_reachable_prod_server(runtime_dsn):
+        raise pytest.UsageError(
+            _prod_dsn_abort_message(runtime_dsn, variable="PKM_DB_* / POSTGRES_*")
+        )
+
+    # Only when nothing else named a target: that is the only situation in which
+    # an empty conninfo can still be handed to libpq and take effect.
+    if not dsn and not runtime_dsn:
+        ambient = _ambient_libpq_target()
+        if ambient and _points_at_a_reachable_prod_server(ambient):
+            raise pytest.UsageError(
+                _prod_dsn_abort_message(ambient, variable="PGHOST/PGPORT/PGDATABASE")
+            )
+
+
+def _ambient_libpq_target() -> str:
+    """The DSN libpq would synthesise from its own environment, if any.
+
+    `psycopg.connect("")` is not "no target": libpq fills the blanks from
+    `PGHOST`/`PGPORT`/`PGDATABASE`. A run with those exported at the production
+    values reaches production through any caller that hands an empty conninfo
+    down, without `DATABASE_URL` ever being set.
+
+    Deliberately narrow. With `PGHOST` unset libpq uses a **Unix domain
+    socket**, which cannot reach the TCP-published prod container at all, so
+    synthesising a `127.0.0.1` host there would invent a risk that does not
+    exist and abort every run of a developer who merely has `PGDATABASE`
+    exported for unrelated work. Returns "" unless `PGHOST` actually names a
+    TCP host.
+    """
+
+    host = os.getenv("PGHOST", "").strip()
+    if not host or host.startswith("/"):  # unset, or an explicit socket directory
+        return ""
+    port = os.getenv("PGPORT", "").strip() or "5432"
+    user = os.getenv("PGUSER", "").strip() or "postgres"
+    dbname = os.getenv("PGDATABASE", "").strip() or user
+    # Only the first host of a multi-host list is modelled; the loopback check
+    # below is what decides, and a list naming loopback first is the risky case.
+    host = host.split(",", 1)[0].strip()
+    if ":" in host and not host.startswith("["):  # bare IPv6 literal
+        host = f"[{host}]"
+    return f"postgresql://{user}@{host}:{port}/{dbname}"
+
+
+def pytest_collection_modifyitems(config, items) -> None:
+    """Skip pg-marked tests when no database was named, with a stated reason."""
+
+    from app.db.dsn import resolve_dsn
+
+    if resolve_dsn():
+        return
+
+    skip_pg = pytest.mark.skip(reason=_PG_DSN_UNSET_REASON)
+    for item in items:
+        if item.get_closest_marker("pg") is not None:
+            item.add_marker(skip_pg)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
+    """Make an unconfigured pg lane loud rather than a silent run of 's'.
+
+    Driven by the skip reports themselves rather than by state stashed during
+    collection: under pytest-xdist the collection hook runs in the workers while
+    this summary runs in the controller, so anything stashed on the worker's
+    config is invisible here. Reports cross that boundary; config stashes do
+    not. Reading the reports also means no banner is printed for a run that
+    simply had no pg tests in it.
+    """
+
+    skipped = terminalreporter.stats.get("skipped", [])
+    if not any(_PG_DSN_UNSET_REASON in str(report.longrepr) for report in skipped):
+        return
+    terminalreporter.write_sep("=", "pg lane skipped", red=True, bold=True)
+    terminalreporter.write_line(_PG_DSN_UNSET_REASON)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,9 @@ def force_memory_store_for_non_pg(request: pytest.FixtureRequest, monkeypatch: p
 
 
 @pytest.fixture(autouse=True)
-def store_schema_autocreate_for_pg_tests(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+def store_schema_autocreate_for_pg_tests(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+):
     """Explicit create-on-demand opt-in for pg-marked tests (KERNEL-04, #2766).
 
     Production store schema is migration-owned; ``_ensure_tables()`` is
@@ -261,9 +263,7 @@ def pytest_configure(config) -> None:
     # build, not quietly disarm the watchdog.
     requested = getattr(config.option, "timeout", None)
     plugins = config.pluginmanager
-    has_real_timeout = plugins.hasplugin("timeout") or plugins.hasplugin(
-        "pytest_timeout"
-    )
+    has_real_timeout = plugins.hasplugin("timeout") or plugins.hasplugin("pytest_timeout")
     if requested and not has_real_timeout:
         raise pytest.UsageError(
             f"--timeout={requested} was requested but the pytest-timeout plugin "
@@ -300,9 +300,7 @@ def pytest_configure(config) -> None:
 # this single gate also stops CREATE/DROP DATABASE against a prod server.
 # --------------------------------------------------------------------------
 
-_PG_LANE_SCRATCH_HINT = (
-    "DATABASE_URL=postgresql://app:app@127.0.0.1:15434/app_test"
-)
+_PG_LANE_SCRATCH_HINT = "DATABASE_URL=postgresql://app:app@127.0.0.1:15434/app_test"
 
 _PG_DSN_UNSET_REASON = (
     "no database configured for the pg lane: set DATABASE_URL or DB_DSN to an "
@@ -368,32 +366,35 @@ def _refuse_prod_dsn_before_any_import() -> None:
 
     control_plane = os.getenv("BUILDEROPS_DATABASE_URL", "").strip()
     if control_plane and _looks_like_prod_test_dsn(control_plane):
-        raise pytest.UsageError(
-            _prod_dsn_abort_message(variable="BUILDEROPS_DATABASE_URL")
-        )
+        raise pytest.UsageError(_prod_dsn_abort_message(variable="BUILDEROPS_DATABASE_URL"))
 
     dsn = resolve_dsn()
     if dsn and _looks_like_prod_test_dsn(dsn):
         raise pytest.UsageError(_prod_dsn_abort_message())
 
     runtime_env = {
-        key: value
-        for key, value in os.environ.items()
-        if key not in {"DATABASE_URL", "DB_DSN"}
+        key: value for key, value in os.environ.items() if key not in {"DATABASE_URL", "DB_DSN"}
     }
     runtime_dsn = explicit_runtime_database_url(runtime_env)
     if runtime_dsn and _looks_like_prod_test_dsn(runtime_dsn):
+        raise pytest.UsageError(_prod_dsn_abort_message(variable="PKM_DB_* / POSTGRES_*"))
+
+    if os.getenv("PGSERVICE", "").strip() or os.getenv("PGSERVICEFILE", "").strip():
         raise pytest.UsageError(
-            _prod_dsn_abort_message(variable="PKM_DB_* / POSTGRES_*")
+            "Refusing to run pg-marked tests: PGSERVICE/PGSERVICEFILE configures "
+            "libpq service indirection whose effective target cannot be inspected "
+            "safely before test imports. The service name and file are not echoed "
+            "because they may lead to credential material. Unset both variables "
+            "and name an explicit "
+            f"non-production DATABASE_URL instead, e.g. {_PG_LANE_SCRATCH_HINT} "
+            "(#4573)."
         )
 
     # A safe primary/runtime DSN does not neutralise callers that pass an empty
     # conninfo and therefore consume libpq's ambient variables.
     ambient = _ambient_libpq_target()
     if ambient and _looks_like_prod_test_dsn(ambient):
-        raise pytest.UsageError(
-            _prod_dsn_abort_message(variable="PGHOST/PGPORT/PGDATABASE")
-        )
+        raise pytest.UsageError(_prod_dsn_abort_message(variable="PGHOST/PGPORT/PGDATABASE"))
 
 
 def _ambient_libpq_target() -> str:
@@ -404,31 +405,53 @@ def _ambient_libpq_target() -> str:
     values reaches production through any caller that hands an empty conninfo
     down, without `DATABASE_URL` ever being set.
 
-    Deliberately narrow. With `PGHOST` unset libpq uses a **Unix domain
-    socket**, which cannot reach the TCP-published prod container at all, so
-    synthesising a `127.0.0.1` host there would invent a risk that does not
-    exist and abort every run of a developer who merely has `PGDATABASE`
-    exported for unrelated work. Returns "" unless `PGHOST` actually names a
-    TCP host.
+    `PGHOSTADDR` is independent of `PGHOST`, and an unset host still permits a
+    Unix-socket connection. Therefore every explicitly named ambient target
+    field participates: host, hostaddr, port, database, or user (whose value is
+    also libpq's default database name). An entirely absent ambient target is
+    the only case that returns "".
     """
 
     host = os.getenv("PGHOST", "").strip()
-    if not host or host.startswith("/"):  # unset, or an explicit socket directory
+    hostaddr = os.getenv("PGHOSTADDR", "").strip()
+    port = os.getenv("PGPORT", "").strip()
+    dbname = os.getenv("PGDATABASE", "").strip()
+    user = os.getenv("PGUSER", "").strip()
+    if not any((host, hostaddr, port, dbname, user)):
         return ""
-    port = os.getenv("PGPORT", "").strip() or "5432"
-    user = os.getenv("PGUSER", "").strip() or "postgres"
-    dbname = os.getenv("PGDATABASE", "").strip() or user
-    return f"host={host} port={port} user={user} dbname={dbname}"
+    try:
+        from psycopg.conninfo import make_conninfo
+
+        fields = {
+            key: value
+            for key, value in {
+                "host": host,
+                "hostaddr": hostaddr,
+                "port": port,
+                "user": user,
+                "dbname": dbname or user,
+            }.items()
+            if value
+        }
+        return make_conninfo(**fields)
+    except Exception:
+        # Malformed configured ambient state is indeterminate, never safe for
+        # a destructive lane. A schemeless value fails closed in the classifier.
+        return "configured ambient libpq target could not be parsed"
 
 
-def _is_builderops_control_plane_item(item: object) -> bool:
+def _is_builderops_dsn_consumer(item: object) -> bool:
     path = getattr(item, "path", None)
     if path is None:
         return False
+    resolved = Path(path).resolve()
     try:
-        Path(path).resolve().relative_to(ROOT / "tests" / "builderops" / "control_plane")
+        resolved.relative_to(ROOT / "tests" / "builderops" / "control_plane")
     except ValueError:
-        return False
+        return (
+            resolved == ROOT / "tests" / "ops" / "test_builderops_backup_restore.py"
+            and "recovery_store" in getattr(item, "fixturenames", ())
+        )
     return True
 
 
@@ -445,7 +468,7 @@ def pytest_collection_modifyitems(config, items) -> None:
             continue
         if primary_configured:
             continue
-        if builderops_configured and _is_builderops_control_plane_item(item):
+        if builderops_configured and _is_builderops_dsn_consumer(item):
             continue
         else:
             item.add_marker(skip_pg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shlex
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -313,106 +312,43 @@ _PG_DSN_UNSET_REASON = (
 )
 
 
-def _redact_dsn(dsn: str) -> str:
-    """Drop any password from a DSN so guard messages stay printable.
+def _looks_like_prod_test_dsn(dsn: str) -> bool:
+    """Classify the effective libpq target without changing the shared guard.
 
-    Covers every shape `app.db.dsn.looks_like_prod_dsn` accepts: libpq keyword
-    form (``host=... password=...``, tokenised with `shlex` exactly as that
-    module does, so a quoted password is not half-echoed), URL userinfo
-    (``postgresql://user:pw@host/db``), and a password passed as a URL query
-    parameter (``...?password=...``), which the userinfo branch alone missed.
+    Issue #4573 requires the existing ``looks_like_prod_dsn`` guard to remain
+    unchanged. Psycopg's parser closes the test-only gap for URI query options,
+    percent encoding, and whitespace around keyword assignments.
     """
 
-    if "://" not in dsn and "=" in dsn:
-        try:
-            fields = shlex.split(dsn)
-        except ValueError:
-            return "<unparseable conninfo redacted>"
-        parts = []
-        index = 0
-        while index < len(fields):
-            field = fields[index]
-            if "=" in field:
-                key, value = field.split("=", 1)
-            elif index + 2 < len(fields) and fields[index + 1] == "=":
-                key, value = field, fields[index + 2]
-                index += 2
-            else:
-                parts.append(field)
-                index += 1
-                continue
-            parts.append(f"{key}=***" if key.lower() == "password" else f"{key}={value}")
-            index += 1
-        return " ".join(parts)
+    from app.db.dsn import looks_like_prod_dsn, resolve_dsn
 
-    scheme, sep, rest = dsn.partition("://")
-    if not sep:
-        # Schemeless and keyword-less. `looks_like_prod_dsn` classifies this as
-        # prod (app/db/dsn.py: `if "://" not in url: return True`), so it can
-        # reach the abort message; a `user:pw@host` shape must not survive.
-        if "@" in dsn:
-            userinfo, _, hostpart = dsn.rpartition("@")
-            user, has_password, _ = userinfo.partition(":")
-            if has_password:
-                return f"{user}:***@{hostpart}"
-        return dsn
+    if looks_like_prod_dsn(dsn):
+        return True
+    try:
+        from psycopg.conninfo import conninfo_to_dict
 
-    rest, query_sep, query = rest.partition("?")
-    if query:
-        redacted_query = "&".join(
-            f"{p.split('=', 1)[0]}=***"
-            if p.split("=", 1)[0].lower() in {"password", "passfile"} and "=" in p
-            else p
-            for p in query.split("&")
-        )
-        query = redacted_query
+        effective = conninfo_to_dict(resolve_dsn(dsn))
+    except Exception:
+        # A configured target the guard cannot understand is not safe enough
+        # for a destructive test lane.
+        return True
 
-    if "@" in rest:
-        userinfo, _, hostpart = rest.rpartition("@")
-        user, has_password, _ = userinfo.partition(":")
-        if has_password:
-            rest = f"{user}:***@{hostpart}"
-
-    return f"{scheme}://{rest}{query_sep}{query}"
+    dbname = str(effective.get("dbname", "") or "").strip()
+    ports = str(effective.get("port", "") or "").split(",")
+    return dbname == "app" or any(port.strip() == "15432" for port in ports)
 
 
-def _prod_dsn_abort_message(dsn: str, *, variable: str = "DATABASE_URL/DB_DSN") -> str:
+def _prod_dsn_abort_message(*, variable: str = "DATABASE_URL/DB_DSN") -> str:
     return (
         f"Refusing to run pg-marked tests: {variable} resolves to a "
-        f"production-looking database ({_redact_dsn(dsn)}). "
+        "production-looking database. The configured connection value is "
+        "not echoed because it may contain credentials. "
         "app.db.dsn.looks_like_prod_dsn flags a DSN whose database name is "
         "exactly 'app' or whose port is the prod-published 15432. The pg lane "
         "runs destructive DDL, TRUNCATE, and CREATE/DROP DATABASE against the "
         f"resolved server. Point it at a scratch database, e.g. "
         f"{_PG_LANE_SCRATCH_HINT} (#4573)."
     )
-
-
-_REACHABLE_PROD_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
-
-
-def _points_at_a_reachable_prod_server(dsn: str) -> bool:
-    """Prod-classified *and* at an address this host can actually answer on.
-
-    Used only for the second resolver below, where the built-in fallback is the
-    compose-internal `…@db:5432/app`. That address is prod-shaped but reachable
-    only from inside the compose network, so treating it as a refusal would
-    abort ordinary runs. A loopback prod address is the real hazard.
-    """
-
-    from urllib.parse import parse_qs, urlsplit
-
-    from app.db.dsn import looks_like_prod_dsn, resolve_dsn
-
-    if not looks_like_prod_dsn(dsn):
-        return False
-    try:
-        parts = urlsplit(resolve_dsn(dsn))
-        query = parse_qs(parts.query, keep_blank_values=True)
-        host = parts.hostname or query.get("host", [None])[-1]
-        return host in _REACHABLE_PROD_HOSTS
-    except ValueError:
-        return True
 
 
 def _refuse_prod_dsn_before_any_import() -> None:
@@ -428,32 +364,36 @@ def _refuse_prod_dsn_before_any_import() -> None:
     """
 
     from app.config.database import explicit_runtime_database_url
-    from app.db.dsn import looks_like_prod_dsn, resolve_dsn
+    from app.db.dsn import resolve_dsn
 
     control_plane = os.getenv("BUILDEROPS_DATABASE_URL", "").strip()
-    if control_plane and looks_like_prod_dsn(control_plane):
+    if control_plane and _looks_like_prod_test_dsn(control_plane):
         raise pytest.UsageError(
-            _prod_dsn_abort_message(control_plane, variable="BUILDEROPS_DATABASE_URL")
+            _prod_dsn_abort_message(variable="BUILDEROPS_DATABASE_URL")
         )
 
     dsn = resolve_dsn()
-    if dsn and looks_like_prod_dsn(dsn):
-        raise pytest.UsageError(_prod_dsn_abort_message(dsn))
+    if dsn and _looks_like_prod_test_dsn(dsn):
+        raise pytest.UsageError(_prod_dsn_abort_message())
 
-    runtime_dsn = explicit_runtime_database_url(os.environ)
-    if runtime_dsn and _points_at_a_reachable_prod_server(runtime_dsn):
+    runtime_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"DATABASE_URL", "DB_DSN"}
+    }
+    runtime_dsn = explicit_runtime_database_url(runtime_env)
+    if runtime_dsn and _looks_like_prod_test_dsn(runtime_dsn):
         raise pytest.UsageError(
-            _prod_dsn_abort_message(runtime_dsn, variable="PKM_DB_* / POSTGRES_*")
+            _prod_dsn_abort_message(variable="PKM_DB_* / POSTGRES_*")
         )
 
-    # Only when nothing else named a target: that is the only situation in which
-    # an empty conninfo can still be handed to libpq and take effect.
-    if not dsn and not runtime_dsn:
-        ambient = _ambient_libpq_target()
-        if ambient and _points_at_a_reachable_prod_server(ambient):
-            raise pytest.UsageError(
-                _prod_dsn_abort_message(ambient, variable="PGHOST/PGPORT/PGDATABASE")
-            )
+    # A safe primary/runtime DSN does not neutralise callers that pass an empty
+    # conninfo and therefore consume libpq's ambient variables.
+    ambient = _ambient_libpq_target()
+    if ambient and _looks_like_prod_test_dsn(ambient):
+        raise pytest.UsageError(
+            _prod_dsn_abort_message(variable="PGHOST/PGPORT/PGDATABASE")
+        )
 
 
 def _ambient_libpq_target() -> str:
@@ -478,31 +418,36 @@ def _ambient_libpq_target() -> str:
     port = os.getenv("PGPORT", "").strip() or "5432"
     user = os.getenv("PGUSER", "").strip() or "postgres"
     dbname = os.getenv("PGDATABASE", "").strip() or user
-    # Only the first host of a multi-host list is modelled; the loopback check
-    # below is what decides, and a list naming loopback first is the risky case.
-    host = host.split(",", 1)[0].strip()
-    if ":" in host and not host.startswith("["):  # bare IPv6 literal
-        host = f"[{host}]"
-    return f"postgresql://{user}@{host}:{port}/{dbname}"
+    return f"host={host} port={port} user={user} dbname={dbname}"
+
+
+def _is_builderops_control_plane_item(item: object) -> bool:
+    path = getattr(item, "path", None)
+    if path is None:
+        return False
+    try:
+        Path(path).resolve().relative_to(ROOT / "tests" / "builderops" / "control_plane")
+    except ValueError:
+        return False
+    return True
 
 
 def pytest_collection_modifyitems(config, items) -> None:
     """Skip pg-marked tests when no database was named, with a stated reason."""
 
-    from app.config.database import explicit_runtime_database_url
     from app.db.dsn import resolve_dsn
 
-    if (
-        resolve_dsn()
-        or os.getenv("BUILDEROPS_DATABASE_URL", "").strip()
-        or explicit_runtime_database_url(os.environ)
-        or _ambient_libpq_target()
-    ):
-        return
-
+    primary_configured = bool(resolve_dsn())
+    builderops_configured = bool(os.getenv("BUILDEROPS_DATABASE_URL", "").strip())
     skip_pg = pytest.mark.skip(reason=_PG_DSN_UNSET_REASON)
     for item in items:
-        if item.get_closest_marker("pg") is not None:
+        if item.get_closest_marker("pg") is None:
+            continue
+        if primary_configured:
+            continue
+        if builderops_configured and _is_builderops_control_plane_item(item):
+            continue
+        else:
             item.add_marker(skip_pg)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,7 +405,18 @@ def _refuse_prod_dsn_before_any_import() -> None:
         raise pytest.UsageError(_prod_dsn_abort_message(variable="PGHOST/PGPORT/PGDATABASE"))
 
 
-def _guard_pg_connection_target(conninfo: object = "") -> None:
+_PSYCOPG_CLIENT_ONLY_KWARGS = {
+    "autocommit",
+    "prepare_threshold",
+    "context",
+    "row_factory",
+    "cursor_factory",
+}
+
+
+def _guard_pg_connection_target(
+    conninfo: object = "", connection_kwargs: dict[str, object] | None = None
+) -> None:
     """Refuse production again at the connection side-effect boundary.
 
     The pre-import check protects inherited configuration, but a test can
@@ -416,8 +427,29 @@ def _guard_pg_connection_target(conninfo: object = "") -> None:
     """
 
     _refuse_prod_dsn_before_any_import()
-    target = str(conninfo or "").strip()
-    if target and _looks_like_prod_test_dsn(target):
+
+    # Psycopg accepts every libpq connection parameter as a keyword argument;
+    # those parameters augment or override the positional conninfo. Classify
+    # the same effective target psycopg will use, not only the first argument.
+    try:
+        from psycopg.conninfo import conninfo_to_dict, make_conninfo
+
+        target = make_conninfo(str(conninfo or ""), **(connection_kwargs or {}))
+        effective = conninfo_to_dict(target)
+    except Exception:
+        # An indeterminate target is never safe for a destructive test lane.
+        raise pytest.UsageError(
+            _prod_dsn_abort_message(variable="psycopg connection target")
+        ) from None
+
+    host = str(effective.get("host", "") or "").strip()
+    hostaddr = str(effective.get("hostaddr", "") or "").strip()
+    hosts = [part.strip() for part in host.split(",") if part.strip()]
+    implicit_or_socket_target = (
+        not host and not hostaddr
+    ) or any(part.startswith("/") or part.startswith("@") for part in hosts)
+
+    if implicit_or_socket_target or _looks_like_prod_test_dsn(target):
         raise pytest.UsageError(_prod_dsn_abort_message(variable="psycopg connection target"))
 
 
@@ -433,16 +465,23 @@ def _install_pg_connection_guard() -> None:
     sync_connect = psycopg.Connection.connect.__func__
     async_connect = psycopg.AsyncConnection.connect.__func__
 
+    def connection_kwargs(kwargs: dict[str, object]) -> dict[str, object]:
+        return {
+            key: value
+            for key, value in kwargs.items()
+            if key not in _PSYCOPG_CLIENT_ONLY_KWARGS
+        }
+
     def guarded_module_connect(conninfo: str = "", *args, **kwargs):
-        _guard_pg_connection_target(conninfo)
+        _guard_pg_connection_target(conninfo, connection_kwargs(kwargs))
         return module_connect(conninfo, *args, **kwargs)
 
     def guarded_sync_connect(owner, conninfo: str = "", *args, **kwargs):
-        _guard_pg_connection_target(conninfo)
+        _guard_pg_connection_target(conninfo, connection_kwargs(kwargs))
         return sync_connect(owner, conninfo, *args, **kwargs)
 
     def guarded_async_connect(owner, conninfo: str = "", *args, **kwargs):
-        _guard_pg_connection_target(conninfo)
+        _guard_pg_connection_target(conninfo, connection_kwargs(kwargs))
         return async_connect(owner, conninfo, *args, **kwargs)
 
     psycopg.connect = guarded_module_connect

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,6 +274,7 @@ def pytest_configure(config) -> None:
 
     # Must run here, before the first test module is imported (#4573).
     _refuse_prod_dsn_before_any_import()
+    _install_pg_connection_guard()
 
 
 # --------------------------------------------------------------------------
@@ -402,6 +403,52 @@ def _refuse_prod_dsn_before_any_import() -> None:
     ambient = _ambient_libpq_target()
     if ambient and _looks_like_prod_test_dsn(ambient):
         raise pytest.UsageError(_prod_dsn_abort_message(variable="PGHOST/PGPORT/PGDATABASE"))
+
+
+def _guard_pg_connection_target(conninfo: object = "") -> None:
+    """Refuse production again at the connection side-effect boundary.
+
+    The pre-import check protects inherited configuration, but a test can
+    mutate environment variables or assemble conninfo after pytest_configure.
+    Re-evaluating every writer immediately before psycopg connects makes those
+    late and dynamic values safe without pretending a static AST census can
+    model arbitrary Python control flow.
+    """
+
+    _refuse_prod_dsn_before_any_import()
+    target = str(conninfo or "").strip()
+    if target and _looks_like_prod_test_dsn(target):
+        raise pytest.UsageError(_prod_dsn_abort_message(variable="psycopg connection target"))
+
+
+def _install_pg_connection_guard() -> None:
+    """Guard all three distinct psycopg connection entry points once."""
+
+    import psycopg
+
+    if getattr(psycopg, "_pkm_test_connection_guard_installed", False):
+        return
+
+    module_connect = psycopg.connect
+    sync_connect = psycopg.Connection.connect.__func__
+    async_connect = psycopg.AsyncConnection.connect.__func__
+
+    def guarded_module_connect(conninfo: str = "", *args, **kwargs):
+        _guard_pg_connection_target(conninfo)
+        return module_connect(conninfo, *args, **kwargs)
+
+    def guarded_sync_connect(owner, conninfo: str = "", *args, **kwargs):
+        _guard_pg_connection_target(conninfo)
+        return sync_connect(owner, conninfo, *args, **kwargs)
+
+    def guarded_async_connect(owner, conninfo: str = "", *args, **kwargs):
+        _guard_pg_connection_target(conninfo)
+        return async_connect(owner, conninfo, *args, **kwargs)
+
+    psycopg.connect = guarded_module_connect
+    psycopg.Connection.connect = classmethod(guarded_sync_connect)
+    psycopg.AsyncConnection.connect = classmethod(guarded_async_connect)
+    psycopg._pkm_test_connection_guard_installed = True
 
 
 def _ambient_libpq_target() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,9 +329,20 @@ def _redact_dsn(dsn: str) -> str:
         except ValueError:
             return "<unparseable conninfo redacted>"
         parts = []
-        for field in fields:
-            key, sep, _ = field.partition("=")
-            parts.append(f"{key}=***" if sep and key.lower() == "password" else field)
+        index = 0
+        while index < len(fields):
+            field = fields[index]
+            if "=" in field:
+                key, value = field.split("=", 1)
+            elif index + 2 < len(fields) and fields[index + 1] == "=":
+                key, value = field, fields[index + 2]
+                index += 2
+            else:
+                parts.append(field)
+                index += 1
+                continue
+            parts.append(f"{key}=***" if key.lower() == "password" else f"{key}={value}")
+            index += 1
         return " ".join(parts)
 
     scheme, sep, rest = dsn.partition("://")
@@ -389,7 +400,7 @@ def _points_at_a_reachable_prod_server(dsn: str) -> bool:
     abort ordinary runs. A loopback prod address is the real hazard.
     """
 
-    from urllib.parse import urlsplit
+    from urllib.parse import parse_qs, urlsplit
 
     from app.db.dsn import looks_like_prod_dsn, resolve_dsn
 
@@ -397,7 +408,9 @@ def _points_at_a_reachable_prod_server(dsn: str) -> bool:
         return False
     try:
         parts = urlsplit(resolve_dsn(dsn))
-        return parts.hostname in _REACHABLE_PROD_HOSTS
+        query = parse_qs(parts.query, keep_blank_values=True)
+        host = parts.hostname or query.get("host", [None])[-1]
+        return host in _REACHABLE_PROD_HOSTS
     except ValueError:
         return True
 
@@ -476,9 +489,15 @@ def _ambient_libpq_target() -> str:
 def pytest_collection_modifyitems(config, items) -> None:
     """Skip pg-marked tests when no database was named, with a stated reason."""
 
+    from app.config.database import explicit_runtime_database_url
     from app.db.dsn import resolve_dsn
 
-    if resolve_dsn():
+    if (
+        resolve_dsn()
+        or os.getenv("BUILDEROPS_DATABASE_URL", "").strip()
+        or explicit_runtime_database_url(os.environ)
+        or _ambient_libpq_target()
+    ):
         return
 
     skip_pg = pytest.mark.skip(reason=_PG_DSN_UNSET_REASON)

--- a/tests/conftest_guards/connect_spy.py
+++ b/tests/conftest_guards/connect_spy.py
@@ -1,11 +1,13 @@
-"""A pytest plugin that records every `psycopg.connect` attempt (#4573).
+"""A pytest plugin that records and blocks every `psycopg.connect` attempt (#4573).
 
 Loaded with `-p` into the child pytest processes driven by
 `test_pg_dsn_resolution.py`, so those tests can assert on what the guarded run
 *actually did* rather than on the absence of a connection-failure string. An
 assertion built from failure messages is vacuous against a connection that
 succeeds — which is precisely the case that matters when the DSN points at a
-live production server.
+live production server. After recording, the plugin raises without calling the
+real connector, so a regression proof can never become the production client
+it is meant to detect.
 
 The spy is installed at plugin import, which pytest performs before any test
 module is imported, so it also sees import-time probes such as a `skipif` that
@@ -44,24 +46,19 @@ def _record(conninfo: str) -> None:
 
 
 def _spy_module_function(module, name: str) -> None:
-    original = getattr(module, name)
-
     def _spying(conninfo: str = "", *args, **kwargs):
         _record(conninfo)
-        return original(conninfo, *args, **kwargs)
+        raise psycopg.OperationalError("connection blocked by pg safety probe")
 
     setattr(module, name, _spying)
 
 
 def _spy_classmethod(cls, name: str) -> None:
-    # `cls.connect` is an already-bound classmethod, so wrapping the bound
-    # object and re-decorating would pass `cls` twice and land the class object
-    # where the conninfo belongs. Take the underlying function instead.
-    original = getattr(cls, name).__func__
-
+    # Preserve classmethod binding so both sync and async class entry points
+    # receive conninfo in the same position as psycopg's real implementation.
     def _spying(owner, conninfo: str = "", *args, **kwargs):
         _record(conninfo)
-        return original(owner, conninfo, *args, **kwargs)
+        raise psycopg.OperationalError("connection blocked by pg safety probe")
 
     setattr(cls, name, classmethod(_spying))
 

--- a/tests/conftest_guards/connect_spy.py
+++ b/tests/conftest_guards/connect_spy.py
@@ -1,0 +1,75 @@
+"""A pytest plugin that records every `psycopg.connect` attempt (#4573).
+
+Loaded with `-p` into the child pytest processes driven by
+`test_pg_dsn_resolution.py`, so those tests can assert on what the guarded run
+*actually did* rather than on the absence of a connection-failure string. An
+assertion built from failure messages is vacuous against a connection that
+succeeds — which is precisely the case that matters when the DSN points at a
+live production server.
+
+The spy is installed at plugin import, which pytest performs before any test
+module is imported, so it also sees import-time probes such as a `skipif` that
+evaluates `pg_available()`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import psycopg
+
+
+ATTEMPTS_ENV = "PG_CONNECT_SPY_LOG"
+
+
+def _log_path() -> Path | None:
+    target = os.environ.get(ATTEMPTS_ENV, "").strip()
+    return Path(target) if target else None
+
+
+# An empty conninfo is NOT nothing: libpq then supplies its own defaults from
+# PGHOST/PGPORT/PGDATABASE or the local socket, which is a silently picked
+# target. It must be recorded as a distinguishable value rather than as a blank
+# line a reader would strip away.
+AMBIENT = "<ambient libpq defaults (empty conninfo)>"
+
+
+def _record(conninfo: str) -> None:
+    path = _log_path()
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{conninfo.strip() or AMBIENT}\n")
+
+
+def _spy_module_function(module, name: str) -> None:
+    original = getattr(module, name)
+
+    def _spying(conninfo: str = "", *args, **kwargs):
+        _record(conninfo)
+        return original(conninfo, *args, **kwargs)
+
+    setattr(module, name, _spying)
+
+
+def _spy_classmethod(cls, name: str) -> None:
+    # `cls.connect` is an already-bound classmethod, so wrapping the bound
+    # object and re-decorating would pass `cls` twice and land the class object
+    # where the conninfo belongs. Take the underlying function instead.
+    original = getattr(cls, name).__func__
+
+    def _spying(owner, conninfo: str = "", *args, **kwargs):
+        _record(conninfo)
+        return original(owner, conninfo, *args, **kwargs)
+
+    setattr(cls, name, classmethod(_spying))
+
+
+# psycopg exposes three connect entry points and they are distinct objects:
+# `psycopg.connect is not psycopg.Connection.connect`. Patching only the module
+# function would let a caller using either classmethod slip past unrecorded,
+# silently weakening every `attempts == []` assertion built on this spy.
+_spy_module_function(psycopg, "connect")
+_spy_classmethod(psycopg.Connection, "connect")
+_spy_classmethod(psycopg.AsyncConnection, "connect")

--- a/tests/conftest_guards/late_connection_probe.py
+++ b/tests/conftest_guards/late_connection_probe.py
@@ -7,6 +7,8 @@ so a broken safety wrapper is measured without ever opening a real socket.
 
 from __future__ import annotations
 
+import asyncio
+
 import psycopg
 import pytest
 
@@ -34,3 +36,29 @@ def test_late_ambient_socket_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None
 def test_late_service_file_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PGSERVICEFILE", "/tmp/hidden-service.conf")
     psycopg.connect("")
+
+
+@pytest.mark.pg
+def test_module_kwargs_only_prod_target_is_blocked() -> None:
+    psycopg.connect(host="127.0.0.1", port=15432, dbname="safe")
+
+
+@pytest.mark.pg
+def test_sync_kwargs_override_safe_conninfo_is_blocked() -> None:
+    safe = "postgresql://app:app@127.0.0.1:15434/app_test"
+    psycopg.Connection.connect(safe, port=15432)
+
+
+@pytest.mark.pg
+def test_async_service_kwarg_is_blocked() -> None:
+    asyncio.run(psycopg.AsyncConnection.connect(service="hidden"))
+
+
+@pytest.mark.pg
+def test_implicit_local_defaults_are_blocked() -> None:
+    psycopg.connect("")
+
+
+@pytest.mark.pg
+def test_explicit_local_socket_is_blocked() -> None:
+    psycopg.connect(host="/var/run/postgresql", dbname="app_test")

--- a/tests/conftest_guards/late_connection_probe.py
+++ b/tests/conftest_guards/late_connection_probe.py
@@ -1,0 +1,36 @@
+"""Child-process probes for late pytest database configuration (#4573).
+
+The filename intentionally does not start with ``test_``: the parent guard
+suite invokes each probe explicitly with the record-and-block psycopg plugin,
+so a broken safety wrapper is measured without ever opening a real socket.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+
+@pytest.mark.pg
+def test_dynamic_explicit_conninfo_is_blocked() -> None:
+    target = "postgresql://app:app@" + "127.0.0.1:15432/app"
+    psycopg.connect(target)
+
+
+@pytest.mark.pg
+def test_late_runtime_default_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PKM_DB_HOST", "127.0.0.1")
+    psycopg.connect("postgresql://app:app@127.0.0.1:15434/app_test")
+
+
+@pytest.mark.pg
+def test_late_ambient_socket_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PGHOST", "/var/run/postgresql")
+    monkeypatch.setenv("PGDATABASE", "app")
+    psycopg.connect("")
+
+
+@pytest.mark.pg
+def test_late_service_file_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PGSERVICEFILE", "/tmp/hidden-service.conf")
+    psycopg.connect("")

--- a/tests/conftest_guards/late_connection_probe.py
+++ b/tests/conftest_guards/late_connection_probe.py
@@ -62,3 +62,33 @@ def test_implicit_local_defaults_are_blocked() -> None:
 @pytest.mark.pg
 def test_explicit_local_socket_is_blocked() -> None:
     psycopg.connect(host="/var/run/postgresql", dbname="app_test")
+
+
+@pytest.mark.pg
+def test_leading_empty_host_member_is_blocked() -> None:
+    psycopg.connect(host=",127.0.0.1", port=15434, dbname="app_test")
+
+
+@pytest.mark.pg
+def test_trailing_empty_host_member_is_blocked() -> None:
+    target = "host=127.0.0.1, port=15434 dbname=app_test"
+    psycopg.Connection.connect(target)
+
+
+@pytest.mark.pg
+def test_empty_hostaddr_member_is_blocked() -> None:
+    asyncio.run(
+        psycopg.AsyncConnection.connect(
+            hostaddr=",127.0.0.1", port=15434, dbname="app_test"
+        )
+    )
+
+
+@pytest.mark.pg
+def test_paired_empty_host_member_is_blocked() -> None:
+    psycopg.connect(
+        host=",127.0.0.1",
+        hostaddr=",127.0.0.1",
+        port=15434,
+        dbname="app_test",
+    )

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -332,6 +332,48 @@ def test_redaction_covers_libpq_keyword_conninfo() -> None:
         _redact_dsn(malformed)
 
 
+def test_effective_libpq_query_parameters_are_classified_as_production() -> None:
+    from app.db.dsn import looks_like_prod_dsn
+
+    assert looks_like_prod_dsn("postgresql:///app_test?host=127.0.0.1&port=15432")
+    assert looks_like_prod_dsn("postgresql:///safe?dbname=app")
+
+
+def test_runtime_guard_reads_libpq_query_host() -> None:
+    from tests.conftest import _points_at_a_reachable_prod_server
+
+    assert _points_at_a_reachable_prod_server("postgresql:///safe?host=127.0.0.1&port=15432")
+
+
+def test_keyword_conninfo_redaction_handles_whitespace_around_equals() -> None:
+    from tests.conftest import _redact_dsn
+
+    redacted = _redact_dsn("host = 127.0.0.1 port = 15432 dbname = app password = hunter2")
+    assert "hunter2" not in redacted
+    assert "password=***" in redacted
+
+
+def test_builderops_dsn_counts_as_configured_for_pg_collection(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tests.conftest as test_config
+
+    class Item:
+        def __init__(self) -> None:
+            self.markers: list[object] = []
+
+        def get_closest_marker(self, name: str) -> object | None:
+            return object() if name == "pg" else None
+
+        def add_marker(self, marker: object) -> None:
+            self.markers.append(marker)
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("BUILDEROPS_DATABASE_URL", "postgresql://app:app@db:5432/builderops")
+    item = Item()
+    test_config.pytest_collection_modifyitems(None, [item])
+    assert item.markers == []
+
+
 # The "no prod DSN survives in default position under tests/" census lives in
 # tests/architecture/test_no_prod_dsn_defaults.py, which inspects string
 # constants via AST rather than raw text — the right tool for that question.

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -1,0 +1,341 @@
+"""The pg lane's database-resolution contract is explicit-or-nothing (#4573).
+
+These tests drive the real `tests/conftest.py` gate through a child pytest
+process, because the behaviour under test *is* the outcome of a run: whether a
+`pytest -m pg` invocation reaches a database at all. Asserting on the hook in
+isolation would prove the function, not the lane.
+
+Two deliberate choices make the proofs load-bearing rather than decorative:
+
+* Whether a database was contacted is measured with a `psycopg.connect` spy
+  (`connect_spy.py`), not inferred from the absence of a connection-*failure*
+  string. The failure-string form passes whether or not a server answered,
+  which is exactly backwards for a guard whose worst case is a *successful*
+  connection to production.
+* The child collects the whole `tests/` tree, not one file, so import-time
+  probes elsewhere in the suite (a `skipif` that calls `pg_available()`) are
+  inside the blast radius of the assertion.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A real scratch-database factory: its fixture resolves an admin DSN through
+# app.db.dsn.resolve_dsn() and issues CREATE/DROP DATABASE against it.
+SCRATCH_FACTORY_TARGET = "tests/migrations/test_store_schema_parity.py"
+
+# A module that probes Postgres at *import* time, via a skipif that calls
+# pg_available(). Collection imports it, so it is the reason the guard cannot
+# live in a collection hook.
+IMPORT_TIME_PROBE_TARGET = "tests/stores/test_capabilities_matrix.py"
+
+# The DSN the removed autouse fixture used to install. Port 15432 and database
+# `app` are both prod markers per app/db/dsn.py :: looks_like_prod_dsn.
+PROD_DSN = "postgresql://app:app@127.0.0.1:15432/app"
+
+# Same production *server*, different database. Only the port marks it, which is
+# what makes it the right probe for the scratch-factory case: creating and
+# dropping databases here still lands on the prod cluster.
+PROD_SERVER_SCRATCH_DSN = "postgresql://app:app@127.0.0.1:15432/scratch_probe"
+
+PYTEST_USAGE_ERROR = 4
+
+
+def _run_pytest(
+    targets: list[str],
+    *,
+    dsn: str | None,
+    spy_log: Path,
+    extra_args: list[str] | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    # Drop the parent's DSN and its plugin policy: the repo's own full-suite
+    # command sets PYTEST_DISABLE_PLUGIN_AUTOLOAD=1, and an inherited copy would
+    # leave the child without xdist, turning `-n 2` into an unknown option
+    # rather than the configuration under test.
+    dropped = {"DATABASE_URL", "DB_DSN", "PYTEST_DISABLE_PLUGIN_AUTOLOAD"}
+    env = {k: v for k, v in os.environ.items() if k not in dropped}
+    if dsn is not None:
+        env["DATABASE_URL"] = dsn
+    env.update(env_overrides or {})
+    env["PYTEST_ADDOPTS"] = ""
+    env["PG_CONNECT_SPY_LOG"] = str(spy_log)
+
+    args = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-rs",
+        "-p",
+        "tests.conftest_guards.connect_spy",
+        "-m",
+        "pg",
+        *(extra_args or []),
+        *targets,
+    ]
+    result = subprocess.run(
+        args, cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=900
+    )
+    attempts = (
+        [line for line in spy_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+        if spy_log.exists()
+        else []
+    )
+    return result, attempts
+
+
+@pytest.fixture
+def spy_log(tmp_path: Path) -> Path:
+    return tmp_path / "connect-attempts.log"
+
+
+def test_pg_marker_without_explicit_dsn_does_not_resolve_a_target(spy_log: Path) -> None:
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET, IMPORT_TIME_PROBE_TARGET], dsn=None, spy_log=spy_log
+    )
+    output = result.stdout + result.stderr
+
+    assert "no database configured for the pg lane" in output, output
+    assert "DATABASE_URL=postgresql://app:app@127.0.0.1:15434/app_test" in output, output
+    assert "pg lane skipped" in output, output
+    assert " skipped" in output, output
+    assert " passed" not in output, output
+
+    # Nothing was dialled with a target we named. `psycopg.connect("")` would
+    # fall through to libpq's ambient defaults, so an empty conninfo is a
+    # finding too, not a pass.
+    assert attempts == [], attempts
+
+
+def test_prod_looking_dsn_aborts_the_run(spy_log: Path) -> None:
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET, IMPORT_TIME_PROBE_TARGET],
+        dsn=PROD_DSN,
+        spy_log=spy_log,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert "Refusing to run pg-marked tests" in output, output
+    assert "production-looking database" in output, output
+    # The password must not be echoed back into CI logs.
+    assert "app:***@127.0.0.1:15432/app" in output, output
+    assert "app:app@127.0.0.1:15432/app" not in output, output
+
+    # The whole point: the abort precedes every connection, including the
+    # import-time probe in IMPORT_TIME_PROBE_TARGET.
+    assert attempts == [], attempts
+
+
+def test_scratch_factories_refuse_a_prod_server(spy_log: Path) -> None:
+    """CREATE/DROP DATABASE on the prod *server* is refused, not only writes to `app`."""
+
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET], dsn=PROD_SERVER_SCRATCH_DSN, spy_log=spy_log
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert "Refusing to run pg-marked tests" in output, output
+    assert "CREATE DATABASE" not in output, output
+    assert " passed" not in output, output
+    assert attempts == [], attempts
+
+
+# pytest-xdist is not in requirements.txt/dev-requirements.txt, so the CI unit
+# lane cannot run the two parallel-mode proofs below. They still gate every
+# local full-suite run and the nightly, which is where xdist is actually used.
+requires_xdist = pytest.mark.skipif(
+    importlib.util.find_spec("xdist") is None,
+    reason="pytest-xdist not installed; the parallel-mode guard proofs need it",
+)
+
+
+@requires_xdist
+def test_guard_survives_xdist(spy_log: Path) -> None:
+    """`make smoke` and CI Smoke both run under xdist, where hooks split hosts.
+
+    The collection hook runs in the workers and the terminal summary in the
+    controller, so a guard that stashes state during collection reports nothing
+    here — a silently skipped PG lane, which the contract forbids explicitly.
+    """
+
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn=None,
+        spy_log=spy_log,
+        extra_args=["-n", "2", "--dist=loadfile"],
+    )
+    output = result.stdout + result.stderr
+
+    assert "pg lane skipped" in output, output
+    assert "no database configured for the pg lane" in output, output
+    assert attempts == [], attempts
+
+
+@requires_xdist
+def test_prod_dsn_aborts_cleanly_under_xdist(spy_log: Path) -> None:
+    """A prod DSN must produce the stated refusal, not an INTERNALERROR."""
+
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn=PROD_DSN,
+        spy_log=spy_log,
+        extra_args=["-n", "2", "--dist=loadfile"],
+    )
+    output = result.stdout + result.stderr
+
+    assert "Refusing to run pg-marked tests" in output, output
+    assert "INTERNALERROR" not in output, output
+    assert attempts == [], attempts
+
+
+def test_control_plane_dsn_is_guarded_too(spy_log: Path) -> None:
+    """BUILDEROPS_DATABASE_URL has its own CREATE SCHEMA path against the server."""
+
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn="postgresql://app:app@127.0.0.1:15434/app_test",
+        spy_log=spy_log,
+        env_overrides={"BUILDEROPS_DATABASE_URL": PROD_DSN},
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert "BUILDEROPS_DATABASE_URL resolves to a production-looking" in output, output
+    assert attempts == [], attempts
+
+
+def test_guarded_targets_are_still_what_the_proofs_assume() -> None:
+    """Guard the guard: both probe targets must keep the property they stand for."""
+
+    factory = (REPO_ROOT / SCRATCH_FACTORY_TARGET).read_text(encoding="utf-8")
+    assert "CREATE DATABASE" in factory
+    assert "DROP DATABASE" in factory
+    assert "resolve_dsn" in factory
+
+    probe = (REPO_ROOT / IMPORT_TIME_PROBE_TARGET).read_text(encoding="utf-8")
+    # An import-time (module-level) call, i.e. one evaluated during collection.
+    assert "skipif" in probe and "pg_available()" in probe
+
+
+def test_runtime_resolver_env_is_guarded_too(spy_log: Path) -> None:
+    """`PKM_DB_*` is a second resolver that reaches the DB without DATABASE_URL.
+
+    `app/config/database.py :: resolve_runtime_database_url` feeds
+    `app/db/db.py :: conn_rw`, so a run with only `PKM_DB_HOST`/`PKM_DB_PORT`
+    set connects while `DATABASE_URL`/`DB_DSN` still look unconfigured.
+    """
+
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn=None,
+        spy_log=spy_log,
+        env_overrides={"PKM_DB_HOST": "127.0.0.1", "PKM_DB_PORT": "15432"},
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert "PKM_DB_* / POSTGRES_* resolves to a production-looking" in output, output
+    assert attempts == [], attempts
+
+
+def test_compose_internal_default_is_not_treated_as_reachable_prod(spy_log: Path) -> None:
+    """The `@db:5432/app` fallback is prod-shaped but only reachable in compose.
+
+    Refusing it would abort ordinary runs, so the second resolver's check is
+    scoped to loopback addresses. This pins that scoping so it cannot silently
+    widen into a false positive.
+    """
+
+    from tests.conftest import _points_at_a_reachable_prod_server
+
+    assert not _points_at_a_reachable_prod_server("postgresql+psycopg://app:app@db:5432/app")
+    assert _points_at_a_reachable_prod_server("postgresql+psycopg://app:app@127.0.0.1:15432/app")
+
+
+def test_connect_spy_cannot_hide_an_attempt(tmp_path: Path) -> None:
+    """The spy is the instrument every `attempts == []` rests on — prove it works.
+
+    All three psycopg entry points are distinct objects, and an *empty* conninfo
+    (libpq ambient defaults) must be recorded as a finding rather than as a
+    blank line a reader would strip.
+    """
+
+    log = tmp_path / "selftest.log"
+    script = (
+        "import asyncio, os, psycopg\n"
+        "import tests.conftest_guards.connect_spy as spy\n"
+        "assert psycopg.connect is not psycopg.Connection.connect\n"
+        "D = 'postgresql://u:p@127.0.0.1:1/closed'\n"
+        "for fn in (psycopg.connect, psycopg.Connection.connect):\n"
+        "    try: fn(D, connect_timeout=1)\n"
+        "    except Exception: pass\n"
+        "try: asyncio.run(psycopg.AsyncConnection.connect(D, connect_timeout=1))\n"
+        "except Exception: pass\n"
+        "try: psycopg.connect('', connect_timeout=1)\n"
+        "except Exception: pass\n"
+    )
+    env = dict(os.environ, PG_CONNECT_SPY_LOG=str(log))
+    subprocess.run(
+        [sys.executable, "-c", script], cwd=REPO_ROOT, env=env, check=True, timeout=120
+    )
+
+    from tests.conftest_guards.connect_spy import AMBIENT
+
+    recorded = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert recorded.count("postgresql://u:p@127.0.0.1:1/closed") == 3, recorded
+    assert AMBIENT in recorded, recorded
+
+
+def test_redaction_covers_libpq_keyword_conninfo() -> None:
+    """looks_like_prod_dsn accepts keyword conninfo, so redaction must too."""
+
+    from tests.conftest import _prod_dsn_abort_message, _redact_dsn
+
+    from app.db.dsn import looks_like_prod_dsn
+
+    leaky = [
+        # keyword conninfo, plain and quoted
+        "host=127.0.0.1 port=5432 dbname=app user=app password=hunter2",
+        "dbname=app user=app password='hunter 2'",
+        # URL userinfo, and password as a query parameter
+        "postgresql://app:hunter2@127.0.0.1:15432/app",
+        "postgresql://app@127.0.0.1:15432/db?password=hunter2",
+        # schemeless: looks_like_prod_dsn classifies this as prod too
+        "app:hunter2@127.0.0.1:15432/app",
+    ]
+    for dsn in leaky:
+        assert looks_like_prod_dsn(dsn), f"probe is not classified prod: {dsn}"
+        assert "hunter2" not in _redact_dsn(dsn), dsn
+        assert "hunter2" not in _prod_dsn_abort_message(dsn), dsn
+
+    # Redaction must not mangle the parts an operator needs to recognise.
+    assert "dbname=app" in _redact_dsn(leaky[0])
+    assert "127.0.0.1:15432" in _redact_dsn(leaky[2])
+    # A DSN with no password is returned intact.
+    assert _redact_dsn("postgresql://app@127.0.0.1:15432/app").endswith("/app")
+
+    # No shape may raise: the abort message is the last thing the operator sees.
+    for malformed in ("postgresql://", "host=", "=", "postgresql://a:b@[::1]:notaport/app"):
+        _redact_dsn(malformed)
+
+
+# The "no prod DSN survives in default position under tests/" census lives in
+# tests/architecture/test_no_prod_dsn_defaults.py, which inspects string
+# constants via AST rather than raw text — the right tool for that question.
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience only
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -54,6 +54,10 @@ LATE_CONNECTION_PROBES = [
     "tests/conftest_guards/late_connection_probe.py::test_async_service_kwarg_is_blocked",
     "tests/conftest_guards/late_connection_probe.py::test_implicit_local_defaults_are_blocked",
     "tests/conftest_guards/late_connection_probe.py::test_explicit_local_socket_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_leading_empty_host_member_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_trailing_empty_host_member_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_empty_hostaddr_member_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_paired_empty_host_member_is_blocked",
 ]
 
 # The DSN the removed autouse fixture used to install. Port 15432 and database

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -12,9 +12,9 @@ Two deliberate choices make the proofs load-bearing rather than decorative:
   string. The failure-string form passes whether or not a server answered,
   which is exactly backwards for a guard whose worst case is a *successful*
   connection to production.
-* The child collects the whole `tests/` tree, not one file, so import-time
-  probes elsewhere in the suite (a `skipif` that calls `pg_available()`) are
-  inside the blast radius of the assertion.
+* The child collects both a real scratch-factory module and the suite's known
+  import-time Postgres probe, so destructive fixture setup and collection-time
+  connection behavior are both inside the blast radius of the assertion.
 """
 
 from __future__ import annotations
@@ -38,6 +38,11 @@ SCRATCH_FACTORY_TARGET = "tests/migrations/test_store_schema_parity.py"
 # pg_available(). Collection imports it, so it is the reason the guard cannot
 # live in a collection hook.
 IMPORT_TIME_PROBE_TARGET = "tests/stores/test_capabilities_matrix.py"
+
+BUILDEROPS_RECOVERY_TARGET = (
+    "tests/ops/test_builderops_backup_restore.py"
+    "::test_recovered_epoch_fences_leases_and_executor_until_reconciliation"
+)
 
 # The DSN the removed autouse fixture used to install. Port 15432 and database
 # `app` are both prod markers per app/db/dsn.py :: looks_like_prod_dsn.
@@ -293,18 +298,18 @@ def test_connect_spy_cannot_hide_an_attempt(tmp_path: Path) -> None:
         "import tests.conftest_guards.connect_spy as spy\n"
         "assert psycopg.connect is not psycopg.Connection.connect\n"
         "D = 'postgresql://u:p@127.0.0.1:1/closed'\n"
+        "errors = []\n"
         "for fn in (psycopg.connect, psycopg.Connection.connect):\n"
         "    try: fn(D, connect_timeout=1)\n"
-        "    except Exception: pass\n"
+        "    except Exception as exc: errors.append(str(exc))\n"
         "try: asyncio.run(psycopg.AsyncConnection.connect(D, connect_timeout=1))\n"
-        "except Exception: pass\n"
+        "except Exception as exc: errors.append(str(exc))\n"
         "try: psycopg.connect('', connect_timeout=1)\n"
-        "except Exception: pass\n"
+        "except Exception as exc: errors.append(str(exc))\n"
+        "assert errors == ['connection blocked by pg safety probe'] * 4, errors\n"
     )
     env = dict(os.environ, PG_CONNECT_SPY_LOG=str(log))
-    subprocess.run(
-        [sys.executable, "-c", script], cwd=REPO_ROOT, env=env, check=True, timeout=120
-    )
+    subprocess.run([sys.executable, "-c", script], cwd=REPO_ROOT, env=env, check=True, timeout=120)
 
     from tests.conftest_guards.connect_spy import AMBIENT
 
@@ -356,9 +361,7 @@ def test_effective_libpq_query_parameters_are_classified_as_production() -> None
 def test_test_guard_reads_effective_libpq_query_port() -> None:
     from tests.conftest import _looks_like_prod_test_dsn
 
-    assert _looks_like_prod_test_dsn(
-        "postgresql:///safe?host=nonloopback.example&port=15432"
-    )
+    assert _looks_like_prod_test_dsn("postgresql:///safe?host=nonloopback.example&port=15432")
 
 
 def test_keyword_conninfo_classifier_handles_whitespace_around_equals() -> None:
@@ -369,12 +372,15 @@ def test_keyword_conninfo_classifier_handles_whitespace_around_equals() -> None:
     )
 
 
-def test_builderops_dsn_counts_as_configured_for_pg_collection(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_builderops_dsn_counts_as_configured_for_pg_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import tests.conftest as test_config
 
     class Item:
-        def __init__(self, path: Path) -> None:
+        def __init__(self, path: Path, *, fixturenames: tuple[str, ...] = ()) -> None:
             self.path = path
+            self.fixturenames = fixturenames
             self.markers: list[object] = []
 
         def get_closest_marker(self, name: str) -> object | None:
@@ -390,9 +396,73 @@ def test_builderops_dsn_counts_as_configured_for_pg_collection(monkeypatch: pyte
     test_config.pytest_collection_modifyitems(None, [item])
     assert item.markers == []
 
+    recovery = Item(
+        REPO_ROOT / "tests/ops/test_builderops_backup_restore.py",
+        fixturenames=("recovery_store",),
+    )
+    test_config.pytest_collection_modifyitems(None, [recovery])
+    assert recovery.markers == []
+
     unrelated = Item(REPO_ROOT / SCRATCH_FACTORY_TARGET)
     test_config.pytest_collection_modifyitems(None, [unrelated])
     assert len(unrelated.markers) == 1
+
+    same_module_nonconsumer = Item(REPO_ROOT / "tests/ops/test_builderops_backup_restore.py")
+    test_config.pytest_collection_modifyitems(None, [same_module_nonconsumer])
+    assert len(same_module_nonconsumer.markers) == 1
+
+
+def test_builderops_dsn_authorizes_the_real_recovery_consumer(spy_log: Path) -> None:
+    builderops_dsn = "postgresql://app:app@127.0.0.1:15434/builderops_test"
+    result, attempts = _run_pytest(
+        [BUILDEROPS_RECOVERY_TARGET],
+        dsn=None,
+        spy_log=spy_log,
+        env_overrides={"BUILDEROPS_DATABASE_URL": builderops_dsn},
+    )
+    output = result.stdout + result.stderr
+
+    assert "no database configured for the pg lane" not in output, output
+    assert "connection blocked by pg safety probe" in output, output
+    assert attempts == [builderops_dsn], attempts
+
+
+@pytest.mark.parametrize(
+    "env_overrides,expected_variable",
+    [
+        (
+            {
+                "PGHOSTADDR": "127.0.0.1",
+                "PGPORT": "15432",
+                "PGDATABASE": "safe",
+            },
+            "PGHOST/PGPORT/PGDATABASE",
+        ),
+        ({"PGUSER": "app"}, "PGHOST/PGPORT/PGDATABASE"),
+        (
+            {"PGSERVICE": "production", "PGSERVICEFILE": "/nonexistent/pg_service.conf"},
+            "PGSERVICE/PGSERVICEFILE configures libpq service indirection",
+        ),
+        (
+            {"PGSERVICEFILE": "/nonexistent/pg_service.conf"},
+            "PGSERVICE/PGSERVICEFILE configures libpq service indirection",
+        ),
+    ],
+)
+def test_ambient_libpq_escape_hatches_fail_before_connect(
+    spy_log: Path, env_overrides: dict[str, str], expected_variable: str
+) -> None:
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn="postgresql://app:app@127.0.0.1:15434/app_test",
+        spy_log=spy_log,
+        env_overrides=env_overrides,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert expected_variable in output, output
+    assert attempts == [], attempts
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -63,7 +63,26 @@ def _run_pytest(
     # command sets PYTEST_DISABLE_PLUGIN_AUTOLOAD=1, and an inherited copy would
     # leave the child without xdist, turning `-n 2` into an unknown option
     # rather than the configuration under test.
-    dropped = {"DATABASE_URL", "DB_DSN", "PYTEST_DISABLE_PLUGIN_AUTOLOAD"}
+    dropped = {
+        "DATABASE_URL",
+        "DB_DSN",
+        "BUILDEROPS_DATABASE_URL",
+        "PKM_DB_HOST",
+        "PKM_DB_PORT",
+        "PKM_DB_NAME_DEV",
+        "PKM_DB_NAME_TEST",
+        "PKM_DB_NAME_PROD",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "PGHOST",
+        "PGPORT",
+        "PGDATABASE",
+        "PGUSER",
+        "PGSERVICE",
+        "PGSERVICEFILE",
+        "PGHOSTADDR",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+    }
     env = {k: v for k, v in os.environ.items() if k not in dropped}
     if dsn is not None:
         env["DATABASE_URL"] = dsn
@@ -130,8 +149,8 @@ def test_prod_looking_dsn_aborts_the_run(spy_log: Path) -> None:
     assert "Refusing to run pg-marked tests" in output, output
     assert "production-looking database" in output, output
     # The password must not be echoed back into CI logs.
-    assert "app:***@127.0.0.1:15432/app" in output, output
     assert "app:app@127.0.0.1:15432/app" not in output, output
+    assert "not echoed because it may contain credentials" in output, output
 
     # The whole point: the abort precedes every connection, including the
     # import-time probe in IMPORT_TIME_PROBE_TARGET.
@@ -251,18 +270,13 @@ def test_runtime_resolver_env_is_guarded_too(spy_log: Path) -> None:
     assert attempts == [], attempts
 
 
-def test_compose_internal_default_is_not_treated_as_reachable_prod(spy_log: Path) -> None:
-    """The `@db:5432/app` fallback is prod-shaped but only reachable in compose.
+def test_unconfigured_runtime_fallback_is_not_treated_as_explicit() -> None:
+    """The compose-shaped fallback is ignored only when no writer named it."""
 
-    Refusing it would abort ordinary runs, so the second resolver's check is
-    scoped to loopback addresses. This pins that scoping so it cannot silently
-    widen into a false positive.
-    """
+    from app.config.database import explicit_runtime_database_url
 
-    from tests.conftest import _points_at_a_reachable_prod_server
-
-    assert not _points_at_a_reachable_prod_server("postgresql+psycopg://app:app@db:5432/app")
-    assert _points_at_a_reachable_prod_server("postgresql+psycopg://app:app@127.0.0.1:15432/app")
+    assert explicit_runtime_database_url({}) is None
+    assert explicit_runtime_database_url({"PKM_DB_HOST": "db"}) is not None
 
 
 def test_connect_spy_cannot_hide_an_attempt(tmp_path: Path) -> None:
@@ -299,65 +313,68 @@ def test_connect_spy_cannot_hide_an_attempt(tmp_path: Path) -> None:
     assert AMBIENT in recorded, recorded
 
 
-def test_redaction_covers_libpq_keyword_conninfo() -> None:
-    """looks_like_prod_dsn accepts keyword conninfo, so redaction must too."""
+def test_refusal_message_never_echoes_conninfo() -> None:
+    """The safest credential redaction is to never echo arbitrary conninfo."""
 
-    from tests.conftest import _prod_dsn_abort_message, _redact_dsn
-
-    from app.db.dsn import looks_like_prod_dsn
+    from tests.conftest import _looks_like_prod_test_dsn, _prod_dsn_abort_message
 
     leaky = [
-        # keyword conninfo, plain and quoted
+        # keyword conninfo, plain, quoted, and whitespace-separated
         "host=127.0.0.1 port=5432 dbname=app user=app password=hunter2",
         "dbname=app user=app password='hunter 2'",
+        "host = 127.0.0.1 port = 15432 dbname = app password = hunter2",
         # URL userinfo, and password as a query parameter
         "postgresql://app:hunter2@127.0.0.1:15432/app",
         "postgresql://app@127.0.0.1:15432/db?password=hunter2",
+        "postgresql://app@127.0.0.1:15432/db?pass%77ord=hunter2",
+        "postgresql://app@127.0.0.1:15432/db?%70assword=hunter2",
         # schemeless: looks_like_prod_dsn classifies this as prod too
         "app:hunter2@127.0.0.1:15432/app",
     ]
     for dsn in leaky:
-        assert looks_like_prod_dsn(dsn), f"probe is not classified prod: {dsn}"
-        assert "hunter2" not in _redact_dsn(dsn), dsn
-        assert "hunter2" not in _prod_dsn_abort_message(dsn), dsn
-
-    # Redaction must not mangle the parts an operator needs to recognise.
-    assert "dbname=app" in _redact_dsn(leaky[0])
-    assert "127.0.0.1:15432" in _redact_dsn(leaky[2])
-    # A DSN with no password is returned intact.
-    assert _redact_dsn("postgresql://app@127.0.0.1:15432/app").endswith("/app")
-
-    # No shape may raise: the abort message is the last thing the operator sees.
-    for malformed in ("postgresql://", "host=", "=", "postgresql://a:b@[::1]:notaport/app"):
-        _redact_dsn(malformed)
+        assert _looks_like_prod_test_dsn(dsn), f"probe is not classified prod: {dsn}"
+        message = _prod_dsn_abort_message()
+        assert "hunter" not in message
+        assert dsn not in message
+        assert "not echoed because it may contain credentials" in message
 
 
 def test_effective_libpq_query_parameters_are_classified_as_production() -> None:
+    from tests.conftest import _looks_like_prod_test_dsn
+
     from app.db.dsn import looks_like_prod_dsn
 
-    assert looks_like_prod_dsn("postgresql:///app_test?host=127.0.0.1&port=15432")
-    assert looks_like_prod_dsn("postgresql:///safe?dbname=app")
+    port_query = "postgresql:///app_test?host=127.0.0.1&port=15432"
+    db_query = "postgresql:///safe?dbname=app"
+    # The shared restore classifier is explicitly out of scope for #4573.
+    assert not looks_like_prod_dsn(port_query)
+    assert not looks_like_prod_dsn(db_query)
+    assert _looks_like_prod_test_dsn(port_query)
+    assert _looks_like_prod_test_dsn(db_query)
 
 
-def test_runtime_guard_reads_libpq_query_host() -> None:
-    from tests.conftest import _points_at_a_reachable_prod_server
+def test_test_guard_reads_effective_libpq_query_port() -> None:
+    from tests.conftest import _looks_like_prod_test_dsn
 
-    assert _points_at_a_reachable_prod_server("postgresql:///safe?host=127.0.0.1&port=15432")
+    assert _looks_like_prod_test_dsn(
+        "postgresql:///safe?host=nonloopback.example&port=15432"
+    )
 
 
-def test_keyword_conninfo_redaction_handles_whitespace_around_equals() -> None:
-    from tests.conftest import _redact_dsn
+def test_keyword_conninfo_classifier_handles_whitespace_around_equals() -> None:
+    from tests.conftest import _looks_like_prod_test_dsn
 
-    redacted = _redact_dsn("host = 127.0.0.1 port = 15432 dbname = app password = hunter2")
-    assert "hunter2" not in redacted
-    assert "password=***" in redacted
+    assert _looks_like_prod_test_dsn(
+        "host = nonloopback.example port = 15432 dbname = safe password = hunter2"
+    )
 
 
 def test_builderops_dsn_counts_as_configured_for_pg_collection(monkeypatch: pytest.MonkeyPatch) -> None:
     import tests.conftest as test_config
 
     class Item:
-        def __init__(self) -> None:
+        def __init__(self, path: Path) -> None:
+            self.path = path
             self.markers: list[object] = []
 
         def get_closest_marker(self, name: str) -> object | None:
@@ -369,9 +386,64 @@ def test_builderops_dsn_counts_as_configured_for_pg_collection(monkeypatch: pyte
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("DB_DSN", raising=False)
     monkeypatch.setenv("BUILDEROPS_DATABASE_URL", "postgresql://app:app@db:5432/builderops")
-    item = Item()
+    item = Item(REPO_ROOT / "tests/builderops/control_plane/test_contract.py")
     test_config.pytest_collection_modifyitems(None, [item])
     assert item.markers == []
+
+    unrelated = Item(REPO_ROOT / SCRATCH_FACTORY_TARGET)
+    test_config.pytest_collection_modifyitems(None, [unrelated])
+    assert len(unrelated.markers) == 1
+
+
+@pytest.mark.parametrize(
+    "env_overrides,expected_variable",
+    [
+        (
+            {"PKM_DB_HOST": "nonloopback.example", "PKM_DB_PORT": "15432"},
+            "PKM_DB_* / POSTGRES_*",
+        ),
+        (
+            {
+                "PGHOST": "nonloopback.example",
+                "PGPORT": "15434,15432",
+                "PGDATABASE": "safe",
+            },
+            "PGHOST/PGPORT/PGDATABASE",
+        ),
+    ],
+)
+def test_each_writer_is_guarded_independently_of_a_safe_primary_dsn(
+    spy_log: Path, env_overrides: dict[str, str], expected_variable: str
+) -> None:
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn="postgresql://app:app@127.0.0.1:15434/app_test",
+        spy_log=spy_log,
+        env_overrides=env_overrides,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert expected_variable in output, output
+    assert attempts == [], attempts
+
+
+def test_runtime_writer_does_not_authorize_primary_dsn_consumers(spy_log: Path) -> None:
+    result, attempts = _run_pytest(
+        [SCRATCH_FACTORY_TARGET],
+        dsn=None,
+        spy_log=spy_log,
+        env_overrides={
+            "PKM_ENVIRONMENT": "test",
+            "PKM_DB_HOST": "127.0.0.1",
+            "PKM_DB_PORT": "15434",
+            "PKM_DB_NAME_TEST": "app_test",
+        },
+    )
+    output = result.stdout + result.stderr
+
+    assert "pg lane skipped" in output, output
+    assert attempts == [], attempts
 
 
 # The "no prod DSN survives in default position under tests/" census lives in

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -44,6 +44,13 @@ BUILDEROPS_RECOVERY_TARGET = (
     "::test_recovered_epoch_fences_leases_and_executor_until_reconciliation"
 )
 
+LATE_CONNECTION_PROBES = [
+    "tests/conftest_guards/late_connection_probe.py::test_dynamic_explicit_conninfo_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_late_runtime_default_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_late_ambient_socket_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_late_service_file_is_blocked",
+]
+
 # The DSN the removed autouse fixture used to install. Port 15432 and database
 # `app` are both prod markers per app/db/dsn.py :: looks_like_prod_dsn.
 PROD_DSN = "postgresql://app:app@127.0.0.1:15432/app"
@@ -316,6 +323,22 @@ def test_connect_spy_cannot_hide_an_attempt(tmp_path: Path) -> None:
     recorded = [line for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert recorded.count("postgresql://u:p@127.0.0.1:1/closed") == 3, recorded
     assert AMBIENT in recorded, recorded
+
+
+@pytest.mark.parametrize("target", LATE_CONNECTION_PROBES)
+def test_connection_guard_blocks_late_and_dynamic_targets(spy_log: Path, target: str) -> None:
+    result, attempts = _run_pytest(
+        [target],
+        dsn="postgresql://app:app@127.0.0.1:15434/app_test",
+        spy_log=spy_log,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, output
+    assert "Refusing to run pg-marked tests" in output, output
+    # If the connection-time wrapper regresses, the child plugin records and
+    # blocks the attempt before a socket opens; a non-empty list is a failure.
+    assert attempts == [], attempts
 
 
 def test_refusal_message_never_echoes_conninfo() -> None:

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -49,6 +49,11 @@ LATE_CONNECTION_PROBES = [
     "tests/conftest_guards/late_connection_probe.py::test_late_runtime_default_is_blocked",
     "tests/conftest_guards/late_connection_probe.py::test_late_ambient_socket_is_blocked",
     "tests/conftest_guards/late_connection_probe.py::test_late_service_file_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_module_kwargs_only_prod_target_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_sync_kwargs_override_safe_conninfo_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_async_service_kwarg_is_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_implicit_local_defaults_are_blocked",
+    "tests/conftest_guards/late_connection_probe.py::test_explicit_local_socket_is_blocked",
 ]
 
 # The DSN the removed autouse fixture used to install. Port 15432 and database

--- a/tests/conftest_guards/test_pg_dsn_resolution.py
+++ b/tests/conftest_guards/test_pg_dsn_resolution.py
@@ -358,6 +358,23 @@ def test_effective_libpq_query_parameters_are_classified_as_production() -> None
     assert _looks_like_prod_test_dsn(db_query)
 
 
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "service=hidden_target",
+        "postgresql:///safe?service=hidden_target",
+    ],
+)
+def test_explicit_service_indirection_aborts_before_connect(spy_log: Path, dsn: str) -> None:
+    result, attempts = _run_pytest([SCRATCH_FACTORY_TARGET], dsn=dsn, spy_log=spy_log)
+    output = result.stdout + result.stderr
+
+    assert result.returncode == PYTEST_USAGE_ERROR, output
+    assert "production-looking database" in output, output
+    assert "hidden_target" not in output, output
+    assert attempts == [], attempts
+
+
 def test_test_guard_reads_effective_libpq_query_port() -> None:
     from tests.conftest import _looks_like_prod_test_dsn
 

--- a/tests/index/test_identity_migration.py
+++ b/tests/index/test_identity_migration.py
@@ -31,7 +31,6 @@ embedding client, exactly like the existing reconcile suite.
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import asdict
 from uuid import uuid4
 
@@ -47,7 +46,7 @@ def _pg_available() -> bool:
 
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()
@@ -277,7 +276,7 @@ def test_doctor_flags_old_identity_rows(tmp_path, monkeypatch) -> None:
     from app.stores import reset_store_backends
 
     def _dsn() -> str:
-        return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+        return resolve_dsn()
 
     monkeypatch.setenv("DATABASE_URL", _dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
@@ -342,7 +341,7 @@ def test_reconcile_converges(tmp_path, monkeypatch) -> None:
     from app.stores import reset_store_backends
 
     def _dsn() -> str:
-        return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+        return resolve_dsn()
 
     monkeypatch.setenv("DATABASE_URL", _dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")

--- a/tests/index/test_index_doctor_route.py
+++ b/tests/index/test_index_doctor_route.py
@@ -14,7 +14,7 @@ def _pg_available() -> bool:
 
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()

--- a/tests/index/test_index_reconcile_route.py
+++ b/tests/index/test_index_reconcile_route.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 
 import pytest
 
@@ -13,7 +12,7 @@ def _pg_available() -> bool:
 
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -37,7 +37,7 @@ def _pg_available() -> bool:
 
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()

--- a/tests/indexer/test_identity_provenance.py
+++ b/tests/indexer/test_identity_provenance.py
@@ -10,7 +10,6 @@ Requires a live Postgres backend; skipped when unavailable.
 
 from __future__ import annotations
 
-import os
 from uuid import uuid4
 
 import psycopg
@@ -28,7 +27,7 @@ FALLBACK = EmbeddingIdentity(provider="gemini", model="gemini-embedding-001", di
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/indexer/test_mixed_identity_detection.py
+++ b/tests/indexer/test_mixed_identity_detection.py
@@ -10,7 +10,6 @@ Requires a live Postgres backend; skipped when unavailable.
 from __future__ import annotations
 
 import json
-import os
 from uuid import uuid4
 
 import psycopg
@@ -26,7 +25,7 @@ pytestmark = pytest.mark.pg
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -27,7 +27,7 @@ def _pg_available() -> bool:
 
 
 def _pg_base_dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _dsn_with_search_path(dsn: str, schema: str) -> str:

--- a/tests/indexer/test_provenance_stamp_pg.py
+++ b/tests/indexer/test_provenance_stamp_pg.py
@@ -11,7 +11,6 @@ Requires a live Postgres backend; skipped when unavailable.
 
 from __future__ import annotations
 
-import os
 from uuid import uuid4
 
 import psycopg
@@ -27,7 +26,7 @@ pytestmark = pytest.mark.pg
 def _pg_available() -> bool:
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()

--- a/tests/int/test_pg_backend.py
+++ b/tests/int/test_pg_backend.py
@@ -1,4 +1,3 @@
-import os
 
 import psycopg
 import pytest
@@ -10,7 +9,7 @@ pytestmark = pytest.mark.pg
 
 
 def _pg_available() -> bool:
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()
@@ -22,7 +21,7 @@ def _pg_available() -> bool:
 def test_pg_roundtrip(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     objects, decisions = get_stores()
     obj = objects.upsert(kind="note", payload={"title": "pg"})

--- a/tests/integration/test_vault_sync_atomicity.py
+++ b/tests/integration/test_vault_sync_atomicity.py
@@ -14,7 +14,7 @@ from app.db.dsn import resolve_dsn
 
 
 def _pg_base_dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/invariants/test_retrieval_spine_invariants.py
+++ b/tests/invariants/test_retrieval_spine_invariants.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import os
 from uuid import UUID, uuid4
 
 import pytest
@@ -103,7 +102,7 @@ def _pg_available() -> bool:
 
     from app.db.dsn import resolve_dsn
 
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()
@@ -135,7 +134,7 @@ def test_identity_converges(tmp_path, monkeypatch) -> None:
     import app.cli.index_rebuild as reconcile_mod
 
     def _dsn() -> str:
-        return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+        return resolve_dsn()
 
     monkeypatch.setenv("DATABASE_URL", _dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")

--- a/tests/ops/test_benchmark_runner.py
+++ b/tests/ops/test_benchmark_runner.py
@@ -295,8 +295,8 @@ class TestSubprocessEnvHermetic:
     def test_subprocess_env_drops_leaked_contamination(self, monkeypatch) -> None:
         # Simulate the leak: a prior test left these in the process env.
         monkeypatch.setenv("VAULT_ROOT", "/nonexistent/leaked/vault/path")
-        monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://app:app@127.0.0.1:15432/app")
-        monkeypatch.setenv("DB_DSN", "postgresql://app:app@127.0.0.1:15432/app")
+        monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://app:app@127.0.0.1:15434/app_test")
+        monkeypatch.setenv("DB_DSN", "postgresql://app:app@127.0.0.1:15434/app_test")
         monkeypatch.setenv("LLM_FORCE_PROVIDER", "ollama")
         monkeypatch.setenv("EMBED_PROFILE", "local")
         monkeypatch.setenv("LLM_MOCK_RESPONSE", '{"type":"note","trust":"external"}')

--- a/tests/ops/test_builderops_backup_restore.py
+++ b/tests/ops/test_builderops_backup_restore.py
@@ -133,7 +133,15 @@ def _schema_dsn(dsn: str, schema: str) -> str:
 
 @pytest.fixture
 def recovery_store() -> Iterator[PostgresBuilderOpsStore]:
-    base_dsn = os.getenv("BUILDEROPS_DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    # Explicit-or-nothing: this used to fall back to the production DSN (#4573).
+    from app.db.dsn import resolve_dsn
+
+    base_dsn = os.getenv("BUILDEROPS_DATABASE_URL", "").strip() or resolve_dsn()
+    if not base_dsn:
+        pytest.skip(
+            "no control-plane database configured: set BUILDEROPS_DATABASE_URL "
+            "(or DATABASE_URL) to an explicit non-production Postgres"
+        )
     try:
         with psycopg.connect(base_dsn, connect_timeout=2, autocommit=True) as conn:
             schema = f"builderops_recovery_{uuid4().hex}"

--- a/tests/runtime/test_panel_outbox_db.py
+++ b/tests/runtime/test_panel_outbox_db.py
@@ -26,7 +26,7 @@ def test_panel_runtime_enqueues_db_outbox(monkeypatch, tmp_path) -> None:
     if not _pg_available():
         pytest.skip("Postgres backend not available")
 
-    dsn = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    dsn = resolve_dsn()
     monkeypatch.setenv("DATABASE_URL", dsn)
     monkeypatch.setenv("STORE_BACKEND", "pg")
     audit_path = tmp_path / "index-outbox.jsonl"

--- a/tests/services/test_audit_writer.py
+++ b/tests/services/test_audit_writer.py
@@ -42,10 +42,10 @@ from app.services.audit import audit_event
 def test_audit_row_written_on_action() -> None:
     """An audit_event call against a live pg writes at least one audit row.
 
-    Requires a running Postgres on the default local DSN
-    (postgresql://app:app@127.0.0.1:15432/app) — skip or xfail if the DB is
-    unreachable.  The default_pg_dsn_for_pg_tests fixture in conftest.py sets
-    DATABASE_URL automatically for pg-marked tests.
+    Requires DATABASE_URL/DB_DSN to name a reachable non-production Postgres —
+    skip or xfail if the DB is unreachable. The pg lane has no default target
+    (#4573): tests/conftest.py skips pg-marked tests when nothing is configured
+    and aborts the run when the configured DSN looks like production.
     """
     import os  # noqa: PLC0415
     import uuid  # noqa: PLC0415

--- a/tests/services/test_outbox_idempotency_pg.py
+++ b/tests/services/test_outbox_idempotency_pg.py
@@ -9,7 +9,6 @@ emulate.
 
 from __future__ import annotations
 
-import os
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
@@ -25,7 +24,7 @@ from app.services.outbox import bootstrap, derive_idempotency_key, write_outbox_
 
 
 def _pg_base_dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/stores/test_backend_auto_detection.py
+++ b/tests/stores/test_backend_auto_detection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 
 import psycopg
 import pytest
@@ -10,7 +9,14 @@ from app.stores import reset_store_backends, resolve_store_backend, resolved_sto
 
 
 def _pg_available() -> bool:
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
+    if not url:
+        # An empty conninfo is not "no target": libpq then supplies its own
+        # from PGHOST/PGPORT/PGDATABASE or the local socket. This module is not
+        # pg-marked, so force_memory_store_for_non_pg has already cleared
+        # DATABASE_URL/DB_DSN and `url` is always empty here — dialling would
+        # mean silently picking whatever the ambient environment names (#4573).
+        return False
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()
@@ -41,7 +47,12 @@ def _reset_between_tests():
 
 def test_store_backend_override_wins(monkeypatch):
     monkeypatch.setenv("STORE_BACKEND", "memory")
-    monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    # Must not be a reachable production address (#4573): this module's autouse
+    # teardown calls reset_store_backends() -> truncate_pg_tables(), and that
+    # finalizer runs BEFORE monkeypatch restores the environment. With the prod
+    # DSN still installed, the teardown issued DELETE against production on any
+    # host publishing it on 15432. The assertion only needs *some* DSN present.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15434/app_test")
     assert resolve_store_backend() == "memory"
 
 
@@ -69,11 +80,24 @@ def test_store_backend_auto_detects_pg_postgresql_dsn(monkeypatch):
 
 
 def test_store_backend_auto_detects_pg(monkeypatch):
-    if not _pg_available():
-        pytest.skip("Postgres backend not available")
+    """A reachable DSN and no override auto-detects the pg backend.
+
+    Driven through the fake connector rather than a live server (#4573). This
+    module is not pg-marked, so `force_memory_store_for_non_pg` clears
+    DATABASE_URL/DB_DSN before the body runs and `resolve_dsn()` is always
+    empty here — the previous form asked a real Postgres whether it was up,
+    which meant dialling whatever the environment named, and on this repo's
+    hosts that was production. Skipping instead would trade a prod dial for a
+    permanently silent `s`, so the assertion is kept and the server removed.
+    """
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(psycopg, "connect", _fake_connect(captured))
     monkeypatch.delenv("STORE_BACKEND", raising=False)
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or "postgresql://app:app@127.0.0.1:15432/app")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15434/app_test")
+
     assert resolve_store_backend() == "pg"
+    assert captured["dsn"] == "postgresql://app:app@127.0.0.1:15434/app_test"
 
 
 def test_store_backend_without_config_raises(monkeypatch):

--- a/tests/stores/test_pg_vector_index.py
+++ b/tests/stores/test_pg_vector_index.py
@@ -15,7 +15,6 @@ These tests require a live Postgres backend; they are skipped under `not pg`.
 
 from __future__ import annotations
 
-import os
 from uuid import uuid4
 
 import psycopg
@@ -33,7 +32,7 @@ FALLBACK = EmbeddingIdentity(provider="gemini", model="gemini-embedding-001", di
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:

--- a/tests/stores/test_store_contract_pg.py
+++ b/tests/stores/test_store_contract_pg.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from uuid import uuid4
 
 import psycopg
@@ -19,7 +18,7 @@ BACKENDS = [
 
 
 def _pg_available() -> bool:
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     try:
         conn = psycopg.connect(url, connect_timeout=1)
         conn.close()
@@ -40,7 +39,7 @@ def test_object_store_roundtrip(monkeypatch, backend):
     if backend == "pg" and not _pg_available():
         pytest.skip("Postgres backend not available")
     if backend == "pg":
-        monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+        monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", backend)
     store = get_object_store()
     oid = uuid4()
@@ -56,7 +55,7 @@ def test_vector_index_search_order(monkeypatch, backend):
     if backend == "pg" and not _pg_available():
         pytest.skip("Postgres backend not available")
     if backend == "pg":
-        monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+        monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", backend)
     monkeypatch.setenv("EMBED_DIM", "4")
 
@@ -73,7 +72,7 @@ def test_relation_neighbors_unique_order(monkeypatch, backend):
     if backend == "pg" and not _pg_available():
         pytest.skip("Postgres backend not available")
     if backend == "pg":
-        monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+        monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", backend)
     rel = get_relation_index()
     src = uuid4()
@@ -90,7 +89,7 @@ def test_relation_memberships_roundtrip_multi_value(monkeypatch, backend):
     if backend == "pg" and not _pg_available():
         pytest.skip("Postgres backend not available")
     if backend == "pg":
-        monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+        monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", backend)
     rel = get_relation_index()
     src = uuid4()
@@ -111,7 +110,7 @@ def test_relation_memberships_are_optional_and_empty_by_default(monkeypatch, bac
     if backend == "pg" and not _pg_available():
         pytest.skip("Postgres backend not available")
     if backend == "pg":
-        monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+        monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", backend)
     rel = get_relation_index()
 
@@ -122,7 +121,7 @@ def test_relation_memberships_are_optional_and_empty_by_default(monkeypatch, bac
 def test_pg_vector_index_query_dim_mismatch(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setenv("EMBED_DIM", "4")
     idx = get_vector_index()
@@ -137,7 +136,7 @@ def test_pg_vector_index_query_dim_mismatch(monkeypatch):
 def test_pg_vector_index_detects_mixed_dims(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     monkeypatch.setenv("EMBED_DIM", "4")
     idx = get_vector_index()
@@ -145,7 +144,7 @@ def test_pg_vector_index_detects_mixed_dims(monkeypatch):
     secondary = uuid4()
     idx.upsert(object_id=primary, kind="note", source_ref="unit-test", payload={"text": "alpha"}, embedding=[1, 0, 0, 0], model=TEST_PG_IDENTITY.model, identity=TEST_PG_IDENTITY)
     idx.upsert(object_id=secondary, kind="note", source_ref="unit-test", payload={"text": "beta"}, embedding=[0.5, 0.5, 0, 0], model=TEST_PG_IDENTITY.model, identity=TEST_PG_IDENTITY)
-    url = resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    url = resolve_dsn()
     with psycopg.connect(url) as conn:
         with conn.cursor() as cur:
             cur.execute("UPDATE store_vector_index SET dim = %s WHERE object_id = %s", (8, secondary))
@@ -157,7 +156,7 @@ def test_pg_vector_index_detects_mixed_dims(monkeypatch):
 def test_pg_vector_index_identity_mismatch(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
-    monkeypatch.setenv("DATABASE_URL", resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app"))
+    monkeypatch.setenv("DATABASE_URL", resolve_dsn())
     monkeypatch.setenv("STORE_BACKEND", "pg")
     idx = get_vector_index()
     primary = uuid4()

--- a/tests/stores/test_vector_generation_identity.py
+++ b/tests/stores/test_vector_generation_identity.py
@@ -13,7 +13,6 @@ These tests require a live Postgres backend; they are skipped under `not pg`.
 from __future__ import annotations
 
 import json
-import os
 from uuid import uuid4
 
 import psycopg
@@ -30,7 +29,7 @@ PRIMARY = EmbeddingIdentity(provider="ollama", model="nomic-embed-text", dim=4, 
 
 
 def _dsn() -> str:
-    return resolve_dsn() or os.getenv("DATABASE_URL", "postgresql://app:app@127.0.0.1:15432/app")
+    return resolve_dsn()
 
 
 def _pg_available() -> bool:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4573

## Linked Issue
Closes #4573

## SBS Impact
- Primary subsystem: Builder System / test harness
- Secondary subsystem(s): durable Product surfaces exercised by pg tests
- Write class: none added; removes unintended destructive writes
- Persistence impact: prevents destructive DDL, TRUNCATE, and scratch-database operations against production
- Derived/rebuildable impact: none
- New or changed contract: pg test database resolution is explicit-or-nothing and every effective in-process psycopg target is checked at the connection boundary
- Owner-doc impact: updated `docs/development/DEV_WORKFLOW.md`
- Transition debt impact: reduces a live production-data footgun
- Boundary risk: fail-closed test-only safety gate; shared runtime classifier is unchanged

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Remove every production DSN fallback from pg tests and CI fixtures.
- Abort before test-module imports when any independently configured primary, runtime, ambient-libpq, or BuilderOps writer resolves to production or to uninspectable service indirection.
- Recheck the complete effective target at all three psycopg connection entry points, including keyword overrides, implicit and explicit Unix sockets, and libpq multi-host positions.
- Keep collection authorization consumer-specific: ordinary pg tests require the primary DSN, while BuilderOps-only consumers may use their own safe DSN.
- Prove refusal with subprocess probes whose psycopg spy records and blocks every attempted connection without opening a socket.
- Keep `app/db/dsn.py` unchanged; effective libpq parsing is test-harness-local as required by Issue #4573.

## Safety mechanism

The pre-import gate covers `DATABASE_URL` / `DB_DSN`, explicit `PKM_DB_*` / `POSTGRES_*` runtime configuration, `PGHOST` / `PGHOSTADDR` / `PGPORT` / `PGDATABASE` / `PGUSER`, `PGSERVICE` / `PGSERVICEFILE`, embedded conninfo `service` options, and `BUILDEROPS_DATABASE_URL`. A safe primary target cannot hide an unsafe secondary writer. The connection-boundary wrapper then combines positional conninfo with libpq keyword parameters using psycopg's own override semantics and rejects production markers, service indirection, implicit targets, Unix sockets, and unsafe multi-host entries. Refusal output never echoes arbitrary conninfo, service names, file paths, or credentials.

## Validation
- Governing safety and architecture suite: 41 passed.
- Full non-pg suite on `26c699db7`: 12,599 passed, 43 skipped, 18 xfailed, zero failures. An initial unrelated E2E route assertion failed once, passed five immediate isolated repetitions, and the complete leased suite then passed; no gate was waived. The patch-id is unchanged at rebased head `b07df05fd`, and the only incoming base repair makes the Linux bootstrap assertion deterministic.
- PR-body/governance contract targets: 115 passed.
- `python3 -m ruff check app tests companion-ui/companion-app`: passed.
- `python3 -m mypy app`: passed across 870 source files.
- `python3 scripts/docs_guard.py`: passed.
- Fresh Sol/xhigh mechanism-convergence review on `26c699db7`: ACCEPT, no P0/P1 findings; the rebased patch at `b07df05fd` is byte-identical.
- Current-head GitHub CI on `b07df05fd`: all checks green, including required Unit tests (not pg), Index PG contracts, smoke, smoke-docker, contract validation, PR contract, evidence pack, CodeQL, and analysis.
- Final independent Sol/xhigh review rounds on `b07df05fd`: 2 consecutive CLEAN, no P0/P1 or P2 findings.
- Exact GitHub merge-ref `d77d75c8d` governing safety and architecture suite: 41 passed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded repository test-harness safety repair; durable evidence is in the guard suite, architecture census, CI, and owner-doc writeback, with no operational-state record or projection needed

## Notes
The unrelated kill-switch regression was delivered separately by PR #4652 under Issue #4629 and is absent from this diff. The Linux-only bootstrap assertion false failure was isolated in direct-repair PR #4653 and is now on the PR base, also absent from this diff.
