### PR TITLE
docs(devui): define server-declared Overview contract

### DIFF
--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -13,7 +13,7 @@ Source of truth: This document owns the owner experience. Accepted ADRs and link
 specifications own the mechanisms; live GitHub, CI, dispatcher, and receipt evidence owns delivery
 truth.
 Last reviewed: 2026-08-09
-Last verified against: `origin/main` `6f4fb5e2cdd1c05b8905f55b25b671c583c76a7e`, ADR-0057,
+Last verified against: `origin/main` `c938e7371148df34be3e2d3d896579e79ed449a4`, ADR-0057,
 ADR-0062, ADR-0064, ADR-0065, the CKM and BuilderOps Cockpit owner contracts, the Deterministic
 Delivery Orchestration specification, the merged Builder System process clarification in PR #4692,
 the advisory Builder System devUI execution audit in PR #4689, and the merged Focus and Conversation
@@ -347,6 +347,58 @@ Capabilities, work, evidence, and receipts are lenses within these views, not ad
 modes. Moving from overview to focus to command and receipt preserves the selected item,
 goal, scope, evidence, and owner-facing state.
 
+### DEVUI-OVERVIEW-BOUNDARY — server-declared read model
+
+The first usable devUI increment is a server-declared, read-only Overview projection. It is a pure
+adapter over `devui.composition.v1`, not a source reader or a browser classification layer. Its
+contract version is `devui-overview-view.v1` and its output is rebuilt per request:
+
+```yaml
+contract_version: devui-overview-view.v1
+authority: projection_only
+composed_at: RFC3339
+trust_frame:
+  provider_states: [SourceState.v1]
+  limitations: [Limitation.v1]
+now: [OverviewItem.v1]
+needs_you: [OverviewItem.v1]
+ready_to_try: [OverviewItem.v1]
+soi_evidence_lens: SoIEvidenceReference.v1 | null
+limitations: [Limitation.v1]
+```
+
+`OverviewItem.v1` carries one typed subject reference, a server-declared zone, a source-backed
+reason for that placement, independent source freshness/completeness/cardinality/linkage/refusal
+or withdrawal evidence, and typed navigation references only. It does not copy a Focus payload, a
+SoI payload, a delivery run, or a Builder System Control payload into a shared object.
+
+The three zones have strict eligibility:
+
+- **Needs you** requires an explicit named owner-authority category and its governing source
+  reference. Missing, stale, unread, unavailable, refused, unsupported, or unlinked authority
+  evidence withdraws the classification; it is not an empty decision list or a technical decision.
+- **Ready to try** requires a receipt-backed ready-to-try fact. Delivery, merge, Issue closure,
+  availability, ready-to-try, owner trial, and owner acceptance remain independent facts; none is
+  inferred from another.
+- **Now** presents the remaining server-declared read situation without promoting technical blocks
+  into owner decisions or treating degraded input as zero/empty.
+
+The composer performs no source reads, I/O, network access, cache lookup, persistence, task/graph
+or session operation, mutation, or browser-state classification. It preserves producer-exact
+withdrawals and each evidence axis through composition. Inferred correlations are refused. Focus,
+Product/Runtime SoI Evidence, delivery execution, and Builder System Control are separate roots:
+links are typed navigation references, never joins or inherited state. A failed or unsupported root
+withdraws only the dependent reference and leaves the remaining read view usable.
+
+The optional `soi_evidence_lens` is a reference to the delivered bounded SoI Evidence View v0 proof;
+it retains that proof's explicit Product/Runtime denominator and current/target claim horizons. It
+does not classify Overview items or become a maturity, priority, or lifecycle authority.
+
+This contract is a nonvisual prerequisite. A local GET-only route may expose it after its own
+bounded implementation proof. A visual shell remains separately gated by the governed Yggdrasil
+design handoff; neither a browser nor a shell may reclassify the server result or add durable
+selection state.
+
 ### DEVUI-FCP-BOUNDARY — Focus and Conversation Port
 
 The first Focus slice is subject-centred. Its subject is exactly one stable GitHub Issue or one
