### PR TITLE
Correct stale MCP ADR-0058 planning anchors to ADR-0061

### DIFF
--- a/docs/MIMER_MCP_CLIENT_ADAPTER/EXPOSE_GOVERNED_MIMER_TOOLS_OVER_MCP.md
+++ b/docs/MIMER_MCP_CLIENT_ADAPTER/EXPOSE_GOVERNED_MIMER_TOOLS_OVER_MCP.md
@@ -92,7 +92,7 @@ human may see an uncertain outcome rather than a duplicate hidden replay.
 
 ## Related GitHub Issues
 
-Issue #3368 stays blocked until ADR-0058 is Accepted and links the explicit owner-decision receipt;
+Issue #3368 stays blocked until ADR-0061 is Accepted and links the explicit owner-decision receipt;
 merging the spec or a Proposed ADR is insufficient. It may then run in parallel with MIMER-MCP-03
 when file ownership is isolated. TCD hint: **Codex / xhigh** because an external protocol maps an
 authority-bearing write and subtle ambiguous-failure semantics; require architecture/security

--- a/docs/MIMER_MCP_CLIENT_ADAPTER/PACKAGE_AND_HARDEN_MIMER_MCP_TRANSPORT.md
+++ b/docs/MIMER_MCP_CLIENT_ADAPTER/PACKAGE_AND_HARDEN_MIMER_MCP_TRANSPORT.md
@@ -71,7 +71,7 @@ authentication, leaks secrets, or leaves an unsupervised process that disappears
 - Tool semantics owned by MIMER-MCP-02.
 - Concrete private host bindings, credentials, desktop-client edits, or operator fleet cutover.
 - A shared ecosystem registry, dynamic remote discovery, or support for transports not selected in
-  the owner-accepted ADR-0058 decision.
+  the owner-accepted ADR-0061 decision.
 
 ## Restart / Durability Posture
 
@@ -90,7 +90,7 @@ transport, preventing a restart from duplicating an append whose acknowledgement
 
 ## Related GitHub Issues
 
-Issue #3369 stays blocked until ADR-0058 is Accepted and links the explicit owner-decision receipt;
+Issue #3369 stays blocked until ADR-0061 is Accepted and links the explicit owner-decision receipt;
 merging the spec or a Proposed ADR is insufficient. It may then run in parallel with MIMER-MCP-02
 under an isolated worktree. TCD hint: **Codex / xhigh** because this is security-sensitive external transport
 and deployment work; require security review and production-call-site trust tests.

--- a/docs/MIMER_MCP_CLIENT_ADAPTER/PARENT_FEATURE_ISSUE.md
+++ b/docs/MIMER_MCP_CLIENT_ADAPTER/PARENT_FEATURE_ISSUE.md
@@ -12,7 +12,7 @@ the owner explicitly accepts topology, wire transport, and authentication in a d
 
 ## Scope
 
-- Draft `docs/adr/ADR-0058-mimer-mcp-client-adapter.md` as a **Proposed** decision with alternatives
+- Draft `docs/adr/ADR-0061-mimer-mcp-client-adapter.md` as a **Proposed** decision with alternatives
   and a recommendation; do not mark it Accepted or superseding without the owner's receipt.
 - If accepted, implement the exact MCP tool surface without creating a second authority or
   vault-write path.
@@ -43,7 +43,7 @@ the owner explicitly accepts topology, wire transport, and authentication in a d
 - Retrieval/context impact: exposes existing ask/retrieve/read behavior without changing ranking, grounding, or context assembly
 - Sync/deployment impact: adds a managed client transport whose binding, restart, and exposure posture must be explicit
 - External boundary impact: adds a constituent-owned protocol adapter and client-facing trust boundary
-- New or changed contract: Proposed ADR-0058 first; accepted/superseding ADR and `docs/contracts/MIMER_CLIENT_CONTRACT.md` change only after an explicit owner receipt; tool-policy contract changes only if internal adapter semantics change
+- New or changed contract: Proposed ADR-0061 first; accepted/superseding ADR and `docs/contracts/MIMER_CLIENT_CONTRACT.md` change only after an explicit owner receipt; tool-policy contract changes only if internal adapter semantics change
 - Owner-doc impact: will-update-in-PR per child; final current-state promotion belongs to the acceptance child
 - Transition debt impact: no SBS transition-debt effect expected; any newly discovered adapter/authority deviation becomes bounded debt
 - Fitness rule impact: strengthens the manual external-adapter/authority review with production-call-site tests
