### PR TITLE
Record devUI Overview source withdrawal

### DIFF
--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -439,6 +439,22 @@ composition envelope, explicit producer evidence, and typed root references; wit
 producer evidence it reports the affected **Needs you** or **Ready to try** classification as
 withdrawn. This does not deliver producer enrichment, a local route, or a visual shell.
 
+#### ARO-01 source-authority resolution (2026-08-10)
+
+The owner authorized continued work only when explicit source-backed facts improve decision quality
+with low cognitive load. The live source audit for Stage A found no existing serialized producer
+contract that satisfies the Overview boundary for either zone:
+
+| Overview fact | Current canonical source/field | Decision | Consequence |
+| --- | --- | --- | --- |
+| **Needs you** owner authority | None. The dispatcher Human Exception packet exposes only the coarse `failure_class`; it does not serialize one of the four Overview categories with a stable subject and governing-source reference. | No current owner is admitted. | The zone remains withdrawn; `agent:needs-human`, technical state, merge, done, closure, and generic terminal receipts are not substitutes. |
+| **Ready to try** | None. No existing producer or receipt contract owns an explicit `ready_to_try` fact with subject linkage, availability, and freshness. | No current owner is admitted. | The zone remains withdrawn; delivery, merge, closure, availability, owner trial, and owner acceptance remain independent facts. |
+
+This is a source-ownership result, not a new devUI authority. The existing GitHub → Cockpit →
+`devui.composition.v1` chain may transport these facts only after a separately governed source
+contract exists; it may not manufacture them or persist a replacement. Until then, producers and
+the composer must preserve the explicit withdrawal state.
+
 ### DEVUI-FCP-BOUNDARY — Focus and Conversation Port
 
 The first Focus slice is subject-centred. Its subject is exactly one stable GitHub Issue or one


### PR DESCRIPTION
Governing-Issue: #4742
Closes #4742

## Summary

- Record the owner-authorized ARO-01 source audit in the devUI Overview boundary.
- State explicitly that no existing source currently owns the four exact owner-authority categories or an explicit `ready_to_try` fact.
- Preserve fail-closed withdrawal semantics and prevent labels, delivery states, or generic receipts from becoming owner truth.

## Verify

- `python3 scripts/docs_guard.py`
- `python3 -m pytest -q tests/builderops/test_devui_overview.py`
- `git diff --check`

## Owner-doc writeback

Updated `docs/DEVUI.md :: ARO-01 source-authority resolution (2026-08-10)`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: docs-only source-authority decision is recorded in the owner doc, Issue, and PR; no BuilderOps record is required.

Final-Review-Rounds: 0

## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

## SBS Impact
- Primary subsystem: Builder System / devUI owner experience
- Secondary subsystem(s): none; no existing source owner was selected
- Write class: owner-doc source-authority contract clarification
- Persistence impact: none
- Derived/rebuildable impact: preserves per-request withdrawal
- New or changed contract: explicit current source ownership/withdrawal result
- Owner-doc impact: `docs/DEVUI.md` updated in this PR
- Transition debt impact: prevents label/delivery-state inference
- Boundary risk: no authority or runtime boundary changed

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR.
- [ ] No owner-doc change implied.
- [ ] Owner-doc follow-up issue created and linked.
