### PR TITLE
Reject CKM-only Conversation Port capability subjects

### DIFF
--- a/app/builderops/devui_conversation_port.py
+++ b/app/builderops/devui_conversation_port.py
@@ -27,7 +27,7 @@ _ISSUE_STABLE_ID = re.compile(
 _CAPABILITY_STABLE_ID = re.compile(r"[a-z][a-z0-9_.:-]{2,127}\Z")
 _SUBJECT_SOURCE_TYPES = {
     "issue": {"github_issue"},
-    "capability": {"ckm_capability", "owner_document"},
+    "capability": {"owner_document"},
 }
 _DIALOGUE_OUTCOMES = (
     "disposition",
@@ -212,6 +212,10 @@ def _subject_ref(value: Any) -> dict[str, Any]:
     authority_ref = _source_ref(
         subject["authority_ref"], label="subject_ref.authority_ref"
     )
+    if kind == "capability" and authority_ref["source_type"] != "owner_document":
+        raise ConversationPortContractError(
+            "capability subject_ref requires owner_document authority"
+        )
     if authority_ref["source_type"] not in _SUBJECT_SOURCE_TYPES[kind]:
         raise ConversationPortContractError(
             "subject_ref authority does not match its governed kind"

--- a/tests/builderops/test_devui_conversation_port.py
+++ b/tests/builderops/test_devui_conversation_port.py
@@ -42,6 +42,7 @@ def _source(source_id: str, *, digest: str = "a") -> dict:
 
 
 def _build(**overrides: object) -> dict:
+    subject_ref = overrides.get("subject_ref", SUBJECT_REF)
     owner_intent_ref = _source("docs/DEVUI.md#DEVUI-FCP-BOUNDARY", digest="b")
     source_refs = [
         _source("docs/DEVUI_FOCUS_CONVERSATION_PORT/README.md", digest="c")
@@ -55,14 +56,14 @@ def _build(**overrides: object) -> dict:
         }
     ]
     material_refs = [
-        SUBJECT_REF["authority_ref"],
+        subject_ref["authority_ref"],  # type: ignore[index]
         owner_intent_ref,
         *source_refs,
         *evidence_snapshot_refs,
     ]
     values: dict[str, object] = {
         "pack_id": "pack-4696-a",
-        "subject_ref": SUBJECT_REF,
+        "subject_ref": subject_ref,
         "purpose": "Reason about the next governed disposition for FCP-03.",
         "owner_intent_ref": owner_intent_ref,
         "source_refs": source_refs,
@@ -146,6 +147,52 @@ def test_context_pack_hash_is_canonical_and_scope_bounded() -> None:
     }
     with pytest.raises(ConversationPortContractError, match="freshness deadline"):
         _build(source_states=expiring_states)
+
+
+def test_context_pack_capability_subject_requires_owner_document_authority() -> None:
+    capability_subject = {
+        "kind": "capability",
+        "stable_id": "devui.conversation-port",
+        "authority_ref": _source(
+            "docs/DEVUI_FOCUS_CONVERSATION_PORT/README.md#conversation-port-contract",
+            digest="d",
+        ),
+        "title": "External Conversation Port",
+    }
+    calls: list[bytes] = []
+
+    def build_and_open(subject_ref: dict) -> dict:
+        pack = _build(subject_ref=subject_ref)
+        exact = canonical_context_pack_bytes(pack)
+
+        def opener(payload: bytes, _content_hash: str) -> dict:
+            calls.append(payload)
+            return {"provider_request_id": "codex-capability-subject"}
+
+        return open_external_conversation(
+            pack_bytes=exact,
+            expected_hash=pack["content_hash"],
+            provider="codex",
+            availability="available",
+            reason="Configured external adapter",
+            opener=opener,
+            now=NOW,
+        )
+
+    ckm_only_subject = {
+        **capability_subject,
+        "authority_ref": {
+            **capability_subject["authority_ref"],
+            "source_type": "ckm_capability",
+        },
+    }
+    with pytest.raises(ConversationPortContractError, match="owner_document"):
+        build_and_open(ckm_only_subject)
+    assert calls == []
+
+    result = build_and_open(capability_subject)
+    assert result["state"] == "opened"
+    assert calls == [canonical_context_pack_bytes(_build(subject_ref=capability_subject))]
 
 
 def test_external_port_has_no_global_session_discovery() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4738

## Linked Issue
Fixes #4738

## SBS Impact
- Primary subsystem: Builder System / devUI owner view
- Secondary subsystem(s): CKM provenance boundary and external Conversation Port
- Write class: authority-bearing read/export projection
- Persistence impact: none; context packs remain immutable, external-first, and non-authoritative
- Derived/rebuildable impact: invalid capability subjects are refused before pack construction or export
- New or changed contract: every Conversation Port capability subject requires owner-document authority; CKM cannot establish primary subject identity
- Owner-doc impact: no owner-doc change implied; the shared boundary is already authoritative in `docs/DEVUI.md` and `docs/DEVUI_FOCUS_CONVERSATION_PORT/README.md`
- Transition debt impact: removes Conversation Port SubjectRef validator drift from the delivered Focus boundary
- Boundary risk: CKM projections remain non-authoritative and cannot establish primary subject identity

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Rejects capability subjects unless their authority reference is an independently validated `owner_document`.
- Proves CKM-only subjects fail before canonical pack bytes or the external opener, while Issue and owner-document capability subjects remain supported.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260810060200_582da5c6` (pre-existing; applied by this repair).
- Reason: The governing Issue and PR fully represent the promoted implementation; no new delivery divergence was produced.

## Notes
Validation on `fe6876f4e`: `pytest -q tests/builderops/test_devui_conversation_port.py` (6 passed); `pytest -q tests/architecture/test_devui_focus_boundaries.py` (1 passed); `ruff check app tests`; `mypy app` (878 source files); `git diff --check`.

Test-first receipt: `tests/builderops/test_devui_conversation_port.py::test_context_pack_capability_subject_requires_owner_document_authority` first failed because the CKM-only capability subject did not raise and reached the build/open pipeline, then passed after the bounded `_subject_ref` repair.

Delivery coordination: `pickup-claim-complete issue=4738 branch=codex/issue-4738-conversation-port-subject-authority worktree=/private/tmp/agentic-pkm-issue-4738 coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4738 lease_id=lease-fe6886e1 holder=codex-issue-4738 evidence=verified-dispatcher-lease`.

TCD: Tier 2 single-Issue light path. Protected P1 authority-integrity risk justified Sol/high implementation capability, but this diff touches none of the named high-risk runtime surfaces that escalate delivery depth; therefore `Final-Review-Rounds: 0`.
---