### PR TITLE
Seed membership projection prerequisites

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -784,6 +784,7 @@ jobs:
               - 'app/stores/postgres.py'
               - 'app/alembic/versions/e6c4a2b8d1f3_mvr05a3_store_object_binding_keys.py'
               - 'app/alembic/versions/f4a05a4b0001_mvr05a4_ingest_projection_binding_keys.py'
+              - 'app/alembic/versions/f7a05a4b0001_seed_membership_prerequisites.py'
               - 'app/alembic/versions/f5a05a5b0001_mvr05a5_replay_projection_binding_keys.py'
               - 'app/db/replay_projection_schema.py'
               - 'app/jobs/episodes_projection.py'

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -796,6 +796,7 @@ jobs:
               - 'app/receipts/outcome_receipt_log.py'
               - 'app/receipts/outcome_receipt_projection.py'
               - 'tests/migrations/test_multi_vault_ingest_projection_keys.py'
+              - 'tests/store/test_membership_store.py'
               - 'tests/migrations/test_ingest_schema_parity.py'
               - 'tests/migrations/test_multi_vault_replay_projection_backfill.py'
               - 'tests/migrations/test_replay_schema_parity.py'
@@ -921,6 +922,7 @@ jobs:
             tests/migrations/test_legacy_objects_fk_migration.py \
             tests/migrations/test_store_schema_parity.py \
             tests/migrations/test_multi_vault_ingest_projection_keys.py \
+            tests/store/test_membership_store.py \
             tests/migrations/test_ingest_schema_parity.py \
             tests/migrations/test_multi_vault_replay_projection_backfill.py \
             tests/migrations/test_replay_schema_parity.py \

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -250,6 +250,7 @@ jobs:
             tests/migrations/test_legacy_objects_fk_migration.py \
             tests/migrations/test_store_schema_parity.py \
             tests/migrations/test_multi_vault_ingest_projection_keys.py \
+            tests/store/test_membership_store.py \
             tests/migrations/test_ingest_schema_parity.py \
             tests/migrations/test_multi_vault_replay_projection_backfill.py \
             tests/migrations/test_replay_schema_parity.py \

