### PR TITLE
Add proven Darwin containment to verification cycle

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -24,6 +24,7 @@ from urllib.parse import urlsplit
 from app.dispatcher import leases as lease_module
 from app.dispatcher import queue as queue_module
 from app.dispatcher.config import load_paths
+from app.dispatcher.darwin_containment import select_verification_containment
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import LeaseRecord, TaskRecord
 from app.dispatcher.singleton import (
@@ -696,6 +697,7 @@ def _build_host_fenced_verification_cycle(
     holder: str,
     worktree: Path,
     context_path: Path,
+    containment_factory: Callable[[], Any],
 ) -> tuple[Any, Callable[[], None]]:
     from app.dispatcher.verification_consumer import (
         CANONICAL_RECEIPT_SCHEMA_PATH,
@@ -738,6 +740,7 @@ def _build_host_fenced_verification_cycle(
             worktree,
             CANONICAL_RECEIPT_SCHEMA_PATH,
             context_path,
+            containment_factory=containment_factory,
         )
         launcher = _InstalledMainExactHeadLauncher(
             raw_launcher,
@@ -810,6 +813,12 @@ def _cmd_verification_cycle(
         if not (worktree / ".git").exists():
             raise ValueError("verification worktree is unavailable")
         _assert_installed_main_worktree(worktree, repository)
+        # The kernel containment fence is selected and proven before the API
+        # client exists, so an unavailable/shared coalition cannot ingest or
+        # claim a BuilderOps verification run.
+        containment_factory = select_verification_containment(
+            args.containment_profile
+        )
         with tempfile.TemporaryDirectory(
             prefix="yggdrasil-verification-cycle-"
         ) as scratch:
@@ -821,6 +830,7 @@ def _cmd_verification_cycle(
                         holder=args.holder,
                         worktree=worktree,
                         context_path=Path(scratch) / "context.json",
+                        containment_factory=containment_factory,
                     )
                 )
                 try:
@@ -1199,6 +1209,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--repo", default=None, help="Explicit owner/repo authority")
     p.add_argument("--holder", default="verification-host")
     p.add_argument("--worktree", default=None)
+    p.add_argument(
+        "--containment-profile",
+        default=None,
+        help=(
+            "Required allowlisted whole-process-tree containment profile; "
+            "installed-main currently supports "
+            "darwin-launchd-resource-coalition-v1"
+        ),
+    )
     p.add_argument("--json", action="store_true")
 
     p = sub.add_parser("pull", help="Pull open agent:ready issues from GitHub")

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -15,7 +15,7 @@ import signal
 import sys
 import time
 from dataclasses import dataclass
-from typing import Callable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol
 
 
 DARWIN_LAUNCHD_COALITION_PROFILE = (
@@ -132,10 +132,13 @@ class DarwinLibprocKernel:
         ]
         signal_with_audit_token.restype = ctypes.c_int
         self._library = library
-        self._list_all_pids = list_all_pids
-        self._pid_info = pid_info
-        self._list_coalitions = list_coalitions
-        self._signal_with_audit_token = signal_with_audit_token
+        # ctypes function objects are dynamically shaped; explicit instance
+        # annotations keep the pinned CI mypy version from treating calls on
+        # these availability-checked symbols as untyped attributes.
+        self._list_all_pids: Any = list_all_pids
+        self._pid_info: Any = pid_info
+        self._list_coalitions: Any = list_coalitions
+        self._signal_with_audit_token: Any = signal_with_audit_token
 
     def list_pids(self) -> tuple[int, ...]:
         count = self._list_all_pids(None, 0)

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -1,0 +1,491 @@
+"""Fail-closed Darwin resource-coalition containment for verification runs.
+
+The profile deliberately uses ``proc_listallpids`` for PID enumeration and
+``proc_listcoalitions`` only as a kernel task-count witness.  A PID is never an
+identity by itself: every signal is fenced by a fresh PID-version and resource
+coalition read.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Mapping, Protocol
+
+
+DARWIN_LAUNCHD_COALITION_PROFILE = (
+    "darwin-launchd-resource-coalition-v1"
+)
+
+_PROC_PIDUNIQIDENTIFIERINFO = 17
+_PROC_PIDCOALITIONINFO = 20
+_LISTCOALITIONS_SINGLE_TYPE = 2
+_COALITION_TYPE_RESOURCE = 0
+_COALITION_NUM_TYPES = 2
+_STABLE_SNAPSHOT_ATTEMPTS = 8
+
+
+@dataclass(frozen=True, order=True)
+class ProcessIdentity:
+    """One PID-version bound to its current resource coalition and parent."""
+
+    pid: int
+    pid_version: int
+    unique_id: int
+    parent_unique_id: int
+    coalition_id: int
+
+
+@dataclass(frozen=True)
+class CoalitionSnapshot:
+    coalition_id: int
+    members: frozenset[ProcessIdentity]
+    kernel_task_count: int
+
+
+class DarwinCoalitionKernel(Protocol):
+    """Narrow injectable kernel interface used by the containment profile."""
+
+    def list_pids(self) -> tuple[int, ...]: ...
+
+    def inspect(self, pid: int) -> ProcessIdentity | None: ...
+
+    def coalition_task_count(self, coalition_id: int) -> int: ...
+
+    def signal(self, identity: ProcessIdentity, sig: int) -> bool: ...
+
+
+class _ProcUniqIdentifierInfo(ctypes.Structure):
+    _fields_ = [
+        ("p_uuid", ctypes.c_ubyte * 16),
+        ("p_uniqueid", ctypes.c_uint64),
+        ("p_puniqueid", ctypes.c_uint64),
+        ("p_idversion", ctypes.c_int32),
+        ("p_orig_ppidversion", ctypes.c_int32),
+        ("p_reserve2", ctypes.c_uint64),
+        ("p_reserve3", ctypes.c_uint64),
+    ]
+
+
+class _ProcPidCoalitionInfo(ctypes.Structure):
+    _fields_ = [
+        ("coalition_id", ctypes.c_uint64 * _COALITION_NUM_TYPES),
+        ("reserved1", ctypes.c_uint64),
+        ("reserved2", ctypes.c_uint64),
+        ("reserved3", ctypes.c_uint64),
+    ]
+
+
+class _ProcInfoCoalition(ctypes.Structure):
+    _fields_ = [
+        ("coalition_id", ctypes.c_uint64),
+        ("coalition_type", ctypes.c_uint32),
+        ("coalition_tasks", ctypes.c_uint32),
+    ]
+
+
+class _AuditToken(ctypes.Structure):
+    _fields_ = [("val", ctypes.c_uint32 * 8)]
+
+
+class DarwinLibprocKernel:
+    """Availability-checked adapter for the allowlisted Darwin private ABI."""
+
+    def __init__(self) -> None:
+        if sys.platform != "darwin":
+            raise ValueError("Darwin containment is unavailable on this platform")
+        try:
+            library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+            list_all_pids = library.proc_listallpids
+            pid_info = library.proc_pidinfo
+            list_coalitions = library.proc_listcoalitions
+            signal_with_audit_token = library.proc_signal_with_audittoken
+        except (OSError, AttributeError) as exc:
+            raise ValueError(
+                "Darwin containment private symbols are unavailable"
+            ) from exc
+        list_all_pids.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        list_all_pids.restype = ctypes.c_int
+        pid_info.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        pid_info.restype = ctypes.c_int
+        list_coalitions.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        list_coalitions.restype = ctypes.c_int
+        signal_with_audit_token.argtypes = [
+            ctypes.POINTER(_AuditToken),
+            ctypes.c_int,
+        ]
+        signal_with_audit_token.restype = ctypes.c_int
+        self._library = library
+        self._list_all_pids = list_all_pids
+        self._pid_info = pid_info
+        self._list_coalitions = list_coalitions
+        self._signal_with_audit_token = signal_with_audit_token
+
+    def list_pids(self) -> tuple[int, ...]:
+        count = self._list_all_pids(None, 0)
+        if count <= 0:
+            raise ValueError("Darwin containment PID enumeration failed")
+        for _ in range(2):
+            capacity = count + 64
+            buffer = (ctypes.c_int * capacity)()
+            observed = self._list_all_pids(buffer, ctypes.sizeof(buffer))
+            if 0 < observed < capacity:
+                return tuple(
+                    sorted({int(buffer[index]) for index in range(observed) if buffer[index] > 0})
+                )
+            count = max(count * 2, observed)
+        raise ValueError("Darwin containment PID enumeration did not converge")
+
+    def _read_pid_info(
+        self,
+        pid: int,
+        flavor: int,
+        value: ctypes.Structure,
+    ) -> int:
+        return int(
+            self._pid_info(
+                pid,
+                flavor,
+                0,
+                ctypes.byref(value),
+                ctypes.sizeof(value),
+            )
+        )
+
+    def inspect(self, pid: int) -> ProcessIdentity | None:
+        if pid <= 0:
+            return None
+        first = _ProcUniqIdentifierInfo()
+        coalition = _ProcPidCoalitionInfo()
+        second = _ProcUniqIdentifierInfo()
+        if self._read_pid_info(pid, _PROC_PIDUNIQIDENTIFIERINFO, first) != ctypes.sizeof(first):
+            return None
+        if self._read_pid_info(pid, _PROC_PIDCOALITIONINFO, coalition) != ctypes.sizeof(coalition):
+            return None
+        if self._read_pid_info(pid, _PROC_PIDUNIQIDENTIFIERINFO, second) != ctypes.sizeof(second):
+            return None
+        if (
+            first.p_idversion != second.p_idversion
+            or first.p_uniqueid != second.p_uniqueid
+            or first.p_puniqueid != second.p_puniqueid
+        ):
+            return None
+        coalition_id = int(coalition.coalition_id[_COALITION_TYPE_RESOURCE])
+        if coalition_id <= 0 or first.p_idversion < 0:
+            return None
+        return ProcessIdentity(
+            pid=pid,
+            pid_version=int(first.p_idversion),
+            unique_id=int(first.p_uniqueid),
+            parent_unique_id=int(first.p_puniqueid),
+            coalition_id=coalition_id,
+        )
+
+    def coalition_task_count(self, coalition_id: int) -> int:
+        record_size = ctypes.sizeof(_ProcInfoCoalition)
+        required = int(
+            self._list_coalitions(
+                _LISTCOALITIONS_SINGLE_TYPE,
+                _COALITION_TYPE_RESOURCE,
+                None,
+                0,
+            )
+        )
+        if required <= 0 or required % record_size:
+            raise ValueError("Darwin containment coalition witness is malformed")
+        buffer = ctypes.create_string_buffer(required)
+        observed = int(
+            self._list_coalitions(
+                _LISTCOALITIONS_SINGLE_TYPE,
+                _COALITION_TYPE_RESOURCE,
+                buffer,
+                required,
+            )
+        )
+        if observed != required:
+            raise ValueError("Darwin containment coalition witness changed")
+        records = (
+            _ProcInfoCoalition * (observed // record_size)
+        ).from_buffer(buffer)
+        matches = [
+            int(record.coalition_tasks)
+            for record in records
+            if int(record.coalition_id) == coalition_id
+            and int(record.coalition_type) == _COALITION_TYPE_RESOURCE
+        ]
+        if len(matches) != 1 or matches[0] <= 0:
+            raise ValueError("Darwin containment coalition witness is unavailable")
+        return matches[0]
+
+    def signal(self, identity: ProcessIdentity, sig: int) -> bool:
+        token = _AuditToken()
+        # libproc's own wrappers consume audit_token.val[5] as PID and val[7]
+        # as PID-version.  The kernel signal call compares that identity
+        # atomically, so PID reuse after pre-signal inspection cannot redirect
+        # the signal to a new process.
+        token.val[5] = identity.pid
+        token.val[7] = identity.pid_version
+        result = int(self._signal_with_audit_token(ctypes.byref(token), sig))
+        return result in (0, errno.ESRCH)
+
+
+def _sample_coalition(
+    kernel: DarwinCoalitionKernel,
+    coalition_id: int,
+) -> CoalitionSnapshot:
+    members = frozenset(
+        identity
+        for pid in kernel.list_pids()
+        if (identity := kernel.inspect(pid)) is not None
+        and identity.coalition_id == coalition_id
+    )
+    kernel_count = kernel.coalition_task_count(coalition_id)
+    if kernel_count != len(members):
+        raise ValueError("Darwin containment coalition task count mismatched")
+    return CoalitionSnapshot(coalition_id, members, kernel_count)
+
+
+def _stable_snapshot(
+    kernel: DarwinCoalitionKernel,
+    coalition_id: int,
+) -> CoalitionSnapshot:
+    prior: CoalitionSnapshot | None = None
+    for _ in range(_STABLE_SNAPSHOT_ATTEMPTS):
+        try:
+            current = _sample_coalition(kernel, coalition_id)
+        except ValueError:
+            prior = None
+            continue
+        if current == prior:
+            return current
+        prior = current
+    raise ValueError("Darwin containment snapshots did not converge")
+
+
+def _trusted_baseline(
+    kernel: DarwinCoalitionKernel,
+    *,
+    current_pid: int,
+) -> tuple[int, frozenset[ProcessIdentity]]:
+    current = kernel.inspect(current_pid)
+    if current is None:
+        raise ValueError("Darwin containment cannot inspect the current CLI")
+    stable = _stable_snapshot(kernel, current.coalition_id)
+    by_unique_id = {
+        identity.unique_id: identity for identity in stable.members
+    }
+    if len(by_unique_id) != len(stable.members):
+        raise ValueError("Darwin containment process identities are ambiguous")
+    baseline: set[ProcessIdentity] = set()
+    cursor = current
+    visited: set[int] = set()
+    while True:
+        if (
+            cursor.unique_id in visited
+            or by_unique_id.get(cursor.unique_id) != cursor
+        ):
+            raise ValueError("Darwin containment ancestor chain is unproven")
+        visited.add(cursor.unique_id)
+        baseline.add(cursor)
+        if cursor.parent_unique_id <= 0:
+            break
+        parent = by_unique_id.get(cursor.parent_unique_id)
+        if parent is None:
+            outside_matches = [
+                identity
+                for pid in kernel.list_pids()
+                if (identity := kernel.inspect(pid)) is not None
+                and identity.unique_id == cursor.parent_unique_id
+            ]
+            if len(outside_matches) != 1:
+                raise ValueError("Darwin containment ancestor is uninspectable")
+            if outside_matches[0].coalition_id == current.coalition_id:
+                raise ValueError("Darwin containment ancestor chain is incomplete")
+            break
+        if parent.coalition_id != current.coalition_id:
+            break
+        cursor = parent
+    if stable.members != frozenset(baseline):
+        raise ValueError("Darwin containment coalition has unrelated members")
+    return current.coalition_id, frozenset(baseline)
+
+
+class DarwinLaunchdCoalitionContainment:
+    """Launch-scoped cleanup proven by resource-coalition snapshots."""
+
+    def __init__(
+        self,
+        kernel: DarwinCoalitionKernel,
+        *,
+        coalition_id: int,
+        baseline: frozenset[ProcessIdentity],
+        sleeper: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._kernel = kernel
+        self._coalition_id = coalition_id
+        self._baseline = baseline
+        self._sleeper = sleeper
+        self._monotonic = monotonic
+        self._attached = False
+
+    def _assert_baseline_only(self) -> None:
+        stable = _stable_snapshot(self._kernel, self._coalition_id)
+        if stable.members != self._baseline:
+            raise ValueError("Darwin containment baseline changed before launch")
+
+    def environment(self, base: Mapping[str, str]) -> dict[str, str]:
+        self._assert_baseline_only()
+        return dict(base)
+
+    def attach(self, root_pid: int) -> None:
+        stable = _stable_snapshot(self._kernel, self._coalition_id)
+        if not self._baseline.issubset(stable.members):
+            raise ValueError("Darwin containment baseline escaped")
+        root = next(
+            (member for member in stable.members if member.pid == root_pid),
+            None,
+        )
+        if root is None or root in self._baseline:
+            raise ValueError("Darwin containment launch root is unproven")
+        by_unique_id = {
+            member.unique_id: member for member in stable.members
+        }
+        for member in stable.members - self._baseline:
+            cursor = member
+            visited: set[int] = set()
+            while cursor != root:
+                if cursor.unique_id in visited:
+                    raise ValueError("Darwin containment launch ancestry cycled")
+                visited.add(cursor.unique_id)
+                parent = by_unique_id.get(cursor.parent_unique_id)
+                if parent is None or parent in self._baseline:
+                    raise ValueError(
+                        "Darwin containment launch ancestry escaped root"
+                    )
+                cursor = parent
+        self._attached = True
+
+    def _signal_identity(self, identity: ProcessIdentity, sig: int) -> bool:
+        fresh = self._kernel.inspect(identity.pid)
+        if fresh != identity or fresh.coalition_id != self._coalition_id:
+            return False
+        try:
+            return self._kernel.signal(identity, sig)
+        except (OSError, PermissionError, ValueError):
+            return False
+
+    def _wait_for_snapshot(
+        self,
+        *,
+        timeout: float,
+        baseline_only: bool,
+    ) -> CoalitionSnapshot | None:
+        deadline = self._monotonic() + timeout
+        prior: CoalitionSnapshot | None = None
+        while True:
+            try:
+                current = _sample_coalition(
+                    self._kernel, self._coalition_id
+                )
+            except ValueError:
+                prior = None
+            else:
+                eligible = (
+                    not baseline_only or current.members == self._baseline
+                )
+                if eligible and current == prior:
+                    return current
+                prior = current if eligible else None
+            if self._monotonic() >= deadline:
+                return None
+            self._sleeper(0.05)
+
+    def cleanup(self) -> bool:
+        if not self._attached:
+            return False
+        try:
+            stable = self._wait_for_snapshot(
+                timeout=1.0, baseline_only=False
+            )
+            if stable is None or not self._baseline.issubset(stable.members):
+                return False
+            targets = sorted(stable.members - self._baseline)
+            if not targets:
+                return self._wait_for_snapshot(
+                    timeout=1.0, baseline_only=True
+                ) is not None
+            if not all(
+                self._signal_identity(target, signal.SIGTERM)
+                for target in targets
+            ):
+                return False
+            if self._wait_for_snapshot(
+                timeout=1.0, baseline_only=True
+            ) is not None:
+                return True
+            stable = self._wait_for_snapshot(
+                timeout=1.0, baseline_only=False
+            )
+            if stable is None or not self._baseline.issubset(stable.members):
+                return False
+            targets = sorted(stable.members - self._baseline)
+            if not all(
+                self._signal_identity(target, signal.SIGKILL)
+                for target in targets
+            ):
+                return False
+            return self._wait_for_snapshot(
+                timeout=5.0, baseline_only=True
+            ) is not None
+        except Exception:
+            return False
+
+
+def select_verification_containment(
+    profile: str | None,
+    *,
+    platform: str = sys.platform,
+    kernel: DarwinCoalitionKernel | None = None,
+    current_pid: int | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Callable[[], DarwinLaunchdCoalitionContainment]:
+    """Preflight and return the one allowlisted production containment factory."""
+
+    if profile != DARWIN_LAUNCHD_COALITION_PROFILE:
+        raise ValueError("verification containment profile is absent or unsupported")
+    if platform != "darwin":
+        raise ValueError("verification containment profile is unsupported on this platform")
+    selected_kernel = kernel or DarwinLibprocKernel()
+    coalition_id, baseline = _trusted_baseline(
+        selected_kernel,
+        current_pid=current_pid if current_pid is not None else os.getpid(),
+    )
+
+    def factory() -> DarwinLaunchdCoalitionContainment:
+        return DarwinLaunchdCoalitionContainment(
+            selected_kernel,
+            coalition_id=coalition_id,
+            baseline=baseline,
+            sleeper=sleeper,
+            monotonic=monotonic,
+        )
+
+    return factory

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -94,17 +94,18 @@ class DarwinLaunchBarrier:
             if self._release_attempted or self._reader is not None or self._writer is None:
                 raise ValueError("Darwin launch barrier is unavailable")
             self._release_attempted = True
+            # Delivery becomes indeterminate before ``write`` returns. From
+            # this point cleanup must use coalition authority.
+            self._may_have_released = True
             try:
                 written = os.write(self._writer, RELEASE_TOKEN)
-            except OSError:
-                self._may_have_released = True
+            except BaseException:
                 try:
                     os.close(self._writer)
                 finally:
                     self._writer = None
                 raise
             if written == len(RELEASE_TOKEN):
-                self._may_have_released = True
                 try:
                     os.close(self._writer)
                 finally:

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -15,7 +15,9 @@ import signal
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from app.dispatcher.darwin_launch_barrier import RELEASE_TOKEN
 
 
 DARWIN_LAUNCHD_COALITION_PROFILE = (
@@ -46,6 +48,55 @@ class CoalitionSnapshot:
     coalition_id: int
     members: frozenset[ProcessIdentity]
     kernel_task_count: int
+
+
+class DarwinLaunchBarrier:
+    """Keep the process-group root paused until containment is attached."""
+
+    def __init__(self, command: Sequence[str]) -> None:
+        if not command:
+            raise ValueError("Darwin launch barrier command is empty")
+        reader, writer = os.pipe()
+        self._reader: int | None = reader
+        self._writer: int | None = writer
+        self.command = [
+            sys.executable,
+            "-m",
+            "app.dispatcher.darwin_launch_barrier",
+            "--release-fd",
+            str(reader),
+            "--",
+            *command,
+        ]
+        self.pass_fds = (reader,)
+
+    def after_spawn(self) -> None:
+        if self._reader is None:
+            raise ValueError("Darwin launch barrier reader is unavailable")
+        os.close(self._reader)
+        self._reader = None
+
+    def release(self) -> None:
+        if self._reader is not None or self._writer is None:
+            raise ValueError("Darwin launch barrier is unavailable")
+        try:
+            written = os.write(self._writer, RELEASE_TOKEN)
+            if written != len(RELEASE_TOKEN):
+                raise OSError("Darwin launch barrier release was partial")
+        finally:
+            os.close(self._writer)
+            self._writer = None
+
+    def close(self) -> None:
+        for attribute in ("_reader", "_writer"):
+            descriptor = getattr(self, attribute)
+            if descriptor is None:
+                continue
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            setattr(self, attribute, None)
 
 
 def _same_signal_identity(
@@ -376,92 +427,32 @@ class DarwinLaunchdCoalitionContainment:
         self._assert_baseline_only()
         return dict(base)
 
-    def _assert_orphaned_launch_tree(
+    def launch_barrier(self, command: Sequence[str]) -> DarwinLaunchBarrier:
+        return DarwinLaunchBarrier(command)
+
+    def capture_launch_root(self, root_pid: int) -> ProcessIdentity:
+        root = self._kernel.inspect(root_pid)
+        if (
+            root is None
+            or root in self._baseline
+            or root.coalition_id != self._coalition_id
+        ):
+            raise ValueError("Darwin containment launch root is unproven")
+        return root
+
+    def attach(
         self,
-        stable: CoalitionSnapshot,
+        root_pid: int,
+        expected_root: ProcessIdentity | None = None,
     ) -> None:
-        """Prove all new tasks descend from one now-absent launch root.
-
-        The coordinator must fail when its Popen root disappears before attach,
-        but its error path still has to reap a detached descendant.  That is
-        safe only when every non-baseline member closes at one absent parent
-        unique ID; a baseline parent or multiple missing roots is foreign or
-        ambiguous and remains fail-closed.
-        """
-
-        members = stable.members
-        by_unique_id = {member.unique_id: member for member in members}
-        if len(by_unique_id) != len(members):
-            raise ValueError("Darwin containment process identities are ambiguous")
-        orphan_root_ids: set[int] = set()
-        for member in members - self._baseline:
-            cursor = member
-            visited: set[int] = set()
-            while True:
-                if cursor.unique_id in visited:
-                    raise ValueError("Darwin containment launch ancestry cycled")
-                visited.add(cursor.unique_id)
-                parent = by_unique_id.get(cursor.parent_unique_id)
-                if parent is None:
-                    if cursor.parent_unique_id <= 0:
-                        raise ValueError(
-                            "Darwin containment launch ancestry escaped root"
-                        )
-                    orphan_root_ids.add(cursor.parent_unique_id)
-                    break
-                if parent in self._baseline:
-                    raise ValueError(
-                        "Darwin containment launch ancestry escaped root"
-                    )
-                cursor = parent
-        if len(orphan_root_ids) != 1:
-            raise ValueError("Darwin containment launch root is unproven")
-        orphan_root_id = next(iter(orphan_root_ids))
-        outside_matches = [
-            identity
-            for pid in self._kernel.list_pids()
-            if (identity := self._kernel.inspect(pid)) is not None
-            and identity.unique_id == orphan_root_id
-        ]
-        if outside_matches:
-            raise ValueError("Darwin containment launch root is unproven")
-
-    def attach(self, root_pid: int) -> None:
+        if expected_root is None or expected_root.pid != root_pid:
+            raise ValueError("Darwin containment launch identity is unavailable")
         stable = _stable_snapshot(self._kernel, self._coalition_id)
-        if not self._baseline.issubset(stable.members):
-            raise ValueError("Darwin containment baseline escaped")
-        root = next(
-            (member for member in stable.members if member.pid == root_pid),
-            None,
-        )
-        if root is None:
-            # Keep the verification cycle fail-closed, but establish only the
-            # narrowly proven cleanup authority before reporting the raced
-            # attach.  Its caller's failure path then cannot strand a detached
-            # same-coalition descendant.
-            if self._kernel.inspect(root_pid) is not None:
-                raise ValueError("Darwin containment launch root is unproven")
-            self._assert_orphaned_launch_tree(stable)
-            self._attached = True
-            raise ValueError("Darwin containment launch root exited before attach")
-        if root in self._baseline:
-            raise ValueError("Darwin containment launch root is unproven")
-        by_unique_id = {
-            member.unique_id: member for member in stable.members
-        }
-        for member in stable.members - self._baseline:
-            cursor = member
-            visited: set[int] = set()
-            while cursor != root:
-                if cursor.unique_id in visited:
-                    raise ValueError("Darwin containment launch ancestry cycled")
-                visited.add(cursor.unique_id)
-                parent = by_unique_id.get(cursor.parent_unique_id)
-                if parent is None or parent in self._baseline:
-                    raise ValueError(
-                        "Darwin containment launch ancestry escaped root"
-                    )
-                cursor = parent
+        if stable.members != self._baseline | {expected_root}:
+            raise ValueError("Darwin containment pre-release membership is unproven")
+        current_root = self._kernel.inspect(root_pid)
+        if current_root != expected_root:
+            raise ValueError("Darwin containment launch identity changed")
         self._attached = True
 
     def _signal_identity(self, identity: ProcessIdentity, sig: int) -> bool:

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -48,6 +48,25 @@ class CoalitionSnapshot:
     kernel_task_count: int
 
 
+def _same_signal_identity(
+    left: ProcessIdentity,
+    right: ProcessIdentity,
+) -> bool:
+    """Compare immutable signal authority while allowing safe reparenting."""
+
+    return (
+        left.pid,
+        left.pid_version,
+        left.unique_id,
+        left.coalition_id,
+    ) == (
+        right.pid,
+        right.pid_version,
+        right.unique_id,
+        right.coalition_id,
+    )
+
+
 class DarwinCoalitionKernel(Protocol):
     """Narrow injectable kernel interface used by the containment profile."""
 
@@ -387,7 +406,7 @@ class DarwinLaunchdCoalitionContainment:
 
     def _signal_identity(self, identity: ProcessIdentity, sig: int) -> bool:
         fresh = self._kernel.inspect(identity.pid)
-        if fresh != identity or fresh.coalition_id != self._coalition_id:
+        if fresh is None or not _same_signal_identity(fresh, identity):
             return False
         try:
             return self._kernel.signal(identity, sig)

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -13,8 +13,10 @@ import errno
 import os
 import signal
 import sys
+import threading
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
 from app.dispatcher.darwin_launch_barrier import RELEASE_TOKEN
@@ -57,18 +59,29 @@ class DarwinLaunchBarrier:
         if not command:
             raise ValueError("Darwin launch barrier command is empty")
         reader, writer = os.pipe()
+        os.set_inheritable(reader, False)
+        os.set_inheritable(writer, False)
         self._reader: int | None = reader
         self._writer: int | None = writer
+        self._release_lock = threading.Lock()
+        self._release_attempted = False
+        self._may_have_released = False
         self.command = [
             sys.executable,
-            "-m",
-            "app.dispatcher.darwin_launch_barrier",
+            "-I",
+            "-S",
+            str(Path(__file__).with_name("darwin_launch_barrier.py").resolve()),
             "--release-fd",
             str(reader),
             "--",
             *command,
         ]
         self.pass_fds = (reader,)
+
+    @property
+    def may_have_released(self) -> bool:
+        with self._release_lock:
+            return self._may_have_released
 
     def after_spawn(self) -> None:
         if self._reader is None:
@@ -77,15 +90,31 @@ class DarwinLaunchBarrier:
         self._reader = None
 
     def release(self) -> None:
-        if self._reader is not None or self._writer is None:
-            raise ValueError("Darwin launch barrier is unavailable")
-        try:
-            written = os.write(self._writer, RELEASE_TOKEN)
-            if written != len(RELEASE_TOKEN):
-                raise OSError("Darwin launch barrier release was partial")
-        finally:
-            os.close(self._writer)
-            self._writer = None
+        with self._release_lock:
+            if self._release_attempted or self._reader is not None or self._writer is None:
+                raise ValueError("Darwin launch barrier is unavailable")
+            self._release_attempted = True
+            try:
+                written = os.write(self._writer, RELEASE_TOKEN)
+            except OSError:
+                self._may_have_released = True
+                try:
+                    os.close(self._writer)
+                finally:
+                    self._writer = None
+                raise
+            if written == len(RELEASE_TOKEN):
+                self._may_have_released = True
+                try:
+                    os.close(self._writer)
+                finally:
+                    self._writer = None
+                return
+            try:
+                os.close(self._writer)
+            finally:
+                self._writer = None
+            raise OSError("Darwin launch barrier release was partial")
 
     def close(self) -> None:
         for attribute in ("_reader", "_writer"):

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -376,6 +376,56 @@ class DarwinLaunchdCoalitionContainment:
         self._assert_baseline_only()
         return dict(base)
 
+    def _assert_orphaned_launch_tree(
+        self,
+        stable: CoalitionSnapshot,
+    ) -> None:
+        """Prove all new tasks descend from one now-absent launch root.
+
+        The coordinator must fail when its Popen root disappears before attach,
+        but its error path still has to reap a detached descendant.  That is
+        safe only when every non-baseline member closes at one absent parent
+        unique ID; a baseline parent or multiple missing roots is foreign or
+        ambiguous and remains fail-closed.
+        """
+
+        members = stable.members
+        by_unique_id = {member.unique_id: member for member in members}
+        if len(by_unique_id) != len(members):
+            raise ValueError("Darwin containment process identities are ambiguous")
+        orphan_root_ids: set[int] = set()
+        for member in members - self._baseline:
+            cursor = member
+            visited: set[int] = set()
+            while True:
+                if cursor.unique_id in visited:
+                    raise ValueError("Darwin containment launch ancestry cycled")
+                visited.add(cursor.unique_id)
+                parent = by_unique_id.get(cursor.parent_unique_id)
+                if parent is None:
+                    if cursor.parent_unique_id <= 0:
+                        raise ValueError(
+                            "Darwin containment launch ancestry escaped root"
+                        )
+                    orphan_root_ids.add(cursor.parent_unique_id)
+                    break
+                if parent in self._baseline:
+                    raise ValueError(
+                        "Darwin containment launch ancestry escaped root"
+                    )
+                cursor = parent
+        if len(orphan_root_ids) != 1:
+            raise ValueError("Darwin containment launch root is unproven")
+        orphan_root_id = next(iter(orphan_root_ids))
+        outside_matches = [
+            identity
+            for pid in self._kernel.list_pids()
+            if (identity := self._kernel.inspect(pid)) is not None
+            and identity.unique_id == orphan_root_id
+        ]
+        if outside_matches:
+            raise ValueError("Darwin containment launch root is unproven")
+
     def attach(self, root_pid: int) -> None:
         stable = _stable_snapshot(self._kernel, self._coalition_id)
         if not self._baseline.issubset(stable.members):
@@ -384,7 +434,17 @@ class DarwinLaunchdCoalitionContainment:
             (member for member in stable.members if member.pid == root_pid),
             None,
         )
-        if root is None or root in self._baseline:
+        if root is None:
+            # Keep the verification cycle fail-closed, but establish only the
+            # narrowly proven cleanup authority before reporting the raced
+            # attach.  Its caller's failure path then cannot strand a detached
+            # same-coalition descendant.
+            if self._kernel.inspect(root_pid) is not None:
+                raise ValueError("Darwin containment launch root is unproven")
+            self._assert_orphaned_launch_tree(stable)
+            self._attached = True
+            raise ValueError("Darwin containment launch root exited before attach")
+        if root in self._baseline:
             raise ValueError("Darwin containment launch root is unproven")
         by_unique_id = {
             member.unique_id: member for member in stable.members

--- a/app/dispatcher/darwin_launch_barrier.py
+++ b/app/dispatcher/darwin_launch_barrier.py
@@ -1,0 +1,47 @@
+"""One-shot exec barrier for the Darwin verification containment root."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Sequence
+
+
+RELEASE_TOKEN = b"verification-launch-release-v1\n"
+
+
+def _read_release(fd: int) -> bool:
+    payload = b""
+    try:
+        while len(payload) <= len(RELEASE_TOKEN):
+            chunk = os.read(fd, len(RELEASE_TOKEN) + 1 - len(payload))
+            if not chunk:
+                break
+            payload += chunk
+    except OSError:
+        return False
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    return payload == RELEASE_TOKEN
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--release-fd", type=int, required=True)
+    parsed, command = parser.parse_known_args(argv)
+    if not command or command[0] != "--" or len(command) == 1:
+        return 1
+    if parsed.release_fd < 0 or not _read_release(parsed.release_fd):
+        return 1
+    try:
+        os.execvpe(command[1], command[1:], os.environ)
+    except OSError:
+        return 1
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through exec.
+    raise SystemExit(main())

--- a/app/dispatcher/darwin_launch_barrier.py
+++ b/app/dispatcher/darwin_launch_barrier.py
@@ -13,6 +13,7 @@ RELEASE_TOKEN = b"verification-launch-release-v1\n"
 def _read_release(fd: int) -> bool:
     payload = b""
     try:
+        os.set_inheritable(fd, False)
         while len(payload) <= len(RELEASE_TOKEN):
             chunk = os.read(fd, len(RELEASE_TOKEN) + 1 - len(payload))
             if not chunk:

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -27,7 +27,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Iterable, Mapping, Protocol, Sequence, cast
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence, cast
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo
 
@@ -2863,9 +2863,11 @@ class CodexExecLauncher:
             )
         try:
             containment = self.containment_factory()
+            barrier_factory = getattr(containment, "launch_barrier", None)
+            has_darwin_barrier = callable(barrier_factory)
             cleanup_tracker = (
                 containment
-                if isinstance(containment, TaggedProcessTreeCleanup)
+                if has_darwin_barrier or isinstance(containment, TaggedProcessTreeCleanup)
                 else self.cleanup_tracker_factory()
             )
             env = containment.environment(base_env)
@@ -2886,6 +2888,7 @@ class CodexExecLauncher:
         process_group_id: int | None = None
         containment_proven = False
         process_lock = threading.Lock()
+        barrier: Any | None = None
         lines: Iterable[str | bytes]
 
         def signal_process_group(sig: int) -> bool:
@@ -2921,10 +2924,58 @@ class CodexExecLauncher:
             except Exception:
                 return False
 
+        def reap_direct_root() -> bool:
+            if process is None:
+                return False
+            try:
+                if process.poll() is not None:
+                    return True
+            except Exception:
+                return False
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+            except Exception:
+                return False
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    process.kill()
+                    process.wait(timeout=5)
+                except Exception:
+                    return False
+            except Exception:
+                return False
+            return True
+
+        def cleanup_darwin_barrier_after_release() -> bool:
+            if not reap_direct_root():
+                return False
+            try:
+                return bool(containment.cleanup())
+            except Exception:
+                return False
+
         def terminate_and_reap_child() -> None:
             nonlocal containment_proven, process_group_id
             with process_lock:
                 if process is None:
+                    return
+                if barrier is not None:
+                    if not bool(getattr(barrier, "may_have_released", False)):
+                        try:
+                            barrier.close()
+                        except Exception:
+                            pass
+                        reap_direct_root()
+                    else:
+                        containment_proven = (
+                            cleanup_darwin_barrier_after_release()
+                            or containment_proven
+                        )
+                    process_group_id = None
                     return
                 try:
                     if process_group_id is not None:
@@ -2995,8 +3046,7 @@ class CodexExecLauncher:
                 resume_session_id,
                 host_fenced_merge=host_fenced_merge,
             )
-            barrier_factory = getattr(containment, "launch_barrier", None)
-            barrier = barrier_factory(command) if callable(barrier_factory) else None
+            barrier = cast(Any, barrier_factory)(command) if has_darwin_barrier else None
             try:
                 if barrier is None:
                     process = subprocess.Popen(
@@ -3211,7 +3261,10 @@ class CodexExecLauncher:
                     # coordinator authority: descendants can detach their stdio
                     # yet remain in the private process group. Remove any such
                     # residual without accepting a terminal receipt early.
-                    if process_group_is_alive():
+                    if barrier is not None:
+                        process_group_id = None
+                        containment_proven = cleanup_darwin_barrier_after_release()
+                    elif process_group_is_alive():
                         terminate_and_reap_child()
                     else:
                         process_group_id = None

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -2887,7 +2887,10 @@ class CodexExecLauncher:
         process: subprocess.Popen[str] | None = None
         process_group_id: int | None = None
         containment_proven = False
-        process_lock = threading.Lock()
+        # Foreground completion, heartbeat loss, and the parent watchdog all
+        # write process/barrier/containment state. Re-entrancy lets shared
+        # cleanup helpers serialize the full lifecycle.
+        process_lock = threading.RLock()
         barrier: Any | None = None
         lines: Iterable[str | bytes]
 
@@ -2925,38 +2928,42 @@ class CodexExecLauncher:
                 return False
 
         def reap_direct_root() -> bool:
-            if process is None:
-                return False
-            try:
-                if process.poll() is not None:
-                    return True
-            except Exception:
-                return False
-            try:
-                process.terminate()
-            except ProcessLookupError:
-                pass
-            except Exception:
-                return False
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
+            with process_lock:
+                if process is None:
+                    return False
                 try:
-                    process.kill()
-                    process.wait(timeout=5)
+                    if process.poll() is not None:
+                        return True
                 except Exception:
                     return False
-            except Exception:
-                return False
-            return True
+                try:
+                    process.terminate()
+                except ProcessLookupError:
+                    pass
+                except Exception:
+                    return False
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    try:
+                        process.kill()
+                        process.wait(timeout=5)
+                    except Exception:
+                        return False
+                except Exception:
+                    return False
+                return True
 
         def cleanup_darwin_barrier_after_release() -> bool:
-            if not reap_direct_root():
-                return False
-            try:
-                return bool(containment.cleanup())
-            except Exception:
-                return False
+            # In R, direct-root reaping is best effort. The audited coalition
+            # cleanup must run even if that adapter fails.
+            with process_lock:
+                root_reaped = reap_direct_root()
+                try:
+                    coalition_clean = bool(containment.cleanup())
+                except Exception:
+                    coalition_clean = False
+                return root_reaped and coalition_clean
 
         def terminate_and_reap_child() -> None:
             nonlocal containment_proven, process_group_id
@@ -3048,27 +3055,34 @@ class CodexExecLauncher:
             )
             barrier = cast(Any, barrier_factory)(command) if has_darwin_barrier else None
             try:
-                if barrier is None:
-                    process = subprocess.Popen(
-                        command,
-                        cwd=self.worktree,
-                        env=env,
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                        start_new_session=True,
-                    )
-                else:
-                    process = subprocess.Popen(
-                        barrier.command,
-                        cwd=self.worktree,
-                        env=env,
-                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                        start_new_session=True,
-                        pass_fds=barrier.pass_fds,
-                    )
-                    barrier.after_spawn()
+                with process_lock:
+                    if barrier is None:
+                        process = subprocess.Popen(
+                            command,
+                            cwd=self.worktree,
+                            env=env,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                            start_new_session=True,
+                        )
+                    else:
+                        process = subprocess.Popen(
+                            barrier.command,
+                            cwd=self.worktree,
+                            env=env,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                            start_new_session=True,
+                            pass_fds=barrier.pass_fds,
+                        )
+                        barrier.after_spawn()
             except Exception:
                 if barrier is not None:
-                    barrier.close()
+                    try:
+                        barrier.close()
+                    except Exception:
+                        pass
+                # U-state failure: release was never attempted, so only the
+                # exact Popen root may be reaped.
+                reap_direct_root()
                 raise
             try:
                 process_group_id = getattr(process, "pid", None)
@@ -3109,7 +3123,11 @@ class CodexExecLauncher:
 
             def watch_parent_liveness() -> None:
                 while not stop_heartbeat.wait(0.25):
-                    if process is None or process.poll() is None:
+                    with process_lock:
+                        parent_exited = (
+                            process is not None and process.poll() is not None
+                        )
+                    if not parent_exited:
                         continue
                     # A normal parent may exit just before the reader drains
                     # its final buffered events and observes EOF. Only treat
@@ -3126,6 +3144,30 @@ class CodexExecLauncher:
                             outcome="parent_exit_authority_lost",
                         )
                     return
