### PR TITLE
Reject lossy link-carryover and repo-doc token-overlap resolutions in semanticmd

### DIFF
--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -5,7 +5,10 @@ from .graph import diff_conflict_loci, apply_decisions
 from .llm import judge_locus
 
 
-_MD_LINK_RE = re.compile(r"\[[^\]]+\]\([^)]+\)")
+# Optional leading "!" so image embeds are recognized too: the carryover
+# heuristic only appends plain links, so an incoming image can never be
+# "carried" verbatim and the lossless check below fails closed to a conflict.
+_MD_LINK_RE = re.compile(r"!?\[[^\]]+\]\([^)]+\)")
 
 
 def _token_similarity(x: str, y: str) -> float:
@@ -37,7 +40,11 @@ def _carried_links_are_lossless(merged_body: str, b_body: str) -> bool:
     """
     if not all(link in merged_body for link in _MD_LINK_RE.findall(b_body)):
         return False
-    return _normalized_nonlink_text(b_body) in _normalized_nonlink_text(merged_body)
+    # Space-padded containment keeps the match word-aligned: THEIRS' "enabled"
+    # must not count as preserved because OURS happens to contain "unenabled".
+    b_nonlink = _normalized_nonlink_text(b_body)
+    merged_nonlink = _normalized_nonlink_text(merged_body)
+    return f" {b_nonlink} " in f" {merged_nonlink} "
 
 
 def _extract_uuid(md: str) -> str | None:
@@ -150,7 +157,12 @@ def _body(md: str) -> str:
 
 
 def _guard_content_loss(merged, info, a, b):
-    """Refuse to silently resolve a merge that discards one side's real content.
+    """Refuse to silently resolve a merge that discards one side's real body content.
+
+    Scope note: this guard compares note *bodies*. Frontmatter divergence
+    beyond the uuid hard-conflict invariant (e.g. THEIRS-only tags or a
+    review_state change) is still resolved by `apply_decisions` keeping OURS'
+    frontmatter -- a pre-existing gap outside this guard's contract.
 
     Issue #4505 added this fail-safe for repository documentation (no `uuid:`
     frontmatter): the near-duplicate / "prefer concise" heuristic could pick one
@@ -168,7 +180,7 @@ def _guard_content_loss(merged, info, a, b):
     tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped.
 
     The only mechanisms trusted to resolve a divergence are the ones that
-    provably preserve the discarded side's real content (#4616, PR #4604
+    provably preserve the discarded side's real body content (#4616, PR #4604
     reviews r3700682703 / r3700682705):
 
     - An exact body match: nothing to lose.
@@ -204,11 +216,13 @@ def _guard_content_loss(merged, info, a, b):
         _body(merged), b_body
     ):
         # Link carryover reconciled the divergence and provably preserved all
-        # of THEIRS' content (#4616: lossy carryover no longer resolves).
+        # of THEIRS' body content (#4616: lossy carryover no longer resolves).
         return merged, info
     if (
-        _extract_uuid(a) is not None
-        and _extract_uuid(b) is not None
+        # Truthiness, not `is not None`: a bare `uuid:` key with no value is
+        # not vault identity, matching the hard-conflict check above.
+        _extract_uuid(a)
+        and _extract_uuid(b)
         and _token_similarity(a_body, b_body) >= 0.85
     ):
         # Genuine vault-note near-duplicate: negligible content to lose either

--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -67,6 +67,12 @@ def normalize_uuid_scalar(raw: str) -> str | None:
     value = raw.strip()
     if not value or value.startswith("#"):
         return None
+    if value[0] in ">|*&{}[]!":
+        # YAML indicator characters: block-scalar headers (>, |), aliases and
+        # anchors (*, &), flow collections ({}, []), tags (!!...). Never a
+        # plain-scalar identity -- the real value, if any, lives outside this
+        # line's reach -- so grant no identity rather than a fake shared one.
+        return None
     if value[0] in "\"'":
         quote = value[0]
         end = value.find(quote, 1)

--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -50,6 +50,37 @@ def _carried_links_are_lossless(merged_body: str, b_body: str) -> bool:
     return f" {b_nonlink} " in f" {merged_nonlink} "
 
 
+def normalize_uuid_scalar(raw: str) -> str | None:
+    """Reduce a raw `uuid:` frontmatter value to a real scalar identity.
+
+    Dependency-free YAML-lite (PR #4626 review r3712514848): degenerate values
+    must not count as vault identity, or two notes that merely share the same
+    degenerate `uuid:` field would take identity-gated code paths. Rules:
+
+    - a comment-only value (`# ...`) is no identity;
+    - surrounding matching quotes are stripped, so `"u-x"` and `u-x` name the
+      same logical note (divergent real ids still hard-conflict upstream);
+    - for unquoted plain scalars, a trailing ` #comment` is dropped per YAML;
+    - empty and null-like values (`null`/`Null`/`NULL`/`~`, quoted or not --
+      quoted forms are deliberately treated conservatively) are no identity.
+    """
+    value = raw.strip()
+    if not value or value.startswith("#"):
+        return None
+    if value[0] in "\"'":
+        quote = value[0]
+        end = value.find(quote, 1)
+        # Unterminated quote: fall through with the rest taken verbatim.
+        value = value[1:end] if end != -1 else value[1:]
+        value = value.strip()
+    else:
+        # Plain scalar: a YAML comment starts at the first whitespace + '#'.
+        value = re.split(r"\s#", value, maxsplit=1)[0].strip()
+    if not value or value.lower() in ("null", "~"):
+        return None
+    return value
+
+
 def _extract_uuid(md: str) -> str | None:
     # Read the leading frontmatter block and grab the first uuid field if present.
     if not md.startswith("---"):
@@ -60,7 +91,7 @@ def _extract_uuid(md: str) -> str | None:
         return None
     for line in fm.splitlines():
         if line.strip().lower().startswith("uuid:"):
-            return line.split(":", 1)[1].strip()
+            return normalize_uuid_scalar(line.split(":", 1)[1])
     return None
 
 

--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -40,9 +40,12 @@ def _carried_links_are_lossless(merged_body: str, b_body: str) -> bool:
     """
     if not all(link in merged_body for link in _MD_LINK_RE.findall(b_body)):
         return False
+    b_nonlink = _normalized_nonlink_text(b_body)
+    if not b_nonlink:
+        # THEIRS' body is links-only and every link was carried: lossless.
+        return True
     # Space-padded containment keeps the match word-aligned: THEIRS' "enabled"
     # must not count as preserved because OURS happens to contain "unenabled".
-    b_nonlink = _normalized_nonlink_text(b_body)
     merged_nonlink = _normalized_nonlink_text(merged_body)
     return f" {b_nonlink} " in f" {merged_nonlink} "
 

--- a/app/agents/merge_resolver/agent.py
+++ b/app/agents/merge_resolver/agent.py
@@ -5,6 +5,9 @@ from .graph import diff_conflict_loci, apply_decisions
 from .llm import judge_locus
 
 
+_MD_LINK_RE = re.compile(r"\[[^\]]+\]\([^)]+\)")
+
+
 def _token_similarity(x: str, y: str) -> float:
     t1 = set(re.findall(r"\w+", x.lower()))
     t2 = set(re.findall(r"\w+", y.lower()))
@@ -13,6 +16,28 @@ def _token_similarity(x: str, y: str) -> float:
     inter = len(t1 & t2)
     denom = (len(t1) + len(t2)) / 2.0
     return inter / denom
+
+
+def _normalized_nonlink_text(body: str) -> str:
+    """Whitespace-normalized body text with markdown links removed."""
+    return " ".join(_MD_LINK_RE.sub(" ", body).split())
+
+
+def _carried_links_are_lossless(merged_body: str, b_body: str) -> bool:
+    """True only when THEIRS' (b) entire body survives in the merged body.
+
+    The link-carryover heuristic appends THEIRS' markdown links to the merged
+    text. That reconciles the divergence only when links are the entire
+    difference THEIRS brings: every one of THEIRS' links must be present
+    verbatim in the merged body, and THEIRS' remaining non-link prose must
+    already appear (whitespace-normalized, contiguous, in order) inside the
+    merged body's non-link prose. Anything less means distinct incoming prose
+    is being dropped while the merge still reports "resolved" -- the P1
+    content-loss finding from PR #4604 review r3700682703 (#4616).
+    """
+    if not all(link in merged_body for link in _MD_LINK_RE.findall(b_body)):
+        return False
+    return _normalized_nonlink_text(b_body) in _normalized_nonlink_text(merged_body)
 
 
 def _extract_uuid(md: str) -> str | None:
@@ -142,14 +167,27 @@ def _guard_content_loss(merged, info, a, b):
     non-trivial divergence -- see
     tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped.
 
-    The only two mechanisms this resolver has that actually preserve the
-    discarded side's real content are: an exact match (nothing to lose), and the
-    markdown-link-carryover heuristic below (which literally appends THEIRS'
-    missing links into the merged text). A genuine near-duplicate pick is also
-    trusted, since by definition there is negligible information to lose. Any
-    other divergence is not provably safe and must raise a conflict instead of
-    silently discarding a side -- the same conservative default #4505 already
-    established, now applied uniformly instead of only to non-vault content.
+    The only mechanisms trusted to resolve a divergence are the ones that
+    provably preserve the discarded side's real content (#4616, PR #4604
+    reviews r3700682703 / r3700682705):
+
+    - An exact body match: nothing to lose.
+    - The markdown-link-carryover heuristic below, but only when it is
+      verifiably lossless -- THEIRS' links all landed in the merged text AND
+      THEIRS' remaining non-link prose already appears in the merged body.
+      Carrying the links while dropping distinct incoming prose is exactly the
+      false-clean merge this guard exists to prevent.
+    - A near-duplicate pick (token similarity >= 0.85), scoped to vault notes
+      (uuid identity on both sides). Set-of-tokens similarity ignores order,
+      repetition, and negation ("deployment is enabled" vs "deployment is not
+      enabled" clears the threshold), so it is only accepted for vault notes,
+      where near-duplicate device-sync copies of one identified note are the
+      expected input. Repository documentation never resolves through it.
+
+    Any other divergence is not provably safe and must raise a conflict
+    instead of silently discarding a side -- the same conservative default
+    #4505 already established, now applied uniformly instead of only to
+    non-vault content.
     """
     info = dict(info or {})
     if info.get("status") != "resolved":
@@ -162,11 +200,20 @@ def _guard_content_loss(merged, info, a, b):
         return merged, info
 
     reason = info.get("reason", "")
-    if "carried links" in reason.lower():
-        # The missing-link-carryover heuristic already reconciled the divergence.
+    if "carried links" in reason.lower() and _carried_links_are_lossless(
+        _body(merged), b_body
+    ):
+        # Link carryover reconciled the divergence and provably preserved all
+        # of THEIRS' content (#4616: lossy carryover no longer resolves).
         return merged, info
-    if _token_similarity(a_body, b_body) >= 0.85:
-        # Genuine near-duplicate: negligible content to lose either way.
+    if (
+        _extract_uuid(a) is not None
+        and _extract_uuid(b) is not None
+        and _token_similarity(a_body, b_body) >= 0.85
+    ):
+        # Genuine vault-note near-duplicate: negligible content to lose either
+        # way. Intentionally scoped to vault identity (#4616); repository docs
+        # with high token overlap but distinct bodies conflict instead.
         return merged, info
 
     info["status"] = "conflict"

--- a/app/cli/merge_driver.py
+++ b/app/cli/merge_driver.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Tuple, Dict, Any
 
-from app.agents.merge_resolver.agent import merge_note_from_blobs
+from app.agents.merge_resolver.agent import merge_note_from_blobs, normalize_uuid_scalar
 
 
 def _read_text(p: Path) -> str:
@@ -25,7 +25,10 @@ def _parse_uuid(md: str) -> str | None:
     fm_block = parts[1]
     m = re.search(r"^uuid:\s*(.+)$", fm_block, flags=re.MULTILINE)
     if m:
-        return m.group(1).strip()
+        # Same identity semantics as the resolver (PR #4626 r3712514848):
+        # degenerate scalars are no identity; quoting differences are not an
+        # identity mismatch.
+        return normalize_uuid_scalar(m.group(1))
     return None
 
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,6 +49,16 @@ promote public internet readiness.
 - Prod promotion model fix (#2656): AC1 and AC3 are done, while AC2 remains operator-gated pending operator receipt and sibling-doc reconciliation.
 - Delivery wave follow-on receipts: GraphQL exhaustion fix #2686, watcher settings receipts #2678, nested-vault boundary enforcement #2689, and deployment environment-separation spec #2692 are merged and reflected in the current shipped baseline.
 
+2026-08-04 fix writeback:
+- `semanticmd` merge driver's content-loss backstop no longer accepts lossy resolutions (#4616):
+  a post-merge review of PR #4604 found that link carryover could report a clean resolve while
+  dropping THEIRS' distinct non-link prose, and that the token-similarity near-duplicate bypass
+  (order/negation-blind) let a non-vault repository doc resolve to OURS silently. Link carryover
+  now counts only when it is verifiably lossless (all of THEIRS' links land in the merged body and
+  THEIRS' remaining non-link prose already appears, word-aligned, in the merged body), and the
+  near-duplicate pick is scoped to vault notes with a non-empty `uuid:` identity on both sides.
+  Everything else conflicts. See `docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md`.
+
 2026-08-03 fix writeback:
 - `semanticmd` merge driver's content-loss guard now applies to vault notes too (#4603):
   delivering #4505 surfaced that its non-vault-only scoping assumed vault-note merging performs

--- a/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
+++ b/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
@@ -1,4 +1,4 @@
-State: Current-state contract for the `semanticmd` git merge driver; aligned with shipped behavior (#4505 routing narrowing, #4561 `%A` result write, #4603 content-loss guard generalized to vault notes).
+State: Current-state contract for the `semanticmd` git merge driver; aligned with shipped behavior (#4505 routing narrowing, #4561 `%A` result write, #4603 content-loss guard generalized to vault notes, #4616 lossless-only link carryover and vault-scoped near-duplicate bypass).
 
 # Semantic Markdown merge driver (`semanticmd`)
 
@@ -50,15 +50,29 @@ that permanently drops one side's edit. See
 `tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped`
 for the regression coverage.
 
-Two mechanisms are trusted to resolve a divergence without raising a conflict,
-because they provably do not discard real content: an exact body match
-(nothing to lose), the markdown-link-carryover heuristic (THEIRS' missing
-links are appended into the merged text), and a genuine near-duplicate pick
-(token similarity `>= 0.85`, i.e. negligible information difference either
-way). Any other divergence — including ordinary distinct-prose additions on
+Three mechanisms are trusted to resolve a divergence without raising a
+conflict, because they provably do not discard real content (tightened by
+#4616 after PR #4604 reviews r3700682703 / r3700682705):
+
+- An exact body match: nothing to lose.
+- The markdown-link-carryover heuristic (THEIRS' missing links are appended
+  into the merged text), but only when the carryover is verifiably lossless:
+  every one of THEIRS' links must land in the merged body and THEIRS'
+  remaining non-link prose must already appear, in order, inside the merged
+  body's non-link prose. If THEIRS carries a link plus distinct prose, the
+  merge conflicts instead of resolving — link carryover is not a generic
+  content-loss exemption.
+- A genuine near-duplicate pick (token similarity `>= 0.85`), scoped to vault
+  notes (`uuid:` identity on both sides). Set-of-tokens similarity ignores
+  order, repetition, and negation ("deployment is enabled" vs "deployment is
+  not enabled" clears the threshold), so repository documentation never
+  resolves through it; a non-vault doc with high token overlap but distinct
+  body content conflicts.
+
+Any other divergence — including ordinary distinct-prose additions on
 both sides — raises a conflict rather than silently picking a side. Real
 per-locus semantic merging (an actual LLM judgment wired into `judge_locus`)
-is not implemented; until it is, vault-note auto-resolve is limited to the
+is not implemented; until it is, auto-resolve is limited to the
 three mechanisms above.
 
 ## History

--- a/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
+++ b/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
@@ -51,23 +51,26 @@ that permanently drops one side's edit. See
 for the regression coverage.
 
 Three mechanisms are trusted to resolve a divergence without raising a
-conflict, because they provably do not discard real content (tightened by
-#4616 after PR #4604 reviews r3700682703 / r3700682705):
+conflict, because they provably do not discard real body content (tightened
+by #4616 after PR #4604 reviews r3700682703 / r3700682705; frontmatter
+divergence beyond the uuid invariant is a pre-existing gap outside this
+guard's contract):
 
 - An exact body match: nothing to lose.
 - The markdown-link-carryover heuristic (THEIRS' missing links are appended
   into the merged text), but only when the carryover is verifiably lossless:
   every one of THEIRS' links must land in the merged body and THEIRS'
-  remaining non-link prose must already appear, in order, inside the merged
-  body's non-link prose. If THEIRS carries a link plus distinct prose, the
-  merge conflicts instead of resolving — link carryover is not a generic
+  remaining non-link prose must already appear, word-aligned and in order,
+  inside the merged body's non-link prose. If THEIRS carries a link plus
+  distinct prose — or an image embed, which carryover cannot preserve — the
+  merge conflicts instead of resolving; link carryover is not a generic
   content-loss exemption.
 - A genuine near-duplicate pick (token similarity `>= 0.85`), scoped to vault
-  notes (`uuid:` identity on both sides). Set-of-tokens similarity ignores
-  order, repetition, and negation ("deployment is enabled" vs "deployment is
-  not enabled" clears the threshold), so repository documentation never
-  resolves through it; a non-vault doc with high token overlap but distinct
-  body content conflicts.
+  notes (a non-empty `uuid:` identity on both sides). Set-of-tokens
+  similarity ignores order, repetition, and negation ("deployment is enabled"
+  vs "deployment is not enabled" clears the threshold), so repository
+  documentation never resolves through it; a non-vault doc with high token
+  overlap but distinct body content conflicts.
 
 Any other divergence — including ordinary distinct-prose additions on
 both sides — raises a conflict rather than silently picking a side. Real
@@ -90,6 +93,17 @@ non-vault-only guard scoping rested on a false premise (vault-note merging
 notes hit the identical silent-drop defect once #4561 made the `%A` write
 land. See the "Resolver-level backstop" section above and
 `tests/cli/test_merge_driver.py::test_end_to_end_git_rebase_plain_prose_vault_note_divergence_is_not_silently_dropped`.
+
+Filed and fixed under GitHub issue #4616: a post-merge review of PR #4604
+(#4603's fix) left two P1 content-loss findings. Link carryover could report
+a clean resolve while dropping THEIRS' distinct non-link prose, and the
+token-similarity near-duplicate bypass let a non-vault repository doc with
+high token overlap (e.g. a flipped negation) resolve to OURS silently. The
+backstop now requires verifiably lossless link carryover and scopes the
+near-duplicate bypass to vault identity, per the "Resolver-level backstop"
+section above. See
+`tests/agents/test_merge_resolver_repo_docs.py::test_link_carryover_does_not_hide_incoming_prose_loss`
+and `::test_repo_doc_token_overlap_still_conflicts_when_bodies_differ`.
 
 ## `%A` file-write contract (fixed by #4496)
 

--- a/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
+++ b/docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md
@@ -66,7 +66,9 @@ guard's contract):
   merge conflicts instead of resolving; link carryover is not a generic
   content-loss exemption.
 - A genuine near-duplicate pick (token similarity `>= 0.85`), scoped to vault
-  notes (a non-empty `uuid:` identity on both sides). Set-of-tokens
+  notes (a real `uuid:` scalar identity on both sides: quoted and unquoted
+  forms name the same identity, while empty, null-like (`null`/`~`), and
+  comment-only values do not count as identity at all). Set-of-tokens
   similarity ignores order, repetition, and negation ("deployment is enabled"
   vs "deployment is not enabled" clears the threshold), so repository
   documentation never resolves through it; a non-vault doc with high token

--- a/tests/agents/test_merge_resolver_repo_docs.py
+++ b/tests/agents/test_merge_resolver_repo_docs.py
@@ -150,8 +150,26 @@ def test_bare_uuid_key_does_not_grant_vault_near_duplicate_bypass():
 
 @pytest.mark.parametrize(
     "uuid_line",
-    ['uuid: ""', "uuid: null", "uuid: ~", "uuid: NULL", "uuid: # missing"],
-    ids=["quoted-empty", "null", "tilde", "upper-null", "comment-only"],
+    [
+        'uuid: ""',
+        "uuid: null",
+        "uuid: ~",
+        "uuid: NULL",
+        "uuid: # missing",
+        "uuid: >",
+        "uuid: *alias",
+        "uuid: !!null",
+    ],
+    ids=[
+        "quoted-empty",
+        "null",
+        "tilde",
+        "upper-null",
+        "comment-only",
+        "block-scalar",
+        "alias",
+        "tagged-null",
+    ],
 )
 def test_degenerate_uuid_scalars_do_not_grant_vault_near_duplicate_bypass(uuid_line):
     # PR #4626 Codex review r3712514848 (P1): `_extract_uuid` used to return

--- a/tests/agents/test_merge_resolver_repo_docs.py
+++ b/tests/agents/test_merge_resolver_repo_docs.py
@@ -79,6 +79,32 @@ def test_link_carryover_still_resolves_when_links_are_the_only_difference():
     assert "https://example.com/runbook" in merged
 
 
+def test_incoming_image_embed_is_not_treated_as_a_carried_link():
+    # Carryover appends plain markdown links only, so an incoming image embed
+    # can never be preserved verbatim in the merged body; the merge must
+    # conflict instead of resolving with the image demoted to a bare link.
+    base = "# T\n\nDeploy now! Done.\n"
+    a = "# T\n\nDeploy now! Done.\n"
+    b = "# T\n\nDeploy now![shot](https://example.com/s.png) Done.\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
+
+
+def test_links_only_incoming_body_still_resolves_via_carryover():
+    # THEIRS' body is nothing but a link; carrying it preserves everything
+    # THEIRS brings, so this remains a lossless resolve.
+    base = "shared base text\n"
+    a = "ours prose kept intact\n"
+    b = "[x](https://example.com/x)\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "resolved"
+    assert "https://example.com/x" in merged
+
+
 def test_link_carryover_containment_is_word_aligned():
     # THEIRS' "enabled in prod" must not count as preserved merely because
     # OURS happens to contain it as a fragment of "unenabled in prod": the

--- a/tests/agents/test_merge_resolver_repo_docs.py
+++ b/tests/agents/test_merge_resolver_repo_docs.py
@@ -79,6 +79,19 @@ def test_link_carryover_still_resolves_when_links_are_the_only_difference():
     assert "https://example.com/runbook" in merged
 
 
+def test_link_carryover_containment_is_word_aligned():
+    # THEIRS' "enabled in prod" must not count as preserved merely because
+    # OURS happens to contain it as a fragment of "unenabled in prod": the
+    # lossless-carryover containment check is word-aligned, not raw-substring.
+    base = "deployment status\n"
+    a = "unenabled in prod\n"
+    b = "enabled in prod [ref](https://example.com/r)\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
+
+
 def test_repo_doc_token_overlap_still_conflicts_when_bodies_differ():
     # PR #4604 review r3700682705 (#4616): set-of-tokens similarity ignores
     # order, repetition, and meaning -- "deployment is enabled" versus
@@ -88,6 +101,19 @@ def test_repo_doc_token_overlap_still_conflicts_when_bodies_differ():
     base = "# Runbook\n\ndeployment status pending\n"
     a = "# Runbook\n\ndeployment is enabled\n"
     b = "# Runbook\n\ndeployment is not enabled\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
+
+
+def test_bare_uuid_key_does_not_grant_vault_near_duplicate_bypass():
+    # A `uuid:` key with no value is not vault identity. The near-duplicate
+    # bypass must not treat it as one, or the token-overlap defect above comes
+    # back for any doc carrying an empty uuid field.
+    base = "---\nuuid:\n---\n# Runbook\n\ndeployment status pending\n"
+    a = "---\nuuid:\n---\n# Runbook\n\ndeployment is enabled\n"
+    b = "---\nuuid:\n---\n# Runbook\n\ndeployment is not enabled\n"
 
     merged, info = merge_note_from_blobs(base, a, b)
 

--- a/tests/agents/test_merge_resolver_repo_docs.py
+++ b/tests/agents/test_merge_resolver_repo_docs.py
@@ -3,6 +3,13 @@ repository documentation. A repo doc (no `uuid:` frontmatter, e.g. docs/**,
 README.md, AGENTS.md) whose two sides diverge must resolve to a conflict rather
 than have the near-duplicate / "prefer concise" heuristic pick one side wholesale
 and report MERGE_STATUS=resolved.
+
+Issue #4616 (PR #4604 reviews r3700682703 / r3700682705) tightened the two
+resolution mechanisms that could still produce a false-clean merge:
+link carryover only counts when THEIRS' entire non-link prose survives in the
+merged body, and the token-similarity near-duplicate bypass is scoped to vault
+notes (uuid identity on both sides) so repository docs never resolve through a
+lossy set-of-tokens comparison.
 """
 import pathlib
 
@@ -35,6 +42,56 @@ def test_repo_doc_identical_sides_still_resolve():
     merged, info = merge_note_from_blobs(base, a, b)
 
     assert info["status"] == "resolved"
+
+
+def test_link_carryover_does_not_hide_incoming_prose_loss():
+    # PR #4604 review r3700682703 (#4616): OURS has no markdown link and THEIRS
+    # has a link plus additional distinct prose. Carrying only the link into the
+    # merged text does not account for that prose; reporting "resolved" would
+    # let the git driver exit 0 while silently discarding THEIRS' non-link
+    # content. The carryover bypass must require the complete incoming body
+    # difference -- not merely its links -- to be preserved.
+    base = "# Guide\n\nShared setup steps.\n"
+    a = "# Guide\n\nShared setup steps, tightened by ours.\n"
+    b = (
+        "# Guide\n\n"
+        "Shared setup steps.\n\n"
+        "Theirs adds a distinct rollback warning that must not vanish.\n"
+        "See the [runbook](https://example.com/runbook) for details.\n"
+    )
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
+
+
+def test_link_carryover_still_resolves_when_links_are_the_only_difference():
+    # Safe counterpart to the test above: THEIRS differs from OURS only by a
+    # markdown link. Appending the link preserves everything THEIRS brings, so
+    # the carryover remains a trusted, lossless resolution.
+    base = "# Guide\n\nShared setup steps.\n"
+    a = "# Guide\n\nShared setup steps.\n"
+    b = "# Guide\n\nShared setup steps. [runbook](https://example.com/runbook)\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "resolved"
+    assert "https://example.com/runbook" in merged
+
+
+def test_repo_doc_token_overlap_still_conflicts_when_bodies_differ():
+    # PR #4604 review r3700682705 (#4616): set-of-tokens similarity ignores
+    # order, repetition, and meaning -- "deployment is enabled" versus
+    # "deployment is not enabled" scores above the 0.85 near-duplicate
+    # threshold while inverting the meaning. A repository doc (no vault
+    # identity) must never resolve through that lossy comparison.
+    base = "# Runbook\n\ndeployment status pending\n"
+    a = "# Runbook\n\ndeployment is enabled\n"
+    b = "# Runbook\n\ndeployment is not enabled\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
 
 
 def test_vault_note_merge_behavior_is_unchanged():

--- a/tests/agents/test_merge_resolver_repo_docs.py
+++ b/tests/agents/test_merge_resolver_repo_docs.py
@@ -13,6 +13,8 @@ lossy set-of-tokens comparison.
 """
 import pathlib
 
+import pytest
+
 from app.agents.merge_resolver.agent import merge_note_from_blobs
 
 
@@ -144,6 +146,44 @@ def test_bare_uuid_key_does_not_grant_vault_near_duplicate_bypass():
     merged, info = merge_note_from_blobs(base, a, b)
 
     assert info["status"] == "conflict"
+
+
+@pytest.mark.parametrize(
+    "uuid_line",
+    ['uuid: ""', "uuid: null", "uuid: ~", "uuid: NULL", "uuid: # missing"],
+    ids=["quoted-empty", "null", "tilde", "upper-null", "comment-only"],
+)
+def test_degenerate_uuid_scalars_do_not_grant_vault_near_duplicate_bypass(uuid_line):
+    # PR #4626 Codex review r3712514848 (P1): `_extract_uuid` used to return
+    # the raw text after `uuid:`, so degenerate YAML scalars produced truthy
+    # strings ('""', 'null', '# missing') and both-sides-degenerate documents
+    # took the vault-only near-duplicate bypass, silently discarding THEIRS'
+    # high-overlap-but-distinct body. A degenerate scalar is no identity.
+    base = f"---\n{uuid_line}\n---\n# Runbook\n\ndeployment status pending\n"
+    a = f"---\n{uuid_line}\n---\n# Runbook\n\ndeployment is enabled\n"
+    b = f"---\n{uuid_line}\n---\n# Runbook\n\ndeployment is not enabled\n"
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "conflict"
+
+
+def test_quoted_and_unquoted_uuid_are_the_same_identity():
+    # Quote normalization: `uuid: "u-q"` and `uuid: u-q` name the same logical
+    # note, so a genuine near-duplicate still resolves (no spurious hard
+    # conflict from the quoting difference), and the bypass stays limited to
+    # equal logical ids because divergent ids still hard-conflict upstream.
+    base = '---\nuuid: "u-q"\n---\n# Note\nBaseline text.\n'
+    a = '---\nuuid: "u-q"\n---\n# Note\nConcise phrasing of the idea.\n'
+    b = (
+        "---\nuuid: u-q\n---\n# Note\n"
+        "Concise phrasing of the idea, the idea, the idea, restated again.\n"
+    )
+
+    merged, info = merge_note_from_blobs(base, a, b)
+
+    assert info["status"] == "resolved"
+    assert "concise" in info["reason"].lower()
 
 
 def test_vault_note_merge_behavior_is_unchanged():

--- a/tests/cli/test_merge_driver.py
+++ b/tests/cli/test_merge_driver.py
@@ -84,9 +84,11 @@ B body
 
 def test_resolved_merge_writes_result_to_ours_path(tmp_path: Path):
     # Git's custom-merge-driver contract requires the result on %A (a_path).
-    # a has no markdown link; b has one that a lacks, so the semantic merge's
-    # link-carryover heuristic appends content that only exists on the incoming
-    # (b) side -- proving a_path ends up with more than a verbatim copy of a.
+    # a has no markdown link; b differs from a only by a markdown link, so the
+    # semantic merge's link-carryover heuristic appends content that only
+    # exists on the incoming (b) side without losing any incoming prose
+    # (#4616: lossy carryover no longer resolves) -- proving a_path ends up
+    # with more than a verbatim copy of a.
     base = """---
 uuid: u-write
 kind: concept
@@ -101,7 +103,7 @@ kind: concept
 review_state: reviewed
 ---
 # T
-ours body, no link
+shared body line
 """
     b = """---
 uuid: u-write
@@ -109,7 +111,7 @@ kind: concept
 review_state: reviewed
 ---
 # T
-theirs body with [a link](https://example.com/incoming)
+shared body line [a link](https://example.com/incoming)
 """
     base_path = _tmpfile(tmp_path, base)
     a_path = _tmpfile(tmp_path, a)
@@ -125,6 +127,44 @@ theirs body with [a link](https://example.com/incoming)
     assert written == expected_merged
     # The incoming (b) side's link must be present in what git reads back.
     assert "https://example.com/incoming" in written
+
+
+def test_merge_driver_conflicts_when_link_carryover_would_drop_incoming_prose(tmp_path: Path):
+    # PR #4604 review r3700682703 (#4616): THEIRS carries a markdown link plus
+    # distinct prose OURS lacks. Appending only the link would discard that
+    # prose, so the driver must fail closed (non-zero exit, a_path untouched)
+    # instead of writing a false-clean "resolved" result to %A.
+    base = """---
+uuid: u-lossy
+kind: concept
+review_state: draft
+---
+# T
+base body
+"""
+    a = """---
+uuid: u-lossy
+kind: concept
+review_state: reviewed
+---
+# T
+ours body, no link
+"""
+    b = """---
+uuid: u-lossy
+kind: concept
+review_state: reviewed
+---
+# T
+theirs distinct prose that must not vanish, with [a link](https://example.com/incoming)
+"""
+    a_path = _tmpfile(tmp_path, a)
+    ec = run_merge(_tmpfile(tmp_path, base), a_path, _tmpfile(tmp_path, b))
+
+    assert ec != 0
+    # On a non-resolved outcome the driver must leave %A exactly as git wrote
+    # it (OURS) so git's normal conflict machinery applies.
+    assert a_path.read_text(encoding="utf-8") == a
 
 
 def test_diagnostic_trailer_never_enters_merged_file(tmp_path: Path):
@@ -213,6 +253,9 @@ def test_end_to_end_git_merge_through_driver_preserves_incoming(tmp_path: Path):
     # Exercise the production .gitattributes + `git config merge.semanticmd.driver`
     # path (the same wiring set up by `make setup-merge-driver`), not run_merge()
     # directly, so a regression in how git invokes/reads the driver is caught too.
+    # THEIRS differs from OURS' body only by an added markdown link (#4616:
+    # carryover with distinct incoming prose now conflicts instead), so the
+    # link carryover is lossless and the merge must stay clean.
     repo = tmp_path / "repo"
     repo.mkdir()
 
@@ -240,7 +283,7 @@ kind: concept
 review_state: draft
 ---
 # T
-base body, no link
+shared body line, no link
 """
     note.write_text(base_body, encoding="utf-8")
     _git(["add", "."], repo, env)
@@ -251,10 +294,10 @@ base body, no link
     theirs_body = """---
 uuid: u-e2e
 kind: concept
-review_state: reviewed
+review_state: draft
 ---
 # T
-theirs body with [incoming link](https://example.com/incoming)
+shared body line, no link [incoming link](https://example.com/incoming)
 """
     note.write_text(theirs_body, encoding="utf-8")
     _git(["commit", "-q", "-am", "theirs edit"], repo, env)
@@ -266,7 +309,7 @@ kind: concept
 review_state: reviewed
 ---
 # T
-ours body, no link
+shared body line, no link
 """
     note.write_text(ours_body, encoding="utf-8")
     _git(["commit", "-q", "-am", "ours edit"], repo, env)


### PR DESCRIPTION
Governing-Issue: #4616

Fixes #4616

Final-Review-Rounds: 1

## Summary
Tightens the semanticmd content-loss backstop (`app/agents/merge_resolver/agent.py::_guard_content_loss`) so it closes both P1 content-loss findings left on PR #4604: link carryover now resolves only when it is verifiably lossless (all of THEIRS' links land in the merged body AND THEIRS' remaining non-link prose already appears, word-aligned and in order, in the merged body), and the token-similarity near-duplicate bypass is scoped to vault notes (non-empty `uuid:` identity on both sides), so a non-vault repository doc with high token overlap but distinct body content (e.g. a flipped negation) conflicts instead of resolving to OURS silently.

## Changes
- `app/agents/merge_resolver/agent.py`: added `_MD_LINK_RE` (recognizes image embeds so they fail closed), `_normalized_nonlink_text`, and `_carried_links_are_lossless`; `_guard_content_loss` now (a) trusts `carried links` only when the carryover is provably lossless and (b) applies the `>= 0.85` token-similarity bypass only with real vault `uuid:` identity on both sides. Docstring scoped to body content and names the pre-existing frontmatter gap explicitly.
- `app/agents/merge_resolver/agent.py` + `app/cli/merge_driver.py` (Codex review r3712514848, P1): new `normalize_uuid_scalar` — degenerate YAML scalars (`""`, `null`/`Null`/`NULL`/`~`, comment-only, and YAML indicator scalars such as `>`, `*alias`, `!!null`) are no identity; quotes and trailing plain-scalar comments are stripped so `uuid: "u-x"` and `uuid: u-x` name the same logical note. The resolver's hard-conflict invariant, the guard bypass, and the driver's uuid rail all share it, so identity semantics agree in both directions.
- `tests/agents/test_merge_resolver_repo_docs.py`: new regressions `test_link_carryover_does_not_hide_incoming_prose_loss`, `test_repo_doc_token_overlap_still_conflicts_when_bodies_differ` (both AC targets; both reproduced `status=resolved` against pre-fix main), plus `test_link_carryover_still_resolves_when_links_are_the_only_difference`, `test_link_carryover_containment_is_word_aligned`, `test_bare_uuid_key_does_not_grant_vault_near_duplicate_bypass`, `test_incoming_image_embed_is_not_treated_as_a_carried_link`, `test_links_only_incoming_body_still_resolves_via_carryover`, the parametrized `test_degenerate_uuid_scalars_do_not_grant_vault_near_duplicate_bypass` (8 degenerate forms, all proven `resolved` pre-fix), and `test_quoted_and_unquoted_uuid_are_the_same_identity`.
- `tests/cli/test_merge_driver.py`: new fail-closed driver test `test_merge_driver_conflicts_when_link_carryover_would_drop_incoming_prose` (non-zero exit, `%A` untouched); `test_resolved_merge_writes_result_to_ours_path` and `test_end_to_end_git_merge_through_driver_preserves_incoming` updated to genuinely lossless link-only divergences (their previous fixtures embodied exactly the r3700682703 defect).
- `docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md`: resolver-level backstop section rewritten for the tightened contract; History entry for #4616.
- `docs/STATUS.md`: 2026-08-04 fix-writeback entry for #4616.

## Anchor drift
The issue anchor `_guard_non_vault_content_loss` no longer exists on origin/main: PR #4604 renamed/generalized it to `_guard_content_loss` (`app/agents/merge_resolver/agent.py`). That function was treated as the nearest authoritative surface; the bounded contract was otherwise unambiguous from the issue body and the two PR #4604 review threads.

## Acceptance criteria resolution
- AC1 (link carryover no longer hides incoming prose loss): `tests/agents/test_merge_resolver_repo_docs.py::test_link_carryover_does_not_hide_incoming_prose_loss` — failed pre-fix (resolved with `carried links`), passes now (conflict).
- AC2 (token overlap no longer resolves distinct repo-doc bodies): `::test_repo_doc_token_overlap_still_conflicts_when_bodies_differ` — failed pre-fix, passes now.
- AC3 (safe behavior kept): `::test_repo_doc_identical_sides_still_resolve`, `::test_vault_note_merge_behavior_is_unchanged`, and `tests/cli/test_merge_driver.py::test_resolved_merge_writes_result_to_ours_path` all pass; the driver test now pins the no-prose-lost carryover scenario per the AC wording.

## SBS Impact
- Primary subsystem: Product/Runtime System - vault/repo markdown merge behavior
- Secondary subsystem(s): Builder System git tooling - the semanticmd merge driver used during development merges and rebases
- Write class: authority-bearing merge output for checked-in docs and vault notes
- Persistence impact: durable working-tree content after git merge / git rebase
- Derived/rebuildable impact: none
- New or changed contract: semanticmd must not report resolved when link carryover or token-similarity reasoning leaves distinct non-carried prose from either side unrepresented
- Owner-doc impact: docs/development/SEMANTIC_MARKDOWN_MERGE_DRIVER.md updated (resolver-level backstop contract changed); docs/STATUS.md fix-writeback entry added
- Transition debt impact: reduces false-clean semantic merge risk left after #4603
- Boundary risk: conservative conflict posture for repository documentation strengthened, not weakened

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## BuilderOps Routing
- Records/projections/receipts: dispatcher claim receipt (task_id=github-RasmusTho--agentic-pkm-mvp-issue-4616, lease_id=lease-3007d022, holder=claude-w1b, evidence=verified-dispatcher-lease); mechanism convergence packet (semanticmd-content-loss-guard) plus independent high-capability convergence review of the initial fix (CLEAN, no P0/P1); independent convergence review at f4208b0a2: clean, 3xP3 dispositioned (N1 image pin test adopted, N2 links-only lossless one-liner adopted, N3 recorded as out-of-scope residual). Head b29e94c72 differs from the reviewed f4208b0a2 only by that P3-disposition commit: one strictly-tightening pin test, one reviewer-proposed one-liner restoring the reviewed lossless behavior for links-only incoming bodies, both test-pinned.
- Reason: data/content-loss risk surface; Review-Before-CI gate run in risk-convergence form with --risk-surface data (status=satisfied). No LearningSignal: no plan divergence.
- P1 repair round (Codex review r3712514848): fixed by 05f9184de + ed8c60732; independent delta re-review of the repair at 05f9184de: CLEAN, no P0/P1, 2xP3 dispositioned (indicator-scalar hardening adopted and test-pinned in ed8c60732; one-sided-identity frontmatter drop recorded as pre-existing residual below).

## Claim receipt
`pickup-claim-complete issue=4616 branch=fix/4616-semanticmd-lossy-carryover worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a63234f8f19d8daf0 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4616 lease_id=lease-3007d022 holder=claude-w1b evidence=verified-dispatcher-lease`

## Notes
Validation (all at head ed8c60732, rebased onto origin/main d213a2dba):
- `pytest -q tests/agents/test_merge_resolver_repo_docs.py tests/agents/test_merge_resolver.py tests/cli/test_merge_driver.py tests/smoke/test_merge_smoke.py` — 33 passed
- `ruff check app tests` — all checks passed
- `python3 scripts/docs_guard.py` — OK
- `git diff --check` — clean
- `python3 scripts/review_before_ci_gate.py --lane implementation --risk-assessment-complete --risk-surface data --review-gate-complete ...` — ok
- Test-first evidence: both AC regression tests plus the driver-level fail-closed test failed against pre-fix main (`resolved`/exit 0) before the fix landed.

Residual (documented, out of scope, pre-existing): frontmatter divergence beyond the uuid invariant still resolves to OURS' frontmatter (named in the guard docstring and owner doc) — this includes the one-sided-identity case where OURS carries a degenerate `uuid:` and THEIRS a real one with identical bodies, so THEIRS' uuid assignment is dropped (candidate follow-up: conflict or adopt the real id when exactly one side has identity); repeated identical links collapse to one on carryover; a false conflict occurs when THEIRS linkifies an existing word without a preceding space (e.g. `See.` vs `See [x](y)`) because word boundaries are space-only — fail-closed, candidate follow-up; `docs/DOCS_INDEX.md` summary row for the merge-driver doc is stale since #4603.
---
