### PR TITLE
Restore TTS engines in default app images

### DIFF
--- a/.github/workflows/app-image-build.yml
+++ b/.github/workflows/app-image-build.yml
@@ -75,6 +75,7 @@ jobs:
             BUILT_AT=${{ env.BUILT_AT }}
 
       - name: Build and push app image (main multi-arch)
+        id: build-app-main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
@@ -97,30 +98,82 @@ jobs:
             "${{ steps.build-identity.outputs.image }}" \
             -c 'from app.version import get_runtime_version; import os; version = get_runtime_version(); assert version["git_sha"] == os.environ["VCS_REF"], version; assert version["built_at"] == os.environ["BUILT_AT"], version'
 
-      - name: Verify pushed app image runtime version and platforms
+      - name: Probe TTS engines in PR image
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint sh \
+            "${{ steps.build-identity.outputs.image }}" \
+            -ec 'command -v piper >/dev/null; piper --help >/dev/null 2>&1; python -c "import asyncio; import kokoro_onnx; from app.api.routes.health_contract import healthz; from app.main import app; assert app is not None; assert asyncio.run(healthz()) == {\"ok\": True}"'
+
+      - name: Verify pushed app image runtime, platforms, and TTS engines
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           set -euo pipefail
           image="${{ steps.build-identity.outputs.image }}"
-          manifest_platforms="$(docker buildx imagetools inspect "${image}" | awk '
-            $1 == "Platform:" {
-              print $2
-            }
-          ' | sort -u)"
-          echo "Discovered manifest platforms:"
-          echo "${manifest_platforms}"
-          for required_platform in linux/amd64 linux/arm64; do
-            if ! echo "${manifest_platforms}" | grep -qx "${required_platform}"; then
-              echo "missing required platform in image manifest: ${required_platform}"
-              exit 1
+          image_ref="${image%:*}@${{ steps.build-app-main.outputs.digest }}"
+          manifest_json="$(mktemp)"
+          proof_file="app-image-tts-engine-proof.json"
+          docker buildx imagetools inspect --raw "${image_ref}" > "${manifest_json}"
+
+          jq -n \
+            --arg contract "app-image-tts-engine-proof.v1" \
+            --arg candidate_sha "${GITHUB_SHA}" \
+            --arg image "${image}" \
+            --arg image_ref "${image_ref}" \
+            --arg image_index_digest "${{ steps.build-app-main.outputs.digest }}" \
+            --arg probe_scope "package_presence_cli_load_import_app_health" \
+            '{contract: $contract, candidate_sha: $candidate_sha, image: $image, image_ref: $image_ref, image_index_digest: $image_index_digest, probe_scope: $probe_scope, platforms: []}' \
+            > "${proof_file}"
+
+          failures=0
+          for platform in linux/amd64 linux/arm64; do
+            architecture="${platform#linux/}"
+            platform_digest="$(jq -er \
+              --arg architecture "${architecture}" \
+              '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture) | .digest' \
+              "${manifest_json}")"
+            probe_result="pass"
+            if ! docker run --rm \
+              --platform "${platform}" \
+              --entrypoint sh \
+              "${image_ref}" \
+              -ec 'command -v piper >/dev/null; piper --help >/dev/null 2>&1; python -c "import asyncio; import kokoro_onnx; import os; from app.api.routes.health_contract import healthz; from app.main import app; from app.version import get_runtime_version; version = get_runtime_version(); assert app is not None; assert asyncio.run(healthz()) == {\"ok\": True}; assert version[\"git_sha\"] == os.environ[\"VCS_REF\"], version; assert version[\"built_at\"] == os.environ[\"BUILT_AT\"], version"'; then
+              probe_result="fail"
+              failures=$((failures + 1))
             fi
+
+            jq \
+              --arg platform "${platform}" \
+              --arg platform_digest "${platform_digest}" \
+              --arg probe_result "${probe_result}" \
+              '.platforms += [{platform: $platform, platform_digest: $platform_digest, probe_result: $probe_result}]' \
+              "${proof_file}" > "${proof_file}.tmp"
+            mv "${proof_file}.tmp" "${proof_file}"
           done
