### PR TITLE
Wire standing-question registration flows

### DIFF
--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -402,8 +402,20 @@ def _write_proposals_to_panel(
         return markdown
 
     if panel_end is None or panel_start is None:
-        # No clear panel structure found; append at end (fallback).
-        lines.extend(proposal_lines)
+        # Never append a loose authority-bearing checkbox. Establish the
+        # smallest fenced Panel that the parser recognises instead.
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.extend(
+            [
+                "%% AI:Start %%%%",
+                "## AI-instruktion",
+                "",
+                "## AI-åtgärder",
+                *proposal_lines,
+                "%% AI:End %%%%",
+            ]
+        )
         return "\n".join(lines)
 
     # Find the AI-åtgärder / AI-actions heading within the panel.

--- a/app/api/routes/capture.py
+++ b/app/api/routes/capture.py
@@ -74,6 +74,7 @@ from app.services.outbox import (
 )
 from app.vault.paths import get_vault_inbox_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
+from app.standing_questions.registration import RegistrationProposalResult, propose_question_registration
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,8 @@ class CaptureResponse(BaseModel):
     events_emitted: list[str] = Field(default_factory=list)
     governed_write: dict[str, Any] | None = None
     ingest_warning: str | None = None
+    registration_state: Literal["proposal_pending", "not_qualified", "degraded"] = "not_qualified"
+    registration_proposal_id: str | None = None
 
 
 def _capture_note_rel(vault_root: Path) -> str:
@@ -191,6 +194,21 @@ def _writeguard_blocked_detail(exc: WritesBlockedError) -> dict[str, Any]:
         "message": str(exc),
         "reason": exc.reason,
     }
+
+
+def _offer_question_registration_proposal(
+    *, vault_root: Path, note_rel: str, trace_id: str
+) -> RegistrationProposalResult | None:
+    """Run proposal-only capture classification after the durable append."""
+    try:
+        return propose_question_registration(
+            capture_note_path=vault_root / note_rel,
+            vault_root=vault_root,
+            trace_id=trace_id,
+        )
+    except (OSError, WritesBlockedError):
+        logger.warning("standing-question proposal pass degraded trace_id=%s", trace_id, exc_info=True)
+        return None
 
 
 def _emit_capture_event(payload: dict[str, Any], trace_id: str) -> list[str]:
@@ -358,6 +376,17 @@ def capture_to_inbox(req: CaptureRequest, request: Request) -> CaptureResponse |
             },
         ) from exc
 
+    registration = _offer_question_registration_proposal(
+        vault_root=vault_root, note_rel=note_rel, trace_id=trace_id
+    )
+    registration_state: Literal["proposal_pending", "not_qualified", "degraded"]
+    if registration is None or not registration.classification.classified:
+        registration_state = "degraded"
+    elif registration.proposal_id is not None:
+        registration_state = "proposal_pending"
+    else:
+        registration_state = "not_qualified"
+
     # Ingest-binding visibility (#3119) — the write above already succeeded;
     # this only decides whether to accompany "written" with a warning that the
     # watcher/worker are not confirmed bound to this vault. Never gates or
@@ -380,6 +409,8 @@ def capture_to_inbox(req: CaptureRequest, request: Request) -> CaptureResponse |
         events_emitted=events_emitted,
         governed_write=governed_write,
         ingest_warning=ingest_warning,
+        registration_state=registration_state,
+        registration_proposal_id=registration.proposal_id if registration else None,
     )
 
 

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -121,6 +121,7 @@ from app.vault.settings_service import (
     SettingsWriteError,
 )
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
+from app.standing_questions.registration import register_question_explicitly
 
 router = APIRouter(prefix="/companion", tags=["companion"])
 
@@ -130,6 +131,20 @@ logger = logging.getLogger(__name__)
 def _reflection_now() -> datetime.datetime:
     """Local-time seam shared by offer evaluation and deterministic tests."""
     return datetime.datetime.now().astimezone()
+
+
+class QuestionRegistrationRequest(BaseModel):
+    """One explicit human request to register an open standing question."""
+
+    text: str = Field(min_length=1)
+    scope: str = Field(default="personal", min_length=1)
+
+
+class QuestionRegistrationResponse(BaseModel):
+    question_id: str
+    status: Literal["open"]
+    registered_via: Literal["explicit"]
+    receipt_locator: str
 
 _LAST_ACTIVE_LOAD_ATTEMPTED_ATTR = "_companion_last_active_load_attempted"
 
