### PR TITLE
Bind production Focus repository prerequisites

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
     environment:
       API_HEALTHCHECK_URL: http://host.docker.internal:18000/readyz
       PKM_ENVIRONMENT: prod
+      COCKPIT_GITHUB_REPO: RasmusTho/agentic-pkm-mvp
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:app@db:5432/app}
       DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
       OLLAMA_BASE_URL: http://ollama:11434

--- a/docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md
+++ b/docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md
@@ -143,8 +143,10 @@ host today, not an edge case.
 
 > Status since #4484: the "no repo-committed deployment config sets it anywhere" half of this
 > finding no longer holds — the runtime image ships the `gh` transport and `docker-compose.dev.yml`
-> commits the slug for the dev channel, so the unset state is now a per-channel choice (`test` and
-> `prod` keep it). EXT-8 is unaffected and more load-bearing for it: distinguishing opted-out from
+> plus `docker-compose.prod.yml` commit `RasmusTho/agentic-pkm-mvp` for dev and prod, so the unset state is now a
+> per-channel choice (`test` keeps it). The prod binding is committed non-secret configuration, not
+> credential-presence or deployment evidence. EXT-8 is unaffected and more load-bearing for it:
+> distinguishing opted-out from
 > broken is what lets an enabled channel's real failure read as a failure. See
 > `GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.
 

--- a/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
+++ b/docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md
@@ -69,11 +69,13 @@ committed things plus one host-supplied value:
    `ffmpeg`/`espeak-ng` (a plain Debian trixie/main package; no third-party apt source). Before
    #4484 it was absent, so `_run_gh` raised `gh CLI not found` on the first call in every channel
    regardless of configuration.
-2. **The repo slug is committed for the dev channel.** `docker-compose.dev.yml :: api` sets
-   `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`. Dev is the channel this command names (18001).
-3. **`test` and `prod` deliberately leave it unset.** They stay byte-identical to the pre-#4484
-   refusal and render *not enabled* rather than broken (EXT-8, #4481). Turning another channel onto
-   the plane is a promotion-lane act.
+2. **The repo slug is committed for dev and prod.** `docker-compose.dev.yml :: api` and
+   `docker-compose.prod.yml :: api` set
+   `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`. Dev is the channel the command above names
+   (18001); prod's committed identity is consumed by the separately promoted devUI path.
+3. **`test` deliberately leaves it unset.** It renders *not enabled* rather than broken (EXT-8,
+   #4481). A committed repository identity is non-secret configuration; it does not prove that a
+   credential is present or that the corresponding revision is running on a host.
 4. **The token is host-supplied.** `GITHUB_TOKEN` reaches the container on the `api` consumer's
    already-declared host-secret env layer (`HOST_SECRET_RUNTIME_ENV_FILE_API` in
    `docker-compose.yaml :: api`, #4422) — the same layer that delivers `HEIMDAL_RAW_STORE_KEY`. No
@@ -82,6 +84,12 @@ committed things plus one host-supplied value:
 
 With the slug set and the token absent, the plane is *configured but failing* — an honest outage,
 not an opt-out. With the slug unset, nobody asked for it and nothing is claimed either way.
+
+The committed repository binding is not deployment or credential-presence evidence. For prod,
+`github.token` and the coupled `heimdal.raw-store-key` must both be present through the declared
+`heimdal-api-ingress` host-secret consumer before the governed layer can support the read. The
+value-free prerequisite command is documented in `docs/OPERATIONS.md`; it neither provisions nor
+prints either credential.
 
 ## Why This Matters
 

--- a/docs/BUILDEROPS_COCKPIT/README.md
+++ b/docs/BUILDEROPS_COCKPIT/README.md
@@ -76,7 +76,9 @@ DDO-06. One experience therefore does not make this registry a control plane.
   `state` is unchanged in either case: an unconfigured plane still owns no countable facts. Since
   #4484 that unset state is a per-channel choice rather than the only reachable state: the runtime
   image ships the `gh` transport the plane reads through, and `docker-compose.dev.yml :: api`
-  commits the repo slug for the dev channel (18001) while `test`/`prod` stay unset. See
+  and `docker-compose.prod.yml :: api` commit `RasmusTho/agentic-pkm-mvp` for dev (18001) and prod;
+  `test` stays unset. The prod repository binding is committed non-secret configuration, not
+  credential-presence or deployment evidence. See
   `GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)` for the full path,
   including the host-supplied `GITHUB_TOKEN` that rides the `api` consumer's existing host-secret
   env layer.

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -86,12 +86,17 @@ both are deliberate:
 
 - **The grant is per-consumer, not per-channel.** A consumer's channels and its secrets are separate
   flat lists, so `github.token` is declared on all three channels. It is inert wherever nothing is
-  provisioned and wherever no channel binds `COCKPIT_GITHUB_REPO` (today only `dev` does), so least
-  privilege holds in effect.
+  provisioned and wherever no channel binds `COCKPIT_GITHUB_REPO` (`dev` and `prod` bind it; `test`
+  does not), so least privilege holds in effect.
 - **The token inherits the layer's activation condition.** `deploy_channel_compose.sh` only wraps
   compose with this consumer's bootstrap when `heimdal.raw-store-key` resolves, so a host without
   that key materializes no layer and therefore receives no `GITHUB_TOKEN` either — provisioning the
   token alone is not sufficient on the governed deploy path.
+
+The committed repository binding is not deployment or credential-presence evidence. The read-only
+prod prerequisite reports separate booleans for `github.token` and the coupled
+`heimdal.raw-store-key`; it creates, changes, persists, or reveals neither value. Repository
+configuration therefore never substitutes for host provisioning or a deployed-host receipt.
 
 The v1 Keychain service is pinned to the stable non-secret namespace
 `yggdrasil.host-secrets`, and its account is derived by percent-encoding each

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -393,10 +393,11 @@ Companion docs:
   `gh` CLI, which the runtime image installs (`Dockerfile`, runtime-stage apt layer) alongside
   `ffmpeg`/`espeak-ng`. Before #4484 the binary was absent, so the plane refused on every channel
   regardless of configuration.
-- The plane is opt-in per channel. `docker-compose.dev.yml :: api` binds
-  `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`; `test` and `prod` deliberately leave it unset and
-  render the source as *not enabled* rather than broken. Turning another channel on is a
-  promotion-lane act, not a config default.
+- The plane is opt-in per channel. `docker-compose.dev.yml :: api` and
+  `docker-compose.prod.yml :: api` bind
+  `COCKPIT_GITHUB_REPO=RasmusTho/agentic-pkm-mvp`; `test` deliberately leaves it unset and renders
+  the source as *not enabled* rather than broken. The prod entry is committed configuration only;
+  it is not evidence that a particular revision is deployed.
 - The token is host-supplied, never committed. Provision it as the **Keychain item** for the declared
   optional identifier `github.token` under consumer `heimdal-api-ingress` (#4489) — do not hand-write
   an env file: on a governed `scripts/deploy_channel.sh` run the layer's file is bootstrap-owned and
@@ -414,6 +415,14 @@ Companion docs:
 - Note the coupling: this layer is only materialized when `heimdal.raw-store-key` also resolves, so
   provisioning the GitHub token alone is not sufficient on the governed deploy path. Identifier and
   account derivation: `docs/LOCAL_SECRET_PROVISIONING/README.md :: Declared identifier contract`.
+- On Demerzel only, after the corresponding commit is available, run
+  `python3 scripts/check_prod_devui_focus_prerequisites.py`. Its stdout is one JSON object containing
+  only the non-secret repository identity plus separate presence booleans for `github.token` and
+  `heimdal.raw-store-key`; exit 0 requires the exact repository and both values. Do not run it on a
+  laptop or copy ambient credential material into a receipt. The command is read-only and does not
+  provision, install, rotate, deploy, restart, or validate a credential by echoing it.
+- The committed repository binding is not deployment or credential-presence evidence. Only a
+  separately governed Demerzel preflight and deployment verification can establish those facts.
 - Check it with `curl -s localhost:18001/api/cockpit/registry | jq '.sources[] |
   select(.name=="github-live")'`. Full path and rationale:
   `docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md :: What makes that command answer fresh (#4484)`.

