### PR TITLE
Add FILE :: Section citation resolution check to the skills consistency lint

### DIFF
--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -100,7 +100,7 @@ Delivery rules:
   duplicated local state is a runner bug to repair before dispatching more work.
 - Learning/evaluation candidates in run-state must carry source refs, an upstream artifact hint,
   evidence kind, and an `outcome` once processed. Terminal outcomes use
-  `docs/development/DELIVERY_FEEDBACK_LOOP.md :: Terminal outcome vocabulary`; missing `outcome`
+  `docs/development/DELIVERY_FEEDBACK_LOOP.md :: Retrospective closure rule`; missing `outcome`
   means unresolved and must be surfaced before parent or epic closure.
 - Dispatcher status in run-state is snapshot-only. Recording `{"db_exists": false}` or similar does
   not start, stop, claim, heartbeat, release, or complete dispatcher work. Keep dispatcher behavior

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -106,7 +106,7 @@ Skill-specific rule: if an AC cannot carry a resolvable `Verify:` target, the AC
 - Preferred format:
   - `docs/PANEL_AGENT.md :: PA2-FREEFORM`
   - `docs/ROADMAP.md :: ORCHV2-TDD`
-  - `docs/STATUS.md :: SETTINGS-PROVENANCE`
+  - `docs/STATUS.md :: CDLM-01`
 - Prefer stable anchor IDs over prose fragments.
 
 ## Pickup label and optional Project projection rules

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -163,7 +163,7 @@ Commit message must:
 - Start with imperative verb (Add, Update, Rebuild, etc.)
 - Summarize the bounded outcome, not the mechanical changes
 - Be truthful about scope
-- Never use `Fix`, `Fixes`, `Fixed`, `Close`, `Closes`, `Closed`, `Resolve`, `Resolves`, or `Resolved` as an issue-closing reference in the commit subject or body. Ordinary non-target prose such as `Fix runtime env` is allowed. The workflow owns the supported separator, target, case, and malformed-reference recognition; see `.github/workflows/issue-pr-governance.yml :: pr-contract closing authority`. Use evidence-only `Refs #<id>` when an Issue reference is useful; authenticated closing keywords belong only in the PR body.
+- Never use `Fix`, `Fixes`, `Fixed`, `Close`, `Closes`, `Closed`, `Resolve`, `Resolves`, or `Resolved` as an issue-closing reference in the commit subject or body. Ordinary non-target prose such as `Fix runtime env` is allowed. The workflow owns the supported separator, target, case, and malformed-reference recognition; see `.github/workflows/issue-pr-governance.yml :: authority-classifier`. Use evidence-only `Refs #<id>` when an Issue reference is useful; authenticated closing keywords belong only in the PR body.
 - Replace `<agent identity> <agent noreply address>` in the `Co-Authored-By` trailer with the actual agent identity and its own noreply address producing the commit (e.g. Claude's `noreply@anthropic.com`, Codex/ChatGPT's own noreply domain); do not copy a hardcoded model name or a different agent's domain from this template
 
 ### Branch-Truth Gate — Pre-Push (mandatory before Step 5) [branch-truth-gate]
@@ -183,7 +183,7 @@ not replace required GitHub checks, branch protection, or final review triage.
 Use `--review-gate-complete` only after the checks returned by the script have run. For a high-risk
 implementation, governance, or direct repair this means a mechanism convergence packet plus a fresh independent high-capability
 review of the local publishable SHA before the selected expensive validation; see
-`AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Mechanism Convergence Gate`. If an emergency direct
+`docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Mechanism Convergence Gate`. If an emergency direct
 repair with no declared high-risk surface must bypass this local gate, use `--bypass-reason` and name
 the bypass in the PR/issue receipt. A declared high-risk surface is never bypassable.
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -219,7 +219,7 @@ Resolve the verdict:
   delivery receipt so the gate is auditable after merge.
 - Do not block indefinitely on a stalled or failed review run: if the reviewer subagent cannot complete
   (tool failure, timeout, repeated crash), classify the stop under
