### PR TITLE
Honor effective reasoning routes

### DIFF
--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from uuid import UUID
 
-from app.components.llm.fabric import LLMBackendTimeout, LLMTaskIntent, get_chat_client
+from app.components.llm.fabric import LLMBackendTimeout, LLMRouter, LLMTaskIntent, get_chat_client
 from app.components.llm.router import LLMRoute
 from app.llm.trace import log_llm_call
 from app.reasoning.prompts import SYSTEM_PROMPT, build_user_prompt
@@ -178,6 +178,16 @@ def _reasoning_backend() -> str:
     return backend
 
 
+def _reasoning_uses_mock_route() -> bool:
+    if _reasoning_backend() == "mock":
+        return True
+    try:
+        route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high"))
+    except Exception:
+        return False
+    return route.provider == "mock"
+
+
 def _simple_preview(text: str, limit: int = 120) -> str:
     text = text or ""
     return text[:limit] + ("..." if len(text) > limit else "")
@@ -295,10 +305,7 @@ def run_reasoning(
                 error="object missing or has no text",
                 result={"summary": "", "issues": [], "suggestions": []},
             )
-        backend = _reasoning_backend()
-        provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()
-        provider = "mock" if provider in {"", "fake"} else provider
-        if backend == "mock" or provider == "mock":
+        if _reasoning_uses_mock_route():
             summary = f"Summary: {_simple_preview(text, 90)}"
             issues = ["needs review for clarity"]
             suggestions = ["Clarify objectives", "Add sources"]
@@ -352,10 +359,7 @@ def run_reasoning(
                 error="no candidate texts found",
                 result={"ranking": []},
             )
-        backend = _reasoning_backend()
-        provider = (os.getenv("LLM_PROVIDER") or "mock").strip().lower()
-        provider = "mock" if provider in {"", "fake"} else provider
-        if backend == "mock" or provider == "mock":
+        if _reasoning_uses_mock_route():
             ranking = []
             for idx, (oid, text) in enumerate(texts):
                 score = max(0.0, 1.0 - 0.05 * idx)

--- a/tests/reasoning/test_provider_review_ranking_robustness.py
+++ b/tests/reasoning/test_provider_review_ranking_robustness.py
@@ -77,6 +77,31 @@ def test_review_uses_mock_result_when_provider_is_unconfigured(
     assert run.result["summary"].startswith("Summary:")
 
 
+def test_review_honors_forced_real_provider_before_mock_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_FORCE_PROVIDER", "ollama")
+    monkeypatch.delenv("CI", raising=False)
+    reset_store_backends()
+    object_id = _store_note()
+    calls = []
+
+    def _chat(**_kwargs: object) -> str:
+        calls.append(_kwargs)
+        return '{"summary": "routed review", "issues": [], "suggestions": []}'
+
+    monkeypatch.setattr(provider_module, "_call_chat", _chat)
+
+    run = run_reasoning(ReasoningMode.REVIEW, [object_id])
+
+    assert run.status == "ok"
+    assert run.result["summary"] == "routed review"
+    assert len(calls) == 1
+
+
 def test_ranking_uses_mock_result_when_provider_is_unconfigured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -96,3 +121,32 @@ def test_ranking_uses_mock_result_when_provider_is_unconfigured(
 
     assert run.status == "ok"
     assert run.result["ranking"]
+
+
+def test_ranking_honors_forced_real_provider_before_mock_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("REASONING_PROVIDER", "llm")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("LLM_FORCE_PROVIDER", "ollama")
+    monkeypatch.delenv("CI", raising=False)
+    reset_store_backends()
+    object_id = _store_note()
+    calls = []
+
+    def _chat(**_kwargs: object) -> str:
+        calls.append(_kwargs)
+        return (
+            '{"ranking": [{"object_uuid": "'
+            + object_id
+            + '", "score": 0.9, "reason": "routed ranking"}]}'
+        )
+
+    monkeypatch.setattr(provider_module, "_call_chat", _chat)
+
+    run = run_reasoning(ReasoningMode.RANKING, [object_id], question="Rank this")
+
+    assert run.status == "ok"
+    assert run.result["ranking"][0]["reason"] == "routed ranking"
+    assert len(calls) == 1


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4668

## Linked Issue
Fixes #4668

## SBS Impact
- Primary subsystem: Product/Runtime System - Reasoning / cognition
- Secondary subsystem(s): LLM routing boundary
- Write class: current-state correction
- Authority impact: none
- Persistence impact: none
- External boundary impact: REVIEW/RANKING now honor effective real-provider routing before returning deterministic mock results.
- Owner-doc impact: none; routing contracts and result shapes are unchanged.
- Transition debt impact: closes the residual P1 review finding from PR #4654.
- Boundary risk: low; no provider, model, persistence, or result-shape contract changed.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Use the LLM router's effective reasoning route before REVIEW/RANKING return deterministic mock results.
- Add regressions proving `LLM_FORCE_PROVIDER=ollama` overrides raw `LLM_PROVIDER=mock` for REVIEW and RANKING without making a live provider call.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The residual review finding, repair contract, and delivery evidence are represented by PR #4654 thread #3729996521, Issue #4668, and this PR; no workflow divergence or authority promotion remains.

## Notes
Claim: issue=4668 branch=codex/repair-4654-effective-review-route worktree=/Users/rasmusthornberg/.codex/worktrees/7ae9/agentic-pkm-mvp coordination_mode=github-label-only-fallback fallback_reason=dispatcher-claim-failed-no-verified-task evidence=github-comment:5225457726

Validation:
- `python3 -m pytest tests/reasoning/test_provider_review_ranking_robustness.py tests/reasoning/test_reasoning_modes_contract.py -q` - 11 passed, 1 warning
- `python3 -m ruff check app/reasoning/provider.py tests/reasoning/test_provider_review_ranking_robustness.py` - passed
- `python3 -m mypy app` - passed across 870 source files
- `git diff --check` - passed
- `python3 scripts/review_before_ci_gate.py --lane implementation --review-gate-complete --risk-assessment-complete --changed-file app/reasoning/provider.py --changed-file tests/reasoning/test_provider_review_ranking_robustness.py` - not required for this lane/surface, ok
