### PR TITLE
fix(devui): preserve provider refusal contract

### DIFF
--- a/app/builderops/devui_overview.py
+++ b/app/builderops/devui_overview.py
@@ -417,7 +417,6 @@ def compose_overview_view(
                 "captured_at",
                 "snapshot",
                 "completeness",
-                "refusal",
             },
             label=f"composition.providers.{name}",
         )
@@ -437,12 +436,12 @@ def compose_overview_view(
                 raise OverviewContractError(
                     f"composition.providers.{name} available provider requires snapshot or captured_at"
                 )
-            if provider["refusal"] is not None:
+            if "refusal" in provider:
                 raise OverviewContractError(
                     f"composition.providers.{name} available provider cannot carry refusal evidence"
                 )
         else:
-            if provider["authority"] is None or provider["refusal"] is None:
+            if provider["authority"] is None or provider.get("refusal") is None:
                 raise OverviewContractError(
                     f"composition.providers.{name} refused provider requires authority and refusal evidence"
                 )
@@ -453,21 +452,25 @@ def compose_overview_view(
                 raise OverviewContractError(
                     f"composition.providers.{name} refused provider cannot carry available evidence"
                 )
-        trust_providers.append(
-            {
-                "role": name,
-                "provider": _string(
-                    provider.get("provider"),
-                    label=f"composition.providers.{name}.provider",
-                ),
-                "status": provider["status"],
-                "authority": _detached(provider.get("authority"), label="provider authority"),
-                "captured_at": captured_at,
-                "snapshot": _detached(provider.get("snapshot"), label="provider snapshot"),
-                "completeness": _detached(provider.get("completeness"), label="provider completeness"),
-                "refusal": _detached(provider.get("refusal"), label="provider refusal"),
-            }
-        )
+        provider_state = {
+            "role": name,
+            "provider": _string(
+                provider.get("provider"),
+                label=f"composition.providers.{name}.provider",
+            ),
+            "status": provider["status"],
+            "authority": _detached(provider.get("authority"), label="provider authority"),
+            "captured_at": captured_at,
+            "snapshot": _detached(provider.get("snapshot"), label="provider snapshot"),
+            "completeness": _detached(
+                provider.get("completeness"), label="provider completeness"
+            ),
+        }
+        if provider["status"] == "refused":
+            provider_state["refusal"] = _detached(
+                provider["refusal"], label="provider refusal"
+            )
+        trust_providers.append(provider_state)
 
     raw_candidates = _mapping(candidates or {}, label="candidates")
     if set(raw_candidates) - _ZONES:

--- a/tests/builderops/test_devui_overview.py
+++ b/tests/builderops/test_devui_overview.py
@@ -7,6 +7,16 @@ from datetime import datetime, timezone
 
 import pytest
 
+from app.builderops.ckm.contracts import (
+    CkmStateIdentity,
+    CompletenessManifest,
+    ObjectClassCompleteness,
+    ResourceDto,
+    ResultEnvelope,
+    SnapshotManifest,
+    canonical_digest,
+    canonical_query_digest,
+)
 from app.builderops.devui_composition import compose_owner_snapshot
 from app.builderops.devui_overview import (
     CONTRACT_VERSION,
@@ -37,7 +47,6 @@ def _composition() -> dict:
                 "captured_at": "2026-08-09T21:00:00+00:00",
                 "snapshot": {"watermark": "work:42"},
                 "completeness": {"claim": {"kind": "counted"}},
-                "refusal": None,
             },
             "capabilities": {
                 "provider": "ckm",
@@ -50,6 +59,64 @@ def _composition() -> dict:
             },
         },
     }
