### PR TITLE
builderops: reject unsupported PromotionIntent targets at creation

### DIFF
--- a/app/builderops/models.py
+++ b/app/builderops/models.py
@@ -48,6 +48,49 @@ PROMOTION_STATUSES = frozenset({
     "superseded",
 })
 
+# Canonical PromotionIntent target-surface registry (issue #4171).
+#
+# This is the single validation authority for `target_authority_surface`:
+# store creation (`SqliteBuilderOpsStore.create_record`) and the promotion
+# gateway's transition path both resolve targets through
+# `canonicalize_promotion_target_surface`, so a record can never be created
+# with a target the gateway later refuses to transition.
+PROMOTION_TARGET_SURFACES = frozenset({
+    "github_issue",
+    "pr_branch_proposal",
+    "adr_doc_proposal",
+    "owner_doc_writeback_proposal",
+    "generated_projection",
+    "discard_receipt",
+})
+
+PROMOTION_TARGET_ALIASES: dict[str, str] = {
+    "github": "github_issue",
+    "github_issue": "github_issue",
+    "issue": "github_issue",
+    "pr": "pr_branch_proposal",
+    "pull_request": "pr_branch_proposal",
+    "branch": "pr_branch_proposal",
+    "pr_branch_proposal": "pr_branch_proposal",
+    "adr": "adr_doc_proposal",
+    "decision_doc": "adr_doc_proposal",
+    "adr_doc_proposal": "adr_doc_proposal",
+    "repo_doc": "owner_doc_writeback_proposal",
+    "repo_skill": "owner_doc_writeback_proposal",
+    "repo_skill_and_workflow_doc": "owner_doc_writeback_proposal",
+    "owner_doc": "owner_doc_writeback_proposal",
+    "doc_writeback": "owner_doc_writeback_proposal",
+    "owner_doc_writeback_proposal": "owner_doc_writeback_proposal",
+    "skill": "owner_doc_writeback_proposal",
+    "skill_or_agents_proposal": "owner_doc_writeback_proposal",
+    "workflow_doc": "owner_doc_writeback_proposal",
+    "agents_md": "owner_doc_writeback_proposal",
+    "generated_projection": "generated_projection",
+    "projection": "generated_projection",
+    "discard": "discard_receipt",
+    "discard_receipt": "discard_receipt",
+}
+
 OBJECT_PREFIXES = {
     "AgentWorklog": "awl",
     "LearningSignal": "lrn",
@@ -382,6 +425,24 @@ def normalize_actor(value: Mapping[str, Any] | str | None) -> JsonDict:
     if not actor.get("actor_type") or not actor.get("id"):
         raise BuilderOpsValidationError("actor requires actor_type and id")
     return actor
+
+
+def canonicalize_promotion_target_surface(value: Any) -> str:
+    """Resolve a PromotionIntent target surface to its canonical registry name.
+
+    Raises the canonical allowed-value error for surfaces outside
+    ``PROMOTION_TARGET_SURFACES``. Both store creation and the promotion
+    gateway validate through this single function (issue #4171).
+    """
+    raw = str(value if value is not None else "").strip().lower()
+    normalized = raw.replace("-", "_").replace(" ", "_")
+    canonical = PROMOTION_TARGET_ALIASES.get(normalized)
+    if canonical is None:
+        allowed = ", ".join(sorted(PROMOTION_TARGET_SURFACES))
+        raise BuilderOpsValidationError(
+            f"unsupported promotion target_authority_surface: {raw}; allowed: {allowed}"
+        )
+    return canonical
 
 
 def validate_source_refs(value: Any, field_name: str = "source_refs") -> None:

--- a/app/builderops/promotion_gateway.py
+++ b/app/builderops/promotion_gateway.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from app.builderops.models import (
+    PROMOTION_TARGET_ALIASES,
+    PROMOTION_TARGET_SURFACES,
     BuilderOpsValidationError,
+    canonicalize_promotion_target_surface,
     normalize_actor,
     utc_now,
     validate_source_refs,
@@ -65,34 +68,21 @@ TARGET_SPECS: dict[str, PromotionTargetSpec] = {
     ),
 }
 
-TARGET_ALIASES = {
-    "github": "github_issue",
-    "github_issue": "github_issue",
-    "issue": "github_issue",
-    "pr": "pr_branch_proposal",
-    "pull_request": "pr_branch_proposal",
-    "branch": "pr_branch_proposal",
-    "pr_branch_proposal": "pr_branch_proposal",
-    "adr": "adr_doc_proposal",
-    "decision_doc": "adr_doc_proposal",
-    "adr_doc_proposal": "adr_doc_proposal",
-    "repo_doc": "owner_doc_writeback_proposal",
-    "repo_skill": "owner_doc_writeback_proposal",
-    "repo_skill_and_workflow_doc": "owner_doc_writeback_proposal",
-    "owner_doc": "owner_doc_writeback_proposal",
-    "doc_writeback": "owner_doc_writeback_proposal",
-    "owner_doc_writeback_proposal": "owner_doc_writeback_proposal",
-    "skill": "owner_doc_writeback_proposal",
-    "skill_or_agents_proposal": "owner_doc_writeback_proposal",
-    "workflow_doc": "owner_doc_writeback_proposal",
-    "agents_md": "owner_doc_writeback_proposal",
-    "generated_projection": "generated_projection",
-    "projection": "generated_projection",
-    "discard": "discard_receipt",
-    "discard_receipt": "discard_receipt",
-}
+# The alias registry is the canonical models registry: creation-time store
+# validation and gateway transitions share one validation authority (#4171).
+TARGET_ALIASES = PROMOTION_TARGET_ALIASES
+
+if set(TARGET_SPECS) != set(PROMOTION_TARGET_SURFACES):  # pragma: no cover
+    raise RuntimeError(
+        "promotion target registry drift between TARGET_SPECS and "
+        f"PROMOTION_TARGET_SURFACES: {sorted(set(TARGET_SPECS) ^ set(PROMOTION_TARGET_SURFACES))}"
+    )
 
 FINAL_PROMOTION_STATES = frozenset({"promoted", "discarded", "superseded"})
+
+# Terminal decisions that never perform a promotion effect; only these may
+# recover a legacy intent whose persisted target surface is unsupported.
+TERMINAL_RECOVERY_DECISIONS = frozenset({"rejected", "discarded"})
 
 
 class BuilderOpsPromotionGateway:
@@ -212,7 +202,22 @@ class BuilderOpsPromotionGateway:
             )
         if result_refs:
             validate_source_refs(result_refs, "result_refs")
