### PR TITLE
Bind outbox dedup to vault identity

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -828,6 +828,9 @@ jobs:
               - 'app/db/db.py'
               - 'app/memory_kv/store.py'
               - 'app/services/vault_sync.py'
+              - 'app/services/outbox.py'
+              - 'app/workers/outbox_worker.py'
+              - 'app/alembic/versions/f6a05a7b0001_mvr05a7_outbox_binding_dual_key.py'
               - 'tests/migrations/test_file_state_adoption.py'
               - 'tests/migrations/test_objects_adoption.py'
               # Both were pg-marked and in no lane at all before #4560, and both
@@ -862,6 +865,8 @@ jobs:
               - 'tests/architecture/durable_table_classification.py'
               - 'tests/architecture/durable_table_classification.json'
               - 'tests/migrations/test_outbox_schema_parity.py'
+              - 'tests/migrations/test_multi_vault_outbox_upgrade.py'
+              - 'tests/services/test_multi_vault_outbox_dual_key_dedup.py'
               - 'tests/services/test_outbox_bootstrap_assert_only.py'
               - 'tests/instance/test_file_state_binding_key.py'
               - 'tests/services/test_vault_sync_binding_scope.py'
@@ -938,6 +943,8 @@ jobs:
             tests/stores/test_vector_generation_identity.py \
             tests/services/test_audit_writer.py \
             tests/migrations/test_outbox_schema_parity.py \
+            tests/migrations/test_multi_vault_outbox_upgrade.py \
+            tests/services/test_multi_vault_outbox_dual_key_dedup.py \
             tests/services/test_outbox_bootstrap_assert_only.py \
             tests/instance/test_file_state_binding_key.py \
             tests/services/test_vault_sync_binding_scope.py \

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -231,7 +231,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          pytest -c /dev/null -q \
+          pytest -c /dev/null --rootdir=. -q \
             tests/int/test_pg_backend.py \
             tests/api/test_status_store_pg.py \
             tests/indexer/test_outbox_roundtrip_pg.py \

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -272,6 +272,8 @@ jobs:
             tests/stores/test_vector_generation_identity.py \
             tests/services/test_audit_writer.py \
             tests/migrations/test_outbox_schema_parity.py \
+            tests/migrations/test_multi_vault_outbox_upgrade.py \
+            tests/services/test_multi_vault_outbox_dual_key_dedup.py \
             tests/migrations/test_yss01_source_registry_schema_parity.py::test_yss01_migration_bootstrap_parity_and_legacy_repair \
             tests/services/test_outbox_bootstrap_assert_only.py \
             tests/instance/test_file_state_binding_key.py \

--- a/app/alembic/versions/f6a05a7b0001_mvr05a7_outbox_binding_dual_key.py
+++ b/app/alembic/versions/f6a05a7b0001_mvr05a7_outbox_binding_dual_key.py
@@ -1,0 +1,69 @@
+"""MVR-05A7: bind outbox rows and preserve scalar-era dedup history.
+
+The scalar outbox persisted only its derived UUID primary key, not the source
+identity or content fingerprint used to derive it.  This revision therefore
+copies, and never recomputes, that key into ``legacy_key``.  Plain scalar-era
+rows belong to the one explicit compatibility binding.  A partially upgraded
+row whose ``legacy_key`` already differs from ``id`` but lacks a binding is
+unprovable and receives the fail-safe quarantine marker.
+"""
+
+from alembic import op
+
+
+revision = "f6a05a7b0001"
+down_revision = "f5a05a5b0001"
+branch_labels = None
+depends_on = None
+reversibility = "forward-only"
+
+_COMPATIBILITY_BINDING_ID = "legacy-compatibility-binding"
+_QUARANTINE_BINDING_ID = "outbox-quarantined-unprovable-binding"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        LOCK TABLE public.outbox IN SHARE ROW EXCLUSIVE MODE;
+
+        ALTER TABLE public.outbox
+          ADD COLUMN IF NOT EXISTS vault_binding_id text;
+        ALTER TABLE public.outbox
+          ADD COLUMN IF NOT EXISTS legacy_key uuid;
+
+        -- A partially upgraded scoped row cannot be attributed from the
+        -- stored envelope.  Preserve it as collision evidence; never guess.
+        UPDATE public.outbox
+           SET vault_binding_id = '{_QUARANTINE_BINDING_ID}'
+         WHERE vault_binding_id IS NULL
+           AND legacy_key IS NOT NULL
+           AND legacy_key <> id;
+        UPDATE public.outbox
+           SET vault_binding_id = '{_QUARANTINE_BINDING_ID}'
+         WHERE vault_binding_id IS NOT NULL
+           AND btrim(vault_binding_id) = '';
+
+        -- This is deliberately a copy.  The original derivation inputs do not
+        -- exist on the row and key rewriting is structurally impossible.
+        UPDATE public.outbox
+           SET legacy_key = id
+         WHERE legacy_key IS NULL;
+
+        -- Every remaining unclassified row is a plain scalar-era row from the
+        -- one compatibility binding established by the preceding MVR slices.
+        UPDATE public.outbox
+           SET vault_binding_id = '{_COMPATIBILITY_BINDING_ID}'
+         WHERE vault_binding_id IS NULL;
+
+        ALTER TABLE public.outbox
+          ALTER COLUMN vault_binding_id
+          SET DEFAULT '{_COMPATIBILITY_BINDING_ID}';
+        ALTER TABLE public.outbox
+          ALTER COLUMN vault_binding_id SET NOT NULL;
+
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError("MVR-05A7 outbox binding and dual-key history are forward-only")

--- a/app/episodes/vault_activity_stream.py
+++ b/app/episodes/vault_activity_stream.py
@@ -29,6 +29,7 @@ from typing import Any, Mapping, Sequence
 from app.db.db import conn_rw
 from app.episodes import engine_state
 from app.events.types import INGEST_OBJECT_CREATED, INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED
+from app.instance.binding_ids import OUTBOX_QUARANTINE_BINDING_ID
 from app.watcher.vault_watcher import extract_context_dimensions_for_note
 from scripts.yaml_roundtrip import load_frontmatter
 
@@ -90,9 +91,10 @@ def read_vault_activity_for_consumer(consumer_id: str, *, limit: int | None = No
     """Read the next unread vault-activity outbox rows for `consumer_id`, without advancing its cursor.
 
     Independent of the outbox worker's `delivered_at` -- reads every matching
-    row regardless of worker-delivery state, ordered `(created_at, id)`
-    ascending (docs/EVENTS.md FIFO-by-created_at ordering), strictly after
-    the consumer's own last-seen position. Call
+    row regardless of worker-delivery state except rows whose source binding
+    is quarantined as unprovable, ordered `(created_at, id)` ascending
+    (docs/EVENTS.md FIFO-by-created_at ordering), strictly after the consumer's
+    own last-seen position. Call
     :func:`advance_vault_activity_cursor` explicitly once the batch is
     durably processed downstream (at-least-once delivery, mirrors the
     Heimdal cursor contract).
@@ -101,6 +103,8 @@ def read_vault_activity_for_consumer(consumer_id: str, *, limit: int | None = No
     topic_placeholders = ", ".join(["%s"] * len(VAULT_ACTIVITY_TOPICS))
     query = f"SELECT id, topic, payload, created_at FROM outbox WHERE topic IN ({topic_placeholders})"
     params: list[Any] = list(VAULT_ACTIVITY_TOPICS)
+    query += " AND vault_binding_id <> %s"
+    params.append(OUTBOX_QUARANTINE_BINDING_ID)
     if created_at is not None and row_id is not None:
         query += " AND (created_at, id) > (%s, %s::uuid)"
         params.extend([created_at, row_id])

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -752,12 +752,12 @@ class EntityReviewOperationJournal:
             cur = _exec(
                 conn,
                 "SELECT topic, payload FROM outbox "
-                "WHERE id = %s OR (legacy_key = %s AND vault_binding_id = %s) "
+                "WHERE vault_binding_id = %s AND (id = %s OR legacy_key = %s) "
                 "ORDER BY (id = %s) DESC LIMIT 1",
                 (
-                    record.outbox_event_id,
-                    record.outbox_event_id,
                     COMPATIBILITY_BINDING_ID,
+                    record.outbox_event_id,
+                    record.outbox_event_id,
                     record.outbox_event_id,
                 ),
             )

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -70,6 +70,7 @@ from typing import Any, Callable, Mapping, Protocol
 
 from app.events.models import new_event
 from app.events.types import HEIMDAL_REGISTER_ENTITY_MERGED
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
 from app.services.outbox import write_outbox_event
 
 # ---------------------------------------------------------------------------
@@ -750,8 +751,15 @@ class EntityReviewOperationJournal:
             self._validate_loaded(record, operation)
             cur = _exec(
                 conn,
-                "SELECT topic, payload FROM outbox WHERE id = %s",
-                (record.outbox_event_id,),
+                "SELECT topic, payload FROM outbox "
+                "WHERE id = %s OR (legacy_key = %s AND vault_binding_id = %s) "
+                "ORDER BY (id = %s) DESC LIMIT 1",
+                (
+                    record.outbox_event_id,
+                    record.outbox_event_id,
+                    COMPATIBILITY_BINDING_ID,
+                    record.outbox_event_id,
+                ),
             )
             row = cur.fetchone() if hasattr(cur, "fetchone") else None
             if row is None:

--- a/app/instance/binding_ids.py
+++ b/app/instance/binding_ids.py
@@ -5,3 +5,10 @@
 # Keeping the value outside ``app.db`` lets identity, rebuild, and diagnostic
 # code name the namespace without acquiring direct database-layer authority.
 COMPATIBILITY_BINDING_ID = "legacy-compatibility-binding"
+
+# MVR-05A7 (#4581): fail-safe attribution for an outbox row whose partially
+# upgraded shape proves that it is not a plain scalar-era row but carries no
+# usable binding.  The dual-key ingress treats this marker as a global legacy
+# collision, so quarantined history can suppress a duplicate effect but can
+# never authorize a new binding-scoped emission.
+OUTBOX_QUARANTINE_BINDING_ID = "outbox-quarantined-unprovable-binding"

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -18,6 +18,10 @@ from app.events.topic_schema_registry import (
     is_registered_topic,
     validate_topic_payload,
 )
+from app.instance.binding_ids import (
+    COMPATIBILITY_BINDING_ID,
+    OUTBOX_QUARANTINE_BINDING_ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +42,16 @@ except Exception:  # pragma: no cover
 
 
 # The outbox table this module owns (Alembic revision f3a1c9d2e4b7, KERNEL-05).
-_OUTBOX_COLUMNS = ("id", "topic", "payload", "created_at", "delivered_at", "attempts")
+_OUTBOX_COLUMNS = (
+    "id",
+    "topic",
+    "payload",
+    "created_at",
+    "delivered_at",
+    "attempts",
+    "vault_binding_id",
+    "legacy_key",
+)
 
 _OUTBOX_MIGRATION_HINT = (
     "Outbox schema is migration-owned (KERNEL-05, #2850): run 'alembic upgrade head' "
@@ -325,7 +338,9 @@ def bootstrap(conn: Any = None) -> None:
             payload jsonb not null,
             created_at timestamptz not null default now(),
             delivered_at timestamptz,
-            attempts int not null default 0
+            attempts int not null default 0,
+            vault_binding_id text not null default 'legacy-compatibility-binding',
+            legacy_key uuid
         )""",
         )
         _exec(conn, "create index if not exists outbox_created_idx on outbox (created_at)")
