### PR TITLE
Redact meeting finalization failure details

### DIFF
--- a/app/api/routes/heimdal_meeting.py
+++ b/app/api/routes/heimdal_meeting.py
@@ -183,7 +183,6 @@ def close_session(
         finalization = {
             "status": "failed",
             "error": type(exc).__name__,
-            "message": str(exc),
         }
     response = _session_response(session, replay=not newly_closed, trace_id=trace_id)
     payload = response.model_dump(exclude_none=True)

--- a/tests/heimdal/test_meeting_finalization.py
+++ b/tests/heimdal/test_meeting_finalization.py
@@ -222,6 +222,31 @@ def test_receipt_store_scopes_equal_session_state_by_binding(tmp_path: Path) -> 
     }
 
 
+def test_close_session_finalization_failure_hides_exception_message(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = f"mtg-{uuid4()}"
+    sentinel = "postgresql://operator:secret@localhost:15432/app"
+
+    def fail_finalization(*_: Any, **__: Any) -> dict[str, Any]:
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(meeting_finalization, "finalize_session", fail_finalization)
+    assert _open_session(client, session_id).status_code == 200
+
+    closed = _close(client, session_id, 0)
+
+    assert closed.status_code == 200
+    response = closed.json()
+    assert response["closed"] is True
+    assert response["trace_id"]
+    assert response["finalization"] == {
+        "status": "failed",
+        "error": "RuntimeError",
+    }
+    assert sentinel not in closed.text
+
+
 def test_gapped_close_is_legible_everywhere(
     client: TestClient, vault: Path
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #4785

Fixes #4785

Final-Review-Rounds: 1

## Summary
Redacts raw meeting-finalization exception text from the client close-session response while preserving the existing typed failure status, error type, trace ID, durable close result, and server diagnostics. The branch was rebased onto current `origin/main`; its one conflict retained the upstream vault-binding regression alongside this security regression.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded Product/Runtime code fix produces no BuilderOps operational material; GitHub Issue and PR provide the delivery authority and receipt.

## Security Review
- Mechanism key: heimdal-meeting-close-finalization-response-redaction
- Invariant: client responses never serialize raw finalization exception messages.
- Independent exact-SHA review: ACCEPT, SHA `fa1e1ea5796d3d6a6c0a184036084727805963e2`; no P0-P3 findings.

## Notes
Validation on `fa1e1ea5796d3d6a6c0a184036084727805963e2`: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/heimdal/test_meeting_finalization.py` (10 passed); `ruff check app tests` (passed); `mypy app/api/routes/heimdal_meeting.py` (passed); `git diff --check origin/main...HEAD` (passed); review-before-CI gate satisfied for `security`. Hosted CI is pending on this rebased head. The full-path merge remains blocked pending the separate #3603 BCP-05 installed-main receipt.