### PR TITLE
docs: clarify PostgreSQL projection boundary behavior

### DIFF
--- a/docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md
+++ b/docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md
@@ -69,9 +69,13 @@ note-store+projection pattern (`docs/EPISODE_RESOLUTION_ENGINE/EPISODE_NOTE_STOR
    `2016-12-31T23:59:60Z` is stored as `2017-01-01 00:00:00+00`, one second later, on all 27
    announced dates; and (b) fractional seconds past the microsecond `TIMESTAMPTZ` resolves to are
    truncated, never rounded, since RFC 3339's `time-secfrac` is unbounded. Both folds happen in the
-   projector, not in Postgres: forwarding a `:60` literal or an over-long fraction to the server is a
-   hard error that aborts the whole TRUNCATE+replay rebuild, so bounding them here is what keeps the
-   projection rebuildable for every value the write seam accepts. Both are query-surface
+   projector, not in Postgres: a zero-fraction `:60` literal would be accepted and folded by the
+   server, while a fractional `:60` literal errors; ordinary fractions beyond microsecond precision
+   can be accepted and rounded, while literals exceeding the server's input-length limit error. The
+   projector folds leap seconds and truncates fractions, never rounds them, so a server-side rounding
+   carry cannot alter a second or cross a day boundary after a folded leap second. This makes the
+   projection's chosen approximation explicit and keeps every value the write seam accepts
+   rebuildable. Both are query-surface
    approximations, not a loss of canonical truth — the vault's canonical RFC 3339 strings remain
    unchanged and the projection fully rebuilds from them; `evidence[].matched_at` remains unchanged
    inside JSON rather than being adapted as a database timestamp.


### PR DESCRIPTION
## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4216

## Linked Issue
Closes #4216

## SBS Impact
- Primary subsystem: Standing Questions projection
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: Corrects documented behavior of the rebuildable projection.
- New or changed contract: none; documents existing behavior
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces
- Boundary risk: Must not imply permission to rewrite canonical vault timestamps.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Correct the Standing Questions owner doc's PostgreSQL 16 boundary behavior without changing runtime behavior or canonical vault timestamps.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-only correction; the stale-contract reconciliation is captured on Issue #4216.

## Notes
Validation: `python3 scripts/docs_guard.py` (pass); exact owner-document Verify targets inspected against `app/standing_questions/projection.py :: _postgres_timestamptz_value`.
