### PR TITLE
[Settings Spine] resolve TTS voice and fallback through the spine

### DIFF
--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -16,6 +16,7 @@ from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_
 from app.settings.runtime import get_settings_bundle
 from app.settings.reasoning_route import describe_effective_reasoning_route
 from app.settings.prompts import resolve_ask_system_prompt
+from app.settings.tiering import active_settings_profile
 
 
 # group 1 = "://user:", group 2 = "@" — replaces only the password portion
@@ -69,6 +70,8 @@ def build_settings_explain_payload() -> dict[str, Any]:
     invalid_actions = invalid_allowed_actions(watcher_settings, allowed_action_ids)
     write_guard = DEFAULT_CONTRACT.evaluate()
     _, ask_prompt_origin = resolve_ask_system_prompt()
+    tts_settings = get_settings_bundle().tts
+    tts_origin = "vault-shared" if (Path(os.getenv("VAULT_ROOT", "vault")) / "settings" / "tts.md").exists() else "registry default"
     settings_provider = None
     settings_model = None
     settings_base_url = None
@@ -170,6 +173,17 @@ def build_settings_explain_payload() -> dict[str, Any]:
             },
         },
         "llm": {"reasoning_model": describe_effective_reasoning_route()},
+        "tts": {
+            "voices": {
+                "sv": {"value": tts_settings.voices.sv, "origin": tts_origin, "tier": active_settings_profile()},
+                "en_us": {"value": tts_settings.voices.en_us, "origin": tts_origin, "tier": active_settings_profile()},
+                "en_gb": {"value": tts_settings.voices.en_gb, "origin": tts_origin, "tier": active_settings_profile()},
+            },
+            "fallback_policy": {"value": tts_settings.fallback_policy, "origin": tts_origin, "tier": active_settings_profile()},
+            "legacy_env_overrides": {
+                key: "deprecated" for key in ("TTS_SV_VOICE", "TTS_EN_US_VOICE", "TTS_EN_GB_VOICE", "TTS_ALLOW_BROWSER_FALLBACK", "TTS_ALLOW_CLOUD_FALLBACK") if os.getenv(key) is not None
+            },
+        },
         "prompts": {"ask.system_prompt": {"origin": ask_prompt_origin}},
     }
 

--- a/app/settings/compiler.py
+++ b/app/settings/compiler.py
@@ -34,6 +34,7 @@ from .models import (
     QaSettings,
     ReviewerSettings,
     SettingsBundle,
+    TTSSettings,
     YggdrasilPaths,
     EmbeddingProfiles,
 )
