### PR TITLE
fix: gate research backlog handoff on promotion intent

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -206,7 +206,7 @@ workflow — see `## App-agent skill family (product-lane)` below for the full d
 - Design handoff path:
   `yggdrasil-design-handoff -> governed exploration/handoff -> disposition (PromotionIntent when crossing authority classes) -> (Companion UI: Crossing B -> normalized spec | other surface: local owner doc/spec) -> docs-to-issue`
 - Architecture research path:
-  `architecture-research -> explicit disposition + PromotionIntent/BuilderOpsReceipt -> feature-breakdown -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
+  `architecture-research -> explicit disposition + accepted PromotionIntent/BuilderOpsReceipt -> feature-breakdown -> promoted receipt -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
 - Maintenance-learning intake path:
   `capture-learning -> learning-to-issue` (when the signal is ready for the backlog) or `learning-retrospective -> learning-to-issue` (when batched retro signals mature into bounded issues)
 - Temporal audit path:

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -206,7 +206,7 @@ workflow — see `## App-agent skill family (product-lane)` below for the full d
 - Design handoff path:
   `yggdrasil-design-handoff -> governed exploration/handoff -> disposition (PromotionIntent when crossing authority classes) -> (Companion UI: Crossing B -> normalized spec | other surface: local owner doc/spec) -> docs-to-issue`
 - Architecture research path:
