### PR TITLE
Clarify Builder System degraded routing

### DIFF
--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -899,7 +899,7 @@ if [ "${BUILDEROPS_BOOTSTRAP:-1}" = "1" ]; then
         )
       fi
       if ! scripts/start_builderops_services.sh "${builderops_bootstrap_args[@]}"; then
-        echo "WARNING: BuilderOps bootstrap failed unexpectedly; continuing runtime startup in degraded BuilderOps mode" >&2
+        echo "WARNING: BuilderOps bootstrap failed unexpectedly; Builder System routing is degraded to GitHub-label-only claims where GitHub is reachable; continuing runtime startup" >&2
       fi
       mark_phase_ok "builderops_bootstrap"
       ;;

--- a/tests/ops/test_builderops_startup_bootstrap.py
+++ b/tests/ops/test_builderops_startup_bootstrap.py
@@ -55,6 +55,7 @@ def test_dev_start_full_invokes_builderops_bootstrap() -> None:
     assert "scripts/start_full_system.sh" in dev_target
     assert "scripts/start_builderops_services.sh" in start_script
     assert "builderops_bootstrap" in start_script
+    assert "Builder System routing is degraded to GitHub-label-only claims" in start_script
     compose = (REPO_ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
     assert "DISPATCHER_HOST_STATE_DIR" in compose
     assert "${DISPATCHER_HOST_STATE_DIR:-./runtime/dispatcher}" in compose


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: The startup warning omitted the affected Builder System routing and its existing GitHub-label-only fallback.
Validation: bash -n scripts/start_full_system.sh; targeted pytest; ruff check app tests.
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): runtime startup diagnostics
- Write class: operator-facing warning text and regression test
- Persistence impact: none
- Derived/rebuildable impact: unaffected
- New or changed contract: none; clarifies the existing GitHub-label-only fallback
- Owner-doc impact: none; startup behavior is unchanged
- Transition debt impact: none
- Boundary risk: low

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Clarify the Builder System fallback when BuilderOps bootstrap fails.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record was created; this is a bounded startup-warning repair.

## Notes
Validation: bash -n scripts/start_full_system.sh; python3 -m pytest -q tests/ops/test_builderops_startup_bootstrap.py::test_dev_start_full_invokes_builderops_bootstrap; ruff check app tests. Docs guard override: no current-state owner doc changes for an operator-facing warning clarification.