### PR TITLE
Guard partial-sync claim and startup classification

### DIFF
--- a/app/ops/builderops_startup.py
+++ b/app/ops/builderops_startup.py
@@ -206,8 +206,22 @@ def _github_sync(
             "repos": payload.get("repos", {}),
             "detail": payload.get("error") or _snippet(pull.stderr or pull.stdout),
         }
+    if payload.get("sync_result") == "partial":
+        _append_reason(result, "dispatcher_pull_partial")
+        return {
+            "status": "degraded",
+            "reason": "dispatcher_pull_partial",
+            "sync_result": "partial",
+            "kill_switch_active": bool(payload.get("kill_switch_active")),
+            "remaining": remaining,
+            "upserted": payload.get("upserted", 0),
+            "reconciled": payload.get("reconciled", 0),
+            "repos": payload.get("repos", {}),
+            "detail": payload.get("sync_note") or "dispatcher pull partial sync",
+        }
     return {
         "status": "ok",
+        "sync_result": payload.get("sync_result"),
         "remaining": remaining,
         "upserted": payload.get("upserted", 0),
         "reconciled": payload.get("reconciled", 0),

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -681,10 +681,10 @@ suppresses the non-essential open-issues scan, the pull is truncated, not failed
 - `python -m app.dispatcher status --json` exposes an additive read-only `last_sync` summary
   (`last_pull_at`, `sync_result`, `sync_note`, `kill_switch_active`) so pickup tooling can
   distinguish a complete sync from a truncated one without spending GitHub API calls.
-- `scripts/issue_pickup_claim.sh` routes a missing-task claim failure that follows a kill-switch
-  partial sync to explicit GitHub-label-only fallback guidance
-  (`--coordination-mode github-label-only-fallback --fallback-reason kill-switch-partial-sync`)
-  instead of an opaque missing-task failure; `agent:ready` is left untouched on that path.
+- Provider-wide partial-sync metadata is not task-specific absence evidence: the essential
+  `agent:ready` scan still ran. `scripts/issue_pickup_claim.sh` therefore keeps a missing-task claim
+  failure opaque and leaves `agent:ready` untouched instead of advertising a lease-bypassing
+  label-only rerun from the partial row alone.
 
 ## Optional Future Projections
 
@@ -768,8 +768,9 @@ The bootstrap is idempotent and operational-only:
   standalone wrapper around the BuilderOps CLI;
 - it attempts dispatcher GitHub pull-sync only when `gh` is installed, authenticated, and the core
   REST rate limit is above the startup safety threshold;
-- if GitHub access is unavailable, unauthenticated, rate-limited, or sync fails, startup continues
-  and records a degraded BuilderOps bootstrap reason instead of failing the runtime stack.
+- if GitHub access is unavailable, unauthenticated, rate-limited, sync fails, or dispatcher pull
+  reports `sync_result=partial`, startup continues and records a degraded BuilderOps bootstrap
+  reason instead of failing the runtime stack.
 
 The structured receipt is written to `tmp/builderops_startup_status.json` and merged under
 `builderops_bootstrap` in `tmp/startup_status.json`. The receipt is operational coordination state:

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -179,45 +179,6 @@ remove_ready_label() {
     "repos/$REPO/issues/$ISSUE_NUMBER/labels/agent%3Aready" >/dev/null
 }
 
-# Distinguish a genuinely failed claim from a task row that is absent only
-# because the last dispatcher pull was truncated by the GitHub rate-limit kill
-# switch (#4606). Reads local dispatcher state only; spends no GitHub API calls.
-classify_claim_failure() {
-  local status_json
-  status_json="$("$PYTHON_BIN" -m app.dispatcher status --json 2>/dev/null || true)"
-  DISPATCHER_CLAIM_JSON="$1" \
-  DISPATCHER_STATUS_JSON="$status_json" \
-  "$JSON_PYTHON_BIN" - <<'PY'
-import json
-import os
-
-
-def _load(name):
-    try:
-        payload = json.loads(os.environ.get(name) or "")
-    except json.JSONDecodeError:
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-claim = _load("DISPATCHER_CLAIM_JSON")
-status = _load("DISPATCHER_STATUS_JSON")
-error = claim.get("error")
-missing_task = isinstance(error, str) and "not found" in error
-last_sync = status.get("last_sync")
-if not isinstance(last_sync, dict):
-    last_sync = {}
-if (
-    missing_task
-    and last_sync.get("sync_result") == "partial"
-    and last_sync.get("kill_switch_active") is True
-):
-    print("kill-switch-partial-sync")
-else:
-    print("claim-failed")
-PY
-}
-
 release_dispatcher_claim() {
   local release_json
   if ! release_json="$(
@@ -250,17 +211,10 @@ PY
 if [[ "$RECEIPT_COORDINATION_MODE" == "dispatcher-backed" ]]; then
   claim_json=""
   if ! claim_json="$("$PYTHON_BIN" -m app.dispatcher claim "$TASK_ID" --agent "$AGENT_ID" --ttl-minutes "$TTL_MINUTES" --json)"; then
-    claim_failure_mode="$(classify_claim_failure "$claim_json" || echo claim-failed)"
-    if [[ "$claim_failure_mode" == "kill-switch-partial-sync" ]]; then
-      {
-        echo "claim-missing-task issue=$ISSUE_NUMBER task_id=$TASK_ID cause=kill-switch-partial-sync sync_result=partial kill_switch_active=true evidence=dispatcher-status-last-sync"
-        echo "the GitHub rate-limit kill switch truncated the last dispatcher pull; the local queue is honestly partial and the task row for issue $ISSUE_NUMBER may be legitimately absent."
-        echo "route to explicit GitHub-label-only fallback instead of re-syncing:"
-        echo "  scripts/issue_pickup_claim.sh --issue $ISSUE_NUMBER --repo $REPO --agent $AGENT_ID --session $SESSION_ID --coordination-mode github-label-only-fallback --fallback-reason kill-switch-partial-sync"
-        echo "agent:ready was not removed"
-      } >&2
-      exit 1
-    fi
+    # Provider-wide partial-sync metadata cannot prove why this exact task is
+    # absent: the kill switch still runs the essential agent:ready scan. Keep
+    # the dispatcher claim failure opaque and leave the label untouched rather
+    # than advertising a lease-bypassing fallback without task-specific proof.
     echo "dispatcher claim failed for expected task $TASK_ID; agent:ready was not removed" >&2
     exit 1
   fi

--- a/tests/ops/test_builderops_startup.py
+++ b/tests/ops/test_builderops_startup.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def test_github_sync_partial_result_is_degraded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.ops import builderops_startup
+
+    responses = iter(
+        [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="5000\n", stderr=""),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "sync_result": "partial",
+                        "sync_note": "kill switch skipped open-issue reconciliation",
+                        "kill_switch_active": True,
+                        "upserted": 3,
+                        "reconciled": 0,
+                        "repos": {
+                            "RasmusTho/agentic-pkm-mvp": {
+                                "sync_result": "partial",
+                                "kill_switch_active": True,
+                            }
+                        },
+                    }
+                ),
+                stderr="",
+            ),
+        ]
+    )
+    monkeypatch.setattr(builderops_startup, "_resolve_gh", lambda _gh_bin: "/usr/bin/gh")
+    monkeypatch.setattr(builderops_startup, "_run", lambda *args, **kwargs: next(responses))
+    result: dict[str, object] = {"reasons": []}
+
+    receipt = builderops_startup._github_sync(
+        python_bin="python3",
+        root=tmp_path,
+        repos=["RasmusTho/agentic-pkm-mvp"],
+        env={},
+        gh_bin="gh",
+        rate_limit_min=25,
+        skip=False,
+        result=result,
+    )
+
+    assert receipt["status"] == "degraded"
+    assert receipt["reason"] == "dispatcher_pull_partial"
+    assert receipt["sync_result"] == "partial"
+    assert receipt["kill_switch_active"] is True
+    assert result["reasons"] == ["dispatcher_pull_partial"]

