### PR TITLE
fix: share effective reasoning route for execution and explain

### DIFF
--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 import os
 from functools import lru_cache
 from typing import Any, Iterable
@@ -32,6 +32,38 @@ class LLMRoute:
     reason: str
     degraded: bool = False
     embedding_identity: EmbeddingIdentity | None = None
+
+
+@dataclass(frozen=True)
+class EffectiveReasoningRoute:
+    """One selected reasoning route plus its effective model provenance."""
+
+    route: LLMRoute
+    model_origin: str
+
+
+def resolve_effective_reasoning_route(
+    selected_route: LLMRoute,
+    *,
+    model_override: str | None = None,
+    selected_model_origin: str = "registry default",
+) -> EffectiveReasoningRoute:
+    """Apply the legacy model override without re-selecting a provider.
+
+    This resolver is deliberately side-effect-free. Callers capture the
+    provider-neutral route once, then both execution and explain consume the
+    same immutable effective value.
+    """
+    normalized_override = (model_override or "").strip()
+    if normalized_override:
+        return EffectiveReasoningRoute(
+            route=replace(selected_route, model=normalized_override),
+            model_origin="env:REASONING_MODEL (deprecated)",
+        )
+    return EffectiveReasoningRoute(
+        route=selected_route,
+        model_origin=selected_model_origin,
+    )
 
 
 def _normalize(value: str | None) -> str:
@@ -159,6 +191,15 @@ class LLMRouter:
         if "reason" in intent.task_kind or intent.task_kind in {"plan"}:
             return routing.default_reasoning
         return routing.default_chat
+
+    def routing_key_configured(self, key: str) -> bool:
+        """Report configuration provenance from this router's captured bundle."""
+        routing = (
+            getattr(self._settings, "llm_routing", None)
+            if self._settings is not None
+            else None
+        )
+        return bool(routing and key in routing.configured_keys)
 
     @staticmethod
     def _route_to_dict(route: LLMRoute) -> dict[str, Any]:
@@ -578,4 +619,11 @@ class LLMRouter:
         return {intent.task_kind: self.describe_intent(intent) for intent in intents}
 
 
-__all__ = ["LLMTaskIntent", "LLMRoute", "LLMRouteError", "LLMRouter"]
+__all__ = [
+    "EffectiveReasoningRoute",
+    "LLMTaskIntent",
+    "LLMRoute",
+    "LLMRouteError",
+    "LLMRouter",
+    "resolve_effective_reasoning_route",
+]

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -9,13 +9,11 @@ from app.components.embeddings import EmbeddingIdentity, resolve_embedding_ident
 from app.components.settings.models_loader import load_models
 from app.settings.models import LLMRoutingSettings, SettingsBundle
 from app.settings.env_defaults import env_default
-from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
+from app.settings.locations import canonical_settings_origin
 from app.settings.runtime import get_settings_bundle
 
 
-_LLM_ROUTING_VAULT_ORIGIN = (
-    f"vault-shared:{CANONICAL_SETTINGS_DIR_NAME}/llm_routing.md"
-)
+_LLM_ROUTING_VAULT_ORIGIN = canonical_settings_origin("llm_routing.md")
 
 
 class _UnsetSettingsBundle:

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -9,7 +9,13 @@ from app.components.embeddings import EmbeddingIdentity, resolve_embedding_ident
 from app.components.settings.models_loader import load_models
 from app.settings.models import LLMRoutingSettings
 from app.settings.env_defaults import env_default
+from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
 from app.settings.runtime import get_settings_bundle
+
+
+_LLM_ROUTING_VAULT_ORIGIN = (
+    f"vault-shared:{CANONICAL_SETTINGS_DIR_NAME}/llm_routing.md"
+)
 
 
 @dataclass(frozen=True)
@@ -32,6 +38,7 @@ class LLMRoute:
     reason: str
     degraded: bool = False
     embedding_identity: EmbeddingIdentity | None = None
+    model_origin: str = "registry default"
 
 
 @dataclass(frozen=True)
@@ -46,7 +53,6 @@ def resolve_effective_reasoning_route(
     selected_route: LLMRoute,
     *,
     model_override: str | None = None,
-    selected_model_origin: str = "registry default",
 ) -> EffectiveReasoningRoute:
     """Apply the legacy model override without re-selecting a provider.
 
@@ -56,13 +62,18 @@ def resolve_effective_reasoning_route(
     """
     normalized_override = (model_override or "").strip()
     if normalized_override:
+        override_origin = "env:REASONING_MODEL (deprecated)"
         return EffectiveReasoningRoute(
-            route=replace(selected_route, model=normalized_override),
-            model_origin="env:REASONING_MODEL (deprecated)",
+            route=replace(
+                selected_route,
+                model=normalized_override,
+                model_origin=override_origin,
+            ),
+            model_origin=override_origin,
         )
     return EffectiveReasoningRoute(
         route=selected_route,
-        model_origin=selected_model_origin,
+        model_origin=selected_route.model_origin,
     )
 
 
@@ -108,6 +119,14 @@ def _provider_enforced() -> bool:
 
 def _default_chat_model() -> str:
     return os.getenv("LLM_MODEL", os.getenv("MERGE_LLM_MODEL", env_default("MERGE_LLM_MODEL")))
+
+
+def _default_chat_model_origin() -> str:
+    if "LLM_MODEL" in os.environ:
+        return "env:LLM_MODEL (deprecated)"
+    if "MERGE_LLM_MODEL" in os.environ:
+        return "env:MERGE_LLM_MODEL (deprecated)"
+    return "registry default"
 
 
 def _default_embed_model() -> str:
@@ -192,8 +211,31 @@ class LLMRouter:
             return routing.default_reasoning
         return routing.default_chat
 
