### PR TITLE
Align settings embedding default with Ollama adapter

### DIFF
--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
 
     db_dsn: str = "postgresql+psycopg://app:app@postgres:5432/app"
     vector_backend: str = "pgvector"
-    embed_model: str = "openai/text-embedding-3-large"
+    embed_model: str = "nomic-embed-text:latest"
     # Matches app/embedding_config.py::DEFAULT_EMBED_DIM (768) — closes the
     # EMBED_DIM/DEFAULT_EMBED_DIM drift (#2296/#2297) rather than layering a
     # third stale value alongside it. See docs/EMBEDDINGS.md :: EMBED_DIM.

--- a/tests/settings/test_embed_model_default.py
+++ b/tests/settings/test_embed_model_default.py
@@ -1,0 +1,9 @@
+from app.llm.embeddings import PROVIDER_REGISTRY
+from app.settings import Settings
+
+
+def test_settings_declares_no_unservable_embed_model() -> None:
+    """The settings default must name a model served by the shipped Ollama adapter."""
+
+    assert Settings.model_fields["embed_model"].default == "nomic-embed-text:latest"
+    assert "ollama" in PROVIDER_REGISTRY

--- a/tests/test_hybrid_rrf.py
+++ b/tests/test_hybrid_rrf.py
@@ -4,7 +4,9 @@ from uuid import uuid4
 
 from app.search.service import search_hybrid
 from app.search.vector_index import VectorResult
-from app.settings import settings
+
+
+_FIXTURE_EMBED_MODEL = "nomic-embed-text:latest"
 
 
 def test_hybrid_rrf_combines_ft_and_vector(monkeypatch, stub_index) -> None:
@@ -18,7 +20,7 @@ def test_hybrid_rrf_combines_ft_and_vector(monkeypatch, stub_index) -> None:
         source_ref="doc-1",
         payload={"title": "First"},
         embedding=[1.0, 0.0],
-        model=settings.embed_model,
+        model=_FIXTURE_EMBED_MODEL,
     )
     stub_index.upsert(
         object_id=second_id,
@@ -26,7 +28,7 @@ def test_hybrid_rrf_combines_ft_and_vector(monkeypatch, stub_index) -> None:
         source_ref="doc-2",
         payload={"title": "Second"},
         embedding=[0.0, 1.0],
-        model=settings.embed_model,
+        model=_FIXTURE_EMBED_MODEL,
     )
     stub_index.upsert(
         object_id=third_id,
@@ -34,7 +36,7 @@ def test_hybrid_rrf_combines_ft_and_vector(monkeypatch, stub_index) -> None:
         source_ref="doc-3",
         payload={"title": "Third"},
         embedding=[0.5, 0.5],
-        model=settings.embed_model,
+        model=_FIXTURE_EMBED_MODEL,
     )
 
     def fake_ft(query_text: str, *, k: int) -> list[VectorResult]:

--- a/tests/test_vector_query.py
+++ b/tests/test_vector_query.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from uuid import uuid4
 
 from app.search.service import search_vector
-from app.settings import settings
+
+
+_FIXTURE_EMBED_MODEL = "nomic-embed-text:latest"
 
 
 def test_vector_query_returns_closest_match(stub_index) -> None:
@@ -15,7 +17,7 @@ def test_vector_query_returns_closest_match(stub_index) -> None:
         source_ref="A",
         payload={"title": "Doc A"},
         embedding=[1.0, 0.0, 0.0],
-        model=settings.embed_model,
+        model=_FIXTURE_EMBED_MODEL,
     )
     stub_index.upsert(
         object_id=b_id,
@@ -23,7 +25,7 @@ def test_vector_query_returns_closest_match(stub_index) -> None:
         source_ref="B",
         payload={"title": "Doc B"},
         embedding=[0.0, 1.0, 0.0],
-        model=settings.embed_model,
+        model=_FIXTURE_EMBED_MODEL,
     )
 
     results = search_vector([0.9, 0.1, 0.0], k=1)


### PR DESCRIPTION
Governing-Issue: #4181

Fixes #4181

Final-Review-Rounds: 0

## Summary
Align the Settings embedding-model default with the shipped Ollama identity and make vector-search fixture labels explicit.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 2 bounded code slice; no BuilderOps material was created.

## Notes
Validation: targeted Verify tests (4 passed); settings/provider suite (235 passed); settings validation; Ruff; mypy. The host-leased non-PG suite remains in progress.
---