### PR TITLE
Stop scaffolding reserved constituent directories

### DIFF
--- a/app/settings/mimer_scaffolder.py
+++ b/app/settings/mimer_scaffolder.py
@@ -31,12 +31,9 @@ class MimerScaffolder:
         mimer_root_dir = self.root.expanduser()
         module_paths = {
             "Mimer": mimer_root_dir / "Mimer",
-            "Hugin": mimer_root_dir / "Hugin",
-            "Munin": mimer_root_dir / "Munin",
             "Ratatosk": mimer_root_dir / "Ratatosk",
             "Brokkr": mimer_root_dir / "Brokkr",
             "Tyr": mimer_root_dir / "Tyr",
-            "Heimdall": mimer_root_dir / "Heimdall",
         }
 
         created: list[Path] = []

--- a/tests/cli/test_yggdrasil_init.py
+++ b/tests/cli/test_yggdrasil_init.py
@@ -20,8 +20,10 @@ def test_yggdrasil_init_scaffolds_directories(tmp_path):
     assert (mimer_root / "🛠️ Workbench").is_dir()
     assert (mimer_root / "⚙️ System" / "vault.layout.md").exists()
 
-    for name in ["Hugin", "Munin", "Ratatosk", "Brokkr", "Tyr", "Heimdall"]:
+    for name in ["Ratatosk", "Brokkr", "Tyr"]:
         assert (tmp_path / name).is_dir()
+    for name in ["Hugin", "Munin", "Heimdall"]:
+        assert not (tmp_path / name).exists()
 
 
 def test_yggdrasil_init_uses_scaffolder(monkeypatch, tmp_path) -> None:

--- a/tests/settings/test_mimer_scaffold_guard.py
+++ b/tests/settings/test_mimer_scaffold_guard.py
@@ -28,7 +28,8 @@ from app.write_guard import DEFAULT_WRITE_GUARD
 
 pytestmark = pytest.mark.not_pg
 
-MODULES = ("Mimer", "Hugin", "Munin", "Ratatosk", "Brokkr", "Tyr", "Heimdall")
+MODULES = ("Mimer", "Ratatosk", "Brokkr", "Tyr")
+LEGACY_MODULES = ("Hugin", "Munin", "Heimdall")
 
 
 def _all_paths(root: Path) -> set[Path]:
@@ -100,9 +101,11 @@ def test_bootstrap_escape_provisions_under_health_block(
 
     assert result.exit_code == 0, result.output
 
-    # Full module + Mimer layout provisioned despite the health block.
+    # The active module layout + Mimer layout provision despite the health block.
     for module in MODULES:
         assert (root / module).is_dir(), f"missing module {module}"
+    for legacy_module in LEGACY_MODULES:
+        assert not (root / legacy_module).exists(), f"unexpected legacy module {legacy_module}"
     settings_dir = root / "Mimer" / "settings"
     assert (settings_dir / "global.md").is_file()
     assert (settings_dir / "system-settings.md").is_file()
@@ -142,3 +145,25 @@ def test_scaffold_output_unchanged_when_allowed(
 
     assert tree_after_second == tree_after_first
     assert contents_after_second == contents_after_first
+
+
+def test_rerun_preserves_legacy_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rerun leaves existing legacy directories and their user data untouched."""
+    root = tmp_path / "Yggdrasil"
+    legacy_files = {
+        root / "Hugin" / "user-note.md": b"keep hugin\n",
+        root / "Munin" / "user-note.md": b"keep munin\n",
+        root / "Heimdall" / "user-note.md": b"keep heimdall\n",
+    }
+    for path, contents in legacy_files.items():
+        path.parent.mkdir(parents=True)
+        path.write_bytes(contents)
+
+    monkeypatch.setattr(DEFAULT_WRITE_GUARD, "snapshot_fn", lambda: {"state": "healthy"})
+    result = CliRunner().invoke(cli, ["yggdrasil-init", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    for path, contents in legacy_files.items():
+        assert path.read_bytes() == contents


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4674

## Linked Issue
Closes #4674

## SBS Impact
- Primary subsystem: WSP
- Secondary subsystem(s): HKA, PDM
- Write class: mechanical
- Persistence impact: Changes only directories provisioned for a new root; never mutates existing content.
- Derived/rebuildable impact: none
- New or changed contract: new-root scaffold layout
- Owner-doc impact: none
- Transition debt impact: Reduces nomenclature compatibility debt.
- Boundary risk: Must not delete or reinterpret existing user directories.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Stops fresh yggdrasil-init roots from creating reserved Hugin and Munin or superseded Heimdall directories.
- Existing legacy directories remain untouched on rerun; Mimer layout and WriteGuard behavior are unchanged.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was produced; this is a bounded current-state scaffold correction.

## Notes
Validation: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings/test_mimer_scaffold_guard.py tests/cli/test_yggdrasil_init.py (6 passed); ruff check app tests; mypy app; python3 scripts/docs_guard.py.