### PR TITLE
bug: re-deliver SETTINGS-07A effective reasoning route

### DIFF
--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -14,6 +14,7 @@ from app.settings.panel_actions_settings import load_panel_actions_settings, pan
 from app.settings.locations import LEGACY_COMPILED_DIR, resolve_settings_file
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
 from app.settings.runtime import get_settings_bundle
+from app.settings.reasoning_route import describe_effective_reasoning_route
 from app.settings.prompts import resolve_ask_system_prompt
 
 
@@ -168,6 +169,7 @@ def build_settings_explain_payload() -> dict[str, Any]:
                 "openai_base_url": "env:OPENAI_BASE_URL" if env_base_url else ("settings:providers.default_chat.base_url" if settings_base_url else "unresolved"),
             },
         },
+        "llm": {"reasoning_model": describe_effective_reasoning_route()},
         "prompts": {"ask.system_prompt": {"origin": ask_prompt_origin}},
     }
 

--- a/app/components/llm/fabric.py
+++ b/app/components/llm/fabric.py
@@ -31,6 +31,8 @@ class ChatClient:
             trace_id=trace_id,
             provider_override=self.route.provider,
             model_override=self.route.model,
+            timeout_seconds=self.route.timeout_seconds,
+            temperature=self.route.temperature,
             max_tokens=max_tokens,
             response_format=response_format,
         )

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -409,6 +409,8 @@ class LLMRouter:
                     mode=cand.mode,
                     reason=reason if degraded else route_reason,
                     degraded=cand.degraded or degraded,
+                    timeout_seconds=cand.timeout_seconds,
+                    temperature=cand.temperature,
                 )
         if provider == "mock":
             # mock ignores the model entirely; a self-consistent deterministic route.

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -31,6 +31,8 @@ class LLMRoute:
     reason: str
     degraded: bool = False
     embedding_identity: EmbeddingIdentity | None = None
+    timeout_seconds: float | None = None
+    temperature: float | None = None
 
 
 def _normalize(value: str | None) -> str:
@@ -219,6 +221,8 @@ class LLMRouter:
             mode="chat",
             reason=provider_reason if provider_degraded else reason,
             degraded=degraded or provider_degraded,
+            timeout_seconds=getattr(routing, "timeout_seconds", None),
+            temperature=getattr(routing, "temperature", None),
         )
 
     def _resolve_embedding_route(

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -472,6 +472,8 @@ class LLMRouter:
                 reason=reason,
                 degraded=degraded,
                 embedding_identity=embedding_identity,
+                timeout_seconds=getattr(getattr(self._settings, "llm_routing", None), "timeout_seconds", None),
+                temperature=getattr(getattr(self._settings, "llm_routing", None), "temperature", None),
             )
 
         candidates = self._route_candidates(intent)

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -35,13 +35,29 @@ def _call_chat(
     kind: str | None,
     trace_id: str | None,
 ) -> str:
-    response, _ = _call_chat_with_route(
-        task_kind=task_kind,
-        pack=pack,
-        agent=agent,
-        kind=kind,
-        trace_id=trace_id,
-    )
+    try:
+        response, _ = _call_chat_with_route(
+            task_kind=task_kind,
+            pack=pack,
+            agent=agent,
+            kind=kind,
+            trace_id=trace_id,
+        )
+    except ReasoningRouteExecutionError as exc:
+        # Every provider-neutral reasoning caller, not only CLAIMS, records
+        # the immutable route selected before its failed execution.
+        log_llm_call(
+            provider=exc.route.provider,
+            model=exc.route.model,
+            agent=agent or "reasoning",
+            kind=kind or task_kind,
+            messages=[],
+            response={"outcome": "provider_failure"},
+            response_text="provider_failure",
+            trace_id=trace_id,
+            status="failed",
+        )
+        raise
     return response
 
 
@@ -267,18 +283,19 @@ def run_reasoning(
                 "outcome": output.outcome,
                 "degraded_reason": output.degraded_reason,
             }
