### PR TITLE
bug: reject Via in ARO-03 direct-loopback admission

### DIFF
--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -22,6 +22,7 @@ _FORWARDED_IDENTITY_HEADERS = frozenset(
         "cf-connecting-ip",
         "forwarded",
         "true-client-ip",
+        "via",
         "x-client-ip",
         "x-envoy-external-address",
         "x-original-forwarded-for",

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -303,6 +303,7 @@ def test_devui_composition_refuses_other_forwarded_identity_headers() -> None:
 
     for name, value in (
         ("Forwarded", "for=127.0.0.1"),
+        ("Via", "1.1 local-proxy"),
         ("X-Real-IP", "127.0.0.1"),
         ("CF-Connecting-IP", "127.0.0.1"),
         ("X-Original-Forwarded-For", "127.0.0.1"),
@@ -501,6 +502,18 @@ def test_overview_route_reuses_local_admission_and_exact_contract(monkeypatch) -
         client.get("/api/devui/overview", headers={"X-Forwarded-For": "203.0.113.10"}).status_code
         == 403
     )
+
+
+def test_overview_route_rejects_via_forwarded_identity(monkeypatch) -> None:
+    monkeypatch.setattr(devui_route, "compose_owner_snapshot", lambda **_: {})
+    monkeypatch.setattr(devui_route, "compose_overview_view", lambda **_: {})
+
+    response = TestClient(app).get(
+        "/api/devui/overview",
+        headers={"Via": "1.1 local-proxy"},
+    )
+
+    assert response.status_code == 403
 
 
 def test_overview_route_preserves_no_source_withdrawals(monkeypatch) -> None:


### PR DESCRIPTION
Governing-Issue: #4791

Fixes #4791

Final-Review-Rounds: 1

## Summary
Classify the standard `Via` header as forwarded identity in the shared devUI local-admission guard. Add a production `/api/devui/overview` TestClient regression that proves a direct-loopback request carrying `Via: 1.1 local-proxy` is refused before composition.

## Recovery Mechanism
- Identity: `aro03_direct_loopback_admission`
- Scope: Via-aware direct-loopback admission only; #4786 and PR #4789 remain unchanged.

## SBS Impact
- Primary subsystem: Product/Runtime System — devUI local API admission boundary
- Secondary subsystem: Builder System — ARO-03 recovery evidence
- Write class: mechanical runtime guard and regression test
- Persistence impact: none
- Derived/rebuildable impact: per-request admission only
- Contract: forwarded `Via` identity is refused
- Owner-doc writeback: none; the existing ARO-03 authority already requires refusal

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No plan divergence or BuilderOps operational material was produced; GitHub Issue/PR and CI are the delivery evidence.

## Validation
- Initial regression failed before the repair: overview with `Via` returned HTTP 200.
- `python3 -m pytest -q tests/api/test_devui_api.py::test_overview_route_rejects_via_forwarded_identity tests/api/test_devui_api.py::test_devui_composition_refuses_other_forwarded_identity_headers tests/api/test_devui_api.py::test_overview_route_reuses_local_admission_and_exact_contract` — 3 passed.
- `python3 -m pytest -q tests/api/test_devui_api.py` — 17 passed.
- `ruff check app tests` — passed.
- `mypy app` — passed.
- `git diff --check` — passed.

## Exact-head Receipt
Head: `031dbfaa2d6d474bf02e5d778ffb252f0879ae97`
Exact-head CI and independent review: pending.
---