### PR TITLE
Probe multiarch images by child digest

### DIFF
--- a/.github/workflows/app-image-build.yml
+++ b/.github/workflows/app-image-build.yml
@@ -136,11 +136,12 @@ jobs:
               --arg architecture "${architecture}" \
               '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture) | .digest' \
               "${manifest_json}")"
+            platform_ref="${image%:*}@${platform_digest}"
             probe_result="pass"
             if ! docker run --rm \
               --platform "${platform}" \
               --entrypoint sh \
-              "${image_ref}" \
+              "${platform_ref}" \
               -ec 'command -v piper >/dev/null; piper --help >/dev/null 2>&1; python -c "import asyncio; import kokoro_onnx; import os; from app.api.routes.health_contract import healthz; from app.main import app; from app.version import get_runtime_version; version = get_runtime_version(); assert app is not None; assert asyncio.run(healthz()) == {\"ok\": True}; assert version[\"git_sha\"] == os.environ[\"VCS_REF\"], version; assert version[\"built_at\"] == os.environ[\"BUILT_AT\"], version"'; then
               probe_result="fail"
               failures=$((failures + 1))

--- a/tests/deploy/test_tts_image_packaging.py
+++ b/tests/deploy/test_tts_image_packaging.py
@@ -40,6 +40,8 @@ def test_app_image_workflow_probes_tts_engines_on_each_platform() -> None:
     assert 'image_ref="${image%:*}@${{ steps.build-app-main.outputs.digest }}"' in workflow
     assert "image_index_digest" in workflow
     assert "platform_digest" in workflow
+    assert 'platform_ref="${image%:*}@${platform_digest}"' in workflow
+    assert '"${platform_ref}" \\' in workflow
     assert "linux/amd64" in workflow
     assert "linux/arm64" in workflow
     assert "Upload TTS engine proof" in workflow


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4655

## Linked Issue
Closes #4655

## SBS Impact
- Primary subsystem: Builder System / CES runtime-artifact verification
- Secondary subsystem(s): Product/Runtime default app image proof
- Write class: boundary repair to the existing multi-architecture verification mechanism
- Persistence impact: none
- Derived/rebuildable impact: SHA-tagged container image and app-image-tts-engine-proof.v1 remain rebuildable
- New or changed contract: none; this repairs execution of the existing immutable per-platform proof contract
- Owner-doc impact: none; PR #4661 already wrote the truthful package-presence contract
- Transition debt impact: none
- Boundary risk: running one index digest twice can collide in the Docker local cache; immutable child refs remove that false failure without weakening receipt identity

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Run each published architecture probe against its immutable child manifest digest instead of reusing the multi-architecture index reference.
- Preserve the existing receipt schema and add a regression guard for child-digest execution.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded post-merge failure, exact artifact identities, convergence analysis, and regression repair are fully represented by Issue #4655, PR #4661, this PR, and GitHub workflow artifacts; no separate operational state or authority promotion remains.

## Notes
Failure evidence: main run 31144526029 published index sha256:fb693438963203dad9888fe69babd4c2da18864c0fbf4e3e80d1c11d15b4f9fc; amd64 child sha256:7eed72bfcafd0edba6dbcada411106e6683fa311966546b1280081b06026a19f passed; arm64 child sha256:5d2510533dcc41ad4f7f5a7045fd277bac7149530ba456473d9452503cd257d7 was blocked by Docker local index-digest overwrite. Both exact child digests pass the full Piper/Kokoro/app/health probe under this repair. Validation: 24 focused tests; Ruff; mypy over 870 files; docs guard; actionlint; diff check; independent Sol/high convergence review clean. Repair budgets: static-quality/workflow assertions 1 standard; review/code correctness/probe-scope truthfulness 1 standard; deployment/model-schema/local-image-label identity 1 standard; deployment/model-schema/multiarch-child-selection 1 standard; zero escalated attempts. Production exclusion: no deployment, channel pin, stable/prod ref, database, service, secret, model, or production configuration read or mutation.