### PR TITLE
fix: expose explicit vault to deployment finalizer

### DIFF
--- a/docker-compose.legacy-vault.yml
+++ b/docker-compose.legacy-vault.yml
@@ -1,7 +1,8 @@
 # Legacy /app/vault compatibility overlay (#2386, Slice 05D of #2311).
 #
-# This overlay re-adds the legacy `/app/vault` bind mount for the api / worker /
-# watcher services. It is intentionally NOT part of the base docker-compose.yaml:
+# This overlay re-adds the legacy `/app/vault` bind mount for the one-shot
+# finalizer plus the api / worker / watcher services. It is intentionally NOT
+# part of the base docker-compose.yaml:
 # a no-vault idle startup (#2005) must never synthesize a repo-local `./vault`
 # bind. The mount remains only as a *compatibility* path for an EXPLICITLY bound
 # vault, until the remaining eager `resolve_vault_root()` consumers (Slices
@@ -21,6 +22,12 @@
 # the explicit-vault branch (NO_VAULT_MODE != 1). The `/Users` + `/Volumes`
 # same-path mounts (#2310) stay in the base compose and are unaffected.
 services:
+  instance-state-init:
+    volumes:
+      # Finalization authenticates the registry's container-facing root after
+      # MVR-01C cutover; it never writes vault content through this alias.
+      - "${VAULT_HOST_ROOT:?VAULT_HOST_ROOT must be set to use the legacy /app/vault compatibility mount}:/app/vault:ro"
+
   api:
     volumes:
       - "${VAULT_HOST_ROOT:?VAULT_HOST_ROOT must be set to use the legacy /app/vault compatibility mount}:/app/vault"

--- a/tests/deploy/test_deploy_channel_vault_overlays.py
+++ b/tests/deploy/test_deploy_channel_vault_overlays.py
@@ -148,6 +148,15 @@ def _mount_source(service: dict[str, object], target: str) -> str | None:
     return None
 
 
+def _mount_is_read_only(service: dict[str, object], target: str) -> bool:
+    volumes = service.get("volumes", [])
+    assert isinstance(volumes, list)
+    for volume in volumes:
+        if isinstance(volume, dict) and volume.get("target") == target:
+            return volume.get("read_only") is True
+    return False
+
+
 @requires_docker
 def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> None:
     services = _services(
@@ -164,6 +173,8 @@ def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> 
         assert env["WATCHER_VAULT_PATH"] == ""
         assert env["DEPLOY_RUNTIME_SENTINEL"] == "governed"
         assert service["image"] == f"ghcr.io/rasmustho/pkm-app:{IMAGE_SHA}"
+
+    assert _mount_source(services["instance-state-init"], "/app/vault") is None
 
 
 @requires_docker
@@ -185,6 +196,10 @@ def test_deploy_channel_test_explicit_vault_uses_governed_overlay_order(
         assert env["WATCHER_VAULT_PATH"] == "/app/vault"
         assert env["DEPLOY_RUNTIME_SENTINEL"] == "governed"
         assert service["image"] == f"ghcr.io/rasmustho/pkm-app:{IMAGE_SHA}"
+
+    finalizer = services["instance-state-init"]
+    assert _mount_source(finalizer, "/app/vault") == selected_vault
+    assert _mount_is_read_only(finalizer, "/app/vault")
 
     migrate = _environment(services["migrate"])
     assert migrate["DATABASE_URL"].endswith("/app_test")
@@ -210,6 +225,10 @@ def test_deploy_channel_non_test_explicit_vault_uses_legacy_overlay_only(
         assert env["DEPLOY_RUNTIME_SENTINEL"] == "governed"
         assert env["DATABASE_URL"].endswith("/app")
         assert env["DB_DSN"].endswith("/app")
+
+    finalizer = services["instance-state-init"]
+    assert _mount_source(finalizer, "/app/vault") == selected_vault
+    assert _mount_is_read_only(finalizer, "/app/vault")
 
 
 @requires_docker


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Closes #4955

## SBS Impact
- Primary subsystem: Product/Runtime deployment producer
- Secondary subsystem(s): Builder System smoke fitness rail
- Write class: current-state producer correction
- Persistence impact: none
- Derived/rebuildable impact: explicit-vault Compose overlay only
- New or changed contract: the one-shot deployment finalizer can authenticate the registry’s explicit `/app/vault` binding through the same governed host source
- Owner-doc impact: overlay-local contract comment updated; no broader owner-doc change
- Transition debt impact: no effect
- Boundary risk: the mount must remain explicit-vault-only, required-variable guarded, and read-only

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- add the governed `VAULT_HOST_ROOT` source at `/app/vault:ro` only for `instance-state-init` in the existing explicit-vault overlay
- leave base/no-vault topology unchanged and require `VAULT_HOST_ROOT` exactly as the runtime-service mounts do
- prove no-vault isolation plus test/prod explicit-vault source and read-only rendering

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260816143406_ff0421dd`, `lrn_20260816153612_61693a96`
- Reason: merged-main smoke exposed the finalizer alias missing from the explicit-vault producer topology

## Notes
- Exact failure: merged-main `632fa7f1`, run `31963947980`, job `95206096150`.
- The preceding launcher/cutover stages were green; failure occurred only when deployment-finish authenticated the persisted `/app/vault` registry path.
- Pre-CI and final exact-SHA reviews on `6b64489bfdb8784f3064f6b1efab4b8dd74c380f` were clean.
- Current-head CI is green; heavy Docker body execution is intentionally skipped on ordinary main PRs, so merged-main smoke remains mandatory.
- Focused validation: 3 render tests passed; Ruff and `git diff --check` clean.
- This is an explicit-overlay producer correction, not a production topology redesign, and does not claim #3859/#2143.