@@ -495,14 +547,21 @@ Delivered now:
 - `devui.composition.v1` at GET `/api/devui/composition`, a per-request projection that preserves
   independent Cockpit and CKM authority, snapshots, completeness, and typed refusals without
   persistence or mutation;
+- `FocusView.v1` / `focus-view.v1`, a pure subject-centred projection with explicit correlation,
+  delivered by #4694 / PR #4703;
+- `conversation-context-pack.v1` and its non-authoritative external disposition composer, delivered
+  by #4696 / PR #4704; and
+- the bounded, read-only SoI Evidence View v0 proof composer and immutable fixtures, delivered by
+  #4710 / PR #4711;
 - DDO-01 through DDO-04 fast lane, contracts, plan compiler, reducer, and WorkerRuntime seam; and
 - parts of the BuilderOps API/PostgreSQL control-plane development baseline.
 
 Not delivered now: one devUI shell; request/preview/authenticated approval in one owner experience;
 PostgreSQL authority cutover; full live run controls; receipt-to-CKM reassessment in the unified
-surface; the Focus/Conversation Port and its `ConversationContextPack.v1` / command-preview target
-contracts; the Builder System Control lens; the SoI Evidence View v0 composer, proof fixtures, and
-UI; owner pilot and tried-by-owner acceptance; and ADR-0065 dispositions.
+surface; the server-declared Overview composer and local Overview route; Focus route/UI and
+Overview-to-Focus navigation; provider conversation runtime; authenticated command preview/Start/Hold;
+the Builder System Control lens; visual shell; owner pilot and tried-by-owner acceptance; and
+ADR-0065 dispositions.
 
 The target turns the current cockpits and Signboard from competing owner destinations into internal
 providers: Direction B stays an exportable/static evidence fallback, BuilderOps Cockpit supplies

--- a/docs/plans/DEVUI_IMPLEMENTATION.md
+++ b/docs/plans/DEVUI_IMPLEMENTATION.md
@@ -1,7 +1,9 @@
 State: Target-state implementation plan (2026-08-09). The read-only `devui.composition.v1` seam,
-pure `focus-view.v1` composer, and nonvisual external context-pack/export composer are delivered.
-The Focus UI, provider conversation runtime, Builder System Control lens, visual shell, and general
-authority-bearing stages remain targets. Existing GitHub Issues remain executable backlog truth.
+pure `focus-view.v1` composer, nonvisual external context-pack/export composer, and bounded SoI
+Evidence View v0 proof are delivered. The server-declared Overview composer and its producer
+enrichment are next nonvisual work. The Focus UI, provider conversation runtime, Builder System
+Control lens, visual shell, and general authority-bearing stages remain targets. Existing GitHub
+Issues remain executable backlog truth.
 Doc role: Builder System implementation and sequencing plan
 Authority: Owns the proposed dependency order for realizing `docs/DEVUI.md`. Subordinate to accepted ADRs, DDO and BuilderOps control-plane specifications, live Issue contracts, and current-state owner docs.
 Owner: Builder System governance
@@ -69,8 +71,10 @@ or concepts the owner must understand to complete the flow.
 | Work/freshness | `build_registry`, Cockpit chain predicates, source-state model | Delivered read-only |
 | Queue/claim/lease activity | Dispatcher store and Signboard API contracts | Delivered operational source; standalone Signboard is not devUI navigation |
 | Unified read composition | `devui.composition.v1`, GET `/api/devui/composition` | Delivered per-request projection; no cache, mutation, or visual shell |
+| Overview zones | `DevuiOverviewView.v1` over the composition envelope | Target: pure server-side composer only; needs producer-authority enrichment before full three-zone classification |
 | Subject focus | `FocusView.v1` over existing read sources | Pure read-only composer delivered by PR #4703; Focus route/UI not delivered |
 | External conversation | `conversation-context-pack.v1` and explicit external adapter boundary | Nonvisual pack/export/disposition composer delivered by PR #4704; provider opening, embedded runtime, and session integration not delivered |
