### PR TITLE
Guard entity-review operation identity preconditions

### DIFF
--- a/app/heimdal/entity_confirm.py
+++ b/app/heimdal/entity_confirm.py
@@ -487,7 +487,21 @@ def apply_human_review_decisions(
             "(EROJ-01, INV-EROJ-3), so nothing was applied"
         )
 
-    vault_identity = register.vault_identity
+    if journal is not None and ordered_terminals:
+        if vault_root.expanduser().resolve() != register.vault_root:
+            raise EntityConfirmError(
+                "apply_human_review_decisions: vault_root does not match the "
+                "EntityRegister vault; refusing to claim an operation"
+            )
+        try:
+            vault_identity = register.operation_vault_identity
+        except EntityRegisterError as exc:
+            raise EntityConfirmError(
+                "apply_human_review_decisions: refusing entity-review operation "
+                f"identity: {exc}"
+            ) from exc
+    else:
+        vault_identity = register.vault_identity
 
     for index, effective_decision in ordered_terminals:
         merged = False

--- a/app/heimdal/entity_register.py
+++ b/app/heimdal/entity_register.py
@@ -66,6 +66,7 @@ from app.events.types import (
 )
 from app.knowledge.write_ops import write_note_relative
 from app.services.outbox import derive_idempotency_key, write_outbox_event
+from app.vault.markdown_settings import MarkdownSettingsError, MarkdownSettingsStore
 from app.vault.manager import VaultContext
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 
@@ -282,7 +283,14 @@ class EntityRegister:
         # respelling of the same selected vault must NOT re-derive
         # entity-review operation ids — that silently duplicates merge events
         # instead of resuming (review F7 on #4350).
-        self._vault_identity = vault_context.active_vault_id or str(self._vault_root)
+        active_vault_id = vault_context.active_vault_id
+        if active_vault_id == "":
+            raise EntityRegisterError(
+                "vault_context.active_vault_id must not be empty; "
+                "entity-review operation identity cannot fall back silently"
+            )
+        self._vault_identity = active_vault_id or str(self._vault_root)
+        self._active_vault_id = active_vault_id
         self._write_guard = write_guard
         self._register_dir = register_dir
         self._conn = conn
@@ -291,6 +299,53 @@ class EntityRegister:
     def vault_identity(self) -> str:
         """Stable identity of the vault this register is bound to."""
         return self._vault_identity
+
+    @property
+    def vault_root(self) -> Path:
+        """Resolved vault root bound to this register."""
+        return self._vault_root
+
+    @property
+    def operation_vault_identity(self) -> str:
+        """Return the selection-owned identity permitted for EROJ operations.
+
+        Generic register mutations can still run in an explicitly supplied
+        path-only context, but an entity-review journal row cannot: a path
+        fallback and a selection id for the same vault would otherwise mint
+        different operation namespaces.  The context id must agree with the
+        root-local, vault-selection authority in ``settings/vault.md``;
+        callers cannot establish operation identity by choosing an id shape.
+        """
+        if self._active_vault_id is None:
+            raise EntityRegisterError(
+                "entity-review operation identity requires a vault-scoped "
+                "vault_context.active_vault_id; refusing path fallback"
+            )
+        try:
+            vault_doc = MarkdownSettingsStore().read(self._vault_root / "settings" / "vault.md")
+        except (OSError, MarkdownSettingsError) as exc:
+            raise EntityRegisterError(
+                "entity-review operation identity requires a vault-scoped "
+                "settings/vault.md selection authority"
+            ) from exc
+        if vault_doc.frontmatter.get("schema") != "design-handoff.vault.v1":
+            raise EntityRegisterError(
+                "entity-review operation identity requires canonical "
+                "settings/vault.md schema design-handoff.vault.v1"
+            )
+        persisted_vault_id = vault_doc.frontmatter.get("vaultId")
+        if not isinstance(persisted_vault_id, str) or not persisted_vault_id:
+            raise EntityRegisterError(
+                "entity-review operation identity requires a non-empty vaultId "
+                "in settings/vault.md"
+            )
+        if persisted_vault_id != self._active_vault_id:
+            raise EntityRegisterError(
+                "entity-review operation identity requires active_vault_id to "
+                "match settings/vault.md vaultId; refusing synthetic identity "
+                f"{self._active_vault_id!r}"
+            )
+        return self._active_vault_id
 
     # -- internal note IO ---------------------------------------------------
 

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -744,7 +744,8 @@ audited `app/heimdal/entity_review_operation_journal.py` autocreate shape;
 `ensure_journal_schema()` is assert-only outside tests (`STORE_SCHEMA_AUTOCREATE=1` opts test
 fixtures into create-on-demand):
 - `entity_review_operations`