+
+
+def _production_cockpit_payload() -> dict:
+    return {
+        "authority": "read_time_join",
+        "generated_at": "2026-08-09T21:00:00+00:00",
+        "claim": {
+            "kind": "counted",
+            "text": "One thread in motion.",
+            "as_of": "2026-08-09T21:00:00+00:00",
+        },
+        "sources": [
+            {
+                "name": "dispatcher-store",
+                "state": "fresh",
+                "last_successful_read": "2026-08-09T21:00:00+00:00",
+                "detail": "read succeeded",
+                "stale_after_days": 7,
+                "configured": True,
+            }
+        ],
+        "unread_planes": [],
+        "withdrawn_counts": [],
+        "bands": {"moving": [{"issue_number": 4715}]},
+    }
+
+
+def _production_ckm_envelope() -> ResultEnvelope:
+    resource = ResourceDto(
+        public_id="ckm_capability_overview",
+        resource_type="capability",
+        display_name="Overview capability",
+        lifecycle="confirmed",
+        provenance=({"kind": "fixture"},),
+        values={},
+        candidate=False,
+    )
+    snapshot = SnapshotManifest.build(
+        state=CkmStateIdentity(epoch="epoch-overview", state_revision=1),
+        taxonomy_digest=canonical_digest({"taxonomy": "overview-fixture"}),
+        watermarks={"capability": "2026-08-09T21:00:00+00:00"},
+        provenance=({"kind": "fixture"},),
+        completeness=CompletenessManifest(
+            object_classes=(
+                ObjectClassCompleteness(object_class="capability", included=1),
+            ),
+            complete=True,
+        ),
+        read_set={"capability": (resource.public_id,)},
+    )
+    return ResultEnvelope(
+        resource_type="capability",
+        query_digest=canonical_query_digest(
+            {"operation": "list_capabilities", "public_id": None}
+        ),
+        snapshot=snapshot,
+        resources=(resource,),
+    )
 
 
 def _evidence(
@@ -370,6 +437,59 @@ def test_refused_provider_requires_refusal_evidence() -> None:
 
     with pytest.raises(OverviewContractError, match="refused provider"):
         compose_overview_view(composition=composition)
+
+
+def test_overview_enforces_status_dependent_refusal_contract() -> None:
+    available_with_refusal = _composition()
+    available_with_refusal["providers"]["work"]["refusal"] = None
+    with pytest.raises(OverviewContractError, match="cannot carry refusal evidence"):
+        compose_overview_view(composition=available_with_refusal)
+
+    refused_without_refusal = _composition()
+    refused_without_refusal["providers"]["capabilities"].pop("refusal")
+    with pytest.raises(OverviewContractError, match="refused provider"):
+        compose_overview_view(composition=refused_without_refusal)
+
+
+def test_overview_accepts_all_available_production_composition_without_refusals() -> None:
+    composition = compose_owner_snapshot(
+        cockpit_reader=_production_cockpit_payload,
+        ckm_reader=_production_ckm_envelope,
+        now=lambda: datetime(2026, 8, 9, 21, 0, tzinfo=timezone.utc),
+    )
+
+    assert all(
+        provider["status"] == "available" and "refusal" not in provider
+        for provider in composition["providers"].values()
+    )
+    result = compose_overview_view(composition=composition)
+    assert [
+        provider["status"] for provider in result["trust_frame"]["provider_states"]
+    ] == ["available", "available"]
+    assert all(
+        "refusal" not in provider
+        for provider in result["trust_frame"]["provider_states"]
+    )
+
+
+def test_overview_preserves_mixed_available_and_refused_production_composition() -> None:
+    def broken_cockpit() -> dict:
+        raise OSError("unavailable")
+
+    composition = compose_owner_snapshot(
+        cockpit_reader=broken_cockpit,
+        ckm_reader=_production_ckm_envelope,
+        now=lambda: datetime(2026, 8, 9, 21, 0, tzinfo=timezone.utc),
+    )
+
+    assert composition["providers"]["work"]["status"] == "refused"
+    assert "refusal" in composition["providers"]["work"]
+    assert composition["providers"]["capabilities"]["status"] == "available"
+    assert "refusal" not in composition["providers"]["capabilities"]
+    result = compose_overview_view(composition=composition)
+    assert [
+        provider["status"] for provider in result["trust_frame"]["provider_states"]
+    ] == ["refused", "available"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Governing-Issue: #4735

Fixes #4735

Final-Review-Rounds: 0

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): devUI read-only owner projection
- Write class: derived/read-only composer and regression tests
- Persistence impact: none
- Derived/rebuildable impact: repairs per-read `devui-overview-view.v1` composition from explicit producer envelopes
- New or changed contract: status-dependent `refusal` key presence at the `devui.composition.v1` to Overview boundary
- Owner-doc impact: no change; current-state correction only
- Transition debt impact: removes a producer/consumer schema mismatch without creating a new authority or mechanism
- Boundary risk: the consumer must not fabricate refusal evidence or reject healthy available producer envelopes

## Summary
- Makes `refusal` exclusive to refused providers at the Overview boundary.
- Covers all-available and mixed available/refused envelopes through the real `compose_owner_snapshot()` producer path.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260810050112_8f21874a`
- Reason: PR #4717 merged despite this P1 producer/consumer contract mismatch; the signal targets the verification workflow for upstream repair.

## Notes
Validation: `pytest -q tests/builderops/test_devui_overview.py tests/builderops/test_devui_composition.py` (79 passed); `ruff check app tests`; `mypy app`; `git diff --check`.