@@ -52,8 +52,8 @@ the owner explicitly accepts topology, wire transport, and authentication in a d
 
 - The parent is a validation hub, never an `agent:ready` implementation issue.
 - #3371 remains `agent:needs-human` after the spec merges. Drafting the proposal does not authorize
-  an agent to choose topology, wire transport, authentication, or mark ADR-0058 Accepted.
-- #3368 and #3369 remain blocked until ADR-0058 is Accepted with a linked owner-decision receipt.
+  an agent to choose topology, wire transport, authentication, or mark ADR-0061 Accepted.
+- #3368 and #3369 remain blocked until ADR-0061 is Accepted with a linked owner-decision receipt.
 - Preserve the client contract's authority, index-lag, ambiguous-write, trace, and no-hidden-truth
   rules.
 - Do not expose `app/mcp/vault_tools.py` or internal orchestrator descriptors as the client server.
@@ -64,12 +64,12 @@ the owner explicitly accepts topology, wire transport, and authentication in a d
 
 ## Acceptance Criteria
 
-- [ ] ADR-0058 presents explicit topology, wire-transport, and authentication alternatives plus a
+- [ ] ADR-0061 presents explicit topology, wire-transport, and authentication alternatives plus a
       recommendation while remaining Proposed until the owner rules.
-  - Verify: doc writeback at `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Options and recommendation`
-- [ ] The owner decision is recorded durably before ADR-0058 becomes Accepted or supersedes existing
+  - Verify: doc writeback at `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Options and recommendation`
+- [ ] The owner decision is recorded durably before ADR-0061 becomes Accepted or supersedes existing
       authority, and the client contract changes only to the accepted choice.
-  - Verify: owner-decision receipt on GitHub Issue #3371 linked from `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Owner decision receipt` plus doc writeback at `docs/contracts/MIMER_CLIENT_CONTRACT.md :: Classification and transports`
+  - Verify: owner-decision receipt on GitHub Issue #3371 linked from `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Owner decision receipt` plus doc writeback at `docs/contracts/MIMER_CLIENT_CONTRACT.md :: Classification and transports`
 - [ ] The exact contracted MCP tool surface delegates to existing client operations and preserves
       the governed capture response and error envelope.
   - Verify: `tests/mcp/test_mimer_server.py::test_server_exposes_exact_contracted_tool_set`
@@ -115,7 +115,7 @@ the owner explicitly accepts topology, wire transport, and authentication in a d
 ## Implementation Tasks
 
 1. #3371 (`agent:needs-human`) — `docs/MIMER_MCP_CLIENT_ADAPTER/RATIFY_MCP_CLIENT_ADAPTER.md`
-2. In parallel only after ADR-0058 is owner-accepted with a linked decision receipt:
+2. In parallel only after ADR-0061 is owner-accepted with a linked decision receipt:
    - #3368 — `docs/MIMER_MCP_CLIENT_ADAPTER/EXPOSE_GOVERNED_MIMER_TOOLS_OVER_MCP.md`
    - #3369 — `docs/MIMER_MCP_CLIENT_ADAPTER/PACKAGE_AND_HARDEN_MIMER_MCP_TRANSPORT.md`
 3. #3370 — `docs/MIMER_MCP_CLIENT_ADAPTER/PROVE_CLIENT_COMPATIBILITY_AND_ACCEPT_MIMER_MCP.md`

--- a/docs/MIMER_MCP_CLIENT_ADAPTER/RATIFY_MCP_CLIENT_ADAPTER.md
+++ b/docs/MIMER_MCP_CLIENT_ADAPTER/RATIFY_MCP_CLIENT_ADAPTER.md
@@ -19,7 +19,7 @@ proposal and then waits for the owner's explicit receipt; it does not autonomous
 
 ## What This Task Does
 
-- Drafts `docs/adr/ADR-0058-mimer-mcp-client-adapter.md` with `State: Proposed`, revisiting
+- Drafts `docs/adr/ADR-0061-mimer-mcp-client-adapter.md` with `State: Proposed`, revisiting
   ADR-0047's concrete-server trigger and ADR-0056's fixed transport set.
 - Presents explicit alternatives, consequences, and a reasoned recommendation for server ownership,
   protocol-tier topology, supported wire transport(s), authentication/trust posture, and the exact