-  - `operation_id` (`uuid`, PK) — deterministic over the INV-EROJ-2 tuple (active vault identity,
+  - `operation_id` (`uuid`, PK) — deterministic over the INV-EROJ-2 tuple (the selection-owned,
+    vault-scoped `active_vault_id`,
     queue entry id, decision-list position, SHA-256 digest of the exact human decision mapping,
     original `from_id`, original `into_id`)
   - `vault_identity` (`text`)

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -259,6 +259,11 @@ class _LoggingRegister(EntityRegister):
 def _vault_root(tmp_path: Path) -> Path:
     root = tmp_path / "vault"
     root.mkdir(parents=True, exist_ok=True)
+    (root / "settings").mkdir(exist_ok=True)
+    (root / "settings" / "vault.md").write_text(
+        "---\nschema: design-handoff.vault.v1\nvaultId: vault-test\n---\n",
+        encoding="utf-8",
+    )
     return root
 
 
@@ -384,6 +389,37 @@ def test_merge_writes_redirect_and_is_reversible(tmp_path: Path) -> None:
     assert restored_entry.lifecycle == LIFECYCLE_CANONICAL
     assert anna_gym in restored_entry.merged_from
 
+
+def test_applicator_refuses_vault_root_register_mismatch(tmp_path: Path) -> None:
+    register_root = _vault_root(tmp_path / "register")
+    applicator_root = _vault_root(tmp_path / "applicator")
+    register = _register(register_root)
+    source = register.mint_canonical("Anna fran gymmet")
+    target = register.mint_canonical("Anna Svensson")
+    entry = queue_for_review(
+        applicator_root,
+        _mention(resolution=RESOLUTION_AMBIGUOUS, confidence=0.75),
+        candidate_entity_ids=[source, target],
+    )
+    write_settings_note(
+        applicator_root,
+        SettingsNote(
+            spec=ENTITY_REVIEW,
+            values={
+                "pending": [item.to_dict() for item in pending_review_entries(applicator_root)],
+                "decisions": [
+                    ReviewDecision(queue_entry_id=entry.queue_entry_id, action="reject").to_dict()
+                ],
+            },
+        ),
+        settings_dir=DEFAULT_SETTINGS_DIR,
+        write_guard=_allowing_guard(),
+    )
+
+    with pytest.raises(EntityConfirmError, match="does not match"):
+        apply_human_review_decisions(
+            applicator_root, register=register, journal=_InMemoryJournal()
+        )
 
 def test_reject_decision_clears_queue_without_register_mutation(tmp_path: Path) -> None:
     vault_root = _vault_root(tmp_path)

--- a/tests/heimdal/test_entity_register.py
+++ b/tests/heimdal/test_entity_register.py
@@ -135,6 +135,42 @@ def _register(tmp_path: Path, *, conn: Any = None, guard: WriteGuard | None = No
     )
 
 
+def test_empty_active_vault_id_fails_loud(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    with pytest.raises(EntityRegisterError, match="must not be empty"):
+        EntityRegister(
+            vault_context=VaultContext(
+                status="selected",
+                active_vault_id="",
+                active_vault_path=str(vault_root),
+            ),
+            write_guard=_allowing_guard(),
+        )
+
+
+def test_operation_vault_identity_refuses_noncanonical_vault_schema(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = vault_root / "settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "vault.md").write_text(
+        "---\nschema: attacker.not-a-vault.v1\nvaultId: vault-synthetic\n---\n",
+        encoding="utf-8",
+    )
+    register = EntityRegister(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-synthetic",
+            active_vault_path=str(vault_root),
+        ),
+        write_guard=_allowing_guard(),
+    )
+
+    with pytest.raises(EntityRegisterError, match="canonical"):
+        _ = register.operation_vault_identity
+
+
 # ---------------------------------------------------------------------------
 # AC: split(entity_id, partition_criteria) exists and a merge followed by a
 # matching split restores the pre-merge identities (reversibility).

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -228,6 +228,11 @@ class _CrashingRegister(EntityRegister):
 def _vault_root(tmp_path: Path) -> Path:
     root = tmp_path / "vault"
     root.mkdir(parents=True, exist_ok=True)
+    (root / "settings").mkdir(exist_ok=True)
+    (root / "settings" / "vault.md").write_text(
+        "---\nschema: design-handoff.vault.v1\nvaultId: vault-test\n---\n",
+        encoding="utf-8",
+    )
     return root
 
 
@@ -313,6 +318,54 @@ def _claim_kwargs(
         "from_id": from_id,
         "into_id": into_id,
     }
+
+
+def test_operation_identity_agrees_across_id_present_and_absent_construction(
+    tmp_path: Path,
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    selected = _register(vault_root)
+    path_only = EntityRegister(
+        vault_context=VaultContext(status="selected", active_vault_path=str(vault_root)),
+        write_guard=_allowing_guard(),
+    )
+
+    assert selected.operation_vault_identity == "vault-test"
+    with pytest.raises(EntityRegisterError, match="refusing path fallback"):
+        _ = path_only.operation_vault_identity
+
+
+def test_synthetic_vault_identity_is_refused_for_operation_binding(tmp_path: Path) -> None:
+    first_root = _vault_root(tmp_path / "first")
+    second_root = _vault_root(tmp_path / "second")
+    (first_root / "settings" / "vault.md").write_text(
+        "---\nschema: design-handoff.vault.v1\nvaultId: vault-first\n---\n",
+        encoding="utf-8",
+    )
+    (second_root / "settings" / "vault.md").write_text(
+        "---\nschema: design-handoff.vault.v1\nvaultId: vault-second\n---\n",
+        encoding="utf-8",
+    )
+    first = EntityRegister(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-attacker-controlled-shared",
+            active_vault_path=str(first_root),
+        ),
+        write_guard=_allowing_guard(),
+    )
+    second = EntityRegister(
+        vault_context=VaultContext(
+            status="selected",
+            active_vault_id="vault-attacker-controlled-shared",
+            active_vault_path=str(second_root),
+        ),
+        write_guard=_allowing_guard(),
+    )
+
+    for register in (first, second):
+        with pytest.raises(EntityRegisterError, match="refusing synthetic identity"):
+            _ = register.operation_vault_identity
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Governing-Issue: #4462

Refs #4462

Final-Review-Rounds: 1

## Summary
Require entity-review journal claims to bind the selected vault id to canonical root-local settings authority, and reject cross-root applicator/register use before any journal access.

## BuilderOps Routing
- Records/projections/receipts: #4462 convergence receipt https://github.com/RasmusTho/agentic-pkm-mvp/issues/4462#issuecomment-5262294477
- Reason: High-risk identity precondition convergence after two P1 review findings; GitHub current-head P1 repair was re-reviewed independently.

## Notes
Validation: focused AC matrix (4 passed, 2 PG-skipped); `python3 -m pytest -q -m "not pg" tests/heimdal` (622 passed, 1 skipped, 19 deselected, 9 xfailed); `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py --language-only`. Independent high-capability convergence review accepted exact head 466f70a7dd07e36aab676a3d73eb113a8c2d174d. Current PR head: 466f70a7dd07e36aab676a3d73eb113a8c2d174d.
---
Verified-Closing-Issues: #4462