### PR TITLE
Make process-group authority-loss regression load-stable via observable finish condition

### DIFF
--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -12,7 +12,8 @@ import re
 import sqlite3
 import subprocess
 import sys
-from threading import Condition, Thread
+from threading import Condition, Event, Thread
+import time
 from typing import Callable, Mapping
 import zipfile
 from zoneinfo import ZoneInfo
@@ -6060,6 +6061,22 @@ def test_background_authority_loss_rejects_late_stdout(
     assert process.stdout.reads == 1
 
 
+# The pre-#4012 harness joined the launcher worker with a fixed 0.5 second
+# wall-clock deadline. Delaying the authority-loss trigger beyond that window
+# reproduces the load-sensitive failure deterministically, so the harness must
+# pass by observing launcher completion, not by winning a scheduling race.
+_AUTHORITY_LOSS_TRIGGER_DELAY = 0.6
+# Fail-closed backstop for the observable launcher-finished condition. It only
+# bounds a genuinely regressed (blocked) launcher; a healthy run finishes right
+# after the intentional trigger delay.
+_LAUNCHER_FINISH_BACKSTOP = 30.0
+
+
+def _delayed_authority_loss_heartbeat() -> None:
+    time.sleep(_AUTHORITY_LOSS_TRIGGER_DELAY)
+    raise RuntimeError("verification lease heartbeat rejected")
+
+
 def _process_group_authority_loss(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> tuple[_DescendantHeldStdoutProcess, CodexExecFailure, dict[str, object]]:
@@ -6084,21 +6101,35 @@ def _process_group_authority_loss(
     )
     outcome: dict[str, BaseException] = {}
 
+    launcher_finished = Event()
+
     def launch() -> None:
         try:
             _authority_loss_launcher(tmp_path).launch(
                 {"head_sha": HEAD},
-                on_heartbeat=lambda: (_ for _ in ()).throw(
-                    RuntimeError("verification lease heartbeat rejected")
-                ),
+                on_heartbeat=_delayed_authority_loss_heartbeat,
             )
         except BaseException as exc:  # noqa: BLE001 - asserted thread outcome
             outcome["error"] = exc
+        finally:
+            launcher_finished.set()
 
     worker = Thread(target=launch, daemon=True)
     worker.start()
     try:
-        worker.join(timeout=0.5)
+        # Wait on the observable completion signal instead of a wall-clock
+        # join: the launcher itself must unblock the descendant-held stdout
+        # via the process-group SIGKILL before this event can fire, because
+        # the test only releases stdout in the cleanup path below. Use the
+        # captured unpatched Event.wait — accelerated_wait caps timeouts at
+        # 0.01s and would turn the backstop into a scheduling race again.
+        assert event_wait(launcher_finished, _LAUNCHER_FINISH_BACKSTOP), {
+            "launcher_still_blocked": True,
+            "group_signals": process.group_signals,
+            "parent_returncode": process.returncode,
+            "wait_calls": process.wait_calls,
+        }
+        worker.join(timeout=_LAUNCHER_FINISH_BACKSTOP)
         assert not worker.is_alive(), {
             "launcher_still_blocked": True,
             "group_signals": process.group_signals,


### PR DESCRIPTION
Governing-Issue: #4012

Fixes #4012

Final-Review-Rounds: 0

## Summary
The process-group authority-loss harness (`_process_group_authority_loss`) joined its launcher worker with a fixed 0.5s wall-clock deadline, which made a required repo gate load-sensitive: it failed under a full `not pg` run and passed in isolation. The harness now waits on an explicit `launcher_finished` event set by the worker (waited with the captured **unpatched** `Event.wait` — the test's `accelerated_wait` patch caps timeouts at 0.01s — under a 30s fail-closed backstop), and the authority-loss trigger is intentionally delayed 0.6s beyond the old 0.5s window so the tests can only pass by observing launcher completion, never by winning a scheduling race. Test-first proof: with the delay alone (old harness intact) all three process-group tests fail deterministically; with the observable-condition harness they pass.

Production assertions are unchanged and exactly as strong: process-group SIGTERM/probe/SIGKILL sequence, `start_new_session=True`, descendant termination, late-descendant-output rejection (`session_id is None`, `stdout.reads == 1`), and the `heartbeat_authority_lost` receipt. The production stdout release still happens only through the launcher's own process-group SIGKILL path — the test releases stdout only in its cleanup fallback after the assertions. `app/dispatcher/verification_consumer.py` is untouched: no production race was proven; the flake mechanism was the harness's wall-clock join racing thread scheduling under load.

## Claim receipt
`pickup-claim-complete issue=4012 branch=fix/4012-authority-loss-load-stable worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a4a2fcfb9291eb4fa coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4012 lease_id=lease-4e1365da holder=claude-w5b evidence=verified-dispatcher-lease`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: single-issue Tier 2 test-stability slice; no BuilderOps records, projections, or receipts produced; no plan divergence to route through capture-learning.

## Reproduction evidence
- Natural stress (pre-fix code): 20 iterations of the three process-group authority-loss tests under 4 parallel full `tests/dispatcher/test_verification_consumer.py` loops + 8 CPU burners on a 10-core host: 0/20 failures — the original flake is a tail-latency event not reproducible on demand locally.
- Deterministic reproduction (AC scenario): delaying the authority-loss trigger 0.6s beyond the old window with the old `worker.join(timeout=0.5)` harness fails all three tests deterministically (`3 failed`), matching the observed load failure mode.

## Stability proof (fixed code)
- 20/20 consecutive runs green: `pytest -q tests/dispatcher/test_verification_consumer.py -k "process_group_authority_loss or authority_loss_terminates_process_group or authority_loss_kills_only_coordinator"` (3 passed each, ~2.2s).
- 20/20 green under load (same selection, concurrent with 4 parallel full-file pytest loops + 8 CPU burners).
- Full file green: `pytest -q tests/dispatcher/test_verification_consumer.py` → 286 passed.

## Notes
Validation: `pytest -q tests/dispatcher/test_verification_consumer.py` (286 passed); the 20x + under-load stability loops above; `ruff check app tests companion-ui/companion-app` (all checks passed); `mypy app` (no issues in 870 source files); `git diff --check` clean; `scripts/review_before_ci_gate.py --lane implementation` → `not_required`, `may_handoff_to_ci: true`. A local full `pytest -q -m "not pg"` run was started but intentionally stopped before completion (it had been launched without the host validation lease); the authoritative full non-PG signal is this PR's `Unit tests (not pg)` CI check.
---