### PR TITLE
test: cover YSS-01 registry migration contract in nightly PG lane

### DIFF
--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -235,12 +235,14 @@ jobs:
             tests/int/test_pg_backend.py \
             tests/api/test_status_store_pg.py \
             tests/indexer/test_outbox_roundtrip_pg.py \
+            tests/knowledge_acquisition/test_source_registry_pg.py::test_pg_backend_contract \
             tests/heimdal/test_entity_review_operation_journal.py \
             tests/migrations/test_entity_review_operation_journal_schema_parity.py \
             tests/migrations/test_file_state_adoption.py \
             tests/migrations/test_objects_adoption.py \
             tests/migrations/test_legacy_objects_fk_migration.py \
             tests/migrations/test_outbox_schema_parity.py \
+            tests/migrations/test_yss01_source_registry_schema_parity.py::test_yss01_migration_bootstrap_parity_and_legacy_repair \
             tests/services/test_outbox_bootstrap_assert_only.py \
             tests/instance/test_file_state_binding_key.py \
             tests/services/test_vault_sync_binding_scope.py \

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -373,3 +373,16 @@ def test_integration_nightly_prepares_pgvector_before_migrations() -> None:
     extension = workflow.index("CREATE EXTENSION IF NOT EXISTS vector")
     migration = workflow.index("alembic upgrade head")
     assert extension < migration
+
+
+def test_integration_nightly_runs_yss01_pg_contract_targets() -> None:
+    workflow = INTEGRATION_NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    pg_contracts = workflow[
+        workflow.index("pg-contracts:") : workflow.index("  k6-search:")
+    ]
+
+    assert "tests/knowledge_acquisition/test_source_registry_pg.py::test_pg_backend_contract" in pg_contracts
+    assert (
+        "tests/migrations/test_yss01_source_registry_schema_parity.py::"
+        "test_yss01_migration_bootstrap_parity_and_legacy_repair"
+    ) in pg_contracts


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Issue-backed bounded workflow repair; workflow files use the Direct Repair lane.
Validation: pytest -q tests/ops/test_ci_workflow.py (23 passed); ruff check tests/ops/test_ci_workflow.py; python3 scripts/docs_guard.py. The workflow-owned pgvector service runs both pg-marked targets after alembic upgrade head.
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4759

## Linked Issue
Fixes #4759

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Product/Runtime System / PDM verification only
- Write class: governance process
- Persistence impact: no production-data change; disposable PostgreSQL migration proof only
- Derived/rebuildable impact: nightly CI evidence gains existing registry-schema proof
- New or changed contract: nightly pg-contracts runs both YSS-01 PostgreSQL targets
- Owner-doc impact: none
- Transition debt impact: reduces migration-verification coverage gap
- Boundary risk: workflow uses only its disposable PostgreSQL service

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds the two existing YSS-01 PostgreSQL contract targets to the disposable nightly pg-contracts job.
- Pins exact placement with a focused workflow regression test.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded CI wiring does not create BuilderOps material.

## Notes
- Local PostgreSQL ports 5432 and 15434 were unavailable; no host assumption was used.