### PR TITLE
Document local not-pg validation fallback

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -144,6 +144,34 @@ change has cross-system blast radius that focused subsystem tests cannot cover:
 
 `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/run_with_host_lease.py --resource pytest-not-pg --execution-id <issue-or-pr>:<sha> -- pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -p xdist.plugin -q -m "not pg" -n auto --dist=loadfile`
 
+### Resource-bounded local `not pg` fallback
+
+Use the canonical command above first. When it cannot execute on the local host because its
+single pytest process exhausts a host resource (for example file descriptors), run the following
+sanctioned fallback instead. It retains the same `not pg` marker selection, runs every top-level
+test directory and root-level `test_*.py` file, and holds the same host-global lease for the whole
+run. It is a local execution fallback, not a way to narrow the required validation standard.
+
+```bash
+export PYTHONPATH="${PWD}:${PWD}/companion-ui/companion-app${PYTHONPATH:+:${PYTHONPATH}}"
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/run_with_host_lease.py \
+  --resource pytest-not-pg \
+  --execution-id <issue-or-pr>:<sha> \
+  -- zsh -c 'find tests -mindepth 1 -maxdepth 1 \
+    \( -type d -name "__pycache__" -prune \) -o \
+    \( -type d -o \( -type f -name "test_*.py" \) \) -print0 | \
+    LC_ALL=C sort -z | \
+    xargs -0 -n 1 python3 -m pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin \
+      -p xdist.plugin -q -m "not pg"'
+```
+
+The explicit `PYTHONPATH` is part of this one sanctioned command because tests outside
+`tests/companion_ui` import the nested `companion_ui` package during collection. Do not add
+one-off path exports to Issue or PR handoffs. Record the canonical command's host-resource failure,
+the fallback command, and every failed shard. A fallback run is complete only when every shard
+passes; if a shard cannot run, record the uncovered shard as a validation gap rather than claiming
+the full `not pg` selection passed.
+
 The full non-PG suite is host-global. The wrapper above holds an atomic repo-common kernel lock for
 the entire child process and releases it automatically when the process exits. A chat handshake,
 process census, or quiet-period check is useful diagnosis but is not mutual exclusion. If the lock

--- a/tests/governance/test_dev_workflow_validation_guidance.py
+++ b/tests/governance/test_dev_workflow_validation_guidance.py
@@ -1,0 +1,25 @@
+"""Regression coverage for the sanctioned resource-bounded ``not pg`` fallback (#4016)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEV_WORKFLOW = REPO_ROOT / "docs" / "development" / "DEV_WORKFLOW.md"
+
+
+def test_not_pg_fallback_is_documented() -> None:
+    """The fallback must remain full-selection, leased, and Companion-import-safe."""
+    text = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "### Resource-bounded local `not pg` fallback" in text
+    assert "single pytest process exhausts a host resource" in text
+    assert "same `not pg` marker selection" in text
+    assert "--resource pytest-not-pg" in text
+    assert ' -m "not pg"' in text
+    assert "-mindepth 1 -maxdepth 1" in text
+    assert ' -type f -name "test_*.py"' in text
+    assert "companion-ui/companion-app" in text
+    assert "Do not add\none-off path exports to Issue or PR handoffs." in text
+    assert "uncovered shard as a validation gap" in text


### PR DESCRIPTION
Governing-Issue: #4016

Fixes #4016

Final-Review-Rounds: 0

## Summary
Documents a sanctioned, host-lease-protected sharded local fallback for the full `not pg` selection when the monolithic pytest process is resource-blocked.

Adds governance coverage for selection equivalence, the canonical Companion UI import path, and required gap reporting.

## SBS Impact
- Classification: Builder System / CES boundary
- Product/runtime behavior: unchanged
- Owner-doc writeback: `docs/development/DEV_WORKFLOW.md`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This implements the existing LearningSignal-backed issue without creating new operational material.

## Notes
Validation: `pytest -q tests/governance/test_dev_workflow_validation_guidance.py`; `ruff check app tests`; `python3 scripts/lint_skills_consistency.py`; `python3 scripts/docs_guard.py`; `git diff --check`.