### PR TITLE
Preserve ADR-0050 temporary Bifrost hub-tracking condition in SBS operating model

### DIFF
--- a/docs/architecture/SBS_OPERATING_MODEL.md
+++ b/docs/architecture/SBS_OPERATING_MODEL.md
@@ -62,7 +62,7 @@ The SBS is described across several docs, each with a single owner. Do not dupli
 | Review-gate fallback policy | this doc §12 | What to do when a required automated review gate is unavailable. |
 | Builder System boundary, authority model, and artifact map | this doc §3 | Defines the continuous-development enabling system, its relationship to the Product/Runtime SBS and CES, how builder agents classify Product, Builder, and boundary work, and the owner/authority/writeback map for Builder System artifacts and workflows. |
 | Builder Learning, evaluation, and TCD governance loop | this doc §3 + `docs/development/DELIVERY_FEEDBACK_LOOP.md` | Defines the allowed inputs, durable destinations, TCD signals, reevaluation inputs, terminal outcomes, and promotion path for builder learning without contaminating Product/Runtime memory. |
-| Cross-repo constituent-surface governance | `docs/adr/ADR-0050-cross-repo-governance-and-bifrost-client-repo.md` | Owns the accepted Bifrost constituent-repo decision and the hub tracking posture; this operating model owns the Builder System's classification and process implications. |
+| Cross-repo constituent-surface governance | `docs/adr/ADR-0050-cross-repo-governance-and-bifrost-client-repo.md` | Owns the accepted Bifrost constituent-repo decision and the temporary hub-tracking posture (until Bifrost has its own board); this operating model owns the Builder System's classification and process implications. |
 
 This matrix is the **source-of-truth verification matrix** required for SBS operationalization. If a new SBS concern appears, add a row here naming exactly one owner doc.
 
@@ -86,10 +86,11 @@ they are used to produce or verify repo-governed changes.
 
 The Builder System may govern a constituent-surface repository as well as this hub repository when
 an accepted decision names that relationship. ADR-0050 is the owner decision for the Bifrost
-constituent-surface repository (`RasmusTho/bifrost`); it keeps cross-repo tracking in this hub and
-does not make Bifrost a Builder System or a Product/Runtime SBS subsystem. Work in that repository
-is classified against this model: the constituent surface is Product/Runtime System work built by
-the Builder System, and changes to the governing route are boundary work.
+constituent-surface repository (`RasmusTho/bifrost`); it keeps cross-repo tracking in this hub only
+until Bifrost has its own board — a temporary posture whose terms ADR-0050 owns, not a permanent
+routing rule — and does not make Bifrost a Builder System or a Product/Runtime SBS subsystem. Work
+in that repository is classified against this model: the constituent surface is Product/Runtime
+System work built by the Builder System, and changes to the governing route are boundary work.
 
 Hub `_shared` skill contracts that Bifrost mirrors are an explicitly **unchecked transition
 posture**, not a synchronization guarantee: drift is accepted only as visible debt until a governed

