### PR TITLE
refactor: consolidate companion_ui import wiring

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -585,10 +585,6 @@ jobs:
       || github.event.changes.base.ref.from != null)
     runs-on: ubuntu-latest
     env:
-      # API tests import the nested Companion package directly. Keep both
-      # package roots explicit so subsystem selection cannot make collection
-      # depend on a prior Companion-specific setup step.
-      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/companion-ui/companion-app
       # NOTE: do NOT set PYTEST_DISABLE_PLUGIN_AUTOLOAD here. Disabling autoload
       # suppresses pytest-asyncio (and others), so every @pytest.mark.asyncio
       # test in tests/sync/* and tests/agents/* false-fails. This job must mirror

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -584,11 +584,10 @@ jobs:
       && (github.event.action != 'edited'
       || github.event.changes.base.ref.from != null)
     runs-on: ubuntu-latest
-    env:
-      # NOTE: do NOT set PYTEST_DISABLE_PLUGIN_AUTOLOAD here. Disabling autoload
-      # suppresses pytest-asyncio (and others), so every @pytest.mark.asyncio
-      # test in tests/sync/* and tests/agents/* false-fails. This job must mirror
-      # the nightly full suite, which autoloads plugins. See issue #2036.
+    # Do not set PYTEST_DISABLE_PLUGIN_AUTOLOAD here. Disabling autoload
+    # suppresses pytest-asyncio (and others), so every @pytest.mark.asyncio
+    # test in tests/sync/* and tests/agents/* false-fails. This job must mirror
+    # the nightly full suite, which autoloads plugins. See issue #2036.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/companion-ui/companion-app/README.md
+++ b/companion-ui/companion-app/README.md
@@ -15,7 +15,7 @@ companion-ui/companion-app/
         └── active_artifact_shell.py      ← Active artifact body shell contract
 ```
 
-The `companion-ui/companion-app/` directory is the package root added to `sys.path` by `tests/companion_ui/conftest.py`.  Import in tests as:
+The `companion-ui/companion-app/` directory is the `companion_ui` package root. Editable installs declare it through `pyproject.toml`; pytest collection from a fresh source worktree uses the single root `conftest.py` fallback. Import in tests as:
 
 ```python
 from companion_ui.canvas_core.session_state import CanvasSessionState

--- a/conftest.py
+++ b/conftest.py
@@ -5,12 +5,9 @@ from pathlib import Path
 
 import pytest
 
