### PR TITLE
fix: bridge CI vault identity for finalizer

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -534,7 +534,20 @@ jobs:
           export LOCAL_GID="$(id -g)"
           source scripts/lib/instance_ownership_host_state.sh
           prepare_instance_ownership_host_state_dir
-          compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"
+          VAULT_IDENTITY_OVERLAY_PATH="${RUNNER_TEMP}/ci-vault-identity.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.yml"
+          # Production finalizers see host-spelled vault roots through the
+          # same-path /Users and /Volumes mounts. Mirror that identity contract
+          # for the /tmp CI fixture without widening any long-lived service.
+          cat > "$VAULT_IDENTITY_OVERLAY_PATH" <<EOF
+          services:
+            instance-state-init:
+              volumes:
+                - type: bind
+                  source: "$VAULT_ROOT"
+                  target: "$VAULT_ROOT"
+                  read_only: true
+          EOF
+          compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml -f $VAULT_IDENTITY_OVERLAY_PATH"
           # #4463: single source of truth for the verifier's artifact paths. The
           # diagnostic below used to read the script's workspace-relative tmp/
           # defaults while the invocation overrode them to absolute /tmp paths,
@@ -580,6 +593,7 @@ jobs:
             fi
             rm -f "$VAULT_BINDING_RECEIPT_PATH" "$VAULT_BINDING_ID_PATH"
             docker compose $compose_files down -v || true
+            rm -f "$VAULT_IDENTITY_OVERLAY_PATH"
             exit "$rc"
           }
           trap cleanup EXIT

--- a/tests/architecture/test_ci_smoke_contract.py
+++ b/tests/architecture/test_ci_smoke_contract.py
@@ -103,4 +103,28 @@ def test_vaultwide_smoke_cleanup_removes_cutover_receipts_and_state() -> None:
 
     assert 'rm -f "$VAULT_BINDING_RECEIPT_PATH" "$VAULT_BINDING_ID_PATH"' in step
     assert "docker compose $compose_files down -v || true" in step
+    assert 'rm -f "$VAULT_IDENTITY_OVERLAY_PATH"' in step
     assert step.index("trap cleanup EXIT") < step.index("run_ci_compose up -d --wait db")
+
+
+def test_vaultwide_smoke_materializes_ci_vault_host_identity_for_finalizer() -> None:
+    step = _vaultwide_panel_step()
+
+    overlay_write = 'cat > "$VAULT_IDENTITY_OVERLAY_PATH" <<EOF'
+    compose_files = (
+        'compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml '
+        '-f $VAULT_IDENTITY_OVERLAY_PATH"'
+    )
+    first_deployment = "\n          prepare_ci_instance_state_deployment\n"
+
+    assert 'VAULT_IDENTITY_OVERLAY_PATH="${RUNNER_TEMP}/ci-vault-identity.' in step
+    assert overlay_write in step
+    assert "          services:\n            instance-state-init:\n" in step
+    assert '                  source: "$VAULT_ROOT"' in step
+    assert '                  target: "$VAULT_ROOT"' in step
+    assert "                  read_only: true" in step
+    assert compose_files in step
+    assert step.index(overlay_write) < step.index(compose_files) < step.index(
+        first_deployment
+    )
+    assert "VAULT_IDENTITY_OVERLAY_PATH" not in _worker_startup_step()

--- a/tests/deploy/test_deploy_channel_vault_overlays.py
+++ b/tests/deploy/test_deploy_channel_vault_overlays.py
@@ -179,6 +179,60 @@ def test_explicit_vault_overlay_parses_without_interpolation() -> None:
 
 
 @requires_docker
+def test_ci_vault_identity_overlay_is_finalizer_only(tmp_path: Path) -> None:
+    vault_root = tmp_path / "ci-vault"
+    ownership_root = tmp_path / "instance-ownership"
+    vault_root.mkdir()
+    ownership_root.mkdir()
+    identity_overlay = tmp_path / "ci-vault-identity.yml"
+    identity_overlay.write_text(
+        "services:\n"
+        "  instance-state-init:\n"
+        "    volumes:\n"
+        "      - type: bind\n"
+        f'        source: "{vault_root}"\n'
+        f'        target: "{vault_root}"\n'
+        "        read_only: true\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
+            "LLM_PROVIDER": "mock",
+            "VAULT_HOST_ROOT": str(vault_root),
+        }
+    )
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(REPO_ROOT / "docker-compose.yaml"),
+            "-f",
+            str(REPO_ROOT / "docker-compose.legacy-vault.yml"),
+            "-f",
+            str(identity_overlay),
+            "config",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    services = _services(json.loads(result.stdout))
+
+    finalizer = services["instance-state-init"]
+    assert _mount_source(finalizer, str(vault_root)) == str(vault_root)
+    assert _mount_is_read_only(finalizer, str(vault_root))
+    for service_name in ("api", "worker", "watcher"):
+        assert _mount_source(services[service_name], str(vault_root)) is None
+
+
+@requires_docker
 def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> None:
     services = _services(
         _render_deploy_compose(tmp_path, channel="test", explicit_vault=False)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Fixes #4955

## SBS Impact
- Primary subsystem: Builder System smoke fitness rail
- Secondary subsystem(s): Product/Runtime deployment smoke boundary
- Write class: CI harness correction
- Persistence impact: none
- Derived/rebuildable impact: ephemeral vaultwide smoke Compose overlay only
- New or changed contract: the CI finalizer receives the same-path fixture identity already present for production `/Users` and `/Volumes` roots
- Owner-doc impact: none
- Transition debt impact: no effect
- Boundary risk: identity bridge must remain vaultwide-only, finalizer-only, and read-only

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- generate a run-scoped Compose override that mounts the seeded CI vault at its host spelling only into `instance-state-init`
- use the same read-only identity bridge for both production-producer calls and deterministic cleanup
- prove workflow isolation, render scope, and existing cross-namespace backup identity behavior

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260816143406_ff0421dd`, `lrn_20260816153612_61693a96`
- Reason: merged-main smoke exposed the CI-only `/tmp/ci-vault` mount-namespace mismatch

## Notes
- Exact failure: merged-main `b5e73134`, run `31966838965`, job `95213194604`.
- The deployment reached MVR-03/MVR-01C registry revision 4, then backup consistency found the host-spelled owner did not match every live lease.
- Production finalizers already mount `/Users` and `/Volumes` at identical paths; this mirrors that contract only for the explicit CI fixture.
- Mechanism convergence and pre-CI exact-SHA review on `87a69ff2b96d439e9df00e455662d25e93b50c78` are clean.
- Focused validation: 16 workflow/Compose tests plus the existing mounted-alias backup test passed; Ruff and `git diff --check` clean.
- Parent and hub issues #2143/#3859 remain untouched.