@@ -33,7 +33,7 @@ proposal and then waits for the owner's explicit receipt; it does not autonomous
 
 ```text
 current: transports = HTTP API + direct filesystem; MCP deferred
-proposal: ADR-0058 State=Proposed
+proposal: ADR-0061 State=Proposed
           options(topology, wire transport, auth) + consequences + recommendation
 gate:     owner-decision receipt on #3371
 accepted path only: update ADR state/supersession + client contract to the ruled option
@@ -47,16 +47,16 @@ owner receipt makes later code review mechanical without fabricating authority.
 
 ## Acceptance Criteria
 
-- [ ] ADR-0058 exists in Proposed state and enumerates topology, wire-transport, and authentication
+- [ ] ADR-0061 exists in Proposed state and enumerates topology, wire-transport, and authentication
       alternatives, consequences, and a recommendation without claiming acceptance or supersession.
-  Verify: doc writeback at `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Options and recommendation`
+  Verify: doc writeback at `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Options and recommendation`
 - [ ] The proposal fixes the invariant operation boundary—ask, governed capture, retrieve/search,
       note read, and health—and explicitly excludes generic vault write and receipt read-back across
       every option.
-  Verify: doc writeback at `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Invariants across all options`
+  Verify: doc writeback at `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Invariants across all options`
 - [ ] The explicit owner ruling is recorded on #3371 and linked from the ADR before its state becomes
       Accepted or it claims to supersede/reconcile ADR-0047/ADR-0056.
-  Verify: owner-decision receipt on GitHub Issue #3371 linked from `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Owner decision receipt`
+  Verify: owner-decision receipt on GitHub Issue #3371 linked from `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Owner decision receipt`
 - [ ] Only after an accepting owner receipt, the Mimer client contract reflects exactly the selected
       topology/transport/auth option while preserving its authority and ambiguous-write invariants.
   Verify: doc writeback at `docs/contracts/MIMER_CLIENT_CONTRACT.md :: Classification and transports` plus the linked owner-decision receipt on #3371
@@ -70,7 +70,7 @@ owner receipt makes later code review mechanical without fabricating authority.
 
 - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_docs_index.py`
 - `rg -n "MCP adapter|MCP transport|receipt read-back|vault_tools|protocol-tier" docs/adr docs/contracts/MIMER_CLIENT_CONTRACT.md docs/ARCHITECTURE.md docs/architecture/ecosystem-federation.md`
-- Confirm `docs/adr/ADR-0058-mimer-mcp-client-adapter.md` stays `State: Proposed` and contains no
+- Confirm `docs/adr/ADR-0061-mimer-mcp-client-adapter.md` stays `State: Proposed` and contains no
   superseding/Accepted claim unless the linked #3371 owner-decision receipt exists.
 - Review the selected client-contract writeback against that receipt, if and only if the owner has
   accepted an option; otherwise confirm the current contract is unchanged.
@@ -93,6 +93,6 @@ owner receipt makes later code review mechanical without fabricating authority.
 
 Issue #3371 remains **`agent:needs-human` after the specification merges**. An Opus/xhigh (or
 equivalent frontier architecture capability) may draft alternatives, consequences, and a
-recommendation to minimize owner review time, but it cannot choose for the owner or mark ADR-0058
+recommendation to minimize owner review time, but it cannot choose for the owner or mark ADR-0061
 Accepted. After the explicit owner receipt, use the same high-assurance architecture capability to
 apply the selected decision exactly; architecture-quality review remains mandatory.

--- a/docs/MIMER_MCP_CLIENT_ADAPTER/README.md
+++ b/docs/MIMER_MCP_CLIENT_ADAPTER/README.md
@@ -86,7 +86,7 @@ In shorthand: `MIMER-MCP-01 -> (MIMER-MCP-02 || MIMER-MCP-03) -> MIMER-MCP-04`.
       without replacing HTTP or direct-filesystem semantics.
   Verify: doc writeback at `docs/contracts/MIMER_CLIENT_CONTRACT.md :: Classification and transports`
   and owner-decision receipt on GitHub Issue #3371 linked from
-  `docs/adr/ADR-0058-mimer-mcp-client-adapter.md :: Owner decision receipt`
+  `docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Owner decision receipt`
 - [ ] The server exposes exactly ask, governed capture, retrieve/search, note read, and health, with
       governed capture receipts and failure semantics preserved.
   Verify: `tests/mcp/test_mimer_server.py::test_server_exposes_exact_contracted_tool_set`
@@ -102,7 +102,7 @@ In shorthand: `MIMER-MCP-01 -> (MIMER-MCP-02 || MIMER-MCP-03) -> MIMER-MCP-04`.
 
 ## Verification Path
 