+
+            def wait_for_process_exit() -> bool:
+                """Wait in bounded, lock-serialized slices.
+
+                Stdout can reach EOF before a live coordinator exits. Do not
+                retain ``process_lock`` across that wait: an authority-loss
+                writer must be able to acquire the lifecycle lock and run its
+                mandated cleanup. Each process operation remains serialized.
+                """
+
+                while not authority_lost.is_set():
+                    with process_lock:
+                        if process is None:
+                            raise RuntimeError("verification coordinator missing")
+                        try:
+                            process.wait(timeout=0.25)
+                        except subprocess.TimeoutExpired:
+                            pass
+                        else:
+                            return True
+                    # Test doubles may time out synchronously; yield after
+                    # releasing the lifecycle lock so cleanup cannot starve.
+                    time.sleep(0.001)
+                return False
 
             try:
                 parent_watchdog_thread = threading.Thread(
@@ -3252,30 +3294,33 @@ class CodexExecLauncher:
         if self.runner is subprocess.run:
             assert process is not None
             try:
-                if authority_lost.is_set():
+                if authority_lost.is_set() or not wait_for_process_exit():
                     stop_heartbeat.set()
                     terminate_and_reap_child()
                 else:
-                    process.wait()
-                    # A clean direct-parent exit is not sufficient to release
-                    # coordinator authority: descendants can detach their stdio
-                    # yet remain in the private process group. Remove any such
-                    # residual without accepting a terminal receipt early.
-                    if barrier is not None:
-                        process_group_id = None
-                        containment_proven = cleanup_darwin_barrier_after_release()
-                    elif process_group_is_alive():
-                        terminate_and_reap_child()
-                    else:
-                        process_group_id = None
-                        containment_proven = cleanup_process_tree()
+                    with process_lock:
+                        # A clean direct-parent exit is not sufficient to release
+                        # coordinator authority: descendants can detach their stdio
+                        # yet remain in the private process group. Remove any such
+                        # residual without accepting a terminal receipt early.
+                        if barrier is not None:
+                            process_group_id = None
+                            containment_proven = (
+                                cleanup_darwin_barrier_after_release()
+                            )
+                        elif process_group_is_alive():
+                            terminate_and_reap_child()
+                        else:
+                            process_group_id = None
+                            containment_proven = cleanup_process_tree()
             except Exception:
                 stop_heartbeat.set()
                 terminate_and_reap_child()
                 raise RuntimeError("verification coordinator process failed") from None
             if stderr_thread:
                 stderr_thread.join(timeout=1)
-            returncode = process.returncode
+            with process_lock:
+                returncode = process.returncode
             stop_heartbeat.set()
             if heartbeat_thread:
                 heartbeat_thread.join(timeout=1)

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -2991,27 +2991,55 @@ class CodexExecLauncher:
             terminate_and_reap_child()
 
         if self.runner is subprocess.run:
-            process = subprocess.Popen(
-                self.command(
-                    resume_session_id,
-                    host_fenced_merge=host_fenced_merge,
-                ),
-                cwd=self.worktree,
-                env=env,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                start_new_session=True,
+            command = self.command(
+                resume_session_id,
+                host_fenced_merge=host_fenced_merge,
             )
+            barrier_factory = getattr(containment, "launch_barrier", None)
+            barrier = barrier_factory(command) if callable(barrier_factory) else None
+            try:
+                if barrier is None:
+                    process = subprocess.Popen(
+                        command,
+                        cwd=self.worktree,
+                        env=env,
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                        start_new_session=True,
+                    )
+                else:
+                    process = subprocess.Popen(
+                        barrier.command,
+                        cwd=self.worktree,
+                        env=env,
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                        start_new_session=True,
+                        pass_fds=barrier.pass_fds,
+                    )
+                    barrier.after_spawn()
+            except Exception:
+                if barrier is not None:
+                    barrier.close()
+                raise
             try:
                 process_group_id = getattr(process, "pid", None)
                 if process_group_id is not None:
                     if cleanup_tracker is not containment:
                         cleanup_tracker.attach(process_group_id)
-                    containment.attach(process_group_id)
+                    capture_root = getattr(containment, "capture_launch_root", None)
+                    if callable(capture_root):
+                        attach = getattr(containment, "attach")
+                        attach(process_group_id, capture_root(process_group_id))
+                    else:
+                        containment.attach(process_group_id)
                 if process.stdout is None or process.stderr is None:
                     raise RuntimeError("coordinator process pipes unavailable")
                 lines = process.stdout
                 stderr = process.stderr
+                if barrier is not None:
+                    barrier.release()
             except Exception:
+                if barrier is not None:
+                    barrier.close()
                 terminate_and_reap_child()
                 raise RuntimeError("verification coordinator setup failed") from None
 

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -3103,7 +3103,10 @@ class CodexExecLauncher:
                     barrier.release()
             except Exception:
                 if barrier is not None:
-                    barrier.close()
+                    try:
+                        barrier.close()
+                    except Exception:
+                        pass
                 terminate_and_reap_child()
                 raise RuntimeError("verification coordinator setup failed") from None
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -223,6 +223,12 @@ identity whose parent-unique-id chain does not close at the launched root. Clean
 bounded deadline and then requires two stable baseline-only snapshots with exact task-count
 equality. This proves cleanup only inside the dedicated job's inherited resource coalition; it does
 not claim control of unrelated launchd jobs in other coalitions. This fence
+remains fail-closed if the launched root exits before attach: the cycle fails rather than proceeding,
+but its failure cleanup may use the containment only after every non-baseline task has a complete
+ancestry chain to one absent, uninspectable parent unique ID. A baseline parent, multiple absent
+roots, an active outside-coalition parent, an identity ambiguity, or a changing/count-mismatched
+snapshot rejects that cleanup authority. This prevents a detached same-coalition descendant from
+outliving the failed setup without admitting an unrelated task as a target. The fence
 does not grant the model child GitHub authority: the installed-main cycle remains
 `github.merge.dry_run`, and BCP-06 stays disabled.
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -181,6 +181,7 @@ python -m app.dispatcher.cli verification-cycle \
   <verification_dispatch_request.v3.json> \
   --holder verification-host \
   --worktree <installed-main-checkout> \
+  --containment-profile darwin-launchd-resource-coalition-v1 \
   --json
 ```
 
@@ -199,6 +200,7 @@ python -m app.dispatcher.cli verification-cycle \
   --repo <owner/repo> \
   --holder verification-host \
   --worktree <installed-main-checkout> \
+  --containment-profile darwin-launchd-resource-coalition-v1 \
   --json
 ```
 
@@ -207,7 +209,24 @@ Both forms are dry-run-safe and API/PostgreSQL-only. A successful command emits 
 Demerzel invocation posts that receipt to #3603. The command itself does not satisfy that parent
 gate or activate BCP-06. Before constructing any client or effect adapter, the command requires the
 selected worktree to be clean `main` at the exact locally fetched `origin/main`; a detached, dirty,
-stale, or feature-branch checkout fails closed. That checkout supplies the installed composition
+stale, or feature-branch checkout fails closed. It also requires the explicit
+`darwin-launchd-resource-coalition-v1` profile while running inside the dedicated launchd job whose
+resource coalition is inherited by the child-wrapper topology. Before API construction or claim,
+the profile enumerates PIDs, binds each task to its PID-version and resource-coalition identity,
+and accepts only two identical snapshots whose complete identity set equals the kernel
+`proc_listcoalitions` task-count witness. The trusted baseline is only the current CLI plus its
+same-coalition ancestor chain up to the first inspected ancestor outside the coalition; a shared,
+uninspectable, changing, count-mismatched, or private-symbol-unavailable coalition fails closed.
+Cleanup freshly revalidates PID-version and coalition identity before signalling every non-baseline
+task through Darwin's PID-version-bound audit-token signal API; attach also rejects any post-baseline
+identity whose parent-unique-id chain does not close at the launched root. Cleanup polls within a
+bounded deadline and then requires two stable baseline-only snapshots with exact task-count
+equality. This proves cleanup only inside the dedicated job's inherited resource coalition; it does
+not claim control of unrelated launchd jobs in other coalitions. This fence
+does not grant the model child GitHub authority: the installed-main cycle remains
+`github.merge.dry_run`, and BCP-06 stays disabled.
+
+That checkout supplies the installed composition
 code only: before launching the network-fenced reviewer, the host materializes an immutable
 `origin/main...current_head_sha` patch, binds its SHA-256 digest and PR head into the dispatch
 context, and requires the reviewer to inspect that exact source evidence rather than treating the

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -228,13 +228,15 @@ with Python isolation flags before it reads anything and imports no application/
 Before the barrier releases, the parent captures
 the root's full PID-version/unique-id/parent-unique-id/coalition identity and requires two stable,
 count-matched snapshots whose complete member set is exactly baseline plus that paused root. Any
-other member, identity change, release failure, or root loss fails setup before the model command
-can exec or spawn descendants; bounded process-group cleanup is then sufficient. The same root PID
+other member, identity change, or root loss fails setup before release, so the model command cannot
+exec or spawn descendants. The same root PID
 survives the direct exec only after attachment has armed containment cleanup. The barrier write end
 is parent-only and never inherited, while the wrapper owns only the read end, marks it
-non-inheritable, and exits without exec on EOF or an invalid release token. Before release, failure
-cleanup handles only the live Popen root and never probes or signals a numeric process group. After
-release, the count-witnessed audit-token coalition cleanup is the sole whole-tree authority; raw
+non-inheritable, and exits without exec on EOF or an invalid release token. Before an attempted
+release, failure cleanup handles only the live Popen root and never probes or signals a numeric
+process group. Any release attempt, including a partial write or an indeterminate exception, enters
+the post-release state. After that point, count-witnessed audit-token coalition cleanup is the sole
+whole-tree authority; raw
 PID, process-group, and Tagged-process tracking are not used for the Darwin profile. The fence
 does not grant the model child GitHub authority: the installed-main cycle remains
 `github.merge.dry_run`, and BCP-06 stays disabled.

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -223,12 +223,14 @@ identity whose parent-unique-id chain does not close at the launched root. Clean
 bounded deadline and then requires two stable baseline-only snapshots with exact task-count
 equality. This proves cleanup only inside the dedicated job's inherited resource coalition; it does
 not claim control of unrelated launchd jobs in other coalitions. This fence
-remains fail-closed if the launched root exits before attach: the cycle fails rather than proceeding,
-but its failure cleanup may use the containment only after every non-baseline task has a complete
-ancestry chain to one absent, uninspectable parent unique ID. A baseline parent, multiple absent
-roots, an active outside-coalition parent, an identity ambiguity, or a changing/count-mismatched
-snapshot rejects that cleanup authority. This prevents a detached same-coalition descendant from
-outliving the failed setup without admitting an unrelated task as a target. The fence
+uses a one-shot exec barrier for the launched root: before the barrier releases, the parent captures
+the root's full PID-version/unique-id/parent-unique-id/coalition identity and requires two stable,
+count-matched snapshots whose complete member set is exactly baseline plus that paused root. Any
+other member, identity change, release failure, or root loss fails setup before the model command
+can exec or spawn descendants; bounded process-group cleanup is then sufficient. The same root PID
+survives the direct exec only after attachment has armed containment cleanup. The barrier write end
+is parent-only and never inherited, while the wrapper owns only the read end and exits without exec
+on EOF or an invalid release token. The fence
 does not grant the model child GitHub authority: the installed-main cycle remains
 `github.merge.dry_run`, and BCP-06 stays disabled.
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -223,14 +223,19 @@ identity whose parent-unique-id chain does not close at the launched root. Clean
 bounded deadline and then requires two stable baseline-only snapshots with exact task-count
 equality. This proves cleanup only inside the dedicated job's inherited resource coalition; it does
 not claim control of unrelated launchd jobs in other coalitions. This fence
-uses a one-shot exec barrier for the launched root: before the barrier releases, the parent captures
+uses a hermetic one-shot exec barrier for the launched root: the absolute repo-owned wrapper starts
+with Python isolation flags before it reads anything and imports no application/package or site hook.
+Before the barrier releases, the parent captures
 the root's full PID-version/unique-id/parent-unique-id/coalition identity and requires two stable,
 count-matched snapshots whose complete member set is exactly baseline plus that paused root. Any
 other member, identity change, release failure, or root loss fails setup before the model command
 can exec or spawn descendants; bounded process-group cleanup is then sufficient. The same root PID
 survives the direct exec only after attachment has armed containment cleanup. The barrier write end
-is parent-only and never inherited, while the wrapper owns only the read end and exits without exec
-on EOF or an invalid release token. The fence
+is parent-only and never inherited, while the wrapper owns only the read end, marks it
+non-inheritable, and exits without exec on EOF or an invalid release token. Before release, failure
+cleanup handles only the live Popen root and never probes or signals a numeric process group. After
+release, the count-witnessed audit-token coalition cleanup is the sole whole-tree authority; raw
+PID, process-group, and Tagged-process tracking are not used for the Darwin profile. The fence
 does not grant the model child GitHub authority: the installed-main cycle remains
 `github.merge.dry_run`, and BCP-06 stays disabled.
 

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -6006,6 +6006,119 @@ def test_barrier_capture_failure_closes_without_coordinator_release(
     assert process.group_signals == []
 
 
+def test_barrier_after_spawn_failure_reaps_exact_root_before_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+
+        def after_spawn(self) -> None:
+            events.append("after_spawn")
+            raise RuntimeError("barrier handoff failed")
+
+        def close(self) -> None:
+            events.append("close")
+            raise OSError("barrier close failed")
+
+    class BarrierContainment(_ProvenContainment):
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            events.append("barrier")
+            return Barrier()
+
+    process = _AuthorityLossProcess([])
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("must not use PGID")),
+    )
+
+    with pytest.raises(RuntimeError, match="barrier handoff failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=BarrierContainment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert events == ["barrier", "after_spawn", "close"]
+    assert process.terminate_calls == 1
+    assert process.wait_calls == 1
+
+
+def test_barrier_release_cleanup_runs_coalition_after_direct_root_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+        may_have_released = False
+
+        def after_spawn(self) -> None:
+            return None
+
+        def release(self) -> None:
+            self.may_have_released = True
+
+        def close(self) -> None:
+            return None
+
+    class BarrierContainment(_ProvenContainment):
+        def __init__(self) -> None:
+            self.cleanup_calls = 0
+
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            return Barrier()
+
+        def capture_launch_root(self, root_pid: int) -> tuple[str, int]:
+            return ("identity", root_pid)
+
+        def attach(self, root_pid: int, identity: object | None = None) -> None:
+            assert identity == ("identity", root_pid)
+            super().attach(root_pid)
+
+        def cleanup(self) -> bool:
+            self.cleanup_calls += 1
+            return True
+
+    class DirectRootFailureProcess(_AuthorityLossProcess):
+        pid = 42_026
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            raise RuntimeError("root adapter failed")
+
+        def wait(self, timeout: float | None = None) -> int:
+            raise RuntimeError("root adapter failed")
+
+    process = DirectRootFailureProcess([])
+    containment = BarrierContainment()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    with pytest.raises(RuntimeError, match="verification coordinator process failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=lambda: containment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert containment.cleanup_calls == 1
+
+
 class _EscapedDescendantContainment(_ProvenContainment):
     def __init__(self, process: _CleanExitDetachedDescendantProcess, *, proven: bool) -> None:
         self.process = process
@@ -6166,6 +6279,86 @@ def test_background_authority_loss_rejects_late_stdout(
 
     assert error.receipt["session_id"] is None
     assert process.stdout.reads == 1
+
+
+def test_heartbeat_cleanup_wins_after_stdout_eof_while_coordinator_is_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EOF must not let terminal waiting starve the authority-loss writer."""
+
+    class EofLiveProcess:
+        def __init__(self) -> None:
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+            self.returncode: int | None = None
+            self.pid = 42_027
+            self.descendant_alive = True
+            self.group_signals: list[tuple[int, int]] = []
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def wait(self, timeout: float | None = None) -> int:
+            if self.returncode is None:
+                raise subprocess.TimeoutExpired("codex", timeout)
+            return self.returncode
+
+        def killpg(self, process_group_id: int, sig: int) -> None:
+            self.group_signals.append((process_group_id, sig))
+            assert process_group_id == self.pid
+            if sig == verification_consumer.signal.SIGTERM:
+                self.returncode = -verification_consumer.signal.SIGTERM
+            elif sig == verification_consumer.signal.SIGKILL:
+                self.descendant_alive = False
+
+    process = EofLiveProcess()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(verification_consumer.os, "killpg", process.killpg)
+    event_wait = verification_consumer.threading.Event.wait
+
+    def accelerated_wait(event, timeout=None):
+        if timeout is not None:
+            timeout = min(timeout, 0.01)
+        return event_wait(event, timeout)
+
+    monkeypatch.setattr(
+        verification_consumer.threading.Event,
+        "wait",
+        accelerated_wait,
+    )
+    outcome: dict[str, BaseException] = {}
+    finished = Event()
+
+    def launch() -> None:
+        try:
+            _authority_loss_launcher(tmp_path).launch(
+                {"head_sha": HEAD},
+                on_heartbeat=lambda: (_ for _ in ()).throw(
+                    RuntimeError("verification lease heartbeat rejected")
+                ),
+            )
+        except BaseException as exc:  # noqa: BLE001 - asserted thread outcome
+            outcome["error"] = exc
+        finally:
+            finished.set()
+
+    worker = Thread(target=launch, daemon=True)
+    worker.start()
+    assert event_wait(finished, 1), "authority-loss cleanup was starved by EOF wait"
+    worker.join(timeout=1)
+
+    error = outcome.get("error")
+    assert isinstance(error, CodexExecFailure), outcome
+    assert error.receipt["outcome"] == "heartbeat_authority_lost"
+    assert process.group_signals == [
+        (process.pid, verification_consumer.signal.SIGTERM),
+        (process.pid, 0),
+        (process.pid, verification_consumer.signal.SIGKILL),
+    ]
 
 
 # The pre-#4012 harness joined the launcher worker with a fixed 0.5 second

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -6053,6 +6053,128 @@ def test_barrier_after_spawn_failure_reaps_exact_root_before_release(
     assert process.wait_calls == 1
 
 
+def test_barrier_capture_failure_close_error_still_reaps_u_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+        may_have_released = False
+
+        def after_spawn(self) -> None:
+            return None
+
+        def close(self) -> None:
+            raise OSError("barrier close failed")
+
+    class FailingCaptureContainment(_ProvenContainment):
+        def __init__(self) -> None:
+            self.cleanup_calls = 0
+
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            return Barrier()
+
+        def capture_launch_root(self, _root_pid: int) -> object:
+            raise RuntimeError("root identity unavailable")
+
+        def cleanup(self) -> bool:
+            self.cleanup_calls += 1
+            return True
+
+    class LiveRootProcess(_AuthorityLossProcess):
+        pid = 42_028
+
+    process = LiveRootProcess([])
+    containment = FailingCaptureContainment()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("must not use PGID")),
+    )
+
+    with pytest.raises(RuntimeError, match="verification coordinator setup failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=lambda: containment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert process.terminate_calls == 1
+    assert process.wait_calls == 1
+    assert containment.cleanup_calls == 0
+
+
+def test_barrier_release_failure_close_error_still_cleans_r_coalition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+        may_have_released = False
+
+        def after_spawn(self) -> None:
+            return None
+
+        def release(self) -> None:
+            self.may_have_released = True
+            raise RuntimeError("release delivery indeterminate")
+
+        def close(self) -> None:
+            raise OSError("barrier close failed")
+
+    class BarrierContainment(_ProvenContainment):
+        def __init__(self) -> None:
+            self.cleanup_calls = 0
+
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            return Barrier()
+
+        def capture_launch_root(self, root_pid: int) -> tuple[str, int]:
+            return ("identity", root_pid)
+
+        def attach(self, root_pid: int, identity: object | None = None) -> None:
+            assert identity == ("identity", root_pid)
+            super().attach(root_pid)
+
+        def cleanup(self) -> bool:
+            self.cleanup_calls += 1
+            return True
+
+    class LiveRootProcess(_AuthorityLossProcess):
+        pid = 42_029
+
+    process = LiveRootProcess([])
+    containment = BarrierContainment()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("must not use PGID")),
+    )
+
+    with pytest.raises(RuntimeError, match="verification coordinator setup failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=lambda: containment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert process.terminate_calls == 1
+    assert process.wait_calls == 1
+    assert containment.cleanup_calls == 1
+
+
 def test_barrier_release_cleanup_runs_coalition_after_direct_root_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -5899,6 +5899,112 @@ class _ProvenContainment:
         return True
 
 
+def test_barrier_attaches_captured_root_before_coordinator_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    observed: dict[str, object] = {}
+
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+
+        def after_spawn(self) -> None:
+            events.append("after_spawn")
+
+        def release(self) -> None:
+            events.append("release")
+
+        def close(self) -> None:
+            events.append("close")
+
+    class BarrierContainment(_ProvenContainment):
+        def launch_barrier(self, command: list[str]) -> Barrier:
+            observed["command"] = command
+            events.append("barrier")
+            return Barrier()
+
+        def capture_launch_root(self, root_pid: int) -> tuple[str, int]:
+            events.append("capture")
+            return ("identity", root_pid)
+
+        def attach(self, root_pid: int, identity: object | None = None) -> None:
+            assert identity == ("identity", root_pid)
+            events.append("attach")
+            super().attach(root_pid)
+
+    process = _CleanExitDetachedDescendantProcess()
+
+    def popen(command: list[str], **kwargs: object) -> _CleanExitDetachedDescendantProcess:
+        observed.setdefault("popen_calls", []).append((command, kwargs))
+        return process
+
+    monkeypatch.setattr(verification_consumer.subprocess, "Popen", popen)
+    containment = BarrierContainment()
+    session_id, _receipt = _authority_loss_launcher(
+        tmp_path,
+        containment_factory=lambda: containment,
+    ).launch({"head_sha": HEAD})
+
+    assert session_id == "01900000-0000-7000-8000-000000000011"
+    popen_command, popen_kwargs = observed["popen_calls"][0]
+    assert popen_command == ["barrier", "coordinator"]
+    assert popen_kwargs["pass_fds"] == (71,)
+    assert events == ["barrier", "after_spawn", "capture", "attach", "release"]
+
+
+def test_barrier_capture_failure_closes_without_coordinator_release(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+
+        def after_spawn(self) -> None:
+            events.append("after_spawn")
+
+        def release(self) -> None:
+            events.append("release")
+
+        def close(self) -> None:
+            events.append("close")
+
+    class FailingBarrierContainment(_ProvenContainment):
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            events.append("barrier")
+            return Barrier()
+
+        def capture_launch_root(self, _root_pid: int) -> object:
+            events.append("capture")
+            raise ValueError("root identity unavailable")
+
+    process = _CleanExitDetachedDescendantProcess()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(verification_consumer.os, "killpg", process.killpg)
+
+    with pytest.raises(RuntimeError, match="verification coordinator setup failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=FailingBarrierContainment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert events == ["barrier", "after_spawn", "capture", "close"]
+    assert process.group_signals == [
+        (process.pid, verification_consumer.signal.SIGTERM),
+        (process.pid, 0),
+        (process.pid, verification_consumer.signal.SIGKILL),
+    ]
+
+
 class _EscapedDescendantContainment(_ProvenContainment):
     def __init__(self, process: _CleanExitDetachedDescendantProcess, *, proven: bool) -> None:
         self.process = process

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -5988,7 +5988,11 @@ def test_barrier_capture_failure_closes_without_coordinator_release(
         "Popen",
         lambda *args, **kwargs: process,
     )
-    monkeypatch.setattr(verification_consumer.os, "killpg", process.killpg)
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("must not use PGID")),
+    )
 
     with pytest.raises(RuntimeError, match="verification coordinator setup failed"):
         _authority_loss_launcher(
@@ -5997,12 +6001,9 @@ def test_barrier_capture_failure_closes_without_coordinator_release(
             cleanup_tracker_factory=_ProvenContainment,
         ).launch({"head_sha": HEAD})
 
-    assert events == ["barrier", "after_spawn", "capture", "close"]
-    assert process.group_signals == [
-        (process.pid, verification_consumer.signal.SIGTERM),
-        (process.pid, 0),
-        (process.pid, verification_consumer.signal.SIGKILL),
-    ]
+    assert events[:3] == ["barrier", "after_spawn", "capture"]
+    assert events[3:] == ["close", "close"]
+    assert process.group_signals == []
 
 
 class _EscapedDescendantContainment(_ProvenContainment):

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import signal
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Callable
 
 import pytest
 
 from app.dispatcher import cli as dispatcher_cli
+from app.dispatcher import darwin_containment
 from app.dispatcher import verification_consumer
 from app.dispatcher import verification_github
 from app.dispatcher import verification_merge
@@ -18,6 +21,7 @@ from app.dispatcher.verification_merge import MergeAuthorityError
 
 REPO = "RasmusTho/agentic-pkm-mvp"
 HEAD = "a" * 40
+CONTAINMENT_PROFILE = "darwin-launchd-resource-coalition-v1"
 
 
 def _request() -> dict[str, object]:
@@ -28,6 +32,28 @@ def _request() -> dict[str, object]:
         "head_sha": HEAD,
         "linked_issue": 4677,
     }
+
+
+def _cycle_args(request_file: Path) -> list[str]:
+    return [
+        "verification-cycle",
+        str(request_file),
+        "--containment-profile",
+        CONTAINMENT_PROFILE,
+        "--json",
+    ]
+
+
+def _allow_containment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        dispatcher_cli,
+        "select_verification_containment",
+        lambda profile: (
+            (lambda: object())
+            if profile == CONTAINMENT_PROFILE
+            else (_ for _ in ()).throw(ValueError("unsupported containment"))
+        ),
+    )
 
 
 class _Client:
@@ -94,6 +120,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     auth = object()
     launcher = object()
     exact_launcher = object()
+    containment_factory = lambda: object()
     consumer = object()
     repository = SimpleNamespace(close=lambda: None)
     executor = object()
@@ -142,11 +169,12 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     monkeypatch.setattr(
         verification_consumer,
         "CodexExecLauncher",
-        lambda worktree, receipt_schema, context_path: (
+        lambda worktree, receipt_schema, context_path, *, containment_factory: (
             seen.update(
                 worktree=worktree,
                 receipt_schema=receipt_schema,
                 context_path=context_path,
+                containment_factory=containment_factory,
             )
             or launcher
         ),
@@ -215,6 +243,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
         holder="verification-host",
         worktree=tmp_path,
         context_path=tmp_path / "context.json",
+        containment_factory=containment_factory,
     )
 
     assert built is runtime
@@ -224,6 +253,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     assert seen["ledger_outbox"] is outbox
     assert seen["consumer_ledger"] is ledger
     assert seen["raw_launcher"] is launcher
+    assert seen["containment_factory"] is containment_factory
     assert seen["launcher"] is exact_launcher
     assert seen["executor_ledger"] is ledger
     assert seen["executor_outbox"] is outbox
@@ -287,6 +317,7 @@ def test_cycle_command_runs_and_recovers_dry_cycle(
 ) -> None:
     request_file = tmp_path / "request.json"
     request_file.write_text(json.dumps(_request()), encoding="utf-8")
+    _allow_containment(monkeypatch)
     runtime = _Runtime()
     monkeypatch.setattr(
         dispatcher_cli,
@@ -318,6 +349,8 @@ def test_cycle_command_runs_and_recovers_dry_cycle(
                 str(request_file),
                 "--holder",
                 "verification-host",
+                "--containment-profile",
+                CONTAINMENT_PROFILE,
                 "--json",
             ]
         )
@@ -337,6 +370,8 @@ def test_cycle_command_runs_and_recovers_dry_cycle(
                 REPO,
                 "--holder",
                 "verification-host",
+                "--containment-profile",
+                CONTAINMENT_PROFILE,
                 "--json",
             ]
         )
@@ -419,6 +454,7 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
     secret = "github_pat_NEVER_PRINT_THIS_VALUE"
     request_file = tmp_path / "request.json"
     request_file.write_text(json.dumps(_request()), encoding="utf-8")
+    _allow_containment(monkeypatch)
     monkeypatch.setattr(
         dispatcher_cli,
         "_make_verification_client",
@@ -437,7 +473,7 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
 
     assert (
         dispatcher_cli.main(
-            ["verification-cycle", str(request_file), "--json"]
+            _cycle_args(request_file)
         )
         == 1
     )
@@ -467,7 +503,7 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
     )
     assert (
         dispatcher_cli.main(
-            ["verification-cycle", str(request_file), "--json"]
+            _cycle_args(request_file)
         )
         == 1
     )
@@ -499,7 +535,7 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
     )
     assert (
         dispatcher_cli.main(
-            ["verification-cycle", str(request_file), "--json"]
+            _cycle_args(request_file)
         )
         == 1
     )
@@ -597,3 +633,321 @@ def test_installed_main_preflight_binds_source_and_target_repository(
     )
     with pytest.raises(ValueError, match="exact clean origin/main"):
         dispatcher_cli._assert_installed_main_worktree(tmp_path, REPO)
+
+
+class _FakeDarwinKernel:
+    def __init__(self) -> None:
+        self.identities = {
+            1: darwin_containment.ProcessIdentity(1, 1, 10, 0, 99),
+            90: darwin_containment.ProcessIdentity(90, 2, 90, 10, 7),
+            100: darwin_containment.ProcessIdentity(100, 3, 100, 90, 7),
+        }
+        self.task_count_override: int | None = None
+        self.pid_reads: list[tuple[int, ...]] = []
+        self.signal_callback: Callable[[int, int], None] | None = None
+
+    def list_pids(self) -> tuple[int, ...]:
+        if self.pid_reads:
+            return self.pid_reads.pop(0)
+        return tuple(self.identities)
+
+    def inspect(self, pid: int) -> darwin_containment.ProcessIdentity | None:
+        return self.identities.get(pid)
+
+    def coalition_task_count(self, coalition_id: int) -> int:
+        if self.task_count_override is not None:
+            return self.task_count_override
+        return sum(
+            identity.coalition_id == coalition_id
+            for identity in self.identities.values()
+        )
+
+    def signal(
+        self, identity: darwin_containment.ProcessIdentity, sig: int
+    ) -> bool:
+        if self.identities.get(identity.pid) != identity:
+            return False
+        if self.signal_callback is not None:
+            self.signal_callback(identity.pid, sig)
+        else:
+            self.identities.pop(identity.pid, None)
+        return True
+
+
+def test_cycle_requires_supported_containment_profile_before_api_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    request_file = tmp_path / "request.json"
+    request_file.write_text(json.dumps(_request()), encoding="utf-8")
+    client_opened = False
+
+    def _unexpected_client() -> _Client:
+        nonlocal client_opened
+        client_opened = True
+        return _Client()
+
+    monkeypatch.setattr(
+        dispatcher_cli, "_assert_installed_main_worktree", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        dispatcher_cli, "_make_verification_client", _unexpected_client
+    )
+
+    assert dispatcher_cli.main(
+        ["verification-cycle", str(request_file), "--json"]
+    ) == 1
+    assert json.loads(capsys.readouterr().out)["error_type"] == "ValueError"
+    assert client_opened is False
+
+    assert dispatcher_cli.main(
+        [
+            "verification-cycle",
+            str(request_file),
+            "--containment-profile",
+            "unsupported-profile",
+            "--json",
+        ]
+    ) == 1
+    assert json.loads(capsys.readouterr().out)["error_type"] == "ValueError"
+    assert client_opened is False
+
+
+def test_cycle_composition_injects_darwin_launchd_coalition_containment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    kernel = _FakeDarwinKernel()
+    signalled: list[tuple[int, int]] = []
+
+    def signaler(pid: int, sig: int) -> None:
+        signalled.append((pid, sig))
+        kernel.identities.pop(pid, None)
+
+    kernel.signal_callback = signaler
+
+    factory = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+    )
+    containment = factory()
+    assert containment.environment({"SAFE": "yes"}) == {"SAFE": "yes"}
+
+    kernel.identities[200] = darwin_containment.ProcessIdentity(200, 4, 200, 100, 7)
+    containment.attach(200)
+    assert containment.cleanup() is True
+    assert (200, signal.SIGTERM) in signalled
+
+
+def test_darwin_private_abi_reads_pid_version_unique_ancestry_and_coalition() -> None:
+    kernel = darwin_containment.DarwinLibprocKernel.__new__(
+        darwin_containment.DarwinLibprocKernel
+    )
+    calls: list[tuple[int, int]] = []
+
+    def pid_info(pid: int, flavor: int, _arg: int, buffer, size: int) -> int:
+        calls.append((flavor, size))
+        if flavor == 17:
+            value = darwin_containment._ProcUniqIdentifierInfo.from_address(  # noqa: SLF001
+                darwin_containment.ctypes.addressof(buffer._obj)
+            )
+            value.p_uniqueid = 900
+            value.p_puniqueid = 800
+            value.p_idversion = 7
+            return darwin_containment.ctypes.sizeof(value)
+        value = darwin_containment._ProcPidCoalitionInfo.from_address(  # noqa: SLF001
+            darwin_containment.ctypes.addressof(buffer._obj)
+        )
+        value.coalition_id[0] = 42
+        return darwin_containment.ctypes.sizeof(value)
+
+    kernel._pid_info = pid_info  # type: ignore[attr-defined]  # noqa: SLF001
+
+    assert kernel.inspect(123) == darwin_containment.ProcessIdentity(
+        123, 7, 900, 800, 42
+    )
+    assert calls == [(17, 56), (20, 40), (17, 56)]
+
+
+def test_darwin_signal_uses_pid_version_bound_audit_token() -> None:
+    kernel = darwin_containment.DarwinLibprocKernel.__new__(
+        darwin_containment.DarwinLibprocKernel
+    )
+    seen: dict[str, object] = {}
+
+    def signal_with_token(token_pointer, sig: int) -> int:
+        token = token_pointer._obj
+        seen.update(pid=token.val[5], pid_version=token.val[7], sig=sig)
+        return 0
+
+    kernel._signal_with_audit_token = signal_with_token  # type: ignore[attr-defined]  # noqa: SLF001
+    identity = darwin_containment.ProcessIdentity(123, 7, 900, 800, 42)
+
+    assert kernel.signal(identity, signal.SIGKILL) is True
+    assert seen == {"pid": 123, "pid_version": 7, "sig": signal.SIGKILL}
+
+
+def test_containment_refuses_pid_reuse_between_snapshot_and_signal() -> None:
+    class ReusingKernel(_FakeDarwinKernel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.child_inspections = 0
+            self.reuse_at: int | None = None
+
+        def inspect(self, pid: int) -> darwin_containment.ProcessIdentity | None:
+            if pid == 200:
+                self.child_inspections += 1
+                if self.reuse_at == self.child_inspections:
+                    self.identities[200] = darwin_containment.ProcessIdentity(
+                        200, 5, 201, 100, 7
+                    )
+            return super().inspect(pid)
+
+    kernel = ReusingKernel()
+    factory = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+        sleeper=lambda _seconds: None,
+    )
+    containment = factory()
+    containment.environment({})
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 4, 200, 100, 7
+    )
+    containment.attach(200)
+    original_signal = kernel.signal
+
+    def reuse_before_atomic_signal(
+        identity: darwin_containment.ProcessIdentity, sig: int
+    ) -> bool:
+        kernel.identities[200] = darwin_containment.ProcessIdentity(
+            200, 5, 201, 100, 7
+        )
+        return original_signal(identity, sig)
+
+    kernel.signal = reuse_before_atomic_signal  # type: ignore[method-assign]
+
+    assert containment.cleanup() is False
+    assert kernel.identities[200].pid_version == 5
+
+
+def test_containment_rejects_unrelated_member_appearing_before_attach() -> None:
+    kernel = _FakeDarwinKernel()
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+    )()
+    containment.environment({})
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 4, 200, 100, 7
+    )
+    kernel.identities[300] = darwin_containment.ProcessIdentity(
+        300, 4, 300, 100, 7
+    )
+
+    with pytest.raises(ValueError, match="ancestry escaped root"):
+        containment.attach(200)
+
+
+def test_cleanup_polls_until_delayed_kernel_task_disappearance() -> None:
+    kernel = _FakeDarwinKernel()
+    clock = [0.0]
+    remove_at = [float("inf")]
+
+    def signaler(_pid: int, _sig: int) -> None:
+        remove_at[0] = clock[0] + 0.15
+
+    def sleeper(seconds: float) -> None:
+        clock[0] += seconds
+        if clock[0] >= remove_at[0]:
+            kernel.identities.pop(200, None)
+
+    kernel.signal_callback = signaler
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+        sleeper=sleeper,
+        monotonic=lambda: clock[0],
+    )()
+    containment.environment({})
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 4, 200, 100, 7
+    )
+    containment.attach(200)
+
+    assert containment.cleanup() is True
+    assert clock[0] >= 0.15
+
+
+@pytest.mark.parametrize("failure", ["shared", "count", "changing"])
+def test_cycle_rejects_shared_or_unproven_coalition_before_api_claim(
+    failure: str,
+) -> None:
+    kernel = _FakeDarwinKernel()
+    if failure == "shared":
+        kernel.identities[200] = darwin_containment.ProcessIdentity(200, 4, 200, 10, 7)
+    elif failure == "count":
+        kernel.task_count_override = 3
+    else:
+        kernel.pid_reads = [
+            (1, 90, 100),
+            (1, 90),
+            (1, 90, 100),
+            (1, 90),
+            (1, 90, 100),
+            (1, 90),
+            (1, 90, 100),
+            (1, 90),
+        ]
+
+    with pytest.raises(ValueError, match="containment"):
+        darwin_containment.select_verification_containment(
+            CONTAINMENT_PROFILE,
+            platform="darwin",
+            kernel=kernel,
+            current_pid=100,
+        )
+
+
+def test_cycle_real_launcher_accepts_terminal_receipt_with_proven_containment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tests.dispatcher.test_verification_consumer import (
+        _CleanExitDetachedDescendantProcess,
+        _EscapedDescendantContainment,
+        _authority_loss_launcher,
+    )
+
+    process = _CleanExitDetachedDescendantProcess()
+    containment = _EscapedDescendantContainment(process, proven=True)
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda process_group_id, sig: (_ for _ in ()).throw(
+            ProcessLookupError(process_group_id)
+        ),
+    )
+
+    session_id, receipt = _authority_loss_launcher(
+        tmp_path,
+        containment_factory=lambda: containment,
+    ).launch({"head_sha": HEAD})
+
+    assert session_id == "01900000-0000-7000-8000-000000000011"
+    assert receipt["verdict"] == "blocked"
+    assert containment.cleanup_calls == 1

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -665,7 +665,16 @@ class _FakeDarwinKernel:
     def signal(
         self, identity: darwin_containment.ProcessIdentity, sig: int
     ) -> bool:
-        if self.identities.get(identity.pid) != identity:
+        current = self.identities.get(identity.pid)
+        if current is None or (
+            current.pid_version,
+            current.unique_id,
+            current.coalition_id,
+        ) != (
+            identity.pid_version,
+            identity.unique_id,
+            identity.coalition_id,
+        ):
             return False
         if self.signal_callback is not None:
             self.signal_callback(identity.pid, sig)
@@ -834,6 +843,44 @@ def test_containment_refuses_pid_reuse_between_snapshot_and_signal() -> None:
 
     assert containment.cleanup() is False
     assert kernel.identities[200].pid_version == 5
+
+
+def test_cleanup_accepts_child_reparented_after_parent_signal() -> None:
+    kernel = _FakeDarwinKernel()
+    signalled: list[int] = []
+
+    def signaler(pid: int, _sig: int) -> None:
+        signalled.append(pid)
+        kernel.identities.pop(pid, None)
+        if pid == 200:
+            child = kernel.identities[201]
+            kernel.identities[201] = darwin_containment.ProcessIdentity(
+                child.pid,
+                child.pid_version,
+                child.unique_id,
+                100,
+                child.coalition_id,
+            )
+
+    kernel.signal_callback = signaler
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+        sleeper=lambda _seconds: None,
+    )()
+    containment.environment({})
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 4, 200, 100, 7
+    )
+    kernel.identities[201] = darwin_containment.ProcessIdentity(
+        201, 4, 201, 200, 7
+    )
+    containment.attach(200)
+
+    assert containment.cleanup() is True
+    assert signalled == [200, 201]
 
 
 def test_containment_rejects_unrelated_member_appearing_before_attach() -> None:

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -875,6 +875,80 @@ def test_darwin_launch_barrier_execs_with_same_pid_after_release() -> None:
     assert stdout.strip() == str(process.pid)
 
 
+def test_darwin_launch_barrier_release_is_one_shot_and_conservative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = darwin_containment.DarwinLaunchBarrier(["coordinator"])
+    barrier.after_spawn()
+    try:
+        monkeypatch.setattr(darwin_containment.os, "write", lambda *_args: 0)
+        with pytest.raises(OSError, match="partial"):
+            barrier.release()
+        assert barrier.may_have_released is False
+        with pytest.raises(ValueError, match="unavailable"):
+            barrier.release()
+    finally:
+        barrier.close()
+
+
+def test_darwin_launch_barrier_marks_unknown_write_failure_released(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = darwin_containment.DarwinLaunchBarrier(["coordinator"])
+    barrier.after_spawn()
+    try:
+        monkeypatch.setattr(
+            darwin_containment.os,
+            "write",
+            lambda *_args: (_ for _ in ()).throw(OSError("unknown write")),
+        )
+        with pytest.raises(OSError, match="unknown write"):
+            barrier.release()
+        assert barrier.may_have_released is True
+    finally:
+        barrier.close()
+
+
+def test_darwin_launch_barrier_uses_absolute_isolated_wrapper() -> None:
+    barrier = darwin_containment.DarwinLaunchBarrier(["coordinator"])
+    try:
+        assert barrier.command[1:3] == ["-I", "-S"]
+        assert Path(barrier.command[3]).is_absolute()
+        assert Path(barrier.command[3]).name == "darwin_launch_barrier.py"
+        assert "-m" not in barrier.command
+    finally:
+        barrier.close()
+
+
+def test_darwin_launch_barrier_ignores_hostile_site_and_app_hooks(
+    tmp_path: Path,
+) -> None:
+    hostile = tmp_path / "hostile"
+    hostile.mkdir()
+    marker = tmp_path / "hook-ran"
+    (hostile / "sitecustomize.py").write_text(
+        f"from pathlib import Path; Path({str(marker)!r}).write_text('site')",
+        encoding="utf-8",
+    )
+    app_dir = hostile / "app"
+    app_dir.mkdir()
+    (app_dir / "__init__.py").write_text(
+        f"from pathlib import Path; Path({str(marker)!r}).write_text('app')",
+        encoding="utf-8",
+    )
+    barrier = darwin_containment.DarwinLaunchBarrier(["coordinator"])
+    process = subprocess.Popen(
+        barrier.command,
+        pass_fds=barrier.pass_fds,
+        env={**os.environ, "PYTHONPATH": str(hostile)},
+    )
+    barrier.after_spawn()
+    barrier.close()
+
+    assert process.wait(timeout=5) == 1
+    assert not marker.exists()
+
+
 def test_containment_refuses_pid_reuse_between_snapshot_and_signal() -> None:
     class ReusingKernel(_FakeDarwinKernel):
         def __init__(self) -> None:

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -884,7 +884,7 @@ def test_darwin_launch_barrier_release_is_one_shot_and_conservative(
         monkeypatch.setattr(darwin_containment.os, "write", lambda *_args: 0)
         with pytest.raises(OSError, match="partial"):
             barrier.release()
-        assert barrier.may_have_released is False
+        assert barrier.may_have_released is True
         with pytest.raises(ValueError, match="unavailable"):
             barrier.release()
     finally:
@@ -903,6 +903,24 @@ def test_darwin_launch_barrier_marks_unknown_write_failure_released(
             lambda *_args: (_ for _ in ()).throw(OSError("unknown write")),
         )
         with pytest.raises(OSError, match="unknown write"):
+            barrier.release()
+        assert barrier.may_have_released is True
+    finally:
+        barrier.close()
+
+
+def test_darwin_launch_barrier_marks_non_oserror_write_failure_released(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = darwin_containment.DarwinLaunchBarrier(["coordinator"])
+    barrier.after_spawn()
+    try:
+        monkeypatch.setattr(
+            darwin_containment.os,
+            "write",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("unknown delivery")),
+        )
+        with pytest.raises(RuntimeError, match="unknown delivery"):
             barrier.release()
         assert barrier.may_have_released is True
     finally:

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -883,6 +883,84 @@ def test_cleanup_accepts_child_reparented_after_parent_signal() -> None:
     assert signalled == [200, 201]
 
 
+def test_cleanup_reaps_detached_child_when_root_exits_before_attach() -> None:
+    """A vanished Popen root must not strand its proven coalition child."""
+
+    kernel = _FakeDarwinKernel()
+    signalled: list[int] = []
+
+    def signaler(pid: int, _sig: int) -> None:
+        signalled.append(pid)
+        kernel.identities.pop(pid, None)
+
+    kernel.signal_callback = signaler
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+        sleeper=lambda _seconds: None,
+    )()
+    containment.environment({})
+    # PID 200 was the Popen root but exited after creating this detached
+    # same-coalition child.  Its unique identity remains the child's parent.
+    kernel.identities[201] = darwin_containment.ProcessIdentity(
+        201, 4, 201, 200, 7
+    )
+
+    with pytest.raises(ValueError, match="root exited before attach"):
+        containment.attach(200)
+
+    assert containment.cleanup() is True
+    assert signalled == [201]
+    assert 201 not in kernel.identities
+
+
+def test_containment_rejects_unrelated_member_when_root_exits_before_attach() -> None:
+    kernel = _FakeDarwinKernel()
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+    )()
+    containment.environment({})
+    kernel.identities[201] = darwin_containment.ProcessIdentity(
+        201, 4, 201, 200, 7
+    )
+    # This member is not descended from the exited launch root: its parent is
+    # part of the protected baseline and must never become a cleanup target.
+    kernel.identities[300] = darwin_containment.ProcessIdentity(
+        300, 4, 300, 100, 7
+    )
+
+    with pytest.raises(ValueError, match="ancestry escaped root"):
+        containment.attach(200)
+
+
+def test_containment_rejects_root_pid_reuse_before_orphan_cleanup() -> None:
+    kernel = _FakeDarwinKernel()
+    containment = darwin_containment.select_verification_containment(
+        CONTAINMENT_PROFILE,
+        platform="darwin",
+        kernel=kernel,
+        current_pid=100,
+    )()
+    containment.environment({})
+    kernel.identities[201] = darwin_containment.ProcessIdentity(
+        201, 4, 201, 200, 7
+    )
+    # A reused Popen PID outside the resource coalition invalidates the
+    # vanished-root proof before cleanup authority can be established.
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 5, 999, 100, 99
+    )
+
+    with pytest.raises(ValueError, match="launch root is unproven"):
+        containment.attach(200)
+    assert containment.cleanup() is False
+
+
 def test_containment_rejects_unrelated_member_appearing_before_attach() -> None:
     kernel = _FakeDarwinKernel()
     containment = darwin_containment.select_verification_containment(

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import signal
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable
@@ -683,6 +686,16 @@ class _FakeDarwinKernel:
         return True
 
 
+def _attach_darwin(
+    containment: darwin_containment.DarwinLaunchdCoalitionContainment,
+    root_pid: int,
+) -> None:
+    containment.attach(
+        root_pid,
+        containment.capture_launch_root(root_pid),
+    )
+
+
 def test_cycle_requires_supported_containment_profile_before_api_claim(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -746,7 +759,7 @@ def test_cycle_composition_injects_darwin_launchd_coalition_containment(
     assert containment.environment({"SAFE": "yes"}) == {"SAFE": "yes"}
 
     kernel.identities[200] = darwin_containment.ProcessIdentity(200, 4, 200, 100, 7)
-    containment.attach(200)
+    _attach_darwin(containment, 200)
     assert containment.cleanup() is True
     assert (200, signal.SIGTERM) in signalled
 
@@ -799,6 +812,69 @@ def test_darwin_signal_uses_pid_version_bound_audit_token() -> None:
     assert seen == {"pid": 123, "pid_version": 7, "sig": signal.SIGKILL}
 
 
+@pytest.mark.parametrize("release", [None, b"invalid-release\n"])
+def test_darwin_launch_barrier_rejects_eof_or_invalid_release(
+    tmp_path: Path,
+    release: bytes | None,
+) -> None:
+    marker = tmp_path / "executed"
+    reader, writer = os.pipe()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "app.dispatcher.darwin_launch_barrier",
+            "--release-fd",
+            str(reader),
+            "--",
+            sys.executable,
+            "-c",
+            f"from pathlib import Path; Path({str(marker)!r}).write_text('ran')",
+        ],
+        pass_fds=(reader,),
+    )
+    os.close(reader)
+    try:
+        if release is not None:
+            assert os.write(writer, release) == len(release)
+    finally:
+        os.close(writer)
+
+    assert process.wait(timeout=5) == 1
+    assert not marker.exists()
+
+
+def test_darwin_launch_barrier_execs_with_same_pid_after_release() -> None:
+    reader, writer = os.pipe()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "app.dispatcher.darwin_launch_barrier",
+            "--release-fd",
+            str(reader),
+            "--",
+            sys.executable,
+            "-c",
+            "import os; print(os.getpid())",
+        ],
+        pass_fds=(reader,),
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    os.close(reader)
+    try:
+        assert os.write(writer, darwin_containment.RELEASE_TOKEN) == len(
+            darwin_containment.RELEASE_TOKEN
+        )
+    finally:
+        os.close(writer)
+
+    stdout, _stderr = process.communicate(timeout=5)
+    assert process.returncode == 0
+    assert stdout.strip() == str(process.pid)
+
+
 def test_containment_refuses_pid_reuse_between_snapshot_and_signal() -> None:
     class ReusingKernel(_FakeDarwinKernel):
         def __init__(self) -> None:
@@ -828,7 +904,7 @@ def test_containment_refuses_pid_reuse_between_snapshot_and_signal() -> None:
     kernel.identities[200] = darwin_containment.ProcessIdentity(
         200, 4, 200, 100, 7
     )
-    containment.attach(200)
+    _attach_darwin(containment, 200)
     original_signal = kernel.signal
 
     def reuse_before_atomic_signal(
@@ -874,17 +950,17 @@ def test_cleanup_accepts_child_reparented_after_parent_signal() -> None:
     kernel.identities[200] = darwin_containment.ProcessIdentity(
         200, 4, 200, 100, 7
     )
+    _attach_darwin(containment, 200)
     kernel.identities[201] = darwin_containment.ProcessIdentity(
         201, 4, 201, 200, 7
     )
-    containment.attach(200)
 
     assert containment.cleanup() is True
     assert signalled == [200, 201]
 
 
-def test_cleanup_reaps_detached_child_when_root_exits_before_attach() -> None:
-    """A vanished Popen root must not strand its proven coalition child."""
+def test_orphaned_child_cannot_gain_cleanup_authority_before_attach() -> None:
+    """The barrier, not orphan inference, prevents this launch race."""
 
     kernel = _FakeDarwinKernel()
     signalled: list[int] = []
@@ -908,15 +984,15 @@ def test_cleanup_reaps_detached_child_when_root_exits_before_attach() -> None:
         201, 4, 201, 200, 7
     )
 
-    with pytest.raises(ValueError, match="root exited before attach"):
-        containment.attach(200)
+    with pytest.raises(ValueError, match="launch root is unproven"):
+        containment.capture_launch_root(200)
 
-    assert containment.cleanup() is True
-    assert signalled == [201]
-    assert 201 not in kernel.identities
+    assert containment.cleanup() is False
+    assert signalled == []
+    assert 201 in kernel.identities
 
 
-def test_containment_rejects_unrelated_member_when_root_exits_before_attach() -> None:
+def test_containment_rejects_foreign_pre_release_member() -> None:
     kernel = _FakeDarwinKernel()
     containment = darwin_containment.select_verification_containment(
         CONTAINMENT_PROFILE,
@@ -925,20 +1001,21 @@ def test_containment_rejects_unrelated_member_when_root_exits_before_attach() ->
         current_pid=100,
     )()
     containment.environment({})
-    kernel.identities[201] = darwin_containment.ProcessIdentity(
-        201, 4, 201, 200, 7
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 4, 200, 100, 7
     )
-    # This member is not descended from the exited launch root: its parent is
-    # part of the protected baseline and must never become a cleanup target.
+    captured = containment.capture_launch_root(200)
+    # The paused wrapper may be the only post-baseline task before release.
     kernel.identities[300] = darwin_containment.ProcessIdentity(
         300, 4, 300, 100, 7
     )
 
-    with pytest.raises(ValueError, match="ancestry escaped root"):
-        containment.attach(200)
+    with pytest.raises(ValueError, match="pre-release membership"):
+        containment.attach(200, captured)
+    assert containment.cleanup() is False
 
 
-def test_containment_rejects_root_pid_reuse_before_orphan_cleanup() -> None:
+def test_containment_rejects_same_coalition_root_pid_reuse_before_release() -> None:
     kernel = _FakeDarwinKernel()
     containment = darwin_containment.select_verification_containment(
         CONTAINMENT_PROFILE,
@@ -947,17 +1024,17 @@ def test_containment_rejects_root_pid_reuse_before_orphan_cleanup() -> None:
         current_pid=100,
     )()
     containment.environment({})
-    kernel.identities[201] = darwin_containment.ProcessIdentity(
-        201, 4, 201, 200, 7
-    )
-    # A reused Popen PID outside the resource coalition invalidates the
-    # vanished-root proof before cleanup authority can be established.
     kernel.identities[200] = darwin_containment.ProcessIdentity(
-        200, 5, 999, 100, 99
+        200, 4, 200, 100, 7
+    )
+    captured = containment.capture_launch_root(200)
+    # Reuse stays inside the resource coalition, so PID alone must not pass.
+    kernel.identities[200] = darwin_containment.ProcessIdentity(
+        200, 5, 999, 100, 7
     )
 
-    with pytest.raises(ValueError, match="launch root is unproven"):
-        containment.attach(200)
+    with pytest.raises(ValueError, match="pre-release membership"):
+        containment.attach(200, captured)
     assert containment.cleanup() is False
 
 
@@ -977,8 +1054,9 @@ def test_containment_rejects_unrelated_member_appearing_before_attach() -> None:
         300, 4, 300, 100, 7
     )
 
-    with pytest.raises(ValueError, match="ancestry escaped root"):
-        containment.attach(200)
+    captured = containment.capture_launch_root(200)
+    with pytest.raises(ValueError, match="pre-release membership"):
+        containment.attach(200, captured)
 
 
 def test_cleanup_polls_until_delayed_kernel_task_disappearance() -> None:
@@ -1007,7 +1085,7 @@ def test_cleanup_polls_until_delayed_kernel_task_disappearance() -> None:
     kernel.identities[200] = darwin_containment.ProcessIdentity(
         200, 4, 200, 100, 7
     )
-    containment.attach(200)
+    _attach_darwin(containment, 200)
 
     assert containment.cleanup() is True
     assert clock[0] >= 0.15

--- a/tests/dispatcher/test_verification_review_repairs_attempt2.py
+++ b/tests/dispatcher/test_verification_review_repairs_attempt2.py
@@ -269,7 +269,8 @@ def test_codex_nonzero_exit_drains_stderr_and_rejects_valid_receipt(
         def poll(self):
             return self.returncode
 
-        def wait(self):
+        def wait(self, timeout=None):
+            assert timeout == 0.25, "terminal wait must remain bounded"
             assert stderr.drained, "stderr must be drained before waiting"
             return self.returncode
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4712

## Linked Issue
Closes #4712

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): BuilderOps verification dispatcher and Demerzel host execution
- Write class: Authority-bearing execution guard and governance/docs
- Persistence impact: None; existing API/PostgreSQL receipts remain authoritative
- Derived/rebuildable impact: Containment preflight and terminal process cleanup only
- New or changed contract: Explicit allowlisted macOS containment profile and converged barrier cleanup state machine for verification-cycle
- Owner-doc impact: Updated in this PR
- Transition debt impact: Reduces the host-wrapper/repo composition split
- Boundary risk: Model descendants must not outlive the fenced launcher; other launchd coalitions remain out of scope and the cycle stays dry-run-only

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds the allowlisted Darwin launchd resource-coalition profile and injects it before BuilderOps API construction or claim.
- Uses PID-version, unique ancestry, exact kernel task-count witnesses, atomic audit-token signals, and bounded baseline-only cleanup proof while preserving dry-run-only authority.
- Converges the barrier U/R lifecycle so ambiguous release, setup faults, authority loss, and terminal completion cannot bypass serialized state-aware cleanup.

## BuilderOps Routing
- Records/projections/receipts: Fallback claimant receipt #5257366908; low-convergence receipt #5257760053; CI-repair and base-drift reuse receipt #5257910371; dispatcher task remains blocked without a lease under preserved exhausted mechanism accounting.
- Reason: Process containment is security/concurrency/state-machine work, so claim and convergence-review receipts are retained for verification without treating the stale dispatcher singleton as authority.

## Notes
Validation after the CI repair: affected containment/cycle selection 33 passed; all explicit AC Verify targets 8 passed; repaired stderr-drain test passed; ruff check app tests passed; mypy app passed across 881 source files; docs language and full governed docs checks passed with the temporal-skip override because the Demerzel owner doc changed and no STATUS/ROADMAP claim changed; review-before-CI gate passed for security, concurrency, and state-machine. Independent Sol/xhigh mechanism review remained clean after the test-only repair. A conflict-free base-only rebase to origin/main 0c7604aa85d35ab56f86a8ae76c9ff89503ae6f5 preserved stable patch-id 182f15558ac52fa73329147861b639f50fdb229c; current head is 1a2c50186f3729f282fc71a23883f08b2a3e736c. No Demerzel pilot, enablement, or installed-host proof was performed. Refs #3603.