@@ -834,6 +849,35 @@ def _active_companion_vault_root_or_picker(
             trace_id=trace_id,
             configured_vault_root=exc.configured_path,
         )
+
+
+@router.post(
+    "/questions/register",
+    response_model=QuestionRegistrationResponse | VaultSelectionRequiredResponse,
+    dependencies=[Depends(require_loopback_or_api_key)],
+)
+def register_companion_question(
+    req: QuestionRegistrationRequest,
+) -> QuestionRegistrationResponse | VaultSelectionRequiredResponse:
+    """Register text the owner explicitly supplied; no proposal parse is involved."""
+    vault_root = _active_companion_vault_root_or_picker(require_initialized=True)
+    if isinstance(vault_root, VaultSelectionRequiredResponse):
+        return vault_root
+    try:
+        note, receipt = register_question_explicitly(
+            text=req.text, scope=req.scope, vault_root=vault_root
+        )
+    except WritesBlockedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "writeguard_blocked", "state": "blocked", "message": str(exc)},
+        ) from exc
+    return QuestionRegistrationResponse(
+        question_id=note["question_id"],
+        status="open",
+        registered_via="explicit",
+        receipt_locator=str(receipt.locator),
+    )
 
 
 def _companion_vault_context_with_lazy_last_active(manager: Any) -> VaultContext:

--- a/app/standing_questions/registration.py
+++ b/app/standing_questions/registration.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import Any
 
 from app.agents.panel.parser import is_ai_fence
