### PR TITLE
fix: preserve watcher zero-match scope health

### DIFF
--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1062,7 +1062,7 @@ def _collect_changed_entries(
         # runtime configuration can reload.  They must not, however, make a
         # blind content scope look healthy.
         if _matches_scope(rel, spec.scope_glob):
-            summary["scope_matched_files"] = int(summary["scope_matched_files"]) + 1
+            summary["scope_matched_files"] = int(summary.get("scope_matched_files", 0)) + 1
         rel_str = str(rel)
         scanned_paths.append(rel_str)
         last_mtime = state.last_mtime(rel_str)

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1058,6 +1058,11 @@ def _collect_changed_entries(
     scanned_paths: list[str] = []
     for rel, mtime, path in _scan_markdown_many(cfg.vault_path, scan_roots, spec.scope_glob):
         summary["scanned_files"] = int(summary["scanned_files"]) + 1
+        # Settings sources are scanned outside a narrow content scope so their
+        # runtime configuration can reload.  They must not, however, make a
+        # blind content scope look healthy.
+        if _matches_scope(rel, spec.scope_glob):
+            summary["scope_matched_files"] = int(summary["scope_matched_files"]) + 1
         rel_str = str(rel)
         scanned_paths.append(rel_str)
         last_mtime = state.last_mtime(rel_str)
@@ -1428,6 +1433,7 @@ def _run_spec_tick(
         "rate_limited": state.rate_limited,
         "enqueue_failures_total": state.enqueue_failures_total,
         "scanned_files": 0,
+        "scope_matched_files": 0,
         "hashed_files": 0,
         "bytes_read": 0,
         "scope_glob": spec.scope_glob,
@@ -1551,9 +1557,10 @@ def _run_spec_tick(
                     removed_delta.errors
                 )
 
-    if int(summary.get("scanned_files", 0)) == 0:
+    if int(summary.get("scope_matched_files", 0)) == 0:
         # The scope glob's directory exists, but the tick matched zero
-        # candidate files — the watcher is running but blind (#2988).
+        # content files — the watcher is running but blind (#2988). Settings
+        # sources may still be scanned/reloaded outside that content scope.
         state.scope_status = "zero_match"
         summary["scope_status"] = "zero_match"
         _warn_scope_once_per_interval(

--- a/tests/watcher/test_scope_zero_match_signal.py
+++ b/tests/watcher/test_scope_zero_match_signal.py
@@ -82,7 +82,8 @@ def test_zero_match_sets_degraded_heartbeat(
 
     summaries = registry.run_registry_once(config_path)
     summary = summaries["ingest"]
-    assert summary.get("scanned_files") == 0
+    assert summary.get("scanned_files") == 1
+    assert summary.get("scope_matched_files") == 0
     assert summary.get("scope_status") == "zero_match"
 
     import json
@@ -101,6 +102,28 @@ def test_zero_match_sets_degraded_heartbeat(
     registry.run_registry_once(config_path)
     messages_second = [rec.getMessage() for rec in caplog.records]
     assert not any("zero" in msg.lower() and "ingest" in msg for msg in messages_second)
+
+
+def test_settings_sources_do_not_mask_scope_zero_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    scope_dir = vault_root / "📥 Inbox"
+    scope_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = tmp_path / "watchers.yaml"
+    _write_config(config_path)
+    _base_env(monkeypatch, vault_root=vault_root, tmp_path=tmp_path, scope_glob="📥 Inbox/*.md")
+
+    summary = registry.run_registry_once(config_path)["ingest"]
+
+    # Canonical settings remain a reloadable scan target outside this narrow
+    # content scope, but they cannot suppress the zero-match health signal.
+    assert summary.get("scanned_files") == 1
+    assert summary.get("scope_matched_files") == 0
+    assert summary.get("settings_source_reloads_in_tick") == 1
+    assert summary.get("scope_status") == "zero_match"
 
 
 def test_missing_scope_prefix_warns(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4807

## Linked Issue
Closes #4807

## SBS Impact
- Primary subsystem: Product Runtime System watcher registry
- Secondary subsystem(s): none
- Write class: runtime observation and watcher health summary
- Persistence impact: watcher state and heartbeat summaries only
- Derived/rebuildable impact: watcher scan and health summary counters
- New or changed contract: settings control sources remain scannable without masking a narrow content-scope zero-match
- Owner-doc impact: no owner-doc change implied
- Transition debt impact: removes the baseline watcher health regression from canonical settings scanning
- Boundary risk: settings-source reload eligibility remains intact

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Separates physical scan count from content-scope match count for watcher health.
- Preserves settings-source reload scanning while restoring degraded zero-match signaling.

## BuilderOps Routing
- Records/projections/receipts: dispatcher lease lease-e4ad8517
- Reason: bounded Tier 2 runtime bug delivery; no separate BuilderOps record was created.

## Notes
Validation: baseline regression reproduced; `pytest -q tests/watcher/test_scope_zero_match_signal.py` (3 passed); `ruff check app/watcher tests/watcher/test_scope_zero_match_signal.py`; `ruff check app tests`; diff check. `docs/WATCHERS.md` source-doc anchor drift was repaired to `docs/tracks/TRACK_WATCHER.md` on #4807 before claim.