+| Product/Runtime SoI evidence | bounded SoI Evidence View v0 composer and manifest | Read-only proof delivered by PR #4711; optional Overview reference retains explicit denominator and claim horizons |
 | First narrow command | Existing artifact-first `start-model-inquiry` skill and receipt | Workflow delivered; devUI preview/Start/Hold adapter not delivered |
 | Builder System Control | Owner docs, process map, skill contracts, bounded capability declarations, BuilderOps/live evidence | Separate read-lens target; not delivered |
 | Proposal/preview | `DeliveryRequest.v1`, `DeliveryPreview.v1`, pure plan compiler | DDO-06 target; compiler seam delivered |
@@ -109,6 +113,20 @@ Current `ckm-local-access-v1` remains `single_operator_local`. Until its audienc
 redaction, redistribution, and version-refusal policy is accepted, CKM façade access remains local.
 The read path remains side-effect free, distinguishes partial/refused/stale/zero, preserves each
 source's snapshot and watermark, and never claims an atomic cross-system snapshot.
+
+Before the visual handoff, Stage A starts with a server-declared `DevuiOverviewView.v1` as specified
+by `docs/DEVUI.md :: DEVUI-OVERVIEW-BOUNDARY — server-declared read model`. The delivery order is:
+
+1. enrich the existing Cockpit/composition producer only where it can expose a named
+   owner-authority category and governing source for **Needs you**;
+2. compose the pure Overview result from `devui.composition.v1`, preserving exact withdrawal and
+   independent evidence axes without any source read, cache, persistence, task/graph/session path,
+   mutation, inferred correlation, or browser-side classification;
+3. expose the read model through a local GET-only route; and
+4. add typed Overview-to-Focus and optional SoI navigation references without joining those roots.
+
+The governed Yggdrasil handoff remains a gate only for the visual shell. It does not block these
+nonvisual contracts, producers, composer, or local read route.
 
 Verify: the three zones answer the owner questions; context survives cockpit-to-detail navigation;
 one or both sources may fail honestly; no technical ID, action endpoint, browser credential, local

--- a/docs/plans/DEVUI_IMPLEMENTATION.md
+++ b/docs/plans/DEVUI_IMPLEMENTATION.md
@@ -117,8 +117,10 @@ source's snapshot and watermark, and never claims an atomic cross-system snapsho
 Before the visual handoff, Stage A starts with a server-declared `DevuiOverviewView.v1` as specified
 by `docs/DEVUI.md :: DEVUI-OVERVIEW-BOUNDARY — server-declared read model`. The delivery order is:
 
-1. enrich the existing Cockpit/composition producer only where it can expose a named
-   owner-authority category and governing source for **Needs you**;
+1. enrich the existing Cockpit/composition producers only where they can expose either a named
+   owner-authority category and governing source for **Needs you**, or an explicit receipt-backed
+   ready-to-try fact and its source reference for **Ready to try**. A merge, delivery, availability,
+   or closed Issue cannot substitute for that producer evidence;
 2. compose the pure Overview result from `devui.composition.v1`, preserving exact withdrawal and
    independent evidence axes without any source read, cache, persistence, task/graph/session path,
    mutation, inferred correlation, or browser-side classification;


### PR DESCRIPTION
- [x] Docs authoring lane

Final-Review-Rounds: 0

## Summary
Reconcile delivered devUI inputs and define the bounded server-declared Overview projection needed before implementation pickup.

## Changes
- Add the projection-only `DevuiOverviewView.v1` contract and strict zone eligibility.
- Record delivered Focus, external context-pack, and SoI Evidence proof inputs.
- Sequence producer enrichment, pure composer, local GET route, and typed navigation before the visual handoff.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring promotion; the owner docs and live GitHub evidence are the authoritative inputs.

## Notes
Validation: `git diff --check`; `python3 -m pytest -q tests/architecture/test_docs_index.py`; `python3 scripts/docs_guard.py`; docs-authoring review-before-CI gate.