### PR TITLE
Harden YouTube OAuth credential durability

### DIFF
--- a/app/knowledge_acquisition/youtube_account_binding.py
+++ b/app/knowledge_acquisition/youtube_account_binding.py
@@ -58,6 +58,10 @@ class DuplicateAccountBindingError(ValueError):
     """Raised when a binding for the same provider channel id already exists."""
 
 
+class AccountBindingAdmissionError(RuntimeError):
+    """The V1 one-account writer cannot admit this connect transition."""
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -461,6 +465,31 @@ class AccountBindingStore:
     def list_all(self) -> tuple[AccountBinding, ...]:
         return self._backend.list_all()
 
+    def admit_single_account_writer(
+        self, *, reconnect_binding_id: str | None
+    ) -> AccountBinding | None:
+        """Validate the V1 singleton while the caller holds writer admission.
+
+        The cross-process lease lives beside encrypted credentials; this store
+        remains the durable authority for whether the admitted transition is a
+        first connection or a reconnect of the sole existing account.
+        """
+
+        bindings = self.list_all()
+        if len(bindings) > 1:
+            raise AccountBindingAdmissionError(
+                "YouTube OAuth V1 requires exactly zero or one durable account binding"
+            )
+        if reconnect_binding_id is None:
+            if bindings:
+                raise AccountBindingAdmissionError(
+                    "YouTube OAuth V1 already has one durable account binding"
+                )
+            return None
+        if not bindings or bindings[0].account_binding_id != reconnect_binding_id:
+            raise KeyError(f"no such account binding: {reconnect_binding_id}")
+        return bindings[0]
+
     def set_state(
         self, account_binding_id: str, *, state: str, reason_code: str | None = None
     ) -> AccountBinding:
@@ -473,6 +502,7 @@ class AccountBindingStore:
 
 __all__ = [
     "AccountBinding",
+    "AccountBindingAdmissionError",
     "AccountBindingSchemaMissingError",
     "AccountBindingStore",
     "AccountBindingValidationError",

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -42,7 +42,7 @@ import os
 import secrets
 import threading
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 from urllib.parse import urlencode, urlsplit
@@ -52,6 +52,7 @@ import httpx
 from app.knowledge_acquisition.source_registry import SourceRegistry
 from app.knowledge_acquisition.youtube_account_binding import AccountBinding, AccountBindingStore
 from app.knowledge_acquisition.youtube_token_store import (
+    OAuthWriterAdmission,
     StoredToken,
     TokenStoreKeyMissingError,
     YouTubeTokenStore,
@@ -320,6 +321,9 @@ class DeviceConnection:
 
     handle: DeviceFlowHandle
     reconnect_binding_id: str | None = None
+    _writer_admission: OAuthWriterAdmission | None = field(
+        default=None, repr=False, compare=False
+    )
 
     def public_view(self) -> dict[str, Any]:
         return self.handle.public_view()
@@ -541,7 +545,7 @@ class TokenProvider:
         binding_id: str,
         token_store: YouTubeTokenStore,
         oauth_client: OAuthClient,
-        binding_store: AccountBindingStore | None = None,
+        binding_store: AccountBindingStore,
         source_registry: SourceRegistry | None = None,
         skew_seconds: int = _ACCESS_TOKEN_SKEW_SECONDS,
     ) -> None:
@@ -564,6 +568,11 @@ class TokenProvider:
             return self._refresh(token)
 
     def _read_token(self) -> StoredToken:
+        binding = self._bindings.get(self._binding_id)
+        if binding is None:
+            raise AuthDegradedError(
+                "auth_missing", "no durable account binding for this credential"
+            )
         try:
             token = self._store.get(self._binding_id)
         except TokenStoreKeyMissingError:
@@ -572,6 +581,11 @@ class TokenProvider:
         if token is None:
             self._degrade("auth_missing")
             raise AuthDegradedError("auth_missing", "no token stored for this binding")
+        if token.provider_channel_id != binding.provider_channel_id:
+            self._degrade("auth_missing")
+            raise AuthDegradedError(
+                "auth_missing", "stored credential identity does not match its binding"
+            )
         return token
 
     def _is_fresh(self, token: StoredToken) -> bool:
@@ -606,17 +620,14 @@ class TokenProvider:
 
     def _degrade(self, reason_code: str) -> None:
         """Stamp the reason on the binding + dependent sources; no cursor touched."""
-        if self._bindings is not None:
-            binding = self._bindings.get(self._binding_id)
-            if binding is not None:
-                self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
+        binding = self._bindings.get(self._binding_id)
+        if binding is not None:
+            self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
         if self._registry is not None:
             for source in self._registry.list_for_account(self._binding_id):
                 self._registry.record_source_degradation(source.binding_id, reason_code=reason_code)
 
     def _clear_degradation(self) -> None:
-        if self._bindings is None:
-            return
         binding = self._bindings.get(self._binding_id)
         if binding is not None and binding.state != "connected":
             self._bindings.set_state(self._binding_id, state="connected", reason_code=None)
@@ -651,12 +662,37 @@ class YouTubeAccountBinder:
     # -- connect (device flow) ------------------------------------------------
 
     def start_device_connection(self) -> DeviceConnection:
-        return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=None)
+        return self._start_connection(reconnect_binding_id=None)
 
     def start_reconnect(self, binding_id: str) -> DeviceConnection:
