### PR TITLE
Admit exact devUI reads through the Companion gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ prod-ui-doctor:
 
 prod-up:
 	@bash -c 'source scripts/lib/heimdal_cold_volume_preflight.sh; heimdal_cold_volume_preflight prod "$(CURDIR)"'
+	@python3 scripts/prod_devui_gateway_preflight.py docker-compose.prod.yml
 	@$(MAKE) --no-print-directory prepare-instance-ownership
 	@$(COMPOSE_PROD) up -d $(COMPOSE_UP_BUILD)
 

--- a/app/api/routes/devui.py
+++ b/app/api/routes/devui.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from app.auth import SUBJECT_TRUSTED_COMPANION_PROXY, resolve_auth_subject
 from app.api.routes.cockpit import read_registry as read_cockpit_registry
 from app.builderops.ckm.query_service import CkmQueryService
 from app.builderops.config import load_paths as load_builderops_paths
@@ -71,13 +72,26 @@ def _has_local_host_header(request: Request) -> bool:
 def _require_local_caller(
     request: Request,
 ) -> None:
-    """Admit only a direct loopback peer with no forwarded identity."""
+    """Admit direct loopback or the exact server-derived Companion proxy."""
 
-    if (
-        not _is_immediate_loopback(request)
-        or not _has_local_host_header(request)
-        or _has_forwarded_identity(request)
-    ):
+    # Reject spoofable forwarding before any subject resolution. In
+    # particular, resolve_auth_subject must never see attacker-supplied XFF and
+    # reinterpret a configured proxy request as loopback.
+    if _has_forwarded_identity(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_LOCAL_ONLY_DETAIL,
+        )
+    if _is_immediate_loopback(request) and _has_local_host_header(request):
+        return
+    try:
+        subject = resolve_auth_subject(request, None)
+    except HTTPException as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_LOCAL_ONLY_DETAIL,
+        ) from exc
+    if subject != SUBJECT_TRUSTED_COMPANION_PROXY:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_LOCAL_ONLY_DETAIL,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -42,12 +42,14 @@ import html as _html
 import json
 import os
 import re
+import socket
 import sys
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Optional
-from urllib.parse import parse_qs, quote, urlencode, urlparse
+from urllib.parse import parse_qs, parse_qsl, quote, urlencode, urlparse
 
 import httpx
 
@@ -182,12 +184,55 @@ _DEFAULT_API_TIMEOUT_SECONDS = 2.0
 # timeout (see the 10.0s httpx.get calls below) independent of this value.
 _DEFAULT_ASK_TIMEOUT_SECONDS = 120.0
 _TRUTHY_ENV = {"1", "true", "yes", "on"}
+_DEVUI_GET_PROXY_PATHS = frozenset(
+    {
+        "/api/devui/focus",
+        "/api/devui/overview",
+    }
+)
+_DEVUI_FORWARDED_IDENTITY_HEADERS = frozenset(
+    {
+        "cf-connecting-ip",
+        "forwarded",
+        "true-client-ip",
+        "via",
+        "x-client-ip",
+        "x-envoy-external-address",
+        "x-original-forwarded-for",
+        "x-real-ip",
+    }
+)
 
 
 class CompanionThreadingHTTPServer(ThreadingHTTPServer):
     """Threaded HTTP server for local/LAN Companion UI browser clients."""
 
     daemon_threads = True
+
+
+def is_explicit_loopback_host(value: str | None) -> bool:
+    """Return whether one explicit bind declaration resolves only to loopback."""
+
+    candidate = (value or "").strip()
+    if not candidate:
+        return False
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        return ip_address(candidate).is_loopback
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(candidate, None, type=socket.SOCK_STREAM)
+    except (socket.gaierror, OSError):
+        return False
+    addresses = {str(info[4][0]) for info in infos if info[4]}
+    if not addresses:
+        return False
+    try:
+        return all(ip_address(address).is_loopback for address in addresses)
+    except ValueError:
+        return False
 
 
 def load_config() -> dict:
