### PR TITLE
Make zero review rounds an explicit light path

### DIFF
--- a/app/dispatcher/verification_contract.py
+++ b/app/dispatcher/verification_contract.py
@@ -43,12 +43,12 @@ FINAL_REVIEW_ROUNDS_LINE_PATTERN = re.compile(
     r"(?m)^Final-Review-Rounds:[ \t]*.*$"
 )
 FINAL_REVIEW_ROUNDS_PATTERN = re.compile(
-    r"(?m)^Final-Review-Rounds:[ \t]*([12])[ \t]*$"
+    r"(?m)^Final-Review-Rounds:[ \t]*([012])[ \t]*$"
 )
 
 
 def resolve_final_review_rounds(body: object) -> int | None:
-    """Return one strict declaration; missing, malformed, or duplicate fails closed."""
+    """Return one strict declaration; zero explicitly selects the light path."""
     if not isinstance(body, str):
         return None
     if re.search(r"\r(?!\n)|[\u2028\u2029]", body):

--- a/scripts/build_verification_dispatch_request.py
+++ b/scripts/build_verification_dispatch_request.py
@@ -168,6 +168,8 @@ def build_request(
     final_review_rounds = resolve_final_review_rounds(pr.get("body"))
     if issue_authority is None or final_review_rounds is None:
         return None
+    if final_review_rounds == 0:
+        return None
     live_closing_issues = _resolve_live_closing_issues(
         pr.get("live_closing_issues"), repository=repository
     )
@@ -246,11 +248,15 @@ def render_markdown(request: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
-def _write_github_output(path: Path | None, *, emitted: bool) -> None:
+def _write_github_output(
+    path: Path | None, *, emitted: bool, reason: str = ""
+) -> None:
     if path is None:
         return
     with path.open("a", encoding="utf-8") as output:
         output.write(f"emitted={'true' if emitted else 'false'}\n")
+        if reason:
+            output.write(f"reason={reason}\n")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -276,7 +282,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         issue=_load_json(args.issue_json),
     )
     if request is None:
-        _write_github_output(args.github_output, emitted=False)
+        final_review_rounds = resolve_final_review_rounds(
+            _load_json(args.pr_json).get("body")
+        )
+        reason = "light-path" if final_review_rounds == 0 else "ineligible"
+        _write_github_output(args.github_output, emitted=False, reason=reason)
         return 0
 
     args.output_json.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/governance/test_verification_dispatch_request.py
+++ b/tests/governance/test_verification_dispatch_request.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from app.dispatcher.verification_contract import MAX_CLOSING_ISSUES
+from app.dispatcher.verification_contract import resolve_final_review_rounds
 from scripts.build_verification_dispatch_request import (
     build_request,
     resolve_issue_contract,
@@ -111,6 +112,24 @@ def test_light_path_emits_no_verification_dispatch_request() -> None:
     )
 
     assert build_request(event=_event(), pr=pr, issue=_issue()) is None
+
+
+def test_one_and_two_rounds_remain_dispatchable() -> None:
+    assert resolve_final_review_rounds(_pr()["body"]) == 1
+    pr = _pr()
+    pr["body"] = str(pr["body"]).replace(
+        "Final-Review-Rounds: 1", "Final-Review-Rounds: 2"
+    )
+    assert resolve_final_review_rounds(pr["body"]) == 2
+
+
+def test_zero_rounds_is_explicit_light_path() -> None:
+    pr = _pr()
+    pr["body"] = str(pr["body"]).replace(
+        "Final-Review-Rounds: 1", "Final-Review-Rounds: 0"
+    )
+
+    assert resolve_final_review_rounds(pr["body"]) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Governing-Issue: #4227

Fixes #4227

Final-Review-Rounds: 0

## SBS Impact
- Primary subsystem: Builder System / verification-dispatch contract
- Secondary subsystem(s): PR governance and CI handoff
- Write class: governance contract and focused test enforcement
- Persistence impact: none
- Derived/rebuildable impact: dispatch no-op classification remains rebuildable from the PR body
- New or changed contract: `Final-Review-Rounds: 0` is an explicit light-path declaration and never enters verified-merge dispatch
- Owner-doc impact: no owner-doc change implied; behavior is already documented by existing governance docs
- Transition debt impact: removes the implicit parser/no-op coincidence
- Boundary risk: none; no runtime, deployment, credential, or external API behavior changed

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## BuilderOps Routing
- Records/projections/receipts: GitHub Issue #4227 pickup receipt `5304005689`
- Reason: bounded governance repair; no BuilderOps operational record or projection is produced.

## Summary
- Recognize `Final-Review-Rounds: 0` explicitly in the shared resolver.
- Preserve the producer no-op for light-path PRs and expose `reason=light-path` in GitHub output.
- Keep one- and two-round declarations unchanged.

## Validation
- `python3 -m pytest -q tests/governance/test_verification_dispatch_request.py tests/dispatcher/test_verification_dispatch.py` — 376 passed
- `ruff check app/dispatcher/verification_contract.py scripts/build_verification_dispatch_request.py tests/governance/test_verification_dispatch_request.py` — passed
- `python3 scripts/docs_guard.py` — passed
- `git diff --check` — passed
- `scripts/agent_workspace_preflight.sh` — passed
- `scripts/review_before_ci_gate.py` — passed

## Scope boundary
No changes to `Final-Review-Rounds: 1|2`, verified-merge ceremony, consumer wiring, PR contract validation, deployment, or promotion.
