### PR TITLE
Add cross-process per-binding effect lease

### DIFF
--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import copy
+import ctypes
 import fcntl
 import hashlib
 import json
 import os
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 from contextlib import contextmanager
@@ -24,6 +26,55 @@ from app.instance.vault_registry import VaultRegistryStore
 
 LEASE_SCHEMA = "agentic-pkm.binding-effect-lease.v1"
 JOURNAL_SCHEMA = "agentic-pkm.binding-effect-lease-journal.v1"
+
+
+class _DarwinProcBsdInfo(ctypes.Structure):
+    """Native ``proc_bsdinfo`` layout from Darwin ``sys/proc_info.h``."""
+
+    _fields_ = [
+        ("pbi_flags", ctypes.c_uint32),
+        ("pbi_status", ctypes.c_uint32),
+        ("pbi_xstatus", ctypes.c_uint32),
+        ("pbi_pid", ctypes.c_uint32),
+        ("pbi_ppid", ctypes.c_uint32),
+        ("pbi_uid", ctypes.c_uint32),
+        ("pbi_gid", ctypes.c_uint32),
+        ("pbi_ruid", ctypes.c_uint32),
+        ("pbi_rgid", ctypes.c_uint32),
+        ("pbi_svuid", ctypes.c_uint32),
+        ("pbi_svgid", ctypes.c_uint32),
+        ("rfu_1", ctypes.c_uint32),
+        ("pbi_comm", ctypes.c_char * 16),
+        ("pbi_name", ctypes.c_char * 32),
+        ("pbi_nfiles", ctypes.c_uint32),
+        ("pbi_pgid", ctypes.c_uint32),
+        ("pbi_pjobc", ctypes.c_uint32),
+        ("e_tdev", ctypes.c_uint32),
+        ("e_tpgid", ctypes.c_uint32),
+        ("pbi_nice", ctypes.c_int32),
+        ("pbi_start_tvsec", ctypes.c_uint64),
+        ("pbi_start_tvusec", ctypes.c_uint64),
+    ]
+
+
+class _DarwinProcBsdShortInfo(ctypes.Structure):
+    """Native ``proc_bsdshortinfo`` used to identify an unreaped zombie."""
+
+    _fields_ = [
+        ("pbsi_pid", ctypes.c_uint32),
+        ("pbsi_ppid", ctypes.c_uint32),
+        ("pbsi_pgid", ctypes.c_uint32),
+        ("pbsi_status", ctypes.c_uint32),
+        ("pbsi_comm", ctypes.c_char * 16),
+        ("pbsi_flags", ctypes.c_uint32),
+        ("pbsi_uid", ctypes.c_uint32),
+        ("pbsi_gid", ctypes.c_uint32),
+        ("pbsi_ruid", ctypes.c_uint32),
+        ("pbsi_rgid", ctypes.c_uint32),
+        ("pbsi_svuid", ctypes.c_uint32),
+        ("pbsi_svgid", ctypes.c_uint32),
+        ("pbsi_rfu", ctypes.c_uint32),
+    ]
 
 
 class BindingEffectLeaseError(RuntimeError):
@@ -484,20 +535,86 @@ class BindingEffectLeaseManager:
             remainder = raw[raw.rindex(")") + 2 :].split()
             return f"proc:{remainder[19]}", remainder[0]
         except (OSError, IndexError, ValueError):
-            try:
-                result = subprocess.run(
-                    ["ps", "-o", "stat=", "-o", "lstart=", "-p", str(pid)],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                    timeout=1,
-                )
-                output = result.stdout.strip().split(maxsplit=1)
-                if len(output) == 2:
-                    return f"ps:{output[1]}", output[0][:1]
-            except (OSError, subprocess.SubprocessError):
-                pass
+            if sys.platform == "darwin":
+                return BindingEffectLeaseManager._darwin_process_identity(pid)
             raise BindingEffectLeaseError("a trustworthy process-incarnation token is unavailable")
+
+    @staticmethod
+    def _darwin_process_identity(pid: int) -> tuple[str, str]:
+        """Return a microsecond-resolution native process incarnation on Darwin."""
+
+        try:
+            library = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+            proc_pidinfo = library.proc_pidinfo
+        except (AttributeError, OSError) as exc:
+            raise BindingEffectLeaseError(
+                "a trustworthy process-incarnation token is unavailable"
+            ) from exc
+        proc_pidinfo.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        proc_pidinfo.restype = ctypes.c_int
+        info = _DarwinProcBsdInfo()
+        result = proc_pidinfo(
+            pid,
+            3,  # PROC_PIDTBSDINFO
+            0,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        )
+        if (
+            result == ctypes.sizeof(info)
+            and info.pbi_pid == pid
+            and info.pbi_status in {1, 2, 3, 4, 5}
+            and info.pbi_start_tvsec > 0
+            and info.pbi_start_tvusec < 1_000_000
+        ):
+            state = "Z" if info.pbi_status == 5 else "?"
+            return (
+                f"darwin:{info.pbi_start_tvsec}:{info.pbi_start_tvusec}",
+                state,
+            )
+
+        # Full BSD info may disappear after process exit while an unreaped PID
+        # still answers `kill(0)`. The native short flavor retains `p_stat`, so
+        # it can prove a zombie is dead without supplying a weak live token.
+        short = _DarwinProcBsdShortInfo()
+        short_result = proc_pidinfo(
+            pid,
+            13,  # PROC_PIDT_SHORTBSDINFO
+            0,
+            ctypes.byref(short),
+            ctypes.sizeof(short),
+        )
+        if (
+            short_result == ctypes.sizeof(short)
+            and short.pbsi_pid == pid
+            and short.pbsi_status == 5
+        ):
+            return f"darwin:zombie:{pid}", "Z"
+        if BindingEffectLeaseManager._darwin_process_is_zombie(pid):
+            return f"darwin:zombie:{pid}", "Z"
+        raise BindingEffectLeaseError("a trustworthy process-incarnation token is unavailable")
+
+    @staticmethod
+    def _darwin_process_is_zombie(pid: int) -> bool:
+        """Use ``ps`` only as terminal-state proof, never as an identity token."""
+
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=1,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.stdout.strip().startswith("Z")
 
     @staticmethod
     def _empty_state(vault_binding_id: str) -> _LeaseState:

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -1012,15 +1012,35 @@ class BindingEffectLeaseManager:
         return cast(_LeaseState, copy.deepcopy(value))
 
     def _ensure_state_root(self) -> None:
-        self.state_root.mkdir(parents=True, exist_ok=True, mode=0o700)
-        os.chmod(self.state_root, 0o700)
-        metadata = self.state_root.lstat()
-        if (
-            not stat.S_ISDIR(metadata.st_mode)
-            or metadata.st_uid != os.geteuid()
-            or metadata.st_mode & 0o777 != 0o700
-        ):
-            raise BindingEffectLeaseError("binding effect lease directory is unsafe")
+        nofollow = getattr(os, "O_NOFOLLOW", None)
+        if nofollow is None:
+            raise BindingEffectLeaseError("binding effect lease directory cannot be opened safely")
+        try:
+            self.state_root.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+        descriptor: int | None = None
+        try:
+            try:
+                descriptor = os.open(
+                    self.state_root,
+                    os.O_RDONLY
+                    | getattr(os, "O_DIRECTORY", 0)
+                    | nofollow
+                    | getattr(os, "O_CLOEXEC", 0),
+                )
+            except OSError as exc:
+                raise BindingEffectLeaseError("binding effect lease directory is unsafe") from exc
+            os.set_inheritable(descriptor, False)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+                raise BindingEffectLeaseError("binding effect lease directory is unsafe")
+            os.fchmod(descriptor, 0o700)
+            if os.fstat(descriptor).st_mode & 0o777 != 0o700:
+                raise BindingEffectLeaseError("binding effect lease directory is unsafe")
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     @staticmethod
     def _open_private_lease_lock(path: Path) -> int:

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -386,7 +386,6 @@ class BindingEffectLeaseManager:
                                     activity_descriptor,
                                     os.getpid(),
                                 )
-                                activity_descriptor = None
                                 pending = None
                                 break
                 if deadline is not None and time.monotonic() >= deadline:
@@ -409,7 +408,9 @@ class BindingEffectLeaseManager:
                     )
             finally:
                 try:
-                    if activity_descriptor is not None:
+                    if activity_descriptor is not None and (
+                        held is None or held.owner_pid == os.getpid()
+                    ):
                         self._close_holder_activity(activity_descriptor)
                 finally:
                     if descriptor is not None and held is None:
@@ -454,13 +455,7 @@ class BindingEffectLeaseManager:
             try:
                 fcntl.flock(held.gate_descriptor, fcntl.LOCK_UN)
             finally:
-                try:
-                    _close_lease_descriptor(held.gate_descriptor)
-                finally:
-                    try:
-                        fcntl.flock(held.activity_descriptor, fcntl.LOCK_UN)
-                    finally:
-                        self._close_holder_activity(held.activity_descriptor)
+                _close_lease_descriptor(held.gate_descriptor)
 
     def _discard_pending(
         self,

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -175,7 +175,8 @@ class _HeldLease:
     vault_binding_id: str
     holder_id: str
     mode: str
-    descriptor: int
+    gate_descriptor: int
+    activity_descriptor: int
     owner_pid: int
 
 
@@ -271,7 +272,7 @@ class BindingEffectLeaseManager:
         self._ensure_state_root()
         holder_id = ""
         pending: _HolderState | None = None
-        pending_descriptor: int | None = None
+        activity_descriptor: int | None = None
         descriptor: int | None = None
         held: _HeldLease | None = None
         try:
@@ -284,12 +285,12 @@ class BindingEffectLeaseManager:
                 ):
                     with self._state_locked(vault_binding_id):
                         current = self._load_reconciled_locked(vault_binding_id)
