### PR TITLE
Harden English documentation detection

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -73,9 +73,17 @@ corpora as documentation; those surfaces contain Swedish and other languages by 
 
 `python3 scripts/docs_guard.py --language-only` scans the complete tracked documentation surface on
 every PR, including implementation PRs. It removes fenced code, inline code, URLs, and comments
-before applying a deterministic primary-language check. Bounded quotations, localization strings,
-and SV/EN examples are permitted inside an otherwise-English document. A document whose primary
-prose is detected as non-English fails with the path and marker evidence; there is no per-file bypass.
+before applying a deterministic primary-language check. Explicit bilingual Markdown tables whose
+headers name at least two languages are treated as localization data, while ordinary technical
+tables remain part of the prose check. Bounded quotations, localization strings, and SV/EN examples
+are permitted inside an otherwise-English document. A document whose primary prose is detected as
+non-English fails with the path and marker evidence; there is no per-file bypass.
+
+The dependency-free detector uses closed-class markers for common Latin-script languages and a
+Unicode-script threshold for non-Latin prose. It is intentionally a CI fitness heuristic, not
+universal language identification: very terse text with too little language evidence, an uncommon
+Latin-script language outside the marker sets, or an unlabeled mixed-language table can remain
+ambiguous. Review remains responsible for those cases.
 
 - Docs-only changes:
   - run any repo docs validation command if one exists