-  `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`, use bounded backoff or a
+  `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`, use bounded backoff or a
   `blocked_technical` receipt, and preserve the merge block. A technical outage never creates a
   CI/review/merge waiver. Route through `owner-decision-brief` only when the classifier finds an
   explicit authority category; that decision does not relax the gate.
@@ -259,7 +259,8 @@ The imported `pr-integration` skill's legacy `cheap fix` shorthand is not an ind
 severity or an exception to this routing. Per its required `PR_HOT_PATH.md` classification, read
 `cheap fix`, `review-feedback repair`, and `fixing commit` as P0/P1 blocking-repair concepts only.
 They do not apply to P2/P3. If a secondary workflow's shorthand cannot represent all four
-severities, this section and `PR_HOT_PATH.md :: Review feedback triage` govern.
+severities, this section and `docs/development/PR_HOT_PATH.md :: CI Status Handling` (its
+review-feedback-triage rules) govern.
 
 ##### Dispatcher receipt compatibility
 
@@ -318,7 +319,7 @@ finding and does not re-trigger review.
   repaired, stop point-fixing and do not start another expensive validation or publish another
   head. P2/P3 observations do not count. Build the mechanism convergence packet and run the
   independent pre-expensive-gate review defined in
-  `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Mechanism Convergence Gate`. Resume the expensive
+  `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Mechanism Convergence Gate`. Resume the expensive
   sequence only after that review is clean. Preserve the existing mechanism/domain binding and
   attempt count; this replan does not reset budget and requires the second final clean round only
   for that triggered mechanism/domain key.
@@ -341,7 +342,7 @@ finding and does not re-trigger review.
   for every escalated round.
 - After one key's budget of 2 standard plus 2 escalated fix attempts is exhausted, or when the
   strongest available capability cannot run or repeatedly fails, classify the stop under
-  `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`. Continue with bounded
+  `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`. Continue with bounded
   technical recovery, backoff, or a blocked-technical receipt when safe; route through
   `owner-decision-brief` only if that classifier identifies an explicit authority/scope category.
   Do not reset an existing finding's binding, and do not ask the owner merely because the
@@ -377,7 +378,7 @@ Rules:
 - A 👍/`+1` reaction is a sufficient Codex pass even when there is no formal review or comment.
 - Do not block indefinitely on a missing verdict: if Codex has posted no reaction, review, or comment
   and recent sibling PRs show the same silence (a repo-wide Codex stall), classify the outage under
-  `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`, use bounded backoff or a
+  `docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: Escalation classifier`, use bounded backoff or a
   `blocked_technical` receipt, and preserve the merge block. A technical outage never creates a
   CI/review/merge waiver. Route through `owner-decision-brief` only when the classifier finds an
   explicit authority category; that decision does not relax the gate.

--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -33,6 +33,15 @@ Deterministic, stdlib-only, read-only. Catches the defect classes found by the
     text as their canonical Python twins in
     `app/dispatcher/verification_contract.py` (regression guard for #4272 — the
     canonical implementation must not silently drift from the gate it mirrors).
