### PR TITLE
governance: add stateful fallback boundary matrix

### DIFF
--- a/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
+++ b/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
@@ -321,6 +321,36 @@ The implementation agent must stop point-fixing and build one convergence packet
 - all prior findings and attempted fixes bound to the same mechanism key; and
 - a test matrix mapping each invariant, transition, crash point, and race to focused proof.
 
+### Stateful fallback boundary matrix
+
+For a high-risk stateful fallback mechanism, the convergence packet must also contain **one
+executable boundary matrix** before a reviewer can record a clean convergence receipt. This is not
+a second convergence gate and does not apply to low-risk ordinary work: use it when the mechanism
+selects or resumes a stateful fallback after an outcome that can affect authority, identity,
+durability, or terminality.
+
+The matrix is executable only when each row names the entrypoint and outcome being exercised, the
+expected state/receipt transition, and the focused proof that runs that row. It must cover these
+axes as applicable to the mechanism:
+
+The required axes are production entrypoints, eligible versus terminal failure classes, effective
+provider/model identity, current and legacy success/failure resume lineage, and adjacent
+authority-isolation paths.
+
+| Axis | Required boundary question |
+| --- | --- |
+| Production entrypoints | Which production entrypoints can start the mechanism, and which are test-only or forbidden from selecting fallback? |
+| Failure classification | Which failure classes are fallback-eligible versus terminal, including authentication, refusal, unsafe output, persistence, and unexpected-failure classes where they exist? |
+| Effective identity | Which effective provider/model identity (or equivalent selected target) is recorded before and after each eligible fallback? |
+| Resume lineage | How do current and legacy success/failure receipts resume, skip, retry, or terminate without replaying a completed or terminal attempt? |
+| Authority isolation | Which adjacent paths must remain unable to borrow the fallback, credentials, identity, receipt, or authority of this mechanism? |
+
+The Model Inquiry adapter chain is a motivating example: its production entrypoint, declared
+subscription targets, fallback-eligible and terminal outcomes, persisted attempt lineage, and
+non-CKM consumer boundary all need one matrix rather than separate point fixes. The same matrix
+shape applies to any comparable stateful fallback mechanism; it does not authorize Model Inquiry,
+Product/Runtime, credential, or artifact mutation outside the governing issue.
+
 A fresh independent reviewer at the strongest capability justified by `AGENTS.md :: Total Cost of
 Development` reviews the packet and local publishable SHA before another expensive validation. Any
 blocker returns to focused repair and packet review. Only a clean convergence review permits the

--- a/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
+++ b/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
@@ -337,6 +337,12 @@ The required axes are production entrypoints, eligible versus terminal failure c
 provider/model identity, current and legacy success/failure resume lineage, and adjacent
 authority-isolation paths.
 
+When `scripts/review_before_ci_gate.py` prepares such work, it must receive both
+`--stateful-fallback` and `--stateful-fallback-matrix-complete`; the gate otherwise remains
+required and cannot hand off to expensive validation or CI. Those flags attest that the packet
+contains the matrix; the governing issue, packet, focused proof, current-SHA CI, and final
+independent review remain the evidence and merge authorities.
+
 | Axis | Required boundary question |
 | --- | --- |
 | Production entrypoints | Which production entrypoints can start the mechanism, and which are test-only or forbidden from selecting fallback? |

--- a/scripts/docs_guard_logic.py
+++ b/scripts/docs_guard_logic.py
@@ -173,6 +173,7 @@ GOVERNANCE_TEMPORAL_ENFORCEMENT = MappingProxyType(
         "scripts/docs_guard.py": "docs/development/DOCUMENTATION_GUARD.md",
         "scripts/docs_guard_logic.py": "docs/development/DOCUMENTATION_GUARD.md",
         "scripts/git_hygiene.py": "docs/development/GIT_HYGIENE.md",
+        "scripts/review_before_ci_gate.py": "docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md",
         "scripts/select_pr_tests.py": "docs/development/TEST_STRATEGY_HOT_PATH.md",
     }
 )

--- a/scripts/review_before_ci_gate.py
+++ b/scripts/review_before_ci_gate.py
@@ -48,6 +48,8 @@ class ReviewBeforeCiGate:
     may_handoff_to_ci: bool
     preserves_ci_authority: bool
     bypass_reason: str | None
