### PR TITLE
Add full-tree collect-only collection-health gate to ci-smoke

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -200,6 +200,20 @@ jobs:
       - name: Prepare tmp dir
         run: mkdir -p tmp
 
+      # Full-tree collection health gate (#3942). A module-level import error
+      # in tests/api/ broke collection of the entire `not pg` suite on main
+      # for two days with zero CI signal (#3941): every PR workflow runs
+      # pytest against explicit path slices, so tree-wide ImportError/
+      # SyntaxError/conftest breakage had no PR-time enforcement. This step
+      # collects (never executes) the full `not pg` selection so any PR that
+      # breaks collection anywhere under tests/ fails loud here. Exit code
+      # gates directly — no pipes, no `|| echo`.
+      - name: Pytest full-tree collection health (collect-only)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
+        timeout-minutes: 5
+        run: |
+          python -m pytest -q --collect-only -m "not pg and not alpha_llm" tests/
+
       - name: Pytest smoke baseline (memory, fail-fast)
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         timeout-minutes: 12


### PR DESCRIPTION
Governing-Issue: #3942

Fixes #3942

Final-Review-Rounds: 0

## Summary
Adds one cheap collection-health step to `.github/workflows/ci-smoke.yaml`: `python -m pytest -q --collect-only -m "not pg and not alpha_llm" tests/`, under the same `heavy_smoke` change-filter condition as the existing pytest smoke slices. Collection only, no execution; catches tree-wide ImportError/SyntaxError/conftest breakage at PR time (the #3941 incident class). Exit code gates directly — no pipes, no `|| echo`; `timeout-minutes: 5` keeps it inside the low-single-digit-minute budget (local collection: ~10-38s).

## SBS Impact
- Primary subsystem: Builder System (CI gating)
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Authority impact: none
- Persistence impact: none
- New or changed contract: ci-smoke additionally asserts full-tree collection health on non-docs-only PRs
- Owner-doc impact: none
- Transition debt impact: reduces (closes the silent-collection-breakage window)
- Fitness rule impact: strengthens

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-slice CI-gating change with no plan divergence; no BuilderOps material routed.

## Claim receipt
`pickup-claim-complete issue=3942 branch=task/3942-collect-only-gate worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a1502347cd42a8a0d coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-3942 lease_id=lease-e11e2bdd holder=claude-w5a evidence=verified-dispatcher-lease`

## Notes
Validation:
- Green baseline: `python -m pytest -q --collect-only -m "not pg and not alpha_llm" tests/` on this branch — `12583/12938 tests collected (355 deselected)`, exit 0.
- Smoke-env parity: same command re-run with the ci-smoke job env (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, single-root `PYTHONPATH`, memory/mock env) — identical collection result, warnings only.
- Regression demonstration (AC evidence): a temporary `tests/api/` module with a deliberate `import module_that_does_not_exist_3942` made the same command exit 2 with `ERROR tests/api/test_tmp_broken_import_demo.py` / `Interrupted: 1 error during collection`; file removed, green re-confirmed before commit.
- YAML sanity: `yaml.safe_load` OK; `yamllint -c .yamllint.yml` OK (only the pre-existing line-4 `on:` truthy warning).
- `git diff --check` clean.
- Governance/architecture suites referencing ci-smoke: `tests/governance/test_ci_smoke_docs_only_gate.py`, `tests/governance/test_ci_test_environment.py`, `tests/governance/test_verification_consumer_contract.py`, `tests/architecture/test_durable_table_ownership.py`, `tests/architecture/test_import_boundary.py`, `tests/architecture/test_pr_hot_path_governance.py` — 67 passed.
- `python3 scripts/docs_guard.py` — OK.
- `scripts/review_before_ci_gate.py --lane implementation` — satisfied (surface:governance).
- Lane note: per `docs/development/PR_HOT_PATH.md :: Governance Lane vs Direct Repair for Workflow Files`, a `ci-smoke.yaml` change may not use the Governance-lane checkbox; this PR is issue-backed (`Governing-Issue`/`Fixes`), which carries no file allowlist restriction.
- Adoption evidence: the delivering PR itself trips the `heavy_smoke` filter (`.github/workflows/**`), so the new step runs live on this PR's ci-smoke check.
---