--- a/tests/scripts/test_issue_pickup_claim.py
+++ b/tests/scripts/test_issue_pickup_claim.py
@@ -445,11 +445,16 @@ def test_label_delete_and_release_failure_reports_cleanup_failed_evidence(
     assert "pickup-claim-complete" not in result.stdout
 
 
-def test_kill_switch_partial_sync_routes_to_label_only_fallback(tmp_path: Path) -> None:
-    """When the expected task row is absent and the last dispatcher sync was a
-    kill-switch partial, the wrapper must route to explicit GitHub-label-only
-    fallback guidance instead of an opaque missing-task failure (#4606,
-    lrn_20260730235456_f70f8ccc)."""
+def test_partial_sync_fallback_requires_requested_task_evidence(
+    tmp_path: Path,
+) -> None:
+    """Provider-wide partial sync is not evidence about one requested task.
+
+    The kill switch skips only the non-essential open-issue reconciliation
+    scan; the essential ``agent:ready`` scan still runs. A missing task must
+    therefore remain an opaque claim failure unless task-specific evidence is
+    available, rather than offering a lease-bypassing label-only rerun.
+    """
     worktree, env = _make_harness(
         tmp_path,
         status_json=json.dumps(
@@ -481,20 +486,14 @@ def test_kill_switch_partial_sync_routes_to_label_only_fallback(tmp_path: Path) 
 
     assert result.returncode != 0
     assert "pickup-claim-complete" not in result.stdout
-    # The failure names the real cause, machine-readably.
-    assert "cause=kill-switch-partial-sync" in result.stderr
-    assert "sync_result=partial" in result.stderr
-    assert "kill_switch_active=true" in result.stderr
-    # Explicit label-only fallback routing guidance with the exact rerun.
-    assert "--coordination-mode github-label-only-fallback" in result.stderr
-    assert "--fallback-reason kill-switch-partial-sync" in result.stderr
-    assert "--issue 3301" in result.stderr
-    # No label mutation happened on this path.
+    assert "cause=kill-switch-partial-sync" not in result.stderr
+    assert "--coordination-mode github-label-only-fallback" not in result.stderr
+    assert "dispatcher claim failed for expected task" in result.stderr
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
     assert "gh api --method DELETE" not in commands
 
 
-def test_missing_task_without_partial_sync_keeps_opaque_claim_failure(
+def test_complete_sync_missing_task_keeps_opaque_claim_failure(
     tmp_path: Path,
 ) -> None:
     """A missing task after a complete (ok) sync is a genuine claim failure and


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4644

## Linked Issue
Closes #4644

## SBS Impact
- Primary subsystem: Builder System / dispatcher and BuilderOps startup coordination
- Secondary subsystem(s): issue pickup fallback; startup receipts
- Write class: governance-bearing coordination guard
- Persistence impact: startup receipts classify partial sync truthfully
- Derived/rebuildable impact: dispatcher queue remains a partial derived projection
- New or changed contract: partial sync is not task-specific absence evidence and cannot advertise lease bypass
- Owner-doc impact: updated docs/AGENT_ISSUE_DISPATCHER.md
- Transition debt impact: removes false-green coordination receipts
- Boundary risk: claim fallback cannot bypass dispatcher without task-specific proof

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Prevent provider-wide partial-sync metadata from authorizing label-only pickup, and report partial dispatcher pulls as degraded BuilderOps startup receipts.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No execution divergence or reusable operational material was produced.

## Notes
Validation: 59 focused tests passed; ruff check app tests scripts; mypy app; bash -n scripts/issue_pickup_claim.sh; python3 scripts/docs_guard.py; git diff --check.