### PR TITLE
governance: preserve real newlines in issue body edits

### DIFF
--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -138,6 +138,7 @@ Impact` unparseable.
 
 1. Read the live body into a file, edit the file as Markdown, and submit that file:
    ```bash
+   set -euo pipefail
    body_file="$(mktemp)"
    gh issue view <N> --repo <owner/repo> --json body --jq .body >"$body_file"
    # Edit "$body_file" while preserving real newlines.
@@ -152,9 +153,14 @@ Impact` unparseable.
      --body-file "$verified_body_file" \
      --issue-number <N> \
      --label agent:ready
+   cmp -s "$body_file" "$verified_body_file" || {
+     echo "GitHub did not store the submitted Issue body exactly" >&2
+     exit 1
+   }
    ```
-3. Add or preserve `agent:ready` only after that command exits successfully. If it fails, leave or
-   restore the Issue to a non-ready truthful state and record the malformed-body repair needed.
+3. Add or preserve `agent:ready` only after both the edit and post-write comparison/validation
+   commands exit successfully. If any step fails, leave or restore the Issue to a non-ready truthful
+   state and record the malformed-body repair needed.
 
 The fresh read and strict validator are the post-condition verification for a body rewrite. Keep
 the temporary body files only for the command sequence, and re-read labels and Issue state after

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -129,6 +129,37 @@ If any of the above is missing or unclear, first try to resolve it from the SoT 
 - when Project repair is explicitly in scope, add missing cards and reconcile Status through
   `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`
 
+## Authoritative Issue body edits and verification
+
+Use a Markdown body file for every canonical Issue-body rewrite. Do not construct an edit by
+JSON-string replacement, shell-escaped `\\n` substitution, or an inline API payload: those paths
+can persist the two literal characters `\\` and `n`, leaving required headings such as `## SBS
+Impact` unparseable.
+
+1. Read the live body into a file, edit the file as Markdown, and submit that file:
+   ```bash
+   body_file="$(mktemp)"
+   gh issue view <N> --repo <owner/repo> --json body --jq .body >"$body_file"
+   # Edit "$body_file" while preserving real newlines.
+   gh issue edit <N> --repo <owner/repo> --body-file "$body_file"
+   ```
+2. Re-read the authoritative GitHub body into a fresh file after the mutation. Do not validate the
+   pre-write local copy as evidence that GitHub stored the intended newlines:
+   ```bash
+   verified_body_file="$(mktemp)"
+   gh issue view <N> --repo <owner/repo> --json body --jq .body >"$verified_body_file"
+   python3 scripts/validate_issue_readiness.py \
+     --body-file "$verified_body_file" \
+     --issue-number <N> \
+     --label agent:ready
+   ```
+3. Add or preserve `agent:ready` only after that command exits successfully. If it fails, leave or
+   restore the Issue to a non-ready truthful state and record the malformed-body repair needed.
+
+The fresh read and strict validator are the post-condition verification for a body rewrite. Keep
+the temporary body files only for the command sequence, and re-read labels and Issue state after
+any accompanying label mutation.
+
 When closing stale or duplicate open issues:
 
 - leave an explicit maintenance receipt comment naming the canonical delivered Issue/PR replacing the open backlog item

--- a/tests/scripts/test_validate_issue_readiness.py
+++ b/tests/scripts/test_validate_issue_readiness.py
@@ -57,6 +57,16 @@ def test_ready_candidate_reports_required_detail() -> None:
     assert report.human_exception_required is False
 
 
+def test_rejects_literal_newline_escaped_headings() -> None:
+    body = (FIXTURE_DIR / "valid_ready_candidate.md").read_text(encoding="utf-8")
+    body = body.replace("\n## SBS Impact", r"\n## SBS Impact")
+
+    report = classify_issue_body(body, labels=["agent:ready"])
+
+    assert report.readiness_classification == "missing_required_sections"
+    assert "SBS Impact" in report.required_sections.missing
+
+
 def test_missing_verify_reports_exact_item_guidance() -> None:
     body = (FIXTURE_DIR / "ac_without_verify.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4017

## Linked Issue
Closes #4017

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): GitHub Issue maintenance
- Write class: governance/docs/process
- Persistence impact: GitHub Issue body only
- Derived/rebuildable impact: none
- New or changed contract: Issue maintenance rewrites preserve real newlines and validate the authoritative post-edit body before ready labels.
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces
- Boundary risk: GitHub Issue API body update

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Document a safe Markdown body-file edit and authoritative post-write readiness check.
- Add a regression test for literal newline-escaped required headings.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue already carries the source LearningSignal; this bounded delivery produced no new BuilderOps material.

## Notes
Validation: pytest -q tests/scripts/test_validate_issue_readiness.py (61 passed); python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py --language-only; git diff --check; review_before_ci_gate governance risk assessment (no high-risk surface).