@@ -15963,6 +16008,7 @@ def make_handler(
     runtime_git_sha: str = "",
     static_assets: dict[str, tuple[str, bytes]] | None = None,
     ask_timeout_seconds: float = _DEFAULT_ASK_TIMEOUT_SECONDS,
+    devui_external_bind_host: str | None = None,
 ) -> type:
     """Return a configured BaseHTTPRequestHandler subclass.
 
@@ -15982,6 +16028,12 @@ def make_handler(
     _resolved_runtime_git_sha = (
         runtime_git_sha or os.getenv("VCS_REF") or "unknown"
     ).strip().lower()
+    # This is the rendered host-publish declaration, not the inside-container
+    # listener or request peer. Docker bridge peers are intentionally not used
+    # as browser-loopback authority.
+    _resolved_devui_enabled = production_profile and is_explicit_loopback_host(
+        devui_external_bind_host
+    )
 
     class _Handler(BaseHTTPRequestHandler):
         _client = client
@@ -15991,8 +16043,9 @@ def make_handler(
         _runtime_git_sha = _resolved_runtime_git_sha
         _static_assets = _merged_static_assets
         _ask_timeout_seconds = ask_timeout_seconds
+        _devui_enabled = _resolved_devui_enabled
 
-        def _send_json(self, status_code: int, payload: dict) -> None:
+        def _send_json(self, status_code: int, payload: object) -> None:
             body = json.dumps(payload).encode("utf-8")
             self.send_response(status_code)
             self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -16085,8 +16138,142 @@ def make_handler(
             )
             self._send_html(404, body)
 
+        def _devui_has_forwarded_identity(self) -> bool:
+            return any(
+                name.lower().startswith("x-forwarded-")
+                or name.lower() in _DEVUI_FORWARDED_IDENTITY_HEADERS
+                for name in self.headers
+            )
+
+        def _devui_has_local_host(self) -> bool:
+            get_all = getattr(self.headers, "get_all", None)
+            if callable(get_all):
+                host_values = get_all("Host") or []
+            else:
+                host_value = self.headers.get("Host")
+                host_values = [host_value] if host_value is not None else []
+            if len(host_values) != 1:
+                return False
+            value = str(host_values[0]).strip().lower()
+            if not value or any(char.isspace() for char in value):
+                return False
+            if any(char in value for char in "/?#@\\,"):
+                return False
+            if value.startswith("["):
+                closing = value.find("]")
+                if closing <= 1:
+                    return False
+                hostname = value[1:closing]
+                suffix = value[closing + 1 :]
+                if suffix and not suffix.startswith(":"):
+                    return False
+                port_text = suffix[1:] if suffix else ""
+            else:
+                if value.count(":") > 1:
+                    return False
+                hostname, separator, port_text = value.rpartition(":")
+                if not separator:
+                    hostname = value
+                    port_text = ""
+            if port_text:
+                try:
+                    port = int(port_text)
+                except ValueError:
+                    return False
+                if not 1 <= port <= 65535:
+                    return False
+            elif value.endswith(":"):
+                return False
+            if hostname == "localhost":
+                return True
+            try:
+                return ip_address(hostname or "").is_loopback
+            except ValueError:
+                return False
+
+        def _devui_request_admitted(self) -> bool:
+            """Authorize a browser hop without treating the Docker peer as proof."""
+
+            if not self._devui_enabled:
+                return False
+            return (
+                not self._devui_has_forwarded_identity()
+                and self._devui_has_local_host()
+            )
+
+        def _proxy_devui_get(self, parsed) -> None:
+            if parsed.path not in _DEVUI_GET_PROXY_PATHS:
+                self._send_json(
+                    404,
+                    {"error": "not_found", "message": "Unknown Companion UI route"},
+                )
+                return
+            if not self._devui_enabled:
+                self._send_json(
+                    404,
+                    {"error": "not_found", "message": "Unknown Companion UI route"},
+                )
+                return
+            if not self._devui_request_admitted():
+                self._send_json(
+                    403,
+                    {
+                        "error": "forbidden",
+                        "message": "devUI is available only through the local loopback gateway",
+                    },
+                )
+                return
+
+            params: dict[str, str] = {}
+            if parsed.path == "/api/devui/overview":
+                if parsed.query:
+                    self._send_json(
+                        404,
+                        {"error": "not_found", "message": "Unknown Companion UI route"},
+                    )
+                    return
+            else:
+                if re.search(r"%(?![0-9a-fA-F]{2})", parsed.query):
+                    pairs: list[tuple[str, str]] = []
+                else:
+                    try:
+                        pairs = parse_qsl(
+                            parsed.query,
+                            keep_blank_values=True,
+                            strict_parsing=True,
+                        )
+                    except ValueError:
+                        pairs = []
+                if len(pairs) != 1 or pairs[0][0] != "subject":
+                    self._send_json(
+                        400,
+                        {"error": "invalid_query", "message": "One subject query is required"},
+                    )
+                    return
+                subject = pairs[0][1]
+                if not subject.strip():
+                    self._send_json(
+                        400,
+                        {"error": "invalid_query", "message": "One subject query is required"},
+                    )
+                    return
+                params = {"subject": subject}
+
+            try:
+                status_code, data = self._client.get_with_status(
+                    parsed.path,
+                    params=params,
+                )
+            except WorkspaceClientError as exc:
+                self._proxy_error(exc)
+                return
+            self._send_json(status_code, data)
+
         def do_GET(self) -> None:
             parsed = urlparse(self.path)
+            if parsed.path == "/api/devui" or parsed.path.startswith("/api/devui/"):
+                self._proxy_devui_get(parsed)
+                return
             if parsed.path == "/healthz":
                 try:
                     self._client.get("/api/health", params={})
@@ -16559,6 +16746,8 @@ def make_handler(
         def route_allowed(cls, method: str, path: str) -> bool:
             method = method.upper()
             if method == "GET":
+                if path in _DEVUI_GET_PROXY_PATHS:
+                    return cls._devui_enabled
                 return cls._get_path_allowed(path)
             if method == "POST":
                 if path in cls._POST_PROXY_PATHS:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
@@ -34,6 +34,7 @@ _PRODUCTION_STATIC_ASSETS = {
 
 def load_config() -> dict:
     """Load production profile config from environment variables."""
+    devui_external_bind_host = os.environ.get("COMPANION_UI_BIND_HOST", "").strip()
     return {
         "host": os.environ.get("HOST", _DEFAULT_HOST),
         "port": int(os.environ.get("PORT", str(_PRODUCTION_PORT))),
@@ -41,6 +42,7 @@ def load_config() -> dict:
             "COMPANION_API_BASE_URL",
             _PRODUCTION_API_BASE_URL,
         ),
+        "devui_external_bind_host": devui_external_bind_host,
     }
 
 
@@ -70,6 +72,7 @@ def main() -> None:
         api_base_url=config["api_base_url"],
         production_profile=True,
         static_assets=_PRODUCTION_STATIC_ASSETS,
+        devui_external_bind_host=config["devui_external_bind_host"],
     )
     server = CompanionThreadingHTTPServer((config["host"], config["port"]), handler)
     print("[companion-ui] Production profile", flush=True)

--- a/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
+++ b/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
@@ -125,6 +125,32 @@ class WorkspaceHttpClient:
             raise WorkspaceClientHTTPError(resp.status_code, resp.text)
         return resp.json()
 
+    def get_with_status(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any],
+    ) -> tuple[int, Any]:
+        """GET JSON without forwarding caller headers, retaining upstream status.
+
+        The production devUI gateway uses this narrow request shape so it can
+        construct a fresh server-side request from only its configured API
+        origin, an exact allowlisted path, and validated query parameters.  A
+        separate method keeps that no-header contract explicit and lets the
+        gateway preserve successful upstream status codes as well as JSON.
+        """
+
+        full_url = self._base_url + url
+        try:
+            resp = httpx.get(full_url, params=params, timeout=self._timeout)
+        except httpx.RequestError as exc:
+            raise WorkspaceClientNetworkError(_transport_error_message(exc)) from exc
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise WorkspaceClientNetworkError("runtime response was not JSON") from exc
+        return resp.status_code, payload
+
     def post(
         self,
         url: str,

--- a/companion-ui/docs/LOCAL_ACCESS_MODEL.md
+++ b/companion-ui/docs/LOCAL_ACCESS_MODEL.md
@@ -33,9 +33,10 @@ personal use.
 
 Rules:
 
-- The Companion UI channel launchers bind to `127.0.0.1` by default.
-- LAN/Tailscale UAT requires an explicit `CUI_BIND_LAN=1` operator action, which binds the UI to
-  `0.0.0.0`.
+- The Companion UI channel launchers bind to `127.0.0.1` by default. Production fixes its host
+  publish to loopback and rejects `CUI_BIND_LAN=1`.
+- LAN/Tailscale UAT requires an explicit `CUI_BIND_LAN=1` operator action on dev/test, which binds
+  the UI to `0.0.0.0`.
 - `HOST` is not a Companion UI channel launcher exposure control.
 - The runtime API used by the page may still be local to the server process.
 - No token, cookie, or login is required for loopback-only personal use.
@@ -54,8 +55,8 @@ LAN or Tailscale access is opt-in trusted-device UAT posture.
 
 Rules:
 
-- The Companion UI channel launchers expose the UI on LAN/Tailscale only when `CUI_BIND_LAN=1` is
-  set.
+- The dev/test Companion UI channel launchers expose the UI on LAN/Tailscale only when
+  `CUI_BIND_LAN=1` is set. Production rejects that flag and remains loopback-only.
 - The operator is responsible for deciding that the LAN or Tailnet is trusted
   enough for the current dev/staging posture.
 - Public internet exposure is not supported.
@@ -96,8 +97,8 @@ Rules (implemented, #3102):
   LAN peer that forges `X-Forwarded-For: 127.0.0.1` is still rejected (the #2706
   anti-spoofing posture is preserved).
 - The browser→`companion-ui` hop remains the trust boundary and is still governed
-  by the UI bind: loopback by default, LAN/Tailscale only with the explicit
-  `CUI_BIND_LAN=1` operator opt-in on trusted devices. Enabling `CUI_BIND_LAN=1`
+  by the UI bind: loopback by default, LAN/Tailscale only on dev/test with the explicit
+  `CUI_BIND_LAN=1` operator opt-in on trusted devices. Enabling `CUI_BIND_LAN=1` on dev/test
   therefore also makes vault selection reachable from that LAN/Tailnet through
   the trusted proxy; treat the network as trusted-device only, as above.
 - Set `COMPANION_UI_PROXY_HOSTS=` (empty) to opt out and fall back to the plain
@@ -110,7 +111,7 @@ Companion vault routes:
   declaration. The production compose path is `127.0.0.1:8113:8113`; the container may listen on
   `0.0.0.0` and see a nonloopback Docker peer without treating either fact as browser authority.
   Missing, wildcard, LAN, bridge, Tailscale, mixed-resolution, or unresolvable declarations disable
-  the devUI routes. `CUI_BIND_LAN=1` does not widen this production devUI exception.
+  the devUI routes. Production rejects `CUI_BIND_LAN=1`; it cannot widen this devUI exception.
 - The browser request must use a loopback-local `Host` and carry no forwarded identity, including
   `Via`. The gateway sends no inbound Host, API key, authorization, forwarding, Via, client-IP, or
   proxy identity to FastAPI.

--- a/companion-ui/docs/LOCAL_ACCESS_MODEL.md
+++ b/companion-ui/docs/LOCAL_ACCESS_MODEL.md
@@ -103,6 +103,25 @@ Rules (implemented, #3102):
 - Set `COMPANION_UI_PROXY_HOSTS=` (empty) to opt out and fall back to the plain
   loopback/API-key gate.
 
+The production devUI reads delivered by #4841 are intentionally narrower than those general
+Companion vault routes:
+
+- Browser authority comes from an explicit all-loopback `COMPANION_UI_BIND_HOST` host-publish
+  declaration. The production compose path is `127.0.0.1:8113:8113`; the container may listen on
+  `0.0.0.0` and see a nonloopback Docker peer without treating either fact as browser authority.
+  Missing, wildcard, LAN, bridge, Tailscale, mixed-resolution, or unresolvable declarations disable
+  the devUI routes. `CUI_BIND_LAN=1` does not widen this production devUI exception.
+- The browser request must use a loopback-local `Host` and carry no forwarded identity, including
+  `Via`. The gateway sends no inbound Host, API key, authorization, forwarding, Via, client-IP, or
+  proxy identity to FastAPI.
+- FastAPI rejects forwarded identity first, then accepts the existing direct-loopback + local-Host
+  path or only the server-derived `trusted_companion_proxy` subject from
+  `resolve_auth_subject(request, None)`. An API key or arbitrary network peer cannot enter this
+  read-only exception.
+- The exception is limited to exact GET `/api/devui/overview` and strict GET
+  `/api/devui/focus?subject=...`. It grants no wildcard, write, page, asset, CORS, or remote-browser
+  access. The later #4836 presentation must consume it without widening it.
+
 ## Token or Session Auth Option
 
 When Companion UI moves beyond loopback-only dev usage, the minimal auth option

--- a/companion-ui/docs/PRODUCTION_EXPOSURE_SECURITY_PROFILE.md
+++ b/companion-ui/docs/PRODUCTION_EXPOSURE_SECURITY_PROFILE.md
@@ -23,7 +23,8 @@ It records posture and review inputs only. It does not implement auth, TLS, CORS
 changes, deployment automation, or runtime behavior.
 
 The current system is personal/local-first. Companion UI channel launchers bind to loopback by
-default; LAN and Tailscale require explicit operator opt-in through `CUI_BIND_LAN=1`.
+default. LAN and Tailscale require explicit `CUI_BIND_LAN=1` opt-in on dev/test; production rejects
+that flag and keeps the Companion publish loopback-only.
 Public-internet scenarios remain unsupported unless a separate hardening contract accepts them.
 
 ## Exposure posture
@@ -31,8 +32,8 @@ Public-internet scenarios remain unsupported unless a separate hardening contrac
 | Exposure mode | Current support posture | Auth/session assumption | CSRF/CORS posture | Review level | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Localhost loopback | Supported default when bound to `127.0.0.1`. | No auth required for loopback-only personal use. | Keep CORS restrictive; mutating routes use explicit non-GET methods. | Level 1 for read-only changes, Level 2 for mutation/rendering changes. | Threat model is mainly local process/browser-origin mistakes and accidental data exposure. |
-| LAN | Explicit `CUI_BIND_LAN=1` operator opt-in, not production hardening. | Network trust alone is not production-grade auth. Token/session auth should precede broader supported non-loopback use. | Arbitrary origins must not be allowed for mutation-capable routes; cookie auth would require CSRF protection. | Level 2 minimum. | Treat as trusted-device personal/staging only. |
-| Tailscale | Explicit `CUI_BIND_LAN=1` operator opt-in; preferred over open LAN for personal multi-device access. | Tailnet membership is not a substitute for application auth once mutation-capable flows mature. | Same as LAN; be explicit about browser origin and session behavior. | Level 2 minimum. | Lower exposure than public internet, but not equivalent to loopback. |
+| LAN | Explicit `CUI_BIND_LAN=1` dev/test operator opt-in, not production hardening. | Network trust alone is not production-grade auth. Token/session auth should precede broader supported non-loopback use. | Arbitrary origins must not be allowed for mutation-capable routes; cookie auth would require CSRF protection. | Level 2 minimum. | Treat as trusted-device personal/staging only; production rejects it. |
+| Tailscale | Explicit `CUI_BIND_LAN=1` dev/test operator opt-in; preferred over open LAN for personal multi-device access. | Tailnet membership is not a substitute for application auth once mutation-capable flows mature. | Same as LAN; be explicit about browser origin and session behavior. | Level 2 minimum. | Lower exposure than public internet, but not equivalent to loopback; production rejects it. |
 | Public internet | Unsupported. | Requires separate accepted auth, TLS, reverse-proxy, token/session, CORS/CSRF, rate-limit, and operational contract before support. | Must be designed before exposure; no default permissive posture. | Level 3 or higher before support. | Do not expose current Companion UI/API publicly as a supported mode. |
 
 ## Auth token and API key posture
@@ -70,8 +71,9 @@ Posture:
   key (the #2706 anti-spoofing hardening is preserved).
 - The browser→`companion-ui` hop stays the network trust boundary, governed by
   the UI bind (loopback default; LAN/Tailscale only via `CUI_BIND_LAN=1` on
-  trusted devices). LAN exposure of the UI transitively reaches vault selection
-  through the trusted proxy — treat LAN/Tailnet as trusted-device only.
+  trusted dev/test devices). LAN exposure of the UI transitively reaches vault selection
+  through the trusted proxy — treat LAN/Tailnet as trusted-device only. Production rejects that
+  flag and remains loopback-only.
 - This does not add token/session/CORS support; those remain future non-loopback
   hardening (below).
 

--- a/companion-ui/docs/PRODUCTION_EXPOSURE_SECURITY_PROFILE.md
+++ b/companion-ui/docs/PRODUCTION_EXPOSURE_SECURITY_PROFILE.md
@@ -75,6 +75,20 @@ Posture:
 - This does not add token/session/CORS support; those remain future non-loopback
   hardening (below).
 
+The #4841 production devUI transport is a deliberately narrower exception. It is unavailable unless
+the process receives an explicit all-loopback `COMPANION_UI_BIND_HOST` declaration matching the
+host publish (`127.0.0.1:8113:8113`). The container's `HOST=0.0.0.0` listener and nonloopback
+Docker peer are not browser-loopback proof. Every browser request must carry one loopback-local
+`Host` and no forwarded identity, including `Via`; the gateway constructs a new upstream request
+and copies no inbound Host, API key, authorization, forwarding, Via, client-IP, or proxy identity.
+
+FastAPI rejects forwarding first and accepts only its preserved direct-loopback + local-Host path or
+the exact server-derived `trusted_companion_proxy` subject. Only GET `/api/devui/overview` and
+strict GET `/api/devui/focus?subject=...` transit; API keys, writes, wildcards, CORS relaxation,
+LAN/Tailscale browser access, and arbitrary bridge peers do not. Port `8113` is the production
+Companion browser origin; port `18000` remains API health/version diagnostics only. #4841 ships no
+page or asset route; #4836 must consume this boundary unchanged before any browser page is claimed.
+
 ## CSRF, CORS, and session assumptions
 
 Current assumptions:

--- a/companion-ui/docs/UI_RUNTIME_BOUNDARIES.md
+++ b/companion-ui/docs/UI_RUNTIME_BOUNDARIES.md
@@ -52,6 +52,18 @@
 - The runtime API target is configuration; it does not relax operator
   bind/exposure posture. Remote exposure of the UI origin remains an explicit
   operator choice, independent of this proxy path.
+- Production devUI transport is a separate, stricter two-route allowlist (#4841): exact GET
+  `/api/devui/overview` with no query and exact GET `/api/devui/focus` with one nonempty
+  `subject` query. Unknown/child devUI paths, duplicate or extra query keys, wildcards, and
+  POST/PUT/PATCH/DELETE are denied. The route is enabled only from an explicit all-loopback
+  `COMPANION_UI_BIND_HOST` declaration and requires a loopback-local browser `Host` with no
+  forwarded identity, including `Via`; it never treats the inside-container peer as loopback
+  authority.
+- For those two reads, the UI server creates a fresh request from only
+  `COMPANION_API_BASE_URL`, the exact path, and the validated query. It copies no inbound `Host`,
+  API key, authorization, forwarding, Via, client-IP, or proxy header, and returns the upstream
+  status and JSON body unchanged. #4841 adds no FastAPI page/static route, packaged page/asset, or
+  browser fallback. Presentation #4836 consumes this transport later at the Companion origin.
 
 ## Control-action register
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,15 +53,19 @@ services:
 
   companion-ui:
     ports: !override
-      - "${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113"
+      # Production is intentionally loopback-only. Keep the browser-facing
+      # publish and the declaration consumed by the process as one fixed
+      # producer pair; an ambient shell value must not widen or disable it.
+      - "127.0.0.1:8113:8113"
     environment:
       PKM_ENVIRONMENT: prod
       PORT: 8113
       COMPANION_API_BASE_URL: http://api:8000
       # Separate the container listener from the browser-facing host publish.
-      # Missing/non-loopback declarations leave ordinary Companion health up
-      # but keep the devUI gateway routes fail-closed.
-      COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}
+      # Noncanonical/direct process launches still fail closed in the runtime,
+      # while this canonical production producer always supplies the exact
+      # declaration matching the host publish above.
+      COMPANION_UI_BIND_HOST: 127.0.0.1
       COMPANION_UI_SERVE_MODULE: companion_ui.workspace.serve_production_page
 
   db:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,10 @@ services:
       PKM_ENVIRONMENT: prod
       PORT: 8113
       COMPANION_API_BASE_URL: http://api:8000
+      # Separate the container listener from the browser-facing host publish.
+      # Missing/non-loopback declarations leave ordinary Companion health up
+      # but keep the devUI gateway routes fail-closed.
+      COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}
       COMPANION_UI_SERVE_MODULE: companion_ui.workspace.serve_production_page
 
   db:

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -688,8 +688,9 @@ Delivered now:
 The production Companion transport prerequisite for the existing Overview and Focus reads is
 delivered by #4841: `127.0.0.1:8113` loopback host publication, local-Host/no-forwarded admission,
 an exact two-GET allowlist, and a fresh upstream request with no client identity or credentials.
-It adds no page or asset route; port `18000` remains diagnostic-only and #4836 must consume this
-transport unchanged.
+The read endpoint is `http://127.0.0.1:8113/devui/overview`; #4841 is transport only: it adds no
+page or asset route, and port `18000` remains direct API health/version diagnostics.
+#4836 must consume this transport unchanged, and #4833 must verify its published candidate.
 
 Not delivered now: one devUI shell; request/preview/authenticated approval in one owner experience;
 PostgreSQL authority cutover; full live run controls; receipt-to-CKM reassessment in the unified

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -685,6 +685,12 @@ Delivered now:
 - DDO-01 through DDO-04 fast lane, contracts, plan compiler, reducer, and WorkerRuntime seam; and
 - parts of the BuilderOps API/PostgreSQL control-plane development baseline.
 
+The production Companion transport prerequisite for the existing Overview and Focus reads is
+delivered by #4841: `127.0.0.1:8113` loopback host publication, local-Host/no-forwarded admission,
+an exact two-GET allowlist, and a fresh upstream request with no client identity or credentials.
+It adds no page or asset route; port `18000` remains diagnostic-only and #4836 must consume this
+transport unchanged.
+
 Not delivered now: one devUI shell; request/preview/authenticated approval in one owner experience;
 PostgreSQL authority cutover; full live run controls; receipt-to-CKM reassessment in the unified
 surface; Focus browser UI, capability-subject route, and Overview-to-Focus

--- a/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/PARENT_FEATURE_ISSUE.md
+++ b/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/PARENT_FEATURE_ISSUE.md
@@ -22,6 +22,8 @@ subject until #4834 merges; **Needs you** and **Ready to try** remain withdrawn.
 binder and #4747 Overview-only shell remain preserved supersession candidates while the recovery
 path produces one connected Overview → visual Focus → return journey through #4746 and #4836. The
 parent coordinates validation only; it is never ready work and claims no deployed or accepted UI.
+#4841 additionally delivers the narrow production Companion transport for the existing two read
+APIs only; it supplies neither a page nor a visual destination.
 
 ## Scope
 
@@ -73,6 +75,9 @@ parent coordinates validation only; it is never ready work and claims no deploye
   receipt from #4746: either `yggdrasil-constrained-reuse.v1` or
   `yggdrasil-design-handoff.v1`. Exact shipped reuse does not run or claim the live system/token
   preflight; any novel, mixed, unknown, extension, or out-of-envelope delta must pass it.
+- #4836 must consume #4841's `127.0.0.1:8113` host publish, local-Host/no-forwarded admission,
+  exact two-GET/header-stripping contract, and direct-loopback-or-server-derived Companion API
+  admission unchanged. Port `18000` remains direct diagnostics, never a browser page origin.
 - No technical label/state, provider metadata, or terminal delivery fact substitutes for explicit
   canonical category or receipt-backed `ready_to_try` evidence.
 - ARO-08 remains serially blocked after #4748 until the repaired source contract, Demerzel
@@ -164,6 +169,8 @@ a compact exact-SHA receipt to the parent. Before #4746 readiness, re-read merge
 the other route. #4833 verifies the published #4836 candidate at its exact ref before merge. ARO-08
 additionally takes its deployed URL/SHA only from shell/browser/deployment receipts and records
 every required identity/effect proof in the structured owner-pilot ledger.
+Before #4836 pickup, re-read merged #4841 and bind its current transport regression evidence;
+#4833 verifies the published #4836 candidate at its exact ref before merge.
 
 ## Validation / Acceptance Path
 

--- a/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/README.md
+++ b/docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/README.md
@@ -29,6 +29,10 @@ for stable #4834 **Now** fixtures plus the delivered #4768 Focus API fixtures an
 Yggdrasil evidence: exact constrained reuse provenance, or the live handoff required for any novel,
 mixed, or unknown delta.
 
+#4841 supplies only the production loopback-published Companion transport for the existing two
+read APIs. #4836 must consume its exact admission and header-stripping boundary; it provides no
+page, asset, or visual destination.
+
 ## Current-to-target truth
 
 | Surface | Current delivered fact | Remaining target |
@@ -37,7 +41,7 @@ mixed, or unknown delta.
 | `devui-overview-view.v1` | Pure composer in `app/builderops/devui_overview.py`, including hostile cross-field validation and typed root-reference preservation | **Excluded from this breakdown; do not duplicate or reopen** |
 | Cockpit producer | #4834 maps only trusted, countable `working` items to source-ordered **Now** candidates with stable GitHub identity and separate Cockpit evidence | Owner-question facts remain separately source-owned or honestly withdrawn; `agent:needs-human`, delivery, and readiness are not admitted |
 | Delivery evidence | Delivery, merge, closure, and terminal verification facts exist independently | A source-owned, receipt-backed `ready_to_try` fact, or an honest withdrawal |
-| API | Local-only GET `/api/devui/composition` and delivered direct-loopback GET `/api/devui/overview`; the latter rebuilds composition once and derives #4834 candidates from that same work payload; no devUI mutation route | Typed navigation only after actual local destinations are governed |
+| API | Local-only GET `/api/devui/composition`, delivered direct-loopback Overview/Focus reads, and #4841's production Companion exact two-GET transport; no devUI mutation or page route | Typed navigation only after actual local destinations are governed |
 | Navigation | Composer validates typed root references | Resolvable local Focus and optional SoI destinations without joins |
 | Visual shell | No Overview browser shell | Accepted constrained-reuse or live-handoff evidence, read-only shell, browser/accessibility proof, owner pilot |
 
@@ -100,6 +104,10 @@ pickup issue.
   Exact shipped-pattern reuse requires an independently reviewed content-addressed
   `yggdrasil-constrained-reuse.v1` receipt with zero novel language; novel, mixed, unknown, or
   out-of-envelope work still requires the live Yggdrasil preflight and handoff receipt.
+- **ARO-INV-8 — production transport stays narrower than presentation.** #4836 must consume #4841's
+  `127.0.0.1:8113` loopback publish, local-Host/no-forwarded gateway admission, exact Overview/Focus
+  GET allowlist, stripped upstream request, and direct-loopback-or-server-derived API rule unchanged.
+  Port `18000` remains direct diagnostics and is not a browser page origin.
 
 ## Capability acceptance
 
@@ -108,6 +116,9 @@ pickup issue.
       serialized, linked, fresh enough, and never inferred.
 - [ ] The local Overview endpoint is GET-only, local-admission constrained, projection-only, and
       preserves the delivered composer contract.
+- [ ] The production shell uses #4841's exact read-only Companion transport at `127.0.0.1:8113`;
+      it never treats port `18000` as a browser page, forwards identity or credentials, adds a
+      wildcard/write route, or infers loopback from the Docker peer.
 - [ ] Every typed navigation reference resolves to an actual admitted local destination or remains
       explicitly unavailable/unsupported; no dead or synthetic link is rendered.
 - [ ] The governed design evidence and shell cover desktop, narrow, 200% zoom, keyboard, screen-reader,
@@ -138,6 +149,10 @@ delivered by PR #4771. Connected handoff #4746 remains blocked until the deliver
 producer #4834 is merged stable and one applicable governed receipt passes independent review. This governance change
 does not accept #4746 or produce its receipt. GitHub owns backlog state; this directory owns the
 stable breakdown and validation path.
+
+Production transport prerequisite [#4841](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4841)
+is consumed only by the source-authorized connected shell
+[#4836](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4836) and does not itself deliver that shell.
 
 ## Governing and supporting sources
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,10 +65,11 @@ browser boundary is the explicitly rendered host publish
 non-loopback, mixed-resolution, or unresolvable declarations leave ordinary Companion health
 available but keep the devUI gateway routes unavailable. Port `18000` remains direct API
 health/version diagnostics only; it is not a supported devUI browser origin.
-The canonical production Compose file fixes both sides of that producer pair to loopback. Both
-production producers — the deploy wrapper and `scripts/prod/start_midgard_ui.sh` — fail before
+The canonical production Compose file fixes both sides of that producer pair to loopback. Every
+production producer — the deploy wrapper, `make prod-up`, the `make prod-start-full` chain through
+`scripts/start_full_system.sh`, and `scripts/prod/start_midgard_ui.sh` — fails before Compose
 mutation if the publish or process declaration is absent, ambient, wildcard, or otherwise drifts
-from the exact pair; the latter also rejects `CUI_BIND_LAN=1`.
+from the exact pair; the UI launcher also rejects `CUI_BIND_LAN=1`.
 
 The gateway admits only a local loopback `Host` with no forwarded identity header, including
 `Forwarded`, every `X-Forwarded-*` name, and `Via`. It proxies exactly GET

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,6 +65,9 @@ browser boundary is the explicitly rendered host publish
 non-loopback, mixed-resolution, or unresolvable declarations leave ordinary Companion health
 available but keep the devUI gateway routes unavailable. Port `18000` remains direct API
 health/version diagnostics only; it is not a supported devUI browser origin.
+The canonical production Compose file fixes both sides of that producer pair to loopback, and the
+production deploy wrapper fails before mutation if the publish or process declaration is absent,
+ambient, wildcard, or otherwise drifts from the exact pair.
 
 The gateway admits only a local loopback `Host` with no forwarded identity header, including
 `Forwarded`, every `X-Forwarded-*` name, and `Via`. It proxies exactly GET

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,8 +7,8 @@ Lightweight policy for local and CI runs.
 ## API keys & endpoints
 - Store keys (`OPENAI_API_KEY`, `DEEPSEEK_API_KEY`) only in local `.env` files or a secrets manager. Never commit them to Git, CI logs, or docs.
 - `LLM_PROVIDER=mock` is the CI default, so no external keys are needed for tests.
-- Integrated Runtime v1 still exposes non-UI local services on trusted interfaces by default: the FastAPI runtime starts `uvicorn` on `0.0.0.0:8000`, Compose publishes the API host port to container port `8000`, and Ollama sets `OLLAMA_HOST=0.0.0.0:11434`. Companion UI launchers bind the browser UI to `127.0.0.1` by default and require `CUI_BIND_LAN=1` for LAN/Tailscale UAT. This is not an internet-ready security boundary.
-- For Companion UI non-loopback UAT, set `CUI_BIND_LAN=1` deliberately. API and Ollama host binding changes are runtime/config changes and should be made deliberately outside the Companion UI launcher default.
+- Integrated Runtime v1 still exposes non-UI local services on trusted interfaces by default: the FastAPI runtime starts `uvicorn` on `0.0.0.0:8000`, Compose publishes the API host port to container port `8000`, and Ollama sets `OLLAMA_HOST=0.0.0.0:11434`. Dev/test Companion UI launchers bind the browser UI to `127.0.0.1` by default and require `CUI_BIND_LAN=1` for LAN/Tailscale UAT; the production launcher rejects that flag and publishes only loopback. This is not an internet-ready security boundary.
+- For Companion UI non-loopback UAT, set `CUI_BIND_LAN=1` deliberately on dev/test only. API and Ollama host binding changes are runtime/config changes and should be made deliberately outside the Companion UI launcher default.
 - Do not expose the API, Ollama, or Companion UI to untrusted networks without an explicit access-control boundary such as an SSH tunnel, VPN, or reverse-proxy design with auth and TLS.
 
 ## Delegated local operator principal (MVR-03, shipped)
@@ -65,9 +65,10 @@ browser boundary is the explicitly rendered host publish
 non-loopback, mixed-resolution, or unresolvable declarations leave ordinary Companion health
 available but keep the devUI gateway routes unavailable. Port `18000` remains direct API
 health/version diagnostics only; it is not a supported devUI browser origin.
-The canonical production Compose file fixes both sides of that producer pair to loopback, and the
-production deploy wrapper fails before mutation if the publish or process declaration is absent,
-ambient, wildcard, or otherwise drifts from the exact pair.
+The canonical production Compose file fixes both sides of that producer pair to loopback. Both
+production producers — the deploy wrapper and `scripts/prod/start_midgard_ui.sh` — fail before
+mutation if the publish or process declaration is absent, ambient, wildcard, or otherwise drifts
+from the exact pair; the latter also rejects `CUI_BIND_LAN=1`.
 
 The gateway admits only a local loopback `Host` with no forwarded identity header, including
 `Forwarded`, every `X-Forwarded-*` name, and `Via`. It proxies exactly GET
@@ -81,7 +82,7 @@ FastAPI rejects forwarded identity before resolving a subject. It then admits ei
 direct-loopback + local-Host path or the exact server-derived result
 `resolve_auth_subject(request, None) == SUBJECT_TRUSTED_COMPANION_PROXY`. API-key subjects,
 arbitrary bridge/LAN/Tailscale peers, and missing or unresolvable Companion proxy configuration
-fail closed. #4841 supplies transport only: it adds no FastAPI page/static route and no remote
+fail closed. #4841 supplies transport only: it adds no page/static route and no remote
 browser mode; presentation consumer #4836 must reuse this boundary unchanged.
 
 ## Least privilege

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,6 +56,31 @@ Selection carries no authority. The active-context selection bearer
 *in addition to* the #2223 gate; it stores no action, write class, or permission, and GOV
 authorizes every binding independently per call.
 
+### devUI loopback-published gateway admission (#4841)
+
+The production devUI read transport uses a narrower subset of the delegated local subjects. Its
+browser boundary is the explicitly rendered host publish
+`COMPANION_UI_BIND_HOST=127.0.0.1` → `127.0.0.1:8113:8113`, not the gateway container's
+`HOST=0.0.0.0` listener and not the request peer observed inside Docker. Missing, wildcard,
+non-loopback, mixed-resolution, or unresolvable declarations leave ordinary Companion health
+available but keep the devUI gateway routes unavailable. Port `18000` remains direct API
+health/version diagnostics only; it is not a supported devUI browser origin.
+
+The gateway admits only a local loopback `Host` with no forwarded identity header, including
+`Forwarded`, every `X-Forwarded-*` name, and `Via`. It proxies exactly GET
+`/api/devui/overview` without a query and GET `/api/devui/focus` with one nonempty `subject`
+query. It rejects unknown devUI paths, wildcards, duplicate/extra query keys, and every write verb.
+Each admitted call is a new server-side request built from the configured API origin plus that
+exact path/query; inbound `Host`, API key, authorization, forwarding, client-IP, and proxy headers
+are never copied upstream.
+
+FastAPI rejects forwarded identity before resolving a subject. It then admits either the existing
+direct-loopback + local-Host path or the exact server-derived result
+`resolve_auth_subject(request, None) == SUBJECT_TRUSTED_COMPANION_PROXY`. API-key subjects,
+arbitrary bridge/LAN/Tailscale peers, and missing or unresolvable Companion proxy configuration
+fail closed. #4841 supplies transport only: it adds no FastAPI page/static route and no remote
+browser mode; presentation consumer #4836 must reuse this boundary unchanged.
+
 ## Least privilege
 - The Postgres account (`DATABASE_URL`) uses `app:app` for local dev. In production create a dedicated role with only the required `INSERT/SELECT/UPDATE`.
 - CLI smoke commands append to the JSONL audit log (`INDEX_OUTBOX_PATH`). Runtime watcher/worker flows use the DB outbox; keep database permissions minimal and scoped to the outbox/index tables.

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -70,9 +70,11 @@ Anchors for the values above: ports/DBs in `docker-compose.{dev,test,prod}.yml`;
 Notes on the current model:
 - `test` and `prod` still bind-mount the **same host checkout** at `/app`. That repo bind-mount is what removes code isolation: a `git checkout` in the one host tree changes the code under both channels' containers at once. `dev` differs only by running the baked local `pkm-app:dev-local` image, not by running a promoted GHCR SHA pin.
 - Companion UI gateways are now declared as managed compose units in the repo, but the running fleet has not yet adopted the pinned-image model. The cutover guard therefore checks gateway-unit participation in the recreate set before #2698 can treat a channel as ready.
-- Production Compose publishes Companion on `127.0.0.1:8113` by default, but devUI admission
-  additionally requires the explicit declaration `COMPANION_UI_BIND_HOST=127.0.0.1` to be passed
-  into the gateway. Missing/nonloopback declarations keep only the devUI routes closed while
+- Production Compose fixes Companion's publish to `127.0.0.1:8113` and passes the matching explicit
+  declaration `COMPANION_UI_BIND_HOST=127.0.0.1` into the gateway as one canonical producer pair;
+  ambient shell configuration cannot widen or silently disable it. The production deploy wrapper
+  fails before mutation if either half drifts. Noncanonical direct launches with missing or
+  nonloopback declarations keep only the devUI routes closed while
   unrelated Companion health remains available. Port `18000` is direct API health/version
   diagnostics, not a supported devUI browser origin; #4836's eventual canonical page is
   `http://127.0.0.1:8113/devui/overview` only after its own deployment receipt.

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -70,6 +70,12 @@ Anchors for the values above: ports/DBs in `docker-compose.{dev,test,prod}.yml`;
 Notes on the current model:
 - `test` and `prod` still bind-mount the **same host checkout** at `/app`. That repo bind-mount is what removes code isolation: a `git checkout` in the one host tree changes the code under both channels' containers at once. `dev` differs only by running the baked local `pkm-app:dev-local` image, not by running a promoted GHCR SHA pin.
 - Companion UI gateways are now declared as managed compose units in the repo, but the running fleet has not yet adopted the pinned-image model. The cutover guard therefore checks gateway-unit participation in the recreate set before #2698 can treat a channel as ready.
+- Production Compose publishes Companion on `127.0.0.1:8113` by default, but devUI admission
+  additionally requires the explicit declaration `COMPANION_UI_BIND_HOST=127.0.0.1` to be passed
+  into the gateway. Missing/nonloopback declarations keep only the devUI routes closed while
+  unrelated Companion health remains available. Port `18000` is direct API health/version
+  diagnostics, not a supported devUI browser origin; #4836's eventual canonical page is
+  `http://127.0.0.1:8113/devui/overview` only after its own deployment receipt.
 - A partial build-identity foundation already exists: #2602 bakes `VCS_REF`/`BUILT_AT` into the image (Dockerfile ARG/LABEL/ENV), `get_runtime_version()` in `app/version.py` reads them (falling back to `git rev-parse` for local dev), `/version` returns `{git_sha, built_at}`, and `/api/health` carries a top-level `version` field. **But the `test`/`prod` `/app` bind-mount overrides the baked code**, so today those channels run the host checkout, not the image — the SHA marker can disagree with what is actually executing until the bind-mount is retired.
 
 ### Multi-vault instance-state rollout boundary
@@ -264,7 +270,7 @@ Companion UI gateways must become **managed units** with deterministic recreate-
 Current reality: `scripts/lib/companion_ui_startup.sh` launches the gateway with `nohup … &`, writes a PID file, and curls `/healthz` to confirm liveness — but nothing supervises or restarts the process, and the launch lives in script + shell history rather than a declared unit. The dev/test gateways run `companion_ui.workspace.serve_dev_page`; prod runs `companion_ui.workspace.serve_production_page`; both render through `render_index_html`, so this is a deployment/supervision change, not a UI-behavior change.
 
 Target contract (S4):
-- **One declared unit per channel gateway.** Either containerize the gateway in the channel's compose project, or declare a `launchd` unit per channel. The unit owns host/port (`HOST`, `PORT`) and the API base URL (`COMPANION_API_BASE_URL`) exactly as the current startup script passes them.
+- **One declared unit per channel gateway.** Either containerize the gateway in the channel's compose project, or declare a `launchd` unit per channel. The unit owns host/port (`HOST`, `PORT`) and the API base URL (`COMPANION_API_BASE_URL`) exactly as the current startup script passes them. The production unit also carries the separate external host-publish declaration `COMPANION_UI_BIND_HOST`; its inside-container listener is not exposure authority.
 - **Recreate-on-deploy.** A deploy recreates the gateway unit so it picks up the deployed image/code, in lockstep with the API recreate — never a half-deployed state where the API is new and the gateway is old.
 - **Restart-on-failure.** The unit restarts the gateway if it exits (compose `restart: unless-stopped`, matching the API/db/worker services in `docker-compose.yaml`, or the `launchd` `KeepAlive` equivalent). A crashed gateway must come back without a human.
 - **Source-of-truth.** The unit definition is committed; there is no "remember the nohup command" step. The per-channel wrappers (`start_niflheim_ui.sh` / `start_bifrost_ui.sh` / `start_midgard_ui.sh`) and doctor scripts are reconciled to invoke the managed unit rather than `nohup`.
@@ -504,6 +510,14 @@ How it is implemented: `_effective_client_host()` in `app/auth.py` reads the fir
 - Untrusted non-loopback callers without a valid API key remain rejected (`require_loopback_or_api_key` still 401s — preserves #2223).
 - The deployment topology (managed gateway + API on the same host) must keep the proxy allowlist narrow; if a channel is ever bound to a LAN/Tailscale interface for UAT, the API-key path (not blanket loopback trust) governs untrusted callers.
 - S6 verification is locked by `tests/api/test_auth_proxy_topology.py` and `tests/api/test_companion_auth_loopback_behind_proxy.py`: a loopback-local or configured same-host proxy may assert the client via `X-Forwarded-For`, while a genuinely non-loopback caller or unconfigured bridge peer with forged `X-Forwarded-For` remains rejected.
+
+The production devUI read path does **not** reuse that forwarding mechanism. #4841 first rejects
+every forwarded identity header, including `Via`, then preserves direct loopback + local Host or
+accepts only `resolve_auth_subject(request, None) == SUBJECT_TRUSTED_COMPANION_PROXY` for the
+configured Companion container peer. The gateway exposes only exact GET `/api/devui/overview`
+and strict GET `/api/devui/focus?subject=...`, constructs a fresh no-credential/no-forwarding
+request, and preserves upstream status/JSON. No API key, arbitrary bridge peer, wildcard, write, or
+inside-container peer-loopback inference enters that exception.
 
 ## What this supersedes
 

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -67,6 +67,11 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
   fails the changing PR instead of first turning `main`'s post-merge smoke red. The docker-compose
   integration itself (mounts, launcher sequence, seeded vault) remains post-merge-only coverage.
 - E2E tests under `tests/e2e/` run after merge and in the nightly suite, not on ordinary PRs. Opt-in classes (live LLM, browser, human UAT, eval) remain in their dedicated post-merge or nightly lanes.
+- The #4841 production devUI transport is a security-boundary change. Its focused contract set is
+  `tests/ops/test_prod_devui_gateway_config.py`,
+  `tests/companion_ui/test_devui_gateway_admission.py`, and `tests/api/test_devui_api.py`, plus
+  the production-launcher target when a producer changes. Merge evidence requires exact-head CI;
+  stale checks from a prior branch head do not satisfy this transport contract.
 - Combined devUI shell recovery #4836 has an explicit pre-merge exception to that post-merge
   browser default: after publishing the candidate ref, an operator must dispatch
   `.github/workflows/browser-runtime.yml` against that exact ref (for example,

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -70,8 +70,9 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - The #4841 production devUI transport is a security-boundary change. Its focused contract set is
   `tests/ops/test_prod_devui_gateway_config.py`,
   `tests/companion_ui/test_devui_gateway_admission.py`, and `tests/api/test_devui_api.py`, plus
-  the production-launcher target when a producer changes. Merge evidence requires exact-head CI;
-  stale checks from a prior branch head do not satisfy this transport contract.
+  every production-producer target when a producer changes (`deploy`, `prod-up`, `prod-start-full`,
+  and `prod-ui`). Merge evidence requires exact-head CI; stale checks from a prior branch head do
+  not satisfy this transport contract.
 - Combined devUI shell recovery #4836 has an explicit pre-merge exception to that post-merge
   browser default: after publishing the candidate ref, an operator must dispatch
   `.github/workflows/browser-runtime.yml` against that exact ref (for example,

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -1089,6 +1089,11 @@ if ! scripts/companion_ui_postdeploy_smoke.sh preflight; then
   exit 86
 fi
 
+if [ "${action}" = "deploy" ] && [ "${channel}" = "prod" ]; then
+  "${PYTHON}" "${ROOT}/scripts/prod_devui_gateway_preflight.py" \
+    "${ROOT}/docker-compose.prod.yml" || exit $?
+fi
+
 if [ "${scalar_rollback}" = "1" ]; then
   prepare_scalar_rollback_environment || exit $?
 fi

--- a/scripts/prod/start_midgard_ui.sh
+++ b/scripts/prod/start_midgard_ui.sh
@@ -22,11 +22,11 @@
 #   scripts/prod/start_midgard_ui.sh
 #
 # Optional environment:
-#   CUI_BIND_LAN=1                 bind the UI to 0.0.0.0 for LAN/Tailscale UAT
 #   CUI_TARGET_NOTE=<rel-path>     verify a note path via /api/companion/workspace
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=../lib/companion_ui_startup.sh
 source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
 
@@ -39,6 +39,11 @@ CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.prod.yml"
 CUI_COMPOSE_PROJECT="pkm-prod"
 CUI_SERVE_MODULE="companion_ui.workspace.serve_production_page"
 CUI_DB_LABEL="app"
+
+if [ "${CUI_BIND_LAN:-0}" = "1" ]; then
+  echo "[companion-ui:prod] CUI_BIND_LAN=1 is unsupported: production Companion publication is loopback-only." >&2
+  exit 78
+fi
 
 # Production guardrail: safest posture by default. Automation/write-capable
 # services (watcher auto-exec) are started ONLY on explicit acknowledgement.
@@ -55,5 +60,8 @@ fi
 export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
   CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE \
   CUI_DB_LABEL CUI_WATCHER_AUTO_EXEC
+
+"${PYTHON:-python3}" "${REPO_ROOT}/scripts/prod_devui_gateway_preflight.py" \
+  "${REPO_ROOT}/docker-compose.prod.yml" || exit $?
 
 cui_run_start

--- a/scripts/prod_devui_gateway_preflight.py
+++ b/scripts/prod_devui_gateway_preflight.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fail-loud validation for the canonical production devUI gateway producer."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+_PUBLISH = '"127.0.0.1:8113:8113"'
+_DECLARATION = re.compile(r"^\s+COMPANION_UI_BIND_HOST:\s+127\.0\.0\.1\s*$", re.MULTILINE)
+
+
+def validate(compose_file: Path) -> None:
+    text = compose_file.read_text(encoding="utf-8")
+    if text.count(_PUBLISH) != 1:
+        raise ValueError("production Companion must publish exactly 127.0.0.1:8113:8113")
+    if len(_DECLARATION.findall(text)) != 1:
+        raise ValueError("production Companion must declare COMPANION_UI_BIND_HOST=127.0.0.1")
+    if "${COMPANION_UI_BIND_HOST" in text:
+        raise ValueError("production Companion bind must not depend on ambient interpolation")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("compose_file", type=Path)
+    args = parser.parse_args()
+    try:
+        validate(args.compose_file)
+    except (OSError, ValueError) as exc:
+        parser.exit(78, f"prod devUI gateway preflight: blocked: {exc}\n")
+    print("prod devUI gateway preflight: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prod_devui_gateway_preflight.py
+++ b/scripts/prod_devui_gateway_preflight.py
@@ -10,15 +10,35 @@ from pathlib import Path
 
 _PUBLISH = '"127.0.0.1:8113:8113"'
 _DECLARATION = re.compile(r"^\s+COMPANION_UI_BIND_HOST:\s+127\.0\.0\.1\s*$", re.MULTILINE)
+_COMPANION_SERVICE = re.compile(
+    r"^  companion-ui:\n(?P<body>.*?)(?=^  [^\s].*:\s*$|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_PORTS = re.compile(r"^    ports:\s*!override\s*$", re.MULTILINE)
 
 
 def validate(compose_file: Path) -> None:
     text = compose_file.read_text(encoding="utf-8")
-    if text.count(_PUBLISH) != 1:
+    service = _COMPANION_SERVICE.search(text)
+    if service is None:
+        raise ValueError("production Companion service is missing")
+    body = service.group("body")
+    ports = _PORTS.search(body)
+    if ports is None:
+        raise ValueError("production Companion ports must replace the base publish")
+    port_lines: list[str] = []
+    for line in body[ports.end() :].splitlines():
+        if line.startswith("      - "):
+            port_lines.append(line.removeprefix("      - ").strip())
+            continue
+        if line.startswith("      #") or not line.strip():
+            continue
+        break
+    if port_lines != [_PUBLISH]:
         raise ValueError("production Companion must publish exactly 127.0.0.1:8113:8113")
-    if len(_DECLARATION.findall(text)) != 1:
+    if len(_DECLARATION.findall(body)) != 1:
         raise ValueError("production Companion must declare COMPANION_UI_BIND_HOST=127.0.0.1")
-    if "${COMPANION_UI_BIND_HOST" in text:
+    if "${COMPANION_UI_BIND_HOST" in body:
         raise ValueError("production Companion bind must not depend on ambient interpolation")
 
 

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -1110,6 +1110,25 @@ run_docker_compose() {
   fi
 }
 
+# All production producers must validate the committed Companion publication
+# before this generic launcher can invoke Compose. `make prod-start-full`
+# reaches it through the Midgård wrapper, and a direct prod/explicit-prod-
+# compose invocation is also a supported operational path.
+_pkm_prod_devui_gateway_selected=0
+case ":${COMPOSE_FILE:-}:" in
+  *":docker-compose.prod.yml:"*) _pkm_prod_devui_gateway_selected=1 ;;
+esac
+_pkm_prod_gateway_channel="${PKM_ENVIRONMENT:-${ENVIRONMENT:-${CHANNEL:-${PKM_CHANNEL:-}}}}"
+_pkm_prod_gateway_channel="$(printf '%s' "$_pkm_prod_gateway_channel" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || printf '%s' "$_pkm_prod_gateway_channel")"
+if [ "$_pkm_prod_gateway_channel" = "prod" ] || [ "${COMPOSE_PROJECT_NAME:-}" = "pkm-prod" ]; then
+  _pkm_prod_devui_gateway_selected=1
+fi
+if [ "$_pkm_prod_devui_gateway_selected" -eq 1 ]; then
+  "${PYTHON:-python3}" "$ROOT/scripts/prod_devui_gateway_preflight.py" \
+    "$ROOT/docker-compose.prod.yml" || exit $?
+fi
+unset _pkm_prod_devui_gateway_selected _pkm_prod_gateway_channel
+
 ensure_prod_instance_state_volume() {
   if [ "${COMPOSE_PROJECT_NAME:-}" != "pkm-prod" ]; then
     return 0

--- a/tests/api/test_devui_api.py
+++ b/tests/api/test_devui_api.py
@@ -320,6 +320,101 @@ def test_devui_composition_refuses_other_forwarded_identity_headers() -> None:
     ).status_code == 403
 
 
+def test_devui_admits_only_direct_loopback_or_server_derived_companion_proxy(
+    monkeypatch,
+) -> None:
+    proxy_ip = "172.19.0.7"
+    monkeypatch.setattr(auth_module.settings, "api_key", "configured-key")
+    monkeypatch.setattr(auth_module.settings, "companion_ui_proxy_hosts", proxy_ip)
+    monkeypatch.setattr(auth_module, "_proxy_dns_cache", {})
+    monkeypatch.setattr(devui_route, "compose_owner_snapshot", lambda **_: {})
+    monkeypatch.setattr(
+        devui_route,
+        "compose_overview_view",
+        lambda **_: {"contract_version": "devui-overview-view.v1"},
+    )
+
+    assert TestClient(app).get("/api/devui/overview").status_code == 200
+    assert (
+        TestClient(app, client=(proxy_ip, 50000)).get(
+            "/api/devui/overview",
+            headers={"Host": "api:8000"},
+        ).status_code
+        == 200
+    )
+
+    for untrusted_host in (
+        "172.19.0.99",
+        "192.168.1.20",
+        "100.64.0.20",
+        "203.0.113.10",
+    ):
+        response = TestClient(app, client=(untrusted_host, 50000)).get(
+            "/api/devui/overview",
+            headers={"X-API-Key": "configured-key"},
+        )
+        assert response.status_code == 403
+
+    forwarded = TestClient(app, client=(proxy_ip, 50000)).get(
+        "/api/devui/overview",
+        headers={"Forwarded": "for=127.0.0.1"},
+    )
+    assert forwarded.status_code == 403
+
+    monkeypatch.setattr(auth_module.settings, "companion_ui_proxy_hosts", "")
+    missing_config = TestClient(app, client=(proxy_ip, 50000)).get(
+        "/api/devui/overview"
+    )
+    assert missing_config.status_code == 403
+
+    monkeypatch.setattr(auth_module.settings, "companion_ui_proxy_hosts", "companion-ui")
+    monkeypatch.setattr(
+        auth_module.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            auth_module.socket.gaierror("unresolvable")
+        ),
+    )
+    unresolvable_config = TestClient(app, client=(proxy_ip, 50000)).get(
+        "/api/devui/overview"
+    )
+    assert unresolvable_config.status_code == 403
+
+
+def test_devui_proxy_admission_preserves_direct_loopback_contract(monkeypatch) -> None:
+    subject = "github:RasmusTho/agentic-pkm-mvp#4768"
+    monkeypatch.setattr(auth_module.settings, "api_key", "configured-key")
+    monkeypatch.setattr(auth_module.settings, "companion_ui_proxy_hosts", "172.19.0.7")
+    monkeypatch.setattr(devui_route, "compose_owner_snapshot", lambda **_: {})
+    monkeypatch.setattr(devui_route, "compose_overview_view", lambda **_: {})
+    monkeypatch.setattr(
+        devui_route,
+        "read_focus_inputs",
+        lambda requested: _focus_inputs(requested),
+    )
+
+    direct = TestClient(app)
+    assert direct.get("/api/devui/overview").status_code == 200
+    assert direct.get("/api/devui/focus", params={"subject": subject}).status_code == 200
+
+    for name, value in (
+        ("Forwarded", "for=127.0.0.1"),
+        ("Via", "1.1 local-proxy"),
+        ("X-Forwarded-For", "127.0.0.1"),
+        ("X-Real-IP", "127.0.0.1"),
+    ):
+        assert direct.get("/api/devui/overview", headers={name: value}).status_code == 403
+
+    assert direct.get(
+        "/api/devui/overview",
+        headers={"Host": "attacker.example"},
+    ).status_code == 403
+
+    for method in (direct.post, direct.put, direct.patch, direct.delete):
+        assert method("/api/devui/overview").status_code == 405
+        assert method("/api/devui/focus", params={"subject": subject}).status_code == 405
+
+
 def test_devui_composition_sanitizes_ckm_refusal_diagnostics(
     monkeypatch,
 ) -> None:

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -19,6 +19,59 @@ def _read(rel_path: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def test_devui_gateway_admission_owner_docs_preserve_security_and_topology() -> None:
+    security = _read("docs/SECURITY.md")
+    access = _read("companion-ui/docs/LOCAL_ACCESS_MODEL.md")
+    runtime = _read("companion-ui/docs/UI_RUNTIME_BOUNDARIES.md")
+    exposure = _read("companion-ui/docs/PRODUCTION_EXPOSURE_SECURITY_PROFILE.md")
+    deployment = _read("docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md")
+    devui = _read("docs/DEVUI.md")
+    strategy = _read("docs/development/TEST_STRATEGY_HOT_PATH.md")
+    stage = _read("docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/README.md")
+    parent = _read("docs/DEVUI_STAGE_A_READ_ONLY_OVERVIEW/PARENT_FEATURE_ISSUE.md")
+
+    security_and_topology = "\n".join(
+        (security, access, runtime, exposure, deployment, devui)
+    )
+    for fragment in (
+        "COMPANION_UI_BIND_HOST=127.0.0.1",
+        "127.0.0.1:8113:8113",
+        "GET `/api/devui/overview`",
+        "GET `/api/devui/focus`",
+        "resolve_auth_subject(request, None)",
+        "SUBJECT_TRUSTED_COMPANION_PROXY",
+        "including `Via`",
+        "no page/static route",
+    ):
+        assert fragment in security_and_topology, fragment
+
+    assert "http://127.0.0.1:8113/devui/overview" in devui
+    assert "port `18000` remains direct API health/version diagnostics" in devui
+    assert "#4841 is transport only" in devui
+    assert "#4836 must consume this transport unchanged" in devui
+    assert "#4833 must verify its published candidate" in devui
+
+    for fragment in (
+        "tests/ops/test_prod_devui_gateway_config.py",
+        "tests/companion_ui/test_devui_gateway_admission.py",
+        "tests/api/test_devui_api.py",
+        "exact-head CI",
+    ):
+        assert fragment in strategy, fragment
+
+    for ledger in (stage, parent):
+        assert "#4841" in ledger
+        assert "#4836" in ledger
+        assert "127.0.0.1:8113" in ledger
+        assert "Port `18000` remains" in ledger
+
+    # Transport is not presentation authority. The actual #4836 candidate
+    # remains governed by the source-authorized Yggdrasil route.
+    for ledger in (devui, stage, parent):
+        assert "Yggdrasil" in ledger
+        assert "#4836" in ledger
+
+
 def test_hot_path_doc_defers_escalation_and_names_direct_repair_contract() -> None:
     text = _read("docs/development/PR_HOT_PATH.md")
 

--- a/tests/companion_ui/test_devui_gateway_admission.py
+++ b/tests/companion_ui/test_devui_gateway_admission.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from email.message import Message
+from typing import Any
+
+import httpx
+
+from companion_ui.workspace.serve_dev_page import make_handler
+from companion_ui.workspace.workspace_http_client import (
+    WorkspaceHttpClient,
+)
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        *,
+        responses: dict[str, dict[str, Any]] | None = None,
+        status_code: int = 200,
+    ) -> None:
+        self.responses = responses or {}
+        self.status_code = status_code
+        self.calls: list[tuple[str, dict[str, Any], dict[str, str] | None]] = []
+
+    def get_with_status(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any],
+    ) -> tuple[int, dict[str, Any]]:
+        self.calls.append((url, params, None))
+        return self.status_code, self.responses.get(url, {})
+
+
+class _GetDriver:
+    def __init__(
+        self,
+        handler_cls: type,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        client_host: str = "172.19.0.1",
+    ) -> None:
+        instance = handler_cls.__new__(handler_cls)
+        instance.path = path
+        instance.client_address = (client_host, 50000)
+        request_headers = Message()
+        request_headers["Host"] = "127.0.0.1:8113"
+        for name, value in (headers or {}).items():
+            if name.lower() == "host":
+                request_headers.replace_header("Host", value)
+            else:
+                request_headers[name] = value
+        instance.headers = request_headers
+        self.instance = instance
+        self.status_code: int | None = None
+        self.payload: dict[str, Any] | None = None
+
+        def send_json(status_code: int, payload: dict[str, Any]) -> None:
+            self.status_code = status_code
+            self.payload = payload
+
+        instance._send_json = send_json
+
+    def run(self) -> None:
+        self.instance.do_GET()
+
+
+def _handler(
+    client: object,
+    *,
+    declared_host: str = "127.0.0.1",
+) -> type:
+    return make_handler(
+        client=client,  # type: ignore[arg-type]
+        api_base_url="http://api:8000",
+        production_profile=True,
+        devui_external_bind_host=declared_host,
+    )
+
+
+def test_gateway_uses_declared_host_publish_not_container_peer_for_local_admission() -> None:
+    client = _FakeClient(responses={"/api/devui/overview": {"ok": True}})
+    handler_cls = _handler(client)
+
+    allowed = _GetDriver(handler_cls, "/api/devui/overview", client_host="172.19.0.7")
+    allowed.run()
+
+    assert allowed.status_code == 200
+    assert client.calls == [("/api/devui/overview", {}, None)]
+
+    for forwarded_header in (
+        "Forwarded",
+        "Via",
+        "X-Forwarded-For",
+        "X-Forwarded-Host",
+        "X-Real-IP",
+        "CF-Connecting-IP",
+        "True-Client-IP",
+        "X-Client-IP",
+    ):
+        refused = _GetDriver(
+            handler_cls,
+            "/api/devui/overview",
+            headers={forwarded_header: "203.0.113.10"},
+        )
+        refused.run()
+        assert refused.status_code == 403
+
+    nonlocal_host = _GetDriver(
+        handler_cls,
+        "/api/devui/overview",
+        headers={"Host": "192.168.1.20:8113"},
+    )
+    nonlocal_host.run()
+    assert nonlocal_host.status_code == 403
+
+    duplicate_host = _GetDriver(handler_cls, "/api/devui/overview")
+    duplicate_host.instance.headers["Host"] = "localhost:8113"
+    duplicate_host.run()
+    assert duplicate_host.status_code == 403
+
+    for malformed_host in (
+        "127.0.0.1@attacker.example",
+        "127.0.0.1/path",
+        "127.0.0.1:invalid",
+        "[::1]attacker.example",
+        "[::1]:invalid",
+        "127.0.0.1 attacker.example",
+        "",
+    ):
+        refused = _GetDriver(
+            handler_cls,
+            "/api/devui/overview",
+            headers={"Host": malformed_host},
+        )
+        refused.run()
+        assert refused.status_code == 403
+
+    for unsafe_declaration in ("", "0.0.0.0", "192.168.1.20", "100.64.0.20"):
+        disabled = _GetDriver(
+            _handler(_FakeClient(), declared_host=unsafe_declaration),
+            "/api/devui/overview",
+        )
+        disabled.run()
+        assert disabled.status_code == 404
+
+    assert client.calls == [("/api/devui/overview", {}, None)]
+
+
+def test_gateway_proxies_only_two_exact_devui_get_contracts() -> None:
+    subject = "github:RasmusTho/agentic-pkm-mvp#4841"
+    client = _FakeClient(
+        responses={
+            "/api/devui/overview": {"view": "overview"},
+            "/api/devui/focus": {"view": "focus"},
+        }
+    )
+    handler_cls = _handler(client)
+
+    overview = _GetDriver(handler_cls, "/api/devui/overview")
+    overview.run()
+    focus = _GetDriver(
+        handler_cls,
+        "/api/devui/focus?subject=github%3ARasmusTho%2Fagentic-pkm-mvp%234841",
+    )
+    focus.run()
+
+    assert overview.status_code == 200
+    assert overview.payload == {"view": "overview"}
+    assert focus.status_code == 200
+    assert focus.payload == {"view": "focus"}
+    assert client.calls == [
+        ("/api/devui/overview", {}, None),
+        ("/api/devui/focus", {"subject": subject}, None),
+    ]
+
+    invalid_focus_queries = (
+        "/api/devui/focus",
+        "/api/devui/focus?subject=",
+        "/api/devui/focus?subject=%20",
+        "/api/devui/focus?subject=one&subject=two",
+        "/api/devui/focus?subject=one&extra=two",
+        "/api/devui/focus?other=one",
+        "/api/devui/focus?subject=one%ZZ",
+    )
+    for path in invalid_focus_queries:
+        refused = _GetDriver(handler_cls, path)
+        refused.run()
+        assert refused.status_code == 400
+
+    for path in (
+        "/api/devui/overview?extra=1",
+        "/api/devui/composition",
+        "/api/devui/unknown",
+        "/api/devui/overview/child",
+    ):
+        refused = _GetDriver(handler_cls, path)
+        refused.run()
+        assert refused.status_code == 404
+
+    for method in ("POST", "PUT", "PATCH", "DELETE"):
+        assert handler_cls.route_allowed(method, "/api/devui/overview") is False
+        assert handler_cls.route_allowed(method, "/api/devui/focus") is False
+
+    disabled_handler = _handler(_FakeClient(), declared_host="")
+    assert disabled_handler.route_allowed("GET", "/api/devui/overview") is False
+    assert disabled_handler.route_allowed("GET", "/api/devui/focus") is False
+
+    error_client = _FakeClient(
+        responses={"/api/devui/overview": {"state": "unavailable"}},
+        status_code=503,
+    )
+    upstream_error = _GetDriver(_handler(error_client), "/api/devui/overview")
+    upstream_error.run()
+    assert upstream_error.status_code == 503
+    assert upstream_error.payload == {"state": "unavailable"}
+
+
+def test_gateway_strips_all_inbound_identity_and_credential_headers(monkeypatch) -> None:
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> httpx.Response:
+        captured.append((url, kwargs))
+        return httpx.Response(206, json={"ok": True})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    client = WorkspaceHttpClient("http://api:8000")
+    handler_cls = _handler(client)
+    allowed = _GetDriver(
+        handler_cls,
+        "/api/devui/focus?subject=github%3ARasmusTho%2Fagentic-pkm-mvp%234841",
+        headers={
+            "X-API-Key": "must-not-transit",
+            "Authorization": "Bearer must-not-transit",
+            "Proxy-Authorization": "Basic must-not-transit",
+        },
+    )
+
+    allowed.run()
+
+    assert allowed.status_code == 206
+    assert captured == [
+        (
+            "http://api:8000/api/devui/focus",
+            {
+                "params": {"subject": "github:RasmusTho/agentic-pkm-mvp#4841"},
+                "timeout": 10.0,
+            },
+        )
+    ]
+
+    for forwarded_header in (
+        "Forwarded",
+        "X-Forwarded-For",
+        "Via",
+        "X-Real-IP",
+    ):
+        refused = _GetDriver(
+            handler_cls,
+            "/api/devui/overview",
+            headers={forwarded_header: "127.0.0.1"},
+        )
+        refused.run()
+        assert refused.status_code == 403
+
+    assert len(captured) == 1

--- a/tests/companion_ui/test_gateway_managed_unit.py
+++ b/tests/companion_ui/test_gateway_managed_unit.py
@@ -95,6 +95,11 @@ def test_channel_overlays_define_distinct_gateway_units() -> None:
         assert env["PKM_ENVIRONMENT"] == channel
         assert env["PORT"] == port
         assert env["COMPANION_UI_SERVE_MODULE"] == module
-        assert service["ports"] == [
-            f"${{COMPANION_UI_BIND_HOST:-127.0.0.1}}:{port}:{port}"
-        ]
+        expected_publish = (
+            "127.0.0.1:8113:8113"
+            if channel == "prod"
+            else f"${{COMPANION_UI_BIND_HOST:-127.0.0.1}}:{port}:{port}"
+        )
+        assert service["ports"] == [expected_publish]
+        if channel == "prod":
+            assert env["COMPANION_UI_BIND_HOST"] == "127.0.0.1"

--- a/tests/companion_ui/test_serve_production_page.py
+++ b/tests/companion_ui/test_serve_production_page.py
@@ -10,6 +10,50 @@ production profiles; the production profile must not strip it."
 from __future__ import annotations
 
 
+def test_production_main_forwards_declared_browser_bind_to_gateway(monkeypatch) -> None:
+    """The real production entrypoint must carry the host-publish proof to the handler."""
+    from companion_ui.workspace import serve_production_page
+
+    captured: dict[str, object] = {}
+
+    class _Client:
+        def __init__(self, *, base_url: str) -> None:
+            captured["client_base_url"] = base_url
+
+    class _Server:
+        def __init__(self, address: tuple[str, int], handler: object) -> None:
+            captured["server_address"] = address
+            captured["server_handler"] = handler
+
+        def serve_forever(self) -> None:
+            captured["served"] = True
+
+    handler_token = object()
+
+    def _make_handler(**kwargs: object) -> object:
+        captured["handler_config"] = kwargs
+        return handler_token
+
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    monkeypatch.setenv("PORT", "8113")
+    monkeypatch.setenv("COMPANION_API_BASE_URL", "http://api:8000")
+    monkeypatch.setenv("COMPANION_UI_BIND_HOST", "127.0.0.1")
+    monkeypatch.setattr(serve_production_page, "WorkspaceHttpClient", _Client)
+    monkeypatch.setattr(serve_production_page, "make_handler", _make_handler)
+    monkeypatch.setattr(serve_production_page, "CompanionThreadingHTTPServer", _Server)
+
+    serve_production_page.main()
+
+    handler_config = captured["handler_config"]
+    assert isinstance(handler_config, dict)
+    assert handler_config["devui_external_bind_host"] == "127.0.0.1"
+    assert handler_config["api_base_url"] == "http://api:8000"
+    assert handler_config["production_profile"] is True
+    assert captured["server_address"] == ("0.0.0.0", 8113)
+    assert captured["server_handler"] is handler_token
+    assert captured["served"] is True
+
+
 def test_production_profile_exposes_operator_overlay() -> None:
     """The production shell HTML includes the Operator overlay toggle and drawer.
 

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -161,6 +161,7 @@ def _deploy_harness(tmp_path: Path) -> tuple[Path, dict[str, str], str]:
         "scripts/deploy_channel.sh",
         "scripts/companion_ui_postdeploy_smoke.sh",
         "scripts/dev_test_environment_clobber_preflight.py",