-- MIMER-MCP-01 drafts `ADR-0058` in `Proposed` state with alternatives and a recommendation, then
+- MIMER-MCP-01 drafts `ADR-0061` in `Proposed` state with alternatives and a recommendation, then
   waits for the owner-decision receipt before any Accepted/superseding language or contract change.
 - MIMER-MCP-02 uses in-process MCP tool tests with stubbed existing client operations plus the
   existing API contract suites.
@@ -132,10 +132,10 @@ composed runtime receipt exists.
 ## Relationship to GitHub Issues
 
 - Parent validation hub: #3366 (`agent:blocked`).
-- MIMER-MCP-01: #3371 — `agent:needs-human`; drafts ADR-0058 as Proposed and waits for the explicit
+- MIMER-MCP-01: #3371 — `agent:needs-human`; drafts ADR-0061 as Proposed and waits for the explicit
   owner-decision receipt. Spec merge does not make it autonomous.
-- MIMER-MCP-02: #3368 — blocked on an owner-accepted ADR-0058 receipt, not only issue/PR completion.
-- MIMER-MCP-03: #3369 — blocked on the same owner-accepted ADR-0058 receipt; may run parallel with
+- MIMER-MCP-02: #3368 — blocked on an owner-accepted ADR-0061 receipt, not only issue/PR completion.
+- MIMER-MCP-03: #3369 — blocked on the same owner-accepted ADR-0061 receipt; may run parallel with
   #3368 only after that gate is satisfied.
 - MIMER-MCP-04: #3370 — blocked on #3368 and #3369; final acceptance/closure handoff.
 

--- a/docs/adr/ADR-0061-mimer-mcp-client-adapter.md
+++ b/docs/adr/ADR-0061-mimer-mcp-client-adapter.md
@@ -1,4 +1,4 @@
-State: Proposed (owner decision pending, 2026-07-11). Prepares — but does not make — the decision to admit MCP (Model Context Protocol) as an additional protocol-tier client adapter over Mimer's existing client contract, exposing exactly the already-shipped ask, governed-capture, retrieve/search, note-read, and health operations. Enumerates topology, wire-transport, and authentication alternatives with consequences and a recommendation. It changes no current authority: `docs/contracts/MIMER_CLIENT_CONTRACT.md`, ADR-0047, and ADR-0056 remain authoritative and MCP is NOT an admitted Mimer client transport until an owner-decision receipt on #3371 accepts one option. Only then may this ADR become Accepted and record supersession precisely. Numbering note: the specification directory and issues #3366–#3371 name this decision "ADR-0058", but ADR-0058 is already taken (event-horizon closure decay); this record is **ADR-0061** and supersedes those stale "ADR-0058" references.
+State: Proposed (owner decision pending, 2026-07-11). Prepares — but does not make — the decision to admit MCP (Model Context Protocol) as an additional protocol-tier client adapter over Mimer's existing client contract, exposing exactly the already-shipped ask, governed-capture, retrieve/search, note-read, and health operations. Enumerates topology, wire-transport, and authentication alternatives with consequences and a recommendation. It changes no current authority: `docs/contracts/MIMER_CLIENT_CONTRACT.md`, ADR-0047, and ADR-0056 remain authoritative and MCP is NOT an admitted Mimer client transport until an owner-decision receipt on #3371 accepts one option. Only then may this ADR become Accepted and record supersession precisely. Numbering note: issues #3366–#3371 (and, before the #4320 correction, the specification directory) name this decision "ADR-0058", but ADR-0058 is already taken (event-horizon closure decay); this record is **ADR-0061** and supersedes those stale "ADR-0058" references.
 Doc role: Decision record (ADR)
 Authority: Not authoritative while Proposed — advisory decision-preparation only. If accepted by an owner receipt on #3371, it becomes authoritative for (a) admitting MCP as an additional protocol-tier client adapter over the Mimer client contract, (b) the topology/wire-transport/auth posture of that adapter, and (c) the fixed operation boundary of the external MCP surface. It never becomes an independent authority path: the adapter delegates to the operations and authority envelope of `docs/contracts/MIMER_CLIENT_CONTRACT.md` and creates no second knowledge API or vault-write path.
 Owner: Architecture (Rasmus)
@@ -244,10 +244,11 @@ under ADR-0047 Rule 4.
   wins.
 - **If declined:** MCP stays deferred; ADR-0056's HTTP + direct-FS transport set and ADR-0047's
   deferral both stand unchanged; #3368–#3370 remain blocked and #3366 stays a blocked validation hub.
