### PR TITLE
Harden review and ranking reasoning modes

### DIFF
--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -296,7 +296,9 @@ def run_reasoning(
                 result={"summary": "", "issues": [], "suggestions": []},
             )
         backend = _reasoning_backend()
-        if backend == "mock":
+        provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()
+        provider = "mock" if provider in {"", "fake"} else provider
+        if backend == "mock" or provider == "mock":
             summary = f"Summary: {_simple_preview(text, 90)}"
             issues = ["needs review for clarity"]
             suggestions = ["Clarify objectives", "Add sources"]
@@ -312,6 +314,8 @@ def run_reasoning(
                 trace_id=trace_id,
             )
             data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise ValueError("review output was not a JSON object")
         except Exception as exc:
             return ReasoningRun(
                 mode=mode,
@@ -349,7 +353,9 @@ def run_reasoning(
                 result={"ranking": []},
             )
         backend = _reasoning_backend()
-        if backend == "mock":
+        provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()
+        provider = "mock" if provider in {"", "fake"} else provider
+        if backend == "mock" or provider == "mock":
             ranking = []
             for idx, (oid, text) in enumerate(texts):
                 score = max(0.0, 1.0 - 0.05 * idx)
@@ -380,6 +386,8 @@ def run_reasoning(
                 trace_id=trace_id,
             )
             data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise ValueError("ranking output was not a JSON object")
         except Exception as exc:
             return ReasoningRun(
                 mode=mode,

--- a/tests/reasoning/test_provider_review_ranking_robustness.py
+++ b/tests/reasoning/test_provider_review_ranking_robustness.py
@@ -1,0 +1,98 @@
+"""Regression coverage for REVIEW/RANKING provider failure handling."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.reasoning import provider as provider_module
+from app.reasoning.models import ReasoningMode
+from app.reasoning.provider import run_reasoning
+from app.stores import get_object_store, reset_store_backends
+
+
+def _llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.delenv("CI", raising=False)
+
+
+def _store_note() -> str:
+    store = get_object_store()
+    object_id = uuid4()
+    store.put(object_id, kind="note", source_ref="note.md", payload={"text": "A note to reason about."})
+    return str(object_id)
+
+
+def test_review_rejects_non_object_json_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+    object_id = _store_note()
+    monkeypatch.setattr(provider_module, "_call_chat", lambda **_kwargs: '["not", "an object"]')
+
+    run = run_reasoning(ReasoningMode.REVIEW, [object_id])
+
+    assert run.status == "failed"
+    assert run.error
+    assert run.result == {"summary": "", "issues": [], "suggestions": []}
+
+
+def test_ranking_rejects_non_object_json_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _llm_env(monkeypatch)
+    reset_store_backends()
+    object_id = _store_note()
+    monkeypatch.setattr(provider_module, "_call_chat", lambda **_kwargs: '"not an object"')
+
+    run = run_reasoning(ReasoningMode.RANKING, [object_id], question="Rank this")
+
+    assert run.status == "failed"
+    assert run.error
+    assert run.result == {"ranking": []}
+
+
+def test_review_uses_mock_result_when_provider_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    reset_store_backends()
+    object_id = _store_note()
+
+    def _must_not_be_called(**_kwargs: object) -> str:  # pragma: no cover - guard
+        raise AssertionError("review must not call the chat backend on a mock route")
+
+    monkeypatch.setattr(provider_module, "_call_chat", _must_not_be_called)
+
+    run = run_reasoning(ReasoningMode.REVIEW, [object_id])
+
+    assert run.status == "ok"
+    assert run.result["summary"].startswith("Summary:")
+
+
+def test_ranking_uses_mock_result_when_provider_is_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    reset_store_backends()
+    object_id = _store_note()
+
+    def _must_not_be_called(**_kwargs: object) -> str:  # pragma: no cover - guard
+        raise AssertionError("ranking must not call the chat backend on a mock route")
+
+    monkeypatch.setattr(provider_module, "_call_chat", _must_not_be_called)
+
+    run = run_reasoning(ReasoningMode.RANKING, [object_id], question="Rank this")
+
+    assert run.status == "ok"
+    assert run.result["ranking"]


### PR DESCRIPTION
Governing-Issue: #4195

Fixes #4195

Final-Review-Rounds: 0

## Summary

- Make REVIEW and RANKING fail closed when a provider returns valid non-object JSON.
- Return the existing deterministic mock results when the resolved LLM provider is mock, avoiding a chat-backend call.

## SBS Impact

- Primary subsystem: Product/Runtime System — Reasoning / cognition
- Write class: derived
- Authority impact: none
- Persistence impact: none
- External boundary: mock routes no longer issue a chat call.
- Owner-doc writeback: none; result shapes and documented contracts are unchanged.

## Claim Receipt

- issue=4195 branch=codex/issue-4195-review-ranking-robustness worktree=/Users/rasmus/.codex/worktrees/a134/workspace-root coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4195 lease_id=lease-de481348 holder=codex-slice-implementer-a134 evidence=verified-dispatcher-lease

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: No delivery divergence, operational state, or learning material beyond the governing GitHub Issue and this PR.

## Notes

Validation: `python3 -m pytest tests/reasoning/test_provider_review_ranking_robustness.py tests/reasoning/test_reasoning_modes_contract.py -q` (9 passed); `python3 -m pytest tests/reasoning -q` (64 passed, 2 skipped); `ruff check app tests` (passed); `mypy app` (passed).
---