-  `architecture-research -> feature-breakdown -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
+  `architecture-research -> explicit disposition + PromotionIntent/BuilderOpsReceipt -> feature-breakdown -> issue-to-code` (audit doc publishes via `publish-pr`; findings reconcile against open epics instead of creating parallel hubs)
 - Maintenance-learning intake path:
   `capture-learning -> learning-to-issue` (when the signal is ready for the backlog) or `learning-retrospective -> learning-to-issue` (when batched retro signals mature into bounded issues)
 - Temporal audit path:

--- a/.codex/skills/architecture-research/SKILL.md
+++ b/.codex/skills/architecture-research/SKILL.md
@@ -87,17 +87,27 @@ GitHub state.
 - Identify the minimal kernel: the smallest invariant subset that carries the pass's correctness
   claims. Everything else is defense in depth and says so.
 
-### Phase 5 — Backlog handoff (reconcile, don't duplicate)
+### Phase 5 — Disposition and backlog handoff (reconcile, don't duplicate)
 
-- Convert the accepted findings into a dependency-ordered task list inside the audit doc, each
-  task with `Verify:`-able acceptance kernel.
+- Record an explicit disposition for every finding before it can leave the advisory audit:
+  accepted, rejected, deferred, or requiring an owner decision. Rejected and deferred findings do
+  not enter backlog creation.
+- For an accepted finding that crosses from research evidence into a normative specification,
+  parent feature, or GitHub backlog, create and durably transition the existing BuilderOps
+  `PromotionIntent` through `BuilderOpsPromotionGateway`. Its source references, target authority
+  surface/ref, intended output, and resulting `BuilderOpsReceipt` are the required handoff
+  evidence. A research audit, task list, or chat transcript alone is not authority to invoke
+  `feature-breakdown` or create a backlog artifact.
+- Only after that promoted handoff evidence exists, convert the accepted findings into a
+  dependency-ordered task list inside the audit doc, each task with `Verify:`-able acceptance
+  kernel.
 - **Reconcile against open epics and issues before creating anything.** Search existing epics,
   spec directories, and issues; where a task overlaps, extend or supersede explicitly (name the
   issue and which half stays where — see the audit's reconciliation-notes pattern) instead of
   filing a parallel hub.
-- Hand the backlog to `.codex/skills/feature-breakdown/SKILL.md` to produce the specification
-  directory, parent feature issue, and child issues. This skill does not file implementation
-  issues directly.
+- Hand the PromotionIntent-backed, reconciled backlog to
+  `.codex/skills/feature-breakdown/SKILL.md` to produce the specification directory, parent
+  feature issue, and child issues. This skill does not file implementation issues directly.
 
 ## Working rules
 

--- a/.codex/skills/architecture-research/SKILL.md
+++ b/.codex/skills/architecture-research/SKILL.md
@@ -93,21 +93,23 @@ GitHub state.
   accepted, rejected, deferred, or requiring an owner decision. Rejected and deferred findings do
   not enter backlog creation.
 - For an accepted finding that crosses from research evidence into a normative specification,
-  parent feature, or GitHub backlog, create and durably transition the existing BuilderOps
-  `PromotionIntent` through `BuilderOpsPromotionGateway`. Its source references, target authority
-  surface/ref, intended output, and resulting `BuilderOpsReceipt` are the required handoff
-  evidence. A research audit, task list, or chat transcript alone is not authority to invoke
-  `feature-breakdown` or create a backlog artifact.
-- Only after that promoted handoff evidence exists, convert the accepted findings into a
+  parent feature, or GitHub backlog, create and transition the existing BuilderOps
+  `PromotionIntent` to `accepted` through `BuilderOpsPromotionGateway`. Its source references,
+  target authority surface/ref, intended output, and accepted-transition `BuilderOpsReceipt` are
+  the required handoff evidence. A research audit, task list, or chat transcript alone is not
+  authority to invoke `feature-breakdown` or create a backlog artifact.
+- Only after that accepted handoff evidence exists, convert the accepted findings into a
   dependency-ordered task list inside the audit doc, each task with `Verify:`-able acceptance
   kernel.
 - **Reconcile against open epics and issues before creating anything.** Search existing epics,
   spec directories, and issues; where a task overlaps, extend or supersede explicitly (name the
   issue and which half stays where — see the audit's reconciliation-notes pattern) instead of
   filing a parallel hub.
-- Hand the PromotionIntent-backed, reconciled backlog to
+- Hand the accepted-PromotionIntent-backed, reconciled backlog to
   `.codex/skills/feature-breakdown/SKILL.md` to produce the specification directory, parent
-  feature issue, and child issues. This skill does not file implementation issues directly.
+  feature issue, and child issues. Record their resulting source/result references, then use the
+  same gateway to transition the intent to `promoted`. This skill does not file implementation
+  issues directly.
 
 ## Working rules
 

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -40,6 +40,13 @@ work, route through the Builder System boundary/artifact map. Boundary tasks nam
 not treat builder learning or BuilderOps records as runtime/user memory without Product System
 authority.
 
+When the input is accepted architecture-research or design material rather than an already
+authoritative owner document/specification, require the upstream explicit disposition and durable
+`PromotionIntent`/`BuilderOpsReceipt` evidence before creating a specification directory, parent
+feature issue, or child issue. Preserve its source and result references in the handoff. This
+check does not add a PromotionIntent wrapper to ordinary breakdown from an already-authoritative,
+bounded owner document or specification.
+
 Key distinction:
 - The specification describes **what the system needs to do**.
 - The GitHub issues describe **what work to pick up next**.

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -42,10 +42,11 @@ authority.
 
 When the input is accepted architecture-research or design material rather than an already
 authoritative owner document/specification, require the upstream explicit disposition and durable
-`PromotionIntent`/`BuilderOpsReceipt` evidence before creating a specification directory, parent
-feature issue, or child issue. Preserve its source and result references in the handoff. This
-check does not add a PromotionIntent wrapper to ordinary breakdown from an already-authoritative,
-bounded owner document or specification.
+`PromotionIntent` accepted-transition `BuilderOpsReceipt` evidence before creating a specification
+directory, parent feature issue, or child issue. Preserve its source reference in the handoff;
+after materialization, record its result references and transition the same intent to `promoted`.
+This check does not add a PromotionIntent wrapper to ordinary breakdown from an
+already-authoritative, bounded owner document or specification.
 
 Key distinction:
 - The specification describes **what the system needs to do**.

--- a/tests/governance/test_architecture_research_promotion_boundary.py
+++ b/tests/governance/test_architecture_research_promotion_boundary.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_research_handoff_requires_promotion_intent() -> None:
+    skill = (REPO_ROOT / ".codex/skills/architecture-research/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Record an explicit disposition for every finding" in skill
+    assert "create and durably transition the existing BuilderOps" in skill
+    assert "PromotionIntent" in skill
+    assert "A research audit, task list, or chat transcript alone is not authority" in skill
+
+
+def test_promoted_research_handoff_is_allowed() -> None:
+    research_skill = (REPO_ROOT / ".codex/skills/architecture-research/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    breakdown_skill = (REPO_ROOT / ".codex/skills/feature-breakdown/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "PromotionIntent-backed, reconciled backlog" in research_skill
+    assert "source and result references" in breakdown_skill
+    assert "does not add a PromotionIntent wrapper to ordinary breakdown" in breakdown_skill

--- a/tests/governance/test_architecture_research_promotion_boundary.py
+++ b/tests/governance/test_architecture_research_promotion_boundary.py
@@ -10,9 +10,10 @@ def test_research_handoff_requires_promotion_intent() -> None:
     )
 
     assert "Record an explicit disposition for every finding" in skill
-    assert "create and durably transition the existing BuilderOps" in skill
+    assert "transition the existing BuilderOps" in skill
+    assert "`PromotionIntent` to `accepted`" in skill
     assert "PromotionIntent" in skill
-    assert "A research audit, task list, or chat transcript alone is not authority" in skill
+    assert "chat transcript alone is not" in skill
 
 
 def test_promoted_research_handoff_is_allowed() -> None:
@@ -23,6 +24,7 @@ def test_promoted_research_handoff_is_allowed() -> None:
         encoding="utf-8"
     )
 
-    assert "PromotionIntent-backed, reconciled backlog" in research_skill
-    assert "source and result references" in breakdown_skill
+    assert "accepted-PromotionIntent-backed, reconciled backlog" in research_skill
+    assert "accepted-transition `BuilderOpsReceipt`" in breakdown_skill
+    assert "record its result references and transition the same intent to `promoted`" in breakdown_skill
     assert "does not add a PromotionIntent wrapper to ordinary breakdown" in breakdown_skill


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4691

## Linked Issue
Closes #4691

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): architecture research, feature breakdown, BuilderOps PromotionIntent
- Write class: governance/docs/process
- Persistence impact: BuilderOps provenance only; no Product/Runtime persistence
- Derived/rebuildable impact: none
- New or changed contract: research-to-backlog authority crossing requires PromotionIntent
- Owner-doc impact: updated in PR
- Transition debt impact: reduces authority-crossing bypass risk
- Boundary risk: research evidence must not directly create executable backlog artifacts

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require an explicit disposition and durable PromotionIntent receipt before architecture research can enter feature-breakdown or backlog creation.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This governance PR implements the existing PromotionIntent/BuilderOpsPromotionGateway boundary and creates no BuilderOps record.

## Notes
Claim: dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4691 lease_id=lease-163da3d3 holder=issue_4691. Validation: pytest -q tests/governance/test_architecture_research_promotion_boundary.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; git diff --check.