-- **Numbering debris cleared:** issues #3366–#3371 and the `MIMER_MCP_CLIENT_ADAPTER/` spec docs
-  reference "ADR-0058" for this decision; that number belongs to event-horizon closure decay. This
-  record is ADR-0061 and supersedes those references; the spec's `ADR-0058-...` filename anchors
-  should be read as pointing here until they are corrected in a follow-up docs pass.
+- **Numbering debris cleared:** issues #3366–#3371 reference "ADR-0058" for this decision; that
+  number belongs to event-horizon closure decay. This record is ADR-0061 and supersedes those
+  stale issue-text references, which should be read as pointing here. The
+  `MIMER_MCP_CLIENT_ADAPTER/` spec docs' filename and decision-number anchors were corrected to
+  ADR-0061 by the #4320 docs pass.
 
 ## Owner decision receipt
 

--- a/docs/architecture/inv-ef1-register.json
+++ b/docs/architecture/inv-ef1-register.json
@@ -1360,6 +1360,13 @@
       "issue": "#2892"
     },
     {
+      "artifact": "docs/adr/ADR-0061-mimer-mcp-client-adapter.md",
+      "category": "ii",
+      "why_load_bearing": "The proposed MCP client-adapter decision record preserves an operator-bound ownership reference while its owner decision remains pending.",
+      "disposition": "stay",
+      "issue": "#4320"
+    },
+    {
       "artifact": "docs/adr/ADR-0060-capture-posture-b-full-voice-identity.md",
       "category": "ii",
       "why_load_bearing": "Documentation preserves a truthful historical or operational reference for the Builder System.",

--- a/tests/docs/test_mimer_mcp_adr_references.py
+++ b/tests/docs/test_mimer_mcp_adr_references.py
@@ -1,0 +1,88 @@
+"""Doc-truth guard for #4320: MCP planning anchors name ADR-0061, not "ADR-0058".
+
+The `docs/MIMER_MCP_CLIENT_ADAPTER/` specification directory historically named the
+MCP client-adapter decision "ADR-0058", but that number belongs to event-horizon
+closure decay (`docs/adr/ADR-0058-event-horizon-closure-decay.md`). The actual
+proposed decision record is `docs/adr/ADR-0061-mimer-mcp-client-adapter.md` (see its
+"Numbering note"). This test keeps the spec directory pointed at ADR-0061 while
+preserving the proposed, owner-decision-pending gate — the renumbering must never be
+read as the MCP decision having been accepted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC_DIR = REPO_ROOT / "docs" / "MIMER_MCP_CLIENT_ADAPTER"
+ADR_0061 = REPO_ROOT / "docs" / "adr" / "ADR-0061-mimer-mcp-client-adapter.md"
+
+
+def _spec_files() -> list[Path]:
+    files = sorted(SPEC_DIR.glob("*.md"))
+    assert files, f"missing MCP specification directory or files: {SPEC_DIR}"
+    return files
+
+
+def test_mimer_mcp_specs_reference_adr_0061() -> None:
+    """No spec file may point at the nonexistent MCP "ADR-0058" record."""
+    offenders: list[str] = []
+    for path in _spec_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "ADR-0058" in line or "adr-0058" in line:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "MCP specification files still reference the stale 'ADR-0058' name for the "
+        "MCP client-adapter decision; the actual record is ADR-0061 "
+        "(docs/adr/ADR-0061-mimer-mcp-client-adapter.md :: Numbering note):\n"
+        + "\n".join(offenders)
+    )
+
+    # The decision references must resolve to the real ADR-0061 record.
+    referencing = [
+        path
+        for path in _spec_files()
+        if "ADR-0061" in path.read_text(encoding="utf-8")
+    ]
+    assert referencing, (
+        "No MCP specification file references ADR-0061; the decision anchor was "
+        "removed instead of corrected."
+    )
+    assert ADR_0061.exists(), f"missing decision record: {ADR_0061}"
+
+
+def test_mimer_mcp_specs_preserve_proposed_owner_gate() -> None:
+    """Corrected specs still state ADR-0061 is proposed and owner-decision pending."""
+    assert ADR_0061.exists(), f"missing decision record: {ADR_0061}"
+    adr_text = ADR_0061.read_text(encoding="utf-8")
+    assert adr_text.startswith("State: Proposed"), (
+        "ADR-0061 no longer opens with 'State: Proposed'; this guard only covers the "
+        "pre-acceptance posture and must be revisited together with the owner receipt."
+    )
+
+    readme = (SPEC_DIR / "README.md").read_text(encoding="utf-8")
+    assert "owner-decision receipt" in readme and "not an admitted Mimer client transport" in readme, (
+        "README.md lost the owner-decision gate wording: MCP must stay non-admitted "
+        "until an explicit owner-decision receipt accepts the proposed ADR-0061."
+    )
+
+    ratify = (SPEC_DIR / "RATIFY_MCP_CLIENT_ADAPTER.md").read_text(encoding="utf-8")
+    assert "State: Proposed" in ratify or "State=Proposed" in ratify, (
+        "RATIFY_MCP_CLIENT_ADAPTER.md no longer requires ADR-0061 to stay in "
+        "Proposed state pending the owner ruling."
+    )
+
+    blocker_phrase = (
+        "stays blocked until ADR-0061 is Accepted and links the explicit "
+        "owner-decision receipt"
+    )
+    for name in (
+        "EXPOSE_GOVERNED_MIMER_TOOLS_OVER_MCP.md",
+        "PACKAGE_AND_HARDEN_MIMER_MCP_TRANSPORT.md",
+    ):
+        text = (SPEC_DIR / name).read_text(encoding="utf-8")
+        assert blocker_phrase in text, (
+            f"{name} lost the downstream blocker: implementation issues stay blocked "
+            "until ADR-0061 is owner-accepted with a linked decision receipt."
+        )


### PR DESCRIPTION
Governing-Issue: #4320

Fixes #4320

- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
The `docs/MIMER_MCP_CLIENT_ADAPTER/` specification directory named the nonexistent MCP "ADR-0058" for the MCP client-adapter decision; that number belongs to event-horizon closure decay. Every stale filename, decision-number, and Verify/blocker reference now points at the actual proposed `docs/adr/ADR-0061-mimer-mcp-client-adapter.md`, the proposed / owner-decision-pending gate is preserved verbatim (nothing implies acceptance), and ADR-0061's numbering note no longer describes this correction as a pending follow-up docs pass. The issue's named doc-truth guard `tests/docs/test_mimer_mcp_adr_references.py` is added (test-first: both tests failed against the unchanged docs, pass after the correction).

## Changes
- `docs/MIMER_MCP_CLIENT_ADAPTER/README.md`, `PARENT_FEATURE_ISSUE.md`, `RATIFY_MCP_CLIENT_ADAPTER.md`, `EXPOSE_GOVERNED_MIMER_TOOLS_OVER_MCP.md`, `PACKAGE_AND_HARDEN_MIMER_MCP_TRANSPORT.md`: all 25 `ADR-0058` references renumbered to `ADR-0061`; owner-gate/blocker wording (`#3368`/`#3369` blocked until owner-accepted receipt, `#3371` `agent:needs-human`, `State: Proposed`) unchanged.
- `docs/adr/ADR-0061-mimer-mcp-client-adapter.md`: numbering note updated so the spec-directory correction reads as done (per #4320) while the stale issue-text references remain documented as historical.
- `tests/docs/test_mimer_mcp_adr_references.py`: new guard for both ACs (`test_mimer_mcp_specs_reference_adr_0061`, `test_mimer_mcp_specs_preserve_proposed_owner_gate`).

Intentionally retained `ADR-0058` mentions: `docs/adr/ADR-0061-...md` numbering note (quoted historical name explaining the renumbering) and all event-horizon closure-decay references outside `docs/MIMER_MCP_CLIENT_ADAPTER/`, which legitimately refer to `docs/adr/ADR-0058-event-horizon-closure-decay.md`.

## Claim receipt
`pickup-claim-complete issue=4320 branch=docs/4320-adr0061-anchor-fix worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a5b39569170cd5ddd coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4320 lease_id=lease-072c0319 holder=claude-w7b evidence=verified-dispatcher-lease`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring lane with no BuilderOps material routed.

## Notes
Validation: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/docs/test_mimer_mcp_adr_references.py` (2 passed; both failed pre-fix), `python3 scripts/docs_guard.py` (OK), `git diff --check` (clean), `rg -n 'ADR-0058-mimer-mcp-client-adapter|owner-accepted ADR-0058' docs/MIMER_MCP_CLIENT_ADAPTER` (no matches), `ruff check app tests companion-ui/companion-app` (all checks passed), `review_before_ci_gate.py --lane docs-authoring` (satisfied).
---