### PR TITLE
test: enforce YSS settings registry parity

### DIFF
--- a/tests/vault/test_settings_definition_parity.py
+++ b/tests/vault/test_settings_definition_parity.py
@@ -1,0 +1,57 @@
+"""Registry parity checks for initialized and routed vault settings files."""
+
+from __future__ import annotations
+
+from app.vault.manager import _initial_settings_files
+from app.vault.settings_service import (
+    SETTING_DEFINITIONS,
+    VAULT_LOCAL_SETTING_FILES,
+    VAULT_SHARED_SETTING_FILES,
+)
+from app.watcher.settings_delta import SCOPED_SETTINGS_FILENAMES
+
+
+def test_youtube_sync_initializer_seeds_match_registered_defaults() -> None:
+    """YSS defaults have one registry source and are faithfully scaffolded."""
+    initial_files = {
+        filename: frontmatter
+        for filename, frontmatter, _body in _initial_settings_files(
+            vault_id="vault-test",
+            vault_name="Test vault",
+            local_instance_id="local-test",
+            machine_role="primary",
+        )
+    }
+
+    for definition in SETTING_DEFINITIONS:
+        if not definition.key.startswith("youtubeSync."):
+            continue
+
+        expected_file = "local.md" if definition.key == "youtubeSync.runnerEnabled" else "youtube.md"
+        assert definition.file == expected_file
+        assert initial_files[expected_file][definition.key] == definition.default_value
+
+
+def test_registered_owner_files_are_routable_by_scope() -> None:
+    """Each registered vault owner file reaches its scoped service and watcher path."""
+    scoped_files_by_scope = {
+        "vault-shared": set(VAULT_SHARED_SETTING_FILES),
+        "vault-local": set(VAULT_LOCAL_SETTING_FILES),
+    }
+
+    registered_owner_files = {
+        definition.file
+        for definition in SETTING_DEFINITIONS
+        if definition.file is not None
+    }
+    assert registered_owner_files <= set(SCOPED_SETTINGS_FILENAMES)
+
+    for definition in SETTING_DEFINITIONS:
+        if definition.file is None:
+            continue
+        assert definition.file in scoped_files_by_scope[definition.scope]
+
+    # Parameterized control files remain explicit rather than static seeds.
+    assert "vault.md" in VAULT_SHARED_SETTING_FILES
+    assert "local.md" in VAULT_LOCAL_SETTING_FILES
+    assert {"vault.md", "local.md", "youtube.md"} <= set(SCOPED_SETTINGS_FILENAMES)

--- a/tests/vault/test_youtube_sync_settings.py
+++ b/tests/vault/test_youtube_sync_settings.py
@@ -60,20 +60,6 @@ def _init_minimal_vault(vault_root: Path) -> Path:
     return settings_dir
 
 
-_EXPECTED_DEFAULTS: dict[str, object] = {
-    "youtubeSync.enabled": False,
-    "youtubeSync.inboxPollSeconds": 180,
-    "youtubeSync.playlistPollSeconds": 3600,
-    "youtubeSync.subscriptionsPollSeconds": 21600,
-    "youtubeSync.reconcileIntervalDays": 7,
-    "youtubeSync.maxConcurrentAcquisitions": 2,
-    "youtubeSync.subscriptionDefaultPolicy": "discover_only",
-    "youtubeSync.captionsEnabled": True,
-    "youtubeSync.mediaDownloadEnabled": False,
-    "youtubeSync.runnerEnabled": False,
-}
-
-
 def test_subscription_default_policy_matches_registry_contract() -> None:
     """Settings and registry share one pinned acquisition-mode vocabulary."""
     definition = SettingsService().registry.get("youtubeSync.subscriptionDefaultPolicy")
@@ -262,11 +248,13 @@ def test_defaults_scopes_provenance_and_gated_writes(tmp_path: Path) -> None:
 
     # --- 1. Defaults resolve built-in when youtube.md/local.md carry no override ---
     resolution = service.resolve(context)
-    for key, expected in _EXPECTED_DEFAULTS.items():
-        effective = resolution.settings[key]
-        assert effective.value == expected, key
-        assert effective.scope == "built-in", key
-        assert effective.source == "built-in", key
+    for definition in SettingsService().registry.definitions:
+        if not definition.key.startswith("youtubeSync."):
+            continue
+        effective = resolution.settings[definition.key]
+        assert effective.value == definition.default_value, definition.key
+        assert effective.scope == "built-in", definition.key
+        assert effective.source == "built-in", definition.key
 
     # --- 2. RUNTIME_GATING_SETTINGS names exactly the two authority-bearing keys ---
     assert "youtubeSync.enabled" in RUNTIME_GATING_SETTINGS


### PR DESCRIPTION
Governing-Issue: #4760

Fixes #4760

Final-Review-Rounds: 0

## Summary
- Add executable parity coverage from the YSS settings registry to initializer seeds and scoped watcher routing.
- Remove the duplicate YSS defaults mirror now covered by registry-based assertions.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded Tier 2 test-only verification; no operational BuilderOps material was produced.

## Notes
SBS Impact: Product/Runtime settings contract verification only; no shipped runtime behavior or settings values changed.
Validation: pytest -q tests/vault/test_settings_definition_parity.py tests/vault/test_youtube_sync_settings.py; ruff check app tests; mypy app; python3 scripts/docs_guard.py --language-only.