+        "scripts/prod_devui_gateway_preflight.py",
         "scripts/lib/deploy_channel_compose.sh",
         "scripts/lib/heimdal_cold_volume_preflight.sh",
         "scripts/lib/instance_state_deployment.sh",
@@ -170,6 +171,10 @@ def _deploy_harness(tmp_path: Path) -> tuple[Path, dict[str, str], str]:
     ):
         destination = root / relative
         shutil.copy2(REPO_ROOT / relative, destination)
+    shutil.copy2(
+        REPO_ROOT / "docker-compose.prod.yml",
+        root / "docker-compose.prod.yml",
+    )
     _install_writer_inventory_harness(root)
     # The host-volume mechanism itself is covered with a fully injected
     # command runner in tests/heimdal.  This channel harness owns deploy
@@ -1979,16 +1984,17 @@ def test_prod_deploy_pending_retry_preflight_fails_open_without_dsn(
     tmp_path: Path,
 ) -> None:
     root, env, sha = _deploy_harness(tmp_path)
-    # No compose files at all: resolution is impossible (not merely "a file
-    # was empty"), so the preflight must skip visibly rather than block or
-    # crash.
+    # No compose files at all: the older pending-retry preflight would skip,
+    # but production now has an earlier fail-loud gateway-producer invariant.
+    # Missing the canonical overlay must block before any mutation.
     _configure_prod_retry_preflight(root, env, tmp_path, compose_files_present=False)