--- a/app/alembic/versions/f7a05a4b0001_seed_membership_prerequisites.py
+++ b/app/alembic/versions/f7a05a4b0001_seed_membership_prerequisites.py
@@ -1,0 +1,126 @@
+"""Seed the named-set prerequisites consumed by membership projection.
+
+Fresh membership rows reference ``sets(id)``.  The retained historical
+lineage references the same UUID through binding-scoped ``store_objects``.
+This revision seeds both producers without weakening the runtime refusal when
+either prerequisite is later removed.
+"""
+
+from alembic import op
+
+
+revision = "f7a05a4b0001"
+down_revision = "f6a05a7b0001"
+branch_labels = None
+depends_on = None
+reversibility = "forward-only"
+
+_PUBLISHED_SET_ID = "afa60fd2-731a-5c30-ae25-07f56c115393"
+_COMPATIBILITY_BINDING_ID = "legacy-compatibility-binding"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        DO $membership_prerequisites$
+        DECLARE
+          membership_columns text[];
+          published_set_id uuid;
+        BEGIN
+          IF to_regclass('public.sets') IS NULL
+             OR to_regclass('public.store_objects') IS NULL
+             OR to_regclass('public.membership') IS NULL THEN
+            RAISE EXCEPTION USING
+              MESSAGE = 'membership prerequisite migration requires sets, store_objects, and membership',
+              HINT = 'Restore the supported migration lineage, then rerun alembic upgrade head.';
+          END IF;
+
+          LOCK TABLE public.sets, public.store_objects, public.membership
+            IN SHARE ROW EXCLUSIVE MODE;
+
+          SELECT array_agg(a.attname ORDER BY key.ordinality)
+            INTO membership_columns
+            FROM pg_constraint c
+            JOIN unnest(c.conkey) WITH ORDINALITY key(attnum, ordinality) ON true
+            JOIN pg_attribute a ON a.attrelid=c.conrelid AND a.attnum=key.attnum
+           WHERE c.conrelid='public.membership'::regclass AND c.contype='p';
+
+          IF membership_columns = ARRAY['vault_binding_id','id']::text[] THEN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint c
+               WHERE c.contype='f' AND c.conrelid='public.membership'::regclass
+                 AND c.conkey=ARRAY[(SELECT attnum FROM pg_attribute
+                   WHERE attrelid='public.membership'::regclass AND attname='set_id'
+                     AND attnum>0 AND NOT attisdropped)]::smallint[]
+                 AND c.confrelid='public.sets'::regclass
+                 AND c.confkey=ARRAY[(SELECT attnum FROM pg_attribute
+                   WHERE attrelid='public.sets'::regclass AND attname='id'
+                     AND attnum>0 AND NOT attisdropped)]::smallint[]
+            ) THEN
+              RAISE EXCEPTION USING
+                MESSAGE = 'membership prerequisite migration found an unsupported fresh set endpoint',
+                HINT = 'Repair membership.set_id to reference sets(id), then rerun.';
+            END IF;
+          ELSIF membership_columns = ARRAY['vault_binding_id','object_id','set_id']::text[] THEN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint c
+               WHERE c.contype='f' AND c.conrelid='public.membership'::regclass
+                 AND c.conkey=ARRAY[
+                   (SELECT attnum FROM pg_attribute WHERE attrelid='public.membership'::regclass
+                     AND attname='vault_binding_id' AND attnum>0 AND NOT attisdropped),
+                   (SELECT attnum FROM pg_attribute WHERE attrelid='public.membership'::regclass
+                     AND attname='set_id' AND attnum>0 AND NOT attisdropped)
+                 ]::smallint[]
+                 AND c.confrelid='public.store_objects'::regclass
+                 AND c.confkey=ARRAY[
+                   (SELECT attnum FROM pg_attribute WHERE attrelid='public.store_objects'::regclass
+                     AND attname='vault_binding_id' AND attnum>0 AND NOT attisdropped),
+                   (SELECT attnum FROM pg_attribute WHERE attrelid='public.store_objects'::regclass
+                     AND attname='object_id' AND attnum>0 AND NOT attisdropped)
+                 ]::smallint[]
+            ) THEN
+              RAISE EXCEPTION USING
+                MESSAGE = 'membership prerequisite migration found an unsupported retained set endpoint',
+                HINT = 'Repair the binding-scoped membership.set_id endpoint, then rerun.';
+            END IF;
+          ELSE
+            RAISE EXCEPTION USING
+              MESSAGE = 'membership prerequisite migration found an unsupported primary-key lineage',
+              HINT = 'Repair to a supported MVR-05A4 membership shape, then rerun.';
+          END IF;
+
+          INSERT INTO public.sets (id, name, meta)
+          VALUES ('{_PUBLISHED_SET_ID}'::uuid, 'published',
+                  '{{"system":"membership-projection"}}'::jsonb)
+          ON CONFLICT (name) DO NOTHING;
+
+          SELECT id INTO published_set_id FROM public.sets WHERE name='published';
+          IF published_set_id IS NULL THEN
+            RAISE EXCEPTION USING
+              MESSAGE = 'membership prerequisite migration could not seed the published set';
+          END IF;
+
+          IF membership_columns = ARRAY['vault_binding_id','object_id','set_id']::text[] THEN
+            INSERT INTO public.store_objects
+              (vault_binding_id, object_id, kind, source_ref, payload)
+            VALUES
+              ('{_COMPATIBILITY_BINDING_ID}', published_set_id, 'membership-set', NULL,
+               '{{"name":"published","registry":"sets"}}'::jsonb)
+            ON CONFLICT (vault_binding_id, object_id) DO NOTHING;
+
+            IF NOT EXISTS (
+              SELECT 1 FROM public.store_objects
+               WHERE vault_binding_id='{_COMPATIBILITY_BINDING_ID}'
+                 AND object_id=published_set_id
+            ) THEN
+              RAISE EXCEPTION USING
+                MESSAGE = 'membership prerequisite migration could not seed the retained published endpoint';
+            END IF;
+          END IF;
+        END $membership_prerequisites$;
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError("membership prerequisite seed is forward-only")

--- a/app/store/membership_store.py
+++ b/app/store/membership_store.py
@@ -48,7 +48,10 @@ def save_membership(object_id: str, set_name: str, *, trace_id: Optional[str] = 
                 else (set_row[0] if set_row else None)
             )
             if set_id is None:
-                raise RuntimeError(f"membership set {set_name!r} does not exist")
+                raise RuntimeError(
+                    f"membership set {set_name!r} does not exist; "
+                    "run alembic upgrade head to seed membership prerequisites"
+                )
 
             common = (COMPATIBILITY_BINDING_ID, object_id, set_id, datetime.now(timezone.utc))
             if list(primary_key or []) == ["vault_binding_id", "id"]:

