### PR TITLE
Add fenced lost-lease recovery

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -624,6 +624,77 @@ class InstanceStateBackup:
         )
         return InstanceStateBackupReceipt(manifest_path)
 
+    def create_lost_lease_recovery_backup(
+        self,
+        backup_root: Path,
+        *,
+        quiescence_proof: DeploymentQuiescenceProof | None,
+        owner_receipt_path: Path | None,
+        vault_binding_id: str,
+    ) -> InstanceStateBackupReceipt:
+        """Capture a verified pre-mutation snapshot for the narrow lost-lease path.
+
+        The ordinary backup validator quite correctly rejects an inconsistent
+        registry/ledger pair.  Recovery needs a backup of that pair before it
+        repairs it, so this variant validates schema, permissions, key
+        authentication, unique registration, and the absence of every current
+        lease while preserving the original bytes unchanged.
+        """
+
+        if quiescence_proof is None:
+            raise InstanceStatePreflightError("canonical quiescence authority is required")
+        owner_payload = quiescence_proof.require_canonical_authority(
+            channel_id=self.layout.channel_id,
+            host_global_root=self.ledger.root,
+            owner_receipt_path=owner_receipt_path,
+        )
+        del owner_payload
+        self.layout.require_existing()
+        registry_store = VaultRegistryStore(self.layout.registry_path)
+        registry = registry_store.load()
+        if set(registry.registrations) != {vault_binding_id}:
+            raise InstanceStatePreflightError(
+                "lost ownership recovery requires exactly one registered owner"
+            )
+        registration = registry.registrations[vault_binding_id]
+        root = Path(registration.path).expanduser().resolve(strict=False)
+        if not root.is_dir():
+            raise InstanceStatePreflightError(
+                "lost ownership recovery requires a materialized registered root"
+            )
+        try:
+            current = self.ledger.require_existing()
+        except LedgerError as exc:
+            raise InstanceStatePreflightError("lost ownership recovery backup verification failed") from exc
+        if current.leases or current.tombstones or current.transfer is not None:
+            raise InstanceStatePreflightError(
+                "lost ownership recovery requires an unambiguous owner inventory"
+            )
+        payloads = self.ledger.capture_backup_artifacts(
+            capture_registry_artifacts=registry_store.capture_backup_artifacts,
+        )
+        checksums = {name: hashlib.sha256(payload).hexdigest() for name, payload in payloads.items()}
+        manifest = {
+            "schema": _BACKUP_SCHEMA,
+            "channel_id": self.layout.channel_id,
+            "registry_checksum": checksums["vault-registry.md"],
+            "ownership_key_id": current.key_id,
+            "ownership_generation": current.generation,
+            "recovery_candidate": vault_binding_id,
+            "checksums": checksums,
+        }
+        destination = Path(backup_root).expanduser().resolve(strict=False)
+        destination.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(destination, 0o700)
+        for name, payload in payloads.items():
+            _atomic_private_write(destination / name, payload)
+        manifest_path = destination / "manifest.json"
+        _atomic_private_write(
+            manifest_path,
+            (json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+        )
+        return InstanceStateBackupReceipt(manifest_path)
+
     def restore(
         self,
         backup_root: Path,

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -654,6 +654,44 @@ class OwnershipLedger:
             self._write_ledger_locked(self._replace(current, leases=leases), key)
             return active
 
+    def recover_missing_active(
+        self,
+        *,
+        channel_id: str,
+        vault_binding_id: str,
+        root: Path,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        """Reconstruct one lost active lease after an external fenced proof.
+
+        This is intentionally stricter than normal registration recovery: the
+        host ledger must contain no live or pending owner at all.  The caller
+        supplies the stopped-window/quiescence and backup proof; this method
+        only performs the authenticated ledger transaction.
+        """
+
+        _require_storage_mutation_capability(_capability)
+        self._assert_existing_artifacts()
+        with self._locked():
+            key = self._load_or_create_key_locked(allow_create=False)
+            current = self._load_or_create_ledger_locked(key, allow_create=False)
+            if current.transfer is not None or current.tombstones:
+                raise LedgerError("lost ownership recovery found non-empty transition history")
+            if current.leases:
+                raise LedgerError("lost ownership recovery found a foreign or pending owner")
+            candidate = self._lease_for_root(
+                channel_id=channel_id,
+                vault_binding_id=vault_binding_id,
+                root=root,
+                key=key,
+                state="active",
+            )
+            self._assert_no_collision(current, candidate, allow_same_channel_nested=False)
+            self._write_ledger_locked(
+                self._replace(current, leases={vault_binding_id: candidate}), key
+            )
+            return candidate
+
     def reserve(
         self,
         *,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2658,6 +2658,60 @@ def _release_instance_state_deployment_lease(
         return receipt | {"released": True, "reason": "abandoned-deployment"}
 
 
+def _recover_lost_ownership_lease(
+    *,
+    channel: str,
+    instance_state_root: Path,
+    host_global_root: Path,
+    backup_root: Path,
+    quiescence_proof_path: Path,
+    owner_receipt_path: Path,
+    vault_binding_id: str,
+) -> dict[str, object]:
+    """Recover one uniquely proven missing lease inside the stopped fence."""
+
+    from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+    state_mount = _assert_mount_root(instance_state_root, "instance-state")
+    ownership_root = _assert_mount_root(host_global_root, "host-global")
+    layout = InstanceStateLayout.for_channel(state_mount, channel)
+    layout.require_existing()
+    proof = _load_deployment_quiescence_proof(quiescence_proof_path)
+    proof.require_canonical_authority(
+        channel_id=channel,
+        host_global_root=ownership_root,
+        owner_receipt_path=owner_receipt_path,
+    )
+    registry = VaultRegistryStore(layout.registry_path).load()
+    registration = registry.registrations.get(vault_binding_id)
+    if registration is None or len(registry.registrations) != 1:
+        raise InstanceStatePreflightError(
+            "lost ownership recovery requires exactly one registered owner"
+        )
+    backup = InstanceStateBackup(layout, OwnershipLedger(ownership_root))
+    with _deployment_admission_locked(ownership_root):
+        with _producer_transition_locked(layout):
+            receipt = backup.create_lost_lease_recovery_backup(
+                backup_root,
+                quiescence_proof=proof,
+                owner_receipt_path=owner_receipt_path,
+                vault_binding_id=vault_binding_id,
+            )
+            lease = backup.ledger.recover_missing_active(
+                channel_id=channel,
+                vault_binding_id=vault_binding_id,
+                root=Path(registration.path),
+                _capability=_STORAGE_MUTATION_CAPABILITY,
+            )
+    return {
+        "channel": channel,
+        "recovered": True,
+        "backup_verified": receipt.manifest_path.is_file(),
+        "lease_state": lease.state,
+        "recovery_receipt": "lost-lease-recovery-v1",
+    }
+
+
 def _fsync_directory(path: Path) -> None:
     descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
     try:
@@ -3418,6 +3472,14 @@ def main(argv: list[str] | None = None) -> int:
     release.add_argument("--host-global-root", type=Path, required=True)
     release.add_argument("--controller-pid", type=int, required=True)
     release.add_argument("--controller-start-token", required=True)
+    recover = subparsers.add_parser("deployment-recover-lost-lease")
+    recover.add_argument("--channel", required=True)
+    recover.add_argument("--instance-state-root", type=Path, required=True)
+    recover.add_argument("--host-global-root", type=Path, required=True)
+    recover.add_argument("--backup-root", type=Path, required=True)
+    recover.add_argument("--quiescence-proof-path", type=Path, required=True)
+    recover.add_argument("--owner-receipt-path", type=Path, required=True)
+    recover.add_argument("--vault-binding-id", required=True)
     prove = subparsers.add_parser("deployment-prove")
     prove.add_argument("--channel", required=True)
     prove.add_argument("--host-global-root", type=Path, required=True)
@@ -3608,6 +3670,17 @@ def main(argv: list[str] | None = None) -> int:
                 sort_keys=True,
             )
         )
+        return 0
+    if args.command == "deployment-recover-lost-lease":
+        print(json.dumps(_recover_lost_ownership_lease(
+            channel=args.channel,
+            instance_state_root=args.instance_state_root,
+            host_global_root=args.host_global_root,
+            backup_root=args.backup_root,
+            quiescence_proof_path=args.quiescence_proof_path,
+            owner_receipt_path=args.owner_receipt_path,
+            vault_binding_id=args.vault_binding_id,
+        ), sort_keys=True))
         return 0
     if args.command == "deployment-prove":
         proof = _prove_instance_state_quiescence(

--- a/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
+++ b/docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md
@@ -287,6 +287,16 @@ then carries only its mapped acceptance criteria and validation commands:
    new-schema mutation stays dormant until 01C performs the guarded authority cutover. This slice,
    not SETTINGS-05, owns creation of the protected store, final legacy-writer fence, final export,
    and backup/restore posture.
+
+   A stranded dev deployment with exactly one durable registration and a missing active lease has
+   one explicit recovery route: after the existing host-global restart fence, two-pass quiescence
+   proof, and drained owner inventory are present, the operator invokes the fenced
+   `deployment-recover-lost-lease` command with the existing binding ID. The command first writes
+   and verifies a protected backup through `InstanceStateBackup`, then reconstructs the lease through
+   the capability-guarded ownership ledger. It refuses foreign or pending owners, multiple
+   registrations, missing roots, invalid proof, or backup failure; ordinary deployment/startup
+   remains fail-closed and never calls this recovery implicitly. Receipts contain only redacted
+   status and opaque binding identity.
 3. **MVR-01C — multi-registration rollback lineage:** explicit scalar target, authenticated
    mutation-filtering gateway/mount restriction, minimum-runtime floor, roll-forward merge, and
    atomic unsealing of second-registration producers only after those rollback mechanisms pass

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -75,6 +75,31 @@ _instance_state_deployment_host_ownership_path() {
   esac
 }
 
+# Explicit operator recovery for exactly one missing active ownership lease.
+# This is deliberately not called by deploy/start: the failed deployment must
+# already have left its host-global restart fence and proved quiescence in
+# place, and the operator must name the existing binding. No JSON file is
+# edited by this path and it never starts a writer.
+recover_lost_instance_state_lease() {
+  local compose_function="$1"
+  local channel="$2"
+  local binding_id="${INSTANCE_LOST_LEASE_BINDING_ID:-}"
+  local backup_root="${INSTANCE_STATE_RECOVERY_BACKUP_PATH:-/app/instance-ownership/backups/${channel}/lost-lease-recovery}"
+  if [ -z "${binding_id}" ]; then
+    echo "instance state recovery: INSTANCE_LOST_LEASE_BINDING_ID is required" >&2
+    return 78
+  fi
+  "${compose_function}" run --rm --no-deps -T instance-state-init \
+    python -m app.instance.runtime deployment-recover-lost-lease \
+      --channel "${channel}" \
+      --instance-state-root /app/instance-state \
+      --host-global-root /app/instance-ownership \
+      --backup-root "${backup_root}" \
+      --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json \
+      --owner-receipt-path /app/instance-ownership/legacy-owner-inventory.json \
+      --vault-binding-id "${binding_id}"
+}
+
 # MVR-01B deploy/start producer. The caller supplies its channel-aware compose
 # function so the same fenced sequence is used by pinned deploys and local
 # full-system starts.

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -37,6 +37,7 @@ from app.instance.runtime import (
     _deployment_fence_path,
     _deployment_lease_path,
     _finish_instance_state_deployment,
+    _recover_lost_ownership_lease,
     _preflight_runtime,
     _prove_instance_state_quiescence,
 )
@@ -505,6 +506,83 @@ def test_legacy_registry_export_happens_after_writer_quiescence(tmp_path) -> Non
     assert producer.index(" stop api worker watcher") < producer.index("deployment-finish")
     assert "deployment-prove" in producer
     assert "probe_count" in WRITER_INVENTORY_HELPER.read_text(encoding="utf-8")
+
+
+def _prepare_lost_lease_runtime(tmp_path: Path):
+    layout = InstanceStateLayout.for_channel(tmp_path / "instance-state", "dev")
+    host_global_root = tmp_path / "host-global"
+    root = tmp_path / "vault"
+    root.mkdir()
+    runtime = InstanceRegistryRuntime.for_paths(layout, host_global_root)
+    registration = runtime._new_registration(root, vault_binding_id="binding-dev")
+    runtime.registry.register(
+        registration,
+        expected_revision=runtime.registry.load().revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    runtime.ledger.load()
+    legacy = tmp_path / "legacy-app-local.md"
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=layout,
+        host_global_root=host_global_root,
+        legacy_path=legacy,
+        owners=[
+            {
+                "channel_id": "dev",
+                "vault_binding_id": "binding-dev",
+                "root": str(root),
+            }
+        ],
+    )
+    return runtime, proof, owner_receipt
+
+
+def test_fenced_lost_lease_recovery_restores_single_registered_owner(tmp_path) -> None:
+    runtime, proof, owner_receipt = _prepare_lost_lease_runtime(tmp_path)
+    result = _recover_lost_ownership_lease(
+        channel="dev",
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=runtime.ledger.root,
+        backup_root=tmp_path / "backup",
+        quiescence_proof_path=runtime.ledger.root / "deployment-quiescence-proof.json",
+        owner_receipt_path=owner_receipt,
+        vault_binding_id="binding-dev",
+    )
+    assert result["recovered"] is True
+    assert result["backup_verified"] is True
+    assert runtime.ledger.active_owner("binding-dev") is not None
+    assert (tmp_path / "backup" / "manifest.json").is_file()
+
+
+def test_fenced_lost_lease_recovery_rejects_non_unique_owner(tmp_path) -> None:
+    runtime, proof, owner_receipt = _prepare_lost_lease_runtime(tmp_path)
+    (tmp_path / "foreign-vault").mkdir()
+    runtime.ledger.reserve(
+        channel_id="test",
+        vault_binding_id="foreign-binding",
+        root=tmp_path / "foreign-vault",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file() and path.name != "bootstrap.lock"
+    }
+    with pytest.raises(InstanceStatePreflightError, match="unambiguous owner inventory"):
+        _recover_lost_ownership_lease(
+            channel="dev",
+            instance_state_root=runtime.layout.root.parent,
+            host_global_root=runtime.ledger.root,
+            backup_root=tmp_path / "backup",
+            quiescence_proof_path=runtime.ledger.root / "deployment-quiescence-proof.json",
+            owner_receipt_path=owner_receipt,
+            vault_binding_id="binding-dev",
+        )
+    assert {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file() and path.name != "bootstrap.lock"
+    } == before
 
 
 def test_diagnostic_export_cannot_be_imported_as_final_authority_without_mutation(


### PR DESCRIPTION
Governing-Issue: #4761
Fixes #4761

## Summary
Add an explicit fenced recovery operation for one uniquely proven missing dev ownership lease. Normal deployment remains fail-closed; recovery requires the existing restart fence, durable two-pass quiescence proof, owner receipt, one registration, materialized root, verified pre-mutation backup, and the capability-guarded ownership ledger path.

## Validation
- 105 focused tests passed, 3 skipped
- ruff check app tests scripts
- mypy app
- git diff --check
- Verify: tests/ops/test_instance_state_volume_contract.py::test_fenced_lost_lease_recovery_restores_single_registered_owner
- Verify: tests/ops/test_instance_state_volume_contract.py::test_fenced_lost_lease_recovery_rejects_non_unique_owner
- Verify: tests/ops/test_instance_state_volume_contract.py::test_inconsistent_registry_ledger_still_fails_closed
- Verify: docs/MULTI_VAULT_RUNTIME/ESTABLISH_INSTANCE_VAULT_REGISTRY.md :: MVR-01B durable deployment and ownership

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: no unresolved divergence or promotion/freshness/roadmap state was introduced; the issue, PR, commit, and test receipt capture bounded delivery evidence.

Final-Review-Rounds: 1