-            failed_route = exc.route if isinstance(exc, ReasoningRouteExecutionError) else resolve_effective_reasoning_route()
-            log_llm_call(
-                provider=failed_route.provider,
-                model=failed_route.model,
-                agent=agent_name,
-                kind=kind_name,
-                messages=[],
-                response=trace_payload,
-                response_text=json.dumps(trace_payload, sort_keys=True),
-                trace_id=trace_id,
-                status="failed",
-            )
+            if not isinstance(exc, ReasoningRouteExecutionError):
+                failed_route = resolve_effective_reasoning_route()
+                log_llm_call(
+                    provider=failed_route.provider,
+                    model=failed_route.model,
+                    agent=agent_name,
+                    kind=kind_name,
+                    messages=[],
+                    response=trace_payload,
+                    response_text=json.dumps(trace_payload, sort_keys=True),
+                    trace_id=trace_id,
+                    status="failed",
+                )
             return ReasoningRun(
                 mode=mode,
                 trace_id=trace_id,
@@ -551,6 +568,8 @@ def run_reasoning(
         except LLMBackendTimeout:
             raise
         except Exception as exc:
+            if isinstance(exc, ReasoningRouteExecutionError):
+                route_payload = _route_payload(exc.route)
             return ReasoningRun(
                 mode=mode,
                 trace_id=trace_id,

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from uuid import UUID
 
-from app.components.llm.fabric import LLMBackendTimeout, LLMRouter, LLMTaskIntent, get_chat_client
+from app.components.llm.fabric import ChatClient, LLMBackendTimeout
 from app.components.llm.router import LLMRoute
+from app.settings.reasoning_route import resolve_effective_reasoning_route
 from app.llm.trace import log_llm_call
 from app.reasoning.prompts import SYSTEM_PROMPT, build_user_prompt
 from app.reasoning.schema import ReasoningInput, ReasoningOutput, ReasoningValidationError, validate_output
@@ -54,7 +55,9 @@ def _call_chat_with_route(
     kind: str | None,
     trace_id: str | None,
 ) -> tuple[str, dict[str, object]]:
-    client = get_chat_client(LLMTaskIntent(task_kind=task_kind, risk="high"))
+    # All provider-neutral reasoning paths use the same effective resolver as
+    # settings-explain and failure tracing.
+    client = ChatClient(resolve_effective_reasoning_route())
     response = client.chat(
         task_kind,
         pack,
@@ -182,7 +185,7 @@ def _reasoning_uses_mock_route() -> bool:
     if _reasoning_backend() == "mock":
         return True
     try:
-        route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high"))
+        route = resolve_effective_reasoning_route()
     except Exception:
         return False
     return route.provider == "mock"
@@ -253,9 +256,8 @@ def run_reasoning(
                 "degraded_reason": output.degraded_reason,
             }
             log_llm_call(
-                provider=os.getenv("LLM_PROVIDER", "").strip().lower()
-                or _reasoning_backend(),
-                model=os.getenv("REASONING_MODEL", "llama3.1:8b"),
+                provider=resolve_effective_reasoning_route().provider,
+                model=resolve_effective_reasoning_route().model,
                 agent=agent_name,
                 kind=kind_name,
                 messages=[],

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -27,6 +27,22 @@ class ReasoningRouteExecutionError(RuntimeError):
         super().__init__(str(cause))
 
 
+def _log_route_failure(
+    route: LLMRoute, *, agent: str | None, kind: str | None, trace_id: str | None
+) -> None:
+    log_llm_call(
+        provider=route.provider,
+        model=route.model,
+        agent=agent or "reasoning",
+        kind=kind or "reasoning",
+        messages=[],
+        response={"outcome": "provider_failure"},
+        response_text="provider_failure",
+        trace_id=trace_id,
+        status="failed",
+    )
+
+
 def _call_chat(
     *,
     task_kind: str,
@@ -46,17 +62,7 @@ def _call_chat(
     except ReasoningRouteExecutionError as exc:
         # Every provider-neutral reasoning caller, not only CLAIMS, records
         # the immutable route selected before its failed execution.
-        log_llm_call(
-            provider=exc.route.provider,
-            model=exc.route.model,
-            agent=agent or "reasoning",
-            kind=kind or task_kind,
-            messages=[],
-            response={"outcome": "provider_failure"},
-            response_text="provider_failure",
-            trace_id=trace_id,
-            status="failed",
-        )
+        _log_route_failure(exc.route, agent=agent, kind=kind or task_kind, trace_id=trace_id)
         raise
     return response
 
@@ -570,6 +576,7 @@ def run_reasoning(
         except Exception as exc:
             if isinstance(exc, ReasoningRouteExecutionError):
                 route_payload = _route_payload(exc.route)
+                _log_route_failure(exc.route, agent=agent_name, kind=kind_name, trace_id=trace_id)
             return ReasoningRun(
                 mode=mode,
                 trace_id=trace_id,

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -19,6 +19,14 @@ from app.stores import get_object_store
 _FIXTURE_PATH = Path("data") / "golden" / "reasoning_samples.jsonl"
 
 
+class ReasoningRouteExecutionError(RuntimeError):
+    """Execution failure carrying the immutable route selected for that call."""
+
+    def __init__(self, route: LLMRoute, cause: Exception) -> None:
+        self.route = route
+        super().__init__(str(cause))
+
+
 def _call_chat(
     *,
     task_kind: str,
@@ -57,14 +65,18 @@ def _call_chat_with_route(
 ) -> tuple[str, dict[str, object]]:
     # All provider-neutral reasoning paths use the same effective resolver as
     # settings-explain and failure tracing.
-    client = ChatClient(resolve_effective_reasoning_route())
-    response = client.chat(
-        task_kind,
-        pack,
-        agent=agent,
-        kind=kind,
-        trace_id=trace_id,
-    )
+    route = resolve_effective_reasoning_route()
+    client = ChatClient(route)
+    try:
+        response = client.chat(
+            task_kind,
+            pack,
+            agent=agent,
+            kind=kind,
+            trace_id=trace_id,
+        )
+    except Exception as exc:
+        raise ReasoningRouteExecutionError(route, exc) from exc
     return response, _route_payload(client.route)
 
 
@@ -255,9 +267,10 @@ def run_reasoning(
                 "outcome": output.outcome,
                 "degraded_reason": output.degraded_reason,
             }
+            failed_route = exc.route if isinstance(exc, ReasoningRouteExecutionError) else resolve_effective_reasoning_route()
             log_llm_call(
-                provider=resolve_effective_reasoning_route().provider,
-                model=resolve_effective_reasoning_route().model,
+                provider=failed_route.provider,
+                model=failed_route.model,
                 agent=agent_name,
                 kind=kind_name,
                 messages=[],

--- a/app/retrieval/tuning.py
+++ b/app/retrieval/tuning.py
@@ -26,12 +26,13 @@ import os
 
 from pydantic import ValidationError
 
-from app.settings.models import RetrievalTuning
+from app.settings.models import RetrievalTuning, SettingsBundle
 from app.settings.runtime import get_settings_bundle
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 
 _CACHED: RetrievalTuning | None = None
+_CACHED_BUNDLE: SettingsBundle | None = None
 
 
 class RetrievalTuningError(ValueError):
@@ -62,13 +63,15 @@ def reset_retrieval_tuning_cache() -> None:
     """
     global _CACHED
     _CACHED = None
+    global _CACHED_BUNDLE
+    _CACHED_BUNDLE = None
 
 
-def _base_tuning() -> RetrievalTuning:
+def _base_tuning(bundle: SettingsBundle) -> RetrievalTuning:
     # The runtime settings bundle is the authoritative typed configuration
     # surface. Do not downgrade a malformed runtime file to defaults here:
     # callers of the actual retrieval resolver must fail just as startup does.
-    return get_settings_bundle().retrieval_tuning
+    return bundle.retrieval_tuning
 
 
 def _parse_int(raw: str, *, env_key: str) -> int:
@@ -101,8 +104,8 @@ def _env(key: str) -> str:
     return os.getenv(key, "").strip()
 
 
-def _resolve_retrieval_tuning() -> RetrievalTuning:
-    base = _base_tuning()
+def _resolve_retrieval_tuning(bundle: SettingsBundle) -> RetrievalTuning:
+    base = _base_tuning(bundle)
     data = base.model_dump()
 
     fusion_raw = _env("RETRIEVAL_FUSION")
@@ -171,9 +174,14 @@ def get_retrieval_tuning() -> RetrievalTuning:
     Resolves once and caches; an invalid or unimplemented resolution is never cached (so a fixed
     override on the next call re-resolves rather than staying stuck raising).
     """
-    global _CACHED
-    if _CACHED is None:
-        _CACHED = _resolve_retrieval_tuning()
+    global _CACHED, _CACHED_BUNDLE
+    bundle = get_settings_bundle()
+    # Bind the memoized value to the exact runtime bundle identity. A lookup
+    # racing a reload can cache the old bundle briefly, but the next lookup
+    # observes the new identity and cannot retain that stale result.
+    if _CACHED is None or _CACHED_BUNDLE is not bundle:
+        _CACHED = _resolve_retrieval_tuning(bundle)
+        _CACHED_BUNDLE = bundle
     return _CACHED
 
 

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -275,10 +275,11 @@ def _http_chat(
     model: str,
     messages: list[dict[str, str]],
     timeout: float,
+    temperature: float = 0.0,
     max_tokens: int | None = None,
     response_format: dict[str, Any] | str | None = None,
 ) -> tuple[str, dict[str, Any]]:
-    payload: dict[str, Any] = {"model": model, "messages": messages}
+    payload: dict[str, Any] = {"model": model, "messages": messages, "temperature": temperature}
     if max_tokens is not None:
         payload["max_tokens"] = int(max_tokens)
     if response_format is not None:
@@ -450,6 +451,7 @@ def call_llm(
                 model=str(model),
                 messages=messages,
                 timeout=timeout,
+                temperature=temperature,
                 max_tokens=max_tokens,
                 response_format=response_format,
             )
@@ -470,6 +472,7 @@ def call_llm(
                 model=str(model),
                 messages=messages,
                 timeout=timeout,
+                temperature=temperature,
                 max_tokens=max_tokens,
                 response_format=response_format,
             )

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -320,6 +320,8 @@ def call_llm(
     trace_id: Optional[str] = None,
     provider_override: str | None = None,
     model_override: str | None = None,
+    timeout_seconds: float | None = None,
+    temperature: float | None = None,
     max_tokens: int | None = None,
     response_format: dict[str, Any] | str | None = None,
 ) -> str:
@@ -338,7 +340,19 @@ def call_llm(
 
     provider = _normalize_provider(provider_override) or _normalize_provider(os.getenv("LLM_PROVIDER")) or "mock"
     model = _normalize_model(model_override) or _default_model()
-    temperature = float(os.getenv("LLM_TEMPERATURE", "0"))
+    # Existing environment values are one-release bootstrap overrides.  The
+    # compiled route supplies the normal value without introducing a second
+    # provider/model selection path.
+    if "LLM_TEMPERATURE" in os.environ:
+        temperature = float(os.environ["LLM_TEMPERATURE"])
+    elif temperature is None:
+        temperature = 0.0
+    if "LLM_TIMEOUT" in os.environ:
+        timeout = env_float("LLM_TIMEOUT")
+    elif timeout_seconds is not None:
+        timeout = timeout_seconds
+    else:
+        timeout = env_float("LLM_TIMEOUT")
     system = pack.get("system", "")
     user = pack.get("user", "")
     messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
@@ -398,7 +412,7 @@ def call_llm(
                     user,
                     str(model),
                     temperature,
-                    timeout=env_float("LLM_TIMEOUT"),
+                    timeout=timeout,
                     max_tokens=max_tokens,
                     response_format=response_format,
                 )
@@ -435,7 +449,7 @@ def call_llm(
                 api_key=api_key,
                 model=str(model),
                 messages=messages,
-                timeout=env_float("LLM_TIMEOUT"),
+                timeout=timeout,
                 max_tokens=max_tokens,
                 response_format=response_format,
             )
@@ -455,7 +469,7 @@ def call_llm(
                 api_key=api_key,
                 model=str(model),
                 messages=messages,
-                timeout=env_float("LLM_TIMEOUT"),
+                timeout=timeout,
                 max_tokens=max_tokens,
                 response_format=response_format,
             )

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -41,6 +41,17 @@ class Providers(BaseModel):
 
 
 class LLMRoutingSettings(BaseModel):
+    timeout_seconds: float | None = Field(
+        default=None,
+        gt=0,
+        description="Compiled LLM request timeout; legacy LLM_TIMEOUT overrides when set.",
+    )
+    temperature: float | None = Field(
+        default=None,
+        ge=0,
+        le=2,
+        description="Compiled LLM sampling temperature; legacy LLM_TEMPERATURE overrides when set.",
+    )
     class RouteTarget(BaseModel):
         model_id: str | None = Field(
             default=None,

--- a/app/settings/reasoning_route.py
+++ b/app/settings/reasoning_route.py
@@ -32,11 +32,22 @@ def describe_effective_reasoning_route() -> dict[str, object]:
     """Return safe explain data from the exact resolver used by execution."""
     route = resolve_effective_reasoning_route()
     legacy_model = (os.getenv("REASONING_MODEL") or "").strip()
+    forced_provider = (os.getenv("LLM_FORCE_PROVIDER") or "").strip()
+    forced_model = (os.getenv("LLM_FORCE_MODEL") or "").strip()
+    env_provider = (os.getenv("LLM_PROVIDER") or "").strip()
+    if forced_provider or forced_model:
+        origin = "env:LLM_FORCE_PROVIDER/LLM_FORCE_MODEL"
+    elif legacy_model:
+        origin = "env:REASONING_MODEL"
+    elif env_provider:
+        origin = "env:LLM_PROVIDER"
+    else:
+        origin = "settings:llm_routing.default_reasoning"
     return {
         "provider": route.provider,
         "model": route.model,
         "mode": route.mode,
         "degraded": route.degraded,
-        "origin": "env:REASONING_MODEL" if legacy_model else "settings:llm_routing.default_reasoning",
+        "origin": origin,
         "tier": active_settings_profile(),
     }

--- a/app/settings/reasoning_route.py
+++ b/app/settings/reasoning_route.py
@@ -1,0 +1,42 @@
+"""One side-effect-free effective route for provider-neutral reasoning.
+
+The compiled Settings Spine owns the provider/model identity.  The temporary
+``REASONING_MODEL`` bootstrap override is deliberately model-only: it must not
+silently turn an OpenAI route into an Ollama route (or vice versa).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+
+from app.components.llm.router import LLMRoute, LLMRouter, LLMTaskIntent
+from app.settings.tiering import active_settings_profile
+
+
+def resolve_effective_reasoning_route() -> LLMRoute:
+    """Resolve the current compiled reasoning route without performing I/O.
+
+    ``LLMRouter`` reads the atomically-published settings generation, so each
+    call observes one bundle.  This resolver adds only the one-release legacy
+    model override and never derives a provider from that override.
+    """
+    route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning", risk="high"))
+    legacy_model = (os.getenv("REASONING_MODEL") or "").strip()
+    if not legacy_model:
+        return route
+    return replace(route, model=legacy_model, reason="legacy:REASONING_MODEL")
+
+
+def describe_effective_reasoning_route() -> dict[str, object]:
+    """Return safe explain data from the exact resolver used by execution."""
+    route = resolve_effective_reasoning_route()
+    legacy_model = (os.getenv("REASONING_MODEL") or "").strip()
+    return {
+        "provider": route.provider,
+        "model": route.model,
+        "mode": route.mode,
+        "degraded": route.degraded,
+        "origin": "env:REASONING_MODEL" if legacy_model else "settings:llm_routing.default_reasoning",
+        "tier": active_settings_profile(),
+    }

--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -177,6 +177,12 @@ def _reload_after_external_signal() -> None:
 
 def reload_settings_bundle(*, notify: bool = True) -> SettingsBundle:
     bundle = _build_bundle()
+    # Retrieval tuning is derived from this bundle and memoized on its hot
+    # path.  A new compiled generation must not leave that cache serving the
+    # prior generation after a cross-process reload.
+    from app.retrieval.tuning import reset_retrieval_tuning_cache
+
+    reset_retrieval_tuning_cache()
     with _LOCK:
         global _CURRENT
         _CURRENT = bundle

--- a/docs/RETRIEVAL.md
+++ b/docs/RETRIEVAL.md
@@ -219,6 +219,11 @@ Implementation lives under `app/retrieval/rerank/` and is applied via `app/retri
 and `app/retrieval/hybrid_rerank_hook.py`, both of which resolve the gate through
 `app.retrieval.tuning.get_retrieval_tuning()`.
 
+The compiled retrieval bundle is the production authority for the rerank gate and
+top-k. `RERANK_ENABLE`, `RERANK_TOP_K`, and `RERANK_PROVIDER` remain visible
+one-release bootstrap overrides; the provider override selects only the reranker
+implementation, never an LLM provider.
+
 ## Output Shape
 `hybrid_search` returns a list of dicts like:
 ```json

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -37,6 +37,12 @@ Runtime settings cover the panel action catalog, watcher policy, and compiled ru
 Today, `python -m app.cli settings-explain` is a narrow operator-facing diagnostics surface for environment/database state plus panel-action and watcher provenance/gating; it is not a full dump of every compiled runtime YAML.
 Compiled bundle files such as `runtime/settings/llm_routing.yaml` remain the direct artifact for the broader runtime payload, while `python -m app.cli settings-validate` checks registries, panel/watcher source artifacts, and any compiled-runtime unresolved-secret sentinels visible locally.
 They also include task-specific LLM routing policy via `<vault>/settings/llm_routing.md` -> `runtime/settings/llm_routing.yaml`.
+The provider-neutral reasoning path and `settings-explain` resolve the same compiled
+`default_reasoning` route. During this one-release compatibility window,
+`REASONING_MODEL` may replace that route's model only; it never selects or changes
+the compiled provider. `llm_routing.timeout_seconds` and `.temperature` feed the
+same route; `LLM_TIMEOUT` and `LLM_TEMPERATURE` remain bootstrap overrides. The
+explain payload reports the effective identity and origin.
 
 Settings tiering guidance (operator-facing vs dev/lab-only), inventory, and migration targets are described below.
 Runtime profile switch for tier enforcement: `PKM_SETTINGS_PROFILE=operator|lab` (default `operator`).

--- a/tests/settings/test_reasoning_route_main_recovery.py
+++ b/tests/settings/test_reasoning_route_main_recovery.py
@@ -6,6 +6,7 @@ from app.cli.settings_explain import build_settings_explain_payload
 from app.components.llm.fabric import ChatClient
 from app.settings.models import LLMRoutingSettings
 from app.reasoning import provider as reasoning_provider
+from app.reasoning.models import ReasoningMode
 from app.settings import runtime
 from app.settings.models import RetrievalTuning, SettingsBundle
 from app.retrieval import tuning
@@ -113,3 +114,23 @@ def test_retrieval_cache_rechecks_bundle_identity_after_reload_race(monkeypatch)
     assert tuning.get_retrieval_tuning().rerank_top_k == 3
     current[0] = second
     assert tuning.get_retrieval_tuning().rerank_top_k == 9
+
+
+def test_ask_failure_returns_the_immutable_selected_route(monkeypatch) -> None:
+    route = reasoning_provider.LLMRoute("openai", "gpt-4.1", "chat", "settings")
+    monkeypatch.setattr(reasoning_provider, "_reasoning_backend", lambda: "llm")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setattr(
+        reasoning_provider,
+        "_call_chat_with_route",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            reasoning_provider.ReasoningRouteExecutionError(route, RuntimeError("boom"))
+        ),
+    )
+
+    result = reasoning_provider.run_reasoning(
+        ReasoningMode.ASK_ANSWER, [], question="What changed?"
+    )
+
+    assert result.status == "failed"
+    assert result.llm_route == {"provider": "openai", "model": "gpt-4.1", "mode": "chat", "reason": "settings", "degraded": False}

--- a/tests/settings/test_reasoning_route_main_recovery.py
+++ b/tests/settings/test_reasoning_route_main_recovery.py
@@ -127,6 +127,8 @@ def test_ask_failure_returns_the_immutable_selected_route(monkeypatch) -> None:
             reasoning_provider.ReasoningRouteExecutionError(route, RuntimeError("boom"))
         ),
     )
+    logged: list[dict[str, object]] = []
+    monkeypatch.setattr(reasoning_provider, "log_llm_call", lambda **kwargs: logged.append(kwargs))
 
     result = reasoning_provider.run_reasoning(
         ReasoningMode.ASK_ANSWER, [], question="What changed?"
@@ -134,3 +136,5 @@ def test_ask_failure_returns_the_immutable_selected_route(monkeypatch) -> None:
 
     assert result.status == "failed"
     assert result.llm_route == {"provider": "openai", "model": "gpt-4.1", "mode": "chat", "reason": "settings", "degraded": False}
+    assert logged[0]["provider"] == "openai"
+    assert logged[0]["model"] == "gpt-4.1"

--- a/tests/settings/test_reasoning_route_main_recovery.py
+++ b/tests/settings/test_reasoning_route_main_recovery.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.cli.settings_explain import build_settings_explain_payload
 from app.components.llm.fabric import ChatClient
 from app.settings.models import LLMRoutingSettings
@@ -69,4 +71,45 @@ def test_model_override_trace_and_reload_generation_remain_consistent(monkeypatc
     runtime.reload_settings_bundle(notify=False)
     assert tuning.get_retrieval_tuning().rerank_top_k == 3
     runtime.reload_settings_bundle(notify=False)
+    assert tuning.get_retrieval_tuning().rerank_top_k == 9
+
+
+def test_force_override_explain_reports_its_real_origin(monkeypatch) -> None:
+    bundle = _compiled_openai_bundle()
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_FORCE_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_FORCE_MODEL", "gpt-4.1-mini")
+    monkeypatch.delenv("REASONING_MODEL", raising=False)
+
+    payload = build_settings_explain_payload()["llm"]["reasoning_model"]
+
+    assert payload["origin"] == "env:LLM_FORCE_PROVIDER/LLM_FORCE_MODEL"
+    assert (payload["provider"], payload["model"]) == ("openai", "gpt-4.1-mini")
+
+
+def test_reasoning_execution_failure_carries_the_selected_route(monkeypatch) -> None:
+    bundle = _compiled_openai_bundle()
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setattr(ChatClient, "chat", lambda self, *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with pytest.raises(reasoning_provider.ReasoningRouteExecutionError) as exc_info:
+        reasoning_provider._call_chat_with_route(
+            task_kind="reasoning", pack={}, agent=None, kind=None, trace_id=None
+        )
+
+    assert (exc_info.value.route.provider, exc_info.value.route.model) == ("openai", "gpt-4.1")
+
+
+def test_retrieval_cache_rechecks_bundle_identity_after_reload_race(monkeypatch) -> None:
+    first = SettingsBundle(retrieval_tuning=RetrievalTuning(rerank_top_k=3))
+    second = SettingsBundle(retrieval_tuning=RetrievalTuning(rerank_top_k=9))
+    current = [first]
+    monkeypatch.setattr("app.retrieval.tuning.get_settings_bundle", lambda: current[0])
+    tuning.reset_retrieval_tuning_cache()
+
+    assert tuning.get_retrieval_tuning().rerank_top_k == 3
+    current[0] = second
     assert tuning.get_retrieval_tuning().rerank_top_k == 9

--- a/tests/settings/test_reasoning_route_main_recovery.py
+++ b/tests/settings/test_reasoning_route_main_recovery.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from app.cli.settings_explain import build_settings_explain_payload
+from app.components.llm.fabric import ChatClient
+from app.settings.models import LLMRoutingSettings
+from app.reasoning import provider as reasoning_provider
+from app.settings import runtime
+from app.settings.models import RetrievalTuning, SettingsBundle
+from app.retrieval import tuning
+from app.settings.reasoning_route import resolve_effective_reasoning_route
+
+
+def _compiled_openai_bundle() -> SettingsBundle:
+    return SettingsBundle(
+        llm_routing=LLMRoutingSettings(
+            default_reasoning=LLMRoutingSettings.TaskPolicy(
+                primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-4.1")
+            )
+        )
+    )
+
+
+def test_registered_explain_and_execution_share_compiled_reasoning_route(monkeypatch) -> None:
+    bundle = _compiled_openai_bundle()
+    monkeypatch.setattr(runtime, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.delenv("REASONING_MODEL", raising=False)
+    monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setattr(ChatClient, "chat", lambda self, *args, **kwargs: "{}")
+
+    route = resolve_effective_reasoning_route()
+    payload = build_settings_explain_payload()
+    _response, execution = reasoning_provider._call_chat_with_route(
+        task_kind="reasoning", pack={"system": "s", "user": "u"}, agent=None, kind=None, trace_id=None
+    )
+
+    assert (route.provider, route.model) == ("openai", "gpt-4.1")
+    assert payload["llm"]["reasoning_model"]["provider"] == route.provider
+    assert payload["llm"]["reasoning_model"]["model"] == route.model
+    assert (execution["provider"], execution["model"]) == (route.provider, route.model)
+
+
+def test_model_override_trace_and_reload_generation_remain_consistent(monkeypatch) -> None:
+    bundle = _compiled_openai_bundle()
+    monkeypatch.setattr(runtime, "get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("REASONING_MODEL", "gpt-4.1-mini")
+    monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    route = resolve_effective_reasoning_route()
+    payload = build_settings_explain_payload()["llm"]["reasoning_model"]
+
+    assert route.provider == "openai"  # model-only compat override cannot flip provider
+    assert route.model == "gpt-4.1-mini"
+    assert route.reason == "legacy:REASONING_MODEL"
+    assert payload["provider"] == "openai"
+    assert payload["model"] == "gpt-4.1-mini"
+
+    first = SettingsBundle(retrieval_tuning=RetrievalTuning(rerank_top_k=3))
+    second = SettingsBundle(retrieval_tuning=RetrievalTuning(rerank_top_k=9))
+    bundles = iter((first, second))
+    monkeypatch.setattr(runtime, "_build_bundle", lambda: next(bundles))
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+    tuning.reset_retrieval_tuning_cache()
+    runtime.reload_settings_bundle(notify=False)
+    assert tuning.get_retrieval_tuning().rerank_top_k == 3
+    runtime.reload_settings_bundle(notify=False)
+    assert tuning.get_retrieval_tuning().rerank_top_k == 9

--- a/tests/settings/test_settings_07a_main_recovery.py
+++ b/tests/settings/test_settings_07a_main_recovery.py
@@ -29,6 +29,7 @@ def test_vault_settings_reach_model_reasoning_and_rerank_consumers_with_one_gene
     monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
     monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER_ENFORCE", raising=False)
     tuning.reset_retrieval_tuning_cache()
 
     route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning"))
@@ -57,6 +58,18 @@ def test_empty_settings_and_legacy_env_preserve_behavior_without_provider_flip(m
     assert route.provider == "mock"
     assert route.model == "llama3.1:8b"  # only the shared resolver applies REASONING_MODEL
     assert (retrieval.rerank, retrieval.rerank_top_k) == ("always", 3)
+
+
+def test_enforced_provider_preserves_compiled_request_options(monkeypatch) -> None:
+    bundle = _bundle()
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_PROVIDER_ENFORCE", "1")
+
+    route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning"))
+
+    assert (route.provider, route.model) == ("openai", "gpt-4.1")
+    assert (route.timeout_seconds, route.temperature) == (12, 0.2)
 
 
 def test_operator_tier_and_last_valid_bundle_fail_closed(monkeypatch, tmp_path) -> None:

--- a/tests/settings/test_settings_07a_main_recovery.py
+++ b/tests/settings/test_settings_07a_main_recovery.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from app.components.llm.router import LLMRouter, LLMTaskIntent
+from app.retrieval import tuning
+from app.settings import runtime
+from app.settings.models import LLMRoutingSettings, RetrievalTuning, SettingsBundle
+from app.settings.tiering import resolve_dev_lab_env_value
+
+
+def _bundle(*, rerank: str = "off", top_k: int = 100) -> SettingsBundle:
+    return SettingsBundle(
+        llm_routing=LLMRoutingSettings(
+            timeout_seconds=12,
+            temperature=0.2,
+            default_reasoning=LLMRoutingSettings.TaskPolicy(
+                primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-4.1")
+            )
+        ),
+        retrieval_tuning=RetrievalTuning(rerank=rerank, rerank_top_k=top_k),
+    )
+
+
+def test_vault_settings_reach_model_reasoning_and_rerank_consumers_with_one_generation(monkeypatch) -> None:
+    bundle = _bundle(rerank="always", top_k=7)
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr("app.retrieval.tuning.get_settings_bundle", lambda: bundle)
+    monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    tuning.reset_retrieval_tuning_cache()
+
+    route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning"))
+    retrieval = tuning.get_retrieval_tuning()
+
+    assert (route.provider, route.model) == ("openai", "gpt-4.1")
+    assert (route.timeout_seconds, route.temperature) == (12, 0.2)
+    assert (retrieval.rerank, retrieval.rerank_top_k) == ("always", 7)
+
+
+def test_empty_settings_and_legacy_env_preserve_behavior_without_provider_flip(monkeypatch) -> None:
+    bundle = SettingsBundle()
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr("app.retrieval.tuning.get_settings_bundle", lambda: bundle)
+    monkeypatch.delenv("LLM_FORCE_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_FORCE_MODEL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("REASONING_MODEL", "compat-model")
+    monkeypatch.setenv("RERANK_ENABLE", "1")
+    monkeypatch.setenv("RERANK_TOP_K", "3")
+    tuning.reset_retrieval_tuning_cache()
+
+    route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning"))
+    retrieval = tuning.get_retrieval_tuning()
+
+    assert route.provider == "mock"
+    assert route.model == "llama3.1:8b"  # only the shared resolver applies REASONING_MODEL
+    assert (retrieval.rerank, retrieval.rerank_top_k) == ("always", 3)
+
+
+def test_operator_tier_and_last_valid_bundle_fail_closed(monkeypatch, tmp_path) -> None:
+    assert resolve_dev_lab_env_value(
+        "LAB_ONLY_MODEL", default="operator-model", env={"LAB_ONLY_MODEL": "lab-model"}
+    ) == "operator-model"
+
+    runtime_dir = tmp_path / "runtime" / "settings"
+    runtime_dir.mkdir(parents=True)
+    for name, payload in (("global.yaml", {}), ("providers.yaml", {}), ("llm_routing.yaml", {})):
+        (runtime_dir / name).write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+    runtime.reload_settings_bundle(notify=False)
+    before = runtime.get_settings_bundle()
+    (runtime_dir / "retrieval_tuning.yaml").write_text("rerank_top_k: invalid\n", encoding="utf-8")
+
+    with pytest.raises(Exception):
+        runtime.reload_settings_bundle(notify=False)
+    assert runtime.get_settings_bundle() is before

--- a/tests/settings/test_settings_07a_main_recovery.py
+++ b/tests/settings/test_settings_07a_main_recovery.py
@@ -73,6 +73,18 @@ def test_enforced_provider_preserves_compiled_request_options(monkeypatch) -> No
     assert (route.timeout_seconds, route.temperature) == (12, 0.2)
 
 
+def test_forced_route_preserves_compiled_request_options(monkeypatch) -> None:
+    bundle = _bundle()
+    monkeypatch.setattr("app.components.llm.router.get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("LLM_FORCE_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_FORCE_MODEL", "gpt-4.1-mini")
+
+    route = LLMRouter().route(LLMTaskIntent(task_kind="reasoning"))
+
+    assert (route.provider, route.model) == ("openai", "gpt-4.1-mini")
+    assert (route.timeout_seconds, route.temperature) == (12, 0.2)
+
+
 def test_openai_compatible_transport_receives_compiled_temperature(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/settings/test_settings_07a_main_recovery.py
+++ b/tests/settings/test_settings_07a_main_recovery.py
@@ -7,6 +7,7 @@ from app.retrieval import tuning
 from app.settings import runtime
 from app.settings.models import LLMRoutingSettings, RetrievalTuning, SettingsBundle
 from app.settings.tiering import resolve_dev_lab_env_value
+from app.services import llm as llm_service
 
 
 def _bundle(*, rerank: str = "off", top_k: int = 100) -> SettingsBundle:
@@ -70,6 +71,36 @@ def test_enforced_provider_preserves_compiled_request_options(monkeypatch) -> No
 
     assert (route.provider, route.model) == ("openai", "gpt-4.1")
     assert (route.timeout_seconds, route.temperature) == (12, 0.2)
+
+
+def test_openai_compatible_transport_receives_compiled_temperature(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Response:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    def fake_post(*_args, **kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(llm_service.requests, "post", fake_post)
+    response, _payload = llm_service._http_chat(
+        url="https://example.test/chat",
+        api_key="test",
+        model="gpt-4.1",
+        messages=[],
+        timeout=12,
+        temperature=0.2,
+    )
+
+    assert response == "ok"
+    assert '"temperature": 0.2' in str(captured["data"])
 
 
 def test_operator_tier_and_last_valid_bundle_fail_closed(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4948

## Linked Issue
Closes #4948

## SBS Impact
- Primary subsystem: WSP
- Secondary subsystem(s): CAO, DRI
- Write class: mechanical durable settings resolution; no new authority
- Persistence impact: canonical vault settings Markdown and compiled last-valid bundle; no migration
- Derived/rebuildable impact: effective settings, provenance, and retrieval cache generations are rebuilt from the canonical bundle
- New or changed contract: execution, failure trace, and explain share one effective provider/model route; SETTINGS-07A keys resolve through SettingsService with bounded environment compatibility
- Owner-doc impact: updated
- Transition debt impact: replaces the non-deliverable stacked recovery path and reduces SETTINGS-07A audit debt
- Boundary risk: explain, execution, or a warm retrieval cache must never observe a different settings generation or provider/model identity

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Re-deliver SETTINGS-07A from main with one compiled effective reasoning route, model-only legacy compatibility, and generation-safe retrieval tuning.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record was produced; the bounded runtime correction is tracked by Issue #4948 and this PR.

## Notes
Validation: pytest targeted settings/router/CLI/retrieval suites (57 passed); ruff; mypy; settings-validate; docs_guard (temporal skip explicitly acknowledged); git diff --check. Claim receipt: github-label-only fallback comment 5306797598 after dispatcher rejected the exact task.