### PR TITLE
Automate MVR-03 principal cutover wiring

### DIFF
--- a/app/instance/local_operator_principal.py
+++ b/app/instance/local_operator_principal.py
@@ -38,7 +38,7 @@ import secrets
 import stat
 import tempfile
 import time
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
@@ -305,6 +305,19 @@ class LocalOperatorPrincipalStore:
             finally:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
+    @contextmanager
+    def cutover_lock(self) -> Iterator[None]:
+        """Serialize the first-role write with attempt-local floor compensation.
+
+        The cutover coordinator uses this same lock for its failed-bootstrap role
+        recheck and compensation. Keeping the boundary public and narrow prevents a
+        stale floor sample from committing a role after another process removed that
+        floor.
+        """
+
+        with self._locked():
+            yield
+
     @staticmethod
     def _ensure_private_directory(directory: Path) -> None:
         directory.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -451,7 +464,7 @@ class LocalOperatorPrincipalStore:
         credential: str | None,
         subjects: Sequence[AuthSubject],
         migration_provenance: str,
-        floor_recorded: bool,
+        floor_guard: Callable[[], bool],
         _capability: Any = None,
     ) -> LocalOperatorPrincipalRecord:
         """Write the first durable delegated-role record.
@@ -462,30 +475,35 @@ class LocalOperatorPrincipalStore:
         """
 
         _require_storage_mutation_capability(_capability)
-        if not floor_recorded:
-            raise PrincipalFloorNotRecordedError(
-                "the minimum_runtime_principal floor must be recorded before the first "
-                "durable delegated-role write"
-            )
-        credential_fingerprint = (
-            fingerprint_credential(credential, new_credential_salt()) if credential else None
-        )
         if migration_provenance not in MIGRATION_PROVENANCES:
             raise PrincipalPreflightError(
                 f"unknown migration provenance {migration_provenance!r}",
                 provisioning_action="use a declared MVR-03 migration provenance",
             )
         normalized = _normalize_subjects(subjects)
-        if SUBJECT_API_KEY in normalized and not credential_fingerprint:
+        if SUBJECT_API_KEY in normalized and not credential:
             raise PrincipalPreflightError(
                 "the api_key_credential subject requires a credential fingerprint",
                 provisioning_action="provision a #2223 API key, then re-run principal bootstrap",
             )
         with self._locked():
+            # Sample the registry floor only after acquiring the same principal lock
+            # used by cutover compensation. A caller-sampled bool can go stale while
+            # waiting here and would permit a role to commit after its floor vanished.
+            if not floor_guard():
+                raise PrincipalFloorNotRecordedError(
+                    "the minimum_runtime_principal floor must be recorded before the first "
+                    "durable delegated-role write"
+                )
             existing = self.load()
             if existing is not None:
+                credential_matches = (
+                    verify_credential(existing.credential_fingerprint, credential)
+                    if credential
+                    else existing.credential_fingerprint is None
+                )
                 if (
-                    existing.credential_fingerprint == credential_fingerprint
+                    credential_matches
                     and existing.subjects == normalized
                     and existing.migration_provenance == migration_provenance
                 ):
@@ -497,6 +515,9 @@ class LocalOperatorPrincipalStore:
                         "re-bootstrapping"
                     ),
                 )
+            credential_fingerprint = (
+                fingerprint_credential(credential, new_credential_salt()) if credential else None
+            )
             now = _now()
             record = LocalOperatorPrincipalRecord(
                 schema=LOCAL_OPERATOR_PRINCIPAL_SCHEMA,

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -184,6 +184,55 @@ class OwnershipLedger:
             ):
                 raise LedgerKeyError("scalar rollback session authentication failed")
 
