### PR TITLE
Wire standing-question evidence matching into production ingest consumers (SQ-03)

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -24,6 +24,7 @@ from app.cli.health_contract import emit_health_contract_status
 from app.cli.watcher import vault_watcher_run, vault_watcher_daemon, watcher_group
 from app.cli.heimdal import heimdal_group
 from app.cli.episodes import episodes_group
+from app.cli.questions import questions_group
 from app.cli.index_rebuild import index as index_cli
 from app.cli.llm_doctor import llm as llm_cli
 from app.cli import index_doctor  # noqa: F401 -- register index doctor command
@@ -1983,6 +1984,7 @@ cli.add_command(vault_watcher_run)
 cli.add_command(vault_watcher_daemon)
 cli.add_command(heimdal_group, name="heimdal")
 cli.add_command(episodes_group, name="episodes")
+cli.add_command(questions_group, name="questions")
 cli.add_command(briefing_group, name="briefing")
 cli.add_command(journaling_group, name="journaling")
 

--- a/app/cli/questions.py
+++ b/app/cli/questions.py
@@ -1,0 +1,68 @@
+"""Standing Questions CLI (SQ-03, #4610).
+
+`questions match-evidence` is the production invocation of the Heimdal
+observation-log evidence tick -- the same operational shape as
+`episodes tick` for the Episode Resolution Engine, which consumes the same
+log through its own cursor. The vault-ingest and KAP completion paths need no
+command here: the outbox worker's own topic handlers invoke the matcher
+inline as events dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+import click
+
+from app.standing_questions.ingest_consumers import run_heimdal_evidence_matching_tick
+
+_VAULT_ROOT_ENV_CANDIDATES = ("WATCHER_VAULT_PATH", "VAULT_ROOT")
+
+
+def _default_vault_root() -> str:
+    for env_name in _VAULT_ROOT_ENV_CANDIDATES:
+        value = os.getenv(env_name)
+        if value and value.strip():
+            return value.strip()
+    return "vault"
+
+
+@click.group(name="questions", help="Standing Questions controls (SQ-01+).")
+def questions_group() -> None:
+    ...
+
+
+@questions_group.command(
+    name="match-evidence",
+    help="Run one standing-question evidence-matching tick over unread Heimdal observations.",
+)
+@click.option(
+    "--vault-root",
+    type=click.Path(),
+    default=None,
+    help=f"Vault root to run against. Defaults to the first set of {_VAULT_ROOT_ENV_CANDIDATES}, else 'vault'.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    help="Maximum observations to consume this tick (default: all unread).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the tick summary as JSON.")
+def match_evidence(vault_root: str | None, limit: int | None, as_json: bool) -> None:
+    root = Path(vault_root) if vault_root else Path(_default_vault_root())
+    summary = run_heimdal_evidence_matching_tick(vault_root=root, limit=limit)
+    if as_json:
+        click.echo(json.dumps(asdict(summary), ensure_ascii=False))
+    else:
+        click.echo(
+            "questions match-evidence: "
+            f"evaluated_pairs={summary.evaluated_pairs} attached={summary.attached} "
+            f"below_threshold={summary.below_threshold} degraded={summary.degraded} "
+            f"excluded_cross_scope={summary.excluded_cross_scope} "
+            f"excluded_non_open={summary.excluded_non_open} "
+            f"unresolved_artifact={summary.unresolved_artifact}"
+        )

--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -35,6 +35,7 @@ from app.services.companion_note import (
     write_companion,
 )
 from app.services.note_uuid import ensure_note_uuid
+from app.standing_questions.question_store import QUESTION_DIRECTORY
 from app.objects import DomainObject, ObjectStore, resolve_canonical_object_id
 from app.stores import get_object_store
 from app.vault.layout import ensure_vault_layout
@@ -102,6 +103,21 @@ _UNINDEXED_SYSTEM_SUBFOLDERS: tuple[str, ...] = ("companions", "drafts")
 
 def _is_locked_error(exc: Exception) -> bool:
     return isinstance(exc, OSError) and getattr(exc, "errno", None) == 35
+
+
+def _is_engine_owned_question_path(rel_path: Path) -> bool:
+    """True for engine-owned Standing Questions notes; this walk must skip them (#4610).
+
+    Question notes carry ``question_id`` (never a frontmatter ``uuid``) and
+    validate against a closed schema (``schemas/question-note.schema.json``,
+    ``additionalProperties: false``) -- healing a ``uuid:`` key in makes the
+    note schema-invalid and silently drops the question from matching and its
+    projection. Their query surface is the ``standing_questions`` projection
+    owned by ``docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md``,
+    not the retrieval index, so they are excluded from this ingest fan-out
+    entirely rather than indexed under an unstable identity.
+    """
+    return rel_path.parts[:1] == (QUESTION_DIRECTORY,)
 
 
 def _is_unindexed_system_path(rel_path: Path, *, system_root: Path) -> bool:
@@ -408,6 +424,8 @@ def _select_candidates(
                 continue
             system_root = Path(get_vault_system_dir_rel(vault_root))
             if _is_unindexed_system_path(rel_path, system_root=system_root):
+                continue
+            if _is_engine_owned_question_path(rel_path):
                 continue
             if not path.is_file():
                 continue
@@ -772,6 +790,8 @@ def _ingest_candidates(
             rel_display = str(rel_path)
             system_root = Path(get_vault_system_dir_rel(vault_root))
             if _is_unindexed_system_path(rel_path, system_root=system_root):
+                continue
+            if _is_engine_owned_question_path(rel_path):
                 continue
             if rel_display in processed:
                 continue

--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -106,14 +106,15 @@ def _is_locked_error(exc: Exception) -> bool:
 
 
 def _is_engine_owned_question_path(rel_path: Path) -> bool:
-    """True for engine-owned Standing Questions notes; this walk must skip them (#4610).
+    """True for engine-owned Standing Questions notes; this walk must skip them
+    (#4610, ``docs/STANDING_QUESTIONS/README.md :: Cross-Task Invariants``
+    keystone ``questions_outside_generic_ingest`` / INV-SQ-H).
 
     Question notes carry ``question_id`` (never a frontmatter ``uuid``) and
     validate against a closed schema (``schemas/question-note.schema.json``,
     ``additionalProperties: false``) -- healing a ``uuid:`` key in makes the
     note schema-invalid and silently drops the question from matching and its
-    projection. Their query surface is the ``standing_questions`` projection
-    owned by ``docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md``,
+    projection. Their query surface is the ``standing_questions`` projection,
     not the retrieval index, so they are excluded from this ingest fan-out
     entirely rather than indexed under an unstable identity.
     """

--- a/app/standing_questions/evidence_matching.py
+++ b/app/standing_questions/evidence_matching.py
@@ -39,7 +39,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 from app.components.llm.constrained import (
@@ -256,20 +256,24 @@ def _resolve_content(vault_root: Path, candidate: CandidateArtifact) -> str | No
         )
         return None
     relative = candidate.artifact_ref[len(VAULT_REF_PREFIX) :]
-    # Defense in depth against question self-citation (#4610 review): the
-    # production candidate builders already exclude engine-owned Question
-    # notes, but any future caller constructing a CandidateArtifact directly
-    # must not be able to route a question back into its own evidence trail.
-    if PurePosixPath(relative).parts[:1] == (QUESTION_DIRECTORY,):
-        _LOGGER.warning(
-            "Standing Questions matching refused engine-owned question note as candidate: %s",
-            candidate.artifact_ref,
-        )
-        return None
     path = (vault_root / relative).resolve()
     if not path.is_relative_to(vault_root) or not path.is_file():
         _LOGGER.warning(
             "Standing Questions matching skipped unresolvable artifact: %s",
+            candidate.artifact_ref,
+        )
+        return None
+    # Defense in depth against question self-citation (#4610 review): the
+    # production candidate builders already exclude engine-owned Question
+    # notes, but any caller constructing a CandidateArtifact directly must not
+    # be able to route a question back into its own evidence trail. Checked on
+    # the RESOLVED path so a traversal ref (`vault://x/../questions/...`)
+    # cannot bypass it. Only refs resolved here traverse this guard -- a
+    # candidate with inline content short-circuited above, which is why the
+    # builders' own exclusion still matters.
+    if path.relative_to(vault_root).parts[:1] == (QUESTION_DIRECTORY,):
+        _LOGGER.warning(
+            "Standing Questions matching refused engine-owned question note as candidate: %s",
             candidate.artifact_ref,
         )
         return None

--- a/app/standing_questions/evidence_matching.py
+++ b/app/standing_questions/evidence_matching.py
@@ -39,7 +39,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from app.components.llm.constrained import (
@@ -56,6 +56,7 @@ from jsonschema import ValidationError
 
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.standing_questions.question_store import (
+    QUESTION_DIRECTORY,
     QuestionNoteRoundTripError,
     QuestionNotOpenError,
     QuestionStore,
@@ -192,10 +193,13 @@ class MatchTickSummary:
     excluded_cross_scope: int = 0
     excluded_non_open: int = 0
     unresolved_artifact: int = 0
-    #: Appends the guarded seam refused or failed AFTER a qualifying match:
-    #: a human-edit write conflict (CAS), a round-trip refusal, or a question
-    #: note that disappeared/corrupted mid-tick. Never silent, never fatal to
-    #: the tick; the pair stays re-evaluable by a later pass.
+    #: Pairs whose guarded append was refused or failed AFTER a qualifying
+    #: match: a human-edit write conflict (CAS), a round-trip refusal, or a
+    #: question note that disappeared/corrupted mid-tick. Never silent, never
+    #: fatal to the tick. Re-offerable sources (vault notes, KA candidates)
+    #: retry naturally on their next event; the Heimdal cursor path does NOT
+    #: re-deliver once its cursor advances past the batch, so a refused
+    #: Heimdal-sourced pair is a logged, counted loss.
     append_refused: int = 0
 
 
@@ -252,6 +256,16 @@ def _resolve_content(vault_root: Path, candidate: CandidateArtifact) -> str | No
         )
         return None
     relative = candidate.artifact_ref[len(VAULT_REF_PREFIX) :]
+    # Defense in depth against question self-citation (#4610 review): the
+    # production candidate builders already exclude engine-owned Question
+    # notes, but any future caller constructing a CandidateArtifact directly
+    # must not be able to route a question back into its own evidence trail.
+    if PurePosixPath(relative).parts[:1] == (QUESTION_DIRECTORY,):
+        _LOGGER.warning(
+            "Standing Questions matching refused engine-owned question note as candidate: %s",
+            candidate.artifact_ref,
+        )
+        return None
     path = (vault_root / relative).resolve()
     if not path.is_relative_to(vault_root) or not path.is_file():
         _LOGGER.warning(
@@ -437,12 +451,17 @@ def match_evidence_to_open_questions(
             # The seam refused or lost the write: a concurrent human edit (CAS
             # conflict -- the canonical note is untouched, a stale `open`
             # payload never overwrites a close), a round-trip refusal, or a
-            # question note deleted mid-tick. Per-question, never fatal to the
-            # tick; the pair stays re-evaluable by any later pass.
+            # question note deleted mid-tick. Never fatal to the tick; counted
+            # per PAIR so every evaluated pair still lands in exactly one
+            # bucket. Re-offerable sources retry on their next event; a
+            # Heimdal-cursor pair is a logged loss once the cursor advances.
             _LOGGER.warning(
-                "Standing Questions evidence append refused for %s: %s", question_id, exc
+                "Standing Questions evidence append refused for %s (%d entries): %s",
+                question_id,
+                len(new_entries),
+                exc,
             )
-            counters.bump("append_refused", 1)
+            counters.bump("append_refused", len(new_entries))
             continue
         dropped = len(new_entries) - len(appended_entries)
         if dropped:

--- a/app/standing_questions/evidence_matching.py
+++ b/app/standing_questions/evidence_matching.py
@@ -52,7 +52,14 @@ from app.standing_questions.projection import (
     QuestionsDirectoryMissingError,
     iter_question_notes,
 )
-from app.standing_questions.question_store import QuestionNotOpenError, QuestionStore
+from jsonschema import ValidationError
+
+from app.knowledge.errors import KnowledgeWriteConflict
+from app.standing_questions.question_store import (
+    QuestionNoteRoundTripError,
+    QuestionNotOpenError,
+    QuestionStore,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -185,6 +192,11 @@ class MatchTickSummary:
     excluded_cross_scope: int = 0
     excluded_non_open: int = 0
     unresolved_artifact: int = 0
+    #: Appends the guarded seam refused or failed AFTER a qualifying match:
+    #: a human-edit write conflict (CAS), a round-trip refusal, or a question
+    #: note that disappeared/corrupted mid-tick. Never silent, never fatal to
+    #: the tick; the pair stays re-evaluable by a later pass.
+    append_refused: int = 0
 
 
 @dataclass
@@ -249,7 +261,7 @@ def _resolve_content(vault_root: Path, candidate: CandidateArtifact) -> str | No
         return None
     try:
         return path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         # #4610 P2: a note deleted (or otherwise made unreadable) between the
         # `is_file()` check above and this read is a normal race for
         # asynchronously consumed ingest events. It is an unresolved no-link
@@ -414,6 +426,23 @@ def match_evidence_to_open_questions(
             )
         except QuestionNotOpenError:
             counters.bump("excluded_non_open")
+            continue
+        except (
+            KnowledgeWriteConflict,
+            QuestionNoteRoundTripError,
+            OSError,
+            ValueError,
+            ValidationError,
+        ) as exc:
+            # The seam refused or lost the write: a concurrent human edit (CAS
+            # conflict -- the canonical note is untouched, a stale `open`
+            # payload never overwrites a close), a round-trip refusal, or a
+            # question note deleted mid-tick. Per-question, never fatal to the
+            # tick; the pair stays re-evaluable by any later pass.
+            _LOGGER.warning(
+                "Standing Questions evidence append refused for %s: %s", question_id, exc
+            )
+            counters.bump("append_refused", 1)
             continue
         dropped = len(new_entries) - len(appended_entries)
         if dropped:

--- a/app/standing_questions/evidence_matching.py
+++ b/app/standing_questions/evidence_matching.py
@@ -52,7 +52,7 @@ from app.standing_questions.projection import (
     QuestionsDirectoryMissingError,
     iter_question_notes,
 )
-from app.standing_questions.question_store import QuestionStore
+from app.standing_questions.question_store import QuestionNotOpenError, QuestionStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -247,7 +247,19 @@ def _resolve_content(vault_root: Path, candidate: CandidateArtifact) -> str | No
             candidate.artifact_ref,
         )
         return None
-    return path.read_text(encoding="utf-8")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        # #4610 P2: a note deleted (or otherwise made unreadable) between the
+        # `is_file()` check above and this read is a normal race for
+        # asynchronously consumed ingest events. It is an unresolved no-link
+        # result for THIS candidate only -- never an aborted tick for the rest.
+        _LOGGER.warning(
+            "Standing Questions matching skipped artifact that disappeared before read: %s (%s)",
+            candidate.artifact_ref,
+            exc,
+        )
+        return None
 
 
 def _build_user_prompt(question_text: str, artifact_text: str) -> str:
@@ -391,21 +403,25 @@ def match_evidence_to_open_questions(
 
         if not new_entries:
             continue
-        # Re-read immediately before the guarded append: a human may have closed the
-        # question mid-tick, and a closed question must never be resurrected by a
-        # race (INV-SQ-F partial failure).
-        current = question_store.read_question(question_id)
-        if current["status"] != "open":
+        # Atomic guarded append (#4610 P2): the open-status predicate and the
+        # evidence write are one operation inside the store's exclusive per-note
+        # lock, so a human close that lands mid-tick fails the append closed --
+        # a closed question is never resurrected and never receives evidence
+        # through this race (INV-SQ-F partial failure).
+        try:
+            _updated, _receipt, appended_entries = question_store.append_evidence(
+                question_id, new_entries
+            )
+        except QuestionNotOpenError:
             counters.bump("excluded_non_open")
             continue
-        question_store.update_system_fields(
-            question_id,
-            {
-                "evidence": [*current["evidence"], *new_entries],
-                "last_matched_at": _utc_now(),
-            },
-        )
-        counters.bump("attached", len(new_entries))
+        dropped = len(new_entries) - len(appended_entries)
+        if dropped:
+            # Basis already present on the fresh in-lock read: a concurrent tick
+            # won the lock first. Idempotency, not attachment.
+            counters.bump("duplicate_basis", dropped)
+        if appended_entries:
+            counters.bump("attached", len(appended_entries))
 
     return counters.summary()
 

--- a/app/standing_questions/ingest_consumers.py
+++ b/app/standing_questions/ingest_consumers.py
@@ -1,0 +1,364 @@
+"""Production ingest-consumer wiring for SQ-03 evidence matching (#4610).
+
+``docs/STANDING_QUESTIONS/MATCH_EVIDENCE_TO_OPEN_QUESTIONS.md`` names exactly
+three existing ingest paths whose artifacts must be checked against open
+questions -- Heimdal captures (observation-log cursor, the same read path the
+Episode Resolution Engine consumes through ``app/heimdal/publish.py``), KAP
+candidates (``knowledge_acquisition.stage.completed`` outbox topic), and
+new/edited vault notes (``ingest.vault.changed`` / ``ingest.object.created``
+outbox topics). PR #4588 shipped the matcher with no caller on any of them;
+this module is that wiring and nothing more: it constructs
+:class:`~app.standing_questions.evidence_matching.CandidateArtifact` values
+from what each consumer already holds and invokes the existing matching tick.
+It adds **no** acquisition source, mutates **no** artifact, and leaves the
+matching threshold and provenance semantics untouched.
+
+Failure posture is per-path:
+
+- The worker-handler paths (vault ingest, KA completion) are **never-crash**:
+  standing-question matching is a downstream consumer of an ingest that already
+  succeeded, so a matching failure logs loudly and returns ``None`` instead of
+  failing (and retry-looping or dead-lettering) the ingest dispatch itself.
+  Matching is idempotent per ``(question_id, artifact_ref)``, so losing one
+  tick to degradation is recoverable by any later pass over the same artifact.
+- The Heimdal cursor tick is **fail-loud with at-least-once delivery**: the
+  cursor only advances after the tick completes, so a crashed tick re-reads the
+  same observations next time (mirrors the ERE consumer contract).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Mapping
+
+from app.events.types import (
+    INGEST_OBJECT_CREATED,
+    INGEST_VAULT_CHANGED,
+    KNOWLEDGE_ACQUISITION_STAGE_COMPLETED,
+)
+from app.heimdal.observation_log import ObservationRow
+from app.heimdal.publish import advance_cursor_for_consumer, read_observations_for_consumer
+from app.standing_questions.evidence_matching import (
+    CandidateArtifact,
+    MatchTickSummary,
+    match_evidence_to_open_questions,
+)
+from app.watcher.vault_watcher import extract_context_dimensions_for_note
+from scripts.yaml_roundtrip import load_frontmatter
+
+_LOGGER = logging.getLogger(__name__)
+
+#: This consumer's own durable cursor over the Heimdal observation log. A new
+#: consumer id starts at sequence zero and never touches another consumer's
+#: position (``app/heimdal/publish.py`` contract) -- registering it here is the
+#: whole "no new egress" Heimdal integration: same log, same read path as
+#: ``mimer.episode_resolution_engine``, one more independent cursor.
+HEIMDAL_EVIDENCE_CONSUMER_ID = "mimer.standing_questions.evidence_matching"
+
+#: Source-stream tag for Heimdal-sourced candidates; matches the
+#: ``heimdal.observations:<id>`` provenance-ref family the ERE already stamps.
+HEIMDAL_SOURCE_STREAM = "heimdal.observations"
+
+#: Scope for artifacts that resolve no scope of their own -- the same posture as
+#: the ERE's ``_DEFAULT_SCOPE`` (``app/episodes/segmenter.py``): unscoped
+#: artifacts land in "default" and are content-free excluded against any
+#: question registered under a real scope.
+DEFAULT_ARTIFACT_SCOPE = "default"
+
+# The KA pipeline stage whose completion means a candidate note now exists
+# (mirrors `_KA_CANDIDATE_STAGE` in the worker's own KA consumer): only this
+# terminal stage offers an artifact to match.
+_KA_CANDIDATE_STAGE = "candidate"
+
+
+def _resolve_note_scope(
+    vault_root: Path,
+    relative_path: str,
+    frontmatter: Mapping[str, Any] | None,
+) -> str:
+    """Resolve a vault note's scope, never raising.
+
+    Uses the caller's already-parsed frontmatter when supplied; otherwise reads
+    the note best-effort (a missing or malformed note yields the default scope
+    -- the matcher's own resolution step will independently count it
+    unresolved if the content is also gone by match time).
+    """
+    if frontmatter is None:
+        try:
+            text = (vault_root / relative_path).read_text(encoding="utf-8")
+            frontmatter, _body = load_frontmatter(text)
+        except Exception:
+            frontmatter = {}
+    dims = extract_context_dimensions_for_note(dict(frontmatter))
+    scope = dims.get("scope")
+    return scope if isinstance(scope, str) and scope.strip() else DEFAULT_ARTIFACT_SCOPE
+
+
+def vault_note_candidate(
+    *,
+    vault_root: Path,
+    relative_path: str,
+    source_stream: str,
+    frontmatter: Mapping[str, Any] | None = None,
+    content: str | None = None,
+) -> CandidateArtifact:
+    """Build the candidate for one new/edited vault note."""
+    artifact_ref = f"vault://{Path(relative_path).as_posix()}"
+    return CandidateArtifact(
+        artifact_ref=artifact_ref,
+        source_stream=source_stream,
+        scope=_resolve_note_scope(vault_root, relative_path, frontmatter),
+        provenance_ref=f"outbox://{source_stream}/{artifact_ref}",
+        content=content,
+    )
+
+
+def candidate_from_ingest_object_created(
+    payload: Mapping[str, Any],
+    *,
+    vault_root: Path,
+) -> CandidateArtifact | None:
+    """Candidate for one ``ingest.object.created`` event, or ``None``.
+
+    The topic carries two producer shapes: vault-side emissions with a note
+    path (resolved like the vault-changed path) and API-side ``POST /ingest``
+    emissions with inline ``content`` and no vault path (resolved as an
+    ``object://`` ref whose content travels with the candidate). A payload
+    with neither offers nothing to match.
+    """
+    relative_path = payload.get("relative_path")
+    if isinstance(relative_path, str) and relative_path.strip():
+        return vault_note_candidate(
+            vault_root=vault_root,
+            relative_path=relative_path.strip(),
+            source_stream=INGEST_OBJECT_CREATED,
+        )
+    vault_path = payload.get("vault_path") or payload.get("path")
+    if isinstance(vault_path, str) and vault_path.strip():
+        try:
+            rel = Path(vault_path).expanduser().resolve().relative_to(vault_root.resolve())
+        except (ValueError, OSError):
+            rel = None
+        if rel is not None:
+            return vault_note_candidate(
+                vault_root=vault_root,
+                relative_path=rel.as_posix(),
+                source_stream=INGEST_OBJECT_CREATED,
+            )
+    content = payload.get("content")
+    object_id = payload.get("uuid") or payload.get("object_id")
+    if isinstance(content, str) and content.strip() and object_id:
+        artifact_ref = f"object://{object_id}"
+        return CandidateArtifact(
+            artifact_ref=artifact_ref,
+            source_stream=INGEST_OBJECT_CREATED,
+            scope=DEFAULT_ARTIFACT_SCOPE,
+            provenance_ref=f"outbox://{INGEST_OBJECT_CREATED}/{artifact_ref}",
+            content=content,
+        )
+    return None
+
+
+def candidate_from_ka_stage_completed(
+    payload: Mapping[str, Any],
+    *,
+    vault_root: Path,
+) -> CandidateArtifact | None:
+    """Candidate for one KA ``stage.completed`` event, or ``None``.
+
+    Only a ``candidate``-stage completion means a candidate note now exists
+    (the worker's own KA consumer draws the same line); intermediate stages
+    offer nothing to match. The note is read-only downstream: content resolves
+    through the matcher's own vault-ref read path at match time.
+    """
+    if str(payload.get("stage") or "") != _KA_CANDIDATE_STAGE:
+        return None
+    artifact_path = payload.get("artifact_path")
+    if not isinstance(artifact_path, str) or not artifact_path.strip():
+        return None
+    content_identity = str(payload.get("content_identity") or "")
+    relative_path = artifact_path.strip()
+    return CandidateArtifact(
+        artifact_ref=f"vault://{Path(relative_path).as_posix()}",
+        source_stream=KNOWLEDGE_ACQUISITION_STAGE_COMPLETED,
+        scope=_resolve_note_scope(vault_root, relative_path, None),
+        provenance_ref=f"knowledge_acquisition:{content_identity or relative_path}",
+        content=None,
+    )
+
+
+def candidate_from_heimdal_observation(row: ObservationRow) -> CandidateArtifact | None:
+    """Candidate for one observation-log row, or ``None``.
+
+    An observation without published ``content`` (withheld, consent-gated, or
+    simply content-free) offers no text to judge and yields no candidate --
+    never a fabricated one. Scope comes from the payload's own ``scope_hint``,
+    the same field the ERE normalizes, defaulting like the ERE does.
+    """
+    payload = row.envelope.get("payload")
+    payload = payload if isinstance(payload, Mapping) else {}
+    observation_id = payload.get("observation_id")
+    if not isinstance(observation_id, str) or not observation_id.strip():
+        return None
+    content = payload.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    scope_hint = payload.get("scope_hint")
+    scope = (
+        scope_hint.strip()
+        if isinstance(scope_hint, str) and scope_hint.strip()
+        else DEFAULT_ARTIFACT_SCOPE
+    )
+    return CandidateArtifact(
+        artifact_ref=f"heimdal://observations/{observation_id}",
+        source_stream=HEIMDAL_SOURCE_STREAM,
+        scope=scope,
+        provenance_ref=f"heimdal.observations:{observation_id}",
+        content=content,
+    )
+
+
+def _never_crash_match(
+    candidate: CandidateArtifact | None,
+    *,
+    vault_root: Path,
+    source: str,
+    trace_id: str | None,
+) -> MatchTickSummary | None:
+    if candidate is None:
+        return None
+    try:
+        return match_evidence_to_open_questions(
+            vault_root=vault_root,
+            candidates=[candidate],
+            trace_id=trace_id,
+        )
+    except Exception:
+        # Loud, never silent -- but a matching failure must not fail (or
+        # retry-loop) the ingest dispatch that already succeeded upstream.
+        _LOGGER.exception(
+            "standing-question evidence matching failed for %s artifact %s (trace_id=%s)",
+            source,
+            candidate.artifact_ref,
+            trace_id or "-",
+        )
+        return None
+
+
+def match_vault_note_ingest(
+    *,
+    vault_root: Path,
+    relative_path: str,
+    frontmatter: Mapping[str, Any] | None = None,
+    content: str | None = None,
+    trace_id: str | None = None,
+) -> MatchTickSummary | None:
+    """Run the matching tick for one ingested vault note (``ingest.vault.changed``).
+
+    Never-crash production call site for the worker's vault-ingest consumer.
+    """
+    try:
+        candidate = vault_note_candidate(
+            vault_root=vault_root,
+            relative_path=relative_path,
+            source_stream=INGEST_VAULT_CHANGED,
+            frontmatter=frontmatter,
+            content=content,
+        )
+    except Exception:
+        _LOGGER.exception(
+            "standing-question candidate construction failed for vault note %s", relative_path
+        )
+        return None
+    return _never_crash_match(
+        candidate, vault_root=vault_root, source=INGEST_VAULT_CHANGED, trace_id=trace_id
+    )
+
+
+def match_ingest_object_created(
+    payload: Mapping[str, Any],
+    *,
+    vault_root: Path,
+    trace_id: str | None = None,
+) -> MatchTickSummary | None:
+    """Run the matching tick for one ``ingest.object.created`` event. Never-crash."""
+    try:
+        candidate = candidate_from_ingest_object_created(payload, vault_root=vault_root)
+    except Exception:
+        _LOGGER.exception(
+            "standing-question candidate construction failed for ingest.object.created payload"
+        )
+        return None
+    return _never_crash_match(
+        candidate, vault_root=vault_root, source=INGEST_OBJECT_CREATED, trace_id=trace_id
+    )
+
+
+def match_ka_candidate_completion(
+    payload: Mapping[str, Any],
+    *,
+    vault_root: Path,
+    trace_id: str | None = None,
+) -> MatchTickSummary | None:
+    """Run the matching tick for one KA candidate-stage completion. Never-crash."""
+    try:
+        candidate = candidate_from_ka_stage_completed(payload, vault_root=vault_root)
+    except Exception:
+        _LOGGER.exception(
+            "standing-question candidate construction failed for KA stage.completed payload"
+        )
+        return None
+    return _never_crash_match(
+        candidate,
+        vault_root=vault_root,
+        source=KNOWLEDGE_ACQUISITION_STAGE_COMPLETED,
+        trace_id=trace_id,
+    )
+
+
+def run_heimdal_evidence_matching_tick(
+    *,
+    vault_root: Path | str,
+    limit: int | None = None,
+    trace_id: str | None = None,
+) -> MatchTickSummary:
+    """Consume the next unread Heimdal observations and match them (fail-loud).
+
+    Reads forward from this consumer's own durable cursor without advancing it,
+    runs one matching tick over the batch, and only then advances the cursor
+    past the batch -- "durably process, then advance" per the publish-seam
+    contract, so a crashed tick re-reads the same observations (at-least-once;
+    the matcher's per-pair idempotency absorbs the redelivery).
+    """
+    rows = read_observations_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, limit=limit)
+    candidates = [
+        candidate
+        for candidate in (candidate_from_heimdal_observation(row) for row in rows)
+        if candidate is not None
+    ]
+    if candidates:
+        summary = match_evidence_to_open_questions(
+            vault_root=vault_root,
+            candidates=candidates,
+            trace_id=trace_id,
+        )
+    else:
+        summary = MatchTickSummary()
+    advance_cursor_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, rows)
+    return summary
+
+
+__all__ = [
+    "DEFAULT_ARTIFACT_SCOPE",
+    "HEIMDAL_EVIDENCE_CONSUMER_ID",
+    "HEIMDAL_SOURCE_STREAM",
+    "candidate_from_heimdal_observation",
+    "candidate_from_ingest_object_created",
+    "candidate_from_ka_stage_completed",
+    "match_ingest_object_created",
+    "match_ka_candidate_completion",
+    "match_vault_note_ingest",
+    "run_heimdal_evidence_matching_tick",
+    "vault_note_candidate",
+]

--- a/app/standing_questions/ingest_consumers.py
+++ b/app/standing_questions/ingest_consumers.py
@@ -399,9 +399,11 @@ def run_heimdal_evidence_matching_tick(
         raise FileNotFoundError(
             f"standing-question evidence tick requires an existing vault root: {resolved_root}"
         )
-    # Decided BEFORE the match and reused for the advance decision: a
-    # questions/ directory created mid-tick must not consume a batch the match
-    # step enumerated zero questions for.
+    # Sampled BEFORE the read and re-verified AFTER the match: a questions/
+    # directory created mid-tick must not consume a batch the match step
+    # enumerated zero questions for, and one removed mid-tick must not either.
+    # (A removal landing inside the match itself remains a narrow residual
+    # window; the cursor then stays put on the next tick's pre-sample.)
     questions_exist = (resolved_root / QUESTION_DIRECTORY).is_dir()
     rows = read_observations_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, limit=limit)
     candidates = [
@@ -417,7 +419,7 @@ def run_heimdal_evidence_matching_tick(
         )
     else:
         summary = MatchTickSummary()
-    if questions_exist:
+    if questions_exist and (resolved_root / QUESTION_DIRECTORY).is_dir():
         advance_cursor_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, rows)
     elif rows:
         _LOGGER.warning(

--- a/app/standing_questions/ingest_consumers.py
+++ b/app/standing_questions/ingest_consumers.py
@@ -28,6 +28,7 @@ Failure posture is per-path:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from pathlib import Path
 from typing import Any, Mapping
@@ -44,7 +45,9 @@ from app.standing_questions.evidence_matching import (
     MatchTickSummary,
     match_evidence_to_open_questions,
 )
+from app.standing_questions.question_store import QUESTION_DIRECTORY
 from app.watcher.vault_watcher import extract_context_dimensions_for_note
+from app.write_guard import WritesBlockedError
 from scripts.yaml_roundtrip import load_frontmatter
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,6 +73,20 @@ DEFAULT_ARTIFACT_SCOPE = "default"
 # (mirrors `_KA_CANDIDATE_STAGE` in the worker's own KA consumer): only this
 # terminal stage offers an artifact to match.
 _KA_CANDIDATE_STAGE = "candidate"
+
+
+def _is_question_note_path(relative_path: str) -> bool:
+    """True when the path is an engine-owned Question note (#4610 review).
+
+    Question notes live in the watched vault, so every matcher append re-enters
+    ingest as a new `ingest.vault.changed` event. Offering the question's own
+    note back to the matcher as candidate evidence would let questions cite
+    themselves, grow their own artifact text on every append, and burn one LLM
+    judgment per open question per cycle. The engine's own output is never its
+    own evidence.
+    """
+    parts = Path(relative_path).parts
+    return bool(parts) and parts[0] == QUESTION_DIRECTORY
 
 
 def _resolve_note_scope(
@@ -102,8 +119,15 @@ def vault_note_candidate(
     source_stream: str,
     frontmatter: Mapping[str, Any] | None = None,
     content: str | None = None,
-) -> CandidateArtifact:
-    """Build the candidate for one new/edited vault note."""
+) -> CandidateArtifact | None:
+    """Build the candidate for one new/edited vault note.
+
+    Returns ``None`` for engine-owned Question notes: the matcher's own writes
+    re-enter ingest through the watcher, and a question must never become its
+    own evidence.
+    """
+    if _is_question_note_path(relative_path):
+        return None
     artifact_ref = f"vault://{Path(relative_path).as_posix()}"
     return CandidateArtifact(
         artifact_ref=artifact_ref,
@@ -147,17 +171,35 @@ def candidate_from_ingest_object_created(
                 source_stream=INGEST_OBJECT_CREATED,
             )
     content = payload.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
     object_id = payload.get("uuid") or payload.get("object_id")
-    if isinstance(content, str) and content.strip() and object_id:
-        artifact_ref = f"object://{object_id}"
-        return CandidateArtifact(
-            artifact_ref=artifact_ref,
-            source_stream=INGEST_OBJECT_CREATED,
-            scope=DEFAULT_ARTIFACT_SCOPE,
-            provenance_ref=f"outbox://{INGEST_OBJECT_CREATED}/{artifact_ref}",
-            content=content,
-        )
-    return None
+    if not object_id:
+        # A path-less, id-less producer still offers matchable content; a
+        # content-hash ref keeps the idempotency fold key stable across
+        # redelivery of the same payload.
+        object_id = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+    # POST /ingest carries no separate frontmatter field, but its content may
+    # itself be a frontmattered note -- resolve scope from it so API-ingested
+    # artifacts are not silently unmatchable against scoped questions.
+    scope = DEFAULT_ARTIFACT_SCOPE
+    try:
+        content_frontmatter, _body = load_frontmatter(content)
+    except Exception:
+        content_frontmatter = None
+    if isinstance(content_frontmatter, Mapping) and content_frontmatter:
+        dims = extract_context_dimensions_for_note(dict(content_frontmatter))
+        resolved = dims.get("scope")
+        if isinstance(resolved, str) and resolved.strip():
+            scope = resolved
+    artifact_ref = f"object://{object_id}"
+    return CandidateArtifact(
+        artifact_ref=artifact_ref,
+        source_stream=INGEST_OBJECT_CREATED,
+        scope=scope,
+        provenance_ref=f"outbox://{INGEST_OBJECT_CREATED}/{artifact_ref}",
+        content=content,
+    )
 
 
 def candidate_from_ka_stage_completed(
@@ -179,6 +221,8 @@ def candidate_from_ka_stage_completed(
         return None
     content_identity = str(payload.get("content_identity") or "")
     relative_path = artifact_path.strip()
+    if _is_question_note_path(relative_path):
+        return None
     return CandidateArtifact(
         artifact_ref=f"vault://{Path(relative_path).as_posix()}",
         source_stream=KNOWLEDGE_ACQUISITION_STAGE_COMPLETED,
@@ -234,6 +278,18 @@ def _never_crash_match(
             candidates=[candidate],
             trace_id=trace_id,
         )
+    except WritesBlockedError as exc:
+        # A blocked runtime is a systemic condition, not a one-off matching
+        # failure -- name it distinctly so operators can tell them apart. The
+        # ingest dispatch itself still proceeds (matcher writes are the only
+        # thing refused, and re-ticking is idempotent).
+        _LOGGER.warning(
+            "standing-question evidence matching blocked by WriteGuard for %s artifact %s: %s",
+            source,
+            candidate.artifact_ref,
+            exc,
+        )
+        return None
     except Exception:
         # Loud, never silent -- but a matching failure must not fail (or
         # retry-loop) the ingest dispatch that already succeeded upstream.
@@ -330,7 +386,19 @@ def run_heimdal_evidence_matching_tick(
     past the batch -- "durably process, then advance" per the publish-seam
     contract, so a crashed tick re-reads the same observations (at-least-once;
     the matcher's per-pair idempotency absorbs the redelivery).
+
+    Two guards keep the cursor honest (#4610 review): a missing vault root
+    fails loud (never a silently synthesized CWD-relative vault -- the same
+    phantom-root hazard #2384 removed from the worker), and a vault whose
+    ``questions/`` directory does not exist yet leaves the cursor untouched --
+    observations are only consumed once a vault where matching can actually
+    evaluate them exists.
     """
+    resolved_root = Path(vault_root).expanduser().resolve()
+    if not resolved_root.is_dir():
+        raise FileNotFoundError(
+            f"standing-question evidence tick requires an existing vault root: {resolved_root}"
+        )
     rows = read_observations_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, limit=limit)
     candidates = [
         candidate
@@ -339,13 +407,21 @@ def run_heimdal_evidence_matching_tick(
     ]
     if candidates:
         summary = match_evidence_to_open_questions(
-            vault_root=vault_root,
+            vault_root=resolved_root,
             candidates=candidates,
             trace_id=trace_id,
         )
     else:
         summary = MatchTickSummary()
-    advance_cursor_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, rows)
+    if (resolved_root / QUESTION_DIRECTORY).is_dir():
+        advance_cursor_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, rows)
+    elif rows:
+        _LOGGER.warning(
+            "standing-question evidence tick left the cursor untouched: no %s/ directory "
+            "under %s (observations remain unconsumed until questions exist)",
+            QUESTION_DIRECTORY,
+            resolved_root,
+        )
     return summary
 
 

--- a/app/standing_questions/ingest_consumers.py
+++ b/app/standing_questions/ingest_consumers.py
@@ -399,6 +399,10 @@ def run_heimdal_evidence_matching_tick(
         raise FileNotFoundError(
             f"standing-question evidence tick requires an existing vault root: {resolved_root}"
         )
+    # Decided BEFORE the match and reused for the advance decision: a
+    # questions/ directory created mid-tick must not consume a batch the match
+    # step enumerated zero questions for.
+    questions_exist = (resolved_root / QUESTION_DIRECTORY).is_dir()
     rows = read_observations_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, limit=limit)
     candidates = [
         candidate
@@ -413,7 +417,7 @@ def run_heimdal_evidence_matching_tick(
         )
     else:
         summary = MatchTickSummary()
-    if (resolved_root / QUESTION_DIRECTORY).is_dir():
+    if questions_exist:
         advance_cursor_for_consumer(HEIMDAL_EVIDENCE_CONSUMER_ID, rows)
     elif rows:
         _LOGGER.warning(

--- a/app/standing_questions/question_store.py
+++ b/app/standing_questions/question_store.py
@@ -366,6 +366,15 @@ class QuestionStore:
     def update_system_fields(
         self, question_id: str, updates: Mapping[str, Any]
     ) -> tuple[dict[str, Any], WriteReceipt]:
+        """Bounded system-field update -- NOT concurrency-hardened (#4610).
+
+        This is an unlocked, versionless read-modify-write: it takes neither
+        the per-note flock nor the CAS `expected_version`, so it can clobber a
+        concurrent :meth:`append_evidence`. Evidence writes must use
+        :meth:`append_evidence`; a future engine writer landing here (e.g.
+        SQ-04 answer refs) must first extend this method with the same lock +
+        CAS discipline. No production caller exists today.
+        """
         current = self.read_question(question_id)
         changes = dict(updates)
         forbidden = set(changes) & (_HUMAN_OWNED_FIELDS | _IMMUTABLE_FIELDS)

--- a/app/standing_questions/question_store.py
+++ b/app/standing_questions/question_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import os
 import re
 import uuid
 from contextlib import contextmanager
@@ -15,11 +16,15 @@ from typing import Any, Iterator, Mapping, Sequence
 from jsonschema import Draft202012Validator, FormatChecker
 
 from app.knowledge.contracts import WriteReceipt
-from app.knowledge.write_ops import write_note_relative
+from app.knowledge.write_ops import read_note_text_with_version, write_note_relative
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
 
 WRITE_ACTION = "standing_questions.write_note"
+#: The spec-named action for engine evidence appends
+#: (``docs/STANDING_QUESTIONS/MATCH_EVIDENCE_TO_OPEN_QUESTIONS.md`` item 5), so
+#: append receipts and guard denials are distinguishable from note creation.
+APPEND_EVIDENCE_ACTION = "standing_questions.append_evidence"
 QUESTION_DIRECTORY = "questions"
 _HUMAN_OWNED_FIELDS = frozenset({"text", "status"})
 _SYSTEM_OWNED_FIELDS = frozenset(
@@ -228,6 +233,19 @@ class QuestionNotOpenError(RuntimeError):
     terminal for the engine)."""
 
 
+class QuestionNoteRoundTripError(ValueError):
+    """Raised before a write when the serialized note would not parse back to the
+    exact payload being written.
+
+    The repo's frontmatter reader (``scripts/yaml_roundtrip.load_frontmatter``)
+    splits on the literal ``---`` substring, so a value containing ``---`` (for
+    example a quoted evidence span copied verbatim from a markdown artifact with
+    a thematic break) would silently truncate the stored span or destroy the
+    note's parseability. This seam refuses such a write outright -- a corrupted
+    or silently altered quote in a human-legible evidence trail is worse than a
+    missed link, which a later tick can still recover."""
+
+
 def mint_question_id() -> str:
     return f"sq-{uuid.uuid4()}"
 
@@ -255,6 +273,9 @@ def question_note_lock_path(vault_root: Path | str, question_id: str) -> Path:
 def _question_note_lock(lock_path: Path) -> Iterator[None]:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+b") as handle:
+        # Mirror the provisional-write ledger-lock idiom: the lock file must
+        # never be group/world readable in a user's (possibly synced) vault.
+        os.chmod(lock_path, 0o600)
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         try:
             yield
@@ -376,15 +397,27 @@ class QuestionStore:
         """Atomically append evidence entries to an ``open`` question (#4610 P2).
 
         The open-status predicate and the append are one operation at this
-        guarded seam: the note is re-read *inside* an exclusive per-note flock
-        (:func:`question_note_lock_path`), the status predicate runs against
-        that same fresh read, and the write derives from it -- so concurrent
-        engine writers serialize, and a close that lands before this writer's
-        turn raises :class:`QuestionNotOpenError` instead of appending to (or
-        overwriting the terminal status of) a non-open question. Checking
-        status in the caller and writing through a separate read-modify-write
-        (the pre-#4610 shape) left a window where a mid-flight human close
-        received new evidence or was resurrected by a stale ``open`` payload.
+        guarded seam, enforced by two independent mechanisms:
+
+        - **Engine serialization**: the note is re-read *inside* an exclusive
+          per-note flock (:func:`question_note_lock_path`), the status
+          predicate runs against that same fresh read, and the write derives
+          from it -- concurrent engine writers serialize, and a close that
+          lands before this writer's turn raises :class:`QuestionNotOpenError`.
+        - **Human-edit compare-and-swap**: humans edit the note directly and do
+          not honor the engine lock, so the write itself carries the fresh
+          read's exact content version (``expected_version``) through the
+          hardened knowledge-port CAS. A human edit -- including a close --
+          landing between the in-lock read and the write leaves the canonical
+          note untouched and raises
+          :class:`app.knowledge.errors.KnowledgeWriteConflict`; the stale
+          ``open`` payload can never overwrite a terminal status.
+
+        Checking status in the caller and writing through a separate unlocked,
+        versionless read-modify-write (the pre-#4610 shape) violated both.
+
+        WriteGuard is asserted before the lock file is created, so a blocked
+        runtime mutates nothing in the vault, not even a lock file.
 
         Idempotency is preserved under the same fresh read: an entry whose
         ``(artifact_ref, quoted_span)`` basis already exists on the note (for
@@ -399,9 +432,14 @@ class QuestionStore:
         entry_list = [dict(entry) for entry in entries]
         if not entry_list:
             raise ValueError("append_evidence requires at least one evidence entry")
+        # Guard before any filesystem effect (including lock-file creation):
+        # a blocked runtime must leave the vault byte-identical. `_write`
+        # re-asserts at the port as defense in depth.
+        self.write_guard.assert_writes_allowed(APPEND_EVIDENCE_ACTION)
         path = self._path(question_id)
         with _question_note_lock(question_note_lock_path(self.vault_root, question_id)):
-            current = parse_question_note(path.read_text(encoding="utf-8"))
+            text, content_version = read_note_text_with_version(path)
+            current = parse_question_note(text)
             if current["status"] != "open":
                 raise QuestionNotOpenError(
                     f"question {question_id} is {current['status']!r}; evidence appends "
@@ -423,34 +461,66 @@ class QuestionStore:
                 "evidence": [*current["evidence"], *fresh_entries],
                 "last_matched_at": matched_at if matched_at is not None else _utc_now(),
             }
-            receipt = self._write(updated)
+            receipt = self._write(
+                updated,
+                action=APPEND_EVIDENCE_ACTION,
+                expected_version=content_version,
+            )
             return updated, receipt, fresh_entries
 
     def _path(self, question_id: str) -> Path:
         return self.vault_root / question_note_path(question_id)
 
-    def _write(self, note: Mapping[str, Any]) -> WriteReceipt:
+    def _write(
+        self,
+        note: Mapping[str, Any],
+        *,
+        action: str = WRITE_ACTION,
+        expected_version: str | None = None,
+    ) -> WriteReceipt:
         payload = validate_question_note(note)
-        # This is the production seam assertion. It runs before serialisation,
-        # path creation, or any filesystem mutation; write_note_relative repeats
-        # the guard at the shared port as defense in depth.
-        self.write_guard.assert_writes_allowed(WRITE_ACTION)
+        serialized = serialize_question_note(payload)
+        # Round-trip guard (#4610 review): the shared frontmatter reader splits
+        # on the literal `---` substring, so a payload value containing it (an
+        # evidence span quoting a markdown thematic break, a ref with `---` in
+        # its name) would silently truncate or destroy the note. Refuse to
+        # write anything that does not parse back to the exact payload.
+        try:
+            reparsed = parse_question_note(serialized)
+        except Exception as exc:
+            raise QuestionNoteRoundTripError(
+                f"refusing question-note write that does not survive serialization "
+                f"round-trip for {payload['question_id']}: {exc}"
+            ) from exc
+        if reparsed != payload:
+            raise QuestionNoteRoundTripError(
+                f"refusing question-note write whose serialized form parses back "
+                f"differently for {payload['question_id']} (frontmatter fence "
+                "collision or lossy value)"
+            )
+        # This is the production seam assertion. It runs before path creation
+        # or any filesystem mutation; write_note_relative repeats the guard at
+        # the shared port as defense in depth.
+        self.write_guard.assert_writes_allowed(action)
         receipt = write_note_relative(
             question_note_path(payload["question_id"]),
-            serialize_question_note(payload),
+            serialized,
             vault_root=self.vault_root,
-            action=WRITE_ACTION,
+            action=action,
             write_guard=self.write_guard,
+            expected_version=expected_version,
         )
-        return replace(receipt, operation=WRITE_ACTION)
+        return replace(receipt, operation=action)
 
 
 __all__ = [
     "ANNOUNCED_LEAP_SECOND_TABLE_REVIEWED",
     "ANNOUNCED_LEAP_SECOND_UTC_DATES",
+    "APPEND_EVIDENCE_ACTION",
     "HumanOwnedFieldMutationError",
     "QUESTION_DIRECTORY",
     "QuestionNotOpenError",
+    "QuestionNoteRoundTripError",
     "QuestionStore",
     "Rfc3339DateTime",
     "WRITE_ACTION",

--- a/app/standing_questions/question_store.py
+++ b/app/standing_questions/question_store.py
@@ -1,14 +1,16 @@
 """Guarded, vault-canonical storage for human-terminal Question notes."""
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import re
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping, Sequence
 
 from jsonschema import Draft202012Validator, FormatChecker
 
@@ -220,6 +222,12 @@ class HumanOwnedFieldMutationError(ValueError):
     """Raised before a write when an engine attempts to change human-owned content."""
 
 
+class QuestionNotOpenError(RuntimeError):
+    """Raised at the guarded write seam when an evidence append targets a
+    question that is no longer ``open`` (INV-SQ-F: answered/closed/rejected are
+    terminal for the engine)."""
+
+
 def mint_question_id() -> str:
     return f"sq-{uuid.uuid4()}"
 
@@ -227,6 +235,31 @@ def mint_question_id() -> str:
 def question_note_path(question_id: str) -> str:
     _validate_question_id(question_id)
     return f"{QUESTION_DIRECTORY}/{question_id}.md"
+
+
+def question_note_lock_path(vault_root: Path | str, question_id: str) -> Path:
+    """The per-note lock file :meth:`QuestionStore.append_evidence` serializes on.
+
+    Exposed (rather than kept private) so the atomicity contract is testable
+    against the exact file the seam locks. A ``.md.lock`` sibling follows the
+    ``app.agent_memory.provisional_write`` ledger-lock idiom and is invisible to
+    the projection walker (which only reads ``*.md``).
+    """
+    return (
+        Path(vault_root).expanduser().resolve()
+        / f"{question_note_path(question_id)}.lock"
+    )
+
+
+@contextmanager
+def _question_note_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def _validate_question_id(question_id: str) -> None:
@@ -333,6 +366,66 @@ class QuestionStore:
         receipt = self._write(updated)
         return updated, receipt
 
+    def append_evidence(
+        self,
+        question_id: str,
+        entries: Sequence[Mapping[str, Any]],
+        *,
+        matched_at: str | None = None,
+    ) -> tuple[dict[str, Any], WriteReceipt | None, list[dict[str, Any]]]:
+        """Atomically append evidence entries to an ``open`` question (#4610 P2).
+
+        The open-status predicate and the append are one operation at this
+        guarded seam: the note is re-read *inside* an exclusive per-note flock
+        (:func:`question_note_lock_path`), the status predicate runs against
+        that same fresh read, and the write derives from it -- so concurrent
+        engine writers serialize, and a close that lands before this writer's
+        turn raises :class:`QuestionNotOpenError` instead of appending to (or
+        overwriting the terminal status of) a non-open question. Checking
+        status in the caller and writing through a separate read-modify-write
+        (the pre-#4610 shape) left a window where a mid-flight human close
+        received new evidence or was resurrected by a stale ``open`` payload.
+
+        Idempotency is preserved under the same fresh read: an entry whose
+        ``(artifact_ref, quoted_span)`` basis already exists on the note (for
+        example appended by a concurrent tick that won the lock first) is
+        dropped, never duplicated. When every entry is dropped, nothing is
+        written and the receipt is ``None``.
+
+        Returns ``(note, receipt, appended_entries)`` -- ``appended_entries``
+        is the subset of ``entries`` actually written, so a caller's outcome
+        counters can distinguish attached from duplicate-dropped.
+        """
+        entry_list = [dict(entry) for entry in entries]
+        if not entry_list:
+            raise ValueError("append_evidence requires at least one evidence entry")
+        path = self._path(question_id)
+        with _question_note_lock(question_note_lock_path(self.vault_root, question_id)):
+            current = parse_question_note(path.read_text(encoding="utf-8"))
+            if current["status"] != "open":
+                raise QuestionNotOpenError(
+                    f"question {question_id} is {current['status']!r}; evidence appends "
+                    "only ever target open questions (INV-SQ-F)"
+                )
+            existing_bases = {
+                (entry.get("artifact_ref"), entry.get("quoted_span"))
+                for entry in current["evidence"]
+            }
+            fresh_entries = [
+                entry
+                for entry in entry_list
+                if (entry.get("artifact_ref"), entry.get("quoted_span")) not in existing_bases
+            ]
+            if not fresh_entries:
+                return current, None, []
+            updated = {
+                **current,
+                "evidence": [*current["evidence"], *fresh_entries],
+                "last_matched_at": matched_at if matched_at is not None else _utc_now(),
+            }
+            receipt = self._write(updated)
+            return updated, receipt, fresh_entries
+
     def _path(self, question_id: str) -> Path:
         return self.vault_root / question_note_path(question_id)
 
@@ -357,12 +450,14 @@ __all__ = [
     "ANNOUNCED_LEAP_SECOND_UTC_DATES",
     "HumanOwnedFieldMutationError",
     "QUESTION_DIRECTORY",
+    "QuestionNotOpenError",
     "QuestionStore",
     "Rfc3339DateTime",
     "WRITE_ACTION",
     "mint_question_id",
     "parse_question_note",
     "parse_rfc3339_datetime",
+    "question_note_lock_path",
     "question_note_path",
     "serialize_question_note",
     "validate_question_note",

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1500,6 +1500,18 @@ def handle_panel_scan_requested(
     resolved_root = _resolve_vault_root(vault_root)
     note_path = _note_path_from_payload(payload, vault_root=resolved_root)
 
+    if _is_engine_owned_question_note(note_path, resolved_root):
+        # #4610: same exclusion as the vault-ingest fan-out. Question notes are
+        # inbox-heal-ineligible and deliberately uuid-less, so letting a scan
+        # through would burn the missing_uuid retry budget and dead-letter on
+        # every matcher evidence append under shipped defaults (vault-wide
+        # panel watcher scope + WATCHER_AUTO_EXEC=1). The panel agent has no
+        # business on an engine-owned Question note either way.
+        logger.debug(
+            "skipping panel scan for engine-owned question note note_path=%s", note_path
+        )
+        return WorkerPanelSummary(emitted=0, deferred=False)
+
     # Capture runtime start timestamp for latency tracking
     runtime_start_ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     trace_id = trace_id or str(payload.get("trace_id") or "") or None

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -959,18 +959,23 @@ def _maybe_heal_uuid(note_path: Path, vault_root: Path) -> str:
 
 
 def _is_engine_owned_question_note(note_path: Path, vault_root: Path) -> bool:
-    """True when the note is an engine-owned Standing Questions note.
+    """True when the note is an engine-owned Standing Questions note (#4610).
 
     Question notes carry their identity in ``question_id`` and validate against
-    a closed schema; the vault-wide uuid heal must not mutate them (#4610).
+    a closed schema; the generic vault-ingest fan-out (uuid heal, companion,
+    indexer) must skip them entirely. Both arguments arrive already resolved
+    (``_resolve_vault_root`` / ``_note_path_from_payload``); a path outside the
+    root is not a question note (and fails the ingest read path on its own
+    terms). OS-level resolution errors propagate to the worker's normal
+    retry/fail-loud machinery rather than silently choosing a branch.
     """
     from app.standing_questions.question_store import QUESTION_DIRECTORY
 
     try:
         rel = note_path.resolve().relative_to(vault_root.resolve())
-    except (ValueError, OSError):
+    except ValueError:
         return False
-    return bool(rel.parts) and rel.parts[0] == QUESTION_DIRECTORY
+    return rel.parts[:1] == (QUESTION_DIRECTORY,)
 
 
 def _ensure_uuid_with_backoff(note_path: Path, *, vault_root: Path) -> str:
@@ -1646,6 +1651,23 @@ def handle_ingest_vault_changed(
     resolved_root = _resolve_vault_root(vault_root)
     note_path = _note_path_from_payload(payload, vault_root=resolved_root)
 
+    if _is_engine_owned_question_note(note_path, resolved_root):
+        # #4610: engine-owned Question notes (`questions/sq-*.md`) are excluded
+        # from this generic ingest fan-out entirely. Their schema is closed
+        # (`schemas/question-note.schema.json`, additionalProperties: false, per
+        # docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md), so
+        # uuid-healing one makes it schema-invalid and silently drops the
+        # question from matching and its projection; and without a healed uuid
+        # the indexer path would mint a fresh random object identity per event
+        # (one orphan indexed object per matcher append, forever). Question
+        # notes carry `question_id`, are queried through the standing_questions
+        # projection, and are never their own candidate evidence -- nothing on
+        # this path applies to them.
+        logger.debug(
+            "skipping engine-owned question note in vault ingest note_path=%s", note_path
+        )
+        return WorkerIngestSummary(ingested=0)
+
     healed_uuid = _maybe_heal_uuid(note_path, resolved_root)
 
     raw_text = _stabilized_note_text(note_path)
@@ -1682,17 +1704,7 @@ def handle_ingest_vault_changed(
     note_uuid = _normalize_uuid_value(frontmatter.get("uuid") or frontmatter.get("id"))
     if not note_uuid and healed_uuid:
         note_uuid = healed_uuid
-    if not note_uuid and not _is_engine_owned_question_note(note_path, resolved_root):
-        # #4610: engine-owned Question notes (`questions/sq-*.md`) are NEVER
-        # uuid-healed. Their schema is deliberately closed
-        # (`schemas/question-note.schema.json`, additionalProperties: false,
-        # field set owned by docs/STANDING_QUESTIONS/
-        # STORE_QUESTION_NOTES_AND_PROJECTION.md), and the SQ-01 ownership
-        # split routes every engine-side mutation through the guarded
-        # QuestionStore seam -- healing a `uuid:` key into one via the
-        # absolute-path port made the note schema-invalid, silently dropping
-        # the question from matching and the projection on the watcher's very
-        # first pass over it.
+    if not note_uuid:
         note_uuid = _ensure_uuid_with_backoff(note_path, vault_root=resolved_root)
         if note_uuid:
             raw_text = _stabilized_note_text(note_path) or raw_text

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -448,6 +448,13 @@ def _dispatch_topic(
     _validate_dispatch_payload(topic, payload, message=message)
     if topic == INGEST_OBJECT_CREATED:
         handle_ingest_object_created(_indexer_payload(payload))
+        # SQ-03 wiring (#4610): every ingested artifact is offered to the
+        # standing-question matcher. Never-crash inside the helper -- matching
+        # is downstream of an ingest that already succeeded. Wired here at the
+        # dispatch table (not inside handle_ingest_object_created) because the
+        # vault-changed handler below funnels into the same indexer function
+        # and must not match its note twice.
+        _match_standing_question_evidence_for_object_created(payload, trace_id=trace_id)
     elif topic == INGEST_VAULT_CHANGED:
         handle_ingest_vault_changed(payload, trace_id=trace_id)
     elif topic == INGEST_OBJECT_DELETED:
@@ -487,6 +494,23 @@ def _dispatch_topic(
 
 def _indexer_payload(payload: Mapping[str, Any]) -> dict[str, object]:
     return dict(payload)
+
+
+def _match_standing_question_evidence_for_object_created(
+    payload: Mapping[str, Any], *, trace_id: str | None
+) -> None:
+    """Offer one ``ingest.object.created`` artifact to the SQ matcher (#4610).
+
+    Imported lazily (mirrors the promotion-consumer branch above) and skipped
+    without a selected vault: matching reads Question notes from the vault, so
+    a vault-less worker has nothing to match against.
+    """
+    vault_root = _resolve_optional_vault_root(None)
+    if vault_root is None:
+        return
+    from app.standing_questions.ingest_consumers import match_ingest_object_created
+
+    match_ingest_object_created(payload, vault_root=vault_root, trace_id=trace_id)
 
 
 def _trace_id_from_envelope(envelope: object) -> str | None:
@@ -639,7 +663,10 @@ def _emit_ka_consumer_signal(
 
 
 def handle_knowledge_acquisition_stage_completed(
-    payload: Mapping[str, Any], *, trace_id: str | None = None
+    payload: Mapping[str, Any],
+    *,
+    trace_id: str | None = None,
+    vault_root: Path | None = None,
 ) -> None:
     """Consume ``knowledge_acquisition.stage.completed`` (KA-06 → KA-07, #3107).
 
@@ -698,6 +725,19 @@ def handle_knowledge_acquisition_stage_completed(
         content_identity,
         trace_id,
     )
+
+    # SQ-03 wiring (#4610): a candidate-stage completion means a candidate note
+    # now exists -- offer it to the standing-question matcher. Never-crash in
+    # the helper (same posture as the best-effort consumer signal above);
+    # skipped without a selected vault because matching reads Question notes
+    # from the vault.
+    resolved_vault_root = _resolve_optional_vault_root(vault_root)
+    if resolved_vault_root is not None:
+        from app.standing_questions.ingest_consumers import match_ka_candidate_completion
+
+        match_ka_candidate_completion(
+            payload, vault_root=resolved_vault_root, trace_id=trace_id
+        )
 
 
 def handle_knowledge_acquisition_stage_dead_lettered(
@@ -1681,6 +1721,25 @@ def handle_ingest_vault_changed(
     }
 
     handle_ingest_object_created(ingest_obj)
+
+    # SQ-03 wiring (#4610): the freshly ingested note is a candidate artifact
+    # for standing-question evidence matching. The helper is never-crash, so a
+    # matching failure cannot fail (or retry-loop) an ingest that already
+    # succeeded; the note itself stays read-only on the matcher side.
+    try:
+        note_relative_path = note_path.relative_to(resolved_root).as_posix()
+    except ValueError:
+        note_relative_path = None
+    if note_relative_path is not None:
+        from app.standing_questions.ingest_consumers import match_vault_note_ingest
+
+        match_vault_note_ingest(
+            vault_root=resolved_root,
+            relative_path=note_relative_path,
+            frontmatter=frontmatter if isinstance(frontmatter, dict) else None,
+            content=content,
+            trace_id=trace_id or (str(payload.get("trace_id") or "") or None),
+        )
     return WorkerIngestSummary(ingested=1)
 
 

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -958,6 +958,21 @@ def _maybe_heal_uuid(note_path: Path, vault_root: Path) -> str:
     return ""
 
 
+def _is_engine_owned_question_note(note_path: Path, vault_root: Path) -> bool:
+    """True when the note is an engine-owned Standing Questions note.
+
+    Question notes carry their identity in ``question_id`` and validate against
+    a closed schema; the vault-wide uuid heal must not mutate them (#4610).
+    """
+    from app.standing_questions.question_store import QUESTION_DIRECTORY
+
+    try:
+        rel = note_path.resolve().relative_to(vault_root.resolve())
+    except (ValueError, OSError):
+        return False
+    return bool(rel.parts) and rel.parts[0] == QUESTION_DIRECTORY
+
+
 def _ensure_uuid_with_backoff(note_path: Path, *, vault_root: Path) -> str:
     max_attempts = 5
     base_sleep = 0.2
@@ -1667,7 +1682,17 @@ def handle_ingest_vault_changed(
     note_uuid = _normalize_uuid_value(frontmatter.get("uuid") or frontmatter.get("id"))
     if not note_uuid and healed_uuid:
         note_uuid = healed_uuid
-    if not note_uuid:
+    if not note_uuid and not _is_engine_owned_question_note(note_path, resolved_root):
+        # #4610: engine-owned Question notes (`questions/sq-*.md`) are NEVER
+        # uuid-healed. Their schema is deliberately closed
+        # (`schemas/question-note.schema.json`, additionalProperties: false,
+        # field set owned by docs/STANDING_QUESTIONS/
+        # STORE_QUESTION_NOTES_AND_PROJECTION.md), and the SQ-01 ownership
+        # split routes every engine-side mutation through the guarded
+        # QuestionStore seam -- healing a `uuid:` key into one via the
+        # absolute-path port made the note schema-invalid, silently dropping
+        # the question from matching and the projection on the watcher's very
+        # first pass over it.
         note_uuid = _ensure_uuid_with_backoff(note_path, vault_root=resolved_root)
         if note_uuid:
             raw_text = _stabilized_note_text(note_path) or raw_text

--- a/docs/STANDING_QUESTIONS/README.md
+++ b/docs/STANDING_QUESTIONS/README.md
@@ -109,6 +109,16 @@ invariants hold *across* tasks, each with its partial-failure walk:
   evidence/candidate-answer fields are the SoR; the PG projection (open-question list, evidence
   trail, pending-review lookups) rebuilds row-for-row from the vault. Losing the projection loses
   only query speed, never a question, an evidence link, or an answer.
+- **INV-SQ-H — Question notes are outside the generic vault fan-out (`questions_outside_generic_ingest`).**
+  Engine-owned `questions/sq-*.md` notes carry their identity in `question_id`, validate against a
+  deliberately closed schema (no frontmatter `uuid`), and are queried through the
+  `standing_questions` projection — never through the retrieval index. Every generic vault
+  consumer therefore skips them: the vault-ingest paths (worker `ingest.vault.changed` handler and
+  the alpha ingest walk) neither uuid-heal, companion-track, nor index them; the panel-scan
+  consumer never scans them; and the evidence matcher never accepts one as candidate evidence (a
+  question must not cite itself). Partial failure: a healed `uuid:` key or any other
+  fan-out-authored frontmatter would make the note schema-invalid and silently drop the question
+  from matching and the projection — exactly the outcome this invariant exists to prevent.
 
 ## Provisional thresholds (RQ-SQ1, RQ-SQ2)
 

--- a/scripts/fs_watcher.py
+++ b/scripts/fs_watcher.py
@@ -96,6 +96,8 @@ def scan_once(port: VaultPort | None = None) -> None:
     for note_path in VAULT.rglob("*.md"):
         if any(part.startswith(".obsidian") for part in note_path.parts):
             continue
+        if "questions" in note_path.relative_to(VAULT).parts:
+            continue
         current_paths.add(str(note_path))
         if _ensure_uuid(note_path, resolved_port):
             continue

--- a/tests/observability/test_github_call_logging.py
+++ b/tests/observability/test_github_call_logging.py
@@ -184,8 +184,8 @@ class TestKillSwitchDisablesScanBelowThreshold:
 
         captured_extra: dict[str, Any] = {}
 
-        def fake_record_sync_success(store, provider, pull_at, *, rate_limit_remaining=None,
-                                     rate_limit_reset=None, extra=None):
+        def fake_record_sync_partial(store, provider, pull_at, *, note,
+                                     rate_limit_remaining=None, rate_limit_reset=None, extra=None):
             captured_extra.update(extra or {})
 
         mock_store = MagicMock()
@@ -202,8 +202,8 @@ class TestKillSwitchDisablesScanBelowThreshold:
             "GITHUB_CALL_LOG_PATH": str(log_file),
             "GITHUB_RATELIMIT_KILL_THRESHOLD": "200",
         }), patch(
-            "app.dispatcher.sync_github.record_sync_success",
-            side_effect=fake_record_sync_success,
+            "app.dispatcher.sync_github.record_sync_partial",
+            side_effect=fake_record_sync_partial,
         ):
             adapter.pull("owner/repo")
 

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -106,11 +106,12 @@ REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
         "hardcoded _EMBED_MODEL phantom with the _requested_embedding_identity() resolver "
         "defined above this call."
     ),
-    ("app/ingest/vault_alpha.py", 566): (
+    ("app/ingest/vault_alpha.py", 585): (
         "Legacy vault-alpha ingest path: keeps classifier/normalizer flows working "
         "against the memory backend during tests/alpha runs; the alpha ingest pipeline "
         "emits its own ingest event upstream of this call in the same run. Line drifted "
-        "527 -> 555 -> 582 -> 558 (site unchanged); re-pinned by #3180 (ERE-05) -- round-3 "
+        "527 -> 555 -> 582 -> 558 -> 566 -> 585 (site unchanged); re-pinned for #4610 after "
+        "the Standing Questions exclusion guard shifted the existing sink; #3180 (ERE-05) round-3 "
         "extracted the episode_ref helper into app/ingest/episode_ref.py, shifting this line "
         "back up. The census gate only fires when this machinery is touched, so the drift "
         "surfaces on the first PR to edit this file."
@@ -1466,16 +1467,16 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_frontmatter: same payload (store_payload = {**payload, 'text': ...}) -> store.put "
         "-> store_objects."
     ),
-    ("app/ingest/vault_alpha.py", 566): (
+    ("app/ingest/vault_alpha.py", 585): (
         "carries_frontmatter: obj.payload carries episode_ref_from_frontmatter(frontmatter); "
         "ObjectStore().save_object(obj) -> (pg) store.put -> store_objects (round-5: the carrying "
         "get_object_store().put below is in try/except:pass, so THIS row must carry it too)."
     ),
-    ("app/ingest/vault_alpha.py", 601): (
+    ("app/ingest/vault_alpha.py", 620): (
         "carries_frontmatter: store_payload carries episode_ref; get_object_store().put -> "
         "store_objects."
     ),
-    ("app/ingest/vault_alpha.py", 615): (
+    ("app/ingest/vault_alpha.py", 634): (
         "carries_frontmatter: same store_payload -> index_ingest_object -> store_vector_index."
     ),
     ("app/ingest/vault_root.py", 91): (

--- a/tests/standing_questions/test_evidence_matching.py
+++ b/tests/standing_questions/test_evidence_matching.py
@@ -477,6 +477,100 @@ def test_append_rechecks_open_status_atomically(tmp_path: Path) -> None:
     assert note_path.read_bytes() == before
 
 
+def test_append_fails_closed_when_human_edit_races_the_write(tmp_path: Path) -> None:
+    """#4610 review finding: humans edit the note directly and do not honor the
+    engine lock, so the seam's write carries the in-lock read's exact content
+    version through the knowledge-port CAS -- a human close landing between the
+    fresh read and the write leaves the canonical note untouched instead of
+    being overwritten by the stale `open` payload."""
+    from app.knowledge.errors import KnowledgeWriteConflict
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+    note_path = vault / "questions" / f"{question_id}.md"
+
+    entry = {
+        "artifact_ref": "vault://notes/outbox-measurements.md",
+        "source_stream": "ingest.vault.changed",
+        "matched_at": "2026-08-04T00:00:00Z",
+        "confidence_class": "high",
+        "provenance_ref": "outbox://ingest.vault.changed/vault://notes/outbox-measurements.md",
+        "quoted_span": RELEVANT_SPAN,
+    }
+
+    original_write = store._write
+
+    def racing_write(payload: dict[str, Any], **kwargs: Any) -> Any:
+        # The human closes AFTER the seam's in-lock fresh read but BEFORE the
+        # port write -- inside the critical section, past the status predicate.
+        current = parse_question_note(note_path.read_text(encoding="utf-8"))
+        note_path.write_text(
+            serialize_question_note({**current, "status": "closed"}), encoding="utf-8"
+        )
+        return original_write(payload, **kwargs)
+
+    store._write = racing_write  # type: ignore[method-assign]
+
+    with pytest.raises(KnowledgeWriteConflict):
+        store.append_evidence(question_id, [entry])
+
+    final = parse_question_note(note_path.read_text(encoding="utf-8"))
+    assert final["status"] == "closed"
+    assert final["evidence"] == []
+
+
+def test_append_refuses_entries_that_break_frontmatter_round_trip(tmp_path: Path) -> None:
+    """#4610 review finding: the shared frontmatter reader splits on the literal
+    `---` substring, so an evidence span quoting a markdown thematic break would
+    silently truncate the stored span or destroy the note. The seam refuses the
+    write outright, and the matcher degrades per-question instead of corrupting
+    or aborting."""
+    from app.standing_questions.question_store import QuestionNoteRoundTripError
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+    note_path = vault / "questions" / f"{question_id}.md"
+    before = note_path.read_bytes()
+
+    fence_span = "the ceiling --- measured at 1.2k events per second"
+    entry = {
+        "artifact_ref": "vault://notes/fenced.md",
+        "source_stream": "ingest.vault.changed",
+        "matched_at": "2026-08-04T00:00:00Z",
+        "confidence_class": "high",
+        "provenance_ref": "outbox://ingest.vault.changed/vault://notes/fenced.md",
+        "quoted_span": fence_span,
+    }
+
+    with pytest.raises(QuestionNoteRoundTripError):
+        store.append_evidence(question_id, [entry])
+    assert note_path.read_bytes() == before
+
+    # Matcher level: a verbatim span containing `---` reaches the seam, is
+    # refused, and lands in `append_refused` -- the note stays intact and
+    # parseable, and no corrupted quote enters the evidence trail.
+    fenced_body = f"Fence notes\n\nWe found {fence_span} in the run.\n"
+    fenced_ref = _write_artifact(vault, "notes/fenced.md", fenced_body)
+    association = _Association({"Fence notes": _attached(span=fence_span)})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(fenced_ref)],
+        store=store,
+        complete=association,
+    )
+
+    assert summary.append_refused == 1
+    assert summary.attached == 0
+    assert store.read_question(question_id)["evidence"] == []
+
+
 def test_disappearing_vault_artifact_does_not_abort_tick(tmp_path: Path, monkeypatch) -> None:
     """#4610 P2: a vault artifact deleted between the existence check and the read --
     a normal race for asynchronously consumed ingest events -- is unresolved for

--- a/tests/standing_questions/test_evidence_matching.py
+++ b/tests/standing_questions/test_evidence_matching.py
@@ -404,6 +404,118 @@ def test_question_closed_mid_tick_is_never_resurrected(tmp_path: Path) -> None:
     assert store.read_question(note["question_id"])["evidence"] == []
 
 
+def test_append_rechecks_open_status_atomically(tmp_path: Path) -> None:
+    """#4610 P2: the open-status predicate and the evidence append are one atomic
+    operation at the guarded write seam -- the seam serializes on an exclusive
+    per-note lock and re-checks status on a fresh read taken AFTER acquiring it,
+    so a close that lands before the engine's turn fails the append closed
+    instead of appending to (or resurrecting) a non-open question."""
+    import fcntl
+    import threading
+
+    from app.standing_questions.question_store import (
+        QuestionNotOpenError,
+        question_note_lock_path,
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+    note_path = vault / "questions" / f"{question_id}.md"
+
+    entry = {
+        "artifact_ref": "vault://notes/outbox-measurements.md",
+        "source_stream": "ingest.vault.changed",
+        "matched_at": "2026-08-04T00:00:00Z",
+        "confidence_class": "high",
+        "provenance_ref": "outbox://ingest.vault.changed/vault://notes/outbox-measurements.md",
+        "quoted_span": RELEVANT_SPAN,
+    }
+
+    outcome: dict[str, Any] = {}
+
+    def engine_append() -> None:
+        try:
+            store.append_evidence(question_id, [entry])
+            outcome["result"] = "appended"
+        except QuestionNotOpenError:
+            outcome["result"] = "refused"
+
+    lock_path = question_note_lock_path(vault, question_id)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as human_lock:
+        fcntl.flock(human_lock.fileno(), fcntl.LOCK_EX)
+        engine = threading.Thread(target=engine_append)
+        engine.start()
+        # The engine's append must serialize on the seam's exclusive lock: while
+        # the "human" holds it, the append cannot have completed.
+        engine.join(timeout=0.5)
+        assert engine.is_alive(), "append must block on the seam's exclusive per-note lock"
+        # The human closes the question while still holding the lock -- strictly
+        # before the engine's critical section begins.
+        current = parse_question_note(note_path.read_text(encoding="utf-8"))
+        note_path.write_text(
+            serialize_question_note({**current, "status": "closed"}), encoding="utf-8"
+        )
+        fcntl.flock(human_lock.fileno(), fcntl.LOCK_UN)
+    engine.join(timeout=10)
+    assert not engine.is_alive()
+
+    # Fail closed: the post-lock fresh read saw `closed`, so no evidence was
+    # appended and the terminal status was never overwritten by a stale payload.
+    assert outcome["result"] == "refused"
+    final = parse_question_note(note_path.read_text(encoding="utf-8"))
+    assert final["status"] == "closed"
+    assert final["evidence"] == []
+
+    # Direct seam call on an already-closed question fails closed too, mutating nothing.
+    before = note_path.read_bytes()
+    with pytest.raises(QuestionNotOpenError):
+        store.append_evidence(question_id, [entry])
+    assert note_path.read_bytes() == before
+
+
+def test_disappearing_vault_artifact_does_not_abort_tick(tmp_path: Path, monkeypatch) -> None:
+    """#4610 P2: a vault artifact deleted between the existence check and the read --
+    a normal race for asynchronously consumed ingest events -- is unresolved for
+    THAT candidate only; the tick continues for the other candidates."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+
+    vanishing_ref = _write_artifact(vault, "notes/vanishing.md", RELEVANT_BODY)
+    surviving_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+
+    real_read_text = Path.read_text
+
+    def deleting_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        if self.name == "vanishing.md":
+            # Simulate the race: the note disappears after `is_file()` said it
+            # existed but before the read reaches the filesystem.
+            self.unlink()
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deleting_read_text)
+    association = _Association({"single-writer ceiling": _attached()})
+
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(vanishing_ref), _candidate(surviving_ref)],
+        store=store,
+        complete=association,
+    )
+
+    # The vanished artifact is a no-link unresolved result, never a fabricated
+    # entry -- and never an aborted tick for the surviving candidate.
+    assert summary.unresolved_artifact == 1
+    assert summary.attached == 1
+    evidence = store.read_question(note["question_id"])["evidence"]
+    assert [entry["artifact_ref"] for entry in evidence] == [surviving_ref]
+
+
 def test_missing_questions_directory_is_a_no_op_tick(tmp_path: Path) -> None:
     """A vault that never registered a question yields an empty tick, not a crash --
     matching is a read-only consumer, so the projection's fail-loud posture (which

--- a/tests/standing_questions/test_evidence_matching.py
+++ b/tests/standing_questions/test_evidence_matching.py
@@ -610,6 +610,48 @@ def test_disappearing_vault_artifact_does_not_abort_tick(tmp_path: Path, monkeyp
     assert [entry["artifact_ref"] for entry in evidence] == [surviving_ref]
 
 
+def test_question_note_refs_are_never_resolvable_candidates(tmp_path: Path) -> None:
+    """#4610 round-3 review: defense in depth against question self-citation at
+    the matcher's own content resolution -- a `vault://questions/...` ref (plain
+    or via `..` traversal) is refused content-free, so a question's frontmatter
+    (which contains every attached quoted span verbatim) can never feed the
+    judge and re-attach to itself."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+
+    # Attach one real evidence entry so the note's frontmatter carries a span
+    # the judge would accept if the note were ever read as an artifact.
+    relevant_ref = _write_artifact(vault, "notes/outbox-measurements.md", RELEVANT_BODY)
+    association = _Association({"single-writer ceiling": _attached()})
+    first = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[_candidate(relevant_ref)],
+        store=store,
+        complete=association,
+    )
+    assert first.attached == 1
+
+    self_association = _Association({RELEVANT_SPAN: _attached()})
+    summary = match_evidence_to_open_questions(
+        vault_root=vault,
+        candidates=[
+            _candidate(f"vault://questions/{question_id}.md"),
+            _candidate(f"vault://notes/../questions/{question_id}.md"),
+        ],
+        store=store,
+        complete=self_association,
+    )
+
+    assert summary.unresolved_artifact == 2
+    assert summary.attached == 0
+    # Content-free refusal: the question note's text never reached the judge.
+    assert self_association.prompts == []
+    assert len(store.read_question(question_id)["evidence"]) == 1
+
+
 def test_missing_questions_directory_is_a_no_op_tick(tmp_path: Path) -> None:
     """A vault that never registered a question yields an empty tick, not a crash --
     matching is a read-only consumer, so the projection's fail-loud posture (which

--- a/tests/standing_questions/test_evidence_matching_runtime_wiring.py
+++ b/tests/standing_questions/test_evidence_matching_runtime_wiring.py
@@ -214,18 +214,15 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
     ):
         assert marker in raw
 
-    # --- Regression: the watcher loop must not destroy or self-cite questions ----
+    # --- Regression: the watcher loop must not destroy or index questions --------
     # Matcher appends re-enter ingest through the watcher (the vault-wide scan
-    # includes questions/). Two invariants, both asserted through the REAL
-    # schema validator on the note the handler just processed:
-    # 1. The handler's uuid-heal must not touch engine-owned Question notes --
-    #    healing a `uuid:` key in made the note schema-invalid
-    #    (additionalProperties: false) and silently dropped the question from
-    #    matching and the projection.
-    # 2. A question is never offered as its own candidate evidence. The note's
-    #    frontmatter contains every attached quoted span, so without the
-    #    builders' questions/ exclusion the fake judge would attach it.
-    outbox_worker.handle_ingest_vault_changed(
+    # includes questions/). Engine-owned Question notes are excluded from the
+    # generic ingest fan-out entirely: uuid-healing one made it schema-invalid
+    # (additionalProperties: false -- silently dropping the question from
+    # matching and its projection), and ingesting it without a uuid minted a
+    # fresh random index identity per event. Asserted through the REAL schema
+    # validator on the note the handler just processed.
+    ingest_summary = outbox_worker.handle_ingest_vault_changed(
         {
             "vault_path": str(question_note_path),
             "relative_path": f"questions/{question_id}.md",
@@ -234,6 +231,7 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
         },
         vault_root=vault,
     )
+    assert ingest_summary.ingested == 0
     surviving = store.read_question(question_id)  # parses via the real validator
     assert "uuid" not in surviving
     assert len(surviving["evidence"]) == 4
@@ -241,3 +239,30 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
         entry["artifact_ref"].startswith("vault://questions/")
         for entry in surviving["evidence"]
     )
+
+
+def test_vault_alpha_ingest_never_touches_question_notes(tmp_path: Path, monkeypatch) -> None:
+    """The second production watcher seam (#4610 round-3 review): the alpha
+    ingest walk (`run_watcher_tick` -> `run_vault_alpha_ingest_paths`) must skip
+    engine-owned Question notes -- it uuid-healed them exactly like the worker
+    seam did, breaking the closed schema on the watcher's first pass."""
+    from app.ingest.vault_alpha import run_vault_alpha_ingest_paths
+
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "index-outbox.jsonl"))
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = QuestionStore(vault, write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}))
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+    note_path = vault / "questions" / f"{question_id}.md"
+    before = note_path.read_bytes()
+
+    summary = run_vault_alpha_ingest_paths(vault, [note_path])
+
+    assert summary.ingested == 0
+    assert note_path.read_bytes() == before  # no healed uuid, no rewrite at all
+    surviving = store.read_question(question_id)  # still parses via the real validator
+    assert "uuid" not in surviving

--- a/tests/standing_questions/test_evidence_matching_runtime_wiring.py
+++ b/tests/standing_questions/test_evidence_matching_runtime_wiring.py
@@ -214,12 +214,17 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
     ):
         assert marker in raw
 
-    # --- Regression: the engine's own Question notes are never candidates --------
-    # Matcher appends re-enter ingest through the watcher; a question must not
-    # cite itself as evidence. (Runs last: the ingest handler's unrelated
-    # uuid-healing also touches the note, so assertions here are raw-text
-    # based.)
-    spans_before = question_note_path.read_text(encoding="utf-8").count("quoted_span:")
+    # --- Regression: the watcher loop must not destroy or self-cite questions ----
+    # Matcher appends re-enter ingest through the watcher (the vault-wide scan
+    # includes questions/). Two invariants, both asserted through the REAL
+    # schema validator on the note the handler just processed:
+    # 1. The handler's uuid-heal must not touch engine-owned Question notes --
+    #    healing a `uuid:` key in made the note schema-invalid
+    #    (additionalProperties: false) and silently dropped the question from
+    #    matching and the projection.
+    # 2. A question is never offered as its own candidate evidence. The note's
+    #    frontmatter contains every attached quoted span, so without the
+    #    builders' questions/ exclusion the fake judge would attach it.
     outbox_worker.handle_ingest_vault_changed(
         {
             "vault_path": str(question_note_path),
@@ -229,6 +234,10 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
         },
         vault_root=vault,
     )
-    assert (
-        question_note_path.read_text(encoding="utf-8").count("quoted_span:") == spans_before
+    surviving = store.read_question(question_id)  # parses via the real validator
+    assert "uuid" not in surviving
+    assert len(surviving["evidence"]) == 4
+    assert not any(
+        entry["artifact_ref"].startswith("vault://questions/")
+        for entry in surviving["evidence"]
     )

--- a/tests/standing_questions/test_evidence_matching_runtime_wiring.py
+++ b/tests/standing_questions/test_evidence_matching_runtime_wiring.py
@@ -1,0 +1,189 @@
+"""Runtime wiring for SQ-03 evidence matching (#4610).
+
+PR #4588 shipped the matcher with no production caller: normal ingestion never
+constructed a ``CandidateArtifact`` or invoked the matching tick. These tests
+exercise the REAL production consumer paths named by
+``docs/STANDING_QUESTIONS/MATCH_EVIDENCE_TO_OPEN_QUESTIONS.md`` -- the worker's
+``ingest.vault.changed`` handler, the worker's
+``knowledge_acquisition.stage.completed`` handler, and the Heimdal
+observation-log cursor tick -- end to end into a real evidence append on a real
+Question note. The only stub is the fenced LLM boundary
+(``constrained_completion``), replaced with a deterministic completion that
+still validates against the registered association schema; every consumer,
+candidate-construction, matcher, and guarded-store path is the production code.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.heimdal.cursor_store import reset_memory_cursor_store
+from app.heimdal.observation_log import reset_memory_observation_log
+from app.heimdal.publish import publish_observation
+from app.standing_questions import evidence_matching
+from app.standing_questions.ingest_consumers import (
+    HEIMDAL_EVIDENCE_CONSUMER_ID,
+    run_heimdal_evidence_matching_tick,
+)
+from app.standing_questions.question_store import QuestionStore
+from app.workers import outbox_worker
+from app.write_guard import WriteGuard
+from tests.helpers.pkm_alpha_helper import reset_memory_stores
+
+pytestmark = pytest.mark.not_pg
+
+QUESTION_TEXT = "How should the event outbox be sharded once a single writer saturates?"
+RELEVANT_BODY = (
+    "We measured the single-writer ceiling at 1.2k events per second, so "
+    "sharding by aggregate id is the only option that keeps ordering per stream.\n"
+)
+RELEVANT_SPAN = "sharding by aggregate id is the only option that keeps ordering per stream"
+
+
+def _fake_constrained_completion(
+    schema_ref: str,
+    *,
+    system: str = "",
+    user: str,
+    task_kind: str = "decide",
+    trace_id: str | None = None,
+    max_tokens: int | None = None,
+    complete: Any = None,
+) -> dict[str, Any]:
+    """Deterministic stand-in for the fenced LLM boundary only.
+
+    Returns a schema-validated attach judgment whenever the artifact span is in
+    the prompt, mirroring what a live backend would return for a clearly
+    relevant artifact. Validated through the real registered schema so the
+    association contract stays live.
+    """
+    from app.components.llm.constrained import validate_payload
+
+    related = RELEVANT_SPAN in user
+    payload = {
+        "related": related,
+        "confidence_class": "high" if related else "low",
+        "relation_label": "states the sharding decision" if related else None,
+        "supporting_span": RELEVANT_SPAN if related else "",
+    }
+    return validate_payload(schema_ref, payload)
+
+
+def _write_note(vault: Path, relative_path: str, *, scope: str, body: str) -> Path:
+    path = vault / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    note_uuid = str(uuid.uuid4())
+    path.write_text(
+        f"---\nuuid: {note_uuid}\nscope: {scope}\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) -> None:
+    """Every production ingest consumer path constructs candidate artifacts and
+    invokes the standing-question matching tick (issue #4610 AC1)."""
+    reset_memory_stores()
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "index-outbox.jsonl"))
+    monkeypatch.setattr(
+        evidence_matching, "constrained_completion", _fake_constrained_completion
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = QuestionStore(vault, write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}))
+    note, _ = store.create_question(text=QUESTION_TEXT, scope="work", registered_via="explicit")
+    question_id = note["question_id"]
+
+    def evidence() -> list[dict[str, Any]]:
+        return store.read_question(question_id)["evidence"]
+
+    # --- Path 1: the worker's real `ingest.vault.changed` consumer ---------------
+    note_path = _write_note(vault, "Inbox/outbox-measurements.md", scope="work", body=RELEVANT_BODY)
+    summary = outbox_worker.handle_ingest_vault_changed(
+        {
+            "vault_path": str(note_path),
+            "relative_path": "Inbox/outbox-measurements.md",
+            "hash": "test-hash",
+            "mtime": 123.0,
+        },
+        vault_root=vault,
+    )
+    assert summary.ingested == 1
+    vault_entries = evidence()
+    assert len(vault_entries) == 1
+    assert vault_entries[0]["source_stream"] == "ingest.vault.changed"
+    assert vault_entries[0]["artifact_ref"] == "vault://Inbox/outbox-measurements.md"
+    assert vault_entries[0]["quoted_span"] == RELEVANT_SPAN
+
+    # --- Path 2: the worker's real KA `stage.completed` consumer -----------------
+    _write_note(vault, "sources/candidate-outbox.md", scope="work", body=RELEVANT_BODY)
+    outbox_worker.handle_knowledge_acquisition_stage_completed(
+        {
+            "stage": "candidate",
+            "stage_version": 1,
+            "content_identity": "sha256:" + "0" * 64,
+            "artifact_path": "sources/candidate-outbox.md",
+        },
+        vault_root=vault,
+    )
+    ka_entries = evidence()
+    assert len(ka_entries) == 2
+    assert ka_entries[1]["source_stream"] == "knowledge_acquisition.stage.completed"
+    assert ka_entries[1]["artifact_ref"] == "vault://sources/candidate-outbox.md"
+
+    # A non-terminal stage completion offers no candidate and attaches nothing.
+    outbox_worker.handle_knowledge_acquisition_stage_completed(
+        {
+            "stage": "normalize",
+            "stage_version": 1,
+            "content_identity": "sha256:" + "1" * 64,
+        },
+        vault_root=vault,
+    )
+    assert len(evidence()) == 2
+
+    # --- Path 3: the Heimdal observation-log cursor tick -------------------------
+    observation_id = "obs-" + str(uuid.uuid4())
+    published = publish_observation(
+        topic="heimdal.observation.published.v1",
+        observation_id=observation_id,
+        payload={
+            "observation_id": observation_id,
+            "content": RELEVANT_BODY,
+            "scope_hint": "work",
+        },
+        source="test",
+    )
+    assert published is not None
+    tick = run_heimdal_evidence_matching_tick(vault_root=vault)
+    assert tick.attached == 1
+    heimdal_entries = evidence()
+    assert len(heimdal_entries) == 3
+    assert heimdal_entries[2]["source_stream"] == "heimdal.observations"
+    assert heimdal_entries[2]["artifact_ref"] == f"heimdal://observations/{observation_id}"
+    assert heimdal_entries[2]["provenance_ref"] == f"heimdal.observations:{observation_id}"
+
+    # The tick owns a durable per-consumer cursor: a re-tick reads nothing new
+    # and appends nothing (consumer-id contract, mirrors the ERE read path).
+    assert HEIMDAL_EVIDENCE_CONSUMER_ID.startswith("mimer.standing_questions")
+    retick = run_heimdal_evidence_matching_tick(vault_root=vault)
+    assert retick.evaluated_pairs == 0
+    assert len(evidence()) == 3
+
+    # Cross-check the durable note on disk, not just the store API: the real
+    # guarded seam wrote all three consumer paths' entries into the vault note.
+    raw = (vault / "questions" / f"{question_id}.md").read_text(encoding="utf-8")
+    for marker in (
+        "ingest.vault.changed",
+        "knowledge_acquisition.stage.completed",
+        "heimdal.observations",
+    ):
+        assert marker in raw

--- a/tests/standing_questions/test_evidence_matching_runtime_wiring.py
+++ b/tests/standing_questions/test_evidence_matching_runtime_wiring.py
@@ -240,6 +240,19 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
         for entry in surviving["evidence"]
     )
 
+    # The panel-scan fan-out is excluded the same way (#4610 round-4 review):
+    # question notes are deliberately uuid-less, so an admitted scan would burn
+    # the missing_uuid retry budget and dead-letter on every evidence append.
+    panel_summary = outbox_worker.handle_panel_scan_requested(
+        {
+            "vault_path": str(question_note_path),
+            "relative_path": f"questions/{question_id}.md",
+        },
+        vault_root=vault,
+    )
+    assert panel_summary.emitted == 0
+    assert panel_summary.deferred is False
+
 
 def test_vault_alpha_ingest_never_touches_question_notes(tmp_path: Path, monkeypatch) -> None:
     """The second production watcher seam (#4610 round-3 review): the alpha

--- a/tests/standing_questions/test_evidence_matching_runtime_wiring.py
+++ b/tests/standing_questions/test_evidence_matching_runtime_wiring.py
@@ -150,7 +150,31 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
     )
     assert len(evidence()) == 2
 
-    # --- Path 3: the Heimdal observation-log cursor tick -------------------------
+    # --- Path 3: the worker's real `ingest.object.created` dispatch branch -------
+    # Wired at the dispatch table (not inside the indexer handler) so the
+    # vault-changed path above cannot double-match; exercised through the same
+    # `_dispatch_topic` entry the daemon loop and `run_once` both use.
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    api_object_uuid = str(uuid.uuid4())
+    outbox_worker._dispatch_topic(
+        outbox_worker.INGEST_OBJECT_CREATED,
+        {
+            "uuid": api_object_uuid,
+            "title": "api ingested artifact",
+            "review_state": "draft",
+            # POST /ingest carries no separate frontmatter field; scope rides
+            # inside the content itself and must still resolve.
+            "content": f"---\nscope: work\n---\n\n{RELEVANT_BODY}",
+        },
+        trace_id="trace-object-created",
+        message={},
+    )
+    object_entries = evidence()
+    assert len(object_entries) == 3
+    assert object_entries[2]["source_stream"] == "ingest.object.created"
+    assert object_entries[2]["artifact_ref"] == f"object://{api_object_uuid}"
+
+    # --- Path 4: the Heimdal observation-log cursor tick -------------------------
     observation_id = "obs-" + str(uuid.uuid4())
     published = publish_observation(
         topic="heimdal.observation.published.v1",
@@ -166,24 +190,45 @@ def test_ingest_consumers_invoke_question_matching(tmp_path: Path, monkeypatch) 
     tick = run_heimdal_evidence_matching_tick(vault_root=vault)
     assert tick.attached == 1
     heimdal_entries = evidence()
-    assert len(heimdal_entries) == 3
-    assert heimdal_entries[2]["source_stream"] == "heimdal.observations"
-    assert heimdal_entries[2]["artifact_ref"] == f"heimdal://observations/{observation_id}"
-    assert heimdal_entries[2]["provenance_ref"] == f"heimdal.observations:{observation_id}"
+    assert len(heimdal_entries) == 4
+    assert heimdal_entries[3]["source_stream"] == "heimdal.observations"
+    assert heimdal_entries[3]["artifact_ref"] == f"heimdal://observations/{observation_id}"
+    assert heimdal_entries[3]["provenance_ref"] == f"heimdal.observations:{observation_id}"
 
     # The tick owns a durable per-consumer cursor: a re-tick reads nothing new
     # and appends nothing (consumer-id contract, mirrors the ERE read path).
     assert HEIMDAL_EVIDENCE_CONSUMER_ID.startswith("mimer.standing_questions")
     retick = run_heimdal_evidence_matching_tick(vault_root=vault)
     assert retick.evaluated_pairs == 0
-    assert len(evidence()) == 3
+    assert len(evidence()) == 4
 
     # Cross-check the durable note on disk, not just the store API: the real
-    # guarded seam wrote all three consumer paths' entries into the vault note.
-    raw = (vault / "questions" / f"{question_id}.md").read_text(encoding="utf-8")
+    # guarded seam wrote every consumer path's entry into the vault note.
+    question_note_path = vault / "questions" / f"{question_id}.md"
+    raw = question_note_path.read_text(encoding="utf-8")
     for marker in (
         "ingest.vault.changed",
         "knowledge_acquisition.stage.completed",
+        "ingest.object.created",
         "heimdal.observations",
     ):
         assert marker in raw
+
+    # --- Regression: the engine's own Question notes are never candidates --------
+    # Matcher appends re-enter ingest through the watcher; a question must not
+    # cite itself as evidence. (Runs last: the ingest handler's unrelated
+    # uuid-healing also touches the note, so assertions here are raw-text
+    # based.)
+    spans_before = question_note_path.read_text(encoding="utf-8").count("quoted_span:")
+    outbox_worker.handle_ingest_vault_changed(
+        {
+            "vault_path": str(question_note_path),
+            "relative_path": f"questions/{question_id}.md",
+            "hash": "q-hash",
+            "mtime": 124.0,
+        },
+        vault_root=vault,
+    )
+    assert (
+        question_note_path.read_text(encoding="utf-8").count("quoted_span:") == spans_before
+    )

--- a/tests/watcher/test_fs_watcher.py
+++ b/tests/watcher/test_fs_watcher.py
@@ -149,6 +149,23 @@ def test_scan_injects_uuid_and_upserts(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert "uuid:" in note.read_text(encoding="utf-8")
 
 
+def test_scan_skips_engine_owned_question_notes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    questions = vault / "questions"
+    questions.mkdir(parents=True)
+    note = questions / "sq-1.md"
+    note.write_text("---\nquestion_id: sq-1\nstatus: open\n---\n\nQuestion", encoding="utf-8")
+
+    watcher = _load_watcher(monkeypatch, vault)
+    monkeypatch.setattr(watcher, "active_edit", lambda _: False)
+    port = RecordingVaultPort()
+    watcher.scan_once(port)
+
+    assert not port.upserts
+    assert "uuid:" not in note.read_text(encoding="utf-8")
+    assert str(note) not in watcher.STATE
+
+
 def test_rename_only_updates_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     vault.mkdir()


### PR DESCRIPTION
Governing-Issue: #4610

Fixes #4610

Final-Review-Rounds: 2

## Summary

Wires the SQ-03 standing-question evidence matcher into the production ingest consumers it was shipped without (P1 residual from merged PR #4588), and repairs the same-review P2s: the open-status predicate and evidence append are now one atomic operation at the guarded QuestionStore seam, and a vault artifact deleted between existence check and read is an unresolved no-link result for that candidate instead of aborting the whole tick. Convergence review of the wiring surfaced and closed a further defect family: engine-owned Question notes are now excluded from the generic vault fan-out at every production seam (new INV-SQ-H), because the uuid-heal/index/panel pipeline was destroying or spamming the very notes the matcher writes to.

## Changes

- `app/standing_questions/ingest_consumers.py` (new): candidate construction and matching invocation for the spec-named paths — `ingest.vault.changed` / `ingest.object.created` outbox topics, `knowledge_acquisition.stage.completed` (candidate stage), and the Heimdal observation-log cursor (own durable consumer id `mimer.standing_questions.evidence_matching`, same read path as the ERE). Never-crash on the worker paths; fail-loud read-then-advance on the cursor tick (root must exist; `questions/` must exist before the read and after the match); engine-owned `questions/` notes are never candidates.
- `app/workers/outbox_worker.py`: `handle_ingest_vault_changed`, the `INGEST_OBJECT_CREATED` dispatch branch, and `handle_knowledge_acquisition_stage_completed` (new optional `vault_root` param) invoke the matcher after successful ingest; matching failures log loudly and never fail or retry-loop the dispatch. `handle_ingest_vault_changed` and `handle_panel_scan_requested` return early for engine-owned Question notes (INV-SQ-H): healing a `uuid:` into one broke its closed schema and silently dropped the question from matching/projection, an unhealed one minted a fresh random index identity per event, and the panel path dead-lettered once per evidence append under shipped defaults.
- `app/ingest/vault_alpha.py`: both walk loops skip `questions/` (the second production seam performing the same schema-breaking heal).
- `app/standing_questions/question_store.py`: new atomic `append_evidence` seam — WriteGuard asserted before any filesystem effect (spec-named `standing_questions.append_evidence` action), exclusive per-note flock (0o600 sibling lock file), fresh in-lock versioned read, open-status predicate on that same read (`QuestionNotOpenError`), duplicate-basis filtering, and a compare-and-swap write (`expected_version` through the hardened knowledge port) so a racing human edit raises `KnowledgeWriteConflict` and is never overwritten by a stale `open` payload. `_write` gains a frontmatter round-trip guard (`QuestionNoteRoundTripError`) refusing writes the shared literal-split reader would corrupt (e.g. a quoted span containing `---`). `update_system_fields` documented as not concurrency-hardened (no production caller; SQ-04 precondition).
- `app/standing_questions/evidence_matching.py`: artifact read race (`OSError`/`UnicodeDecodeError` between `is_file()` and read) degrades to `unresolved_artifact` per candidate; the write path uses the atomic seam; seam refusals/conflicts are contained per pair in a new `append_refused` counter (honest wording: Heimdal-cursor pairs are a logged loss once the cursor advances); `_resolve_content` refuses `vault://questions/...` refs on the resolved path (traversal-proof self-citation defense).
- `app/cli/questions.py` (new) + registration: `questions match-evidence [--json]` — the production invocation of the Heimdal cursor tick, mirroring `episodes tick` and the spec's Concretely section.
- `docs/STANDING_QUESTIONS/README.md`: new INV-SQ-H (`questions_outside_generic_ingest`) naming the exclusion contract the code now cites.
- Tests: `tests/standing_questions/test_evidence_matching_runtime_wiring.py` (new) drives the real worker handlers, real dispatch-table branch, real alpha-ingest walk, real panel handler, and real cursor tick end-to-end into durable evidence appends (only the fenced LLM boundary is stubbed, still schema-validated), including live regressions for heal-exclusion (real validator) and panel-skip; `tests/standing_questions/test_evidence_matching.py` gains the two Verify tests plus CAS-race, round-trip-refusal, and content-free self-citation regressions.

## Verify targets (test-first)

- `tests/standing_questions/test_evidence_matching_runtime_wiring.py::test_ingest_consumers_invoke_question_matching` — failed first (`ModuleNotFoundError: app.standing_questions.ingest_consumers`), green after.
- `tests/standing_questions/test_evidence_matching.py::test_append_rechecks_open_status_atomically` — failed first (no seam: `ImportError`), green after; proves the append blocks on the seam lock and fails closed on the post-lock fresh read.
- `tests/standing_questions/test_evidence_matching.py::test_disappearing_vault_artifact_does_not_abort_tick` — failed first (`FileNotFoundError` aborted the tick), green after.

## Review-Before-CI Gate (risk-convergence)

`scripts/review_before_ci_gate.py --lane implementation --risk-assessment-complete --risk-surface concurrency --risk-surface data` → satisfied on the publishable SHA. Mechanism convergence packet built (`standing_questions.evidence_append` + ingest wiring: invariants, states, transitions, crash ordering, lock/race analysis, test matrix) and iterated across five independent high-capability review rounds, each a fresh reviewer on the then-current SHA:

- Round 1 (SHA b138b6c07): 2×P1 (frontmatter-fence corruption via a `---` span; human close overwritten by the versionless write), 5×P2, 4×P3 → all repaired (round-trip guard; CAS `expected_version` write; self-match exclusion; guard-before-lock + 0o600; cursor guards; object-created scope/id repair; UnicodeDecodeError; spec-named action).
- Round 2 (SHA 2cebe6946): verified round-1 fixes; new P1 — the watcher uuid-heal destroyed Question notes (closed schema, `additionalProperties: false`), making the delivered wiring inoperative under a live watcher → question notes excluded from healing at the worker seam; regression rewritten through the real validator.
- Round 3 (delta): found the heal still live via the `vault_alpha` seam (P1) and unbounded duplicate index identities on the guarded path (P1) → question notes excluded from the generic ingest fan-out entirely at both seams; traversal-proof matcher refusal; both-sides cursor sample. Verdict: publishable on the ingest-heal mechanism, one adjacent P1 remaining.
- Round 4 (delta): mutation-proved all three prior fixes live; last P1 — panel-scan fan-out dead-lettered once per evidence append under shipped defaults → early return in `handle_panel_scan_requested` + live regression + INV-SQ-H doc anchor.
- Round 5 (delta, narrow): **CLEAN** — early-return placement, ack semantics, live regression (empirically mutation-tested), doc consistency all verified; three P3 observations recorded below.

Rebase after round 5 carried the review forward under the base-drift evidence-reuse rule: `git patch-id --stable` identical before/after rebase, bounded current-head checks re-run green.

## Current-head CI repair receipt

- Failed GitHub check: Unit tests (not pg), run 30967069599 / job 92183233408 on `19523b270b7ef4c56c8473ca33c070e77a18b40a`: four failures. Three were PR-caused closed-census line bindings shifted by the `vault_alpha` exclusion; one was pre-existing current-main drift where the kill-switch test still patched `record_sync_success` after production moved the degraded path to `record_sync_partial`.
- Accounting preserved: existing `standing_questions.evidence_append` 2 rounds; ingest-heal/generic-vault-fan-out 2 rounds; scoped closure 1 round. New static-quality keys are `vault_alpha_closed_census_line_binding` attempt 1 and `dispatcher_partial_sync_test_target` attempt 1; no runtime key was reset or rebound.
- Validated repair SHA: `93e137ceefbd1fd376f40e1bd43106b6a4516b28`; rebased publishable SHA: `5aa64a21adef77ab86c3a9c16b491d4df545f119` on `origin/main` `5955038954fa0efce9b91614083b8b258b766ad6`. Stable patch ID `b2a98fdc58123d416fd509823e905763ae9bef78`, the 14-path delivery set, and every delivery-owned blob are identical; the rebase was conflict-free and incoming changes had no path overlap. The independent Codex Sol/high mechanism-convergence review and expensive validation evidence therefore carry under the base-drift rule; current-head bounded checks were rerun green.
- Local proof: repaired four-test set 4 passed; governing Issue verification files 18 passed; `ruff check app tests` clean; `mypy app` clean (872 files); `git diff --check origin/main...HEAD` clean. Host-leased full non-PG run reached the repaired checks clean and ended with three unrelated retrieval global-store/xdist order failures in untouched files; the exact three-test isolation rerun passed 3/3. Current-head GitHub CI remains the merge authority.
- Deferred P2 truth repair: canonical #4172 entries `KD-38CCC6BEB78C` and `KD-A575CB68E871` were corrected in place from the mistyped nonexistent SHA to the exact reviewed head `19523b270b7ef4c56c8473ca33c070e77a18b40a`; the original PR threads already carried that correct disposition and remain resolved.

## Claim receipt

`pickup-claim-complete issue=4610 branch=fix/4610-sq-evidence-matcher-wiring worktree=/Volumes/ColimaT7/workspace-root/.claude/worktrees/agent-a6ffaa0d5cb568a34 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4610 lease_id=lease-29631e7a holder=claude-w4a evidence=verified-dispatcher-lease`

## BuilderOps Routing

- Records/projections/receipts: claim receipt above; five-round convergence review record in this PR body; follow-up task chip raised for the pre-existing corrupted-note repair (see residuals).
- Reason: no LearningSignal — review findings were handled inside the slice's own repair budget (2 rounds for the append mechanism, 2 for the ingest-heal mechanism, 1 scoped closure round) without plan divergence beyond the recorded convergence loop.

## Notes

Validation (all re-run on the publishable SHA after the final rebase unless noted):
- `pytest -q tests/standing_questions/` — 165 passed (includes both Verify test files)
- `pytest -q -m "not pg" tests/workers/ tests/runtime/test_worker_*.py tests/heimdal/test_observation_log.py tests/cli/ tests/watcher/ tests/ingest/` — pass (578 at round-3 head; touched subsets re-run green after each later commit; one pre-existing `pg`-marked failure, `tests/workers/test_outbox_worker_poison_txn_pg.py`, fails identically on clean origin/main)
- `ruff check app tests` — clean; `mypy app` — clean (872 files); `git diff --check` — clean

Residual risks / follow-ups (reviewed, non-blocking, out of scope for #4610):
- Question notes already corrupted by the pre-existing heal on `main` remain invisible to matching/projection until repaired; plus residual write-capable maintenance walks (`pkm note-scan`, `pkm note-update`, test-only `run_registry_once`) and the alpha locked-log retention — follow-up task raised covering detection/repair and those guards.
- Shared root cause of the round-trip hazard: `scripts/yaml_roundtrip.load_frontmatter` splits on the literal `---` substring repo-wide; this PR fail-closes the question-note seam only.
- CAS side effects (shared-port behavior): each successful append retains pre-exchange conflicted copies under `questions/_conflicts/` (O(n²) over appends; engine-cadence retention policy is follow-up), and a lost human-race append stages a human-visible conflicted copy (quarantined from all engine readers).
- Heimdal-cursor pairs whose append was refused are a logged, counted loss (`append_refused`) once the cursor advances; vault/KA sources re-offer naturally.
- Unbounded synchronous LLM fan-out: one completion per open same-scope question per ingested artifact, inline on worker dispatch; the spec's "not already linked" prefilter half runs post-judgment. Batching/budget is future work.
- Panel emit seam still enqueues one benign, acked no-op `panel.scan.requested` row per append (watcher-side emit filter is optional future cleanup); the `questions/` panel/ingest exclusion covers the whole directory, not only `sq-*.md` (consistent across all seams, documented in INV-SQ-H).
- `update_system_fields` remains an unlocked, versionless RMW with no production caller; documented as an SQ-04 precondition.

Owner-doc: `docs/STANDING_QUESTIONS/README.md` gained INV-SQ-H (`questions_outside_generic_ingest`) in the same change — the one behavior contract this implementation added. The matcher/CLI behavior itself matches the already-published `docs/STANDING_QUESTIONS/MATCH_EVIDENCE_TO_OPEN_QUESTIONS.md` contract (this PR supplies the wiring that doc already describes, including the `questions match-evidence` CLI shape it names).
---