### PR TITLE
fix: delay CI vault identity until registration

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -547,7 +547,7 @@ jobs:
                   target: "$VAULT_ROOT"
                   read_only: true
           EOF
-          compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml -f $VAULT_IDENTITY_OVERLAY_PATH"
+          compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"
           # #4463: single source of truth for the verifier's artifact paths. The
           # diagnostic below used to read the script's workspace-relative tmp/
           # defaults while the invocation overrode them to absolute /tmp paths,
@@ -662,6 +662,11 @@ jobs:
             exit "$binding_parse_rc"
           fi
           read -r MVR01C_ROLLBACK_VAULT_BINDING_ID < "$VAULT_BINDING_ID_PATH"
+          # The first fresh-volume deployment intentionally treats the seeded
+          # fixture as unadopted. Materialize its host spelling only after the
+          # worker has registered the binding, so the cutover deployment can
+          # reconcile that adopted lease without weakening the rev-0 gate.
+          compose_files="$compose_files -f $VAULT_IDENTITY_OVERLAY_PATH"
           export MVR01C_ROLLBACK_VAULT_BINDING_ID
           export MVR01C_ROLLBACK_VAULT_ROOT="$VAULT_ROOT"
           export MVR03_PRINCIPAL_CUTOVER=1

--- a/tests/architecture/test_ci_smoke_contract.py
+++ b/tests/architecture/test_ci_smoke_contract.py
@@ -111,11 +111,13 @@ def test_vaultwide_smoke_materializes_ci_vault_host_identity_for_finalizer() -> 
     step = _vaultwide_panel_step()
 
     overlay_write = 'cat > "$VAULT_IDENTITY_OVERLAY_PATH" <<EOF'
-    compose_files = (
-        'compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml '
-        '-f $VAULT_IDENTITY_OVERLAY_PATH"'
+    initial_compose_files = (
+        'compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"'
     )
-    first_deployment = "\n          prepare_ci_instance_state_deployment\n"
+    identity_append = (
+        'compose_files="$compose_files -f $VAULT_IDENTITY_OVERLAY_PATH"'
+    )
+    deployment = "\n          prepare_ci_instance_state_deployment\n"
 
     assert 'VAULT_IDENTITY_OVERLAY_PATH="${RUNNER_TEMP}/ci-vault-identity.' in step
     assert overlay_write in step
@@ -123,8 +125,10 @@ def test_vaultwide_smoke_materializes_ci_vault_host_identity_for_finalizer() -> 
     assert '                  source: "$VAULT_ROOT"' in step
     assert '                  target: "$VAULT_ROOT"' in step
     assert "                  read_only: true" in step
-    assert compose_files in step
-    assert step.index(overlay_write) < step.index(compose_files) < step.index(
-        first_deployment
-    )
+    assert initial_compose_files in step
+    assert identity_append in step
+    first_deployment = step.index(deployment)
+    second_deployment = step.index(deployment, first_deployment + len(deployment))
+    assert step.index(overlay_write) < step.index(initial_compose_files)
+    assert first_deployment < step.index(identity_append) < second_deployment
     assert "VAULT_IDENTITY_OVERLAY_PATH" not in _worker_startup_step()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4955

## Linked Issue
Refs #4955

## SBS Impact
- Primary subsystem: Builder System smoke fitness rail
- Secondary subsystem(s): Product/Runtime deployment smoke boundary
- Write class: CI harness correction
- Persistence impact: none
- Derived/rebuildable impact: ephemeral vaultwide smoke Compose overlay only
- New or changed contract: the CI-only vault identity bridge enters after worker registration and before cutover deployment
- Owner-doc impact: none
- Transition debt impact: no effect
- Boundary risk: identity bridge must remain vaultwide-only, finalizer-only, read-only, and absent from the first fresh-volume deployment

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- keep the first fresh-volume prepare on base plus legacy Compose so the seeded fixture remains intentionally unadopted
- append the run-scoped same-path finalizer identity overlay only after successful worker binding receipt parse
- prove the overlay enters between the first and second prepares while worker startup remains unaffected

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260816143406_ff0421dd`, `lrn_20260816153612_61693a96`
- Reason: merged-main smoke exposed that materializing the host spelling before adoption creates a binding-less live owner

## Notes
- Exact failure: merged-main `1138637f`, run `31968257375`, job `95216614288`.
- The first deployment failed closed because the early same-path bridge materialized `/tmp/ci-vault` before the worker registered its binding.
- Pre-CI independent review is CLEAN on exact SHA `ea74700ddce7552fc8fd03a01e65044ca9878ec4` against `1138637f0fd423e521281390c9612faa7d5af8e6`.
- Focused validation: 17 tests passed; Ruff, YAML parse, and `git diff --check` clean.
- Parent and hub issues #2143/#3859 remain untouched.
Fixes #4955