-    def routing_key_configured(self, key: str) -> bool:
-        """Report configuration provenance from this router's captured bundle."""
+    def _task_policy_source_key(self, intent: LLMTaskIntent) -> str | None:
+        routing = (
+            getattr(self._settings, "llm_routing", None)
+            if self._settings is not None
+            else None
+        )
+        if routing is None:
+            return None
+        if intent.task_kind in routing.tasks:
+            return "tasks"
+        if intent.task_kind == "embed":
+            return "default_embedding"
+        if intent.task_kind in {"eval", "deepeval", "ragas"}:
+            return "default_eval"
+        if "reason" in intent.task_kind or intent.task_kind == "plan":
+            return "default_reasoning"
+        return "default_chat"
+
+    def _task_policy_model_origin(self, intent: LLMTaskIntent) -> str:
+        source_key = self._task_policy_source_key(intent)
+        if source_key and self._routing_key_configured(source_key):
+            return _LLM_ROUTING_VAULT_ORIGIN
+        return "registry default"
+
+    def _routing_key_configured(self, key: str) -> bool:
         routing = (
             getattr(self._settings, "llm_routing", None)
             if self._settings is not None
@@ -240,6 +282,7 @@ class LLMRouter:
         *,
         degraded: bool,
         reason: str,
+        target_model_origin: str,
     ) -> LLMRoute:
         target_provider, target_model = _resolve_target_model_id(target, expected_kind="chat")
         provider_source = None
@@ -250,17 +293,27 @@ class LLMRouter:
             model_source = target.model or target_model
         provider_candidate = provider_source or self._llm_provider_env or getattr(routing, "default_provider", None)
         provider, provider_degraded, provider_reason = _resolve_provider(provider_candidate)
-        model = (
-            model_source
-            or getattr(routing, "default_chat_model", None)
-            or _default_chat_model()
-        )
+        configured_default_model = getattr(routing, "default_chat_model", None)
+        if model_source:
+            model = model_source
+            model_origin = target_model_origin
+        elif configured_default_model:
+            model = configured_default_model
+            model_origin = (
+                _LLM_ROUTING_VAULT_ORIGIN
+                if self._routing_key_configured("default_chat_model")
+                else "registry default"
+            )
+        else:
+            model = _default_chat_model()
+            model_origin = _default_chat_model_origin()
         return LLMRoute(
             provider=provider,
             model=model,
             mode="chat",
             reason=provider_reason if provider_degraded else reason,
             degraded=degraded or provider_degraded,
+            model_origin=model_origin,
         )
 
     def _resolve_embedding_route(
@@ -392,10 +445,12 @@ class LLMRouter:
                     candidates.append(fallback_route)
             return candidates
 
+        policy_model_origin = self._task_policy_model_origin(intent)
         primary_route = self._resolve_chat_route(
             getattr(policy, "primary", None),
             degraded=self._default_degraded,
             reason="settings" if policy is not None else self._default_reason,
+            target_model_origin=policy_model_origin,
         )
         candidates = [primary_route]
         fallback_target = self._default_fallback_target(intent, policy)
@@ -405,6 +460,7 @@ class LLMRouter:
                     fallback_target,
                     degraded=True,
                     reason="fallback",
+                    target_model_origin=policy_model_origin,
                 )
             )
         elif primary_route.provider != "mock":
@@ -415,6 +471,7 @@ class LLMRouter:
                     mode=_default_mode(intent.task_kind),
                     reason="fallback",
                     degraded=True,
+                    model_origin="registry default",
                 )
             )
         return candidates
@@ -447,6 +504,7 @@ class LLMRouter:
                     mode=cand.mode,
                     reason=reason if degraded else route_reason,
                     degraded=cand.degraded or degraded,
+                    model_origin=cand.model_origin,
                 )
         if provider == "mock":
             # mock ignores the model entirely; a self-consistent deterministic route.
@@ -456,6 +514,7 @@ class LLMRouter:
                 mode=_default_mode(intent.task_kind),
                 reason=reason if degraded else ("enforced-provider:mock" if enforce else "fallback"),
                 degraded=degraded,
+                model_origin="registry default",
             )
         if enforce:
             served = ", ".join(f"{c.provider}/{c.model}" for c in candidates) or "<none>"
@@ -508,6 +567,11 @@ class LLMRouter:
                 reason=reason,
                 degraded=degraded,
                 embedding_identity=embedding_identity,
+                model_origin=(
+                    "env:LLM_FORCE_MODEL"
+                    if forced_model
+                    else _default_chat_model_origin()
+                ),
             )
 
         candidates = self._route_candidates(intent)
@@ -520,6 +584,7 @@ class LLMRouter:
                         mode=cand.mode,
                         reason="deterministic",
                         degraded=cand.degraded,
+                        model_origin=cand.model_origin,
                     )
         routing = getattr(self._settings, "llm_routing", None) if self._settings is not None else None
         has_explicit_task_policy = bool(routing and intent.task_kind in routing.tasks)
@@ -605,6 +670,7 @@ class LLMRouter:
                 policy.primary,
                 degraded=self._default_degraded,
                 reason="settings",
+                target_model_origin=self._task_policy_model_origin(intent),
             )
             payload["preferred"] = self._route_to_dict(preferred_route)
 

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable
 
 from app.components.embeddings import EmbeddingIdentity, resolve_embedding_identity
 from app.components.settings.models_loader import load_models
-from app.settings.models import LLMRoutingSettings
+from app.settings.models import LLMRoutingSettings, SettingsBundle
 from app.settings.env_defaults import env_default
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
 from app.settings.runtime import get_settings_bundle
@@ -16,6 +16,13 @@ from app.settings.runtime import get_settings_bundle
 _LLM_ROUTING_VAULT_ORIGIN = (
     f"vault-shared:{CANONICAL_SETTINGS_DIR_NAME}/llm_routing.md"
 )
+
+
+class _UnsetSettingsBundle:
+    pass
+
+
+_UNSET_SETTINGS_BUNDLE = _UnsetSettingsBundle()
 
 
 @dataclass(frozen=True)
@@ -183,16 +190,23 @@ def _is_shipped_default_embedding_target(
 
 
 class LLMRouter:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        settings_bundle: SettingsBundle | None | _UnsetSettingsBundle = _UNSET_SETTINGS_BUNDLE,
+    ) -> None:
         self._llm_provider_env = os.getenv("LLM_PROVIDER") if "LLM_PROVIDER" in os.environ else None
         provider, degraded, reason = _resolve_provider(self._llm_provider_env)
         self._default_provider = provider
         self._default_degraded = degraded
         self._default_reason = reason
