### PR TITLE
Reconcile workflow risk governance owner list

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -358,6 +358,7 @@ Use this lane only when:
   - `scripts/py312_smoke_test.sh`
   - `scripts/await_pr_checks.sh`
   - `scripts/review_before_ci_gate.py`
+  - `scripts/workflow_review_risk.py`
   - `scripts/run_with_host_lease.py`
   - `scripts/verify_runtime_chain.sh`
   - `scripts/validate_source_anchors.py`
@@ -378,6 +379,7 @@ Use this lane only when:
   - `tests/governance/test_skills_consistency_lint.py`
   - `tests/ops/test_project_status_reconcile.py`
   - `tests/ops/test_review_before_ci_gate.py`
+  - `tests/ops/test_review_before_ci_workflow_risk.py`
   - `tests/ops/test_host_global_lease.py`
   - `tests/scripts/test_validate_issue_readiness.py`
   - `tests/scripts/test_docs_guard.py`


### PR DESCRIPTION
Governing-Issue: #4938

Fixes #4938

Final-Review-Rounds: 1

## Summary
Adds the two workflow-risk classifier surfaces already admitted by executable governance to the authoritative `DEV_WORKFLOW` owner list. This restores the owner-doc/executable parity check without changing workflow-risk behavior.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none; current-state owner-doc reconciliation only
- Owner-doc impact: updates `docs/development/DEV_WORKFLOW.md` to match merged executable governance
- Transition debt impact: closes the merged-main owner-doc regression reported on #4938

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The reopened Issue already durably records this bounded merged-main regression; no separate operational record or authority crossing was produced.

## Notes
Validation: exact four focused targets passed (4 passed), including `tests/governance/test_issue_pr_governance.py::test_governance_lane_allowed_surfaces_match_owner_doc`; `python3 scripts/docs_guard.py --language-only`; `git diff --check`; local review-before-CI gate satisfied with no TCD high-risk surface.
---