--- a/app/stores/pg.py
+++ b/app/stores/pg.py
@@ -77,7 +77,8 @@ def _connect():
 # defect MVR-05A1 (#4560) removed from `app/db/db.py`.  MVR-05A3 extends the
 # explicit test-fixture producer through the minimum child-FK shape guarded by
 # the store parent rekey.  `sets` is reproduced only as the unchanged fresh-
-# lineage parent required by membership.set_id; it is not rekeyed here.
+# lineage parent required by membership.set_id; the fixture also seeds the
+# named `published` row consumed by the production membership writer.
 _MIGRATION_OWNED_AUTOCREATE_SQL: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "store_objects",
@@ -261,6 +262,15 @@ _MIGRATION_OWNED_AUTOCREATE_SQL: tuple[tuple[str, tuple[str, ...]], ...] = (
                 name TEXT UNIQUE NOT NULL,
                 meta JSONB NOT NULL DEFAULT '{}'::jsonb
             )
+            """,
+            """
+            INSERT INTO sets (id, name, meta)
+            VALUES (
+                'afa60fd2-731a-5c30-ae25-07f56c115393'::uuid,
+                'published',
+                '{"system":"membership-projection"}'::jsonb
+            )
+            ON CONFLICT (name) DO NOTHING
             """,
         ),
     ),

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -3,7 +3,7 @@ Doc role: Reference
 Authority: Human-readable snapshot of the current database schema and DB outbox bootstrap; migrations and bootstrap code remain the executable source of truth.
 Temporal class: operational
 Source of truth: code
-Last verified against: app/stores/pg.py + app/alembic/versions/e6c4a2b8d1f3_mvr05a3_store_object_binding_keys.py + app/alembic/versions/f4a05a4b0001_mvr05a4_ingest_projection_binding_keys.py + app/alembic/versions/f5a05a5b0001_mvr05a5_replay_projection_binding_keys.py + app/services/outbox.py + app/workers/outbox_binding_gate.py + app/instance/mvr05_cutover.py + app/alembic/versions/f3a1c9d2e4b7_kernel05_outbox_schema_in_migrations.py + app/heimdal/observation_log.py + app/heimdal/cursor_store.py + app/alembic/versions/8b21e6a1f0c4_heim_observation_log_and_cursor.py + app/services/vault_sync.py + app/alembic/versions/c7f4b1a83d29_mvr05a0_file_state_binding_key.py + app/alembic/versions/d1e8a0c5f37b_mvr05a1_objects_agent_memories_adoption.py + app/db/db.py + tests/architecture/durable_table_classification.json (2026-08-16)
+Last verified against: app/stores/pg.py + app/alembic/versions/e6c4a2b8d1f3_mvr05a3_store_object_binding_keys.py + app/alembic/versions/f4a05a4b0001_mvr05a4_ingest_projection_binding_keys.py + app/alembic/versions/f7a05a4b0001_seed_membership_prerequisites.py + app/alembic/versions/f5a05a5b0001_mvr05a5_replay_projection_binding_keys.py + app/services/outbox.py + app/workers/outbox_binding_gate.py + app/instance/mvr05_cutover.py + app/alembic/versions/f3a1c9d2e4b7_kernel05_outbox_schema_in_migrations.py + app/heimdal/observation_log.py + app/heimdal/cursor_store.py + app/alembic/versions/8b21e6a1f0c4_heim_observation_log_and_cursor.py + app/services/vault_sync.py + app/alembic/versions/c7f4b1a83d29_mvr05a0_file_state_binding_key.py + app/alembic/versions/d1e8a0c5f37b_mvr05a1_objects_agent_memories_adoption.py + app/db/db.py + tests/architecture/durable_table_classification.json (2026-08-16)
 
 ## v5.5 Baseline Delta (Current Reality)
 - Registry watcher is the runtime default; legacy snapshot watcher is dev-only.
@@ -629,8 +629,10 @@ copy, or delete rows.
   a composite `store_objects(vault_binding_id, object_id)` FK)
 - The projector/backfill producer accepts a set name, resolves it through the retained `sets`
   registry, and writes the resolved UUID. On the historical objects-as-sets lineage that same UUID
-  must already exist in binding-scoped `store_objects`; a missing registry or endpoint row fails
-  the write instead of fabricating membership.
+  must also exist in binding-scoped `store_objects`. Revision `f7a05a4b0001` seeds the named
+  `published` set for both supported lineages and mirrors its resolved UUID into the compatibility
+  binding's `store_objects` only on the historical lineage. A later missing registry or endpoint
+  row still fails the write with migration guidance instead of fabricating membership.
 - `created_at` (`timestamptz`, default `now()`)
 - `PRIMARY KEY (vault_binding_id, object_id, set_id)` on the retained lineage
 

--- a/docs/MULTI_VAULT_RUNTIME/ROUTE_REQUESTS_THROUGH_ACTIVE_CONTEXT.md
+++ b/docs/MULTI_VAULT_RUNTIME/ROUTE_REQUESTS_THROUGH_ACTIVE_CONTEXT.md
@@ -352,7 +352,10 @@ catalog (`id` fresh or `(object_id, set_id)` retained historical), preserves
 the fresh `sets(id)` endpoint, and refuses any unknown inbound-FK shape before
 schema mutation. The projector resolves its public set name through `sets` and
 writes that UUID on both supported membership shapes; a retained objects-as-sets
-database must already carry the same UUID in binding-scoped `store_objects`.
+database carries the same UUID in binding-scoped `store_objects`. Prerequisite
+repair #4939 seeds the named `published` registry row for both supported lineages
+and the compatibility-binding endpoint required by the retained lineage before
+projection; runtime deletion of either prerequisite continues to fail closed.
 Its retained ingest views join by `vault_binding_id`.
 
 MVR-05A5 keys all six replay projections by `vault_binding_id`, scopes standing-question,

--- a/tests/architecture/durable_table_classification.json
+++ b/tests/architecture/durable_table_classification.json
@@ -783,15 +783,22 @@
     },
     "sets": {
       "classification": "binding-scoped",
-      "reason": "`sets` holds legacy named collections of vault artifacts. Zero producers remain under app/**, so there is nothing to migrate today, but the shape is vault-derived and `membership.set_id` still references it on the fresh lineage.",
+      "reason": "`sets` holds legacy named collections of vault artifacts. Production population is migration-owned; the only app/** producer is the explicit STORE_SCHEMA_AUTOCREATE test fixture that mirrors the seeded `published` prerequisite. The shape remains vault-derived and `membership.set_id` still references it on the fresh lineage.",
       "owning_revision": "202510241200",
       "declaring_revisions": [
         "202510241200"
       ],
       "binding_key": "pending",
       "binding_column": null,
-      "producers": [],
-      "rebuild_mechanism": "no-producer",
+      "producers": [
+        {
+          "module": "app/stores/pg.py",
+          "operations": [
+            "insert"
+          ]
+        }
+      ],
+      "rebuild_mechanism": "row-scoped",
       "escalation_conditions": [
         "inbound-fk-target"
       ]

--- a/tests/store/test_membership_store.py
+++ b/tests/store/test_membership_store.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import uuid
+from ipaddress import ip_address
+from pathlib import Path
+
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+from psycopg import sql
+from psycopg.conninfo import conninfo_to_dict
+from sqlalchemy.engine import make_url
+
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
+from app.store.membership_store import save_membership
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_BINDING_HEAD = "d1e8a0c5f37b"
+PRE_SEED_HEAD = "f6a05a7b0001"
+SEED_HEAD = "f7a05a4b0001"
+BINDING = COMPATIBILITY_BINDING_ID
+
+
+def _admin_dsn() -> str:
+    from app.db.dsn import resolve_dsn
+
+    dsn = resolve_dsn()
+    if not dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    if not _is_allowed_scratch_admin_dsn(dsn):
+        pytest.fail("membership prerequisite tests require an explicit local dev or CI test target")
+    return dsn
+
+
+def _is_allowed_scratch_admin_dsn(dsn: str) -> bool:
+    try:
+        target = conninfo_to_dict(dsn)
+    except Exception:
+        return False
+    host = target.get("host")
+    hostaddr = target.get("hostaddr")
+    port = target.get("port") or "5432"
+    database = target.get("dbname")
+    if target.get("service"):
+        return False
+    if hostaddr:
+        try:
+            address = ip_address(hostaddr)
+        except ValueError:
+            return False
+        if not address.is_loopback:
+            return False
+        if host == "127.0.0.1" and hostaddr != "127.0.0.1":
+            return False
+    return (host == "127.0.0.1" and port == "15433" and database == "app_dev") or (
+        host in {"localhost", "127.0.0.1"}
+        and port in {"5432", "15434"}
+        and database == "app_test"
+    )
+
+
+@pytest.fixture
+def scratch_db_factory():
+    admin = _admin_dsn()
+    try:
+        with psycopg.connect(admin, connect_timeout=2):
+            pass
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    created: list[str] = []
+
+    def create() -> str:
+        name = f"scratch_membership_{uuid.uuid4().hex[:12]}"
+        with psycopg.connect(admin, autocommit=True) as conn:
+            conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(name)))
+        created.append(name)
+        dsn = make_url(admin).set(database=name).render_as_string(hide_password=False)
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        return dsn
+
+    yield create
+    for name in created:
+        with psycopg.connect(admin, autocommit=True) as conn:
+            conn.execute(sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(name)))
+
+
+def _upgrade(dsn: str, monkeypatch: pytest.MonkeyPatch, revision: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    command.upgrade(cfg, revision)
+
+
+def _prepare_retained_lineage(dsn: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    _upgrade(dsn, monkeypatch, PRE_BINDING_HEAD)
+    with psycopg.connect(dsn) as conn:
+        for (name,) in conn.execute(
+            "SELECT conname FROM pg_constraint WHERE conrelid='membership'::regclass"
+        ).fetchall():
+            conn.execute(sql.SQL("ALTER TABLE membership DROP CONSTRAINT {}").format(sql.Identifier(name)))
+        conn.execute("ALTER TABLE membership DROP COLUMN id")
+        conn.execute("ALTER TABLE membership ADD PRIMARY KEY (object_id,set_id)")
+        conn.execute(
+            "ALTER TABLE membership ADD CONSTRAINT membership_object_id_fkey "
+            "FOREIGN KEY (object_id) REFERENCES store_objects(object_id) ON DELETE CASCADE"
+        )
+        conn.execute(
+            "ALTER TABLE membership ADD CONSTRAINT membership_set_id_fkey "
+            "FOREIGN KEY (set_id) REFERENCES store_objects(object_id) ON DELETE CASCADE"
+        )
+    _upgrade(dsn, monkeypatch, PRE_SEED_HEAD)
+
+
+def _published_set_id(dsn: str) -> uuid.UUID:
+    with psycopg.connect(dsn) as conn:
+        row = conn.execute("SELECT id FROM sets WHERE name='published'").fetchone()
+    assert row is not None
+    return row[0]
+
+
+@pytest.mark.pg
+def test_published_set_is_seeded_before_projection(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    migrated_dsn = scratch_db_factory()
+    _upgrade(migrated_dsn, monkeypatch, SEED_HEAD)
+    migrated_set_id = _published_set_id(migrated_dsn)
+
+    fixture_dsn = scratch_db_factory()
+    monkeypatch.setenv("DATABASE_URL", fixture_dsn)
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    import app.stores.pg as pg_store
+
+    monkeypatch.setattr(pg_store, "_TABLES_READY", False)
+    pg_store._ensure_tables()
+    fixture_set_id = _published_set_id(fixture_dsn)
+
+    assert migrated_set_id == fixture_set_id == uuid.UUID(
+        "afa60fd2-731a-5c30-ae25-07f56c115393"
+    )
+
+
+@pytest.mark.pg
+def test_retained_lineage_has_binding_store_object(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dsn = scratch_db_factory()
+    _prepare_retained_lineage(dsn, monkeypatch)
+    _upgrade(dsn, monkeypatch, SEED_HEAD)
+    set_id = _published_set_id(dsn)
+    with psycopg.connect(dsn) as conn:
+        assert conn.execute(
+            "SELECT kind, payload->>'name' FROM store_objects "
+            "WHERE vault_binding_id=%s AND object_id=%s",
+            (BINDING, set_id),
+        ).fetchone() == ("membership-set", "published")
+
+
+class _MissingSetCursor:
+    def __init__(self) -> None:
+        self.sql: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def execute(self, statement, _params=None):
+        self.sql.append(statement)
+
+    def fetchone(self):
+        if self.sql[-1] == "SELECT id FROM sets WHERE name = %s":
+            return None
+        return {"primary_key": ["vault_binding_id", "id"]}
+
+
+class _Connection:
+    def __init__(self, cursor: _MissingSetCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+@pytest.mark.not_pg
+def test_missing_membership_prerequisite_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _MissingSetCursor()
+    monkeypatch.setattr("app.store.membership_store.conn_rw", lambda: _Connection(cursor))
+
+    with pytest.raises(RuntimeError, match="run alembic upgrade head"):
+        save_membership("object", "published")
+
+    assert not any("INSERT INTO membership" in statement for statement in cursor.sql)

--- a/tests/store/test_membership_store.py
+++ b/tests/store/test_membership_store.py
@@ -11,6 +11,7 @@ from alembic.config import Config
 from psycopg import sql
 from psycopg.conninfo import conninfo_to_dict
 from sqlalchemy.engine import make_url
+from sqlalchemy.exc import DBAPIError
 
 from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
 from app.store.membership_store import save_membership
@@ -122,6 +123,13 @@ def _published_set_id(dsn: str) -> uuid.UUID:
     return row[0]
 
 
+def _revision(dsn: str) -> str:
+    with psycopg.connect(dsn) as conn:
+        row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    assert row is not None
+    return row[0]
+
+
 @pytest.mark.pg
 def test_published_set_is_seeded_before_projection(
     scratch_db_factory, monkeypatch: pytest.MonkeyPatch
@@ -158,6 +166,127 @@ def test_retained_lineage_has_binding_store_object(
             "WHERE vault_binding_id=%s AND object_id=%s",
             (BINDING, set_id),
         ).fetchone() == ("membership-set", "published")
+
+    existing_dsn = scratch_db_factory()
+    _prepare_retained_lineage(existing_dsn, monkeypatch)
+    existing_set_id = uuid.uuid4()
+    with psycopg.connect(existing_dsn) as conn:
+        conn.execute(
+            "INSERT INTO sets(id,name,meta) VALUES (%s,'published','{\"legacy\":true}'::jsonb)",
+            (existing_set_id,),
+        )
+        conn.execute(
+            "INSERT INTO store_objects(vault_binding_id,object_id,kind,payload) "
+            "VALUES (%s,%s,'legacy-set','{\"opaque\":true}'::jsonb)",
+            (BINDING, existing_set_id),
+        )
+    _upgrade(existing_dsn, monkeypatch, SEED_HEAD)
+    assert _published_set_id(existing_dsn) == existing_set_id
+    with psycopg.connect(existing_dsn) as conn:
+        assert conn.execute(
+            "SELECT kind,payload FROM store_objects "
+            "WHERE vault_binding_id=%s AND object_id=%s",
+            (BINDING, existing_set_id),
+        ).fetchone() == ("legacy-set", {"opaque": True})
+
+
+@pytest.mark.pg
+def test_seed_collision_rolls_back_and_retry_recovers(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dsn = scratch_db_factory()
+    _upgrade(dsn, monkeypatch, PRE_SEED_HEAD)
+    collision_id = uuid.UUID("afa60fd2-731a-5c30-ae25-07f56c115393")
+    with psycopg.connect(dsn) as conn:
+        conn.execute(
+            "INSERT INTO sets(id,name) VALUES (%s,'unrelated-existing-set')",
+            (collision_id,),
+        )
+
+    with pytest.raises(DBAPIError, match="sets_pkey"):
+        _upgrade(dsn, monkeypatch, SEED_HEAD)
+    assert _revision(dsn) == PRE_SEED_HEAD
+    with psycopg.connect(dsn) as conn:
+        assert conn.execute("SELECT count(*) FROM sets WHERE name='published'").fetchone() == (0,)
+        conn.execute("DELETE FROM sets WHERE id=%s", (collision_id,))
+
+    _upgrade(dsn, monkeypatch, SEED_HEAD)
+    assert _published_set_id(dsn) == collision_id
+
+
+@pytest.mark.pg
+def test_unsupported_lineage_rolls_back_without_partial_seed(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dsn = scratch_db_factory()
+    _upgrade(dsn, monkeypatch, PRE_SEED_HEAD)
+    with psycopg.connect(dsn) as conn:
+        (primary_key,) = conn.execute(
+            "SELECT conname FROM pg_constraint "
+            "WHERE conrelid='membership'::regclass AND contype='p'"
+        ).fetchone()
+        conn.execute(
+            sql.SQL("ALTER TABLE membership DROP CONSTRAINT {}").format(
+                sql.Identifier(primary_key)
+            )
+        )
+        conn.execute("ALTER TABLE membership ADD PRIMARY KEY (vault_binding_id,object_id)")
+
+    with pytest.raises(DBAPIError, match="unsupported primary-key lineage"):
+        _upgrade(dsn, monkeypatch, SEED_HEAD)
+    assert _revision(dsn) == PRE_SEED_HEAD
+    with psycopg.connect(dsn) as conn:
+        assert conn.execute("SELECT count(*) FROM sets WHERE name='published'").fetchone() == (0,)
+
+
+@pytest.mark.pg
+def test_concurrent_set_writer_blocks_seed_and_retry_recovers(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dsn = scratch_db_factory()
+    _upgrade(dsn, monkeypatch, PRE_SEED_HEAD)
+    blocker = psycopg.connect(dsn)
+    try:
+        blocker.execute("LOCK TABLE sets IN ROW EXCLUSIVE MODE")
+        monkeypatch.setenv("PGOPTIONS", "-c lock_timeout=250ms")
+        with pytest.raises(DBAPIError, match="lock timeout"):
+            _upgrade(dsn, monkeypatch, SEED_HEAD)
+        assert _revision(dsn) == PRE_SEED_HEAD
+    finally:
+        blocker.close()
+        monkeypatch.delenv("PGOPTIONS", raising=False)
+
+    _upgrade(dsn, monkeypatch, SEED_HEAD)
+    assert _published_set_id(dsn)
+
+
+@pytest.mark.pg
+def test_retained_endpoint_deletion_refuses_partial_projection(
+    scratch_db_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dsn = scratch_db_factory()
+    _prepare_retained_lineage(dsn, monkeypatch)
+    _upgrade(dsn, monkeypatch, SEED_HEAD)
+    set_id = _published_set_id(dsn)
+    object_id = uuid.uuid4()
+    with psycopg.connect(dsn) as conn:
+        conn.execute(
+            "INSERT INTO store_objects(vault_binding_id,object_id,kind,payload) "
+            "VALUES (%s,%s,'note','{}'::jsonb)",
+            (BINDING, object_id),
+        )
+        conn.execute(
+            "DELETE FROM store_objects WHERE vault_binding_id=%s AND object_id=%s",
+            (BINDING, set_id),
+        )
+
+    with pytest.raises(psycopg.errors.ForeignKeyViolation, match="membership_set_id_fkey"):
+        save_membership(str(object_id), "published")
+    with psycopg.connect(dsn) as conn:
+        assert conn.execute(
+            "SELECT count(*) FROM membership WHERE vault_binding_id=%s AND object_id=%s",
+            (BINDING, object_id),
+        ).fetchone() == (0,)
 
 
 class _MissingSetCursor:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4939

## Linked Issue
Closes #4939

## SBS Impact
- Primary subsystem: WSP persistence boundary
- Secondary subsystem(s): GOV verification and deployment migration rail
- Write class: Existing migration-owned and test-fixture registry writes; no new runtime write authority
- Persistence impact: Forward-only seed of sets plus the retained compatibility-binding store_objects endpoint
- Derived/rebuildable impact: Membership projection remains derived and fails loudly when prerequisites are missing
- New or changed contract: Published membership prerequisites are migration/bootstrap-owned before projection
- Owner-doc impact: docs/DB_SCHEMA.md and the MVR route owner document are updated
- Transition debt impact: None introduced; both supported historical lineages remain explicit
- Boundary risk: High data/migration boundary, mitigated by locked transactional convergence proofs and exact PG CI

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Seed the named published membership prerequisite across both supported database lineages while keeping runtime projection fail-closed.
- Mirror the seed in the explicit test bootstrap and classify that producer in the durable-table inventory.
- Attach the exact PostgreSQL migration contract to PR-path and nightly CI.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Normal Issue, PR, CI, and owner-doc records fully represent this delivery; no operational divergence warrants a BuilderOps record.

## Notes
Pickup-Receipt: task_id=github-RasmusTho--agentic-pkm-mvp-issue-4939 lease_id=lease-352999b1 holder=codex-issue-4939 evidence=verified-dispatcher-lease. Local Sol/high exact-SHA convergence review passed before expensive validation. The leased non-PG suite passed 13,538 tests; its relevant durable-writer failure was repaired and its exact guard now passes. Two unrelated retrieval failures pass in isolation; five untouched host-census tests observed concurrent writers. Local destructive PG execution was intentionally skipped because no explicit non-production DSN was available; the current-head PR PostgreSQL lane is the merge gate.