-        if self._bindings.get(binding_id) is None:
-            raise KeyError(f"no such account binding: {binding_id}")
-        return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=binding_id)
+        return self._start_connection(reconnect_binding_id=binding_id)
+
+    def _start_connection(self, *, reconnect_binding_id: str | None) -> DeviceConnection:
+        admission = self._store.acquire_writer_admission()
+        try:
+            self._reconcile_orphan_credentials()
+            self._bindings.admit_single_account_writer(
+                reconnect_binding_id=reconnect_binding_id
+            )
+            handle = self._client.start_device_flow()
+        except BaseException:
+            admission.release()
+            raise
+        return DeviceConnection(
+            handle=handle,
+            reconnect_binding_id=reconnect_binding_id,
+            _writer_admission=admission,
+        )
+
+    def _reconcile_orphan_credentials(self) -> None:
+        """Delete only ciphertext ids with no durable account-binding ancestor."""
+
+        bound_ids = {
+            binding.account_binding_id for binding in self._bindings.list_all()
+        }
+        for binding_id in self._store.binding_ids():
+            if binding_id not in bound_ids:
+                self._store.delete(binding_id)
 
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
         """Complete one device poll, persist tokens encrypted, bind the account.
@@ -665,8 +701,20 @@ class YouTubeAccountBinder:
         material. Raises :class:`DeviceAuthorizationPending` if the user has not
         approved yet (the caller re-polls after ``interval``).
         """
-        bundle = self._client.poll_device_flow(connection.handle.device_code)
-        return self._bind_from_bundle(bundle, connection.reconnect_binding_id)
+        admission = connection._writer_admission
+        if admission is None or admission.released:
+            raise RuntimeError("device connection has no active OAuth writer admission")
+        try:
+            bundle = self._client.poll_device_flow(connection.handle.device_code)
+        except DeviceAuthorizationPending:
+            raise
+        except BaseException:
+            admission.release()
+            raise
+        try:
+            return self._bind_from_bundle(bundle, connection.reconnect_binding_id)
+        finally:
+            admission.release()
 
     def _bind_from_bundle(self, bundle: TokenBundle, reconnect_binding_id: str | None) -> dict[str, Any]:
         if not bundle.refresh_token:
@@ -692,6 +740,10 @@ class YouTubeAccountBinder:
         # leave a connected projection with no credential behind it (#3990).
         self._store.put(binding_id, token)
         if binding is None:
