### PR TITLE
Report dispatcher pull kill-switch truncation as partial sync

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -34,6 +34,7 @@ from app.dispatcher.sync_github import (
     GhCliIssueSource,
     PullSyncAdapter,
     get_sync_meta,
+    get_sync_meta_readonly,
 )
 
 REQUIRED_COMMANDS = frozenset([
@@ -323,6 +324,7 @@ def _cmd_status(args: argparse.Namespace, store: SqliteStore) -> int:
     status = singleton_status(paths)
     control_plane: dict[str, Any]
     fallback_reason: str | None = None
+    last_sync: dict[str, Any] | None = None
     if status["db_exists"]:
         from app.dispatcher.control_plane import readonly_state
         try:
@@ -334,12 +336,25 @@ def _cmd_status(args: argparse.Namespace, store: SqliteStore) -> int:
                 "error": str(exc),
             }
             fallback_reason = "dispatcher_db_uninitialized"
+        # Additive last-sync summary so pickup tooling can distinguish a
+        # complete sync from a kill-switch partial one without spending
+        # GitHub API calls (#4606). Read-only: status is an observation
+        # command and must not initialize or migrate the database.
+        sync_meta = get_sync_meta_readonly(paths.db_path, PROVIDER_IDENTITY)
+        if sync_meta:
+            last_sync = {
+                "last_pull_at": sync_meta.get("last_pull_at"),
+                "sync_result": sync_meta.get("sync_result"),
+                "sync_note": sync_meta.get("sync_note"),
+                "kill_switch_active": bool(sync_meta.get("kill_switch_active")),
+            }
     else:
         control_plane = {"mode": "unavailable", "revision": None}
     _emit({
         "ok": True,
         **status,
         "control_plane": control_plane,
+        "last_sync": last_sync,
         **_coordination_payload(
             bool(status["db_exists"]) and fallback_reason is None,
             fallback_reason=fallback_reason,
@@ -492,6 +507,8 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
     total_reconciled = 0
     per_repo: dict[str, dict[str, Any]] = {}
     failures: list[str] = []
+    partials: list[str] = []
+    kill_switch_partial = False
     last_sync_result: str | None = None
     last_sync_note: str | None = None
     try:
@@ -515,6 +532,17 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
                 repo_entry["sync_note"] = note or "dispatcher pull source failed"
                 failures.append(f"{repo}: {repo_entry['sync_note']}")
             else:
+                # Partial is not a hard source failure (#4606): the essential
+                # ready read succeeded, so its upserts count — but the
+                # truncation must stay visible per repo and top-level.
+                if result == "partial":
+                    repo_entry["sync_note"] = note or "dispatcher pull partial sync"
+                    repo_entry["kill_switch_active"] = bool(
+                        sync_meta.get("kill_switch_active")
+                    )
+                    if repo_entry["kill_switch_active"]:
+                        kill_switch_partial = True
+                    partials.append(f"{repo}: {repo_entry['sync_note']}")
                 total_upserted += len(upserted)
                 total_reconciled += reconciled
             per_repo[repo] = repo_entry
@@ -539,7 +567,7 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
         }, args.json)
         return 1
 
-    _emit({
+    payload: dict[str, Any] = {
         "ok": True,
         "upserted": total_upserted,
         "reconciled": total_reconciled,
@@ -548,7 +576,14 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
         "sync_result": last_sync_result,
         "sync_note": last_sync_note,
         "repos": per_repo,
-    }, args.json)
+    }
+    if partials:
+        # In a mixed multi-repo pull the last-processed repo can be a complete
+        # one; the aggregate outcome must still read as partial (#4606).
+        payload["sync_result"] = "partial"
+        payload["sync_note"] = "; ".join(partials)
+        payload["kill_switch_active"] = kill_switch_partial
+    _emit(payload, args.json)
     return 0
 
 

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -422,6 +422,37 @@ def record_sync_success(
     _write_sync_meta(store, provider, sync_state, pull_at)
 
 
+def record_sync_partial(
+    store: DispatcherStore,
+    provider: str,
+    pull_at: str,
+    note: str,
+    rate_limit_remaining: int | None = None,
+    rate_limit_reset: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Persist a degraded/partial pull-sync metadata record for *provider*.
+
+    Used when the essential ready read succeeded but a non-essential scan was
+    suppressed (e.g. the rate-limit kill switch), so the queue projection is
+    honestly partial rather than falsely complete (#4606). Not a hard source
+    failure: task upserts from the essential read are preserved.
+    """
+    merged: dict[str, Any] = dict(extra or {})
+    if rate_limit_remaining is not None:
+        merged["rate_limit_remaining"] = rate_limit_remaining
+    if rate_limit_reset is not None:
+        merged["rate_limit_reset"] = rate_limit_reset
+
+    sync_state = SyncState(
+        last_pull_at=pull_at,
+        sync_result="partial",
+        sync_note=note,
+        extra=merged,
+    )
+    _write_sync_meta(store, provider, sync_state, pull_at)
+
+
 def record_sync_failure(
     store: DispatcherStore,
     provider: str,
@@ -474,6 +505,37 @@ def get_sync_meta(store: DispatcherStore, provider: str) -> dict[str, Any] | Non
     if record is None:
         return None
     return record.sync_state
+
+
+def get_sync_meta_readonly(db_path: Any, provider: str) -> dict[str, Any] | None:
+    """Read the last recorded sync metadata without touching the database.
+
+    Observation commands (``dispatcher status``) must not open the store's
+    normal connection path, which self-heals the schema and mutates the file.
+    SQLite's ``mode=ro`` URI guarantees a pure read; any open/shape error
+    yields ``None`` rather than an initialized or migrated database (#4606).
+    """
+    import json as _json
+    import sqlite3 as _sqlite3
+    from pathlib import Path as _Path
+
+    uri = f"{_Path(db_path).resolve().as_uri()}?mode=ro"
+    try:
+        with _sqlite3.connect(uri, uri=True) as conn:
+            conn.execute("PRAGMA query_only = ON")
+            row = conn.execute(
+                "SELECT sync_state FROM dispatcher_tasks WHERE task_id = ?",
+                (_meta_task_id(provider),),
+            ).fetchone()
+    except _sqlite3.Error:
+        return None
+    if row is None or row[0] is None:
+        return None
+    try:
+        payload = _json.loads(row[0])
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 # ---------------------------------------------------------------------------
@@ -852,14 +914,32 @@ class PullSyncAdapter:
         extra["reconciled_count"] = reconciled
         extra["kill_switch_active"] = kill_switch
 
-        record_sync_success(
-            self._store,
-            self._provider,
-            pull_at,
-            rate_limit_remaining=rl_remaining,
-            rate_limit_reset=rl_reset,
-            extra=extra,
-        )
+        if kill_switch:
+            # The essential ready read succeeded, but the suppressed
+            # open-issues scan makes the queue projection partial. Record a
+            # machine-readable degraded outcome instead of a false-green ok
+            # (#4606, lrn_20260730235456_f70f8ccc).
+            record_sync_partial(
+                self._store,
+                self._provider,
+                pull_at,
+                note=(
+                    "kill switch active: non-essential open-issues scan "
+                    "skipped; queue projection is partial"
+                ),
+                rate_limit_remaining=rl_remaining,
+                rate_limit_reset=rl_reset,
+                extra=extra,
+            )
+        else:
+            record_sync_success(
+                self._store,
+                self._provider,
+                pull_at,
+                rate_limit_remaining=rl_remaining,
+                rate_limit_reset=rl_reset,
+                extra=extra,
+            )
         return upserted
 
     def _reconcile_stale_ready(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -506,7 +506,7 @@ Event types (minimum):
 When present, `sync_state` may include:
 - `last_pull_at` (RFC3339)
 - `source_version` (etag/hash/updated marker)
-- `sync_result` (`ok`, `stale`, `conflict`, `error`)
+- `sync_result` (`ok`, `partial`, `stale`, `conflict`, `error`)
 - `sync_note` (string)
 - `labels` (list of GitHub label names, recorded on every pull since #4441)
 - `url` (the issue's browser `html_url`, or null; Signboard cards and the
@@ -665,6 +665,26 @@ If the `GitHubIssueSource` raises during `list_issues`:
 Observable signals:
 - Sync meta row (`_sync_meta:github`) carries `sync_result` and `sync_note` for last-attempt observability.
 - `get_sync_meta(store, provider)` returns the raw metadata dict for CLI or diagnostic use.
+
+## Kill-Switch Partial Sync (#4606)
+
+When the GitHub rate-limit kill switch (`app/dispatcher/github_call_logger.py::is_kill_switch_active`)
+suppresses the non-essential open-issues scan, the pull is truncated, not failed:
+
+- The essential `agent:ready` read still runs and its upserts are preserved; no additional GitHub
+  API calls are spent.
+- `record_sync_partial` writes `sync_result=partial` with `kill_switch_active=true` and a
+  machine-readable `sync_note` — never a plain `ok` (the false-green captured by LearningSignal
+  `lrn_20260730235456_f70f8ccc`).
+- `python -m app.dispatcher pull --json` keeps `ok=true`/exit 0 (not a hard source failure) but
+  reports `sync_result=partial` and `kill_switch_active=true` top-level and per repo.
+- `python -m app.dispatcher status --json` exposes an additive read-only `last_sync` summary
+  (`last_pull_at`, `sync_result`, `sync_note`, `kill_switch_active`) so pickup tooling can
+  distinguish a complete sync from a truncated one without spending GitHub API calls.
+- `scripts/issue_pickup_claim.sh` routes a missing-task claim failure that follows a kill-switch
+  partial sync to explicit GitHub-label-only fallback guidance
+  (`--coordination-mode github-label-only-fallback --fallback-reason kill-switch-partial-sync`)
+  instead of an opaque missing-task failure; `agent:ready` is left untouched on that path.
 
 ## Optional Future Projections
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -675,6 +675,14 @@ Platform-side governance applied:
 - local Agent Issue Dispatcher hot-path coordination is now active: agents use dispatcher
   `status` / `next` / `claim` / `heartbeat` / `complete` for operational pickup while GitHub
   Issues, labels, and PR state remain the durable lifecycle truth
+- dispatcher pull sync is honest under the GitHub rate-limit kill switch (#4606,
+  LearningSignal `lrn_20260730235456_f70f8ccc`): a kill-switch-truncated pull records
+  `sync_result=partial` with `kill_switch_active=true` instead of a false-green `ok`,
+  `dispatcher pull --json` and the additive read-only `last_sync` block in
+  `dispatcher status --json` surface the partial outcome, and
+  `scripts/issue_pickup_claim.sh` routes a missing-task claim failure after such a sync to
+  explicit GitHub-label-only fallback guidance (see
+  `docs/AGENT_ISSUE_DISPATCHER.md :: Kill-Switch Partial Sync (#4606)`)
 - the verification-dispatch integration line now fails closed on exact-head, authoritative
   `github-actions` required-check evidence, preserves review/repair budgets across restart, and
   rejects ambiguous legacy active-plus-terminal authority chains. Host rollout remains disabled

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -179,6 +179,45 @@ remove_ready_label() {
     "repos/$REPO/issues/$ISSUE_NUMBER/labels/agent%3Aready" >/dev/null
 }
 
+# Distinguish a genuinely failed claim from a task row that is absent only
+# because the last dispatcher pull was truncated by the GitHub rate-limit kill
+# switch (#4606). Reads local dispatcher state only; spends no GitHub API calls.
+classify_claim_failure() {
+  local status_json
+  status_json="$("$PYTHON_BIN" -m app.dispatcher status --json 2>/dev/null || true)"
+  DISPATCHER_CLAIM_JSON="$1" \
+  DISPATCHER_STATUS_JSON="$status_json" \
+  "$JSON_PYTHON_BIN" - <<'PY'
+import json
+import os
+
+
+def _load(name):
+    try:
+        payload = json.loads(os.environ.get(name) or "")
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+claim = _load("DISPATCHER_CLAIM_JSON")
+status = _load("DISPATCHER_STATUS_JSON")
+error = claim.get("error")
+missing_task = isinstance(error, str) and "not found" in error
+last_sync = status.get("last_sync")
+if not isinstance(last_sync, dict):
+    last_sync = {}
+if (
+    missing_task
+    and last_sync.get("sync_result") == "partial"
+    and last_sync.get("kill_switch_active") is True
+):
+    print("kill-switch-partial-sync")
+else:
+    print("claim-failed")
+PY
+}
+
 release_dispatcher_claim() {
   local release_json
   if ! release_json="$(
@@ -211,6 +250,17 @@ PY
 if [[ "$RECEIPT_COORDINATION_MODE" == "dispatcher-backed" ]]; then
   claim_json=""
   if ! claim_json="$("$PYTHON_BIN" -m app.dispatcher claim "$TASK_ID" --agent "$AGENT_ID" --ttl-minutes "$TTL_MINUTES" --json)"; then
+    claim_failure_mode="$(classify_claim_failure "$claim_json" || echo claim-failed)"
+    if [[ "$claim_failure_mode" == "kill-switch-partial-sync" ]]; then
+      {
+        echo "claim-missing-task issue=$ISSUE_NUMBER task_id=$TASK_ID cause=kill-switch-partial-sync sync_result=partial kill_switch_active=true evidence=dispatcher-status-last-sync"
+        echo "the GitHub rate-limit kill switch truncated the last dispatcher pull; the local queue is honestly partial and the task row for issue $ISSUE_NUMBER may be legitimately absent."
+        echo "route to explicit GitHub-label-only fallback instead of re-syncing:"
+        echo "  scripts/issue_pickup_claim.sh --issue $ISSUE_NUMBER --repo $REPO --agent $AGENT_ID --session $SESSION_ID --coordination-mode github-label-only-fallback --fallback-reason kill-switch-partial-sync"
+        echo "agent:ready was not removed"
+      } >&2
+      exit 1
+    fi
     echo "dispatcher claim failed for expected task $TASK_ID; agent:ready was not removed" >&2
     exit 1
   fi

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -776,6 +776,60 @@ def test_pull_command_reports_sync_source_failure(tmp_env):
 
 
 # ---------------------------------------------------------------------------
+# AC (#4606): _cmd_pull preserves successful upserts from the essential ready
+#     read while making a kill-switch partial sync visible and non-ambiguous.
+# Verify: test_pull_json_surfaces_kill_switch_partial_sync
+# ---------------------------------------------------------------------------
+
+def test_pull_json_surfaces_kill_switch_partial_sync(tmp_env):
+    """pull --json must expose a kill-switch-truncated sync as partial, not a
+    plain ok-complete receipt (#4606, lrn_20260730235456_f70f8ccc)."""
+    from unittest.mock import MagicMock, patch
+    from app.dispatcher.sync_github import GitHubIssueSource
+
+    _run(["init", "--json"])
+
+    mock_source = MagicMock(spec=GitHubIssueSource)
+    mock_source.list_issues.return_value = [
+        {
+            "number": 101,
+            "title": "Test issue 1",
+            "state": "open",
+            "labels": [{"name": "prio:high"}, {"name": "agent:ready"}],
+            "createdAt": "2026-04-20T10:00:00Z",
+            "updatedAt": "2026-04-21T12:00:00Z",
+            "body": VALID_READY_BODY,
+        }
+    ]
+    # Remaining below the kill-switch threshold suppresses the open-issue scan.
+    mock_source.get_rate_limit.return_value = {"remaining": 10, "reset": None}
+
+    with patch("app.dispatcher.cli.GhCliIssueSource", return_value=mock_source):
+        code, data = _run(["pull", "--repo", "test/repo", "--json"])
+
+    # Not a hard failure: the essential ready read succeeded.
+    assert code == 0, data
+    mock_source.list_open_issues.assert_not_called()
+    assert data["ok"] is True
+    assert data["upserted"] == 1
+    # Machine-readable non-complete outcome.
+    assert data["sync_result"] == "partial"
+    assert data["kill_switch_active"] is True
+    repo_entry = data["repos"]["test/repo"]
+    assert repo_entry["sync_result"] == "partial"
+    assert repo_entry["upserted"] == 1
+    assert repo_entry["kill_switch_active"] is True
+
+    # The wrapper's dispatcher-pull consumption path reads status --json, so
+    # the real status surface must expose the same partial outcome.
+    code, status_data = _run(["status", "--json"])
+    assert code == 0
+    last_sync = status_data["last_sync"]
+    assert last_sync["sync_result"] == "partial"
+    assert last_sync["kill_switch_active"] is True
+
+
+# ---------------------------------------------------------------------------
 # AC: dispatcher next --json on a missing DB exits 1 with
 #     {"ok": false, "error": "...dispatcher not initialised..."}
 # Verify: test_guard_missing_db

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -858,6 +858,58 @@ def test_pull_kill_switch_fires_when_graphql_exhausted_and_core_healthy(
     assert sync_meta.get("kill_switch_active") is True
 
 
+def test_pull_reports_partial_when_kill_switch_skips_open_issue_scan(
+    tmp_store: SqliteStore,
+) -> None:
+    """A kill-switch-truncated pull must record a machine-readable partial
+    outcome, not plain ok-complete success (#4606,
+    LearningSignal lrn_20260730235456_f70f8ccc).
+
+    The essential agent:ready read still succeeds and upserts, but the
+    suppressed open-issues scan means the queue projection is honestly
+    partial — sync metadata must say so.
+    """
+    source = _mock_source(
+        [SAMPLE_ISSUE_HIGH],
+        rate_limit={"remaining": 10, "reset": "2026-07-31T00:00:00Z"},
+    )
+
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+    upserted = adapter.pull(REPO)
+
+    # Constraint: the essential ready read is preserved under the kill switch.
+    assert [task.issue_number for task in upserted] == [101]
+    # Constraint: no additional GitHub API spend — the expensive scan stays off.
+    source.list_open_issues.assert_not_called()
+
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "partial"
+    assert meta.get("kill_switch_active") is True
+    note = meta.get("sync_note") or ""
+    assert "kill" in note and "open-issues" in note
+
+
+def test_pull_sync_result_stays_ok_when_kill_switch_inactive(
+    tmp_store: SqliteStore,
+) -> None:
+    """Complete-sync success behavior is unchanged when the kill switch is
+    inactive and both scans succeed (#4606 constraint)."""
+    source = _mock_source(
+        [SAMPLE_ISSUE_HIGH],
+        rate_limit={"remaining": 5000, "reset": "2026-07-31T00:00:00Z"},
+    )
+
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+    adapter.pull(REPO)
+
+    source.list_open_issues.assert_called_once()
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "ok"
+    assert meta.get("kill_switch_active") is False
+
+
 def test_gh_cli_get_rate_limit_returns_none_on_gh_failure() -> None:
     """Non-zero gh exit (auth failure, invalid flags, network error) yields None, not a crash."""
     source = GhCliIssueSource()

--- a/tests/scripts/test_issue_pickup_claim.py
+++ b/tests/scripts/test_issue_pickup_claim.py
@@ -443,3 +443,92 @@ def test_label_delete_and_release_failure_reports_cleanup_failed_evidence(
     assert "holder=codex-3301" in result.stderr
     assert "cleanup=released" not in result.stderr
     assert "pickup-claim-complete" not in result.stdout
+
+
+def test_kill_switch_partial_sync_routes_to_label_only_fallback(tmp_path: Path) -> None:
+    """When the expected task row is absent and the last dispatcher sync was a
+    kill-switch partial, the wrapper must route to explicit GitHub-label-only
+    fallback guidance instead of an opaque missing-task failure (#4606,
+    lrn_20260730235456_f70f8ccc)."""
+    worktree, env = _make_harness(
+        tmp_path,
+        status_json=json.dumps(
+            {
+                "ok": True,
+                "db_exists": True,
+                "coordination_mode": "dispatcher-backed",
+                "fallback_reason": None,
+                "last_sync": {
+                    "last_pull_at": "2026-07-30T23:54:56+00:00",
+                    "sync_result": "partial",
+                    "sync_note": (
+                        "kill switch active: non-essential open-issues scan skipped"
+                    ),
+                    "kill_switch_active": True,
+                },
+            }
+        ),
+        claim_json=json.dumps(
+            {
+                "ok": False,
+                "error": "Task github-RasmusTho--agentic-pkm-mvp-issue-3301 not found",
+            }
+        ),
+        claim_rc=1,
+    )
+
+    result = _run(worktree, env)
+
+    assert result.returncode != 0
+    assert "pickup-claim-complete" not in result.stdout
+    # The failure names the real cause, machine-readably.
+    assert "cause=kill-switch-partial-sync" in result.stderr
+    assert "sync_result=partial" in result.stderr
+    assert "kill_switch_active=true" in result.stderr
+    # Explicit label-only fallback routing guidance with the exact rerun.
+    assert "--coordination-mode github-label-only-fallback" in result.stderr
+    assert "--fallback-reason kill-switch-partial-sync" in result.stderr
+    assert "--issue 3301" in result.stderr
+    # No label mutation happened on this path.
+    commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert "gh api --method DELETE" not in commands
+
+
+def test_missing_task_without_partial_sync_keeps_opaque_claim_failure(
+    tmp_path: Path,
+) -> None:
+    """A missing task after a complete (ok) sync is a genuine claim failure and
+    must not be routed to label-only fallback guidance (#4606)."""
+    worktree, env = _make_harness(
+        tmp_path,
+        status_json=json.dumps(
+            {
+                "ok": True,
+                "db_exists": True,
+                "coordination_mode": "dispatcher-backed",
+                "fallback_reason": None,
+                "last_sync": {
+                    "last_pull_at": "2026-07-30T23:54:56+00:00",
+                    "sync_result": "ok",
+                    "sync_note": None,
+                    "kill_switch_active": False,
+                },
+            }
+        ),
+        claim_json=json.dumps(
+            {
+                "ok": False,
+                "error": "Task github-RasmusTho--agentic-pkm-mvp-issue-3301 not found",
+            }
+        ),
+        claim_rc=1,
+    )
+
+    result = _run(worktree, env)
+
+    assert result.returncode != 0
+    assert "pickup-claim-complete" not in result.stdout
+    assert "cause=kill-switch-partial-sync" not in result.stderr
+    assert "dispatcher claim failed for expected task" in result.stderr
+    commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert "gh api --method DELETE" not in commands


### PR DESCRIPTION
Governing-Issue: #4606

Fixes #4606

Final-Review-Rounds: 0

## Summary
`dispatcher pull` reported `{ok: true}` while the GitHub rate-limit kill switch had suppressed the expensive open-issue scan, leaving the queue silently partial (LearningSignal `lrn_20260730235456_f70f8ccc`). Kill-switch-truncated pulls now record and surface a machine-readable `sync_result="partial"` with `kill_switch_active=true`, and the pickup wrapper routes the resulting missing-task claim failure to explicit GitHub-label-only fallback guidance instead of an opaque failure.

## Changes
- `app/dispatcher/sync_github.py`: new `record_sync_partial` helper; `PullSyncAdapter.pull` records `sync_result="partial"` plus a machine-readable `sync_note` and `kill_switch_active=true` when the kill switch suppresses the open-issues scan. Essential `agent:ready` read, its upserts, and zero-additional-API-spend behavior are preserved; complete-sync `ok` behavior unchanged when the kill switch is inactive. New `get_sync_meta_readonly` reads sync meta via a `mode=ro` SQLite URI so observation paths never initialize/migrate the DB.
- `app/dispatcher/cli.py::_cmd_pull`: partial is not a hard source failure — exit stays 0 and upserts count, but the receipt reports `sync_result="partial"`, `kill_switch_active=true`, and per-repo partial detail (aggregate stays partial in mixed multi-repo pulls). `_cmd_status` gains an additive read-only `last_sync` summary (`last_pull_at`, `sync_result`, `sync_note`, `kill_switch_active`).
- `scripts/issue_pickup_claim.sh`: on a dispatcher claim failure, a local-only classifier (no GitHub API spend) distinguishes a missing task row after a kill-switch partial sync and emits explicit label-only fallback guidance (`--coordination-mode github-label-only-fallback --fallback-reason kill-switch-partial-sync`) with the exact rerun command; `agent:ready` stays untouched on that path. Genuine claim failures keep the existing message.
- Docs writeback: `docs/AGENT_ISSUE_DISPATCHER.md` (adds `partial` to the sync-result enumeration and a `Kill-Switch Partial Sync (#4606)` section) and `docs/STATUS.md` (delivery-governance snapshot note).
- Tests: sync-adapter partial recording + ok-preservation, CLI pull/status surfacing, wrapper fallback routing + non-partial opaque-failure preservation.

## Acceptance Criteria mapping
- Sync metadata + `pull --json` expose non-complete outcome — Verify: `tests/dispatcher/test_sync_github.py::test_pull_reports_partial_when_kill_switch_skips_open_issue_scan` (plus `::test_pull_sync_result_stays_ok_when_kill_switch_inactive` guarding the unchanged complete-sync path)
- `_cmd_pull` preserves upserts while making partial visible — Verify: `tests/dispatcher/test_cli.py::test_pull_json_surfaces_kill_switch_partial_sync`
- Pickup wrapper routes kill-switch partial sync to explicit label-only fallback guidance — Verify: `tests/scripts/test_issue_pickup_claim.py::test_kill_switch_partial_sync_routes_to_label_only_fallback` (plus `::test_missing_task_without_partial_sync_keeps_opaque_claim_failure`)

All three AC tests were written first and failed against unchanged `origin/main` (false-green reproduced) before the fix.

## BuilderOps Routing
- Records/projections/receipts: applies LearningSignal `builderops_object:lrn_20260730235456_f70f8ccc` (named by the governing issue); dispatcher-backed pickup claim receipt below; dispatcher queue projection now honestly partial under kill switch.
- Reason: bug slice repairing a dispatcher false-green captured by an existing LearningSignal; no new BuilderOps record needed beyond applying it.

## Claim receipt
`pickup-claim-complete issue=4606 branch=fix/4606-dispatcher-pull-partial-sync worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a9fc3db170f71c141 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4606 lease_id=lease-5c2f012f holder=claude-w2b evidence=verified-dispatcher-lease`

## Notes
Validation (on rebased head `746fd6368`):
- `pytest tests/dispatcher/ tests/scripts/test_issue_pickup_claim.py -q` — 1212 passed
- `pytest tests/dispatcher/test_sync_github.py tests/dispatcher/test_cli.py tests/scripts/test_issue_pickup_claim.py -q` — 95 passed (issue's Suggested Validation)
- `pytest tests/architecture/test_dispatcher_skill_integration.py tests/builderops/test_delivery_orchestration_contracts.py tests/dispatcher/test_worktree_portability.py -q` — 37 passed (other wrapper consumers)
- `ruff check app tests companion-ui/companion-app` — all checks passed
- `bash -n scripts/issue_pickup_claim.sh` — clean; `git diff --check` — clean
- `python3 scripts/docs_guard.py` — OK; `pytest tests/governance/test_issue_pr_governance.py -q` — 103 passed
- `scripts/review_before_ci_gate.py --lane implementation` — satisfied (risk assessment complete, no declared high-risk surface; Tier 2 light path)
---

🤖 Generated with [Claude Code](https://claude.com/claude-code)