### PR TITLE
Clarify CI failure dedupe agreement

### DIFF
--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -204,13 +204,13 @@ authority across the current open registry instead of reopening history or dupli
      class: #4463 was filed as distinct from #4371 although both described the same failing
      `smoke-docker` / `CI gate: vaultwide panel verifier` step. Cite them as precedent only; do
      not reopen either closed issue.
-   - A match on the same workflow/job/step plus the same script/test target or error class is a
-     duplicate: comment on the existing issue with the new evidence instead of creating another.
-     Failures that share a workflow but differ by job, step, script/test target, or error class
-     are distinct defects — do not collapse them into one issue.
+   - Every available stable failure discriminator must agree across both reports before classifying
+     a duplicate. If any available workflow, job, step, script/test target, or error
+     class differs or is missing from the other report, the evidence is not a duplicate match:
+     keep the failures distinct instead of collapsing them into one issue.
    - Keep the existing same-symptom/title search as the secondary key: it remains the primary
-     search for non-CI bugs and the fallback when stable identity fields are unavailable. If a
-     matching issue exists, comment with new evidence instead of creating a duplicate.
+     search for non-CI bugs and the fallback only when neither report provides stable identity
+     fields. If a matching issue exists, comment with new evidence instead of creating a duplicate.
 3. Create or update Issue body:
    - Always use the canonical contract sections from `.codex/skills/_shared/ISSUE_CONTRACT.md`.
    - Classify the defect as Product/Runtime System, Builder System, or boundary work using

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -377,7 +377,7 @@ def test_lint_fails_when_pr_contract_validator_flags_diverge_from_workflow(
     ), errors
 
 
-def test_bug_to_issue_duplicate_search_requires_stable_ci_identity() -> None:
+def test_bug_to_issue_duplicate_search_requires_all_available_ci_discriminators() -> None:
     """CI/test duplicate search must key on stable failure identity, not prose.
 
     Regression guard for issue #4607 (LearningSignal
@@ -424,6 +424,23 @@ def test_bug_to_issue_duplicate_search_requires_stable_ci_identity() -> None:
         "duplicate-search guidance no longer orders stable-identity comparison "
         "before prose title/symptom matching"
     )
+
+    # Duplicate classification is conjunctive: one matching target cannot
+    # outweigh a different error class (PR #4628 review r3712645788).
+    assert re.search(
+        r"(?:all|every)\s+(?:\S+\s+){0,5}available\s+(?:\S+\s+){0,5}"
+        r"(?:agree|match)",
+        lowered,
+    ), "every available stable CI discriminator must agree before deduping"
+    assert re.search(
+        r"(?:any|one)\s+(?:\S+\s+){0,16}(?:differ|mismatch|missing)\S*"
+        r"(?:\S+\s+){0,16}(?:distinct|separate|not\s+(?:a\s+)?duplicate)",
+        lowered,
+    ), "one available discriminator mismatch must keep failures distinct"
+    assert not re.search(
+        r"same\s+(?:script/)?test\s+target\s+or\s+(?:exception/)?error\s+class",
+        lowered,
+    ), "target-or-error matching reintroduces the contradictory duplicate rule"
 
     # The pre-existing same-symptom/title search stays as the secondary key.
     assert "symptom" in lowered and "title" in lowered, (


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4645

## Linked Issue
Closes #4645

## SBS Impact
- Primary subsystem: Builder System / bug intake governance
- Secondary subsystem(s): CI failure dedupe; issue creation workflow
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: CI/test duplicate search requires all available stable discriminators to agree
- Owner-doc impact: updated .codex/skills/bug-to-issue/SKILL.md
- Transition debt impact: reduces duplicate or incorrectly collapsed bug routing
- Boundary risk: one matching discriminator cannot collapse distinct failures

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make CI/test bug dedupe conjunctive across every available stable discriminator and prevent target-or-error ambiguity from returning.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No execution divergence or reusable operational material was produced.

## Notes
Validation: 25 governance tests passed; python3 scripts/lint_skills_consistency.py; ruff check app tests scripts; skill quick validation; python3 scripts/docs_guard.py; git diff --check.