### PR TITLE
Authenticate exact reuse from Git objects

### DIFF
--- a/app/builderops/devui_exact_reuse_provenance.py
+++ b/app/builderops/devui_exact_reuse_provenance.py
@@ -98,7 +98,10 @@ def validate_exact_reuse(repo_root: Path, candidate_sha: str) -> ExactReuseRecei
     if not isinstance(imports, list) or tuple(imports) != _APPROVED_IMPORTS:
         raise ExactReuseProvenanceError("remote fonts are not the hardcoded approved literals")
     source_text = source_bytes.decode("utf-8", errors="strict")
-    if tuple(re.findall(r"@import\s+url\(['\"]([^'\"]+)['\"]\)", source_text)) != _APPROVED_IMPORTS:
+    # Every import form counts.  Matching only ``url('...')`` would let a
+    # residual quoted import evade the literal allowlist.
+    import_forms = re.findall(r"@import\s+([^;]+);", source_text)
+    if len(import_forms) != 2 or tuple(re.findall(r"@import\s+url\(['\"]([^'\"]+)['\"]\)", source_text)) != _APPROVED_IMPORTS:
         raise ExactReuseProvenanceError("source imports are not the approved literal pair")
     if any(token not in source_text for token in _TOKENS):
         raise ExactReuseProvenanceError("source lacks required parsed tokens")