+11. Every backticked `FILE :: Section` citation in the instruction chain
+    (`.codex/skills/README.md`, each `SKILL.md`, `.codex/skills/_shared/**`,
+    `AGENTS.md`, `CLAUDE.md`, `.codex/AGENTS.md`) resolves: the cited path
+    exists inside the repository and the cited section matches a Markdown
+    heading in that file (whitespace/case-normalized, tolerating enum
+    prefixes and trailing parenthetical qualifiers the heading carries), a
+    stable all-caps anchor ID present in the file, or — for non-Markdown
+    targets — text present in the file (enforcement gate for the
+    read-scope-bearing citation contract of #4189/PR #4275; issue #4297).
 
 Exit 0 with no output when clean; exit 1 with one error per line otherwise.
 
@@ -540,6 +549,167 @@ def check_pr_contract_validator_matches_workflow(repo_root: Path) -> list[str]:
     return errors
 
 
+# --- Check 11: `FILE :: Section` citation resolution (issue #4297) ----------
+#
+# PR #4275 made `FILE :: Section` citations read-scope-bearing
+# (`.codex/skills/_shared/READ_SCOPE.md :: The protocol`). This check keeps
+# them from silently rotting when a cited heading is renamed or removed.
+
+_CODE_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+# Inline code span; DOTALL-free `[^`]` already crosses newlines. Spans with a
+# blank line inside are rejected later (not a real Markdown inline span).
+_INLINE_SPAN_RE = re.compile(r"`([^`]+)`")
+_CITATION_SEPARATOR = " :: "
+# The cited path must look like a repository file path: path charset only and
+# a dotted final component. This is what keeps skill-name citations
+# (`verification-and-closure :: Running the local review gate`) and protocol
+# placeholders (`FILE :: Section`) out of scope for this check — the former
+# are validated as skill references by check 2, the latter are grammar, not
+# citations.
+_CITATION_PATH_RE = re.compile(r"^[A-Za-z0-9_.][A-Za-z0-9_.\-/]*\.[A-Za-z0-9]+$")
+# Stable anchor IDs (`docs/PANEL_AGENT.md :: PA2-FREEFORM`) resolve by
+# presence anywhere in the cited file — they are anchors, not headings
+# (`.codex/skills/_shared/ISSUE_CONTRACT.md :: Source Anchors`).
+_ANCHOR_ID_RE = re.compile(r"^[A-Z][A-Z0-9]*(?:[-_][A-Z0-9]+)+$")
+_MD_HEADING_RE = re.compile(r"^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$")
+_HEADING_ENUM_PREFIX_RE = re.compile(r"^\d+[a-z]?\.\s+")
+_HEADING_TRAILING_PAREN_RE = re.compile(r"\s*\([^()]*\)$")
+# Template/placeholder citations are instruction grammar, not references:
+# angle/brace-bracketed slots and the learning-log date-entry template.
+_CITATION_PLACEHOLDER_MARKERS = ("<", ">", "{", "}", "YYYY-MM-DD")
+
+
+def _blank_code_fences(text: str) -> str:
+    """Replace fenced-code-block lines with blanks, preserving line numbers."""
+    out: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines():
+        match = _CODE_FENCE_RE.match(line)
+        if match and fence is None:
+            fence = match.group(1)
+            out.append("")
+        elif match and match.group(1) == fence:
+            fence = None
+            out.append("")
+        else:
+            out.append("" if fence else line)
+    return "\n".join(out)
+
+
+def _normalize_section(text: str) -> str:
+    text = text.replace("`", "").replace("*", "")
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def _markdown_heading_index(text: str) -> set[str]:
+    """Normalized headings, plus variants without the decorations citations
+    conventionally omit: a leading enum prefix (`3. `, `4b. `) and a trailing
+    parenthetical qualifier (`Agency default (minimize human time)`)."""
+    index: set[str] = set()
+    for line in _blank_code_fences(text).splitlines():
+        match = _MD_HEADING_RE.match(line)
+        if not match:
+            continue
+        heading = match.group(1)
+        bare = _HEADING_ENUM_PREFIX_RE.sub("", heading)
+        for variant in (
+            heading,
+            bare,
+            _HEADING_TRAILING_PAREN_RE.sub("", heading),
+            _HEADING_TRAILING_PAREN_RE.sub("", bare),
+        ):
+            index.add(_normalize_section(variant))
+    return index
+
+
+def _citation_scan_files(repo_root: Path) -> list[Path]:
+    """The instruction-chain surface named by issue #4297, existing files only
+    (synthetic test trees may seed just a few of them)."""
+    skills_root = repo_root / ".codex" / "skills"
+    candidates: list[Path] = [
+        repo_root / "AGENTS.md",
+        repo_root / "CLAUDE.md",
+        repo_root / ".codex" / "AGENTS.md",
+        skills_root / "README.md",
+    ]
+    candidates += [d / "SKILL.md" for d in _skill_dirs(skills_root)]
+    shared_dir = skills_root / "_shared"
+    if shared_dir.is_dir():
+        candidates += sorted(p for p in shared_dir.rglob("*") if p.is_file())
+    return [p for p in candidates if p.is_file()]
+
+
+def _iter_section_citations(text: str) -> list[tuple[int, str, str]]:
+    """Yield `(lineno, path, section)` for each `FILE :: Section` citation."""
+    citations: list[tuple[int, str, str]] = []
+    scannable = _blank_code_fences(text)
+    for match in _INLINE_SPAN_RE.finditer(scannable):
+        span = match.group(1)
+        if "\n\n" in span or _CITATION_SEPARATOR not in span:
+            continue
+        flat = re.sub(r"\s+", " ", span).strip()
+        if any(marker in flat for marker in _CITATION_PLACEHOLDER_MARKERS):
+            continue
+        cited_path, section = flat.split(_CITATION_SEPARATOR, 1)
+        if not _CITATION_PATH_RE.match(cited_path) or not section.strip():
+            continue
+        lineno = scannable.count("\n", 0, match.start()) + 1
+        citations.append((lineno, cited_path, section.strip()))
+    return citations
+
+
+def check_section_citations(repo_root: Path) -> list[str]:
+    """Check 11: every `FILE :: Section` citation resolves (issue #4297).
+
+    A citation resolves when its path names an existing file inside the
+    repository and its section matches a Markdown heading there (normalized;
+    heading decorations the citation omits are tolerated), is a stable
+    all-caps anchor ID present in the file, or — for a non-Markdown target,
+    where headings do not exist — is text present in the file.
+    """
+    errors: list[str] = []
+    heading_cache: dict[Path, set[str]] = {}
+    for path in _citation_scan_files(repo_root):
+        rel = path.relative_to(repo_root)
+        for lineno, cited_path, section in _iter_section_citations(
+            path.read_text(encoding="utf-8")
+        ):
+            citation = f"`{cited_path} :: {section}`"
+            if cited_path.startswith("/") or ".." in cited_path.split("/"):
+                errors.append(
+                    f"{rel}:{lineno}: section citation {citation} points "
+                    "outside the repository"
+                )
+                continue
+            target = repo_root / cited_path
+            if not target.is_file():
+                errors.append(
+                    f"{rel}:{lineno}: section citation {citation} cites a "
+                    "file that does not exist in the repository"
+                )
+                continue
+            target_text = target.read_text(encoding="utf-8")
+            if target.suffix == ".md":
+                if target not in heading_cache:
+                    heading_cache[target] = _markdown_heading_index(target_text)
+                if _normalize_section(section) in heading_cache[target]:
+                    continue
+                if _ANCHOR_ID_RE.match(section) and section in target_text:
+                    continue
+                errors.append(
+                    f"{rel}:{lineno}: section citation {citation} matches "
+                    f"no Markdown heading or anchor ID in {cited_path} — "
+                    "update the citation or restore the heading"
+                )
+            elif section not in target_text:
+                errors.append(
+                    f"{rel}:{lineno}: section citation {citation} names "
+                    f"text not present in {cited_path} — update the citation "
+                    "or restore the referenced marker"
+                )
+    return errors
+
+
 def run_lint(repo_root: Path) -> list[str]:
     skills_root = repo_root / ".codex" / "skills"
     if not skills_root.is_dir():
@@ -554,6 +724,7 @@ def run_lint(repo_root: Path) -> list[str]:
     errors += check_sbs_impact_fields_consistent(repo_root)
     errors += check_required_sections_consistent(repo_root)
     errors += check_pr_contract_validator_matches_workflow(repo_root)
+    errors += check_section_citations(repo_root)
     return errors
 
 

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -1156,7 +1156,9 @@ def test_commit_message_closing_keywords_are_forbidden() -> None:
     assert "Start with imperative verb (Add, Update, Rebuild, etc.)" in guidance
     assert "Start with imperative verb (Fix, Add, Update, Rebuild, etc.)" not in guidance
     assert "Never include any issue-closing keyword in the commit subject or body" not in guidance
-    assert ".github/workflows/issue-pr-governance.yml :: pr-contract closing authority" in guidance
+    # The citation targets the workflow's `// authority-classifier:start`
+    # marker so it stays resolvable under the section-citation lint (#4297).
+    assert ".github/workflows/issue-pr-governance.yml :: authority-classifier" in guidance
     assert "const closingKeyword =" in workflow
     assert "closingAttemptSeparator" in workflow
     assert "closingAttemptTarget" in workflow

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -445,6 +445,186 @@ def test_bug_to_issue_duplicate_search_requires_stable_ci_identity() -> None:
     )
 
 
