### PR TITLE
[Settings Spine] bind TTS explain to compiled provenance

### DIFF
--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -14,6 +14,7 @@ from app.settings.panel_actions_settings import load_panel_actions_settings, pan
 from app.settings.locations import LEGACY_COMPILED_DIR, resolve_settings_file
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
 from app.settings.runtime import get_settings_bundle
+from app.settings.ingestion import get_settings_ingestion_state
 from app.settings.reasoning_route import describe_effective_reasoning_route
 from app.settings.prompts import resolve_ask_system_prompt
 from app.settings.tiering import active_settings_profile
@@ -71,7 +72,9 @@ def build_settings_explain_payload() -> dict[str, Any]:
     write_guard = DEFAULT_CONTRACT.evaluate()
     _, ask_prompt_origin = resolve_ask_system_prompt()
     tts_settings = get_settings_bundle().tts
-    tts_origin = "vault-shared" if (Path(os.getenv("VAULT_ROOT", "vault")) / "settings" / "tts.md").exists() else "registry default"
+    # Explain the source that compiled the active bundle (or retained the
+    # last-valid bundle), never a convenient repository-relative file.
+    tts_origin = get_settings_ingestion_state().tts_origin
     settings_provider = None
     settings_model = None
     settings_base_url = None

--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -14,7 +14,11 @@ from app.settings.panel_actions_settings import load_panel_actions_settings, pan
 from app.settings.locations import LEGACY_COMPILED_DIR, resolve_settings_file
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
 from app.settings.runtime import get_settings_bundle
-from app.settings.ingestion import get_settings_ingestion_state
+from app.settings.ingestion import (
+    STATE_NO_VAULT,
+    get_compiled_generation_tts_origin,
+    get_settings_ingestion_state,
+)
 from app.settings.reasoning_route import describe_effective_reasoning_route
 from app.settings.prompts import resolve_ask_system_prompt
 from app.settings.tiering import active_settings_profile
@@ -74,7 +78,10 @@ def build_settings_explain_payload() -> dict[str, Any]:
     tts_settings = get_settings_bundle().tts
     # Explain the source that compiled the active bundle (or retained the
     # last-valid bundle), never a convenient repository-relative file.
-    tts_origin = get_settings_ingestion_state().tts_origin
+    ingestion_state = get_settings_ingestion_state()
+    tts_origin = ingestion_state.tts_origin
+    if ingestion_state.state == STATE_NO_VAULT:
+        tts_origin = get_compiled_generation_tts_origin() or tts_origin
     settings_provider = None
     settings_model = None
     settings_base_url = None

--- a/app/settings/compiler.py
+++ b/app/settings/compiler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import tempfile
@@ -102,6 +103,14 @@ def dump(runtime_dir: Path, relative: str, payload: Dict[str, Any]) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("w", encoding="utf-8") as handle:
         yaml.safe_dump(payload, handle, allow_unicode=True, sort_keys=True)
+
+
+def _source_fingerprints(source_paths: dict[Path, Path]) -> dict[str, str]:
+    """Record the source bytes that produced one published runtime generation."""
+    return {
+        str(relative): hashlib.sha256(path.read_bytes()).hexdigest()
+        for relative, path in sorted(source_paths.items(), key=lambda item: str(item[0]))
+    }
 
 
 def _new_staged_runtime_dir() -> Path:
@@ -601,6 +610,12 @@ def compile_all(
             _panel_actions_payload(panel_actions_settings),
         )
         dump(staged_runtime, "watchers.yaml", _watcher_settings_payload(watcher_settings))
+        with (staged_runtime / "sources.json").open("w", encoding="utf-8") as handle:
+            json.dump(
+                {"version": 1, "sources": _source_fingerprints(source_paths)},
+                handle,
+                sort_keys=True,
+            )
         _publish_staged_runtime(staged_runtime)
     except Exception:
         shutil.rmtree(staged_runtime, ignore_errors=True)

--- a/app/settings/ingestion.py
+++ b/app/settings/ingestion.py
@@ -132,6 +132,12 @@ def _compiled_generation_tts_origin() -> str | None:
             return None
         sources = resolve_compiled_sources(source_dir.parent)
         tts_source = sources.get(Path("tts.md"))