-          docker run --rm \
-            --platform linux/amd64 \
-            --entrypoint python \
-            "${image}" \
-            -c 'from app.version import get_runtime_version; import os; version = get_runtime_version(); assert version["git_sha"] == os.environ["VCS_REF"], version; assert version["built_at"] == os.environ["BUILT_AT"], version'
+
+          jq -e '
+            .contract == "app-image-tts-engine-proof.v1" and
+            (.candidate_sha | length == 40) and
+            (.image_index_digest | startswith("sha256:")) and
+            .probe_scope == "package_presence_cli_load_import_app_health" and
+            ([.platforms[].platform] | sort == ["linux/amd64", "linux/arm64"]) and
+            (all(.platforms[]; (.platform_digest | startswith("sha256:")) and .probe_result == "pass"))
+          ' "${proof_file}"
+          if [ "${failures}" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Upload TTS engine proof
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-image-tts-engine-proof-${{ github.sha }}
+          path: app-image-tts-engine-proof.json
+          if-no-files-found: error
 
   build-builderops-images:
     name: Build independent BuilderOps images

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,6 @@
 # (tests/deploy/test_dockerfile_python_alignment.py).
 FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS builder
 
-# TTS layer toggle — see the guarded RUN below. Declared after FROM so it is
-# in scope for this stage. Default 0: the TTS pins cannot install on this
-# python:3.12 base (see the KNOWN BREAKAGE note at the guarded RUN), so
-# attempting them by default made every default build fail — `docker build .`,
-# the compose builds and app-image-build.yml pass no INSTALL_TTS arg. The
-# layer is opt-in (--build-arg INSTALL_TTS=1) until the pins gain 3.12 support.
-ARG INSTALL_TTS=0
-
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
@@ -30,24 +22,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY requirements.txt requirements-tts.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# KNOWN BREAKAGE (#3896 review): requirements-tts.txt pins piper-tts==1.2.0
-# -> piper-phonemize~=1.1.0, and piper-phonemize 1.1.0 publishes NO cp312
-# linux wheels and no sdist (PyPI has cp39–cp311 manylinux x86_64/aarch64
-# wheels only; the sole cp312 wheel is macOS x86_64). On this python:3.12
-# base the TTS layer therefore CANNOT install on linux; it worked on the
-# pre-#3893 python:3.11 base (cp311 manylinux wheels exist). The #3893 CI
-# alignment (python 3.12) and a buildable default TTS image are mutually
-# exclusive until the TTS pins gain 3.12 support, and the #3896 AC requires
-# the default `docker build .` to produce a working image — so the layer is
-# OPT-IN (ARG INSTALL_TTS=0 above). The default image ships WITHOUT
-# piper/kokoro baked in: app/tts/providers.py degrades (those voices report
-# unavailable rather than crashing) and the skip is loud in the build log.
-# Once the pins support 3.12, bake TTS with: docker build --build-arg INSTALL_TTS=1 .
-RUN if [ "$INSTALL_TTS" = "1" ]; then \
-      pip install --no-cache-dir -r requirements-tts.txt; \
-    else \
-      echo "INSTALL_TTS=$INSTALL_TTS: SKIPPING requirements-tts.txt — piper/kokoro NOT baked into this image"; \
-    fi
+# Piper 1.6 ships CPython-ABI3 manylinux wheels for both x86_64 and aarch64,
+# so the Python 3.12 default image can carry the same TTS manifest everywhere.
+RUN pip install --no-cache-dir -r requirements-tts.txt
 
 
 FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS runtime

--- a/companion-ui/docs/LOCAL_FIRST_TTS_CONTRACT.md
+++ b/companion-ui/docs/LOCAL_FIRST_TTS_CONTRACT.md
@@ -94,9 +94,15 @@ bind-mounted to a fixed container path and the `TTS_*_DIR` values above are the 
   (`docker-compose.yaml`, `api` service).
 - Container: `TTS_MODEL_DIR=/data/tts/models`, `TTS_CACHE_DIR=/data/tts/cache`,
   `TTS_LOG_DIR=/data/tts/logs` (tracked, fixed for every channel).
-- Machine-local values (`TTS_HOST_ROOT`, `TTS_ENABLED`) live in `.env.prod.local`; the engines
-  (`piper`, `kokoro_onnx`) are baked into the image. Direct (non-container) hosts use the SSD paths
-  above directly.
+- Machine-local values (`TTS_HOST_ROOT`, `TTS_ENABLED`) live in `.env.prod.local`. The ordinary
+  SHA-tagged app image bakes the `piper` command and importable `kokoro_onnx` dependency from one
+  shared manifest on both `linux/amd64` and `linux/arm64`; the main image workflow verifies Piper
+  CLI loading, Kokoro importability, application import, and health behavior on each platform. Its
+  `app-image-tts-engine-proof.v1` receipt is package-presence proof, not model-backed synthesis, and
+  records the exact probe scope plus each platform digest. Direct (non-container) hosts use the SSD
+  paths above directly.
+- Engine presence does not enable TTS. Models and generated audio remain on the external mount,
+  `TTS_ENABLED` remains false by default, and local-only/no-fallback policy remains unchanged.
 
 Provisioning runbook: `docs/runbooks/RUNBOOK_TTS_PROVISIONING.md`.
 

--- a/docs/runbooks/RUNBOOK_TTS_PROVISIONING.md
+++ b/docs/runbooks/RUNBOOK_TTS_PROVISIONING.md
@@ -11,7 +11,11 @@ Mechanism issue: #2082. Health-surface contract: `companion-ui/docs/LOCAL_FIRST_
 enablement — which cannot live in the repo.
 
 ## How it fits together
-- The runtime image bakes the engines: `piper` (CLI on PATH) + `kokoro_onnx` (Python).
+- The ordinary SHA-tagged runtime image bakes the engines from one shared dependency manifest:
+  `piper` (CLI on PATH) + `kokoro_onnx` (Python). On `linux/amd64` and `linux/arm64`, the main image
+  workflow verifies Piper CLI loading, Kokoro importability, application import, and health
+  behavior. Its `app-image-tts-engine-proof.v1` receipt is package-presence proof, not model-backed synthesis,
+  and records the exact probe scope plus the image-index and per-platform digests.
 - Compose bind-mounts the SSD root `${TTS_HOST_ROOT}` → `/data/tts` in the `api` container; the app
   reads the fixed container paths `TTS_MODEL_DIR=/data/tts/models`, `TTS_CACHE_DIR=/data/tts/cache`,
   `TTS_LOG_DIR=/data/tts/logs` (tracked in `docker-compose.yaml`).
@@ -27,14 +31,12 @@ enablement — which cannot live in the repo.
 2. Fetch models: `scripts/fetch_tts_models.sh "$TTS_HOST_ROOT/models"`
    (confirm upstream URLs/checksums on first run).
 3. Set `~/workspace-prod/.env.prod.local`: `TTS_HOST_ROOT=...`, `TTS_ENABLED=true`.
-4. Deploy (prod overlay pattern — cherry-pick the merged commit, do NOT `git pull`; see
-   project demerzel prod ops). Pass `--env-file .env.prod.local` so Compose picks up `TTS_HOST_ROOT`
-   / `TTS_ENABLED` for host-side interpolation (Compose only auto-loads `.env`, not `.env.prod.local`;
-   without this, `${TTS_HOST_ROOT:-./tmp/tts}` in `docker-compose.yaml` falls back to the dev scratch
-   dir and the SSD models from step 2 are never mounted at `/data/tts`):
-   `docker compose --env-file .env.prod.local -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d --build api`
-   — validate the engine builds on the host arch (linux/arm64 on Apple silicon); if a pinned wheel
-   lacks an arm64 build, swap to a system `piper` binary and set `TTS_PIPER_COMMAND`.
+4. Before any separately governed deployment, require the normal SHA-tagged image's
+   `app-image-tts-engine-proof.v1` receipt to show `probe_result=pass` for the exact image-index
+   digest and its `linux/arm64` platform digest. Promote that same prebuilt artifact through the
+   release-channel workflow; do not rebuild on the host, substitute a system Piper binary, or create
+   a TTS-only image variant. Pass `.env.prod.local` through the governed channel configuration so
+   Compose binds the SSD models at `/data/tts`.
 5. Verify: `curl -s http://127.0.0.1:18000/api/companion/tts/status | jq '.environment, .providers'`
    → `TTS_ENABLED=true`, providers `available=true`. Post the receipt to #1699 (this is AC4) and close it.
 

--- a/requirements-tts.txt
+++ b/requirements-tts.txt
@@ -3,7 +3,8 @@
 # `kokoro_onnx` is importable. Model files are NOT installed here — they live on
 # the external SSD (scripts/fetch_tts_models.sh + companion-ui/docs/LOCAL_FIRST_TTS_CONTRACT.md).
 #
-# NOTE: validate these resolve on the prod arch (linux/arm64, Apple silicon) at
-# image build — tracked as AC1 of the mechanism issue and the mac-mini deploy task.
-piper-tts==1.2.0
-kokoro-onnx==0.4.9
+# Piper 1.6 uses CPython-ABI3 manylinux wheels published for both x86_64 and
+# aarch64; Kokoro 0.5 supports Python 3.12. The main image workflow executes
+# both packages on each published platform before emitting its proof receipt.
+piper-tts==1.6.0
+kokoro-onnx==0.5.0

--- a/tests/deploy/test_ci_image_build.py
+++ b/tests/deploy/test_ci_image_build.py
@@ -65,9 +65,10 @@ def test_built_image_version_reports_build_sha(monkeypatch) -> None:
     assert "if: github.event_name == 'pull_request'" in workflow
     assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in workflow
     assert "docker buildx imagetools inspect" in workflow
-    assert "manifest_platforms=\"" in workflow
-    assert "awk '" in workflow
-    assert "--platform linux/amd64" in workflow
+    assert 'manifest_json="$(mktemp)"' in workflow
+    assert 'image_ref="${image%:*}@${{ steps.build-app-main.outputs.digest }}"' in workflow
+    assert 'for platform in linux/amd64 linux/arm64' in workflow
+    assert '--platform "${platform}"' in workflow
 
     monkeypatch.setenv("VCS_REF", "0123456789abcdef0123456789abcdef01234567")
     monkeypatch.setenv("BUILT_AT", "2026-06-30T00:00:00Z")
@@ -83,7 +84,7 @@ def test_single_image_artifact_per_commit() -> None:
 
     assert "strategy:" not in product_image_job
     assert product_image_job.count("uses: docker/build-push-action@") == 2
-    assert product_image_job.count("if: github.event_name == 'pull_request'") == 2
+    assert product_image_job.count("if: github.event_name == 'pull_request'") == 3
     assert (
         product_image_job.count("if: github.event_name == 'push' && github.ref == 'refs/heads/main'")
         >= 1

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -30,10 +30,8 @@ docs, .git, ops). Contracts guarded here:
    package) must be re-included in .dockerignore and COPYed by the runtime
    stage or the worker/watcher/heimdal compose services crash at boot with
    ModuleNotFoundError.