+    def authenticate_principal_cutover_receipt(
+        self,
+        payload: Mapping[str, object],
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> dict[str, object]:
+        """Authenticate one attempt-local clean-failure receipt."""
+
+        _require_storage_mutation_capability(_capability)
+        self._assert_existing_artifacts()
+        with self._locked():
+            key = self._load_or_create_key_locked(allow_create=False)
+            self._load_or_create_ledger_locked(key, allow_create=False)
+            encoded = json.dumps(
+                dict(payload), sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+            return {
+                "keyId": key.key_id,
+                "keyGeneration": key.generation,
+                "hmacSha256": hmac.new(key.secret, encoded, hashlib.sha256).hexdigest(),
+            }
+
+    def verify_principal_cutover_receipt(
+        self,
+        payload: Mapping[str, object],
+        authentication: Mapping[str, object],
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> None:
+        """Reject a forged or stale-key principal cutover receipt."""
+
+        _require_storage_mutation_capability(_capability)
+        self._assert_existing_artifacts()
+        with self._locked():
+            key = self._load_or_create_key_locked(allow_create=False)
+            self._load_or_create_ledger_locked(key, allow_create=False)
+            encoded = json.dumps(
+                dict(payload), sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+            expected = hmac.new(key.secret, encoded, hashlib.sha256).hexdigest()
+            if (
+                authentication.get("keyId") != key.key_id
+                or authentication.get("keyGeneration") != key.generation
+                or not hmac.compare_digest(
+                    str(authentication.get("hmacSha256") or ""), expected
+                )
+            ):
+                raise LedgerKeyError("principal cutover receipt authentication failed")
+
     def require_scalar_rollback_ready(
         self,
         *,

--- a/app/instance/principal_fence.py
+++ b/app/instance/principal_fence.py
@@ -19,8 +19,9 @@ Ordering this module enforces:
       -> record the floor -> first durable delegated-role write
 
 A missing producer, a drain failure, or a crash before the floor leaves old auth state
-authoritative and this migration untouched. A failure *after* the floor requires compatible
-roll-forward and cannot restart an old producer.
+authoritative and this migration untouched. Before any role persists, the automated cutover may
+compensate only its own floor under the same stopped lease; every ambiguous or post-role failure
+preserves the fence for compatible roll-forward and cannot restart an old producer.
 """
 
 from __future__ import annotations
@@ -97,6 +98,10 @@ class PrincipalFenceError(PrincipalPreflightError):
     """The principal cutover fence is incomplete; nothing durable may be written."""
 
 
+class PrincipalFloorCompensationError(PrincipalFenceError):
+    """The cutover could not prove that its floor compensation completed safely."""
+
+
 @dataclass(frozen=True)
 class AuthProducer:
     """One enabled producer that must be drained and stopped before the floor."""
@@ -161,6 +166,14 @@ class PrincipalFenceInventory:
         return tuple(producer for producer in self.producers if not producer.quiesced)
 
 
+@dataclass(frozen=True)
+class PrincipalFloorWrite:
+    """Ephemeral result binding bootstrap compensation to this floor attempt."""
+
+    snapshot: Any
+    advanced: bool
+
+
 def discover_auth_producers(
     *,
     compose_path: Path,
@@ -219,13 +232,18 @@ def discover_auth_producers(
         if relative.startswith("scripts/"):
             path = repo_root / relative
             present = path.is_file()
-            if present:
-                evidence.append(
-                    f"native:{relative}:"
-                    f"{hashlib.sha256(path.read_bytes()).hexdigest()}"
+            if not present:
+                raise PrincipalFenceError(
+                    f"declared native auth producer is missing: {relative}",
+                    provisioning_action=(
+                        "mount every NATIVE_AUTH_PRODUCERS script under the declared "
+                        "native producer root, then re-run the cutover"
+                    ),
                 )
-            else:
-                evidence.append(f"native:{relative}:absent")
+            evidence.append(
+                f"native:{relative}:"
+                f"{hashlib.sha256(path.read_bytes()).hexdigest()}"
+            )
         else:
             present = True
             evidence.append(f"native:{relative}:module")
@@ -303,7 +321,7 @@ def record_principal_floor(
     *,
     inventory: PrincipalFenceInventory,
     _capability: Any = None,
-) -> Any:
+) -> PrincipalFloorWrite:
     """Record the `minimum_runtime_principal` floor -- and only then may a role be written.
 
     It reuses MVR-01's `runtimeFloors` extension slot rather than inventing a second floor
@@ -321,18 +339,39 @@ def record_principal_floor(
     snapshot = registry_store.load()
     extensions = snapshot.extensions or {}
     floors = dict(extensions.get("runtimeFloors") or {})
+    existing_floor = str(floors.get(MINIMUM_RUNTIME_PRINCIPAL_KEY) or "").strip()
+    if existing_floor:
+        if existing_floor != MINIMUM_RUNTIME_PRINCIPAL:
+            raise PrincipalFenceError(
+                "a different principal runtime floor is already recorded",
+                provisioning_action="keep the deployment stopped and inspect runtime floor state",
+            )
+        existing_fence = (extensions.get("principalState") or {}).get("fence")
+        if (
+            not isinstance(existing_fence, Mapping)
+            or str(existing_fence.get("channel_id") or "") != inventory.channel_id
+            or dict(existing_fence) != inventory.as_payload()
+        ):
+            raise PrincipalFenceError(
+                "the existing MVR-03 floor has no matching current producer fence",
+                provisioning_action="keep the deployment stopped and inspect principal state",
+            )
+        return PrincipalFloorWrite(snapshot=snapshot, advanced=False)
     floors[MINIMUM_RUNTIME_PRINCIPAL_KEY] = MINIMUM_RUNTIME_PRINCIPAL
     principal_state = dict(extensions.get("principalState") or {})
     principal_state["fence"] = json.loads(json.dumps(inventory.as_payload()))
-    return registry_store.set_extension_state(
-        principal_state=principal_state,
-        background_state=dict(extensions.get("backgroundState") or {}),
-        runtime_floors=floors,
-        # Pin the revision this function actually read. Without it a dimension or
-        # background write committing between that read and the locked write would be
-        # silently clobbered by the payload re-supplied above (MVR-04, #3858).
-        expected_revision=snapshot.revision,
-        _capability=_capability,
+    return PrincipalFloorWrite(
+        snapshot=registry_store.set_extension_state(
+            principal_state=principal_state,
+            background_state=dict(extensions.get("backgroundState") or {}),
+            runtime_floors=floors,
+            # Pin the revision this function actually read. Without it a dimension or
+            # background write committing between that read and the locked write would be
+            # silently clobbered by the payload re-supplied above (MVR-04, #3858).
+            expected_revision=snapshot.revision,
+            _capability=_capability,
+        ),
+        advanced=True,
     )
 
 
@@ -343,6 +382,52 @@ def principal_floor_recorded(registry_store: Any) -> bool:
     if not isinstance(floors, dict):
         return False
     return str(floors.get(MINIMUM_RUNTIME_PRINCIPAL_KEY) or "").strip() == MINIMUM_RUNTIME_PRINCIPAL
+
+
+def compensate_principal_floor(
+    registry_store: Any,
+    *,
+    channel_id: str,
+    expected_registry_revision: int,
+    _capability: Any = None,
+) -> Any:
+    """Remove only this attempt's MVR-03 floor after a pre-role bootstrap failure.
+
+    The runtime caller first proves the same deployment lease is still stopped and that no
+    delegated-role record became durable. This registry mutation preserves sibling state and
+    refuses if anything changed after the floor receipt's pinned revision.
+    """
+
+    snapshot = registry_store.load()
+    if snapshot.revision != expected_registry_revision:
+        raise PrincipalFloorCompensationError(
+            "principal state changed after this cutover advanced the floor",
+            provisioning_action="keep the stopped deployment fence and inspect principal state",
+        )
+    extensions = snapshot.extensions or {}
+    floors = dict(extensions.get("runtimeFloors") or {})
+    principal_state = dict(extensions.get("principalState") or {})
+    floor = str(floors.get(MINIMUM_RUNTIME_PRINCIPAL_KEY) or "").strip()
+    if floor != MINIMUM_RUNTIME_PRINCIPAL:
+        raise PrincipalFloorCompensationError(
+            "the recorded principal floor is not the MVR-03 cutover floor",
+            provisioning_action="keep the stopped deployment fence and inspect runtime floor state",
+        )
+    fence = principal_state.get("fence")
+    if not isinstance(fence, Mapping) or str(fence.get("channel_id") or "") != channel_id:
+        raise PrincipalFloorCompensationError(
+            "the recorded principal fence does not belong to this channel",
+            provisioning_action="keep the stopped deployment fence and inspect principal state",
+        )
+    floors.pop(MINIMUM_RUNTIME_PRINCIPAL_KEY, None)
+    principal_state.pop("fence", None)
+    return registry_store.set_extension_state(
+        principal_state=principal_state,
+        background_state=dict(extensions.get("backgroundState") or {}),
+        runtime_floors=floors,
+        expected_revision=snapshot.revision,
+        _capability=_capability,
+    )
 
 
 def inventory_from_quiescence(
@@ -434,9 +519,12 @@ __all__ = [
     "PRINCIPAL_FENCE_SCHEMA",
     "AuthProducer",
     "PrincipalFenceError",
+    "PrincipalFloorCompensationError",
     "PrincipalFenceInventory",
+    "PrincipalFloorWrite",
     "build_fence_inventory",
     "discover_auth_producers",
+    "compensate_principal_floor",
     "principal_floor_recorded",
     "record_principal_floor",
     "require_complete_fence",

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3179,6 +3179,7 @@ def _dimension_command(args: argparse.Namespace) -> int:
 PRINCIPAL_COMMANDS = (
     "principal-show",
     "principal-record-floor",
+    "principal-cutover",
     "principal-bootstrap",
     "principal-rotate-credential",
     "principal-add-role",
@@ -3267,9 +3268,12 @@ def _principal_command(args: argparse.Namespace) -> int:
     from app.instance.local_operator_principal import (
         PrincipalPreflightError,
         preflight_auth_posture,
+        verify_credential,
     )
     from app.instance.principal_fence import (
         PrincipalFenceError,
+        PrincipalFloorCompensationError,
+        compensate_principal_floor,
         inventory_from_quiescence,
         principal_floor_recorded,
         record_principal_floor,
@@ -3280,7 +3284,12 @@ def _principal_command(args: argparse.Namespace) -> int:
     store = open_local_operator_principal_store(registry_path)
     extra: dict[str, object] = {}
     try:
-        if args.command == "principal-record-floor":
+        floor_write = None
+        inventory = None
+        posture = None
+        subjects = None
+        proof = None
+        if args.command in {"principal-record-floor", "principal-cutover"}:
             # Runs INSIDE MVR-01B's existing stopped window, after `deployment-prove`, with
             # the compose policy mounted read-only -- the same shape as
             # `authority-cutover`. It consumes that window's proof rather than inventing a
@@ -3301,9 +3310,10 @@ def _principal_command(args: argparse.Namespace) -> int:
             # deployment that records it and then fails to write the role would leave the
             # instance fenced, rollback-blocked, and principal-less. Refusing here makes
             # that ordering unreachable rather than merely unlikely.
-            preflight_auth_posture(
-                current_auth_posture(loopback_listener_proven=args.loopback_listener)
+            posture = current_auth_posture(
+                loopback_listener_proven=args.loopback_listener
             )
+            subjects = preflight_auth_posture(posture)
             inventory = inventory_from_quiescence(
                 channel_id=args.channel,
                 quiescence_proof=proof,
@@ -3311,41 +3321,205 @@ def _principal_command(args: argparse.Namespace) -> int:
                 compose_path=Path(args.compose_base),
                 repo_root=Path(args.native_producer_root),
             )
-            snapshot = record_principal_floor(
-                registry,
-                inventory=inventory,
-                _capability=local_operator_storage_capability(),
-            )
-            print(
-                json.dumps(
-                    {
-                        "ok": True,
-                        "consumer": args.consumer,
-                        "floor_recorded": True,
-                        "registry_revision": snapshot.revision,
-                        "fenced_producers": len(inventory.producers),
-                    },
-                    sort_keys=True,
+            try:
+                floor_write = record_principal_floor(
+                    registry,
+                    inventory=inventory,
+                    _capability=local_operator_storage_capability(),
                 )
-            )
-            return 0
+            except (OSError, RegistryError) as error:
+                if args.command == "principal-cutover":
+                    # Once the registry mutation starts, an unreadable outcome is not an
+                    # ordinary preflight failure: preserve the stopped lease because the
+                    # floor may be durable even though no receipt could be returned.
+                    raise PrincipalFloorCompensationError(
+                        "principal floor write outcome is ambiguous",
+                        provisioning_action=(
+                            "keep the deployment stopped and inspect principal state"
+                        ),
+                    ) from error
+                raise
+            if args.command == "principal-record-floor":
+                print(
+                    json.dumps(
+                        {
+                            "ok": True,
+                            "consumer": args.consumer,
+                            "floor_recorded": True,
+                            "floor_advanced": floor_write.advanced,
+                            "registry_revision": floor_write.snapshot.revision,
+                            "fenced_producers": len(inventory.producers),
+                        },
+                        sort_keys=True,
+                    )
+                )
+                return 0
         if args.command == "principal-show":
             record = store.require()
-        elif args.command == "principal-bootstrap":
+        elif args.command in {"principal-bootstrap", "principal-cutover"}:
             # The posture is read from server configuration, not asserted by flags, so the
             # bound subjects match what the request path will actually admit.
-            posture = current_auth_posture(
-                loopback_listener_proven=args.loopback_listener,
+            if posture is None:
+                posture = current_auth_posture(
+                    loopback_listener_proven=args.loopback_listener,
+                )
+            provenance = posture.migration_provenance(
+                existing_install=args.existing_install
             )
-            record = store.bootstrap(
-                credential=posture.credential,
-                subjects=preflight_auth_posture(posture),
-                migration_provenance=posture.migration_provenance(
-                    existing_install=args.existing_install
-                ),
-                floor_recorded=principal_floor_recorded(registry),
-                _capability=local_operator_storage_capability(),
-            )
+            compensation_enabled = args.command == "principal-cutover"
+            if compensation_enabled:
+                assert floor_write is not None
+                assert proof is not None
+
+                def _require_same_cutover_authority() -> None:
+                    """Re-prove this process's stopped lease before either mutation."""
+
+                    try:
+                        current_proof = json.loads(
+                            Path(args.quiescence_proof_path).read_text(encoding="utf-8")
+                        )
+                        _require_proved_deployment_lease(
+                            host_global_root=Path(args.host_global_root),
+                            channel=args.channel,
+                            nonce=current_proof.get("nonce"),
+                        )
+                        if current_proof.get("nonce") != proof.get("nonce"):
+                            raise PrincipalFloorCompensationError(
+                                "principal cutover lease changed after the floor write",
+                                provisioning_action=(
+                                    "keep the deployment stopped and inspect principal state"
+                                ),
+                            )
+                    except (
+                        OSError,
+                        ValueError,
+                        PrincipalFenceError,
+                        RegistryError,
+                    ) as error:
+                        raise PrincipalFloorCompensationError(
+                            "principal cutover cannot re-prove its stopped deployment window",
+                            provisioning_action=(
+                                "keep the deployment stopped and restore its proved lease before retrying"
+                            ),
+                        ) from error
+
+                _require_same_cutover_authority()
+                try:
+                    if registry.load().revision != floor_write.snapshot.revision:
+                        raise PrincipalFloorCompensationError(
+                            "principal state changed between floor and bootstrap",
+                            provisioning_action=(
+                                "keep the deployment stopped and inspect principal state"
+                            ),
+                        )
+                except (OSError, ValueError, PrincipalFenceError, RegistryError) as error:
+                    raise PrincipalFloorCompensationError(
+                        "principal cutover cannot re-prove its stopped deployment window",
+                        provisioning_action=(
+                            "keep the deployment stopped and restore its proved lease before retrying"
+                        ),
+                    ) from error
+            if subjects is None:
+                subjects = preflight_auth_posture(posture)
+            try:
+                record = store.bootstrap(
+                    credential=posture.credential,
+                    subjects=subjects,
+                    migration_provenance=provenance,
+                    floor_guard=lambda: principal_floor_recorded(registry),
+                    _capability=local_operator_storage_capability(),
+                )
+            except Exception as bootstrap_error:
+                if not compensation_enabled:
+                    raise
+                # Serialize the post-failure role read and compensation with bootstrap's
+                # floor guard + first-role write. Either bootstrap commits first and this
+                # path preserves its floor, or compensation completes first and a waiting
+                # bootstrap re-samples the missing floor and refuses to write.
+                with store.cutover_lock():
+                    try:
+                        committed = store.load()
+                    except (OSError, PrincipalPreflightError, RegistryError) as state_error:
+                        raise PrincipalFloorCompensationError(
+                            "bootstrap failed with ambiguous delegated-role state",
+                            provisioning_action=(
+                                "keep the deployment stopped and inspect the private principal record"
+                            ),
+                        ) from state_error
+                    if committed is not None:
+                        credential_matches = (
+                            verify_credential(
+                                committed.credential_fingerprint, posture.credential
+                            )
+                            if posture.credential
+                            else committed.credential_fingerprint is None
+                        )
+                        if (
+                            credential_matches
+                            and committed.subjects == subjects
+                            and committed.migration_provenance == provenance
+                        ):
+                            # Atomic persistence won before a later bootstrap step raised. Never
+                            # lower the floor beneath that role and never misreport the raised
+                            # bootstrap as success: preserve the stopped fence for a clean retry.
+                            raise PrincipalFloorCompensationError(
+                                "bootstrap reported failure after matching delegated-role state became durable",
+                                provisioning_action=(
+                                    "keep the deployment stopped and retry the idempotent bootstrap"
+                                ),
+                            ) from bootstrap_error
+                        raise PrincipalFloorCompensationError(
+                            "bootstrap failed after different delegated-role state became durable",
+                            provisioning_action=(
+                                "keep the deployment stopped and reconcile principal state"
+                            ),
+                        ) from bootstrap_error
+
+                    assert floor_write is not None
+                    if not floor_write.advanced:
+                        raise PrincipalFloorCompensationError(
+                            "bootstrap failed while a pre-existing principal floor remained active",
+                            provisioning_action=(
+                                "keep the deployment stopped and reconcile principal state"
+                            ),
+                        ) from bootstrap_error
+                    try:
+                        # Lease recheck, role absence, and compensation remain one
+                        # principal-lock-serialized decision.
+                        _require_same_cutover_authority()
+                        compensate_principal_floor(
+                            registry,
+                            channel_id=args.channel,
+                            expected_registry_revision=floor_write.snapshot.revision,
+                            _capability=local_operator_storage_capability(),
+                        )
+                    except Exception as compensation_error:
+                        raise PrincipalFloorCompensationError(
+                            "bootstrap failed and the principal floor could not be compensated",
+                            provisioning_action=(
+                                "keep the deployment stopped and repair the cutover before retrying"
+                            ),
+                        ) from compensation_error
+                if isinstance(
+                    bootstrap_error,
+                    (PrincipalPreflightError, CapabilityNotReadyError),
+                ):
+                    raise bootstrap_error
+                raise PrincipalPreflightError(
+                    "principal bootstrap failed before role persistence and the floor was compensated",
+                    provisioning_action=(
+                        "repair the bootstrap producer, then retry the cutover"
+                    ),
+                ) from bootstrap_error
+            if compensation_enabled:
+                assert floor_write is not None
+                assert inventory is not None
+                extra = {
+                    "floor_recorded": True,
+                    "floor_advanced": floor_write.advanced,
+                    "floor_registry_revision": floor_write.snapshot.revision,
+                    "fenced_producers": len(inventory.producers),
+                }
         elif args.command == "principal-rotate-credential":
             record = store.rotate_credential(
                 credential=_read_credential(args),
@@ -3384,14 +3558,45 @@ def _principal_command(args: argparse.Namespace) -> int:
             record = store.reconcile_roll_forward(
                 _capability=local_operator_storage_capability(),
             )
-    except (PrincipalFenceError, PrincipalPreflightError, CapabilityNotReadyError) as exc:
+    except PrincipalFloorCompensationError as exc:
         print(
             json.dumps(
                 {"ok": False, "consumer": args.consumer, "error": str(exc)},
                 sort_keys=True,
             )
         )
-        return 1
+        # Preserve the proved deployment fence for governed repair when role/floor
+        # state is ambiguous or compensation itself could not be proven.
+        return 75
+    except (PrincipalFenceError, PrincipalPreflightError, CapabilityNotReadyError) as exc:
+        exit_code = 1
+        if args.command == "principal-cutover":
+            try:
+                if principal_floor_recorded(registry):
+                    exit_code = 75
+            except (OSError, PrincipalPreflightError, RegistryError):
+                exit_code = 75
+        print(
+            json.dumps(
+                {"ok": False, "consumer": args.consumer, "error": str(exc)},
+                sort_keys=True,
+            )
+        )
+        return exit_code
+    except (OSError, ValueError, RegistryError):
+        if args.command != "principal-cutover":
+            raise
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "consumer": args.consumer,
+                    "error": "principal cutover state is ambiguous; keep the deployment stopped",
+                },
+                sort_keys=True,
+            )
+        )
+        return 75
     print(
         json.dumps(
             {
@@ -3518,7 +3723,7 @@ def main(argv: list[str] | None = None) -> int:
         command = subparsers.add_parser(name)
         command.add_argument("--registry-path", type=Path, required=True)
         command.add_argument("--consumer", default=None)
-        if name == "principal-record-floor":
+        if name in {"principal-record-floor", "principal-cutover"}:
             # Explicit mounted source paths, matching `authority-cutover`: the runtime image
             # contains no repo checkout, so nothing here may be derived from `__file__`.
             command.add_argument("--channel", required=True)
@@ -3547,6 +3752,7 @@ def main(argv: list[str] | None = None) -> int:
             # configuration. This flag only declares that the deployment exposes a
             # loopback-local listener, and every request still proves loopback itself.
             command.add_argument("--loopback-listener", action="store_true")
+        if name in {"principal-bootstrap", "principal-cutover"}:
             command.add_argument("--existing-install", action="store_true")
         if name == "principal-rotate-credential":
             command.add_argument("--credential-stdin", action="store_true")

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3180,6 +3180,7 @@ PRINCIPAL_COMMANDS = (
     "principal-show",
     "principal-record-floor",
     "principal-cutover",
+    "principal-verify-cutover-clean-failure",
     "principal-bootstrap",
     "principal-rotate-credential",
     "principal-add-role",
@@ -3187,6 +3188,113 @@ PRINCIPAL_COMMANDS = (
     "principal-export-auth-state",
     "principal-roll-forward",
 )
+
+_PRINCIPAL_CUTOVER_CLEAN_FAILURE_SCHEMA = (
+    "agentic-pkm.principal-cutover-clean-failure.v1"
+)
+
+
+def _principal_cutover_receipt_path(
+    *, host_global_root: Path, receipt_path: Path, attempt_id: str
+) -> Path:
+    """Resolve one private attempt receipt without permitting path injection."""
+
+    if re.fullmatch(r"[0-9a-f]{32}", attempt_id) is None:
+        raise RegistryError("principal cutover attempt id is invalid")
+    root = host_global_root.resolve(strict=True)
+    path = receipt_path.resolve(strict=False)
+    if (
+        path.parent != root
+        or path.name != f"principal-cutover-clean-failure-{attempt_id}.json"
+    ):
+        raise RegistryError(
+            "principal cutover clean-failure receipt path is invalid"
+        )
+    return path
+
+
+def _verify_principal_cutover_clean_failure(args: argparse.Namespace) -> int:
+    """Consume an authenticated clean-failure receipt for this stopped attempt."""
+
+    from app.instance.principal_fence import principal_floor_recorded
+
+    root = Path(args.host_global_root)
+    receipt_path = _principal_cutover_receipt_path(
+        host_global_root=root,
+        receipt_path=Path(args.clean_failure_receipt_path),
+        attempt_id=args.attempt_id,
+    )
+    metadata = receipt_path.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_mode & 0o777 != 0o600
+    ):
+        raise RegistryError("principal cutover receipt is unsafe")
+    document = json.loads(receipt_path.read_text(encoding="utf-8"))
+    payload = document.get("payload") if isinstance(document, dict) else None
+    authentication = (
+        document.get("authentication") if isinstance(document, dict) else None
+    )
+    if not isinstance(payload, dict) or not isinstance(authentication, dict):
+        raise RegistryError("principal cutover receipt is invalid")
+
+    proof = json.loads(Path(args.quiescence_proof_path).read_text(encoding="utf-8"))
+    lease = _require_proved_deployment_lease(
+        host_global_root=root,
+        channel=args.channel,
+        nonce=proof.get("nonce"),
+    )
+    expected = {
+        "schema": _PRINCIPAL_CUTOVER_CLEAN_FAILURE_SCHEMA,
+        "channel_id": args.channel,
+        "deployment_nonce": lease["nonce"],
+        "attempt_id": args.attempt_id,
+        "outcome": "clean_failure",
+        "floor_recorded": False,
+        "role_recorded": False,
+    }
+    if any(payload.get(key) != value for key, value in expected.items()):
+        raise RegistryError("principal cutover receipt binding is invalid")
+    floor_advanced = payload.get("floor_advanced")
+    floor_revision = payload.get("floor_registry_revision")
+    result_revision = payload.get("result_registry_revision")
+    if (
+        type(floor_advanced) is not bool
+        or not isinstance(result_revision, int)
+        or isinstance(result_revision, bool)
+        or (
+            floor_advanced
+            and (
+                not isinstance(floor_revision, int)
+                or isinstance(floor_revision, bool)
+                or result_revision <= floor_revision
+            )
+        )
+        or (not floor_advanced and floor_revision is not None)
+    ):
+        raise RegistryError("principal cutover receipt revisions are invalid")
+
+    ledger = OwnershipLedger(root)
+    ledger.verify_principal_cutover_receipt(
+        payload,
+        authentication,
+        _capability=local_operator_storage_capability(),  # type: ignore[arg-type]
+    )
+    registry = VaultRegistryStore(Path(args.registry_path))
+    store = open_local_operator_principal_store(Path(args.registry_path))
+    with store.cutover_lock():
+        if store.load() is not None or principal_floor_recorded(registry):
+            raise RegistryError(
+                "principal cutover clean-failure state is no longer current"
+            )
+        if registry.load().revision != result_revision:
+            raise RegistryError(
+                "principal cutover clean-failure revision is stale"
+            )
+        receipt_path.unlink()
+    print(json.dumps({"ok": True, "clean_failure_verified": True}, sort_keys=True))
+    return 0
 
 
 def _read_credential(args: argparse.Namespace) -> str | None:
@@ -3278,6 +3386,18 @@ def _principal_command(args: argparse.Namespace) -> int:
         principal_floor_recorded,
         record_principal_floor,
     )
+
+    if args.command == "principal-verify-cutover-clean-failure":
+        try:
+            return _verify_principal_cutover_clean_failure(args)
+        except (OSError, ValueError, LedgerError, PrincipalPreflightError, RegistryError):
+            print(
+                json.dumps(
+                    {"ok": False, "error": "principal cutover receipt is not current"},
+                    sort_keys=True,
+                )
+            )
+            return 1
 
     registry_path = Path(args.registry_path)
     registry = VaultRegistryStore(registry_path)
@@ -3576,6 +3696,61 @@ def _principal_command(args: argparse.Namespace) -> int:
                     exit_code = 75
             except (OSError, PrincipalPreflightError, RegistryError):
                 exit_code = 75
+            if exit_code == 1:
+                try:
+                    assert proof is not None
+                    receipt_path = _principal_cutover_receipt_path(
+                        host_global_root=Path(args.host_global_root),
+                        receipt_path=Path(args.clean_failure_receipt_path),
+                        attempt_id=args.attempt_id,
+                    )
+                    with store.cutover_lock():
+                        if store.load() is not None or principal_floor_recorded(registry):
+                            raise PrincipalFloorCompensationError(
+                                "principal clean-failure state became ambiguous",
+                                provisioning_action=(
+                                    "keep the deployment stopped and inspect principal state"
+                                ),
+                            )
+                        result_revision = registry.load().revision
+                        floor_revision = (
+                            floor_write.snapshot.revision
+                            if floor_write is not None and floor_write.advanced
+                            else None
+                        )
+                        payload: dict[str, object] = {
+                            "schema": _PRINCIPAL_CUTOVER_CLEAN_FAILURE_SCHEMA,
+                            "channel_id": args.channel,
+                            "deployment_nonce": proof["nonce"],
+                            "attempt_id": args.attempt_id,
+                            "outcome": "clean_failure",
+                            "floor_advanced": bool(
+                                floor_write is not None and floor_write.advanced
+                            ),
+                            "floor_registry_revision": floor_revision,
+                            "result_registry_revision": result_revision,
+                            "floor_recorded": False,
+                            "role_recorded": False,
+                        }
+                        authentication = OwnershipLedger(
+                            Path(args.host_global_root)
+                        ).authenticate_principal_cutover_receipt(
+                            payload,
+                            _capability=local_operator_storage_capability(),  # type: ignore[arg-type]
+                        )
+                        _write_private_json(
+                            receipt_path,
+                            {"payload": payload, "authentication": authentication},
+                        )
+                except (
+                    OSError,
+                    ValueError,
+                    LedgerError,
+                    PrincipalFloorCompensationError,
+                    PrincipalPreflightError,
+                    RegistryError,
+                ):
+                    exit_code = 75
         print(
             json.dumps(
                 {"ok": False, "consumer": args.consumer, "error": str(exc)},
@@ -3723,18 +3898,28 @@ def main(argv: list[str] | None = None) -> int:
         command = subparsers.add_parser(name)
         command.add_argument("--registry-path", type=Path, required=True)
         command.add_argument("--consumer", default=None)
-        if name in {"principal-record-floor", "principal-cutover"}:
+        if name in {
+            "principal-record-floor",
+            "principal-cutover",
+            "principal-verify-cutover-clean-failure",
+        }:
             # Explicit mounted source paths, matching `authority-cutover`: the runtime image
             # contains no repo checkout, so nothing here may be derived from `__file__`.
             command.add_argument("--channel", required=True)
             command.add_argument("--host-global-root", type=Path, required=True)
-            command.add_argument("--inventory-path", type=Path, required=True)
             command.add_argument("--quiescence-proof-path", type=Path, required=True)
+        if name in {"principal-record-floor", "principal-cutover"}:
+            command.add_argument("--inventory-path", type=Path, required=True)
             command.add_argument("--compose-base", type=Path, required=True)
             command.add_argument("--native-producer-root", type=Path, required=True)
             # The floor preflights the posture the subsequent role write will use, so it
             # needs the same declaration `principal-bootstrap` takes.
             command.add_argument("--loopback-listener", action="store_true")
+        if name in {"principal-cutover", "principal-verify-cutover-clean-failure"}:
+            command.add_argument("--attempt-id", required=True)
+            command.add_argument(
+                "--clean-failure-receipt-path", type=Path, required=True
+            )
         if name == "principal-revoke-subject":
             command.add_argument(
                 "--subject",

--- a/config/deploy/dev.env
+++ b/config/deploy/dev.env
@@ -1,2 +1,4 @@
 # Initial deploy pin for the dev channel. S5's deploy script updates this value.
 APP_IMAGE_TAG=b0a814e7d1a70c2c009ab1d2780f81d84715f6bf
+# Docker-published API traffic is not proven loopback inside the container.
+MVR03_PRINCIPAL_LOOPBACK_LISTENER=0

--- a/config/deploy/prod.env
+++ b/config/deploy/prod.env
@@ -1,2 +1,4 @@
 # Initial deploy pin for the prod channel. S5's deploy script updates this value.
 APP_IMAGE_TAG=314632235404cae1c51dc92b5f37174aa02b5fb0
+# Docker-published API traffic is not proven loopback inside the container.
+MVR03_PRINCIPAL_LOOPBACK_LISTENER=0

--- a/config/deploy/test.env
+++ b/config/deploy/test.env
@@ -1,2 +1,4 @@
 # Initial deploy pin for the test channel. S5's deploy script updates this value.
 APP_IMAGE_TAG=314632235404cae1c51dc92b5f37174aa02b5fb0
+# Docker-published API traffic is not proven loopback inside the container.
+MVR03_PRINCIPAL_LOOPBACK_LISTENER=0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,14 @@ services:
         BUILT_AT: ${BUILT_AT:-unknown}
     image: ${APP_IMAGE_REPOSITORY:-ghcr.io/rasmustho/pkm-app}:${APP_IMAGE_TAG:-dev-local}
     user: "0:0"
+    # MVR-03 runs current_auth_posture() in this one-shot before it records the
+    # floor and role. Mirror the API's non-host-secret config layers so API_KEY,
+    # when configured in the governed runtime env, resolves identically without
+    # exposing the API service's unrelated Heimdal/GitHub host-secret layer.
+    env_file:
+      - ./config/runtime.defaults.env
+      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+        required: false
     volumes:
       - "instance-state:/app/instance-state"
       - type: bind
@@ -96,6 +104,12 @@ services:
       - "./docker-compose.yaml:/run/scalar-rollback-policy/docker-compose.yaml:ro"
       - "./docker-compose.scalar-rollback.yml:/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml:ro"
       - "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro"
+      # Exact production native auth producers. The image deliberately excludes
+      # these host launchers; the cutover hashes the mounted bytes and fails
+      # closed if any declared path is absent.
+      - "./scripts/deploy_channel.sh:/run/principal-fence-native-producers/scripts/deploy_channel.sh:ro"
+      - "./scripts/start_full_system.sh:/run/principal-fence-native-producers/scripts/start_full_system.sh:ro"
+      - "./scripts/export_runtime_env.sh:/run/principal-fence-native-producers/scripts/export_runtime_env.sh:ro"
       - "/Users:/Users"
       - "/Volumes:/Volumes"
     command:
@@ -110,6 +124,9 @@ services:
       LOCAL_GID: ${LOCAL_GID:-0}
       LLM_PROVIDER: ${LLM_PROVIDER:-mock}
       DESIGN_HANDOFF_APP_LOCAL_SETTINGS: ${DESIGN_HANDOFF_APP_LOCAL_SETTINGS:-/app/tmp/agentic-pkm/app-local.md}
+      # Same server-owned proxy posture as api. The loopback subject is separate:
+      # the deployment wrapper passes its explicit per-channel declaration.
+      COMPANION_UI_PROXY_HOSTS: ${COMPANION_UI_PROXY_HOSTS:-companion-ui}
     restart: "no"
 
   api:

--- a/docs/MULTI_VAULT_RUNTIME/README.md
+++ b/docs/MULTI_VAULT_RUNTIME/README.md
@@ -1,9 +1,9 @@
 # Multi-vault runtime selection
 
 State: Active capability specification. Delivered: MVR-01A/01B/01C (#3853/#3854/#3855) mechanical
-substrate and authority cutover, MVR-02 (#3856) explicit instance default, and MVR-03 (#3857, partial) the
+substrate and authority cutover, MVR-02 (#3856) explicit instance default, and MVR-03 (#3857 plus #4524) the
 versioned request/session `ActiveContextSet` seam with its selection store, delegated-principal
-producer, and fail-closed runtime floor — whose deployment-wrapper activation is still open — and
+producer, fail-closed runtime floor, and explicit stopped-window deployment activation — and
 MVR-04 (#3858) non-authoritative dimension membership with all-or-nothing member resolution.
 Task 05 onward remains unstarted, so no global "multi-vault delivered"
 claim is allowed: production request-carrier propagation, binding-keyed persistence, and background

--- a/docs/MULTI_VAULT_RUNTIME/VERSION_ACTIVE_CONTEXT_SELECTION.md
+++ b/docs/MULTI_VAULT_RUNTIME/VERSION_ACTIVE_CONTEXT_SELECTION.md
@@ -11,13 +11,16 @@ can_parallelize_with: []
 
 # Version Active Context Selection
 
-State: **Partially delivered** by #3857. Shipped: the V1 seam, the TTL-bound selection store and
+State: **Delivered** by #3857 plus automated deployment activation in #4524. Shipped: the V1
+seam, the TTL-bound selection store and
 resolver, per-binding GOV authorization, the delegated local-operator principal record with its
 governed commands, the `minimum_runtime_principal` floor and auth-producer fence (fail-closed,
-operator-invoked), the production create/replace/inspect/clear endpoints, and full-context cache
-identity. **Not shipped:** automated activation of the principal cutover from
-`scripts/lib/instance_state_deployment.sh` — it needs credential/listener posture and the native
-launcher paths inside the `instance-state-init` one-shot, and #3857 remains open for it. Production request-carrier propagation stays sealed for MVR-05B (#3860); the dimension field was
+explicitly activated), the production create/replace/inspect/clear endpoints, and full-context cache
+identity. `scripts/lib/instance_state_deployment.sh` now activates the principal floor and role
+inside the existing stopped window only under the explicit cutover opt-in, with matching
+credential/proxy posture, complete native-producer mounts, and attempt-bound bootstrap-failure
+compensation. Production request-carrier propagation stays sealed for MVR-05B (#3860); the
+dimension field was
 unsealed by MVR-04 (#3858) as typed `DimensionFilter` provenance. Shipped truth lives in
 `docs/contracts/ACTIVE_CONTEXT_SET.md :: Shipped V1 seam (MVR-03, #3857)`,
 `docs/SECURITY.md :: Delegated local operator principal`, and

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -291,8 +291,11 @@ Currently recorded floors:
 | `minimumRuntimeSchema` | per MVR-01 | MVR-01B/01C (#3854/#3855) | scalar API/worker startup before the registry/queue schema it needs |
 | `minimumRuntimePrincipal` | `mvr-03` | MVR-03 (#3857) | a credential-only image with no delegated-principal producer |
 
-`minimumRuntimePrincipal` is set once the private delegated operator-role record becomes
-authoritative. A pre-MVR-03 image cannot resolve a principal at all, so
+`minimumRuntimePrincipal` is set together with the private delegated operator-role cutover only
+when a channel deployment carries the explicit `MVR03_PRINCIPAL_CUTOVER=1` opt-in. The governed
+dev/test/prod channel files each declare that their Docker-published API is not a proven loopback
+listener; the deployment wrapper resolves that channel declaration and passes the same posture to
+the single-process floor/role cutover. A pre-MVR-03 image cannot resolve a principal at all, so
 `app/instance/runtime.py::_require_runtime_floor` refuses it during scalar-rollback preflight,
 *before* any legacy projection is materialized. The compatible path is roll-forward: the prior
 image's final credential/auth revision is exported under lock and reconciled into the same
@@ -300,7 +303,7 @@ role id, and an ambiguous or divergent lineage fails closed without overwriting 
 
 A floor is lowered only by a later explicitly verified reversible migration. Rolling the
 `stable` ref back does not lower it, and forward-only acknowledgement at promotion time does
-not authorize crossing it. Full operator preflight and the exact commands live in
+not authorize crossing it. Full operator preflight and the automated cutover operation live in
 `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md :: Minimum runtime principal floor`.
 
 ### Vault is not release state

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -350,11 +350,14 @@ for compensation. If a complete matching role became durable before a later boot
 failed, it is never rolled back or reported as success. That case, an unreadable registry,
 changed lease, any other ambiguous role state, or failed compensation returns the distinct
 fail-closed status `75`; the wrapper preserves the lease/restart fence for repair instead of
-restarting old producers. Status `1` is the only classified clean failure for which the wrapper
-may release the stopped window: the command has proved either that no floor was written or that
-its attempt-local floor was compensated. Every other nonzero child status, including a signal or
-container death after the floor write, is unclassified and preserves the lease/restart fence. A
-crash before the floor leaves old auth state authoritative and the migration untouched.
+restarting old producers. No numeric child status authorizes release: Compose can return the same
+status as the runtime without executing it. A clean failure instead writes a private, HMAC-signed,
+one-shot receipt bound to the wrapper's random attempt id, current channel/deployment nonce, and
+floor/result registry revisions. A second one-shot verifies that binding against the still-proved
+lease and current no-floor/no-role state, then consumes the receipt; only that success lets the
+wrapper release. A missing, forged, stale, unsafe, or replayed receipt — and every signal or
+container death — preserves the lease/restart fence. A crash before the floor leaves old auth state
+authoritative and the migration untouched.
 
 **Automated, explicit activation (#4524).** `scripts/lib/instance_state_deployment.sh` invokes
 step 3 between `deployment-prove` and `deployment-finish` only when

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -350,8 +350,11 @@ for compensation. If a complete matching role became durable before a later boot
 failed, it is never rolled back or reported as success. That case, an unreadable registry,
 changed lease, any other ambiguous role state, or failed compensation returns the distinct
 fail-closed status `75`; the wrapper preserves the lease/restart fence for repair instead of
-restarting old producers. A crash before the floor leaves old auth state authoritative and the
-migration untouched.
+restarting old producers. Status `1` is the only classified clean failure for which the wrapper
+may release the stopped window: the command has proved either that no floor was written or that
+its attempt-local floor was compensated. Every other nonzero child status, including a signal or
+container death after the floor write, is unclassified and preserves the lease/restart fence. A
+crash before the floor leaves old auth state authoritative and the migration untouched.
 
 **Automated, explicit activation (#4524).** `scripts/lib/instance_state_deployment.sh` invokes
 step 3 between `deployment-prove` and `deployment-finish` only when

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -329,30 +329,38 @@ because its auth producers are the same processes MVR-01B already fences:
    `worker`, `watcher`, `heimdal-capture-watch`.
 2. `scripts/instance_state_writer_inventory.py prove-quiescent` probes production truth twice
    and `deployment-prove` binds the proof to the channel lease.
-3. `principal-record-floor` runs in that window. It requires the lease in `proved` phase for
-   this channel and nonce, consumes the quiescence proof plus the drained legacy-owner
-   inventory, enumerates `docker-compose.yaml` (failing closed on any unclassified service),
-   and adds the producers MVR-01B does not classify — the Companion proxy, credential
-   rotation, the headless CLI, and bootstrap/init. Only then does it record the floor.
-4. `principal-bootstrap` writes the delegated-role record; it refuses while the floor is
-   absent.
-5. `deployment-finish` closes the window.
+3. `principal-cutover` performs the floor and role stages in one runtime process. It requires
+   the lease in `proved` phase for this channel and nonce, consumes the quiescence proof plus
+   the drained legacy-owner inventory, enumerates `docker-compose.yaml` (failing closed on any
+   unclassified service), and adds the producers MVR-01B does not classify — the Companion
+   proxy, credential rotation, the headless CLI, and bootstrap/init. Only then does it record
+   the floor, re-prove the same lease and registry revision, and bootstrap the role.
+4. `deployment-finish` closes the window.
 
-`require_complete_fence` refuses steps 3–4 if the inventory is incomplete, if writers were not
+`require_complete_fence` refuses step 3 if the inventory is incomplete, if writers were not
 drained, if the inventory was not revalidated after quiescence, if it was probed once, if any
-producer role is missing, or if operations are not fenced. `principal-record-floor` also
-refuses without the proved deployment lease for this channel and nonce, and it preflights the
-auth posture the subsequent role write will use — so a floor can never be recorded on an
-instance where the role could not then be written. A crash before the floor leaves old auth
-state authoritative and the migration untouched.
+producer role is missing, or if operations are not fenced. `principal-cutover` also refuses
+without the proved deployment lease for this channel and nonce, and it preflights the auth
+posture before the floor write. The fact that this invocation advanced the floor is held only
+in process, never accepted from a caller flag. If bootstrap fails before a role record becomes
+durable, the failed-bootstrap role recheck and removal of that attempt's MVR-03 floor and fence
+run under the same principal-store lock used by the bootstrap floor guard and first-role write,
+before the wrapper releases the stopped window. A pre-existing floor is never eligible
+for compensation. If a complete matching role became durable before a later bootstrap step
+failed, it is never rolled back or reported as success. That case, an unreadable registry,
+changed lease, any other ambiguous role state, or failed compensation returns the distinct
+fail-closed status `75`; the wrapper preserves the lease/restart fence for repair instead of
+restarting old producers. A crash before the floor leaves old auth state authoritative and the
+migration untouched.
 
-> **Not yet automated.** `scripts/lib/instance_state_deployment.sh` does **not** invoke steps
-> 3–4. Wiring them requires the credential/listener posture and the native launcher paths to be
-> available inside the `instance-state-init` one-shot, which that service does not currently
-> have; a half-wired cutover would record the floor and then fail the role write, leaving the
-> instance fenced and rollback-blocked. Until that plumbing ships, an operator runs steps 3–4
-> explicitly inside the stopped window using the commands below. This is tracked as bounded
-> follow-up work on #3857.
+**Automated, explicit activation (#4524).** `scripts/lib/instance_state_deployment.sh` invokes
+step 3 between `deployment-prove` and `deployment-finish` only when
+`MVR03_PRINCIPAL_CUTOVER=1`. Deploying a capable image without that opt-in never advances the
+floor. The `instance-state-init` one-shot consumes the same generated runtime-env credential
+layer and `COMPANION_UI_PROXY_HOSTS` declaration as `api`; it does not receive the API's
+unrelated Heimdal/GitHub host-secret layer. The exact three native launcher producers are
+mounted read-only under `/run/principal-fence-native-producers`, and a missing declared path
+fails before the floor is written.
 
 **Rollback: credential-only images are blocked.** While the floor exists,
 `_preflight_scalar_rollback` raises `CapabilityNotReadyError` before materializing any legacy
@@ -369,30 +377,26 @@ divergent, or ambiguous auth state fails closed without overwriting either linea
 may be lowered only by a later explicitly verified reversible migration — never by a scalar
 rollback.
 
-**Cutover commands (run inside the stopped window, between `deployment-prove` and
-`deployment-finish`).** Both refuse outside that window.
+**Cutover operation.** Run one ordinary governed channel deploy/start with the explicit
+one-time opt-in; the wrapper owns the stopped-window operation and its compensation ordering:
 
 ```bash
-REG=/app/instance-state/agentic-pkm/vault-registry.md
-OWN=/app/instance-ownership
-
-python -m app.instance.runtime principal-record-floor \
-  --channel "$CHANNEL" --registry-path "$REG" --host-global-root "$OWN" \
-  --inventory-path "$OWN/legacy-owner-inventory.json" \
-  --quiescence-proof-path "$OWN/deployment-quiescence-proof.json" \
-  --compose-base <mounted docker-compose.yaml> \
-  --native-producer-root <mounted repo root> \
-  [--loopback-listener]
-
-python -m app.instance.runtime principal-bootstrap \
-  --registry-path "$REG" [--loopback-listener] [--existing-install]
+MVR03_PRINCIPAL_CUTOVER=1 scripts/deploy_channel.sh deploy <dev|test|prod> <sha>
 ```
 
 The posture is **read** from server configuration (`API_KEY`, `COMPANION_UI_PROXY_HOSTS`), so
 the subjects bound at bootstrap are the ones the request path will actually admit.
-`--loopback-listener` declares that this deployment exposes a loopback-local listener, which
-makes `trusted_loopback` a *bindable* subject; every request still proves loopback
-independently in `app/auth.py::resolve_auth_subject` before that subject is used.
+`config/deploy/{dev,test,prod}.env` explicitly sets
+`MVR03_PRINCIPAL_LOOPBACK_LISTENER=0`: Docker-published traffic is not proven loopback inside
+the API container. A future/native channel may declare `1` only when its effective listener is
+proved loopback-local. Both `scripts/deploy_channel.sh` and `scripts/start_full_system.sh` pin
+that declaration from the selected channel file rather than trusting ambient shell state. The
+wrapper passes the resulting `--loopback-listener` declaration to the atomic cutover. A bare
+`scripts/start_full_system.sh` invocation uses its existing implicit `dev` channel for this
+declaration too, rather than accepting an undeclared ambient value. Every
+request still proves loopback independently in
+`app/auth.py::resolve_auth_subject` before that subject is used. `API_KEY` remains config input,
+never argv, command output, or a receipt.
 
 **Governed commands (run against a live instance, outside the cutover window).**
 

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -29,6 +29,8 @@ Environment:
   DEPLOY_ACK_EMBEDDING_REBUILD_REQUIRED=1
                                     acknowledge only the embedding-index rebuild transition
   DEPLOY_HEALTH_TIMEOUT_SECONDS=90  health gate timeout
+  MVR03_PRINCIPAL_CUTOVER=1         explicitly activate the one-time principal floor/role cutover
+  MVR03_PRINCIPAL_LOOPBACK_LISTENER is pinned from config/deploy/<channel>.env (0 or 1)
 EOF
 }
 
@@ -106,6 +108,26 @@ receipt_dir="${ROOT}/ops/deployments"
 promotion_dir="${ROOT}/ops/promotions"
 image_repository="${APP_IMAGE_REPOSITORY:-ghcr.io/rasmustho/pkm-app}"
 health_timeout="${DEPLOY_HEALTH_TIMEOUT_SECONDS:-90}"
+
+# Pin the topology declaration from the governed channel file before the
+# shared deployment wrapper runs. Do not inherit an ambient shell value across
+# channels: Docker-published dev/test/prod API traffic is not proven loopback
+# inside the container, while a future channel may explicitly declare 1.
+if [ "${action}" = "deploy" ] && [ "${MVR03_PRINCIPAL_CUTOVER:-0}" = "1" ]; then
+  mvr03_principal_loopback_listener="$(
+    awk -F= '/^MVR03_PRINCIPAL_LOOPBACK_LISTENER=/{print $2; exit}' "${pin_file}"
+  )"
+  case "${mvr03_principal_loopback_listener}" in
+    0|1)
+      export MVR03_PRINCIPAL_LOOPBACK_LISTENER="${mvr03_principal_loopback_listener}"
+      ;;
+    *)
+      echo "MVR03_PRINCIPAL_LOOPBACK_LISTENER is missing or invalid for the selected channel" >&2
+      exit 78
+      ;;
+  esac
+  unset mvr03_principal_loopback_listener
+fi
 
 read_pin() {
   local file="$1"

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -69,6 +69,15 @@ publish_runtime_env() {
   trap - EXIT
 }
 
+append_principal_auth_posture() {
+  # API_KEY is Product/GOV request-path posture, distinct from OPENAI_API_KEY.
+  # Keep it in the existing private generated runtime env consumed by both api
+  # and instance-state-init; never place the credential in argv or a receipt.
+  if [ -n "${API_KEY:-}" ]; then
+    printf "%s\n" "API_KEY=${API_KEY}" >> "$runtime_env_output_path"
+  fi
+}
+
 if [ "${NO_VAULT_MODE:-0}" -eq 1 ]; then
   # Preserve an explicit selector, while retaining the established no-vault
   # idle fallback. Persisting either value keeps a later pinned-image render
@@ -116,6 +125,7 @@ ENV
   if [ -n "${HEIMDAL_CAPTURE_INTERVAL_SECONDS:-}" ]; then
     printf "%s\n" "HEIMDAL_CAPTURE_INTERVAL_SECONDS=${HEIMDAL_CAPTURE_INTERVAL_SECONDS}" >> "$runtime_env_output_path"
   fi
+  append_principal_auth_posture
   publish_runtime_env
   echo "Exported no-vault idle runtime env -> $runtime_env_path"
   exit 0
@@ -186,6 +196,8 @@ ENV
 if [ -n "${SIGNBOARD_ROOT:-}" ]; then
   printf "SIGNBOARD_ROOT=%s\n" "$SIGNBOARD_ROOT" >> "$runtime_env_output_path"
 fi
+
+append_principal_auth_posture
 
 python3 - <<'PY' >> "$runtime_env_output_path"
 from __future__ import annotations

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -403,6 +403,55 @@ _deploy_channel_needs_api_ingress_secret() {
   return 1
 }
 
+_deploy_channel_principal_cutover_receipt_requested() {
+  local arg
+  for arg in "$@"; do
+    [ "${arg}" = "principal-cutover" ] && return 0
+  done
+  return 1
+}
+
+# Governed Compose normally suppresses all output because config/startup text
+# can contain machine paths or environment values. The MVR-03 wrapper needs two
+# boolean fields from this one exact command; parse the private capture and emit a new
+# whitelist-only receipt rather than forwarding any raw Compose bytes.
+_deploy_channel_redact_principal_cutover_receipt() {
+  local output_file="${1:?captured output file required}"
+  "${PYTHON:-python3}" - "${output_file}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+except OSError:
+    raise SystemExit(1)
+for line in reversed(lines):
+    try:
+        payload = json.loads(line)
+    except (TypeError, ValueError):
+        continue
+    advanced = payload.get("floor_advanced") if isinstance(payload, dict) else None
+    if (
+        payload.get("floor_recorded") is True
+        and type(advanced) is bool
+    ):
+        print(
+            json.dumps(
+                {
+                    "floor_advanced": advanced,
+                    "floor_recorded": True,
+                },
+                sort_keys=True,
+            )
+        )
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 deploy_channel_compose() {
   local root="${1:?repo root required}"
   local channel="${2:?channel required}"
@@ -621,6 +670,11 @@ deploy_channel_compose() {
           return 92
         fi
         cat "${compose_stdout_file}"
+      elif _deploy_channel_principal_cutover_receipt_requested "$@"; then
+        if ! _deploy_channel_redact_principal_cutover_receipt "${compose_stdout_file}"; then
+          echo "governed compose output blocked: command=principal-cutover receipt=invalid" >&2
+          return 92
+        fi
       fi
       return 0
     fi

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -117,6 +117,8 @@ prepare_instance_state_deployment() {
   local repo_root inventory_helper controller_pid controller_start_token
   local inventory_host_path owner_inventory_host_path inventory_rc
   local quiescence_inventory_host_target_path owner_inventory_host_target_path
+  local principal_attempt_id principal_receipt_path principal_receipt_host_path
+  local receipt_verify_rc
   local native_producer
   local principal_loopback_flag=""
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -337,11 +339,23 @@ prepare_instance_state_deployment() {
   # caller-controlled flags. It consumes MVR-01B's proved lease, quiescence proof,
   # and drained owner inventory; it never adds a second drain/probe mechanism.
   # Before any role record commits, a bootstrap failure compensates only a floor
-  # advanced by this in-process attempt. The command's status 1 is the sole
-  # compensated/pre-floor failure receipt. Every other nonzero status is
-  # unclassified (including signals/container death), so the durable
-  # stopped-window fence remains for governed repair.
+  # advanced by this in-process attempt. A numeric child status is never a clean
+  # failure receipt: Compose itself can return the same code. Only a private,
+  # HMAC-authenticated receipt bound to this attempt and proved lease may release
+  # the stopped window. Missing/stale/invalid receipts and signals preserve it.
   if [ "${MVR03_PRINCIPAL_CUTOVER:-0}" = "1" ]; then
+    principal_attempt_id="$(python3 -c 'import uuid; print(uuid.uuid4().hex)')"
+    inventory_rc=$?
+    if [ "${inventory_rc}" -ne 0 ]; then
+      echo "instance state deployment: principal cutover attempt creation failed" >&2
+      return "${inventory_rc}"
+    fi
+    principal_receipt_path="/app/instance-ownership/principal-cutover-clean-failure-${principal_attempt_id}.json"
+    principal_receipt_host_path="$(_instance_state_deployment_host_ownership_path "${principal_receipt_path}")" || {
+      echo "instance state deployment: principal cutover receipt path is invalid" >&2
+      return 78
+    }
+    rm -f -- "${principal_receipt_host_path}"
     "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
       python -m app.instance.runtime principal-cutover \
         --channel "${channel}" \
@@ -351,12 +365,24 @@ prepare_instance_state_deployment() {
         --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json \
         --compose-base /run/scalar-rollback-policy/docker-compose.yaml \
         --native-producer-root /run/principal-fence-native-producers \
+        --attempt-id "${principal_attempt_id}" \
+        --clean-failure-receipt-path "${principal_receipt_path}" \
         --existing-install \
         --consumer bootstrap-init \
         ${principal_loopback_flag:+"${principal_loopback_flag}"}
     inventory_rc=$?
     if [ "${inventory_rc}" -ne 0 ]; then
-      if [ "${inventory_rc}" -ne 1 ]; then
+      "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
+        python -m app.instance.runtime principal-verify-cutover-clean-failure \
+          --channel "${channel}" \
+          --registry-path /app/instance-state/agentic-pkm/vault-registry.md \
+          --host-global-root /app/instance-ownership \
+          --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json \
+          --attempt-id "${principal_attempt_id}" \
+          --clean-failure-receipt-path "${principal_receipt_path}"
+      receipt_verify_rc=$?
+      rm -f -- "${principal_receipt_host_path}"
+      if [ "${receipt_verify_rc}" -ne 0 ]; then
         echo "instance state deployment: principal cutover requires stopped-window repair" >&2
         return "${inventory_rc}"
       fi

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -117,9 +117,42 @@ prepare_instance_state_deployment() {
   local repo_root inventory_helper controller_pid controller_start_token
   local inventory_host_path owner_inventory_host_path inventory_rc
   local quiescence_inventory_host_target_path owner_inventory_host_target_path
+  local native_producer
+  local principal_loopback_flag=""
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   inventory_helper="${repo_root}/scripts/instance_state_writer_inventory.py"
   controller_pid="$$"
+
+  # The principal floor is an irreversible compatibility boundary, so merely
+  # deploying a capable image never activates it. Validate the complete opt-in
+  # and channel topology declaration before init, lease acquisition, or writer
+  # stop; error receipts name variables/boolean state only, never env values.
+  case "${MVR03_PRINCIPAL_CUTOVER:-0}" in
+    0) ;;
+    1)
+      case "${MVR03_PRINCIPAL_LOOPBACK_LISTENER:-}" in
+        0) ;;
+        1) principal_loopback_flag="--loopback-listener" ;;
+        *)
+          echo "instance state deployment: MVR03_PRINCIPAL_LOOPBACK_LISTENER must be an explicit boolean" >&2
+          return 78
+          ;;
+      esac
+      for native_producer in \
+        scripts/deploy_channel.sh \
+        scripts/start_full_system.sh \
+        scripts/export_runtime_env.sh; do
+        if [ ! -f "${repo_root}/${native_producer}" ]; then
+          echo "instance state deployment: a declared principal native producer is missing" >&2
+          return 78
+        fi
+      done
+      ;;
+    *)
+      echo "instance state deployment: MVR03_PRINCIPAL_CUTOVER must be a boolean" >&2
+      return 78
+      ;;
+  esac
 
   # The host-global state dir is resolved and prepared by the caller before
   # this producer runs (deploy_channel.sh calls prepare_instance_ownership_host_state_dir
@@ -297,6 +330,39 @@ prepare_instance_state_deployment() {
       "${compose_function}" "${channel}" "${runtime_user}" \
       "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
+  fi
+
+  # Explicit MVR-03 authority transition. One runtime process records the floor
+  # and then bootstraps the role, keeping the attempt-local floor receipt out of
+  # caller-controlled flags. It consumes MVR-01B's proved lease, quiescence proof,
+  # and drained owner inventory; it never adds a second drain/probe mechanism.
+  # Before any role record commits, a bootstrap failure compensates only a floor
+  # advanced by this in-process attempt. Status 75 means floor/role state is
+  # ambiguous, so the durable stopped-window fence remains for governed repair.
+  if [ "${MVR03_PRINCIPAL_CUTOVER:-0}" = "1" ]; then
+    "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
+      python -m app.instance.runtime principal-cutover \
+        --channel "${channel}" \
+        --registry-path /app/instance-state/agentic-pkm/vault-registry.md \
+        --host-global-root /app/instance-ownership \
+        --inventory-path "${inventory_path}" \
+        --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json \
+        --compose-base /run/scalar-rollback-policy/docker-compose.yaml \
+        --native-producer-root /run/principal-fence-native-producers \
+        --existing-install \
+        --consumer bootstrap-init \
+        ${principal_loopback_flag:+"${principal_loopback_flag}"}
+    inventory_rc=$?
+    if [ "${inventory_rc}" -ne 0 ]; then
+      if [ "${inventory_rc}" -eq 75 ]; then
+        echo "instance state deployment: principal cutover requires stopped-window repair" >&2
+        return "${inventory_rc}"
+      fi
+      _release_abandoned_instance_state_deployment_lease \
+        "${compose_function}" "${channel}" "${runtime_user}" \
+        "${controller_pid}" "${controller_start_token}"
+      return "${inventory_rc}"
+    fi
   fi
 
   # An explicit scalar fork is imported only while the host-global lease,

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -337,8 +337,10 @@ prepare_instance_state_deployment() {
   # caller-controlled flags. It consumes MVR-01B's proved lease, quiescence proof,
   # and drained owner inventory; it never adds a second drain/probe mechanism.
   # Before any role record commits, a bootstrap failure compensates only a floor
-  # advanced by this in-process attempt. Status 75 means floor/role state is
-  # ambiguous, so the durable stopped-window fence remains for governed repair.
+  # advanced by this in-process attempt. The command's status 1 is the sole
+  # compensated/pre-floor failure receipt. Every other nonzero status is
+  # unclassified (including signals/container death), so the durable
+  # stopped-window fence remains for governed repair.
   if [ "${MVR03_PRINCIPAL_CUTOVER:-0}" = "1" ]; then
     "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
       python -m app.instance.runtime principal-cutover \
@@ -354,7 +356,7 @@ prepare_instance_state_deployment() {
         ${principal_loopback_flag:+"${principal_loopback_flag}"}
     inventory_rc=$?
     if [ "${inventory_rc}" -ne 0 ]; then
-      if [ "${inventory_rc}" -eq 75 ]; then
+      if [ "${inventory_rc}" -ne 1 ]; then
         echo "instance state deployment: principal cutover requires stopped-window repair" >&2
         return "${inventory_rc}"
       fi

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -38,14 +38,33 @@ unset _pkm_initial_channel _pkm_initial_channel_lower
 
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"
-_pkm_deploy_pin_channel="${PKM_ENVIRONMENT:-${ENVIRONMENT:-${CHANNEL:-${PKM_CHANNEL:-}}}}"
+# This launcher already passes an unset channel to the deployment wrapper as
+# `dev` below. Resolve the MVR-03 topology declaration from that same implicit
+# channel so an explicit cutover cannot arrive with an undeclared listener.
+_pkm_deploy_pin_channel="${PKM_ENVIRONMENT:-${ENVIRONMENT:-${CHANNEL:-${PKM_CHANNEL:-dev}}}}"
 _pkm_deploy_pin_channel="$(printf '%s' "${_pkm_deploy_pin_channel}" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || printf '%s' "${_pkm_deploy_pin_channel}")"
 case "${_pkm_deploy_pin_channel:-}" in
   dev|test|prod)
-    load_env_defaults_file "config/deploy/${_pkm_deploy_pin_channel}.env"
+    _pkm_deploy_pin_file="config/deploy/${_pkm_deploy_pin_channel}.env"
+    load_env_defaults_file "${_pkm_deploy_pin_file}"
+    # The channel file, not ambient shell state, owns whether this topology is
+    # proven loopback-local. Pin it exactly as deploy_channel.sh does so both
+    # native producers feed the stopped-window wrapper the same declaration.
+    _pkm_mvr03_loopback_listener="$(
+      awk -F= '/^MVR03_PRINCIPAL_LOOPBACK_LISTENER=/{print $2; exit}' "${_pkm_deploy_pin_file}"
+    )"
+    case "${_pkm_mvr03_loopback_listener}" in
+      0|1)
+        export MVR03_PRINCIPAL_LOOPBACK_LISTENER="${_pkm_mvr03_loopback_listener}"
+        ;;
+      *)
+        echo "ERROR: MVR03_PRINCIPAL_LOOPBACK_LISTENER is missing or invalid for the selected channel" >&2
+        exit 78
+        ;;
+    esac
     ;;
 esac
-unset _pkm_deploy_pin_channel
+unset _pkm_deploy_pin_channel _pkm_deploy_pin_file _pkm_mvr03_loopback_listener
 
 if [ "$_pkm_caller_vault_root_set" -eq 0 ] && [ "$_pkm_channel_vault_root_set" -eq 0 ]; then
   # A bare start with no caller- or channel-selected vault must stay in the

--- a/tests/_mvr03_principal_harness.py
+++ b/tests/_mvr03_principal_harness.py
@@ -148,7 +148,7 @@ def run_principal_cutover(
         credential=posture.credential,
         subjects=preflight_auth_posture(posture),
         migration_provenance=posture.migration_provenance(existing_install=existing_install),
-        floor_recorded=True,
+        floor_guard=lambda: True,
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
 

--- a/tests/deploy/test_ghcr_push_and_pin.py
+++ b/tests/deploy/test_ghcr_push_and_pin.py
@@ -39,10 +39,13 @@ def test_per_channel_pin_files_present() -> None:
             if line.strip() and not line.strip().startswith("#")
         ]
 
-        assert len(lines) == 1
-        key, value = lines[0].split("=", 1)
-        assert key == "APP_IMAGE_TAG"
-        assert re.fullmatch(r"[0-9a-f]{40}", value)
+        values = dict(line.split("=", 1) for line in lines)
+        assert set(values) == {
+            "APP_IMAGE_TAG",
+            "MVR03_PRINCIPAL_LOOPBACK_LISTENER",
+        }
+        assert re.fullmatch(r"[0-9a-f]{40}", values["APP_IMAGE_TAG"])
+        assert values["MVR03_PRINCIPAL_LOOPBACK_LISTENER"] == "0"
 
 
 def test_compose_image_uses_pinned_tag_and_mount_is_flagged() -> None:
@@ -62,7 +65,8 @@ def test_compose_image_uses_pinned_tag_and_mount_is_flagged() -> None:
     assert "COMPOSE_FILE=\"$(COMPOSE_DEV_FILES)\"" in makefile
     assert "-f $(APP_CODE_BIND_COMPOSE)" in makefile
     assert 'APP_CODE_BIND_MOUNT:-1' in start_full_system
-    assert 'load_env_defaults_file "config/deploy/${_pkm_deploy_pin_channel}.env"' in start_full_system
+    assert '_pkm_deploy_pin_file="config/deploy/${_pkm_deploy_pin_channel}.env"' in start_full_system
+    assert 'load_env_defaults_file "${_pkm_deploy_pin_file}"' in start_full_system
     assert 'compose_up_build_args=("--build")' in start_full_system
     assert "compose_up_build_args=()" in start_full_system
     assert 'app_code_bind_overlay=":docker-compose.app-bind.yml"' in start_full_system

--- a/tests/deploy/test_ghcr_push_and_pin.py
+++ b/tests/deploy/test_ghcr_push_and_pin.py
@@ -39,7 +39,10 @@ def test_per_channel_pin_files_present() -> None:
             if line.strip() and not line.strip().startswith("#")
         ]
 
-        values = dict(line.split("=", 1) for line in lines)
+        assert len(lines) == 2
+        pairs = [line.split("=", 1) for line in lines]
+        assert len({key for key, _ in pairs}) == len(pairs)
+        values = dict(pairs)
         assert set(values) == {
             "APP_IMAGE_TAG",
             "MVR03_PRINCIPAL_LOOPBACK_LISTENER",

--- a/tests/integration/test_local_operator_principal_bootstrap.py
+++ b/tests/integration/test_local_operator_principal_bootstrap.py
@@ -91,7 +91,7 @@ def test_existing_single_user_auth_migrates_to_distinct_delegated_role(
             credential=posture.credential,
             subjects=preflight_auth_posture(posture),
             migration_provenance=PROVENANCE_EXISTING_CREDENTIAL,
-            floor_recorded=False,
+            floor_guard=lambda: False,
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert not principal_record_path(runtime).exists(), (

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -141,6 +141,7 @@ def _wrapper_run(
     cutover: bool,
     loopback: str = "0",
     fail_cutover: int = 0,
+    verify_cutover: int = 1,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     tmp_path.mkdir(parents=True)
     event_log = tmp_path / "events.log"
@@ -181,6 +182,7 @@ def _wrapper_run(
         "fake_compose() {\n"
         "  printf 'compose:%s\\n' \"$*\" >> \"$EVENT_LOG\"\n"
         "  case \" $* \" in\n"
+        "    *' principal-verify-cutover-clean-failure '*) return \"${VERIFY_CUTOVER:-1}\" ;;\n"
         "    *' principal-cutover '*) return \"${FAIL_CUTOVER:-0}\" ;;\n"
         "  esac\n"
         "  return 0\n"
@@ -197,6 +199,7 @@ def _wrapper_run(
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
         "FAIL_CUTOVER": str(fail_cutover),
+        "VERIFY_CUTOVER": str(verify_cutover),
         "REAL_PYTHON": sys.executable,
     }
     env.pop("MVR03_PRINCIPAL_CUTOVER", None)
@@ -241,11 +244,18 @@ def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> N
     )
 
     cutover_failure, failure_events = _wrapper_run(
-        tmp_path / "cutover-failure", cutover=True, fail_cutover=1
+        tmp_path / "cutover-failure", cutover=True, fail_cutover=1, verify_cutover=0
     )
     assert cutover_failure.returncode == 1
     assert not any("deployment-finish" in event for event in failure_events)
     assert any("deployment-release" in event for event in failure_events)
+
+    compose_failure, compose_failure_events = _wrapper_run(
+        tmp_path / "compose-failure", cutover=True, fail_cutover=1
+    )
+    assert compose_failure.returncode == 1
+    assert not any("deployment-finish" in event for event in compose_failure_events)
+    assert not any("deployment-release" in event for event in compose_failure_events)
 
     ambiguous, ambiguous_events = _wrapper_run(
         tmp_path / "ambiguous", cutover=True, fail_cutover=75
@@ -382,6 +392,7 @@ def _record_floor_in_proved_window(
 
 
 def _cutover_args(runtime: object, *, inventory: Path, proof_path: Path) -> list[str]:
+    attempt_id = "a" * 32
     return [
         "principal-cutover",
         "--channel",
@@ -394,6 +405,10 @@ def _cutover_args(runtime: object, *, inventory: Path, proof_path: Path) -> list
         str(inventory),
         "--quiescence-proof-path",
         str(proof_path),
+        "--attempt-id",
+        attempt_id,
+        "--clean-failure-receipt-path",
+        str(runtime.ledger.root / f"principal-cutover-clean-failure-{attempt_id}.json"),  # type: ignore[attr-defined]
         "--compose-base",
         str(REPO_ROOT / "docker-compose.yaml"),
         "--native-producer-root",
@@ -403,6 +418,112 @@ def _cutover_args(runtime: object, *, inventory: Path, proof_path: Path) -> list
         "--consumer",
         "bootstrap-init",
     ]
+
+
+def _verify_cutover_receipt_args(
+    runtime: object, *, proof_path: Path, attempt_id: str = "a" * 32
+) -> list[str]:
+    return [
+        "principal-verify-cutover-clean-failure",
+        "--channel",
+        "prod",
+        "--registry-path",
+        str(runtime.layout.registry_path),  # type: ignore[attr-defined]
+        "--host-global-root",
+        str(runtime.ledger.root),  # type: ignore[attr-defined]
+        "--quiescence-proof-path",
+        str(proof_path),
+        "--attempt-id",
+        attempt_id,
+        "--clean-failure-receipt-path",
+        str(runtime.ledger.root / f"principal-cutover-clean-failure-{attempt_id}.json"),  # type: ignore[attr-defined]
+    ]
+
+
+def test_clean_failure_receipt_is_authenticated_current_and_one_shot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the runtime's current attempt-bound compensation receipt authorizes release."""
+
+    def _fail_before_write(self: LocalOperatorPrincipalStore, **kwargs: object) -> None:
+        raise PrincipalPreflightError("injected clean failure", provisioning_action="retry")
+
+    runtime, _, _ = active_runtime(tmp_path / "valid")
+    _, inventory = deployment_authority(
+        runtime, runtime.layout.root / "missing-legacy.md"
+    )
+    proof = runtime.ledger.root / "deployment-quiescence-proof.json"
+    monkeypatch.setattr(LocalOperatorPrincipalStore, "bootstrap", _fail_before_write)
+    failed = _cli(*_cutover_args(runtime, inventory=inventory, proof_path=proof))
+    assert failed["_exit_code"] == 1
+    verified = _cli(*_verify_cutover_receipt_args(runtime, proof_path=proof))
+    assert verified["_exit_code"] == 0
+    replay = _cli(*_verify_cutover_receipt_args(runtime, proof_path=proof))
+    assert replay["_exit_code"] == 1
+
+    forged_runtime, _, _ = active_runtime(tmp_path / "forged")
+    _, forged_inventory = deployment_authority(
+        forged_runtime, forged_runtime.layout.root / "missing-legacy.md"
+    )
+    forged_proof = forged_runtime.ledger.root / "deployment-quiescence-proof.json"
+    forged = _cli(
+        *_cutover_args(
+            forged_runtime, inventory=forged_inventory, proof_path=forged_proof
+        )
+    )
+    assert forged["_exit_code"] == 1
+    forged_path = (
+        forged_runtime.ledger.root / "principal-cutover-clean-failure-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+    )
+    document = json.loads(forged_path.read_text(encoding="utf-8"))
+    document["payload"]["attempt_id"] = "b" * 32
+    forged_path.write_text(json.dumps(document), encoding="utf-8")
+    forged_path.chmod(0o600)
+    rejected = _cli(*_verify_cutover_receipt_args(forged_runtime, proof_path=forged_proof))
+    assert rejected["_exit_code"] == 1
+
+    stale_runtime, _, _ = active_runtime(tmp_path / "stale")
+    _, stale_inventory = deployment_authority(
+        stale_runtime, stale_runtime.layout.root / "missing-legacy.md"
+    )
+    stale_proof = stale_runtime.ledger.root / "deployment-quiescence-proof.json"
+    stale = _cli(
+        *_cutover_args(stale_runtime, inventory=stale_inventory, proof_path=stale_proof)
+    )
+    assert stale["_exit_code"] == 1
+    stale_snapshot = stale_runtime.registry.load()
+    stale_runtime.registry.commit_state(
+        registrations=dict(stale_snapshot.registrations),
+        removal_tombstones=dict(stale_snapshot.removal_tombstones),
+        transfer_lineage=stale_snapshot.transfer_lineage,
+        extensions=dict(stale_snapshot.extensions),
+        expected_revision=stale_snapshot.revision,
+        _capability=local_operator_storage_capability(),
+    )
+    stale_rejected = _cli(
+        *_verify_cutover_receipt_args(stale_runtime, proof_path=stale_proof)
+    )
+    assert stale_rejected["_exit_code"] == 1
+
+    nonce_runtime, _, _ = active_runtime(tmp_path / "nonce")
+    _, nonce_inventory = deployment_authority(
+        nonce_runtime, nonce_runtime.layout.root / "missing-legacy.md"
+    )
+    nonce_proof = nonce_runtime.ledger.root / "deployment-quiescence-proof.json"
+    nonce_failed = _cli(
+        *_cutover_args(
+            nonce_runtime, inventory=nonce_inventory, proof_path=nonce_proof
+        )
+    )
+    assert nonce_failed["_exit_code"] == 1
+    changed_proof = json.loads(nonce_proof.read_text(encoding="utf-8"))
+    changed_proof["nonce"] = "different-attempt"
+    nonce_proof.write_text(json.dumps(changed_proof), encoding="utf-8")
+    nonce_proof.chmod(0o600)
+    nonce_rejected = _cli(
+        *_verify_cutover_receipt_args(nonce_runtime, proof_path=nonce_proof)
+    )
+    assert nonce_rejected["_exit_code"] == 1
 
 
 def test_compensation_is_lease_bound_and_preserves_a_preexisting_floor(
@@ -529,6 +650,7 @@ def test_committed_role_is_ambiguous_and_never_compensated(
     assert result["_exit_code"] == 75, result
     assert principal_floor_recorded(runtime.registry)
     assert open_local_operator_principal_store(runtime.layout.registry_path).require()
+    assert not list(runtime.ledger.root.glob("principal-cutover-clean-failure-*.json"))
 
 
 def test_governed_compose_cutover_receipt_is_whitelist_redacted(tmp_path: Path) -> None:

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -241,9 +241,9 @@ def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> N
     )
 
     cutover_failure, failure_events = _wrapper_run(
-        tmp_path / "cutover-failure", cutover=True, fail_cutover=43
+        tmp_path / "cutover-failure", cutover=True, fail_cutover=1
     )
-    assert cutover_failure.returncode == 43
+    assert cutover_failure.returncode == 1
     assert not any("deployment-finish" in event for event in failure_events)
     assert any("deployment-release" in event for event in failure_events)
 
@@ -253,6 +253,23 @@ def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> N
     assert ambiguous.returncode == 75
     assert not any("deployment-finish" in event for event in ambiguous_events)
     assert not any("deployment-release" in event for event in ambiguous_events)
+
+    # A killed cutover child can die after the floor commit but before the role
+    # commit, bypassing in-process compensation. Its Compose/signal status is not
+    # a clean-failure receipt, so the wrapper must preserve the stopped fence.
+    crashed, crashed_events = _wrapper_run(
+        tmp_path / "crashed-after-floor", cutover=True, fail_cutover=137
+    )
+    assert crashed.returncode == 137
+    assert not any("deployment-finish" in event for event in crashed_events)
+    assert not any("deployment-release" in event for event in crashed_events)
+
+    unclassified, unclassified_events = _wrapper_run(
+        tmp_path / "unclassified", cutover=True, fail_cutover=43
+    )
+    assert unclassified.returncode == 43
+    assert not any("deployment-finish" in event for event in unclassified_events)
+    assert not any("deployment-release" in event for event in unclassified_events)
 
 
 def test_failed_bootstrap_compensates_floor_before_window_release(

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -1,0 +1,545 @@
+"""Production wiring for the explicit MVR-03 principal cutover (#4524)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.instance import principal_fence
+from app.instance.local_operator_principal import (
+    LocalOperatorPrincipalStore,
+    PrincipalFloorNotRecordedError,
+    PrincipalPreflightError,
+    PROVENANCE_EXISTING_CREDENTIAL,
+    SUBJECT_LOOPBACK,
+)
+from app.instance.principal_fence import (
+    NATIVE_AUTH_PRODUCERS,
+    PrincipalFenceError,
+    compensate_principal_floor,
+    discover_auth_producers,
+    principal_floor_recorded,
+)
+from app.instance.runtime import main as instance_runtime_main
+from app.instance.runtime import local_operator_storage_capability
+from app.instance.runtime import open_local_operator_principal_store
+from app.instance.vault_registry import RegistryError, VaultRegistryStore
+from app.release_channels.channel_isolation_preflight import resolve_effective_dsn
+from tests._mvr_default_vault_harness import REPO_ROOT, active_runtime, deployment_authority
+
+
+def _cli(*args: str) -> dict[str, object]:
+    buffer = StringIO()
+    with redirect_stdout(buffer):
+        code = instance_runtime_main(list(args))
+    payload = json.loads(buffer.getvalue().strip().splitlines()[-1])
+    payload["_exit_code"] = code
+    return payload
+
+
+def test_cutover_oneshot_resolves_the_request_path_posture(tmp_path: Path) -> None:
+    """The one-shot and API consume one generated credential/proxy posture."""
+
+    runtime_env = tmp_path / "runtime.env"
+    declared_key = "test-product-gov-key"
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/export_runtime_env.sh")],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "API_KEY": declared_key,
+            "COMPANION_UI_PROXY_HOSTS": "companion-ui",
+            "LLM_PROVIDER": "mock",
+            "NO_VAULT_MODE": "1",
+            "RUNTIME_ENV_PATH": str(runtime_env),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8"))
+    services = compose["services"]
+    oneshot = services["instance-state-init"]
+    api = services["api"]
+    assert oneshot["env_file"] == api["env_file"][:2]
+    assert "HOST_SECRET_RUNTIME_ENV_FILE_API" not in json.dumps(oneshot["env_file"])
+    assert (
+        oneshot["environment"]["COMPANION_UI_PROXY_HOSTS"]
+        == api["environment"]["COMPANION_UI_PROXY_HOSTS"]
+    )
+
+    lookup = {
+        "WATCHER_RUNTIME_ENV_FILE": str(runtime_env),
+        "COMPANION_UI_PROXY_HOSTS": "companion-ui",
+    }
+    for key in ("API_KEY", "COMPANION_UI_PROXY_HOSTS"):
+        assert resolve_effective_dsn(
+            REPO_ROOT / "docker-compose.yaml",
+            "instance-state-init",
+            key,
+            environ=lookup,
+            load_dotenv=False,
+        ) == resolve_effective_dsn(
+            REPO_ROOT / "docker-compose.yaml",
+            "api",
+            key,
+            environ=lookup,
+            load_dotenv=False,
+        )
+
+    mounts = json.dumps(oneshot["volumes"])
+    for relative in NATIVE_AUTH_PRODUCERS:
+        if relative.startswith("scripts/"):
+            assert f"/run/principal-fence-native-producers/{relative}" in mounts
+    for channel in ("dev", "test", "prod"):
+        channel_config = (REPO_ROOT / "config/deploy" / f"{channel}.env").read_text(
+            encoding="utf-8"
+        )
+        assert "MVR03_PRINCIPAL_LOOPBACK_LISTENER=0" in channel_config
+    for native_launcher in ("scripts/deploy_channel.sh", "scripts/start_full_system.sh"):
+        launcher = (REPO_ROOT / native_launcher).read_text(encoding="utf-8")
+        assert 'export MVR03_PRINCIPAL_LOOPBACK_LISTENER="${' in launcher
+    start_full_system = (REPO_ROOT / "scripts/start_full_system.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'PKM_CHANNEL:-dev' in start_full_system
+
+
+def test_missing_native_producer_path_fails_closed(tmp_path: Path) -> None:
+    """A wrong mounted root cannot understate the native producer inventory."""
+
+    root = tmp_path / "native-root"
+    for relative in NATIVE_AUTH_PRODUCERS:
+        if not relative.startswith("scripts/") or relative.endswith("start_full_system.sh"):
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative, target)
+
+    with pytest.raises(PrincipalFenceError, match="start_full_system.sh"):
+        discover_auth_producers(
+            compose_path=REPO_ROOT / "docker-compose.yaml",
+            repo_root=root,
+        )
+
+
+def _wrapper_run(
+    tmp_path: Path,
+    *,
+    cutover: bool,
+    loopback: str = "0",
+    fail_cutover: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    tmp_path.mkdir(parents=True)
+    event_log = tmp_path / "events.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python = fake_bin / "python3"
+    python.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = -c ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+        'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
+        'case " $* " in\n'
+        "  *' produce-legacy-owners '*)\n"
+        '    while [ "$#" -gt 0 ]; do\n'
+        '      if [ "$1" = --output ]; then printf \'{"writers_drained":false}\\n\' > "$2"; exit 0; fi\n'
+        "      shift\n"
+        "    done; exit 2 ;;\n"
+        "  *' controller-token '*) printf 'linux:%064d\\n' 0; exit 0 ;;\n"
+        "  *' prove-quiescent '*)\n"
+        '    while [ "$#" -gt 0 ]; do\n'
+        '      if [ "$1" = --output ]; then printf \'{}\\n\' > "$2"; exit 0; fi\n'
+        "      shift\n"
+        "    done; exit 2 ;;\n"
+        "  *' validate-legacy-owners '*)\n"
+        '    while [ "$#" -gt 0 ]; do\n'
+        '      if [ "$1" = --output ]; then printf \'{"writers_drained":true}\\n\' > "$2"; exit 0; fi\n'
+        "      shift\n"
+        "    done; exit 2 ;;\n"
+        "esac\n"
+        "exit 2\n",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    harness = tmp_path / "run-wrapper.sh"
+    harness.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -u\n"
+        f"source '{REPO_ROOT / 'scripts/lib/instance_state_deployment.sh'}'\n"
+        "fake_compose() {\n"
+        "  printf 'compose:%s\\n' \"$*\" >> \"$EVENT_LOG\"\n"
+        "  case \" $* \" in\n"
+        "    *' principal-cutover '*) return \"${FAIL_CUTOVER:-0}\" ;;\n"
+        "  esac\n"
+        "  return 0\n"
+        "}\n"
+        "prepare_instance_state_deployment fake_compose prod\n",
+        encoding="utf-8",
+    )
+    harness.chmod(0o755)
+    ownership_root = tmp_path / "instance-ownership"
+    ownership_root.mkdir()
+    env = {
+        **os.environ,
+        "EVENT_LOG": str(event_log),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
+        "FAIL_CUTOVER": str(fail_cutover),
+        "REAL_PYTHON": sys.executable,
+    }
+    env.pop("MVR03_PRINCIPAL_CUTOVER", None)
+    env.pop("MVR03_PRINCIPAL_LOOPBACK_LISTENER", None)
+    if cutover:
+        env["MVR03_PRINCIPAL_CUTOVER"] = "1"
+        env["MVR03_PRINCIPAL_LOOPBACK_LISTENER"] = loopback
+    result = subprocess.run(
+        ["bash", str(harness)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, event_log.read_text(encoding="utf-8").splitlines()
+
+
+def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> None:
+    """Opt-in, ordering, arguments, and every shell failure edge are pinned."""
+
+    disabled, disabled_events = _wrapper_run(tmp_path / "disabled", cutover=False)
+    assert disabled.returncode == 0, disabled.stderr
+    assert not any("principal-cutover" in event for event in disabled_events)
+
+    success, events = _wrapper_run(tmp_path / "success", cutover=True)
+    assert success.returncode == 0, success.stderr
+    prove = next(i for i, event in enumerate(events) if "deployment-prove" in event)
+    cutover = next(i for i, event in enumerate(events) if "principal-cutover" in event)
+    finish = next(i for i, event in enumerate(events) if "deployment-finish" in event)
+    assert prove < cutover < finish
+    assert "--native-producer-root /run/principal-fence-native-producers" in events[cutover]
+    assert "--floor-advanced" not in events[cutover]
+    assert "--floor-registry-revision" not in events[cutover]
+    assert "--loopback-listener" not in events[cutover]
+
+    loopback, loopback_events = _wrapper_run(tmp_path / "loopback", cutover=True, loopback="1")
+    assert loopback.returncode == 0, loopback.stderr
+    assert all(
+        "--loopback-listener" in event
+        for event in loopback_events
+        if "principal-cutover" in event
+    )
+
+    cutover_failure, failure_events = _wrapper_run(
+        tmp_path / "cutover-failure", cutover=True, fail_cutover=43
+    )
+    assert cutover_failure.returncode == 43
+    assert not any("deployment-finish" in event for event in failure_events)
+    assert any("deployment-release" in event for event in failure_events)
+
+    ambiguous, ambiguous_events = _wrapper_run(
+        tmp_path / "ambiguous", cutover=True, fail_cutover=75
+    )
+    assert ambiguous.returncode == 75
+    assert not any("deployment-finish" in event for event in ambiguous_events)
+    assert not any("deployment-release" in event for event in ambiguous_events)
+
+
+def test_failed_bootstrap_compensates_floor_before_window_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real runtime producer removes its floor if role persistence never starts."""
+
+    runtime, _, _ = active_runtime(tmp_path)
+    proof, inventory = deployment_authority(runtime, runtime.layout.root / "missing-legacy.md")
+    proof_path = runtime.ledger.root / "deployment-quiescence-proof.json"
+
+    def _fail_before_write(self: LocalOperatorPrincipalStore, **kwargs: object) -> None:
+        raise PrincipalPreflightError(
+            "injected bootstrap failure",
+            provisioning_action="retry after repairing the bootstrap producer",
+        )
+
+    monkeypatch.setattr(LocalOperatorPrincipalStore, "bootstrap", _fail_before_write)
+    failed = _cli(*_cutover_args(runtime, inventory=inventory, proof_path=proof_path))
+    assert failed["_exit_code"] == 1
+    assert not principal_floor_recorded(runtime.registry)
+    extensions = runtime.registry.load().extensions
+    assert "fence" not in (extensions.get("principalState") or {})
+    assert proof.nonce
+
+
+def test_stale_floor_sample_cannot_commit_after_compensation(tmp_path: Path) -> None:
+    """The floor guard samples inside the lock shared with compensation."""
+
+    runtime, _, _ = active_runtime(tmp_path)
+    floor, _, _ = _record_floor_in_proved_window(runtime)
+    store = open_local_operator_principal_store(runtime.layout.registry_path)
+    stale_sample = principal_floor_recorded(runtime.registry)
+    started = threading.Event()
+    errors: list[BaseException] = []
+
+    def _bootstrap_after_stale_sample() -> None:
+        started.set()
+        try:
+            store.bootstrap(
+                credential=None,
+                subjects=(SUBJECT_LOOPBACK,),
+                migration_provenance=PROVENANCE_EXISTING_CREDENTIAL,
+                floor_guard=lambda: principal_floor_recorded(runtime.registry),
+                _capability=local_operator_storage_capability(),
+            )
+        except BaseException as error:
+            errors.append(error)
+
+    # Hold the exact lock bootstrap must acquire. The waiting producer has seen
+    # the old floor, but compensation wins before its callable guard executes.
+    with store.cutover_lock():
+        producer = threading.Thread(target=_bootstrap_after_stale_sample)
+        producer.start()
+        assert started.wait(timeout=1)
+        compensate_principal_floor(
+            runtime.registry,
+            channel_id="prod",
+            expected_registry_revision=int(floor["registry_revision"]),
+            _capability=local_operator_storage_capability(),
+        )
+    producer.join(timeout=2)
+
+    assert not producer.is_alive()
+    assert stale_sample is True
+    assert len(errors) == 1
+    assert isinstance(errors[0], PrincipalFloorNotRecordedError)
+    assert store.load() is None
+    assert not principal_floor_recorded(runtime.registry)
+
+
+def _record_floor_receipt(
+    runtime: object, *, inventory: Path, proof_path: Path
+) -> dict[str, object]:
+    return _cli(
+        "principal-record-floor",
+        "--channel",
+        "prod",
+        "--registry-path",
+        str(runtime.layout.registry_path),  # type: ignore[attr-defined]
+        "--host-global-root",
+        str(runtime.ledger.root),  # type: ignore[attr-defined]
+        "--inventory-path",
+        str(inventory),
+        "--quiescence-proof-path",
+        str(proof_path),
+        "--compose-base",
+        str(REPO_ROOT / "docker-compose.yaml"),
+        "--native-producer-root",
+        str(REPO_ROOT),
+        "--loopback-listener",
+        "--consumer",
+        "bootstrap-init",
+    )
+
+
+def _record_floor_in_proved_window(
+    runtime: object,
+) -> tuple[dict[str, object], Path, Path]:
+    proof, inventory = deployment_authority(
+        runtime, runtime.layout.root / "missing-legacy.md"  # type: ignore[attr-defined]
+    )
+    proof_path = runtime.ledger.root / "deployment-quiescence-proof.json"  # type: ignore[attr-defined]
+    floor = _record_floor_receipt(
+        runtime, inventory=inventory, proof_path=proof_path
+    )
+    assert floor["_exit_code"] == 0, floor
+    assert proof.nonce
+    return floor, proof_path, inventory
+
+
+def _cutover_args(runtime: object, *, inventory: Path, proof_path: Path) -> list[str]:
+    return [
+        "principal-cutover",
+        "--channel",
+        "prod",
+        "--registry-path",
+        str(runtime.layout.registry_path),  # type: ignore[attr-defined]
+        "--host-global-root",
+        str(runtime.ledger.root),  # type: ignore[attr-defined]
+        "--inventory-path",
+        str(inventory),
+        "--quiescence-proof-path",
+        str(proof_path),
+        "--compose-base",
+        str(REPO_ROOT / "docker-compose.yaml"),
+        "--native-producer-root",
+        str(REPO_ROOT),
+        "--loopback-listener",
+        "--existing-install",
+        "--consumer",
+        "bootstrap-init",
+    ]
+
+
+def test_compensation_is_lease_bound_and_preserves_a_preexisting_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only this attempt's advanced floor is compensatable under its live lease."""
+
+    def _fail_before_write(self: LocalOperatorPrincipalStore, **kwargs: object) -> None:
+        raise PrincipalPreflightError(
+            "injected bootstrap failure", provisioning_action="retry"
+        )
+
+    # Changing the proof after this process records the floor makes the outcome
+    # ambiguous: compensation is refused and the stopped fence remains.
+    lease_runtime, _, _ = active_runtime(tmp_path / "lease")
+    _, lease_inventory = deployment_authority(
+        lease_runtime, lease_runtime.layout.root / "missing-legacy.md"
+    )
+    lease_proof = lease_runtime.ledger.root / "deployment-quiescence-proof.json"
+    def _fail_after_losing_lease(
+        self: LocalOperatorPrincipalStore, **kwargs: object
+    ) -> None:
+        lease_proof.write_text(
+            json.dumps({"channel_id": "prod", "nonce": "not-this-lease"}),
+            encoding="utf-8",
+        )
+        lease_proof.chmod(0o600)
+        raise PrincipalPreflightError(
+            "injected bootstrap failure after lease loss", provisioning_action="retry"
+        )
+
+    monkeypatch.setattr(LocalOperatorPrincipalStore, "bootstrap", _fail_after_losing_lease)
+    refused = _cli(
+        *_cutover_args(
+            lease_runtime, inventory=lease_inventory, proof_path=lease_proof
+        )
+    )
+    assert refused["_exit_code"] == 75
+    assert principal_floor_recorded(lease_runtime.registry)
+    monkeypatch.setattr(LocalOperatorPrincipalStore, "bootstrap", _fail_before_write)
+
+    # The public command has no attempt-advance flag to forge. An existing floor
+    # is recognized in-process as advanced=false and cannot be compensated.
+    existing_runtime, _, _ = active_runtime(tmp_path / "existing")
+    first_floor, existing_proof, existing_inventory = _record_floor_in_proved_window(
+        existing_runtime
+    )
+    assert first_floor["floor_advanced"] is True
+    with pytest.raises(SystemExit):
+        instance_runtime_main(
+            _cutover_args(
+                existing_runtime,
+                inventory=existing_inventory,
+                proof_path=existing_proof,
+            )
+            + ["--floor-advanced"]
+        )
+    existing = _cli(
+        *_cutover_args(
+            existing_runtime,
+            inventory=existing_inventory,
+            proof_path=existing_proof,
+        )
+    )
+    assert existing["_exit_code"] == 75
+    assert principal_floor_recorded(existing_runtime.registry)
+
+
+def test_registry_read_ambiguity_after_floor_preserves_fence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable post-floor revision keeps the lease/fence stopped (status 75)."""
+
+    runtime, _, _ = active_runtime(tmp_path)
+    _, inventory = deployment_authority(
+        runtime, runtime.layout.root / "missing-legacy.md"
+    )
+    proof = runtime.ledger.root / "deployment-quiescence-proof.json"
+    original_record = principal_fence.record_principal_floor
+    original_load = VaultRegistryStore.load
+    armed = False
+
+    def _record_then_arm(*args: object, **kwargs: object) -> object:
+        nonlocal armed
+        receipt = original_record(*args, **kwargs)
+        armed = True
+        return receipt
+
+    def _ambiguous_once(self: VaultRegistryStore) -> object:
+        nonlocal armed
+        if armed:
+            armed = False
+            raise RegistryError("injected unreadable post-floor revision")
+        return original_load(self)
+
+    monkeypatch.setattr(principal_fence, "record_principal_floor", _record_then_arm)
+    monkeypatch.setattr(VaultRegistryStore, "load", _ambiguous_once)
+    result = _cli(*_cutover_args(runtime, inventory=inventory, proof_path=proof))
+    assert result["_exit_code"] == 75, result
+    assert principal_floor_recorded(runtime.registry)
+    assert "fence" in (runtime.registry.load().extensions.get("principalState") or {})
+
+
+def test_committed_role_is_ambiguous_and_never_compensated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-rename failure preserves role/floor/fence and is never false success."""
+
+    runtime, _, _ = active_runtime(tmp_path)
+    _, inventory = deployment_authority(
+        runtime, runtime.layout.root / "missing-legacy.md"
+    )
+    proof = runtime.ledger.root / "deployment-quiescence-proof.json"
+    original_bootstrap = LocalOperatorPrincipalStore.bootstrap
+
+    def _commit_then_fail(
+        self: LocalOperatorPrincipalStore, **kwargs: object
+    ) -> None:
+        original_bootstrap(self, **kwargs)
+        raise OSError("injected post-commit durability failure")
+
+    monkeypatch.setattr(LocalOperatorPrincipalStore, "bootstrap", _commit_then_fail)
+    result = _cli(*_cutover_args(runtime, inventory=inventory, proof_path=proof))
+    assert result["_exit_code"] == 75, result
+    assert principal_floor_recorded(runtime.registry)
+    assert open_local_operator_principal_store(runtime.layout.registry_path).require()
+
+
+def test_governed_compose_cutover_receipt_is_whitelist_redacted(tmp_path: Path) -> None:
+    """No raw Compose/path/env bytes escape the guarded release-channel producer."""
+
+    captured = tmp_path / "compose.out"
+    captured.write_text(
+        "raw=/Users/private/vault API_KEY=must-not-escape\n"
+        '{"floor_advanced":true,"floor_recorded":true,"registry_revision":9,'
+        '"raw_path":"/Volumes/private"}\n',
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source '{REPO_ROOT / 'scripts/lib/deploy_channel_compose.sh'}'; "
+            f"_deploy_channel_redact_principal_cutover_receipt '{captured}'",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "floor_advanced": True,
+        "floor_recorded": True,
+    }
+    assert "/Users" not in result.stdout
+    assert "/Volumes" not in result.stdout
+    assert "must-not-escape" not in result.stdout

--- a/tests/ops/test_mvr03_principal_mixed_version_fence.py
+++ b/tests/ops/test_mvr03_principal_mixed_version_fence.py
@@ -161,7 +161,7 @@ def test_every_legacy_auth_producer_stops_before_principal_floor_write(tmp_path)
             credential=None,
             subjects=posture.subjects(),
             migration_provenance=posture.migration_provenance(existing_install=True),
-            floor_recorded=False,
+            floor_guard=lambda: False,
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert not principal_record_path(runtime).exists()
@@ -182,7 +182,7 @@ def test_every_legacy_auth_producer_stops_before_principal_floor_write(tmp_path)
         credential=None,
         subjects=posture.subjects(),
         migration_provenance=posture.migration_provenance(existing_install=True),
-        floor_recorded=True,
+        floor_guard=lambda: True,
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
     assert record.revision == 1
@@ -331,25 +331,17 @@ def test_principal_fence_inventory_covers_every_enabled_auth_producer(tmp_path) 
         == digest
     )
 
-    # -- the deployment wrapper is deliberately NOT wired yet ---------------------------
-    # Honest scope boundary, asserted so it cannot drift into an accidental claim. The
-    # floor/fence mechanism is implemented and proven here, but automated activation from
-    # `scripts/deploy_channel.sh` is NOT shipped: it needs credential/listener posture
-    # plumbed into the `instance-state-init` one-shot and the native launcher paths mounted
-    # into it, neither of which this slice delivers. Three independent review rounds found
-    # blockers in that link; it is handed back as bounded follow-up work rather than shipped
-    # half-wired, because a cutover that records the floor and then fails to write the role
-    # leaves the instance fenced and rollback-blocked.
-    #
-    # The operator path today is the explicit governed commands documented in
-    # `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md :: Minimum runtime principal floor`.
+    # -- the production wrapper owns the explicit cutover -------------------------------
+    # #4524 wires the floor/role operation only under the irreversible-floor opt-in.
+    # One runtime process owns same-window compensation before the wrapper releases the lease, so
+    # the old half-wired floor-without-role state is no longer an accepted failure edge.
     wrapper = (REPO_ROOT / "scripts/lib/instance_state_deployment.sh").read_text(
         encoding="utf-8"
     )
-    assert "principal-record-floor" not in wrapper, (
-        "wiring the cutover into the deployment wrapper requires the posture and launcher "
-        "mounts named in the MVR-03 follow-up; do not enable it without them"
-    )
+    assert "MVR03_PRINCIPAL_CUTOVER" in wrapper
+    assert wrapper.index("deployment-prove") < wrapper.index("principal-cutover")
+    assert wrapper.index("principal-cutover") < wrapper.index("deployment-finish")
+    assert "--floor-advanced" not in wrapper
 
     # The ordering hazard that made half-wiring dangerous is closed in code regardless:
     # `principal-record-floor` preflights the posture the subsequent role write will use, so
@@ -358,6 +350,9 @@ def test_principal_fence_inventory_covers_every_enabled_auth_producer(tmp_path) 
     assert "preflight_auth_posture(" in floor_source
     assert floor_source.index("preflight_auth_posture(") < floor_source.index(
         "record_principal_floor("
+    )
+    assert floor_source.index("record_principal_floor(") < floor_source.index(
+        "store.bootstrap("
     )
 
     # -- fail-closed inputs to the reworked inventory ------------------------------------


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4524

## Linked Issue
Closes #4524

## SBS Impact
- Primary subsystem: GOV
- Secondary subsystem(s): WSP, SFC
- Write class: deployment orchestration; no new durable state shape
- Persistence impact: none new; uses existing floor, role, and ownership key
- Derived/rebuildable impact: none
- New or changed contract: explicit cutover opt-in and authenticated clean-failure release receipt
- Owner-doc impact: updated in PR
- Transition debt impact: reduced; manual cutover sequence retired
- Boundary risk: auth, concurrency, release-channel, crash recovery

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Automate the explicit MVR-03 principal floor and delegated-role cutover inside the existing proved deployment window. The one-shot now shares the API auth posture, validates every native producer, and preserves the stopped fence for every ambiguous/crash outcome. Clean failures use a private HMAC-authenticated attempt receipt before the wrapper may release.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260812171913_93a3a552
- Reason: Existing plan-divergence signal covers the prior manual-wiring repair history; no new BuilderOps record was needed for the bounded convergence repairs.

## Notes
Validation: focused Issue suite 17 passed; deployment/MVR batch 54 passed; Ruff, mypy, Bash, settings, docs, Compose and diff gates passed. Canonical not-pg on c65cee310: 13,202 passed, 44 skipped, 18 xfailed, 2 unrelated retrieval global-state failures; both failures pass together serially and the branch has no diff in their code/tests. Required current-head CI remains the merge authority.