@@ -505,6 +506,16 @@ def compile_all(
     if "embeddings" in file_paths:
         _update_reference(file_paths["embeddings"], "Embeddings", bundle.embedding_profiles, writeback_allowed(file_paths["embeddings"]), vault_root=resolved_vault_root)
 
+    tts_payload = _merge_sections(file_sections.get("tts", {}))
+    tts_model, tts_canonical, tts_fixed = _hydrate_model(payload=tts_payload, model_cls=TTSSettings)
+    bundle.tts = tts_model
+    if tts_fixed and "tts" in file_paths and writeback_allowed(file_paths["tts"]):
+        writeback_settings_block(
+            file_paths["tts"], tts_canonical, previous=tts_payload, vault_root=resolved_vault_root
+        )
+    if "tts" in file_paths:
+        _update_reference(file_paths["tts"], "TTS", bundle.tts, writeback_allowed(file_paths["tts"]), vault_root=resolved_vault_root)
+
     yggdrasil_payload = _merge_sections(file_sections.get("yggdrasil", {}))
     if yggdrasil_payload:
         ygg_model, ygg_canonical, ygg_fixed = _hydrate_model(
@@ -577,6 +588,7 @@ def compile_all(
         dump(staged_runtime, "global.yaml", bundle.global_.model_dump())
         dump(staged_runtime, "providers.yaml", bundle.providers.model_dump())
         dump(staged_runtime, "llm_routing.yaml", bundle.llm_routing.model_dump())
+        dump(staged_runtime, "tts.yaml", bundle.tts.model_dump())
         dump(staged_runtime, "instance.yaml", bundle.instance.model_dump())
         if bundle.yggdrasil_paths is not None:
             dump(staged_runtime, "yggdrasil.yaml", bundle.yggdrasil_paths.model_dump())

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -380,6 +380,26 @@ class RetrievalTuning(BaseModel):
     )
 
 
+class TTSSettings(BaseModel):
+    """Vault-shared voice and fallback posture for the local TTS path.
+
+    The browser/cloud modes are intentionally lab-only experiments.  The
+    production resolver clamps them to ``local_only``; an explicit legacy
+    environment override remains available for one release.
+    """
+
+    class Voices(BaseModel):
+        sv: str = Field(default="sv_SE-lisa-medium", min_length=1)
+        en_us: str = Field(default="bf_isabella", min_length=1)
+        en_gb: str = Field(default="bf_isabella", min_length=1)
+
+    voices: Voices = Field(default_factory=Voices)
+    fallback_policy: Literal["local_only", "browser", "cloud"] = Field(
+        default="local_only",
+        description="Fallback posture; browser/cloud are lab-tier only and cloud remains refused by synthesis.",
+    )
+
+
 class QaSettings(AgentBase):
     search_k: int = Field(default=8, description="Documents retrieved before filtering.")
     context_docs: int = Field(default=5, description="Documents kept in the final answer context.")
@@ -492,6 +512,7 @@ class SettingsBundle(BaseModel):
     llm_routing: LLMRoutingSettings = Field(default_factory=LLMRoutingSettings)
     embedding_profiles: EmbeddingProfiles = Field(default_factory=EmbeddingProfiles)
     retrieval_tuning: RetrievalTuning = Field(default_factory=RetrievalTuning)
+    tts: TTSSettings = Field(default_factory=TTSSettings)
     agents: Dict[str, Any] = Field(default_factory=dict)
     yggdrasil_paths: Optional[YggdrasilPaths] = None
     instance: InstanceSettings = Field(default_factory=InstanceSettings)

--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -22,6 +22,7 @@ from .models import (
     SettingsBundle,
     EmbeddingProfiles,
     RetrievalTuning,
+    TTSSettings,
     YggdrasilPaths,
 )
 from app.config.environment import active_environment
@@ -81,6 +82,7 @@ def _build_bundle() -> SettingsBundle:
         retrieval_tuning_yaml = _read_typed_mapping_yaml(
             runtime_dir / "retrieval_tuning.yaml", setting_name="retrieval_tuning.yaml"
         )
+        tts_yaml = _read_typed_mapping_yaml(runtime_dir / "tts.yaml", setting_name="tts.yaml")
         instance_yaml = _read_yaml(runtime_dir / "instance.yaml")
         yggdrasil_yaml = _read_yaml(runtime_dir / "yggdrasil.yaml")
         agents_dir = runtime_dir / "agents"
@@ -130,6 +132,7 @@ def _build_bundle() -> SettingsBundle:
         llm_routing=LLMRoutingSettings(**llm_routing_yaml),
         embedding_profiles=embedding_profiles,
         retrieval_tuning=retrieval_tuning,
+        tts=TTSSettings(**tts_yaml),
         agents=agents,
         yggdrasil_paths=yggdrasil_paths,
         instance=instance_settings,

--- a/app/tts/config.py
+++ b/app/tts/config.py
@@ -4,6 +4,9 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from app.settings.runtime import get_settings_bundle
+from app.settings.tiering import is_lab_profile
+
 
 def _truthy_env(name: str, *, default: bool = False) -> bool:
     raw = os.getenv(name)
@@ -19,6 +22,13 @@ def _int_env(name: str, *, default: int) -> int:
     except ValueError:
         return default
     return value if value > 0 else default
+
+
+def _configured_fallback_flags(policy: str) -> tuple[bool, bool]:
+    """Resolve the typed fallback posture without widening operator defaults."""
+    if not is_lab_profile():
+        return False, False
+    return policy == "browser", policy == "cloud"
 
 
 @dataclass(frozen=True)
@@ -54,6 +64,8 @@ def load_tts_config() -> TTSConfig:
     model_dir = Path(os.getenv("TTS_MODEL_DIR") or default_root / "models")
     cache_dir = Path(os.getenv("TTS_CACHE_DIR") or default_root / "cache")
     log_dir = Path(os.getenv("TTS_LOG_DIR") or default_root / "logs")
+    settings = get_settings_bundle().tts
+    configured_browser, configured_cloud = _configured_fallback_flags(settings.fallback_policy)
     return TTSConfig(
         enabled=_truthy_env("TTS_ENABLED"),
         local_only=_truthy_env("TTS_LOCAL_ONLY", default=True),
@@ -64,11 +76,11 @@ def load_tts_config() -> TTSConfig:
         cache_eviction=(os.getenv("TTS_CACHE_EVICTION") or "lru").strip().lower(),
         max_concurrent_jobs=_int_env("TTS_MAX_CONCURRENT_JOBS", default=1),
         max_chars_per_request=_int_env("TTS_MAX_CHARS_PER_REQUEST", default=4000),
-        allow_browser_fallback=_truthy_env("TTS_ALLOW_BROWSER_FALLBACK"),
-        allow_cloud_fallback=_truthy_env("TTS_ALLOW_CLOUD_FALLBACK"),
+        allow_browser_fallback=_truthy_env("TTS_ALLOW_BROWSER_FALLBACK", default=configured_browser),
+        allow_cloud_fallback=_truthy_env("TTS_ALLOW_CLOUD_FALLBACK", default=configured_cloud),
         piper_command=(os.getenv("TTS_PIPER_COMMAND") or "").strip() or None,
         kokoro_command=(os.getenv("TTS_KOKORO_COMMAND") or "").strip() or None,
-        sv_voice=(os.getenv("TTS_SV_VOICE") or "sv_SE-lisa-medium").strip(),
-        en_us_voice=(os.getenv("TTS_EN_US_VOICE") or "bf_isabella").strip(),
-        en_gb_voice=(os.getenv("TTS_EN_GB_VOICE") or "bf_isabella").strip(),
+        sv_voice=(os.getenv("TTS_SV_VOICE") or settings.voices.sv).strip(),
+        en_us_voice=(os.getenv("TTS_EN_US_VOICE") or settings.voices.en_us).strip(),
+        en_gb_voice=(os.getenv("TTS_EN_GB_VOICE") or settings.voices.en_gb).strip(),
     )

--- a/docs/SETTINGS_SPINE/TTS_SETTINGS.md
+++ b/docs/SETTINGS_SPINE/TTS_SETTINGS.md
@@ -55,4 +55,6 @@ Provider installation, external TTS calls, deployment, model-routing/rerank, wat
 
 ## Related GitHub Issues
 
-Implements [#4797](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4797) after #4796 merges and is reconciled on `origin/main`.
+Implements [#4797](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4797) after the
+main-targeted SETTINGS-07A recovery [#4948](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4948)
+is merged and reconciled on `origin/main`; the historical #4796 attempt is superseded.

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -289,14 +289,22 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "app/components/settings/",
             "app/settings/",
             "app/cli/settings_explain.py",
+            # TTS consumes the compiled Settings Spine directly.  Keep voice
+            # and fallback changes on focused TTS regression coverage rather
+            # than failing the required check as an unowned runtime path.
+            "app/tts/",
             "app/services/companion_eligibility.py",
             "app/services/settings.py",
             "docs/settings/",
+            "docs/SETTINGS_SPINE/TTS_SETTINGS.md",
+            "vault/settings/tts.md",
             "tests/settings/",
+            "tests/tts/",
             "tests/config/",
         ),
         (
             "tests/settings",
+            "tests/tts",
             "tests/config",
             "tests/cli/test_settings_explain_cli.py",
             "tests/services/test_companion_eligibility.py",

--- a/tests/deploy/test_tts_image_packaging.py
+++ b/tests/deploy/test_tts_image_packaging.py
@@ -83,5 +83,9 @@ def test_engine_image_excludes_models_and_preserves_disabled_local_only_defaults
         assert forbidden not in dockerfile
     assert 'enabled=_truthy_env("TTS_ENABLED")' in config
     assert 'local_only=_truthy_env("TTS_LOCAL_ONLY", default=True)' in config
-    assert 'allow_browser_fallback=_truthy_env("TTS_ALLOW_BROWSER_FALLBACK")' in config
-    assert 'allow_cloud_fallback=_truthy_env("TTS_ALLOW_CLOUD_FALLBACK")' in config
+    # Legacy environment flags remain the final one-release compatibility
+    # override, while the default posture comes from the tier-gated Settings
+    # Spine resolver.
+    assert 'allow_browser_fallback=_truthy_env("TTS_ALLOW_BROWSER_FALLBACK", default=configured_browser)' in config
+    assert 'allow_cloud_fallback=_truthy_env("TTS_ALLOW_CLOUD_FALLBACK", default=configured_cloud)' in config
+    assert 'if not is_lab_profile():' in config

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -258,6 +258,7 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
     for adapter_path in (
         "app/cli/settings_explain.py",
         "app/components/settings/providers_loader.py",
+        "app/tts/config.py",
         "app/services/companion_eligibility.py",
         "app/services/settings.py",
     ):
@@ -266,6 +267,11 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
         assert focused_selection.unowned_paths == ()
         assert "tests/cli/test_settings_explain_cli.py" in focused_selection.targets
         assert "tests/services/test_companion_eligibility.py" in focused_selection.targets
+
+    tts_selection = select_tests(["app/tts/config.py", "vault/settings/tts.md"])
+    assert tts_selection.subsystems == ("settings",)
+    assert tts_selection.unowned_paths == ()
+    assert "tests/tts" in tts_selection.targets
 
 
 def test_settings_adapter_cannot_mask_unknown_runtime_path() -> None:

--- a/tests/tts/test_settings_backed_voices.py
+++ b/tests/tts/test_settings_backed_voices.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from app.cli.settings_explain import build_settings_explain_payload
+from app.settings import compiler
+from app.settings.models import SettingsBundle, TTSSettings
+from app.tts.config import load_tts_config
+from app.tts.planning import build_tts_plan
+
+def test_voice_resolves_from_settings_on_synthesis_path(monkeypatch, tmp_path) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = vault_root / "settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "tts.md").write_text(
+        "# TTS\n\n```yaml settings\nvoices:\n  sv: sv_SE-nst-medium\n  en_us: af_heart\n  en_gb: bf_emma\nfallback_policy: local_only\n```\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(compiler, "RUNTIME", tmp_path / "runtime" / "settings")
+    bundle = compiler.compile_all(vault_root=vault_root)
+    monkeypatch.setattr("app.tts.config.get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr("app.cli.settings_explain.get_settings_bundle", lambda: bundle)
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    monkeypatch.setenv("TTS_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.delenv("TTS_SV_VOICE", raising=False)
+
+    config = load_tts_config()
+    plan = build_tts_plan(text="Hej från inställningar", config=config, language="sv-SE")
+    payload = build_settings_explain_payload()
+
+    assert config.sv_voice == "sv_SE-nst-medium"
+    assert plan["voice_id"] == "sv_SE-nst-medium"
+    assert payload["tts"]["voices"]["sv"] == {
+        "value": "sv_SE-nst-medium",
+        "origin": "vault-shared",
+        "tier": "operator",
+    }
+
+
+def test_empty_settings_and_legacy_tts_env_preserve_behavior(monkeypatch) -> None:
+    monkeypatch.setattr("app.tts.config.get_settings_bundle", lambda: SettingsBundle())
+    monkeypatch.setenv("TTS_SV_VOICE", "legacy-voice")
+    monkeypatch.setenv("TTS_ALLOW_BROWSER_FALLBACK", "1")
+    monkeypatch.delenv("TTS_ALLOW_CLOUD_FALLBACK", raising=False)
+
+    config = load_tts_config()
+
+    assert config.sv_voice == "legacy-voice"
+    assert config.allow_browser_fallback is True
+    assert config.allow_cloud_fallback is False
+    assert config.local_only is True
+
+
+def test_tts_fallback_policy_stays_explicit_and_tier_gated(monkeypatch) -> None:
+    bundle = SettingsBundle(tts=TTSSettings(fallback_policy="browser"))
+    monkeypatch.setattr("app.tts.config.get_settings_bundle", lambda: bundle)
+    monkeypatch.delenv("TTS_ALLOW_BROWSER_FALLBACK", raising=False)
+    monkeypatch.delenv("TTS_ALLOW_CLOUD_FALLBACK", raising=False)
+    monkeypatch.delenv("PKM_SETTINGS_PROFILE", raising=False)
+
+    assert load_tts_config().allow_browser_fallback is False
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    assert load_tts_config().allow_browser_fallback is True

--- a/vault/settings/tts.md
+++ b/vault/settings/tts.md
@@ -1,0 +1,20 @@
+---
+uuid: 00000000-0000-0000-0000-000000000007
+title: Text to Speech
+origin: user
+review_state: evergreen
+trust: internal
+---
+# Text to Speech Settings
+
+Local voice selection is vault-shared. The default fallback posture is local-only;
+browser and cloud policies are lab-tier experiments, and cloud remains refused by
+the production synthesis path.
+
+```yaml settings
+voices:
+  sv: sv_SE-lisa-medium
+  en_us: bf_isabella
+  en_gb: bf_isabella
+fallback_policy: local_only
+```


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4797

## Linked Issue
Closes #4797

## SBS Impact
- Primary subsystem: WSP
- Secondary subsystem(s): CAO
- Write class: mechanical durable settings resolution; no new write authority
- Persistence impact: vault settings markdown and registry defaults
- Derived/rebuildable impact: none
- New or changed contract: TTS voice and fallback policy resolve from SettingsService with env compatibility
- Owner-doc impact: follow-up SETTINGS-08
- Transition debt impact: reduces audit F3
- Boundary risk: no silent cloud or browser fallback may be introduced

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [x] Owner-doc follow-up issue created and linked. (3166)

## Summary
- Resolve vault TTS voices and explicit fallback posture through the compiled Settings Spine, with explain provenance, legacy environment compatibility, and focused CI ownership.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material: implementation followed the issue contract without a delivery divergence.

## Notes
Validation: pytest -q tests/deploy/test_tts_image_packaging.py tests/scripts/test_select_pr_tests.py tests/tts/test_settings_backed_voices.py tests/tts/test_readback_segments_and_norm.py tests/cli/test_settings_explain_cli.py (123 passed); ruff check app tests scripts/select_pr_tests.py; mypy app; python3 -m app.cli settings-validate --json; python3 scripts/docs_guard.py --language-only. Earlier current-head CI failures repaired: TTS CI ownership and the packaging assertion for the tier-gated fallback default. Broad not-pg validation was stopped before completion because it entered deploy-channel tests outside this issue’s no-host-runtime boundary.