+            # Do not delete the token if this write raises: a transport failure
+            # can be an indeterminate commit. The token remains non-authoritative
+            # without a binding row, and the next admitted start reconciles it
+            # from durable binding truth without risking a committed credential.
             binding = self._bindings.create(
                 provider_channel_id=identity.channel_id,
                 display_label=identity.channel_title,
@@ -751,7 +803,10 @@ class YouTubeAccountBinder:
                     state, reason_code = "degraded", "auth_missing"
                 else:
                     token = self._store.get(binding_id)
-                    if token is None:
+                    if (
+                        token is None
+                        or token.provider_channel_id != binding.provider_channel_id
+                    ):
                         state, reason_code = "degraded", "auth_missing"
             except Exception:  # fail closed without exposing store/decryption detail
                 state, reason_code = "degraded", "auth_key_missing"

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -10,7 +10,8 @@ read plaintext when the key is absent.
 Boundary (INV-YSS-5 / INV-YSS-7):
 
 - The store file path is an **app-local** binding, defaulting under the
-  channel runtime dir (``runtime/knowledge_acquisition/``); it is never placed
+  canonical channel runtime-artifact root (``tmp*/knowledge_acquisition/``);
+  it is independent of process CWD/worktree and is never placed
   inside a vault and never tracked by git. Per-channel isolation (dev/test/prod
   never share OAuth state) comes from the per-channel runtime dir / the
   ``YOUTUBE_TOKEN_STORE_PATH`` override, exactly as the dispatcher isolates its
@@ -30,9 +31,12 @@ Boundary (INV-YSS-5 / INV-YSS-7):
 from __future__ import annotations
 
 import base64
+import fcntl
 import json
 import os
+import stat
 import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,13 +44,19 @@ from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from app.config.environment import active_environment
+from app.config.paths import resolve_runtime_artifact_path
+
 KEY_ENV_VAR = "YOUTUBE_TOKEN_STORE_KEY"
 PATH_ENV_VAR = "YOUTUBE_TOKEN_STORE_PATH"
 
 _AES_KEY_BYTES = 32  # AES-256
 _NONCE_BYTES = 12  # standard AES-GCM nonce size
 _SCHEMA = "youtube-token-store.v1"
-_DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
+_STATE_DIRECTORY = "knowledge_acquisition"
+_TOKEN_STORE_FILENAME = "youtube_token_store.enc"
+_WRITER_LOCK_FILENAME = "youtube_oauth_writer.lock"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class TokenStoreKeyMissingError(RuntimeError):
@@ -56,6 +66,14 @@ class TokenStoreKeyMissingError(RuntimeError):
     ``auth_key_missing`` reason code (INV-YSS-4); it is never swallowed into a
     silent plaintext path.
     """
+
+
+class OAuthStateBoundaryError(RuntimeError):
+    """The private channel OAuth state boundary is absent or unsafe."""
+
+
+class OAuthWriterAdmissionError(RuntimeError):
+    """Another process owns the channel's one OAuth writer transition."""
 
 
 def resolve_token_store_key() -> bytes:
@@ -84,12 +102,73 @@ def resolve_token_store_key() -> bytes:
     return key
 
 
-def default_token_store_path() -> Path:
-    """App-local default path, overridable per channel via ``YOUTUBE_TOKEN_STORE_PATH``."""
+def _canonical_repository_root() -> Path:
+    """Resolve the shared checkout root when running from a Git worktree."""
+
+    try:
+        dot_git = _REPO_ROOT / ".git"
+        if dot_git.is_dir():
+            return _REPO_ROOT
+        if dot_git.is_file():
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if marker.startswith("gitdir:"):
+                git_dir = Path(marker.removeprefix("gitdir:").strip())
+                if not git_dir.is_absolute():
+                    git_dir = _REPO_ROOT / git_dir
+                common_marker = git_dir / "commondir"
+                if common_marker.is_file():
+                    common = Path(common_marker.read_text(encoding="utf-8").strip())
+                    if not common.is_absolute():
+                        common = git_dir / common
+                    return common.resolve(strict=True).parent
+    except OSError:
+        pass
+    raise OAuthStateBoundaryError(
+        "canonical channel runtime-artifact root is not configured"
+    )
+
+
+def canonical_oauth_state_root() -> Path:
+    """Resolve one checkout-independent private root inside channel artifacts."""
+
+    configured_outbox = (os.environ.get("INDEX_OUTBOX_PATH") or "").strip()
+    if configured_outbox:
+        outbox = Path(configured_outbox).expanduser()
+        if not outbox.is_absolute():
+            raise OAuthStateBoundaryError(
+                "channel runtime-artifact authority must be an absolute path"
+            )
+        runtime_root = Path(os.path.abspath(outbox.parent))
+    else:
+        scoped = resolve_runtime_artifact_path(
+            Path("tmp/index-outbox.jsonl"), environment=active_environment()
+        )
+        runtime_root = _canonical_repository_root() / scoped.parent
+    if not runtime_root.is_absolute():
+        raise OAuthStateBoundaryError(
+            "channel runtime-artifact authority must be an absolute path"
+        )
+    return runtime_root / _STATE_DIRECTORY
+
+
+def _token_store_path(state_root: Path) -> Path:
     override = (os.environ.get(PATH_ENV_VAR) or "").strip()
-    if override:
-        return Path(override).expanduser()
-    return _DEFAULT_REL_PATH
+    candidate = Path(override).expanduser() if override else state_root / _TOKEN_STORE_FILENAME
+    if not candidate.is_absolute():
+        candidate = state_root / candidate
+    candidate = Path(os.path.abspath(candidate))
+    normalized_root = Path(os.path.abspath(state_root))
+    if candidate.parent != normalized_root or candidate.name in {"", ".", ".."}:
+        raise OAuthStateBoundaryError(
+            "YouTube OAuth state must remain inside the private channel runtime boundary"
+        )
+    return candidate
+
+
+def default_token_store_path() -> Path:
+    """Channel-rooted path, optionally renamed only inside the same private root."""
+
+    return _token_store_path(canonical_oauth_state_root())
 
 
 def _now_iso() -> str:
@@ -153,19 +232,53 @@ class StoredToken:
         )
 
 