-        try:
-            self._settings = get_settings_bundle()
-        except Exception:
-            self._settings = None
+        if isinstance(settings_bundle, _UnsetSettingsBundle):
+            try:
+                self._settings = get_settings_bundle()
+            except Exception:
+                self._settings = None
+        else:
+            self._settings = settings_bundle
 
     def _task_policy(self, intent: LLMTaskIntent) -> LLMRoutingSettings.TaskPolicy | None:
         if self._settings is None:

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -209,11 +209,25 @@ def _reasoning_backend() -> str:
 
 
 def _fallback_reasoning_identity() -> tuple[str, str]:
-    """Best-effort identity only when no executable agent was constructed."""
-    effective = llm_router.resolve_effective_reasoning_route(
-        LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high")),
-        model_override=os.getenv("REASONING_MODEL"),
-    )
+    """Best-effort identity only when no executable agent was constructed.
+
+    Routing may itself be the failure being traced.  Reuse the shared resolver
+    when a route can be selected, but never let a second routing failure escape
+    the provider-failure handler.
+    """
+    try:
+        effective = llm_router.resolve_effective_reasoning_route(
+            LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high")),
+            model_override=os.getenv("REASONING_MODEL"),
+        )
+    except Exception:
+        provider = (os.getenv("LLM_PROVIDER") or "unknown").strip().lower()
+        if provider == "llm":
+            provider = "ollama"
+        elif provider == "fake":
+            provider = "mock"
+        model = (os.getenv("REASONING_MODEL") or "unknown").strip() or "unknown"
+        return provider, model
     return effective.route.provider, effective.route.model
 
 

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -8,13 +8,13 @@ from typing import Any, Dict, List, Tuple
 from uuid import UUID
 
 from app.components.llm.fabric import ChatClient, LLMBackendTimeout, LLMRouter, LLMTaskIntent, get_chat_client
+from app.components.llm import router as llm_router
 from app.components.llm.router import LLMRoute
 from app.llm.trace import log_llm_call
 from app.reasoning.prompts import SYSTEM_PROMPT, build_user_prompt
 from app.reasoning.schema import ReasoningInput, ReasoningOutput, ReasoningValidationError, validate_output
 from app.reasoning.models import ReasoningMode, ReasoningRun
 from app.stores import get_object_store
-from app.settings.wave_one import reasoning_model
 
 _FIXTURE_PATH = Path("data") / "golden" / "reasoning_samples.jsonl"
 
@@ -108,22 +108,13 @@ class MockDeliberationAgent(BaseDeliberationAgent):
 class OllamaDeliberationAgent(BaseDeliberationAgent):
     def __init__(self, *, model: str | None = None) -> None:
         if model is None:
