### PR TITLE
fix: preserve extractor-id narrowing in acquisition requests

### DIFF
--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -990,8 +990,8 @@ class AcquisitionRequests:
         # Normalize: the stored snapshot always mirrors the authoritative
         # policy_version column, so no later reader can see the two disagree.
         snapshot["policy_version"] = policy_version
-        if snapshot.get("extractor_ids") is not None:
-            extractor_ids = snapshot["extractor_ids"]
+        extractor_ids = snapshot.get("extractor_ids")
+        if extractor_ids is not None:
             if not isinstance(extractor_ids, list) or not all(
                 isinstance(x, str) and x.strip() for x in extractor_ids
             ):
@@ -1016,7 +1016,7 @@ class AcquisitionRequests:
                     "policy_snapshot.extractor_requirements must map non-empty extractor ids "
                     "to a required/optional materialization classification"
                 )
-            selected = tuple(snapshot.get("extractor_ids") or ("summary",))
+            selected = tuple(extractor_ids or ("summary",))
             if set(extractor_requirements) != set(selected):
                 raise AcquisitionRequestValidationError(
                     "policy_snapshot.extractor_requirements must classify every selected "

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -869,6 +869,25 @@ def test_enqueue_rejects_invalid_extractor_requirements() -> None:
         )
 
 
+def test_enqueue_accepts_summary_requirements_when_extractor_ids_are_omitted() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+
+    row = _enqueue(
+        q,
+        conn,
+        policy_snapshot={
+            "policy_version": 1,
+            "extractor_requirements": {"summary": "required_for_materialization"},
+        },
+    )
+
+    assert row.policy_snapshot == {
+        "policy_version": 1,
+        "extractor_requirements": {"summary": "required_for_materialization"},
+    }
+
+
 def test_drain_passes_extractor_requirements_and_completes_optional_failure() -> None:
     from app.knowledge_acquisition.acquire import AcquireStageReceipt, AcquisitionReceipt
 


### PR DESCRIPTION
Governing-Issue: #4855

Fixes #4855

Final-Review-Rounds: 0

## Summary
Read `extractor_ids` once so validation and tuple selection share the same narrowed value, preserving the omitted-value `summary` default without changing the stored snapshot or mismatch refusal. Add the named regression covering summary-only requirements with omitted extractor IDs.

## SBS Impact
- Primary subsystem: Knowledge Acquisition / durable acquisition requests
- Secondary subsystem(s): static type gate and extraction-lineage validation
- Write class: current-state correctness repair
- Persistence impact: none; stored request shape is unchanged
- Derived/rebuildable impact: none
- New or changed contract: none
- Owner-doc impact: no change; runtime semantics and owner contracts are unchanged
- Transition debt impact: removes the main-branch MyPy regression inherited from PR #4832
- Boundary risk: default extractor selection and mismatch refusal are preserved by named tests

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The repair followed the Issue contract without a delivery divergence or operational state requiring BuilderOps capture.

## Notes
Validation:
- `pytest -q tests/knowledge_acquisition/test_acquisition_requests.py::test_enqueue_accepts_summary_requirements_when_extractor_ids_are_omitted tests/knowledge_acquisition/test_acquisition_requests.py::test_enqueue_rejects_requirement_map_that_does_not_match_selected_extractors` (2 passed)
- `pytest -q tests/knowledge_acquisition/test_acquisition_requests.py` (36 passed)
- `mypy app/knowledge_acquisition/acquisition_requests.py` (1 source file clean)
- `mypy app` (884 source files clean)
- `ruff check app tests companion-ui/companion-app` (clean)
- `git diff --check` (clean)

Pickup receipt: `coordination_mode=dispatcher-backed task_id=github-RasmusTho--agentic-pkm-mvp-issue-4855 lease_id=lease-da7aedad holder=codex-issue-4855 evidence=verified-dispatcher-lease`.

Owner-doc decision: no change; the implementation is semantics-preserving and restores static proof for already-documented behavior.
---