### PR TITLE
fix: make finalizer vault mount preflight-safe

### DIFF
--- a/docker-compose.legacy-vault.yml
+++ b/docker-compose.legacy-vault.yml
@@ -26,7 +26,13 @@ services:
     volumes:
       # Finalization authenticates the registry's container-facing root after
       # MVR-01C cutover; it never writes vault content through this alias.
-      - "${VAULT_HOST_ROOT:?VAULT_HOST_ROOT must be set to use the legacy /app/vault compatibility mount}:/app/vault:ro"
+      # Long syntax keeps the read-only mode outside the guarded source. The
+      # deployment fence renders this file with `config --no-interpolate`,
+      # where the equivalent short form has too many colon delimiters.
+      - type: bind
+        source: "${VAULT_HOST_ROOT:?VAULT_HOST_ROOT must be set to use the legacy /app/vault compatibility mount}"
+        target: /app/vault
+        read_only: true
 
   api:
     volumes:

--- a/tests/deploy/test_deploy_channel_vault_overlays.py
+++ b/tests/deploy/test_deploy_channel_vault_overlays.py
@@ -158,6 +158,27 @@ def _mount_is_read_only(service: dict[str, object], target: str) -> bool:
 
 
 @requires_docker
+def test_explicit_vault_overlay_parses_without_interpolation() -> None:
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(REPO_ROOT / "docker-compose.yaml"),
+            "-f",
+            str(REPO_ROOT / "docker-compose.legacy-vault.yml"),
+            "config",
+            "--no-interpolate",
+            "--no-env-resolution",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@requires_docker
 def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> None:
     services = _services(
         _render_deploy_compose(tmp_path, channel="test", explicit_vault=False)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Fixes #4955

## SBS Impact
- Primary subsystem: Product/Runtime deployment producer
- Secondary subsystem(s): Builder System smoke fitness rail
- Write class: current-state producer correction
- Persistence impact: none
- Derived/rebuildable impact: explicit-vault Compose overlay only
- New or changed contract: the finalizer read-only bind remains guarded and survives the deployment fence no-interpolate render
- Owner-doc impact: no broader owner-doc change
- Transition debt impact: no effect
- Boundary risk: preserve explicit-vault-only, required-variable guarded, read-only semantics

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- express only the `instance-state-init` explicit-vault bind in Compose long syntax
- preserve the required `VAULT_HOST_ROOT` guard, `/app/vault` target, and read-only mode
- add the exact `config --no-interpolate --no-env-resolution` regression that failed on merged main

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260816143406_ff0421dd`, `lrn_20260816153612_61693a96`
- Reason: merged-main smoke exposed a Compose short-syntax parser conflict at the finalizer alias boundary

## Notes
- Exact failure: merged-main `8b890563`, run `31965275276`, job `95209386647`.
- Failure classification: `${VAULT_HOST_ROOT:?...}:/app/vault:ro` is rejected as too many colons by the deployment preflight no-interpolate render.
- Mechanism convergence review accepted only equivalent long syntax; no runtime environment or topology change.
- Pre-CI exact-SHA review on `53ac00d70fd2f9277e629e801f57e762913872db` was clean.
- Focused validation: 9 tests passed; Ruff and `git diff --check` clean.
- This PR leaves #3859/#2143 untouched.