-                        pending_descriptor = self._open_pending_activity(
+                        activity_descriptor = self._open_holder_activity(
                             vault_binding_id, holder_id, create=True
                         )
                         try:
                             fcntl.flock(
-                                pending_descriptor,
+                                activity_descriptor,
                                 fcntl.LOCK_EX | fcntl.LOCK_NB,
                             )
                         except BlockingIOError as exc:
@@ -333,6 +334,21 @@ class BindingEffectLeaseManager:
                             except BlockingIOError:
                                 pass
                             else:
+                                if activity_descriptor is None:
+                                    activity_descriptor = self._open_holder_activity(
+                                        vault_binding_id,
+                                        holder_id,
+                                        create=True,
+                                    )
+                                    try:
+                                        fcntl.flock(
+                                            activity_descriptor,
+                                            fcntl.LOCK_EX | fcntl.LOCK_NB,
+                                        )
+                                    except BlockingIOError as exc:
+                                        raise BindingEffectLeaseError(
+                                            "effect holder activity identity is already locked"
+                                        ) from exc
                                 holder = self._holder(
                                     holder_id,
                                     ticket=(
@@ -353,29 +369,25 @@ class BindingEffectLeaseManager:
                                         if item["holderId"] != holder_id
                                     ]
                                     updated["exclusiveHolder"] = holder
-                                    if pending_descriptor is None:
+                                    if activity_descriptor is None:
                                         raise BindingEffectLeaseError(
                                             "exclusive waiter activity identity is missing"
                                         )
-                                    self._unlink_pending_activity_locked(
-                                        vault_binding_id,
-                                        holder_id,
-                                        pending_descriptor,
-                                    )
                                 self._commit_locked(vault_binding_id, current, updated)
-                                if pending_descriptor is not None:
-                                    self._close_pending_activity(
-                                        pending_descriptor,
+                                if activity_descriptor is None:
+                                    raise BindingEffectLeaseError(
+                                        "effect holder activity identity is missing"
                                     )
-                                    pending_descriptor = None
-                                    pending = None
                                 held = _HeldLease(
                                     vault_binding_id,
                                     holder_id,
                                     mode,
                                     descriptor,
+                                    activity_descriptor,
                                     os.getpid(),
                                 )
+                                activity_descriptor = None
+                                pending = None
                                 break
                 if deadline is not None and time.monotonic() >= deadline:
                     raise BindingEffectLeaseTimeout(
@@ -393,14 +405,12 @@ class BindingEffectLeaseManager:
                     self._discard_pending(
                         vault_binding_id,
                         holder_id,
-                        pending_descriptor,
+                        activity_descriptor,
                     )
             finally:
                 try:
-                    if pending_descriptor is not None:
-                        self._close_pending_activity(
-                            pending_descriptor,
-                        )
+                    if activity_descriptor is not None:
+                        self._close_holder_activity(activity_descriptor)
                 finally:
                     if descriptor is not None and held is None:
                         try:
@@ -435,17 +445,28 @@ class BindingEffectLeaseManager:
                 if not found:
                     raise BindingEffectLeaseError("held binding effect lease state is missing")
                 self._commit_locked(held.vault_binding_id, current, updated)
+                self._unlink_holder_activity_locked(
+                    held.vault_binding_id,
+                    held.holder_id,
+                    held.activity_descriptor,
+                )
         finally:
             try:
-                fcntl.flock(held.descriptor, fcntl.LOCK_UN)
+                fcntl.flock(held.gate_descriptor, fcntl.LOCK_UN)
             finally:
-                _close_lease_descriptor(held.descriptor)
+                try:
+                    _close_lease_descriptor(held.gate_descriptor)
+                finally:
+                    try:
+                        fcntl.flock(held.activity_descriptor, fcntl.LOCK_UN)
+                    finally:
+                        self._close_holder_activity(held.activity_descriptor)
 
     def _discard_pending(
         self,
         vault_binding_id: str,
         holder_id: str,
-        pending_descriptor: int | None,
+        activity_descriptor: int | None,
     ) -> None:
         with self._state_locked(vault_binding_id):
             current = self._load_reconciled_locked(vault_binding_id)
@@ -454,14 +475,14 @@ class BindingEffectLeaseManager:
                 item for item in updated["exclusivePending"] if item["holderId"] != holder_id
             ]
             if updated != current:
-                if pending_descriptor is None:
+                if activity_descriptor is None:
                     raise BindingEffectLeaseError("exclusive waiter activity identity is missing")
-                self._unlink_pending_activity_locked(
+                self._commit_locked(vault_binding_id, current, updated)
+                self._unlink_holder_activity_locked(
                     vault_binding_id,
                     holder_id,
-                    pending_descriptor,
+                    activity_descriptor,
                 )
-                self._commit_locked(vault_binding_id, current, updated)
 
     @contextmanager
     def _state_locked(self, vault_binding_id: str) -> Iterator[None]:
@@ -483,15 +504,19 @@ class BindingEffectLeaseManager:
         state = self._load_state_locked(vault_binding_id)
         updated = copy.deepcopy(state)
         referenced_activity = {
-            self._pending_activity_path(vault_binding_id, item["holderId"])
-            for item in state["exclusivePending"]
+            self._holder_activity_path(vault_binding_id, item["holderId"])
+            for item in (
+                state["sharedHolders"]
+                + state["exclusivePending"]
+                + ([state["exclusiveHolder"]] if state["exclusiveHolder"] is not None else [])
+            )
         }
-        self._scavenge_pending_activity_locked(vault_binding_id, referenced_activity)
+        self._scavenge_holder_activity_locked(vault_binding_id, referenced_activity)
         pending: list[_HolderState] = []
         abandoned: list[tuple[_HolderState, int | None]] = []
         try:
             for item in state["exclusivePending"]:
-                if self._pending_waiter_active(
+                if self._holder_activity_active(
                     vault_binding_id,
                     item,
                     abandoned,
@@ -504,11 +529,21 @@ class BindingEffectLeaseManager:
                 try:
                     fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except BlockingIOError:
-                    updated["sharedHolders"] = [
-                        item for item in state["sharedHolders"] if self._holder_alive(item)
-                    ]
+                    shared: list[_HolderState] = []
+                    for item in state["sharedHolders"]:
+                        if self._holder_activity_active(
+                            vault_binding_id,
+                            item,
+                            abandoned,
+                        ):
+                            shared.append(item)
+                    updated["sharedHolders"] = shared
                     holder = state["exclusiveHolder"]
-                    if holder is not None and not self._holder_alive(holder):
+                    if holder is not None and not self._holder_activity_active(
+                        vault_binding_id,
+                        holder,
+                        abandoned,
+                    ):
                         updated["exclusiveHolder"] = None
                 else:
                     updated["sharedHolders"] = []
@@ -518,19 +553,27 @@ class BindingEffectLeaseManager:
                 if gate is not None:
                     _close_lease_descriptor(gate)
             if updated != state:
+                committed = self._commit_locked(vault_binding_id, state, updated)
                 for item, descriptor in abandoned:
                     if descriptor is not None:
-                        self._unlink_pending_activity_locked(
+                        self._unlink_holder_activity_locked(
                             vault_binding_id,
                             item["holderId"],
                             descriptor,
                         )
-                committed = self._commit_locked(vault_binding_id, state, updated)
-                self._scavenge_pending_activity_locked(
+                self._scavenge_holder_activity_locked(
                     vault_binding_id,
                     {
-                        self._pending_activity_path(vault_binding_id, item["holderId"])
-                        for item in committed["exclusivePending"]
+                        self._holder_activity_path(vault_binding_id, item["holderId"])
+                        for item in (
+                            committed["sharedHolders"]
+                            + committed["exclusivePending"]
+                            + (
+                                [committed["exclusiveHolder"]]
+                                if committed["exclusiveHolder"] is not None
+                                else []
+                            )
+                        )
                     },
                 )
                 return committed
@@ -538,7 +581,7 @@ class BindingEffectLeaseManager:
         finally:
             for _, descriptor in abandoned:
                 if descriptor is not None:
-                    self._close_pending_activity(descriptor)
+                    self._close_holder_activity(descriptor)
 
     def _load_state_locked(self, vault_binding_id: str) -> _LeaseState:
         path = self._state_path(vault_binding_id)
@@ -674,22 +717,19 @@ class BindingEffectLeaseManager:
         start, state = self._process_identity(pid)
         return state != "Z" and str(holder.get("processStart") or "") == start
 
-    def _pending_waiter_active(
+    def _holder_activity_active(
         self,
         vault_binding_id: str,
         holder: _HolderState,
         abandoned: list[tuple[_HolderState, int | None]],
     ) -> bool:
-        """Require both a live process incarnation and an active waiter lock."""
+        """Use the cross-namespace activity lock as holder liveness authority."""
 
         holder_id = str(holder.get("holderId") or "")
-        if not self._holder_alive(holder):
-            abandoned.append((holder, None))
-            return False
         descriptor: int | None = None
         try:
             try:
-                descriptor = self._open_pending_activity(vault_binding_id, holder_id, create=False)
+                descriptor = self._open_holder_activity(vault_binding_id, holder_id, create=False)
             except FileNotFoundError:
                 abandoned.append((holder, None))
                 return False
@@ -703,21 +743,21 @@ class BindingEffectLeaseManager:
             if descriptor is not None and not any(
                 owned_descriptor == descriptor for _, owned_descriptor in abandoned
             ):
-                self._close_pending_activity(descriptor)
+                self._close_holder_activity(descriptor)
 
-    def _open_pending_activity(
+    def _open_holder_activity(
         self,
         vault_binding_id: str,
         holder_id: str,
         *,
         create: bool,
     ) -> int:
-        return self._open_pending_activity_path(
-            self._pending_activity_path(vault_binding_id, holder_id),
+        return self._open_holder_activity_path(
+            self._holder_activity_path(vault_binding_id, holder_id),
             create=create,
         )
 
-    def _open_pending_activity_path(self, path: Path, *, create: bool = False) -> int:
+    def _open_holder_activity_path(self, path: Path, *, create: bool = False) -> int:
         flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
         if create:
             flags |= os.O_CREAT | os.O_EXCL
@@ -732,7 +772,7 @@ class BindingEffectLeaseManager:
                 or metadata.st_uid != os.geteuid()
                 or metadata.st_mode & 0o777 != 0o600
             ):
-                raise BindingEffectLeaseError("exclusive waiter activity file is unsafe")
+                raise BindingEffectLeaseError("effect holder activity file is unsafe")
             return descriptor
         except BaseException:
             if descriptor is not None:
@@ -740,30 +780,30 @@ class BindingEffectLeaseManager:
             raise
 
     @staticmethod
-    def _close_pending_activity(descriptor: int) -> None:
+    def _close_holder_activity(descriptor: int) -> None:
         _close_lease_descriptor(descriptor)
 
-    def _unlink_pending_activity_locked(
+    def _unlink_holder_activity_locked(
         self,
         vault_binding_id: str,
         holder_id: str,
         descriptor: int,
     ) -> None:
-        self._unlink_pending_activity_path_locked(
-            self._pending_activity_path(vault_binding_id, holder_id),
+        self._unlink_holder_activity_path_locked(
+            self._holder_activity_path(vault_binding_id, holder_id),
             descriptor,
         )
 
-    def _scavenge_pending_activity_locked(
+    def _scavenge_holder_activity_locked(
         self,
         vault_binding_id: str,
         referenced: set[Path],
     ) -> None:
         stem = self._binding_stem(vault_binding_id)
-        for path in self.state_root.glob(f"{stem}.*.pending.lock"):
+        for path in self.state_root.glob(f"{stem}.*.activity.lock"):
             if path in referenced:
                 continue
-            suffix = path.name.removeprefix(f"{stem}.").removesuffix(".pending.lock")
+            suffix = path.name.removeprefix(f"{stem}.").removesuffix(".activity.lock")
             if len(suffix) != 64 or any(
                 character not in "0123456789abcdef" for character in suffix
             ):
@@ -771,19 +811,19 @@ class BindingEffectLeaseManager:
             descriptor: int | None = None
             try:
                 try:
-                    descriptor = self._open_pending_activity_path(path)
+                    descriptor = self._open_holder_activity_path(path)
                 except FileNotFoundError:
                     continue
                 try:
                     fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except BlockingIOError:
                     continue
-                self._unlink_pending_activity_path_locked(path, descriptor)
+                self._unlink_holder_activity_path_locked(path, descriptor)
             finally:
                 if descriptor is not None:
-                    self._close_pending_activity(descriptor)
+                    self._close_holder_activity(descriptor)
 
-    def _unlink_pending_activity_path_locked(self, path: Path, descriptor: int) -> None:
+    def _unlink_holder_activity_path_locked(self, path: Path, descriptor: int) -> None:
         try:
             path_metadata = path.stat(follow_symlinks=False)
         except FileNotFoundError:
@@ -1047,10 +1087,10 @@ class BindingEffectLeaseManager:
     def _gate_path(self, vault_binding_id: str) -> Path:
         return self.state_root / f"{self._binding_stem(vault_binding_id)}.effect.lock"
 
-    def _pending_activity_path(self, vault_binding_id: str, holder_id: str) -> Path:
+    def _holder_activity_path(self, vault_binding_id: str, holder_id: str) -> Path:
         binding_stem = self._binding_stem(vault_binding_id)
         holder_stem = hashlib.sha256(holder_id.encode("utf-8")).hexdigest()
-        return self.state_root / f"{binding_stem}.{holder_stem}.pending.lock"
+        return self.state_root / f"{binding_stem}.{holder_stem}.activity.lock"
 
     def _atomic_private_json(self, path: Path, value: Mapping[str, object]) -> None:
         payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -489,33 +489,33 @@ class BindingEffectLeaseManager:
         self._scavenge_pending_activity_locked(vault_binding_id, referenced_activity)
         pending: list[_HolderState] = []
         abandoned: list[tuple[_HolderState, int | None]] = []
-        for item in state["exclusivePending"]:
-            active, descriptor = self._pending_waiter_status(vault_binding_id, item)
-            if active:
-                pending.append(item)
-            else:
-                abandoned.append((item, descriptor))
-        updated["exclusivePending"] = pending
-        gate: int | None = None
         try:
-            gate = self._open_private_lease_lock(self._gate_path(vault_binding_id))
+            for item in state["exclusivePending"]:
+                active, descriptor = self._pending_waiter_status(vault_binding_id, item)
+                if active:
+                    pending.append(item)
+                else:
+                    abandoned.append((item, descriptor))
+            updated["exclusivePending"] = pending
+            gate: int | None = None
             try:
-                fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
-                updated["sharedHolders"] = [
-                    item for item in state["sharedHolders"] if self._holder_alive(item)
-                ]
-                holder = state["exclusiveHolder"]
-                if holder is not None and not self._holder_alive(holder):
+                gate = self._open_private_lease_lock(self._gate_path(vault_binding_id))
+                try:
+                    fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    updated["sharedHolders"] = [
+                        item for item in state["sharedHolders"] if self._holder_alive(item)
+                    ]
+                    holder = state["exclusiveHolder"]
+                    if holder is not None and not self._holder_alive(holder):
+                        updated["exclusiveHolder"] = None
+                else:
+                    updated["sharedHolders"] = []
                     updated["exclusiveHolder"] = None
-            else:
-                updated["sharedHolders"] = []
-                updated["exclusiveHolder"] = None
-                fcntl.flock(gate, fcntl.LOCK_UN)
-        finally:
-            if gate is not None:
-                _close_lease_descriptor(gate)
-        try:
+                    fcntl.flock(gate, fcntl.LOCK_UN)
+            finally:
+                if gate is not None:
+                    _close_lease_descriptor(gate)
             if updated != state:
                 for item, descriptor in abandoned:
                     if descriptor is not None:

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -542,11 +542,10 @@ class BindingEffectLeaseManager:
 
     def _load_state_locked(self, vault_binding_id: str) -> _LeaseState:
         path = self._state_path(vault_binding_id)
-        if path.exists():
-            self._assert_private_file(path)
+        if os.path.lexists(path):
             try:
-                value = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError) as exc:
+                value = json.loads(self._read_private_text(path))
+            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
                 raise BindingEffectLeaseError("binding effect lease state is corrupt") from exc
             local_state = self._validate_state(vault_binding_id, value)
             registry_state = self._registry_state(vault_binding_id)
@@ -606,11 +605,10 @@ class BindingEffectLeaseManager:
 
     def _recover_journal_locked(self, vault_binding_id: str) -> None:
         path = self._journal_path(vault_binding_id)
-        if not path.exists():
+        if not os.path.lexists(path):
             return
-        self._assert_private_file(path)
         try:
-            value = json.loads(path.read_text(encoding="utf-8"))
+            value = json.loads(self._read_private_text(path))
             if (
                 not isinstance(value, dict)
                 or value.get("schema") != JOURNAL_SCHEMA
@@ -619,7 +617,14 @@ class BindingEffectLeaseManager:
                 raise ValueError
             previous = self._validate_state(vault_binding_id, value["previous"])
             next_state = self._validate_state(vault_binding_id, value["next"])
-        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        except (
+            OSError,
+            UnicodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as exc:
             raise BindingEffectLeaseError("binding effect lease journal is invalid") from exc
         registry_state = self._registry_state(vault_binding_id)
         if registry_state == next_state:
@@ -996,14 +1001,36 @@ class BindingEffectLeaseManager:
             raise
 
     @staticmethod
-    def _assert_private_file(path: Path) -> None:
-        metadata = path.stat()
-        if (
-            not stat.S_ISREG(metadata.st_mode)
-            or metadata.st_uid != os.geteuid()
-            or metadata.st_mode & 0o777 != 0o600
-        ):
-            raise BindingEffectLeaseError(f"binding effect lease file is unsafe: {path.name}")
+    def _read_private_text(path: Path) -> str:
+        nofollow = getattr(os, "O_NOFOLLOW", None)
+        if nofollow is None:
+            raise BindingEffectLeaseError(
+                f"binding effect lease file cannot be opened safely: {path.name}"
+            )
+        descriptor: int | None = None
+        try:
+            try:
+                descriptor = os.open(
+                    path,
+                    os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0),
+                )
+            except OSError as exc:
+                raise BindingEffectLeaseError(
+                    f"binding effect lease file is unsafe: {path.name}"
+                ) from exc
+            os.set_inheritable(descriptor, False)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_mode & 0o777 != 0o600
+            ):
+                raise BindingEffectLeaseError(f"binding effect lease file is unsafe: {path.name}")
+            with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as handle:
+                return handle.read()
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     def _binding_stem(self, vault_binding_id: str) -> str:
         return hashlib.sha256(vault_binding_id.encode("utf-8")).hexdigest()

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -26,6 +27,38 @@ from app.instance.vault_registry import VaultRegistryStore
 
 LEASE_SCHEMA = "agentic-pkm.binding-effect-lease.v1"
 JOURNAL_SCHEMA = "agentic-pkm.binding-effect-lease-journal.v1"
+
+
+_PENDING_ACTIVITY_FDS: set[int] = set()
+_PENDING_ACTIVITY_FDS_LOCK = threading.Lock()
+
+
+def _pending_activity_before_fork() -> None:
+    _PENDING_ACTIVITY_FDS_LOCK.acquire()
+
+
+def _pending_activity_after_fork_parent() -> None:
+    _PENDING_ACTIVITY_FDS_LOCK.release()
+
+
+def _pending_activity_after_fork_child() -> None:
+    try:
+        for descriptor in _PENDING_ACTIVITY_FDS:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        _PENDING_ACTIVITY_FDS.clear()
+    finally:
+        _PENDING_ACTIVITY_FDS_LOCK.release()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        before=_pending_activity_before_fork,
+        after_in_parent=_pending_activity_after_fork_parent,
+        after_in_child=_pending_activity_after_fork_child,
+    )
 
 
 class _DarwinProcBsdInfo(ctypes.Structure):
@@ -226,6 +259,7 @@ class BindingEffectLeaseManager:
         holder_id = f"holder-{uuid4()}"
         deadline = None if timeout is None else time.monotonic() + timeout
         pending: _HolderState | None = None
+        pending_descriptor: int | None = None
         try:
             if mode == "exclusive":
                 with self.ownership_ledger.active_binding_fence(
@@ -233,6 +267,18 @@ class BindingEffectLeaseManager:
                 ):
                     with self._state_locked(vault_binding_id):
                         current = self._load_reconciled_locked(vault_binding_id)
+                        pending_descriptor = self._open_pending_activity(
+                            vault_binding_id, holder_id, create=True
+                        )
+                        try:
+                            fcntl.flock(
+                                pending_descriptor,
+                                fcntl.LOCK_EX | fcntl.LOCK_NB,
+                            )
+                        except BlockingIOError as exc:
+                            raise BindingEffectLeaseError(
+                                "exclusive waiter activity identity is already locked"
+                            ) from exc
                         pending = self._holder(
                             holder_id,
                             ticket=int(current["nextTicket"]),
@@ -290,7 +336,22 @@ class BindingEffectLeaseManager:
                                         if item["holderId"] != holder_id
                                     ]
                                     updated["exclusiveHolder"] = holder
+                                    if pending_descriptor is None:
+                                        raise BindingEffectLeaseError(
+                                            "exclusive waiter activity identity is missing"
+                                        )
+                                    self._unlink_pending_activity_locked(
+                                        vault_binding_id,
+                                        holder_id,
+                                        pending_descriptor,
+                                    )
                                 self._commit_locked(vault_binding_id, current, updated)
+                                if pending_descriptor is not None:
+                                    self._close_pending_activity(
+                                        pending_descriptor,
+                                    )
+                                    pending_descriptor = None
+                                    pending = None
                                 return _HeldLease(vault_binding_id, holder_id, mode, descriptor)
                 if deadline is not None and time.monotonic() >= deadline:
                     raise BindingEffectLeaseTimeout(
@@ -298,12 +359,24 @@ class BindingEffectLeaseManager:
                     )
                 time.sleep(self.poll_interval)
         except BaseException:
-            if pending is not None:
-                self._discard_pending(vault_binding_id, holder_id)
             try:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                if pending is not None:
+                    self._discard_pending(
+                        vault_binding_id,
+                        holder_id,
+                        pending_descriptor,
+                    )
             finally:
-                os.close(descriptor)
+                try:
+                    if pending_descriptor is not None:
+                        self._close_pending_activity(
+                            pending_descriptor,
+                        )
+                finally:
+                    try:
+                        fcntl.flock(descriptor, fcntl.LOCK_UN)
+                    finally:
+                        os.close(descriptor)
             raise
 
     def _release(self, held: _HeldLease) -> None:
@@ -335,7 +408,12 @@ class BindingEffectLeaseManager:
             finally:
                 os.close(held.descriptor)
 
-    def _discard_pending(self, vault_binding_id: str, holder_id: str) -> None:
+    def _discard_pending(
+        self,
+        vault_binding_id: str,
+        holder_id: str,
+        pending_descriptor: int | None,
+    ) -> None:
         with self._state_locked(vault_binding_id):
             current = self._load_reconciled_locked(vault_binding_id)
             updated = copy.deepcopy(current)
@@ -343,6 +421,13 @@ class BindingEffectLeaseManager:
                 item for item in updated["exclusivePending"] if item["holderId"] != holder_id
             ]
             if updated != current:
+                if pending_descriptor is None:
+                    raise BindingEffectLeaseError("exclusive waiter activity identity is missing")
+                self._unlink_pending_activity_locked(
+                    vault_binding_id,
+                    holder_id,
+                    pending_descriptor,
+                )
                 self._commit_locked(vault_binding_id, current, updated)
 
     @contextmanager
@@ -365,9 +450,20 @@ class BindingEffectLeaseManager:
     def _load_reconciled_locked(self, vault_binding_id: str) -> _LeaseState:
         state = self._load_state_locked(vault_binding_id)
         updated = copy.deepcopy(state)
-        updated["exclusivePending"] = [
-            item for item in state["exclusivePending"] if self._holder_alive(item)
-        ]
+        referenced_activity = {
+            self._pending_activity_path(vault_binding_id, item["holderId"])
+            for item in state["exclusivePending"]
+        }
+        self._scavenge_pending_activity_locked(vault_binding_id, referenced_activity)
+        pending: list[_HolderState] = []
+        abandoned: list[tuple[_HolderState, int | None]] = []
+        for item in state["exclusivePending"]:
+            active, descriptor = self._pending_waiter_status(vault_binding_id, item)
+            if active:
+                pending.append(item)
+            else:
+                abandoned.append((item, descriptor))
+        updated["exclusivePending"] = pending
         gate = os.open(
             self._gate_path(vault_binding_id),
             os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
@@ -390,9 +486,29 @@ class BindingEffectLeaseManager:
                 fcntl.flock(gate, fcntl.LOCK_UN)
         finally:
             os.close(gate)
-        if updated != state:
-            return self._commit_locked(vault_binding_id, state, updated)
-        return state
+        try:
+            if updated != state:
+                for item, descriptor in abandoned:
+                    if descriptor is not None:
+                        self._unlink_pending_activity_locked(
+                            vault_binding_id,
+                            item["holderId"],
+                            descriptor,
+                        )
+                committed = self._commit_locked(vault_binding_id, state, updated)
+                self._scavenge_pending_activity_locked(
+                    vault_binding_id,
+                    {
+                        self._pending_activity_path(vault_binding_id, item["holderId"])
+                        for item in committed["exclusivePending"]
+                    },
+                )
+                return committed
+            return state
+        finally:
+            for _, descriptor in abandoned:
+                if descriptor is not None:
+                    self._close_pending_activity(descriptor)
 
     def _load_state_locked(self, vault_binding_id: str) -> _LeaseState:
         path = self._state_path(vault_binding_id)
@@ -522,6 +638,124 @@ class BindingEffectLeaseManager:
             pass
         start, state = self._process_identity(pid)
         return state != "Z" and str(holder.get("processStart") or "") == start
+
+    def _pending_waiter_status(
+        self,
+        vault_binding_id: str,
+        holder: Mapping[str, object],
+    ) -> tuple[bool, int | None]:
+        """Require both a live process incarnation and an active waiter lock."""
+
+        holder_id = str(holder.get("holderId") or "")
+        if not self._holder_alive(holder):
+            return False, None
+        try:
+            descriptor = self._open_pending_activity(vault_binding_id, holder_id, create=False)
+        except FileNotFoundError:
+            return False, None
+        try:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                self._close_pending_activity(descriptor)
+                return True, None
+            return False, descriptor
+        except BaseException:
+            self._close_pending_activity(descriptor)
+            raise
+
+    def _open_pending_activity(
+        self,
+        vault_binding_id: str,
+        holder_id: str,
+        *,
+        create: bool,
+    ) -> int:
+        return self._open_pending_activity_path(
+            self._pending_activity_path(vault_binding_id, holder_id),
+            create=create,
+        )
+
+    def _open_pending_activity_path(self, path: Path, *, create: bool = False) -> int:
+        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        if create:
+            flags |= os.O_CREAT | os.O_EXCL
+        with _PENDING_ACTIVITY_FDS_LOCK:
+            descriptor = os.open(path, flags, 0o600)
+            try:
+                os.set_inheritable(descriptor, False)
+                if create:
+                    os.fchmod(descriptor, 0o600)
+                metadata = os.fstat(descriptor)
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or metadata.st_uid != os.geteuid()
+                    or metadata.st_mode & 0o777 != 0o600
+                ):
+                    raise BindingEffectLeaseError("exclusive waiter activity file is unsafe")
+                _PENDING_ACTIVITY_FDS.add(descriptor)
+                return descriptor
+            except BaseException:
+                os.close(descriptor)
+                raise
+
+    @staticmethod
+    def _close_pending_activity(descriptor: int) -> None:
+        with _PENDING_ACTIVITY_FDS_LOCK:
+            _PENDING_ACTIVITY_FDS.discard(descriptor)
+            os.close(descriptor)
+
+    def _unlink_pending_activity_locked(
+        self,
+        vault_binding_id: str,
+        holder_id: str,
+        descriptor: int,
+    ) -> None:
+        self._unlink_pending_activity_path_locked(
+            self._pending_activity_path(vault_binding_id, holder_id),
+            descriptor,
+        )
+
+    def _scavenge_pending_activity_locked(
+        self,
+        vault_binding_id: str,
+        referenced: set[Path],
+    ) -> None:
+        stem = self._binding_stem(vault_binding_id)
+        for path in self.state_root.glob(f"{stem}.*.pending.lock"):
+            if path in referenced:
+                continue
+            suffix = path.name.removeprefix(f"{stem}.").removesuffix(".pending.lock")
+            if len(suffix) != 64 or any(
+                character not in "0123456789abcdef" for character in suffix
+            ):
+                raise BindingEffectLeaseError("exclusive waiter activity filename is invalid")
+            try:
+                descriptor = self._open_pending_activity_path(path)
+            except FileNotFoundError:
+                continue
+            try:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    continue
+                self._unlink_pending_activity_path_locked(path, descriptor)
+            finally:
+                self._close_pending_activity(descriptor)
+
+    def _unlink_pending_activity_path_locked(self, path: Path, descriptor: int) -> None:
+        try:
+            path_metadata = path.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        descriptor_metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(path_metadata.st_mode) or (
+            path_metadata.st_dev,
+            path_metadata.st_ino,
+        ) != (descriptor_metadata.st_dev, descriptor_metadata.st_ino):
+            raise BindingEffectLeaseError("exclusive waiter activity path identity changed")
+        path.unlink()
+        self._fsync_directory(self.state_root)
 
     @staticmethod
     def _process_start(pid: int) -> str:
@@ -732,6 +966,11 @@ class BindingEffectLeaseManager:
 
     def _gate_path(self, vault_binding_id: str) -> Path:
         return self.state_root / f"{self._binding_stem(vault_binding_id)}.effect.lock"
+
+    def _pending_activity_path(self, vault_binding_id: str, holder_id: str) -> Path:
+        binding_stem = self._binding_stem(vault_binding_id)
+        holder_stem = hashlib.sha256(holder_id.encode("utf-8")).hexdigest()
+        return self.state_root / f"{binding_stem}.{holder_stem}.pending.lock"
 
     def _atomic_private_json(self, path: Path, value: Mapping[str, object]) -> None:
         payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -413,7 +413,7 @@ class BindingEffectLeaseManager:
                     ):
                         self._close_holder_activity(activity_descriptor)
                 finally:
-                    if descriptor is not None and held is None:
+                    if descriptor is not None and (held is None or held.owner_pid == os.getpid()):
                         try:
                             fcntl.flock(descriptor, fcntl.LOCK_UN)
                         finally:
@@ -424,38 +424,30 @@ class BindingEffectLeaseManager:
             raise BindingEffectLeaseError(
                 "a fork child cannot release its parent's binding effect lease"
             )
-        try:
-            with self._state_locked(held.vault_binding_id):
-                current = self._load_reconciled_locked(held.vault_binding_id)
-                updated = copy.deepcopy(current)
-                if held.mode == "shared":
-                    before = len(updated["sharedHolders"])
-                    updated["sharedHolders"] = [
-                        item
-                        for item in updated["sharedHolders"]
-                        if item["holderId"] != held.holder_id
-                    ]
-                    found = len(updated["sharedHolders"]) != before
-                else:
-                    found = bool(
-                        updated["exclusiveHolder"]
-                        and updated["exclusiveHolder"]["holderId"] == held.holder_id
-                    )
-                    if found:
-                        updated["exclusiveHolder"] = None
-                if not found:
-                    raise BindingEffectLeaseError("held binding effect lease state is missing")
-                self._commit_locked(held.vault_binding_id, current, updated)
-                self._unlink_holder_activity_locked(
-                    held.vault_binding_id,
-                    held.holder_id,
-                    held.activity_descriptor,
+        with self._state_locked(held.vault_binding_id):
+            current = self._load_reconciled_locked(held.vault_binding_id)
+            updated = copy.deepcopy(current)
+            if held.mode == "shared":
+                before = len(updated["sharedHolders"])
+                updated["sharedHolders"] = [
+                    item for item in updated["sharedHolders"] if item["holderId"] != held.holder_id
+                ]
+                found = len(updated["sharedHolders"]) != before
+            else:
+                found = bool(
+                    updated["exclusiveHolder"]
+                    and updated["exclusiveHolder"]["holderId"] == held.holder_id
                 )
-        finally:
-            try:
-                fcntl.flock(held.gate_descriptor, fcntl.LOCK_UN)
-            finally:
-                _close_lease_descriptor(held.gate_descriptor)
+                if found:
+                    updated["exclusiveHolder"] = None
+            if not found:
+                raise BindingEffectLeaseError("held binding effect lease state is missing")
+            self._commit_locked(held.vault_binding_id, current, updated)
+            self._unlink_holder_activity_locked(
+                held.vault_binding_id,
+                held.holder_id,
+                held.activity_descriptor,
+            )
 
     def _discard_pending(
         self,

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -355,17 +355,14 @@ class BindingEffectLeaseManager:
                 value = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as exc:
                 raise BindingEffectLeaseError("binding effect lease state is corrupt") from exc
-            return self._validate_state(vault_binding_id, value)
-        snapshot = self.registry_store.load()
-        raw_states = snapshot.extensions.get("bindingEffectLeases") or {}
-        if not isinstance(raw_states, Mapping):
-            raise BindingEffectLeaseError("registry binding effect lease state is invalid")
-        value = raw_states.get(vault_binding_id)
-        return (
-            self._empty_state(vault_binding_id)
-            if value is None
-            else self._validate_state(vault_binding_id, value)
-        )
+            local_state = self._validate_state(vault_binding_id, value)
+            registry_state = self._registry_state(vault_binding_id)
+            if local_state != registry_state:
+                raise BindingEffectLeaseError(
+                    "binding effect lease state diverges from registry without a journal"
+                )
+            return local_state
+        return self._registry_state(vault_binding_id)
 
     def _commit_locked(
         self,
@@ -393,10 +390,23 @@ class BindingEffectLeaseManager:
                 _capability=self.capability,
             )
         except Exception:
-            self._atomic_private_json(self._state_path(vault_binding_id), previous_state)
-            self._journal_path(vault_binding_id).unlink(missing_ok=True)
-            self._fsync_directory(self.state_root)
-            raise
+            try:
+                registry_state = self._registry_state(vault_binding_id)
+            except Exception:
+                raise
+            if registry_state == next_state:
+                self._atomic_private_json(self._state_path(vault_binding_id), next_state)
+                self._journal_path(vault_binding_id).unlink(missing_ok=True)
+                self._fsync_directory(self.state_root)
+                return next_state
+            if registry_state == previous_state:
+                self._atomic_private_json(self._state_path(vault_binding_id), previous_state)
+                self._journal_path(vault_binding_id).unlink(missing_ok=True)
+                self._fsync_directory(self.state_root)
+                raise
+            raise BindingEffectLeaseError(
+                "binding effect lease commit diverges from both journal endpoints"
+            )
         self._journal_path(vault_binding_id).unlink(missing_ok=True)
         self._fsync_directory(self.state_root)
         return next_state
@@ -418,16 +428,7 @@ class BindingEffectLeaseManager:
             next_state = self._validate_state(vault_binding_id, value["next"])
         except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
             raise BindingEffectLeaseError("binding effect lease journal is invalid") from exc
-        snapshot = self.registry_store.load()
-        states = snapshot.extensions.get("bindingEffectLeases") or {}
-        if not isinstance(states, Mapping):
-            raise BindingEffectLeaseError("registry binding effect lease state is invalid")
-        registry_state = states.get(vault_binding_id)
-        registry_state = (
-            self._empty_state(vault_binding_id)
-            if registry_state is None
-            else self._validate_state(vault_binding_id, registry_state)
-        )
+        registry_state = self._registry_state(vault_binding_id)
         if registry_state == next_state:
             recovered = next_state
         elif registry_state == previous:
@@ -439,6 +440,18 @@ class BindingEffectLeaseManager:
         self._atomic_private_json(self._state_path(vault_binding_id), recovered)
         path.unlink()
         self._fsync_directory(self.state_root)
+
+    def _registry_state(self, vault_binding_id: str) -> _LeaseState:
+        snapshot = self.registry_store.load()
+        states = snapshot.extensions.get("bindingEffectLeases") or {}
+        if not isinstance(states, Mapping):
+            raise BindingEffectLeaseError("registry binding effect lease state is invalid")
+        value = states.get(vault_binding_id)
+        return (
+            self._empty_state(vault_binding_id)
+            if value is None
+            else self._validate_state(vault_binding_id, value)
+        )
 
     def _holder(self, holder_id: str, *, ticket: int, mode: str) -> _HolderState:
         return {
@@ -460,33 +473,42 @@ class BindingEffectLeaseManager:
             return False
         except PermissionError:
             pass
-        return str(holder.get("processStart") or "") == self._process_start(pid)
+        start, state = self._process_identity(pid)
+        return state != "Z" and str(holder.get("processStart") or "") == start
 
     @staticmethod
     def _process_start(pid: int) -> str:
+        return BindingEffectLeaseManager._process_identity(pid)[0]
+
+    @staticmethod
+    def _process_identity(pid: int) -> tuple[str, str]:
         stat_path = Path(f"/proc/{pid}/stat")
         try:
-            fields = stat_path.read_text(encoding="utf-8").split()
-            return f"proc:{fields[21]}"
-        except (OSError, IndexError):
+            raw = stat_path.read_text(encoding="utf-8")
+            remainder = raw[raw.rindex(")") + 2 :].split()
+            return f"proc:{remainder[19]}", remainder[0]
+        except (OSError, IndexError, ValueError):
             try:
                 result = subprocess.run(
-                    ["ps", "-o", "lstart=", "-p", str(pid)],
+                    ["ps", "-o", "stat=", "-o", "lstart=", "-p", str(pid)],
                     check=True,
                     capture_output=True,
                     text=True,
                     timeout=1,
                 )
-                started = result.stdout.strip()
-                if started:
-                    return f"ps:{started}"
+                output = result.stdout.strip().split(maxsplit=1)
+                if len(output) == 2:
+                    return f"ps:{output[1]}", output[0][:1]
             except (OSError, subprocess.SubprocessError):
                 pass
             try:
                 boot = Path("/proc/sys/kernel/random/boot_id")
-                return f"pid:{pid}:boot:{boot.read_text(encoding='ascii').strip()}"
+                return (
+                    f"pid:{pid}:boot:{boot.read_text(encoding='ascii').strip()}",
+                    "?",
+                )
             except OSError:
-                return f"pid:{pid}"
+                return f"pid:{pid}", "?"
 
     @staticmethod
     def _empty_state(vault_binding_id: str) -> _LeaseState:

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -75,6 +75,7 @@ def _open_lease_descriptor(path: Path, flags: int, mode: int = 0o600) -> int:
             return descriptor
         except BaseException:
             if descriptor is not None:
+                _LEASE_LOCK_FDS.discard(descriptor)
                 os.close(descriptor)
             raise
 

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -63,17 +63,19 @@ if hasattr(os, "register_at_fork"):
 
 def _open_lease_descriptor(path: Path, flags: int, mode: int = 0o600) -> int:
     with _LEASE_LOCK_FDS_LOCK:
-        descriptor = os.open(
-            path,
-            flags | getattr(os, "O_CLOEXEC", 0),
-            mode,
-        )
+        descriptor: int | None = None
         try:
+            descriptor = os.open(
+                path,
+                flags | getattr(os, "O_CLOEXEC", 0),
+                mode,
+            )
             os.set_inheritable(descriptor, False)
             _LEASE_LOCK_FDS.add(descriptor)
             return descriptor
         except BaseException:
-            os.close(descriptor)
+            if descriptor is not None:
+                os.close(descriptor)
             raise
 
 
@@ -273,12 +275,14 @@ class BindingEffectLeaseManager:
         if not vault_binding_id.strip() or mode not in {"shared", "exclusive"}:
             raise BindingEffectLeaseError("binding and lease mode must be explicit")
         self._ensure_state_root()
-        descriptor = self._open_private_lease_lock(self._gate_path(vault_binding_id))
-        holder_id = f"holder-{uuid4()}"
-        deadline = None if timeout is None else time.monotonic() + timeout
+        holder_id = ""
         pending: _HolderState | None = None
         pending_descriptor: int | None = None
+        descriptor: int | None = None
         try:
+            descriptor = self._open_private_lease_lock(self._gate_path(vault_binding_id))
+            holder_id = f"holder-{uuid4()}"
+            deadline = None if timeout is None else time.monotonic() + timeout
             if mode == "exclusive":
                 with self.ownership_ledger.active_binding_fence(
                     vault_binding_id, channel_id=channel_id, root=root
@@ -397,10 +401,11 @@ class BindingEffectLeaseManager:
                             pending_descriptor,
                         )
                 finally:
-                    try:
-                        fcntl.flock(descriptor, fcntl.LOCK_UN)
-                    finally:
-                        _close_lease_descriptor(descriptor)
+                    if descriptor is not None:
+                        try:
+                            fcntl.flock(descriptor, fcntl.LOCK_UN)
+                        finally:
+                            _close_lease_descriptor(descriptor)
             raise
 
     def _release(self, held: _HeldLease) -> None:
@@ -461,15 +466,17 @@ class BindingEffectLeaseManager:
     @contextmanager
     def _state_locked(self, vault_binding_id: str) -> Iterator[None]:
         self._ensure_state_root()
-        descriptor = self._open_private_lease_lock(self._lock_path(vault_binding_id))
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        descriptor: int | None = None
         try:
-            self._recover_journal_locked(vault_binding_id)
-            yield
-        finally:
+            descriptor = self._open_private_lease_lock(self._lock_path(vault_binding_id))
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
             try:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                self._recover_journal_locked(vault_binding_id)
+                yield
             finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            if descriptor is not None:
                 _close_lease_descriptor(descriptor)
 
     def _load_reconciled_locked(self, vault_binding_id: str) -> _LeaseState:
@@ -489,8 +496,9 @@ class BindingEffectLeaseManager:
             else:
                 abandoned.append((item, descriptor))
         updated["exclusivePending"] = pending
-        gate = self._open_private_lease_lock(self._gate_path(vault_binding_id))
+        gate: int | None = None
         try:
+            gate = self._open_private_lease_lock(self._gate_path(vault_binding_id))
             try:
                 fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
@@ -505,7 +513,8 @@ class BindingEffectLeaseManager:
                 updated["exclusiveHolder"] = None
                 fcntl.flock(gate, fcntl.LOCK_UN)
         finally:
-            _close_lease_descriptor(gate)
+            if gate is not None:
+                _close_lease_descriptor(gate)
         try:
             if updated != state:
                 for item, descriptor in abandoned:
@@ -669,20 +678,22 @@ class BindingEffectLeaseManager:
         holder_id = str(holder.get("holderId") or "")
         if not self._holder_alive(holder):
             return False, None
+        descriptor: int | None = None
+        transfer_descriptor = False
         try:
-            descriptor = self._open_pending_activity(vault_binding_id, holder_id, create=False)
-        except FileNotFoundError:
-            return False, None
-        try:
+            try:
+                descriptor = self._open_pending_activity(vault_binding_id, holder_id, create=False)
+            except FileNotFoundError:
+                return False, None
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
-                self._close_pending_activity(descriptor)
                 return True, None
+            transfer_descriptor = True
             return False, descriptor
-        except BaseException:
-            self._close_pending_activity(descriptor)
-            raise
+        finally:
+            if descriptor is not None and not transfer_descriptor:
+                self._close_pending_activity(descriptor)
 
     def _open_pending_activity(
         self,
@@ -700,8 +711,9 @@ class BindingEffectLeaseManager:
         flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
         if create:
             flags |= os.O_CREAT | os.O_EXCL
-        descriptor = _open_lease_descriptor(path, flags)
+        descriptor: int | None = None
         try:
+            descriptor = _open_lease_descriptor(path, flags)
             if create:
                 os.fchmod(descriptor, 0o600)
             metadata = os.fstat(descriptor)
@@ -713,7 +725,8 @@ class BindingEffectLeaseManager:
                 raise BindingEffectLeaseError("exclusive waiter activity file is unsafe")
             return descriptor
         except BaseException:
-            _close_lease_descriptor(descriptor)
+            if descriptor is not None:
+                _close_lease_descriptor(descriptor)
             raise
 
     @staticmethod
@@ -745,18 +758,20 @@ class BindingEffectLeaseManager:
                 character not in "0123456789abcdef" for character in suffix
             ):
                 raise BindingEffectLeaseError("exclusive waiter activity filename is invalid")
+            descriptor: int | None = None
             try:
-                descriptor = self._open_pending_activity_path(path)
-            except FileNotFoundError:
-                continue
-            try:
+                try:
+                    descriptor = self._open_pending_activity_path(path)
+                except FileNotFoundError:
+                    continue
                 try:
                     fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except BlockingIOError:
                     continue
                 self._unlink_pending_activity_path_locked(path, descriptor)
             finally:
-                self._close_pending_activity(descriptor)
+                if descriptor is not None:
+                    self._close_pending_activity(descriptor)
 
     def _unlink_pending_activity_path_locked(self, path: Path, descriptor: int) -> None:
         try:
@@ -959,18 +974,20 @@ class BindingEffectLeaseManager:
 
     @staticmethod
     def _open_private_lease_lock(path: Path) -> int:
-        descriptor = _open_lease_descriptor(
-            path,
-            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
-        )
+        descriptor: int | None = None
         try:
+            descriptor = _open_lease_descriptor(
+                path,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            )
             os.fchmod(descriptor, 0o600)
             metadata = os.fstat(descriptor)
             if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.geteuid():
                 raise BindingEffectLeaseError(f"binding effect lease lock is unsafe: {path.name}")
             return descriptor
         except BaseException:
-            _close_lease_descriptor(descriptor)
+            if descriptor is not None:
+                _close_lease_descriptor(descriptor)
             raise
 
     @staticmethod

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -205,18 +205,14 @@ class BindingEffectLeaseManager:
         root: Path,
         timeout: float | None = None,
     ) -> Iterator[BindingEffectLeaseObservation]:
-        held = self._acquire(
+        with self._acquire(
             vault_binding_id,
             mode="shared",
             channel_id=channel_id,
             root=root,
             timeout=timeout,
-        )
-        try:
+        ):
             yield self.observe(vault_binding_id)
-        finally:
-            if held is not None:
-                self._release(held)
 
     @contextmanager
     def exclusive_change(
@@ -227,18 +223,14 @@ class BindingEffectLeaseManager:
         root: Path,
         timeout: float | None = None,
     ) -> Iterator[BindingEffectLeaseObservation]:
-        held = self._acquire(
+        with self._acquire(
             vault_binding_id,
             mode="exclusive",
             channel_id=channel_id,
             root=root,
             timeout=timeout,
-        )
-        try:
+        ):
             yield self.observe(vault_binding_id)
-        finally:
-            if held is not None:
-                self._release(held)
 
     def observe(self, vault_binding_id: str) -> BindingEffectLeaseObservation:
         with self._state_locked(vault_binding_id):
@@ -263,6 +255,7 @@ class BindingEffectLeaseManager:
             time.sleep(self.poll_interval)
         return False
 
+    @contextmanager
     def _acquire(
         self,
         vault_binding_id: str,
@@ -271,7 +264,7 @@ class BindingEffectLeaseManager:
         channel_id: str,
         root: Path,
         timeout: float | None,
-    ) -> _HeldLease:
+    ) -> Iterator[_HeldLease]:
         if not vault_binding_id.strip() or mode not in {"shared", "exclusive"}:
             raise BindingEffectLeaseError("binding and lease mode must be explicit")
         self._ensure_state_root()
@@ -279,6 +272,7 @@ class BindingEffectLeaseManager:
         pending: _HolderState | None = None
         pending_descriptor: int | None = None
         descriptor: int | None = None
+        held: _HeldLease | None = None
         try:
             descriptor = self._open_private_lease_lock(self._gate_path(vault_binding_id))
             holder_id = f"holder-{uuid4()}"
@@ -374,21 +368,27 @@ class BindingEffectLeaseManager:
                                     )
                                     pending_descriptor = None
                                     pending = None
-                                return _HeldLease(
+                                held = _HeldLease(
                                     vault_binding_id,
                                     holder_id,
                                     mode,
                                     descriptor,
                                     os.getpid(),
                                 )
+                                break
                 if deadline is not None and time.monotonic() >= deadline:
                     raise BindingEffectLeaseTimeout(
                         f"timed out waiting for {mode} binding effect lease"
                     )
                 time.sleep(self.poll_interval)
-        except BaseException:
+            if held is None:
+                raise BindingEffectLeaseError("binding effect acquisition ended without a holder")
+            yield held
+        finally:
             try:
-                if pending is not None:
+                if held is not None:
+                    self._release(held)
+                elif pending is not None:
                     self._discard_pending(
                         vault_binding_id,
                         holder_id,
@@ -401,12 +401,11 @@ class BindingEffectLeaseManager:
                             pending_descriptor,
                         )
                 finally:
-                    if descriptor is not None:
+                    if descriptor is not None and held is None:
                         try:
                             fcntl.flock(descriptor, fcntl.LOCK_UN)
                         finally:
                             _close_lease_descriptor(descriptor)
-            raise
 
     def _release(self, held: _HeldLease) -> None:
         if held.owner_pid != os.getpid():
@@ -491,11 +490,12 @@ class BindingEffectLeaseManager:
         abandoned: list[tuple[_HolderState, int | None]] = []
         try:
             for item in state["exclusivePending"]:
-                active, descriptor = self._pending_waiter_status(vault_binding_id, item)
-                if active:
+                if self._pending_waiter_active(
+                    vault_binding_id,
+                    item,
+                    abandoned,
+                ):
                     pending.append(item)
-                else:
-                    abandoned.append((item, descriptor))
             updated["exclusivePending"] = pending
             gate: int | None = None
             try:
@@ -668,31 +668,35 @@ class BindingEffectLeaseManager:
         start, state = self._process_identity(pid)
         return state != "Z" and str(holder.get("processStart") or "") == start
 
-    def _pending_waiter_status(
+    def _pending_waiter_active(
         self,
         vault_binding_id: str,
-        holder: Mapping[str, object],
-    ) -> tuple[bool, int | None]:
+        holder: _HolderState,
+        abandoned: list[tuple[_HolderState, int | None]],
+    ) -> bool:
         """Require both a live process incarnation and an active waiter lock."""
 
         holder_id = str(holder.get("holderId") or "")
         if not self._holder_alive(holder):
-            return False, None
+            abandoned.append((holder, None))
+            return False
         descriptor: int | None = None
-        transfer_descriptor = False
         try:
             try:
                 descriptor = self._open_pending_activity(vault_binding_id, holder_id, create=False)
             except FileNotFoundError:
-                return False, None
+                abandoned.append((holder, None))
+                return False
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
-                return True, None
-            transfer_descriptor = True
-            return False, descriptor
+                return True
+            abandoned.append((holder, descriptor))
+            return False
         finally:
-            if descriptor is not None and not transfer_descriptor:
+            if descriptor is not None and not any(
+                owned_descriptor == descriptor for _, owned_descriptor in abandoned
+            ):
                 self._close_pending_activity(descriptor)
 
     def _open_pending_activity(

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -29,36 +29,58 @@ LEASE_SCHEMA = "agentic-pkm.binding-effect-lease.v1"
 JOURNAL_SCHEMA = "agentic-pkm.binding-effect-lease-journal.v1"
 
 
-_PENDING_ACTIVITY_FDS: set[int] = set()
-_PENDING_ACTIVITY_FDS_LOCK = threading.Lock()
+_LEASE_LOCK_FDS: set[int] = set()
+_LEASE_LOCK_FDS_LOCK = threading.Lock()
 
 
-def _pending_activity_before_fork() -> None:
-    _PENDING_ACTIVITY_FDS_LOCK.acquire()
+def _lease_locks_before_fork() -> None:
+    _LEASE_LOCK_FDS_LOCK.acquire()
 
 
-def _pending_activity_after_fork_parent() -> None:
-    _PENDING_ACTIVITY_FDS_LOCK.release()
+def _lease_locks_after_fork_parent() -> None:
+    _LEASE_LOCK_FDS_LOCK.release()
 
 
-def _pending_activity_after_fork_child() -> None:
+def _lease_locks_after_fork_child() -> None:
     try:
-        for descriptor in _PENDING_ACTIVITY_FDS:
+        for descriptor in _LEASE_LOCK_FDS:
             try:
                 os.close(descriptor)
             except OSError:
                 pass
-        _PENDING_ACTIVITY_FDS.clear()
+        _LEASE_LOCK_FDS.clear()
     finally:
-        _PENDING_ACTIVITY_FDS_LOCK.release()
+        _LEASE_LOCK_FDS_LOCK.release()
 
 
 if hasattr(os, "register_at_fork"):
     os.register_at_fork(
-        before=_pending_activity_before_fork,
-        after_in_parent=_pending_activity_after_fork_parent,
-        after_in_child=_pending_activity_after_fork_child,
+        before=_lease_locks_before_fork,
+        after_in_parent=_lease_locks_after_fork_parent,
+        after_in_child=_lease_locks_after_fork_child,
     )
+
+
+def _open_lease_descriptor(path: Path, flags: int, mode: int = 0o600) -> int:
+    with _LEASE_LOCK_FDS_LOCK:
+        descriptor = os.open(
+            path,
+            flags | getattr(os, "O_CLOEXEC", 0),
+            mode,
+        )
+        try:
+            os.set_inheritable(descriptor, False)
+            _LEASE_LOCK_FDS.add(descriptor)
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+
+def _close_lease_descriptor(descriptor: int) -> None:
+    with _LEASE_LOCK_FDS_LOCK:
+        _LEASE_LOCK_FDS.discard(descriptor)
+        os.close(descriptor)
 
 
 class _DarwinProcBsdInfo(ctypes.Structure):
@@ -151,6 +173,7 @@ class _HeldLease:
     holder_id: str
     mode: str
     descriptor: int
+    owner_pid: int
 
 
 class BindingEffectLeaseManager:
@@ -250,12 +273,7 @@ class BindingEffectLeaseManager:
         if not vault_binding_id.strip() or mode not in {"shared", "exclusive"}:
             raise BindingEffectLeaseError("binding and lease mode must be explicit")
         self._ensure_state_root()
-        descriptor = os.open(
-            self._gate_path(vault_binding_id),
-            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
-            0o600,
-        )
-        os.fchmod(descriptor, 0o600)
+        descriptor = self._open_private_lease_lock(self._gate_path(vault_binding_id))
         holder_id = f"holder-{uuid4()}"
         deadline = None if timeout is None else time.monotonic() + timeout
         pending: _HolderState | None = None
@@ -352,7 +370,13 @@ class BindingEffectLeaseManager:
                                     )
                                     pending_descriptor = None
                                     pending = None
-                                return _HeldLease(vault_binding_id, holder_id, mode, descriptor)
+                                return _HeldLease(
+                                    vault_binding_id,
+                                    holder_id,
+                                    mode,
+                                    descriptor,
+                                    os.getpid(),
+                                )
                 if deadline is not None and time.monotonic() >= deadline:
                     raise BindingEffectLeaseTimeout(
                         f"timed out waiting for {mode} binding effect lease"
@@ -376,10 +400,14 @@ class BindingEffectLeaseManager:
                     try:
                         fcntl.flock(descriptor, fcntl.LOCK_UN)
                     finally:
-                        os.close(descriptor)
+                        _close_lease_descriptor(descriptor)
             raise
 
     def _release(self, held: _HeldLease) -> None:
+        if held.owner_pid != os.getpid():
+            raise BindingEffectLeaseError(
+                "a fork child cannot release its parent's binding effect lease"
+            )
         try:
             with self._state_locked(held.vault_binding_id):
                 current = self._load_reconciled_locked(held.vault_binding_id)
@@ -406,7 +434,7 @@ class BindingEffectLeaseManager:
             try:
                 fcntl.flock(held.descriptor, fcntl.LOCK_UN)
             finally:
-                os.close(held.descriptor)
+                _close_lease_descriptor(held.descriptor)
 
     def _discard_pending(
         self,
@@ -433,19 +461,16 @@ class BindingEffectLeaseManager:
     @contextmanager
     def _state_locked(self, vault_binding_id: str) -> Iterator[None]:
         self._ensure_state_root()
-        descriptor = os.open(
-            self._lock_path(vault_binding_id),
-            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
-            0o600,
-        )
-        os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "a+b", closefd=True) as handle:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        descriptor = self._open_private_lease_lock(self._lock_path(vault_binding_id))
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            self._recover_journal_locked(vault_binding_id)
+            yield
+        finally:
             try:
-                self._recover_journal_locked(vault_binding_id)
-                yield
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                _close_lease_descriptor(descriptor)
 
     def _load_reconciled_locked(self, vault_binding_id: str) -> _LeaseState:
         state = self._load_state_locked(vault_binding_id)
@@ -464,12 +489,7 @@ class BindingEffectLeaseManager:
             else:
                 abandoned.append((item, descriptor))
         updated["exclusivePending"] = pending
-        gate = os.open(
-            self._gate_path(vault_binding_id),
-            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
-            0o600,
-        )
-        os.fchmod(gate, 0o600)
+        gate = self._open_private_lease_lock(self._gate_path(vault_binding_id))
         try:
             try:
                 fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -485,7 +505,7 @@ class BindingEffectLeaseManager:
                 updated["exclusiveHolder"] = None
                 fcntl.flock(gate, fcntl.LOCK_UN)
         finally:
-            os.close(gate)
+            _close_lease_descriptor(gate)
         try:
             if updated != state:
                 for item, descriptor in abandoned:
@@ -677,33 +697,28 @@ class BindingEffectLeaseManager:
         )
 
     def _open_pending_activity_path(self, path: Path, *, create: bool = False) -> int:
-        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
         if create:
             flags |= os.O_CREAT | os.O_EXCL
-        with _PENDING_ACTIVITY_FDS_LOCK:
-            descriptor = os.open(path, flags, 0o600)
-            try:
-                os.set_inheritable(descriptor, False)
-                if create:
-                    os.fchmod(descriptor, 0o600)
-                metadata = os.fstat(descriptor)
-                if (
-                    not stat.S_ISREG(metadata.st_mode)
-                    or metadata.st_uid != os.geteuid()
-                    or metadata.st_mode & 0o777 != 0o600
-                ):
-                    raise BindingEffectLeaseError("exclusive waiter activity file is unsafe")
-                _PENDING_ACTIVITY_FDS.add(descriptor)
-                return descriptor
-            except BaseException:
-                os.close(descriptor)
-                raise
+        descriptor = _open_lease_descriptor(path, flags)
+        try:
+            if create:
+                os.fchmod(descriptor, 0o600)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or metadata.st_mode & 0o777 != 0o600
+            ):
+                raise BindingEffectLeaseError("exclusive waiter activity file is unsafe")
+            return descriptor
+        except BaseException:
+            _close_lease_descriptor(descriptor)
+            raise
 
     @staticmethod
     def _close_pending_activity(descriptor: int) -> None:
-        with _PENDING_ACTIVITY_FDS_LOCK:
-            _PENDING_ACTIVITY_FDS.discard(descriptor)
-            os.close(descriptor)
+        _close_lease_descriptor(descriptor)
 
     def _unlink_pending_activity_locked(
         self,
@@ -941,6 +956,22 @@ class BindingEffectLeaseManager:
             or metadata.st_mode & 0o777 != 0o700
         ):
             raise BindingEffectLeaseError("binding effect lease directory is unsafe")
+
+    @staticmethod
+    def _open_private_lease_lock(path: Path) -> int:
+        descriptor = _open_lease_descriptor(
+            path,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.geteuid():
+                raise BindingEffectLeaseError(f"binding effect lease lock is unsafe: {path.name}")
+            return descriptor
+        except BaseException:
+            _close_lease_descriptor(descriptor)
+            raise
 
     @staticmethod
     def _assert_private_file(path: Path) -> None:

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -240,9 +240,7 @@ class BindingEffectLeaseManager:
                                     ]
                                     updated["exclusiveHolder"] = holder
                                 self._commit_locked(vault_binding_id, current, updated)
-                                return _HeldLease(
-                                    vault_binding_id, holder_id, mode, descriptor
-                                )
+                                return _HeldLease(vault_binding_id, holder_id, mode, descriptor)
                 if deadline is not None and time.monotonic() >= deadline:
                     raise BindingEffectLeaseTimeout(
                         f"timed out waiting for {mode} binding effect lease"
@@ -291,9 +289,7 @@ class BindingEffectLeaseManager:
             current = self._load_reconciled_locked(vault_binding_id)
             updated = copy.deepcopy(current)
             updated["exclusivePending"] = [
-                item
-                for item in updated["exclusivePending"]
-                if item["holderId"] != holder_id
+                item for item in updated["exclusivePending"] if item["holderId"] != holder_id
             ]
             if updated != current:
                 self._commit_locked(vault_binding_id, current, updated)
@@ -501,14 +497,7 @@ class BindingEffectLeaseManager:
                     return f"ps:{output[1]}", output[0][:1]
             except (OSError, subprocess.SubprocessError):
                 pass
-            try:
-                boot = Path("/proc/sys/kernel/random/boot_id")
-                return (
-                    f"pid:{pid}:boot:{boot.read_text(encoding='ascii').strip()}",
-                    "?",
-                )
-            except OSError:
-                return f"pid:{pid}", "?"
+            raise BindingEffectLeaseError("a trustworthy process-incarnation token is unavailable")
 
     @staticmethod
     def _empty_state(vault_binding_id: str) -> _LeaseState:
@@ -522,9 +511,7 @@ class BindingEffectLeaseManager:
             "exclusiveHolder": None,
         }
 
-    def _validate_state(
-        self, vault_binding_id: str, value: object
-    ) -> _LeaseState:
+    def _validate_state(self, vault_binding_id: str, value: object) -> _LeaseState:
         if not isinstance(value, dict):
             raise BindingEffectLeaseError("binding effect lease state is not a mapping")
         expected = set(self._empty_state(vault_binding_id))

--- a/app/instance/binding_effect_lease.py
+++ b/app/instance/binding_effect_lease.py
@@ -1,0 +1,644 @@
+"""Cross-process per-binding shared/exclusive effect leases (MVR-05A6)."""
+
+from __future__ import annotations
+
+import copy
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Mapping, TypedDict, cast
+from uuid import uuid4
+
+from app.instance._storage_boundary import _StorageMutationCapability
+from app.instance.ownership_ledger import OwnershipLedger
+from app.instance.vault_registry import VaultRegistryStore
+
+
+LEASE_SCHEMA = "agentic-pkm.binding-effect-lease.v1"
+JOURNAL_SCHEMA = "agentic-pkm.binding-effect-lease-journal.v1"
+
+
+class BindingEffectLeaseError(RuntimeError):
+    """The binding effect window cannot be entered or recovered safely."""
+
+
+class BindingEffectLeaseTimeout(BindingEffectLeaseError):
+    """The requested effect window did not become available in time."""
+
+
+class _HolderState(TypedDict):
+    holderId: str
+    pid: int
+    processStart: str
+    ticket: int
+    mode: str
+
+
+class _LeaseState(TypedDict):
+    schema: str
+    vaultBindingId: str
+    generation: int
+    nextTicket: int
+    sharedHolders: list[_HolderState]
+    exclusivePending: list[_HolderState]
+    exclusiveHolder: _HolderState | None
+
+
+@dataclass(frozen=True)
+class BindingEffectLeaseObservation:
+    vault_binding_id: str
+    generation: int
+    shared_count: int
+    exclusive_pending_count: int
+    exclusive_held: bool
+
+
+@dataclass
+class _HeldLease:
+    vault_binding_id: str
+    holder_id: str
+    mode: str
+    descriptor: int
+
+
+class BindingEffectLeaseManager:
+    """Persist fairness state while `flock` owns effect-window exclusion."""
+
+    def __init__(
+        self,
+        *,
+        registry_store: VaultRegistryStore,
+        ownership_ledger: OwnershipLedger,
+        state_root: Path,
+        capability: _StorageMutationCapability,
+        poll_interval: float = 0.02,
+    ) -> None:
+        self.registry_store = registry_store
+        self.ownership_ledger = ownership_ledger
+        self.state_root = Path(state_root)
+        self.capability = capability
+        self.poll_interval = poll_interval
+
+    @contextmanager
+    def shared_effect(
+        self,
+        vault_binding_id: str,
+        *,
+        channel_id: str,
+        root: Path,
+        timeout: float | None = None,
+    ) -> Iterator[BindingEffectLeaseObservation]:
+        held = self._acquire(
+            vault_binding_id,
+            mode="shared",
+            channel_id=channel_id,
+            root=root,
+            timeout=timeout,
+        )
+        try:
+            yield self.observe(vault_binding_id)
+        finally:
+            if held is not None:
+                self._release(held)
+
+    @contextmanager
+    def exclusive_change(
+        self,
+        vault_binding_id: str,
+        *,
+        channel_id: str,
+        root: Path,
+        timeout: float | None = None,
+    ) -> Iterator[BindingEffectLeaseObservation]:
+        held = self._acquire(
+            vault_binding_id,
+            mode="exclusive",
+            channel_id=channel_id,
+            root=root,
+            timeout=timeout,
+        )
+        try:
+            yield self.observe(vault_binding_id)
+        finally:
+            if held is not None:
+                self._release(held)
+
+    def observe(self, vault_binding_id: str) -> BindingEffectLeaseObservation:
+        with self._state_locked(vault_binding_id):
+            state = self._load_reconciled_locked(vault_binding_id)
+            return BindingEffectLeaseObservation(
+                vault_binding_id=vault_binding_id,
+                generation=int(state["generation"]),
+                shared_count=len(state["sharedHolders"]),
+                exclusive_pending_count=len(state["exclusivePending"]),
+                exclusive_held=state["exclusiveHolder"] is not None,
+            )
+
+    def persisted_state(self, vault_binding_id: str) -> dict[str, object]:
+        with self._state_locked(vault_binding_id):
+            return dict(copy.deepcopy(self._load_reconciled_locked(vault_binding_id)))
+
+    def wait_for_exclusive_pending(self, vault_binding_id: str, *, timeout: float) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.observe(vault_binding_id).exclusive_pending_count:
+                return True
+            time.sleep(self.poll_interval)
+        return False
+
+    def _acquire(
+        self,
+        vault_binding_id: str,
+        *,
+        mode: str,
+        channel_id: str,
+        root: Path,
+        timeout: float | None,
+    ) -> _HeldLease:
+        if not vault_binding_id.strip() or mode not in {"shared", "exclusive"}:
+            raise BindingEffectLeaseError("binding and lease mode must be explicit")
+        self._ensure_state_root()
+        descriptor = os.open(
+            self._gate_path(vault_binding_id),
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        os.fchmod(descriptor, 0o600)
+        holder_id = f"holder-{uuid4()}"
+        deadline = None if timeout is None else time.monotonic() + timeout
+        pending: _HolderState | None = None
+        try:
+            if mode == "exclusive":
+                with self.ownership_ledger.active_binding_fence(
+                    vault_binding_id, channel_id=channel_id, root=root
+                ):
+                    with self._state_locked(vault_binding_id):
+                        current = self._load_reconciled_locked(vault_binding_id)
+                        pending = self._holder(
+                            holder_id,
+                            ticket=int(current["nextTicket"]),
+                            mode="pending",
+                        )
+                        updated = copy.deepcopy(current)
+                        updated["nextTicket"] = int(current["nextTicket"]) + 1
+                        updated["exclusivePending"].append(pending)
+                        self._commit_locked(vault_binding_id, current, updated)
+
+            while True:
+                with self.ownership_ledger.active_binding_fence(
+                    vault_binding_id, channel_id=channel_id, root=root
+                ):
+                    with self._state_locked(vault_binding_id):
+                        current = self._load_reconciled_locked(vault_binding_id)
+                        if mode == "shared":
+                            available = (
+                                not current["exclusivePending"]
+                                and current["exclusiveHolder"] is None
+                            )
+                            lock_mode = fcntl.LOCK_SH
+                        else:
+                            queue = current["exclusivePending"]
+                            available = (
+                                bool(queue)
+                                and queue[0]["holderId"] == holder_id
+                                and not current["sharedHolders"]
+                                and current["exclusiveHolder"] is None
+                            )
+                            lock_mode = fcntl.LOCK_EX
+                        if available:
+                            try:
+                                fcntl.flock(descriptor, lock_mode | fcntl.LOCK_NB)
+                            except BlockingIOError:
+                                pass
+                            else:
+                                holder = self._holder(
+                                    holder_id,
+                                    ticket=(
+                                        int(pending["ticket"])
+                                        if pending is not None
+                                        else int(current["nextTicket"])
+                                    ),
+                                    mode=mode,
+                                )
+                                updated = copy.deepcopy(current)
+                                if mode == "shared":
+                                    updated["nextTicket"] = int(current["nextTicket"]) + 1
+                                    updated["sharedHolders"].append(holder)
+                                else:
+                                    updated["exclusivePending"] = [
+                                        item
+                                        for item in current["exclusivePending"]
+                                        if item["holderId"] != holder_id
+                                    ]
+                                    updated["exclusiveHolder"] = holder
+                                self._commit_locked(vault_binding_id, current, updated)
+                                return _HeldLease(
+                                    vault_binding_id, holder_id, mode, descriptor
+                                )
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise BindingEffectLeaseTimeout(
+                        f"timed out waiting for {mode} binding effect lease"
+                    )
+                time.sleep(self.poll_interval)
+        except BaseException:
+            if pending is not None:
+                self._discard_pending(vault_binding_id, holder_id)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+            raise
+
+    def _release(self, held: _HeldLease) -> None:
+        try:
+            with self._state_locked(held.vault_binding_id):
+                current = self._load_reconciled_locked(held.vault_binding_id)
+                updated = copy.deepcopy(current)
+                if held.mode == "shared":
+                    before = len(updated["sharedHolders"])
+                    updated["sharedHolders"] = [
+                        item
+                        for item in updated["sharedHolders"]
+                        if item["holderId"] != held.holder_id
+                    ]
+                    found = len(updated["sharedHolders"]) != before
+                else:
+                    found = bool(
+                        updated["exclusiveHolder"]
+                        and updated["exclusiveHolder"]["holderId"] == held.holder_id
+                    )
+                    if found:
+                        updated["exclusiveHolder"] = None
+                if not found:
+                    raise BindingEffectLeaseError("held binding effect lease state is missing")
+                self._commit_locked(held.vault_binding_id, current, updated)
+        finally:
+            try:
+                fcntl.flock(held.descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(held.descriptor)
+
+    def _discard_pending(self, vault_binding_id: str, holder_id: str) -> None:
+        with self._state_locked(vault_binding_id):
+            current = self._load_reconciled_locked(vault_binding_id)
+            updated = copy.deepcopy(current)
+            updated["exclusivePending"] = [
+                item
+                for item in updated["exclusivePending"]
+                if item["holderId"] != holder_id
+            ]
+            if updated != current:
+                self._commit_locked(vault_binding_id, current, updated)
+
+    @contextmanager
+    def _state_locked(self, vault_binding_id: str) -> Iterator[None]:
+        self._ensure_state_root()
+        descriptor = os.open(
+            self._lock_path(vault_binding_id),
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "a+b", closefd=True) as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                self._recover_journal_locked(vault_binding_id)
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _load_reconciled_locked(self, vault_binding_id: str) -> _LeaseState:
+        state = self._load_state_locked(vault_binding_id)
+        updated = copy.deepcopy(state)
+        updated["exclusivePending"] = [
+            item for item in state["exclusivePending"] if self._holder_alive(item)
+        ]
+        gate = os.open(
+            self._gate_path(vault_binding_id),
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        os.fchmod(gate, 0o600)
+        try:
+            try:
+                fcntl.flock(gate, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                updated["sharedHolders"] = [
+                    item for item in state["sharedHolders"] if self._holder_alive(item)
+                ]
+                holder = state["exclusiveHolder"]
+                if holder is not None and not self._holder_alive(holder):
+                    updated["exclusiveHolder"] = None
+            else:
+                updated["sharedHolders"] = []
+                updated["exclusiveHolder"] = None
+                fcntl.flock(gate, fcntl.LOCK_UN)
+        finally:
+            os.close(gate)
+        if updated != state:
+            return self._commit_locked(vault_binding_id, state, updated)
+        return state
+
+    def _load_state_locked(self, vault_binding_id: str) -> _LeaseState:
+        path = self._state_path(vault_binding_id)
+        if path.exists():
+            self._assert_private_file(path)
+            try:
+                value = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise BindingEffectLeaseError("binding effect lease state is corrupt") from exc
+            return self._validate_state(vault_binding_id, value)
+        snapshot = self.registry_store.load()
+        raw_states = snapshot.extensions.get("bindingEffectLeases") or {}
+        if not isinstance(raw_states, Mapping):
+            raise BindingEffectLeaseError("registry binding effect lease state is invalid")
+        value = raw_states.get(vault_binding_id)
+        return (
+            self._empty_state(vault_binding_id)
+            if value is None
+            else self._validate_state(vault_binding_id, value)
+        )
+
+    def _commit_locked(
+        self,
+        vault_binding_id: str,
+        previous: Mapping[str, object],
+        candidate: Mapping[str, object],
+    ) -> _LeaseState:
+        previous_state = self._validate_state(vault_binding_id, previous)
+        next_state = self._validate_state(
+            vault_binding_id,
+            {**copy.deepcopy(candidate), "generation": int(previous_state["generation"]) + 1},
+        )
+        journal = {
+            "schema": JOURNAL_SCHEMA,
+            "vaultBindingId": vault_binding_id,
+            "previous": previous_state,
+            "next": next_state,
+        }
+        self._atomic_private_json(self._journal_path(vault_binding_id), journal)
+        self._atomic_private_json(self._state_path(vault_binding_id), next_state)
+        try:
+            self.registry_store.set_binding_effect_lease_state(
+                vault_binding_id,
+                next_state,
+                _capability=self.capability,
+            )
+        except Exception:
+            self._atomic_private_json(self._state_path(vault_binding_id), previous_state)
+            self._journal_path(vault_binding_id).unlink(missing_ok=True)
+            self._fsync_directory(self.state_root)
+            raise
+        self._journal_path(vault_binding_id).unlink(missing_ok=True)
+        self._fsync_directory(self.state_root)
+        return next_state
+
+    def _recover_journal_locked(self, vault_binding_id: str) -> None:
+        path = self._journal_path(vault_binding_id)
+        if not path.exists():
+            return
+        self._assert_private_file(path)
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            if (
+                not isinstance(value, dict)
+                or value.get("schema") != JOURNAL_SCHEMA
+                or value.get("vaultBindingId") != vault_binding_id
+            ):
+                raise ValueError
+            previous = self._validate_state(vault_binding_id, value["previous"])
+            next_state = self._validate_state(vault_binding_id, value["next"])
+        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise BindingEffectLeaseError("binding effect lease journal is invalid") from exc
+        snapshot = self.registry_store.load()
+        states = snapshot.extensions.get("bindingEffectLeases") or {}
+        if not isinstance(states, Mapping):
+            raise BindingEffectLeaseError("registry binding effect lease state is invalid")
+        registry_state = states.get(vault_binding_id)
+        registry_state = (
+            self._empty_state(vault_binding_id)
+            if registry_state is None
+            else self._validate_state(vault_binding_id, registry_state)
+        )
+        if registry_state == next_state:
+            recovered = next_state
+        elif registry_state == previous:
+            recovered = previous
+        else:
+            raise BindingEffectLeaseError(
+                "binding effect lease journal diverges from registry state"
+            )
+        self._atomic_private_json(self._state_path(vault_binding_id), recovered)
+        path.unlink()
+        self._fsync_directory(self.state_root)
+
+    def _holder(self, holder_id: str, *, ticket: int, mode: str) -> _HolderState:
+        return {
+            "holderId": holder_id,
+            "pid": os.getpid(),
+            "processStart": self._process_start(os.getpid()),
+            "ticket": ticket,
+            "mode": mode,
+        }
+
+    def _holder_alive(self, holder: Mapping[str, object]) -> bool:
+        try:
+            raw_pid = holder["pid"]
+            if not isinstance(raw_pid, int) or isinstance(raw_pid, bool):
+                return False
+            pid = raw_pid
+            os.kill(pid, 0)
+        except (KeyError, ProcessLookupError, ValueError, TypeError):
+            return False
+        except PermissionError:
+            pass
+        return str(holder.get("processStart") or "") == self._process_start(pid)
+
+    @staticmethod
+    def _process_start(pid: int) -> str:
+        stat_path = Path(f"/proc/{pid}/stat")
+        try:
+            fields = stat_path.read_text(encoding="utf-8").split()
+            return f"proc:{fields[21]}"
+        except (OSError, IndexError):
+            try:
+                result = subprocess.run(
+                    ["ps", "-o", "lstart=", "-p", str(pid)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=1,
+                )
+                started = result.stdout.strip()
+                if started:
+                    return f"ps:{started}"
+            except (OSError, subprocess.SubprocessError):
+                pass
+            try:
+                boot = Path("/proc/sys/kernel/random/boot_id")
+                return f"pid:{pid}:boot:{boot.read_text(encoding='ascii').strip()}"
+            except OSError:
+                return f"pid:{pid}"
+
+    @staticmethod
+    def _empty_state(vault_binding_id: str) -> _LeaseState:
+        return {
+            "schema": LEASE_SCHEMA,
+            "vaultBindingId": vault_binding_id,
+            "generation": 0,
+            "nextTicket": 1,
+            "sharedHolders": [],
+            "exclusivePending": [],
+            "exclusiveHolder": None,
+        }
+
+    def _validate_state(
+        self, vault_binding_id: str, value: object
+    ) -> _LeaseState:
+        if not isinstance(value, dict):
+            raise BindingEffectLeaseError("binding effect lease state is not a mapping")
+        expected = set(self._empty_state(vault_binding_id))
+        if set(value) != expected or value.get("schema") != LEASE_SCHEMA:
+            raise BindingEffectLeaseError("binding effect lease state has an invalid shape")
+        if value.get("vaultBindingId") != vault_binding_id:
+            raise BindingEffectLeaseError("binding effect lease state binding mismatch")
+        generation = value.get("generation")
+        next_ticket = value.get("nextTicket")
+        shared = value.get("sharedHolders")
+        pending = value.get("exclusivePending")
+        exclusive = value.get("exclusiveHolder")
+        if (
+            not isinstance(generation, int)
+            or isinstance(generation, bool)
+            or generation < 0
+            or not isinstance(next_ticket, int)
+            or isinstance(next_ticket, bool)
+            or next_ticket <= 0
+            or not isinstance(shared, list)
+            or not isinstance(pending, list)
+            or (exclusive is not None and not isinstance(exclusive, dict))
+        ):
+            raise BindingEffectLeaseError("binding effect lease state values are invalid")
+        holders = shared + pending + ([] if exclusive is None else [exclusive])
+        seen_ids: set[str] = set()
+        seen_tickets: set[int] = set()
+        for holder in holders:
+            if not isinstance(holder, dict) or set(holder) != {
+                "holderId",
+                "pid",
+                "processStart",
+                "ticket",
+                "mode",
+            }:
+                raise BindingEffectLeaseError("binding effect lease holder is invalid")
+            holder_id = holder.get("holderId")
+            pid = holder.get("pid")
+            process_start = holder.get("processStart")
+            ticket = holder.get("ticket")
+            if (
+                not isinstance(holder_id, str)
+                or not holder_id
+                or not isinstance(pid, int)
+                or isinstance(pid, bool)
+                or pid <= 0
+                or not isinstance(process_start, str)
+                or not process_start
+                or not isinstance(ticket, int)
+                or isinstance(ticket, bool)
+                or ticket <= 0
+                or ticket >= next_ticket
+                or holder_id in seen_ids
+                or ticket in seen_tickets
+            ):
+                raise BindingEffectLeaseError("binding effect lease holder is invalid")
+            seen_ids.add(holder_id)
+            seen_tickets.add(ticket)
+        if any(item.get("mode") != "shared" for item in shared):
+            raise BindingEffectLeaseError("binding effect shared holder mode is invalid")
+        if any(item.get("mode") != "pending" for item in pending):
+            raise BindingEffectLeaseError("binding effect pending holder mode is invalid")
+        if exclusive is not None and exclusive.get("mode") != "exclusive":
+            raise BindingEffectLeaseError("binding effect exclusive holder mode is invalid")
+        if exclusive is not None and shared:
+            raise BindingEffectLeaseError("binding effect lease state overlaps holders")
+        return cast(_LeaseState, copy.deepcopy(value))
+
+    def _ensure_state_root(self) -> None:
+        self.state_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.state_root, 0o700)
+        metadata = self.state_root.lstat()
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o777 != 0o700
+        ):
+            raise BindingEffectLeaseError("binding effect lease directory is unsafe")
+
+    @staticmethod
+    def _assert_private_file(path: Path) -> None:
+        metadata = path.stat()
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o777 != 0o600
+        ):
+            raise BindingEffectLeaseError(f"binding effect lease file is unsafe: {path.name}")
+
+    def _binding_stem(self, vault_binding_id: str) -> str:
+        return hashlib.sha256(vault_binding_id.encode("utf-8")).hexdigest()
+
+    def _state_path(self, vault_binding_id: str) -> Path:
+        return self.state_root / f"{self._binding_stem(vault_binding_id)}.json"
+
+    def _journal_path(self, vault_binding_id: str) -> Path:
+        return self.state_root / f"{self._binding_stem(vault_binding_id)}.journal.json"
+
+    def _lock_path(self, vault_binding_id: str) -> Path:
+        return self.state_root / f"{self._binding_stem(vault_binding_id)}.state.lock"
+
+    def _gate_path(self, vault_binding_id: str) -> Path:
+        return self.state_root / f"{self._binding_stem(vault_binding_id)}.effect.lock"
+
+    def _atomic_private_json(self, path: Path, value: Mapping[str, object]) -> None:
+        payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb", closefd=True) as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+            self._fsync_directory(path.parent)
+        except BaseException:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            Path(temporary).unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        descriptor = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+__all__ = [
+    "BindingEffectLeaseError",
+    "BindingEffectLeaseManager",
+    "BindingEffectLeaseObservation",
+    "BindingEffectLeaseTimeout",
+    "LEASE_SCHEMA",
+]

--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import os
+import shutil
 import stat
 import tempfile
 from dataclasses import dataclass
@@ -786,6 +787,7 @@ class InstanceStateBackup:
                 "backup key identity is inconsistent; keep the global fence until "
                 "fenced re-key and ledger reconstruction complete"
             )
+        self._clear_binding_effect_lease_state_for_restore()
         self.layout.ensure()
         self.ledger.root.mkdir(parents=True, exist_ok=True, mode=0o700)
         os.chmod(self.ledger.root, 0o700)
@@ -828,6 +830,40 @@ class InstanceStateBackup:
             restored_ledger.key_id,
             restored_ledger.generation,
         )
+
+    def _clear_binding_effect_lease_state_for_restore(self) -> None:
+        """Detach rebuildable lease files before restoring registry authority."""
+
+        state_root = self.layout.root / "binding-effect-leases"
+        quarantine = self.layout.root / ".binding-effect-leases.restore-stale"
+        if os.path.lexists(quarantine):
+            self._require_private_lease_directory(quarantine)
+            shutil.rmtree(quarantine)
+            _fsync_directory(self.layout.root)
+        if not os.path.lexists(state_root):
+            return
+        self._require_private_lease_directory(state_root)
+        os.replace(state_root, quarantine)
+        _fsync_directory(self.layout.root)
+        shutil.rmtree(quarantine)
+        _fsync_directory(self.layout.root)
+
+    @staticmethod
+    def _require_private_lease_directory(path: Path) -> None:
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            raise InstanceStatePreflightError(
+                "binding effect lease restore state is unsafe"
+            ) from exc
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o777 != 0o700
+        ):
+            raise InstanceStatePreflightError(
+                "binding effect lease restore state is unsafe"
+            )
 
     def _verify_staged_backup(
         self,
@@ -1045,6 +1081,14 @@ def _atomic_private_write(path: Path, payload: bytes) -> None:
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _read_private_bytes(path: Path) -> bytes:

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -851,6 +851,32 @@ class OwnershipLedger:
         lease = self.load().leases.get(vault_binding_id)
         return lease if lease is not None and lease.state == "active" else None
 
+    @contextmanager
+    def active_binding_fence(
+        self,
+        vault_binding_id: str,
+        *,
+        channel_id: str,
+        root: Path,
+    ) -> Iterator[OwnershipLease]:
+        """Hold the host-global fence while a per-binding fence is acquired."""
+
+        self._assert_existing_artifacts()
+        with self._locked():
+            key = self._load_or_create_key_locked(allow_create=False)
+            current = self._load_or_create_ledger_locked(key, allow_create=False)
+            lease = current.leases.get(vault_binding_id)
+            if (
+                lease is None
+                or lease.state != "active"
+                or lease.channel_id != channel_id
+                or not self._matches_root(lease, root, key)
+            ):
+                raise LedgerError(
+                    "binding effect acquisition requires the matching active ownership lease"
+                )
+            yield lease
+
     def begin_transfer(
         self,
         *,

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Protocol
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Protocol, cast
 from uuid import uuid4
 
 import yaml
@@ -90,6 +90,110 @@ _REGISTRATION_FIELDS = {
     "localInstanceId",
     "lastOpenedAt",
 }
+_BINDING_EFFECT_LEASE_SCHEMA = "agentic-pkm.binding-effect-lease.v1"
+
+
+def _validate_binding_effect_holder(value: object, *, mode: str) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != {
+        "holderId",
+        "pid",
+        "processStart",
+        "ticket",
+        "mode",
+    }:
+        raise RegistryError("binding effect lease state has an invalid holder")
+    if (
+        not isinstance(value.get("holderId"), str)
+        or not str(value["holderId"]).strip()
+        or not isinstance(value.get("pid"), int)
+        or isinstance(value.get("pid"), bool)
+        or int(value["pid"]) <= 0
+        or not isinstance(value.get("processStart"), str)
+        or not str(value["processStart"]).strip()
+        or not isinstance(value.get("ticket"), int)
+        or isinstance(value.get("ticket"), bool)
+        or int(value["ticket"]) <= 0
+        or value.get("mode") != mode
+    ):
+        raise RegistryError("binding effect lease state has an invalid holder")
+    return copy.deepcopy(value)
+
+
+def _validate_binding_effect_lease_state(
+    vault_binding_id: str,
+    value: object,
+) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != {
+        "schema",
+        "vaultBindingId",
+        "generation",
+        "nextTicket",
+        "sharedHolders",
+        "exclusivePending",
+        "exclusiveHolder",
+    }:
+        raise RegistryError("binding effect lease state has an invalid shape")
+    if value.get("schema") != _BINDING_EFFECT_LEASE_SCHEMA:
+        raise RegistryError("binding effect lease state has an invalid schema")
+    if value.get("vaultBindingId") != vault_binding_id:
+        raise RegistryError("binding effect lease state has a mismatched binding")
+    generation = value.get("generation")
+    next_ticket = value.get("nextTicket")
+    if (
+        not isinstance(generation, int)
+        or isinstance(generation, bool)
+        or generation < 0
+        or not isinstance(next_ticket, int)
+        or isinstance(next_ticket, bool)
+        or next_ticket <= 0
+    ):
+        raise RegistryError("binding effect lease state has an invalid generation")
+    raw_shared = value.get("sharedHolders")
+    raw_pending = value.get("exclusivePending")
+    if not isinstance(raw_shared, list) or not isinstance(raw_pending, list):
+        raise RegistryError("binding effect lease state holders must be lists")
+    shared = [_validate_binding_effect_holder(item, mode="shared") for item in raw_shared]
+    pending = [_validate_binding_effect_holder(item, mode="pending") for item in raw_pending]
+    raw_exclusive = value.get("exclusiveHolder")
+    exclusive = (
+        None
+        if raw_exclusive is None
+        else _validate_binding_effect_holder(raw_exclusive, mode="exclusive")
+    )
+    holders = shared + pending + ([] if exclusive is None else [exclusive])
+    holder_ids = [str(item["holderId"]) for item in holders]
+    tickets = [cast(int, item["ticket"]) for item in holders]
+    if len(holder_ids) != len(set(holder_ids)) or len(tickets) != len(set(tickets)):
+        raise RegistryError("binding effect lease state has duplicate holders")
+    if exclusive is not None and shared:
+        raise RegistryError("binding effect lease state overlaps shared and exclusive holders")
+    if any(ticket >= next_ticket for ticket in tickets):
+        raise RegistryError("binding effect lease state ticket is outside its sequence")
+    return {
+        "schema": _BINDING_EFFECT_LEASE_SCHEMA,
+        "vaultBindingId": vault_binding_id,
+        "generation": generation,
+        "nextTicket": next_ticket,
+        "sharedHolders": shared,
+        "exclusivePending": pending,
+        "exclusiveHolder": exclusive,
+    }
+
+
+def _validate_binding_effect_lease_extension(
+    extensions: Mapping[str, object],
+    registrations: Mapping[str, VaultRegistration],
+) -> None:
+    raw_states = extensions.get("bindingEffectLeases")
+    if raw_states is None:
+        return
+    if not isinstance(raw_states, dict):
+        raise RegistryError("binding effect lease state must be a mapping")
+    for binding_id, value in raw_states.items():
+        normalized = str(binding_id)
+        if normalized not in registrations:
+            raise RegistryError("binding effect lease state names an unknown binding")
+        _validate_binding_effect_lease_state(normalized, value)
 
 
 class RegistryMigrationError(RegistryError):
@@ -677,6 +781,12 @@ class VaultRegistryStore:
             next_extensions = copy.deepcopy(
                 current.extensions if extensions is None else extensions
             )
+            if next_extensions.get("bindingEffectLeases") != current.extensions.get(
+                "bindingEffectLeases"
+            ):
+                raise RegistryError(
+                    "binding effect lease state requires its dedicated producer"
+                )
             if current.authority == REGISTRY_AUTHORITY_ACTIVE:
                 floor = next_extensions.get("scalarRollback")
                 if not isinstance(floor, dict):
@@ -741,6 +851,34 @@ class VaultRegistryStore:
             self._assert_revision(current, expected_revision)
             updated = self._with_registrations(current, dict(current.registrations))
             updated.extensions["dimensions"] = copy.deepcopy(dict(dimensions))
+            self._write_locked(updated)
+            return updated
+
+    def set_binding_effect_lease_state(
+        self,
+        vault_binding_id: str,
+        state: Mapping[str, object],
+        *,
+        expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Persist exactly one validated MVR-05A6 lease-state generation."""
+
+        _require_storage_mutation_capability(_capability)
+        normalized_binding = vault_binding_id.strip()
+        validated = _validate_binding_effect_lease_state(normalized_binding, state)
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            self._assert_revision(current, expected_revision)
+            if normalized_binding not in current.registrations:
+                raise RegistryError("binding effect lease state names an unknown binding")
+            updated = self._with_registrations(current, dict(current.registrations))
+            states = copy.deepcopy(updated.extensions.get("bindingEffectLeases") or {})
+            if not isinstance(states, dict):
+                raise RegistryError("binding effect lease state must be a mapping")
+            states[normalized_binding] = validated
+            updated.extensions["bindingEffectLeases"] = states
             self._write_locked(updated)
             return updated
 
@@ -1701,6 +1839,7 @@ class VaultRegistryStore:
         if app_install_id is None:
             raise RegistryError("registry appInstallId is required")
         extensions = {key: copy.deepcopy(value) for key, value in frontmatter.items() if key not in _REGISTRY_FIELDS}
+        _validate_binding_effect_lease_extension(extensions, registrations)
         if authority == REGISTRY_AUTHORITY_ACTIVE:
             floor = extensions.get("scalarRollback")
             if (

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -865,20 +865,27 @@ class VaultRegistryStore:
         """Persist exactly one validated MVR-05A6 lease-state generation."""
 
         _require_storage_mutation_capability(_capability)
-        normalized_binding = vault_binding_id.strip()
-        validated = _validate_binding_effect_lease_state(normalized_binding, state)
+        if not isinstance(vault_binding_id, str) or not vault_binding_id.strip():
+            raise RegistryError("vault_binding_id is required")
+        validated = _validate_binding_effect_lease_state(vault_binding_id, state)
         with self._locked():
             self._assert_no_scalar_rollback_session_locked()
             current = self._read_current_locked(recover=True)
             self._assert_revision(current, expected_revision)
-            if normalized_binding not in current.registrations:
+            if vault_binding_id not in current.registrations:
                 raise RegistryError("binding effect lease state names an unknown binding")
-            updated = self._with_registrations(current, dict(current.registrations))
-            states = copy.deepcopy(updated.extensions.get("bindingEffectLeases") or {})
+            extensions = copy.deepcopy(current.extensions)
+            states = copy.deepcopy(extensions.get("bindingEffectLeases") or {})
             if not isinstance(states, dict):
                 raise RegistryError("binding effect lease state must be a mapping")
-            states[normalized_binding] = validated
-            updated.extensions["bindingEffectLeases"] = states
+            states[vault_binding_id] = validated
+            extensions["bindingEffectLeases"] = states
+            # Lease bookkeeping is mechanical state, not binding authority. Keep
+            # the registry revision and scalar-rollback floor unchanged so an
+            # in-flight context does not rotate merely because an effect enters
+            # or leaves its lease window. The registry lock plus `_write_locked`
+            # still serialises and journals complete previous/next payloads.
+            updated = replace(current, extensions=extensions)
             self._write_locked(updated)
             return updated
 

--- a/importlinter.ini
+++ b/importlinter.ini
@@ -151,6 +151,7 @@ protected_modules =
     app.instance.instance_state
     app.instance.ownership_ledger
 allowed_importers =
+    app.instance.binding_effect_lease
     app.instance.instance_state
     app.instance.runtime
 as_packages = False
@@ -161,6 +162,7 @@ type = protected
 protected_modules =
     app.instance._storage_boundary
 allowed_importers =
+    app.instance.binding_effect_lease
     app.instance.local_operator_principal
     app.instance.ownership_ledger
     app.instance.runtime

--- a/tests/architecture/test_import_boundary.py
+++ b/tests/architecture/test_import_boundary.py
@@ -293,6 +293,7 @@ def test_instance_storage_mutation_import_contract_is_complete() -> None:
         "app.instance.ownership_ledger",
     }
     assert _module_list(section["allowed_importers"]) == {
+        "app.instance.binding_effect_lease",
         "app.instance.instance_state",
         "app.instance.runtime",
     }
@@ -304,9 +305,10 @@ def test_instance_storage_mutation_import_contract_is_complete() -> None:
     }
     # This set is deliberately enumerated rather than pattern-matched: every durable
     # instance-state writer must be a named, reviewed entry. MVR-03 (#3857) added
-    # `local_operator_principal`, the private delegated operator-role record, which writes
-    # under the same boundary and therefore takes the same seal.
+    # `local_operator_principal`; MVR-05A6 (#4580) adds the per-binding effect lease.
+    # Both write under the same boundary and therefore take the same seal.
     assert _module_list(capability_section["allowed_importers"]) == {
+        "app.instance.binding_effect_lease",
         "app.instance.local_operator_principal",
         "app.instance.ownership_ledger",
         "app.instance.runtime",

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -4,6 +4,34 @@ import ast
 from pathlib import Path
 
 
+def _unordered_state_lock_lines(source: str) -> list[int]:
+    tree = ast.parse(source)
+    acquisition = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_acquire"
+    )
+    violations: list[int] = []
+
+    def visit(node: ast.AST, *, ownership_fenced: bool) -> None:
+        if isinstance(node, ast.With):
+            contexts = [ast.unparse(item.context_expr) for item in node.items]
+            fenced = ownership_fenced or any(
+                "active_binding_fence" in context for context in contexts
+            )
+            if any("_state_locked" in context for context in contexts) and not fenced:
+                violations.append(node.lineno)
+            for statement in node.body:
+                visit(statement, ownership_fenced=fenced)
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child, ownership_fenced=ownership_fenced)
+
+    visit(acquisition, ownership_fenced=False)
+    return violations
+
+
 def test_production_callers_take_the_ownership_fence_before_the_binding_lease() -> None:
     source = Path("app/instance/binding_effect_lease.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
@@ -12,14 +40,7 @@ def test_production_callers_take_the_ownership_fence_before_the_binding_lease() 
         for node in ast.walk(tree)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
-    acquisition = methods["_acquire"]
-    with_nodes = [node for node in ast.walk(acquisition) if isinstance(node, ast.With)]
-    assert any(
-        "active_binding_fence" in ast.unparse(item.context_expr)
-        and any("_state_locked" in ast.unparse(child) for child in ast.walk(node))
-        for node in with_nodes
-        for item in node.items
-    )
+    assert _unordered_state_lock_lines(source) == []
 
     for name in ("shared_effect", "exclusive_change"):
         assert "self._acquire" in ast.unparse(methods[name])
@@ -29,3 +50,11 @@ def test_production_callers_take_the_ownership_fence_before_the_binding_lease() 
         and node.name in {"acquire_shared", "acquire_exclusive"}
         for node in ast.walk(tree)
     )
+
+    inverted = """
+class Example:
+    def _acquire(self):
+        with self._state_locked('binding-a'):
+            self._mutate()
+"""
+    assert _unordered_state_lock_lines(inverted)

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_production_callers_take_the_ownership_fence_before_the_binding_lease() -> None:
+    source = Path("app/instance/binding_effect_lease.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    methods = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    acquisition = methods["_acquire"]
+    with_nodes = [node for node in ast.walk(acquisition) if isinstance(node, ast.With)]
+    assert any(
+        "active_binding_fence" in ast.unparse(item.context_expr)
+        and any("_state_locked" in ast.unparse(child) for child in ast.walk(node))
+        for node in with_nodes
+        for item in node.items
+    )
+
+    for name in ("shared_effect", "exclusive_change"):
+        assert "self._acquire" in ast.unparse(methods[name])
+
+    assert not any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in {"acquire_shared", "acquire_exclusive"}
+        for node in ast.walk(tree)
+    )

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -9,19 +9,19 @@ def _unordered_state_lock_lines(source: str) -> list[int]:
     acquisition = next(
         node
         for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "_acquire"
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "_acquire"
     )
     violations: list[int] = []
 
     def visit(node: ast.AST, *, ownership_fenced: bool) -> None:
         if isinstance(node, ast.With):
             contexts = [ast.unparse(item.context_expr) for item in node.items]
-            fenced = ownership_fenced or any(
-                "active_binding_fence" in context for context in contexts
-            )
-            if any("_state_locked" in context for context in contexts) and not fenced:
-                violations.append(node.lineno)
+            fenced = ownership_fenced
+            for context in contexts:
+                if "_state_locked" in context and not fenced:
+                    violations.append(node.lineno)
+                if "active_binding_fence" in context:
+                    fenced = True
             for statement in node.body:
                 visit(statement, ownership_fenced=fenced)
             return
@@ -54,7 +54,7 @@ def test_production_callers_take_the_ownership_fence_before_the_binding_lease() 
     inverted = """
 class Example:
     def _acquire(self):
-        with self._state_locked('binding-a'):
+        with self._state_locked('binding-a'), self.active_binding_fence('binding-a'):
             self._mutate()
 """
     assert _unordered_state_lock_lines(inverted)

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -44,6 +44,11 @@ def test_production_callers_take_the_ownership_fence_before_the_binding_lease() 
 
     for name in ("shared_effect", "exclusive_change"):
         assert "self._acquire" in ast.unparse(methods[name])
+        assert any(
+            isinstance(node, ast.With)
+            and any("self._acquire" in ast.unparse(item.context_expr) for item in node.items)
+            for node in ast.walk(methods[name])
+        )
 
     assert not any(
         isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -69,7 +74,7 @@ def test_pending_activity_locks_never_add_a_blocking_lock_order_edge() -> None:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
 
-    for name in ("_acquire", "_pending_waiter_status", "_scavenge_pending_activity_locked"):
+    for name in ("_acquire", "_pending_waiter_active", "_scavenge_pending_activity_locked"):
         calls = [
             node
             for node in ast.walk(methods[name])

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -74,7 +74,7 @@ def test_pending_activity_locks_never_add_a_blocking_lock_order_edge() -> None:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
 
-    for name in ("_acquire", "_pending_waiter_active", "_scavenge_pending_activity_locked"):
+    for name in ("_acquire", "_holder_activity_active", "_scavenge_holder_activity_locked"):
         calls = [
             node
             for node in ast.walk(methods[name])
@@ -100,4 +100,4 @@ def test_every_live_lease_lock_descriptor_uses_the_fork_close_registry() -> None
         rendered = ast.unparse(methods[name])
         assert "_open_private_lease_lock" in rendered
         assert "os.open" not in rendered
-    assert "_open_lease_descriptor" in ast.unparse(methods["_open_pending_activity_path"])
+    assert "_open_lease_descriptor" in ast.unparse(methods["_open_holder_activity_path"])

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -58,3 +58,25 @@ class Example:
             self._mutate()
 """
     assert _unordered_state_lock_lines(inverted)
+
+
+def test_pending_activity_locks_never_add_a_blocking_lock_order_edge() -> None:
+    source = Path("app/instance/binding_effect_lease.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    methods = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    for name in ("_acquire", "_pending_waiter_status", "_scavenge_pending_activity_locked"):
+        calls = [
+            node
+            for node in ast.walk(methods[name])
+            if isinstance(node, ast.Call)
+            and ast.unparse(node.func).endswith("fcntl.flock")
+            and len(node.args) >= 2
+            and "LOCK_EX" in ast.unparse(node.args[1])
+        ]
+        assert calls
+        assert all("LOCK_NB" in ast.unparse(call.args[1]) for call in calls)

--- a/tests/architecture/test_multi_vault_lease_lock_order.py
+++ b/tests/architecture/test_multi_vault_lease_lock_order.py
@@ -80,3 +80,19 @@ def test_pending_activity_locks_never_add_a_blocking_lock_order_edge() -> None:
         ]
         assert calls
         assert all("LOCK_NB" in ast.unparse(call.args[1]) for call in calls)
+
+
+def test_every_live_lease_lock_descriptor_uses_the_fork_close_registry() -> None:
+    source = Path("app/instance/binding_effect_lease.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    methods = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    for name in ("_acquire", "_state_locked", "_load_reconciled_locked"):
+        rendered = ast.unparse(methods[name])
+        assert "_open_private_lease_lock" in rendered
+        assert "os.open" not in rendered
+    assert "_open_lease_descriptor" in ast.unparse(methods["_open_pending_activity_path"])

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import queue
 import threading
 import time
 from pathlib import Path
@@ -57,11 +58,17 @@ def _manager_for_existing(root: str) -> BindingEffectLeaseManager:
 def _hold_shared(root: str, acquired, release) -> None:
     manager = _manager_for_existing(root)
     vault = Path(root) / "vaults" / "binding-a"
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault, timeout=5
-    ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=5):
         acquired.set()
         release.wait(5)
+
+
+def _record_exclusive(root: str, name: str, entered) -> None:
+    manager = _manager_for_existing(root)
+    vault = Path(root) / "vaults" / "binding-a"
+    with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=5):
+        entered.put(name)
+        time.sleep(0.03)
 
 
 def test_exclusive_acquirer_waits_for_an_in_flight_shared_holder(tmp_path) -> None:
@@ -72,16 +79,12 @@ def test_exclusive_acquirer_waits_for_an_in_flight_shared_holder(tmp_path) -> No
     exclusive_entered = threading.Event()
 
     def hold_shared() -> None:
-        with manager.shared_effect(
-            "binding-a", channel_id="dev", root=vault, timeout=2
-        ):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=2):
             shared_entered.set()
             shared_release.wait(2)
 
     def acquire_exclusive() -> None:
-        with manager.exclusive_change(
-            "binding-a", channel_id="dev", root=vault, timeout=2
-        ):
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=2):
             exclusive_entered.set()
 
     shared = threading.Thread(target=hold_shared)
@@ -105,16 +108,12 @@ def test_pending_exclusive_blocks_new_shared_acquisition(tmp_path) -> None:
     exclusive_entered = threading.Event()
 
     def first_shared() -> None:
-        with manager.shared_effect(
-            "binding-a", channel_id="dev", root=vault, timeout=2
-        ):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=2):
             first_entered.set()
             first_release.wait(2)
 
     def exclusive() -> None:
-        with manager.exclusive_change(
-            "binding-a", channel_id="dev", root=vault, timeout=2
-        ):
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=2):
             exclusive_entered.set()
 
     shared_thread = threading.Thread(target=first_shared)
@@ -125,9 +124,7 @@ def test_pending_exclusive_blocks_new_shared_acquisition(tmp_path) -> None:
     assert manager.wait_for_exclusive_pending("binding-a", timeout=1)
 
     with pytest.raises(BindingEffectLeaseTimeout):
-        with manager.shared_effect(
-            "binding-a", channel_id="dev", root=vault, timeout=0.05
-        ):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=0.05):
             pytest.fail("a new shared holder barged ahead of a pending exclusive")
 
     first_release.set()
@@ -141,12 +138,8 @@ def test_leases_for_distinct_bindings_do_not_serialise(tmp_path) -> None:
     vault_a = tmp_path / "vaults" / "binding-a"
     vault_b = tmp_path / "vaults" / "binding-b"
 
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault_a, timeout=1
-    ):
-        with manager.exclusive_change(
-            "binding-b", channel_id="dev", root=vault_b, timeout=0.2
-        ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault_a, timeout=1):
+        with manager.exclusive_change("binding-b", channel_id="dev", root=vault_b, timeout=0.2):
             assert manager.observe("binding-a").shared_count == 1
             assert manager.observe("binding-b").exclusive_held
 
@@ -163,17 +156,13 @@ def test_exclusion_holds_across_separate_processes(tmp_path) -> None:
     manager = _manager_for_existing(str(tmp_path))
     vault = tmp_path / "vaults" / "binding-a"
     with pytest.raises(BindingEffectLeaseTimeout):
-        with manager.exclusive_change(
-            "binding-a", channel_id="dev", root=vault, timeout=0.1
-        ):
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=0.1):
             pytest.fail("cross-process exclusive overlapped a shared holder")
 
     release.set()
     process.join(5)
     assert process.exitcode == 0
-    with manager.exclusive_change(
-        "binding-a", channel_id="dev", root=vault, timeout=1
-    ):
+    with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=1):
         assert manager.observe("binding-a").exclusive_held
 
 
@@ -181,16 +170,12 @@ def test_unreaped_dead_exclusive_waiter_does_not_occupy_fifo_head(tmp_path) -> N
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"
 
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault, timeout=1
-    ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
         pid = os.fork()
         if pid == 0:
             child = _manager_for_existing(str(tmp_path))
             try:
-                with child.exclusive_change(
-                    "binding-a", channel_id="dev", root=vault, timeout=10
-                ):
+                with child.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=10):
                     os._exit(0)
             except BaseException:
                 os._exit(2)
@@ -199,9 +184,35 @@ def test_unreaped_dead_exclusive_waiter_does_not_occupy_fifo_head(tmp_path) -> N
         time.sleep(0.05)
 
     try:
-        with manager.exclusive_change(
-            "binding-a", channel_id="dev", root=vault, timeout=2
-        ):
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=2):
             assert manager.observe("binding-a").exclusive_held
     finally:
         os.waitpid(pid, 0)
