### PR TITLE
Align test clobber preflight with deploy runtime env default

### DIFF
--- a/scripts/dev_test_environment_clobber_preflight.py
+++ b/scripts/dev_test_environment_clobber_preflight.py
@@ -56,6 +56,11 @@ _CHANNEL_OVERLAYS = {
     "test": "docker-compose.test.yml",
 }
 
+_RUNTIME_ENV_DEFAULTS = {
+    "dev": "./tmp/runtime.env",
+    "test": "./tmp-test/runtime.env",
+}
+
 
 def _repo_root() -> Path:
     # This script is invoked by path (sys.path[0] is scripts/, not the repo
@@ -103,6 +108,13 @@ def _deploy_env_file_interpolation_environ(
             {key: value for key, value in parsed.items() if value is not None}
         )
     merged.update(os.environ)
+
+    # ``deploy_channel_compose`` resolves this selector before calling
+    # Compose, then exports the selected value. The channel deploy env file
+    # may override it, but when it does not the test channel must still use
+    # its wrapper-derived ``tmp-test`` default rather than the base-compose
+    # expression's dev-shaped fallback.
+    merged.setdefault("WATCHER_RUNTIME_ENV_FILE", _RUNTIME_ENV_DEFAULTS[channel])
     return merged
 
 

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -1888,8 +1888,9 @@ def _configure_dev_test_environment_clobber_preflight(
     # check would skip rather than detect the clobber.
     (root / "config").mkdir(exist_ok=True)
     (root / "config/runtime.defaults.env").write_text("", encoding="utf-8")
-    (root / "tmp").mkdir(exist_ok=True)
-    (root / "tmp/runtime.env").write_text(
+    runtime_dir = root / ("tmp-test" if channel == "test" else "tmp")
+    runtime_dir.mkdir(exist_ok=True)
+    (runtime_dir / "runtime.env").write_text(
         "HEIMDAL_CAPTURE_WATCH_DIR=/real/capture/dir\n", encoding="utf-8"
     )
     # Ambient interpolation sources this preflight must resolve against must
@@ -1945,8 +1946,7 @@ def test_dev_deploy_preflight_passes_fixed_shape(tmp_path: Path) -> None:
 def test_test_channel_deploy_preflight_rejects_environment_override_clobbering_env_file(
     tmp_path: Path,
 ) -> None:
-    """Mirrors the dev-channel AC for the test channel, confirming the guard
-    is wired to both non-prod channels, not just dev."""
+    """The deploy path checks the wrapper-derived ``tmp-test`` env file."""
     root, env, sha = _deploy_harness(tmp_path)
     _configure_dev_test_environment_clobber_preflight(
         root, env, tmp_path, channel="test", overlay_content=_HEIMDAL_CLOBBER_OVERLAY

--- a/tests/ops/test_dev_test_environment_clobber_preflight.py
+++ b/tests/ops/test_dev_test_environment_clobber_preflight.py
@@ -43,6 +43,13 @@ services:
       HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-}
 """
 
+_TEST_CLOBBER_OVERLAY = """\
+services:
+  heimdal-capture-watch:
+    environment:
+      HEIMDAL_CAPTURE_WATCH_DIR: ${HEIMDAL_CAPTURE_WATCH_DIR:-}
+"""
+
 
 def _write_fixture_repo(tmp_path: Path) -> None:
     (tmp_path / "docker-compose.yaml").write_text(_BASE_COMPOSE, encoding="utf-8")
@@ -52,6 +59,17 @@ def _write_fixture_repo(tmp_path: Path) -> None:
     (tmp_path / "tmp").mkdir()
     (tmp_path / "tmp" / "runtime.env").write_text(
         "HEIMDAL_CAPTURE_WATCH_DIR=/real/capture/dir\n", encoding="utf-8"
+    )
+
+
+def _write_test_runtime_env_fixture(tmp_path: Path) -> None:
+    (tmp_path / "docker-compose.test.yml").write_text(
+        _TEST_CLOBBER_OVERLAY, encoding="utf-8"
+    )
+    (tmp_path / "tmp-test").mkdir()
+    (tmp_path / "tmp-test" / "runtime.env").write_text(
+        "HEIMDAL_CAPTURE_WATCH_DIR=/real/test/capture/dir\n",
+        encoding="utf-8",
     )
 
 
@@ -139,6 +157,49 @@ def test_preflight_missing_deploy_env_file_contributes_nothing(
     assert not (tmp_path / "config" / "deploy" / "dev.env").exists()
 
     rc, receipt = _run("dev", tmp_path, capsys)
+
+    assert rc == 1
+    assert receipt["status"] == "blocked"
+    violating = {(v["service"], v["field"]) for v in receipt["violations"]}
+    assert ("heimdal-capture-watch", "HEIMDAL_CAPTURE_WATCH_DIR") in violating
+
+
+def test_preflight_uses_deploy_wrapper_runtime_env_default(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test preflight mirrors the wrapper's ``tmp-test`` runtime-env default."""
+    monkeypatch.delenv("HEIMDAL_CAPTURE_WATCH_DIR", raising=False)
+    monkeypatch.delenv("WATCHER_RUNTIME_ENV_FILE", raising=False)
+    _write_fixture_repo(tmp_path)
+    _write_test_runtime_env_fixture(tmp_path)
+
+    rc, receipt = _run("test", tmp_path, capsys)
+
+    assert rc == 1
+    assert receipt["status"] == "blocked"
+    violation = receipt["violations"][0]
+    assert (violation["service"], violation["field"]) == (
+        "heimdal-capture-watch",
+        "HEIMDAL_CAPTURE_WATCH_DIR",
+    )
+    assert "/real/test/capture/dir" in violation["actual"]
+    assert "/tmp-test/runtime.env" in violation["actual"]
+
+
+def test_blank_override_against_derived_runtime_env_file_fails_closed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank test override cannot mask a value only in ``tmp-test``."""
+    monkeypatch.delenv("HEIMDAL_CAPTURE_WATCH_DIR", raising=False)
+    monkeypatch.delenv("WATCHER_RUNTIME_ENV_FILE", raising=False)
+    _write_fixture_repo(tmp_path)
+    _write_test_runtime_env_fixture(tmp_path)
+
+    rc, receipt = _run("test", tmp_path, capsys)
 
     assert rc == 1
     assert receipt["status"] == "blocked"


### PR DESCRIPTION
Governing-Issue: #4643

Fixes #4643

Final-Review-Rounds: 0

## Summary
Make the dev/test clobber preflight and its deploy integration fixture model the test runtime-env default already derived and exported by the deploy wrapper.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260806112105_16048351`
- Reason: Required CI exposed that the original issue validation omitted the production deploy integration fixture.

## Notes
Validation: `pytest -q tests/deploy/test_deploy_channel.py tests/ops/test_dev_test_environment_clobber_preflight.py tests/release_channels/test_channel_isolation_preflight.py` (93 passed); `ruff check app tests scripts`; `git diff --check`; `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` because this current-state correction does not change a temporal owner-doc claim.

CI repair rounds: 1/2 for `test-channel-derived-runtime-env-fixture`.