--- a/scripts/docs_guard_logic.py
+++ b/scripts/docs_guard_logic.py
@@ -77,14 +77,55 @@ _NON_ENGLISH_MARKERS = MappingProxyType(
             wanneer waar hoe waarom na vóór zonder tussen omdat daarom
             """.split()
         ),
+        "polish": frozenset(
+            """
+            ten ta te i nie jest są dla oraz każdy każda każde musi muszą
+            powinien powinna powinno przed po bez między ponieważ dlatego
+            który która które jak gdzie kiedy przez nad pod wszystkich być
+            """.split()
+        ),
+        "portuguese": frozenset(
+            """
+            os um uma e é são não com para em de do da dos das este esta estes
+            estas que quem sobre por como também pode deve nós vocês eles elas
+            mas ou se quando onde porque depois antes sem entre
+            """.split()
+        ),
+        "turkish": frozenset(
+            """
+            bu ve bir için ile değil olan olarak önce sonra çünkü ancak veya
+            nasıl neden nerede her tüm gerekir olmalıdır tarafından arasında
+            üzerinde
+            """.split()
+        ),
+        "vietnamese": frozenset(
+            """
+            và là của cho trong không với một những các được phải trước sau vì
+            nhưng hoặc nếu khi nơi như này đó mọi đều rất đối tất cả
+            """.split()
+        ),
     }
 )
 _FENCED_BLOCK_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 _NON_PROSE_RE = re.compile(r"`[^`\n]+`|https?://\S+|<!--.*?-->", re.DOTALL)
 _WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+_TABLE_SEPARATOR_CELL_RE = re.compile(r":?-{3,}:?")
+_LOCALIZATION_TABLE_LABELS = frozenset(
+    """
+    en english sv swedish de german fr french es spanish it italian nl dutch
+    pl polish pt portuguese tr turkish vi vietnamese ru russian ja japanese zh
+    chinese
+    """.split()
+)
 _MIN_NON_ENGLISH_MARKERS = 8
 _MIN_NON_ENGLISH_SHARE = 0.35
+_MIN_MEDIUM_NON_ENGLISH_MARKERS = 5
+_MIN_MEDIUM_NON_ENGLISH_UNIQUE_MARKERS = 4
+_MIN_MEDIUM_NON_ENGLISH_SHARE = 0.65
+_MIN_SHORT_NON_ENGLISH_MARKERS = 3
+_MIN_SHORT_NON_ENGLISH_SHARE = 0.80
 _MIN_NON_LATIN_LETTERS = 20
+_MIN_SHORT_NON_LATIN_LETTERS = 8
 _MIN_NON_LATIN_SHARE = 0.30
 
 TEMPORAL_DOCS = frozenset(
@@ -126,8 +167,53 @@ def is_governed_documentation_path(path: str) -> bool:
     return "/" not in path or path.startswith(DOCUMENTATION_PREFIXES)
 
 
+def _markdown_table_cells(line: str) -> list[str]:
+    stripped = line.strip()
+    if "|" not in stripped:
+        return []
+    stripped = stripped.removeprefix("|").removesuffix("|")
+    return [cell.strip().casefold() for cell in stripped.split("|")]
+
+
+def _strip_explicit_localization_tables(text: str) -> str:
+    """Remove Markdown tables whose headers explicitly name two languages."""
+
+    lines = text.splitlines()
+    kept: list[str] = []
+    index = 0
+    while index < len(lines):
+        header = _markdown_table_cells(lines[index])
+        separator = (
+            _markdown_table_cells(lines[index + 1])
+            if index + 1 < len(lines)
+            else []
+        )
+        is_table = (
+            len(header) >= 2
+            and len(header) == len(separator)
+            and all(_TABLE_SEPARATOR_CELL_RE.fullmatch(cell) for cell in separator)
+        )
+        language_columns = sum(
+            cell in _LOCALIZATION_TABLE_LABELS for cell in header
+        )
+        if not is_table or language_columns < 2:
+            kept.append(lines[index])
+            index += 1
+            continue
+
+        index += 2
+        while index < len(lines) and _markdown_table_cells(lines[index]):
+            index += 1
+        kept.append("")
+    return "\n".join(kept)
+
+
 def _primary_non_english_language(text: str) -> tuple[str, int, int, float] | None:
-    prose = _NON_PROSE_RE.sub(" ", _FENCED_BLOCK_RE.sub(" ", text))
+    prose_without_fences = _FENCED_BLOCK_RE.sub(" ", text)
+    prose_without_localization_tables = _strip_explicit_localization_tables(
+        prose_without_fences
+    )
+    prose = _NON_PROSE_RE.sub(" ", prose_without_localization_tables)
     tokens = [token.lower() for token in _WORD_RE.findall(prose)]
     english_hits = sum(token in _ENGLISH_MARKERS for token in tokens)
     language, non_english_hits = max(
@@ -139,26 +225,55 @@ def _primary_non_english_language(text: str) -> tuple[str, int, int, float] | No
     )
     marker_total = english_hits + non_english_hits
     non_english_share = non_english_hits / marker_total if marker_total else 0.0
-    if (
+    non_english_unique_hits = len(
+        set(tokens).intersection(_NON_ENGLISH_MARKERS[language])
+    )
+    long_document_match = (
         non_english_hits >= _MIN_NON_ENGLISH_MARKERS
         and non_english_share >= _MIN_NON_ENGLISH_SHARE
-    ):
+    )
+    medium_document_match = (
+        non_english_hits >= _MIN_MEDIUM_NON_ENGLISH_MARKERS
+        and non_english_unique_hits >= _MIN_MEDIUM_NON_ENGLISH_UNIQUE_MARKERS
+        and non_english_share >= _MIN_MEDIUM_NON_ENGLISH_SHARE
+    )
+    short_document_match = (
+        non_english_hits >= _MIN_SHORT_NON_ENGLISH_MARKERS
+        and non_english_share >= _MIN_SHORT_NON_ENGLISH_SHARE
+    )
+    if long_document_match or medium_document_match or short_document_match:
         return language, non_english_hits, english_hits, non_english_share
 
     letters = [character for character in prose if character.isalpha()]
-    non_latin_letters = sum(
-        "LATIN" not in unicodedata.name(character, "") for character in letters
+    non_latin_names = [
+        unicodedata.name(character, "")
+        for character in letters
+        if "LATIN" not in unicodedata.name(character, "")
+    ]
+    non_latin_letters = len(non_latin_names)
+    short_non_latin_letters = sum(
+        "GREEK" not in character_name for character_name in non_latin_names
     )
     non_latin_share = non_latin_letters / len(letters) if letters else 0.0
-    if (
+    long_non_latin_match = (
         non_latin_letters >= _MIN_NON_LATIN_LETTERS
         and non_latin_share >= _MIN_NON_LATIN_SHARE
-    ):
+    )
+    short_non_latin_match = (
+        short_non_latin_letters >= _MIN_SHORT_NON_LATIN_LETTERS
+        and short_non_latin_letters / len(letters) >= _MIN_NON_LATIN_SHARE
+        if letters
+        else False
+    )
+    if long_non_latin_match or short_non_latin_match:
+        matched_non_latin_letters = (
+            non_latin_letters if long_non_latin_match else short_non_latin_letters
+        )
         return (
             "non_latin",
-            non_latin_letters,
-            len(letters) - non_latin_letters,
-            non_latin_share,
+            matched_non_latin_letters,
+            len(letters) - matched_non_latin_letters,
+            matched_non_latin_letters / len(letters),
         )
     return None
 

--- a/scripts/docs_guard_logic.py
+++ b/scripts/docs_guard_logic.py
@@ -110,12 +110,37 @@ _FENCED_BLOCK_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 _NON_PROSE_RE = re.compile(r"`[^`\n]+`|https?://\S+|<!--.*?-->", re.DOTALL)
 _WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
 _TABLE_SEPARATOR_CELL_RE = re.compile(r":?-{3,}:?")
-_LOCALIZATION_TABLE_LABELS = frozenset(
-    """
-    en english sv swedish de german fr french es spanish it italian nl dutch
-    pl polish pt portuguese tr turkish vi vietnamese ru russian ja japanese zh
-    chinese
-    """.split()
+_LOCALIZATION_TABLE_IDENTITIES = MappingProxyType(
+    {
+        "en": "english",
+        "english": "english",
+        "sv": "swedish",
+        "swedish": "swedish",
+        "de": "german",
+        "german": "german",
+        "fr": "french",
+        "french": "french",
+        "es": "spanish",
+        "spanish": "spanish",
+        "it": "italian",
+        "italian": "italian",
+        "nl": "dutch",
+        "dutch": "dutch",
+        "pl": "polish",
+        "polish": "polish",
+        "pt": "portuguese",
+        "portuguese": "portuguese",
+        "tr": "turkish",
+        "turkish": "turkish",
+        "vi": "vietnamese",
+        "vietnamese": "vietnamese",
+        "ru": "russian",
+        "russian": "russian",
+        "ja": "japanese",
+        "japanese": "japanese",
+        "zh": "chinese",
+        "chinese": "chinese",
+    }
 )
 _MIN_NON_ENGLISH_MARKERS = 8
 _MIN_NON_ENGLISH_SHARE = 0.35
@@ -123,6 +148,7 @@ _MIN_MEDIUM_NON_ENGLISH_MARKERS = 5
 _MIN_MEDIUM_NON_ENGLISH_UNIQUE_MARKERS = 4
 _MIN_MEDIUM_NON_ENGLISH_SHARE = 0.65
 _MIN_SHORT_NON_ENGLISH_MARKERS = 3
+_MIN_SHORT_NON_ENGLISH_UNIQUE_MARKERS = 2
 _MIN_SHORT_NON_ENGLISH_SHARE = 0.80
 _MIN_NON_LATIN_LETTERS = 20
 _MIN_SHORT_NON_LATIN_LETTERS = 8
@@ -193,10 +219,12 @@ def _strip_explicit_localization_tables(text: str) -> str:
             and len(header) == len(separator)
             and all(_TABLE_SEPARATOR_CELL_RE.fullmatch(cell) for cell in separator)
         )
-        language_columns = sum(
-            cell in _LOCALIZATION_TABLE_LABELS for cell in header
-        )
-        if not is_table or language_columns < 2:
+        language_identities = {
+            _LOCALIZATION_TABLE_IDENTITIES[cell]
+            for cell in header
+            if cell in _LOCALIZATION_TABLE_IDENTITIES
+        }
+        if not is_table or len(language_identities) < 2:
             kept.append(lines[index])
             index += 1
             continue
@@ -239,6 +267,7 @@ def _primary_non_english_language(text: str) -> tuple[str, int, int, float] | No
     )
     short_document_match = (
         non_english_hits >= _MIN_SHORT_NON_ENGLISH_MARKERS
+        and non_english_unique_hits >= _MIN_SHORT_NON_ENGLISH_UNIQUE_MARKERS
         and non_english_share >= _MIN_SHORT_NON_ENGLISH_SHARE
     )
     if long_document_match or medium_document_match or short_document_match:

--- a/tests/scripts/test_docs_guard.py
+++ b/tests/scripts/test_docs_guard.py
@@ -150,6 +150,109 @@ The fenced string is test data and does not change the document language.
     assert "Docs language guard: OK" in result.stdout
 
 
+def test_language_guard_rejects_adversarial_primary_non_english_docs(
+    tmp_path: Path,
+) -> None:
+    repo = _guard_repo(tmp_path)
+    documents = {
+        "SHORT_SWEDISH.md": "# Beslut\n\nDet här beskriver hur arbetet ska göras.\n",
+        "POLISH.md": """# Zasady
+
+Ten dokument opisuje zasady projektu oraz sposób pracy zespołu. Każda zmiana
+powinna zostać sprawdzona przed połączeniem, ponieważ jakość i bezpieczeństwo
+systemu są ważne dla wszystkich użytkowników. Dokumentacja musi być jasna,
+dokładna i dostępna.
+""",
+        "PORTUGUESE.md": """# Regras
+
+Este documento descreve as regras e como a equipe deve trabalhar. As mudanças
+são verificadas antes da entrega.
+""",
+        "TURKISH.md": """# Kurallar
+
+Bu belge projenin kurallarını ve ekibin çalışma biçimini açıklar. Her değişiklik
+birleştirilmeden önce doğrulanmalıdır çünkü sistemin kalitesi ve güvenliği tüm
+kullanıcılar için önemlidir. Belgeler açık ve doğru olmalıdır.
+""",
+        "VIETNAMESE.md": """# Quy tắc
+
+Tài liệu này mô tả các quy tắc của dự án và cách nhóm làm việc. Mọi thay đổi
+phải được kiểm tra trước khi hợp nhất vì chất lượng và sự an toàn của hệ thống
+rất quan trọng đối với tất cả người dùng.
+""",
+        "SHORT_CHINESE.md": "# 规则\n\n本文说明项目规则和工作方式。\n",
+    }
+    for name, content in documents.items():
+        (repo / "docs" / name).write_text(content, encoding="utf-8")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-m", "adversarial-non-english-docs"], repo)
+
+    result = _guard_result(repo, "--language-only")
+
+    assert result.returncode == 1
+    for name in documents:
+        assert f'"path": "docs/{name}"' in result.stdout
+
+
+def test_language_guard_allows_adversarial_english_and_localization_docs(
+    tmp_path: Path,
+) -> None:
+    repo = _guard_repo(tmp_path)
+    documents = {
+        "LOCALIZATION.md": """# Labels
+
+This table defines bounded localization strings for the interface.
+
+| Key | English | Swedish |
+| --- | --- | --- |
+| save | Save the note | Spara den här anteckningen |
+| open | Open the note | Öppna den här anteckningen |
+| clear | This must be clear | Det här måste vara tydligt |
+| next | What happens next | Vad händer efter detta |
+| where | Where is it | Var är den |
+
+The table is localization data, while the governing contract remains English.
+""",
+        "TECHNICAL.md": """# API matrix
+
+| Method | Path | Status | Notes |
+| --- | --- | --- | --- |
+| GET | /v1/items | 200 | idempotent |
+| POST | /v1/items | 202 | queued |
+| DELETE | /v1/items/{id} | 204 | terminal |
+
+Complexity: O(n). Schema: Item{id, version, checksum}. Exit code: 0.
+""",
+        "MATH_TABLE.md": """# Symbol table
+
+| α | β | γ | δ |
+| --- | --- | --- | --- |
+| ε | ζ | η | θ |
+| ι | κ | λ | μ |
+""",
+        "EXAMPLES.md": """# Examples
+
+This document defines the contract and its verification evidence.
+
+```text
+Det här dokumentet är på svenska och ska inte påverka kontrollen.
+```
+
+Use `Spara den här anteckningen` for the Swedish locale. The primary prose
+remains English and the example is explicitly bounded.
+""",
+    }
+    for name, content in documents.items():
+        (repo / "docs" / name).write_text(content, encoding="utf-8")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-m", "adversarial-allowed-docs"], repo)
+
+    result = _guard_result(repo, "--language-only")
+
+    assert result.returncode == 0, result.stdout
+    assert "Docs language guard: OK" in result.stdout
+
+
 def test_product_vault_markdown_is_not_repository_documentation(tmp_path: Path) -> None:
     repo = _guard_repo(tmp_path)
     (repo / "vault").mkdir()

--- a/tests/scripts/test_docs_guard.py
+++ b/tests/scripts/test_docs_guard.py
@@ -181,6 +181,13 @@ phải được kiểm tra trước khi hợp nhất vì chất lượng và s�
 rất quan trọng đối với tất cả người dùng.
 """,
         "SHORT_CHINESE.md": "# 规则\n\n本文说明项目规则和工作方式。\n",
+        "ALIAS_TABLE.md": """# Innehåll
+
+| English | en |
+| --- | --- |
+| Det här dokumentet beskriver vad som ska göras | Vi behöver förstå hur arbetet ska genomföras |
+| Den här texten måste vara tydlig | Därför ska varje beslut vara enkelt att följa |
+""",
     }
     for name, content in documents.items():
         (repo / "docs" / name).write_text(content, encoding="utf-8")