+    stateful_fallback: bool
+    stateful_fallback_matrix_complete: bool
     changed_files: list[str]
     matched_surfaces: list[str]
     required_local_checks: list[str]
@@ -62,6 +64,8 @@ def evaluate_review_before_ci_gate(
     bypass_reason: str | None = None,
     risk_surfaces: Sequence[str] = (),
     risk_assessment_complete: bool = False,
+    stateful_fallback: bool = False,
+    stateful_fallback_matrix_complete: bool = False,
 ) -> ReviewBeforeCiGate:
     """Return local review-before-CI gate guidance for a PR prep stage."""
 
@@ -77,6 +81,14 @@ def evaluate_review_before_ci_gate(
         raise ReviewBeforeCiGateError("at least one changed file is required")
 
     risks = _normalize_risk_surfaces(risk_surfaces)
+    if stateful_fallback_matrix_complete and not stateful_fallback:
+        raise ReviewBeforeCiGateError(
+            "stateful_fallback_matrix_complete requires stateful_fallback"
+        )
+    if stateful_fallback and not risks:
+        raise ReviewBeforeCiGateError(
+            "stateful_fallback requires at least one declared high-risk surface"
+        )
     if risks and normalized_lane not in RISK_REVIEW_LANES:
         raise ReviewBeforeCiGateError(
             "risk_surfaces are valid only for implementation, governance, or direct-repair lanes"
@@ -104,9 +116,25 @@ def evaluate_review_before_ci_gate(
             review_gate_complete=False,
             may_handoff_to_ci=True,
             bypass_reason=bypass,
+            stateful_fallback=stateful_fallback,
+            stateful_fallback_matrix_complete=stateful_fallback_matrix_complete,
             files=files,
             matched=matched,
             summary="local review-before-CI gate bypassed with explicit reason; required GitHub checks still apply",
+        )
+    if stateful_fallback and not stateful_fallback_matrix_complete:
+        return _gate(
+            normalized_lane,
+            "required",
+            required,
+            review_gate_complete=False,
+            may_handoff_to_ci=False,
+            bypass_reason=None,
+            stateful_fallback=True,
+            stateful_fallback_matrix_complete=False,
+            files=files,
+            matched=matched,
+            summary="complete the executable stateful fallback boundary matrix before expensive validation or CI",
         )
     if required and not review_gate_complete:
         return _gate(
@@ -116,6 +144,8 @@ def evaluate_review_before_ci_gate(
             review_gate_complete=False,
             may_handoff_to_ci=False,
             bypass_reason=None,
+            stateful_fallback=stateful_fallback,
+            stateful_fallback_matrix_complete=stateful_fallback_matrix_complete,
             files=files,
             matched=matched,
             summary="run cheap local review/contract checks before expensive validation or CI",
@@ -128,6 +158,8 @@ def evaluate_review_before_ci_gate(
             review_gate_complete=True,
             may_handoff_to_ci=True,
             bypass_reason=None,
+            stateful_fallback=stateful_fallback,
+            stateful_fallback_matrix_complete=stateful_fallback_matrix_complete,
             files=files,
             matched=matched,
             summary="local review-before-CI gate satisfied; continue to GitHub CI handoff",
@@ -139,6 +171,8 @@ def evaluate_review_before_ci_gate(
         review_gate_complete=False,
         may_handoff_to_ci=True,
         bypass_reason=None,
+        stateful_fallback=stateful_fallback,
+        stateful_fallback_matrix_complete=stateful_fallback_matrix_complete,
         files=files,
         matched=matched,
         summary="docs/governance review-before-CI gate is not required for this lane/surface",
@@ -153,6 +187,8 @@ def _gate(
     review_gate_complete: bool,
     may_handoff_to_ci: bool,
     bypass_reason: str | None,
+    stateful_fallback: bool,
+    stateful_fallback_matrix_complete: bool,
     files: list[str],
     matched: list[str],
     summary: str,
@@ -165,9 +201,11 @@ def _gate(
         may_handoff_to_ci=may_handoff_to_ci,
         preserves_ci_authority=True,
         bypass_reason=bypass_reason,
+        stateful_fallback=stateful_fallback,
+        stateful_fallback_matrix_complete=stateful_fallback_matrix_complete,
         changed_files=files,
         matched_surfaces=matched,
-        required_local_checks=_required_checks(matched),
+        required_local_checks=_required_checks(matched, stateful_fallback=stateful_fallback),
         summary=summary,
     )
 
@@ -187,7 +225,9 @@ def _matched_surfaces(
     return sorted(matched)
 
 
-def _required_checks(matched: Sequence[str]) -> list[str]:
+def _required_checks(
+    matched: Sequence[str], *, stateful_fallback: bool = False
+) -> list[str]:
     if not matched:
         return []
     checks: list[str] = []
@@ -206,6 +246,10 @@ def _required_checks(matched: Sequence[str]) -> list[str]:
                 "build the mechanism convergence packet (invariants, states, transitions, crash ordering, producers/consumers/recovery, locks, and test map)",
                 "run a fresh independent high-capability review of the local publishable SHA and convergence packet before selected expensive validation",
             ]
+        )
+    if stateful_fallback:
+        checks.append(
+            "complete one executable stateful fallback boundary matrix (production entrypoints, eligible versus terminal failure classes, effective provider/model identity, current and legacy success/failure resume lineage, and adjacent authority-isolation paths)"
         )
     return checks
 
@@ -244,6 +288,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--bypass-reason")
     parser.add_argument("--risk-surface", action="append", default=[])
     parser.add_argument("--risk-assessment-complete", action="store_true")
+    parser.add_argument("--stateful-fallback", action="store_true")
+    parser.add_argument("--stateful-fallback-matrix-complete", action="store_true")
     return parser
 
 
@@ -257,6 +303,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             bypass_reason=args.bypass_reason,
             risk_surfaces=args.risk_surface,
             risk_assessment_complete=args.risk_assessment_complete,
+            stateful_fallback=args.stateful_fallback,
+            stateful_fallback_matrix_complete=args.stateful_fallback_matrix_complete,
         )
     except ReviewBeforeCiGateError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True), file=sys.stderr)

--- a/tests/governance/test_autonomous_escalation_contract.py
+++ b/tests/governance/test_autonomous_escalation_contract.py
@@ -85,3 +85,16 @@ def test_repair_budget_policy_is_consistent_across_governing_surfaces() -> None:
         assert "two standard repair attempts" in normalized
         assert "two strongest-capability repair attempts" in normalized
         assert "does not create a Human Exception" in normalized
+
+
+def test_stateful_fallback_convergence_requires_executable_boundary_matrix() -> None:
+    contract = GATE_CONTRACT.read_text(encoding="utf-8")
+
+    assert "### Stateful fallback boundary matrix" in contract
+    assert "one\nexecutable boundary matrix" in contract
+    assert (
+        "production entrypoints, eligible versus terminal failure classes, effective\n"
+        "provider/model identity, current and legacy success/failure resume lineage, and adjacent\n"
+        "authority-isolation paths"
+    ) in contract
+    assert "does not replace current-SHA CI or the final independent review gate" in contract

--- a/tests/governance/test_autonomous_escalation_contract.py
+++ b/tests/governance/test_autonomous_escalation_contract.py
@@ -89,12 +89,13 @@ def test_repair_budget_policy_is_consistent_across_governing_surfaces() -> None:
 
 def test_stateful_fallback_convergence_requires_executable_boundary_matrix() -> None:
     contract = GATE_CONTRACT.read_text(encoding="utf-8")
+    normalized = " ".join(contract.split())
 
     assert "### Stateful fallback boundary matrix" in contract
-    assert "one\nexecutable boundary matrix" in contract
+    assert "one executable boundary matrix" in normalized
     assert (
-        "production entrypoints, eligible versus terminal failure classes, effective\n"
-        "provider/model identity, current and legacy success/failure resume lineage, and adjacent\n"
+        "production entrypoints, eligible versus terminal failure classes, effective "
+        "provider/model identity, current and legacy success/failure resume lineage, and adjacent "
         "authority-isolation paths"
-    ) in contract
+    ) in normalized
     assert "does not replace current-SHA CI or the final independent review gate" in contract

--- a/tests/ops/test_review_before_ci_gate.py
+++ b/tests/ops/test_review_before_ci_gate.py
@@ -222,6 +222,59 @@ def test_high_risk_implementation_requires_convergence_review_before_expensive_g
     assert any("before selected expensive validation" in check for check in gate.required_local_checks)
 
 
+def test_stateful_fallback_requires_executable_boundary_matrix_before_handoff() -> None:
+    blocked = evaluate_review_before_ci_gate(
+        lane="implementation",
+        changed_files=["app/model_inquiry/runner.py"],
+        risk_surfaces=["credential-durability", "state-machine"],
+        risk_assessment_complete=True,
+        review_gate_complete=True,
+        stateful_fallback=True,
+    )
+    complete = evaluate_review_before_ci_gate(
+        lane="implementation",
+        changed_files=["app/model_inquiry/runner.py"],
+        risk_surfaces=["credential-durability", "state-machine"],
+        risk_assessment_complete=True,
+        review_gate_complete=True,
+        stateful_fallback=True,
+        stateful_fallback_matrix_complete=True,
+    )
+
+    assert blocked.status == "required"
+    assert blocked.may_handoff_to_ci is False
+    assert blocked.stateful_fallback_matrix_complete is False
+    assert any("executable stateful fallback boundary matrix" in check for check in blocked.required_local_checks)
+    assert complete.status == "satisfied"
+    assert complete.may_handoff_to_ci is True
+    assert complete.stateful_fallback_matrix_complete is True
+
+
+def test_stateful_fallback_matrix_completion_cannot_fail_open() -> None:
+    with pytest.raises(
+        ReviewBeforeCiGateError,
+        match="stateful_fallback_matrix_complete requires stateful_fallback",
+    ):
+        evaluate_review_before_ci_gate(
+            lane="implementation",
+            changed_files=["app/model_inquiry/runner.py"],
+            risk_surfaces=["state-machine"],
+            risk_assessment_complete=True,
+            stateful_fallback_matrix_complete=True,
+        )
+
+    with pytest.raises(
+        ReviewBeforeCiGateError,
+        match="stateful_fallback requires at least one declared high-risk surface",
+    ):
+        evaluate_review_before_ci_gate(
+            lane="implementation",
+            changed_files=["app/model_inquiry/runner.py"],
+            risk_assessment_complete=True,
+            stateful_fallback=True,
+        )
+
+
 def test_standard_implementation_keeps_existing_hot_path() -> None:
     gate = evaluate_review_before_ci_gate(
         lane="implementation",

--- a/tests/scripts/test_docs_guard.py
+++ b/tests/scripts/test_docs_guard.py
@@ -76,6 +76,25 @@ def test_governance_script_and_high_risk_temporal_doc_require_both_owner_docs(
     assert "temporal code/config changed" in result.stdout
 
 
+def test_review_before_ci_gate_uses_its_convergence_contract_as_owner_doc(
+    tmp_path: Path,
+) -> None:
+    repo = _guard_repo(tmp_path)
+    (repo / "scripts/review_before_ci_gate.py").write_text(
+        "# governance\n", encoding="utf-8"
+    )
+    (repo / "docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md").write_text(
+        "convergence writeback\n", encoding="utf-8"
+    )
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-m", "review-gate-owner-doc"], repo)
+
+    result = _guard_result(repo)
+
+    assert result.returncode == 0
+    assert "Docs guard: OK" in result.stdout
+
+
 def test_primary_swedish_documentation_fails_with_evidence(tmp_path: Path) -> None:
     repo = _guard_repo(tmp_path)
     (repo / "docs/SWEDISH.md").write_text(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4734

## Linked Issue
Closes #4734

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Model Inquiry governance
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: convergence packets become more reproducible for stateful fallback repairs
- New or changed contract: high-risk stateful fallback convergence packets include one executable boundary matrix
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces repeated adjacent P1 repair loops on fallback mechanisms
- Boundary risk: guidance does not authorize Product/Runtime mutation or waive current-SHA CI/final review gates

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require one executable boundary matrix before a clean convergence receipt for high-risk stateful fallback mechanisms.
- Define production-entrypoint, failure-classification, effective-identity, resume-lineage, and authority-isolation axes without changing Model Inquiry runtime behavior.
- Add a focused governance regression test and preserve current-SHA CI plus the final independent review gate.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue already promotes LearningSignal lrn_20260809230133_941a4e4e; this bounded Tier 1 governance delivery created no new divergence or operational record.

## Notes
Docs Governance Decision: Artifact role: governance process contract. Owner: Builder-agent governance. Action: update existing owner doc and focused contract test. Traceability: #4734, lrn_20260809230133_941a4e4e, #4713 / PR #4716. DOCS_INDEX impact: none; existing indexed owner document. SBS/interface ownership: Builder System / CES boundary; no Product/Runtime interface mutation. Human Exception: none.
