### PR TITLE
bug-to-issue: dedupe CI failures by stable workflow/job/step identity

### DIFF
--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -195,8 +195,22 @@ authority across the current open registry instead of reopening history or dupli
 1. Resolve repo:
    - If repo specified, use it.
    - If not, infer from current git remote; if still unknown, ask for `owner/repo`.
-2. Check for existing issue:
-   - Search open issues for the same symptom/title. If a matching issue exists, comment with new evidence instead of creating a duplicate.
+2. Check for existing issue (live, immediately before creating one):
+   - **CI/test failures dedupe by stable failure identity first, not prose.** When the bug is a
+     CI or test failure, compare stable failure identity against open issues before relying on
+     prose title, symptom wording, or attributed subsystem: workflow name, job name, step name,
+     the failing script/test target, and the raised exception/error class when available. Two
+     reporters can describe the same red step with unrelated symptoms — motivating duplicate
+     class: #4463 was filed as distinct from #4371 although both described the same failing
+     `smoke-docker` / `CI gate: vaultwide panel verifier` step. Cite them as precedent only; do
+     not reopen either closed issue.
+   - A match on the same workflow/job/step plus the same script/test target or error class is a
+     duplicate: comment on the existing issue with the new evidence instead of creating another.
+     Failures that share a workflow but differ by job, step, script/test target, or error class
+     are distinct defects — do not collapse them into one issue.
+   - Keep the existing same-symptom/title search as the secondary key: it remains the primary
+     search for non-CI bugs and the fallback when stable identity fields are unavailable. If a
+     matching issue exists, comment with new evidence instead of creating a duplicate.
 3. Create or update Issue body:
    - Always use the canonical contract sections from `.codex/skills/_shared/ISSUE_CONTRACT.md`.
    - Classify the defect as Product/Runtime System, Builder System, or boundary work using

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -7,6 +7,7 @@ seeded into a synthetic tree.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scripts.lint_skills_consistency import run_lint
@@ -374,6 +375,74 @@ def test_lint_fails_when_pr_contract_validator_flags_diverge_from_workflow(
     assert any(
         "TIER1_LANE_PATTERN" in e and "flags" in e for e in errors
     ), errors
+
+
+def test_bug_to_issue_duplicate_search_requires_stable_ci_identity() -> None:
+    """CI/test duplicate search must key on stable failure identity, not prose.
+
+    Regression guard for issue #4607 (LearningSignal
+    lrn_20260731204320_6025370c): #4463 was filed as distinct from #4371
+    because the prose symptoms differed, although both described the same
+    failing workflow/job/step. The `bug-to-issue` workflow must require
+    comparing stable CI failure identity (workflow name, job name, step name,
+    script/test target, exception/error class when available) before relying
+    on prose title/symptom or attributed subsystem. The assertions below are
+    semantic markers: they fail if the instruction regresses to
+    title/symptom-only matching, but tolerate rewording and reformatting.
+    """
+    skill = REPO_ROOT / ".codex" / "skills" / "bug-to-issue" / "SKILL.md"
+    text = skill.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## Normal bounded bug-Issue workflow$(.*?)(?=^## |\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, (
+        f"{skill}: section '## Normal bounded bug-Issue workflow' not found"
+    )
+    section = match.group(1)
+    lowered = section.lower()
+
+    # Every stable CI identity key must be named in the duplicate-search step.
+    for identity_key in ("workflow name", "job name", "step name"):
+        assert identity_key in lowered, (
+            f"duplicate-search guidance no longer names the stable CI identity "
+            f"key '{identity_key}'"
+        )
+    assert "test target" in lowered or "script" in lowered, (
+        "duplicate-search guidance no longer names the failing script/test target"
+    )
+    assert "error class" in lowered or "exception" in lowered, (
+        "duplicate-search guidance no longer names the raised exception/error class"
+    )
+
+    # Identity must be the primary key: stated as compared before prose evidence.
+    assert re.search(r"stable\s+(failure\s+)?identity", lowered), (
+        "duplicate-search guidance no longer keys on stable failure identity"
+    )
+    assert re.search(r"before\s+(?:\S+\s+){0,8}(?:prose|title|symptom)", lowered), (
+        "duplicate-search guidance no longer orders stable-identity comparison "
+        "before prose title/symptom matching"
+    )
+
+    # The pre-existing same-symptom/title search stays as the secondary key.
+    assert "symptom" in lowered and "title" in lowered, (
+        "the existing same-symptom/title search must remain as secondary evidence"
+    )
+
+    # Distinct failures sharing a workflow must not be collapsed.
+    assert re.search(r"(differ|distinct|not\s+collapse|do\s+not\s+collapse)", lowered), (
+        "guidance must keep failures that share a workflow but differ by "
+        "job/step/script/error class as distinct issues"
+    )
+
+    # The motivating duplicate class is named, without reopening either issue.
+    assert "#4371" in section and "#4463" in section, (
+        "guidance must name #4371/#4463 as the motivating duplicate class"
+    )
+    assert re.search(r"(do\s+not\s+reopen|not\s+reopen|without\s+reopening)", lowered), (
+        "guidance must state the motivating issues are precedent, not reopened"
+    )
 
 
 def test_planned_marker_allows_unknown_reference(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #4607

Fixes #4607

Final-Review-Rounds: 0

## Summary
`.codex/skills/bug-to-issue/SKILL.md :: Normal bounded bug-Issue workflow` now requires CI/test duplicate searches to key first on stable failure identity — workflow name, job name, step name, failing script/test target, and raised exception/error class when available — before relying on prose title/symptom or attributed subsystem. The pre-existing same-symptom/title search stays as the secondary key, failures sharing a workflow but differing by job/step/script/error class stay distinct, and the #4371/#4463 pair is named as the motivating duplicate class (precedent only; neither is reopened). A governance regression test pins the instruction so it cannot regress to title/symptom-only matching.

## Lane
Issue-backed PR delivering #4607 (Builder System governance surface: skill text + governance test). Issue authority (`Governing-Issue` + `Fixes`) is the single lane classifier per `publish-pr`; checkbox lanes are for issue-free PRs. Tier 1, light delivery path.

## Changes
- `.codex/skills/bug-to-issue/SKILL.md` — step 2 of `:: Normal bounded bug-Issue workflow` rewritten: stable-identity-first dedupe for CI/test failures, no-collapse rule for distinct job/step/script/error-class failures, symptom/title search retained as secondary, #4371/#4463 named as precedent without reopening. (AC1, AC3)
- `tests/governance/test_skills_consistency_lint.py::test_bug_to_issue_duplicate_search_requires_stable_ci_identity` — semantic-marker regression test over the section; written test-first and confirmed failing against the pre-change skill text (missing `workflow name` identity key), green after the writeback. (AC2)

## Test-first proof
The new test was committed conceptually before the skill edit: run against the unchanged `origin/main` skill text it fails with `AssertionError: duplicate-search guidance no longer names the stable CI identity key 'workflow name'`; after the doc writeback the full file passes (18 passed).

## DOCS_INDEX consistency
Per `docs/development/AGENT_INSTRUCTION_GOVERNANCE.md :: Maintenance rules`, `docs/DOCS_INDEX.md` updates are required when canonical entrypoints, reading order, or doc roles change. This is a section-level edit inside an existing skill — no entrypoint, reading-order, or role change — so no DOCS_INDEX update is triggered.

## BuilderOps Routing
- Records/projections/receipts: applies LearningSignal `builderops_object:lrn_20260731204320_6025370c` (duplicate-routing miss #4463 vs #4371); no new BuilderOps records created.
- Reason: Tier 1 governance writeback delivering an already-captured LearningSignal; no plan divergence occurred.

## Claim receipt
`pickup-claim-complete issue=4607 branch=fix/4607-bug-to-issue-ci-identity-dedupe worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a7e3632cd0000546d coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4607 lease_id=lease-b2162285 holder=claude-w3b evidence=verified-dispatcher-lease`

## Notes
Validation:
- `pytest -q tests/governance/test_skills_consistency_lint.py` — 18 passed (includes the new regression test)
- `python3 scripts/lint_skills_consistency.py` — clean (exit 0, no output)
- full `pytest -q tests/governance -m "not pg"` — 502 passed
- `pytest -q tests/architecture/test_agent_skill_entrypoints.py` — 11 passed
- `ruff check app tests scripts` — all checks passed
- `python3 scripts/docs_guard.py` — OK
- `git diff --check` — clean
- `scripts/review_before_ci_gate.py --lane governance --risk-assessment-complete` (no risk surfaces; skill text + test only) — satisfied
---