+        # The published generation is the authority for the bundle currently
+        # being served.  A watcher may have replaced the source with malformed
+        # content after that generation was published; comparing against the
+        # now-invalid bytes would erase the retained generation's provenance.
+        # Source presence still distinguishes a removed vault source (defaults)
+        # from a retained vault generation whose replacement cannot compile.
         actual_tts = (
             hashlib.sha256(tts_source.read_bytes()).hexdigest()
             if tts_source is not None
@@ -139,9 +145,12 @@ def _compiled_generation_tts_origin() -> str | None:
         )
     except (OSError, TypeError, ValueError, KeyError):
         return None
-    if expected.get("tts.md") != actual_tts:
+    if expected.get("tts.md") is None or actual_tts is None:
         return None
-    return "vault-shared" if Path("tts.md") in sources else "registry default"
+    # A differing hash means the source changed after publication.  The
+    # selected compiled generation remains vault-authored until a successful
+    # replacement is published, so retain the vault provenance.
+    return "vault-shared"
 
 
 def get_compiled_generation_tts_origin() -> str | None:

--- a/app/settings/ingestion.py
+++ b/app/settings/ingestion.py
@@ -20,6 +20,8 @@ Scope boundary: binding settings-source resolution to the *selected* vault path
 
 from __future__ import annotations
 
