### PR TITLE
Normalize active Companion UI Hugin labels

### DIFF
--- a/companion-ui/companion-app/canvas_suggestion_flow.css
+++ b/companion-ui/companion-app/canvas_suggestion_flow.css
@@ -164,7 +164,7 @@
   .suggested-insertion::before { transition: none; }
 }
 
-/* ---- Hugin rail ---- */
+/* ---- Chat rail ---- */
 .hugin-rail {
   background: var(--bg-surface);
   display: grid;

--- a/companion-ui/companion-app/canvas_suggestion_flow.html
+++ b/companion-ui/companion-app/canvas_suggestion_flow.html
@@ -67,7 +67,7 @@ tags: [arch, q2-planning]
       <h1>Decision capture scaffold</h1>
 
       <h2>Context</h2>
-      <p>We need a way for Hugin to propose body edits in this note without violating the gated
+      <p>We need a way for Chat to propose body edits in this note without violating the gated
          execution invariant. Anything beyond the note body must enter the governance pipeline.</p>
 
       <!-- SuggestedInsertion — in-document preview marker -->
@@ -91,17 +91,17 @@ tags: [arch, q2-planning]
     </main>
 
     <!-- ===========================================================
-         HUGIN RAIL — conversation thread + action surface
+         CHAT RAIL — conversation thread + action surface
          =========================================================== -->
     <aside class="hugin-rail"
            data-testid="margin-rail"
            data-sheet="peek"
-           aria-label="Hugin conversation rail"
+           aria-label="Chat conversation rail"
            id="rail">
 
       <!-- Collapsed strip (landscape) -->
       <div class="rail-collapsed-strip"
-           aria-label="Expand Hugin rail"
+           aria-label="Expand Chat rail"
            role="button"
            tabindex="0"
            id="collapsed-strip">
@@ -112,7 +112,7 @@ tags: [arch, q2-planning]
       <!-- Rail header -->
       <div class="rail-header">
         <span class="hugin-dot" aria-hidden="true"></span>
-        <span style="color:var(--fg-2); letter-spacing:var(--tracking-wider);">HUGIN</span>
+        <span style="color:var(--fg-2); letter-spacing:var(--tracking-wider);">CHAT</span>
         <span class="turn-meta" id="turn-count">14 turns</span>
       </div>
 
@@ -133,17 +133,17 @@ tags: [arch, q2-planning]
         <div class="thinking-indicator"
              data-testid="thinking-indicator"
              data-thinking="inactive"
-             aria-label="Hugin is thinking"
+             aria-label="Chat is thinking"
              id="thinking"
              style="display:none;">
-          <span>HUGIN</span>
+          <span>CHAT</span>
           <span class="ddot" aria-hidden="true"></span>
           <span class="ddot" aria-hidden="true"></span>
           <span class="ddot" aria-hidden="true"></span>
           <button class="thinking-cancel"
                   type="button"
                   data-intent="canvas.cancelTurn"
-                  aria-label="Cancel Hugin reasoning"
+                  aria-label="Cancel Chat reasoning"
                   id="btn-cancel">Cancel</button>
         </div>
 
@@ -153,7 +153,7 @@ tags: [arch, q2-planning]
              data-variant="body"
              data-suggestion-id="suggestion-001"
              id="card-body">
-          <span class="card-label">HUGIN · PROPOSED ADDITION</span>
+          <span class="card-label">AGENT · PROPOSED ADDITION</span>
           <span>Introduce explicit staged-suggestion actions with no direct persistence side effects.</span>
           <span class="diff-hint">+3 lines after <code>## Current state</code></span>
           <div class="card-actions">
@@ -192,7 +192,7 @@ tags: [arch, q2-planning]
              data-suggestion-id="suggestion-002"
              id="card-gov"
              style="display:none;">
-          <span class="card-label">HUGIN · GOVERNANCE-BEARING PROPOSAL</span>
+          <span class="card-label">AGENT · GOVERNANCE-BEARING PROPOSAL</span>
           <span>Promote <code>maturity: draft → committed</code> and add tag <code>#arch/decision</code>.</span>
           <span class="card-classification"
                 data-testid="suggestion-card-classification"
@@ -271,8 +271,8 @@ tags: [arch, q2-planning]
       <!-- ---- Composer ---- -->
       <div class="composer-wrap">
         <input type="text"
-               placeholder="Message Hugin…"
-               aria-label="Message Hugin"
+               placeholder="Message Chat…"
+               aria-label="Message Chat"
                data-testid="composer-input"
                id="composer-input" />
         <button class="btn primary"
@@ -284,7 +284,7 @@ tags: [arch, q2-planning]
         </button>
       </div>
 
-    </aside><!-- /hugin-rail -->
+    </aside><!-- /chat-rail -->
 
   </div><!-- /canvas-stage -->
 
@@ -397,16 +397,16 @@ tags: [arch, q2-planning]
     composerInput.disabled = !composerEnabled;
     btnSend.disabled = !composerEnabled;
     composerInput.placeholder = {
-      'idle':                   'Message Hugin…',
-      'thinking':               'Hugin is thinking…',
+      'idle':                   'Message Chat…',
+      'thinking':               'Chat is thinking…',
       'suggestion-staged:body': 'Apply or discard to continue',
       'suggestion-staged:gov':  'Queue or discard to continue',
       'apply-pending':          'Applying edit…',
       'governance-pending':     'Routing to governance…',
-      'applied':                'Message Hugin…',
-      'discarded':              'Message Hugin…',
+      'applied':                'Message Chat…',
+      'discarded':              'Message Chat…',
       'blocked':                'Canvas disabled in this environment',
-    }[s] || 'Message Hugin…';
+    }[s] || 'Message Chat…';
 
     console.log('[canvas-shell] state →', s);
 