-from app.agents.panel.writeback import parse_action_line
+from app.agents.panel.writeback import parse_action_line, stable_action_id
 from app.agents.panel_agent.runtime import _write_proposals_to_panel
 from app.components.llm.constrained import CompletionFn
 from app.components.llm.question_intent_classifier import (
@@ -73,6 +73,7 @@ REGISTRATION_LABEL_PREFIX = "Registrera stående fråga: "
 #: Fixed forever: changing it would let an already-registered capture register a
 #: second time.
 _REGISTRATION_NAMESPACE = uuid.UUID("6f9a1c2e-4d3b-4a55-9c7e-2b8f1d0a7e34")
+_PANEL_PROPOSAL_MARKER = "979"
 
 
 @dataclass(frozen=True)
@@ -275,9 +276,28 @@ def confirm_question_registrations(
     already_registered = 0
     refused_non_verbatim = 0
 
+    inside_panel = False
     for line in capture_text.splitlines():
+        if is_ai_fence(line):
+            inside_panel = not inside_panel
+            continue
+        # A checked line only represents a registration decision when it is a
+        # system-authored action in a fenced Panel.  Human checklist prose
+        # never grants the runtime authority to mint a Question note.
+        if not inside_panel:
+            continue
         parsed = parse_action_line(line.strip())
         if parsed is None or not parsed.label.startswith(REGISTRATION_LABEL_PREFIX):
+            continue
+        if (
+            parsed.proposal_marker != _PANEL_PROPOSAL_MARKER
+            or not parsed.option_id
+            or not parsed.action_id
+        ):
+            continue
+        if parsed.action_id != stable_action_id(parsed.label):
+            if parsed.checked:
+                refused_non_verbatim += 1
             continue
         if not parsed.checked:
             unchecked += 1
@@ -292,6 +312,10 @@ def confirm_question_registrations(
                 "verbatim in its capture: %s",
                 capture_path,
             )
+            refused_non_verbatim += 1
+            continue
+        proposal_id = proposal_id_for(capture_id, extracted)
+        if f"(förslag {proposal_id[:12]})" not in parsed.label:
             refused_non_verbatim += 1
             continue
         try:

--- a/tests/standing_questions/test_registration.py
+++ b/tests/standing_questions/test_registration.py
@@ -1,0 +1,76 @@
+"""P1 regressions for Panel-provenance registration confirmation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.agents.panel.parser import parse_panel
+from app.standing_questions.registration import (
+    REGISTRATION_LABEL_PREFIX,
+    confirm_question_registrations,
+    propose_question_registration,
+)
+from tests.standing_questions._registration_fixtures import (
+    EXTRACTED_QUESTION,
+    healthy_guard,
+    healthy_store,
+    make_vault,
+    question_notes,
+    registration_payload,
+    completion_returning,
+    write_capture,
+)
+
+
+def test_confirmation_requires_system_panel_proposal_metadata(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(vault)
+    store = healthy_store(vault)
+    # Identical checked prose outside the Panel is human-authored checklist text,
+    # not a system proposal and therefore cannot create a question.
+    capture.write_text(
+        capture.read_text(encoding="utf-8")
+        + f'\n- [x] {REGISTRATION_LABEL_PREFIX}"{EXTRACTED_QUESTION}" (förslag forged)\n',
+        encoding="utf-8",
+    )
+    result = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+    assert result.created == ()
+    assert question_notes(vault) == []
+
+    proposed = propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        complete=completion_returning(registration_payload()),
+        write_guard=healthy_guard(),
+    )
+    assert proposed.proposal_id
+    capture.write_text(
+        capture.read_text(encoding="utf-8").replace("- [ ] " + REGISTRATION_LABEL_PREFIX, "- [x] " + REGISTRATION_LABEL_PREFIX, 1),
+        encoding="utf-8",
+    )
+    confirmed = confirm_question_registrations(
+        capture_note_path=capture, vault_root=vault, scope="work", store=store
+    )
+    assert len(confirmed.created) == 1
+
+
+def test_registration_proposal_creates_valid_panel_action_section(tmp_path: Path) -> None:
+    vault = make_vault(tmp_path)
+    capture = write_capture(
+        vault,
+        body=f"# Capture\n\n{EXTRACTED_QUESTION}\n",
+    )
+    result = propose_question_registration(
+        capture_note_path=capture,
+        vault_root=vault,
+        complete=completion_returning(registration_payload()),
+        write_guard=healthy_guard(),
+    )
+    assert result.written is True
+    parsed = parse_panel(capture.read_text(encoding="utf-8"))
+    assert parsed.fenced is True
+    assert len(parsed.actions) == 1
+    assert parsed.actions[0].proposal_pending is True
+    assert parsed.actions[0].option_id

--- a/tests/standing_questions/test_registration_runtime_wiring.py
+++ b/tests/standing_questions/test_registration_runtime_wiring.py
@@ -1,0 +1,42 @@
+"""Production-route coverage for Standing Questions registration (#4611)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import app.api.routes.capture as capture_module
+import app.api.routes.companion as companion_module
+from app.components.llm.question_intent_classifier import QuestionIntentClass, QuestionIntentClassification
+from app.standing_questions.registration import RegistrationProposalResult
+from tests.standing_questions._registration_fixtures import make_vault, question_notes
+
+
+def test_capture_flow_surfaces_registration_proposals(tmp_path: Path, monkeypatch) -> None:
+    vault = make_vault(tmp_path)
+    capture = vault / "Inbox" / "inbox.md"
+    capture.parent.mkdir()
+    capture.write_text("question", encoding="utf-8")
+    proposal = RegistrationProposalResult(
+        classification=QuestionIntentClassification(
+            intent_class=QuestionIntentClass.QUESTION_REGISTRATION, classified=True
+        ),
+        proposal_id="proposal-1",
+    )
+    monkeypatch.setattr(capture_module, "propose_question_registration", lambda **_: proposal)
+    result = capture_module._offer_question_registration_proposal(
+        vault_root=vault, note_rel="Inbox/inbox.md", trace_id="trace"
+    )
+    assert result == proposal
+
+
+def test_companion_explicit_registration_route_writes_question(tmp_path: Path, monkeypatch) -> None:
+    vault = make_vault(tmp_path)
+    monkeypatch.setattr(companion_module, "_active_companion_vault_root_or_picker", lambda **_: vault)
+    response = companion_module.register_companion_question(
+        companion_module.QuestionRegistrationRequest(
+            text="Should we keep the architecture decision open?", scope="work"
+        )
+    )
+    assert response.status == "open"
+    assert response.registered_via == "explicit"
+    assert len(question_notes(vault)) == 1


### PR DESCRIPTION
Governing-Issue: #4611

Fixes #4611

Final-Review-Rounds: 0

## Summary
Wires capture proposals and explicit Companion registration into production paths. Confirmation now requires fenced Panel provenance and proposal insertion creates a valid Panel section.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Issue contract and GitHub lifecycle fully represent this bounded runtime repair.

## Notes
Validation: pytest targeted Verify targets; ruff check app tests companion-ui/companion-app; mypy app; git diff --check.