### PR TITLE
Fail loud for local not-pg fallback shards

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -178,20 +178,47 @@ export PYTHONPATH="${PWD}:${PWD}/companion-ui/companion-app${PYTHONPATH:+:${PYTH
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/run_with_host_lease.py \
   --resource pytest-not-pg \
   --execution-id <issue-or-pr>:<sha> \
-  -- zsh -c 'find tests -mindepth 1 -maxdepth 1 \
-    \( -type d -name "__pycache__" -prune \) -o \
-    \( -type d -o \( -type f -name "test_*.py" \) \) -print0 | \
-    LC_ALL=C sort -z | \
-    xargs -0 -n 1 python3 -m pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin \
-      -p xdist.plugin -q -m "not pg"'
+  -- zsh -o pipefail -c '
+    shard_list="$(mktemp)" || exit $?
+    trap "rm -f -- \"$shard_list\"" EXIT
+    find tests -mindepth 1 -maxdepth 1 \
+      \( -type d -name "__pycache__" -prune \) -o \
+      \( -type d -o \( -type f -name "test_*.py" \) \) -print0 | \
+      LC_ALL=C sort -z >"$shard_list"
+    selected_shards=()
+    while IFS= read -r -d "" shard; do
+      if [[ -d "$shard" ]]; then
+        collectible="$(find "$shard" -type f -name "test_*.py" -print -quit)"
+        discovery_status=$?
+        (( discovery_status == 0 )) || exit "$discovery_status"
+        [[ -n "$collectible" ]] || continue
+      fi
+      selected_shards+=("$shard")
+    done <"$shard_list"
+    (( ${#selected_shards[@]} > 0 )) || { print -u2 -- "no collectible not-pg shards discovered"; exit 1; }
+    failed=0
+    for shard in "${selected_shards[@]}"; do
+      python3 -m pytest -p pytest_asyncio.plugin -p anyio.pytest_plugin -p xdist.plugin \
+        -q -m "not pg" "$shard"
+      shard_status=$?
+      if (( shard_status != 0 )); then
+        print -u2 -- "uncovered shard: $shard (pytest exit $shard_status)"
+        failed=1
+      fi
+    done
+    (( failed == 0 ))'
 ```
 
 The explicit `PYTHONPATH` is part of this one sanctioned command because tests outside
 `tests/companion_ui` import the nested `companion_ui` package during collection. Do not add
 one-off path exports to Issue or PR handoffs. Record the canonical command's host-resource failure,
-the fallback command, and every failed shard. A fallback run is complete only when every shard
-passes; if a shard cannot run, record the uncovered shard as a validation gap rather than claiming
-the full `not pg` selection passed.
+the fallback command, and every failed shard. The command selects a directory only after finding a
+collectible `test_*.py` file beneath it, so helper-only directories are never passed to pytest. Its
+`pipefail` discovery pipeline and per-directory collection checks fail the leased command before a
+partial shard list can produce a receipt. A fallback run is complete only when every selected shard
+passes; if a shard cannot run, the command reports it as an `uncovered shard` and exits nonzero, so
+record the uncovered shard as a validation gap rather than claiming the full `not pg` selection
+passed.
 
 The full non-PG suite is host-global. The wrapper above holds an atomic repo-common kernel lock for
 the entire child process and releases it automatically when the process exits. A chat handshake,

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -185,6 +185,8 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 scripts/run_with_host_lease.py \
       \( -type d -name "__pycache__" -prune \) -o \
       \( -type d -o \( -type f -name "test_*.py" \) \) -print0 | \
       LC_ALL=C sort -z >"$shard_list"
+    discovery_pipeline_status=$?
+    (( discovery_pipeline_status == 0 )) || exit "$discovery_pipeline_status"
     selected_shards=()
     while IFS= read -r -d "" shard; do
       if [[ -d "$shard" ]]; then
@@ -214,8 +216,8 @@ The explicit `PYTHONPATH` is part of this one sanctioned command because tests o
 one-off path exports to Issue or PR handoffs. Record the canonical command's host-resource failure,
 the fallback command, and every failed shard. The command selects a directory only after finding a
 collectible `test_*.py` file beneath it, so helper-only directories are never passed to pytest. Its
-`pipefail` discovery pipeline and per-directory collection checks fail the leased command before a
-partial shard list can produce a receipt. A fallback run is complete only when every selected shard
+`pipefail` discovery pipeline is checked before its output is used, and its per-directory collection
+checks fail the leased command before a partial shard list can produce a receipt. A fallback run is complete only when every selected shard
 passes; if a shard cannot run, the command reports it as an `uncovered shard` and exits nonzero, so
 record the uncovered shard as a validation gap rather than claiming the full `not pg` selection
 passed.

--- a/tests/governance/test_dev_workflow_validation_guidance.py
+++ b/tests/governance/test_dev_workflow_validation_guidance.py
@@ -41,6 +41,8 @@ def test_local_fallback_preserves_discovery_pipeline_failure() -> None:
 
     assert "-- zsh -o pipefail -c '" in text
     assert 'LC_ALL=C sort -z >"$shard_list"' in text
+    assert 'discovery_pipeline_status=$?' in text
+    assert '(( discovery_pipeline_status == 0 )) || exit "$discovery_pipeline_status"' in text
     assert '(( discovery_status == 0 )) || exit "$discovery_status"' in text
     assert "partial shard list can produce a receipt" in text
     assert 'print -u2 -- "uncovered shard: $shard (pytest exit $shard_status)"' in text

--- a/tests/governance/test_dev_workflow_validation_guidance.py
+++ b/tests/governance/test_dev_workflow_validation_guidance.py
@@ -23,3 +23,24 @@ def test_not_pg_fallback_is_documented() -> None:
     assert "companion-ui/companion-app" in text
     assert "Do not add\none-off path exports to Issue or PR handoffs." in text
     assert "uncovered shard as a validation gap" in text
+
+
+def test_local_fallback_excludes_non_test_directories() -> None:
+    """Only directories with a collectible test file become pytest shards (#4690)."""
+    text = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'collectible="$(find "$shard" -type f -name "test_*.py" -print -quit)"' in text
+    assert '[[ -n "$collectible" ]] || continue' in text
+    assert 'selected_shards+=("$shard")' in text
+    assert "helper-only directories are never passed to pytest" in text
+
+
+def test_local_fallback_preserves_discovery_pipeline_failure() -> None:
+    """Discovery errors must fail the leased command, not yield a partial receipt (#4690)."""
+    text = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "-- zsh -o pipefail -c '" in text
+    assert 'LC_ALL=C sort -z >"$shard_list"' in text
+    assert '(( discovery_status == 0 )) || exit "$discovery_status"' in text
+    assert "partial shard list can produce a receipt" in text
+    assert 'print -u2 -- "uncovered shard: $shard (pytest exit $shard_status)"' in text


### PR DESCRIPTION
Governing-Issue: #4690

Fixes #4690

Final-Review-Rounds: 0

## Summary
Make the sanctioned local not-pg fallback discover only collectible test shards and fail closed on discovery or shard execution errors.
The fallback now reports uncovered shards before returning a nonzero status.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded Tier 2 Builder/CES documentation and regression-test repair; no operational record or authority crossing was produced.

## Notes
Validation: pytest -q tests/governance/test_dev_workflow_validation_guidance.py; ruff check app tests companion-ui/companion-app; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; python3 scripts/review_before_ci_gate.py --lane implementation --risk-assessment-complete --review-gate-complete; git diff --check.
---