-        proposal = self.render_proposal(intent_id)
+        try:
+            self._target_spec(intent)
+            target_supported = True
+        except BuilderOpsPromotionError:
+            # Terminal recovery for legacy intents persisted before
+            # creation-time target validation (#4171): rejected/discarded may
+            # proceed with a receipt and no promotion effect; every promoting
+            # decision keeps raising the canonical unsupported-target error.
+            if normalized_decision not in TERMINAL_RECOVERY_DECISIONS:
+                raise
+            target_supported = False
+        proposal = (
+            self.render_proposal(intent_id)
+            if target_supported
+            else _unsupported_target_recovery_proposal(intent)
+        )
         refs = source_refs if source_refs is not None else intent["source_refs"]
         receipt_extra: dict[str, Any] = {
             "promotion_decision": normalized_decision,
@@ -250,14 +255,12 @@ class BuilderOpsPromotionGateway:
         return record
 
     def _target_spec(self, intent: Mapping[str, Any]) -> PromotionTargetSpec:
-        raw = str(intent.get("target_authority_surface", "")).strip().lower()
-        normalized = raw.replace("-", "_").replace(" ", "_")
-        canonical = TARGET_ALIASES.get(normalized)
-        if canonical is None:
-            allowed = ", ".join(sorted(TARGET_SPECS))
-            raise BuilderOpsPromotionError(
-                f"unsupported promotion target_authority_surface: {raw}; allowed: {allowed}"
+        try:
+            canonical = canonicalize_promotion_target_surface(
+                intent.get("target_authority_surface")
             )
+        except BuilderOpsValidationError as exc:
+            raise BuilderOpsPromotionError(str(exc)) from exc
         return TARGET_SPECS[canonical]
 
     def _validate_transition(
@@ -368,6 +371,49 @@ def _render_repo_proposal_body(
     ])
 
 
+def _unsupported_target_recovery_proposal(intent: Mapping[str, Any]) -> dict[str, Any]:
+    """Receipt material for terminally recovering an unsupported-target intent.
+
+    Never a promotable proposal: it exists so an already-persisted legacy
+    intent whose ``target_authority_surface`` is outside the canonical
+    registry can reach ``rejected``/``discarded`` with a durable receipt and
+    no promotion effect (issue #4171).
+    """
+    return {
+        "intent_id": intent["id"],
+        "proposal_kind": "unsupported_target_terminal_recovery",
+        "target_authority_surface": str(intent.get("target_authority_surface", "")),
+        "target_action": intent["target_action"],
+        "target_ref": intent["target_ref"],
+        "requires_human_gate": True,
+        "requires_pr": False,
+        "would_mutate_authority": False,
+        "title": intent["summary"],
+        "body": _render_unsupported_target_recovery_body(intent),
+        "source_refs": intent["source_refs"],
+    }
+
+
+def _render_unsupported_target_recovery_body(intent: Mapping[str, Any]) -> str:
+    allowed = ", ".join(sorted(TARGET_SPECS))
+    return "\n".join([
+        f"# Terminal recovery receipt for {intent['id']}",
+        "",
+        "## Rationale",
+        (
+            f"target_authority_surface `{intent.get('target_authority_surface', '')}` "
+            f"is outside the canonical promotion target registry (allowed: {allowed})."
+        ),
+        "This records a terminal non-promoted disposition only; no promotion effect was performed.",
+        "",
+        "## Source Anchors",
+        *_format_source_refs(intent["source_refs"]),
+        "",
+        "## Authority Boundary",
+        "Unsupported-target PromotionIntents can only be rejected or discarded; they are never promoted.",
+    ])
+
+
 def _render_discard_body(intent: Mapping[str, Any]) -> str:
     return "\n".join([
         f"# Discard receipt proposal for {intent['id']}",
@@ -412,5 +458,6 @@ def _parent_ref(intent: Mapping[str, Any]) -> str:
 __all__ = [
     "BuilderOpsPromotionError",
     "BuilderOpsPromotionGateway",
+    "TARGET_ALIASES",
     "TARGET_SPECS",
 ]

--- a/app/builderops/store.py
+++ b/app/builderops/store.py
@@ -14,6 +14,7 @@ from app.builderops.models import (
     BuilderOpsConflictError,
     BuilderOpsLeaseError,
     BuilderOpsValidationError,
+    canonicalize_promotion_target_surface,
     normalize_actor,
     normalize_record,
     utc_now,
@@ -119,6 +120,15 @@ class SqliteBuilderOpsStore:
                     return dict(existing)
 
             payload = normalize_record(record)
+            if payload["object_type"] == "PromotionIntent":
+                # Creation-time gate (#4171): reject target surfaces outside
+                # the canonical promotion registry before persistence, so no
+                # record can be created that the promotion gateway would later
+                # refuse to transition. Legacy records are unaffected because
+                # state transitions do not re-enter create_record.
+                canonicalize_promotion_target_surface(
+                    payload["target_authority_surface"]
+                )
             try:
                 self._insert_record_payload(conn, payload)
             except sqlite3.IntegrityError as exc:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -484,6 +484,12 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
   product/runtime truth and never bypass repo authority gates. (ADR-0010's "not implemented" header
   predates this store/CLI/API delivery under the #1500-series follow-ups and is the stale surface to
   reconcile next.)
+- BuilderOps `PromotionIntent` creation validates `target_authority_surface` against the canonical
+  promotion target registry shared with the promotion gateway
+  (`app/builderops/models.py::PROMOTION_TARGET_SURFACES`): unsupported targets fail before
+  persistence at every boundary (store, CLI, MCP boundary, API), and legacy records persisted with
+  unsupported targets can only reach `rejected`/`discarded` through a receipt-bearing terminal
+  recovery transition that performs no promotion effect (#4171).
 - The BCP-05 verification lane now has a repo-side BuilderOps API/PostgreSQL/outbox implementation
   under PR #4416. That code presence is not a delivery claim: issue #3603 and its installed-main
   Demerzel pilot receipt remain the authority for whether BCP-05 acceptance is complete. The

--- a/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
+++ b/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
@@ -666,6 +666,14 @@ receipt.
 **Lifecycle states:** `draft`, `review_pending`, `accepted`, `promoted`, `discarded`,
 `superseded`.
 
+**Target surface registry:** `target_authority_surface` must resolve (directly or through a
+supported alias) to the canonical promotion target registry shared by store creation and the
+promotion gateway (`app/builderops/models.py::PROMOTION_TARGET_SURFACES`): `github_issue`,
+`pr_branch_proposal`, `adr_doc_proposal`, `owner_doc_writeback_proposal`, `generated_projection`,
+`discard_receipt`. Creation fails before persistence for any other value. A legacy record persisted
+with an unsupported target can only reach `rejected` or `discarded` through a receipt-bearing
+terminal recovery transition; it is never promotable.
+
 **Source/reference fields:** Must include the BuilderOps source objects that would cross the
 boundary. Must include any target issue/doc/ADR/skill refs if known.
 

--- a/tests/builderops/test_builderops_promotion_gateway.py
+++ b/tests/builderops/test_builderops_promotion_gateway.py
@@ -4,8 +4,16 @@ from pathlib import Path
 
 import pytest
 
-from app.builderops.models import BuilderOpsValidationError
+from app.builderops.models import (
+    PROMOTION_TARGET_ALIASES,
+    PROMOTION_TARGET_SURFACES,
+    BuilderOpsValidationError,
+    canonicalize_promotion_target_surface,
+    normalize_record,
+)
 from app.builderops.promotion_gateway import (
+    TARGET_ALIASES,
+    TARGET_SPECS,
     BuilderOpsPromotionError,
     BuilderOpsPromotionGateway,
 )
@@ -279,16 +287,164 @@ def test_repo_skill_and_workflow_doc_target_renders_as_writeback_proposal(
     assert "normal PR workflow" in proposal["body"]
 
 
+def _inject_legacy_intent(
+    store: SqliteBuilderOpsStore,
+    *,
+    intent_id: str,
+    target_surface: str,
+) -> dict[str, object]:
+    """Persist an intent bypassing creation validation.
+
+    Simulates records persisted before issue #4171 added creation-time
+    target-surface validation (e.g. `prom_20260727085216_b24bc805` with
+    `target_authority_surface=github_issue_set`).
+    """
+    record = normalize_record({
+        "object_type": "PromotionIntent",
+        "id": intent_id,
+        "summary": "Legacy intent persisted before creation validation",
+        "target_authority_surface": "github_issue",
+        "target_action": "create",
+        "target_ref": "pending",
+        "target_authority_class": "operational",
+        "intended_output": "Legacy record with an unsupported target surface.",
+        "source_refs": _source_refs(),
+        "created_by": _actor(),
+    })
+    record["target_authority_surface"] = target_surface
+    with store._connect() as conn:
+        store._insert_record_payload(conn, record)
+        conn.commit()
+    return record
+
+
 def test_disallowed_target_rejected(
     store: SqliteBuilderOpsStore,
     gateway: BuilderOpsPromotionGateway,
 ) -> None:
-    intent = _create_intent(
+    intent = _inject_legacy_intent(
         store,
         intent_id="prom_bad_target",
         target_surface="product_runtime_truth",
-        target_ref="runtime",
     )
 
     with pytest.raises(BuilderOpsPromotionError, match="unsupported promotion target"):
         gateway.render_proposal(intent["id"])
+
+
+def test_creation_and_transition_share_target_registry(
+    store: SqliteBuilderOpsStore,
+    gateway: BuilderOpsPromotionGateway,
+) -> None:
+    """Store creation and gateway transition validate against one registry."""
+    # The gateway's registry is literally the canonical models registry.
+    assert TARGET_ALIASES is PROMOTION_TARGET_ALIASES
+    assert set(TARGET_SPECS) == set(PROMOTION_TARGET_SURFACES)
+    assert set(PROMOTION_TARGET_ALIASES.values()) == set(PROMOTION_TARGET_SURFACES)
+    for canonical in PROMOTION_TARGET_SURFACES:
+        assert TARGET_SPECS[canonical].canonical == canonical
+
+    # Every supported alias is accepted at creation and canonicalized
+    # identically by the gateway.
+    for index, (alias, canonical) in enumerate(sorted(PROMOTION_TARGET_ALIASES.items())):
+        intent = _create_intent(
+            store,
+            intent_id=f"prom_alias_{index:03d}",
+            target_surface=alias,
+        )
+        assert intent["target_authority_surface"] == alias
+        proposal = gateway.render_proposal(intent["id"])
+        assert proposal["target_authority_surface"] == canonical
+        assert canonicalize_promotion_target_surface(alias) == canonical
+
+    # An unsupported surface fails at creation with the same canonical error
+    # the gateway raises at transition time.
+    with pytest.raises(BuilderOpsValidationError) as creation_error:
+        _create_intent(
+            store,
+            intent_id="prom_registry_bad",
+            target_surface="github_issue_set",
+        )
+
+    legacy = _inject_legacy_intent(
+        store,
+        intent_id="prom_registry_legacy",
+        target_surface="github_issue_set",
+    )
+    lease = store.acquire_lease(legacy["id"], actor=_actor())
+    with pytest.raises(BuilderOpsPromotionError) as transition_error:
+        gateway.transition_intent(
+            legacy["id"],
+            decision="accepted",
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="transition:registry-legacy-accept",
+            rationale="Unsupported targets must not be accepted.",
+        )
+    assert str(creation_error.value) == str(transition_error.value)
+    assert "unsupported promotion target_authority_surface: github_issue_set" in str(
+        creation_error.value
+    )
+
+
+def test_unsupported_legacy_intent_can_be_discarded_without_effect(
+    store: SqliteBuilderOpsStore,
+    gateway: BuilderOpsPromotionGateway,
+) -> None:
+    intent = _inject_legacy_intent(
+        store,
+        intent_id="prom_legacy_stuck_001",
+        target_surface="github_issue_set",
+    )
+    lease = store.acquire_lease(intent["id"], actor=_actor())
+
+    # No promotion effect is reachable for the unsupported target.
+    with pytest.raises(BuilderOpsPromotionError, match="unsupported promotion target"):
+        gateway.transition_intent(
+            intent["id"],
+            decision="accepted",
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="transition:legacy-accept",
+            rationale="Must not accept an unsupported target.",
+        )
+    with pytest.raises(BuilderOpsPromotionError, match="unsupported promotion target"):
+        gateway.dry_run_promotion(
+            intent["id"],
+            actor=_actor(),
+            idempotency_key="dry-run:legacy",
+        )
+
+    # The terminal recovery path works and carries a durable receipt.
+    discarded = gateway.transition_intent(
+        intent["id"],
+        decision="discarded",
+        actor=_actor(),
+        lease_id=lease["lease_id"],
+        idempotency_key="transition:legacy-discard",
+        rationale="Terminal recovery: target surface is outside the registry.",
+    )
+    record = discarded["record"]
+    receipt = discarded["receipt"]
+    assert record["lifecycle_state"] == "discarded"
+    assert record["promotion_status"] == "discarded"
+    assert record["target_authority_surface"] == "github_issue_set"
+    assert receipt["object_type"] == "BuilderOpsReceipt"
+    assert receipt["promotion_decision"] == "discarded"
+    assert receipt["promotion_proposal"]["proposal_kind"] == (
+        "unsupported_target_terminal_recovery"
+    )
+    assert receipt["promotion_proposal"]["would_mutate_authority"] is False
+    assert store.get_record(receipt["id"]) == receipt
+    assert store.get_record(intent["id"])["lifecycle_state"] == "discarded"
+
+    # Recovery is terminal only: the record never becomes promotable.
+    with pytest.raises(BuilderOpsPromotionError, match="already terminal"):
+        gateway.transition_intent(
+            intent["id"],
+            decision="accepted",
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="transition:legacy-accept-after-discard",
+            rationale="Terminal records stay terminal.",
+        )

--- a/tests/builderops/test_builderops_store.py
+++ b/tests/builderops/test_builderops_store.py
@@ -181,6 +181,54 @@ def test_create_read_list_core_builderops_records(store: SqliteBuilderOpsStore) 
     ]
 
 
+def test_create_promotion_intent_rejects_unsupported_target_surface(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    """Creation fails before persistence with the canonical allowed-value error.
+
+    Regression for issue #4171: the store accepted
+    `target_authority_surface=github_issue_set` at creation while the promotion
+    gateway rejected it at transition time, leaving the record permanently
+    stuck outside every terminal state.
+    """
+    with pytest.raises(
+        BuilderOpsValidationError,
+        match=(
+            r"unsupported promotion target_authority_surface: github_issue_set; "
+            r"allowed: adr_doc_proposal, discard_receipt, generated_projection, "
+            r"github_issue, owner_doc_writeback_proposal, pr_branch_proposal"
+        ),
+    ):
+        store.create_promotion_intent(
+            id="prom_unsupported_001",
+            summary="Promotion with unsupported target",
+            target_authority_surface="github_issue_set",
+            target_action="create",
+            target_ref="pending",
+            target_authority_class="operational",
+            intended_output="Should never persist.",
+            source_refs=_source_ref(),
+            created_by=_actor(),
+        )
+
+    assert store.get_record("prom_unsupported_001") is None
+    assert store.list_records("PromotionIntent") == []
+
+    # The same registry accepts supported aliases unchanged.
+    aliased = store.create_promotion_intent(
+        id="prom_alias_001",
+        summary="Promotion via supported alias",
+        target_authority_surface="github",
+        target_action="create",
+        target_ref="pending",
+        target_authority_class="operational",
+        intended_output="Alias creation stays supported.",
+        source_refs=_source_ref(),
+        created_by=_actor(),
+    )
+    assert aliased["target_authority_surface"] == "github"
+
+
 def test_store_supports_retro_cluster_member_ids(
     store: SqliteBuilderOpsStore,
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #4171

Fixes #4171

Final-Review-Rounds: 0

## Summary

Moves the PromotionIntent target-surface registry to `app/builderops/models.py` as the single validation authority (`PROMOTION_TARGET_SURFACES`, `PROMOTION_TARGET_ALIASES`, `canonicalize_promotion_target_surface`). `SqliteBuilderOpsStore.create_record` now canonicalizes `target_authority_surface` before persistence, so no boundary (store API, CLI, MCP boundary, HTTP API — all funnel through this choke point) can create a record the promotion gateway later refuses to transition; the gateway resolves targets through the same function, with an import-time drift guard between `TARGET_SPECS` and the canonical registry. Adds a receipt-bearing terminal recovery path: legacy intents persisted with unsupported targets (e.g. `prom_20260727085216_b24bc805` with `github_issue_set`) can reach `rejected`/`discarded` with a durable `unsupported_target_terminal_recovery` receipt and no promotion effect, while `accepted`/`promoted` keep raising the canonical allowed-value error. Supported aliases and canonicalization are byte-for-byte unchanged.

## Acceptance Criteria resolution

- Unsupported target fails before persistence with the canonical allowed-value error — `tests/builderops/test_builderops_store.py::test_create_promotion_intent_rejects_unsupported_target_surface` (failed pre-fix: creation accepted `github_issue_set`).
- Store, CLI/boundary, and transition share one registry and aliases — `tests/builderops/test_builderops_promotion_gateway.py::test_creation_and_transition_share_target_registry` (registry identity + alias parity + identical creation/transition error text).
- Legacy unsupported intent reaches a terminal non-promoted state with a durable receipt, no promotion effect — `tests/builderops/test_builderops_promotion_gateway.py::test_unsupported_legacy_intent_can_be_discarded_without_effect` (failed pre-fix: every terminal transition blocked — the stuck-record class).
- Supported creation and accepted-to-promoted transitions unchanged — `tests/builderops/test_builderops_promotion_gateway.py::test_promotion_intent_gateway_state_transitions` (pre-existing test, untouched, green).

`test_disallowed_target_rejected` now injects its unsupported-target record as a legacy row (creation rightly rejects it), keeping gateway read-time rejection covered.

## SBS Impact

- Primary subsystem: BuilderOps control plane (Builder System)
- Write class: Builder System validation and recovery
- Authority impact: prevents invalid staged promotion records; no Product/Runtime authority change
- Persistence impact: validates new durable intents; terminal receipt path for legacy invalid intents
- New/changed contract: creation and transition share one target-surface registry (documented in `docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md` PromotionIntent section and `docs/STATUS.md`)

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded single-issue bug fix; the governing Issue and this PR carry the contract and evidence; no plan divergence to signal.

## Review-Before-CI gate (state-machine risk surface)

Declared `--risk-surface state-machine` (change alters which records may traverse terminal promotion transitions). Mechanism convergence packet built (mechanism key `builderops.promotion_intent.target_surface_lifecycle`); fresh independent high-capability review of publishable SHA b0d494d50 returned CLEAN (3 non-blocking P3 observations: packet wording on pre-fix idempotency replays; pre-existing read-then-write transition race unchanged by this PR; latent registry-drift KeyError double-guarded by import-time check + parity test). Mechanism patch proven byte-identical after rebase over disjoint base commits (governance/skills surfaces only); `scripts/review_before_ci_gate.py` satisfied at the current head.

## Claim receipt

pickup-claim-complete issue=4171 branch=fix/4171-promotion-intent-target-validation worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a123711bb155d2c78 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4171 lease_id=lease-4c59e148 holder=claude-w6b evidence=verified-dispatcher-lease

## Notes

Validation: pre-fix failure proven for both behavioral ACs (creation DID NOT RAISE; repro showed accepted/rejected/discarded all blocked for `github_issue_set`). Post-fix: 4 named AC tests green; full `pytest -q tests/builderops/` 1096 passed; focused store/gateway/CLI-automation/API tests 37 passed at head; `ruff check app tests` clean; `mypy app` clean (870 files); `python3 scripts/docs_guard.py` clean (STATUS.md temporal note); `git diff --check` clean.

Follow-up (operational, not repo code): the live stuck record `prom_20260727085216_b24bc805` can now be discarded via the normal lease + `transition_intent(decision="discarded")` recovery path in the operator's BuilderOps DB.
---