### PR TITLE
feat(devui): add Overview projection composer

### DIFF
--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any
 
 
@@ -82,6 +83,17 @@ def _string(value: Any, *, label: str) -> str:
     return value
 
 
+def _timestamp(value: Any, *, label: str) -> str:
+    raw = _string(value, label=label)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise OverviewContractError(f"{label} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise OverviewContractError(f"{label} must be an RFC3339 timestamp")
+    return raw
+
+
 def _keys(
     value: Mapping[str, Any], *, allowed: set[str], required: set[str], label: str
 ) -> None:
@@ -144,7 +156,9 @@ def _evidence(value: Any, *, label: str) -> dict[str, Any]:
     )
     _string(evidence["evidence_id"], label=f"{label}.evidence_id")
     evidence["source_ref"] = _source_ref(evidence["source_ref"], label=f"{label}.source_ref")
-    _string(evidence["captured_at"], label=f"{label}.captured_at")
+    evidence["captured_at"] = _timestamp(
+        evidence["captured_at"], label=f"{label}.captured_at"
+    )
     for field, allowed in (
         ("availability", _AVAILABILITY),
         ("freshness", _FRESHNESS),
@@ -359,7 +373,9 @@ def compose_overview_view(
         raise OverviewContractError("composition contract version is unsupported")
     if envelope["authority"] != "projection_only":
         raise OverviewContractError("composition must remain projection_only")
-    _string(envelope["captured_at"], label="composition.captured_at")
+    envelope["captured_at"] = _timestamp(
+        envelope["captured_at"], label="composition.captured_at"
+    )
     providers = _mapping(envelope["providers"], label="composition.providers")
     trust_providers: list[dict[str, Any]] = []
     for name, provider in providers.items():
@@ -390,6 +406,11 @@ def compose_overview_view(
         )
         if provider.get("status") not in {"available", "refused"}:
             raise OverviewContractError(f"composition.providers.{name}.status is unsupported")
+        captured_at = provider["captured_at"]
+        if captured_at is not None:
+            captured_at = _timestamp(
+                captured_at, label=f"composition.providers.{name}.captured_at"
+            )
         trust_providers.append(
             {
                 "role": name,
@@ -399,7 +420,7 @@ def compose_overview_view(
                 ),
                 "status": provider["status"],
                 "authority": _detached(provider.get("authority"), label="provider authority"),
-                "captured_at": provider.get("captured_at"),
+                "captured_at": captured_at,
                 "snapshot": _detached(provider.get("snapshot"), label="provider snapshot"),
                 "completeness": _detached(provider.get("completeness"), label="provider completeness"),
                 "refusal": _detached(provider.get("refusal"), label="provider refusal"),

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -33,6 +33,7 @@ _DELIVERY_FACTS = frozenset(
         "merged",
         "delivery",
         "availability",
+        "issue_closure",
         "ready_to_try",
         "owner_trial",
         "owner_acceptance",
@@ -164,13 +165,14 @@ def _evidence(value: Any, *, label: str) -> dict[str, Any]:
     if evidence["cardinality"] == "measured_empty":
         if (
             evidence["availability"] != "available"
+            or evidence["freshness"] != "fresh"
             or evidence["completeness"] != "complete"
             or evidence["linkage"] != "linked"
             or not isinstance(evidence.get("read_watermark"), str)
             or not evidence["read_watermark"].strip()
         ):
             raise OverviewContractError(
-                f"{label}.measured_empty requires an available, complete, linked watermark"
+                f"{label}.measured_empty requires fresh, available, complete, linked evidence with a watermark"
             )
     if evidence["availability"] != "available" and evidence["cardinality"] == "measured_empty":
         raise OverviewContractError(f"{label} cannot make an empty claim from an unavailable source")
@@ -264,6 +266,7 @@ def _candidate(value: Any, *, zone: str) -> dict[str, Any]:
         facts = _mapping(facts, label=f"{zone} candidate.delivery_facts")
         if set(facts) - _DELIVERY_FACTS:
             raise OverviewContractError(f"{zone} candidate.delivery_facts has unknown facts")
+        evidence_ids = {item["evidence_id"] for item in evidence}
         for key, fact in facts.items():
             fact = _mapping(fact, label=f"{zone} candidate.delivery_facts.{key}")
             _keys(
@@ -278,6 +281,10 @@ def _candidate(value: Any, *, zone: str) -> dict[str, Any]:
                 fact["source_ref"], label=f"{zone} candidate.delivery_facts.{key}.source_ref"
             )
             _string(fact["evidence_id"], label=f"{zone} candidate.delivery_facts.{key}.evidence_id")
+            if fact["state"] == "evidenced" and fact["evidence_id"] not in evidence_ids:
+                raise OverviewContractError(
+                    f"{zone} candidate.delivery_facts.{key} evidenced fact requires source evidence"
+                )
             if fact.get("receipt_ref") is not None:
                 fact["receipt_ref"] = _source_ref(
                     fact["receipt_ref"], label=f"{zone} candidate.delivery_facts.{key}.receipt_ref"
@@ -294,6 +301,7 @@ def _withdrawal(candidate: Mapping[str, Any], *, zone: str, reason: str) -> dict
         "subject_ref": candidate["subject_ref"],
         "reason": reason,
         "evidence": candidate["evidence"],
+        "limitations": candidate["limitations"],
     }
 
 
@@ -357,11 +365,38 @@ def compose_overview_view(
     for name, provider in providers.items():
         provider = _mapping(provider, label=f"composition.providers.{name}")
         _string(name, label="composition provider name")
+        _keys(
+            provider,
+            allowed={
+                "provider",
+                "status",
+                "authority",
+                "captured_at",
+                "snapshot",
+                "completeness",
+                "refusal",
+                "payload",
+            },
+            required={
+                "provider",
+                "status",
+                "authority",
+                "captured_at",
+                "snapshot",
+                "completeness",
+                "refusal",
+            },
+            label=f"composition.providers.{name}",
+        )
         if provider.get("status") not in {"available", "refused"}:
             raise OverviewContractError(f"composition.providers.{name}.status is unsupported")
         trust_providers.append(
             {
-                "provider": name,
+                "role": name,
+                "provider": _string(
+                    provider.get("provider"),
+                    label=f"composition.providers.{name}.provider",
+                ),
                 "status": provider["status"],
                 "authority": _detached(provider.get("authority"), label="provider authority"),
                 "captured_at": provider.get("captured_at"),

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -441,10 +441,18 @@ def compose_overview_view(
                 raise OverviewContractError(
                     f"composition.providers.{name} available provider cannot carry refusal evidence"
                 )
-        elif provider["authority"] is None or provider["refusal"] is None:
-            raise OverviewContractError(
-                f"composition.providers.{name} refused provider requires authority and refusal evidence"
-            )
+        else:
+            if provider["authority"] is None or provider["refusal"] is None:
+                raise OverviewContractError(
+                    f"composition.providers.{name} refused provider requires authority and refusal evidence"
+                )
+            if any(
+                provider.get(field) is not None
+                for field in ("captured_at", "snapshot", "completeness", "payload")
+            ):
+                raise OverviewContractError(
+                    f"composition.providers.{name} refused provider cannot carry available evidence"
+                )
         trust_providers.append(
             {
                 "role": name,

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -38,6 +38,14 @@ _DELIVERY_FACTS = frozenset(
         "owner_acceptance",
     }
 )
+_OWNER_AUTHORITY_CATEGORIES = frozenset(
+    {
+        "irreversible_external_effect",
+        "security_privacy_cost_commitment",
+        "production_release_operator_action",
+        "contradictory_source_authority",
+    }
+)
 
 
 class OverviewContractError(ValueError):
@@ -294,11 +302,16 @@ def _classify(candidate: dict[str, Any], *, zone: str) -> tuple[dict[str, Any] |
     if zone == "needs_you":
         authority = candidate.get("owner_authority")
         evidence = evidence_by_id.get(authority["evidence_id"]) if authority else None
-        if authority is None or evidence is None or not _is_actionable(evidence):
+        if (
+            authority is None
+            or authority["category"] not in _OWNER_AUTHORITY_CATEGORIES
+            or evidence is None
+            or not _is_actionable(evidence)
+        ):
             return None, _withdrawal(
                 candidate,
                 zone=zone,
-                reason="owner authority is missing, unlinked, or degraded",
+                reason="owner authority is missing, unknown, unlinked, or degraded",
             )
     if zone == "ready_to_try":
         facts = candidate.get("delivery_facts") or {}
@@ -380,15 +393,16 @@ def compose_overview_view(
         "limitations": [],
     }
     for zone in _ZONE_ORDER:
-        if zone in {"needs_you", "ready_to_try"} and zone not in raw_candidates:
+        zone_candidates = _list(raw_candidates.get(zone, []), label=f"candidates.{zone}")
+        if zone in {"needs_you", "ready_to_try"} and not zone_candidates:
             result["limitations"].append(
                 {
                     "kind": "classification_withdrawn",
                     "zone": zone,
-                    "reason": "the producer supplied no classification evidence",
+                    "reason": "the producer supplied no actionable classification evidence",
                 }
             )
-        for raw in _list(raw_candidates.get(zone, []), label=f"candidates.{zone}"):
+        for raw in zone_candidates:
             candidate = _candidate(raw, zone=zone)
             classified, withdrawal = _classify(candidate, zone=zone)
             if classified is not None:

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -363,7 +363,9 @@ def compose_overview_view(
             {
                 "provider": name,
                 "status": provider["status"],
+                "authority": _detached(provider.get("authority"), label="provider authority"),
                 "captured_at": provider.get("captured_at"),
+                "snapshot": _detached(provider.get("snapshot"), label="provider snapshot"),
                 "completeness": _detached(provider.get("completeness"), label="provider completeness"),
                 "refusal": _detached(provider.get("refusal"), label="provider refusal"),
             }

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -8,6 +8,7 @@ interprets missing evidence as an empty or affirmative claim.
 from __future__ import annotations
 
 import copy
+import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
@@ -48,6 +49,12 @@ _OWNER_AUTHORITY_CATEGORIES = frozenset(
         "contradictory_source_authority",
     }
 )
+_RFC3339_TIMESTAMP = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-[0-9]{2}T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]"
+    r"(?:\.[0-9]+)?(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])\Z",
+    re.ASCII,
+)
 
 
 class OverviewContractError(ValueError):
@@ -85,6 +92,8 @@ def _string(value: Any, *, label: str) -> str:
 
 def _timestamp(value: Any, *, label: str) -> str:
     raw = _string(value, label=label)
+    if _RFC3339_TIMESTAMP.fullmatch(raw) is None:
+        raise OverviewContractError(f"{label} must be an RFC3339 timestamp")
     try:
         parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError as exc:
@@ -299,6 +308,14 @@ def _candidate(value: Any, *, zone: str) -> dict[str, Any]:
                 raise OverviewContractError(
                     f"{zone} candidate.delivery_facts.{key} evidenced fact requires source evidence"
                 )
+            if fact["state"] == "evidenced":
+                supporting_evidence = next(
+                    item for item in evidence if item["evidence_id"] == fact["evidence_id"]
+                )
+                if not _is_actionable(supporting_evidence):
+                    raise OverviewContractError(
+                        f"{zone} candidate.delivery_facts.{key} evidenced fact requires actionable source evidence"
+                    )
             if fact.get("receipt_ref") is not None:
                 fact["receipt_ref"] = _source_ref(
                     fact["receipt_ref"], label=f"{zone} candidate.delivery_facts.{key}.receipt_ref"
@@ -410,6 +427,23 @@ def compose_overview_view(
         if captured_at is not None:
             captured_at = _timestamp(
                 captured_at, label=f"composition.providers.{name}.captured_at"
+            )
+        if provider["status"] == "available":
+            if provider["authority"] is None or provider["completeness"] is None:
+                raise OverviewContractError(
+                    f"composition.providers.{name} available provider requires authority and completeness"
+                )
+            if provider["snapshot"] is None and captured_at is None:
+                raise OverviewContractError(
+                    f"composition.providers.{name} available provider requires snapshot or captured_at"
+                )
+            if provider["refusal"] is not None:
+                raise OverviewContractError(
+                    f"composition.providers.{name} available provider cannot carry refusal evidence"
+                )
+        elif provider["authority"] is None or provider["refusal"] is None:
+            raise OverviewContractError(
+                f"composition.providers.{name} refused provider requires authority and refusal evidence"
             )
         trust_providers.append(
             {

--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -1,0 +1,401 @@
+"""Pure server-side Overview projection for the devUI owner experience.
+
+The module consumes an already-composed ``devui.composition.v1`` envelope and
+explicit producer evidence.  It never opens sources, retains state, or
+interprets missing evidence as an empty or affirmative claim.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+CONTRACT_VERSION = "devui-overview-view.v1"
+_COMPOSITION_VERSION = "devui.composition.v1"
+_ZONE_ORDER = ("now", "needs_you", "ready_to_try")
+_ZONES = frozenset(_ZONE_ORDER)
+_AVAILABILITY = frozenset({"available", "unavailable", "refused", "unsupported"})
+_FRESHNESS = frozenset({"fresh", "stale", "unknown"})
+_COMPLETENESS = frozenset(
+    {"complete", "partial", "unread", "missing", "not_applicable"}
+)
+_CARDINALITY = frozenset(
+    {"nonempty", "measured_empty", "not_measured", "not_countable"}
+)
+_LINKAGE = frozenset({"linked", "unlinked", "not_assessed", "not_applicable"})
+_ROOT_KINDS = frozenset(
+    {"focus", "soi_evidence", "delivery_execution", "builder_system_control"}
+)
+_DELIVERY_FACTS = frozenset(
+    {
+        "merged",
+        "delivery",
+        "availability",
+        "ready_to_try",
+        "owner_trial",
+        "owner_acceptance",
+    }
+)
+
+
+class OverviewContractError(ValueError):
+    """Raised when an Overview input could make an authority claim ambiguous."""
+
+
+def _detached(value: Any, *, label: str) -> Any:
+    try:
+        return copy.deepcopy(value)
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        raise OverviewContractError(f"{label} must be copyable") from exc
+
+
+def _mapping(value: Any, *, label: str) -> dict[str, Any]:
+    copied = _detached(value, label=label)
+    if not isinstance(copied, dict) or any(not isinstance(key, str) for key in copied):
+        raise OverviewContractError(f"{label} must be an object with string keys")
+    return copied
+
+
+def _list(value: Any, *, label: str) -> list[Any]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise OverviewContractError(f"{label} must be a list")
+    copied = _detached(list(value), label=label)
+    if not isinstance(copied, list):  # pragma: no cover - deepcopy guard
+        raise OverviewContractError(f"{label} must be a list")
+    return copied
+
+
+def _string(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OverviewContractError(f"{label} must be a non-empty string")
+    return value
+
+
+def _keys(
+    value: Mapping[str, Any], *, allowed: set[str], required: set[str], label: str
+) -> None:
+    unknown = set(value) - allowed
+    missing = required - set(value)
+    if unknown:
+        raise OverviewContractError(f"{label} has unknown fields: {sorted(unknown)}")
+    if missing:
+        raise OverviewContractError(f"{label} is missing fields: {sorted(missing)}")
+
+
+def _source_ref(value: Any, *, label: str) -> dict[str, Any]:
+    source = _mapping(value, label=label)
+    _keys(
+        source,
+        allowed={"source_type", "source_id", "version", "snapshot", "content_hash", "locator"},
+        required={"source_type", "source_id", "locator"},
+        label=label,
+    )
+    for field in ("source_type", "source_id", "locator"):
+        _string(source[field], label=f"{label}.{field}")
+    if all(source.get(field) is None for field in ("version", "snapshot", "content_hash")):
+        raise OverviewContractError(f"{label} requires a version, snapshot, or content hash")
+    for field in ("version", "snapshot", "content_hash"):
+        if source.get(field) is not None:
+            _string(source[field], label=f"{label}.{field}")
+    return source
+
+
+def _evidence(value: Any, *, label: str) -> dict[str, Any]:
+    evidence = _mapping(value, label=label)
+    _keys(
+        evidence,
+        allowed={
+            "evidence_id",
+            "claim",
+            "source_ref",
+            "availability",
+            "freshness",
+            "completeness",
+            "cardinality",
+            "linkage",
+            "captured_at",
+            "read_watermark",
+            "limitation",
+        },
+        required={
+            "evidence_id",
+            "claim",
+            "source_ref",
+            "availability",
+            "freshness",
+            "completeness",
+            "cardinality",
+            "linkage",
+            "captured_at",
+            "limitation",
+        },
+        label=label,
+    )
+    _string(evidence["evidence_id"], label=f"{label}.evidence_id")
+    evidence["source_ref"] = _source_ref(evidence["source_ref"], label=f"{label}.source_ref")
+    _string(evidence["captured_at"], label=f"{label}.captured_at")
+    for field, allowed in (
+        ("availability", _AVAILABILITY),
+        ("freshness", _FRESHNESS),
+        ("completeness", _COMPLETENESS),
+        ("cardinality", _CARDINALITY),
+        ("linkage", _LINKAGE),
+    ):
+        if evidence[field] not in allowed:
+            raise OverviewContractError(f"{label}.{field} is unsupported")
+    if evidence["claim"] is not None:
+        _string(evidence["claim"], label=f"{label}.claim")
+        if evidence["linkage"] != "linked":
+            raise OverviewContractError(f"{label} unlinked evidence cannot support a claim")
+        if evidence["availability"] != "available":
+            raise OverviewContractError(f"{label} unavailable evidence cannot support a claim")
+    else:
+        _string(evidence["limitation"], label=f"{label}.limitation")
+    if evidence["cardinality"] == "measured_empty":
+        if (
+            evidence["availability"] != "available"
+            or evidence["completeness"] != "complete"
+            or evidence["linkage"] != "linked"
+            or not isinstance(evidence.get("read_watermark"), str)
+            or not evidence["read_watermark"].strip()
+        ):
+            raise OverviewContractError(
+                f"{label}.measured_empty requires an available, complete, linked watermark"
+            )
+    if evidence["availability"] != "available" and evidence["cardinality"] == "measured_empty":
+        raise OverviewContractError(f"{label} cannot make an empty claim from an unavailable source")
+    return evidence
+
+
+def _is_actionable(evidence: Mapping[str, Any]) -> bool:
+    return (
+        evidence["claim"] is not None
+        and evidence["availability"] == "available"
+        and evidence["freshness"] == "fresh"
+        and evidence["completeness"] == "complete"
+        and evidence["cardinality"] == "nonempty"
+        and evidence["linkage"] == "linked"
+    )
+
+
+def _root_ref(value: Any, *, label: str) -> dict[str, Any]:
+    root = _mapping(value, label=label)
+    _keys(
+        root,
+        allowed={"kind", "navigation_ref", "status", "limitation"},
+        required={"kind", "navigation_ref", "status", "limitation"},
+        label=label,
+    )
+    if root["kind"] not in _ROOT_KINDS:
+        raise OverviewContractError(f"{label}.kind is unsupported")
+    root["navigation_ref"] = _source_ref(
+        root["navigation_ref"], label=f"{label}.navigation_ref"
+    )
+    if root["status"] not in {"available", "degraded", "unsupported", "unlinked"}:
+        raise OverviewContractError(f"{label}.status is unsupported")
+    if root["limitation"] is not None:
+        _string(root["limitation"], label=f"{label}.limitation")
+    return root
+
+
+def _candidate(value: Any, *, zone: str) -> dict[str, Any]:
+    candidate = _mapping(value, label=f"{zone} candidate")
+    _keys(
+        candidate,
+        allowed={
+            "subject_ref",
+            "reason",
+            "evidence",
+            "owner_authority",
+            "delivery_facts",
+            "navigation_refs",
+            "limitations",
+        },
+        required={"subject_ref", "reason", "evidence", "navigation_refs", "limitations"},
+        label=f"{zone} candidate",
+    )
+    candidate["subject_ref"] = _source_ref(
+        candidate["subject_ref"], label=f"{zone} candidate.subject_ref"
+    )
+    _string(candidate["reason"], label=f"{zone} candidate.reason")
+    evidence = [_evidence(item, label=f"{zone} candidate.evidence") for item in _list(candidate["evidence"], label=f"{zone} candidate.evidence")]
+    if not evidence:
+        raise OverviewContractError(f"{zone} candidate requires source evidence")
+    if len({item["evidence_id"] for item in evidence}) != len(evidence):
+        raise OverviewContractError(f"{zone} candidate has duplicate evidence ids")
+    candidate["evidence"] = evidence
+    candidate["navigation_refs"] = [
+        _root_ref(item, label=f"{zone} candidate.navigation_refs")
+        for item in _list(candidate["navigation_refs"], label=f"{zone} candidate.navigation_refs")
+    ]
+    candidate["limitations"] = [
+        _string(item, label=f"{zone} candidate.limitations")
+        for item in _list(candidate["limitations"], label=f"{zone} candidate.limitations")
+    ]
+
+    authority = candidate.get("owner_authority")
+    if authority is not None:
+        authority = _mapping(authority, label=f"{zone} candidate.owner_authority")
+        _keys(
+            authority,
+            allowed={"category", "governing_source", "evidence_id"},
+            required={"category", "governing_source", "evidence_id"},
+            label=f"{zone} candidate.owner_authority",
+        )
+        _string(authority["category"], label=f"{zone} candidate.owner_authority.category")
+        authority["governing_source"] = _source_ref(
+            authority["governing_source"], label=f"{zone} candidate.owner_authority.governing_source"
+        )
+        _string(authority["evidence_id"], label=f"{zone} candidate.owner_authority.evidence_id")
+        candidate["owner_authority"] = authority
+
+    facts = candidate.get("delivery_facts")
+    if facts is not None:
+        facts = _mapping(facts, label=f"{zone} candidate.delivery_facts")
+        if set(facts) - _DELIVERY_FACTS:
+            raise OverviewContractError(f"{zone} candidate.delivery_facts has unknown facts")
+        for key, fact in facts.items():
+            fact = _mapping(fact, label=f"{zone} candidate.delivery_facts.{key}")
+            _keys(
+                fact,
+                allowed={"state", "source_ref", "receipt_ref", "evidence_id"},
+                required={"state", "source_ref", "evidence_id"},
+                label=f"{zone} candidate.delivery_facts.{key}",
+            )
+            if fact["state"] not in {"evidenced", "unknown", "not_applicable"}:
+                raise OverviewContractError(f"{zone} candidate.delivery_facts.{key}.state is unsupported")
+            fact["source_ref"] = _source_ref(
+                fact["source_ref"], label=f"{zone} candidate.delivery_facts.{key}.source_ref"
+            )
+            _string(fact["evidence_id"], label=f"{zone} candidate.delivery_facts.{key}.evidence_id")
+            if fact.get("receipt_ref") is not None:
+                fact["receipt_ref"] = _source_ref(
+                    fact["receipt_ref"], label=f"{zone} candidate.delivery_facts.{key}.receipt_ref"
+                )
+            facts[key] = fact
+        candidate["delivery_facts"] = facts
+    return candidate
+
+
+def _withdrawal(candidate: Mapping[str, Any], *, zone: str, reason: str) -> dict[str, Any]:
+    return {
+        "kind": "classification_withdrawn",
+        "zone": zone,
+        "subject_ref": candidate["subject_ref"],
+        "reason": reason,
+        "evidence": candidate["evidence"],
+    }
+
+
+def _classify(candidate: dict[str, Any], *, zone: str) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    evidence_by_id = {item["evidence_id"]: item for item in candidate["evidence"]}
+    if zone == "needs_you":
+        authority = candidate.get("owner_authority")
+        evidence = evidence_by_id.get(authority["evidence_id"]) if authority else None
+        if authority is None or evidence is None or not _is_actionable(evidence):
+            return None, _withdrawal(
+                candidate,
+                zone=zone,
+                reason="owner authority is missing, unlinked, or degraded",
+            )
+    if zone == "ready_to_try":
+        facts = candidate.get("delivery_facts") or {}
+        ready = facts.get("ready_to_try")
+        evidence = evidence_by_id.get(ready["evidence_id"]) if ready else None
+        if (
+            ready is None
+            or ready["state"] != "evidenced"
+            or ready.get("receipt_ref") is None
+            or evidence is None
+            or not _is_actionable(evidence)
+        ):
+            return None, _withdrawal(
+                candidate,
+                zone=zone,
+                reason="receipt-backed ready-to-try evidence is missing, unlinked, or degraded",
+            )
+    return candidate, None
+
+
+def compose_overview_view(
+    *,
+    composition: Mapping[str, Any],
+    candidates: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+    root_references: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Compose the rebuildable owner Overview without source access or mutation."""
+
+    envelope = _mapping(composition, label="composition")
+    _keys(
+        envelope,
+        allowed={"contract_version", "authority", "captured_at", "providers"},
+        required={"contract_version", "authority", "captured_at", "providers"},
+        label="composition",
+    )
+    if envelope["contract_version"] != _COMPOSITION_VERSION:
+        raise OverviewContractError("composition contract version is unsupported")
+    if envelope["authority"] != "projection_only":
+        raise OverviewContractError("composition must remain projection_only")
+    _string(envelope["captured_at"], label="composition.captured_at")
+    providers = _mapping(envelope["providers"], label="composition.providers")
+    trust_providers: list[dict[str, Any]] = []
+    for name, provider in providers.items():
+        provider = _mapping(provider, label=f"composition.providers.{name}")
+        _string(name, label="composition provider name")
+        if provider.get("status") not in {"available", "refused"}:
+            raise OverviewContractError(f"composition.providers.{name}.status is unsupported")
+        trust_providers.append(
+            {
+                "provider": name,
+                "status": provider["status"],
+                "captured_at": provider.get("captured_at"),
+                "completeness": _detached(provider.get("completeness"), label="provider completeness"),
+                "refusal": _detached(provider.get("refusal"), label="provider refusal"),
+            }
+        )
+
+    raw_candidates = _mapping(candidates or {}, label="candidates")
+    if set(raw_candidates) - _ZONES:
+        raise OverviewContractError("candidates has unsupported zones")
+    parsed_roots = [
+        _root_ref(item, label="root_references")
+        for item in _list(root_references, label="root_references")
+    ]
+    soi_roots = [root for root in parsed_roots if root["kind"] == "soi_evidence"]
+    if len(soi_roots) > 1:
+        raise OverviewContractError("root_references may contain at most one soi_evidence lens")
+
+    result: dict[str, Any] = {
+        "contract_version": CONTRACT_VERSION,
+        "authority": "projection_only",
+        "composed_at": envelope["captured_at"],
+        "trust_frame": {"provider_states": trust_providers, "limitations": []},
+        "now": [],
+        "needs_you": [],
+        "ready_to_try": [],
+        "root_references": parsed_roots,
+        "soi_evidence_lens": soi_roots[0] if soi_roots else None,
+        "limitations": [],
+    }
+    for zone in _ZONE_ORDER:
+        if zone in {"needs_you", "ready_to_try"} and zone not in raw_candidates:
+            result["limitations"].append(
+                {
+                    "kind": "classification_withdrawn",
+                    "zone": zone,
+                    "reason": "the producer supplied no classification evidence",
+                }
+            )
+        for raw in _list(raw_candidates.get(zone, []), label=f"candidates.{zone}"):
+            candidate = _candidate(raw, zone=zone)
+            classified, withdrawal = _classify(candidate, zone=zone)
+            if classified is not None:
+                result[zone].append(classified)
+            if withdrawal is not None:
+                result["limitations"].append(withdrawal)
+    return result
+
+
+__all__ = ["CONTRACT_VERSION", "OverviewContractError", "compose_overview_view"]

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -363,6 +363,7 @@ trust_frame:
 now: [OverviewItem.v1]
 needs_you: [OverviewItem.v1]
 ready_to_try: [OverviewItem.v1]
+root_references: [TypedRootReference.v1]
 soi_evidence_lens: SoIEvidenceReference.v1 | null
 limitations: [Limitation.v1]
 ```
@@ -398,6 +399,11 @@ This contract is a nonvisual prerequisite. A local GET-only route may expose it 
 bounded implementation proof. A visual shell remains separately gated by the governed Yggdrasil
 design handoff; neither a browser nor a shell may reclassify the server result or add durable
 selection state.
+
+The pure composer is implemented in `app/builderops/devui_overview.py`. It accepts only the
+composition envelope, explicit producer evidence, and typed root references; without actionable
+producer evidence it reports the affected **Needs you** or **Ready to try** classification as
+withdrawn. This does not deliver producer enrichment, a local route, or a visual shell.
 
 ### DEVUI-FCP-BOUNDARY — Focus and Conversation Port
 
@@ -553,12 +559,14 @@ Delivered now:
   by #4696 / PR #4704; and
 - the bounded, read-only SoI Evidence View v0 proof composer and immutable fixtures, delivered by
   #4710 / PR #4711;
+- the pure `devui-overview-view.v1` server-side composer, which preserves missing producer
+  classification as an explicit withdrawal rather than an empty owner or ready list;
 - DDO-01 through DDO-04 fast lane, contracts, plan compiler, reducer, and WorkerRuntime seam; and
 - parts of the BuilderOps API/PostgreSQL control-plane development baseline.
 
 Not delivered now: one devUI shell; request/preview/authenticated approval in one owner experience;
 PostgreSQL authority cutover; full live run controls; receipt-to-CKM reassessment in the unified
-surface; the server-declared Overview composer and local Overview route; Focus route/UI and
+surface; the local Overview route; Focus route/UI and
 Overview-to-Focus navigation; provider conversation runtime; authenticated command preview/Start/Hold;
 the Builder System Control lens; visual shell; owner pilot and tried-by-owner acceptance; and
 ADR-0065 dispositions.

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -376,8 +376,11 @@ SoI payload, a delivery run, or a Builder System Control payload into a shared o
 The three zones have strict eligibility:
 
 - **Needs you** requires an explicit named owner-authority category and its governing source
-  reference. Missing, stale, unread, unavailable, refused, unsupported, or unlinked authority
-  evidence withdraws the classification; it is not an empty decision list or a technical decision.
+  reference. The only eligible categories are `irreversible_external_effect`,
+  `security_privacy_cost_commitment`, `production_release_operator_action`, and
+  `contradictory_source_authority`. Missing, unknown, stale, unread, unavailable, refused,
+  unsupported, or unlinked authority evidence withdraws the classification; it is not an empty
+  decision list or a technical decision.
 - **Ready to try** requires a receipt-backed ready-to-try fact. Delivery, merge, Issue closure,
   availability, ready-to-try, owner trial, and owner acceptance remain independent facts; none is
   inferred from another.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,12 +5,22 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-07-30
+Last reviewed: 2026-08-09
 Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/OPERATIONS.md, docs/HUMAN-FLOWS.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, docs/CONCEPTS/MOMENT_ARTIFACT_CONTRACT.md, docs/CONCEPTS/RELEVANCE_EVALUATOR_CONTRACT.md, docs/CONCEPTS/REACHOUT_AND_SCARCITY_GATE_CONTRACT.md, docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md, docs/plans/CONTEXTUAL_RELEVANCE_ENGINE.md, docs/CKM_COCKPIT_DIRECTION_B/README.md, docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md, app/agent_memory/provisional_recall.py, app/agents/ask/graph.py, app/relevance/evaluator.py, app/relevance/materialization.py, app/relevance/attention_loop.py, app/relevance/now_surface.py, app/instance/filesystem_identity.py, app/instance/vault_registry.py, app/dispatcher/verification_api.py, app/dispatcher/verification_runtime.py, scripts/select_pr_tests.py, companion-ui/companion-app/companion_ui/workspace/now_surface.py, tests/agent_memory/test_provisional_memory_recall.py, tests/agent_memory/test_provisional_memory_call_sites.py, tests/relevance/test_vault_native_moments.py, tests/relevance/test_attention_loop_runtime.py, merged PRs #1948/#1977/#2092/#2097/#2098/#2115/#2119/#2127/#2128/#2129/#2131/#2133/#2135/#2137/#2140/#2142/#2636/#2642/#2643/#2645/#2656/#2678/#2686/#2689/#2692/#3730/#4224/#4244/#4420/#4424, issue #3720, PRs #3743/#4416, closed parent issue #4080, live issue #3603, and current repo state at `origin/main` `f0bafe6e79f3cc1a087b2c2fcbe40450c8302da2` on 2026-07-30
 
 Status snapshot now includes SoT baseline + release-line fields and intent/event counters (`promote.intent.created`, `panel.intent.executed`, `watcher.run`, ingest runs by plane). Code still exposes `sot_forward_line_version` / `feature_line_version` as the v5.6 release-line marker, but GitHub issue truth treats v5.6 as delivered rather than active. `watcher_runs` now counts watcher audit events from the registry watcher as well as the legacy snapshot watcher, while runtime health still relies on heartbeat + tick logs.
 
 Concept anchors: layering, portability, archive exposure, trust semantics, event compatibility, and config-as-product are now defined as concept contracts under `docs/CONCEPTS/` and are considered the canonical statements of intent. This status document describes operational snapshots and may lag those contracts.
+
+2026-08-09 devUI read-model writeback (verified against `docs/DEVUI.md`,
+`docs/plans/DEVUI_IMPLEMENTATION.md`, and `app/builderops/devui_overview.py`):
+
+- The pure `devui-overview-view.v1` server-side composer derives the nonvisual Overview from
+  `devui.composition.v1`, explicit producer evidence, and typed root references. It preserves
+  unsupported owner and ready classification as withdrawal rather than an empty list; it performs
+  no source I/O, persistence, mutation, task/session operation, inferred correlation, or browser
+  classification. Producer enrichment, a local Overview route, and every visual or command surface
+  remain undelivered.
 
 Roadmap reset note: `docs/plans/MAJOR_ROADMAP_RESET_2026_06_04.md` is the accepted strategic reset
 input for sequencing, not a runtime-promotion document. This status file remains the current-state

--- a/docs/plans/DEVUI_IMPLEMENTATION.md
+++ b/docs/plans/DEVUI_IMPLEMENTATION.md
@@ -1,7 +1,7 @@
 State: Target-state implementation plan (2026-08-09). The read-only `devui.composition.v1` seam,
 pure `focus-view.v1` composer, nonvisual external context-pack/export composer, and bounded SoI
-Evidence View v0 proof are delivered. The server-declared Overview composer and its producer
-enrichment are next nonvisual work. The Focus UI, provider conversation runtime, Builder System
+Evidence View v0 proof and the pure server-declared Overview composer are delivered. Producer
+enrichment for owner and ready classification is the next nonvisual work. The Focus UI, provider conversation runtime, Builder System
 Control lens, visual shell, and general authority-bearing stages remain targets. Existing GitHub
 Issues remain executable backlog truth.
 Doc role: Builder System implementation and sequencing plan
@@ -71,7 +71,7 @@ or concepts the owner must understand to complete the flow.
 | Work/freshness | `build_registry`, Cockpit chain predicates, source-state model | Delivered read-only |
 | Queue/claim/lease activity | Dispatcher store and Signboard API contracts | Delivered operational source; standalone Signboard is not devUI navigation |
 | Unified read composition | `devui.composition.v1`, GET `/api/devui/composition` | Delivered per-request projection; no cache, mutation, or visual shell |
-| Overview zones | `DevuiOverviewView.v1` over the composition envelope | Target: pure server-side composer only; needs producer-authority enrichment before full three-zone classification |
+| Overview zones | `DevuiOverviewView.v1` over the composition envelope | Pure server-side composer delivered; it withdraws unsupported Needs you and Ready to try classifications until producer-authority enrichment exists |
 | Subject focus | `FocusView.v1` over existing read sources | Pure read-only composer delivered by PR #4703; Focus route/UI not delivered |
 | External conversation | `conversation-context-pack.v1` and explicit external adapter boundary | Nonvisual pack/export/disposition composer delivered by PR #4704; provider opening, embedded runtime, and session integration not delivered |
 | Product/Runtime SoI evidence | bounded SoI Evidence View v0 composer and manifest | Read-only proof delivered by PR #4711; optional Overview reference retains explicit denominator and claim horizons |
@@ -117,13 +117,15 @@ source's snapshot and watermark, and never claims an atomic cross-system snapsho
 Before the visual handoff, Stage A starts with a server-declared `DevuiOverviewView.v1` as specified
 by `docs/DEVUI.md :: DEVUI-OVERVIEW-BOUNDARY — server-declared read model`. The delivery order is:
 
-1. enrich the existing Cockpit/composition producers only where they can expose either a named
+1. compose the pure Overview result from `devui.composition.v1`, preserving exact withdrawal and
+   independent evidence axes without any source read, cache, persistence, task/graph/session path,
+   mutation, inferred correlation, or browser-side classification. Until an eligible producer
+   supplies the authority, receipt, and linkage evidence, **Needs you** and **Ready to try** are
+   explicitly withdrawn rather than treated as empty;
+2. enrich the existing Cockpit/composition producers only where they can expose either a named
    owner-authority category and governing source for **Needs you**, or an explicit receipt-backed
    ready-to-try fact and its source reference for **Ready to try**. A merge, delivery, availability,
    or closed Issue cannot substitute for that producer evidence;
-2. compose the pure Overview result from `devui.composition.v1`, preserving exact withdrawal and
-   independent evidence axes without any source read, cache, persistence, task/graph/session path,
-   mutation, inferred correlation, or browser-side classification;
 3. expose the read model through a local GET-only route; and
 4. add typed Overview-to-Focus and optional SoI navigation references without joining those roots.
 

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -233,6 +233,24 @@ def test_evidenced_delivery_fact_requires_resolving_evidence() -> None:
             composition=_composition(), candidates={"now": [candidate]}
         )
 
+    unsupported = _candidate()
+    unsupported["evidence"].append(
+        _evidence(
+            "unsupported",
+            claim=None,
+            availability="refused",
+            freshness="unknown",
+            completeness="unread",
+            cardinality="not_measured",
+            linkage="unlinked",
+        )
+    )
+    unsupported["delivery_facts"]["merged"]["evidence_id"] = "unsupported"
+    with pytest.raises(OverviewContractError, match="evidenced fact requires actionable"):
+        compose_overview_view(
+            composition=_composition(), candidates={"now": [unsupported]}
+        )
+
 
 def test_overview_preserves_exact_withdrawals_and_independent_evidence_axes() -> None:
     candidate = _candidate(
@@ -293,9 +311,20 @@ def test_measured_empty_requires_fresh_source_evidence() -> None:
 
 
 @pytest.mark.parametrize("zone", ("needs_you", "ready_to_try"))
-def test_malformed_timestamps_cannot_support_classification(zone: str) -> None:
+@pytest.mark.parametrize(
+    "captured_at",
+    (
+        "not-rfc3339",
+        "2026-08-09 21:00:00+00:00",
+        "20260809T210000+00:00",
+        "2026-08-09T21:00:00",
+    ),
+)
+def test_malformed_timestamps_cannot_support_classification(
+    zone: str, captured_at: str
+) -> None:
     candidate = _candidate()
-    candidate["evidence"][0 if zone == "needs_you" else 1]["captured_at"] = "not-rfc3339"
+    candidate["evidence"][0 if zone == "needs_you" else 1]["captured_at"] = captured_at
 
     with pytest.raises(OverviewContractError, match="RFC3339"):
         compose_overview_view(
@@ -313,6 +342,32 @@ def test_composition_and_provider_timestamps_must_be_rfc3339() -> None:
     malformed_provider["providers"]["work"]["captured_at"] = "not-rfc3339"
     with pytest.raises(OverviewContractError, match="RFC3339"):
         compose_overview_view(composition=malformed_provider)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("authority", "completeness"),
+)
+def test_available_provider_requires_coherent_trust_fields(field: str) -> None:
+    composition = _composition()
+    composition["providers"]["work"][field] = None
+
+    with pytest.raises(OverviewContractError, match="available provider"):
+        compose_overview_view(composition=composition)
+
+    missing_identity = _composition()
+    missing_identity["providers"]["work"]["snapshot"] = None
+    missing_identity["providers"]["work"]["captured_at"] = None
+    with pytest.raises(OverviewContractError, match="snapshot or captured_at"):
+        compose_overview_view(composition=missing_identity)
+
+
+def test_refused_provider_requires_refusal_evidence() -> None:
+    composition = _composition()
+    composition["providers"]["capabilities"]["refusal"] = None
+
+    with pytest.raises(OverviewContractError, match="refused provider"):
+        compose_overview_view(composition=composition)
 
 
 def test_withdrawal_preserves_producer_limitations() -> None:

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -29,6 +29,7 @@ def _composition() -> dict:
         "captured_at": "2026-08-09T21:00:00+00:00",
         "providers": {
             "work": {
+                "provider": "builderops_cockpit",
                 "status": "available",
                 "authority": "read_time_join",
                 "captured_at": "2026-08-09T21:00:00+00:00",
@@ -37,6 +38,7 @@ def _composition() -> dict:
                 "refusal": None,
             },
             "capabilities": {
+                "provider": "ckm",
                 "status": "refused",
                 "authority": "projection_marker",
                 "captured_at": None,
@@ -87,6 +89,7 @@ def _candidate(*, evidence: list[dict] | None = None) -> dict:
             "merged": {"state": "evidenced", "source_ref": _source("merge"), "evidence_id": "ready"},
             "delivery": {"state": "evidenced", "source_ref": _source("delivery"), "evidence_id": "ready"},
             "availability": {"state": "evidenced", "source_ref": _source("availability"), "evidence_id": "ready"},
+            "issue_closure": {"state": "evidenced", "source_ref": _source("closure"), "evidence_id": "ready"},
             "ready_to_try": {
                 "state": "evidenced",
                 "source_ref": _source("ready"),
@@ -110,7 +113,8 @@ def test_overview_production_composer_is_projection_only_and_has_no_io_or_state_
     assert result["contract_version"] == CONTRACT_VERSION
     assert result["authority"] == "projection_only"
     assert result["composed_at"] == composition["captured_at"]
-    assert result["trust_frame"]["provider_states"][0]["provider"] == "work"
+    assert result["trust_frame"]["provider_states"][0]["role"] == "work"
+    assert result["trust_frame"]["provider_states"][0]["provider"] == "builderops_cockpit"
     assert result["trust_frame"]["provider_states"][0]["authority"] == "read_time_join"
     assert result["trust_frame"]["provider_states"][0]["snapshot"] == {"watermark": "work:42"}
     assert result["now"][0]["subject_ref"] == candidates["now"][0]["subject_ref"]
@@ -118,6 +122,11 @@ def test_overview_production_composer_is_projection_only_and_has_no_io_or_state_
     assert "store" not in result
     assert "effects" not in result
     assert composition == _composition()
+
+    missing_identity = _composition()
+    del missing_identity["providers"]["work"]["authority"]
+    with pytest.raises(OverviewContractError, match="missing fields"):
+        compose_overview_view(composition=missing_identity)
 
 
 def test_overview_without_producer_candidates_withdraws_owner_and_ready_classifications() -> None:
@@ -161,6 +170,26 @@ def test_needs_you_requires_named_owner_authority_and_withdraws_on_degraded_evid
     assert all(item["kind"] == "classification_withdrawn" for item in withdrawals)
 
 
+@pytest.mark.parametrize(
+    "category",
+    (
+        "irreversible_external_effect",
+        "security_privacy_cost_commitment",
+        "production_release_operator_action",
+        "contradictory_source_authority",
+    ),
+)
+def test_needs_you_accepts_each_canonical_owner_authority_category(category: str) -> None:
+    candidate = _candidate()
+    candidate["owner_authority"]["category"] = category
+
+    result = compose_overview_view(
+        composition=_composition(), candidates={"needs_you": [candidate]}
+    )
+
+    assert result["needs_you"] == [candidate]
+
+
 def test_ready_to_try_requires_receipt_backed_fact_and_preserves_delivery_axes() -> None:
     ready = _candidate()
     merged_only = _candidate()
@@ -176,19 +205,40 @@ def test_ready_to_try_requires_receipt_backed_fact_and_preserves_delivery_axes()
 
     assert result["ready_to_try"] == [ready]
     facts = result["ready_to_try"][0]["delivery_facts"]
+    assert set(facts) == {
+        "merged",
+        "delivery",
+        "availability",
+        "issue_closure",
+        "ready_to_try",
+        "owner_trial",
+        "owner_acceptance",
+    }
     assert facts["merged"]["state"] == "evidenced"
     assert facts["delivery"]["state"] == "evidenced"
     assert facts["availability"]["state"] == "evidenced"
+    assert facts["issue_closure"]["state"] == "evidenced"
     assert facts["ready_to_try"]["receipt_ref"] == _source("receipt-ready")
     assert facts["owner_trial"]["state"] == "unknown"
     assert facts["owner_acceptance"]["state"] == "unknown"
     assert any(item["zone"] == "ready_to_try" for item in result["limitations"])
 
 
+def test_evidenced_delivery_fact_requires_resolving_evidence() -> None:
+    candidate = _candidate()
+    candidate["delivery_facts"]["merged"]["evidence_id"] = "missing"
+
+    with pytest.raises(OverviewContractError, match="evidenced fact requires source evidence"):
+        compose_overview_view(
+            composition=_composition(), candidates={"now": [candidate]}
+        )
+
+
 def test_overview_preserves_exact_withdrawals_and_independent_evidence_axes() -> None:
     candidate = _candidate(
         evidence=[
             _evidence("authority"),
+            _evidence("ready"),
             _evidence(
                 "withdrawn",
                 claim=None,
@@ -208,16 +258,57 @@ def test_overview_preserves_exact_withdrawals_and_independent_evidence_axes() ->
     result = compose_overview_view(composition=_composition(), candidates={"now": [candidate]})
 
     evidence = result["now"][0]["evidence"]
-    assert evidence[1]["availability"] == "refused"
-    assert evidence[1]["completeness"] == "unread"
-    assert evidence[1]["cardinality"] == "not_measured"
-    assert evidence[1]["linkage"] == "unlinked"
-    assert evidence[2]["cardinality"] == "measured_empty"
-    assert evidence[2]["read_watermark"] == "receipt-seq:0"
+    assert evidence[2]["availability"] == "refused"
+    assert evidence[2]["completeness"] == "unread"
+    assert evidence[2]["cardinality"] == "not_measured"
+    assert evidence[2]["linkage"] == "unlinked"
+    assert evidence[3]["cardinality"] == "measured_empty"
+    assert evidence[3]["read_watermark"] == "receipt-seq:0"
     inferred = deepcopy(candidate)
-    inferred["evidence"][1]["claim"] = "guessed relation"
+    inferred["evidence"][2]["claim"] = "guessed relation"
     with pytest.raises(OverviewContractError, match="unlinked evidence"):
         compose_overview_view(composition=_composition(), candidates={"now": [inferred]})
+
+
+def test_measured_empty_requires_fresh_source_evidence() -> None:
+    for freshness in ("stale", "unknown"):
+        candidate = _candidate(
+            evidence=[
+                {
+                    **_evidence(
+                        "empty",
+                        claim="Measured no items.",
+                        freshness=freshness,
+                        cardinality="measured_empty",
+                    ),
+                    "read_watermark": "receipt-seq:0",
+                }
+            ]
+        )
+
+        with pytest.raises(OverviewContractError, match="measured_empty requires fresh"):
+            compose_overview_view(
+                composition=_composition(), candidates={"now": [candidate]}
+            )
+
+
+def test_withdrawal_preserves_producer_limitations() -> None:
+    candidate = _candidate()
+    candidate["owner_authority"]["category"] = "ci_failure"
+    candidate["limitations"] = [
+        "The producer could not prove that this is an owner-authority decision."
+    ]
+
+    result = compose_overview_view(
+        composition=_composition(), candidates={"needs_you": [candidate]}
+    )
+
+    withdrawal = next(
+        item
+        for item in result["limitations"]
+        if item.get("subject_ref") == candidate["subject_ref"]
+    )
+    assert withdrawal["limitations"] == candidate["limitations"]
 
 
 def test_overview_keeps_roots_separate_and_survives_degraded_references() -> None:

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timezone
 
 import pytest
 
+from app.builderops.devui_composition import compose_owner_snapshot
 from app.builderops.devui_overview import (
     CONTRACT_VERSION,
     OverviewContractError,
@@ -383,6 +385,40 @@ def test_refused_provider_rejects_available_evidence(field: str, value: object) 
     composition = _composition()
     composition["providers"]["capabilities"][field] = value
 
+    with pytest.raises(OverviewContractError, match="cannot carry available evidence"):
+        compose_overview_view(composition=composition)
+
+
+@pytest.mark.parametrize("provider", ("work", "capabilities"))
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("captured_at", "2026-08-09T21:00:00+00:00"),
+        ("snapshot", {"watermark": "forged:1"}),
+        ("completeness", {"claim": {"kind": "counted"}}),
+        ("payload", {"resources": []}),
+    ),
+)
+def test_production_refusals_reject_available_evidence_at_overview_boundary(
+    provider: str, field: str, value: object
+) -> None:
+    def broken_cockpit() -> dict:
+        raise OSError("unavailable")
+
+    composition = compose_owner_snapshot(
+        cockpit_reader=broken_cockpit,
+        ckm_reader=lambda: object(),  # type: ignore[return-value]
+        now=lambda: datetime(2026, 8, 9, 21, 0, tzinfo=timezone.utc),
+    )
+
+    assert [
+        state["status"]
+        for state in compose_overview_view(composition=composition)["trust_frame"][
+            "provider_states"
+        ]
+    ] == ["refused", "refused"]
+
+    composition["providers"][provider][field] = value
     with pytest.raises(OverviewContractError, match="cannot carry available evidence"):
         compose_overview_view(composition=composition)
 

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -1,0 +1,242 @@
+"""Contract tests for the pure devUI Overview projection (#4715)."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from app.builderops.devui_overview import (
+    CONTRACT_VERSION,
+    OverviewContractError,
+    compose_overview_view,
+)
+
+
+def _source(name: str) -> dict[str, str]:
+    return {
+        "source_type": "github_issue",
+        "source_id": name,
+        "version": "updated-at:2026-08-09T21:00:00+00:00",
+        "locator": f"https://example.test/{name}",
+    }
+
+
+def _composition() -> dict:
+    return {
+        "contract_version": "devui.composition.v1",
+        "authority": "projection_only",
+        "captured_at": "2026-08-09T21:00:00+00:00",
+        "providers": {
+            "work": {
+                "status": "available",
+                "captured_at": "2026-08-09T21:00:00+00:00",
+                "completeness": {"claim": {"kind": "counted"}},
+                "refusal": None,
+            },
+            "capabilities": {
+                "status": "refused",
+                "captured_at": None,
+                "completeness": None,
+                "refusal": {"code": "unavailable"},
+            },
+        },
+    }
+
+
+def _evidence(
+    evidence_id: str,
+    *,
+    claim: str | None = "The source supports this claim.",
+    availability: str = "available",
+    freshness: str = "fresh",
+    completeness: str = "complete",
+    cardinality: str = "nonempty",
+    linkage: str = "linked",
+) -> dict:
+    return {
+        "evidence_id": evidence_id,
+        "claim": claim,
+        "source_ref": _source(f"source-{evidence_id}"),
+        "availability": availability,
+        "freshness": freshness,
+        "completeness": completeness,
+        "cardinality": cardinality,
+        "linkage": linkage,
+        "captured_at": "2026-08-09T21:00:00+00:00",
+        "read_watermark": None,
+        "limitation": None if claim is not None else "The source cannot support this claim.",
+    }
+
+
+def _candidate(*, evidence: list[dict] | None = None) -> dict:
+    return {
+        "subject_ref": _source("RasmusTho/agentic-pkm-mvp#4715"),
+        "reason": "The server-declared reason for this placement.",
+        "evidence": evidence or [_evidence("authority"), _evidence("ready")],
+        "owner_authority": {
+            "category": "explicit_owner_decision",
+            "governing_source": _source("RasmusTho/agentic-pkm-mvp#4715"),
+            "evidence_id": "authority",
+        },
+        "delivery_facts": {
+            "merged": {"state": "evidenced", "source_ref": _source("merge"), "evidence_id": "ready"},
+            "delivery": {"state": "evidenced", "source_ref": _source("delivery"), "evidence_id": "ready"},
+            "availability": {"state": "evidenced", "source_ref": _source("availability"), "evidence_id": "ready"},
+            "ready_to_try": {
+                "state": "evidenced",
+                "source_ref": _source("ready"),
+                "receipt_ref": _source("receipt-ready"),
+                "evidence_id": "ready",
+            },
+            "owner_trial": {"state": "unknown", "source_ref": _source("trial"), "evidence_id": "ready"},
+            "owner_acceptance": {"state": "unknown", "source_ref": _source("acceptance"), "evidence_id": "ready"},
+        },
+        "navigation_refs": [],
+        "limitations": [],
+    }
+
+
+def test_overview_production_composer_is_projection_only_and_has_no_io_or_state_path() -> None:
+    composition = _composition()
+    candidates = {"now": [_candidate()]}
+
+    result = compose_overview_view(composition=composition, candidates=candidates)
+
+    assert result["contract_version"] == CONTRACT_VERSION
+    assert result["authority"] == "projection_only"
+    assert result["composed_at"] == composition["captured_at"]
+    assert result["trust_frame"]["provider_states"][0]["provider"] == "work"
+    assert result["now"][0]["subject_ref"] == candidates["now"][0]["subject_ref"]
+    assert "cache" not in result
+    assert "store" not in result
+    assert "effects" not in result
+    assert composition == _composition()
+
+
+def test_overview_without_producer_candidates_withdraws_owner_and_ready_classifications() -> None:
+    result = compose_overview_view(composition=_composition())
+
+    assert result["now"] == []
+    assert result["needs_you"] == []
+    assert result["ready_to_try"] == []
+    assert {(item["zone"], item["reason"]) for item in result["limitations"]} == {
+        ("needs_you", "the producer supplied no classification evidence"),
+        ("ready_to_try", "the producer supplied no classification evidence"),
+    }
+
+
+def test_needs_you_requires_named_owner_authority_and_withdraws_on_degraded_evidence() -> None:
+    good = _candidate()
+    missing = _candidate()
+    missing.pop("owner_authority")
+    stale = _candidate()
+    stale["evidence"][0]["freshness"] = "stale"
+    stale["evidence"][0]["claim"] = None
+    stale["evidence"][0]["limitation"] = "authority source is stale"
+
+    result = compose_overview_view(
+        composition=_composition(), candidates={"needs_you": [good, missing, stale]}
+    )
+
+    assert result["needs_you"] == [good]
+    withdrawals = [item for item in result["limitations"] if item["zone"] == "needs_you"]
+    assert len(withdrawals) == 2
+    assert all(item["kind"] == "classification_withdrawn" for item in withdrawals)
+
+
+def test_ready_to_try_requires_receipt_backed_fact_and_preserves_delivery_axes() -> None:
+    ready = _candidate()
+    merged_only = _candidate()
+    merged_only["delivery_facts"]["ready_to_try"] = {
+        "state": "unknown",
+        "source_ref": _source("ready"),
+        "evidence_id": "ready",
+    }
+
+    result = compose_overview_view(
+        composition=_composition(), candidates={"ready_to_try": [ready, merged_only]}
+    )
+
+    assert result["ready_to_try"] == [ready]
+    facts = result["ready_to_try"][0]["delivery_facts"]
+    assert facts["merged"]["state"] == "evidenced"
+    assert facts["delivery"]["state"] == "evidenced"
+    assert facts["availability"]["state"] == "evidenced"
+    assert facts["ready_to_try"]["receipt_ref"] == _source("receipt-ready")
+    assert facts["owner_trial"]["state"] == "unknown"
+    assert facts["owner_acceptance"]["state"] == "unknown"
+    assert any(item["zone"] == "ready_to_try" for item in result["limitations"])
+
+
+def test_overview_preserves_exact_withdrawals_and_independent_evidence_axes() -> None:
+    candidate = _candidate(
+        evidence=[
+            _evidence("authority"),
+            _evidence(
+                "withdrawn",
+                claim=None,
+                availability="refused",
+                freshness="unknown",
+                completeness="unread",
+                cardinality="not_measured",
+                linkage="unlinked",
+            ),
+            {
+                **_evidence("empty", claim="Measured no items.", cardinality="measured_empty"),
+                "read_watermark": "receipt-seq:0",
+            },
+        ]
+    )
+
+    result = compose_overview_view(composition=_composition(), candidates={"now": [candidate]})
+
+    evidence = result["now"][0]["evidence"]
+    assert evidence[1]["availability"] == "refused"
+    assert evidence[1]["completeness"] == "unread"
+    assert evidence[1]["cardinality"] == "not_measured"
+    assert evidence[1]["linkage"] == "unlinked"
+    assert evidence[2]["cardinality"] == "measured_empty"
+    assert evidence[2]["read_watermark"] == "receipt-seq:0"
+    inferred = deepcopy(candidate)
+    inferred["evidence"][1]["claim"] = "guessed relation"
+    with pytest.raises(OverviewContractError, match="unlinked evidence"):
+        compose_overview_view(composition=_composition(), candidates={"now": [inferred]})
+
+
+def test_overview_keeps_roots_separate_and_survives_degraded_references() -> None:
+    roots = [
+        {
+            "kind": "focus",
+            "navigation_ref": _source("focus:4715"),
+            "status": "available",
+            "limitation": None,
+        },
+        {
+            "kind": "soi_evidence",
+            "navigation_ref": _source("soi:mimer"),
+            "status": "degraded",
+            "limitation": "The explicit denominator source is stale.",
+        },
+        {
+            "kind": "delivery_execution",
+            "navigation_ref": _source("delivery:4715"),
+            "status": "unsupported",
+            "limitation": "No delivery control is admitted.",
+        },
+        {
+            "kind": "builder_system_control",
+            "navigation_ref": _source("bsc:main"),
+            "status": "unlinked",
+            "limitation": "Control has no selected Focus relation.",
+        },
+    ]
+
+    result = compose_overview_view(
+        composition=_composition(), candidates={"now": [_candidate()]}, root_references=roots
+    )
+
+    assert result["now"]
+    assert result["root_references"] == roots
+    assert result["soi_evidence_lens"] == roots[1]
+    assert all(set(ref) == {"kind", "navigation_ref", "status", "limitation"} for ref in roots)

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -42,7 +42,7 @@ def _composition() -> dict:
                 "status": "refused",
                 "authority": "projection_marker",
                 "captured_at": None,
-                "snapshot": {"watermark": "ckm:9"},
+                "snapshot": None,
                 "completeness": None,
                 "refusal": {"code": "unavailable"},
             },
@@ -367,6 +367,23 @@ def test_refused_provider_requires_refusal_evidence() -> None:
     composition["providers"]["capabilities"]["refusal"] = None
 
     with pytest.raises(OverviewContractError, match="refused provider"):
+        compose_overview_view(composition=composition)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("captured_at", "2026-08-09T21:00:00+00:00"),
+        ("snapshot", {"watermark": "forged:1"}),
+        ("completeness", {"claim": {"kind": "counted"}}),
+        ("payload", {"resources": []}),
+    ),
+)
+def test_refused_provider_rejects_available_evidence(field: str, value: object) -> None:
+    composition = _composition()
+    composition["providers"]["capabilities"][field] = value
+
+    with pytest.raises(OverviewContractError, match="cannot carry available evidence"):
         compose_overview_view(composition=composition)
 
 

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -30,13 +30,17 @@ def _composition() -> dict:
         "providers": {
             "work": {
                 "status": "available",
+                "authority": "read_time_join",
                 "captured_at": "2026-08-09T21:00:00+00:00",
+                "snapshot": {"watermark": "work:42"},
                 "completeness": {"claim": {"kind": "counted"}},
                 "refusal": None,
             },
             "capabilities": {
                 "status": "refused",
+                "authority": "projection_marker",
                 "captured_at": None,
+                "snapshot": {"watermark": "ckm:9"},
                 "completeness": None,
                 "refusal": {"code": "unavailable"},
             },
@@ -107,6 +111,8 @@ def test_overview_production_composer_is_projection_only_and_has_no_io_or_state_
     assert result["authority"] == "projection_only"
     assert result["composed_at"] == composition["captured_at"]
     assert result["trust_frame"]["provider_states"][0]["provider"] == "work"
+    assert result["trust_frame"]["provider_states"][0]["authority"] == "read_time_join"
+    assert result["trust_frame"]["provider_states"][0]["snapshot"] == {"watermark": "work:42"}
     assert result["now"][0]["subject_ref"] == candidates["now"][0]["subject_ref"]
     assert "cache" not in result
     assert "store" not in result

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -292,6 +292,29 @@ def test_measured_empty_requires_fresh_source_evidence() -> None:
             )
 
 
+@pytest.mark.parametrize("zone", ("needs_you", "ready_to_try"))
+def test_malformed_timestamps_cannot_support_classification(zone: str) -> None:
+    candidate = _candidate()
+    candidate["evidence"][0 if zone == "needs_you" else 1]["captured_at"] = "not-rfc3339"
+
+    with pytest.raises(OverviewContractError, match="RFC3339"):
+        compose_overview_view(
+            composition=_composition(), candidates={zone: [candidate]}
+        )
+
+
+def test_composition_and_provider_timestamps_must_be_rfc3339() -> None:
+    malformed_composition = _composition()
+    malformed_composition["captured_at"] = "not-rfc3339"
+    with pytest.raises(OverviewContractError, match="RFC3339"):
+        compose_overview_view(composition=malformed_composition)
+
+    malformed_provider = _composition()
+    malformed_provider["providers"]["work"]["captured_at"] = "not-rfc3339"
+    with pytest.raises(OverviewContractError, match="RFC3339"):
+        compose_overview_view(composition=malformed_provider)
+
+
 def test_withdrawal_preserves_producer_limitations() -> None:
     candidate = _candidate()
     candidate["owner_authority"]["category"] = "ci_failure"

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -75,7 +75,7 @@ def _candidate(*, evidence: list[dict] | None = None) -> dict:
         "reason": "The server-declared reason for this placement.",
         "evidence": evidence or [_evidence("authority"), _evidence("ready")],
         "owner_authority": {
-            "category": "explicit_owner_decision",
+            "category": "contradictory_source_authority",
             "governing_source": _source("RasmusTho/agentic-pkm-mvp#4715"),
             "evidence_id": "authority",
         },
@@ -121,8 +121,16 @@ def test_overview_without_producer_candidates_withdraws_owner_and_ready_classifi
     assert result["needs_you"] == []
     assert result["ready_to_try"] == []
     assert {(item["zone"], item["reason"]) for item in result["limitations"]} == {
-        ("needs_you", "the producer supplied no classification evidence"),
-        ("ready_to_try", "the producer supplied no classification evidence"),
+        ("needs_you", "the producer supplied no actionable classification evidence"),
+        ("ready_to_try", "the producer supplied no actionable classification evidence"),
+    }
+
+    empty = compose_overview_view(
+        composition=_composition(), candidates={"needs_you": [], "ready_to_try": []}
+    )
+    assert {(item["zone"], item["reason"]) for item in empty["limitations"]} == {
+        ("needs_you", "the producer supplied no actionable classification evidence"),
+        ("ready_to_try", "the producer supplied no actionable classification evidence"),
     }
 
 
@@ -130,18 +138,20 @@ def test_needs_you_requires_named_owner_authority_and_withdraws_on_degraded_evid
     good = _candidate()
     missing = _candidate()
     missing.pop("owner_authority")
+    unknown = _candidate()
+    unknown["owner_authority"]["category"] = "ci_failure"
     stale = _candidate()
     stale["evidence"][0]["freshness"] = "stale"
     stale["evidence"][0]["claim"] = None
     stale["evidence"][0]["limitation"] = "authority source is stale"
 
     result = compose_overview_view(
-        composition=_composition(), candidates={"needs_you": [good, missing, stale]}
+        composition=_composition(), candidates={"needs_you": [good, missing, unknown, stale]}
     )
 
     assert result["needs_you"] == [good]
     withdrawals = [item for item in result["limitations"] if item["zone"] == "needs_you"]
-    assert len(withdrawals) == 2
+    assert len(withdrawals) == 3
     assert all(item["kind"] == "classification_withdrawn" for item in withdrawals)
 
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4715

## Linked Issue
Fixes #4715

## SBS Impact
- Primary subsystem: Builder System read-model composition at the CES-governed devUI contract boundary.
- Secondary subsystem(s): Product/Runtime SoI Evidence is read only through typed navigation references.
- Write class: Pure rebuildable in-process projection and contract tests.
- Persistence impact: None.
- Derived/rebuildable impact: `devui-overview-view.v1` is rebuilt from the supplied composition envelope and explicit producer evidence.
- New or changed contract: Adds the pure `devui-overview-view.v1` composer; unsupported Needs you and Ready to try claims withdraw rather than becoming empty classifications.
- Owner-doc impact: Updated `docs/DEVUI.md`, `docs/plans/DEVUI_IMPLEMENTATION.md`, and current-state `docs/STATUS.md` in this PR.
- Transition debt impact: None introduced; producer enrichment, GET route, and visual/command stages remain explicitly undelivered.
- Boundary risk: No source I/O, persistence, mutation, task/graph/session state, browser classification, or cross-root joins are admitted.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds the pure server-side devUI Overview composer and strict source-evidence eligibility for its three zones.
- Keeps missing or degraded owner/ready evidence as explicit withdrawal and preserves typed root navigation without joins.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This slice adds only a rebuildable read model; the dispatcher claim and GitHub Issue/PR/CI retain lifecycle authority.

## Notes
- Validation: `pytest -q tests/builderops/test_devui_overview.py tests/builderops/test_devui_composition.py tests/builderops/test_devui_soi_evidence_view.py tests/architecture/test_devui_focus_boundaries.py tests/architecture/test_docs_index.py`; `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py`.