### PR TITLE
Return YouTube fetch failures to durable retries

### DIFF
--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -74,6 +74,43 @@ class AcquisitionError(RuntimeError):
     """A new-item acquisition could not complete (item-scoped, loud, traced)."""
 
 
+class RetryableSourceAcquisitionError(AcquisitionError):
+    """Expected source-access failure with a safe queue failure classification."""
+
+    def __init__(self, *, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def _caption_failure_for_queue(exc: youtube_plugin.CaptionAcquisitionError) -> RetryableSourceAcquisitionError:
+    """Classify the plugin's expected access failures without persisting provider text.
+
+    ``CaptionAcquisitionError`` is the plugin boundary's explicit operational
+    failure type.  Its detail can include a provider response or a source URL,
+    neither of which belongs in a durable queue row or outbox event.
+    """
+    detail = str(exc).casefold()
+    inaccessible_markers = (
+        "private",
+        "not available",
+        "unavailable",
+        "not found",
+        "does not exist",
+        "has been removed",
+        "sign in",
+        "sign-in",
+        "http error 403",
+        "http error 404",
+    )
+    if any(marker in detail for marker in inaccessible_markers):
+        return RetryableSourceAcquisitionError(
+            reason_code="source_gone", message="YouTube source is inaccessible"
+        )
+    return RetryableSourceAcquisitionError(
+        reason_code="network_error", message="YouTube source fetch failed"
+    )
+
+
 class DatabaseNotConfiguredError(RuntimeError):
     """Raised when the acquisition entrypoint runs without a configured runtime DB.
 
@@ -220,7 +257,10 @@ def acquire_youtube(
     fetch = fetch_fn or youtube_plugin.fetch
     video_id = youtube_plugin.extract_video_id(url_or_id)
 
-    outcome = fetch(url_or_id)
+    try:
+        outcome = fetch(url_or_id)
+    except youtube_plugin.CaptionAcquisitionError as exc:
+        raise _caption_failure_for_queue(exc) from exc
     if not outcome.ok:
         # No raw record was fabricated (youtube_plugin.fetch returns object_id=None on this
         # path) — nothing to dead-letter at a KA-06 stage because there is no raw/content
@@ -419,6 +459,7 @@ def _reload_raw(*, source_kind: str, item_ref: str, content_identity: str) -> di
 __all__ = [
     "YOUTUBE_SOURCE_KIND",
     "AcquisitionError",
+    "RetryableSourceAcquisitionError",
     "DatabaseNotConfiguredError",
     "AcquireStageReceipt",
     "AcquisitionReceipt",

--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -92,14 +92,9 @@ def _caption_failure_for_queue(exc: youtube_plugin.CaptionAcquisitionError) -> R
     detail = str(exc).casefold()
     inaccessible_markers = (
         "private",
-        "not available",
-        "unavailable",
         "not found",
         "does not exist",
         "has been removed",
-        "sign in",
-        "sign-in",
-        "http error 403",
         "http error 404",
     )
     if any(marker in detail for marker in inaccessible_markers):

--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -1264,7 +1264,11 @@ def drain_one(
     (config errors such as ``DatabaseNotConfiguredError`` included) propagate
     loud rather than being folded into queue state.
     """
-    from app.knowledge_acquisition.acquire import AcquisitionError, acquire_youtube
+    from app.knowledge_acquisition.acquire import (
+        AcquisitionError,
+        RetryableSourceAcquisitionError,
+        acquire_youtube,
+    )
     from app.write_guard import DEFAULT_WRITE_GUARD
 
     if request.source_kind != YOUTUBE_SOURCE_KIND:
@@ -1338,7 +1342,7 @@ def drain_one(
     except AcquisitionError as exc:
         return queue.fail(
             request.request_id,
-            reason_code="network_error",
+            reason_code=(exc.reason_code if isinstance(exc, RetryableSourceAcquisitionError) else "network_error"),
             error=exc,
             now=now,
             conn=conn,

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -356,6 +356,39 @@ def test_drain_one_sanitizes_transient_youtube_plugin_failure(
     assert "credential-material" not in persisted
 
 
+@pytest.mark.parametrize(
+    "provider_detail",
+    ("HTTP Error 403: Forbidden", "Sign in to confirm you are not a bot"),
+)
+def test_drain_one_keeps_transient_provider_access_failures_retryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider_detail: str
+) -> None:
+    """Provider throttling and bot checks are not durable source-gone outcomes."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(q, conn)
+    claimed = q.claim_batch(1, conn=conn)
+
+    monkeypatch.setattr(
+        plugin,
+        "yt_dlp_extract_info",
+        lambda _url: (_ for _ in ()).throw(plugin.CaptionAcquisitionError(provider_detail)),
+    )
+
+    result = drain_one(
+        claimed[0],
+        vault_context=_vault(tmp_path / "vault"),
+        queue=q,
+        write_guard=_allowing_guard(),
+        conn=conn,
+    )
+
+    assert result.status == "pending"
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "network_error"
+    assert result.last_failure["error"] == "RetryableSourceAcquisitionError: YouTube source fetch failed"
+
+
 def test_drain_one_maps_pipeline_dead_letter(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -282,6 +282,108 @@ def test_request_durable_before_drain_and_restart_converges(monkeypatch: pytest.
 # ---------------------------------------------------------------------------
 
 
+def test_drain_one_requeues_private_youtube_plugin_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Expected inaccessible-source failures never strand a claimed request."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(q, conn)
+    claimed = q.claim_batch(1, conn=conn)
+
+    monkeypatch.setattr(
+        plugin,
+        "yt_dlp_extract_info",
+        lambda _url: (_ for _ in ()).throw(
+            plugin.CaptionAcquisitionError("private video at https://provider.test/watch?token=secret")
+        ),
+    )
+
+    result = drain_one(
+        claimed[0],
+        vault_context=_vault(tmp_path / "vault"),
+        queue=q,
+        write_guard=_allowing_guard(),
+        conn=conn,
+    )
+
+    assert result.status == "pending"
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "source_gone"
+    assert result.last_failure["error"] == "RetryableSourceAcquisitionError: YouTube source is inaccessible"
+    assert result.next_attempt_at is not None
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed) == 1
+    assert failed[0]["reason_code"] == "source_gone"
+    assert failed[0]["terminal"] is False
+
+
+def test_drain_one_sanitizes_transient_youtube_plugin_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Transient caption egress is retryable and stores no provider detail."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(q, conn)
+    claimed = q.claim_batch(1, conn=conn)
+    _stub_caption_fetch(monkeypatch)
+    monkeypatch.setattr(
+        plugin,
+        "fetch_caption_body",
+        lambda _url: (_ for _ in ()).throw(
+            plugin.CaptionAcquisitionError("upstream timeout cookie=credential-material")
+        ),
+    )
+
+    result = drain_one(
+        claimed[0],
+        vault_context=_vault(tmp_path / "vault"),
+        queue=q,
+        write_guard=_allowing_guard(),
+        conn=conn,
+    )
+
+    assert result.status == "pending"
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "network_error"
+    assert result.last_failure["error"] == "RetryableSourceAcquisitionError: YouTube source fetch failed"
+    assert result.next_attempt_at is not None
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed) == 1
+    assert failed[0]["reason_code"] == "network_error"
+    assert failed[0]["terminal"] is False
+    persisted = json.dumps({"failure": result.last_failure, "event": failed[0]})
+    assert "credential-material" not in persisted
+
+
+def test_drain_one_maps_pipeline_dead_letter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing stage dead-letter behavior remains terminal and item-scoped."""
+    _stub_caption_fetch(monkeypatch)
+    clear_registry()
+    summary_extractor.register(complete=_stub_completion("not json at all"))
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(q, conn)
+    claimed = q.claim_batch(1, conn=conn)
+
+    result = drain_one(
+        claimed[0],
+        vault_context=_vault(tmp_path / "vault"),
+        queue=q,
+        write_guard=_allowing_guard(),
+        conn=conn,
+    )
+
+    assert result.status == "dead_lettered"
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "pipeline_dead_letter"
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed) == 1
+    assert failed[0]["terminal"] is True
+
+
 def test_writeguard_block_reported_and_retryable_at_call_site(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #4762

Refs #4762

Final-Review-Rounds: 1

## Summary
Expected YouTube CaptionAcquisitionError failures now return claimed acquisition requests to the existing retry state machine instead of leaving them in progress. Private or inaccessible sources map to source_gone; transient provider failures map to network_error; persisted queue and event detail is safe.

## BuilderOps Routing
- Records/projections/receipts: dispatcher-backed claim task_id=github-RasmusTho--agentic-pkm-mvp-issue-4762, lease_id=lease-02e8d748, holder=issue_4762.
- Reason: Product runtime code change; no separate BuilderOps record produced.

## Risk and validation
- Risk surfaces: external-api, state-machine.
- Mechanism convergence: explicit CaptionAcquisitionError only; private to source_gone, transient to network_error; provider detail replaced before durable persistence; arbitrary errors remain loud; existing terminal/idempotent transitions unchanged.
- Independent local review: clean at 6ee2d807db95b7121b60e2c9bcb006913a6bb37a after one P1 repair.
- Validation: pytest -q tests/knowledge_acquisition/test_acquisition_requests.py tests/knowledge_acquisition/test_acquire.py tests/knowledge_acquisition/test_youtube_fetch.py (52 passed); ruff check app tests; mypy app; python3 scripts/docs_guard.py --language-only; python3 scripts/review_before_ci_gate.py with external-api and state-machine.
Verified-Closing-Issues: #4762