### PR TITLE
Clarify research/design PromotionIntent routing

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -186,7 +186,7 @@ workflow — see `## App-agent skill family (product-lane)` below for the full d
 - Docs backlog path:
   `docs-governance -> (docs-authoring | docs-to-issue | feature-breakdown)`
 - Design handoff path:
-  `yggdrasil-design-handoff -> governed exploration/handoff -> (Companion UI: Crossing B -> normalized spec | other surface: local owner doc/spec) -> docs-to-issue`
+  `yggdrasil-design-handoff -> governed exploration/handoff -> disposition (PromotionIntent when crossing authority classes) -> (Companion UI: Crossing B -> normalized spec | other surface: local owner doc/spec) -> docs-to-issue`
 - Architecture research path:
   `architecture-research -> feature-breakdown -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
 - Maintenance-learning intake path:

--- a/.codex/skills/yggdrasil-design-handoff/SKILL.md
+++ b/.codex/skills/yggdrasil-design-handoff/SKILL.md
@@ -64,7 +64,12 @@ invent a replacement token set, or continue with an unverified similarly named s
    degraded, and blocked states when relevant. Confirm that colors, type, spacing, radii, icons,
    and components are grounded in the design system. Name any proposed extension in
    `open-questions.md`; do not use it silently in the prototype.
-7. **Archive and cross deliberately.** For Companion UI, preserve the package under
+7. **Dispose and cross deliberately.** Record whether the research/design result is accepted,
+   rejected, deferred, or requires an owner decision. When accepted material crosses an authority
+   class into a normative owner document or specification, create or consume the existing
+   BuilderOps `PromotionIntent` boundary with source refs, target surface/ref, intended output, and
+   its receipt. `PromotionIntent` is proposal/provenance material; it does not write the target.
+   For Companion UI, preserve the package under
    `companion-ui/design_handoff/<YYYY-MM-DD>-<slug>/` only when requested and route implementation
    intent through Crossing B. For other Product or Builder surfaces, keep the external package as
    supporting design input and normalize accepted intent through that surface's local owner

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -40,6 +40,17 @@ The Builder System has these layers:
    [docs/development/DELIVERY_FEEDBACK_LOOP.md:1-220].
 9. Exception layer: `agent:needs-human`, blocker receipts, release operator acknowledgements, and Human Exception packets stop autonomous continuation when authority is missing; CI/review/merge gates remain non-waivable [`.codex/skills/_shared/LABEL_TAXONOMY.md`:18-27], [docs/architecture/SBS_OPERATING_MODEL.md §12].
 
+### Authority-crossing rule for research and design
+
+Research findings and external design handoffs are supporting inputs until they receive an explicit
+disposition: accepted, rejected, deferred, or requiring an owner decision. When accepted material
+crosses into a normative owner document or specification, the route must use the existing BuilderOps
+`PromotionIntent` boundary with source references, target authority surface/ref, intended output, and
+the resulting receipt. `PromotionIntent` is proposal and provenance material only; the target repo
+document or specification becomes authoritative through the normal PR workflow. A research note,
+design package, or chat transcript alone cannot define implementation scope or create an executable
+Issue.
+
 ## Evidence Legend
 
 Statuses in this document use the requested terms:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue

## SBS Impact
- Primary subsystem: Builder System governance
- Secondary subsystem(s): Yggdrasil design handoff and docs-to-issue routing
- Write class: governance documentation and repo-local skill routing
- Persistence impact: none to Product/Runtime; one staged BuilderOps PromotionIntent records the authority crossing
- Derived/rebuildable impact: none
- New or changed contract: clarifies use of the existing PromotionIntent boundary; adds no record type, graph, or mutation authority
- Owner-doc impact: updates the Builder System process map and routing guidance
- Boundary risk: PromotionIntent remains proposal/provenance material; target docs/specs remain authoritative only through the normal PR workflow

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make research/design disposition explicit before normative writeback.
- Require the existing PromotionIntent boundary when accepted material crosses authority classes.
- Keep implementation scope gated by a bounded Issue and the normal PR chain.

## BuilderOps Routing
- Records/projections/receipts: PromotionIntent `prom_20260808150433_1bad7699`; acceptance receipt `receipt_20260808150517_ffa1edd6`
- Reason: The accepted PromotionIntent records provenance for this governance writeback; it is proposal/provenance only and does not write the target surface.

## Validation
- `python3 scripts/docs_guard.py`
- `python3 scripts/lint_skills_consistency.py`
- `python3 -m pytest -q tests/governance/test_skills_consistency_lint.py tests/architecture/test_agent_skill_entrypoints.py tests/governance/test_project_pickup_deprecation.py` (51 passed)
- `git diff --check`