@@ -482,6 +497,39 @@ def derive_idempotency_key(topic: str, source_id: str, content_fingerprint: str)
     return str(uuid_module.uuid5(OUTBOX_IDEMPOTENCY_NAMESPACE, digest))
 
 
+def derive_binding_scoped_idempotency_key(
+    topic: str,
+    vault_binding_id: str,
+    legacy_key: str,
+) -> str:
+    """Derive the post-cutover row id without changing the legacy namespace.
+
+    ``legacy_key`` is the unchanged key produced by the existing per-topic
+    derivation.  Folding that durable identity together with the binding keeps
+    equal logical emissions independent across bindings while preserving the
+    fixed :data:`OUTBOX_IDEMPOTENCY_NAMESPACE`.
+    """
+    return derive_idempotency_key(topic, vault_binding_id, legacy_key)
+
+
+def _resolve_outbox_vault_binding_id(vault_binding_id: str | None) -> str:
+    """Resolve the one binding at the outbox choke point.
+
+    Existing 05A compatibility producers intentionally omit the binding and
+    resolve to the single scalar compatibility identity here.  Native callers
+    pass their already-authorized binding explicitly.  The quarantine marker
+    is evidence-only and can never be selected by a producer.
+    """
+    if vault_binding_id is None:
+        return COMPATIBILITY_BINDING_ID
+    if not isinstance(vault_binding_id, str) or not vault_binding_id.strip():
+        raise ValueError(f"write_outbox_event requires a non-empty vault_binding_id, got {vault_binding_id!r}")
+    resolved = vault_binding_id.strip()
+    if resolved == OUTBOX_QUARANTINE_BINDING_ID:
+        raise ValueError("the outbox quarantine marker cannot authorize an emission")
+    return resolved
+
+
 def payload_fingerprint(payload: Mapping[str, Any] | None, *, exclude: tuple[str, ...] = ("trace_id",)) -> str:
     """Stable sha256 fingerprint of an event payload for key derivation.
 
@@ -499,6 +547,7 @@ def write_outbox_event(
     conn: Any = None,
     *,
     idempotency_key: str,
+    vault_binding_id: str | None = None,
     required_db: bool = False,
 ) -> str:
     """Insert one event into the DB outbox, keyed by a mandatory idempotency key.