+def test_lint_detects_unresolvable_section_citation(tmp_path: Path) -> None:
+    """Check 11 (issue #4297): a `path :: Heading` citation must resolve.
+
+    A citation whose path does not exist, or whose heading does not match a
+    Markdown heading in the cited file, is reported as an error.
+    """
+    root = _seed_tree(tmp_path)
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "GUIDE.md").write_text(
+        "# Guide\n\n## Real Section\n\nBody.\n\n### Deep Subsection\n\nMore.\n",
+        encoding="utf-8",
+    )
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nSee `docs/GUIDE.md :: Real Section` and"
+            " `docs/GUIDE.md :: Renamed Away Section` and"
+            " `docs/MISSING.md :: Real Section`.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    citation_errors = [e for e in errors if "section citation" in e]
+    assert any(
+        "`docs/GUIDE.md :: Renamed Away Section`" in e and "no Markdown heading" in e
+        for e in citation_errors
+    ), errors
+    assert any(
+        "`docs/MISSING.md :: Real Section`" in e and "does not exist" in e
+        for e in citation_errors
+    ), errors
+    # The resolving citation is not flagged.
+    assert not any("`docs/GUIDE.md :: Real Section`" in e for e in citation_errors), errors
+
+
+def test_section_citations_resolve_on_real_repo() -> None:
+    """The live instruction chain has no unresolvable citations (issue #4297)."""
+    from scripts.lint_skills_consistency import check_section_citations
+
+    errors = check_section_citations(REPO_ROOT)
+    assert errors == [], "unresolvable section citations:\n" + "\n".join(errors)
+
+
+def test_section_citation_resolves_subheading_and_decorated_headings(tmp_path: Path) -> None:
+    """Sub-headings, enum prefixes, parentheticals, and backticks all resolve."""
+    root = _seed_tree(tmp_path)
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "GUIDE.md").write_text(
+        "# Guide\n\n"
+        "## 3. Numbered Section\n\n"
+        "### 4b. Deep Rule\n\n"
+        "## Total Cost (qualifier here)\n\n"
+        "### `Verify:` marker rule\n\n",
+        encoding="utf-8",
+    )
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nSee `docs/GUIDE.md :: Numbered Section`,"
+            " `docs/GUIDE.md :: Deep Rule`,"
+            " `docs/GUIDE.md :: Total Cost`,"
+            " `docs/GUIDE.md :: Total Cost (qualifier here)`,"
+            " and `docs/GUIDE.md :: Verify: marker rule`.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    assert not any("section citation" in e for e in errors), errors
+
+
+def test_section_citation_ignores_fences_placeholders_and_non_paths(tmp_path: Path) -> None:
+    """Code fences, placeholder citations, and skill-name citations are not parsed."""
+    root = _seed_tree(tmp_path)
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nThe protocol shape is `FILE :: Section` and"
+            " `docs/<path> :: <anchor>` and"
+            " `alpha-skill :: Some Runbook Step` and"
+            " `docs/learning-log.md :: YYYY-MM-DD entry`.\n"
+            "\n```bash\n"
+            "echo '`docs/NOPE.md :: Fenced Citation`'\n"
+            "```\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    assert not any("section citation" in e for e in errors), errors
+
+
+def test_section_citation_outside_repo_fails(tmp_path: Path) -> None:
+    """A citation whose path escapes the repository root is an error."""
+    root = _seed_tree(tmp_path)
+    # A real file outside the lint root must still not resolve.
+    (tmp_path.parent / "escape.md").write_text("# Escaped\n", encoding="utf-8")
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8") + "\nSee `../escape.md :: Escaped`.\n",
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    assert any(
+        "section citation" in e and "outside the repository" in e for e in errors
+    ), errors
+
+
+def test_section_citation_spanning_a_line_break_resolves(tmp_path: Path) -> None:
+    """A backticked citation wrapped across a line break still parses."""
+    root = _seed_tree(tmp_path)
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "GUIDE.md").write_text(
+        "# Guide\n\n## A Long Heading That Wraps In Prose\n\nBody.\n",
+        encoding="utf-8",
+    )
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nSee `docs/GUIDE.md :: A Long Heading That\n"
+            "  Wraps In Prose` for details, and the broken"
+            " `docs/GUIDE.md :: Not\n  A Heading` twin.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    citation_errors = [e for e in errors if "section citation" in e]
+    assert not any("A Long Heading That Wraps In Prose" in e for e in citation_errors), errors
+    assert any("Not A Heading" in e for e in citation_errors), errors
+
+
+def test_section_citation_anchor_id_and_non_markdown_targets(tmp_path: Path) -> None:
+    """Stable anchor IDs resolve by presence; non-md targets resolve by content."""
+    root = _seed_tree(tmp_path)
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "STATUS.md").write_text(
+        "# Status\n\nShipped PA9-EXAMPLE earlier.\n", encoding="utf-8"
+    )
+    scripts_dir = root / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "tool.py").write_text(
+        "def real_function() -> None:\n    pass\n", encoding="utf-8"
+    )
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nSee `docs/STATUS.md :: PA9-EXAMPLE` and"
+            " `docs/STATUS.md :: PA9-GONE` and"
+            " `scripts/tool.py :: real_function` and"
+            " `scripts/tool.py :: missing_function`.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    citation_errors = [e for e in errors if "section citation" in e]
+    assert not any("PA9-EXAMPLE" in e for e in citation_errors), errors
+    assert any("PA9-GONE" in e for e in citation_errors), errors
+    assert not any("real_function" in e for e in citation_errors), errors
+    assert any("missing_function" in e for e in citation_errors), errors
+
+
 def test_planned_marker_allows_unknown_reference(tmp_path: Path) -> None:
     root = _seed_tree(tmp_path)
     skills_root = root / ".codex" / "skills"


