### PR TITLE
Add non-mutating Known Defects dry run

### DIFF
--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -66,6 +66,30 @@ python3 .codex/skills/bug-to-issue/scripts/known_defects.py intake \
   --trigger "<explicit re-evaluation or promotion trigger>"
 ```
 
+Diagnostic or audit probes must validate candidate P2 payloads with the
+non-mutating `--dry-run` mode before any registry write. This mode validates
+the complete payload and emits a non-authoritative candidate entry, but
+deliberately does not discover, create, lock, or append to the registry:
+
+```bash
+python3 .codex/skills/bug-to-issue/scripts/known_defects.py intake \
+  --dry-run \
+  --classification confirmed-defect \
+  --severity P2 \
+  --source-pr <PR> \
+  --source-sha <FULL_40_CHARACTER_SHA> \
+  --review-url <PR_OR_REVIEW_THREAD_URL> \
+  --symptom "<reproducible symptom>" \
+  --evidence "<concrete review or reproduction evidence>" \
+  --impact "<who or what is affected>" \
+  --workaround "<known workaround or 'none known'>" \
+  --trigger "<explicit re-evaluation or promotion trigger>"
+```
+
+The returned `dry_run` receipt is not registry authority and is never a
+promotion path. Perform normal intake only after the diagnostic result has
+been reviewed and a durable deferred-defect write is intended.
+
 The helper:
 
 - rejects maintainability and unproven classifications without GitHub mutation;

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -106,8 +106,8 @@ The helper:
 - rejects unlocked or mislabeled registries and parses only exact first-line markers with the
   expected schema shape;
 - detects the exact defect marker across existing registries before appending;
-- posts one compact JSON `known-defect-receipt.v1` with `created`, `duplicate`, `excluded`, or
-  `promotion_required` status.
+- posts one compact JSON `known-defect-receipt.v1` with `created`, `duplicate`, `excluded`,
+  `promotion_required`, or non-authoritative diagnostic `dry_run` status.
 
 Every entry records:
 

--- a/.codex/skills/bug-to-issue/scripts/known_defects.py
+++ b/.codex/skills/bug-to-issue/scripts/known_defects.py
@@ -1373,6 +1373,21 @@ def intake_defect(
     )
 
 
+def validate_intake_dry_run(defect: KnownDefect) -> dict[str, Any]:
+    """Return a validated candidate entry without accessing registry authority.
+
+    A dry run deliberately does not discover, create, lock, or append to a
+    registry.  Its result is diagnostic output only; callers must run normal
+    intake to obtain a durable registry receipt.
+    """
+    return {
+        "schema": "known-defect-receipt.v1",
+        "status": "dry_run",
+        "defect_id": defect.defect_id,
+        "candidate_entry": defect.render_entry(phase="final"),
+    }
+
+
 def lookup_defect(
     defect_id: str,
     gateway: RegistryGateway,
@@ -1898,6 +1913,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     intake.add_argument("--registry-issue", type=int)
+    intake.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "validate and render the candidate entry without reading or mutating "
+            "the Known Defects registry"
+        ),
+    )
 
     lookup = subparsers.add_parser("lookup", help="look up one deterministic defect id")
     _add_common_repo_argument(lookup)
@@ -1952,10 +1975,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     defect_key=args.defect_key,
                     defect_id_override=args.defect_id,
                 )
-                receipt = intake_defect(
-                    defect,
-                    GhRegistryGateway(repo),
-                    registry_issue=args.registry_issue,
+                receipt = (
+                    validate_intake_dry_run(defect)
+                    if args.dry_run
+                    else intake_defect(
+                        defect,
+                        GhRegistryGateway(repo),
+                        registry_issue=args.registry_issue,
+                    )
                 )
         elif args.command == "lookup":
             receipt = lookup_defect(args.defect_id, GhRegistryGateway(repo))

--- a/tests/governance/test_known_defects_registry.py
+++ b/tests/governance/test_known_defects_registry.py
@@ -240,6 +240,55 @@ def test_repeated_intake_is_idempotent_and_reuses_one_registry() -> None:
     assert gateway.label_ensured == 2
 
 
+def test_known_defects_intake_dry_run_does_not_mutate_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class GatewayMustNotBeConstructed:
+        def __init__(self, _repo: str) -> None:
+            raise AssertionError("dry-run must not access registry authority")
+
+    monkeypatch.setattr(known_defects, "GhRegistryGateway", GatewayMustNotBeConstructed)
+
+    rc = known_defects.main(
+        [
+            "intake",
+            "--dry-run",
+            "--repo",
+            "RasmusTho/agentic-pkm-mvp",
+            "--classification",
+            "confirmed-defect",
+            "--severity",
+            "P2",
+            "--source-pr",
+            "4321",
+            "--source-sha",
+            "a" * 40,
+            "--review-url",
+            "https://github.com/RasmusTho/agentic-pkm-mvp/pull/4321#discussion_r123",
+            "--symptom",
+            "Retry receipts can display the stale attempt count.",
+            "--evidence",
+            "The review reproduced count=1 after the second attempt.",
+            "--impact",
+            "Operators may misread repair progress.",
+            "--workaround",
+            "Read the raw attempt events.",
+            "--trigger",
+            "Promote after a second occurrence or when this blocks closure.",
+        ]
+    )
+
+    receipt = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert receipt["schema"] == "known-defect-receipt.v1"
+    assert receipt["status"] == "dry_run"
+    assert receipt["defect_id"].startswith("KD-")
+    assert receipt["candidate_entry"].startswith(
+        "<!-- known-defect-entry:v1 id="
+    )
+
+
 def test_entry_records_every_required_field() -> None:
     defect = _defect()
 

--- a/tests/governance/test_known_defects_registry.py
+++ b/tests/governance/test_known_defects_registry.py
@@ -287,6 +287,10 @@ def test_known_defects_intake_dry_run_does_not_mutate_registry(
     assert receipt["candidate_entry"].startswith(
         "<!-- known-defect-entry:v1 id="
     )
+    skill = (
+        REPO_ROOT / ".codex" / "skills" / "bug-to-issue" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "non-authoritative diagnostic `dry_run` status" in skill
 
 
 def test_entry_records_every_required_field() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4733

## Linked Issue
Closes #4733

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): review-comment closure automation and Known Defects registry workflow
- Write class: governance/docs/process plus builder tooling
- Persistence impact: prevents accidental registry mutation during diagnostics
- Derived/rebuildable impact: dry-run output is non-authoritative unless normal intake is intentionally run
- New or changed contract: diagnostic probes must use non-mutating validation mode
- Owner-doc impact: none
- Transition debt impact: reduces weak/decontextualized P2 registry entries from audit tooling
- Boundary risk: dry-run output is not durable defect authority or a promotion path

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds a non-mutating dry-run intake path for diagnostic Known Defects probes.

## BuilderOps Routing
- Records/projections/receipts: dispatcher lease-7b6492b7
- Reason: Claim coordination only; no new BuilderOps record was created.

## Notes
Validation: `python3 -m pytest -q tests/governance/test_known_defects_registry.py`; `python3 scripts/lint_skills_consistency.py`; `ruff check .codex/skills/bug-to-issue/scripts/known_defects.py tests/governance/test_known_defects_registry.py`; `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py`.