@@ -443,7 +443,7 @@ tags: [arch, q2-planning]
     if (tab === 'body') {
       cardBody.style.display = 'flex';
       cardBody.dataset.variant = 'body';
-      cardBody.querySelector('.card-label').textContent = 'HUGIN · PROPOSED ADDITION';
+      cardBody.querySelector('.card-label').textContent = 'AGENT · PROPOSED ADDITION';
       cardBody.querySelector('.card-actions').style.display = 'flex';
       btnApply.disabled = false;
       btnDiscard.disabled = false;
@@ -499,7 +499,7 @@ tags: [arch, q2-planning]
     setTimeout(() => {
       thinking.style.display = 'none';
       thinking.querySelector('.thinking-cancel').style.display = '';
-      thinking.querySelector('span').textContent = 'HUGIN';
+      thinking.querySelector('span').textContent = 'CHAT';
 
       const receiptId = 'body_edit#a' + Math.random().toString(16).slice(2, 6);
       lastApplied = receiptId;
@@ -543,7 +543,7 @@ tags: [arch, q2-planning]
     insertion.dataset.state = 'staged';
     insertion.removeAttribute('data-receipt');
     cardBody.dataset.variant = 'body';
-    cardBody.querySelector('.card-label').textContent = 'HUGIN · PROPOSED ADDITION';
+    cardBody.querySelector('.card-label').textContent = 'AGENT · PROPOSED ADDITION';
     cardBody.querySelector('.card-actions').style.display = 'flex';
     btnApply.disabled = false;
     btnDiscard.disabled = false;

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/portrait_sheet.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/portrait_sheet.py
@@ -1,11 +1,11 @@
 """Portrait/mobile bottom sheet model for the bounded suggestion rail (#873).
 
-At viewport widths < 900 px, the Hugin rail becomes a bottom sheet replacing
+At viewport widths < 900 px, the Chat rail becomes a bottom sheet replacing
 the side rail.  This module models the snap state and transition rules without
 any CSS, React, DOM, localStorage, or gesture handling.
 
 Snap points (from issue #873 §Snap points):
-  PEEK             60 px  Default / collapsed; shows Hugin dot + turn count.
+  PEEK             60 px  Default / collapsed; shows agent dot + turn count.
   HALF             50vh   Expanded conversation; document still visible above.
   FULL_MINUS_CHROME calc(100vh - 64px)  Full conversation.
   CLOSED           Not visible at all.

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -6046,7 +6046,7 @@ def _render_panel_proposal_rows(
         proposal_id = _e(proposal.get("proposal_id", ""))
         artifact_id = _e(proposal.get("artifact_id", ""))
         # Provenance line: agent · ISO-timestamp · confidence N (AC4)
-        prov_agent = _e(str(proposal.get("agent") or proposal.get("author") or "hugin"))
+        prov_agent = _e(str(proposal.get("agent") or proposal.get("author") or "agent"))
         prov_ts_raw = str(proposal.get("created_at") or proposal.get("timestamp") or "")
         prov_ts = _e(prov_ts_raw[:16]) if prov_ts_raw else _e(datetime.now().strftime("%Y-%m-%dT%H:%M"))
         prov_conf = _e(str(proposal.get("confidence") or "—"))

--- a/companion-ui/companion-app/converse_layout.html
+++ b/companion-ui/companion-app/converse_layout.html
@@ -46,7 +46,7 @@
           </article>
         </main>
 
-        <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Hugin rail">
+        <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Chat rail">
           <div class="rail-collapsed-strip" data-testid="rail-collapsed-strip" aria-label="Collapsed rail strip">
             <span class="hugin-dot" aria-hidden="true"></span>
             <span class="collapsed-unread">3 new</span>
@@ -55,7 +55,7 @@
 
           <header class="rail-header">
             <span class="hugin-dot" aria-hidden="true"></span>
-            <span class="hugin-label">HUGIN</span>
+            <span class="hugin-label">CHAT</span>
             <span class="turn-count">18 turns</span>
           </header>
 
@@ -76,7 +76,7 @@
               data-suggestion-id="suggestion-001"
               data-proposal-id="suggestion-001"
             >
-              <p class="suggestion-card-label" data-testid="suggestion-card-label">HUGIN · PROPOSED ADDITION</p>
+              <p class="suggestion-card-label" data-testid="suggestion-card-label">AGENT · PROPOSED ADDITION</p>
               <p>Add a staged insertion for explicit user-controlled apply/discard flow.</p>
               <p class="suggestion-card-diff-hint" data-testid="suggestion-card-diff-hint">+3 lines after ## Current state</p>
               <div class="suggestion-actions">
@@ -101,8 +101,8 @@
               </div>
             </article>
 
-            <div class="thinking-indicator" data-testid="thinking-indicator" data-thinking="active" aria-label="Hugin thinking">
-              <span class="thinking-label">HUGIN</span>
+            <div class="thinking-indicator" data-testid="thinking-indicator" data-thinking="active" aria-label="Chat is thinking">
+              <span class="thinking-label">CHAT</span>
               <span class="thinking-dot"></span>
               <span class="thinking-dot"></span>
               <span class="thinking-dot"></span>
@@ -177,7 +177,7 @@
       <div class="bottom-sheet-handle" data-testid="bottom-sheet-handle" aria-hidden="true"></div>
       <header class="rail-header">
         <span class="hugin-dot" aria-hidden="true"></span>
-        <span class="hugin-label">HUGIN</span>
+        <span class="hugin-label">CHAT</span>
         <span class="turn-count">18 turns ›</span>
       </header>
       <section class="conversation-thread" aria-label="Conversation thread">
@@ -187,7 +187,7 @@
       </section>
       <footer class="composer-stack">
         <div class="composer" data-composer-state="enabled">
-          <input type="text" placeholder="Message Hugin…" aria-label="Compose message" />
+          <input type="text" placeholder="Message Chat…" aria-label="Compose message" />
           <button type="button" data-testid="bottom-sheet-composer-send">Send</button>
         </div>
       </footer>

--- a/companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
+++ b/companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
@@ -9,7 +9,7 @@
 
 ## Purpose and scope
 
-The Canvas Suggestion Flow is the interaction pattern for the moment Hugin proposes a change to the active note:
+The Canvas Suggestion Flow is the interaction pattern for the moment Chat proposes a change to the active note:
 
 1. A proposal arrives from the server with a pre-declared classification (body-edit or governance-bearing).
 2. The user previews the proposal and decides to apply, queue, or discard it.
@@ -163,7 +163,7 @@ Forbidden: no transition may skip `apply_pending` or `governance_pending` to jum
 |---|---|---|
 | `canvas-shell` | Root container | Carries `data-suggestion-state` (DOM name) |
 | `document-pane` | Active note render area | |
-| `margin-rail` | Hugin conversation rail | |
+| `margin-rail` | Chat conversation rail | |
 | `conversation-thread` | Thread scroll container | |
 | `suggestion-card` | SuggestionCard | Carries `data-variant` |
 | `suggestion-card-classification` | Classification label (governance variant) | |

--- a/companion-ui/docs/SYSTEM_ENTRY_POINT_SPEC.md
+++ b/companion-ui/docs/SYSTEM_ENTRY_POINT_SPEC.md
@@ -54,7 +54,7 @@ Design language in the handoff package maps to architecture language per `compan
 | "cognitive mode" (runtime-declared) | **server-declared cognitive mode** | this spec §Resolved Q6; `COGNITIVE_MODES.md` |
 | "capture" | governed append to the vault inbox | this spec §Resolved Q17 |
 | "context lane" / "place band" | parked placeholders (Q15–Q16) | this spec §Parked |
-| "Hugin chat margin rail" | chat rail slot; implementation owned by the canvas-chat lane | `docs/CANVAS_CHAT_SURFACE/README.md` |
+| "Chat margin rail" | chat rail slot; implementation owned by the canvas-chat lane | `docs/CANVAS_CHAT_SURFACE/README.md` |
 
 ## Entry-point state model (NORMATIVE)
 

--- a/companion-ui/docs/TEMPORAL_OVERLAYS.md
+++ b/companion-ui/docs/TEMPORAL_OVERLAYS.md
@@ -158,7 +158,7 @@ Provenance allows the user to answer:
 - *How did I arrive at this claim?*
 - *What was I uncertain about here, and did I resolve it?*
 - *This looks odd — when did I change this, and why?*
-- *What would I lose if I accepted Hugin's suggestion here?*
+- *What would I lose if I accepted the agent's suggestion here?*
 
 ### Provenance in the Surface
 

--- a/tests/companion_ui/test_converse_layout_shell.py
+++ b/tests/companion_ui/test_converse_layout_shell.py
@@ -105,7 +105,7 @@ def test_suggestion_card_mirrors_proposal_identity_cues() -> None:
 
     assert 'data-testid="suggestion-card"' in html_text
     assert 'data-testid="suggestion-card-label"' in html_text
-    assert "HUGIN · PROPOSED ADDITION" in html_text
+    assert "AGENT · PROPOSED ADDITION" in html_text
     assert 'data-testid="suggestion-card-diff-hint"' in html_text
     assert 'data-suggestion-id="suggestion-001"' in html_text
     assert 'data-proposal-id="suggestion-001"' in html_text

--- a/tests/companion_ui/test_panel_section_state_model.py
+++ b/tests/companion_ui/test_panel_section_state_model.py
@@ -40,7 +40,7 @@ _PROPOSAL_FIXTURE = {
     "artifact_id": "art-001",
     "description": "Add a section on agentic systems",
     "status": "staged",
-    "agent": "hugin",
+    "agent": "agent",
     "created_at": "2026-05-26T14:18",
     "confidence": "0.82",
     "affordances": {"confirm": True, "reject": True, "correct": True},

--- a/tests/companion_ui/test_semantic_nomenclature.py
+++ b/tests/companion_ui/test_semantic_nomenclature.py
@@ -1,0 +1,69 @@
+"""Regression coverage for current Companion UI terminology."""
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+from tests.companion_ui._visible_text import visible_text
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ACTIVE_MARKUP = (
+    _REPO_ROOT / "companion-ui/companion-app/canvas_suggestion_flow.html",
+    _REPO_ROOT / "companion-ui/companion-app/converse_layout.html",
+)
+_ACTIVE_TEXT_SURFACES = (
+    _REPO_ROOT / "companion-ui/companion-app/companion_ui/canvas_suggestion_flow/portrait_sheet.py",
+    _REPO_ROOT / "companion-ui/docs/CANVAS_SUGGESTION_FLOW.md",
+    _REPO_ROOT / "companion-ui/docs/SYSTEM_ENTRY_POINT_SPEC.md",
+    _REPO_ROOT / "companion-ui/docs/TEMPORAL_OVERLAYS.md",
+)
+
+
+class _AccessibleLabels(HTMLParser):
+    """Collect user-facing markup attributes without inspecting CSS selectors."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.values: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name in {"aria-label", "placeholder", "title"} and value:
+                self.values.append(value)
+
+
+def test_active_companion_ui_has_no_hugin_agent_label() -> None:
+    """Current copy is normalized; dated design handoffs remain historical evidence."""
+    for path in _ACTIVE_MARKUP:
+        markup = path.read_text(encoding="utf-8")
+        labels = _AccessibleLabels()
+        labels.feed(markup)
+        assert "hugin" not in visible_text(markup), path
+        assert "hugin" not in " ".join(labels.values).casefold(), path
+
+    for path in _ACTIVE_TEXT_SURFACES:
+        assert "hugin" not in path.read_text(encoding="utf-8").casefold(), path
+
+    term_map = (_REPO_ROOT / "companion-ui/docs/CORE_TERM_MAPPING.md").read_text(encoding="utf-8")
+    assert "| **Hugin** | Historical design label;" in term_map
+    assert "Reserved and inactive." in term_map
+    assert "| **Munin** | Historical design label;" in term_map
+    assert "Dated handoff history may retain it with historical status." in term_map
+
+
+def test_canvas_copy_uses_chat_surface_terms() -> None:
+    canvas_markup = (_REPO_ROOT / "companion-ui/companion-app/canvas_suggestion_flow.html").read_text(encoding="utf-8")
+    converse_markup = (_REPO_ROOT / "companion-ui/companion-app/converse_layout.html").read_text(encoding="utf-8")
+
+    assert "chat conversation rail" in canvas_markup.casefold()
+    assert "message chat" in canvas_markup.casefold()
+    assert "agent · proposed addition" in visible_text(canvas_markup)
+    assert "chat rail" in converse_markup.casefold()
+    assert "message chat" in converse_markup.casefold()
+    assert "agent · proposed addition" in visible_text(converse_markup)
+
+    # Stable structural selectors remain the test and state-machine contract.
+    for markup in (canvas_markup, converse_markup):
+        assert 'data-testid="margin-rail"' in markup
+        assert 'data-testid="conversation-thread"' in markup

--- a/tests/companion_ui/test_semantic_nomenclature.py
+++ b/tests/companion_ui/test_semantic_nomenclature.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from html.parser import HTMLParser
 from pathlib import Path
 
+from companion_ui.workspace.serve_dev_page import render_index_html
 from tests.companion_ui._visible_text import visible_text
 
 
@@ -50,6 +51,30 @@ def test_active_companion_ui_has_no_hugin_agent_label() -> None:
     assert "Reserved and inactive." in term_map
     assert "| **Munin** | Historical design label;" in term_map
     assert "Dated handoff history may retain it with historical status." in term_map
+
+
+def test_production_workspace_proposal_fallback_uses_agent_label() -> None:
+    """The production renderer must not reintroduce a reserved agent name."""
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/test.md",
+        fields={
+            "panel_proposal_count": 1,
+            "panel_state": "proposals-staged",
+            "panel_proposals": [{
+                "proposal_id": "prop-test-001",
+                "artifact_id": "art-001",
+                "description": "Add a section on agentic systems",
+                "status": "staged",
+                "created_at": "2026-05-26T14:18",
+                "confidence": "0.82",
+                "affordances": {"confirm": True, "reject": True, "correct": True},
+            }],
+        },
+    )
+
+    assert "hugin" not in visible_text(html)
+    assert "agent&nbsp;&middot;&nbsp;2026-05-26t14:18" in html.casefold()
 
 
 def test_canvas_copy_uses_chat_surface_terms() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4675

## Linked Issue
Closes #4675

## SBS Impact
- Primary subsystem: HIX
- Secondary subsystem(s): none
- Write class: mechanical
- Persistence impact: none
- Derived/rebuildable impact: current UI/spec labels only
- New or changed contract: none
- Owner-doc impact: none
- Transition debt impact: reduces nomenclature representation debt
- Boundary risk: UI labels do not create a fourth interaction surface or imply UI authority

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Normalizes active Companion UI canvas, rail, and production proposal-provenance labels to Chat or agent terminology while preserving stable selectors and dated design-handoff provenance.
- Adds focused nomenclature coverage for static assets and the rendered no-agent/no-author workspace fallback.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps operational material was produced; this is a bounded current UI/spec terminology correction.

## Notes
Validation: focused nomenclature and panel-state tests (13 passed); PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui (1931 passed, 7 skipped); python3 scripts/docs_guard.py (OK); ruff check app tests companion-ui/companion-app (OK); review_before_ci_gate (OK); git diff --check (OK). P1 review repair replied on the original thread at commit 51a865eda97b101eb14b3c2de4cbe39e68ec656b.
