### PR TITLE
Align kill-switch sync metadata test (#4629)

### DIFF
--- a/tests/observability/test_github_call_logging.py
+++ b/tests/observability/test_github_call_logging.py
@@ -184,8 +184,8 @@ class TestKillSwitchDisablesScanBelowThreshold:
 
         captured_extra: dict[str, Any] = {}
 
-        def fake_record_sync_success(store, provider, pull_at, *, rate_limit_remaining=None,
-                                     rate_limit_reset=None, extra=None):
+        def fake_record_sync_partial(store, provider, pull_at, *, note=None,
+                                     rate_limit_remaining=None, rate_limit_reset=None, extra=None):
             captured_extra.update(extra or {})
 
         mock_store = MagicMock()
@@ -202,8 +202,8 @@ class TestKillSwitchDisablesScanBelowThreshold:
             "GITHUB_CALL_LOG_PATH": str(log_file),
             "GITHUB_RATELIMIT_KILL_THRESHOLD": "200",
         }), patch(
-            "app.dispatcher.sync_github.record_sync_success",
-            side_effect=fake_record_sync_success,
+            "app.dispatcher.sync_github.record_sync_partial",
+            side_effect=fake_record_sync_partial,
         ):
             adapter.pull("owner/repo")
 


### PR DESCRIPTION
## Contract

Governing-Issue: #4629
Fixes #4629
Final-Review-Rounds: 0

## Summary

- patch the kill-switch test at the current `record_sync_partial` seam
- assert the existing `kill_switch_active` metadata contract without changing runtime behavior

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded repository test correction with no operational-state or learning-signal payload

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q -p pytest_asyncio.plugin -p anyio.pytest_plugin tests/observability/test_github_call_logging.py` — 12 passed
- `python3 -m ruff check app tests companion-ui/companion-app` — passed
- `python3 scripts/review_before_ci_gate.py --lane implementation --changed-file tests/observability/test_github_call_logging.py --risk-assessment-complete --review-gate-complete` — not required / may hand off to CI