-            self._client = get_chat_client(
-                LLMTaskIntent(task_kind="reasoning", risk="high")
+            effective = llm_router.resolve_effective_reasoning_route(
+                LLMRouter().route(
+                    LLMTaskIntent(task_kind="reasoning", risk="high")
+                ),
+                model_override=os.getenv("REASONING_MODEL"),
             )
-            override_model = (os.getenv("REASONING_MODEL") or "").strip()
-            if override_model:
-                route = self._client.route
-                self._client = ChatClient(
-                    route=LLMRoute(
-                        provider=route.provider,
-                        model=override_model,
-                        mode=route.mode,
-                        reason="deprecated REASONING_MODEL override",
-                        degraded=route.degraded,
-                        embedding_identity=route.embedding_identity,
-                    )
-                )
+            self._client = ChatClient(route=effective.route)
         else:
             self._client = ChatClient(
                 route=LLMRoute(
@@ -219,12 +210,11 @@ def _reasoning_backend() -> str:
 
 def _fallback_reasoning_identity() -> tuple[str, str]:
     """Best-effort identity only when no executable agent was constructed."""
-    provider = os.getenv("LLM_PROVIDER", "").strip().lower()
-    if provider == "llm":
-        provider = "ollama"
-    if provider in {"", "fake"}:
-        provider = "mock" if provider == "fake" else "ollama"
-    return provider, reasoning_model(provider)
+    effective = llm_router.resolve_effective_reasoning_route(
+        LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high")),
+        model_override=os.getenv("REASONING_MODEL"),
+    )
+    return effective.route.provider, effective.route.model
 
 
 def _reasoning_uses_mock_route() -> bool:

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -123,6 +123,7 @@ class OllamaDeliberationAgent(BaseDeliberationAgent):
                     mode="chat",
                     reason="explicit reasoning model",
                     degraded=False,
+                    model_origin="explicit constructor argument",
                 )
             )
         self.provider = self._client.route.provider

--- a/app/settings/locations.py
+++ b/app/settings/locations.py
@@ -21,6 +21,17 @@ LEGACY_SYSTEM_SETTINGS = LEGACY_SYSTEM_SETTINGS_DIR / "system-settings.yaml"
 LEGACY_HEALTH_SETTINGS = Path("_system") / "Settings" / "health.md"
 
 
+def canonical_settings_origin(relative_path: Path | str) -> str:
+    """Format one canonical settings provenance without creating path authority."""
+
+    relative = Path(relative_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(
+            f"settings origin path must be canonical-relative: {relative}"
+        )
+    return f"vault-shared:{CANONICAL_SETTINGS_DIR_NAME}/{relative.as_posix()}"
+
+
 def canonical_settings_root(vault_root: Path) -> Path:
     root = Path(vault_root).expanduser().resolve()
     return contained_settings_path(root, root / CANONICAL_SETTINGS_DIR_NAME)
@@ -155,6 +166,7 @@ __all__ = [
     "LEGACY_HEALTH_SETTINGS",
     "LEGACY_SYSTEM_SETTINGS",
     "LEGACY_SYSTEM_SETTINGS_DIR",
+    "canonical_settings_origin",
     "canonical_settings_root",
     "contained_settings_path",
     "resolve_compiled_sources",

--- a/app/settings/wave_one.py
+++ b/app/settings/wave_one.py
@@ -72,19 +72,28 @@ def _reasoning_resolution() -> tuple[str, str]:
     effective = resolve_effective_reasoning_route(
         selected_route,
         model_override=_override("REASONING_MODEL"),
-        selected_model_origin=(
-            "env:LLM_FORCE_MODEL"
-            if _override("LLM_FORCE_MODEL") is not None
-            else _vault_shared_origin("llm_routing.md")
-            if router.routing_key_configured("default_reasoning")
-            else "registry default"
-        ),
     )
     return effective.route.model, effective.model_origin
 
 
 def reasoning_model() -> str:
     return _reasoning_resolution()[0]
+
+
+def _reasoning_explanation() -> dict[str, object]:
+    from app.components.llm.router import LLMRouteError
+
+    try:
+        value, origin = _reasoning_resolution()
+    except LLMRouteError as exc:
+        return {
+            "value": None,
+            "origin": "unresolved:routing-error",
+            "tier": "operator",
+            "status": "error",
+            "error": str(exc),
+        }
+    return {"value": value, "origin": origin, "tier": "operator"}
 
 
 def _default_chat_resolution(
@@ -130,7 +139,6 @@ def wave_one_explain() -> dict[str, dict[str, object]]:
 
     effective_retrieval = get_effective_retrieval_resolution()
     routing = get_settings_bundle().llm_routing
-    reasoning_value, reasoning_origin = _reasoning_resolution()
     default_chat_value, default_chat_origin = _default_chat_resolution(routing=routing)
     return {
         "llm.timeout_seconds": {
@@ -161,11 +169,7 @@ def wave_one_explain() -> dict[str, dict[str, object]]:
             ),
             "tier": "lab",
         },
-        "llm.reasoning_model": {
-            "value": reasoning_value,
-            "origin": reasoning_origin,
-            "tier": "operator",
-        },
+        "llm.reasoning_model": _reasoning_explanation(),
         "llm.default_chat_model": {
             "value": default_chat_value,
             "origin": default_chat_origin,

--- a/app/settings/wave_one.py
+++ b/app/settings/wave_one.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 
 from app.settings.env_defaults import env_default
-from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
+from app.settings.locations import canonical_settings_origin
 from app.settings.models import LLMRoutingSettings, SettingsBundle
 from app.settings.runtime import get_settings_bundle
 from app.settings.tiering import is_lab_profile
@@ -23,7 +23,7 @@ def _override(name: str) -> str | None:
 
 def _vault_shared_origin(relative_path: str) -> str:
     """Format canonical provenance without introducing a second path authority."""
-    return f"vault-shared:{CANONICAL_SETTINGS_DIR_NAME}/{relative_path}"
+    return canonical_settings_origin(relative_path)
 
 
 def _normalized_provider(value: str | None) -> str:

--- a/app/settings/wave_one.py
+++ b/app/settings/wave_one.py
@@ -11,7 +11,7 @@ import os
 
 from app.settings.env_defaults import env_default
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
-from app.settings.models import LLMRoutingSettings
+from app.settings.models import LLMRoutingSettings, SettingsBundle
 from app.settings.runtime import get_settings_bundle
 from app.settings.tiering import is_lab_profile
 
@@ -58,14 +58,20 @@ def llm_temperature(routing: LLMRoutingSettings | None = None) -> float:
     return effective_routing.temperature
 
 
-def _reasoning_resolution() -> tuple[str, str]:
+def _reasoning_resolution(
+    settings_bundle: SettingsBundle | None = None,
+) -> tuple[str, str]:
     from app.components.llm.router import (
         LLMRouter,
         LLMTaskIntent,
         resolve_effective_reasoning_route,
     )
 
-    router = LLMRouter()
+    router = (
+        LLMRouter(settings_bundle=settings_bundle)
+        if settings_bundle is not None
+        else LLMRouter()
+    )
     selected_route = router.route(
         LLMTaskIntent(task_kind="reasoning", risk="high")
     )
@@ -80,11 +86,13 @@ def reasoning_model() -> str:
     return _reasoning_resolution()[0]
 
 
-def _reasoning_explanation() -> dict[str, object]:
+def _reasoning_explanation(
+    settings_bundle: SettingsBundle,
+) -> dict[str, object]:
     from app.components.llm.router import LLMRouteError
 
     try:
-        value, origin = _reasoning_resolution()
+        value, origin = _reasoning_resolution(settings_bundle)
     except LLMRouteError as exc:
         return {
             "value": None,
@@ -138,7 +146,8 @@ def wave_one_explain() -> dict[str, dict[str, object]]:
     from app.retrieval.tuning import get_effective_retrieval_resolution
 
     effective_retrieval = get_effective_retrieval_resolution()
-    routing = get_settings_bundle().llm_routing
+    settings_bundle = get_settings_bundle()
+    routing = settings_bundle.llm_routing
     default_chat_value, default_chat_origin = _default_chat_resolution(routing=routing)
     return {
         "llm.timeout_seconds": {
@@ -169,7 +178,7 @@ def wave_one_explain() -> dict[str, dict[str, object]]:
             ),
             "tier": "lab",
         },
-        "llm.reasoning_model": _reasoning_explanation(),
+        "llm.reasoning_model": _reasoning_explanation(settings_bundle),
         "llm.default_chat_model": {
             "value": default_chat_value,
             "origin": default_chat_origin,

--- a/app/settings/wave_one.py
+++ b/app/settings/wave_one.py
@@ -66,11 +66,16 @@ def _reasoning_resolution() -> tuple[str, str]:
     )
 
     router = LLMRouter()
+    selected_route = router.route(
+        LLMTaskIntent(task_kind="reasoning", risk="high")
+    )
     effective = resolve_effective_reasoning_route(
-        router.route(LLMTaskIntent(task_kind="reasoning", risk="high")),
+        selected_route,
         model_override=_override("REASONING_MODEL"),
         selected_model_origin=(
-            _vault_shared_origin("llm_routing.md")
+            "env:LLM_FORCE_MODEL"
+            if _override("LLM_FORCE_MODEL") is not None
+            else _vault_shared_origin("llm_routing.md")
             if router.routing_key_configured("default_reasoning")
             else "registry default"
         ),

--- a/app/settings/wave_one.py
+++ b/app/settings/wave_one.py
@@ -58,34 +58,28 @@ def llm_temperature(routing: LLMRoutingSettings | None = None) -> float:
     return effective_routing.temperature
 
 
-def _reasoning_resolution(
-    selected_provider: str | None = None,
-    routing: LLMRoutingSettings | None = None,
-) -> tuple[str, str]:
-    raw = _override("REASONING_MODEL")
-    if raw is not None:
-        return raw, "env:REASONING_MODEL (deprecated)"
-    effective_routing = routing or get_settings_bundle().llm_routing
-    route = effective_routing.default_reasoning.primary
-    provider = _normalized_provider(selected_provider or _override("LLM_PROVIDER") or "ollama")
-    route_provider = _normalized_provider(route.provider)
-    if (
-        route.model
-        and route_provider
-        and route_provider == provider
-        and _configured(effective_routing, "default_reasoning")
-    ):
-        route_model = route.model
-        return route_model, _vault_shared_origin("llm_routing.md")
-    if effective_routing.reasoning_model and _configured(
-        effective_routing, "reasoning_model"
-    ):
-        return effective_routing.reasoning_model, _vault_shared_origin("llm_routing.md")
-    return env_default("REASONING_MODEL"), "registry default"
+def _reasoning_resolution() -> tuple[str, str]:
+    from app.components.llm.router import (
+        LLMRouter,
+        LLMTaskIntent,
+        resolve_effective_reasoning_route,
+    )
+
+    router = LLMRouter()
+    effective = resolve_effective_reasoning_route(
+        router.route(LLMTaskIntent(task_kind="reasoning", risk="high")),
+        model_override=_override("REASONING_MODEL"),
+        selected_model_origin=(
+            _vault_shared_origin("llm_routing.md")
+            if router.routing_key_configured("default_reasoning")
+            else "registry default"
+        ),
+    )
+    return effective.route.model, effective.model_origin
 
 
-def reasoning_model(selected_provider: str | None = None) -> str:
-    return _reasoning_resolution(selected_provider)[0]
+def reasoning_model() -> str:
+    return _reasoning_resolution()[0]
 
 
 def _default_chat_resolution(
@@ -131,7 +125,7 @@ def wave_one_explain() -> dict[str, dict[str, object]]:
 
     effective_retrieval = get_effective_retrieval_resolution()
     routing = get_settings_bundle().llm_routing
-    reasoning_value, reasoning_origin = _reasoning_resolution(routing=routing)
+    reasoning_value, reasoning_origin = _reasoning_resolution()
     default_chat_value, default_chat_origin = _default_chat_resolution(routing=routing)
     return {
         "llm.timeout_seconds": {

--- a/tests/settings/test_canonical_location.py
+++ b/tests/settings/test_canonical_location.py
@@ -15,6 +15,7 @@ from app.settings import compiler
 import app.settings.migration as migration_module
 from app.settings.health_settings import load_health_settings
 from app.settings.locations import (
+    canonical_settings_origin,
     contained_settings_path,
     read_settings_mapping,
     resolve_compiled_sources,
@@ -30,6 +31,15 @@ from app.write_guard import WritesBlockedError
 def _write_settings_markdown(path: Path, payload: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"# Settings\n\n```yaml settings\n{payload}```\n", encoding="utf-8")
+
+
+def test_canonical_settings_origin_uses_the_single_location_authority() -> None:
+    assert (
+        canonical_settings_origin("llm_routing.md")
+        == "vault-shared:settings/llm_routing.md"
+    )
+    with pytest.raises(ValueError, match="canonical-relative"):
+        canonical_settings_origin("../llm_routing.md")
 
 
 def test_all_stacks_read_canonical_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/settings/test_llm_retrieval_settings.py
+++ b/tests/settings/test_llm_retrieval_settings.py
@@ -116,6 +116,9 @@ def test_empty_settings_and_legacy_env_preserve_llm_and_rerank_behavior(monkeypa
     monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
     monkeypatch.setattr(wave_one, "get_settings_bundle", SettingsBundle)
     monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", SettingsBundle)
+    monkeypatch.setattr(
+        "app.components.llm.router.get_settings_bundle", SettingsBundle
+    )
     assert wave_one.llm_timeout_seconds() == 60.0
     assert wave_one.llm_temperature() == 0.0
     assert wave_one.reasoning_model() == "llama3.1:8b"
@@ -298,13 +301,22 @@ def test_reasoning_model_preserves_provider_model_identity_and_trace(
     )
     bundle = SettingsBundle(llm_routing=routing)
     monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(
+        "app.components.llm.router.get_settings_bundle", lambda: bundle
+    )
 
-    assert wave_one.reasoning_model("openai") == "gpt-reasoning"
-    assert wave_one.reasoning_model("ollama") == "llama3.1:8b"
-    assert OllamaDeliberationAgent().model == "llama3.1:8b"
+    assert wave_one.reasoning_model() == "gpt-reasoning"
+    assert OllamaDeliberationAgent().execution_identity() == (
+        "openai",
+        "gpt-reasoning",
+    )
 
     monkeypatch.setenv("REASONING_MODEL", "legacy-reasoning")
-    assert wave_one.reasoning_model("ollama") == "legacy-reasoning"
+    assert wave_one.reasoning_model() == "legacy-reasoning"
+    assert OllamaDeliberationAgent().execution_identity() == (
+        "openai",
+        "legacy-reasoning",
+    )
     monkeypatch.delenv("REASONING_MODEL")
 
 
@@ -379,6 +391,9 @@ def test_registered_cli_reports_effective_llm_provenance(
 ) -> None:
     monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
     monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(
+        "app.components.llm.router.get_settings_bundle", lambda: bundle
+    )
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
 

--- a/tests/settings/test_reasoning_route_recovery.py
+++ b/tests/settings/test_reasoning_route_recovery.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+from app.cli import cli
+from app.components.embeddings import EmbeddingIdentity
+from app.components.llm import router as llm_router
+from app.components.llm.fabric import ChatClient
+from app.components.llm.router import LLMRoute
+from app.reasoning import provider as reasoning_provider
+from app.reasoning.models import ReasoningMode
+from app.reasoning.provider import OllamaDeliberationAgent
+from app.reasoning.schema import ReasoningInput
+from app.retrieval import tuning as retrieval_tuning
+from app.settings import compiler, wave_one
+
+
+pytestmark = pytest.mark.not_pg
+
+
+@pytest.fixture(autouse=True)
+def _clean_route_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "CI",
+        "LLM_FORCE_MODEL",
+        "LLM_FORCE_PROVIDER",
+        "LLM_MODEL",
+        "LLM_PROVIDER",
+        "MERGE_LLM_MODEL",
+        "REASONING_MODEL",
+        "REASONING_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _compile_openai_reasoning_bundle(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    settings_dir = tmp_path / "settings"
+    settings_dir.mkdir()
+    (settings_dir / "llm_routing.md").write_text(
+        dedent(
+            """
+            ---
+            uuid: llm-routing
+            ---
+            ## Routing
+            ```yaml settings
+            default_reasoning:
+              primary:
+                model_id: openai.chat.gpt_4_1
+            ```
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(compiler, "RUNTIME", tmp_path / "runtime" / "settings")
+    return compiler.compile_all(vault_dir=settings_dir, auto_heal=False)
+
+
+def test_registered_cli_and_execution_share_compiled_no_env_reasoning_route(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _compile_openai_reasoning_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: bundle)
+
+    resolver_calls: list[tuple[str, str]] = []
+    original_resolver = llm_router.resolve_effective_reasoning_route
+
+    def recording_resolver(*args, **kwargs):
+        resolved = original_resolver(*args, **kwargs)
+        resolver_calls.append((resolved.route.provider, resolved.route.model))
+        return resolved
+
+    monkeypatch.setattr(
+        llm_router,
+        "resolve_effective_reasoning_route",
+        recording_resolver,
+    )
+
+    def unexpected_execution(*_args, **_kwargs):
+        raise AssertionError("settings explain must not execute a provider")
+
+    monkeypatch.setattr(ChatClient, "chat", unexpected_execution)
+    result = CliRunner().invoke(
+        cli,
+        ["settings", "explain", "llm.reasoning_model"],
+    )
+
+    assert result.exit_code == 0, result.output
+    explained = json.loads(result.output)["llm.reasoning_model"]
+    assert explained == {
+        "origin": "vault-shared:settings/llm_routing.md",
+        "tier": "operator",
+        "value": "gpt-4.1",
+    }
+
+    agent = OllamaDeliberationAgent()
+    assert agent.execution_identity() == ("openai", "gpt-4.1")
+
+    executed_routes: list[LLMRoute] = []
+
+    def successful_chat(self, *_args, **_kwargs):
+        executed_routes.append(self.route)
+        return '{"claims": [], "evidence": [], "inferences": []}'
+
+    monkeypatch.setattr(ChatClient, "chat", successful_chat)
+    agent.reason(
+        ReasoningInput(
+            object_uuid="00000000-0000-0000-0000-000000000001",
+            text="reason over this",
+        )
+    )
+
+    assert [(route.provider, route.model) for route in executed_routes] == [
+        ("openai", "gpt-4.1")
+    ]
+    assert resolver_calls == [
+        ("openai", "gpt-4.1"),
+        ("openai", "gpt-4.1"),
+    ]
+
+
+def test_reasoning_route_preserves_override_execution_and_trace_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_identity = EmbeddingIdentity(
+        provider="openai",
+        model="unused-embedding-model",
+        dim=3,
+    )
+    selected_route = LLMRoute(
+        provider="openai",
+        model="gpt-4.1",
+        mode="chat",
+        reason="settings",
+        degraded=True,
+        embedding_identity=embedding_identity,
+    )
+    original_route = replace(selected_route)
+
+    resolved = llm_router.resolve_effective_reasoning_route(
+        selected_route,
+        model_override=" legacy-reasoning ",
+        selected_model_origin="vault-shared:settings/llm_routing.md",
+    )
+
+    assert selected_route == original_route
+    assert resolved.route == replace(selected_route, model="legacy-reasoning")
+    assert resolved.model_origin == "env:REASONING_MODEL (deprecated)"
+
+    monkeypatch.setenv("REASONING_MODEL", "legacy-reasoning")
+    monkeypatch.setattr(
+        llm_router.LLMRouter,
+        "route",
+        lambda _self, _intent: selected_route,
+    )
+    agent = OllamaDeliberationAgent()
+    assert agent.execution_identity() == ("openai", "legacy-reasoning")
+    assert agent._client.route == resolved.route
+
+    successful_routes: list[LLMRoute] = []
+
+    def successful_chat(self, *_args, **_kwargs):
+        successful_routes.append(self.route)
+        return '{"claims": [], "evidence": [], "inferences": []}'
+
+    monkeypatch.setattr(ChatClient, "chat", successful_chat)
+    agent.reason(
+        ReasoningInput(
+            object_uuid="00000000-0000-0000-0000-000000000001",
+            text="reason over this",
+        )
+    )
+    assert successful_routes == [resolved.route]
+
+    def failing_chat(_self, *_args, **_kwargs):
+        raise RuntimeError("provider unavailable")
+
+    traced: dict[str, object] = {}
+    monkeypatch.setattr(ChatClient, "chat", failing_chat)
+    monkeypatch.setattr(
+        reasoning_provider,
+        "get_deliberation_agent",
+        lambda: agent,
+    )
+    monkeypatch.setattr(
+        reasoning_provider,
+        "_load_object_text",
+        lambda _object_id: ("reason over this", {}),
+    )
+    monkeypatch.setattr(
+        reasoning_provider,
+        "log_llm_call",
+        lambda **kwargs: traced.update(kwargs),
+    )
+
+    result = reasoning_provider.run_reasoning(
+        ReasoningMode.CLAIMS,
+        ["00000000-0000-0000-0000-000000000001"],
+        trace_id="trace-effective-route",
+    )
+
+    assert result.status == "failed"
+    assert traced["provider"] == "openai"
+    assert traced["model"] == "legacy-reasoning"

--- a/tests/settings/test_reasoning_route_recovery.py
+++ b/tests/settings/test_reasoning_route_recovery.py
@@ -31,6 +31,7 @@ def _clean_route_environment(monkeypatch: pytest.MonkeyPatch) -> None:
         "LLM_FORCE_PROVIDER",
         "LLM_MODEL",
         "LLM_PROVIDER",
+        "LLM_PROVIDER_ENFORCE",
         "MERGE_LLM_MODEL",
         "REASONING_MODEL",
         "REASONING_PROVIDER",
@@ -128,6 +129,25 @@ def test_registered_cli_and_execution_share_compiled_no_env_reasoning_route(
     ]
 
 
+def test_reasoning_explain_reports_force_model_origin(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _compile_openai_reasoning_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_FORCE_MODEL", "forced-reasoning-model")
+
+    explained = wave_one.wave_one_explain()["llm.reasoning_model"]
+
+    assert explained == {
+        "origin": "env:LLM_FORCE_MODEL",
+        "tier": "operator",
+        "value": "forced-reasoning-model",
+    }
+
+
 def test_reasoning_route_preserves_override_execution_and_trace_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -211,3 +231,36 @@ def test_reasoning_route_preserves_override_execution_and_trace_identity(
     assert result.status == "failed"
     assert traced["provider"] == "openai"
     assert traced["model"] == "legacy-reasoning"
+
+
+def test_routing_failure_keeps_provider_failure_trace_non_throwing(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _compile_openai_reasoning_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_PROVIDER_ENFORCE", "1")
+    monkeypatch.setenv("REASONING_MODEL", "declared-reasoning-model")
+    monkeypatch.setattr(
+        reasoning_provider,
+        "_load_object_text",
+        lambda _object_id: ("reason over this", {}),
+    )
+    traced: dict[str, object] = {}
+    monkeypatch.setattr(
+        reasoning_provider,
+        "log_llm_call",
+        lambda **kwargs: traced.update(kwargs),
+    )
+
+    result = reasoning_provider.run_reasoning(
+        ReasoningMode.CLAIMS,
+        ["00000000-0000-0000-0000-000000000001"],
+        trace_id="trace-routing-failure",
+    )
+
+    assert result.status == "failed"
+    assert "no routing candidate" in (result.error or "")
+    assert traced["provider"] == "ollama"
+    assert traced["model"] == "declared-reasoning-model"

--- a/tests/settings/test_reasoning_route_recovery.py
+++ b/tests/settings/test_reasoning_route_recovery.py
@@ -18,6 +18,7 @@ from app.reasoning.provider import OllamaDeliberationAgent
 from app.reasoning.schema import ReasoningInput
 from app.retrieval import tuning as retrieval_tuning
 from app.settings import compiler, wave_one
+from app.settings.models import LLMRoutingSettings, SettingsBundle
 
 
 pytestmark = pytest.mark.not_pg
@@ -349,3 +350,59 @@ def test_route_failure_keeps_registered_settings_explain_serializable(
     assert explained["origin"] == "unresolved:routing-error"
     assert explained["status"] == "error"
     assert "no routing candidate" in explained["error"]
+
+
+def test_wave_one_explain_uses_one_captured_llm_bundle_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def bundle(label: str, timeout: float) -> SettingsBundle:
+        return SettingsBundle(
+            llm_routing=LLMRoutingSettings(
+                timeout_seconds=timeout,
+                default_reasoning=LLMRoutingSettings.TaskPolicy(
+                    primary=LLMRoutingSettings.RouteTarget(
+                        provider="openai",
+                        model=f"reasoning-{label}",
+                    )
+                ),
+                default_chat=LLMRoutingSettings.TaskPolicy(
+                    primary=LLMRoutingSettings.RouteTarget(
+                        provider="mock",
+                        model=f"chat-{label}",
+                    )
+                ),
+                configured_keys=[
+                    "default_chat",
+                    "default_reasoning",
+                    "timeout_seconds",
+                ],
+            )
+        )
+
+    old_bundle = bundle("old", 17.0)
+    new_bundle = bundle("new", 29.0)
+    bundle_reads: list[SettingsBundle] = []
+    available = iter((old_bundle, new_bundle))
+
+    def sequenced_bundle() -> SettingsBundle:
+        selected = next(available)
+        bundle_reads.append(selected)
+        return selected
+
+    def unexpected_router_reload() -> SettingsBundle:
+        raise AssertionError("captured-bundle explain must not reload settings")
+
+    monkeypatch.setattr(wave_one, "get_settings_bundle", sequenced_bundle)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", unexpected_router_reload)
+    monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: old_bundle)
+
+    explained = wave_one.wave_one_explain()
+
+    assert bundle_reads == [old_bundle]
+    assert explained["llm.timeout_seconds"]["value"] == 17.0
+    assert explained["llm.default_chat_model"]["value"] == "chat-old"
+    assert explained["llm.reasoning_model"] == {
+        "origin": "vault-shared:settings/llm_routing.md",
+        "tier": "operator",
+        "value": "reasoning-old",
+    }

--- a/tests/settings/test_reasoning_route_recovery.py
+++ b/tests/settings/test_reasoning_route_recovery.py
@@ -63,6 +63,34 @@ def _compile_openai_reasoning_bundle(tmp_path, monkeypatch: pytest.MonkeyPatch):
     return compiler.compile_all(vault_dir=settings_dir, auto_heal=False)
 
 
+def _compile_openai_task_reasoning_bundle(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    settings_dir = tmp_path / "settings"
+    settings_dir.mkdir()
+    (settings_dir / "llm_routing.md").write_text(
+        dedent(
+            """
+            ---
+            uuid: llm-routing
+            ---
+            ## Routing
+            ```yaml settings
+            tasks:
+              reasoning:
+                primary:
+                  model_id: openai.chat.gpt_4_1
+            ```
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(compiler, "RUNTIME", tmp_path / "runtime" / "settings")
+    return compiler.compile_all(vault_dir=settings_dir, auto_heal=False)
+
+
 def test_registered_cli_and_execution_share_compiled_no_env_reasoning_route(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -148,6 +176,29 @@ def test_reasoning_explain_reports_force_model_origin(
     }
 
 
+def test_task_specific_reasoning_route_preserves_vault_origin(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _compile_openai_task_reasoning_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: bundle)
+
+    result = CliRunner().invoke(
+        cli,
+        ["settings", "explain", "llm.reasoning_model"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["llm.reasoning_model"] == {
+        "origin": "vault-shared:settings/llm_routing.md",
+        "tier": "operator",
+        "value": "gpt-4.1",
+    }
+    assert OllamaDeliberationAgent().execution_identity() == ("openai", "gpt-4.1")
+
+
 def test_reasoning_route_preserves_override_execution_and_trace_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -163,17 +214,21 @@ def test_reasoning_route_preserves_override_execution_and_trace_identity(
         reason="settings",
         degraded=True,
         embedding_identity=embedding_identity,
+        model_origin="vault-shared:settings/llm_routing.md",
     )
     original_route = replace(selected_route)
 
     resolved = llm_router.resolve_effective_reasoning_route(
         selected_route,
         model_override=" legacy-reasoning ",
-        selected_model_origin="vault-shared:settings/llm_routing.md",
     )
 
     assert selected_route == original_route
-    assert resolved.route == replace(selected_route, model="legacy-reasoning")
+    assert resolved.route == replace(
+        selected_route,
+        model="legacy-reasoning",
+        model_origin="env:REASONING_MODEL (deprecated)",
+    )
     assert resolved.model_origin == "env:REASONING_MODEL (deprecated)"
 
     monkeypatch.setenv("REASONING_MODEL", "legacy-reasoning")
@@ -264,3 +319,33 @@ def test_routing_failure_keeps_provider_failure_trace_non_throwing(
     assert "no routing candidate" in (result.error or "")
     assert traced["provider"] == "ollama"
     assert traced["model"] == "declared-reasoning-model"
+
+
+def test_route_failure_keeps_registered_settings_explain_serializable(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _compile_openai_reasoning_bundle(tmp_path, monkeypatch)
+    monkeypatch.setattr(llm_router, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(wave_one, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(retrieval_tuning, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_PROVIDER_ENFORCE", "1")
+
+    retrieval_result = CliRunner().invoke(
+        cli,
+        ["settings", "explain", "retrieval.rerank.top_k"],
+    )
+    reasoning_result = CliRunner().invoke(
+        cli,
+        ["settings", "explain", "llm.reasoning_model"],
+    )
+
+    assert retrieval_result.exit_code == 0, retrieval_result.output
+    assert "retrieval.rerank.top_k" in json.loads(retrieval_result.output)
+    assert reasoning_result.exit_code == 0, reasoning_result.output
+    explained = json.loads(reasoning_result.output)["llm.reasoning_model"]
+    assert explained["value"] is None
+    assert explained["origin"] == "unresolved:routing-error"
+    assert explained["status"] == "error"
+    assert "no routing candidate" in explained["error"]


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4847

## Linked Issue
Fixes #4847

## SBS Impact
- Primary subsystem: WSP settings spine
- Secondary subsystem(s): CAO/Product provider-neutral LLM routing and reasoning execution
- Write class: Mechanical effective-route resolution; no new authority
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: Registered reasoning-model explain and provider-neutral execution consume one side-effect-free effective-route resolver.
- Owner-doc impact: none; the stacked #4800 base already documents shared effective routing and this recovery restores that stated behavior.
- Transition debt impact: no new transition debt; the bounded `REASONING_MODEL` compatibility override remains model-only.
- Boundary risk: Explain must not guess or execute a route independently of the production reasoning selection.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Resolve the effective provider-neutral reasoning route once while preserving provider, model, execution mode, degradation, embedding, and trace identity.
- Make both `OllamaDeliberationAgent` execution and registered `settings explain llm.reasoning_model` consume that shared pure resolver.
- Add canonical compiled/no-environment CLI and production-shaped execution proofs, including the bounded legacy model override.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded current-state code correction produced no BuilderOps material or cross-authority proposal.

## Notes
- This is a deliberately stacked recovery PR targeting `codex/issue-4796-llm-retrieval-settings-20260812` at PR #4800's exact blocked head. Merging it advances that branch without landing or closing #4796 by proxy.
- It does not reset, rebind, or consume additional repair attempts for #4800's exhausted `retrieval-settings/effective-resolution-and-provenance` receipt.
- Recovery mechanism repair attempt 1 guards the failure-trace fallback against routing failure and reports `LLM_FORCE_MODEL` as environment provenance; this accounting belongs only to #4847.
- Recovery repair attempt 2 followed the low-convergence circuit breaker: a Sol/ultra convergence review blocked mixed settings generations, the captured-bundle repair landed on `8b7618b254f32550c5dfbee57f46e9ff3dbf0a5e`, and its pre-expensive re-review was clean.
- Current-head CI then found one separate static-quality mechanism: the single-location architecture scanner rejected a router-local settings artifact string. Static-quality repair attempt 1 routes provenance through the canonical location formatter and its exact architecture selector is green on `c25ae0920004df6824e532712c969f6525827f77`.
- The circuit breaker explicitly requests one fresh clean independent final review on the published repaired head, so this recovery declares `Final-Review-Rounds: 1` and uses the full verified-merge path. It never selects the backward-compatibility-only value `2`.

## Validation
- `python3 -m pytest -q tests/settings/test_reasoning_route_recovery.py tests/settings/test_llm_retrieval_settings.py::test_canonical_compiled_routes_reach_real_llm_consumers tests/settings/test_llm_retrieval_settings.py::test_registered_cli_reports_effective_llm_provenance tests/reasoning/test_provider_mock.py tests/reasoning/test_reasoning_trace_e2e.py` — 12 passed.
- `python3 -m pytest -q tests/settings/test_reasoning_route_recovery.py tests/settings/test_llm_retrieval_settings.py tests/settings/test_canonical_location.py tests/architecture/test_settings_single_location.py::test_no_new_settings_paths tests/cli/test_settings_explain_cli.py tests/reasoning/test_provider_mock.py tests/reasoning/test_reasoning_llm_logging.py tests/reasoning/test_reasoning_trace_e2e.py tests/components/llm/test_router.py tests/components/llm/test_router_enforced_provider.py tests/components/llm/test_router_failures.py tests/components/llm/test_fabric.py` — 126 passed on `c25ae0920004df6824e532712c969f6525827f77`.
- `ruff check app tests companion-ui/companion-app` — clean.
- `mypy app` — clean across 884 source files.
- `python3 -m app.cli settings-validate --json` — `ok: true`.
- `git diff --check` — clean.