+    (root / "docker-compose.prod.yml").unlink()
 
     result = _run_deploy(root, env, sha, channel="prod")
 
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "prod pending-retry preflight: skipped:no_dsn" in result.stdout
-    assert (tmp_path / "docker-called").exists()
+    assert result.returncode == 78
+    assert "prod devUI gateway preflight: blocked" in result.stderr
+    assert not (tmp_path / "docker-called").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_companion_ui_startup_targets.py
+++ b/tests/ops/test_companion_ui_startup_targets.py
@@ -421,6 +421,13 @@ exit 0
     fake_curl = fake_bin / "curl"
     fake_curl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fake_curl.chmod(0o700)
+    preflight_capture = tmp_path / "preflight-invocation"
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        "#!/bin/sh\nprintf '%s\\n%s\\n' \"${1:-}\" \"${2:-}\" >> \"${PREFLIGHT_CAPTURE}\"\nexit 0\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o700)
 
     env = os.environ.copy()
     env.update(
@@ -433,7 +440,8 @@ exit 0
             # HAR-03's cold-volume readiness is an independent production
             # prerequisite. This test isolates the later gateway environment
             # handoff after that gate has already passed.
-            "PYTHON": "/usr/bin/true",
+            "PYTHON": str(fake_python),
+            "PREFLIGHT_CAPTURE": str(preflight_capture),
         }
     )
     env.pop("VAULT_ROOT", None)