### PR DESCRIPTION
Governing-Issue: #4297

Fixes #4297

Final-Review-Rounds: 0

## Summary
Adds check 11 (`check_section_citations`) to `scripts/lint_skills_consistency.py`: every backticked `FILE :: Section` citation in the instruction chain (`.codex/skills/README.md`, each `SKILL.md`, `.codex/skills/_shared/**`, `AGENTS.md`, `CLAUDE.md`, `.codex/AGENTS.md`) must name an existing repository file and resolve to a real Markdown heading (whitespace/case-normalized, tolerating enum prefixes like `3.`/`4b.` and trailing parenthetical qualifiers the heading carries), a stable all-caps anchor ID present in the file, or — for non-Markdown targets, where headings do not exist — text present in the file. Paths outside the repository fail. Code fences, placeholder citations (`FILE :: Section`, `docs/<path> :: <anchor>`, `YYYY-MM-DD` templates), and skill-name citations (owned by check 2) are out of scope by grammar. Registered in `run_lint()`, so it executes in the existing unconditional "Skills consistency lint" step of the `smoke` job — no workflow change (the #4281 self-skip hazard does not apply).

## Stale citations repaired (found by the new check, fixed in this PR)
- `.codex/skills/docs-to-issue/SKILL.md:109`: `docs/STATUS.md :: SETTINGS-PROVENANCE` → `docs/STATUS.md :: CDLM-01` (SETTINGS-PROVENANCE no longer appears anywhere in docs/STATUS.md; CDLM-01 is a live anchor).
- `.codex/skills/deliver-issue-set/SKILL.md:103`: `docs/development/DELIVERY_FEEDBACK_LOOP.md :: Terminal outcome vocabulary` → `:: Retrospective closure rule` (no such heading exists; the terminal-outcome vocabulary lives under `### 4b. Retrospective closure rule`).
- `.codex/skills/publish-pr/SKILL.md:166`: `.github/workflows/issue-pr-governance.yml :: pr-contract closing authority` → `:: authority-classifier` (no such text in the workflow; the closing-authority logic sits under the `// authority-classifier:start` marker). The pinned assertion in `tests/governance/test_issue_pr_governance.py::test_commit_message_closing_keywords_are_forbidden` was updated to the repaired citation; its contract (publish-pr must route to the workflow as closing authority) is unchanged.
- `.codex/skills/publish-pr/SKILL.md:186` and `.codex/skills/verification-and-closure/SKILL.md:222/321/344/380`: bare-filename `AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md :: ...` → full `docs/development/` path (bare filenames do not resolve from the repo root).
- `.codex/skills/verification-and-closure/SKILL.md:262`: `PR_HOT_PATH.md :: Review feedback triage` → `docs/development/PR_HOT_PATH.md :: CI Status Handling` ("Review feedback triage" is a numbered list item, not a heading; `## CI Status Handling` is its owning heading).

None of these touch the citation defects the companion issue owns in `.codex/skills/issue-to-code/SKILL.md` / `.codex/skills/_shared/READ_SCOPE.md` (out of scope per #4297).

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): CI, architecture fitness, and validation rails
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: none — enforces the `FILE :: Section` read-scope-bearing contract PR #4275 introduced
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: none

## Claim receipt
pickup-claim-complete issue=4297 branch=task/4297-citation-resolution-check worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a97cd72ce89c3bb2d coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4297 lease_id=lease-71a2a84d holder=claude-w6a evidence=verified-dispatcher-lease

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-issue governance slice; no plan divergence — the stale citations found and fixed are the triage work the issue itself mandates.

## Notes
Test-first proof: `test_lint_detects_unresolvable_section_citation`, `test_section_citations_resolve_on_real_repo` (direct import), `test_section_citation_outside_repo_fails`, `test_section_citation_spanning_a_line_break_resolves`, and `test_section_citation_anchor_id_and_non_markdown_targets` all failed against the unchanged script before implementation (5 failed, 2 passed on the pre-implementation run).

Validation:
- `python3 scripts/lint_skills_consistency.py` — exit 0 on the current tree (after the nine repairs; before them the new check reported exactly those nine).
- `pytest -q tests/governance/test_skills_consistency_lint.py` — 25 passed.
- `pytest -q -m "not pg" tests/governance/` — 509 passed.
- `pytest -q tests/ops/test_ci_workflow.py::test_ci_smoke_keeps_legacy_skills_lint_when_consolidating_smoke` — 1 passed (AC3).
- `ruff check app tests scripts` — clean; `git diff --check` — clean; `python3 scripts/docs_guard.py` — OK.
- Manual regression (Suggested Validation): renamed the `Classification Procedure` heading in a scratch copy of `docs/architecture/SBS_OPERATING_MODEL.md`; the lint exited 1 naming all three citing sites.
---