--- a/docs/architecture/inv-ef1-register.json
+++ b/docs/architecture/inv-ef1-register.json
@@ -1808,6 +1808,13 @@
       "issue": "#2892"
     },
     {
+      "artifact": "tests/architecture/test_sbs_operating_model_bifrost_tracking.py",
+      "category": "iv",
+      "why_load_bearing": "The guard test mirrors ADR-0050's hub-tracking condition, which names the Bifrost client repo; repo-coordination lineage, not an operator-bound host detail.",
+      "disposition": "stay",
+      "issue": "#4327"
+    },
+    {
       "artifact": "tests/builderops/test_epic_run_state.py",
       "category": "iii",
       "why_load_bearing": "Test fixture pins the existing operator-bound compatibility behavior.",

--- a/tests/architecture/test_sbs_operating_model_bifrost_tracking.py
+++ b/tests/architecture/test_sbs_operating_model_bifrost_tracking.py
@@ -1,0 +1,53 @@
+"""Guard ADR-0050's temporary Bifrost hub-tracking condition in the SBS operating model.
+
+Issue #4327 (review thread r3564898001 on PR #3496): the operating model's cross-repo
+tracking statement must carry ADR-0050's limiting condition — hub tracking applies only
+until Bifrost has its own board — so future agents do not read hub tracking as a
+permanent routing rule. ADR-0050 stays authoritative; the operating model links to it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPERATING_MODEL = REPO_ROOT / "docs" / "architecture" / "SBS_OPERATING_MODEL.md"
+ADR_0050 = REPO_ROOT / "docs" / "adr" / "ADR-0050-cross-repo-governance-and-bifrost-client-repo.md"
+
+# ADR-0050 :: Decision 1 ("One source of truth for tracking"): hub tracking holds only
+# until Bifrost has its own board.
+TRACKING_CONDITION = "until Bifrost has its own board"
+
+
+def _cross_repo_scope_section(text: str) -> str:
+    match = re.search(
+        r"^### Cross-repo constituent-surface scope\n(.*?)(?=^#{2,3} )",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, (
+        "SBS_OPERATING_MODEL.md no longer has the 'Cross-repo constituent-surface scope' "
+        "subsection; update this test's anchor alongside the doc."
+    )
+    return match.group(1)
+
+
+def test_bifrost_tracking_condition_matches_adr_0050() -> None:
+    adr_text = ADR_0050.read_text(encoding="utf-8")
+    assert TRACKING_CONDITION in adr_text, (
+        "ADR-0050 no longer states the hub-tracking condition "
+        f"{TRACKING_CONDITION!r}; it is the authority this test mirrors — "
+        "re-align the operating model and this test with the superseding decision."
+    )
+
+    section = _cross_repo_scope_section(OPERATING_MODEL.read_text(encoding="utf-8"))
+    assert TRACKING_CONDITION in section, (
+        "SBS_OPERATING_MODEL.md :: Cross-repo constituent-surface scope states the hub "
+        f"tracking posture without ADR-0050's limiting condition {TRACKING_CONDITION!r}; "
+        "hub tracking is temporary, not a permanent routing rule (issue #4327)."
+    )
+    assert "ADR-0050" in section, (
+        "The cross-repo scope subsection must keep referencing ADR-0050 as the "
+        "authoritative decision record rather than duplicating its content."
+    )


### PR DESCRIPTION
Governing-Issue: #4327

Fixes #4327

- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Qualifies the SBS operating model's cross-repo tracking statement (and the source-of-truth matrix row) with ADR-0050's limiting condition: hub tracking applies only until Bifrost has its own board. ADR-0050 remains the detailed authority — the operating model links to it and does not duplicate its content. Resolves review thread r3564898001 on PR #3496.

## Changes
- `docs/architecture/SBS_OPERATING_MODEL.md` :: Cross-repo constituent-surface scope — hub tracking now stated as temporary ("only until Bifrost has its own board — a temporary posture whose terms ADR-0050 owns, not a permanent routing rule"); the §2 matrix row for ADR-0050 now says "temporary hub-tracking posture (until Bifrost has its own board)". The existing "unchecked transition posture" statement is untouched.
- `tests/architecture/test_sbs_operating_model_bifrost_tracking.py` — new guard test named by the issue AC (`test_bifrost_tracking_condition_matches_adr_0050`): asserts ADR-0050 still states the condition, the operating-model subsection carries it, and the subsection keeps referencing ADR-0050. Written test-first; failed against the unchanged doc, passes after the writeback.
- `docs/architecture/inv-ef1-register.json` — CI-repair round 1: category-iv `stay` row covering the new test file for the INV-EF1 public seam gate (see below).

## CI-repair round 1 of 2
The smoke job's "INV-EF1 public seam gate" (`scripts/public_seam_lint.py --mode gate`) flagged 5 `vault-bifrost` hits in the new test file — the test necessarily names Bifrost because it mirrors ADR-0050's condition. Repair uses the gate's own sanctioned coverage mechanism: a register row in `docs/architecture/inv-ef1-register.json` (artifact + category iv, disposition `stay`, issue #4327), matching peer rows such as `tests/heimdal/test_cdlm_roundtrip_script.py`. The gate script and patterns are unchanged. Reproduced red locally (same 5 hits), then green after the row; the gate's contract tests (`tests/scripts/test_public_seam_lint.py`) still pass.

## Anchor drift
Issue anchor `ADR-0050 :: Cross-repo governance rule` has no matching heading; the nearest authoritative passages used were the ADR frontmatter Authority item (a) and `## Decision :: 1. Constituent-surface repos are governed constituents of Yggdrasil` ("stay tracked in the hub repo until Bifrost has its own board").

## Claim receipt
pickup-claim-complete issue=4327 branch=docs/4327-adr0050-bifrost-condition worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a2b63f77a5ed87cbb coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4327 lease_id=lease-f18ad8da holder=claude-w7a evidence=verified-dispatcher-lease

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs slice with no BuilderOps material routed.

## Notes
Validation: `pytest -q tests/architecture/test_sbs_operating_model_bifrost_tracking.py tests/scripts/test_public_seam_lint.py` (6 passed; guard test failed pre-change as required), `python3 scripts/public_seam_lint.py --mode gate` (uncovered_hits: 0), `python3 scripts/docs_guard.py` (OK), `python3 scripts/lint_skills_consistency.py` (OK), `ruff check app tests companion-ui/companion-app` (all passed), `git diff --check` (clean), register JSON parse check, issue-suggested `rg -n 'Bifrost|own board|hub'` spot-check. Branch-truth gate passed pre-commit and pre-push on both commits; review-before-CI gate satisfied (docs-authoring lane).
---