### PR TITLE
Make test-channel bootstrap assertion deterministic

### DIFF
--- a/tests/ops/test_test_channel_bootstrap_idempotent.py
+++ b/tests/ops/test_test_channel_bootstrap_idempotent.py
@@ -22,7 +22,7 @@ from app.ops.test_channel_bootstrap import (
     bootstrap_test_channel,
     derive_test_channel_env,
 )
-from app.vault.manager import REQUIRED_SETTINGS_FILES
+from app.vault.manager import REQUIRED_SETTINGS_FILES, SETTINGS_DIR_NAME
 
 
 def test_bootstrap_brings_up_a_selected_channel_correct_vault(tmp_path: Path) -> None:
@@ -32,7 +32,7 @@ def test_bootstrap_brings_up_a_selected_channel_correct_vault(tmp_path: Path) ->
     assert result.ok, (result.vault_status, result.preflight.format_report() if result.preflight else None)
     assert result.vault_status == "selected"
     # vault init actually scaffolded the #1991-required settings files.
-    settings_dir = next(p for p in vault.iterdir() if p.is_dir())
+    settings_dir = vault / SETTINGS_DIR_NAME
     for required in REQUIRED_SETTINGS_FILES:
         assert (settings_dir / required).exists(), f"missing {required}"
 


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: The required Unit tests (not pg) job can false-fail on Linux because unordered vault directory enumeration may select the layout folder instead of the canonical settings directory.
Validation: python3 -m pytest -q tests/ops/test_test_channel_bootstrap_idempotent.py (7 passed); python3 -m ruff check tests/ops/test_test_channel_bootstrap_idempotent.py (passed)
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System / test harness
- Secondary subsystem(s): test-channel bootstrap verification
- Write class: none
- Persistence impact: none; assertion-only
- Derived/rebuildable impact: none
- New or changed contract: none; deterministic assertion of the existing settings-directory contract
- Owner-doc impact: none
- Transition debt impact: removes a Linux-only CI false failure
- Boundary risk: test-only path selection

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Name the canonical settings directory in the bootstrap assertion so filesystem iteration order cannot change the result.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: routine deterministic CI repair

## Notes
Observed in PR #4624 Unit tests (not pg), run 31110809974, job 92648056111.