+
+
+def test_cross_process_exclusive_waiters_preserve_fifo_order(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    context = multiprocessing.get_context("spawn")
+    entered = context.Queue()
+
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        first = context.Process(target=_record_exclusive, args=(str(tmp_path), "first", entered))
+        first.start()
+        assert manager.wait_for_exclusive_pending("binding-a", timeout=3)
+        second = context.Process(target=_record_exclusive, args=(str(tmp_path), "second", entered))
+        second.start()
+        deadline = time.monotonic() + 3
+        while (
+            manager.observe("binding-a").exclusive_pending_count < 2 and time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+        assert manager.observe("binding-a").exclusive_pending_count == 2
+
+    assert entered.get(timeout=3) == "first"
+    assert entered.get(timeout=3) == "second"
+    with pytest.raises(queue.Empty):
+        entered.get_nowait()
+    first.join(5)
+    second.join(5)
+    assert first.exitcode == second.exitcode == 0

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -163,8 +163,10 @@ def test_lease_bookkeeping_does_not_rotate_binding_revision(tmp_path) -> None:
     assert manager.persisted_state("binding-a")["generation"] == 2
 
 
-def test_opaque_binding_id_round_trips_through_acquire_and_release(tmp_path) -> None:
-    binding_id = " binding-a "
+@pytest.mark.parametrize("binding_id", [" binding-a ", "vault-å"])
+def test_opaque_binding_id_round_trips_through_acquire_and_release(
+    tmp_path, binding_id
+) -> None:
     manager = _build_manager(tmp_path, binding_id)
     vault = tmp_path / "vaults" / binding_id
 

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import multiprocessing
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from app.instance.binding_effect_lease import (
+    BindingEffectLeaseManager,
+    BindingEffectLeaseTimeout,
+)
+from app.instance.ownership_ledger import OwnershipLedger
+from app.instance.vault_registry import VaultRegistration, VaultRegistryStore
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
+
+
+def _build_manager(root: Path, *binding_ids: str) -> BindingEffectLeaseManager:
+    registry = VaultRegistryStore(root / "instance" / "vault-registry.md")
+    ledger = OwnershipLedger(root / "host-global")
+    for binding_id in binding_ids:
+        vault = root / "vaults" / binding_id
+        vault.mkdir(parents=True, exist_ok=True)
+        registry.register(
+            VaultRegistration(binding_id, f"path:{vault}", str(vault)),
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+        ledger.reserve(
+            channel_id="dev",
+            vault_binding_id=binding_id,
+            root=vault,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+        ledger.activate(binding_id, _capability=STORAGE_MUTATION_CAPABILITY)
+    return BindingEffectLeaseManager(
+        registry_store=registry,
+        ownership_ledger=ledger,
+        state_root=root / "instance" / "binding-effect-leases",
+        capability=STORAGE_MUTATION_CAPABILITY,
+        poll_interval=0.005,
+    )
+
+
+def _manager_for_existing(root: str) -> BindingEffectLeaseManager:
+    path = Path(root)
+    return BindingEffectLeaseManager(
+        registry_store=VaultRegistryStore(path / "instance" / "vault-registry.md"),
+        ownership_ledger=OwnershipLedger(path / "host-global"),
+        state_root=path / "instance" / "binding-effect-leases",
+        capability=STORAGE_MUTATION_CAPABILITY,
+        poll_interval=0.005,
+    )
+
+
+def _hold_shared(root: str, acquired, release) -> None:
+    manager = _manager_for_existing(root)
+    vault = Path(root) / "vaults" / "binding-a"
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault, timeout=5
+    ):
+        acquired.set()
+        release.wait(5)
+
+
+def test_exclusive_acquirer_waits_for_an_in_flight_shared_holder(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    shared_entered = threading.Event()
+    shared_release = threading.Event()
+    exclusive_entered = threading.Event()
+
+    def hold_shared() -> None:
+        with manager.shared_effect(
+            "binding-a", channel_id="dev", root=vault, timeout=2
+        ):
+            shared_entered.set()
+            shared_release.wait(2)
+
+    def acquire_exclusive() -> None:
+        with manager.exclusive_change(
+            "binding-a", channel_id="dev", root=vault, timeout=2
+        ):
+            exclusive_entered.set()
+
+    shared = threading.Thread(target=hold_shared)
+    exclusive = threading.Thread(target=acquire_exclusive)
+    shared.start()
+    assert shared_entered.wait(1)
+    exclusive.start()
+    time.sleep(0.05)
+    assert not exclusive_entered.is_set()
+    shared_release.set()
+    shared.join(2)
+    exclusive.join(2)
+    assert exclusive_entered.is_set()
+
+
+def test_pending_exclusive_blocks_new_shared_acquisition(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    first_entered = threading.Event()
+    first_release = threading.Event()
+    exclusive_entered = threading.Event()
+
+    def first_shared() -> None:
+        with manager.shared_effect(
+            "binding-a", channel_id="dev", root=vault, timeout=2
+        ):
+            first_entered.set()
+            first_release.wait(2)
+
+    def exclusive() -> None:
+        with manager.exclusive_change(
+            "binding-a", channel_id="dev", root=vault, timeout=2
+        ):
+            exclusive_entered.set()
+
+    shared_thread = threading.Thread(target=first_shared)
+    exclusive_thread = threading.Thread(target=exclusive)
+    shared_thread.start()
+    assert first_entered.wait(1)
+    exclusive_thread.start()
+    assert manager.wait_for_exclusive_pending("binding-a", timeout=1)
+
+    with pytest.raises(BindingEffectLeaseTimeout):
+        with manager.shared_effect(
+            "binding-a", channel_id="dev", root=vault, timeout=0.05
+        ):
+            pytest.fail("a new shared holder barged ahead of a pending exclusive")
+
+    first_release.set()
+    shared_thread.join(2)
+    exclusive_thread.join(2)
+    assert exclusive_entered.is_set()
+
+
+def test_leases_for_distinct_bindings_do_not_serialise(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a", "binding-b")
+    vault_a = tmp_path / "vaults" / "binding-a"
+    vault_b = tmp_path / "vaults" / "binding-b"
+
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault_a, timeout=1
+    ):
+        with manager.exclusive_change(
+            "binding-b", channel_id="dev", root=vault_b, timeout=0.2
+        ):
+            assert manager.observe("binding-a").shared_count == 1
+            assert manager.observe("binding-b").exclusive_held
+
+
+def test_exclusion_holds_across_separate_processes(tmp_path) -> None:
+    _build_manager(tmp_path, "binding-a")
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    release = context.Event()
+    process = context.Process(target=_hold_shared, args=(str(tmp_path), acquired, release))
+    process.start()
+    assert acquired.wait(3)
+
+    manager = _manager_for_existing(str(tmp_path))
+    vault = tmp_path / "vaults" / "binding-a"
+    with pytest.raises(BindingEffectLeaseTimeout):
+        with manager.exclusive_change(
+            "binding-a", channel_id="dev", root=vault, timeout=0.1
+        ):
+            pytest.fail("cross-process exclusive overlapped a shared holder")
+
+    release.set()
+    process.join(5)
+    assert process.exitcode == 0
+    with manager.exclusive_change(
+        "binding-a", channel_id="dev", root=vault, timeout=1
+    ):
+        assert manager.observe("binding-a").exclusive_held

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from app.instance.active_context_service import binding_revision_for
 from app.instance.binding_effect_lease import (
     BindingEffectLeaseManager,
     BindingEffectLeaseTimeout,
@@ -142,6 +143,37 @@ def test_leases_for_distinct_bindings_do_not_serialise(tmp_path) -> None:
         with manager.exclusive_change("binding-b", channel_id="dev", root=vault_b, timeout=0.2):
             assert manager.observe("binding-a").shared_count == 1
             assert manager.observe("binding-b").exclusive_held
+
+
+def test_lease_bookkeeping_does_not_rotate_binding_revision(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    before = manager.registry_store.load()
+    binding_revision = binding_revision_for(before, "binding-a")
+
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        inside = manager.registry_store.load()
+        assert inside.revision == before.revision
+        assert binding_revision_for(inside, "binding-a") == binding_revision
+        assert manager.persisted_state("binding-a")["generation"] == 1
+
+    after = manager.registry_store.load()
+    assert after.revision == before.revision
+    assert binding_revision_for(after, "binding-a") == binding_revision
+    assert manager.persisted_state("binding-a")["generation"] == 2
+
+
+def test_opaque_binding_id_round_trips_through_acquire_and_release(tmp_path) -> None:
+    binding_id = " binding-a "
+    manager = _build_manager(tmp_path, binding_id)
+    vault = tmp_path / "vaults" / binding_id
+
+    with manager.shared_effect(binding_id, channel_id="dev", root=vault, timeout=1):
+        persisted = manager.persisted_state(binding_id)
+        assert persisted["vaultBindingId"] == binding_id
+        assert binding_id in manager.registry_store.load().extensions["bindingEffectLeases"]
+
+    assert manager.persisted_state(binding_id)["vaultBindingId"] == binding_id
 
 
 def test_exclusion_holds_across_separate_processes(tmp_path) -> None:

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -134,6 +134,44 @@ def test_pending_exclusive_blocks_new_shared_acquisition(tmp_path) -> None:
     assert exclusive_entered.is_set()
 
 
+def test_foreign_pid_namespace_preserves_live_shared_and_pending_authority(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    foreign_observer = _manager_for_existing(str(tmp_path))
+    vault = tmp_path / "vaults" / "binding-a"
+    exclusive_entered = threading.Event()
+
+    def exclusive() -> None:
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=2):
+            exclusive_entered.set()
+
+    def reject_observer_local_pid_identity(holder) -> bool:
+        raise AssertionError("observer-local PID identity is not lease authority")
+
+    monkeypatch.setattr(
+        foreign_observer,
+        "_holder_alive",
+        reject_observer_local_pid_identity,
+    )
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        exclusive_thread = threading.Thread(target=exclusive)
+        exclusive_thread.start()
+        assert manager.wait_for_exclusive_pending("binding-a", timeout=1)
+
+        observation = foreign_observer.observe("binding-a")
+        assert observation.shared_count == 1
+        assert observation.exclusive_pending_count == 1
+        with pytest.raises(BindingEffectLeaseTimeout):
+            with foreign_observer.shared_effect(
+                "binding-a", channel_id="dev", root=vault, timeout=0.05
+            ):
+                pytest.fail("a foreign observer cannot erase a live pending waiter")
+
+    exclusive_thread.join(2)
+    assert exclusive_entered.is_set()
+
+
 def test_leases_for_distinct_bindings_do_not_serialise(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a", "binding-b")
     vault_a = tmp_path / "vaults" / "binding-a"
@@ -164,9 +202,7 @@ def test_lease_bookkeeping_does_not_rotate_binding_revision(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("binding_id", [" binding-a ", "vault-å"])
-def test_opaque_binding_id_round_trips_through_acquire_and_release(
-    tmp_path, binding_id
-) -> None:
+def test_opaque_binding_id_round_trips_through_acquire_and_release(tmp_path, binding_id) -> None:
     manager = _build_manager(tmp_path, binding_id)
     vault = tmp_path / "vaults" / binding_id
 

--- a/tests/instance/test_binding_effect_lease.py
+++ b/tests/instance/test_binding_effect_lease.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing
+import os
 import threading
 import time
 from pathlib import Path
@@ -174,3 +175,33 @@ def test_exclusion_holds_across_separate_processes(tmp_path) -> None:
         "binding-a", channel_id="dev", root=vault, timeout=1
     ):
         assert manager.observe("binding-a").exclusive_held
+
+
+def test_unreaped_dead_exclusive_waiter_does_not_occupy_fifo_head(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault, timeout=1
+    ):
+        pid = os.fork()
+        if pid == 0:
+            child = _manager_for_existing(str(tmp_path))
+            try:
+                with child.exclusive_change(
+                    "binding-a", channel_id="dev", root=vault, timeout=10
+                ):
+                    os._exit(0)
+            except BaseException:
+                os._exit(2)
+        assert manager.wait_for_exclusive_pending("binding-a", timeout=3)
+        os.kill(pid, 9)
+        time.sleep(0.05)
+
+    try:
+        with manager.exclusive_change(
+            "binding-a", channel_id="dev", root=vault, timeout=2
+        ):
+            assert manager.observe("binding-a").exclusive_held
+    finally:
+        os.waitpid(pid, 0)

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -30,6 +30,19 @@ def _crash_inside_exclusive(root: str, acquired) -> None:
         os._exit(19)
 
 
+def _fork_child_then_crash_effect_holder(root: str, mode: str, acquired, release_child) -> None:
+    manager = _manager_for_existing(root)
+    vault = Path(root) / "vaults" / "binding-a"
+    effect = manager.shared_effect if mode == "shared" else manager.exclusive_change
+    with effect("binding-a", channel_id="dev", root=vault, timeout=5):
+        pid = os.fork()
+        if pid == 0:
+            release_child.wait(5)
+            os._exit(0)
+        acquired.set()
+        os._exit(23)
+
+
 def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) -> None:
     _build_manager(tmp_path, "binding-a")
     context = multiprocessing.get_context("spawn")
@@ -66,6 +79,64 @@ def test_crashed_exclusive_holder_recovers_for_a_later_shared_effect(tmp_path) -
     vault = tmp_path / "vaults" / "binding-a"
     with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=2):
         assert manager.observe("binding-a").shared_count == 1
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork inheritance proof")
+@pytest.mark.parametrize(
+    ("holder_mode", "later_mode"),
+    [("shared", "exclusive"), ("exclusive", "shared")],
+)
+def test_fork_child_cannot_extend_a_crashed_effect_holder(
+    tmp_path, holder_mode, later_mode
+) -> None:
+    _build_manager(tmp_path, "binding-a")
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    release_child = context.Event()
+    process = context.Process(
+        target=_fork_child_then_crash_effect_holder,
+        args=(str(tmp_path), holder_mode, acquired, release_child),
+    )
+    process.start()
+    assert acquired.wait(3)
+    process.join(5)
+    assert process.exitcode == 23
+
+    manager = _manager_for_existing(str(tmp_path))
+    vault = tmp_path / "vaults" / "binding-a"
+    effect = manager.shared_effect if later_mode == "shared" else manager.exclusive_change
+    try:
+        with effect("binding-a", channel_id="dev", root=vault, timeout=1):
+            observation = manager.observe("binding-a")
+            assert observation.shared_count == (1 if later_mode == "shared" else 0)
+            assert observation.exclusive_held is (later_mode == "exclusive")
+    finally:
+        release_child.set()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork ownership proof")
+def test_fork_child_cannot_release_the_parent_effect(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    held = manager._acquire(
+        "binding-a",
+        mode="shared",
+        channel_id="dev",
+        root=vault,
+        timeout=1,
+    )
+    pid = os.fork()
+    if pid == 0:
+        try:
+            manager._release(held)
+        except BindingEffectLeaseError:
+            os._exit(0)
+        os._exit(2)
+
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert manager.observe("binding-a").shared_count == 1
+    manager._release(held)
 
 
 @pytest.mark.parametrize("crash_point", ["journal", "state"])

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import app.instance.binding_effect_lease as lease_module
 from app.instance.binding_effect_lease import BindingEffectLeaseError
 from app.instance.vault_registry import RegistryError
 from tests.instance.test_binding_effect_lease import _build_manager, _manager_for_existing
@@ -14,11 +15,17 @@ from tests.instance.test_binding_effect_lease import _build_manager, _manager_fo
 def _crash_inside_shared(root: str, acquired) -> None:
     manager = _manager_for_existing(root)
     vault = Path(root) / "vaults" / "binding-a"
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault, timeout=5
-    ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=5):
         acquired.set()
         os._exit(17)
+
+
+def _crash_inside_exclusive(root: str, acquired) -> None:
+    manager = _manager_for_existing(root)
+    vault = Path(root) / "vaults" / "binding-a"
+    with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=5):
+        acquired.set()
+        os._exit(19)
 
 
 def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) -> None:
@@ -33,9 +40,7 @@ def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) 
 
     manager = _manager_for_existing(str(tmp_path))
     vault = tmp_path / "vaults" / "binding-a"
-    with manager.exclusive_change(
-        "binding-a", channel_id="dev", root=vault, timeout=2
-    ):
+    with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=2):
         observation = manager.observe("binding-a")
         assert observation.shared_count == 0
         assert observation.exclusive_held
@@ -43,6 +48,22 @@ def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) 
     persisted = manager.persisted_state("binding-a")
     assert "completed" not in persisted
     assert "completion" not in persisted
+
+
+def test_crashed_exclusive_holder_recovers_for_a_later_shared_effect(tmp_path) -> None:
+    _build_manager(tmp_path, "binding-a")
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    process = context.Process(target=_crash_inside_exclusive, args=(str(tmp_path), acquired))
+    process.start()
+    assert acquired.wait(3)
+    process.join(5)
+    assert process.exitcode == 19
+
+    manager = _manager_for_existing(str(tmp_path))
+    vault = tmp_path / "vaults" / "binding-a"
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=2):
+        assert manager.observe("binding-a").shared_count == 1
 
 
 @pytest.mark.parametrize("crash_point", ["journal", "state"])
