### PR TITLE
Guard rescue stashes against stale dispatcher contracts

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -193,6 +193,13 @@ task id, issue number, status, owner, lease id, lease resource, holder, expiry, 
 before removing `agent:ready`. Database or singleton existence alone never produces a
 dispatcher-backed pickup receipt.
 
+Rescue-stash notes, stale local pickup plans, and prior-session handoffs are
+non-authoritative context. Before using any of them to resume issue pickup,
+fetch and compare against current `origin/main`, this pickup contract, and the
+relevant dispatcher tests. They cannot bypass the wrapper, its verified claim,
+or current stale-takeover semantics; when they conflict, preserve the material
+for diagnosis and follow the current contract instead.
+
 If dispatcher claim verification fails, the wrapper exits without changing the Issue label. If the
 lease was verified but label removal fails, it releases the lease before failing. The success receipt
 contains `task_id`, `lease_id`, `holder`, and `evidence=verified-dispatcher-lease`.

--- a/.codex/skills/resume-work/SKILL.md
+++ b/.codex/skills/resume-work/SKILL.md
@@ -74,6 +74,22 @@ Then read the two context hints, if they exist:
 
 From that, classify into one of the four situations and act.
 
+### Rescue-stash contract gate
+
+Treat rescue-stash material as untrusted recovery input, not as a plan or an
+authority record. Before replaying, applying, or copying any rescue-stash
+change, fetch `origin/main` and compare the material with the current
+repository contracts and their focused tests. For dispatcher-related material,
+that comparison must include the current dispatcher claim and stale-takeover
+semantics; a stale local rescue plan cannot authorize a label mutation, claim,
+takeover, or contract rewrite.
+
+If the rescue material no longer matches the current contract, do not apply it
+blindly. Reconstruct the needed bounded delta from current `origin/main`, or
+escalate through the normal contract/SoT ambiguity path when the intended
+delta cannot be determined safely. Never apply or delete a rescue stash merely
+to make recovery look complete.
+
 For an interrupted `type:bug` implementation from a larger bug set, resume only its original
 dedicated Codex task/session and worktree. Do not absorb another bug into that session; the serial
 default and any independent-wave exception remain governed by

--- a/.codex/skills/resume-work/SKILL.md
+++ b/.codex/skills/resume-work/SKILL.md
@@ -79,11 +79,14 @@ From that, classify into one of the four situations and act.
 Treat rescue-stash material as untrusted recovery input, not as a plan or an
 authority record. Before replaying, applying, or copying any rescue-stash
 change, fetch `origin/main` and compare the material with the current
-repository contracts and their focused tests. For dispatcher-related material,
-that comparison must include the current dispatcher claim and stale-takeover
-semantics; a stale local rescue plan cannot authorize a label mutation, claim,
-takeover, or contract rewrite.
+repository contracts and their focused tests. The authoritative dispatcher
+pickup rules remain `.codex/skills/issue-to-code/SKILL.md :: Dispatcher
+Integration`; recovery must use that current contract rather than promoting a
+stale local rescue plan into claim, takeover, label-mutation, or contract
+authority.
 
+If a fresh fetch is unavailable, continue ordinary read-only reconstruction,
+but do not replay rescue-stash material on the strength of a cached ref alone.
 If the rescue material no longer matches the current contract, do not apply it
 blindly. Reconstruct the needed bounded delta from current `origin/main`, or
 escalate through the normal contract/SoT ambiguity path when the intended

--- a/tests/governance/test_resume_work_contracts.py
+++ b/tests/governance/test_resume_work_contracts.py
@@ -1,0 +1,31 @@
+"""Regression guards for recovery instructions that affect dispatcher authority."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_stale_rescue_material_must_match_current_dispatcher_contracts() -> None:
+    """Rescue guidance must not make stale local material claim dispatcher authority."""
+    resume_work = _read(".codex/skills/resume-work/SKILL.md")
+    issue_to_code = _read(".codex/skills/issue-to-code/SKILL.md")
+    resume_work_flat = " ".join(resume_work.split())
+    issue_to_code_flat = " ".join(issue_to_code.split())
+
+    assert "### Rescue-stash contract gate" in resume_work
+    assert "fetch `origin/main`" in resume_work
+    assert "current dispatcher claim and stale-takeover semantics" in resume_work_flat
+    assert "do not apply it blindly" in resume_work_flat
+    assert "Never apply or delete a rescue stash" in resume_work
+
+    assert "Rescue-stash notes, stale local pickup plans" in issue_to_code_flat
+    assert "fetch and compare against current `origin/main`" in issue_to_code_flat
+    assert "cannot bypass the wrapper, its verified claim" in issue_to_code_flat
+    assert "current stale-takeover semantics" in issue_to_code_flat

--- a/tests/governance/test_resume_work_contracts.py
+++ b/tests/governance/test_resume_work_contracts.py
@@ -21,7 +21,8 @@ def test_stale_rescue_material_must_match_current_dispatcher_contracts() -> None
 
     assert "### Rescue-stash contract gate" in resume_work
     assert "fetch `origin/main`" in resume_work
-    assert "current dispatcher claim and stale-takeover semantics" in resume_work_flat
+    assert ".codex/skills/issue-to-code/SKILL.md :: Dispatcher Integration" in resume_work_flat
+    assert "cached ref alone" in resume_work_flat
     assert "do not apply it blindly" in resume_work_flat
     assert "Never apply or delete a rescue stash" in resume_work
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4019

## Linked Issue
Closes #4019

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): dispatcher/resume workflow
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: resume-work compares rescue material to current dispatcher contracts before application
- Owner-doc impact: updated
- Transition debt impact: reduces
- Boundary risk: stale rescue artifacts must not override current dispatcher authority contracts

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require rescue-stash recovery to compare current dispatcher contracts before replay.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue already records the applied LearningSignal; no new BuilderOps record is needed.

## Notes
Validation: pytest -q tests/governance/test_resume_work_contracts.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; review-before-CI gate passed.