### PR TITLE
devUI: compose a versioned read-only owner snapshot

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -175,6 +175,11 @@ try:
 except ImportError:
     cockpit_router = None
 
+try:
+    from app.api.routes.devui import router as devui_router
+except ImportError:
+    devui_router = None
+
 static_dir = Path(__file__).resolve().parent.parent / "web" / "static"
 logger = logging.getLogger(__name__)
 
@@ -362,6 +367,8 @@ def _create_app() -> FastAPI:
         application.include_router(signboard_router, prefix="/api")
     if cockpit_router is not None:
         application.include_router(cockpit_router, prefix="/api")
+    if devui_router is not None:
+        application.include_router(devui_router, prefix="/api")
     return application
 
 

--- a/app/api/routes/cockpit.py
+++ b/app/api/routes/cockpit.py
@@ -63,8 +63,7 @@ def _matrix_path() -> Path:
     return _REPO_ROOT / "docs" / "architecture" / "traceability-matrix.md"
 
 
-@router.get("/registry")
-async def registry() -> dict[str, Any]:
+def read_registry() -> dict[str, Any]:
     """Recompute the registry from the authorities. Nothing is cached."""
     paths = load_paths()
     return build_registry(
@@ -77,4 +76,9 @@ async def registry() -> dict[str, Any]:
     )
 
 
-__all__ = ["router"]
+@router.get("/registry")
+async def registry() -> dict[str, Any]:
+    return read_registry()
+
+
+__all__ = ["read_registry", "router"]

--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -4,15 +4,47 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.routes.cockpit import read_registry as read_cockpit_registry
+from app.auth import (
+    SUBJECT_TRUSTED_LOOPBACK,
+    api_key_header,
+    resolve_auth_subject,
+)
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.config import load_paths as load_builderops_paths
 from app.builderops.devui_composition import compose_owner_snapshot
 
 
-router = APIRouter(prefix="/devui", tags=["devui"])
+_LOCAL_ONLY_DETAIL = "devUI composition is available only to a local caller"
+
+
+def _require_local_caller(
+    request: Request,
+    api_key: str | None = Depends(api_key_header),
+) -> None:
+    """Keep CKM's single-operator-local audience narrower than API auth."""
+
+    try:
+        subject = resolve_auth_subject(request, api_key)
+    except HTTPException:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_LOCAL_ONLY_DETAIL,
+        ) from None
+    if subject != SUBJECT_TRUSTED_LOOPBACK:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_LOCAL_ONLY_DETAIL,
+        )
+
+
+router = APIRouter(
+    prefix="/devui",
+    tags=["devui"],
+    dependencies=[Depends(_require_local_caller)],
+)
 
 
 def _read_ckm_capabilities() -> Any:

--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -1,0 +1,33 @@
+"""Read-only devUI composition API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from app.api.routes.cockpit import read_registry as read_cockpit_registry
+from app.builderops.ckm.query_service import CkmQueryService
+from app.builderops.config import load_paths as load_builderops_paths
+from app.builderops.devui_composition import compose_owner_snapshot
+
+
+router = APIRouter(prefix="/devui", tags=["devui"])
+
+
+def _read_ckm_capabilities() -> Any:
+    paths = load_builderops_paths()
+    return CkmQueryService(paths.db_path).list_capabilities()
+
+
+@router.get("/composition")
+async def composition() -> dict[str, Any]:
+    """Rebuild the unified read envelope without caching or mutation."""
+
+    return compose_owner_snapshot(
+        cockpit_reader=read_cockpit_registry,
+        ckm_reader=_read_ckm_capabilities,
+    )
+
+
+__all__ = ["router"]

--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -2,38 +2,54 @@
 
 from __future__ import annotations
 
+from ipaddress import ip_address
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.routes.cockpit import read_registry as read_cockpit_registry
-from app.auth import (
-    SUBJECT_TRUSTED_LOOPBACK,
-    api_key_header,
-    resolve_auth_subject,
-)
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.config import load_paths as load_builderops_paths
 from app.builderops.devui_composition import compose_owner_snapshot
 
 
 _LOCAL_ONLY_DETAIL = "devUI composition is available only to a local caller"
+_FORWARDED_IDENTITY_HEADERS = frozenset(
+    {
+        "cf-connecting-ip",
+        "forwarded",
+        "true-client-ip",
+        "x-client-ip",
+        "x-real-ip",
+    }
+)
+
+
+def _has_forwarded_identity(request: Request) -> bool:
+    return any(
+        name.startswith("x-forwarded-") or name in _FORWARDED_IDENTITY_HEADERS
+        for name in request.headers
+    )
+
+
+def _is_immediate_loopback(request: Request) -> bool:
+    host = request.client.host if request.client is not None else None
+    if host in {"localhost", "testclient"}:
+        return True
+    if not host:
+        return False
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _require_local_caller(
     request: Request,
-    api_key: str | None = Depends(api_key_header),
 ) -> None:
-    """Keep CKM's single-operator-local audience narrower than API auth."""
+    """Admit only a direct loopback peer with no forwarded identity."""
 
-    try:
-        subject = resolve_auth_subject(request, api_key)
-    except HTTPException:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=_LOCAL_ONLY_DETAIL,
-        ) from None
-    if subject != SUBJECT_TRUSTED_LOOPBACK:
+    if not _is_immediate_loopback(request) or _has_forwarded_identity(request):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_LOCAL_ONLY_DETAIL,

--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -20,6 +20,8 @@ _FORWARDED_IDENTITY_HEADERS = frozenset(
         "forwarded",
         "true-client-ip",
         "x-client-ip",
+        "x-envoy-external-address",
+        "x-original-forwarded-for",
         "x-real-ip",
     }
 )
@@ -44,12 +46,33 @@ def _is_immediate_loopback(request: Request) -> bool:
         return False
 
 
+def _has_local_host_header(request: Request) -> bool:
+    value = request.headers.get("host", "").strip().lower()
+    if value == "testserver" and request.client is not None:
+        return request.client.host == "testclient"
+    if value.startswith("["):
+        closing = value.find("]")
+        hostname = value[1:closing] if closing > 0 else ""
+    else:
+        hostname = value.rsplit(":", 1)[0] if value.count(":") == 1 else value
+    if hostname == "localhost":
+        return True
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
 def _require_local_caller(
     request: Request,
 ) -> None:
     """Admit only a direct loopback peer with no forwarded identity."""
 