--- a/scripts/check_prod_devui_focus_prerequisites.py
+++ b/scripts/check_prod_devui_focus_prerequisites.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
-from typing import Any
-
-from app.ops.host_secret_bootstrap import _security_keychain_lookup
-from app.ops.host_secret_contract import HostSecretContract, load_host_secret_contract
-from app.release_channels.channel_isolation_preflight import _load_compose
-
+from typing import TYPE_CHECKING, Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+if TYPE_CHECKING:
+    from app.ops.host_secret_contract import HostSecretContract
 _EXPECTED_REPOSITORY = "RasmusTho/agentic-pkm-mvp"
 _CHANNEL = "prod"
 _CONSUMER = "heimdal-api-ingress"
@@ -23,12 +23,30 @@ _CREDENTIALS = (
 )
 
 
+def _load_compose(path: Path) -> dict[str, Any]:
+    from app.release_channels.channel_isolation_preflight import _load_compose as loader
+
+    return loader(path)
+
+
+def load_host_secret_contract(path: Path) -> "HostSecretContract":
+    from app.ops.host_secret_contract import load_host_secret_contract as loader
+
+    return loader(path)
+
+
+def _security_keychain_lookup(service: str, account: str) -> str:
+    from app.ops.host_secret_bootstrap import _security_keychain_lookup as lookup
+
+    return lookup(service, account)
+
+
 def _load_prod_repository_binding() -> object:
     compose = _load_compose(_REPO_ROOT / "docker-compose.prod.yml")
     return compose["services"]["api"]["environment"].get("COCKPIT_GITHUB_REPO")
 
 
