### PR TITLE
Bake required repository packages into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 #                               migrations + app/alembic.ini used by
 #                               scripts/run_migrations.sh)
 # - mimer_runtime/              imported directly by app/** (cross_scope, dri, ...)
+# - llm_contract/               neutral model-access contract imported by
+#                               app/builderops/model_access_resolver.py
 # - schemas/                    JSON schemas resolved via REPO_ROOT at runtime
 #                               (app/episodes/schema.py, app/retrieval/envelope.py, ...)
 # - config/ + configs/          runtime defaults/settings files (config/agent.yaml,
@@ -108,6 +110,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 #                               the set from the source imports.
 COPY app/ ./app/
 COPY mimer_runtime/ ./mimer_runtime/
+COPY llm_contract/ ./llm_contract/
 COPY schemas/ ./schemas/
 COPY config/ ./config/
 COPY configs/ ./configs/

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -36,6 +36,7 @@ docs, .git, ops). Contracts guarded here:
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -56,6 +57,31 @@ _SCRIPTS_IMPORT_RE = re.compile(
     r"^\s*(?:from\s+scripts\.([A-Za-z0-9_]+)\s+import\b|import\s+scripts\.([A-Za-z0-9_]+))",
     flags=re.MULTILINE,
 )
+
+
+def _runtime_imported_repo_packages() -> set[str]:
+    """Return checked-in top-level packages imported by baked runtime trees.
+
+    ``scripts`` is intentionally excluded: it is copied as a curated module
+    list and guarded separately by ``test_runtime_imported_scripts_modules``.
+    """
+    packages: set[str] = set()
+    for package_dir in RUNTIME_PACKAGE_DIRS:
+        for path in sorted((REPO_ROOT / package_dir).rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    candidates = (alias.name.split(".", 1)[0] for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                    candidates = (node.module.split(".", 1)[0],)
+                else:
+                    continue
+                for candidate in candidates:
+                    if candidate == "scripts":
+                        continue
+                    if (REPO_ROOT / candidate / "__init__.py").is_file():
+                        packages.add(candidate)
+    return packages
 
 
 def _dockerfile_text() -> str:
@@ -219,6 +245,27 @@ def test_runtime_imported_scripts_modules_are_baked_into_image() -> None:
         ), (
             f"runtime stage must COPY {needed} — app/** imports it at runtime "
             "(worker/watcher/heimdal services crash at boot without it)"
+        )
+
+
+def test_runtime_imported_repo_packages_are_baked_into_image() -> None:
+    """Every checked-in package imported by baked runtime code is allowlisted.
+
+    This exercises the Dockerfile/runtime-entrypoint seam rather than host
+    imports, preventing a buildable image whose watcher crashes at startup.
+    """
+    packages = _runtime_imported_repo_packages()
+    assert packages, "expected baked runtime trees to import a checked-in package"
+
+    final_stage = _dockerfile_text()[_dockerfile_text().rindex("FROM ") :]
+    for package in sorted(packages):
+        assert re.search(
+            rf"^\s*COPY\s+{re.escape(package)}/\s+\./{re.escape(package)}/\s*$",
+            final_stage,
+            flags=re.MULTILINE,
+        ), (
+            f"runtime stage must COPY checked-in package {package}/ imported by "
+            "a baked runtime package"
         )
 
 


### PR DESCRIPTION
Governing-Issue: #4895

Fixes #4895

Final-Review-Rounds: 0

## Summary
Adds the missing `llm_contract/` allowlist entry to the runtime image and a source-derived Dockerfile guard for checked-in top-level package imports from baked runtime trees.

## SBS Impact
- Classification: Builder System to runtime-image boundary
- Runtime behavior: preserves existing service entrypoints; makes the immutable image complete for their existing imports
- Persistence: none
- Owner-doc writeback: none; the deployment contract remains unchanged

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: planned single-issue implementation with no delivery divergence or operational record produced.

## Notes
Validation: `pytest -q tests/deploy/test_dockerfile_hardening.py` (13 passed); `ruff check app tests companion-ui/companion-app` (passed); `git diff --check` (passed). CI Smoke, including the full-compose vaultwide panel verifier, is pending on this exact head.
---