+import hashlib
+import json
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -116,10 +118,35 @@ def _compiled_generation_tts_origin() -> str | None:
     repository-relative path probe.
     """
     source_dir = _selected_settings_source_dir()
-    if source_dir is None or not (runtime.RUNTIME / "tts.yaml").is_file():
+    manifest_path = runtime.RUNTIME / "sources.json"
+    if (
+        source_dir is None
+        or not (runtime.RUNTIME / "tts.yaml").is_file()
+        or not manifest_path.is_file()
+    ):
         return None
-    sources = resolve_compiled_sources(source_dir.parent)
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        expected = manifest["sources"]
+        if manifest.get("version") != 1 or not isinstance(expected, dict):
+            return None
+        sources = resolve_compiled_sources(source_dir.parent)
+        tts_source = sources.get(Path("tts.md"))
+        actual_tts = (
+            hashlib.sha256(tts_source.read_bytes()).hexdigest()
+            if tts_source is not None
+            else None
+        )
+    except (OSError, TypeError, ValueError, KeyError):
+        return None
+    if expected.get("tts.md") != actual_tts:
+        return None
     return "vault-shared" if Path("tts.md") in sources else "registry default"
+
+
+def get_compiled_generation_tts_origin() -> str | None:
+    """Return provenance only when the published generation matches its sources."""
+    return _compiled_generation_tts_origin()
 
 
 def get_settings_ingestion_state() -> SettingsIngestionState:
@@ -129,17 +156,6 @@ def get_settings_ingestion_state() -> SettingsIngestionState:
     # defaults against invalid sources.
     signal = read_reload_signal()
     prior = _get_local_ingestion_state()
-    if prior.state == STATE_NO_VAULT:
-        compiled_tts_origin = _compiled_generation_tts_origin()
-        if compiled_tts_origin is not None:
-            _set_state(
-                SettingsIngestionState(
-                    state=STATE_OK,
-                    source="vault",
-                    tts_origin=compiled_tts_origin,
-                )
-            )
-            prior = _get_local_ingestion_state()
     if signal is not None and signal.state != STATE_OK and prior.state in _VALID_PRIOR_STATES:
         _set_state(
             SettingsIngestionState(
@@ -286,5 +302,6 @@ __all__ = [
     "STATE_NO_VAULT",
     "ingest_settings",
     "get_settings_ingestion_state",
+    "get_compiled_generation_tts_origin",
     "reset_settings_ingestion_state",
 ]

--- a/app/settings/ingestion.py
+++ b/app/settings/ingestion.py
@@ -21,7 +21,7 @@ Scope boundary: binding settings-source resolution to the *selected* vault path
 from __future__ import annotations
 
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -59,9 +59,21 @@ class SettingsIngestionState:
     source: str  # "vault" | "defaults"
     loaded_at: str | None = None
     error: str | None = None
+    # This is compiled-generation metadata, not a new user setting.  It keeps
+    # explain output bound to the same selected source that produced the active
+    # (or retained last-valid) bundle.
+    tts_origin: str = "registry default"
 
     def to_payload(self) -> dict[str, Any]:
-        return asdict(self)
+        # The reload signal deliberately carries only cross-process invalidation
+        # state.  Source provenance stays process-local with the generation it
+        # describes, so a fresh process cannot claim another process's bundle.
+        return {
+            "state": self.state,
+            "source": self.source,
+            "loaded_at": self.loaded_at,
+            "error": self.error,
+        }
 
 
 # Boot default: nothing ingested yet. Truthful "no_vault" on defaults until the
@@ -191,9 +203,16 @@ def ingest_settings(
         # one) so ingestion never depends on the global subscription still being
         # registered to actually take effect.
         if selected_root is not None:
+            compiled_sources = resolve_compiled_sources(selected_root)
             compiler.compile_all(auto_heal=False, vault_root=selected_root)
+            tts_origin = (
+                "vault-shared"
+                if Path("tts.md") in compiled_sources
+                else "registry default"
+            )
         else:
             compiler.compile_all(auto_heal=False, vault_dir=sources_dir)
+            tts_origin = "vault-shared" if (sources_dir / "tts.md").exists() else "registry default"
         reload_settings_bundle()
     except Exception as exc:
         if had_valid:
@@ -202,6 +221,7 @@ def ingest_settings(
                 source="vault",
                 loaded_at=prior.loaded_at,
                 error=str(exc),
+                tts_origin=prior.tts_origin,
             )
         else:
             # No last-valid bundle to fall back to: boot on defaults, but say so
@@ -217,7 +237,12 @@ def ingest_settings(
             publish_reload_signal(**degraded.to_payload())
         return degraded
 
-    result = SettingsIngestionState(state=STATE_OK, source="vault", loaded_at=_now_iso())
+    result = SettingsIngestionState(
+        state=STATE_OK,
+        source="vault",
+        loaded_at=_now_iso(),
+        tts_origin=tts_origin,
+    )
     _set_state(result)
     if publish_signal:
         publish_reload_signal(**result.to_payload())

--- a/app/settings/ingestion.py
+++ b/app/settings/ingestion.py
@@ -29,6 +29,7 @@ from typing import Any
 from app.config.environment import active_environment
 from app.config.paths import VaultRootMisconfiguredError, resolve_optional_vault_root
 from app.settings import compiler
+from app.settings import runtime
 from app.settings.locations import (
     CANONICAL_SETTINGS_DIR_NAME,
     canonical_settings_root,
@@ -105,6 +106,22 @@ def _selected_settings_source_dir() -> Path | None:
     return canonical_settings_root(vault_root)
 
 
+def _compiled_generation_tts_origin() -> str | None:
+    """Recover TTS provenance for a fresh process reading a compiled bundle.
+
+    ``settings explain`` may run without this process having performed ingestion.
+    The runtime projection proves that a compiled generation is available; the
+    selected source map identifies whether that generation included ``tts.md``.
+    This keeps provenance tied to the selected settings spine rather than to a
+    repository-relative path probe.
+    """
+    source_dir = _selected_settings_source_dir()
+    if source_dir is None or not (runtime.RUNTIME / "tts.yaml").is_file():
+        return None
+    sources = resolve_compiled_sources(source_dir.parent)
+    return "vault-shared" if Path("tts.md") in sources else "registry default"
+
+
 def get_settings_ingestion_state() -> SettingsIngestionState:
     # A watcher reload runs in a different container.  Its signal carries
     # error evidence, but not this process's in-memory bundle history: a fresh
@@ -112,6 +129,17 @@ def get_settings_ingestion_state() -> SettingsIngestionState:
     # defaults against invalid sources.
     signal = read_reload_signal()
     prior = _get_local_ingestion_state()
+    if prior.state == STATE_NO_VAULT:
+        compiled_tts_origin = _compiled_generation_tts_origin()
+        if compiled_tts_origin is not None:
+            _set_state(
+                SettingsIngestionState(
+                    state=STATE_OK,
+                    source="vault",
+                    tts_origin=compiled_tts_origin,
+                )
+            )
+            prior = _get_local_ingestion_state()
     if signal is not None and signal.state != STATE_OK and prior.state in _VALID_PRIOR_STATES:
         _set_state(
             SettingsIngestionState(

--- a/app/settings/ingestion.py
+++ b/app/settings/ingestion.py
@@ -119,6 +119,7 @@ def get_settings_ingestion_state() -> SettingsIngestionState:
                 source="vault",
                 loaded_at=prior.loaded_at,
                 error=signal.error,
+                tts_origin=prior.tts_origin,
             )
         )
     with _STATE_LOCK:

--- a/tests/settings/test_ingestion_startup.py
+++ b/tests/settings/test_ingestion_startup.py
@@ -23,6 +23,7 @@ from app.settings.ingestion import (
     ingest_settings,
     reset_settings_ingestion_state,
 )
+from app.settings.reload_signal import publish_reload_signal
 from app.watcher.settings_delta import handle_settings_source_delta
 from app.watcher.state import WatcherState
 import app.watcher.registry as registry
@@ -185,6 +186,30 @@ def test_tts_provenance_follows_compatibility_source_and_retained_last_valid(
         encoding="utf-8",
     )
     state = ingest_settings(reason="invalid_tts_source")
+
+    assert state.state == STATE_DEGRADED
+    assert state.tts_origin == "vault-shared"
+
+
+def test_tts_provenance_survives_a_cross_process_degraded_signal(
+    sandbox_sources: Path,
+) -> None:
+    source = sandbox_sources / "tts.md"
+    source.write_text(
+        "# TTS\n\n```yaml settings\nvoices:\n  sv: sv_SE-nst-medium\n```\n",
+        encoding="utf-8",
+    )
+    loaded = ingest_settings(reason="valid_tts_generation")
+    assert loaded.tts_origin == "vault-shared"
+
+    publish_reload_signal(
+        state=STATE_DEGRADED,
+        source="vault",
+        loaded_at=loaded.loaded_at,
+        error="invalid replacement generation",
+    )
+
+    state = get_settings_ingestion_state()
 
     assert state.state == STATE_DEGRADED
     assert state.tts_origin == "vault-shared"

--- a/tests/settings/test_ingestion_startup.py
+++ b/tests/settings/test_ingestion_startup.py
@@ -168,6 +168,28 @@ def test_invalid_settings_degrade_loud(sandbox_sources: Path) -> None:
     assert runtime.get_settings_bundle().global_.log_level == "DEBUG"
 
 
+def test_tts_provenance_follows_compatibility_source_and_retained_last_valid(
+    sandbox_sources: Path,
+) -> None:
+    """The selected legacy-compatible source, not a repo path, owns TTS explain."""
+    source = sandbox_sources / "tts.md"
+    source.write_text(
+        "# TTS\n\n```yaml settings\nvoices:\n  sv: sv_SE-nst-medium\n```\n",
+        encoding="utf-8",
+    )
+
+    assert ingest_settings(reason="compat_tts_source").tts_origin == "vault-shared"
+
+    source.write_text(
+        "# TTS\n\n```yaml settings\nfallback_policy: unsupported\n```\n",
+        encoding="utf-8",
+    )
+    state = ingest_settings(reason="invalid_tts_source")
+
+    assert state.state == STATE_DEGRADED
+    assert state.tts_origin == "vault-shared"
+
+
 def test_late_specialized_validation_keeps_prior_projection_for_fresh_process(
     sandbox_sources: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tts/test_settings_backed_voices.py
+++ b/tests/tts/test_settings_backed_voices.py
@@ -112,6 +112,43 @@ def test_settings_explain_recovers_origin_from_compiled_generation(
     assert get_settings_ingestion_state().state == STATE_NO_VAULT
 
 
+def test_settings_explain_keeps_retained_origin_after_invalid_replacement(
+    monkeypatch, tmp_path
+) -> None:
+    """A fresh process keeps the published vault provenance during degradation."""
+    vault_root = tmp_path / "vault"
+    settings_dir = vault_root / "settings"
+    settings_dir.mkdir(parents=True)
+    source = settings_dir / "tts.md"
+    source.write_text(
+        "# TTS\n\n```yaml settings\nvoices:\n  sv: sv_SE-nst-medium\n```\n",
+        encoding="utf-8",
+    )
+    runtime_dir = tmp_path / "runtime" / "settings"
+    monkeypatch.setattr(compiler, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    monkeypatch.setenv("SETTINGS_RELOAD_SIGNAL_PATH", str(tmp_path / "reload.json"))
+    reset_settings_ingestion_state()
+
+    compiler.compile_all(vault_root=vault_root)
+
+    # The watcher has written an invalid replacement, but the last complete
+    # compiled generation remains the one the fresh process can serve.
+    source.write_text(
+        "# TTS\n\n```yaml settings\nfallback_policy: [unterminated\n```\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+    reset_settings_ingestion_state()
+
+    payload = build_settings_explain_payload()
+
+    assert payload["tts"]["voices"]["sv"]["origin"] == "vault-shared"
+    reset_settings_ingestion_state()
+
+
 def test_settings_explain_uses_compiled_tts_provenance_for_compatibility_and_last_valid(
     monkeypatch,
 ) -> None:

--- a/tests/tts/test_settings_backed_voices.py
+++ b/tests/tts/test_settings_backed_voices.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from app.cli.settings_explain import build_settings_explain_payload
 from app.settings import compiler
 from app.settings import runtime
-from app.settings.ingestion import SettingsIngestionState, reset_settings_ingestion_state
+from app.settings.ingestion import (
+    STATE_NO_VAULT,
+    SettingsIngestionState,
+    get_settings_ingestion_state,
+    reset_settings_ingestion_state,
+)
 from app.settings.models import SettingsBundle, TTSSettings
 from app.tts.config import load_tts_config
 from app.tts.planning import build_tts_plan
@@ -90,6 +95,21 @@ def test_settings_explain_recovers_origin_from_compiled_generation(
     payload = build_settings_explain_payload()
 
     assert payload["tts"]["voices"]["sv"]["origin"] == "vault-shared"
+    assert get_settings_ingestion_state().state == STATE_NO_VAULT
+
+    (settings_dir / "global.md").write_text("# unrelated settings\n", encoding="utf-8")
+    reset_settings_ingestion_state()
+    unchanged_tts_payload = build_settings_explain_payload()
+
+    assert unchanged_tts_payload["tts"]["voices"]["sv"]["origin"] == "vault-shared"
+    assert get_settings_ingestion_state().state == STATE_NO_VAULT
+
+    (settings_dir / "tts.md").unlink()
+    reset_settings_ingestion_state()
+    stale_payload = build_settings_explain_payload()
+
+    assert stale_payload["tts"]["voices"]["sv"]["origin"] == "registry default"
+    assert get_settings_ingestion_state().state == STATE_NO_VAULT
 
 
 def test_settings_explain_uses_compiled_tts_provenance_for_compatibility_and_last_valid(

--- a/tests/tts/test_settings_backed_voices.py
+++ b/tests/tts/test_settings_backed_voices.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from app.cli.settings_explain import build_settings_explain_payload
 from app.settings import compiler
+from app.settings import runtime
 from app.settings.ingestion import SettingsIngestionState, reset_settings_ingestion_state
 from app.settings.models import SettingsBundle, TTSSettings
 from app.tts.config import load_tts_config
@@ -64,6 +65,31 @@ def test_no_vault_settings_explain_reports_registry_default_origin(monkeypatch, 
 
     assert payload["tts"]["voices"]["sv"]["origin"] == "registry default"
     reset_settings_ingestion_state()
+
+
+def test_settings_explain_recovers_origin_from_compiled_generation(
+    monkeypatch, tmp_path
+) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = vault_root / "settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "tts.md").write_text(
+        "# TTS\n\n```yaml settings\nvoices:\n  sv: sv_SE-nst-medium\n```\n",
+        encoding="utf-8",
+    )
+    runtime_dir = tmp_path / "runtime" / "settings"
+    monkeypatch.setattr(compiler, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    monkeypatch.setenv("SETTINGS_RELOAD_SIGNAL_PATH", str(tmp_path / "reload.json"))
+    reset_settings_ingestion_state()
+
+    compiler.compile_all(vault_root=vault_root)
+
+    payload = build_settings_explain_payload()
+
+    assert payload["tts"]["voices"]["sv"]["origin"] == "vault-shared"
 
 
 def test_settings_explain_uses_compiled_tts_provenance_for_compatibility_and_last_valid(

--- a/tests/tts/test_settings_backed_voices.py
+++ b/tests/tts/test_settings_backed_voices.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from app.cli.settings_explain import build_settings_explain_payload
 from app.settings import compiler
+from app.settings.ingestion import SettingsIngestionState, reset_settings_ingestion_state
 from app.settings.models import SettingsBundle, TTSSettings
 from app.tts.config import load_tts_config
 from app.tts.planning import build_tts_plan
@@ -18,6 +19,10 @@ def test_voice_resolves_from_settings_on_synthesis_path(monkeypatch, tmp_path) -
     bundle = compiler.compile_all(vault_root=vault_root)
     monkeypatch.setattr("app.tts.config.get_settings_bundle", lambda: bundle)
     monkeypatch.setattr("app.cli.settings_explain.get_settings_bundle", lambda: bundle)
+    monkeypatch.setattr(
+        "app.cli.settings_explain.get_settings_ingestion_state",
+        lambda: SettingsIngestionState(state="ok", source="vault", tts_origin="vault-shared"),
+    )
     monkeypatch.setenv("VAULT_ROOT", str(vault_root))
     monkeypatch.setenv("TTS_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.delenv("TTS_SV_VOICE", raising=False)
@@ -47,6 +52,36 @@ def test_empty_settings_and_legacy_tts_env_preserve_behavior(monkeypatch) -> Non
     assert config.allow_browser_fallback is True
     assert config.allow_cloud_fallback is False
     assert config.local_only is True
+
+
+def test_no_vault_settings_explain_reports_registry_default_origin(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("app.cli.settings_explain.get_settings_bundle", SettingsBundle)
+    monkeypatch.delenv("VAULT_ROOT", raising=False)
+    monkeypatch.setenv("SETTINGS_RELOAD_SIGNAL_PATH", str(tmp_path / "settings-reload.json"))
+    reset_settings_ingestion_state()
+
+    payload = build_settings_explain_payload()
+
+    assert payload["tts"]["voices"]["sv"]["origin"] == "registry default"
+    reset_settings_ingestion_state()
+
+
+def test_settings_explain_uses_compiled_tts_provenance_for_compatibility_and_last_valid(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("app.cli.settings_explain.get_settings_bundle", SettingsBundle)
+    monkeypatch.delenv("VAULT_ROOT", raising=False)
+
+    for state in (
+        SettingsIngestionState(state="ok", source="vault", tts_origin="vault-shared"),
+        SettingsIngestionState(
+            state="degraded_last_valid", source="vault", tts_origin="vault-shared"
+        ),
+    ):
+        monkeypatch.setattr(
+            "app.cli.settings_explain.get_settings_ingestion_state", lambda: state
+        )
+        assert build_settings_explain_payload()["tts"]["voices"]["sv"]["origin"] == "vault-shared"
 
 
 def test_tts_fallback_policy_stays_explicit_and_tier_gated(monkeypatch) -> None:


### PR DESCRIPTION
Governing-Issue: #4797

Fixes #4797

Final-Review-Rounds: 1

## Summary
Repair the protected P1 provenance defect from merged PR #4952. TTS explain now reports the selected compiled ingestion source, retaining that source through direct and cross-process last-valid degradation, instead of probing a repository-relative file.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded runtime current-state repair; the Issue and PR provide the governed delivery evidence.

## Notes
Validation: `pytest -q tests/tts/test_settings_backed_voices.py tests/settings/test_ingestion_startup.py tests/cli/test_settings_explain_cli.py` (31 passed); `ruff check app tests` (passed); `mypy app` (passed). The canonical leased parallel non-PG command could not start because `pytest-xdist` is unavailable. A bounded leased plain `pytest -q -m "not pg"` run was interrupted after 8m56s: 5,635 passed; unrelated failures were `tests/api/test_active_context_resolution.py::test_concurrent_sessions_are_isolated` and `tests/architecture/test_multi_vault_projection_inventory.py::test_enabled_gov_revocation_producers_are_fenced_or_absent`; neither touches the changed TTS/settings provenance surface.

P1 mechanism: `failure_domain=settings_provenance`; `mechanism_id=tts_settings_explain_origin_from_filesystem`. A first independent review found and this head repairs the cross-process retained-generation path. Fresh exact-head CI and one clean independent final review are required before merge.