-def _lookup_present(contract: HostSecretContract, logical_id: str) -> bool:
+def _lookup_present(contract: "HostSecretContract", logical_id: str) -> bool:
     account = contract.keychain_account(
         channel=_CHANNEL,
         consumer=_CONSUMER,
@@ -59,11 +77,11 @@ def main() -> int:
         _emit(payload)
         return 1
 
-    payload["repository"] = repository if isinstance(repository, str) else None
     if repository != _EXPECTED_REPOSITORY:
         print("repository: unexpected binding", file=sys.stderr)
         _emit(payload)
         return 1
+    payload["repository"] = _EXPECTED_REPOSITORY
 
     try:
         contract = load_host_secret_contract(

--- a/scripts/check_prod_devui_focus_prerequisites.py
+++ b/scripts/check_prod_devui_focus_prerequisites.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Report value-free production prerequisites for the devUI Focus GitHub read."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from app.ops.host_secret_bootstrap import _security_keychain_lookup
+from app.ops.host_secret_contract import HostSecretContract, load_host_secret_contract
+from app.release_channels.channel_isolation_preflight import _load_compose
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXPECTED_REPOSITORY = "RasmusTho/agentic-pkm-mvp"
+_CHANNEL = "prod"
+_CONSUMER = "heimdal-api-ingress"
+_CREDENTIALS = (
+    ("github.token", "github_token_present"),
+    ("heimdal.raw-store-key", "heimdal_raw_store_key_present"),
+)
+
+
+def _load_prod_repository_binding() -> object:
+    compose = _load_compose(_REPO_ROOT / "docker-compose.prod.yml")
+    return compose["services"]["api"]["environment"].get("COCKPIT_GITHUB_REPO")
+
+
+def _lookup_present(contract: HostSecretContract, logical_id: str) -> bool:
+    account = contract.keychain_account(
+        channel=_CHANNEL,
+        consumer=_CONSUMER,
+        secret=logical_id,
+    )
+    value = _security_keychain_lookup(contract.keychain_service, account)
+    try:
+        return bool(value)
+    finally:
+        del value
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def main() -> int:
+    payload: dict[str, Any] = {
+        "repository": None,
+        "github_token_present": False,
+        "heimdal_raw_store_key_present": False,
+    }
+
+    try:
+        repository = _load_prod_repository_binding()
+    except Exception:
+        print("repository: configuration unavailable", file=sys.stderr)
+        _emit(payload)
+        return 1
+
+    payload["repository"] = repository if isinstance(repository, str) else None
+    if repository != _EXPECTED_REPOSITORY:
+        print("repository: unexpected binding", file=sys.stderr)
+        _emit(payload)
+        return 1
+
+    try:
+        contract = load_host_secret_contract(
+            _REPO_ROOT / "config/secrets/host_secret_contract.json"
+        )
+    except Exception:
+        for logical_id, _output_key in _CREDENTIALS:
+            print(f"{logical_id}: declaration unavailable", file=sys.stderr)
+        _emit(payload)
+        return 1
+
+    for logical_id, output_key in _CREDENTIALS:
+        try:
+            payload[output_key] = _lookup_present(contract, logical_id)
+        except Exception:
+            print(f"{logical_id}: unavailable", file=sys.stderr)
+        else:
+            if not payload[output_key]:
+                print(f"{logical_id}: unavailable", file=sys.stderr)
+
+    _emit(payload)
+    return 0 if all(payload[key] is True for _logical_id, key in _CREDENTIALS) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/builderops/test_devui_focus_inputs.py
+++ b/tests/builderops/test_devui_focus_inputs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from app.builderops.devui_focus_inputs import FocusInputError, read_focus_inputs
+
+
+def test_focus_inputs_require_exact_configured_repository_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "title": "Source-authorized Issue",
+                    "html_url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/4835",
+                    "updated_at": "2026-08-13T12:00:00Z",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setenv("COCKPIT_GITHUB_REPO", "RasmusTho/agentic-pkm-mvp")
+    monkeypatch.setattr("app.builderops.devui_focus_inputs.subprocess.run", fake_run)
+
+    result = read_focus_inputs("github:RasmusTho/agentic-pkm-mvp#4835")
+    assert result["subject"]["stable_id"] == "github:RasmusTho/agentic-pkm-mvp#4835"
+    assert calls == [["gh", "api", "repos/RasmusTho/agentic-pkm-mvp/issues/4835"]]
+
+    calls.clear()
+    with pytest.raises(FocusInputError, match="repository is not configured"):
+        read_focus_inputs("github:someone-else/agentic-pkm-mvp#4835")
+    assert calls == [], "a repository mismatch must refuse before any GitHub read"

--- a/tests/ops/test_cockpit_github_plane_enablement.py
+++ b/tests/ops/test_cockpit_github_plane_enablement.py
@@ -15,8 +15,8 @@ This file asserts the committed side of that path:
    already-declared host-secret env layer, which is how a value reaches that
    container without a new secret mechanism or compose surface — and, since
    #4489, that the layer actually *delivers* it rather than only naming it; and
-3. the other channels stay unset, so the opt-in posture (and #4481's
-   opted-out-vs-broken distinction) still holds where nobody asked for it.
+3. channels without an explicit repository binding stay unset, preserving
+   #4481's opted-out-vs-broken distinction.
 """
 
 from __future__ import annotations
@@ -29,10 +29,7 @@ from app.release_channels.channel_isolation_preflight import _load_compose
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _BASE_COMPOSE = _REPO_ROOT / "docker-compose.yaml"
 _DEV_COMPOSE = _REPO_ROOT / "docker-compose.dev.yml"
-_OPTED_OUT_COMPOSE = (
-    _REPO_ROOT / "docker-compose.test.yml",
-    _REPO_ROOT / "docker-compose.prod.yml",
-)
+_OPTED_OUT_COMPOSE = (_REPO_ROOT / "docker-compose.test.yml",)
 
 _REPO_SLUG = "RasmusTho/agentic-pkm-mvp"
 _TOKEN_KEY = "GITHUB_TOKEN"
@@ -81,8 +78,8 @@ def test_api_service_receives_cockpit_repo_and_token_key() -> None:
     )
 
 
-def test_other_channels_stay_opted_out_of_the_live_plane() -> None:
-    """The plane stays opt-in: only the enabled channel binds the slug.
+def test_non_enabled_channels_stay_opted_out_of_the_live_plane() -> None:
+    """The plane stays opt-in: a non-enabled channel does not bind the slug.
 
     With `COCKPIT_GITHUB_REPO` unset a channel's behavior is byte-identical to
     the pre-#4484 refusal, and the source renders *not enabled* rather than

--- a/tests/ops/test_prod_devui_focus_config.py
+++ b/tests/ops/test_prod_devui_focus_config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.ops.host_secret_contract import load_host_secret_contract
+from app.release_channels.channel_isolation_preflight import _load_compose
+from scripts import check_prod_devui_focus_prerequisites as preflight
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REPO = "RasmusTho/agentic-pkm-mvp"
+_CONSUMER = "heimdal-api-ingress"
+_SECRETS = ("github.token", "heimdal.raw-store-key")
+
+
+def _json_output(capsys: pytest.CaptureFixture[str]) -> tuple[dict[str, object], str]:
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert len(lines) == 1
+    return json.loads(lines[0]), captured.err
+
+
+def test_prod_binds_canonical_cockpit_github_repository_without_secret() -> None:
+    prod = _load_compose(_REPO_ROOT / "docker-compose.prod.yml")
+    environment = prod["services"]["api"]["environment"]
+    assert environment["COCKPIT_GITHUB_REPO"] == _REPO
+    assert "GITHUB_TOKEN" not in environment
+
+
+def test_focus_credential_preflight_reports_coupled_presence_booleans_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def lookup(service: str, account: str) -> str:
+        calls.append((service, account))
+        return "present-but-never-rendered"
+
+    monkeypatch.setattr(preflight, "_security_keychain_lookup", lookup)
+    assert preflight.main() == 0
+    payload, diagnostics = _json_output(capsys)
+
+    assert payload == {
+        "repository": _REPO,
+        "github_token_present": True,
+        "heimdal_raw_store_key_present": True,
+    }
+    assert diagnostics == ""
+    contract = load_host_secret_contract()
+    assert calls == [
+        (
+            contract.keychain_service,
+            contract.keychain_account(channel="prod", consumer=_CONSUMER, secret=secret),
+        )
+        for secret in _SECRETS
+    ]
+
+
+@pytest.mark.parametrize("failure", ["absent", "unreadable", "undeclared", "wrong-repo"])
+def test_focus_credential_preflight_failures_are_value_account_and_path_free(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    failure: str,
+) -> None:
+    forbidden = (
+        "ghp_SUPER_SECRET_SENTINEL",
+        "prod:heimdal-api-ingress:secret-account-sentinel",
+        "/Users/operator/private/keychain-sentinel",
+        "config/secrets/private-sentinel.json",
+    )
+
+    if failure == "wrong-repo":
+        monkeypatch.setattr(
+            preflight,
+            "_load_prod_repository_binding",
+            lambda: "somebody/incorrect-repository",
+        )
+    elif failure == "undeclared":
+        real_contract = load_host_secret_contract()
+
+        class UndeclaredContract:
+            keychain_service = real_contract.keychain_service
+
+            def keychain_account(self, **_kwargs: str) -> str:
+                raise ValueError(" ".join(forbidden))
+
+        monkeypatch.setattr(
+            preflight,
+            "load_host_secret_contract",
+            lambda _path: UndeclaredContract(),
+        )
+    elif failure == "unreadable":
+        monkeypatch.setattr(
+            preflight,
+            "_security_keychain_lookup",
+            lambda _service, _account: (_ for _ in ()).throw(RuntimeError(" ".join(forbidden))),
+        )
+    else:
+        monkeypatch.setattr(preflight, "_security_keychain_lookup", lambda _service, _account: "")
+
+    assert preflight.main() != 0
+    payload, diagnostics = _json_output(capsys)
+    assert set(payload) == {
+        "repository",
+        "github_token_present",
+        "heimdal_raw_store_key_present",
+    }
+    assert payload["github_token_present"] is False or payload["heimdal_raw_store_key_present"] is False
+    rendered = json.dumps(payload) + diagnostics
+    assert all(item not in rendered for item in forbidden)
+    assert "Keychain" not in rendered
+
+
+def test_prod_focus_repo_binding_is_owner_documented_without_delivery_claim() -> None:
+    docs = (
+        _REPO_ROOT / "docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md",
+        _REPO_ROOT / "docs/LOCAL_SECRET_PROVISIONING/README.md",
+        _REPO_ROOT / "docs/OPERATIONS.md",
+    )
+    marker = "committed repository binding is not deployment or credential-presence evidence"
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        assert _REPO in text
+        assert "heimdal.raw-store-key" in text
+        assert marker in text.lower(), path

--- a/tests/ops/test_prod_devui_focus_config.py
+++ b/tests/ops/test_prod_devui_focus_config.py
@@ -67,7 +67,7 @@ def test_focus_credential_preflight_failures_are_value_account_and_path_free(
     failure: str,
 ) -> None:
     forbidden = (
-        "ghp_SUPER_SECRET_SENTINEL",
+        "credential-value-sentinel",
         "prod:heimdal-api-ingress:secret-account-sentinel",
         "/Users/operator/private/keychain-sentinel",
         "config/secrets/private-sentinel.json",

--- a/tests/ops/test_prod_devui_focus_config.py
+++ b/tests/ops/test_prod_devui_focus_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -77,7 +79,7 @@ def test_focus_credential_preflight_failures_are_value_account_and_path_free(
         monkeypatch.setattr(
             preflight,
             "_load_prod_repository_binding",
-            lambda: "somebody/incorrect-repository",
+            lambda: "/Users/operator/private/repository-binding",
         )
     elif failure == "undeclared":
         real_contract = load_host_secret_contract()
@@ -115,14 +117,44 @@ def test_focus_credential_preflight_failures_are_value_account_and_path_free(
     assert "Keychain" not in rendered
 
 
+def test_documented_preflight_entrypoint_bootstraps_repo_and_redacts_import_failures() -> None:
+    script = _REPO_ROOT / "scripts/check_prod_devui_focus_prerequisites.py"
+    result = subprocess.run(
+        [sys.executable, "-S", str(script)],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert result.stdout.count("\n") == 1
+    assert json.loads(result.stdout) == {
+        "repository": None,
+        "github_token_present": False,
+        "heimdal_raw_store_key_present": False,
+    }
+    rendered = result.stdout + result.stderr
+    assert "Traceback" not in rendered
+    assert str(_REPO_ROOT) not in rendered
+
+
 def test_prod_focus_repo_binding_is_owner_documented_without_delivery_claim() -> None:
-    docs = (
+    owner_docs = (
+        _REPO_ROOT / "docs/BUILDEROPS_COCKPIT/README.md",
+        _REPO_ROOT / "docs/BUILDEROPS_COCKPIT/DESIGN_DECISIONS.md",
+    )
+    source_docs = (
         _REPO_ROOT / "docs/BUILDEROPS_COCKPIT/GITHUB_LIVE_PLANE.md",
         _REPO_ROOT / "docs/LOCAL_SECRET_PROVISIONING/README.md",
         _REPO_ROOT / "docs/OPERATIONS.md",
     )
     marker = "committed repository binding is not deployment or credential-presence evidence"
-    for path in docs:
+    for path in owner_docs:
+        text = path.read_text(encoding="utf-8")
+        assert _REPO in text
+        assert "credential-presence or deployment evidence" in text, path
+    for path in source_docs:
         text = path.read_text(encoding="utf-8")
         assert _REPO in text
         assert "heimdal.raw-store-key" in text


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4835

## Linked Issue
Closes #4835

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): OEF production deployment boundary; external GitHub boundary
- Write class: Authority-bearing non-secret deployment configuration plus a read-only diagnostic
- Persistence impact: None; no credentials, runtime state, or user data are written
- Derived/rebuildable impact: Production Focus repository admission and reproducible prerequisite evidence
- New or changed contract: Prod binds the canonical GitHub repository while both host credentials remain separately proven external prerequisites
- Owner-doc impact: Updated in this PR without a deployment or provisioning claim
- Transition debt impact: Removes a guaranteed production Focus refusal at source-config level; deployment remains separate
- Boundary risk: Secret or account disclosure, weakened exact repository admission, or false deployment evidence; guarded by strict refusal

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Bind the production API service to the canonical repository required by the real Focus adapter while leaving the test channel opted out.
- Add a read-only, value-free Demerzel prerequisite command that reports only the repository and separate coupled credential-presence booleans, plus exact admission and non-disclosure tests.
- The change is source delivery only: it is not a deployment, credential-provisioning, runtime, or acceptance claim.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Issue #4835, Git, focused tests, CI, and later deployment receipts own this source delivery; no BuilderOps operational record was produced.

## Notes
Late-change supersession / repair round 1:
- Previous head `994f413c7a1502b73973315cd54e2cbf2225d930` review/CI evidence is superseded by the repair and base rebase.
- Stable binding: `failure_domain=prod_focus_prerequisite_contract_integrity`; `mechanism_id=direct_entrypoint_non_disclosure_and_owner_doc_consistency`.
- Repair: bootstrap the repository before application imports; fail closed without rendering an untrusted repository value; reconcile both canonical Cockpit owner docs; add direct-entrypoint redaction proof; repair Issue #4835's docs-guard command to `--language-only`.
- Current candidate head `720bda7a5c1063e29a54145f3282577813f1a3e3` passed fresh independent convergence and final-review preflight with no P0/P1/P2/P3, plus `pytest -q tests/ops/test_prod_devui_focus_config.py tests/ops/test_cockpit_github_plane_enablement.py tests/builderops/test_devui_focus_inputs.py` (12 passed), targeted Ruff, `python3 scripts/docs_guard.py --language-only`, and `git diff --check`.
- Local Docker CLI is unavailable; hosted `smoke-docker` on the current head remains required CI evidence.
- The real prerequisite command has intentionally not run on this laptop; it may run only on Demerzel as a later read-only post-merge/promotion prerequisite.
- No credential, host configuration, deployment, restart, promotion, or data mutation occurred.
