### PR TITLE
Add bash 3 compatibility lint for skill fences

### DIFF
--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -104,6 +104,14 @@ KEBAB_TOKEN_RE = re.compile(r"`([a-z][a-z0-9]*(?:-[a-z0-9]+)+)`")
 ROUTING_ENTRY_RE = re.compile(r"^- `([a-z][a-z0-9-]+)`\s*$", re.MULTILINE)
 LABEL_ITEM_RE = re.compile(r"^\s*[-*]\s+`((?:type|prio|agent):[a-z-]+)`\s*\|?\s*$")
 BLOCK_SCALAR_DESCRIPTION_RE = re.compile(r"^[|>](?:[+-]?\d*|\d+[+-]?)$")
+BASH_FENCE_RE = re.compile(r"^\s*```(?:bash|sh)\s*$", re.IGNORECASE)
+BASH4_ONLY_CONSTRUCTS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("mapfile", re.compile(r"\bmapfile\b")),
+    ("readarray", re.compile(r"\breadarray\b")),
+    ("declare -A", re.compile(r"\bdeclare\s+-A\b")),
+    ("${var,,}", re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*,,\}")),
+    ("${var^^}", re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\^\^\}")),
+)
 FULL_TAXONOMY_MIN_ITEMS = 6
 
 
@@ -276,6 +284,40 @@ def check_feature_breakdown_docs_index(skills_root: Path) -> list[str]:
             f"{rel}: missing the DOCS_INDEX registration instruction "
             "(must reference 'docs/DOCS_INDEX.md'; see #3559)"
         )
+    return errors
+
+
+def check_bash4_only_builtins(skills_root: Path) -> list[str]:
+    """Check 8: skill bash fences must remain compatible with macOS bash 3.2.
+
+    Only fenced ``bash`` and ``sh`` blocks are scanned so prose and examples in
+    other languages can mention these constructs without becoming lint errors.
+    """
+    errors: list[str] = []
+    for skill_dir in _skill_dirs(skills_root):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        rel = skill_md.relative_to(skills_root.parent.parent)
+        in_bash_fence = False
+        for lineno, line in enumerate(
+            skill_md.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if in_bash_fence:
+                if line.strip().startswith("```"):
+                    in_bash_fence = False
+                    continue
+                if line.lstrip().startswith("#"):
+                    continue
+                for construct, pattern in BASH4_ONLY_CONSTRUCTS:
+                    if pattern.search(line):
+                        errors.append(
+                            f"{rel}:{lineno}: bash-4-only construct `{construct}` "
+                            "in fenced shell block (macOS bash 3.2 is supported)"
+                        )
+                continue
+            if BASH_FENCE_RE.match(line):
+                in_bash_fence = True
     return errors
 
 
@@ -721,6 +763,7 @@ def run_lint(repo_root: Path) -> list[str]:
     errors += check_label_taxonomy(skills_root)
     errors += check_retired_phrases(skills_root)
     errors += check_feature_breakdown_docs_index(skills_root)
+    errors += check_bash4_only_builtins(skills_root)
     errors += check_sbs_impact_fields_consistent(repo_root)
     errors += check_required_sections_consistent(repo_root)
     errors += check_pr_contract_validator_matches_workflow(repo_root)

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -176,6 +176,35 @@ def test_lint_detects_retired_phrase(tmp_path: Path) -> None:
     assert any("retired phrase" in e for e in errors), errors
 
 
+def test_lint_detects_bash4_only_builtin(tmp_path: Path) -> None:
+    root = _seed_tree(tmp_path)
+    alpha = root / ".codex" / "skills" / "alpha-skill" / "SKILL.md"
+    alpha.write_text(
+        alpha.read_text(encoding="utf-8")
+        + (
+            "\nmapfile in prose is allowed.\n"
+            "```python\n"
+            "mapfile = []\n"
+            "```\n"
+            "```bash\n"
+            "# mapfile in a shell comment is allowed.\n"
+            "mapfile -t values < input\n"
+            "readarray -t more < input\n"
+            "declare -A lookup\n"
+            "lower=${name,,}\n"
+            "upper=${name^^}\n"
+            "```\n"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_lint(root)
+
+    for construct in ("mapfile", "readarray", "declare -A", "${var,,}", "${var^^}"):
+        assert any(f"`{construct}`" in error for error in errors), errors
+    assert len([error for error in errors if "bash-4-only construct" in error]) == 5
+
+
 def test_sbs_impact_fields_consistent_on_real_repo() -> None:
     """The four real SBS Impact copies must agree (issue #4188)."""
     errors = run_lint(REPO_ROOT)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #3943

## Linked Issue
Closes #3943

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): CI / governance lint
- Write class: governance/tooling
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: Skills lint rejects bash-4-only constructs in fenced shell blocks.
- Owner-doc impact: none
- Transition debt impact: reduces the macOS bash 3.2 regression gap
- Boundary risk: none; no Product/Runtime authority crosses this change

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds static detection of bash-4-only constructs inside skill bash and sh fences.
- Keeps prose, non-shell blocks, and shell comments out of scope.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded issue and PR are the durable delivery record; no divergence occurred.

## Notes
Validation: pytest tests/governance/test_skills_consistency_lint.py -q; python3 scripts/lint_skills_consistency.py; ruff check app tests; python3 scripts/docs_guard.py.