@@ -527,6 +576,12 @@ def write_outbox_event(
     if not isinstance(idempotency_key, str) or not idempotency_key.strip():
         raise ValueError(f"write_outbox_event requires a non-empty idempotency_key, got {idempotency_key!r}")
     envelope = _coerce_event(event)
+    resolved_binding_id = _resolve_outbox_vault_binding_id(vault_binding_id)
+    scoped_key = derive_binding_scoped_idempotency_key(
+        envelope.event_type,
+        resolved_binding_id,
+        idempotency_key,
+    )
     if is_registered_topic(envelope.event_type):
         validate_topic_payload(envelope.event_type, envelope.payload)
         # Stamp on a copy: `envelope` may be the caller's own `Event` instance
@@ -550,8 +605,30 @@ def write_outbox_event(
     try:
         cur = _exec(
             conn,
-            "insert into outbox (id, topic, payload, created_at, attempts) values (%s, %s, %s::jsonb, %s, %s) on conflict (id) do nothing returning id",
-            (idempotency_key, envelope.event_type, stored, created_at, 0),
+            "insert into outbox (id, topic, payload, created_at, attempts, legacy_key, vault_binding_id) "
+            "select %s, %s, %s::jsonb, %s, %s, %s, %s "
+            "where not exists ("
+            "select 1 from outbox existing where "
+            "existing.id = %s or ("
+            "existing.legacy_key = %s and ("
+            "existing.id = %s or "
+            "existing.vault_binding_id = %s"
+            ")"
+            ")"
+            ") on conflict (id) do nothing returning id",
+            (
+                scoped_key,
+                envelope.event_type,
+                stored,
+                created_at,
+                0,
+                idempotency_key,
+                resolved_binding_id,
+                scoped_key,
+                idempotency_key,
+                idempotency_key,
+                OUTBOX_QUARANTINE_BINDING_ID,
+            ),
         )
         if hasattr(cur, "fetchone"):
             row = cur.fetchone()
@@ -645,6 +722,7 @@ def insert_object_and_outbox(
     conn: Any = None,
     observation: str | None = None,
     required_db: bool = False,
+    vault_binding_id: str | None = None,
 ) -> str:
     """Helper som bygger ett Event och skickar det till outbox.
 
@@ -697,6 +775,7 @@ def insert_object_and_outbox(
         event,
         conn=conn,
         idempotency_key=key,
+        vault_binding_id=vault_binding_id,
         required_db=required_db,
     )
 
@@ -730,15 +809,26 @@ def poll_outbox_one(
     """
     conn, close = _use_conn(conn)
     try:
-        cur = _exec(conn, "select id, topic, payload from outbox where delivered_at is null order by created_at asc limit 1")
+        cur = _exec(
+            conn,
+            "select id, topic, payload, vault_binding_id from outbox "
+            "where delivered_at is null order by created_at asc limit 1",
+        )
         row = cur.fetchone()
         if not row:
             return None
         row_id = _row_value(row, 0, "id")
         row_topic = _row_value(row, 1, "topic")
         row_payload = _row_value(row, 2, "payload")
+        row_binding_id = _row_value(row, 3, "vault_binding_id")
         event = _coerce_event_from_db(row_payload, row_topic)
-        msg = {"id": str(row_id), "topic": event.event_type, "payload": dict(event.payload), "event": event}
+        msg = {
+            "id": str(row_id),
+            "topic": event.event_type,
+            "payload": dict(event.payload),
+            "event": event,
+            "vault_binding_id": str(row_binding_id),
+        }
         if handler:
             try:
                 handler(event.event_type, event.payload)
@@ -827,6 +917,7 @@ __all__ = [
     "OUTBOX_DEAD_LETTER_TOPIC",
     "OUTBOX_IDEMPOTENCY_NAMESPACE",
     "dead_letter_stats",
+    "derive_binding_scoped_idempotency_key",
     "derive_idempotency_key",
     "payload_fingerprint",
     "write_outbox_event",

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -611,7 +611,7 @@ def write_outbox_event(
             "select 1 from outbox existing where "
             "existing.id = %s or ("
             "existing.legacy_key = %s and ("
-            "existing.id = %s or "
+            "(existing.id = %s and existing.vault_binding_id = %s) or "
             "existing.vault_binding_id = %s"
             ")"
             ")"
@@ -627,6 +627,7 @@ def write_outbox_event(
                 scoped_key,
                 idempotency_key,
                 idempotency_key,
+                resolved_binding_id,
                 OUTBOX_QUARANTINE_BINDING_ID,
             ),
         )

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -813,7 +813,9 @@ def poll_outbox_one(
         cur = _exec(
             conn,
             "select id, topic, payload, vault_binding_id from outbox "
-            "where delivered_at is null order by created_at asc limit 1",
+            "where delivered_at is null and vault_binding_id <> %s "
+            "order by created_at asc limit 1",
+            (OUTBOX_QUARANTINE_BINDING_ID,),
         )
         row = cur.fetchone()
         if not row:

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -35,6 +35,7 @@ from app.events.topic_schema_registry import (
     validate_topic_payload,
 )
 from app.indexer.consumer import process_event as process_indexer_event
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
 from app.knowledge.write_ops import read_note_text_with_version
 from app.objects import resolve_canonical_object_id
 from app.outbox.events import INDEX_EMBEDDING_REQUESTED
@@ -368,6 +369,9 @@ def run_once(
             attempts=0,
             trace_id=None if trace_id == "-" else trace_id,
             error=str(uuid_exc),
+            source_vault_binding_id=str(
+                message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+            ),
         )
         return WorkerTickResult(state="processed", processed=1)
     except SchemaViolationDispatchError as schema_exc:
@@ -387,6 +391,9 @@ def run_once(
             attempts=0,
             trace_id=None if trace_id == "-" else trace_id,
             error=str(schema_exc),
+            source_vault_binding_id=str(
+                message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+            ),
         )
         return WorkerTickResult(state="processed", processed=1)
     ack_outbox(message["id"])
@@ -446,10 +453,17 @@ def _dispatch_topic(
     invalid payload against a registered schema must never partially process.
     """
     _validate_dispatch_payload(topic, payload, message=message)
+    source_vault_binding_id = str(
+        message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+    )
     if topic == INGEST_OBJECT_CREATED:
         handle_ingest_object_created(_indexer_payload(payload))
     elif topic == INGEST_VAULT_CHANGED:
-        handle_ingest_vault_changed(payload, trace_id=trace_id)
+        handle_ingest_vault_changed(
+            payload,
+            trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
+        )
     elif topic == INGEST_OBJECT_DELETED:
         handle_ingest_object_deleted(payload)
     elif topic == PANEL_SCAN_REQUESTED:
@@ -458,6 +472,7 @@ def _dispatch_topic(
             payload,
             trace_id=trace_id,
             scan_requested_ts=event_timestamp,
+            source_vault_binding_id=source_vault_binding_id,
         )
     elif topic == PROMOTE_INTENT_CREATED:
         from app.promotion.consumer import consume_promotion_intent_payload
@@ -478,9 +493,17 @@ def _dispatch_topic(
             }
         )
     elif topic == KNOWLEDGE_ACQUISITION_STAGE_COMPLETED:
-        handle_knowledge_acquisition_stage_completed(payload, trace_id=trace_id)
+        handle_knowledge_acquisition_stage_completed(
+            payload,
+            trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
+        )
     elif topic == KNOWLEDGE_ACQUISITION_STAGE_DEAD_LETTERED:
-        handle_knowledge_acquisition_stage_dead_lettered(payload, trace_id=trace_id)
+        handle_knowledge_acquisition_stage_dead_lettered(
+            payload,
+            trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
+        )
     else:
         logger.debug("worker skipping unsupported topic=%s trace_id=%s", topic, trace_id)
 
@@ -593,6 +616,7 @@ def _emit_ka_consumer_signal(
     fingerprint: str,
     payload: Mapping[str, Any],
     trace_id: str | None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     """Durable, item-scoped observability signal for a handled KA stage event.
 
@@ -626,7 +650,11 @@ def _emit_ka_consumer_signal(
     try:
         append_jsonl_outbox_event(_outbox_audit_path(), event, default_source="worker")
         if _use_db_outbox():
-            write_outbox_event(event, idempotency_key=key)
+            write_outbox_event(
+                event,
+                idempotency_key=key,
+                vault_binding_id=source_vault_binding_id,
+            )
     except Exception:
         # Best-effort observability signal: a failure here must never re-block
         # the outbox poll loop or fail the dispatch of the KA stage event
@@ -639,7 +667,10 @@ def _emit_ka_consumer_signal(
 
 
 def handle_knowledge_acquisition_stage_completed(
-    payload: Mapping[str, Any], *, trace_id: str | None = None
+    payload: Mapping[str, Any],
+    *,
+    trace_id: str | None = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     """Consume ``knowledge_acquisition.stage.completed`` (KA-06 → KA-07, #3107).
 
@@ -692,6 +723,7 @@ def handle_knowledge_acquisition_stage_completed(
             "artifact_path": payload.get("artifact_path"),
         },
         trace_id=trace_id,
+        source_vault_binding_id=source_vault_binding_id,
     )
     logger.info(
         "knowledge_acquisition candidate ready for triage content_identity=%s trace_id=%s",
@@ -701,7 +733,10 @@ def handle_knowledge_acquisition_stage_completed(
 
 
 def handle_knowledge_acquisition_stage_dead_lettered(
-    payload: Mapping[str, Any], *, trace_id: str | None = None
+    payload: Mapping[str, Any],
+    *,
+    trace_id: str | None = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     """Consume ``knowledge_acquisition.stage.dead_lettered`` (KA-06 → KA-07, #3107).
 
@@ -746,6 +781,7 @@ def handle_knowledge_acquisition_stage_dead_lettered(
             "error": payload.get("error"),
         },
         trace_id=trace_id,
+        source_vault_binding_id=source_vault_binding_id,
     )
     logger.warning(
         "knowledge_acquisition stage dead-letter surfaced content_identity=%s stage=%s "
@@ -1009,6 +1045,7 @@ def _emit_retry_dead_letter(
     retry_count: int,
     trace_id: str | None,
     original_event_id: str | None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     event = make_outbox_event(
         OUTBOX_EVENT_DEAD_LETTERED,
@@ -1034,6 +1071,7 @@ def _emit_retry_dead_letter(
                 _original_event_id(payload, original_event_id) or str(note_path),
                 f"retry-exhausted:{reason}:{retry_count}",
             ),
+            vault_binding_id=source_vault_binding_id,
         )
 
 
@@ -1047,6 +1085,7 @@ def _dead_letter_outbox_message(
     trace_id: str | None,
     error: str,
     conn: Any = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     """Audit a poison outbox row that exceeded the dispatch-attempt budget.
 
@@ -1086,9 +1125,18 @@ def _dead_letter_outbox_message(
             )
             if conn is not None:
                 with conn.transaction():
-                    write_outbox_event(event, conn=conn, idempotency_key=key)
+                    write_outbox_event(
+                        event,
+                        conn=conn,
+                        idempotency_key=key,
+                        vault_binding_id=source_vault_binding_id,
+                    )
             else:
-                write_outbox_event(event, idempotency_key=key)
+                write_outbox_event(
+                    event,
+                    idempotency_key=key,
+                    vault_binding_id=source_vault_binding_id,
+                )
         logger.warning(
             "worker dead-lettered poison outbox row topic=%s id=%s reason=%s attempts=%s",
             topic,
@@ -1121,6 +1169,7 @@ def _dead_letter_and_ack(
     attempts: int,
     trace_id: str | None,
     error: str,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> None:
     """Write the dead-letter audit row and ack the poisoned row atomically (#3930).
 
@@ -1141,6 +1190,7 @@ def _dead_letter_and_ack(
             attempts=attempts,
             trace_id=trace_id,
             error=error,
+            source_vault_binding_id=source_vault_binding_id,
         )
         ack_outbox(message_id)
         return
@@ -1160,6 +1210,7 @@ def _dead_letter_and_ack(
                 trace_id=trace_id,
                 error=error,
                 conn=conn,
+                source_vault_binding_id=source_vault_binding_id,
             )
             ack_outbox(conn, message_id)
     finally:
@@ -1176,6 +1227,7 @@ def _record_failed_dispatch(
     payload: Mapping[str, Any],
     trace_id: str | None,
     error: BaseException,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> bool:
     """Record one failed dispatch: bump the poison budget, dead-letter at the cap.
 
@@ -1214,6 +1266,7 @@ def _record_failed_dispatch(
                 attempts=attempts,
                 trace_id=trace_id,
                 error=str(error),
+                source_vault_binding_id=source_vault_binding_id,
             )
             ack_outbox(message_id)
             return True
@@ -1242,6 +1295,7 @@ def _record_failed_dispatch(
                 trace_id=trace_id,
                 error=str(error),
                 conn=conn,
+                source_vault_binding_id=source_vault_binding_id,
             )
             # Ack and commit share one guard: either can raise on the same
             # broken-connection fault that would make the other fail too, and
@@ -1352,6 +1406,7 @@ def _queue_transient_retry(
     reason: str,
     trace_id: str | None = None,
     original_event_id: str | None = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> bool:
     retry_count = _payload_retry_count(payload)
     if retry_count >= _MAX_TRANSIENT_RETRY_ATTEMPTS:
@@ -1364,6 +1419,7 @@ def _queue_transient_retry(
                 retry_count=retry_count,
                 trace_id=trace_id,
                 original_event_id=original_event_id,
+                source_vault_binding_id=source_vault_binding_id,
             )
         except Exception:
             logger.exception(
@@ -1406,6 +1462,7 @@ def _queue_transient_retry(
                     f"retry:{retry_count + 1}:{reason}",
                 ),
                 required_db=True,
+                vault_binding_id=source_vault_binding_id,
             )
         else:
             append_jsonl_outbox_event(_outbox_audit_path(), retry_event, default_source="worker")
@@ -1436,6 +1493,7 @@ def handle_panel_scan_requested(
     vault_root: Path | None = None,
     trace_id: str | None = None,
     scan_requested_ts: str | None = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> WorkerPanelSummary:
     resolved_root = _resolve_vault_root(vault_root)
     note_path = _note_path_from_payload(payload, vault_root=resolved_root)
@@ -1452,6 +1510,7 @@ def handle_panel_scan_requested(
             note_path=note_path,
             reason="file_unstable",
             trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
         ):
             if _retry_exhausted(payload):
                 logger.warning("panel scan dropped after exhausted retries (file unstable) note_path=%s", note_path)
@@ -1476,6 +1535,7 @@ def handle_panel_scan_requested(
             note_path=note_path,
             reason="missing_uuid",
             trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
         ):
             if _retry_exhausted(payload):
                 logger.warning("panel scan dropped after exhausted retries (missing uuid) note_path=%s", note_path)
@@ -1587,6 +1647,7 @@ def handle_ingest_vault_changed(
     *,
     vault_root: Path | None = None,
     trace_id: str | None = None,
+    source_vault_binding_id: str = COMPATIBILITY_BINDING_ID,
 ) -> WorkerIngestSummary:
     resolved_root = _resolve_vault_root(vault_root)
     note_path = _note_path_from_payload(payload, vault_root=resolved_root)
@@ -1601,6 +1662,7 @@ def handle_ingest_vault_changed(
             note_path=note_path,
             reason="missing_or_unstable_note",
             trace_id=trace_id,
+            source_vault_binding_id=source_vault_binding_id,
         ):
             if _retry_exhausted(payload):
                 logger.warning("ingest dropped after exhausted retries note_path=%s", note_path)
@@ -1913,6 +1975,9 @@ def run(
                             attempts=0,
                             trace_id=None if trace_id == "-" else trace_id,
                             error=str(uuid_exc),
+                            source_vault_binding_id=str(
+                                message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+                            ),
                         )
                         continue
                     except SchemaViolationDispatchError as schema_exc:
@@ -1935,6 +2000,9 @@ def run(
                             attempts=0,
                             trace_id=None if trace_id == "-" else trace_id,
                             error=str(schema_exc),
+                            source_vault_binding_id=str(
+                                message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+                            ),
                         )
                         continue
                     except Exception as handler_exc:
@@ -1964,6 +2032,9 @@ def run(
                             payload=payload,
                             trace_id=None if trace_id == "-" else trace_id,
                             error=handler_exc,
+                            source_vault_binding_id=str(
+                                message.get("vault_binding_id") or COMPATIBILITY_BINDING_ID
+                            ),
                         ):
                             errors_total += 1
                             continue

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -47,6 +47,14 @@ All outbox records MUST include this minimal envelope:
   not emit an all-null block. Distinct from generic unknown additionals — this field has a defined
   contract. See `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md` (SSI-03) for field semantics and guardrail notes.
 
+The canonical DB-outbox row also carries durable routing identity outside the serialized event
+envelope: `vault_binding_id` names the source binding, and nullable `legacy_key` preserves the
+pre-cutover idempotency key. Existing pending and delivered rows are backfilled by copying `id` to
+`legacy_key`; the migration never attempts to reconstruct inputs that were not persisted. Rows whose
+partially upgraded binding cannot be proved carry the explicit quarantine marker and remain
+collision evidence. Worker retry, dead-letter, and knowledge-signal re-emissions inherit this stored
+binding from their source row rather than resolving ambient context.
+
 Notes:
 
 - Producers MAY add additional top-level fields for compatibility or convenience; consumers MUST ignore unknown fields (see `docs/CONCEPTS/EVENT_COMPATIBILITY_CONTRACT.md`).
@@ -64,11 +72,17 @@ Notes:
 - Consumers MUST deduplicate by `event_id` and treat duplicates as no-ops.
 - Every DB outbox insert MUST carry a deterministic idempotency key (KERNEL-02, #2764):
   `app/services/outbox.py::write_outbox_event` requires `idempotency_key` (a keyless call is a
-  `TypeError`), the key becomes the row `id` with `ON CONFLICT (id) DO NOTHING`, and producers MUST
-  derive it through the single shared helper
+  `TypeError`), and producers MUST derive the unchanged legacy key through the single shared helper
   `app/services/outbox.py::derive_idempotency_key(topic, source_id, content_fingerprint)`
   (`uuid5(namespace, sha256(topic ‖ source_id ‖ fingerprint))`). Ad-hoc key schemes are forbidden;
   `tests/architecture/test_outbox_producer_idempotency.py` gates every callsite.
+- During the multi-vault compatibility window, `write_outbox_event` is the sole binding-aware choke
+  point. It preserves the unchanged producer key in `legacy_key`, derives the row `id` from
+  `(topic, vault_binding_id, legacy_key)`, and atomically suppresses an insert when either that scoped
+  `id` or any pre-cutover `id = legacy_key` row already exists. Delivered history participates in
+  the same check. New scoped rows do not collide merely because two bindings share a `legacy_key`.
+  The fixed `OUTBOX_IDEMPOTENCY_NAMESPACE` is not rotated; both derivations use its existing literal
+  promise, and no stored key is rewritten.
 - Per-topic fingerprints are chosen deliberately: vault-sync and watcher ingest events key on
   `(topic, object uuid/path, content fingerprint + observation marker)`, where the observation
   marker is the observed file stat mtime (vault-sync passes it as a fingerprint-only component; the

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -79,10 +79,11 @@ Notes:
 - During the multi-vault compatibility window, `write_outbox_event` is the sole binding-aware choke
   point. It preserves the unchanged producer key in `legacy_key`, derives the row `id` from
   `(topic, vault_binding_id, legacy_key)`, and atomically suppresses an insert when either that scoped
-  `id` or any pre-cutover `id = legacy_key` row already exists. Delivered history participates in
-  the same check. New scoped rows do not collide merely because two bindings share a `legacy_key`.
-  The fixed `OUTBOX_IDEMPOTENCY_NAMESPACE` is not rotated; both derivations use its existing literal
-  promise, and no stored key is rewritten.
+  `id` or a pre-cutover `id = legacy_key` row for the same classified binding already exists.
+  Delivered history participates in the same check; quarantined history suppresses every binding as
+  fail-safe collision evidence. New scoped rows do not collide merely because two bindings share a
+  `legacy_key`. The fixed `OUTBOX_IDEMPOTENCY_NAMESPACE` is not rotated; both derivations use its
+  existing literal promise, and no stored key is rewritten.
 - Per-topic fingerprints are chosen deliberately: vault-sync and watcher ingest events key on
   `(topic, object uuid/path, content fingerprint + observation marker)`, where the observation
   marker is the observed file stat mtime (vault-sync passes it as a fingerprint-only component; the

--- a/tests/architecture/test_durable_table_ownership.py
+++ b/tests/architecture/test_durable_table_ownership.py
@@ -805,6 +805,10 @@ DURABLE_OWNERSHIP_PG_TARGETS = (
     # same `objects` table this slice rekeys.
     "tests/migrations/test_legacy_objects_fk_migration.py",
     "tests/migrations/test_outbox_schema_parity.py",
+    # MVR-05A7 (#4581): forward-only outbox classification plus runtime
+    # dual-key compatibility dedup both require real PostgreSQL.
+    "tests/migrations/test_multi_vault_outbox_upgrade.py",
+    "tests/services/test_multi_vault_outbox_dual_key_dedup.py",
     # Exercises `outbox.bootstrap()`, which calls the `ensure_schema` seam this
     # slice rewrote; it was also pg-marked and in no lane.
     "tests/services/test_outbox_bootstrap_assert_only.py",
@@ -896,6 +900,9 @@ def test_the_pr_path_pg_lane_is_triggered_by_the_sources_it_guards() -> None:
         "app/db/db.py",
         "app/memory_kv/store.py",
         "app/services/vault_sync.py",
+        "app/services/outbox.py",
+        "app/workers/outbox_worker.py",
+        "app/alembic/versions/f6a05a7b0001_mvr05a7_outbox_binding_dual_key.py",
         "app/alembic/versions/e6c4a2b8d1f3_mvr05a3_store_object_binding_keys.py",
         "app/alembic/versions/f5a05a5b0001_mvr05a5_replay_projection_binding_keys.py",
         "app/db/replay_projection_schema.py",

--- a/tests/architecture/test_multi_vault_pg_ci_lane.py
+++ b/tests/architecture/test_multi_vault_pg_ci_lane.py
@@ -21,6 +21,7 @@ def test_mvr05_pg_targets_run_on_provisioned_postgres_and_cannot_skip() -> None:
     """MVR-05A7's PostgreSQL proofs run in both real-DB lanes without skip guards."""
     nightly = (REPO_ROOT / ".github/workflows/integration-nightly.yaml").read_text()
     pr_path = (REPO_ROOT / ".github/workflows/ci-smoke.yaml").read_text()
+    assert "--rootdir=." in _pytest_step(nightly, "Bounded PG verification lane")
 
     for target in PG_TARGETS:
         assert target in _pytest_step(nightly, "Bounded PG verification lane")

--- a/tests/architecture/test_multi_vault_pg_ci_lane.py
+++ b/tests/architecture/test_multi_vault_pg_ci_lane.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PG_TARGETS = (
+    "tests/migrations/test_multi_vault_outbox_upgrade.py",
+    "tests/services/test_multi_vault_outbox_dual_key_dedup.py",
+)
+
+
+def _pytest_step(workflow: str, step_name: str) -> str:
+    marker = workflow.index(step_name)
+    start = workflow.index("pytest", marker)
+    end = workflow.index("\n\n", start)
+    return workflow[start:end]
+
+
+def test_mvr05_pg_targets_run_on_provisioned_postgres_and_cannot_skip() -> None:
+    """MVR-05A7's PostgreSQL proofs run in both real-DB lanes without skip guards."""
+    nightly = (REPO_ROOT / ".github/workflows/integration-nightly.yaml").read_text()
+    pr_path = (REPO_ROOT / ".github/workflows/ci-smoke.yaml").read_text()
+
+    for target in PG_TARGETS:
+        assert target in _pytest_step(nightly, "Bounded PG verification lane")
+        assert target in _pytest_step(pr_path, "durable table ownership PG surface")
+        assert f"- '{target}'" in pr_path
+
+        source = (REPO_ROOT / target).read_text()
+        assert "pytest.skip" not in source
+        assert "pytest.importorskip" not in source

--- a/tests/architecture/test_outbox_producer_durability.py
+++ b/tests/architecture/test_outbox_producer_durability.py
@@ -156,6 +156,42 @@ def _call_name(node: ast.Call) -> str | None:
     return None
 
 
+def test_every_outbox_producer_routes_through_the_binding_aware_choke_point() -> None:
+    """MVR-05A7: one binding-aware insert seam and explicit worker inheritance."""
+    direct_inserts: list[str] = []
+    for path in sorted(APP_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    if "insert into outbox" in " ".join(arg.value.lower().split()):
+                        direct_inserts.append(str(path.relative_to(APP_ROOT.parent)))
+    assert direct_inserts == ["app/services/outbox.py"]
+
+    outbox_source = DEFINING_MODULE.read_text(encoding="utf-8")
+    assert "derive_binding_scoped_idempotency_key" in outbox_source
+    assert "_resolve_outbox_vault_binding_id" in outbox_source
+    normalized_outbox_source = " ".join(outbox_source.split())
+    assert "legacy_key" in normalized_outbox_source
+    assert "vault_binding_id" in normalized_outbox_source
+
+    worker_path = APP_ROOT / "workers" / "outbox_worker.py"
+    worker_tree = ast.parse(worker_path.read_text(encoding="utf-8"), filename=str(worker_path))
+    worker_writes = [
+        node
+        for node in ast.walk(worker_tree)
+        if isinstance(node, ast.Call) and _call_name(node) == "write_outbox_event"
+    ]
+    assert len(worker_writes) == 5
+    assert all(
+        any(keyword.arg == "vault_binding_id" for keyword in call.keywords)
+        for call in worker_writes
+    )
+
+
 def _enclosing_function_node(
     node: ast.AST, parents: dict[ast.AST, ast.AST]
 ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:

--- a/tests/events/test_topic_schema_registry.py
+++ b/tests/events/test_topic_schema_registry.py
@@ -21,6 +21,7 @@ import pytest
 
 import app.workers.outbox_worker as outbox_worker
 from app.events.models import Event, new_event
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
 from app.events.topic_schema_registry import (
     TopicSchemaViolation,
     UnregisteredTopicError,
@@ -29,7 +30,7 @@ from app.events.topic_schema_registry import (
     resolve_payload_schema_version,
     validate_topic_payload,
 )
-from app.services.outbox import write_outbox_event
+from app.services.outbox import derive_binding_scoped_idempotency_key, write_outbox_event
 
 pytestmark = pytest.mark.not_pg
 
@@ -117,7 +118,9 @@ def test_write_validates_and_stamps_schema() -> None:
     # index.embedding.requested.v1 requires payload.object_id (string).
     valid_event = new_event(event_type="index.embedding.requested", payload={"object_id": "obj-123"})
     row_id = write_outbox_event(valid_event, conn=_FakeConn(), idempotency_key="key-valid-1")
-    assert row_id == "key-valid-1"
+    assert row_id == derive_binding_scoped_idempotency_key(
+        "index.embedding.requested", COMPATIBILITY_BINDING_ID, "key-valid-1"
+    )
 
     invalid_event = new_event(event_type="index.embedding.requested", payload={"not_object_id": "x"})
     with pytest.raises(TopicSchemaViolation):
@@ -185,7 +188,9 @@ def test_unregistered_topic_is_written_unvalidated() -> None:
     assert not is_registered_topic("some.unregistered.topic")
     event = new_event(event_type="some.unregistered.topic", payload={"anything": "goes"})
     row_id = write_outbox_event(event, conn=_FakeConn(), idempotency_key="key-unreg-1")
-    assert row_id == "key-unreg-1"
+    assert row_id == derive_binding_scoped_idempotency_key(
+        "some.unregistered.topic", COMPATIBILITY_BINDING_ID, "key-unreg-1"
+    )
 
 
 def test_pre_registry_rows_grandfathered_v0() -> None:

--- a/tests/heimdal/test_attribution.py
+++ b/tests/heimdal/test_attribution.py
@@ -82,7 +82,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self.rows[row_id] = {
@@ -92,6 +92,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/heimdal/test_entity_confirm.py
+++ b/tests/heimdal/test_entity_confirm.py
@@ -103,7 +103,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self.rows[row_id] = {
@@ -113,6 +113,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/heimdal/test_entity_register.py
+++ b/tests/heimdal/test_entity_register.py
@@ -88,7 +88,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])  # conflict: nothing inserted / returned
             self.rows[row_id] = {
@@ -98,6 +98,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -77,6 +77,7 @@ from app.heimdal.settings_notes import (
     read_settings_note,
     write_settings_note,
 )
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
 from app.services import outbox as outbox_module
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard
@@ -563,7 +564,11 @@ def test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear(
     events = _merged_event_rows(scratch_dsn)
     assert len(events) == 1
     event_id, payload = events[0]
-    assert event_id == operation.outbox_event_id
+    assert event_id == outbox_module.derive_binding_scoped_idempotency_key(
+        MERGED_TOPIC,
+        COMPATIBILITY_BINDING_ID,
+        operation.outbox_event_id,
+    )
     assert payload["from_id"] == from_id
     assert payload["into_id"] == into_id
     assert payload["operation_id"] == operation.operation_id
@@ -604,11 +609,18 @@ class _CallerTransactionJournal(EntityReviewOperationJournal):
             source="heimdal.entity_review",
         )
         outbox_module.write_outbox_event(
-            event, conn=self.caller_conn, idempotency_key=operation.outbox_event_id
+            event,
+            conn=self.caller_conn,
+            idempotency_key=operation.outbox_event_id,
         )
         # Same-transaction read-your-own-write: the caller can see the row...
+        scoped_event_id = outbox_module.derive_binding_scoped_idempotency_key(
+            MERGED_TOPIC,
+            COMPATIBILITY_BINDING_ID,
+            operation.outbox_event_id,
+        )
         seen = self.caller_conn.execute(
-            "SELECT count(*) FROM outbox WHERE id = %s", (operation.outbox_event_id,)
+            "SELECT count(*) FROM outbox WHERE id = %s", (scoped_event_id,)
         ).fetchone()
         assert seen == (1,), "the caller transaction must see its own uncommitted insert"
         # ...and on the #4253 path that visibility was treated as durability.

--- a/tests/heimdal/test_entity_review_operation_journal.py
+++ b/tests/heimdal/test_entity_review_operation_journal.py
@@ -77,7 +77,10 @@ from app.heimdal.settings_notes import (
     read_settings_note,
     write_settings_note,
 )
-from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
+from app.instance.binding_ids import (
+    COMPATIBILITY_BINDING_ID,
+    OUTBOX_QUARANTINE_BINDING_ID,
+)
 from app.services import outbox as outbox_module
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard
@@ -578,6 +581,54 @@ def test_merge_event_commit_is_visible_on_fresh_connection_before_pending_clear(
     journal.commit_merge_event(operation)
     assert len(_merged_event_rows(scratch_dsn)) == 1
     assert journal.verify_committed_visibility(committed) is True
+
+
+def test_quarantined_event_cannot_authorize_pending_review_clear(
+    scratch_dsn: str, tmp_path: Path
+) -> None:
+    vault_root = _vault_root(tmp_path)
+    register = _register(vault_root)
+    queue_entry_id, from_id, into_id, raw_decision = _queue_merge_decision(
+        vault_root, register
+    )
+    journal = _journal(scratch_dsn)
+    operation = journal.claim_operation(
+        **_claim_kwargs(register, queue_entry_id, from_id, into_id, raw_decision)
+    )
+    register.ensure_merge_effects(from_id, into_id)
+    envelope = {
+        "event_type": MERGED_TOPIC,
+        "payload": {
+            "from_id": from_id,
+            "into_id": into_id,
+            "operation_id": operation.operation_id,
+        },
+    }
+    with psycopg.connect(scratch_dsn) as conn:
+        conn.execute(
+            "UPDATE entity_review_operations SET state = %s WHERE operation_id = %s",
+            (STATE_EVENT_COMMITTED, operation.operation_id),
+        )
+        conn.execute(
+            "INSERT INTO outbox "
+            "(id, legacy_key, vault_binding_id, topic, payload) "
+            "VALUES (%s, %s, %s, %s, %s::jsonb)",
+            (
+                operation.outbox_event_id,
+                operation.outbox_event_id,
+                OUTBOX_QUARANTINE_BINDING_ID,
+                MERGED_TOPIC,
+                json.dumps(envelope),
+            ),
+        )
+
+    committed = replace(operation, state=STATE_EVENT_COMMITTED)
+    assert journal.verify_committed_visibility(committed) is False
+    with pytest.raises(EntityConfirmError, match="committed visibility"):
+        apply_human_review_decisions(vault_root, register=register, journal=journal)
+    assert [e.queue_entry_id for e in pending_review_entries(vault_root)] == [
+        queue_entry_id
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/knowledge_acquisition/_acquisition_requests_contract.py
+++ b/tests/knowledge_acquisition/_acquisition_requests_contract.py
@@ -55,7 +55,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self.rows[row_id] = {
@@ -64,6 +64,8 @@ class FakeOutboxConn:
                 "payload": payload,
                 "created_at": created_at,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -66,7 +66,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self.rows[row_id] = {
@@ -76,6 +76,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/knowledge_acquisition/test_replay.py
+++ b/tests/knowledge_acquisition/test_replay.py
@@ -101,7 +101,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self.rows[row_id] = {
@@ -111,6 +111,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")

--- a/tests/knowledge_acquisition/test_stage_events.py
+++ b/tests/knowledge_acquisition/test_stage_events.py
@@ -36,6 +36,7 @@ from app.knowledge_acquisition.stage_events import (
     stage_completed_key,
     stage_dead_letter_key,
 )
+from app.services.outbox import derive_binding_scoped_idempotency_key
 
 pytestmark = pytest.mark.not_pg
 
@@ -78,7 +79,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])  # conflict: nothing inserted / returned
             self.rows[row_id] = {
@@ -88,6 +89,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")
@@ -142,16 +145,21 @@ def test_envelope_and_deterministic_idempotency_key() -> None:
         conn=conn,
     )
 
-    # Exactly one row, keyed by the deterministic idempotency key (row id == key).
+    # Exactly one row, keyed by the binding-scoped derivative while retaining
+    # the unchanged producer key as compatibility history.
     assert len(conn.rows) == 1
     (row,) = conn.rows.values()
-    assert row["id"] == key
+    legacy_key = stage_completed_key(
+        stage="normalize", stage_version=1, content_identity=content_identity
+    )
+    assert row["id"] == derive_binding_scoped_idempotency_key(
+        STAGE_COMPLETED_TOPIC, "legacy-compatibility-binding", legacy_key
+    )
+    assert row["legacy_key"] == legacy_key
     assert row["topic"] == STAGE_COMPLETED_TOPIC
 
     # The key is deterministic: independently derived from (stage, version, identity).
-    assert key == stage_completed_key(
-        stage="normalize", stage_version=1, content_identity=content_identity
-    )
+    assert key == row["id"]
 
     # The persisted payload is a standard envelope (Event shape, docs/EVENTS.md fields).
     envelope = Event.model_validate_json(row["payload"])
@@ -458,10 +466,14 @@ def test_summary_v2_non_finite_confidence_dead_letter_has_v2_identity() -> None:
     assert len(rows) == 1
     envelope = Event.model_validate_json(rows[0]["payload"])
     assert envelope.payload["stage_version"] == EXTRACTOR_VERSION
-    assert rows[0]["id"] == stage_dead_letter_key(
+    legacy_key = stage_dead_letter_key(
         stage="extracted",
         stage_version=EXTRACTOR_VERSION,
         content_identity=normalized["source_content_identity"],
         extractor_id="summary",
         failure_scope="required",
     )
+    assert rows[0]["id"] == derive_binding_scoped_idempotency_key(
+        STAGE_DEAD_LETTERED_TOPIC, "legacy-compatibility-binding", legacy_key
+    )
+    assert rows[0]["legacy_key"] == legacy_key

--- a/tests/migrations/test_multi_vault_outbox_upgrade.py
+++ b/tests/migrations/test_multi_vault_outbox_upgrade.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from app.instance.binding_ids import (
+    COMPATIBILITY_BINDING_ID,
+    OUTBOX_QUARANTINE_BINDING_ID,
+)
+
+pytestmark = pytest.mark.pg
+
+PRE_OUTBOX_BINDING_HEAD = "f5a05a5b0001"
+OUTBOX_BINDING_HEAD = "f6a05a7b0001"
+
+
+def _upgrade(dsn: str, monkeypatch: pytest.MonkeyPatch, revision: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.setenv("DB_DSN", dsn)
+    config = Config("alembic.ini")
+    config.set_main_option("sqlalchemy.url", dsn)
+    command.upgrade(config, revision)
+
+
+@pytest.fixture
+def scratch_db(monkeypatch: pytest.MonkeyPatch):
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    name = f"scratch_mvr05a7_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{name}"')
+    base, _, _ = admin_dsn.rpartition("/")
+    dsn = f"{base}/{name}"
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    try:
+        yield dsn
+    finally:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+
+
+def test_legacy_rows_keep_their_keys_and_classify_or_quarantine(
+    scratch_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _upgrade(scratch_db, monkeypatch, PRE_OUTBOX_BINDING_HEAD)
+    pending_id = uuid.uuid4()
+    delivered_id = uuid.uuid4()
+    with psycopg.connect(scratch_db) as conn:
+        conn.execute(
+            "INSERT INTO outbox (id, topic, payload) VALUES (%s, 'pending', '{}'::jsonb)",
+            (pending_id,),
+        )
+        conn.execute(
+            "INSERT INTO outbox (id, topic, payload, delivered_at) "
+            "VALUES (%s, 'delivered', '{}'::jsonb, now())",
+            (delivered_id,),
+        )
+
+    _upgrade(scratch_db, monkeypatch, OUTBOX_BINDING_HEAD)
+
+    with psycopg.connect(scratch_db) as conn:
+        rows = conn.execute(
+            "SELECT id, legacy_key, vault_binding_id, delivered_at IS NOT NULL "
+            "FROM outbox ORDER BY topic"
+        ).fetchall()
+    assert rows == [
+        (delivered_id, delivered_id, COMPATIBILITY_BINDING_ID, True),
+        (pending_id, pending_id, COMPATIBILITY_BINDING_ID, False),
+    ]
+    assert OUTBOX_QUARANTINE_BINDING_ID != COMPATIBILITY_BINDING_ID
+
+
+def test_partially_upgraded_unprovable_row_is_quarantined(
+    scratch_db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _upgrade(scratch_db, monkeypatch, PRE_OUTBOX_BINDING_HEAD)
+    scoped_id = uuid.uuid4()
+    legacy_id = uuid.uuid4()
+    with psycopg.connect(scratch_db) as conn:
+        conn.execute("ALTER TABLE outbox ADD COLUMN legacy_key uuid")
+        conn.execute("ALTER TABLE outbox ADD COLUMN vault_binding_id text")
+        conn.execute(
+            "INSERT INTO outbox (id, legacy_key, topic, payload) "
+            "VALUES (%s, %s, 'partial', '{}'::jsonb)",
+            (scoped_id, legacy_id),
+        )
+
+    _upgrade(scratch_db, monkeypatch, OUTBOX_BINDING_HEAD)
+
+    with psycopg.connect(scratch_db) as conn:
+        row = conn.execute(
+            "SELECT id, legacy_key, vault_binding_id FROM outbox WHERE id = %s", (scoped_id,)
+        ).fetchone()
+    assert row == (scoped_id, legacy_id, OUTBOX_QUARANTINE_BINDING_ID)

--- a/tests/migrations/test_outbox_schema_parity.py
+++ b/tests/migrations/test_outbox_schema_parity.py
@@ -3,10 +3,9 @@
 Follow-up to KERNEL-04 (#2766): the same create-on-boot class existed for the
 DB outbox (`app/services/outbox.py::bootstrap()`), including a nested
 `except Exception: pass` around `ensure_schema` (silent-failure seam on the
-canonical queue). This test asserts the `f3a1c9d2e4b7` migration produces
-exactly the outbox-table shape the audited `bootstrap()` produced, and that
-re-running migrations on an existing environment is a no-op (no data
-movement).
+canonical queue). This test asserts the current outbox migration produces
+exactly the table shape the audited `bootstrap()` produces, and that upgrading
+an existing environment preserves its rows while installing binding metadata.
 
 Spec: docs/RUNTIME_CORRECTNESS_KERNEL/STORE_SCHEMA_IN_MIGRATIONS.md (pattern
 precedent); docs/audits/SYSTEM_REDESIGN_CORRECTNESS_KERNEL_2026-07-02.md :: I-S3
@@ -28,10 +27,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # The head revision before the outbox table became migration-owned.
 PRE_OUTBOX_HEAD = "699c97b7c007"
 
-# The KERNEL-05 outbox-schema-owning revision this test asserts parity against.
-# Pinned explicitly (not "head") so later migrations adding DDL on top of the
-# outbox table don't make this test compare against a moving target.
-OUTBOX_SCHEMA_HEAD = "f3a1c9d2e4b7"
+# The current outbox-schema-owning revision this test asserts parity against.
+# Pinned explicitly (not "head") so unrelated later DDL cannot move the target.
+OUTBOX_SCHEMA_HEAD = "f6a05a7b0001"
 
 
 def _admin_dsn() -> str:
@@ -182,8 +180,24 @@ def test_fresh_db_parity(scratch_db_factory, monkeypatch: pytest.MonkeyPatch) ->
     assert migrated_shape["columns"], "outbox table missing after alembic upgrade"
 
 
-def test_upgrade_idempotent_on_existing(scratch_db_factory, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Existing environments (pre-KERNEL-05 head + bootstrap-created outbox table) no-op."""
+def test_outbox_declares_the_binding_and_legacy_key_columns_in_both_shapes(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    migrated = scratch_db_factory()
+    bootstrapped = scratch_db_factory()
+    _alembic_upgrade(migrated, monkeypatch, OUTBOX_SCHEMA_HEAD)
+    _run_bootstrap(bootstrapped, monkeypatch)
+
+    for shape in (_schema_snapshot(migrated), _schema_snapshot(bootstrapped)):
+        columns = {row[0]: row for row in shape["columns"]}
+        assert columns["vault_binding_id"][1:3] == ("text", "NO")
+        assert columns["legacy_key"][1:3] == ("uuid", "YES")
+
+
+def test_upgrade_preserves_existing_rows_and_installs_binding_metadata(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing scalar rows survive and become explicit compatibility history."""
     dsn = scratch_db_factory()
 
     # Simulate an existing environment: schema lineage at the pre-outbox head,
@@ -198,11 +212,14 @@ def test_upgrade_idempotent_on_existing(scratch_db_factory, monkeypatch: pytest.
             (row_id, "test.topic", "{}"),
         )
 
-    before = _schema_snapshot(dsn)
-    _alembic_upgrade(dsn, monkeypatch, OUTBOX_SCHEMA_HEAD)  # applies only the outbox-schema revision
+    _alembic_upgrade(dsn, monkeypatch, OUTBOX_SCHEMA_HEAD)
     after = _schema_snapshot(dsn)
 
-    assert before == after, "Migration changed an existing environment's outbox schema"
+    columns = {row[0]: row for row in after["columns"]}
+    assert columns["vault_binding_id"][1:3] == ("text", "NO")
+    assert columns["legacy_key"][1:3] == ("uuid", "YES")
     with psycopg.connect(dsn) as conn:
-        row = conn.execute("SELECT count(*) FROM outbox WHERE id = %s", (row_id,)).fetchone()
-        assert row is not None and row[0] == 1, "Migration moved/destroyed existing outbox data"
+        row = conn.execute(
+            "SELECT id, legacy_key, vault_binding_id FROM outbox WHERE id = %s", (row_id,)
+        ).fetchone()
+        assert row == (row_id, row_id, "legacy-compatibility-binding")

--- a/tests/migrations/test_outbox_schema_parity.py
+++ b/tests/migrations/test_outbox_schema_parity.py
@@ -24,8 +24,8 @@ pytestmark = pytest.mark.pg
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# The head revision before the outbox table became migration-owned.
-PRE_OUTBOX_HEAD = "699c97b7c007"
+# The head revision immediately before outbox binding metadata was added.
+PRE_BINDING_HEAD = "f5a05a5b0001"
 
 # The current outbox-schema-owning revision this test asserts parity against.
 # Pinned explicitly (not "head") so unrelated later DDL cannot move the target.
@@ -200,10 +200,10 @@ def test_upgrade_preserves_existing_rows_and_installs_binding_metadata(
     """Existing scalar rows survive and become explicit compatibility history."""
     dsn = scratch_db_factory()
 
-    # Simulate an existing environment: schema lineage at the pre-outbox head,
-    # outbox table created by the historical create-on-demand bootstrap.
-    _alembic_upgrade(dsn, monkeypatch, PRE_OUTBOX_HEAD)
-    _run_bootstrap(dsn, monkeypatch)
+    # Simulate the exact pre-cutover production schema. Advancing from the old
+    # pre-outbox head would also exercise unrelated intervening migrations;
+    # this proof owns only the f5a05a5b0001 -> f6a05a7b0001 outbox transition.
+    _alembic_upgrade(dsn, monkeypatch, PRE_BINDING_HEAD)
 
     row_id = uuid.uuid4()
     with psycopg.connect(dsn) as conn:

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -27,7 +27,9 @@ def test_worker_run_dispatches_ingest_vault_changed(
 ) -> None:
     called: list[dict] = []
 
-    def fake_handle(payload, *, vault_root=None, trace_id=None):
+    def fake_handle(
+        payload, *, vault_root=None, trace_id=None, source_vault_binding_id=None
+    ):
         called.append({"payload": dict(payload), "trace_id": trace_id})
         return outbox_worker.WorkerIngestSummary(ingested=0)
 
@@ -125,7 +127,14 @@ def test_worker_run_dispatches_panel_scan_requested(
     called: list[dict] = []
     acked: list[str] = []
 
-    def fake_handle(payload, *, vault_root=None, trace_id=None, scan_requested_ts=None):
+    def fake_handle(
+        payload,
+        *,
+        vault_root=None,
+        trace_id=None,
+        scan_requested_ts=None,
+        source_vault_binding_id=None,
+    ):
         called.append(dict(payload))
         return outbox_worker.WorkerPanelSummary(emitted=0, deferred=False)
 
@@ -166,7 +175,14 @@ def test_worker_run_acks_panel_scan_requested_after_retry_budget_exhausted(
 ) -> None:
     acked: list[str] = []
 
-    def fake_handle(payload, *, vault_root=None, trace_id=None, scan_requested_ts=None):
+    def fake_handle(
+        payload,
+        *,
+        vault_root=None,
+        trace_id=None,
+        scan_requested_ts=None,
+        source_vault_binding_id=None,
+    ):
         return outbox_worker.WorkerPanelSummary(emitted=0, deferred=False)
 
     monkeypatch.setattr(outbox_worker, "handle_panel_scan_requested", fake_handle)

--- a/tests/services/test_multi_vault_outbox_dual_key_dedup.py
+++ b/tests/services/test_multi_vault_outbox_dual_key_dedup.py
@@ -7,7 +7,9 @@ import psycopg
 from psycopg import sql
 import pytest
 
+from app.episodes import vault_activity_stream
 from app.events.models import new_event
+from app.events.types import INGEST_VAULT_CHANGED
 from app.instance.binding_ids import (
     COMPATIBILITY_BINDING_ID,
     OUTBOX_QUARANTINE_BINDING_ID,
@@ -15,6 +17,7 @@ from app.instance.binding_ids import (
 from app.services.outbox import (
     derive_binding_scoped_idempotency_key,
     derive_idempotency_key,
+    poll_outbox_one,
     write_outbox_event,
 )
 
@@ -143,3 +146,91 @@ def test_distinct_bindings_do_not_dedup_against_each_other(
             ("binding-b", UUID(legacy_key)),
             (COMPATIBILITY_BINDING_ID, UUID(legacy_key)),
         ]
+
+
+def test_quarantined_pending_row_cannot_dispatch_or_block_later_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _isolated_outbox(monkeypatch) as conn:
+        quarantined_id = uuid4()
+        conn.execute(
+            "INSERT INTO outbox "
+            "(id, legacy_key, vault_binding_id, topic, payload, created_at) "
+            "VALUES (%s, %s, %s, %s, '{}'::jsonb, '2000-01-01T00:00:00Z')",
+            (
+                quarantined_id,
+                uuid4(),
+                OUTBOX_QUARANTINE_BINDING_ID,
+                "mvr.quarantined",
+            ),
+        )
+        legacy_key = derive_idempotency_key("mvr.dispatchable", "later", "same")
+        dispatchable_id = write_outbox_event(
+            _event("later"),
+            conn,
+            idempotency_key=legacy_key,
+            vault_binding_id="binding-a",
+        )
+
+        handled: list[tuple[str, dict]] = []
+        message = poll_outbox_one(
+            conn,
+            handler=lambda topic, payload: handled.append((topic, payload)),
+        )
+
+        assert message is not None
+        assert message["id"] == dispatchable_id
+        assert message["vault_binding_id"] == "binding-a"
+        assert handled == [("mvr.test", {"source_id": "later"})]
+        quarantined = conn.execute(
+            "SELECT delivered_at FROM outbox WHERE id = %s", (quarantined_id,)
+        ).fetchone()
+        assert quarantined == (None,)
+
+
+def test_quarantined_vault_activity_row_cannot_reach_episode_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _isolated_outbox(monkeypatch) as conn:
+        quarantined_id = uuid4()
+        conn.execute(
+            "INSERT INTO outbox "
+            "(id, legacy_key, vault_binding_id, topic, payload, created_at) "
+            "VALUES (%s, %s, %s, %s, '{}'::jsonb, '2000-01-01T00:00:00Z')",
+            (
+                quarantined_id,
+                uuid4(),
+                OUTBOX_QUARANTINE_BINDING_ID,
+                INGEST_VAULT_CHANGED,
+            ),
+        )
+        valid_event = new_event(
+            event_type=INGEST_VAULT_CHANGED,
+            payload={"relative_path": "later.md", "mtime": 1.0},
+            source="test",
+        )
+        legacy_key = derive_idempotency_key(INGEST_VAULT_CHANGED, "later.md", "same")
+        dispatchable_id = write_outbox_event(
+            valid_event,
+            conn,
+            idempotency_key=legacy_key,
+            vault_binding_id="binding-a",
+        )
+
+        @contextmanager
+        def _existing_connection():
+            yield conn
+
+        monkeypatch.setattr(vault_activity_stream, "conn_rw", _existing_connection)
+        monkeypatch.setattr(
+            vault_activity_stream,
+            "get_vault_activity_cursor",
+            lambda _consumer_id: (None, None),
+        )
+
+        rows = vault_activity_stream.read_vault_activity_for_consumer(
+            "quarantine-proof", limit=1
+        )
+
+        assert [row.id for row in rows] == [dispatchable_id]
+        assert all(row.id != str(quarantined_id) for row in rows)

--- a/tests/services/test_multi_vault_outbox_dual_key_dedup.py
+++ b/tests/services/test_multi_vault_outbox_dual_key_dedup.py
@@ -73,7 +73,7 @@ def test_binding_keyed_producer_suppresses_against_pending_and_delivered_legacy_
                     _event(source_id),
                     conn,
                     idempotency_key=legacy_key,
-                    vault_binding_id="binding-a",
+                    vault_binding_id=COMPATIBILITY_BINDING_ID,
                 )
                 == ""
             )
@@ -111,21 +111,35 @@ def test_distinct_bindings_do_not_dedup_against_each_other(
 ) -> None:
     with _isolated_outbox(monkeypatch) as conn:
         legacy_key = derive_idempotency_key("mvr.test", "shared-logical-event", "same")
-        ids = {
+        conn.execute(
+            "INSERT INTO outbox "
+            "(id, legacy_key, vault_binding_id, topic, payload) "
+            "VALUES (%s, %s, %s, %s, '{}'::jsonb)",
+            (legacy_key, legacy_key, COMPATIBILITY_BINDING_ID, "mvr.test"),
+        )
+
+        scoped_id = write_outbox_event(
+            _event("shared-logical-event"),
+            conn,
+            idempotency_key=legacy_key,
+            vault_binding_id="binding-b",
+        )
+        assert scoped_id == derive_binding_scoped_idempotency_key(
+            "mvr.test", "binding-b", legacy_key
+        )
+        assert (
             write_outbox_event(
                 _event("shared-logical-event"),
                 conn,
                 idempotency_key=legacy_key,
-                vault_binding_id=binding,
+                vault_binding_id="binding-b",
             )
-            for binding in ("binding-a", "binding-b")
-        }
-
-        assert ids == {
-            derive_binding_scoped_idempotency_key("mvr.test", "binding-a", legacy_key),
-            derive_binding_scoped_idempotency_key("mvr.test", "binding-b", legacy_key),
-        }
+            == ""
+        )
         rows = conn.execute(
             "SELECT vault_binding_id, legacy_key FROM outbox ORDER BY vault_binding_id"
         ).fetchall()
-        assert rows == [("binding-a", legacy_key), ("binding-b", legacy_key)]
+        assert rows == [
+            ("binding-b", legacy_key),
+            (COMPATIBILITY_BINDING_ID, legacy_key),
+        ]

--- a/tests/services/test_multi_vault_outbox_dual_key_dedup.py
+++ b/tests/services/test_multi_vault_outbox_dual_key_dedup.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from uuid import uuid4
+
+import psycopg
+from psycopg import sql
+import pytest
+
+from app.events.models import new_event
+from app.instance.binding_ids import (
+    COMPATIBILITY_BINDING_ID,
+    OUTBOX_QUARANTINE_BINDING_ID,
+)
+from app.services.outbox import (
+    derive_binding_scoped_idempotency_key,
+    derive_idempotency_key,
+    write_outbox_event,
+)
+
+pytestmark = pytest.mark.pg
+
+
+@contextmanager
+def _isolated_outbox(monkeypatch: pytest.MonkeyPatch):
+    from app.db.dsn import resolve_dsn
+    from app.services.outbox import bootstrap
+
+    base_dsn = resolve_dsn()
+    schema = f"mvr05a7_{uuid4().hex}"
+    with psycopg.connect(base_dsn, autocommit=True) as admin:
+        admin.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
+    dsn = f"{base_dsn}?options=-csearch_path%3D{schema}"
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.setenv("DB_DSN", dsn)
+    monkeypatch.setenv("STORE_BACKEND", "pg")
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            bootstrap(conn)
+            yield conn
+    finally:
+        with psycopg.connect(base_dsn, autocommit=True) as admin:
+            admin.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(schema)))
+
+
+def _event(source_id: str):
+    return new_event(event_type="mvr.test", payload={"source_id": source_id}, source="test")
+
+
+def test_binding_keyed_producer_suppresses_against_pending_and_delivered_legacy_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _isolated_outbox(monkeypatch) as conn:
+        for delivered in (False, True):
+            source_id = f"legacy-{delivered}"
+            legacy_key = derive_idempotency_key("mvr.test", source_id, "same")
+            conn.execute(
+                "INSERT INTO outbox "
+                "(id, legacy_key, vault_binding_id, topic, payload, delivered_at) "
+                "VALUES (%s, %s, %s, %s, '{}'::jsonb, "
+                "CASE WHEN %s THEN now() ELSE NULL END)",
+                (
+                    legacy_key,
+                    legacy_key,
+                    COMPATIBILITY_BINDING_ID,
+                    "mvr.test",
+                    delivered,
+                ),
+            )
+
+            assert (
+                write_outbox_event(
+                    _event(source_id),
+                    conn,
+                    idempotency_key=legacy_key,
+                    vault_binding_id="binding-a",
+                )
+                == ""
+            )
+            count = conn.execute(
+                "SELECT count(*) FROM outbox WHERE legacy_key = %s", (legacy_key,)
+            ).fetchone()
+            assert count == (1,)
+
+        # Partially upgraded rows with no provable binding are collision
+        # evidence. Any binding must fail safe against their legacy key.
+        legacy_key = derive_idempotency_key("mvr.test", "partial", "same")
+        conn.execute(
+            "INSERT INTO outbox "
+            "(id, legacy_key, vault_binding_id, topic, payload) "
+            "VALUES (%s, %s, %s, %s, '{}'::jsonb)",
+            (uuid4(), legacy_key, OUTBOX_QUARANTINE_BINDING_ID, "mvr.test"),
+        )
+        assert (
+            write_outbox_event(
+                _event("partial"),
+                conn,
+                idempotency_key=legacy_key,
+                vault_binding_id="binding-a",
+            )
+            == ""
+        )
+        count = conn.execute(
+            "SELECT count(*) FROM outbox WHERE legacy_key = %s", (legacy_key,)
+        ).fetchone()
+        assert count == (1,)
+
+
+def test_distinct_bindings_do_not_dedup_against_each_other(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _isolated_outbox(monkeypatch) as conn:
+        legacy_key = derive_idempotency_key("mvr.test", "shared-logical-event", "same")
+        ids = {
+            write_outbox_event(
+                _event("shared-logical-event"),
+                conn,
+                idempotency_key=legacy_key,
+                vault_binding_id=binding,
+            )
+            for binding in ("binding-a", "binding-b")
+        }
+
+        assert ids == {
+            derive_binding_scoped_idempotency_key("mvr.test", "binding-a", legacy_key),
+            derive_binding_scoped_idempotency_key("mvr.test", "binding-b", legacy_key),
+        }
+        rows = conn.execute(
+            "SELECT vault_binding_id, legacy_key FROM outbox ORDER BY vault_binding_id"
+        ).fetchall()
+        assert rows == [("binding-a", legacy_key), ("binding-b", legacy_key)]

--- a/tests/services/test_multi_vault_outbox_dual_key_dedup.py
+++ b/tests/services/test_multi_vault_outbox_dual_key_dedup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import psycopg
 from psycopg import sql
@@ -140,6 +140,6 @@ def test_distinct_bindings_do_not_dedup_against_each_other(
             "SELECT vault_binding_id, legacy_key FROM outbox ORDER BY vault_binding_id"
         ).fetchall()
         assert rows == [
-            ("binding-b", legacy_key),
-            (COMPATIBILITY_BINDING_ID, legacy_key),
+            ("binding-b", UUID(legacy_key)),
+            (COMPATIBILITY_BINDING_ID, UUID(legacy_key)),
         ]

--- a/tests/services/test_outbox_idempotency.py
+++ b/tests/services/test_outbox_idempotency.py
@@ -26,6 +26,7 @@ import pytest
 from app.events.models import new_event
 from app.events.types import INGEST_OBJECT_CREATED, INGEST_VAULT_CHANGED
 from app.services.outbox import (
+    derive_binding_scoped_idempotency_key,
     derive_idempotency_key,
     insert_object_and_outbox,
     payload_fingerprint,
@@ -57,7 +58,7 @@ class FakeOutboxConn:
         text = " ".join(sql.lower().split())
         if text.startswith("insert into outbox (id,"):
             assert "on conflict (id) do nothing" in text
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])  # conflict: no row inserted, nothing returned
             self.rows[row_id] = {
@@ -67,6 +68,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
         raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")
@@ -109,7 +112,9 @@ def test_duplicate_emit_single_row() -> None:
     first = write_outbox_event(_event(uuid="note-uuid-1"), conn, idempotency_key=key)
     second = write_outbox_event(_event(uuid="note-uuid-1"), conn, idempotency_key=key)
 
-    assert first == key
+    assert first == derive_binding_scoped_idempotency_key(
+        INGEST_OBJECT_CREATED, "legacy-compatibility-binding", key
+    )
     assert second == ""  # swallowed duplicate returns no row id
     assert len(conn.rows) == 1
 
@@ -366,6 +371,7 @@ def _capture_worker_keys(
         inner_conn=None,
         *,
         idempotency_key: str,
+        vault_binding_id: str | None = None,
         required_db: bool = False,
     ) -> str:
         keys.append(idempotency_key)
@@ -374,7 +380,12 @@ def _capture_worker_keys(
         # The supplied fake connection owns the test transaction. Keeping it
         # explicit preserves this harness on the pre-#4064 base while the spy
         # accepts the newer caller contract when #4064 is rebased.
-        return real(event, conn, idempotency_key=idempotency_key)
+        return real(
+            event,
+            conn,
+            idempotency_key=idempotency_key,
+            vault_binding_id=vault_binding_id,
+        )
 
     monkeypatch.setattr(outbox_worker, "write_outbox_event", _spy)
     monkeypatch.setattr(outbox_worker, "_use_db_outbox", lambda: True)

--- a/tests/services/test_outbox_idempotency_pg.py
+++ b/tests/services/test_outbox_idempotency_pg.py
@@ -20,7 +20,12 @@ from psycopg import sql  # noqa: E402
 from app.db.dsn import resolve_dsn  # noqa: E402
 from app.events.models import new_event  # noqa: E402
 from app.events.types import INGEST_OBJECT_CREATED  # noqa: E402
-from app.services.outbox import bootstrap, derive_idempotency_key, write_outbox_event  # noqa: E402
+from app.services.outbox import (  # noqa: E402
+    bootstrap,
+    derive_binding_scoped_idempotency_key,
+    derive_idempotency_key,
+    write_outbox_event,
+)
 
 
 def _pg_base_dsn() -> str:
@@ -70,17 +75,24 @@ def test_same_key_from_two_connections_yields_one_row() -> None:
             first = write_outbox_event(event, conn_a, idempotency_key=key)
             second = write_outbox_event(event, conn_b, idempotency_key=key)
 
-            assert first == key
+            scoped_key = derive_binding_scoped_idempotency_key(
+                INGEST_OBJECT_CREATED, "legacy-compatibility-binding", key
+            )
+            assert first == scoped_key
             assert second == ""  # ON CONFLICT (id) DO NOTHING at the real PK
 
             row = conn_a.execute(
-                "select count(*) from outbox where id = %s", (key,)
+                "select count(*) from outbox where id = %s", (scoped_key,)
             ).fetchone()
             assert row is not None and int(row[0]) == 1
 
             # A different derived key from either connection is a genuine row.
             other = derive_idempotency_key(INGEST_OBJECT_CREATED, "note-uuid-pg", "content-hash-pg-2")
-            assert write_outbox_event(event, conn_b, idempotency_key=other) == other
+            assert write_outbox_event(event, conn_b, idempotency_key=other) == (
+                derive_binding_scoped_idempotency_key(
+                    INGEST_OBJECT_CREATED, "legacy-compatibility-binding", other
+                )
+            )
             row = conn_b.execute("select count(*) from outbox").fetchone()
             assert row is not None and int(row[0]) == 2
         finally:

--- a/tests/test_outbox_contract.py
+++ b/tests/test_outbox_contract.py
@@ -8,6 +8,7 @@ from app.events.types import INGEST_OBJECT_CREATED
 from app.services.outbox import (
     append_jsonl_outbox_event,
     coerce_outbox_event,
+    derive_binding_scoped_idempotency_key,
     derive_idempotency_key,
     serialize_outbox_record,
     write_outbox_event,
@@ -40,9 +41,13 @@ def test_write_outbox_event_serializes_payload():
     sql, params = conn.executed[0]
 
     assert "insert into outbox" in sql.lower()
-    row_id, topic, payload_json, created_at, attempts = params
+    row_id, topic, payload_json, created_at, attempts, legacy_key, vault_binding_id, *_ = params
 
-    assert row_id == key
+    assert row_id == derive_binding_scoped_idempotency_key(
+        INGEST_OBJECT_CREATED, "legacy-compatibility-binding", key
+    )
+    assert legacy_key == key
+    assert vault_binding_id == "legacy-compatibility-binding"
     assert topic == INGEST_OBJECT_CREATED
     data = json.loads(payload_json)
     assert data["event_type"] == INGEST_OBJECT_CREATED
@@ -70,7 +75,7 @@ def test_write_outbox_event_accepts_panel_event_source_models():
     assert len(conn.executed) == 1
     sql, params = conn.executed[0]
     assert "insert into outbox" in sql.lower()
-    row_id, topic, payload_json, created_at, attempts = params
+    row_id, topic, payload_json, created_at, attempts, legacy_key, vault_binding_id, *_ = params
 
     assert topic == "panel.intent.executed"
     data = json.loads(payload_json)

--- a/tests/workers/test_multi_vault_outbox_reemission_binding.py
+++ b/tests/workers/test_multi_vault_outbox_reemission_binding.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.workers import outbox_worker
+
+pytestmark = pytest.mark.not_pg
+
+
+class _TxnConn:
+    def transaction(self):
+        return nullcontext()
+
+
+def test_worker_reemissions_inherit_the_source_row_binding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: list[str | None] = []
+
+    def capture(*args, **kwargs):
+        captured.append(kwargs.get("vault_binding_id"))
+        return "stored"
+
+    monkeypatch.setattr(outbox_worker, "write_outbox_event", capture)
+    monkeypatch.setattr(outbox_worker, "append_jsonl_outbox_event", lambda *a, **k: True)
+    monkeypatch.setattr(outbox_worker, "_use_db_outbox", lambda: True)
+    monkeypatch.setattr(outbox_worker, "_draft_schema_violation_case", lambda **kwargs: None)
+    binding = "binding-source-a"
+    identity = str(uuid4())
+
+    outbox_worker._emit_ka_consumer_signal(
+        outbox_worker.KA_CANDIDATE_READY_FOR_TRIAGE,
+        content_identity=identity,
+        fingerprint="candidate:v1",
+        payload={"content_identity": identity},
+        trace_id="trace",
+        source_vault_binding_id=binding,
+    )
+    outbox_worker._emit_retry_dead_letter(
+        "panel.scan.requested",
+        {"event_id": identity},
+        note_path=tmp_path / "note.md",
+        reason="missing_uuid",
+        retry_count=3,
+        trace_id="trace",
+        original_event_id=identity,
+        source_vault_binding_id=binding,
+    )
+    for conn in (None, _TxnConn()):
+        outbox_worker._dead_letter_outbox_message(
+            "panel.scan.requested",
+            {"event_id": identity},
+            message_id=identity,
+            reason="poison",
+            attempts=5,
+            trace_id="trace",
+            error="boom",
+            conn=conn,
+            source_vault_binding_id=binding,
+        )
+    assert outbox_worker._queue_transient_retry(
+        "panel.scan.requested",
+        {"event_id": identity},
+        note_path=tmp_path / "note.md",
+        reason="unstable",
+        trace_id="trace",
+        original_event_id=identity,
+        source_vault_binding_id=binding,
+    )
+
+    assert captured == [binding, binding, binding, binding, binding]

--- a/tests/workers/test_outbox_worker.py
+++ b/tests/workers/test_outbox_worker.py
@@ -235,7 +235,17 @@ def test_schema_violation_dead_letters_at_dispatch(monkeypatch: pytest.MonkeyPat
 
     dead_letters: list[dict[str, Any]] = []
 
-    def _capture_dead_letter(topic, payload, *, message_id, reason, attempts, trace_id, error):
+    def _capture_dead_letter(
+        topic,
+        payload,
+        *,
+        message_id,
+        reason,
+        attempts,
+        trace_id,
+        error,
+        source_vault_binding_id,
+    ):
         dead_letters.append(
             {
                 "topic": topic,

--- a/tests/workers/test_outbox_worker_consumes_ingest.py
+++ b/tests/workers/test_outbox_worker_consumes_ingest.py
@@ -63,7 +63,7 @@ class FakeOutboxConn:
         if text.startswith("insert into outbox"):
             # Keyed insert shape (KERNEL-02): id is the mandatory idempotency
             # key with ON CONFLICT (id) DO NOTHING semantics.
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in self.rows:
                 return _FakeCursor([])
             self._seq += 1
@@ -74,6 +74,8 @@ class FakeOutboxConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
 
@@ -83,7 +85,9 @@ class FakeOutboxConn:
             if not undelivered:
                 return _FakeCursor([])
             head = undelivered[0]
-            return _FakeCursor([(head["id"], head["topic"], head["payload"])])
+            return _FakeCursor(
+                [(head["id"], head["topic"], head["payload"], head["vault_binding_id"])]
+            )
 
         if text.startswith("update outbox set attempts"):
             msg_id = params[0]

--- a/tests/workers/test_outbox_worker_poison_txn.py
+++ b/tests/workers/test_outbox_worker_poison_txn.py
@@ -92,7 +92,7 @@ class FakeTxnConn:
             self.ops.append("dead_letter_insert")
             if "dead_letter_insert" in self.fail_on:
                 raise RuntimeError("injected dead-letter insert failure")
-            row_id, topic, payload, created_at, attempts = params
+            row_id, topic, payload, created_at, attempts, legacy_key, vault_binding_id, *_ = params
             if row_id in rows:
                 return _FakeCursor([])
             rows[row_id] = {
@@ -102,6 +102,8 @@ class FakeTxnConn:
                 "created_at": created_at,
                 "delivered_at": None,
                 "attempts": attempts,
+                "legacy_key": legacy_key,
+                "vault_binding_id": vault_binding_id,
             }
             return _FakeCursor([(row_id,)])
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4581

## Linked Issue
Closes #4581

## SBS Impact
- Primary subsystem: EBF
- Secondary subsystem(s): WSP, OEF
- Write class: existing durable event emission; no new write authority
- Persistence impact: two additive outbox columns, copy-only legacy-key backfill, classified compatibility binding, and quarantine for unprovable rows
- Derived/rebuildable impact: outbox dedup is binding-scoped while pending and delivered pre-cutover history remains effective
- New or changed contract: dual-key compatibility dedup at the single outbox write choke point; the UUID namespace remains unchanged
- Owner-doc impact: docs/EVENTS.md updated in this PR
- Transition debt impact: reduces MVR D1 on the event surface
- Boundary risk: incorrect legacy matching could either duplicate delivered effects or collapse distinct bindings; quarantine and exact PostgreSQL proofs fail safe

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a forward-only outbox migration that preserves every legacy key, classifies compatibility rows, and quarantines unprovable partial rows.
- Route binding-scoped IDs and dual-key compatibility dedup through write_outbox_event while preserving the fixed namespace and delivered-row history.
- Propagate the source binding through all five worker re-emissions and register the migration/runtime proofs in both real-Postgres CI lanes.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Git, issue, PR, convergence-review, CI, and owner-doc receipts fully represent this bounded runtime delivery; no separate BuilderOps material was created.

## Notes
Validation before publication: Sol/high mechanism convergence ACCEPT at pre-rebase SHA cac3bf39a with P0/P1/P2/P3 zero after one repaired P1; stable patch ID 9519f8b8c25a3340488a772cc5a5e3ddf44b9156 and binary patch hash 54447555251bc4325ead78cbb94572f6667ae611bd25b547f6ea15532bf52e06 carried byte-identically over irrelevant base-only commit fd56aefc1..60f6a1322; rebased head acee776a1 reran 59 focused contracts, 116 governance/PR-body tests, ruff check app tests, mypy app (894 files), docs_guard, and source-anchor validation green. Canonical host-leased xdist suite ran twice: 13,529/13,530 passed with only unrelated cross-worker global-store flakes, each green in isolated reruns; the sanctioned sequential-shard fallback made every executable non-PG shard green, with the sole uncovered tests/int shard selecting zero tests because it is entirely PG-marked. The first real-PG run exposed bounded EROJ compatibility lookup, fixture-revision, UUID assertion, and nightly rootdir integration defects. Repair SHA 09d338225 was accepted by the Sol/high convergence gate with binary diff hash 084a9867a6608b1c97347fcfe15a0c466babc2d504dc6e04887aad26a6fcb9d0 and no P0-P3 findings. Current-head lint, mypy, docs, source anchors, and focused contracts are green; the host-leased non-PG suite recorded 13,533 passed with one unrelated retrieval global-state failure that passed immediately in isolated retry. Exact-head CI receipts: required Unit tests (not pg) passed on rerun attempt 2 (job 95078367499); PR Index PG contracts passed (job 95075410580); manually dispatched nightly pg-contracts passed (run 31910814114, job 95075456638). Optional nightly full-suite 3.12 failed only because a governance subprocess assumes origin/main exists in a shallow feature-branch checkout; the same test passes locally with the ref present. Optional k6-search failed at its pre-existing missing-outbox bootstrap seam, also reproduced on the latest main nightly (run 31860277693). Neither optional failure intersects MVR-05A7 behavior.

Post-final-review repair head 4637587ed0bab5d68e449fb8312583b31a2bf817 now fails closed across every effect-producing outbox reader: primary polling, episode vault-activity admission, and EROJ committed-visibility all exclude quarantine authority; real-PG regressions cover later-row progress and pending-review preservation. The low-convergence circuit breaker completed with an exact-head Sol/high ACCEPT and P0-P3 zero. Current-head local gates: ruff app/tests, mypy app (894 files), docs language/full guard with truthful temporal-skip override, source anchors, 74 focused non-PG tests, and host-leased canonical non-PG suite 13,534 passed / 49 skipped / 18 xfailed. Confirmed P2 index scaling and schema/docstring drift are durably deferred as KD-F6C27879496A and KD-318E47A35E1A on #4172 per transition policy.