-# companion_ui lives at companion-ui/companion-app, outside the rootdir pythonpath,
-# and is imported at module level by test trees beyond tests/companion_ui (tests/api,
-# tests/uat, tests/tts). It must be importable for every collection target and for
-# ini-less CI invocations (`pytest -c /dev/null`), which skip pytest.ini pythonpath
-# but still load this conftest.
-# See: https://github.com/RasmusTho/agentic-pkm-mvp/issues/3941
+# Test collection from a fresh source worktree is the pytest consumer class that
+# has no editable-install prerequisite. Keep this one root-level fallback;
+# package consumers use the pyproject.toml editable-install declaration.
 _COMPANION_APP_ROOT = Path(__file__).resolve().parent / "companion-ui" / "companion-app"
 if str(_COMPANION_APP_ROOT) not in sys.path:
     sys.path.insert(0, str(_COMPANION_APP_ROOT))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -557,7 +557,6 @@ services:
       COMPANION_API_BASE_URL: ${COMPANION_UI_API_BASE_URL:-http://api:8000}
       COMPANION_UI_SERVE_MODULE: ${COMPANION_UI_SERVE_MODULE:-companion_ui.workspace.serve_dev_page}
       PKM_ENVIRONMENT: ${PKM_ENVIRONMENT:-dev}
-      PYTHONPATH: /app/companion-ui/companion-app:/app
     ports:
       - "${COMPANION_UI_BIND_HOST:-127.0.0.1}:${COMPANION_UI_HOST_PORT:-8111}:${COMPANION_UI_PORT:-8111}"
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ browser = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["."]
-include = ["app*", "llm_contract*"]
+where = [".", "companion-ui/companion-app"]
+include = ["app*", "llm_contract*", "companion_ui*"]
 
 [tool.setuptools.package-data]
 "app.settings" = ["*.yaml"]

--- a/tests/api/test_companion_no_vault_routing.py
+++ b/tests/api/test_companion_no_vault_routing.py
@@ -441,13 +441,6 @@ def test_queue_review_client_routes_picker_payload_to_picker() -> None:
     instead of marking the action ``pending_intent`` (the masquerade fixed by
     #2184).
     """
-    import sys
-
-    companion_app_root = (
-        _REPO_ROOT / "companion-ui" / "companion-app"
-    )
-    if str(companion_app_root) not in sys.path:
-        sys.path.insert(0, str(companion_app_root))
     from companion_ui.workspace.serve_dev_page import render_index_html
 
     html = render_index_html(

--- a/tests/architecture/test_companion_ui_sys_path.py
+++ b/tests/architecture/test_companion_ui_sys_path.py
@@ -24,3 +24,34 @@ def test_companion_ui_importable_from_any_test_tree() -> None:
         f"{package_dirs} (expected {expected}); a machine-local install or an "
         "absolute sys.path entry from another checkout is shadowing the repo copy"
     )
+
+
+def test_no_test_local_companion_ui_sys_path_shims() -> None:
+    """Collection must rely on the declared consumer mechanism, not local shims."""
+    repo_root = Path(__file__).resolve().parents[2]
+    shim_paths = (
+        "tests/companion_ui/conftest.py",
+        "tests/tts/test_readback_segments_and_norm.py",
+        "tests/uat/test_golden_path_integrated_runtime.py",
+        "tests/api/test_companion_no_vault_routing.py",
+    )
+    for relative_path in shim_paths:
+        shim_path = repo_root / relative_path
+        if not shim_path.exists():
+            continue
+        source = shim_path.read_text(encoding="utf-8")
+        assert "companion-ui/companion-app" not in source
+        assert "companion_app_root" not in source
+
+
+def test_ci_and_compose_use_declared_companion_ui_import_mechanisms() -> None:
+    """CI shares root pytest collection; compose relies on its working directory."""
+    repo_root = Path(__file__).resolve().parents[2]
+    ci_source = (repo_root / ".github/workflows/ci-smoke.yaml").read_text(encoding="utf-8")
+    compose_source = (repo_root / "docker-compose.yaml").read_text(encoding="utf-8")
+    unit_test_job = ci_source.split("  pr-unit-tests-not-pg:", 1)[1].split(
+        "  pr-index-pg-contracts:", 1
+    )[0]
+
+    assert "${{ github.workspace }}/companion-ui/companion-app" not in unit_test_job
+    assert "PYTHONPATH: /app/companion-ui/companion-app:/app" not in compose_source

--- a/tests/companion_ui/conftest.py
+++ b/tests/companion_ui/conftest.py
@@ -1,7 +1,0 @@
-"""Add companion-ui/companion-app to sys.path so companion_ui package is importable."""
-import sys
-from pathlib import Path
-
-_pkg_root = Path(__file__).resolve().parents[2] / "companion-ui" / "companion-app"
-if str(_pkg_root) not in sys.path:
-    sys.path.insert(0, str(_pkg_root))

--- a/tests/tts/test_readback_segments_and_norm.py
+++ b/tests/tts/test_readback_segments_and_norm.py
@@ -16,7 +16,6 @@ Each test asserts the fixed behaviour on the production call path:
 from __future__ import annotations
 
 import subprocess
-import sys
 import wave
 from array import array
 from pathlib import Path
@@ -28,13 +27,6 @@ from app.tts.planning import build_tts_plan
 from app.tts.providers import TTSVoice, resolve_voice
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-
-# The Companion UI dev page (read-back surface) lives in a sibling package that
-# is only on sys.path via tests/companion_ui/conftest.py. Add it here too so the
-# AC1/AC2 UI assertions below can import the production render function.
-_COMPANION_APP = REPO_ROOT / "companion-ui" / "companion-app"
-if str(_COMPANION_APP) not in sys.path:
-    sys.path.insert(0, str(_COMPANION_APP))
 
 
 def _config(tmp_path: Path) -> TTSConfig:

--- a/tests/uat/test_golden_path_integrated_runtime.py
+++ b/tests/uat/test_golden_path_integrated_runtime.py
@@ -13,7 +13,6 @@ import io
 import json
 import os
 import subprocess
-import sys
 import time
 from dataclasses import dataclass
 from functools import lru_cache
@@ -22,10 +21,6 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
-
-_COMPANION_APP_ROOT = Path(__file__).resolve().parents[2] / "companion-ui" / "companion-app"
-if str(_COMPANION_APP_ROOT) not in sys.path:
-    sys.path.insert(0, str(_COMPANION_APP_ROOT))
 
 import app.api.routes.canvas as canvas_module
 import app.api.routes.companion as companion_module


### PR DESCRIPTION
Governing-Issue: #3948

Fixes #3948

Final-Review-Rounds: 0

## Summary
Consolidates companion_ui imports by packaging the editable-install consumer, retaining one root pytest fallback for fresh source worktrees, and deleting four test-local shims.

The requirements-only CI job and companion-ui compose service no longer add redundant PYTHONPATH overrides. Compose behavior and Dockerfile copy strategy are unchanged; the service working directory already exposes companion_ui.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none; deployment configuration was read only to confirm no runtime-image content change
- Write class: mechanical
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none; Dockerfile and release channels unchanged
- External boundary impact: none
- New or changed contract: one declared companion_ui import mechanism per consumer class
- Owner-doc impact: none expected
- Transition debt impact: reduces redundant import wiring
- Fitness rule impact: strengthens architecture coverage for test, CI, and compose consumers

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No delivery divergence or operational material beyond this issue, PR, and normal GitHub evidence.

## Validation
- `python3 -m pytest -q tests/architecture/test_companion_ui_sys_path.py tests/tts/test_readback_segments_and_norm.py tests/uat/test_golden_path_integrated_runtime.py tests/api/test_companion_no_vault_routing.py` (26 passed, 4 skipped)
- `python3 -m pytest -q --collect-only -m \"not pg\"` (13,515 collected; 390 deselected)
- `ruff check app tests companion-ui/companion-app`
- `python3 scripts/docs_guard.py --language-only`
- Fresh temporary venv: `pip install -e . --no-deps` then import resolves to this worktree
- YAML parse for CI and compose
- Full `pytest -q -m \"not pg\"` completed with 10 unrelated existing environment/integration failures (Docker unavailable; host-dependent Keychain/integration fixtures); affected companion_ui targets remained green.
- Docker smoke: local Docker unavailable; hosted Docker smoke required before merge.

## Owner-doc writeback
No owner-doc change expected: this is Builder System test/dev import wiring and preserves runtime image/deployment behavior.