-    if not _is_immediate_loopback(request) or _has_forwarded_identity(request):
+    if (
+        not _is_immediate_loopback(request)
+        or not _has_local_host_header(request)
+        or _has_forwarded_identity(request)
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_LOCAL_ONLY_DETAIL,

--- a/app/builderops/cockpit_docs_plane.py
+++ b/app/builderops/cockpit_docs_plane.py
@@ -44,6 +44,7 @@ grep-guards this file for exactly that reason).
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -51,6 +52,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "CapabilityNode",
@@ -397,7 +400,7 @@ def read_docs_plane(
         capabilities = _read_capabilities(capabilities_yaml_path, mtimes)
         matrix_edges = _read_matrix(matrix_path, mtimes)
         task_docs, spec_dirs = _read_spec_dirs(docs_root, mtimes)
-    except Exception as exc:  # noqa: BLE001 - any reader failure degrades to refusal
+    except Exception:  # noqa: BLE001 - any reader failure degrades to refusal
         # Broad on purpose, matching cockpit_github_plane.fetch_github_live:
         # the caller must never see an exception from this function. A
         # DocsPlaneReadError covers the read helpers' own OSError wrapping,
@@ -405,11 +408,12 @@ def read_docs_plane(
         # Path.iterdir()) or a malformed capabilities.yaml (e.g. parsing to
         # a non-list, raising TypeError) must degrade the same way — a
         # single source's failure must never crash the whole registry.
+        logger.exception("Cockpit docs-plane read failed")
         return DocsPlaneResult(
             snapshot=None,
             state="unavailable",
             last_successful_read=None,
-            detail=f"read failed: {exc}",
+            detail="read failed",
         )
     if not mtimes:
         watermark = datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/app/builderops/cockpit_github_plane.py
+++ b/app/builderops/cockpit_github_plane.py
@@ -26,12 +26,15 @@ own the dispatcher's pull-sync mirror and are out of scope here (#4440/#4441).
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "GithubIssue",
@@ -379,12 +382,13 @@ def fetch_github_live(
         )
     try:
         snapshot = reader(repo)
-    except Exception as exc:  # noqa: BLE001 - any reader failure degrades to refusal
+    except Exception:  # noqa: BLE001 - any reader failure degrades to refusal
+        logger.exception("Cockpit GitHub live-plane read failed for repo=%s", repo)
         return GithubLiveResult(
             snapshot=None,
             state="unavailable",
             last_successful_read=None,
-            detail=f"read failed: {exc}",
+            detail="read failed",
         )
     detail = (
         f"{len(snapshot.issues)} open issues, {len(snapshot.pulls)} open PRs,"

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -207,13 +207,14 @@ def _read_tasks(db_path: Path, sources: _Sources) -> list[dict[str, Any]] | None
                 " FROM dispatcher_tasks WHERE status != '_meta'"
                 " ORDER BY updated_at DESC, created_at DESC"
             ).fetchall()
-    except sqlite3.Error as exc:
+    except sqlite3.Error:
+        logger.exception("Cockpit dispatcher-store read failed")
         sources.add(
             _SourceRead(
                 name="dispatcher-store",
                 state="unavailable",
                 last_successful_read=None,
-                detail=f"read failed: {exc}",
+                detail="read failed",
             )
         )
         return None
@@ -264,13 +265,14 @@ def _read_verification_runs(
                 " updated_at"
                 " FROM verification_runs ORDER BY updated_at ASC"
             ).fetchall()
-    except sqlite3.Error as exc:
+    except sqlite3.Error:
+        logger.exception("Cockpit verification-runs read failed")
         sources.add(
             _SourceRead(
                 name="verification-runs",
                 state="unavailable",
                 last_successful_read=None,
-                detail=f"read failed: {exc}",
+                detail="read failed",
             )
         )
         return {}
@@ -299,8 +301,12 @@ def _read_deploy_receipts(
             continue
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            errors.append(f"{path.name}: {exc}")
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            logger.exception(
+                "Cockpit deploy receipt read failed for channel=%s",
+                channel,
+            )
+            errors.append(channel)
             continue
         receipts.append(
             {
@@ -315,7 +321,7 @@ def _read_deploy_receipts(
                 name="deploy-receipts",
                 state="unavailable",
                 last_successful_read=None,
-                detail="; ".join(errors),
+                detail=f"{len(errors)} unreadable channel receipt(s)",
             )
         )
     elif receipts:

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -26,6 +26,7 @@ Honesty rules this module enforces (owner doc: docs/BUILDEROPS_COCKPIT/README.md
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -61,6 +62,8 @@ from app.builderops.cockpit_github_plane import (
     default_github_reader,
     fetch_github_live,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "BANDS",
@@ -984,17 +987,21 @@ def build_registry(
                     evaluated_predicates,
                     now,
                 )
-            except Exception as exc:  # noqa: BLE001 - one thread's derivation
+            except Exception:  # noqa: BLE001 - one thread's derivation
                 # failure must never crash the whole render (the #4451-class
                 # bug this exact pattern exists to prevent, applied per task
                 # rather than per source): the thread renders as explicitly
                 # unclassified instead of taking bands/tasks/everything down.
+                logger.exception(
+                    "Cockpit chain-position derivation failed for task_id=%s",
+                    task.get("task_id"),
+                )
                 unclassified.append(
                     {
                         "id": task.get("task_id"),
                         "title": task.get("title"),
                         "status": status,
-                        "reason": f"chain-position derivation failed: {exc}",
+                        "reason": "chain-position derivation failed",
                     }
                 )
                 continue

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -13,11 +13,21 @@ from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
+from app.builderops.ckm.contracts import (
+    ACCESS_POLICY_VERSION,
+    EFFECTIVE_AUDIENCE,
+    ENVELOPE_SCHEMA_VERSION,
+    REDACTION_PROFILE,
+    RESOURCE_SCHEMA_VERSION,
+)
+from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
+
 
 CONTRACT_VERSION = "devui.composition.v1"
 logger = logging.getLogger(__name__)
 _CKM_REFUSAL_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
 _CKM_REFUSAL_MESSAGE = "CKM refused the read request"
+_CKM_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 
 
 class _Envelope(Protocol):
@@ -107,6 +117,72 @@ def _cockpit_contribution(reader: ProviderReader) -> dict[str, Any]:
         )
 
 
+def _is_nonnegative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _valid_ckm_snapshot(
+    snapshot: Mapping[str, Any],
+    resources: list[Any],
+) -> bool:
+    completeness = snapshot.get("completeness")
+    object_classes = (
+        completeness.get("object_classes")
+        if isinstance(completeness, Mapping)
+        else None
+    )
+    capability_accounting = None
+    if isinstance(object_classes, list):
+        capability_accounting = next(
+            (
+                item
+                for item in object_classes
+                if isinstance(item, Mapping)
+                and item.get("object_class") == "capability"
+            ),
+            None,
+        )
+    digests = (
+        snapshot.get("taxonomy_digest"),
+        snapshot.get("read_set_digest"),
+        snapshot.get("snapshot_digest"),
+    )
+    watermarks = snapshot.get("watermarks")
+    provenance = snapshot.get("provenance")
+    return bool(
+        isinstance(snapshot.get("epoch"), str)
+        and snapshot["epoch"]
+        and _is_nonnegative_int(snapshot.get("state_revision"))
+        and snapshot.get("ckm_schema_version") == CKM_SCHEMA_VERSION
+        and snapshot.get("envelope_schema_version") == ENVELOPE_SCHEMA_VERSION
+        and snapshot.get("resource_schema_version") == RESOURCE_SCHEMA_VERSION
+        and all(
+            isinstance(digest, str) and _CKM_DIGEST.fullmatch(digest)
+            for digest in digests
+        )
+        and snapshot.get("effective_audience") == EFFECTIVE_AUDIENCE
+        and snapshot.get("access_policy_version") == ACCESS_POLICY_VERSION
+        and snapshot.get("redaction_profile") == REDACTION_PROFILE
+        and isinstance(watermarks, Mapping)
+        and all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in watermarks.items()
+        )
+        and isinstance(provenance, list)
+        and all(isinstance(item, Mapping) for item in provenance)
+        and isinstance(completeness, Mapping)
+        and completeness.get("complete") is True
+        and isinstance(capability_accounting, Mapping)
+        and capability_accounting.get("included") == len(resources)
+        and all(
+            _is_nonnegative_int(capability_accounting.get(field))
+            for field in ("included", "filtered", "omitted", "truncated")
+        )
+        and capability_accounting.get("omitted") == 0
+        and capability_accounting.get("truncated") == 0
+    )
+
+
 def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
     provider = "ckm"
     authority = {"status": "derived_projection", "authoritative": False}
@@ -141,12 +217,17 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
         snapshot = payload.get("snapshot")
         resources = payload.get("resources")
         if (
-            not isinstance(projection, Mapping)
+            payload.get("schema_version") != ENVELOPE_SCHEMA_VERSION
+            or payload.get("resource_type") != "capability"
+            or not isinstance(payload.get("query_digest"), str)
+            or not payload["query_digest"]
+            or not isinstance(projection, Mapping)
             or projection.get("status") != "derived_projection"
             or projection.get("authoritative") is not False
             or not isinstance(snapshot, Mapping)
-            or not isinstance(snapshot.get("completeness"), Mapping)
             or not isinstance(resources, list)
+            or not all(isinstance(resource, Mapping) for resource in resources)
+            or not _valid_ckm_snapshot(snapshot, resources)
         ):
             raise ValueError("malformed CKM result envelope")
         return {

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -109,8 +109,10 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
         or not isinstance(withdrawn_counts, list)
     ):
         return False
-    if "as_of" in claim and not _aware_iso_timestamp(claim.get("as_of")):
+    generated_at = payload["generated_at"]
+    if claim.get("as_of") != generated_at:
         return False
+    source_states: dict[str, str] = {}
     for source in sources:
         if (
             not isinstance(source, Mapping)
@@ -122,17 +124,36 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
             or source["stale_after_days"] < 0
         ):
             return False
-        read_at = source.get("last_successful_read")
-        if read_at is not None and not _aware_iso_timestamp(read_at):
+        name = source["name"]
+        if name in source_states:
             return False
+        source_states[name] = source["state"]
+        read_at = source.get("last_successful_read")
+        if source["state"] == "unavailable":
+            if read_at is not None:
+                return False
+        elif not _aware_iso_timestamp(read_at):
+            return False
+        if source["configured"] is False and source["state"] != "unavailable":
+            return False
+    withdrawn_sources: set[str] = set()
     for withdrawal in withdrawn_counts:
+        withdrawal_source = (
+            withdrawal.get("source") if isinstance(withdrawal, Mapping) else None
+        )
         if (
             not isinstance(withdrawal, Mapping)
-            or not _nonempty_string(withdrawal.get("source"))
+            or not isinstance(withdrawal_source, str)
+            or not withdrawal_source
+            or withdrawal_source in withdrawn_sources
+            or source_states.get(withdrawal_source) != "stale"
             or not isinstance(withdrawal.get("counts"), list)
+            or not withdrawal["counts"]
+            or len(withdrawal["counts"]) != len(set(withdrawal["counts"]))
             or any(not _nonempty_string(item) for item in withdrawal["counts"])
         ):
             return False
+        withdrawn_sources.add(withdrawal_source)
     return True
 
 

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -1,0 +1,186 @@
+"""Read-only composition of Builder System evidence for devUI.
+
+The composition is rebuilt for every read. It preserves provider envelopes and
+their independent authority/snapshot semantics; it owns no durable state and
+does not turn provider refusals into empty results.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+
+CONTRACT_VERSION = "devui.composition.v1"
+
+
+class _Envelope(Protocol):
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+ProviderReader = Callable[[], Mapping[str, Any] | _Envelope]
+Now = Callable[[], datetime]
+
+
+def _payload(reader: ProviderReader) -> Mapping[str, Any]:
+    result = reader()
+    if hasattr(result, "to_dict"):
+        result = result.to_dict()
+    if not isinstance(result, Mapping):
+        raise TypeError("provider returned a non-object payload")
+    return result
+
+
+def _refusal(
+    *,
+    provider: str,
+    authority: str | Mapping[str, Any],
+    message: str,
+    code: str,
+    details: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "status": "refused",
+        "authority": authority,
+        "captured_at": None,
+        "snapshot": None,
+        "completeness": None,
+        "refusal": {
+            "code": code,
+            "message": message,
+            "details": dict(details),
+        },
+    }
+
+
+def _cockpit_contribution(reader: ProviderReader) -> dict[str, Any]:
+    provider = "builderops_cockpit"
+    authority = "read_time_join"
+    try:
+        payload = _payload(reader)
+        generated_at = payload.get("generated_at")
+        claim = payload.get("claim")
+        sources = payload.get("sources")
+        unread_planes = payload.get("unread_planes")
+        withdrawn_counts = payload.get("withdrawn_counts")
+        if (
+            payload.get("authority") != authority
+            or not isinstance(generated_at, str)
+            or not generated_at
+            or not isinstance(claim, Mapping)
+            or not isinstance(sources, list)
+            or not isinstance(unread_planes, list)
+            or not isinstance(withdrawn_counts, list)
+        ):
+            raise ValueError("malformed BuilderOps Cockpit registry envelope")
+        return {
+            "provider": provider,
+            "status": "available",
+            "authority": payload["authority"],
+            "captured_at": generated_at,
+            "snapshot": {
+                "generated_at": generated_at,
+                "sources": sources,
+            },
+            "completeness": {
+                "claim": claim,
+                "unread_planes": unread_planes,
+                "withdrawn_counts": withdrawn_counts,
+            },
+            "payload": payload,
+        }
+    except Exception as exc:
+        return _refusal(
+            provider=provider,
+            authority=authority,
+            code="provider_unavailable",
+            message="BuilderOps Cockpit could not provide its read snapshot",
+            details={"reason": str(exc)},
+        )
+
+
+def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
+    provider = "ckm"
+    authority = {"status": "derived_projection", "authoritative": False}
+    try:
+        payload = _payload(reader)
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            code = error.get("code")
+            message = error.get("message")
+            details = error.get("details")
+            if (
+                isinstance(code, str)
+                and code
+                and isinstance(message, str)
+                and message
+                and isinstance(details, Mapping)
+            ):
+                return _refusal(
+                    provider=provider,
+                    authority=authority,
+                    code=code,
+                    message=message,
+                    details=details,
+                )
+            raise ValueError("malformed CKM refusal envelope")
+
+        projection = payload.get("projection")
+        snapshot = payload.get("snapshot")
+        resources = payload.get("resources")
+        if (
+            not isinstance(projection, Mapping)
+            or projection.get("status") != "derived_projection"
+            or projection.get("authoritative") is not False
+            or not isinstance(snapshot, Mapping)
+            or not isinstance(snapshot.get("completeness"), Mapping)
+            or not isinstance(resources, list)
+        ):
+            raise ValueError("malformed CKM result envelope")
+        return {
+            "provider": provider,
+            "status": "available",
+            "authority": projection,
+            # CKM identifies the source snapshot by epoch, revision, digest,
+            # and watermarks. Inventing a global timestamp here would weaken
+            # that contract, so captured_at remains explicitly absent.
+            "captured_at": None,
+            "snapshot": snapshot,
+            "completeness": snapshot["completeness"],
+            "payload": payload,
+        }
+    except Exception as exc:
+        return _refusal(
+            provider=provider,
+            authority=authority,
+            code="provider_unavailable",
+            message="CKM could not provide its read snapshot",
+            details={"reason": str(exc)},
+        )
+
+
+def compose_owner_snapshot(
+    *,
+    cockpit_reader: ProviderReader,
+    ckm_reader: ProviderReader,
+    now: Now | None = None,
+) -> dict[str, Any]:
+    """Capture independent provider reads beneath one projection envelope."""
+
+    captured_at = (now or (lambda: datetime.now(timezone.utc)))()
+    if captured_at.tzinfo is None:
+        raise ValueError("composition capture time must be timezone-aware")
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "authority": "projection_only",
+        "captured_at": captured_at.isoformat(),
+        "providers": {
+            "work": _cockpit_contribution(cockpit_reader),
+            "capabilities": _ckm_contribution(ckm_reader),
+        },
+    }
+
+
+__all__ = ["CONTRACT_VERSION", "compose_owner_snapshot"]

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -11,37 +11,24 @@ import logging
 import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import Any
 
-from app.builderops.ckm.contracts import (
-    ACCESS_POLICY_VERSION,
-    EFFECTIVE_AUDIENCE,
-    ENVELOPE_SCHEMA_VERSION,
-    REDACTION_PROFILE,
-    RESOURCE_SCHEMA_VERSION,
-)
-from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
+from app.builderops.ckm.contracts import ErrorEnvelope, ResultEnvelope
 
 
 CONTRACT_VERSION = "devui.composition.v1"
 logger = logging.getLogger(__name__)
 _CKM_REFUSAL_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
 _CKM_REFUSAL_MESSAGE = "CKM refused the read request"
-_CKM_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 
 
-class _Envelope(Protocol):
-    def to_dict(self) -> dict[str, Any]: ...
-
-
-ProviderReader = Callable[[], Mapping[str, Any] | _Envelope]
+CockpitReader = Callable[[], Mapping[str, Any]]
+CkmReader = Callable[[], ResultEnvelope | ErrorEnvelope]
 Now = Callable[[], datetime]
 
 
-def _payload(reader: ProviderReader) -> Mapping[str, Any]:
+def _cockpit_payload(reader: CockpitReader) -> Mapping[str, Any]:
     result = reader()
-    if hasattr(result, "to_dict"):
-        result = result.to_dict()
     if not isinstance(result, Mapping):
         raise TypeError("provider returned a non-object payload")
     return result
@@ -70,11 +57,11 @@ def _refusal(
     }
 
 
-def _cockpit_contribution(reader: ProviderReader) -> dict[str, Any]:
+def _cockpit_contribution(reader: CockpitReader) -> dict[str, Any]:
     provider = "builderops_cockpit"
     authority = "read_time_join"
     try:
-        payload = _payload(reader)
+        payload = _cockpit_payload(reader)
         generated_at = payload.get("generated_at")
         claim = payload.get("claim")
         sources = payload.get("sources")
@@ -117,82 +104,15 @@ def _cockpit_contribution(reader: ProviderReader) -> dict[str, Any]:
         )
 
 
-def _is_nonnegative_int(value: Any) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
-
-
-def _valid_ckm_snapshot(
-    snapshot: Mapping[str, Any],
-    resources: list[Any],
-) -> bool:
-    completeness = snapshot.get("completeness")
-    object_classes = (
-        completeness.get("object_classes")
-        if isinstance(completeness, Mapping)
-        else None
-    )
-    capability_accounting = None
-    if isinstance(object_classes, list):
-        capability_accounting = next(
-            (
-                item
-                for item in object_classes
-                if isinstance(item, Mapping)
-                and item.get("object_class") == "capability"
-            ),
-            None,
-        )
-    digests = (
-        snapshot.get("taxonomy_digest"),
-        snapshot.get("read_set_digest"),
-        snapshot.get("snapshot_digest"),
-    )
-    watermarks = snapshot.get("watermarks")
-    provenance = snapshot.get("provenance")
-    return bool(
-        isinstance(snapshot.get("epoch"), str)
-        and snapshot["epoch"]
-        and _is_nonnegative_int(snapshot.get("state_revision"))
-        and snapshot.get("ckm_schema_version") == CKM_SCHEMA_VERSION
-        and snapshot.get("envelope_schema_version") == ENVELOPE_SCHEMA_VERSION
-        and snapshot.get("resource_schema_version") == RESOURCE_SCHEMA_VERSION
-        and all(
-            isinstance(digest, str) and _CKM_DIGEST.fullmatch(digest)
-            for digest in digests
-        )
-        and snapshot.get("effective_audience") == EFFECTIVE_AUDIENCE
-        and snapshot.get("access_policy_version") == ACCESS_POLICY_VERSION
-        and snapshot.get("redaction_profile") == REDACTION_PROFILE
-        and isinstance(watermarks, Mapping)
-        and all(
-            isinstance(key, str) and isinstance(value, str)
-            for key, value in watermarks.items()
-        )
-        and isinstance(provenance, list)
-        and all(isinstance(item, Mapping) for item in provenance)
-        and isinstance(completeness, Mapping)
-        and completeness.get("complete") is True
-        and isinstance(capability_accounting, Mapping)
-        and capability_accounting.get("included") == len(resources)
-        and all(
-            _is_nonnegative_int(capability_accounting.get(field))
-            for field in ("included", "filtered", "omitted", "truncated")
-        )
-        and capability_accounting.get("omitted") == 0
-        and capability_accounting.get("truncated") == 0
-    )
-
-
-def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
+def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
     provider = "ckm"
     authority = {"status": "derived_projection", "authoritative": False}
     try:
-        payload = _payload(reader)
-        error = payload.get("error")
-        if isinstance(error, Mapping):
-            code = error.get("code")
-            message = error.get("message")
-            details = error.get("details")
+        result = reader()
+        if isinstance(result, ErrorEnvelope):
+            code = result.error.code
+            message = result.error.message
+            details = result.error.details
             if (
                 isinstance(code, str)
                 and _CKM_REFUSAL_CODE.fullmatch(code)
@@ -213,21 +133,15 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
                 )
             raise ValueError("malformed CKM refusal envelope")
 
-        projection = payload.get("projection")
-        snapshot = payload.get("snapshot")
-        resources = payload.get("resources")
+        if not isinstance(result, ResultEnvelope):
+            raise ValueError("CKM reader returned an unvalidated envelope")
+        payload = result.to_dict()
+        projection = payload["projection"]
+        snapshot = payload["snapshot"]
         if (
-            payload.get("schema_version") != ENVELOPE_SCHEMA_VERSION
-            or payload.get("resource_type") != "capability"
-            or not isinstance(payload.get("query_digest"), str)
-            or not payload["query_digest"]
-            or not isinstance(projection, Mapping)
+            result.resource_type != "capability"
             or projection.get("status") != "derived_projection"
             or projection.get("authoritative") is not False
-            or not isinstance(snapshot, Mapping)
-            or not isinstance(resources, list)
-            or not all(isinstance(resource, Mapping) for resource in resources)
-            or not _valid_ckm_snapshot(snapshot, resources)
         ):
             raise ValueError("malformed CKM result envelope")
         return {
@@ -255,8 +169,8 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
 
 def compose_owner_snapshot(
     *,
-    cockpit_reader: ProviderReader,
-    ckm_reader: ProviderReader,
+    cockpit_reader: CockpitReader,
+    ckm_reader: CkmReader,
     now: Now | None = None,
 ) -> dict[str, Any]:
     """Capture independent provider reads beneath one projection envelope."""

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -8,12 +8,21 @@ does not turn provider refusals into empty results.
 from __future__ import annotations
 
 import logging
+import json
 import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any
 
-from app.builderops.ckm.contracts import ErrorEnvelope, ResultEnvelope
+from app.builderops.ckm.contracts import (
+    ENVELOPE_SCHEMA_VERSION,
+    RESOURCE_SCHEMA_VERSION,
+    CkmStateIdentity,
+    ErrorEnvelope,
+    ResultEnvelope,
+    SnapshotManifest,
+    validate_contract_request,
+)
 
 
 CONTRACT_VERSION = "devui.composition.v1"
@@ -31,7 +40,63 @@ def _cockpit_payload(reader: CockpitReader) -> Mapping[str, Any]:
     result = reader()
     if not isinstance(result, Mapping):
         raise TypeError("provider returned a non-object payload")
-    return result
+    return _json_object(result)
+
+
+def _json_object(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a detached JSON-safe object or refuse before API serialization."""
+
+    encoded = json.dumps(payload, ensure_ascii=False, allow_nan=False)
+    decoded = json.loads(encoded)
+    if not isinstance(decoded, dict):
+        raise TypeError("provider returned a non-object JSON payload")
+    return decoded
+
+
+def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
+    """Re-run current CKM policy and snapshot invariants at the adapter boundary."""
+
+    snapshot = result.snapshot
+    validate_contract_request(
+        ckm_schema_version=snapshot.ckm_schema_version,
+        envelope_schema_version=result.schema_version,
+        resource_schema_version=snapshot.resource_schema_version,
+        resource_type=result.resource_type,
+        effective_audience=snapshot.effective_audience,
+        access_policy_version=snapshot.access_policy_version,
+        redaction_profile=snapshot.redaction_profile,
+    )
+    if snapshot.envelope_schema_version != ENVELOPE_SCHEMA_VERSION:
+        raise ValueError("unsupported CKM snapshot envelope schema version")
+    if any(resource.schema_version != RESOURCE_SCHEMA_VERSION for resource in result.resources):
+        raise ValueError("unsupported CKM resource schema version")
+
+    rebuilt_snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(
+            epoch=snapshot.epoch,
+            state_revision=snapshot.state_revision,
+            schema_version=snapshot.ckm_schema_version,
+        ),
+        taxonomy_digest=snapshot.taxonomy_digest,
+        watermarks=snapshot.watermarks,
+        provenance=snapshot.provenance,
+        completeness=snapshot.completeness,
+        read_set=snapshot.read_set,
+    )
+    if rebuilt_snapshot.to_dict() != snapshot.to_dict():
+        raise ValueError("CKM snapshot identity does not match its declared read set")
+
+    # Re-instantiation re-runs ResultEnvelope's resource ordering, completeness,
+    # and exact read-set checks even if a frozen dataclass was copied/replaced.
+    ResultEnvelope(
+        resource_type=result.resource_type,
+        query_digest=result.query_digest,
+        snapshot=result.snapshot,
+        resources=result.resources,
+        projection=result.projection,
+        schema_version=result.schema_version,
+    )
+    return _json_object(result.to_dict())
 
 
 def _refusal(
@@ -110,6 +175,8 @@ def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
     try:
         result = reader()
         if isinstance(result, ErrorEnvelope):
+            if result.schema_version != ENVELOPE_SCHEMA_VERSION:
+                raise ValueError("unsupported CKM refusal envelope version")
             code = result.error.code
             message = result.error.message
             details = result.error.details
@@ -135,7 +202,7 @@ def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
 
         if not isinstance(result, ResultEnvelope):
             raise ValueError("CKM reader returned an unvalidated envelope")
-        payload = result.to_dict()
+        payload = _validated_ckm_payload(result)
         projection = payload["projection"]
         snapshot = payload["snapshot"]
         if (

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -7,12 +7,14 @@ does not turn provider refusals into empty results.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
 
 CONTRACT_VERSION = "devui.composition.v1"
+logger = logging.getLogger(__name__)
 
 
 class _Envelope(Protocol):
@@ -91,13 +93,14 @@ def _cockpit_contribution(reader: ProviderReader) -> dict[str, Any]:
             },
             "payload": payload,
         }
-    except Exception as exc:
+    except Exception:
+        logger.exception("BuilderOps Cockpit devUI provider read failed")
         return _refusal(
             provider=provider,
             authority=authority,
             code="provider_unavailable",
             message="BuilderOps Cockpit could not provide its read snapshot",
-            details={"reason": str(exc)},
+            details={"reason": "provider read failed"},
         )
 
 
@@ -151,13 +154,14 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
             "completeness": snapshot["completeness"],
             "payload": payload,
         }
-    except Exception as exc:
+    except Exception:
+        logger.exception("CKM devUI provider read failed")
         return _refusal(
             provider=provider,
             authority=authority,
             code="provider_unavailable",
             message="CKM could not provide its read snapshot",
-            details={"reason": str(exc)},
+            details={"reason": "provider read failed"},
         )
 
 

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -8,6 +8,7 @@ does not turn provider refusals into empty results.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -15,6 +16,8 @@ from typing import Any, Protocol
 
 CONTRACT_VERSION = "devui.composition.v1"
 logger = logging.getLogger(__name__)
+_CKM_REFUSAL_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_CKM_REFUSAL_MESSAGE = "CKM refused the read request"
 
 
 class _Envelope(Protocol):
@@ -116,7 +119,7 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
             details = error.get("details")
             if (
                 isinstance(code, str)
-                and code
+                and _CKM_REFUSAL_CODE.fullmatch(code)
                 and isinstance(message, str)
                 and message
                 and isinstance(details, Mapping)
@@ -125,8 +128,12 @@ def _ckm_contribution(reader: ProviderReader) -> dict[str, Any]:
                     provider=provider,
                     authority=authority,
                     code=code,
-                    message=message,
-                    details=details,
+                    # CKM's local read contract may include filesystem paths
+                    # and raw SQLite/OSError text in message/details. The
+                    # unified owner projection preserves the typed code, but
+                    # never republishes that diagnostic material.
+                    message=_CKM_REFUSAL_MESSAGE,
+                    details={},
                 )
             raise ValueError("malformed CKM refusal envelope")
 

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -30,6 +30,7 @@ from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
 CONTRACT_VERSION = "devui.composition.v1"
 logger = logging.getLogger(__name__)
 _CKM_REFUSAL_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_CKM_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
 _CKM_REFUSAL_MESSAGE = "CKM refused the read request"
 _LIST_CAPABILITIES_QUERY_DIGEST = canonical_query_digest(
     {"operation": "list_capabilities", "public_id": None}
@@ -76,6 +77,25 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
         raise ValueError("unsupported CKM schema version")
     if result.query_digest != _LIST_CAPABILITIES_QUERY_DIGEST:
         raise ValueError("CKM query identity does not match list_capabilities")
+    if not isinstance(snapshot.epoch, str) or not snapshot.epoch:
+        raise ValueError("CKM snapshot epoch must be a non-empty string")
+    if type(snapshot.state_revision) is not int or snapshot.state_revision < 0:
+        raise ValueError("CKM state revision must be a non-negative integer")
+    if not isinstance(snapshot.taxonomy_digest, str) or not _CKM_DIGEST.fullmatch(
+        snapshot.taxonomy_digest
+    ):
+        raise ValueError("CKM taxonomy identity must be a canonical digest")
+    if type(snapshot.completeness.complete) is not bool:
+        raise ValueError("CKM completeness marker must be boolean")
+    for accounting in snapshot.completeness.object_classes:
+        counts = (
+            accounting.included,
+            accounting.filtered,
+            accounting.omitted,
+            accounting.truncated,
+        )
+        if any(type(count) is not int or count < 0 for count in counts):
+            raise ValueError("CKM completeness counts must be non-negative integers")
     validate_contract_request(
         ckm_schema_version=snapshot.ckm_schema_version,
         envelope_schema_version=result.schema_version,

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -139,6 +139,12 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
     dispatcher_state = source_states.get("dispatcher-store")
     if (
         dispatcher_state is None
+        or next(
+            source["configured"]
+            for source in sources
+            if source["name"] == "dispatcher-store"
+        )
+        is not True
         or (claim["kind"] == "refused" and dispatcher_state != "unavailable")
         or (claim["kind"] == "counted" and dispatcher_state not in {"fresh", "empty"})
     ):

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -21,14 +21,19 @@ from app.builderops.ckm.contracts import (
     ErrorEnvelope,
     ResultEnvelope,
     SnapshotManifest,
+    canonical_query_digest,
     validate_contract_request,
 )
+from app.builderops.ckm.schema import CKM_SCHEMA_VERSION
 
 
 CONTRACT_VERSION = "devui.composition.v1"
 logger = logging.getLogger(__name__)
 _CKM_REFUSAL_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
 _CKM_REFUSAL_MESSAGE = "CKM refused the read request"
+_LIST_CAPABILITIES_QUERY_DIGEST = canonical_query_digest(
+    {"operation": "list_capabilities", "public_id": None}
+)
 
 
 CockpitReader = Callable[[], Mapping[str, Any]]
@@ -57,6 +62,20 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
     """Re-run current CKM policy and snapshot invariants at the adapter boundary."""
 
     snapshot = result.snapshot
+    versions = (
+        (result.schema_version, ENVELOPE_SCHEMA_VERSION),
+        (snapshot.ckm_schema_version, CKM_SCHEMA_VERSION),
+        (snapshot.envelope_schema_version, ENVELOPE_SCHEMA_VERSION),
+        (snapshot.resource_schema_version, RESOURCE_SCHEMA_VERSION),
+        *(
+            (resource.schema_version, RESOURCE_SCHEMA_VERSION)
+            for resource in result.resources
+        ),
+    )
+    if any(type(value) is not int or value != expected for value, expected in versions):
+        raise ValueError("unsupported CKM schema version")
+    if result.query_digest != _LIST_CAPABILITIES_QUERY_DIGEST:
+        raise ValueError("CKM query identity does not match list_capabilities")
     validate_contract_request(
         ckm_schema_version=snapshot.ckm_schema_version,
         envelope_schema_version=result.schema_version,
@@ -66,11 +85,6 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
         access_policy_version=snapshot.access_policy_version,
         redaction_profile=snapshot.redaction_profile,
     )
-    if snapshot.envelope_schema_version != ENVELOPE_SCHEMA_VERSION:
-        raise ValueError("unsupported CKM snapshot envelope schema version")
-    if any(resource.schema_version != RESOURCE_SCHEMA_VERSION for resource in result.resources):
-        raise ValueError("unsupported CKM resource schema version")
-
     rebuilt_snapshot = SnapshotManifest.build(
         state=CkmStateIdentity(
             epoch=snapshot.epoch,
@@ -175,7 +189,10 @@ def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
     try:
         result = reader()
         if isinstance(result, ErrorEnvelope):
-            if result.schema_version != ENVELOPE_SCHEMA_VERSION:
+            if (
+                type(result.schema_version) is not int
+                or result.schema_version != ENVELOPE_SCHEMA_VERSION
+            ):
                 raise ValueError("unsupported CKM refusal envelope version")
             code = result.error.code
             message = result.error.message

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -18,9 +18,13 @@ from app.builderops.ckm.contracts import (
     ENVELOPE_SCHEMA_VERSION,
     RESOURCE_SCHEMA_VERSION,
     CkmStateIdentity,
+    CompletenessManifest,
     ErrorEnvelope,
+    ObjectClassCompleteness,
+    ResourceDto,
     ResultEnvelope,
     SnapshotManifest,
+    TaggedValue,
     canonical_query_digest,
     validate_contract_request,
 )
@@ -52,6 +56,7 @@ def _cockpit_payload(reader: CockpitReader) -> Mapping[str, Any]:
 def _json_object(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Return a detached JSON-safe object or refuse before API serialization."""
 
+    _require_string_mapping_keys(payload)
     encoded = json.dumps(payload, ensure_ascii=False, allow_nan=False)
     decoded = json.loads(encoded)
     if not isinstance(decoded, dict):
@@ -59,10 +64,31 @@ def _json_object(payload: Mapping[str, Any]) -> dict[str, Any]:
     return decoded
 
 
+def _require_string_mapping_keys(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("provider JSON objects require string keys")
+            _require_string_mapping_keys(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _require_string_mapping_keys(item)
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
 def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
     """Re-run current CKM policy and snapshot invariants at the adapter boundary."""
 
+    if type(result) is not ResultEnvelope:
+        raise TypeError("CKM result must use the exact public envelope type")
     snapshot = result.snapshot
+    if type(snapshot) is not SnapshotManifest:
+        raise TypeError("CKM snapshot must use the exact public manifest type")
+    if type(snapshot.completeness) is not CompletenessManifest:
+        raise TypeError("CKM completeness must use the exact public manifest type")
     versions = (
         (result.schema_version, ENVELOPE_SCHEMA_VERSION),
         (snapshot.ckm_schema_version, CKM_SCHEMA_VERSION),
@@ -77,7 +103,7 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
         raise ValueError("unsupported CKM schema version")
     if result.query_digest != _LIST_CAPABILITIES_QUERY_DIGEST:
         raise ValueError("CKM query identity does not match list_capabilities")
-    if not isinstance(snapshot.epoch, str) or not snapshot.epoch:
+    if not _nonempty_string(snapshot.epoch):
         raise ValueError("CKM snapshot epoch must be a non-empty string")
     if type(snapshot.state_revision) is not int or snapshot.state_revision < 0:
         raise ValueError("CKM state revision must be a non-negative integer")
@@ -88,6 +114,8 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
     if type(snapshot.completeness.complete) is not bool:
         raise ValueError("CKM completeness marker must be boolean")
     for accounting in snapshot.completeness.object_classes:
+        if type(accounting) is not ObjectClassCompleteness:
+            raise TypeError("CKM accounting must use the exact public contract type")
         counts = (
             accounting.included,
             accounting.filtered,
@@ -96,6 +124,44 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
         )
         if any(type(count) is not int or count < 0 for count in counts):
             raise ValueError("CKM completeness counts must be non-negative integers")
+    if not isinstance(snapshot.watermarks, Mapping) or any(
+        not _nonempty_string(key) or not _nonempty_string(value)
+        for key, value in snapshot.watermarks.items()
+    ):
+        raise ValueError("CKM watermarks must use non-empty string keys and values")
+    if not isinstance(snapshot.read_set, Mapping):
+        raise TypeError("CKM read set must be a mapping")
+    for object_class, public_ids in snapshot.read_set.items():
+        if not _nonempty_string(object_class) or isinstance(public_ids, (str, bytes)):
+            raise ValueError("CKM read set identity is malformed")
+        if not isinstance(public_ids, (list, tuple)) or any(
+            not _nonempty_string(public_id) for public_id in public_ids
+        ):
+            raise ValueError("CKM read set public IDs must be non-empty strings")
+    if not isinstance(snapshot.provenance, (list, tuple)) or any(
+        not isinstance(item, Mapping) for item in snapshot.provenance
+    ):
+        raise ValueError("CKM snapshot provenance must contain mappings")
+
+    for resource in result.resources:
+        if type(resource) is not ResourceDto:
+            raise TypeError("CKM resources must use the exact public DTO type")
+        if not all(
+            _nonempty_string(value)
+            for value in (resource.public_id, resource.display_name, resource.lifecycle)
+        ):
+            raise ValueError("CKM resource identity fields must be non-empty strings")
+        if type(resource.candidate) is not bool:
+            raise ValueError("CKM resource candidate marker must be boolean")
+        if not isinstance(resource.provenance, (list, tuple)) or any(
+            not isinstance(item, Mapping) for item in resource.provenance
+        ):
+            raise ValueError("CKM resource provenance must contain mappings")
+        if not isinstance(resource.values, Mapping) or any(
+            not _nonempty_string(key) or type(value) is not TaggedValue
+            for key, value in resource.values.items()
+        ):
+            raise ValueError("CKM resource values must be typed and string-keyed")
     validate_contract_request(
         ckm_schema_version=snapshot.ckm_schema_version,
         envelope_schema_version=result.schema_version,
@@ -210,7 +276,8 @@ def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
         result = reader()
         if isinstance(result, ErrorEnvelope):
             if (
-                type(result.schema_version) is not int
+                type(result) is not ErrorEnvelope
+                or type(result.schema_version) is not int
                 or result.schema_version != ENVELOPE_SCHEMA_VERSION
             ):
                 raise ValueError("unsupported CKM refusal envelope version")

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -41,6 +41,10 @@ _CKM_REFUSAL_MESSAGE = "CKM refused the read request"
 _LIST_CAPABILITIES_QUERY_DIGEST = canonical_query_digest(
     {"operation": "list_capabilities", "public_id": None}
 )
+_COCKPIT_WITHDRAWALS = {
+    "github-live": ("github.open_issues", "github.open_prs", "github.branches"),
+    "docs-frontmatter": ("capability_lanes.lanes",),
+}
 
 
 CockpitReader = Callable[[], Mapping[str, Any]]
@@ -150,6 +154,7 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
     ):
         return False
     withdrawn_sources: set[str] = set()
+    actual_withdrawals: dict[str, tuple[str, ...]] = {}
     for withdrawal in withdrawn_counts:
         withdrawal_source = (
             withdrawal.get("source") if isinstance(withdrawal, Mapping) else None
@@ -167,6 +172,14 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
         ):
             return False
         withdrawn_sources.add(withdrawal_source)
+        actual_withdrawals[withdrawal_source] = tuple(withdrawal["counts"])
+    expected_withdrawals = {
+        source: counts
+        for source, counts in _COCKPIT_WITHDRAWALS.items()
+        if source_states.get(source) == "stale"
+    }
+    if actual_withdrawals != expected_withdrawals:
+        return False
     return True
 
 

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -17,10 +17,12 @@ from typing import Any
 from app.builderops.ckm.contracts import (
     ENVELOPE_SCHEMA_VERSION,
     RESOURCE_SCHEMA_VERSION,
+    CkmContractError,
     CkmStateIdentity,
     CompletenessManifest,
     ErrorEnvelope,
     ObjectClassCompleteness,
+    ProjectionMarker,
     ResourceDto,
     ResultEnvelope,
     SnapshotManifest,
@@ -89,6 +91,8 @@ def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
         raise TypeError("CKM snapshot must use the exact public manifest type")
     if type(snapshot.completeness) is not CompletenessManifest:
         raise TypeError("CKM completeness must use the exact public manifest type")
+    if type(result.projection) is not ProjectionMarker:
+        raise TypeError("CKM projection must use the exact public marker type")
     versions = (
         (result.schema_version, ENVELOPE_SCHEMA_VERSION),
         (snapshot.ckm_schema_version, CKM_SCHEMA_VERSION),
@@ -277,6 +281,7 @@ def _ckm_contribution(reader: CkmReader) -> dict[str, Any]:
         if isinstance(result, ErrorEnvelope):
             if (
                 type(result) is not ErrorEnvelope
+                or type(result.error) is not CkmContractError
                 or type(result.schema_version) is not int
                 or result.schema_version != ENVELOPE_SCHEMA_VERSION
             ):

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -82,6 +82,60 @@ def _nonempty_string(value: Any) -> bool:
     return isinstance(value, str) and bool(value)
 
 
+def _aware_iso_timestamp(value: Any) -> bool:
+    if not _nonempty_string(value):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
+    claim = payload.get("claim")
+    sources = payload.get("sources")
+    unread_planes = payload.get("unread_planes")
+    withdrawn_counts = payload.get("withdrawn_counts")
+    if (
+        payload.get("authority") != "read_time_join"
+        or not _aware_iso_timestamp(payload.get("generated_at"))
+        or not isinstance(claim, Mapping)
+        or claim.get("kind") not in {"counted", "refused"}
+        or not _nonempty_string(claim.get("text"))
+        or not isinstance(sources, list)
+        or not isinstance(unread_planes, list)
+        or any(not _nonempty_string(item) for item in unread_planes)
+        or not isinstance(withdrawn_counts, list)
+    ):
+        return False
+    if "as_of" in claim and not _aware_iso_timestamp(claim.get("as_of")):
+        return False
+    for source in sources:
+        if (
+            not isinstance(source, Mapping)
+            or not _nonempty_string(source.get("name"))
+            or source.get("state") not in {"fresh", "stale", "empty", "unavailable"}
+            or not _nonempty_string(source.get("detail"))
+            or type(source.get("configured")) is not bool
+            or type(source.get("stale_after_days")) is not int
+            or source["stale_after_days"] < 0
+        ):
+            return False
+        read_at = source.get("last_successful_read")
+        if read_at is not None and not _aware_iso_timestamp(read_at):
+            return False
+    for withdrawal in withdrawn_counts:
+        if (
+            not isinstance(withdrawal, Mapping)
+            or not _nonempty_string(withdrawal.get("source"))
+            or not isinstance(withdrawal.get("counts"), list)
+            or any(not _nonempty_string(item) for item in withdrawal["counts"])
+        ):
+            return False
+    return True
+
+
 def _validated_ckm_payload(result: ResultEnvelope) -> dict[str, Any]:
     """Re-run current CKM policy and snapshot invariants at the adapter boundary."""
 
@@ -237,15 +291,7 @@ def _cockpit_contribution(reader: CockpitReader) -> dict[str, Any]:
         sources = payload.get("sources")
         unread_planes = payload.get("unread_planes")
         withdrawn_counts = payload.get("withdrawn_counts")
-        if (
-            payload.get("authority") != authority
-            or not isinstance(generated_at, str)
-            or not generated_at
-            or not isinstance(claim, Mapping)
-            or not isinstance(sources, list)
-            or not isinstance(unread_planes, list)
-            or not isinstance(withdrawn_counts, list)
-        ):
+        if not _valid_cockpit_contract(payload):
             raise ValueError("malformed BuilderOps Cockpit registry envelope")
         return {
             "provider": provider,

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -136,6 +136,13 @@ def _valid_cockpit_contract(payload: Mapping[str, Any]) -> bool:
             return False
         if source["configured"] is False and source["state"] != "unavailable":
             return False
+    dispatcher_state = source_states.get("dispatcher-store")
+    if (
+        dispatcher_state is None
+        or (claim["kind"] == "refused" and dispatcher_state != "unavailable")
+        or (claim["kind"] == "counted" and dispatcher_state not in {"fresh", "empty"})
+    ):
+        return False
     withdrawn_sources: set[str] = set()
     for withdrawal in withdrawn_counts:
         withdrawal_source = (

--- a/app/builderops/devui_composition.py
+++ b/app/builderops/devui_composition.py
@@ -60,6 +60,7 @@ def _json_object(payload: Mapping[str, Any]) -> dict[str, Any]:
 
     _require_string_mapping_keys(payload)
     encoded = json.dumps(payload, ensure_ascii=False, allow_nan=False)
+    encoded.encode("utf-8", errors="strict")
     decoded = json.loads(encoded)
     if not isinstance(decoded, dict):
         raise TypeError("provider returned a non-object JSON payload")

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -337,13 +337,15 @@ Delivered now:
 - CKM core, query/snapshot contracts, and generated Development Overview;
 - static, inert CKM Cockpit Direction B;
 - BuilderOps Cockpit `/cockpit` as a fresh, read-only work register;
+- `devui.composition.v1` at GET `/api/devui/composition`, a per-request projection that preserves
+  independent Cockpit and CKM authority, snapshots, completeness, and typed refusals without
+  persistence or mutation;
 - DDO-01 through DDO-04 fast lane, contracts, plan compiler, reducer, and WorkerRuntime seam; and
 - parts of the BuilderOps API/PostgreSQL control-plane development baseline.
 
-Not delivered now: a composed versioned read contract; one devUI shell; request/preview/authenticated
-approval in one owner experience; PostgreSQL authority cutover; full live run controls; receipt-to-
-CKM reassessment in the unified surface; owner pilot and tried-by-owner acceptance; and ADR-0065
-dispositions.
+Not delivered now: one devUI shell; request/preview/authenticated approval in one owner experience;
+PostgreSQL authority cutover; full live run controls; receipt-to-CKM reassessment in the unified
+surface; owner pilot and tried-by-owner acceptance; and ADR-0065 dispositions.
 
 The target turns the current cockpits and Signboard from competing owner destinations into internal
 providers: Direction B stays an exportable/static evidence fallback, BuilderOps Cockpit supplies

--- a/docs/plans/DEVUI_IMPLEMENTATION.md
+++ b/docs/plans/DEVUI_IMPLEMENTATION.md
@@ -1,4 +1,4 @@
-State: Target-state implementation plan (2026-08-08). No devUI implementation is authorized or claimed by this document. Existing GitHub Issues remain executable backlog truth; no Issues were created or changed by this plan.
+State: Target-state implementation plan (2026-08-08). The read-only `devui.composition.v1` seam is delivered; the visual shell and authority-bearing stages remain targets. Existing GitHub Issues remain executable backlog truth.
 Doc role: Builder System implementation and sequencing plan
 Authority: Owns the proposed dependency order for realizing `docs/DEVUI.md`. Subordinate to accepted ADRs, DDO and BuilderOps control-plane specifications, live Issue contracts, and current-state owner docs.
 Owner: Builder System governance
@@ -61,6 +61,7 @@ or concepts the owner must understand to complete the flow.
 | Capability/evidence snapshot | `CkmQueryService`, `CkmProjectionBatch`, Direction B owner-readable models | Delivered for local single-operator access; remote policy absent |
 | Work/freshness | `build_registry`, Cockpit chain predicates, source-state model | Delivered read-only |
 | Queue/claim/lease activity | Dispatcher store and Signboard API contracts | Delivered operational source; standalone Signboard is not devUI navigation |
+| Unified read composition | `devui.composition.v1`, GET `/api/devui/composition` | Delivered per-request projection; no cache, mutation, or visual shell |
 | Proposal/preview | `DeliveryRequest.v1`, `DeliveryPreview.v1`, pure plan compiler | DDO-06 target; compiler seam delivered |
 | Lawful transitions | DDO reducer and versioned lifecycle commands | Pure reducer delivered; durable binding is DDO-05 target |
 | Worker | `WorkerRuntimePort` and context/invocation/result contracts | Seam delivered; durable correlation/reattach target |

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -130,3 +130,54 @@ def test_devui_composition_refuses_other_forwarded_identity_headers() -> None:
             "/api/devui/composition",
             headers={name: value},
         ).status_code == 403
+
+
+def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
+    monkeypatch,
+) -> None:
+    secret = "/private/ckm.sqlite3"
+    cockpit = {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-08T21:00:00+00:00",
+        "claim": {"kind": "refused", "text": "source unavailable"},
+        "sources": [],
+        "unread_planes": [],
+        "withdrawn_counts": [],
+    }
+    refusal = {
+        "schema_version": 1,
+        "error": {
+            "code": "unsupported_store",
+            "message": f"SQLite could not open {secret}",
+            "details": {
+                "path": secret,
+                "reason": f"OperationalError while reading {secret}",
+            },
+        },
+    }
+
+    class RefusingCkm:
+        def __init__(self, db_path: Path) -> None:
+            self.db_path = db_path
+
+        def list_capabilities(self):
+            return SimpleNamespace(to_dict=lambda: refusal)
+
+    monkeypatch.setattr(devui_route, "read_cockpit_registry", lambda: cockpit)
+    monkeypatch.setattr(
+        devui_route,
+        "load_builderops_paths",
+        lambda: SimpleNamespace(db_path=Path(secret)),
+    )
+    monkeypatch.setattr(devui_route, "CkmQueryService", RefusingCkm)
+
+    payload = TestClient(app).get("/api/devui/composition").json()
+    contribution = payload["providers"]["capabilities"]
+
+    assert contribution["refusal"] == {
+        "code": "unsupported_store",
+        "message": "CKM refused the read request",
+        "details": {},
+    }
+    assert secret not in repr(payload)
+    assert "OperationalError" not in repr(payload)

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
+import app.auth as auth_module
 from app.api.app import app
 from app.api.routes import devui as devui_route
 
@@ -67,3 +68,35 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
         if getattr(route, "path", None) == "/api/devui/composition"
     )
     assert route.methods == {"GET"}
+
+
+def test_devui_composition_refuses_non_loopback_even_with_api_key(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(auth_module.settings, "api_key", "valid-key")
+
+    def must_not_read() -> dict:
+        raise AssertionError("local providers must not be read for a remote caller")
+
+    monkeypatch.setattr(devui_route, "read_cockpit_registry", must_not_read)
+    remote = TestClient(app, client=("203.0.113.10", 50000))
+
+    response = remote.get(
+        "/api/devui/composition",
+        headers={"X-API-Key": "valid-key"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "devUI composition is available only to a local caller"
+    }
+
+
+def test_devui_composition_refuses_forwarded_remote_caller(monkeypatch) -> None:
+    monkeypatch.setattr(auth_module.settings, "api_key", None)
+    response = TestClient(app).get(
+        "/api/devui/composition",
+        headers={"X-Forwarded-For": "203.0.113.10"},
+    )
+
+    assert response.status_code == 403

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -100,3 +100,33 @@ def test_devui_composition_refuses_forwarded_remote_caller(monkeypatch) -> None:
     )
 
     assert response.status_code == 403
+
+
+def test_devui_composition_refuses_trusted_proxy_forwarding_loopback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        auth_module.settings,
+        "companion_trusted_proxy_hosts",
+        "172.18.0.1",
+    )
+    response = TestClient(app, client=("172.18.0.1", 50000)).get(
+        "/api/devui/composition",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_devui_composition_refuses_other_forwarded_identity_headers() -> None:
+    client = TestClient(app, client=("127.0.0.1", 50000))
+
+    for name, value in (
+        ("Forwarded", "for=127.0.0.1"),
+        ("X-Real-IP", "127.0.0.1"),
+        ("CF-Connecting-IP", "127.0.0.1"),
+    ):
+        assert client.get(
+            "/api/devui/composition",
+            headers={name: value},
+        ).status_code == 403

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -16,6 +16,7 @@ from app.builderops.ckm.contracts import (
     CompletenessManifest,
     ErrorEnvelope,
     ObjectClassCompleteness,
+    ResourceDto,
     ResultEnvelope,
     SnapshotManifest,
     canonical_digest,
@@ -45,6 +46,40 @@ def _empty_ckm_envelope() -> ResultEnvelope:
         ),
         snapshot=snapshot,
         resources=(),
+    )
+
+
+def _ckm_envelope_with_display(display_name: str) -> ResultEnvelope:
+    resource = ResourceDto(
+        public_id="ckm_capability_example",
+        resource_type="capability",
+        display_name=display_name,
+        lifecycle="confirmed",
+        provenance=({"kind": "fixture"},),
+        values={},
+        candidate=False,
+    )
+    completeness = CompletenessManifest(
+        object_classes=(
+            ObjectClassCompleteness(object_class="capability", included=1),
+        ),
+        complete=True,
+    )
+    snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(epoch="epoch-1", state_revision=1),
+        taxonomy_digest=canonical_digest({"taxonomy": "fixture"}),
+        watermarks={},
+        provenance=(),
+        completeness=completeness,
+        read_set={"capability": (resource.public_id,)},
+    )
+    return ResultEnvelope(
+        resource_type="capability",
+        query_digest=canonical_query_digest(
+            {"operation": "list_capabilities", "public_id": None}
+        ),
+        snapshot=snapshot,
+        resources=(resource,),
     )
 
 
@@ -243,3 +278,60 @@ def test_devui_composition_isolates_unserializable_cockpit_payload(
     assert response.status_code == 200
     assert response.json()["providers"]["work"]["status"] == "refused"
     assert response.json()["providers"]["capabilities"]["status"] == "available"
+
+
+def test_devui_composition_isolates_non_utf8_provider_strings(monkeypatch) -> None:
+    healthy_cockpit = {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-08T21:00:00+00:00",
+        "claim": {"kind": "counted", "text": "one thread"},
+        "sources": [],
+        "unread_planes": [],
+        "withdrawn_counts": [],
+        "bands": {},
+    }
+    malformed_cockpit = {
+        **healthy_cockpit,
+        "bands": {"label": "bad\ud800"},
+    }
+
+    class Ckm:
+        envelope = _empty_ckm_envelope()
+
+        def __init__(self, db_path: Path) -> None:
+            self.db_path = db_path
+
+        def list_capabilities(self):
+            return self.envelope
+
+    monkeypatch.setattr(
+        devui_route,
+        "load_builderops_paths",
+        lambda: SimpleNamespace(db_path=Path("/state/builderops.sqlite3")),
+    )
+    monkeypatch.setattr(devui_route, "CkmQueryService", Ckm)
+
+    monkeypatch.setattr(
+        devui_route,
+        "read_cockpit_registry",
+        lambda: malformed_cockpit,
+    )
+    response = TestClient(app, raise_server_exceptions=False).get(
+        "/api/devui/composition"
+    )
+    assert response.status_code == 200
+    assert response.json()["providers"]["work"]["status"] == "refused"
+    assert response.json()["providers"]["capabilities"]["status"] == "available"
+
+    monkeypatch.setattr(
+        devui_route,
+        "read_cockpit_registry",
+        lambda: healthy_cockpit,
+    )
+    Ckm.envelope = _ckm_envelope_with_display("bad\ud800")
+    response = TestClient(app, raise_server_exceptions=False).get(
+        "/api/devui/composition"
+    )
+    assert response.status_code == 200
+    assert response.json()["providers"]["work"]["status"] == "available"
+    assert response.json()["providers"]["capabilities"]["status"] == "refused"

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -204,3 +204,42 @@ def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
     }
     assert secret not in repr(payload)
     assert "OperationalError" not in repr(payload)
+
+
+def test_devui_composition_isolates_unserializable_cockpit_payload(
+    monkeypatch,
+) -> None:
+    malformed_cockpit = {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-08T21:00:00+00:00",
+        "claim": {"kind": "counted", "text": "one thread"},
+        "sources": [],
+        "unread_planes": [],
+        "withdrawn_counts": [],
+        "bands": {"moving": object()},
+    }
+
+    class HealthyCkm:
+        def __init__(self, db_path: Path) -> None:
+            self.db_path = db_path
+
+        def list_capabilities(self):
+            return _empty_ckm_envelope()
+
+    monkeypatch.setattr(
+        devui_route,
+        "read_cockpit_registry",
+        lambda: malformed_cockpit,
+    )
+    monkeypatch.setattr(
+        devui_route,
+        "load_builderops_paths",
+        lambda: SimpleNamespace(db_path=Path("/state/builderops.sqlite3")),
+    )
+    monkeypatch.setattr(devui_route, "CkmQueryService", HealthyCkm)
+
+    response = TestClient(app).get("/api/devui/composition")
+
+    assert response.status_code == 200
+    assert response.json()["providers"]["work"]["status"] == "refused"
+    assert response.json()["providers"]["capabilities"]["status"] == "available"

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -199,11 +199,18 @@ def test_devui_composition_refuses_other_forwarded_identity_headers() -> None:
         ("Forwarded", "for=127.0.0.1"),
         ("X-Real-IP", "127.0.0.1"),
         ("CF-Connecting-IP", "127.0.0.1"),
+        ("X-Original-Forwarded-For", "127.0.0.1"),
+        ("X-Envoy-External-Address", "127.0.0.1"),
     ):
         assert client.get(
             "/api/devui/composition",
             headers={name: value},
         ).status_code == 403
+
+    assert client.get(
+        "/api/devui/composition",
+        headers={"Host": "attacker.example"},
+    ).status_code == 403
 
 
 def test_devui_composition_sanitizes_ckm_refusal_diagnostics(

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -24,14 +24,34 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
     ckm = {
         "schema_version": 1,
         "resource_type": "capability",
-        "query_digest": "digest",
+        "query_digest": "1" * 64,
         "projection": {"status": "derived_projection", "authoritative": False},
         "snapshot": {
             "epoch": "epoch-1",
             "state_revision": 1,
-            "snapshot_digest": "snapshot-1",
+            "ckm_schema_version": 5,
+            "envelope_schema_version": 1,
+            "resource_schema_version": 1,
+            "taxonomy_digest": "2" * 64,
+            "effective_audience": "single_operator_local",
+            "access_policy_version": "ckm-local-access-v1",
+            "redaction_profile": "none",
+            "read_set_digest": "3" * 64,
+            "snapshot_digest": "4" * 64,
             "watermarks": {},
-            "completeness": {"complete": True, "object_classes": []},
+            "provenance": [],
+            "completeness": {
+                "complete": True,
+                "object_classes": [
+                    {
+                        "object_class": "capability",
+                        "included": 0,
+                        "filtered": 0,
+                        "omitted": 0,
+                        "truncated": 0,
+                    }
+                ],
+            },
         },
         "resources": [],
     }

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -10,6 +10,42 @@ from fastapi.testclient import TestClient
 import app.auth as auth_module
 from app.api.app import app
 from app.api.routes import devui as devui_route
+from app.builderops.ckm.contracts import (
+    CkmContractError,
+    CkmStateIdentity,
+    CompletenessManifest,
+    ErrorEnvelope,
+    ObjectClassCompleteness,
+    ResultEnvelope,
+    SnapshotManifest,
+    canonical_digest,
+    canonical_query_digest,
+)
+
+
+def _empty_ckm_envelope() -> ResultEnvelope:
+    completeness = CompletenessManifest(
+        object_classes=(
+            ObjectClassCompleteness(object_class="capability", included=0),
+        ),
+        complete=True,
+    )
+    snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(epoch="epoch-1", state_revision=1),
+        taxonomy_digest=canonical_digest({"taxonomy": "fixture"}),
+        watermarks={},
+        provenance=(),
+        completeness=completeness,
+        read_set={"capability": ()},
+    )
+    return ResultEnvelope(
+        resource_type="capability",
+        query_digest=canonical_query_digest(
+            {"operation": "list_capabilities", "public_id": None}
+        ),
+        snapshot=snapshot,
+        resources=(),
+    )
 
 
 def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
@@ -21,40 +57,8 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
         "unread_planes": [],
         "withdrawn_counts": [],
     }
-    ckm = {
-        "schema_version": 1,
-        "resource_type": "capability",
-        "query_digest": "1" * 64,
-        "projection": {"status": "derived_projection", "authoritative": False},
-        "snapshot": {
-            "epoch": "epoch-1",
-            "state_revision": 1,
-            "ckm_schema_version": 5,
-            "envelope_schema_version": 1,
-            "resource_schema_version": 1,
-            "taxonomy_digest": "2" * 64,
-            "effective_audience": "single_operator_local",
-            "access_policy_version": "ckm-local-access-v1",
-            "redaction_profile": "none",
-            "read_set_digest": "3" * 64,
-            "snapshot_digest": "4" * 64,
-            "watermarks": {},
-            "provenance": [],
-            "completeness": {
-                "complete": True,
-                "object_classes": [
-                    {
-                        "object_class": "capability",
-                        "included": 0,
-                        "filtered": 0,
-                        "omitted": 0,
-                        "truncated": 0,
-                    }
-                ],
-            },
-        },
-        "resources": [],
-    }
+    ckm_envelope = _empty_ckm_envelope()
+    ckm = ckm_envelope.to_dict()
     seen: list[Path] = []
 
     class ReadOnlyCkm:
@@ -62,7 +66,7 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
             seen.append(db_path)
 
         def list_capabilities(self):
-            return SimpleNamespace(to_dict=lambda: ckm)
+            return ckm_envelope
 
     monkeypatch.setattr(devui_route, "read_cockpit_registry", lambda: cockpit)
     monkeypatch.setattr(
@@ -164,24 +168,23 @@ def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
         "unread_planes": [],
         "withdrawn_counts": [],
     }
-    refusal = {
-        "schema_version": 1,
-        "error": {
-            "code": "unsupported_store",
-            "message": f"SQLite could not open {secret}",
-            "details": {
+    refusal = ErrorEnvelope(
+        CkmContractError(
+            code="unsupported_store",
+            message=f"SQLite could not open {secret}",
+            details={
                 "path": secret,
                 "reason": f"OperationalError while reading {secret}",
             },
-        },
-    }
+        )
+    )
 
     class RefusingCkm:
         def __init__(self, db_path: Path) -> None:
             self.db_path = db_path
 
         def list_capabilities(self):
-            return SimpleNamespace(to_dict=lambda: refusal)
+            return refusal
 
     monkeypatch.setattr(devui_route, "read_cockpit_registry", lambda: cockpit)
     monkeypatch.setattr(

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -24,6 +24,17 @@ from app.builderops.ckm.contracts import (
 )
 
 
+def _dispatcher_source(read_at: str) -> dict:
+    return {
+        "name": "dispatcher-store",
+        "state": "fresh",
+        "last_successful_read": read_at,
+        "detail": "read succeeded",
+        "stale_after_days": 7,
+        "configured": True,
+    }
+
+
 def _empty_ckm_envelope() -> ResultEnvelope:
     completeness = CompletenessManifest(
         object_classes=(
@@ -92,7 +103,7 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
             "text": "one thread",
             "as_of": "2026-08-08T21:00:00+00:00",
         },
-        "sources": [],
+        "sources": [_dispatcher_source("2026-08-08T21:00:00+00:00")],
         "unread_planes": [],
         "withdrawn_counts": [],
     }
@@ -207,7 +218,14 @@ def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
             "text": "source unavailable",
             "as_of": "2026-08-08T21:00:00+00:00",
         },
-        "sources": [],
+        "sources": [
+            {
+                **_dispatcher_source("2026-08-08T21:00:00+00:00"),
+                "state": "unavailable",
+                "last_successful_read": None,
+                "detail": "read failed",
+            }
+        ],
         "unread_planes": [],
         "withdrawn_counts": [],
     }
@@ -260,7 +278,7 @@ def test_devui_composition_isolates_unserializable_cockpit_payload(
             "text": "one thread",
             "as_of": "2026-08-08T21:00:00+00:00",
         },
-        "sources": [],
+        "sources": [_dispatcher_source("2026-08-08T21:00:00+00:00")],
         "unread_planes": [],
         "withdrawn_counts": [],
         "bands": {"moving": object()},
@@ -301,7 +319,7 @@ def test_devui_composition_isolates_non_utf8_provider_strings(monkeypatch) -> No
             "text": "one thread",
             "as_of": "2026-08-08T21:00:00+00:00",
         },
-        "sources": [],
+        "sources": [_dispatcher_source("2026-08-08T21:00:00+00:00")],
         "unread_planes": [],
         "withdrawn_counts": [],
         "bands": {},

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -87,7 +87,11 @@ def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
     cockpit = {
         "authority": "read_time_join",
         "generated_at": "2026-08-08T21:00:00+00:00",
-        "claim": {"kind": "counted", "text": "one thread"},
+        "claim": {
+            "kind": "counted",
+            "text": "one thread",
+            "as_of": "2026-08-08T21:00:00+00:00",
+        },
         "sources": [],
         "unread_planes": [],
         "withdrawn_counts": [],
@@ -198,7 +202,11 @@ def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
     cockpit = {
         "authority": "read_time_join",
         "generated_at": "2026-08-08T21:00:00+00:00",
-        "claim": {"kind": "refused", "text": "source unavailable"},
+        "claim": {
+            "kind": "refused",
+            "text": "source unavailable",
+            "as_of": "2026-08-08T21:00:00+00:00",
+        },
         "sources": [],
         "unread_planes": [],
         "withdrawn_counts": [],
@@ -247,7 +255,11 @@ def test_devui_composition_isolates_unserializable_cockpit_payload(
     malformed_cockpit = {
         "authority": "read_time_join",
         "generated_at": "2026-08-08T21:00:00+00:00",
-        "claim": {"kind": "counted", "text": "one thread"},
+        "claim": {
+            "kind": "counted",
+            "text": "one thread",
+            "as_of": "2026-08-08T21:00:00+00:00",
+        },
         "sources": [],
         "unread_planes": [],
         "withdrawn_counts": [],
@@ -284,7 +296,11 @@ def test_devui_composition_isolates_non_utf8_provider_strings(monkeypatch) -> No
     healthy_cockpit = {
         "authority": "read_time_join",
         "generated_at": "2026-08-08T21:00:00+00:00",
-        "claim": {"kind": "counted", "text": "one thread"},
+        "claim": {
+            "kind": "counted",
+            "text": "one thread",
+            "as_of": "2026-08-08T21:00:00+00:00",
+        },
         "sources": [],
         "unread_planes": [],
         "withdrawn_counts": [],

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -1,0 +1,69 @@
+"""API contract for the read-only devUI composition route (#4682)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.api.routes import devui as devui_route
+
+
+def test_devui_composition_route_is_get_only_and_read_only(monkeypatch) -> None:
+    cockpit = {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-08T21:00:00+00:00",
+        "claim": {"kind": "counted", "text": "one thread"},
+        "sources": [],
+        "unread_planes": [],
+        "withdrawn_counts": [],
+    }
+    ckm = {
+        "schema_version": 1,
+        "resource_type": "capability",
+        "query_digest": "digest",
+        "projection": {"status": "derived_projection", "authoritative": False},
+        "snapshot": {
+            "epoch": "epoch-1",
+            "state_revision": 1,
+            "snapshot_digest": "snapshot-1",
+            "watermarks": {},
+            "completeness": {"complete": True, "object_classes": []},
+        },
+        "resources": [],
+    }
+    seen: list[Path] = []
+
+    class ReadOnlyCkm:
+        def __init__(self, db_path: Path) -> None:
+            seen.append(db_path)
+
+        def list_capabilities(self):
+            return SimpleNamespace(to_dict=lambda: ckm)
+
+    monkeypatch.setattr(devui_route, "read_cockpit_registry", lambda: cockpit)
+    monkeypatch.setattr(
+        devui_route,
+        "load_builderops_paths",
+        lambda: SimpleNamespace(db_path=Path("/state/builderops.sqlite3")),
+    )
+    monkeypatch.setattr(devui_route, "CkmQueryService", ReadOnlyCkm)
+
+    client = TestClient(app)
+    response = client.get("/api/devui/composition")
+
+    assert response.status_code == 200
+    assert response.json()["contract_version"] == "devui.composition.v1"
+    assert response.json()["providers"]["work"]["payload"] == cockpit
+    assert response.json()["providers"]["capabilities"]["payload"] == ckm
+    assert seen == [Path("/state/builderops.sqlite3")]
+
+    assert client.post("/api/devui/composition").status_code == 405
+    route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/api/devui/composition"
+    )
+    assert route.methods == {"GET"}

--- a/tests/builderops/test_cockpit_chain_states.py
+++ b/tests/builderops/test_cockpit_chain_states.py
@@ -1076,6 +1076,7 @@ def test_one_threads_derivation_failure_does_not_crash_the_render(
     unclassified = {entry["id"]: entry for entry in payload["unclassified"]}
     assert len(unclassified) == 1
     (reason,) = [entry["reason"] for entry in unclassified.values()]
-    assert "synthetic derivation bug" in reason
+    assert reason == "chain-position derivation failed"
+    assert "synthetic derivation bug" not in repr(payload)
     # The other thread is entirely unaffected.
     assert _issues_in(payload, "working") == {951}

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+import app.builderops.cockpit_registry as cockpit_registry
 from app.builderops.cockpit_registry import BANDS, RUNG_ORDER, build_registry
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.store import SqliteStore
@@ -119,6 +120,23 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
         item for item in _band(payload, "flawed")["items"] if item["issue_number"] == 3
     )
     assert flawed_item["why_now"] == "blocked: upstream"
+
+
+def test_chain_derivation_failure_does_not_expose_exception_details(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store, db_path = _make_store(tmp_path)
+    store.upsert_task(_task(status="in_progress", issue_number=7))
+
+    def fail_derivation(*args, **kwargs):
+        raise RuntimeError("secret path: /private/dispatcher.sqlite3")
+
+    monkeypatch.setattr(cockpit_registry, "derive_position", fail_derivation)
+    payload = _registry(db_path, tmp_path)
+
+    assert payload["unclassified"][0]["reason"] == "chain-position derivation failed"
+    assert "/private/dispatcher.sqlite3" not in repr(payload)
 
 
 def test_refused_emptiness_on_dead_source(tmp_path: Path) -> None:

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import app.builderops.cockpit_registry as cockpit_registry
+import app.builderops.cockpit_docs_plane as cockpit_docs_plane
+from app.builderops.cockpit_github_plane import fetch_github_live
 from app.builderops.cockpit_registry import BANDS, RUNG_ORDER, build_registry
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.store import SqliteStore
@@ -137,6 +139,48 @@ def test_chain_derivation_failure_does_not_expose_exception_details(
 
     assert payload["unclassified"][0]["reason"] == "chain-position derivation failed"
     assert "/private/dispatcher.sqlite3" not in repr(payload)
+
+
+def test_nested_source_refusals_do_not_expose_exception_details(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    secret = "/private/token-store"
+    _, db_path = _make_store(tmp_path)
+    deploys = tmp_path / "deploys"
+    deploys.mkdir()
+    (deploys / "prod-latest.json").write_bytes(b"\xffsecret")
+
+    def fail_connection(path: Path):
+        raise sqlite3.OperationalError(f"cannot read {secret}")
+
+    monkeypatch.setattr(cockpit_registry, "_read_only_connection", fail_connection)
+    payload = build_registry(db_path=db_path, deploy_receipt_dir=deploys)
+    sources = {source["name"]: source for source in payload["sources"]}
+
+    assert sources["dispatcher-store"]["detail"] == "read failed"
+    assert sources["verification-runs"]["detail"] == "read failed"
+    assert sources["deploy-receipts"]["detail"] == "1 unreadable channel receipt(s)"
+    assert secret not in repr(payload)
+
+    def fail_docs(*args, **kwargs):
+        raise OSError(f"cannot read {secret}")
+
+    monkeypatch.setattr(cockpit_docs_plane, "_read_capabilities", fail_docs)
+    docs = cockpit_docs_plane.read_docs_plane(
+        capabilities_yaml_path=tmp_path / "capabilities.yaml",
+        matrix_path=tmp_path / "matrix.md",
+        docs_root=tmp_path / "docs",
+    )
+    github = fetch_github_live(
+        "RasmusTho/agentic-pkm-mvp",
+        reader=lambda repo: (_ for _ in ()).throw(OSError(f"cannot read {secret}")),
+    )
+
+    assert docs.detail == "read failed"
+    assert github.detail == "read failed"
+    assert secret not in repr(docs)
+    assert secret not in repr(github)
 
 
 def test_refused_emptiness_on_dead_source(tmp_path: Path) -> None:

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -308,6 +308,20 @@ def test_contradictory_cockpit_evidence_is_refused() -> None:
     ]
     variants.append(orphaned_withdrawal)
 
+    counted_unavailable = deepcopy(_cockpit_payload())
+    counted_unavailable["sources"][0].update(
+        {"state": "unavailable", "last_successful_read": None}
+    )
+    variants.append(counted_unavailable)
+
+    refused_fresh = deepcopy(_cockpit_payload())
+    refused_fresh["claim"]["kind"] = "refused"
+    variants.append(refused_fresh)
+
+    missing_dispatcher = deepcopy(_cockpit_payload())
+    missing_dispatcher["sources"] = []
+    variants.append(missing_dispatcher)
+
     for payload in variants:
         result = compose_owner_snapshot(
             cockpit_reader=lambda payload=payload: payload,

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -4,6 +4,20 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
+from app.builderops.ckm.contracts import (
+    CkmContractError,
+    CkmStateIdentity,
+    CompletenessManifest,
+    ErrorEnvelope,
+    ObjectClassCompleteness,
+    ResourceDto,
+    ResultEnvelope,
+    SnapshotManifest,
+    canonical_digest,
+    canonical_query_digest,
+)
 from app.builderops.devui_composition import compose_owner_snapshot
 
 
@@ -28,55 +42,48 @@ def _cockpit_payload() -> dict:
     }
 
 
-def _ckm_payload() -> dict:
-    return {
-        "schema_version": 1,
-        "resource_type": "capability",
-        "query_digest": "1" * 64,
-        "projection": {"status": "derived_projection", "authoritative": False},
-        "snapshot": {
-            "epoch": "epoch-7",
-            "state_revision": 42,
-            "ckm_schema_version": 5,
-            "envelope_schema_version": 1,
-            "resource_schema_version": 1,
-            "taxonomy_digest": "2" * 64,
-            "effective_audience": "single_operator_local",
-            "access_policy_version": "ckm-local-access-v1",
-            "redaction_profile": "none",
-            "read_set_digest": "3" * 64,
-            "snapshot_digest": "4" * 64,
-            "watermarks": {"capability": "2026-08-08T20:58:00+00:00"},
-            "provenance": [{"kind": "fixture"}],
-            "completeness": {
-                "complete": True,
-                "object_classes": [
-                    {
-                        "object_class": "capability",
-                        "included": 1,
-                        "filtered": 0,
-                        "omitted": 0,
-                        "truncated": 0,
-                    }
-                ],
-            },
-        },
-        "resources": [
-            {
-                "public_id": "ckm_capability_example",
-                "resource_type": "capability",
-            }
-        ],
-    }
+def _ckm_envelope() -> ResultEnvelope:
+    resource = ResourceDto(
+        public_id="ckm_capability_example",
+        resource_type="capability",
+        display_name="Example capability",
+        lifecycle="confirmed",
+        provenance=({"kind": "fixture"},),
+        values={},
+        candidate=False,
+    )
+    completeness = CompletenessManifest(
+        object_classes=(
+            ObjectClassCompleteness(object_class="capability", included=1),
+        ),
+        complete=True,
+    )
+    snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(epoch="epoch-7", state_revision=42),
+        taxonomy_digest=canonical_digest({"taxonomy": "fixture"}),
+        watermarks={"capability": "2026-08-08T20:58:00+00:00"},
+        provenance=({"kind": "fixture"},),
+        completeness=completeness,
+        read_set={"capability": (resource.public_id,)},
+    )
+    return ResultEnvelope(
+        resource_type="capability",
+        query_digest=canonical_query_digest(
+            {"operation": "list_capabilities", "public_id": None}
+        ),
+        snapshot=snapshot,
+        resources=(resource,),
+    )
 
 
 def test_composition_preserves_provider_snapshot_and_authority() -> None:
     cockpit = _cockpit_payload()
-    ckm = _ckm_payload()
+    ckm_envelope = _ckm_envelope()
+    ckm = ckm_envelope.to_dict()
 
     result = compose_owner_snapshot(
         cockpit_reader=lambda: cockpit,
-        ckm_reader=lambda: ckm,
+        ckm_reader=lambda: ckm_envelope,
         now=lambda: NOW,
     )
 
@@ -103,9 +110,9 @@ def test_composition_preserves_provider_snapshot_and_authority() -> None:
     assert capabilities["status"] == "available"
     assert capabilities["authority"] == ckm["projection"]
     assert capabilities["captured_at"] is None
-    assert capabilities["snapshot"] is ckm["snapshot"]
-    assert capabilities["completeness"] is ckm["snapshot"]["completeness"]
-    assert capabilities["payload"] is ckm
+    assert capabilities["snapshot"] == ckm["snapshot"]
+    assert capabilities["completeness"] == ckm["snapshot"]["completeness"]
+    assert capabilities["payload"] == ckm
 
 
 def test_composition_uses_existing_read_only_provider_contracts() -> None:
@@ -115,14 +122,13 @@ def test_composition_uses_existing_read_only_provider_contracts() -> None:
         reads.append("cockpit")
         return _cockpit_payload()
 
-    class CkmEnvelope:
-        def to_dict(self) -> dict:
-            reads.append("ckm")
-            return _ckm_payload()
+    def read_ckm() -> ResultEnvelope:
+        reads.append("ckm")
+        return _ckm_envelope()
 
     result = compose_owner_snapshot(
         cockpit_reader=read_cockpit,
-        ckm_reader=CkmEnvelope,
+        ckm_reader=read_ckm,
         now=lambda: NOW,
     )
 
@@ -137,7 +143,7 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
 
     result = compose_owner_snapshot(
         cockpit_reader=broken_cockpit,
-        ckm_reader=lambda: _ckm_payload(),
+        ckm_reader=_ckm_envelope,
         now=lambda: NOW,
     )
 
@@ -162,14 +168,13 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
 
     refused_ckm = compose_owner_snapshot(
         cockpit_reader=lambda: _cockpit_payload(),
-        ckm_reader=lambda: {
-            "schema_version": 1,
-            "error": {
-                "code": "missing_store",
-                "message": "CKM database does not exist",
-                "details": {"path": "/unavailable/ckm.sqlite3"},
-            },
-        },
+        ckm_reader=lambda: ErrorEnvelope(
+            CkmContractError(
+                code="missing_store",
+                message="CKM database does not exist",
+                details={"path": "/unavailable/ckm.sqlite3"},
+            )
+        ),
         now=lambda: NOW,
     )["providers"]["capabilities"]
 
@@ -183,13 +188,43 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
     assert "payload" not in refused_ckm
 
 
-def test_malformed_ckm_snapshot_is_refused() -> None:
-    malformed = _ckm_payload()
-    malformed["snapshot"] = {"completeness": {}}
-
+@pytest.mark.parametrize(
+    "unvalidated_payload",
+    [
+        {"snapshot": {"completeness": {}}},
+        {
+            "contract_version": True,
+            "schema_version": True,
+            "snapshot": {"completeness": {"complete": True}},
+        },
+        {
+            "snapshot": {
+                "snapshot_digest": "forged",
+                "read_set_digest": "forged",
+                "completeness": {"complete": True},
+            },
+            "resources": [],
+        },
+        {
+            "snapshot": {
+                "completeness": {
+                    "complete": True,
+                    "object_classes": [
+                        {"object_class": "capability", "included": 0},
+                        {"object_class": "capability", "included": 0},
+                    ],
+                }
+            },
+            "resources": [],
+        },
+    ],
+)
+def test_unvalidated_ckm_mapping_is_refused(
+    unvalidated_payload: dict,
+) -> None:
     contribution = compose_owner_snapshot(
         cockpit_reader=lambda: _cockpit_payload(),
-        ckm_reader=lambda: malformed,
+        ckm_reader=lambda: unvalidated_payload,  # type: ignore[return-value]
         now=lambda: NOW,
     )["providers"]["capabilities"]
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -208,6 +208,8 @@ def test_unserializable_cockpit_payload_is_isolated_from_healthy_ckm() -> None:
     "unsupported_envelope",
     [
         replace(_ckm_envelope(), schema_version=999),
+        replace(_ckm_envelope(), schema_version=True),
+        replace(_ckm_envelope(), schema_version=1.0),
         replace(
             _ckm_envelope(),
             snapshot=replace(
@@ -217,11 +219,44 @@ def test_unserializable_cockpit_payload_is_isolated_from_healthy_ckm() -> None:
         ),
         replace(
             _ckm_envelope(),
+            snapshot=replace(
+                _ckm_envelope().snapshot,
+                ckm_schema_version=5.0,
+            ),
+        ),
+        replace(
+            _ckm_envelope(),
+            snapshot=replace(
+                _ckm_envelope().snapshot,
+                envelope_schema_version=True,
+            ),
+        ),
+        replace(
+            _ckm_envelope(),
+            snapshot=replace(
+                _ckm_envelope().snapshot,
+                resource_schema_version=True,
+            ),
+        ),
+        replace(
+            _ckm_envelope(),
             resources=(replace(_ckm_envelope().resources[0], schema_version=999),),
+        ),
+        replace(
+            _ckm_envelope(),
+            resources=(replace(_ckm_envelope().resources[0], schema_version=True),),
         ),
         ErrorEnvelope(
             CkmContractError(code="missing_store", message="missing", details={}),
             schema_version=999,
+        ),
+        ErrorEnvelope(
+            CkmContractError(code="missing_store", message="missing", details={}),
+            schema_version=True,
+        ),
+        ErrorEnvelope(
+            CkmContractError(code="missing_store", message="missing", details={}),
+            schema_version=1.0,
         ),
     ],
 )
@@ -231,6 +266,21 @@ def test_unsupported_typed_ckm_versions_are_refused(
     contribution = compose_owner_snapshot(
         cockpit_reader=_cockpit_payload,
         ckm_reader=lambda: unsupported_envelope,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "payload" not in contribution
+
+
+def test_ckm_query_identity_must_match_list_capabilities() -> None:
+    forged = replace(_ckm_envelope(), query_digest="forged")
+
+    contribution = compose_owner_snapshot(
+        cockpit_reader=_cockpit_payload,
+        ckm_reader=lambda: forged,
         now=lambda: NOW,
     )["providers"]["capabilities"]
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -16,6 +16,7 @@ from app.builderops.ckm.contracts import (
     ResourceDto,
     ResultEnvelope,
     SnapshotManifest,
+    TaggedValue,
     canonical_digest,
     canonical_query_digest,
 )
@@ -83,21 +84,25 @@ def _rebuilt_ckm_envelope(
     state_revision: int = 42,
     taxonomy_digest: str | None = None,
     completeness: CompletenessManifest | None = None,
+    watermarks: dict | None = None,
+    provenance: tuple[dict, ...] | None = None,
+    resource: ResourceDto | None = None,
 ) -> ResultEnvelope:
     original = _ckm_envelope()
+    selected_resource = resource or original.resources[0]
     rebuilt_snapshot = SnapshotManifest.build(
         state=CkmStateIdentity(epoch=epoch, state_revision=state_revision),
         taxonomy_digest=taxonomy_digest or canonical_digest({"taxonomy": "fixture"}),
-        watermarks=original.snapshot.watermarks,
-        provenance=original.snapshot.provenance,
+        watermarks=watermarks if watermarks is not None else original.snapshot.watermarks,
+        provenance=provenance if provenance is not None else original.snapshot.provenance,
         completeness=completeness or original.snapshot.completeness,
-        read_set=original.snapshot.read_set,
+        read_set={"capability": (selected_resource.public_id,)},
     )
     return ResultEnvelope(
         resource_type=original.resource_type,
         query_digest=original.query_digest,
         snapshot=rebuilt_snapshot,
-        resources=original.resources,
+        resources=(selected_resource,),
     )
 
 
@@ -340,6 +345,47 @@ def test_ckm_query_identity_must_match_list_capabilities() -> None:
     ],
 )
 def test_malformed_typed_ckm_snapshot_scalars_are_refused(
+    malformed_envelope: ResultEnvelope,
+) -> None:
+    contribution = compose_owner_snapshot(
+        cockpit_reader=_cockpit_payload,
+        ckm_reader=lambda: malformed_envelope,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "payload" not in contribution
+
+
+@pytest.mark.parametrize(
+    "malformed_envelope",
+    [
+        _rebuilt_ckm_envelope(watermarks={1: "value"}),
+        _rebuilt_ckm_envelope(watermarks={"capability": 123}),
+        _rebuilt_ckm_envelope(
+            resource=replace(_ckm_envelope().resources[0], public_id=123)
+        ),
+        _rebuilt_ckm_envelope(
+            resource=replace(_ckm_envelope().resources[0], display_name=123)
+        ),
+        _rebuilt_ckm_envelope(
+            resource=replace(_ckm_envelope().resources[0], lifecycle=123)
+        ),
+        _rebuilt_ckm_envelope(
+            resource=replace(_ckm_envelope().resources[0], candidate=0)
+        ),
+        _rebuilt_ckm_envelope(provenance=({1: "fixture"},)),
+        _rebuilt_ckm_envelope(
+            resource=replace(
+                _ckm_envelope().resources[0],
+                values={1: TaggedValue.measured("x")},
+            )
+        ),
+    ],
+)
+def test_malformed_typed_ckm_public_shape_is_refused(
     malformed_envelope: ResultEnvelope,
 ) -> None:
     contribution = compose_owner_snapshot(

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -119,7 +119,7 @@ def test_composition_uses_existing_read_only_provider_contracts() -> None:
 
 def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
     def broken_cockpit() -> dict:
-        raise OSError("dispatcher store is unreadable")
+        raise OSError("secret path: /private/dispatcher.sqlite3")
 
     result = compose_owner_snapshot(
         cockpit_reader=broken_cockpit,
@@ -138,10 +138,11 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
         "refusal": {
             "code": "provider_unavailable",
             "message": "BuilderOps Cockpit could not provide its read snapshot",
-            "details": {"reason": "dispatcher store is unreadable"},
+            "details": {"reason": "provider read failed"},
         },
     }
     assert "payload" not in work
+    assert "/private/dispatcher.sqlite3" not in repr(work)
     assert result["providers"]["capabilities"]["status"] == "available"
     assert result["providers"]["capabilities"]["payload"]["resources"]
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -333,6 +333,25 @@ def test_contradictory_cockpit_evidence_is_refused() -> None:
     )
     variants.append(unconfigured_dispatcher)
 
+    stale_github_without_withdrawal = deepcopy(_cockpit_payload())
+    stale_github_without_withdrawal["sources"].append(
+        {
+            "name": "github-live",
+            "state": "stale",
+            "last_successful_read": "2026-08-01T20:59:58+00:00",
+            "detail": "read succeeded",
+            "stale_after_days": 7,
+            "configured": True,
+        }
+    )
+    variants.append(stale_github_without_withdrawal)
+
+    stale_github_wrong_withdrawal = deepcopy(stale_github_without_withdrawal)
+    stale_github_wrong_withdrawal["withdrawn_counts"] = [
+        {"source": "github-live", "counts": ["not.a.real.count"]}
+    ]
+    variants.append(stale_github_wrong_withdrawal)
+
     for payload in variants:
         result = compose_owner_snapshot(
             cockpit_reader=lambda payload=payload: payload,

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -160,5 +160,10 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
     )["providers"]["capabilities"]
 
     assert refused_ckm["status"] == "refused"
-    assert refused_ckm["refusal"]["code"] == "missing_store"
+    assert refused_ckm["refusal"] == {
+        "code": "missing_store",
+        "message": "CKM refused the read request",
+        "details": {},
+    }
+    assert "/unavailable/ckm.sqlite3" not in repr(refused_ckm)
     assert "payload" not in refused_ckm

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -77,6 +77,30 @@ def _ckm_envelope() -> ResultEnvelope:
     )
 
 
+def _rebuilt_ckm_envelope(
+    *,
+    epoch: str = "epoch-7",
+    state_revision: int = 42,
+    taxonomy_digest: str | None = None,
+    completeness: CompletenessManifest | None = None,
+) -> ResultEnvelope:
+    original = _ckm_envelope()
+    rebuilt_snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(epoch=epoch, state_revision=state_revision),
+        taxonomy_digest=taxonomy_digest or canonical_digest({"taxonomy": "fixture"}),
+        watermarks=original.snapshot.watermarks,
+        provenance=original.snapshot.provenance,
+        completeness=completeness or original.snapshot.completeness,
+        read_set=original.snapshot.read_set,
+    )
+    return ResultEnvelope(
+        resource_type=original.resource_type,
+        query_digest=original.query_digest,
+        snapshot=rebuilt_snapshot,
+        resources=original.resources,
+    )
+
+
 def test_composition_preserves_provider_snapshot_and_authority() -> None:
     cockpit = _cockpit_payload()
     ckm_envelope = _ckm_envelope()
@@ -281,6 +305,46 @@ def test_ckm_query_identity_must_match_list_capabilities() -> None:
     contribution = compose_owner_snapshot(
         cockpit_reader=_cockpit_payload,
         ckm_reader=lambda: forged,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "payload" not in contribution
+
+
+@pytest.mark.parametrize(
+    "malformed_envelope",
+    [
+        _rebuilt_ckm_envelope(epoch=""),
+        _rebuilt_ckm_envelope(state_revision=-1),
+        _rebuilt_ckm_envelope(state_revision=True),
+        _rebuilt_ckm_envelope(taxonomy_digest="forged"),
+        _rebuilt_ckm_envelope(
+            completeness=CompletenessManifest(
+                object_classes=(
+                    ObjectClassCompleteness(object_class="capability", included=True),
+                ),
+                complete=True,
+            )
+        ),
+        _rebuilt_ckm_envelope(
+            completeness=CompletenessManifest(
+                object_classes=(
+                    ObjectClassCompleteness(object_class="capability", included=1),
+                ),
+                complete=1,
+            )
+        ),
+    ],
+)
+def test_malformed_typed_ckm_snapshot_scalars_are_refused(
+    malformed_envelope: ResultEnvelope,
+) -> None:
+    contribution = compose_owner_snapshot(
+        cockpit_reader=_cockpit_payload,
+        ckm_reader=lambda: malformed_envelope,
         now=lambda: NOW,
     )["providers"]["capabilities"]
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 
 import pytest
@@ -24,6 +24,21 @@ from app.builderops.devui_composition import compose_owner_snapshot
 
 
 NOW = datetime(2026, 8, 8, 21, 0, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class _FakeProjection:
+    status: str = "derived_projection"
+    authoritative: bool = False
+    leaked: str = "/private/authority-secret"
+
+
+@dataclass(frozen=True)
+class _FakeError:
+    code: str = "missing_store"
+    message: str = "forged"
+    details: dict | None = None
+
 
 
 def _cockpit_payload() -> dict:
@@ -397,6 +412,29 @@ def test_malformed_typed_ckm_public_shape_is_refused(
     assert contribution["status"] == "refused"
     assert contribution["snapshot"] is None
     assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "payload" not in contribution
+
+
+@pytest.mark.parametrize(
+    "malformed_envelope",
+    [
+        replace(_ckm_envelope(), projection=_FakeProjection()),
+        ErrorEnvelope(error=_FakeError(details={})),
+    ],
+)
+def test_untyped_nested_ckm_contract_members_are_refused(
+    malformed_envelope: ResultEnvelope | ErrorEnvelope,
+) -> None:
+    contribution = compose_owner_snapshot(
+        cockpit_reader=_cockpit_payload,
+        ckm_reader=lambda: malformed_envelope,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "/private/authority-secret" not in repr(contribution)
     assert "payload" not in contribution
 
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -322,6 +322,17 @@ def test_contradictory_cockpit_evidence_is_refused() -> None:
     missing_dispatcher["sources"] = []
     variants.append(missing_dispatcher)
 
+    unconfigured_dispatcher = deepcopy(_cockpit_payload())
+    unconfigured_dispatcher["claim"]["kind"] = "refused"
+    unconfigured_dispatcher["sources"][0].update(
+        {
+            "state": "unavailable",
+            "last_successful_read": None,
+            "configured": False,
+        }
+    )
+    variants.append(unconfigured_dispatcher)
+
     for payload in variants:
         result = compose_owner_snapshot(
             cockpit_reader=lambda payload=payload: payload,

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 
@@ -45,7 +46,11 @@ def _cockpit_payload() -> dict:
     return {
         "authority": "read_time_join",
         "generated_at": "2026-08-08T20:59:58+00:00",
-        "claim": {"kind": "counted", "text": "2 threads in motion."},
+        "claim": {
+            "kind": "counted",
+            "text": "2 threads in motion.",
+            "as_of": "2026-08-08T20:59:58+00:00",
+        },
         "sources": [
             {
                 "name": "dispatcher-store",
@@ -272,6 +277,45 @@ def test_semantically_malformed_cockpit_payload_is_isolated() -> None:
     assert result["providers"]["work"]["status"] == "refused"
     assert result["providers"]["work"]["captured_at"] is None
     assert result["providers"]["capabilities"]["status"] == "available"
+
+
+def test_contradictory_cockpit_evidence_is_refused() -> None:
+    variants: list[dict] = []
+
+    missing_as_of = deepcopy(_cockpit_payload())
+    del missing_as_of["claim"]["as_of"]
+    variants.append(missing_as_of)
+
+    mismatched_as_of = deepcopy(_cockpit_payload())
+    mismatched_as_of["claim"]["as_of"] = "2025-01-01T00:00:00+00:00"
+    variants.append(mismatched_as_of)
+
+    missing_read_time = deepcopy(_cockpit_payload())
+    missing_read_time["sources"][0]["last_successful_read"] = None
+    variants.append(missing_read_time)
+
+    unconfigured_fresh = deepcopy(_cockpit_payload())
+    unconfigured_fresh["sources"][0]["configured"] = False
+    variants.append(unconfigured_fresh)
+
+    duplicate_source = deepcopy(_cockpit_payload())
+    duplicate_source["sources"].append(deepcopy(duplicate_source["sources"][0]))
+    variants.append(duplicate_source)
+
+    orphaned_withdrawal = deepcopy(_cockpit_payload())
+    orphaned_withdrawal["withdrawn_counts"] = [
+        {"source": "missing-source", "counts": []}
+    ]
+    variants.append(orphaned_withdrawal)
+
+    for payload in variants:
+        result = compose_owner_snapshot(
+            cockpit_reader=lambda payload=payload: payload,
+            ckm_reader=_ckm_envelope,
+            now=lambda: NOW,
+        )
+        assert result["providers"]["work"]["status"] == "refused"
+        assert result["providers"]["capabilities"]["status"] == "available"
 
 
 @pytest.mark.parametrize(

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -1,0 +1,163 @@
+"""Contract tests for the read-only devUI provider composition (#4682)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.builderops.devui_composition import compose_owner_snapshot
+
+
+NOW = datetime(2026, 8, 8, 21, 0, tzinfo=timezone.utc)
+
+
+def _cockpit_payload() -> dict:
+    return {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-08T20:59:58+00:00",
+        "claim": {"kind": "counted", "text": "2 threads in motion."},
+        "sources": [
+            {
+                "name": "dispatcher-store",
+                "state": "fresh",
+                "read_at": "2026-08-08T20:59:58+00:00",
+            }
+        ],
+        "unread_planes": ["github-review-threads"],
+        "withdrawn_counts": [],
+        "bands": {"moving": [{"issue_number": 4682}]},
+    }
+
+
+def _ckm_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "resource_type": "capability",
+        "query_digest": "query-digest",
+        "projection": {"status": "derived_projection", "authoritative": False},
+        "snapshot": {
+            "epoch": "epoch-7",
+            "state_revision": 42,
+            "snapshot_digest": "snapshot-digest",
+            "watermarks": {"capability": "2026-08-08T20:58:00+00:00"},
+            "completeness": {
+                "complete": True,
+                "object_classes": [
+                    {
+                        "object_class": "capability",
+                        "included": 1,
+                        "filtered": 0,
+                        "omitted": 0,
+                        "truncated": 0,
+                    }
+                ],
+            },
+        },
+        "resources": [{"public_id": "ckm_capability_example"}],
+    }
+
+
+def test_composition_preserves_provider_snapshot_and_authority() -> None:
+    cockpit = _cockpit_payload()
+    ckm = _ckm_payload()
+
+    result = compose_owner_snapshot(
+        cockpit_reader=lambda: cockpit,
+        ckm_reader=lambda: ckm,
+        now=lambda: NOW,
+    )
+
+    assert result["contract_version"] == "devui.composition.v1"
+    assert result["authority"] == "projection_only"
+    assert result["captured_at"] == "2026-08-08T21:00:00+00:00"
+
+    work = result["providers"]["work"]
+    assert work["status"] == "available"
+    assert work["authority"] == cockpit["authority"]
+    assert work["captured_at"] == cockpit["generated_at"]
+    assert work["snapshot"] == {
+        "generated_at": cockpit["generated_at"],
+        "sources": cockpit["sources"],
+    }
+    assert work["completeness"] == {
+        "claim": cockpit["claim"],
+        "unread_planes": cockpit["unread_planes"],
+        "withdrawn_counts": cockpit["withdrawn_counts"],
+    }
+    assert work["payload"] is cockpit
+
+    capabilities = result["providers"]["capabilities"]
+    assert capabilities["status"] == "available"
+    assert capabilities["authority"] == ckm["projection"]
+    assert capabilities["captured_at"] is None
+    assert capabilities["snapshot"] is ckm["snapshot"]
+    assert capabilities["completeness"] is ckm["snapshot"]["completeness"]
+    assert capabilities["payload"] is ckm
+
+
+def test_composition_uses_existing_read_only_provider_contracts() -> None:
+    reads: list[str] = []
+
+    def read_cockpit() -> dict:
+        reads.append("cockpit")
+        return _cockpit_payload()
+
+    class CkmEnvelope:
+        def to_dict(self) -> dict:
+            reads.append("ckm")
+            return _ckm_payload()
+
+    result = compose_owner_snapshot(
+        cockpit_reader=read_cockpit,
+        ckm_reader=CkmEnvelope,
+        now=lambda: NOW,
+    )
+
+    assert reads == ["cockpit", "ckm"]
+    assert result["providers"]["work"]["provider"] == "builderops_cockpit"
+    assert result["providers"]["capabilities"]["provider"] == "ckm"
+
+
+def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
+    def broken_cockpit() -> dict:
+        raise OSError("dispatcher store is unreadable")
+
+    result = compose_owner_snapshot(
+        cockpit_reader=broken_cockpit,
+        ckm_reader=lambda: _ckm_payload(),
+        now=lambda: NOW,
+    )
+
+    work = result["providers"]["work"]
+    assert work == {
+        "provider": "builderops_cockpit",
+        "status": "refused",
+        "authority": "read_time_join",
+        "captured_at": None,
+        "snapshot": None,
+        "completeness": None,
+        "refusal": {
+            "code": "provider_unavailable",
+            "message": "BuilderOps Cockpit could not provide its read snapshot",
+            "details": {"reason": "dispatcher store is unreadable"},
+        },
+    }
+    assert "payload" not in work
+    assert result["providers"]["capabilities"]["status"] == "available"
+    assert result["providers"]["capabilities"]["payload"]["resources"]
+
+    refused_ckm = compose_owner_snapshot(
+        cockpit_reader=lambda: _cockpit_payload(),
+        ckm_reader=lambda: {
+            "schema_version": 1,
+            "error": {
+                "code": "missing_store",
+                "message": "CKM database does not exist",
+                "details": {"path": "/unavailable/ckm.sqlite3"},
+            },
+        },
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert refused_ckm["status"] == "refused"
+    assert refused_ckm["refusal"]["code"] == "missing_store"
+    assert "payload" not in refused_ckm

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -32,13 +32,22 @@ def _ckm_payload() -> dict:
     return {
         "schema_version": 1,
         "resource_type": "capability",
-        "query_digest": "query-digest",
+        "query_digest": "1" * 64,
         "projection": {"status": "derived_projection", "authoritative": False},
         "snapshot": {
             "epoch": "epoch-7",
             "state_revision": 42,
-            "snapshot_digest": "snapshot-digest",
+            "ckm_schema_version": 5,
+            "envelope_schema_version": 1,
+            "resource_schema_version": 1,
+            "taxonomy_digest": "2" * 64,
+            "effective_audience": "single_operator_local",
+            "access_policy_version": "ckm-local-access-v1",
+            "redaction_profile": "none",
+            "read_set_digest": "3" * 64,
+            "snapshot_digest": "4" * 64,
             "watermarks": {"capability": "2026-08-08T20:58:00+00:00"},
+            "provenance": [{"kind": "fixture"}],
             "completeness": {
                 "complete": True,
                 "object_classes": [
@@ -52,7 +61,12 @@ def _ckm_payload() -> dict:
                 ],
             },
         },
-        "resources": [{"public_id": "ckm_capability_example"}],
+        "resources": [
+            {
+                "public_id": "ckm_capability_example",
+                "resource_type": "capability",
+            }
+        ],
     }
 
 
@@ -167,3 +181,23 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
     }
     assert "/unavailable/ckm.sqlite3" not in repr(refused_ckm)
     assert "payload" not in refused_ckm
+
+
+def test_malformed_ckm_snapshot_is_refused() -> None:
+    malformed = _ckm_payload()
+    malformed["snapshot"] = {"completeness": {}}
+
+    contribution = compose_owner_snapshot(
+        cockpit_reader=lambda: _cockpit_payload(),
+        ckm_reader=lambda: malformed,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"] == {
+        "code": "provider_unavailable",
+        "message": "CKM could not provide its read snapshot",
+        "details": {"reason": "provider read failed"},
+    }
+    assert "payload" not in contribution

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -50,7 +50,10 @@ def _cockpit_payload() -> dict:
             {
                 "name": "dispatcher-store",
                 "state": "fresh",
-                "read_at": "2026-08-08T20:59:58+00:00",
+                "last_successful_read": "2026-08-08T20:59:58+00:00",
+                "detail": "read succeeded",
+                "stale_after_days": 7,
+                "configured": True,
             }
         ],
         "unread_planes": ["github-review-threads"],
@@ -245,6 +248,29 @@ def test_unserializable_cockpit_payload_is_isolated_from_healthy_ckm() -> None:
 
     assert result["providers"]["work"]["status"] == "refused"
     assert result["providers"]["work"]["snapshot"] is None
+    assert result["providers"]["capabilities"]["status"] == "available"
+
+
+def test_semantically_malformed_cockpit_payload_is_isolated() -> None:
+    malformed_cockpit = _cockpit_payload()
+    malformed_cockpit.update(
+        {
+            "generated_at": "not-a-timestamp",
+            "claim": {"kind": "counted", "text": 7},
+            "sources": [None],
+            "unread_planes": [7],
+            "withdrawn_counts": [{"source": 7, "counts": [None]}],
+        }
+    )
+
+    result = compose_owner_snapshot(
+        cockpit_reader=lambda: malformed_cockpit,
+        ckm_reader=_ckm_envelope,
+        now=lambda: NOW,
+    )
+
+    assert result["providers"]["work"]["status"] == "refused"
+    assert result["providers"]["work"]["captured_at"] is None
     assert result["providers"]["capabilities"]["status"] == "available"
 
 

--- a/tests/builderops/test_devui_composition.py
+++ b/tests/builderops/test_devui_composition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timezone
 
 import pytest
@@ -104,7 +105,7 @@ def test_composition_preserves_provider_snapshot_and_authority() -> None:
         "unread_planes": cockpit["unread_planes"],
         "withdrawn_counts": cockpit["withdrawn_counts"],
     }
-    assert work["payload"] is cockpit
+    assert work["payload"] == cockpit
 
     capabilities = result["providers"]["capabilities"]
     assert capabilities["status"] == "available"
@@ -186,6 +187,57 @@ def test_provider_failure_is_isolated_and_never_rendered_as_zero() -> None:
     }
     assert "/unavailable/ckm.sqlite3" not in repr(refused_ckm)
     assert "payload" not in refused_ckm
+
+
+def test_unserializable_cockpit_payload_is_isolated_from_healthy_ckm() -> None:
+    malformed_cockpit = _cockpit_payload()
+    malformed_cockpit["bands"] = {"moving": object()}
+
+    result = compose_owner_snapshot(
+        cockpit_reader=lambda: malformed_cockpit,
+        ckm_reader=_ckm_envelope,
+        now=lambda: NOW,
+    )
+
+    assert result["providers"]["work"]["status"] == "refused"
+    assert result["providers"]["work"]["snapshot"] is None
+    assert result["providers"]["capabilities"]["status"] == "available"
+
+
+@pytest.mark.parametrize(
+    "unsupported_envelope",
+    [
+        replace(_ckm_envelope(), schema_version=999),
+        replace(
+            _ckm_envelope(),
+            snapshot=replace(
+                _ckm_envelope().snapshot,
+                envelope_schema_version=999,
+            ),
+        ),
+        replace(
+            _ckm_envelope(),
+            resources=(replace(_ckm_envelope().resources[0], schema_version=999),),
+        ),
+        ErrorEnvelope(
+            CkmContractError(code="missing_store", message="missing", details={}),
+            schema_version=999,
+        ),
+    ],
+)
+def test_unsupported_typed_ckm_versions_are_refused(
+    unsupported_envelope: ResultEnvelope | ErrorEnvelope,
+) -> None:
+    contribution = compose_owner_snapshot(
+        cockpit_reader=_cockpit_payload,
+        ckm_reader=lambda: unsupported_envelope,
+        now=lambda: NOW,
+    )["providers"]["capabilities"]
+
+    assert contribution["status"] == "refused"
+    assert contribution["snapshot"] is None
+    assert contribution["refusal"]["code"] == "provider_unavailable"
+    assert "payload" not in contribution
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4682

## Linked Issue
Closes #4682

## SBS Impact
- Primary subsystem: Builder System / devUI read projection
- Secondary subsystem(s): BuilderOps Cockpit, CKM, dispatcher/Signboard evidence
- Write class: none; GET-only derived composition
- Persistence impact: none
- Derived/rebuildable impact: rebuilt per request from existing provider reads
- New or changed contract: `devui.composition.v1` and GET `/api/devui/composition`
- Owner-doc impact: `docs/DEVUI.md` and `docs/plans/DEVUI_IMPLEMENTATION.md` updated
- Transition debt impact: closes the missing shared Stage A read-contract seam
- Boundary risk: provider authority and failures must remain independent; no mutation or second truth

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- compose existing BuilderOps Cockpit and CKM read envelopes beneath one versioned, projection-only response
- isolate provider failures as typed refusals while preserving the healthy provider, snapshot identity, completeness, and authority
- expose one GET-only route and record the delivered current state without implementing the visual shell

## BuilderOps Routing
- Records/projections/receipts: PromotionIntent `prom_20260808204218_9d2ca248`
- Reason: applies the promoted owner decision behind PR #4681; implementation state remains governed by Issue #4682 and this PR

## Notes
- Pickup receipt: `coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4682 lease_id=lease-9b580a19 holder=codex evidence=verified-dispatcher-lease`
- Validation: affected devUI, Cockpit provider, API, and auth-proxy suites (82 passed)
- Validation: `ruff check app tests companion-ui/companion-app` (passed)
- Validation: `mypy app` (872 source files, no issues)
- Validation: `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` and `git diff --check` (passed); skip is explicit because the owning current-state docs are updated while STATUS/ROADMAP truth is unchanged
- TCD risk: full path after security/auth review findings; independent mechanism-convergence review is clean at `143c67625` with P0/P1/P2/P3 = 0
- Review repair: devUI accepts only CKM's existing typed `ResultEnvelope` / `ErrorEnvelope`; arbitrary mappings, including forged version, digest, resource, or completeness shapes, are refused
- Review repair: exact nested CKM contract types, scalar/query/snapshot identity, JSON key shape, and strict UTF-8 response encodability are checked inside each provider isolation boundary
- Review repair: Cockpit claim time, source identity/readability/configuration, dispatcher countability, unread planes, and withdrawn-count evidence are bound before the provider is marked available
- Review repair: stale count-owning Cockpit sources require the producer-exact withdrawal set; local admission binds socket peer and Host to loopback and rejects forwarded/proxy identity headers
- Review repair: CKM refusal keeps its bounded typed code but replaces raw message/details so local paths and SQLite/OSError diagnostics cannot reach the unified response
- The visual devUI shell remains out of scope and still requires the Yggdrasil design handoff.
