### PR TITLE
fix(builderops): harden Builder Thread privacy admission

### DIFF
--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -16,6 +16,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
+from urllib.parse import urlsplit
 
 
 PRIVACY_CLASS: Literal["shared_non_sensitive"] = "shared_non_sensitive"
@@ -24,11 +25,15 @@ _REQUEST_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SOURCE_REF = re.compile(
     r"^(?:builderops|conversation|doc|git|github):[A-Za-z0-9._:/#@+-]{1,255}$"
 )
-_PRIVATE_HOST_PATH = re.compile(
-    r"(?i)(?:~[\\/]\.ssh(?:[\\/]|$)|"
-    r"(?<![A-Za-z0-9._-])/(?:Users|home|private|root|etc|var|opt)(?:/|$)|"
-    r"\b[A-Za-z]:\\(?:Users|home|private|root|etc|var|opt)(?:\\|$))"
+_PRIVATE_POSIX_PATH = re.compile(
+    r"(?i)(?:~[\\/]\.ssh(?:[\\/]|$)|/(?:Users|home|private|root|etc|var|opt)(?:/|$))"
 )
+_PRIVATE_WINDOWS_PATH = re.compile(
+    r"(?i)(?:\b[A-Za-z]:\\(?:Users|home|private|root|etc|var|opt)(?:\\|$)|"
+    r"\\\\[^\\\s]+\\(?:Users|home|private|root|etc|var|opt)(?:\\|$)|"
+    r"(?<!\\)\\(?:Users|home|private|root|etc|var|opt)(?:\\|$))"
+)
+_URI = re.compile(r"\b[A-Za-z][A-Za-z0-9+.-]*://[^\s<>()]+")
 _PRIVATE_CONTENT = re.compile(
     r"(?im)(password|secret|credential|token|api[_-]?key|bearer\s+|"
     r"^aws_(?:access_key_id|secret_access_key)\s*=|"
@@ -578,7 +583,7 @@ def _validate_identity(value: str | None, *, field: str) -> None:
 def _validate_text(value: str | None, *, field: str) -> None:
     if not isinstance(value, str) or not value.strip() or len(value) > _MAX_TEXT:
         raise BuilderThreadError(f"{field} must be bounded non-empty text")
-    if _PRIVATE_HOST_PATH.search(value) or _PRIVATE_CONTENT.search(value):
+    if _contains_private_host_path(value) or _PRIVATE_CONTENT.search(value):
         raise BuilderThreadError(f"{field} is not shared_non_sensitive")
     if _CODE_OR_PATCH.search(value):
         raise BuilderThreadError(f"{field} is not shared_non_sensitive")
@@ -590,8 +595,34 @@ def _validate_source_refs(source_refs: tuple[str, ...]) -> None:
     for source_ref in source_refs:
         if not isinstance(source_ref, str) or not _SOURCE_REF.fullmatch(source_ref):
             raise BuilderThreadError("source_ref must be typed bounded provenance")
-        if _PRIVATE_HOST_PATH.search(source_ref) or _PRIVATE_CONTENT.search(source_ref):
+        if _contains_private_host_path(source_ref) or _PRIVATE_CONTENT.search(source_ref):
             raise BuilderThreadError("source_ref is not shared_non_sensitive")
+
+
+def _contains_private_host_path(value: str) -> bool:
+    """Reject local paths while preserving a URI's ordinary path component.
+
+    A shared link can naturally contain names such as ``/home``.  URI query and
+    fragment text do not receive that exemption because they may carry a local
+    path as data rather than name the public resource being linked.
+    """
+    for match in _PRIVATE_POSIX_PATH.finditer(value):
+        if not _is_uri_path_component(value, match.start()):
+            return True
+    return _PRIVATE_WINDOWS_PATH.search(value) is not None
+
+
+def _is_uri_path_component(value: str, offset: int) -> bool:
+    for uri_match in _URI.finditer(value):
+        if not uri_match.start() <= offset < uri_match.end():
+            continue
+        parsed = urlsplit(uri_match.group())
+        if not parsed.netloc or not parsed.path:
+            return False
+        path_start = uri_match.start() + len(parsed.scheme) + 3 + len(parsed.netloc)
+        path_end = path_start + len(parsed.path)
+        return path_start <= offset < path_end
+    return False
 
 
 def _capture_key(recipient: str, subject: str, source_refs: tuple[str, ...]) -> str:

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -16,7 +16,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 
 PRIVACY_CLASS: Literal["shared_non_sensitive"] = "shared_non_sensitive"
@@ -609,7 +609,31 @@ def _contains_private_host_path(value: str) -> bool:
     for match in _PRIVATE_POSIX_PATH.finditer(value):
         if not _is_uri_path_component(value, match.start()):
             return True
-    return _PRIVATE_WINDOWS_PATH.search(value) is not None
+    if _PRIVATE_WINDOWS_PATH.search(value) is not None:
+        return True
+    return any(
+        _contains_private_path_data(component)
+        for uri_match in _URI.finditer(value)
+        for component in _decoded_uri_data(uri_match.group())
+    )
+
+
+def _decoded_uri_data(uri: str) -> tuple[str, str]:
+    parsed = urlsplit(uri)
+    return _decode_uri_component(parsed.query), _decode_uri_component(parsed.fragment)
+
+
+def _decode_uri_component(value: str) -> str:
+    for _ in range(3):
+        decoded = unquote(value)
+        if decoded == value:
+            break
+        value = decoded
+    return value
+
+
+def _contains_private_path_data(value: str) -> bool:
+    return _PRIVATE_POSIX_PATH.search(value) is not None or _PRIVATE_WINDOWS_PATH.search(value) is not None
 
 
 def _is_uri_path_component(value: str, offset: int) -> bool:

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -24,9 +24,13 @@ _REQUEST_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SOURCE_REF = re.compile(
     r"^(?:builderops|conversation|doc|git|github):[A-Za-z0-9._:/#@+-]{1,255}$"
 )
+_PRIVATE_HOST_PATH = re.compile(
+    r"(?i)(?:~[\\/]\.ssh(?:[\\/]|$)|"
+    r"(?<![A-Za-z0-9._-])/(?:Users|home|private|root|etc|var|opt)(?:/|$)|"
+    r"\b[A-Za-z]:\\(?:Users|home|private|root|etc|var|opt)(?:\\|$))"
+)
 _PRIVATE_CONTENT = re.compile(
     r"(?im)(password|secret|credential|token|api[_-]?key|bearer\s+|"
-    r"(?:~/.ssh|/(?:Users|home|private|root|etc|var|opt)/)|"
     r"^aws_(?:access_key_id|secret_access_key)\s*=|"
     r"^authorization:\s*(?:basic|bearer)\b|^-----begin [a-z ]+private key-----|"
     r"\bAKIA[0-9A-Z]{16}\b|\bgithub_pat_[A-Za-z0-9_]{20,}|"
@@ -574,7 +578,7 @@ def _validate_identity(value: str | None, *, field: str) -> None:
 def _validate_text(value: str | None, *, field: str) -> None:
     if not isinstance(value, str) or not value.strip() or len(value) > _MAX_TEXT:
         raise BuilderThreadError(f"{field} must be bounded non-empty text")
-    if _PRIVATE_CONTENT.search(value):
+    if _PRIVATE_HOST_PATH.search(value) or _PRIVATE_CONTENT.search(value):
         raise BuilderThreadError(f"{field} is not shared_non_sensitive")
     if _CODE_OR_PATCH.search(value):
         raise BuilderThreadError(f"{field} is not shared_non_sensitive")
@@ -586,7 +590,7 @@ def _validate_source_refs(source_refs: tuple[str, ...]) -> None:
     for source_ref in source_refs:
         if not isinstance(source_ref, str) or not _SOURCE_REF.fullmatch(source_ref):
             raise BuilderThreadError("source_ref must be typed bounded provenance")
-        if _PRIVATE_CONTENT.search(source_ref):
+        if _PRIVATE_HOST_PATH.search(source_ref) or _PRIVATE_CONTENT.search(source_ref):
             raise BuilderThreadError("source_ref is not shared_non_sensitive")
 
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -412,6 +412,9 @@ and is never a live target.
 
 The operational boundary accepts only bounded `shared_non_sensitive` material,
 typed provenance, endpoint-bound actor identities, and named-recipient questions.
+Concrete private host paths and credential-like forms are refused before the
+serialized writer persists an envelope; recovery re-admits every envelope through
+the same privacy boundary without logging its contents.
 The writer host explicitly initializes the external root with its pinned vault
 identity from `BUILDEROPS_THREAD_WRITER_ROOT` and
 `BUILDEROPS_THREAD_WRITER_VAULT_ID`, then retains immutable, writer-sequenced

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -287,7 +287,9 @@ writer-sequenced command envelope per request so exact retries survive a writer
 restart; changed semantics under the same request ID fail closed. A thread is capped at 32 entries
 and the writer at 100 total contributions, keeping reads bounded. An unavailable
 writer returns a typed degraded failure and never enables direct client filesystem
-fallback.
+fallback. Concrete private host paths and credential-like forms are refused before
+an envelope is written, and every recovered envelope is re-admitted through the
+same privacy boundary without logging its contents.
 
 This boundary is deliberately not a distributed filesystem protocol. It has no
 vault-global claims, slot reservations, cross-device locks, hard-link/fsync race

--- a/tests/builderops/test_builder_thread_privacy.py
+++ b/tests/builderops/test_builder_thread_privacy.py
@@ -34,6 +34,8 @@ def _client(writer: SerializedThreadWriter) -> BuilderThreadClient:
         "C:\\Users\\operator\\.ssh\\id_rsa",
         "\\\\server\\Users\\operator\\.ssh\\id_rsa",
         "\\Users\\operator\\.ssh\\id_rsa",
+        "https://example.test/page?next=%2Froot%2F.ssh%2Fid_rsa",
+        "https://example.test/page#next=%252Froot%252F.ssh%252Fid_rsa",
         "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
     ),
 )
@@ -93,11 +95,20 @@ def test_ordinary_urls_remain_shared_non_sensitive(tmp_path: Path, ordinary_text
     assert writer.accepted_mutation_count == 1
 
 
-def test_recovery_rejects_privacy_invalid_persisted_envelope(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "rejected_content",
+    (
+        "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+        "https://example.test/page?next=%2Froot%2F.ssh%2Fid_rsa",
+    ),
+)
+def test_recovery_rejects_privacy_invalid_persisted_envelope(
+    tmp_path: Path, rejected_content: str
+) -> None:
     _, root = _writer(tmp_path)
     command = {
         "actor": "codex:desktop",
-        "content": "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+        "content": rejected_content,
         "kind": "create",
         "recipient": "claude:mac",
         "request_id": "privacy-recovery-4728",

--- a/tests/builderops/test_builder_thread_privacy.py
+++ b/tests/builderops/test_builder_thread_privacy.py
@@ -32,6 +32,8 @@ def _client(writer: SerializedThreadWriter) -> BuilderThreadClient:
     (
         "/root/.ssh/id_rsa",
         "C:\\Users\\operator\\.ssh\\id_rsa",
+        "\\\\server\\Users\\operator\\.ssh\\id_rsa",
+        "\\Users\\operator\\.ssh\\id_rsa",
         "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
     ),
 )
@@ -73,6 +75,7 @@ def test_rejected_text_never_reaches_external_artifact(tmp_path: Path) -> None:
     (
         "Read https://example.test/users/guide before replying.",
         "The support URL is https://example.test/home/start.",
+        "The IPv6 URL is https://[::1]/home/start.",
     ),
 )
 def test_ordinary_urls_remain_shared_non_sensitive(tmp_path: Path, ordinary_text: str) -> None:

--- a/tests/builderops/test_builder_thread_privacy.py
+++ b/tests/builderops/test_builder_thread_privacy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from app.builderops.builder_threads_serialized import (
+    BuilderThreadClient,
+    BuilderThreadError,
+    InProcessWriterEndpoint,
+    SerializedThreadWriter,
+    initialize_external_writer_root,
+)
+
+
+def _writer(tmp_path: Path) -> tuple[SerializedThreadWriter, Path]:
+    root = tmp_path / "external-builderops-vault"
+    initialize_external_writer_root(root, vault_id="builderops-mac-mini")
+    return SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root), root
+
+
+def _client(writer: SerializedThreadWriter) -> BuilderThreadClient:
+    return BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+
+
+@pytest.mark.parametrize(
+    "rejected_text",
+    (
+        "/root/.ssh/id_rsa",
+        "C:\\Users\\operator\\.ssh\\id_rsa",
+        "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+    ),
+)
+def test_private_paths_and_secret_forms_fail_closed(tmp_path: Path, rejected_text: str) -> None:
+    writer, _ = _writer(tmp_path)
+
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        _client(writer).create(
+            request_id="privacy-admission-4728",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Bounded question",
+            content=rejected_text,
+            source_refs=("github:4728",),
+        )
+
+    assert writer.accepted_mutation_count == 0
+
+
+def test_rejected_text_never_reaches_external_artifact(tmp_path: Path) -> None:
+    writer, root = _writer(tmp_path)
+
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        _client(writer).create(
+            request_id="privacy-no-write-4728",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Bounded question",
+            content="sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+            source_refs=("github:4728",),
+        )
+
+    assert tuple((root / "builder-thread-entries").glob("*.json")) == ()
+    assert writer.accepted_mutation_count == 0
+
+
+@pytest.mark.parametrize(
+    "ordinary_text",
+    (
+        "Read https://example.test/users/guide before replying.",
+        "The support URL is https://example.test/home/start.",
+    ),
+)
+def test_ordinary_urls_remain_shared_non_sensitive(tmp_path: Path, ordinary_text: str) -> None:
+    writer, _ = _writer(tmp_path)
+
+    _client(writer).create(
+        request_id="ordinary-url-4728",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Bounded question",
+        content=ordinary_text,
+        source_refs=("github:4728",),
+    )
+
+    assert writer.accepted_mutation_count == 1
+
+
+def test_recovery_rejects_privacy_invalid_persisted_envelope(tmp_path: Path) -> None:
+    _, root = _writer(tmp_path)
+    command = {
+        "actor": "codex:desktop",
+        "content": "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+        "kind": "create",
+        "recipient": "claude:mac",
+        "request_id": "privacy-recovery-4728",
+        "source_refs": ["github:4728"],
+        "subject": "Bounded question",
+        "thread_id": None,
+    }
+    command_bytes = json.dumps(command, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+    payload = {
+        "command": command,
+        "request_digest": hashlib.sha256(command_bytes).hexdigest(),
+        "sequence": 1,
+        "schema": "builder-thread-command.v1",
+        "vault_id": "builderops-mac-mini",
+    }
+    (root / "builder-thread-entries" / "privacy-recovery-4728.json").write_text(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)


### PR DESCRIPTION
Governing-Issue: #4728

Fixes #4728

Final-Review-Rounds: 2

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): BuilderOps Vault privacy admission
- Write class: authority-bearing privacy boundary
- Persistence impact: prevents unsafe external artifact persistence
- Derived/rebuildable impact: rejected content remains absent; recovery rejects invalid envelopes before state rebuild
- New or changed contract: concrete private host paths and credential-like values are refused before persistence and during recovery
- Owner-doc impact: updated BuilderOps Vault Store and Operations documentation
- Transition debt impact: reduces the narrow admission heuristic gap identified in #4719 review
- Boundary risk: credential durability; rejected material must never cross into shared-non-sensitive storage

## Summary
- Reject concrete POSIX and Windows private host paths alongside credential-like content at the serialized writer privacy boundary.
- Prove rejection occurs before any external envelope write and is repeated during writer recovery, while ordinary URLs remain accepted.

## BuilderOps Routing
- Records/projections/receipts: `LearningSignal lrn_20260812164255_f16fd07c` (workflow divergence; no repo projection)
- Reason: Verification resumed before the live exhausted repair-budget ledger was reconciled; the signal names the verification-and-closure resume gate that should absorb the fix.

## Notes
Blocked technical — do not merge. The live Issue #4728 receipt records that the stable `builder-thread-privacy-admission/path-uri-classification` / `review-code-correctness` mechanism exhausted its two standard plus two strongest-capability repair attempts at published head `89cc0763d503318cf021696bd31d38d73faf5670`. Mechanism-convergence replanning does not reset that budget.

Historical validation on the published branch (`pytest -q tests/builderops/test_builder_thread_privacy.py tests/builderops/test_builder_threads_serialized.py` (40 passed), `ruff check app tests`, `mypy app`, and `python3 scripts/docs_guard.py`) is superseded as merge authority by later protected P1 findings.

An unpublished convergence investigation reached local head `5b2e744f49ed1a37a55b843870dc28bb8d544628`, where focused privacy/serialized tests reported 179 passed, but a fresh Sol/ultra convergence review remained `BLOCKING`: whitespace/terminal Windows drive forms, terminal named-user tilde forms, malformed IPv6 ZoneIDs, and malformed existing IDNA A-labels could still reach persistence. That local evidence was not pushed and does not authorize CI, final review, merge, or closure.

Risk/review: this is a credential-durability full-path delivery whose already-started authenticated contract requires `Final-Review-Rounds: 2`. The prior clean-review claim on `0be1fdeaab9bd5bbc2476b194457445c5d22bb9b` is superseded. No clean current-head convergence receipt exists.