--- a/app/builderops/devui_exact_reuse_provenance.py
+++ b/app/builderops/devui_exact_reuse_provenance.py
@@ -29,6 +29,10 @@ _PRIMITIVES = {
 _TRANSFORMS = ("drop_remote_font_imports", "use_declared_local_font_fallback")
 _STATES = ("normal", "empty", "loading", "degraded", "error", "narrow", "200%", "keyboard", "screen-reader", "print", "javascript-off")
 _FALLBACK = "system-ui, sans-serif"
+_SCHEMA_VERSION = "devui.exact-reuse.git-object.v1"
+_PINNED_SOURCE_COMMIT = "f7237a133f239cb710c32ac3d94c7c4fb495a481"
+_PINNED_SOURCE_PATH = "companion-ui/companion-app/colors_and_type.css"
+_PINNED_SOURCE_BLOB = "17fe326b415aee53791fd8ddaf43f7312b199bb7"
 _HEX40 = re.compile(r"^[0-9a-f]{40}$")
 _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
@@ -82,6 +86,8 @@ def _declaration(repo: Path, candidate: str) -> tuple[str, dict[str, object]]:
         raise ExactReuseProvenanceError("candidate declaration is not valid JSON") from exc
     if not isinstance(value, dict) or set(value) != _KEYS:
         raise ExactReuseProvenanceError("candidate declaration schema is closed")
+    if value["schema_version"] != _SCHEMA_VERSION:
+        raise ExactReuseProvenanceError("candidate declaration schema version is invalid")
     return oid, value
 
 
@@ -94,6 +100,8 @@ def validate_exact_reuse(repo_root: Path, candidate_sha: str) -> ExactReuseRecei
     commit, path, claimed_blob = source["commit"], source["path"], source["blob_oid"]
     if not all(isinstance(value, str) for value in (commit, path, claimed_blob)) or not _HEX40.fullmatch(commit) or not _HEX40.fullmatch(claimed_blob):
         raise ExactReuseProvenanceError("source identity is invalid")
+    if (commit, path, claimed_blob) != (_PINNED_SOURCE_COMMIT, _PINNED_SOURCE_PATH, _PINNED_SOURCE_BLOB):
+        raise ExactReuseProvenanceError("source identity is not the approved immutable source object")
     if subprocess.run(("git", "-C", str(repo_root), "merge-base", "--is-ancestor", commit, candidate)).returncode:
         raise ExactReuseProvenanceError("source commit is not reachable from candidate")
     source_oid, source_bytes = _regular_blob(repo_root, commit, path)

--- a/app/builderops/devui_exact_reuse_provenance.py
+++ b/app/builderops/devui_exact_reuse_provenance.py
@@ -1,0 +1,112 @@
+"""Fail-closed Git-object provenance for the narrow devUI exact-reuse route.
+
+The validator deliberately never opens a declaration or source path from a
+worktree.  Every authoritative byte is read with ``git cat-file`` from the
+candidate commit or its reachable source commit.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DECLARATION_PATH = "config/builderops/devui_exact_reuse_declaration.json"
+_GOOGLE = "https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap"
+_BUNNY = "https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap"
+_APPROVED_IMPORTS = (_GOOGLE, _BUNNY)
+_KEYS = frozenset({"schema_version", "source", "remote_font_imports", "source_tokens", "font_fallback", "transforms", "state_matrix"})
+_SOURCE_KEYS = frozenset({"commit", "path", "blob_oid"})
+_TOKENS = ("--font-ui", "--font-display", "--font-mono")
+_TRANSFORMS = ("drop_remote_font_imports", "use_declared_local_font_fallback")
+_STATES = ("normal", "empty", "loading", "degraded", "error", "narrow", "200%", "keyboard", "screen-reader", "print", "javascript-off")
+_FALLBACK = "system-ui, sans-serif"
+_HEX40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ExactReuseProvenanceError(ValueError):
+    """The candidate cannot prove the narrow exact-reuse contract."""
+
+
+@dataclass(frozen=True)
+class ExactReuseReceipt:
+    candidate_sha: str
+    declaration_blob_oid: str
+    source_commit: str
+    source_blob_oid: str
+    remote_font_imports: tuple[str, str]
+    state_matrix: tuple[str, ...]
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(("git", "-C", str(repo), *args), text=True, capture_output=True)
+    if result.returncode:
+        raise ExactReuseProvenanceError("required immutable Git object is unavailable")
+    return result.stdout
+
+
+def _exact_commit(repo: Path, candidate_sha: str) -> str:
+    if not _HEX40.fullmatch(candidate_sha):
+        raise ExactReuseProvenanceError("candidate must be a full committed SHA")
+    resolved = _git(repo, "rev-parse", f"{candidate_sha}^{{commit}}").strip()
+    if resolved != candidate_sha:
+        raise ExactReuseProvenanceError("candidate SHA must resolve exactly")
+    return resolved
+
+
+def _regular_blob(repo: Path, commit: str, path: str) -> tuple[str, bytes]:
+    if not path or path.startswith("/") or ".." in Path(path).parts:
+        raise ExactReuseProvenanceError("invalid object path")
+    row = _git(repo, "ls-tree", commit, "--", path).strip()
+    parts = row.split(maxsplit=3)
+    if len(parts) != 4 or parts[0] != "100644" or parts[1] != "blob" or parts[3] != path:
+        raise ExactReuseProvenanceError("path is not an exact regular blob")
+    oid = parts[2]
+    return oid, _git(repo, "cat-file", "blob", oid).encode()
+
+
+def _declaration(repo: Path, candidate: str) -> tuple[str, dict[str, object]]:
+    oid, raw = _regular_blob(repo, candidate, DECLARATION_PATH)
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExactReuseProvenanceError("candidate declaration is not valid JSON") from exc
+    if not isinstance(value, dict) or set(value) != _KEYS:
+        raise ExactReuseProvenanceError("candidate declaration schema is closed")
+    return oid, value
+
+
+def validate_exact_reuse(repo_root: Path, candidate_sha: str) -> ExactReuseReceipt:
+    candidate = _exact_commit(repo_root, candidate_sha)
+    declaration_oid, declaration = _declaration(repo_root, candidate)
+    source = declaration["source"]
+    if not isinstance(source, dict) or set(source) != _SOURCE_KEYS:
+        raise ExactReuseProvenanceError("source declaration is closed")
+    commit, path, claimed_blob = source["commit"], source["path"], source["blob_oid"]
+    if not all(isinstance(value, str) for value in (commit, path, claimed_blob)) or not _HEX40.fullmatch(commit) or not _HEX40.fullmatch(claimed_blob):
+        raise ExactReuseProvenanceError("source identity is invalid")
+    if subprocess.run(("git", "-C", str(repo_root), "merge-base", "--is-ancestor", commit, candidate)).returncode:
+        raise ExactReuseProvenanceError("source commit is not reachable from candidate")
+    source_oid, source_bytes = _regular_blob(repo_root, commit, path)
+    if source_oid != claimed_blob:
+        raise ExactReuseProvenanceError("source blob does not match declaration")
+    imports = declaration["remote_font_imports"]
+    if not isinstance(imports, list) or tuple(imports) != _APPROVED_IMPORTS:
+        raise ExactReuseProvenanceError("remote fonts are not the hardcoded approved literals")
+    source_text = source_bytes.decode("utf-8", errors="strict")
+    if tuple(re.findall(r"@import\s+url\(['\"]([^'\"]+)['\"]\)", source_text)) != _APPROVED_IMPORTS:
+        raise ExactReuseProvenanceError("source imports are not the approved literal pair")
+    if any(token not in source_text for token in _TOKENS):
+        raise ExactReuseProvenanceError("source lacks required parsed tokens")
+    if declaration["source_tokens"] != list(_TOKENS) or declaration["font_fallback"] != _FALLBACK or declaration["transforms"] != list(_TRANSFORMS) or declaration["state_matrix"] != list(_STATES):
+        raise ExactReuseProvenanceError("fallback, transforms, or state matrix is invalid")
+    return ExactReuseReceipt(candidate, declaration_oid, commit, source_oid, _APPROVED_IMPORTS, _STATES)
+
+
+def build_review_input(repo_root: Path, candidate_sha: str) -> ExactReuseReceipt:
+    """Return only a receipt bound to a full committed candidate SHA and blob."""
+    return validate_exact_reuse(repo_root, candidate_sha)

--- a/app/builderops/devui_exact_reuse_provenance.py
+++ b/app/builderops/devui_exact_reuse_provenance.py
@@ -21,6 +21,11 @@ _APPROVED_IMPORTS = (_GOOGLE, _BUNNY)
 _KEYS = frozenset({"schema_version", "source", "remote_font_imports", "source_tokens", "font_fallback", "transforms", "state_matrix"})
 _SOURCE_KEYS = frozenset({"commit", "path", "blob_oid"})
 _TOKENS = ("--font-ui", "--font-display", "--font-mono")
+_PRIMITIVES = {
+    "--font-display": "'EB Garamond', Georgia, serif",
+    "--font-ui": "'Space Grotesk', system-ui, sans-serif",
+    "--font-mono": "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+}
 _TRANSFORMS = ("drop_remote_font_imports", "use_declared_local_font_fallback")
 _STATES = ("normal", "empty", "loading", "degraded", "error", "narrow", "200%", "keyboard", "screen-reader", "print", "javascript-off")
 _FALLBACK = "system-ui, sans-serif"
@@ -103,8 +108,12 @@ def validate_exact_reuse(repo_root: Path, candidate_sha: str) -> ExactReuseRecei
     import_forms = re.findall(r"@import\s+([^;]+);", source_text)
     if len(import_forms) != 2 or tuple(re.findall(r"@import\s+url\(['\"]([^'\"]+)['\"]\)", source_text)) != _APPROVED_IMPORTS:
         raise ExactReuseProvenanceError("source imports are not the approved literal pair")
-    if any(token not in source_text for token in _TOKENS):
-        raise ExactReuseProvenanceError("source lacks required parsed tokens")
+    parsed_primitives = {
+        name: value.strip()
+        for name, value in re.findall(r"(--font-(?:display|ui|mono))\s*:\s*([^;]+);", source_text)
+    }
+    if parsed_primitives != _PRIMITIVES:
+        raise ExactReuseProvenanceError("source primitives are not the pinned parsed values")
     if declaration["source_tokens"] != list(_TOKENS) or declaration["font_fallback"] != _FALLBACK or declaration["transforms"] != list(_TRANSFORMS) or declaration["state_matrix"] != list(_STATES):
         raise ExactReuseProvenanceError("fallback, transforms, or state matrix is invalid")
     return ExactReuseReceipt(candidate, declaration_oid, commit, source_oid, _APPROVED_IMPORTS, _STATES)

--- a/config/builderops/devui_exact_reuse_declaration.json
+++ b/config/builderops/devui_exact_reuse_declaration.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "devui.exact-reuse.git-object.v1",
+  "source": {
+    "commit": "f7237a133f239cb710c32ac3d94c7c4fb495a481",
+    "path": "companion-ui/companion-app/colors_and_type.css",
+    "blob_oid": "17fe326b415aee53791fd8ddaf43f7312b199bb7"
+  },
+  "remote_font_imports": [
+    "https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap",
+    "https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap"
+  ],
+  "source_tokens": ["--font-ui", "--font-display", "--font-mono"],
+  "font_fallback": "system-ui, sans-serif",
+  "transforms": ["drop_remote_font_imports", "use_declared_local_font_fallback"],
+  "state_matrix": ["normal", "empty", "loading", "degraded", "error", "narrow", "200%", "keyboard", "screen-reader", "print", "javascript-off"]
+}

--- a/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/VALIDATE_OVERVIEW_YGGDRASIL_DESIGN.md
+++ b/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/VALIDATE_OVERVIEW_YGGDRASIL_DESIGN.md
@@ -113,6 +113,19 @@ accepted guidance is normalized back into this capability specification before A
 - Walk the complete state matrix and record token SHA-256, component inputs, screenshots, and open questions.
 - Run `git diff --check` on normalized repository artifacts.
 
+### Narrow exact-reuse provenance route
+
+When a bounded delivery needs to reuse the shipped token sheet without a new
+design generation, the only admitted route is the checked-in
+`config/builderops/devui_exact_reuse_declaration.json` evaluated by
+`app.builderops.devui_exact_reuse_provenance`.  The declaration is read as a
+regular blob from the exact committed candidate tree; its source is a regular
+blob from an immutable commit reachable from that candidate.  The validator
+hardcodes the approved Google/Bunny import literals and rejects all other
+URLs, transforms, fallback families, or state matrices.  This route does not
+replace the live Yggdrasil gate for generated, novel, mixed, unknown, or
+out-of-envelope work.
+
 ## Suggested Validation
 
 - Validate the complete handoff receipt and state matrix before accepting normalization.

--- a/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
+++ b/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
@@ -100,6 +100,19 @@ def test_validator_uses_hardcoded_literal_font_pair_not_source_derived_urls(obje
     with pytest.raises(ExactReuseProvenanceError):
         validate_exact_reuse(repo, bad_candidate)
 
+    # A quoted import is still an import and must not evade the URL matcher.
+    source.write_text(
+        "@import url('" + APPROVED_IMPORTS[0] + "');\n"
+        "@import url('" + APPROVED_IMPORTS[1] + "');\n"
+        "@import 'https://evil.invalid/residual.css';\n"
+        ":root { --font-ui: x; --font-display: x; --font-mono: x; }\n"
+    )
+    source_commit = _commit(repo, "residual import")
+    source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")
+    (repo / DECLARATION_PATH).write_text(json.dumps(_declaration(source_commit, source_blob)))
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, _commit(repo, "residual candidate"))
+
 
 def test_validator_preserves_closed_schema_fallback_transforms_and_state_matrix(object_repo: tuple[Path, str, str]) -> None:
     repo, candidate, _ = object_repo

--- a/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
+++ b/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
@@ -56,7 +56,7 @@ def object_repo(tmp_path: Path) -> tuple[Path, str, str]:
     (repo / "source.css").write_text(
         "@import url('" + APPROVED_IMPORTS[0] + "');\n"
         "@import url('" + APPROVED_IMPORTS[1] + "');\n"
-        ":root { --font-display: 'EB Garamond', Georgia, serif; --font-ui: 'Space Grotesk', system-ui, sans-serif; --font-mono: 'JetBrains Mono', monospace; }\n"
+        ":root { --font-display: 'EB Garamond', Georgia, serif; --font-ui: 'Space Grotesk', system-ui, sans-serif; --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace; }\n"
     )
     source_commit = _commit(repo, "source")
     source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")

--- a/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
+++ b/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from app.builderops import devui_exact_reuse_provenance as provenance
 from app.builderops.devui_exact_reuse_provenance import (
     DECLARATION_PATH,
     ExactReuseProvenanceError,
@@ -49,7 +50,7 @@ def _declaration(source_commit: str, source_blob: str, **overrides: object) -> d
 
 
 @pytest.fixture()
-def object_repo(tmp_path: Path) -> tuple[Path, str, str]:
+def object_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str, str]:
     repo = tmp_path / "objects"
     repo.mkdir()
     _git(repo, "init")
@@ -60,6 +61,9 @@ def object_repo(tmp_path: Path) -> tuple[Path, str, str]:
     )
     source_commit = _commit(repo, "source")
     source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")
+    monkeypatch.setattr(provenance, "_PINNED_SOURCE_COMMIT", source_commit)
+    monkeypatch.setattr(provenance, "_PINNED_SOURCE_PATH", "source.css")
+    monkeypatch.setattr(provenance, "_PINNED_SOURCE_BLOB", source_blob)
     declaration = repo / DECLARATION_PATH
     declaration.parent.mkdir(parents=True)
     declaration.write_text(json.dumps(_declaration(source_commit, source_blob)))
@@ -123,6 +127,25 @@ def test_validator_preserves_closed_schema_fallback_transforms_and_state_matrix(
     bad_candidate = _commit(repo, "duplicate state")
     with pytest.raises(ExactReuseProvenanceError):
         validate_exact_reuse(repo, bad_candidate)
+
+
+def test_validator_rejects_wrong_schema_version_and_comment_obfuscated_import(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, _ = object_repo
+    declaration = json.loads(_git(repo, "show", f"{candidate}:{DECLARATION_PATH}"))
+    declaration["schema_version"] = "devui.exact-reuse.git-object.v2"
+    (repo / DECLARATION_PATH).write_text(json.dumps(declaration))
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, _commit(repo, "wrong schema"))
+
+    # The production route is pinned to the real approved source object; a
+    # syntactically disguised arbitrary import must never become an authority.
+    source = repo / "source.css"
+    source.write_text("@import/**/url('https://evil.invalid/font.css');\n")
+    source_commit = _commit(repo, "obfuscated source")
+    source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")
+    (repo / DECLARATION_PATH).write_text(json.dumps(_declaration(source_commit, source_blob)))
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, _commit(repo, "obfuscated candidate"))
 
 
 def test_review_input_requires_committed_candidate_sha_and_declaration_blob_receipt(object_repo: tuple[Path, str, str]) -> None:

--- a/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
+++ b/tests/builderops/test_devui_exact_reuse_git_object_provenance.py
@@ -1,0 +1,121 @@
+"""Git-object-only exact-reuse provenance tests for #4884."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app.builderops.devui_exact_reuse_provenance import (
+    DECLARATION_PATH,
+    ExactReuseProvenanceError,
+    build_review_input,
+    validate_exact_reuse,
+)
+
+
+APPROVED_IMPORTS = [
+    "https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap",
+    "https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap",
+]
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", "-C", str(repo), *args), check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(repo, "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _declaration(source_commit: str, source_blob: str, **overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": "devui.exact-reuse.git-object.v1",
+        "source": {"commit": source_commit, "path": "source.css", "blob_oid": source_blob},
+        "remote_font_imports": APPROVED_IMPORTS,
+        "source_tokens": ["--font-ui", "--font-display", "--font-mono"],
+        "font_fallback": "system-ui, sans-serif",
+        "transforms": ["drop_remote_font_imports", "use_declared_local_font_fallback"],
+        "state_matrix": ["normal", "empty", "loading", "degraded", "error", "narrow", "200%", "keyboard", "screen-reader", "print", "javascript-off"],
+    }
+    value.update(overrides)
+    return value
+
+
+@pytest.fixture()
+def object_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "objects"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "source.css").write_text(
+        "@import url('" + APPROVED_IMPORTS[0] + "');\n"
+        "@import url('" + APPROVED_IMPORTS[1] + "');\n"
+        ":root { --font-display: 'EB Garamond', Georgia, serif; --font-ui: 'Space Grotesk', system-ui, sans-serif; --font-mono: 'JetBrains Mono', monospace; }\n"
+    )
+    source_commit = _commit(repo, "source")
+    source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")
+    declaration = repo / DECLARATION_PATH
+    declaration.parent.mkdir(parents=True)
+    declaration.write_text(json.dumps(_declaration(source_commit, source_blob)))
+    candidate = _commit(repo, "candidate")
+    return repo, candidate, source_blob
+
+
+def test_dirty_or_replaced_worktree_declaration_cannot_change_verdict(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, _ = object_repo
+    baseline = validate_exact_reuse(repo, candidate)
+    (repo / DECLARATION_PATH).write_text("not json")
+    assert validate_exact_reuse(repo, candidate) == baseline
+
+
+def test_validator_rejects_missing_different_or_nonblob_candidate_and_source_objects(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, source_blob = object_repo
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, "main")
+    declaration = json.loads(_git(repo, "show", f"{candidate}:{DECLARATION_PATH}"))
+    declaration["source"]["blob_oid"] = "0" * 40  # type: ignore[index]
+    (repo / DECLARATION_PATH).write_text(json.dumps(declaration))
+    bad_candidate = _commit(repo, "wrong object")
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, bad_candidate)
+    assert source_blob
+
+
+def test_validator_uses_hardcoded_literal_font_pair_not_source_derived_urls(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, _ = object_repo
+    assert validate_exact_reuse(repo, candidate).remote_font_imports == tuple(APPROVED_IMPORTS)
+    source = (repo / "source.css")
+    source.write_text("@import url('https://evil.invalid/a.css');\n@import url('https://evil.invalid/b.css');\n")
+    source_commit = _commit(repo, "third party css")
+    source_blob = _git(repo, "rev-parse", f"{source_commit}:source.css")
+    declaration = _declaration(source_commit, source_blob, remote_font_imports=["https://evil.invalid/a.css", "https://evil.invalid/b.css"])
+    (repo / DECLARATION_PATH).write_text(json.dumps(declaration))
+    bad_candidate = _commit(repo, "third party candidate")
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, bad_candidate)
+
+
+def test_validator_preserves_closed_schema_fallback_transforms_and_state_matrix(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, _ = object_repo
+    assert validate_exact_reuse(repo, candidate).state_matrix[0] == "normal"
+    declaration = json.loads(_git(repo, "show", f"{candidate}:{DECLARATION_PATH}"))
+    declaration["state_matrix"].append("normal")
+    (repo / DECLARATION_PATH).write_text(json.dumps(declaration))
+    bad_candidate = _commit(repo, "duplicate state")
+    with pytest.raises(ExactReuseProvenanceError):
+        validate_exact_reuse(repo, bad_candidate)
+
+
+def test_review_input_requires_committed_candidate_sha_and_declaration_blob_receipt(object_repo: tuple[Path, str, str]) -> None:
+    repo, candidate, _ = object_repo
+    receipt = build_review_input(repo, candidate)
+    assert receipt.candidate_sha == candidate
+    assert len(receipt.declaration_blob_oid) == 40
+    with pytest.raises(ExactReuseProvenanceError):
+        build_review_input(repo, "HEAD")


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 2

Governing-Issue: #4884

## Linked Issue
Closes #4884

## SBS Impact
- Primary subsystem: Builder System / devUI visual-boundary governance
- Secondary subsystem(s): devUI Stage A and Companion UI design governance
- Write class: authority-bearing checked-in declaration, pure validator, focused tests, owner-doc writeback
- Persistence impact: checked-in Git objects only; no user, vault, runtime, host, session, secret, or GitHub data
- Derived/rebuildable impact: each verdict is rebuilt from a committed candidate tree plus immutable pinned source object
- New or changed contract: exact reuse is admitted only from exact candidate/source blobs plus a hardcoded remote-font allowlist
- Owner-doc impact: updated
- Transition debt impact: replaces terminal mutable-worktree mechanism without broadening eligibility
- Boundary risk: dirty declaration, wrong candidate object, third-party CSS, or non-regular source object accepted as provenance

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Authenticate narrow exact-reuse declarations from immutable Git objects.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: none: bounded Git-object validator and owner-doc writeback; reviewer findings are retained in Git and Issue/PR evidence.

## Notes
Candidate SHA 3bcfb1b5f1b00319dfdd674abe9b677cc927e064 was independently reviewed after the protected repair. Validation: six focused Git-object provenance tests; ruff; docs guard; skill consistency; diff check.