@@ -229,6 +236,10 @@ Complexity: O(n). Schema: Item{id, version, checksum}. Exit code: 0.
 | --- | --- | --- | --- |
 | ε | ζ | η | θ |
 | ι | κ | λ | μ |
+""",
+        "REPEATED_AMBIGUOUS.md": """# Concise English
+
+Her view, her note, her decision.
 """,
         "EXAMPLES.md": """# Examples
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4765

## Linked Issue
Closes #4765

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: CI documentation fitness result only
- New or changed contract: English-primary detection covers bounded short prose and representative Latin/non-Latin languages without treating explicit localization examples as governing prose.
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces
- Boundary risk: Product/vault content and multilingual test corpora remain outside the governed documentation scan.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Harden deterministic English-primary documentation detection for short and additional Latin-script prose.
- Preserve explicit bilingual localization tables, fenced and inline examples, Product/vault/test exclusions, and technical notation.
- Repair review-found alias-collision and repeated-marker false evidence with distinct language identities and distinct short-form markers.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The audit and repair are fully represented by GitHub Issue #4765, this repository diff, review threads, and CI; no separate BuilderOps material was produced.

## Notes
Validation on exact head 897e56ab11cbc254c943a3679a927b4a7b9ef348: pytest -q tests/scripts/test_docs_guard.py (13 passed); governing AC tests (3 passed); python3 scripts/docs_guard.py --language-only (OK); ruff check app tests companion-ui/companion-app (passed); ruff check scripts/docs_guard.py scripts/docs_guard_logic.py tests/scripts/test_docs_guard.py (passed); mypy app (878 files, no issues); git diff --check (passed); all relevant CI and required Unit tests (not pg) green. Two review findings on the prior head were classified as protected P1 AC failures, repaired, replied to, and resolved. Fresh independent exact-head review: clean, no P0/P1/P2/P3 findings. Pickup receipt: task_id=github-RasmusTho--agentic-pkm-mvp-issue-4765 lease_id=lease-cc9c584c holder=codex-root evidence=verified-dispatcher-lease.