-7. The TTS layer (requirements-tts.txt) is opt-in: its pins cannot install
-   on the python:3.12 base (piper-phonemize~=1.1.0 has no cp312 linux
-   wheels), so attempting it by default makes `docker build .` fail — the
-   #3896 AC requires the default build to produce a working image.
+7. The default builder installs the shared TTS requirements so every ordinary
+   app image contains the Piper and Kokoro engine dependencies (#4655).
 """
 
 from __future__ import annotations
@@ -224,28 +222,12 @@ def test_runtime_imported_scripts_modules_are_baked_into_image() -> None:
         )
 
 
-def test_tts_layer_is_opt_in_so_default_build_succeeds() -> None:
-    """requirements-tts.txt pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0,
-    which publishes no cp312 linux wheels and no sdist, so installing it on
-    the python:3.12 base fails EVERY default build (`docker build .`,
-    compose build, app-image-build.yml — none pass INSTALL_TTS). The #3896 AC
-    requires the default build to produce a working image, so the TTS layer
-    must be opt-in (default 0) until the pins gain 3.12 support; the guarded
-    RUN keeps the skip loud in the build log."""
+def test_tts_layer_is_installed_in_default_builder() -> None:
+    """The ordinary image always installs the shared TTS manifest (#4655)."""
     text = _dockerfile_text()
-    assert re.search(r"^ARG INSTALL_TTS=0\s*$", text, flags=re.MULTILINE), (
-        "INSTALL_TTS must default to 0: the TTS pins cannot install on the "
-        "python:3.12 base, so a default of 1 makes every default build fail "
-        "(#3896 AC: image builds)"
-    )
-    assert 'if [ "$INSTALL_TTS" = "1" ]' in text, (
-        "the TTS install must stay behind the INSTALL_TTS guard so it can be "
-        "re-enabled with --build-arg INSTALL_TTS=1 once the pins support 3.12"
-    )
-    assert "requirements-tts.txt" in text, (
-        "the guarded TTS layer (requirements-tts.txt) must remain in the "
-        "builder stage as the opt-in path"
-    )
+    builder_stage = text.split("FROM ", 2)[1]
+    assert "INSTALL_TTS" not in text
+    assert "pip install --no-cache-dir -r requirements-tts.txt" in builder_stage
 
 
 def test_docs_settings_runtime_tree_is_reincluded_and_copied() -> None:

--- a/tests/deploy/test_dockerfile_python_alignment.py
+++ b/tests/deploy/test_dockerfile_python_alignment.py
@@ -55,26 +55,9 @@ def test_dockerfile_python_minor_matches_ci_smoke() -> None:
     )
 
 
-def test_tts_layer_is_opt_in_so_default_build_succeeds() -> None:
-    """requirements-tts.txt pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0,
-    which publishes no cp312 linux wheels and no sdist, so installing it on
-    the python:3.12 base fails EVERY default build (`docker build .`,
-    compose build, app-image-build.yml — none pass INSTALL_TTS). The
-    app-image-build.yml "Build SHA-tagged app image" job requires the default
-    build to produce a working image, so the TTS layer must be opt-in
-    (default 0) until the pins gain 3.12 support; the guarded RUN keeps the
-    skip loud in the build log."""
+def test_tts_layer_uses_python_aligned_default_install() -> None:
+    """The Python 3.12 builder installs the compatible TTS pins by default."""
     text = DOCKERFILE_PATH.read_text(encoding="utf-8")
-    assert re.search(r"^ARG INSTALL_TTS=0\s*$", text, flags=re.MULTILINE), (
-        "INSTALL_TTS must default to 0: the TTS pins cannot install on the "
-        "python:3.12 base, so a default of 1 makes every default build fail "
-        "(app-image-build.yml passes no INSTALL_TTS build-arg)"
-    )
-    assert 'if [ "$INSTALL_TTS" = "1" ]' in text, (
-        "the TTS install must stay behind the INSTALL_TTS guard so it can be "
-        "re-enabled with --build-arg INSTALL_TTS=1 once the pins support 3.12"
-    )
-    assert "SKIPPING requirements-tts.txt" in text, (
-        "the skip must be loud in the build log so a missing TTS layer is "
-        "diagnosable from CI output alone"
-    )
+    builder_stage = text.split("FROM ", 2)[1]
+    assert "INSTALL_TTS" not in text
+    assert "pip install --no-cache-dir -r requirements-tts.txt" in builder_stage

--- a/tests/deploy/test_tts_image_packaging.py
+++ b/tests/deploy/test_tts_image_packaging.py
@@ -1,0 +1,85 @@
+"""Default multi-architecture app-image TTS packaging contract (#4655)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE_PATH = REPO_ROOT / "Dockerfile"
+TTS_REQUIREMENTS_PATH = REPO_ROOT / "requirements-tts.txt"
+APP_IMAGE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/app-image-build.yml"
+TTS_CONFIG_PATH = REPO_ROOT / "app/tts/config.py"
+TTS_OWNER_DOC_PATH = REPO_ROOT / "companion-ui/docs/LOCAL_FIRST_TTS_CONTRACT.md"
+TTS_RUNBOOK_PATH = REPO_ROOT / "docs/runbooks/RUNBOOK_TTS_PROVISIONING.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_default_app_image_installs_both_tts_engines() -> None:
+    dockerfile = _text(DOCKERFILE_PATH)
+    requirements = _text(TTS_REQUIREMENTS_PATH)
+    builder_stage = dockerfile.split("FROM ", 2)[1]
+
+    assert "INSTALL_TTS" not in dockerfile
+    assert "pip install --no-cache-dir -r requirements-tts.txt" in builder_stage
+    assert re.search(r"^piper-tts==1\.6\.0$", requirements, flags=re.MULTILINE)
+    assert re.search(r"^kokoro-onnx==0\.5\.0$", requirements, flags=re.MULTILINE)
+
+
+def test_app_image_workflow_probes_tts_engines_on_each_platform() -> None:
+    workflow = _text(APP_IMAGE_WORKFLOW_PATH)
+
+    assert "Probe TTS engines in PR image" in workflow
+    assert "command -v piper" in workflow
+    assert "import kokoro_onnx" in workflow
+    assert "Verify pushed app image runtime, platforms, and TTS engines" in workflow
+    assert "app-image-tts-engine-proof.v1" in workflow
+    assert 'image_ref="${image%:*}@${{ steps.build-app-main.outputs.digest }}"' in workflow
+    assert "image_index_digest" in workflow
+    assert "platform_digest" in workflow
+    assert "linux/amd64" in workflow
+    assert "linux/arm64" in workflow
+    assert "Upload TTS engine proof" in workflow
+
+
+def test_engine_proof_is_truthful_about_package_presence_scope() -> None:
+    workflow = _text(APP_IMAGE_WORKFLOW_PATH)
+    owner_doc = _text(TTS_OWNER_DOC_PATH)
+    runbook = _text(TTS_RUNBOOK_PATH)
+
+    assert 'probe_scope: $probe_scope' in workflow
+    assert (
+        '--arg probe_scope "package_presence_cli_load_import_app_health"' in workflow
+    )
+    assert '.probe_scope == "package_presence_cli_load_import_app_health"' in workflow
+    assert "package-presence proof, not model-backed synthesis" in owner_doc
+    assert "package-presence proof, not model-backed synthesis" in runbook
+
+
+def test_tts_dependency_contract_is_identical_across_linux_platforms() -> None:
+    dockerfile = _text(DOCKERFILE_PATH)
+    workflow = _text(APP_IMAGE_WORKFLOW_PATH)
+
+    assert len(
+        re.findall(r"^(?:COPY|RUN).*requirements-tts\.txt", dockerfile, flags=re.MULTILINE)
+    ) == 2
+    assert "TARGETARCH" not in dockerfile
+    assert "TARGETPLATFORM" not in dockerfile
+    assert "platforms: linux/amd64,linux/arm64" in workflow
+    assert "requirements-tts-amd64" not in workflow
+    assert "requirements-tts-arm64" not in workflow
+
+
+def test_engine_image_excludes_models_and_preserves_disabled_local_only_defaults() -> None:
+    dockerfile = _text(DOCKERFILE_PATH)
+    config = _text(TTS_CONFIG_PATH)
+
+    for forbidden in ("*.onnx", "voices-v1.0.bin", "fetch_tts_models.sh"):
+        assert forbidden not in dockerfile
+    assert 'enabled=_truthy_env("TTS_ENABLED")' in config
+    assert 'local_only=_truthy_env("TTS_LOCAL_ONLY", default=True)' in config
+    assert 'allow_browser_fallback=_truthy_env("TTS_ALLOW_BROWSER_FALLBACK")' in config
+    assert 'allow_cloud_fallback=_truthy_env("TTS_ALLOW_CLOUD_FALLBACK")' in config


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4655

## Linked Issue
Closes #4655

## SBS Impact
- Primary subsystem: Product/Runtime image packaging and local-first TTS runtime
- Secondary subsystem(s): CI image publication; operator provisioning runbook
- Write class: boundary work (Product/Runtime package contract with Builder-System verification receipt)
- Persistence impact: none
- Derived/rebuildable impact: container images and app-image-tts-engine-proof.v1 artifact are rebuildable
- New or changed contract: default app image includes piper-tts 1.6.0 and kokoro-onnx 0.5.0 on linux/amd64 and linux/arm64
- Owner-doc impact: LOCAL_FIRST_TTS_CONTRACT and RUNBOOK_TTS_PROVISIONING updated in this PR
- Transition debt impact: removes the accidental INSTALL_TTS opt-in variant and host-install fallback
- Boundary risk: external Python wheels and QEMU multi-architecture execution are verified fail-closed before receipt publication

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Restore Piper and Kokoro ONNX as unconditional dependencies of the default application image.
- Build and probe one immutable linux/amd64 + linux/arm64 image index, then publish a per-platform digest receipt on main.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Normal bounded Issue/PR delivery evidence is sufficient; no operational state, learning divergence, or authority-class promotion requires a BuilderOps record.

## Notes
Claim: dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-4655, lease lease-bf7d41f2, holder codex-sol. Validation: 24 focused deploy/workflow tests; Ruff; mypy over 870 files; docs guard; actionlint; diff check; exact-current-SHA linux/arm64 image with Piper, Kokoro, application import, health handler, Uvicorn startup, and live /healthz. Production exclusion: no production database, deployment, stable/prod ref, release, service, secret, or production configuration was read or changed. Repair budget used: static-quality/workflow assertions 1 standard; review/code correctness probe-scope truthfulness 1 standard; deployment/model-schema image identity 1 standard; zero escalated attempts. Residual risk is limited to registry/build-runner availability, covered by current-SHA CI and the post-merge immutable multi-architecture receipt.