### PR TITLE
Start database before migration-sensitive worker smoke

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -380,6 +380,7 @@ jobs:
           # start_full_system.sh / deploy_channel.sh do.
           source scripts/lib/instance_state_deployment.sh
           run_ci_compose() { docker compose $compose_files "$@"; }
+          run_ci_compose up -d --wait db
           prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"
 
           docker compose $compose_files up -d --build worker
@@ -561,6 +562,7 @@ jobs:
           # MVR-01B: run the exact production launcher producer before raw compose up.
           source scripts/lib/instance_state_deployment.sh
           run_ci_compose() { docker compose $compose_files "$@"; }
+          run_ci_compose up -d --wait db
           prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"
 
           docker compose $compose_files up -d --build db api watcher worker

--- a/tests/architecture/test_ci_smoke_contract.py
+++ b/tests/architecture/test_ci_smoke_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_SMOKE = REPO_ROOT / ".github" / "workflows" / "ci-smoke.yaml"
+
+
+def _workflow_text() -> str:
+    return CI_SMOKE.read_text(encoding="utf-8")
+
+
+def _worker_startup_step() -> str:
+    workflow = _workflow_text()
+    return workflow.split('      - name: "Docker smoke: worker emits startup log"', maxsplit=1)[
+        1
+    ].split('      - name: "CI gate: vaultwide panel verifier"', maxsplit=1)[0]
+
+
+def test_worker_smoke_starts_db_before_instance_state_deployment() -> None:
+    step = _worker_startup_step()
+
+    db_start = "run_ci_compose up -d --wait db"
+    deployment = 'prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"'
+
+    assert db_start in step
+    assert step.index(db_start) < step.index(deployment)
+
+
+def test_worker_smoke_cleanup_covers_started_dependencies() -> None:
+    step = _worker_startup_step()
+
+    trap_registration = "trap cleanup EXIT"
+    db_start = "run_ci_compose up -d --wait db"
+    cleanup = "docker compose $compose_files down -v || true"
+
+    assert cleanup in step
+    assert step.index(trap_registration) < step.index(db_start)
+    assert 'if [ "$rc" -ne 0 ]; then' in step
+    assert 'exit "$rc"' in step
+
+
+def test_push_smoke_registers_worker_startup_gate() -> None:
+    workflow = _workflow_text()
+    trigger = workflow.split("\nconcurrency:", maxsplit=1)[0]
+    docker_job = workflow.split("  smoke-docker:", maxsplit=1)[1]
+
+    assert "  push:\n    branches: [main]" in trigger
+    assert '      - name: "Docker smoke: worker emits startup log"' in docker_job
+    assert "if: github.event_name != 'pull_request' || github.base_ref == 'stable'" in docker_job


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Closes #4955

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Product/Runtime deployment smoke boundary
- Write class: CI/fitness rail
- Persistence impact: none
- Derived/rebuildable impact: CI evidence only
- New or changed contract: Migration-sensitive Docker smoke supplies its declared Compose database dependency
- Owner-doc impact: none
- Transition debt impact: no effect
- Boundary risk: CI exercises the production deployment producer without a separate launcher path

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Start and health-wait for the Compose database before both CI instance-state deployment producer invocations.
- Add focused contracts for dependency ordering, deterministic cleanup, and the push-triggered worker startup gate.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The issue and PR fully represent this bounded smoke-harness repair; no separate operational record or learning divergence was produced.

## Notes
Validation: ruff check app tests companion-ui/companion-app; mypy app; pytest -q tests/architecture/test_ci_smoke_contract.py tests/ops/test_ci_smoke_workflow.py tests/governance/test_ci_smoke_docs_only_gate.py (17 passed); python3 scripts/docs_guard.py; git diff --check. Fresh pre-CI review of 968cae07ac8523250f0512408ce306c955b55045: CLEAN.