### PR TITLE
fix: expose MVR-01C launcher to cutover producer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,6 +121,9 @@ services:
       - "./docker-compose.yaml:/run/scalar-rollback-policy/docker-compose.yaml:ro"
       - "./docker-compose.scalar-rollback.yml:/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml:ro"
       - "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro"
+      # The MVR-01C authority producer verifies the exact host launcher bytes;
+      # keep the launcher out of the image and expose only its canonical path.
+      - "./scripts/scalar_rollback_native.sh:/app/scripts/scalar_rollback_native.sh:ro"
       # Exact production native auth producers. The image deliberately excludes
       # these host launchers; the cutover hashes the mounted bytes and fails
       # closed if any declared path is absent.

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -2158,6 +2158,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
     assert f"--volume {selected_root}:/app/selected-vault:ro" in cutover
     assert "--rollback-vault-binding-id binding-selected" in cutover
     assert "--selected-root /app/selected-vault" in cutover
+    assert "--native-launcher /app/scripts/scalar_rollback_native.sh" in cutover
 
 
 def _legacy_owner_source_fixture(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
@@ -3357,6 +3358,10 @@ def test_registry_volume_and_preflight_cover_all_consumers(tmp_path) -> None:
     assert "instance-state" in compose["volumes"]
     init = compose["services"]["instance-state-init"]
     assert "instance-state:/app/instance-state" in init["volumes"]
+    assert (
+        "./scripts/scalar_rollback_native.sh:/app/scripts/scalar_rollback_native.sh:ro"
+        in init["volumes"]
+    )
     assert any(
         isinstance(mount, dict)
         and mount.get("target") == "/app/instance-ownership"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Closes #4955

## SBS Impact
- Primary subsystem: Product/Runtime deployment producer
- Secondary subsystem(s): Builder System smoke fitness rail
- Write class: current-state producer correction
- Persistence impact: none
- Derived/rebuildable impact: container mount topology only
- New or changed contract: the one-shot MVR-01C producer receives its already-canonical host launcher at the exact read-only path it verifies
- Owner-doc impact: none; current docs already describe this production producer contract
- Transition debt impact: no effect
- Boundary risk: launcher bytes must remain host-sourced, read-only, and scoped to `instance-state-init`

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- expose `scripts/scalar_rollback_native.sh` read-only at `/app/scripts/scalar_rollback_native.sh` only in the one-shot `instance-state-init` producer
- retain the Dockerfile exclusion and the runtime guard’s existing ownership/mode/hash validation
- assert both the Compose producer mount and the production authority-cutover argument

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260816143406_ff0421dd`, `lrn_20260816153612_61693a96`
- Reason: the repeated merged-main smoke sequence exposed the missing production MVR-01C producer input

## Notes
- Exact failure: merged-main `5e1dfe27`, run `31962713929`, job `95203067648`.
- Mechanism convergence rejected a CI-only overlay because it would conceal a live production producer defect.
- Pre-CI and final exact-SHA reviews on `d5feaa5e05a274696c94accc607faacd57bb697e` were clean.
- Current-head CI is green; heavy Docker body execution is intentionally skipped on ordinary main PRs, so merged-main smoke remains mandatory.
- Focused validation: 2 tests passed; Ruff, Compose config, and `git diff --check` clean.
- This is one missing read-only producer bind, not a production topology redesign, and does not claim #3859/#2143.