+class OAuthWriterAdmission:
+    """Held file descriptor for one start-to-finish OAuth writer transition."""
+
+    def __init__(self, descriptor: int) -> None:
+        self._descriptor = descriptor
+        self._released = False
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        try:
+            fcntl.flock(self._descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(self._descriptor)
+
+    def __repr__(self) -> str:
+        return "OAuthWriterAdmission(path=***)"
+
+
 class YouTubeTokenStore:
     """AES-256-GCM encrypted token store, one JSON file, one record per binding.
 
-    Thread-safe for concurrent access within a process; cross-process safety is
-    provided by an atomic replace on every write.
+    Thread-safe for concurrent access within a process. Atomic replacement
+    prevents partial records; the writer admission serializes connect/reconnect
+    transitions across processes.
     """
 
     def __init__(self, path: Path | str | None = None) -> None:
-        self._path = Path(path) if path is not None else default_token_store_path()
+        if path is None:
+            state_root = canonical_oauth_state_root()
+            self._path = _token_store_path(state_root)
+            self._channel_runtime_root: Path | None = state_root.parent
+        else:
+            explicit = Path(path).expanduser()
+            if not explicit.is_absolute():
+                raise OAuthStateBoundaryError("explicit OAuth state path must be absolute")
+            self._path = Path(os.path.abspath(explicit))
+            self._channel_runtime_root = None
         self._lock = threading.Lock()
 
     def __repr__(self) -> str:
-        return f"YouTubeTokenStore(path={str(self._path)!r})"
+        return "YouTubeTokenStore(path=***)"
 
     @property
     def path(self) -> Path:
@@ -173,21 +286,248 @@ class YouTubeTokenStore:
 
     # --- file helpers (no key required) -------------------------------------
 
-    def _load_file(self) -> dict[str, Any]:
+    @staticmethod
+    def _assert_private_directory(metadata: os.stat_result) -> None:
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_mode & 0o777 != 0o700
+            or metadata.st_uid != os.geteuid()
+        ):
+            raise OAuthStateBoundaryError(
+                "YouTube OAuth state directory must be a current-user-owned mode-0700 directory"
+            )
+
+    @staticmethod
+    def _assert_private_file(metadata: os.stat_result) -> None:
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_mode & 0o777 != 0o600
+            or metadata.st_uid != os.geteuid()
+        ):
+            raise OAuthStateBoundaryError(
+                "YouTube OAuth state file must be a current-user-owned mode-0600 regular file"
+            )
+
+    @staticmethod
+    def _assert_safe_runtime_directory(metadata: os.stat_result) -> None:
+        """Accept a private root or the shipped sticky shared scratch root."""
+
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise OAuthStateBoundaryError(
+                "channel runtime-artifact root is not a safe directory"
+            )
+        writable_by_others = bool(metadata.st_mode & 0o022)
+        sticky = bool(metadata.st_mode & stat.S_ISVTX)
+        if writable_by_others and not sticky:
+            raise OAuthStateBoundaryError(
+                "channel runtime-artifact root is not a safe directory"
+            )
+
+    @staticmethod
+    def _assert_no_symlink_ancestry(path: Path, *, allow_missing_leaf: bool) -> None:
+        """Reject traversal through a symlink before opening private state."""
+
+        if not path.is_absolute():
+            raise OAuthStateBoundaryError("OAuth state boundary must be absolute")
+        current = Path(path.anchor)
+        parts = path.parts[1:]
+        for index, component in enumerate(parts):
+            current /= component
+            try:
+                metadata = current.lstat()
+            except FileNotFoundError:
+                if allow_missing_leaf and index == len(parts) - 1:
+                    return
+                raise OAuthStateBoundaryError(
+                    "OAuth state boundary has a missing ancestor"
+                ) from None
+            except OSError:
+                raise OAuthStateBoundaryError(
+                    "OAuth state boundary ancestry is unavailable"
+                ) from None
+            if stat.S_ISLNK(metadata.st_mode):
+                raise OAuthStateBoundaryError(
+                    "OAuth state boundary must not traverse symlinks"
+                )
+            if index != len(parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+                raise OAuthStateBoundaryError(
+                    "OAuth state boundary ancestry must contain only directories"
+                )
+
+    def _open_state_directory(self) -> int:
+        parent = self._path.parent
+        self._assert_no_symlink_ancestry(parent, allow_missing_leaf=True)
+        if self._channel_runtime_root is not None:
+            try:
+                self._assert_no_symlink_ancestry(
+                    self._channel_runtime_root, allow_missing_leaf=False
+                )
+                flags = (
+                    os.O_RDONLY
+                    | getattr(os, "O_DIRECTORY", 0)
+                    | getattr(os, "O_NOFOLLOW", 0)
+                )
+                runtime_fd = os.open(self._channel_runtime_root, flags)
+            except FileNotFoundError:
+                raise OAuthStateBoundaryError(
+                    "canonical channel runtime-artifact root does not exist"
+                ) from None
+            except OSError:
+                raise OAuthStateBoundaryError(
+                    "canonical channel runtime-artifact root is unavailable"
+                ) from None
+            runtime_metadata = os.fstat(runtime_fd)
+            try:
+                self._assert_safe_runtime_directory(runtime_metadata)
+            except OAuthStateBoundaryError:
+                os.close(runtime_fd)
+                raise
+            try:
+                try:
+                    os.mkdir(_STATE_DIRECTORY, mode=0o700, dir_fd=runtime_fd)
+                except FileExistsError:
+                    pass
+                descriptor = os.open(_STATE_DIRECTORY, flags, dir_fd=runtime_fd)
+            except OSError:
+                raise OAuthStateBoundaryError(
+                    "private YouTube OAuth state directory is unavailable"
+                ) from None
+            finally:
+                os.close(runtime_fd)
+        else:
+            try:
+                metadata = parent.lstat()
+            except FileNotFoundError:
+                try:
+                    parent.mkdir(mode=0o700)
+                except FileExistsError:
+                    pass
+                except OSError:
+                    raise OAuthStateBoundaryError(
+                        "private YouTube OAuth state directory is unavailable"
+                    ) from None
+                metadata = parent.lstat()
+            self._assert_private_directory(metadata)
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            try:
+                descriptor = os.open(parent, flags)
+            except OSError:
+                raise OAuthStateBoundaryError(
+                    "private YouTube OAuth state directory is unavailable"
+                ) from None
         try:
-            raw = self._path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            return {"schema": _SCHEMA, "records": {}}
+            self._assert_private_directory(os.fstat(descriptor))
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+
+    def _load_file(self) -> dict[str, Any]:
+        directory_fd = self._open_state_directory()
+        try:
+            try:
+                descriptor = os.open(
+                    self._path.name,
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=directory_fd,
+                )
+            except FileNotFoundError:
+                return {"schema": _SCHEMA, "records": {}}
+            try:
+                self._assert_private_file(os.fstat(descriptor))
+                with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+                    raw = handle.read()
+            except BaseException:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+                raise
+        finally:
+            os.close(directory_fd)
         data = json.loads(raw)
         if not isinstance(data, dict) or "records" not in data:
-            raise ValueError(f"corrupt token store file at {self._path}")
+            raise ValueError("corrupt YouTube token store")
         return data
 
     def _write_file(self, data: dict[str, Any]) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
-        os.replace(tmp, self._path)
+        directory_fd = self._open_state_directory()
+        temporary_name = f".{self._path.name}.{uuid.uuid4().hex}.tmp"
+        descriptor: int | None = None
+        try:
+            try:
+                existing = os.open(
+                    self._path.name,
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=directory_fd,
+                )
+            except FileNotFoundError:
+                existing = None
+            if existing is not None:
+                try:
+                    self._assert_private_file(os.fstat(existing))
+                finally:
+                    os.close(existing)
+            descriptor = os.open(
+                temporary_name,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=directory_fd,
+            )
+            payload = json.dumps(data, sort_keys=True).encode("utf-8")
+            with os.fdopen(descriptor, "wb") as handle:
+                descriptor = None
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(
+                temporary_name,
+                self._path.name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
+            os.fsync(directory_fd)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            try:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except FileNotFoundError:
+                pass
+            os.close(directory_fd)
+
+    def acquire_writer_admission(self) -> OAuthWriterAdmission:
+        """Acquire the channel's nonblocking cross-process OAuth writer lease."""
+
+        directory_fd = self._open_state_directory()
+        try:
+            descriptor = os.open(
+                _WRITER_LOCK_FILENAME,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=directory_fd,
+            )
+            try:
+                self._assert_private_file(os.fstat(descriptor))
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    raise OAuthWriterAdmissionError(
+                        "another YouTube OAuth writer transition is active"
+                    ) from None
+            except BaseException:
+                os.close(descriptor)
+                raise
+            return OAuthWriterAdmission(descriptor)
+        finally:
+            os.close(directory_fd)
 
     def has_record(self, binding_id: str) -> bool:
         """True if a token record exists for ``binding_id`` (no key required)."""
@@ -249,10 +589,14 @@ class YouTubeTokenStore:
 
 __all__ = [
     "KEY_ENV_VAR",
+    "OAuthStateBoundaryError",
+    "OAuthWriterAdmission",
+    "OAuthWriterAdmissionError",
     "PATH_ENV_VAR",
     "StoredToken",
     "TokenStoreKeyMissingError",
     "YouTubeTokenStore",
+    "canonical_oauth_state_root",
     "default_token_store_path",
     "resolve_token_store_key",
 ]

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -107,10 +107,26 @@ Keychain-bootstrap boundary.
 
 ## Restart / Durability Posture
 
-Bindings and encrypted tokens survive restart on disk (app-local, per channel). A restart with a
-missing key degrades to `auth_key_missing` — visible, fail-closed, recoverable by re-provisioning
-the key; consent is not silently re-requested. In-flight device-flow sessions do not survive
-restart; the user simply restarts the connect step (the UI/CLI says so).
+Bindings and encrypted tokens survive restart on disk. The encrypted token file and the shared
+connect/reconnect admission lock live in a private `knowledge_acquisition/` directory under the
+canonical channel runtime-artifact root, independent of process CWD or linked worktree. The writer
+refuses path escape, symlink traversal, non-sticky shared writable runtime directories,
+non-current-user-owned/non-`0700` private directories, and non-current-user-owned/non-`0600` state
+files before credential or admission effects. The shipped sticky `1777` channel scratch mount is a
+container/bootstrap boundary only; credential and admission state stays in its private child.
+
+V1 admits one connect or reconnect transition at a time across processes and permits at most one
+durable YouTube account binding. Admission happens before provider egress and remains held through
+token and binding persistence. Tokens remain the first durable write, but only a matching durable
+account-binding row makes one positive authority: status, refresh, and reconnect fail closed on an
+unbound or identity-mismatched token. A failed or indeterminate binding write leaves its token
+non-authoritative; the next admitted start performs one bounded reconciliation pass that deletes
+only token ids proven unbound by durable binding truth and preserves every valid bound credential.
+
+A restart with a missing key degrades to `auth_key_missing` — visible, fail-closed, recoverable by
+re-provisioning the key; consent is not silently re-requested. In-flight device-flow sessions do not
+survive restart; after process-held admission is released, the user restarts the connect step (the
+UI/CLI says so).
 
 ## Related Docs
 

--- a/tests/knowledge_acquisition/test_youtube_oauth_durability.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth_durability.py
@@ -1,0 +1,357 @@
+"""Issue #4830: channel-bound, crash-convergent YouTube OAuth writer."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+
+import pytest
+
+from app.knowledge_acquisition import source_registry as sr
+from app.knowledge_acquisition import youtube_account_binding as yab
+from app.knowledge_acquisition import youtube_oauth as oauth
+from app.knowledge_acquisition import youtube_token_store as tokstore
+
+
+STORE_KEY = "8b" * 32
+CHANNEL_A = "UC__test__oauth_durability_a"
+CHANNEL_B = "UC__test__oauth_durability_b"
+
+
+class _OAuthClient:
+    """Provider seam whose counters prove admission happens before egress."""
+
+    def __init__(self, *, channel_id: str = CHANNEL_A) -> None:
+        self.channel_id = channel_id
+        self.starts = 0
+        self.polls = 0
+
+    def start_device_flow(self) -> oauth.DeviceFlowHandle:
+        self.starts += 1
+        return oauth.DeviceFlowHandle(
+            device_code="synthetic-device-code",
+            user_code="TEST-CODE",
+            verification_url="https://example.invalid/device",
+            verification_url_complete="https://example.invalid/device?synthetic",
+            interval=1,
+            expires_in=60,
+        )
+
+    def poll_device_flow(self, _device_code: str) -> oauth.TokenBundle:
+        self.polls += 1
+        return oauth.TokenBundle(
+            access_token=f"synthetic-access-{self.channel_id}",
+            refresh_token=f"synthetic-refresh-{self.channel_id}",
+            expires_in=3600,
+            scope=oauth.SCOPE,
+            token_type="Bearer",
+        )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, STORE_KEY)
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.delenv(tokstore.PATH_ENV_VAR, raising=False)
+    yab.reset_memory_account_bindings()
+    sr.reset_memory_source_registry()
+    yield
+    yab.reset_memory_account_bindings()
+    sr.reset_memory_source_registry()
+
+
+def _binder(
+    client: _OAuthClient,
+    store: tokstore.YouTubeTokenStore,
+    bindings: yab.AccountBindingStore,
+) -> oauth.YouTubeAccountBinder:
+    return oauth.YouTubeAccountBinder(
+        oauth_client=client,  # type: ignore[arg-type]
+        token_store=store,
+        binding_store=bindings,
+        identity_probe=lambda _token: oauth.ChannelIdentity(
+            channel_id=client.channel_id,
+            channel_title=f"Channel {client.channel_id[-1]}",
+        ),
+    )
+
+
+def _token(channel_id: str = CHANNEL_A) -> tokstore.StoredToken:
+    return tokstore.StoredToken(
+        refresh_token=f"synthetic-refresh-{channel_id}",
+        access_token=f"synthetic-access-{channel_id}",
+        expires_at="2999-01-01T00:00:00+00:00",
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-08-12T00:00:00+00:00",
+        provider_channel_id=channel_id,
+    )
+
+
+def test_default_oauth_state_is_channel_bound_and_hardened(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With no explicit runtime path, a linked worktree resolves through its
+    # normalized Git common directory to the same checkout-independent root.
+    primary_checkout = tmp_path / "primary-checkout"
+    common_git = primary_checkout / ".git"
+    common_git.mkdir(parents=True)
+    linked_checkout = tmp_path / "linked-checkout"
+    linked_checkout.mkdir()
+    linked_git = common_git / "worktrees" / "linked-checkout"
+    linked_git.mkdir(parents=True)
+    (linked_git / "commondir").write_text("../..\n", encoding="utf-8")
+    (linked_checkout / ".git").write_text(
+        f"gitdir: {linked_git}\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("INDEX_OUTBOX_PATH", raising=False)
+    monkeypatch.setattr(tokstore, "_REPO_ROOT", primary_checkout)
+    primary_path = tokstore.default_token_store_path()
+    monkeypatch.setattr(tokstore, "_REPO_ROOT", linked_checkout)
+    linked_path = tokstore.default_token_store_path()
+    assert primary_path == linked_path
+    assert primary_path == (
+        primary_checkout
+        / "tmp-dev"
+        / "knowledge_acquisition"
+        / "youtube_token_store.enc"
+    )
+
+    # Docker/Compose deliberately provides /app/tmp as a sticky 1777 scratch
+    # volume for host-UID-remapped processes. The private current-UID child is
+    # the credential boundary under that shipped producer.
+    runtime_root = tmp_path / "channel-runtime"
+    runtime_root.mkdir(mode=0o700)
+    runtime_root.chmod(0o1777)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(runtime_root / "index-outbox.jsonl"))
+
+    cwd_a = tmp_path / "checkout-a"
+    cwd_b = tmp_path / "checkout-b"
+    cwd_a.mkdir()
+    cwd_b.mkdir()
+    monkeypatch.chdir(cwd_a)
+    first = tokstore.default_token_store_path()
+    monkeypatch.chdir(cwd_b)
+    second = tokstore.default_token_store_path()
+
+    assert first == second
+    assert first.is_absolute()
+    assert first.is_relative_to(runtime_root)
+    store = tokstore.YouTubeTokenStore()
+    store.put("binding-a", _token())
+    assert store.path.parent.stat().st_mode & 0o777 == 0o700
+    assert store.path.parent.stat().st_uid == os.geteuid()
+    assert store.path.stat().st_mode & 0o777 == 0o600
+    assert store.path.stat().st_uid == os.geteuid()
+
+    # A symlinked writer parent is rejected before either the credential or
+    # admission file can escape the channel root.
+    hostile_root = tmp_path / "hostile-runtime"
+    hostile_root.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o700)
+    (hostile_root / "knowledge_acquisition").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(hostile_root / "index-outbox.jsonl"))
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.YouTubeTokenStore().put("binding-b", _token())
+    assert list(outside.iterdir()) == []
+
+    # Existing state parents are never silently accepted or chmod-repaired
+    # when another principal can access them.
+    unsafe_root = tmp_path / "unsafe-runtime"
+    unsafe_root.mkdir(mode=0o700)
+    unsafe_parent = unsafe_root / "knowledge_acquisition"
+    unsafe_parent.mkdir(mode=0o755)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(unsafe_root / "index-outbox.jsonl"))
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.YouTubeTokenStore().put("binding-c", _token())
+    assert list(unsafe_parent.iterdir()) == []
+
+    # The outer runtime authority must itself be a non-symlink safe directory;
+    # neither failure may create the private state parent or its lock file.
+    unsafe_runtime = tmp_path / "group-writable-runtime"
+    unsafe_runtime.mkdir(mode=0o770)
+    unsafe_runtime.chmod(0o770)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(unsafe_runtime / "index-outbox.jsonl"))
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.YouTubeTokenStore().acquire_writer_admission()
+    assert list(unsafe_runtime.iterdir()) == []
+
+    real_runtime = tmp_path / "real-runtime"
+    real_runtime.mkdir(mode=0o700)
+    linked_runtime = tmp_path / "linked-runtime"
+    linked_runtime.symlink_to(real_runtime, target_is_directory=True)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(linked_runtime / "index-outbox.jsonl"))
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.YouTubeTokenStore().acquire_writer_admission()
+    assert list(real_runtime.iterdir()) == []
+
+    monkeypatch.setenv(tokstore.PATH_ENV_VAR, str(runtime_root / ".." / "escaped.enc"))
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.default_token_store_path()
+    assert not (tmp_path / "escaped.enc").exists()
+
+
+def test_concurrent_connect_converges_to_one_binding_and_credential(tmp_path: Path) -> None:
+    store_path = tmp_path / "oauth-state" / "tokens.enc"
+    store_path.parent.mkdir(mode=0o700)
+    bindings = yab.AccountBindingStore.for_runtime()
+    first_client = _OAuthClient()
+    second_client = _OAuthClient()
+    first = _binder(first_client, tokstore.YouTubeTokenStore(store_path), bindings)
+    second = _binder(second_client, tokstore.YouTubeTokenStore(store_path), bindings)
+
+    connection = first.start_device_connection()
+    with pytest.raises(tokstore.OAuthWriterAdmissionError):
+        second.start_device_connection()
+    assert second_client.starts == 0
+    assert second_client.polls == 0
+
+    cross_process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os, sys\n"
+            "from app.knowledge_acquisition.youtube_account_binding import AccountBindingStore\n"
+            "from app.knowledge_acquisition.youtube_oauth import YouTubeAccountBinder\n"
+            "from app.knowledge_acquisition.youtube_token_store import (\n"
+            "    OAuthWriterAdmissionError, YouTubeTokenStore\n"
+            ")\n"
+            "os.environ['STORE_BACKEND'] = 'memory'\n"
+            "class Provider:\n"
+            "    def start_device_flow(self):\n"
+            "        raise RuntimeError('provider egress reached')\n"
+            "binder = YouTubeAccountBinder(\n"
+            "    oauth_client=Provider(), token_store=YouTubeTokenStore(sys.argv[1]),\n"
+            "    binding_store=AccountBindingStore.for_runtime(),\n"
+            "    identity_probe=lambda _token: None,\n"
+            ")\n"
+            "try:\n"
+            "    binder.start_device_connection()\n"
+            "except OAuthWriterAdmissionError:\n"
+            "    raise SystemExit(0)\n"
+            "raise SystemExit(1)\n",
+            str(store_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert cross_process.returncode == 0
+
+    receipt = first.finish_device_connection(connection)
+    rows = bindings.list_all()
+    encrypted = tokstore.YouTubeTokenStore(store_path)
+    assert receipt["status"] == "connected"
+    assert len(rows) == 1
+    assert encrypted.binding_ids() == (rows[0].account_binding_id,)
+    assert first_client.starts == 1
+
+
+def test_token_first_failure_and_recovery_reconcile_orphan_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store_path = tmp_path / "oauth-state" / "tokens.enc"
+    store_path.parent.mkdir(mode=0o700)
+    store = tokstore.YouTubeTokenStore(store_path)
+    bindings = yab.AccountBindingStore.for_runtime()
+    binder = _binder(_OAuthClient(), store, bindings)
+    original_create = bindings.create
+
+    def fail_binding(**_kwargs: object) -> yab.AccountBinding:
+        raise OSError("synthetic binding persistence failure")
+
+    monkeypatch.setattr(bindings, "create", fail_binding)
+    connection = binder.start_device_connection()
+    with pytest.raises(OSError, match="synthetic binding persistence failure"):
+        binder.finish_device_connection(connection)
+    assert bindings.list_all() == ()
+    failed_binding_id = store.binding_ids()[0]
+    assert binder.status(failed_binding_id)["status"] == "absent"
+    with pytest.raises(oauth.AuthDegradedError):
+        oauth.TokenProvider(
+            binding_id=failed_binding_id,
+            token_store=store,
+            oauth_client=_OAuthClient(),  # type: ignore[arg-type]
+            binding_store=bindings,
+        ).get_access_token()
+
+    # Model a process death after token-first persistence: no cleanup handler
+    # ran, so the next admitted start must reconcile the unbound ciphertext
+    # before provider egress. Low-level storage may retain bytes, but runtime
+    # authority surfaces must not accept them.
+    orphan_id = "orphan-from-crash-window"
+    store.put(orphan_id, _token())
+    assert binder.status(orphan_id)["status"] == "absent"
+    provider = oauth.TokenProvider(
+        binding_id=orphan_id,
+        token_store=store,
+        oauth_client=_OAuthClient(),  # type: ignore[arg-type]
+        binding_store=bindings,
+    )
+    with pytest.raises(oauth.AuthDegradedError):
+        provider.get_access_token()
+    with pytest.raises(KeyError):
+        binder.start_reconnect(orphan_id)
+
+    monkeypatch.setattr(bindings, "create", original_create)
+    retry_client = _OAuthClient()
+    retry = _binder(retry_client, store, bindings)
+    retry_connection = retry.start_device_connection()
+    assert failed_binding_id not in store.binding_ids()
+    assert orphan_id not in store.binding_ids()
+    receipt = retry.finish_device_connection(retry_connection)
+    bound_id = receipt["account"]["binding_id"]
+    assert store.binding_ids() == (bound_id,)
+    assert bindings.get(bound_id) is not None
+
+    # Reconciliation must never delete a credential that already has a valid
+    # durable binding row.
+    next_client = _OAuthClient()
+    next_binder = _binder(next_client, store, bindings)
+    with pytest.raises(yab.AccountBindingAdmissionError):
+        next_binder.start_device_connection()
+    assert store.has_record(bound_id) is True
+
+
+def test_reconnect_preserves_identity_under_concurrent_admission(tmp_path: Path) -> None:
+    store_path = tmp_path / "oauth-state" / "tokens.enc"
+    store_path.parent.mkdir(mode=0o700)
+    store = tokstore.YouTubeTokenStore(store_path)
+    bindings = yab.AccountBindingStore.for_runtime()
+    initial = _binder(_OAuthClient(channel_id=CHANNEL_A), store, bindings)
+    connected = initial.finish_device_connection(initial.start_device_connection())
+    binding_id = connected["account"]["binding_id"]
+
+    reconnect_client = _OAuthClient(channel_id=CHANNEL_A)
+    reconnect = _binder(reconnect_client, tokstore.YouTubeTokenStore(store_path), bindings)
+    competing_client = _OAuthClient(channel_id=CHANNEL_B)
+    competing = _binder(competing_client, tokstore.YouTubeTokenStore(store_path), bindings)
+
+    reconnect_connection = reconnect.start_reconnect(binding_id)
+    outcome: list[BaseException] = []
+
+    def compete() -> None:
+        try:
+            competing.start_device_connection()
+        except BaseException as exc:  # noqa: BLE001 - assertion captures the loser outcome
+            outcome.append(exc)
+
+    thread = threading.Thread(target=compete)
+    thread.start()
+    thread.join(timeout=3)
+    assert thread.is_alive() is False
+    assert outcome
+    assert competing_client.starts == 0
+
+    receipt = reconnect.finish_device_connection(reconnect_connection)
+    rows = bindings.list_all()
+    assert receipt["account"]["binding_id"] == binding_id
+    assert len(rows) == 1
+    assert rows[0].provider_channel_id == CHANNEL_A
+    assert store.binding_ids() == (binding_id,)
+    assert store.get(binding_id).provider_channel_id == CHANNEL_A


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4830

## Linked Issue
Closes #4830

## SBS Impact
- Primary subsystem: EBF
- Secondary subsystem(s): PDM, GOV, OEF
- Write class: mechanical durable credential and account-binding state
- Persistence impact: existing encrypted token and binding stores become channel-bound and crash-convergent
- Derived/rebuildable impact: admission locks and reconciliation observations remain rebuildable
- New or changed contract: one hardened channel-rooted writer enforces V1 single-account authority
- Owner-doc impact: updated in this PR
- Transition debt impact: closes the durability prerequisite exposed by #4067
- Boundary risk: credentials cannot escape their channel, become unbound authority, or bind the wrong account

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make YouTube OAuth credential and account-binding persistence channel-rooted, single-writer, and crash-convergent. Harden credential state against unsafe paths, enforce binding-positive token authority, and reconcile orphan token-first writes without deleting valid credentials.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260812133703_b0e3284d
- Reason: Issue #4830 applies the prior convergence signal; no new BuilderOps record was needed.

## Notes
Validation on exact SHA 0612556632e574b79b5a157510c049f96490eac4:
- 22 focused OAuth durability/regression tests passed.
- Ruff passed across app, tests, and companion surfaces.
- Mypy passed for 881 source files.
- Docs guard passed with the sanctioned temporal-skip override because the exact owner doc changed but no temporal surface did.
- Independent Sol/xhigh high-risk convergence review passed with P0-P3 none.
- Broad xdist reached 13,117 passed, 44 skipped, 18 xfailed; its one unrelated shared hybrid-state failure passed standalone before pre-existing teardown behavior. A resource-bounded per-shard fallback kept every completed shard green and was stopped only during out-of-scope live remote Ollama reproduction at the coordinator time bound.