@@ -64,9 +85,7 @@ def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
 
     monkeypatch.setattr(manager, "_atomic_private_json", interrupt_during_outer_commit)
     with pytest.raises(KeyboardInterrupt, match="crash after lease"):
-        with manager.shared_effect(
-            "binding-a", channel_id="dev", root=vault, timeout=1
-        ):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
             pytest.fail("the interrupted acquisition cannot expose an effect window")
     assert journal_path.exists()
 
@@ -97,23 +116,20 @@ def test_registry_post_commit_error_converges_to_committed_journal_endpoint(
         "_verify_generation",
         fail_first_post_commit_verification,
     )
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault, timeout=1
-    ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
         assert manager.observe("binding-a").shared_count == 1
 
     assert not manager._journal_path("binding-a").exists()
-    assert manager.persisted_state("binding-a") == manager.registry_store.load().extensions[
-        "bindingEffectLeases"
-    ]["binding-a"]
+    assert (
+        manager.persisted_state("binding-a")
+        == manager.registry_store.load().extensions["bindingEffectLeases"]["binding-a"]
+    )
 
 
 def test_journal_less_registry_state_divergence_fails_closed(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"
-    with manager.shared_effect(
-        "binding-a", channel_id="dev", root=vault, timeout=1
-    ):
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
         pass
     state = manager.persisted_state("binding-a")
     manager._atomic_private_json(
@@ -123,3 +139,87 @@ def test_journal_less_registry_state_divergence_fails_closed(tmp_path) -> None:
 
     with pytest.raises(BindingEffectLeaseError, match="diverges from registry"):
         manager.observe("binding-a")
+
+
+def test_unreadable_registry_retains_outer_journal_until_recovery(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_registry_state = manager._registry_state
+    producer_failed = False
+
+    def fail_before_registry_commit(*args, **kwargs) -> None:
+        nonlocal producer_failed
+        producer_failed = True
+        raise RegistryError("registry unavailable")
+
+    def unreadable_after_failure(binding_id):
+        if producer_failed:
+            raise RegistryError("registry still unavailable")
+        return real_registry_state(binding_id)
+
+    monkeypatch.setattr(
+        manager.registry_store,
+        "set_binding_effect_lease_state",
+        fail_before_registry_commit,
+    )
+    monkeypatch.setattr(manager, "_registry_state", unreadable_after_failure)
+    with pytest.raises(RegistryError, match="still unavailable"):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+            pytest.fail("an indeterminate commit cannot expose an effect window")
+    assert manager._journal_path("binding-a").exists()
+
+    recovered = _manager_for_existing(str(tmp_path))
+    assert recovered.observe("binding-a").shared_count == 0
+    assert not recovered._journal_path("binding-a").exists()
+
+
+def test_third_registry_endpoint_retains_journal_and_fails_closed(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_producer = manager.registry_store.set_binding_effect_lease_state
+
+    def commit_third_endpoint(binding_id, state, **kwargs) -> None:
+        third = {**state, "generation": int(state["generation"]) + 1}
+        real_producer(binding_id, third, **kwargs)
+        raise RegistryError("ambiguous registry outcome")
+
+    monkeypatch.setattr(
+        manager.registry_store,
+        "set_binding_effect_lease_state",
+        commit_third_endpoint,
+    )
+    with pytest.raises(BindingEffectLeaseError, match="both journal endpoints"):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+            pytest.fail("a third endpoint cannot expose an effect window")
+    assert manager._journal_path("binding-a").exists()
+
+    recovered = _manager_for_existing(str(tmp_path))
+    with pytest.raises(BindingEffectLeaseError, match="diverges from registry"):
+        recovered.observe("binding-a")
+    assert recovered._journal_path("binding-a").exists()
+
+
+def test_process_identity_refuses_untrustworthy_fallback_and_pid_reuse(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    start, _ = manager._process_identity(os.getpid())
+    stale = {
+        "holderId": "stale",
+        "pid": os.getpid(),
+        "processStart": f"{start}-previous-incarnation",
+        "ticket": 1,
+        "mode": "pending",
+    }
+    assert not manager._holder_alive(stale)
+
+    def no_procfs(*args, **kwargs):
+        raise OSError("procfs unavailable")
+
+    def no_ps(*args, **kwargs):
+        raise FileNotFoundError("ps unavailable")
+
+    monkeypatch.setattr(Path, "read_text", no_procfs)
+    monkeypatch.setattr(lease_module.subprocess, "run", no_ps)
+    with pytest.raises(BindingEffectLeaseError, match="trustworthy process-incarnation"):
+        manager._process_identity(os.getpid())

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -457,6 +457,24 @@ def test_state_symlink_is_rejected_without_reading_its_target(tmp_path) -> None:
         manager.observe("binding-a")
 
 
+def test_state_root_symlink_is_rejected_without_mutating_its_target(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    external = tmp_path / "external-state-root"
+    external.mkdir(mode=0o755)
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("unchanged\n", encoding="utf-8")
+    state_root = manager.state_root
+    state_root.symlink_to(external, target_is_directory=True)
+    before = external.stat().st_mode & 0o777
+
+    with pytest.raises(BindingEffectLeaseError, match="directory is unsafe"):
+        manager.observe("binding-a")
+
+    assert state_root.is_symlink()
+    assert external.stat().st_mode & 0o777 == before == 0o755
+    assert sentinel.read_text(encoding="utf-8") == "unchanged\n"
+
+
 def test_journal_symlink_is_rejected_without_reading_its_target(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.instance.test_binding_effect_lease import _build_manager, _manager_for_existing
+
+
+def _crash_inside_shared(root: str, acquired) -> None:
+    manager = _manager_for_existing(root)
+    vault = Path(root) / "vaults" / "binding-a"
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault, timeout=5
+    ):
+        acquired.set()
+        os._exit(17)
+
+
+def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) -> None:
+    _build_manager(tmp_path, "binding-a")
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    process = context.Process(target=_crash_inside_shared, args=(str(tmp_path), acquired))
+    process.start()
+    assert acquired.wait(3)
+    process.join(5)
+    assert process.exitcode == 17
+
+    manager = _manager_for_existing(str(tmp_path))
+    vault = tmp_path / "vaults" / "binding-a"
+    with manager.exclusive_change(
+        "binding-a", channel_id="dev", root=vault, timeout=2
+    ):
+        observation = manager.observe("binding-a")
+        assert observation.shared_count == 0
+        assert observation.exclusive_held
+
+    persisted = manager.persisted_state("binding-a")
+    assert "completed" not in persisted
+    assert "completion" not in persisted
+
+
+def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    state_path = manager._state_path("binding-a")
+    journal_path = manager._journal_path("binding-a")
+    real_write = manager._atomic_private_json
+
+    def interrupt_after_state_write(path, value) -> None:
+        real_write(path, value)
+        if path == state_path and value.get("generation") == 1:
+            raise KeyboardInterrupt("crash after lease state write")
+
+    monkeypatch.setattr(manager, "_atomic_private_json", interrupt_after_state_write)
+    with pytest.raises(KeyboardInterrupt, match="crash after lease state write"):
+        with manager.shared_effect(
+            "binding-a", channel_id="dev", root=vault, timeout=1
+        ):
+            pytest.fail("the interrupted acquisition cannot expose an effect window")
+    assert journal_path.exists()
+
+    recovered = _manager_for_existing(str(tmp_path))
+    observation = recovered.observe("binding-a")
+    assert observation.shared_count == 0
+    assert not observation.exclusive_held
+    assert not journal_path.exists()

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from app.instance.binding_effect_lease import BindingEffectLeaseError
+from app.instance.vault_registry import RegistryError
 from tests.instance.test_binding_effect_lease import _build_manager, _manager_for_existing
 
 
@@ -43,8 +45,9 @@ def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) 
     assert "completion" not in persisted
 
 
+@pytest.mark.parametrize("crash_point", ["journal", "state"])
 def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, crash_point
 ) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"
@@ -52,13 +55,15 @@ def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
     journal_path = manager._journal_path("binding-a")
     real_write = manager._atomic_private_json
 
-    def interrupt_after_state_write(path, value) -> None:
+    def interrupt_during_outer_commit(path, value) -> None:
         real_write(path, value)
-        if path == state_path and value.get("generation") == 1:
+        if path == journal_path and crash_point == "journal":
+            raise KeyboardInterrupt("crash after lease journal prepare")
+        if path == state_path and crash_point == "state" and value.get("generation") == 1:
             raise KeyboardInterrupt("crash after lease state write")
 
-    monkeypatch.setattr(manager, "_atomic_private_json", interrupt_after_state_write)
-    with pytest.raises(KeyboardInterrupt, match="crash after lease state write"):
+    monkeypatch.setattr(manager, "_atomic_private_json", interrupt_during_outer_commit)
+    with pytest.raises(KeyboardInterrupt, match="crash after lease"):
         with manager.shared_effect(
             "binding-a", channel_id="dev", root=vault, timeout=1
         ):
@@ -70,3 +75,51 @@ def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
     assert observation.shared_count == 0
     assert not observation.exclusive_held
     assert not journal_path.exists()
+
+
+def test_registry_post_commit_error_converges_to_committed_journal_endpoint(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_verify = manager.registry_store._verify_generation
+    calls = 0
+
+    def fail_first_post_commit_verification(generation) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RegistryError("post-commit verification failed")
+        real_verify(generation)
+
+    monkeypatch.setattr(
+        manager.registry_store,
+        "_verify_generation",
+        fail_first_post_commit_verification,
+    )
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault, timeout=1
+    ):
+        assert manager.observe("binding-a").shared_count == 1
+
+    assert not manager._journal_path("binding-a").exists()
+    assert manager.persisted_state("binding-a") == manager.registry_store.load().extensions[
+        "bindingEffectLeases"
+    ]["binding-a"]
+
+
+def test_journal_less_registry_state_divergence_fails_closed(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    with manager.shared_effect(
+        "binding-a", channel_id="dev", root=vault, timeout=1
+    ):
+        pass
+    state = manager.persisted_state("binding-a")
+    manager._atomic_private_json(
+        manager._state_path("binding-a"),
+        {**state, "generation": int(state["generation"]) + 1},
+    )
+
+    with pytest.raises(BindingEffectLeaseError, match="diverges from registry"):
+        manager.observe("binding-a")

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import multiprocessing
 import errno
+import json
+import multiprocessing
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -436,6 +437,50 @@ def test_journal_less_registry_state_divergence_fails_closed(tmp_path) -> None:
     )
 
     with pytest.raises(BindingEffectLeaseError, match="diverges from registry"):
+        manager.observe("binding-a")
+
+
+def test_state_symlink_is_rejected_without_reading_its_target(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        pass
+
+    state_path = manager._state_path("binding-a")
+    external = tmp_path / "external-state.json"
+    external.write_bytes(state_path.read_bytes())
+    external.chmod(0o600)
+    state_path.unlink()
+    state_path.symlink_to(external)
+
+    with pytest.raises(BindingEffectLeaseError, match="file is unsafe"):
+        manager.observe("binding-a")
+
+
+def test_journal_symlink_is_rejected_without_reading_its_target(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        pass
+
+    state = manager.persisted_state("binding-a")
+    external = tmp_path / "external-journal.json"
+    external.write_text(
+        json.dumps(
+            {
+                "schema": lease_module.JOURNAL_SCHEMA,
+                "vaultBindingId": "binding-a",
+                "previous": state,
+                "next": state,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    external.chmod(0o600)
+    manager._journal_path("binding-a").symlink_to(external)
+
+    with pytest.raises(BindingEffectLeaseError, match="file is unsafe"):
         manager.observe("binding-a")
 
 

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import multiprocessing
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -199,9 +200,43 @@ def test_third_registry_endpoint_retains_journal_and_fails_closed(tmp_path, monk
     assert recovered._journal_path("binding-a").exists()
 
 
-def test_process_identity_refuses_untrustworthy_fallback_and_pid_reuse(
-    tmp_path, monkeypatch
-) -> None:
+class _FakeProcPidInfo:
+    def __init__(self, *, status: int, second: int, microsecond: int, result: int | None = None):
+        self.status = status
+        self.second = second
+        self.microsecond = microsecond
+        self.result = result
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, pid, flavor, arg, buffer, size):
+        assert arg == 0
+        if flavor == 3:
+            info = lease_module.ctypes.cast(
+                buffer,
+                lease_module.ctypes.POINTER(lease_module._DarwinProcBsdInfo),
+            ).contents
+            info.pbi_pid = pid
+            info.pbi_status = self.status
+            info.pbi_start_tvsec = self.second
+            info.pbi_start_tvusec = self.microsecond
+            return size if self.result is None else self.result
+        assert flavor == 13
+        short = lease_module.ctypes.cast(
+            buffer,
+            lease_module.ctypes.POINTER(lease_module._DarwinProcBsdShortInfo),
+        ).contents
+        short.pbsi_pid = pid
+        short.pbsi_status = self.status
+        return size
+
+
+class _FakeLibproc:
+    def __init__(self, proc_pidinfo) -> None:
+        self.proc_pidinfo = proc_pidinfo
+
+
+def test_process_identity_refuses_pid_reuse(tmp_path, monkeypatch) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     start, _ = manager._process_identity(os.getpid())
     stale = {
@@ -213,13 +248,126 @@ def test_process_identity_refuses_untrustworthy_fallback_and_pid_reuse(
     }
     assert not manager._holder_alive(stale)
 
+    native = _FakeProcPidInfo(status=2, second=100, microsecond=222)
+    monkeypatch.setattr(
+        lease_module.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: _FakeLibproc(native),
+    )
+    token, state = manager._darwin_process_identity(os.getpid())
+    assert token == "darwin:100:222"
+    assert state == "?"
+
+    same_second_stale = {**stale, "processStart": "darwin:100:221"}
+    monkeypatch.setattr(manager, "_process_identity", lambda pid: (token, state))
+    assert not manager._holder_alive(same_second_stale)
+
+
+def test_darwin_zombie_is_stale_even_with_matching_native_identity(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    native = _FakeProcPidInfo(status=5, second=100, microsecond=222)
+    monkeypatch.setattr(
+        lease_module.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: _FakeLibproc(native),
+    )
+    monkeypatch.setattr(Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(OSError()))
+    monkeypatch.setattr(lease_module.sys, "platform", "darwin")
+
+    holder = {
+        "holderId": "zombie",
+        "pid": os.getpid(),
+        "processStart": "darwin:100:222",
+        "ticket": 1,
+        "mode": "pending",
+    }
+    assert not manager._holder_alive(holder)
+
+
+def test_darwin_ps_is_terminal_zombie_proof_not_a_live_identity(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    unavailable_full_info = _FakeProcPidInfo(
+        status=2,
+        second=100,
+        microsecond=222,
+        result=0,
+    )
+    monkeypatch.setattr(
+        lease_module.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: _FakeLibproc(unavailable_full_info),
+    )
+    monkeypatch.setattr(
+        lease_module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="Z+\n"),
+    )
+    assert manager._darwin_process_identity(os.getpid()) == (
+        f"darwin:zombie:{os.getpid()}",
+        "Z",
+    )
+
+    monkeypatch.setattr(
+        lease_module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="S+\n"),
+    )
+    with pytest.raises(BindingEffectLeaseError, match="trustworthy process-incarnation"):
+        manager._darwin_process_identity(os.getpid())
+
+
+@pytest.mark.parametrize(
+    ("status", "second", "microsecond", "result"),
+    [
+        (2, 100, 222, 0),
+        (6, 100, 222, None),
+        (2, 0, 222, None),
+        (2, 100, 1_000_000, None),
+    ],
+)
+def test_darwin_identity_rejects_short_or_malformed_native_results(
+    tmp_path, monkeypatch, status, second, microsecond, result
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    native = _FakeProcPidInfo(
+        status=status,
+        second=second,
+        microsecond=microsecond,
+        result=result,
+    )
+    monkeypatch.setattr(
+        lease_module.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: _FakeLibproc(native),
+    )
+    with pytest.raises(BindingEffectLeaseError, match="trustworthy process-incarnation"):
+        manager._darwin_process_identity(os.getpid())
+
+
+def test_process_identity_refuses_unavailable_native_fallback(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+
     def no_procfs(*args, **kwargs):
         raise OSError("procfs unavailable")
 
-    def no_ps(*args, **kwargs):
-        raise FileNotFoundError("ps unavailable")
+    def no_libproc(*args, **kwargs):
+        raise OSError("libproc unavailable")
 
     monkeypatch.setattr(Path, "read_text", no_procfs)
-    monkeypatch.setattr(lease_module.subprocess, "run", no_ps)
+    monkeypatch.setattr(lease_module.sys, "platform", "darwin")
+    monkeypatch.setattr(lease_module.ctypes, "CDLL", no_libproc)
     with pytest.raises(BindingEffectLeaseError, match="trustworthy process-incarnation"):
         manager._process_identity(os.getpid())
+
+
+@pytest.mark.skipif(lease_module.sys.platform != "darwin", reason="Darwin-only libproc proof")
+def test_live_darwin_process_identity_uses_native_microseconds(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    token, state = manager._darwin_process_identity(os.getpid())
+
+    assert lease_module.ctypes.sizeof(lease_module._DarwinProcBsdInfo) == 136
+    prefix, second, microsecond = token.split(":")
+    assert prefix == "darwin"
+    assert int(second) > 0
+    assert 0 <= int(microsecond) < 1_000_000
+    assert state != "Z"

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -144,13 +144,14 @@ def test_fork_child_cannot_extend_a_crashed_effect_holder(
 def test_fork_child_cannot_release_the_parent_effect(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"
-    held = manager._acquire(
+    lease_context = manager._acquire(
         "binding-a",
         mode="shared",
         channel_id="dev",
         root=vault,
         timeout=1,
     )
+    held = lease_context.__enter__()
     pid = os.fork()
     if pid == 0:
         try:
@@ -162,7 +163,7 @@ def test_fork_child_cannot_release_the_parent_effect(tmp_path) -> None:
     _, status = os.waitpid(pid, 0)
     assert os.waitstatus_to_exitcode(status) == 0
     assert manager.observe("binding-a").shared_count == 1
-    manager._release(held)
+    lease_context.__exit__(None, None, None)
 
 
 def test_state_lock_cancellation_closes_the_acquired_descriptor(tmp_path, monkeypatch) -> None:
@@ -219,6 +220,39 @@ def test_holder_identity_failure_closes_the_effect_descriptor(tmp_path, monkeypa
         os.close(probe)
 
 
+@pytest.mark.parametrize("mode", ["shared", "exclusive"])
+def test_public_context_cancellation_releases_the_adopted_effect(
+    tmp_path, monkeypatch, mode
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    baseline = set(lease_module._LEASE_LOCK_FDS)
+    real_observe = manager.observe
+    effect = manager.shared_effect if mode == "shared" else manager.exclusive_change
+
+    def cancel_after_acquisition(vault_binding_id):
+        raise KeyboardInterrupt("cancel after held lease adoption")
+
+    monkeypatch.setattr(manager, "observe", cancel_after_acquisition)
+    with pytest.raises(KeyboardInterrupt, match="held lease adoption"):
+        with effect("binding-a", channel_id="dev", root=vault, timeout=1):
+            pytest.fail("cancellation cannot expose the effect body")
+    monkeypatch.setattr(manager, "observe", real_observe)
+
+    assert set(lease_module._LEASE_LOCK_FDS) == baseline
+    observation = real_observe("binding-a")
+    assert observation.shared_count == 0
+    assert not observation.exclusive_held
+    probe = os.open(manager._gate_path("binding-a"), os.O_RDWR)
+    try:
+        lease_module.fcntl.flock(
+            probe,
+            lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+        )
+    finally:
+        os.close(probe)
+
+
 def test_reconciliation_cancellation_closes_transferred_pending_descriptor(
     tmp_path, monkeypatch
 ) -> None:
@@ -262,20 +296,20 @@ def test_later_pending_probe_failure_closes_an_earlier_transfer(tmp_path, monkey
         "holder-abandoned-second",
     )
     baseline = set(lease_module._LEASE_LOCK_FDS)
-    real_status = manager._pending_waiter_status
+    real_status = manager._pending_waiter_active
     calls = 0
 
-    def fail_second_probe(vault_binding_id, holder):
+    def fail_second_probe(vault_binding_id, holder, abandoned):
         nonlocal calls
         calls += 1
         if calls == 2:
             raise KeyboardInterrupt("later pending probe failed")
-        return real_status(vault_binding_id, holder)
+        return real_status(vault_binding_id, holder, abandoned)
 
-    monkeypatch.setattr(manager, "_pending_waiter_status", fail_second_probe)
+    monkeypatch.setattr(manager, "_pending_waiter_active", fail_second_probe)
     with pytest.raises(KeyboardInterrupt, match="later pending probe"):
         manager.observe("binding-a")
-    monkeypatch.setattr(manager, "_pending_waiter_status", real_status)
+    monkeypatch.setattr(manager, "_pending_waiter_active", real_status)
 
     assert set(lease_module._LEASE_LOCK_FDS) == baseline
     probe = os.open(first, os.O_RDWR)
@@ -465,12 +499,15 @@ def test_pending_activity_requires_a_held_lock_from_the_live_waiter(tmp_path) ->
     descriptor = manager._open_pending_activity("binding-a", holder["holderId"], create=True)
     lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
     try:
-        assert manager._pending_waiter_status("binding-a", holder) == (True, None)
+        abandoned = []
+        assert manager._pending_waiter_active("binding-a", holder, abandoned)
+        assert abandoned == []
     finally:
         manager._close_pending_activity(descriptor)
 
-    active, stale_descriptor = manager._pending_waiter_status("binding-a", holder)
-    assert not active
+    abandoned = []
+    assert not manager._pending_waiter_active("binding-a", holder, abandoned)
+    [(_, stale_descriptor)] = abandoned
     assert stale_descriptor is not None
     manager._close_pending_activity(stale_descriptor)
     manager._pending_activity_path("binding-a", holder["holderId"]).unlink()
@@ -569,7 +606,7 @@ def test_pending_activity_probe_error_fails_closed(tmp_path, monkeypatch) -> Non
 
     monkeypatch.setattr(lease_module.fcntl, "flock", unsupported)
     with pytest.raises(OSError, match="flock unsupported"):
-        manager._pending_waiter_status("binding-a", holder)
+        manager._pending_waiter_active("binding-a", holder, [])
     monkeypatch.setattr(lease_module.fcntl, "flock", real_flock)
     manager._close_pending_activity(descriptor)
 

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -196,6 +196,47 @@ def test_state_lock_cancellation_closes_the_acquired_descriptor(tmp_path, monkey
         os.close(probe)
 
 
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork descriptor proof")
+def test_descriptor_registration_cancellation_rolls_back_before_fd_reuse(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    assert lease_module._LEASE_LOCK_FDS == set()
+
+    class InterruptingRegistry(set):
+        added_descriptor: int | None = None
+
+        def add(self, descriptor) -> None:
+            super().add(descriptor)
+            self.added_descriptor = descriptor
+            raise KeyboardInterrupt("cancel after descriptor registration")
+
+    registry = InterruptingRegistry()
+    monkeypatch.setattr(lease_module, "_LEASE_LOCK_FDS", registry)
+    with pytest.raises(KeyboardInterrupt, match="descriptor registration"):
+        manager.observe("binding-a")
+
+    assert registry == set()
+    assert registry.added_descriptor is not None
+    with pytest.raises(OSError):
+        os.fstat(registry.added_descriptor)
+
+    unrelated = os.open("/dev/null", os.O_RDONLY)
+    assert unrelated == registry.added_descriptor
+    pid = os.fork()
+    if pid == 0:
+        try:
+            os.fstat(unrelated)
+        except OSError:
+            os._exit(2)
+        os._exit(0)
+    try:
+        _, status = os.waitpid(pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+    finally:
+        os.close(unrelated)
+
+
 def test_holder_identity_failure_closes_the_effect_descriptor(tmp_path, monkeypatch) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     vault = tmp_path / "vaults" / "binding-a"

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -139,6 +139,60 @@ def test_fork_child_cannot_release_the_parent_effect(tmp_path) -> None:
     manager._release(held)
 
 
+def test_state_lock_cancellation_closes_the_acquired_descriptor(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    baseline = set(lease_module._LEASE_LOCK_FDS)
+    real_flock = lease_module.fcntl.flock
+    interrupted = False
+
+    def acquire_then_interrupt(descriptor, operation):
+        nonlocal interrupted
+        result = real_flock(descriptor, operation)
+        if not interrupted and operation == lease_module.fcntl.LOCK_EX:
+            interrupted = True
+            raise KeyboardInterrupt("cancel after state lock acquisition")
+        return result
+
+    monkeypatch.setattr(lease_module.fcntl, "flock", acquire_then_interrupt)
+    with pytest.raises(KeyboardInterrupt, match="state lock acquisition"):
+        manager.observe("binding-a")
+    monkeypatch.setattr(lease_module.fcntl, "flock", real_flock)
+
+    assert set(lease_module._LEASE_LOCK_FDS) == baseline
+    probe = os.open(manager._lock_path("binding-a"), os.O_RDWR)
+    try:
+        real_flock(
+            probe,
+            lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+        )
+    finally:
+        os.close(probe)
+
+
+def test_holder_identity_failure_closes_the_effect_descriptor(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    baseline = set(lease_module._LEASE_LOCK_FDS)
+
+    def fail_holder_identity():
+        raise KeyboardInterrupt("holder identity unavailable")
+
+    monkeypatch.setattr(lease_module, "uuid4", fail_holder_identity)
+    with pytest.raises(KeyboardInterrupt, match="holder identity unavailable"):
+        with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+            pytest.fail("holder identity failure cannot expose an effect")
+
+    assert set(lease_module._LEASE_LOCK_FDS) == baseline
+    probe = os.open(manager._gate_path("binding-a"), os.O_RDWR)
+    try:
+        lease_module.fcntl.flock(
+            probe,
+            lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+        )
+    finally:
+        os.close(probe)
+
+
 @pytest.mark.parametrize("crash_point", ["journal", "state"])
 def test_pre_registry_commit_crash_rolls_back_from_the_separate_journal(
     tmp_path, monkeypatch, crash_point

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing
+import errno
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -198,6 +199,178 @@ def test_third_registry_endpoint_retains_journal_and_fails_closed(tmp_path, monk
     with pytest.raises(BindingEffectLeaseError, match="diverges from registry"):
         recovered.observe("binding-a")
     assert recovered._journal_path("binding-a").exists()
+
+
+def test_failed_pending_discard_does_not_leave_a_live_process_at_fifo_head(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_producer = manager.registry_store.set_binding_effect_lease_state
+    discard_failed = False
+
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+
+        def fail_pending_discard(binding_id, state, **kwargs) -> None:
+            nonlocal discard_failed
+            current = manager.registry_store.load().extensions["bindingEffectLeases"][binding_id]
+            if not discard_failed and current["exclusivePending"] and not state["exclusivePending"]:
+                discard_failed = True
+                raise RegistryError("pending discard unavailable")
+            real_producer(binding_id, state, **kwargs)
+
+        monkeypatch.setattr(
+            manager.registry_store,
+            "set_binding_effect_lease_state",
+            fail_pending_discard,
+        )
+        with pytest.raises(RegistryError, match="pending discard unavailable"):
+            with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=0.02):
+                pytest.fail("exclusive acquisition cannot overlap a shared holder")
+
+    monkeypatch.setattr(
+        manager.registry_store,
+        "set_binding_effect_lease_state",
+        real_producer,
+    )
+    with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+        assert manager.observe("binding-a").exclusive_pending_count == 0
+
+
+def test_pending_activity_requires_a_held_lock_from_the_live_waiter(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    manager._ensure_state_root()
+    holder = manager._holder("holder-active", ticket=1, mode="pending")
+    descriptor = manager._open_pending_activity("binding-a", holder["holderId"], create=True)
+    lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
+    try:
+        assert manager._pending_waiter_status("binding-a", holder) == (True, None)
+    finally:
+        manager._close_pending_activity(descriptor)
+
+    active, stale_descriptor = manager._pending_waiter_status("binding-a", holder)
+    assert not active
+    assert stale_descriptor is not None
+    manager._close_pending_activity(stale_descriptor)
+    manager._pending_activity_path("binding-a", holder["holderId"]).unlink()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork inheritance proof")
+def test_forked_child_neither_unlocks_nor_extends_pending_activity(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    manager._ensure_state_root()
+    path = manager._pending_activity_path("binding-a", "holder-fork")
+    descriptor = manager._open_pending_activity("binding-a", "holder-fork", create=True)
+    lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
+    child_read, parent_write = os.pipe()
+    parent_read, child_write = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(parent_write)
+        os.close(parent_read)
+        probe = os.open(path, os.O_RDWR)
+        try:
+            try:
+                lease_module.fcntl.flock(
+                    probe,
+                    lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+                )
+            except BlockingIOError:
+                os.write(child_write, b"B")
+            else:
+                os._exit(2)
+            os.read(child_read, 1)
+            lease_module.fcntl.flock(
+                probe,
+                lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+            )
+            os.write(child_write, b"A")
+            os._exit(0)
+        except BaseException:
+            os._exit(3)
+
+    os.close(child_read)
+    os.close(child_write)
+    try:
+        assert os.read(parent_read, 1) == b"B"
+        manager._close_pending_activity(descriptor)
+        os.write(parent_write, b"R")
+        assert os.read(parent_read, 1) == b"A"
+        _, status = os.waitpid(pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+    finally:
+        os.close(parent_write)
+        os.close(parent_read)
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("crash_point", ["before-pending", "after-exclusive"])
+def test_pending_activity_crash_windows_converge_without_file_leaks(
+    tmp_path, monkeypatch, crash_point
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_commit = manager._commit_locked
+
+    def crash(vault_binding_id, previous, candidate):
+        pending = candidate["exclusivePending"]
+        exclusive = candidate["exclusiveHolder"]
+        if crash_point == "before-pending" and pending and not previous["exclusivePending"]:
+            raise KeyboardInterrupt("crash before pending commit")
+        committed = real_commit(vault_binding_id, previous, candidate)
+        if crash_point == "after-exclusive" and exclusive is not None:
+            raise KeyboardInterrupt("crash after exclusive commit")
+        return committed
+
+    monkeypatch.setattr(manager, "_commit_locked", crash)
+    with pytest.raises(KeyboardInterrupt, match="crash"):
+        with manager.exclusive_change("binding-a", channel_id="dev", root=vault, timeout=1):
+            if crash_point == "before-pending":
+                pytest.fail("pending commit was expected to crash")
+
+    monkeypatch.setattr(manager, "_commit_locked", real_commit)
+    observation = manager.observe("binding-a")
+    assert observation.exclusive_pending_count == 0
+    assert not observation.exclusive_held
+    assert list(manager.state_root.glob("*.pending.lock")) == []
+
+
+def test_pending_activity_probe_error_fails_closed(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    manager._ensure_state_root()
+    holder = manager._holder("holder-probe", ticket=1, mode="pending")
+    descriptor = manager._open_pending_activity("binding-a", holder["holderId"], create=True)
+    lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
+    real_flock = lease_module.fcntl.flock
+
+    def unsupported(*args, **kwargs):
+        raise OSError(errno.ENOTSUP, "flock unsupported")
+
+    monkeypatch.setattr(lease_module.fcntl, "flock", unsupported)
+    with pytest.raises(OSError, match="flock unsupported"):
+        manager._pending_waiter_status("binding-a", holder)
+    monkeypatch.setattr(lease_module.fcntl, "flock", real_flock)
+    manager._close_pending_activity(descriptor)
+
+
+def test_pending_activity_unlink_rejects_path_replacement(tmp_path) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    manager._ensure_state_root()
+    holder_id = "holder-replaced"
+    path = manager._pending_activity_path("binding-a", holder_id)
+    descriptor = manager._open_pending_activity("binding-a", holder_id, create=True)
+    lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
+    displaced = path.with_suffix(".displaced")
+    path.rename(displaced)
+    path.touch(mode=0o600)
+    try:
+        with pytest.raises(BindingEffectLeaseError, match="path identity changed"):
+            manager._unlink_pending_activity_locked("binding-a", holder_id, descriptor)
+        assert path.exists()
+    finally:
+        manager._close_pending_activity(descriptor)
+        path.unlink(missing_ok=True)
+        displaced.unlink(missing_ok=True)
 
 
 class _FakeProcPidInfo:

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -43,6 +43,32 @@ def _fork_child_then_crash_effect_holder(root: str, mode: str, acquired, release
         os._exit(23)
 
 
+def _persist_abandoned_pending(manager, *holder_ids: str) -> list[Path]:
+    descriptors: list[int] = []
+    paths: list[Path] = []
+    try:
+        with manager._state_locked("binding-a"):
+            current = manager._load_reconciled_locked("binding-a")
+            updated = dict(current)
+            updated["exclusivePending"] = list(current["exclusivePending"])
+            next_ticket = int(current["nextTicket"])
+            for holder_id in holder_ids:
+                descriptor = manager._open_pending_activity("binding-a", holder_id, create=True)
+                descriptors.append(descriptor)
+                lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
+                updated["exclusivePending"].append(
+                    manager._holder(holder_id, ticket=next_ticket, mode="pending")
+                )
+                paths.append(manager._pending_activity_path("binding-a", holder_id))
+                next_ticket += 1
+            updated["nextTicket"] = next_ticket
+            manager._commit_locked("binding-a", current, updated)
+    finally:
+        for descriptor in descriptors:
+            manager._close_pending_activity(descriptor)
+    return paths
+
+
 def test_crashed_holder_recovers_without_deadlock_or_false_completion(tmp_path) -> None:
     _build_manager(tmp_path, "binding-a")
     context = multiprocessing.get_context("spawn")
@@ -191,6 +217,76 @@ def test_holder_identity_failure_closes_the_effect_descriptor(tmp_path, monkeypa
         )
     finally:
         os.close(probe)
+
+
+def test_reconciliation_cancellation_closes_transferred_pending_descriptor(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    [sentinel] = _persist_abandoned_pending(manager, "holder-abandoned")
+    baseline = set(lease_module._LEASE_LOCK_FDS)
+    real_flock = lease_module.fcntl.flock
+    nonblocking_exclusive_calls = 0
+
+    def cancel_at_gate_probe(descriptor, operation):
+        nonlocal nonblocking_exclusive_calls
+        result = real_flock(descriptor, operation)
+        if operation == lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB:
+            nonblocking_exclusive_calls += 1
+            if nonblocking_exclusive_calls == 2:
+                raise KeyboardInterrupt("cancel after pending descriptor transfer")
+        return result
+
+    monkeypatch.setattr(lease_module.fcntl, "flock", cancel_at_gate_probe)
+    with pytest.raises(KeyboardInterrupt, match="pending descriptor transfer"):
+        manager.observe("binding-a")
+    monkeypatch.setattr(lease_module.fcntl, "flock", real_flock)
+
+    assert set(lease_module._LEASE_LOCK_FDS) == baseline
+    probe = os.open(sentinel, os.O_RDWR)
+    try:
+        real_flock(
+            probe,
+            lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+        )
+    finally:
+        os.close(probe)
+    assert manager.observe("binding-a").exclusive_pending_count == 0
+
+
+def test_later_pending_probe_failure_closes_an_earlier_transfer(tmp_path, monkeypatch) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    first, _ = _persist_abandoned_pending(
+        manager,
+        "holder-abandoned-first",
+        "holder-abandoned-second",
+    )
+    baseline = set(lease_module._LEASE_LOCK_FDS)
+    real_status = manager._pending_waiter_status
+    calls = 0
+
+    def fail_second_probe(vault_binding_id, holder):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise KeyboardInterrupt("later pending probe failed")
+        return real_status(vault_binding_id, holder)
+
+    monkeypatch.setattr(manager, "_pending_waiter_status", fail_second_probe)
+    with pytest.raises(KeyboardInterrupt, match="later pending probe"):
+        manager.observe("binding-a")
+    monkeypatch.setattr(manager, "_pending_waiter_status", real_status)
+
+    assert set(lease_module._LEASE_LOCK_FDS) == baseline
+    probe = os.open(first, os.O_RDWR)
+    try:
+        lease_module.fcntl.flock(
+            probe,
+            lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+        )
+    finally:
+        os.close(probe)
+    assert manager.observe("binding-a").exclusive_pending_count == 0
 
 
 @pytest.mark.parametrize("crash_point", ["journal", "state"])

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import errno
+import inspect
 import json
 import multiprocessing
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -260,6 +262,54 @@ def test_holder_identity_failure_closes_the_effect_descriptor(tmp_path, monkeypa
         )
     finally:
         os.close(probe)
+
+
+def test_held_activity_descriptor_has_one_cleanup_owner_at_cancellation_boundary(
+    tmp_path, monkeypatch
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    wrapped_acquire = manager._acquire.__wrapped__
+    source, start = inspect.getsourcelines(wrapped_acquire)
+    cancellation_line = next(
+        start + offset for offset, line in enumerate(source) if line.strip() == "pending = None"
+    )
+    real_close = manager._close_holder_activity
+    reused: list[int] = []
+
+    def close_then_force_reuse(descriptor: int) -> None:
+        real_close(descriptor)
+        if not reused:
+            replacement = os.open("/dev/null", os.O_RDONLY)
+            assert replacement == descriptor
+            reused.append(replacement)
+
+    def cancel_after_held_assignment(frame, event, arg):
+        del arg
+        if (
+            event == "line"
+            and frame.f_code is wrapped_acquire.__code__
+            and frame.f_lineno == cancellation_line
+        ):
+            sys.settrace(None)
+            raise KeyboardInterrupt("cancel after held activity assignment")
+        return cancel_after_held_assignment
+
+    monkeypatch.setattr(manager, "_close_holder_activity", close_then_force_reuse)
+    sys.settrace(cancel_after_held_assignment)
+    try:
+        with pytest.raises(KeyboardInterrupt, match="held activity assignment"):
+            with manager.shared_effect("binding-a", channel_id="dev", root=vault, timeout=1):
+                pytest.fail("cancellation cannot expose the effect window")
+    finally:
+        sys.settrace(None)
+
+    assert len(reused) == 1
+    try:
+        os.fstat(reused[0])
+    finally:
+        os.close(reused[0])
+    assert manager.observe("binding-a").shared_count == 0
 
 
 @pytest.mark.parametrize("mode", ["shared", "exclusive"])

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -54,19 +54,19 @@ def _persist_abandoned_pending(manager, *holder_ids: str) -> list[Path]:
             updated["exclusivePending"] = list(current["exclusivePending"])
             next_ticket = int(current["nextTicket"])
             for holder_id in holder_ids:
-                descriptor = manager._open_pending_activity("binding-a", holder_id, create=True)
+                descriptor = manager._open_holder_activity("binding-a", holder_id, create=True)
                 descriptors.append(descriptor)
                 lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
                 updated["exclusivePending"].append(
                     manager._holder(holder_id, ticket=next_ticket, mode="pending")
                 )
-                paths.append(manager._pending_activity_path("binding-a", holder_id))
+                paths.append(manager._holder_activity_path("binding-a", holder_id))
                 next_ticket += 1
             updated["nextTicket"] = next_ticket
             manager._commit_locked("binding-a", current, updated)
     finally:
         for descriptor in descriptors:
-            manager._close_pending_activity(descriptor)
+            manager._close_holder_activity(descriptor)
     return paths
 
 
@@ -338,7 +338,7 @@ def test_later_pending_probe_failure_closes_an_earlier_transfer(tmp_path, monkey
         "holder-abandoned-second",
     )
     baseline = set(lease_module._LEASE_LOCK_FDS)
-    real_status = manager._pending_waiter_active
+    real_status = manager._holder_activity_active
     calls = 0
 
     def fail_second_probe(vault_binding_id, holder, abandoned):
@@ -348,10 +348,10 @@ def test_later_pending_probe_failure_closes_an_earlier_transfer(tmp_path, monkey
             raise KeyboardInterrupt("later pending probe failed")
         return real_status(vault_binding_id, holder, abandoned)
 
-    monkeypatch.setattr(manager, "_pending_waiter_active", fail_second_probe)
+    monkeypatch.setattr(manager, "_holder_activity_active", fail_second_probe)
     with pytest.raises(KeyboardInterrupt, match="later pending probe"):
         manager.observe("binding-a")
-    monkeypatch.setattr(manager, "_pending_waiter_active", real_status)
+    monkeypatch.setattr(manager, "_holder_activity_active", real_status)
 
     assert set(lease_module._LEASE_LOCK_FDS) == baseline
     probe = os.open(first, os.O_RDWR)
@@ -582,29 +582,29 @@ def test_pending_activity_requires_a_held_lock_from_the_live_waiter(tmp_path) ->
     manager = _build_manager(tmp_path, "binding-a")
     manager._ensure_state_root()
     holder = manager._holder("holder-active", ticket=1, mode="pending")
-    descriptor = manager._open_pending_activity("binding-a", holder["holderId"], create=True)
+    descriptor = manager._open_holder_activity("binding-a", holder["holderId"], create=True)
     lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
     try:
         abandoned = []
-        assert manager._pending_waiter_active("binding-a", holder, abandoned)
+        assert manager._holder_activity_active("binding-a", holder, abandoned)
         assert abandoned == []
     finally:
-        manager._close_pending_activity(descriptor)
+        manager._close_holder_activity(descriptor)
 
     abandoned = []
-    assert not manager._pending_waiter_active("binding-a", holder, abandoned)
+    assert not manager._holder_activity_active("binding-a", holder, abandoned)
     [(_, stale_descriptor)] = abandoned
     assert stale_descriptor is not None
-    manager._close_pending_activity(stale_descriptor)
-    manager._pending_activity_path("binding-a", holder["holderId"]).unlink()
+    manager._close_holder_activity(stale_descriptor)
+    manager._holder_activity_path("binding-a", holder["holderId"]).unlink()
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork inheritance proof")
 def test_forked_child_neither_unlocks_nor_extends_pending_activity(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     manager._ensure_state_root()
-    path = manager._pending_activity_path("binding-a", "holder-fork")
-    descriptor = manager._open_pending_activity("binding-a", "holder-fork", create=True)
+    path = manager._holder_activity_path("binding-a", "holder-fork")
+    descriptor = manager._open_holder_activity("binding-a", "holder-fork", create=True)
     lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
     child_read, parent_write = os.pipe()
     parent_read, child_write = os.pipe()
@@ -637,7 +637,7 @@ def test_forked_child_neither_unlocks_nor_extends_pending_activity(tmp_path) -> 
     os.close(child_write)
     try:
         assert os.read(parent_read, 1) == b"B"
-        manager._close_pending_activity(descriptor)
+        manager._close_holder_activity(descriptor)
         os.write(parent_write, b"R")
         assert os.read(parent_read, 1) == b"A"
         _, status = os.waitpid(pid, 0)
@@ -683,7 +683,7 @@ def test_pending_activity_probe_error_fails_closed(tmp_path, monkeypatch) -> Non
     manager = _build_manager(tmp_path, "binding-a")
     manager._ensure_state_root()
     holder = manager._holder("holder-probe", ticket=1, mode="pending")
-    descriptor = manager._open_pending_activity("binding-a", holder["holderId"], create=True)
+    descriptor = manager._open_holder_activity("binding-a", holder["holderId"], create=True)
     lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
     real_flock = lease_module.fcntl.flock
 
@@ -692,27 +692,27 @@ def test_pending_activity_probe_error_fails_closed(tmp_path, monkeypatch) -> Non
 
     monkeypatch.setattr(lease_module.fcntl, "flock", unsupported)
     with pytest.raises(OSError, match="flock unsupported"):
-        manager._pending_waiter_active("binding-a", holder, [])
+        manager._holder_activity_active("binding-a", holder, [])
     monkeypatch.setattr(lease_module.fcntl, "flock", real_flock)
-    manager._close_pending_activity(descriptor)
+    manager._close_holder_activity(descriptor)
 
 
 def test_pending_activity_unlink_rejects_path_replacement(tmp_path) -> None:
     manager = _build_manager(tmp_path, "binding-a")
     manager._ensure_state_root()
     holder_id = "holder-replaced"
-    path = manager._pending_activity_path("binding-a", holder_id)
-    descriptor = manager._open_pending_activity("binding-a", holder_id, create=True)
+    path = manager._holder_activity_path("binding-a", holder_id)
+    descriptor = manager._open_holder_activity("binding-a", holder_id, create=True)
     lease_module.fcntl.flock(descriptor, lease_module.fcntl.LOCK_EX)
     displaced = path.with_suffix(".displaced")
     path.rename(displaced)
     path.touch(mode=0o600)
     try:
         with pytest.raises(BindingEffectLeaseError, match="path identity changed"):
-            manager._unlink_pending_activity_locked("binding-a", holder_id, descriptor)
+            manager._unlink_holder_activity_locked("binding-a", holder_id, descriptor)
         assert path.exists()
     finally:
-        manager._close_pending_activity(descriptor)
+        manager._close_holder_activity(descriptor)
         path.unlink(missing_ok=True)
         displaced.unlink(missing_ok=True)
 

--- a/tests/instance/test_binding_effect_lease_recovery.py
+++ b/tests/instance/test_binding_effect_lease_recovery.py
@@ -313,6 +313,79 @@ def test_held_activity_descriptor_has_one_cleanup_owner_at_cancellation_boundary
 
 
 @pytest.mark.parametrize("mode", ["shared", "exclusive"])
+def test_held_gate_descriptor_has_one_outer_owner_at_release_entry(
+    tmp_path, monkeypatch, mode
+) -> None:
+    manager = _build_manager(tmp_path, "binding-a")
+    vault = tmp_path / "vaults" / "binding-a"
+    real_release = manager._release
+    source, start = inspect.getsourcelines(real_release)
+    cancellation_line = next(
+        start + offset
+        for offset, line in enumerate(source)
+        if line.strip() == "if held.owner_pid != os.getpid():"
+    )
+    real_close = lease_module._close_lease_descriptor
+    gate_descriptor: list[int] = []
+    reused: list[int] = []
+
+    def recording_release(held) -> None:
+        gate_descriptor.append(held.gate_descriptor)
+        real_release(held)
+
+    def close_then_force_reuse(descriptor: int) -> None:
+        real_close(descriptor)
+        if gate_descriptor and descriptor == gate_descriptor[0] and not reused:
+            replacement = os.open("/dev/null", os.O_RDONLY)
+            assert replacement == descriptor
+            reused.append(replacement)
+
+    def cancel_at_release_entry(frame, event, arg):
+        del arg
+        if (
+            event == "line"
+            and frame.f_code is real_release.__func__.__code__
+            and frame.f_lineno == cancellation_line
+        ):
+            sys.settrace(None)
+            raise KeyboardInterrupt("cancel at held gate release entry")
+        return cancel_at_release_entry
+
+    monkeypatch.setattr(manager, "_release", recording_release)
+    monkeypatch.setattr(
+        lease_module,
+        "_close_lease_descriptor",
+        close_then_force_reuse,
+    )
+    effect = manager.shared_effect if mode == "shared" else manager.exclusive_change
+    sys.settrace(cancel_at_release_entry)
+    try:
+        with pytest.raises(KeyboardInterrupt, match="held gate release entry"):
+            with effect("binding-a", channel_id="dev", root=vault, timeout=1):
+                pass
+    finally:
+        sys.settrace(None)
+
+    assert len(reused) == 1
+    try:
+        os.fstat(reused[0])
+        probe = os.open(manager._gate_path("binding-a"), os.O_RDWR)
+        try:
+            lease_module.fcntl.flock(
+                probe,
+                lease_module.fcntl.LOCK_EX | lease_module.fcntl.LOCK_NB,
+            )
+        finally:
+            os.close(probe)
+    finally:
+        os.close(reused[0])
+
+    observation = manager.observe("binding-a")
+    assert observation.shared_count == 0
+    assert not observation.exclusive_held
+
+
+@pytest.mark.parametrize("mode", ["shared", "exclusive"])
 def test_public_context_cancellation_releases_the_adopted_effect(
     tmp_path, monkeypatch, mode
 ) -> None:

--- a/tests/instance/test_binding_effect_lease_store.py
+++ b/tests/instance/test_binding_effect_lease_store.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from app.instance.vault_registry import RegistryError, VaultRegistration, VaultRegistryStore
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
+
+
+def test_lease_state_has_its_own_validated_producer(tmp_path) -> None:
+    store = VaultRegistryStore(tmp_path / "vault-registry.md")
+    store.register(
+        VaultRegistration("binding-a", "path:/vault/a", "/vault/a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    valid = {
+        "schema": "agentic-pkm.binding-effect-lease.v1",
+        "vaultBindingId": "binding-a",
+        "generation": 1,
+        "nextTicket": 2,
+        "sharedHolders": [],
+        "exclusivePending": [],
+        "exclusiveHolder": None,
+    }
+    updated = store.set_binding_effect_lease_state(
+        "binding-a",
+        valid,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    assert updated.extensions["bindingEffectLeases"]["binding-a"] == valid
+
+    with pytest.raises(RegistryError, match="binding effect lease state"):
+        store.set_binding_effect_lease_state(
+            "binding-a",
+            {**valid, "sharedHolders": [{"pid": "not-an-int"}]},
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert store.load().extensions["bindingEffectLeases"]["binding-a"] == valid
+
+    with pytest.raises(TypeError):
+        store.set_extension_state(  # type: ignore[call-arg]
+            principal_state={},
+            background_state={},
+            runtime_floors={},
+            binding_effect_leases={},
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+
+    with pytest.raises(RegistryError, match="unknown binding"):
+        store.remove_registration(
+            "binding-a",
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert "binding-a" in store.load().registrations

--- a/tests/instance/test_binding_effect_lease_store.py
+++ b/tests/instance/test_binding_effect_lease_store.py
@@ -1,32 +1,49 @@
 from __future__ import annotations
 
+import copy
+from dataclasses import replace
+
 import pytest
 
 from app.instance.vault_registry import RegistryError, VaultRegistration, VaultRegistryStore
 from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
 
-def test_lease_state_has_its_own_validated_producer(tmp_path) -> None:
-    store = VaultRegistryStore(tmp_path / "vault-registry.md")
-    store.register(
-        VaultRegistration("binding-a", "path:/vault/a", "/vault/a"),
-        _capability=STORAGE_MUTATION_CAPABILITY,
-    )
-    valid = {
+def _valid_lease_state(binding_id: str) -> dict[str, object]:
+    return {
         "schema": "agentic-pkm.binding-effect-lease.v1",
-        "vaultBindingId": "binding-a",
+        "vaultBindingId": binding_id,
         "generation": 1,
         "nextTicket": 2,
         "sharedHolders": [],
         "exclusivePending": [],
         "exclusiveHolder": None,
     }
+
+
+def test_lease_state_has_its_own_validated_producer(tmp_path) -> None:
+    store = VaultRegistryStore(tmp_path / "vault-registry.md")
+    registration = VaultRegistration("binding-a", "path:/vault/a", "/vault/a")
+    registered = store.register(
+        registration,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    valid = _valid_lease_state("binding-a")
     updated = store.set_binding_effect_lease_state(
         "binding-a",
         valid,
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
     assert updated.extensions["bindingEffectLeases"]["binding-a"] == valid
+    assert updated.revision == registered.revision
+
+    lifecycle_update = store.update_registration(
+        registration,
+        expected_revision=registered.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    assert lifecycle_update.revision == registered.revision + 1
+    assert lifecycle_update.extensions["bindingEffectLeases"]["binding-a"] == valid
 
     with pytest.raises(RegistryError, match="binding effect lease state"):
         store.set_binding_effect_lease_state(
@@ -51,3 +68,41 @@ def test_lease_state_has_its_own_validated_producer(tmp_path) -> None:
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert "binding-a" in store.load().registrations
+
+
+def test_lease_state_preserves_active_scalar_rollback_authority(tmp_path) -> None:
+    store = VaultRegistryStore(tmp_path / "vault-registry.md")
+    registration = VaultRegistration("binding-a", "path:/vault/a", "/vault/a")
+    registered = store.register(
+        registration,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    extensions = copy.deepcopy(registered.extensions)
+    extensions["scalarRollback"] = {
+        "schema": "agentic-pkm.scalar-rollback-floor.v1",
+        "targetVaultBindingId": registration.vault_binding_id,
+        "targetRef": registration.ref,
+        "targetPath": registration.path,
+        "forkRegistryRevision": registered.revision,
+        "gatewayPreflight": "authenticated-mutation-filter",
+        "nativeGuardPreflight": "deny-by-default",
+        "rollForwardLineage": "agentic-pkm.scalar-roll-forward-lineage.v1",
+        "composePolicySha256": "a" * 64,
+        "gatewayPolicySha256": "b" * 64,
+        "nativeLauncherSha256": "c" * 64,
+    }
+    active = replace(registered, authority="active", extensions=extensions)
+    with store._locked():
+        store._write_locked(active)
+
+    updated = store.set_binding_effect_lease_state(
+        registration.vault_binding_id,
+        _valid_lease_state(registration.vault_binding_id),
+        expected_revision=active.revision,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    reloaded = store.load()
+
+    assert updated.revision == active.revision
+    assert updated.extensions["scalarRollback"] == active.extensions["scalarRollback"]
+    assert reloaded == updated

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -19,6 +19,7 @@ import app.instance.instance_state as instance_state_module
 import app.instance.ownership_ledger as ownership_ledger_module
 import app.instance.runtime as runtime_module
 
+from app.instance.binding_effect_lease import BindingEffectLeaseManager
 from app.instance.instance_state import (
     DeploymentQuiescenceProof,
     InstanceStateBackup,
@@ -4536,6 +4537,68 @@ def test_prod_instance_state_and_ledger_survive_volume_loss_with_verified_restor
             quiescence_proof=restore_proof,
             owner_receipt_path=owner_receipt,
         )
+
+
+def test_restore_rebuilds_binding_effect_lease_state_from_restored_registry(tmp_path) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host-global")
+    root = tmp_path / "vault"
+    root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=root,
+        watcher_vault_path=root,
+    )
+    backup_root = tmp_path / "backup"
+    legacy_path = tmp_path / "missing-legacy.md"
+    _create_canonical_backup(
+        runtime=runtime,
+        backup_root=backup_root,
+        legacy_path=legacy_path,
+    )
+    _clear_test_deployment_authority(
+        layout=layout,
+        host_global_root=runtime.ledger.root,
+    )
+
+    state_root = layout.root / "binding-effect-leases"
+    manager = BindingEffectLeaseManager(
+        registry_store=runtime.registry,
+        ownership_ledger=runtime.ledger,
+        state_root=state_root,
+        capability=STORAGE_MUTATION_CAPABILITY,
+        poll_interval=0.005,
+    )
+    with manager.shared_effect(
+        registration.vault_binding_id,
+        channel_id="prod",
+        root=root,
+        timeout=1,
+    ):
+        pass
+    assert manager.persisted_state(registration.vault_binding_id)["generation"] == 2
+
+    restore_proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=layout,
+        host_global_root=runtime.ledger.root,
+        legacy_path=legacy_path,
+        owners=_current_registry_owners(runtime),
+    )
+    InstanceStateBackup(layout, runtime.ledger).restore(
+        backup_root,
+        quiescence_proof=restore_proof,
+        owner_receipt_path=owner_receipt,
+    )
+
+    assert not state_root.exists()
+    observation = manager.observe(registration.vault_binding_id)
+    assert observation.generation == 0
+    with manager.shared_effect(
+        registration.vault_binding_id,
+        channel_id="prod",
+        root=root,
+        timeout=1,
+    ):
+        assert manager.observe(registration.vault_binding_id).shared_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -478,17 +478,17 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2357): (
+    ("app/instance/vault_registry.py", 2496): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 (site "
-        "unchanged); re-pinned after directly related MVR-04 (#3858/#4794) insertions "
-        "earlier in vault_registry.py, which added the locked dimension writer "
-        "and the transactional dimension-membership repair hook in "
-        "remove_registration. MVR-04 adds no new write_frontmatter site: like "
-        "MVR-02 before it, it writes the registry through _atomic_private_write, "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 "
+        "(site unchanged); re-pinned after directly related MVR-05A6 (#4580) inserted "
+        "the validated binding-effect lease producer earlier in vault_registry.py. "
+        "MVR-05A6 adds no new "
+        "write_frontmatter site: like MVR-02/MVR-04, it writes the registry through "
+        "_atomic_private_write, "
         "not the vault-content seam."
     ),
 }

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -478,12 +478,12 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2496): (
+    ("app/instance/vault_registry.py", 2503): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 "
         "(site unchanged); re-pinned after directly related MVR-05A6 (#4580) inserted "
         "the validated binding-effect lease producer earlier in vault_registry.py. "
         "MVR-05A6 adds no new "


### PR DESCRIPTION
Final-Review-Rounds: 1

Governing-Issue: #4580

## Linked Issue

Fixes #4580

## SBS Impact

- Primary subsystem: WSP
- Secondary subsystem(s): GOV, OEF
- Write class: mechanical instance-local state; no human-artifact write authority
- Persistence impact: durable instance-local per-binding lease state plus crash journal
- Derived/rebuildable impact: lease state is instance-local and rebuildable from a quiesced instance
- New or changed contract: cross-process per-binding shared/exclusive effect lease acquired after the host-global ownership fence
- Owner-doc impact: follow-up issue #4582 owns deployment/operations wiring; MVR-05B owns the architecture writeback
- Transition debt impact: none
- Boundary risk: lock-order inversion, stale process authority, or ambiguous registry recovery could deadlock an enabled binding; focused guards and fail-closed recovery cover these paths

## Owner-Doc Writeback

- [ ] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [x] Owner-doc follow-up issue created and linked: #4582 (with MVR-05B retaining its assigned architecture writeback).

## Summary

- add a durable, countable cross-process shared/exclusive lease keyed by vault binding, with FIFO exclusive fairness and distinct-binding concurrency
- make per-holder activity locks authoritative across PID namespaces, enforce host-global ownership-fence-first ordering, and converge lease state with the validated registry producer through previous/next-only crash journals
- rebuild lease-local state from restored registry authority under the existing quiescence fence and reject linked private state paths without mutating their targets
- add deterministic process, crash, cancellation, fork, descriptor, fairness, restore, lock-order, registry-producer, private-path, and WriteGuard proofs without wiring the MVR-05A8 worker/revocation consumers

## Validation

- focused lease/import/WriteGuard/restore selector: 58 passed
- registry/active-context regression selector: 13 passed
- `pytest -q tests/guard/test_no_direct_db_imports.py`: passed
- `ruff check app tests`: passed
- `mypy app`: passed (893 source files)
- `lint-imports --config importlinter.ini`: passed (5 contracts kept, 0 broken)
- source-anchor validator: passed against issue #4580
- host-leased serial non-PG suite: 13,529 passed, 49 skipped, 405 deselected, 18 xfailed
- Sol/xhigh mechanism convergence at `b193b17240c33761366858615c856b60e7d68dfd`: P0/P1/P2 all zero; one historical severity-routing observation remains P3 `record_only`
- base integration: rebased onto `06fdf08012672b087af059818ea6398dcba8e319`; zero incoming path overlap, stable patch ID and all 12 delivery blobs/full binary patch preserved byte-identically

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: protected mechanism repair iterations were resolved and independently re-reviewed within this issue delivery; no reusable Builder-System learning or authority-class promotion was identified.

## Notes

- Residual platform risk is fail-closed: acquisition is refused without `O_NOFOLLOW` or trustworthy local process-incarnation metadata; cross-namespace liveness authority comes from per-holder locks, not observer-local PIDs.
- #4581 remains blocked; this PR does not claim or wire MVR-05A7/MVR-05A8 work.