@@ -459,6 +467,25 @@ exit 0
         "compose_file=docker-compose.yaml:docker-compose.prod.yml",
         "compose_project=pkm-prod",
     ]
+    assert preflight_capture.read_text(encoding="utf-8").splitlines()[:2] == [
+        str(REPO_ROOT / "scripts" / "prod_devui_gateway_preflight.py"),
+        str(REPO_ROOT / "docker-compose.prod.yml"),
+    ]
+
+    lan_capture = tmp_path / "lan-compose-environment"
+    lan_env = dict(env)
+    lan_env.update({"CUI_BIND_LAN": "1", "DOCKER_CAPTURE": str(lan_capture)})
+    lan_result = subprocess.run(
+        ["bash", str(PROD_START)],
+        cwd=REPO_ROOT,
+        env=lan_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert lan_result.returncode == 78
+    assert "production Companion publication is loopback-only" in lan_result.stderr
+    assert not lan_capture.exists()
 
 
 def test_prod_defaults_to_safe_posture_and_gates_automation() -> None:

--- a/tests/ops/test_companion_ui_startup_targets.py
+++ b/tests/ops/test_companion_ui_startup_targets.py
@@ -14,6 +14,7 @@ Per-channel coverage is added as each sibling issue ships:
 """
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -366,6 +367,98 @@ def test_prod_start_binds_midgard_channel_and_ports() -> None:
     assert "serve_production_page" in text, (
         "prod start must launch the Companion UI production page module (Issue #1360)."
     )
+
+
+def test_prod_launcher_injects_loopback_publish_declaration(tmp_path: Path) -> None:
+    """Execute the canonical prod wrapper and capture its real Compose environment."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    capture = tmp_path / "compose-environment"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/bin/sh
+case "${1:-}" in
+  info)
+    exit 0
+    ;;
+  ps)
+    case "$*" in
+      *name=api*) printf '%s\n' fake-api ;;
+      *name=companion-ui*) printf '%s\n' fake-companion-ui ;;
+    esac
+    exit 0
+    ;;
+  inspect)
+    exit 0
+    ;;
+  exec)
+    case "$*" in
+      *'ls -1'*) printf '%s\n' 0 ;;
+    esac
+    exit 0
+    ;;
+  compose)
+    if [ "${2:-}" = up ]; then
+      {
+        printf 'bind=%s\n' "${COMPANION_UI_BIND_HOST-<unset>}"
+        printf 'host_port=%s\n' "${COMPANION_UI_HOST_PORT-<unset>}"
+        printf 'container_port=%s\n' "${COMPANION_UI_PORT-<unset>}"
+        printf 'api_base_url=%s\n' "${COMPANION_UI_API_BASE_URL-<unset>}"
+        printf 'serve_module=%s\n' "${COMPANION_UI_SERVE_MODULE-<unset>}"
+        printf 'environment=%s\n' "${PKM_ENVIRONMENT-<unset>}"
+        printf 'compose_file=%s\n' "${COMPOSE_FILE-<unset>}"
+        printf 'compose_project=%s\n' "${COMPOSE_PROJECT_NAME-<unset>}"
+      } > "${DOCKER_CAPTURE}"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o700)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_curl.chmod(0o700)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path),
+            "DOCKER_CAPTURE": str(capture),
+            "CUI_BIND_LAN": "0",
+            "CUI_HEALTH_ATTEMPTS": "1",
+            # HAR-03's cold-volume readiness is an independent production
+            # prerequisite. This test isolates the later gateway environment
+            # handoff after that gate has already passed.
+            "PYTHON": "/usr/bin/true",
+        }
+    )
+    env.pop("VAULT_ROOT", None)
+    env.pop("VAULT_HOST_ROOT", None)
+
+    result = subprocess.run(
+        ["bash", str(PROD_START)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert capture.read_text(encoding="utf-8").splitlines() == [
+        "bind=127.0.0.1",
+        "host_port=8113",
+        "container_port=8113",
+        "api_base_url=http://api:8000",
+        "serve_module=companion_ui.workspace.serve_production_page",
+        "environment=prod",
+        "compose_file=docker-compose.yaml:docker-compose.prod.yml",
+        "compose_project=pkm-prod",
+    ]
 
 
 def test_prod_defaults_to_safe_posture_and_gates_automation() -> None:

--- a/tests/ops/test_prod_devui_gateway_config.py
+++ b/tests/ops/test_prod_devui_gateway_config.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+from companion_ui.workspace.serve_dev_page import is_explicit_loopback_host
+from companion_ui.workspace.serve_production_page import load_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_devui_gateway_requires_explicit_loopback_host_publish(monkeypatch) -> None:
+    compose = (REPO_ROOT / "docker-compose.prod.yml").read_text(encoding="utf-8")
+
+    assert '"${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113"' in compose
+    assert "COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}" in compose
+
+    def resolve_declared_host(host: str, *_args: object, **_kwargs: object) -> list[tuple]:
+        if host == "loopback.example":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+        if host == "nonloopback.example":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.44", 0))]
+        raise socket.gaierror(host)
+
+    monkeypatch.setattr(socket, "getaddrinfo", resolve_declared_host)
+    monkeypatch.setenv("HOST", "0.0.0.0")
+
+    cases = (
+        (None, False),
+        ("", False),
+        ("0.0.0.0", False),
+        ("*", False),
+        ("192.168.1.10", False),
+        ("172.18.0.1", False),
+        ("100.64.0.10", False),
+        ("nonloopback.example", False),
+        ("unresolvable.example", False),
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("loopback.example", True),
+    )
+
+    for declared_host, expected_enabled in cases:
+        if declared_host is None:
+            monkeypatch.delenv("COMPANION_UI_BIND_HOST", raising=False)
+        else:
+            monkeypatch.setenv("COMPANION_UI_BIND_HOST", declared_host)
+
+        config = load_config()
+
+        assert config["host"] == "0.0.0.0"
+        assert config["devui_external_bind_host"] == (declared_host or "")
+        assert (
+            is_explicit_loopback_host(config["devui_external_bind_host"])
+            is expected_enabled
+        )

--- a/tests/ops/test_prod_devui_gateway_config.py
+++ b/tests/ops/test_prod_devui_gateway_config.py
@@ -74,9 +74,10 @@ def test_prod_deploy_preflight_rejects_missing_wildcard_or_ambient_bind(
     assert canonical.stdout.strip() == "prod devUI gateway preflight: ok"
 
     unsafe_variants = (
-        "ports:\n  - \"127.0.0.1:8113:8113\"\nenvironment: {}\n",
-        "ports:\n  - \"127.0.0.1:8113:8113\"\nenvironment:\n  COMPANION_UI_BIND_HOST: 0.0.0.0\n",
-        "ports:\n  - \"${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113\"\nenvironment:\n  COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}\n",
+        "services:\n  companion-ui:\n    ports: !override\n      - \"127.0.0.1:8113:8113\"\n    environment: {}\n",
+        "services:\n  companion-ui:\n    ports: !override\n      - \"127.0.0.1:8113:8113\"\n    environment:\n      COMPANION_UI_BIND_HOST: 0.0.0.0\n",
+        "services:\n  companion-ui:\n    ports: !override\n      - \"${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113\"\n    environment:\n      COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}\n",
+        "services:\n  companion-ui:\n    ports: !override\n      - \"127.0.0.1:8113:8113\"\n      - \"0.0.0.0:8114:8113\"\n    environment:\n      COMPANION_UI_BIND_HOST: 127.0.0.1\n",
     )
     for index, content in enumerate(unsafe_variants):
         compose_file = tmp_path / f"unsafe-{index}.yml"

--- a/tests/ops/test_prod_devui_gateway_config.py
+++ b/tests/ops/test_prod_devui_gateway_config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import socket
+import subprocess
+import sys
 from pathlib import Path
 
 from companion_ui.workspace.serve_dev_page import is_explicit_loopback_host
@@ -8,13 +10,15 @@ from companion_ui.workspace.serve_production_page import load_config
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PREFLIGHT = REPO_ROOT / "scripts" / "prod_devui_gateway_preflight.py"
 
 
 def test_devui_gateway_requires_explicit_loopback_host_publish(monkeypatch) -> None:
     compose = (REPO_ROOT / "docker-compose.prod.yml").read_text(encoding="utf-8")
 
-    assert '"${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113"' in compose
-    assert "COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}" in compose
+    assert '"127.0.0.1:8113:8113"' in compose
+    assert "COMPANION_UI_BIND_HOST: 127.0.0.1" in compose
+    assert "${COMPANION_UI_BIND_HOST" not in compose
 
     def resolve_declared_host(host: str, *_args: object, **_kwargs: object) -> list[tuple]:
         if host == "loopback.example":
@@ -55,3 +59,38 @@ def test_devui_gateway_requires_explicit_loopback_host_publish(monkeypatch) -> N
             is_explicit_loopback_host(config["devui_external_bind_host"])
             is expected_enabled
         )
+
+
+def test_prod_deploy_preflight_rejects_missing_wildcard_or_ambient_bind(
+    tmp_path: Path,
+) -> None:
+    canonical = subprocess.run(
+        [sys.executable, str(PREFLIGHT), str(REPO_ROOT / "docker-compose.prod.yml")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert canonical.returncode == 0, canonical.stdout + canonical.stderr
+    assert canonical.stdout.strip() == "prod devUI gateway preflight: ok"
+
+    unsafe_variants = (
+        "ports:\n  - \"127.0.0.1:8113:8113\"\nenvironment: {}\n",
+        "ports:\n  - \"127.0.0.1:8113:8113\"\nenvironment:\n  COMPANION_UI_BIND_HOST: 0.0.0.0\n",
+        "ports:\n  - \"${COMPANION_UI_BIND_HOST:-127.0.0.1}:8113:8113\"\nenvironment:\n  COMPANION_UI_BIND_HOST: ${COMPANION_UI_BIND_HOST:-}\n",
+    )
+    for index, content in enumerate(unsafe_variants):
+        compose_file = tmp_path / f"unsafe-{index}.yml"
+        compose_file.write_text(content, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(PREFLIGHT), str(compose_file)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 78
+        assert "prod devUI gateway preflight: blocked" in result.stderr
+
+    deploy_script = (REPO_ROOT / "scripts" / "deploy_channel.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "prod_devui_gateway_preflight.py" in deploy_script

--- a/tests/ops/test_prod_devui_gateway_config.py
+++ b/tests/ops/test_prod_devui_gateway_config.py
@@ -94,4 +94,17 @@ def test_prod_deploy_preflight_rejects_missing_wildcard_or_ambient_bind(
     deploy_script = (REPO_ROOT / "scripts" / "deploy_channel.sh").read_text(
         encoding="utf-8"
     )
+    full_start = (REPO_ROOT / "scripts" / "start_full_system.sh").read_text(
+        encoding="utf-8"
+    )
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
     assert "prod_devui_gateway_preflight.py" in deploy_script
+    assert "prod_devui_gateway_preflight.py" in full_start
+    assert full_start.index("prod_devui_gateway_preflight.py") < full_start.index(
+        "compose_up()"
+    )
+    prod_up = makefile[makefile.index("prod-up:") : makefile.index("prod-down:")]
+    assert "prod_devui_gateway_preflight.py" in prod_up
+    assert prod_up.index("prod_devui_gateway_preflight.py") < prod_up.index(
+        "$(COMPOSE_PROD) up"
+    )


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4841

## Linked Issue
Closes #4841

## SBS Impact
- Primary subsystem: Companion devUI gateway admission
- Secondary subsystem(s): production Compose and startup producers
- Write class: read-only transport; startup fail-closed validation
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: exact loopback-only host publish enforced by every canonical production producer
- Owner-doc impact: updated SECURITY, DEVUI, local-access profile, and test strategy owner docs
- Transition debt impact: none
- Boundary risk: security boundary: remote browser exposure and forwarded identity rejected

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reconstruct the #4841 devUI read-only Companion gateway on current main and make every canonical production startup producer fail closed unless the exact loopback host publish is present.

## BuilderOps Routing
- Records/projections/receipts: Dispatcher stale-lease takeover receipt: Issue #4841 comment 5405698642.
- Reason: Recovered the stale #4841 delivery lease in a dedicated registered worktree; no BuilderOps authority change.

## Notes
Validation on a1898ce9ac6fbd5e202c751ae320dc40c5123af0: ruff and mypy clean; 168 focused tests passed (two existing dependency deprecation warnings); docs guard passed with the explicit no-temporal-status override. Mechanism convergence covers deploy, prod-up, prod-start-full/direct prod startup, and prod-ui before Compose mutation. Independent final security/convergence review accepted this exact head with no P0/P1.