### PR TITLE
Add dormant settings rebind record and floor

### DIFF
--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -4049,7 +4049,7 @@ def main(argv: list[str] | None = None) -> int:
                     nonce=proof.get("nonce"),
                 )
                 registry = VaultRegistryStore(args.registry_path)
-                result = SettingsRebindStore(
+                rebind_record = SettingsRebindStore(
                     registry,
                     capability=local_operator_storage_capability(),
                 ).install_dormant()
@@ -4057,9 +4057,9 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "ok": True,
-                    "desired_revision": result.desired_revision,
-                    "applied_revision": result.applied_revision,
-                    "phase": result.phase,
+                    "desired_revision": rebind_record.desired_revision,
+                    "applied_revision": rebind_record.applied_revision,
+                    "phase": rebind_record.phase,
                 },
                 sort_keys=True,
             )

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -54,6 +54,11 @@ from app.instance.local_operator_principal import (
     PRINCIPAL_RECORD_FILENAME,
     PrincipalPreflightError,
 )
+from app.instance.settings_rebind import (
+    MINIMUM_SETTINGS_REBIND_RUNTIME,
+    MINIMUM_SETTINGS_REBIND_RUNTIME_KEY,
+    SettingsRebindStore,
+)
 from app.instance.vault_registry import (
     AppLocalSettings,
     AppLocalSettingsStore,
@@ -128,6 +133,17 @@ class InstanceRegistryRuntime:
         self.registry = VaultRegistryStore(layout.registry_path)
         self.ledger = ledger
         self._legacy_path = legacy_path or (layout.root / "legacy-app-local.md")
+
+    def open_settings_rebind_store(self) -> SettingsRebindStore:
+        """Resolve the dormant SETTINGS-05 record through protected runtime state.
+
+        This intentionally only exposes record recovery.  It does not select a
+        vault, resolve a watcher root, or permit a caller to initiate a rebind.
+        """
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        _require_runtime_floor(self.registry.load(), scalar_runtime=False)
+        return SettingsRebindStore(self.registry, capability=_STORAGE_MUTATION_CAPABILITY)
 
     @classmethod
     def for_paths(
@@ -872,6 +888,11 @@ def _require_runtime_floor(snapshot: RegistrySnapshot, *, scalar_runtime: bool) 
         raise CapabilityNotReadyError(
             "minimum runtime principal blocks a credential-only scalar image; use a "
             "compatible roll-forward image instead of scalar rollback"
+        )
+    settings_rebind_floor = floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+    if settings_rebind_floor is not None and str(settings_rebind_floor) != MINIMUM_SETTINGS_REBIND_RUNTIME:
+        raise CapabilityNotReadyError(
+            "minimum settings rebind runtime blocks this API/watcher image before root resolution"
         )
 
 

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -894,6 +894,11 @@ def _require_runtime_floor(snapshot: RegistrySnapshot, *, scalar_runtime: bool) 
         raise CapabilityNotReadyError(
             "minimum settings rebind runtime blocks this API/watcher image before root resolution"
         )
+    if scalar_runtime and settings_rebind_floor == MINIMUM_SETTINGS_REBIND_RUNTIME:
+        raise CapabilityNotReadyError(
+            "minimum settings rebind runtime blocks a legacy scalar image; use a compatible "
+            "roll-forward image instead of rollback"
+        )
 
 
 def _preflight_scalar_rollback(
@@ -3896,6 +3901,11 @@ def main(argv: list[str] | None = None) -> int:
     mvr05_floor.add_argument("--host-global-root", type=Path, required=True)
     mvr05_floor.add_argument("--quiescence-proof-path", type=Path, required=True)
     mvr05_floor.add_argument("--fence-plan", type=Path, required=True)
+    rebind_install = subparsers.add_parser("settings-rebind-install-dormant")
+    rebind_install.add_argument("--channel", required=True)
+    rebind_install.add_argument("--registry-path", type=Path, required=True)
+    rebind_install.add_argument("--host-global-root", type=Path, required=True)
+    rebind_install.add_argument("--quiescence-proof-path", type=Path, required=True)
     for name in ("default-vault-get", "default-vault-set", "default-vault-clear"):
         command = subparsers.add_parser(name)
         command.add_argument("--registry-path", type=Path, required=True)
@@ -4022,6 +4032,38 @@ def main(argv: list[str] | None = None) -> int:
                     _capability=local_operator_storage_capability(),
                 )
         print(json.dumps({"ok": True, "registry_revision": result.revision}, sort_keys=True))
+        return 0
+    if args.command == "settings-rebind-install-dormant":
+        layout = InstanceStateLayout(
+            root=args.registry_path.parent,
+            channel_id=args.channel,
+            registry_path=args.registry_path,
+        )
+        layout.require_existing()
+        with _deployment_admission_locked(args.host_global_root):
+            with _producer_transition_locked(layout):
+                proof = json.loads(args.quiescence_proof_path.read_text(encoding="utf-8"))
+                _require_proved_deployment_lease(
+                    host_global_root=args.host_global_root,
+                    channel=args.channel,
+                    nonce=proof.get("nonce"),
+                )
+                registry = VaultRegistryStore(args.registry_path)
+                result = SettingsRebindStore(
+                    registry,
+                    capability=local_operator_storage_capability(),
+                ).install_dormant()
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "desired_revision": result.desired_revision,
+                    "applied_revision": result.applied_revision,
+                    "phase": result.phase,
+                },
+                sort_keys=True,
+            )
+        )
         return 0
     if args.command == "preflight":
         return _preflight_runtime(

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -1,0 +1,124 @@
+"""Dormant, durable SETTINGS-05 rebind record.
+
+This module deliberately owns persistence and recovery only.  It has no picker,
+API, watcher, or vault-root side effects; SETTINGS-05B/05C own those activation
+paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+SETTINGS_REBIND_SCHEMA = "settings_rebind.v1"
+MINIMUM_SETTINGS_REBIND_RUNTIME_KEY = "minimum_settings_rebind_runtime"
+MINIMUM_SETTINGS_REBIND_RUNTIME = "1"
+_PHASES = frozenset({"dormant", "prepared", "committed", "no_lifecycle"})
+_POSTURES = frozenset({"dormant", "watcher", "no_lifecycle"})
+
+
+class SettingsRebindError(RuntimeError):
+    """A SETTINGS-05 protected-state record is malformed or unsafe."""
+
+
+def _canonical_payload(value: Mapping[str, object]) -> bytes:
+    payload = dict(value)
+    payload.pop("checksum", None)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def checksum_for(value: Mapping[str, object]) -> str:
+    return hashlib.sha256(_canonical_payload(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class SettingsRebindRecord:
+    desired_revision: int
+    applied_revision: int
+    phase: str
+    lifecycle_posture: str
+    prior_binding_id: str | None
+    candidate_binding_id: str | None
+
+    def as_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": SETTINGS_REBIND_SCHEMA,
+            "desiredRevision": self.desired_revision,
+            "appliedRevision": self.applied_revision,
+            "phase": self.phase,
+            "lifecyclePosture": self.lifecycle_posture,
+            "priorBindingId": self.prior_binding_id,
+            "candidateBindingId": self.candidate_binding_id,
+        }
+        payload["checksum"] = checksum_for(payload)
+        return payload
+
+    @classmethod
+    def dormant(cls, *, binding_id: str | None = None) -> "SettingsRebindRecord":
+        return cls(0, 0, "dormant", "dormant", binding_id, binding_id)
+
+    @classmethod
+    def from_payload(cls, value: Mapping[str, object]) -> "SettingsRebindRecord":
+        required = {
+            "schema", "desiredRevision", "appliedRevision", "phase", "lifecyclePosture",
+            "priorBindingId", "candidateBindingId", "checksum",
+        }
+        if set(value) != required or value.get("schema") != SETTINGS_REBIND_SCHEMA:
+            raise SettingsRebindError("settings rebind record schema is invalid")
+        desired, applied = value.get("desiredRevision"), value.get("appliedRevision")
+        if (
+            not isinstance(desired, int) or isinstance(desired, bool) or desired < 0
+            or not isinstance(applied, int) or isinstance(applied, bool) or applied < 0
+            or applied > desired
+        ):
+            raise SettingsRebindError("settings rebind revisions are invalid")
+        phase, posture = value.get("phase"), value.get("lifecyclePosture")
+        if phase not in _PHASES or posture not in _POSTURES:
+            raise SettingsRebindError("settings rebind phase or lifecycle posture is invalid")
+        prior, candidate = value.get("priorBindingId"), value.get("candidateBindingId")
+        if prior is not None and (not isinstance(prior, str) or not prior.strip()):
+            raise SettingsRebindError("settings rebind prior binding is invalid")
+        if candidate is not None and (not isinstance(candidate, str) or not candidate.strip()):
+            raise SettingsRebindError("settings rebind candidate binding is invalid")
+        checksum = value.get("checksum")
+        if not isinstance(checksum, str) or checksum != checksum_for(value):
+            raise SettingsRebindError("settings rebind checksum is invalid")
+        return cls(desired, applied, str(phase), str(posture), prior, candidate)
+
+
+def validate_settings_rebind_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise SettingsRebindError("settings rebind record must be a mapping")
+    record = SettingsRebindRecord.from_payload(value)
+    return record.as_payload()
+
+
+class SettingsRebindStore:
+    """Narrow facade over the already-authoritative protected registry store."""
+
+    def __init__(self, registry_store: Any, *, capability: Any) -> None:
+        self._registry = registry_store
+        self._capability = capability
+
+    def install_dormant(self, *, binding_id: str | None = None) -> SettingsRebindRecord:
+        """Install the compatibility floor before the first authoritative record."""
+        self._registry.record_settings_rebind_floor(_capability=self._capability)
+        current = self._registry.load()
+        if current.settings_rebind is None:
+            self._registry.set_settings_rebind_state(
+                SettingsRebindRecord.dormant(binding_id=binding_id).as_payload(),
+                expected_revision=current.revision,
+                _capability=self._capability,
+            )
+        return self.read()
+
+    def read(self) -> SettingsRebindRecord:
+        snapshot = self._registry.load()
+        if snapshot.settings_rebind is None:
+            raise SettingsRebindError("settings rebind record has not been installed")
+        return SettingsRebindRecord.from_payload(copy.deepcopy(snapshot.settings_rebind))
+

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -113,15 +113,11 @@ class SettingsRebindStore:
         self._capability = capability
 
     def install_dormant(self, *, binding_id: str | None = None) -> SettingsRebindRecord:
-        """Install the compatibility floor before the first authoritative record."""
-        self._registry.record_settings_rebind_floor(_capability=self._capability)
-        current = self._registry.load()
-        if current.settings_rebind is None:
-            self._registry.set_settings_rebind_state(
-                SettingsRebindRecord.dormant(binding_id=binding_id).as_payload(),
-                expected_revision=current.revision,
-                _capability=self._capability,
-            )
+        """Atomically install the floor and first authoritative dormant record."""
+        self._registry.install_settings_rebind_dormant(
+            SettingsRebindRecord.dormant(binding_id=binding_id).as_payload(),
+            _capability=self._capability,
+        )
         return self.read()
 
     def read(self) -> SettingsRebindRecord:

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -79,6 +79,14 @@ class SettingsRebindRecord:
         phase, posture = value.get("phase"), value.get("lifecyclePosture")
         if phase not in _PHASES or posture not in _POSTURES:
             raise SettingsRebindError("settings rebind phase or lifecycle posture is invalid")
+        if phase == "dormant" and (desired != applied or posture != "dormant"):
+            raise SettingsRebindError("dormant settings rebind state must be fully applied")
+        if phase == "prepared" and (desired != applied + 1 or posture != "watcher"):
+            raise SettingsRebindError("prepared settings rebind state is not one revision ahead")
+        if phase == "committed" and (desired != applied or posture != "watcher"):
+            raise SettingsRebindError("committed settings rebind state must be fully applied")
+        if phase == "no_lifecycle" and (desired != applied or posture != "no_lifecycle"):
+            raise SettingsRebindError("no_lifecycle settings rebind state must be fully applied")
         prior, candidate = value.get("priorBindingId"), value.get("candidateBindingId")
         if prior is not None and (not isinstance(prior, str) or not prior.strip()):
             raise SettingsRebindError("settings rebind prior binding is invalid")
@@ -121,4 +129,3 @@ class SettingsRebindStore:
         if snapshot.settings_rebind is None:
             raise SettingsRebindError("settings rebind record has not been installed")
         return SettingsRebindRecord.from_payload(copy.deepcopy(snapshot.settings_rebind))
-

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -2038,6 +2038,35 @@ class VaultRegistryStore:
             for key, value in frontmatter.items()
             if key not in known_legacy_fields
         }
+        settings_rebind: dict[str, Any] | None = None
+        if rewritten_rebind is not None:
+            # A pre-SETTINGS-05 record was only a MVR migration repair hook.  It
+            # has no revision/checksum/floor contract and must never be carried
+            # forward as an authoritative v1 record.  Adopt its one provisional
+            # binding identity into a *dormant* SETTINGS record in the same
+            # registry transaction, or refuse an ambiguous legacy shape.
+            binding_ids = {
+                str(value["vaultBindingId"])
+                for key in ("prior", "candidate", "applied")
+                if isinstance((value := rewritten_rebind.get(key)), dict)
+                and _optional_str(value.get("vaultBindingId")) is not None
+            }
+            if len(binding_ids) > 1:
+                raise RegistryMigrationError(
+                    "legacy settings rebind references multiple binding identities"
+                )
+            binding_id = next(iter(binding_ids), None)
+            from app.instance.settings_rebind import SettingsRebindRecord
+
+            settings_rebind = SettingsRebindRecord.dormant(
+                binding_id=binding_id
+            ).as_payload()
+            floors = dict(extensions.get("runtimeFloors") or {})
+            existing_floor = floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+            if existing_floor not in (None, MINIMUM_SETTINGS_REBIND_RUNTIME):
+                raise RegistryMigrationError("legacy settings rebind runtime floor is incompatible")
+            floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = MINIMUM_SETTINGS_REBIND_RUNTIME
+            extensions["runtimeFloors"] = floors
         # A legacy payload may already carry an explicit default. It is untrusted:
         # binding identity is minted during this migration, so it is adopted only
         # when it names exactly one migrated registration. Otherwise the raw value
@@ -2070,7 +2099,7 @@ class VaultRegistryStore:
             app_install_id=app_install_id,
             last_active_vault_ref=last_active_vault_ref,
             registrations=registrations,
-            settings_rebind=rewritten_rebind,
+            settings_rebind=settings_rebind,
             extensions=extensions,
             default_vault_binding_id=default_binding_id,
             default_vault_provenance=default_provenance,

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -1933,6 +1933,9 @@ class VaultRegistryStore:
                 settings_rebind = validate_settings_rebind_payload(settings_rebind)
             except SettingsRebindError as exc:
                 raise RegistryError(str(exc)) from exc
+            floors = extensions.get("runtimeFloors") or {}
+            if floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY) != MINIMUM_SETTINGS_REBIND_RUNTIME:
+                raise RegistryError("settings rebind record requires its runtime floor")
         default_binding_id, default_provenance = _read_default_from_frontmatter(
             frontmatter, registrations, extensions
         )

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -31,6 +31,12 @@ from app.instance.filesystem_identity import (
     same_filesystem_root,
 )
 from app.receipts.settings_write import emit_settings_write_receipts_for_changes
+from app.instance.settings_rebind import (
+    MINIMUM_SETTINGS_REBIND_RUNTIME,
+    MINIMUM_SETTINGS_REBIND_RUNTIME_KEY,
+    SettingsRebindError,
+    validate_settings_rebind_payload,
+)
 
 if TYPE_CHECKING:
     from app.instance.runtime import InstanceRegistryRuntime
@@ -968,6 +974,59 @@ class VaultRegistryStore:
             _capability=_capability,
         )
 
+    def record_settings_rebind_floor(
+        self,
+        *,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Record SETTINGS-05's compatibility floor before its first record.
+
+        This is intentionally a dedicated producer: it pins the revision it
+        observed and carries sibling extension state unchanged rather than
+        making a settings record writer an unrestricted extension writer.
+        """
+        _require_storage_mutation_capability(_capability)
+        current = self.load()
+        floors = dict(current.extensions.get("runtimeFloors") or {})
+        existing = floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+        if existing not in (None, MINIMUM_SETTINGS_REBIND_RUNTIME):
+            raise RegistryError("settings rebind runtime floor is incompatible")
+        if existing == MINIMUM_SETTINGS_REBIND_RUNTIME:
+            return current
+        floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = MINIMUM_SETTINGS_REBIND_RUNTIME
+        return self.set_extension_state(
+            principal_state=dict(current.extensions.get("principalState") or {}),
+            background_state=dict(current.extensions.get("backgroundState") or {}),
+            runtime_floors=floors,
+            expected_revision=current.revision,
+            _capability=_capability,
+        )
+
+    def set_settings_rebind_state(
+        self,
+        value: Mapping[str, object],
+        *,
+        expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Atomically persist one checksum-validated dormant rebind record."""
+        _require_storage_mutation_capability(_capability)
+        try:
+            validated = validate_settings_rebind_payload(value)
+        except SettingsRebindError as exc:
+            raise RegistryError(str(exc)) from exc
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            self._assert_revision(current, expected_revision)
+            floors = current.extensions.get("runtimeFloors") or {}
+            if floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY) != MINIMUM_SETTINGS_REBIND_RUNTIME:
+                raise RegistryError("settings rebind runtime floor must precede the record")
+            updated = self._with_registrations(current, dict(current.registrations))
+            updated = replace(updated, settings_rebind=copy.deepcopy(validated))
+            self._write_locked(updated)
+            return updated
+
     def require_authoritative_activation(
         self,
         proof: RegistryActivationProof,
@@ -1869,8 +1928,11 @@ class VaultRegistryStore:
             ):
                 raise RegistryError("active registry scalar rollback floor is invalid")
         settings_rebind = frontmatter.get("settingsRebind")
-        if settings_rebind is not None and not isinstance(settings_rebind, dict):
-            raise RegistryError("settingsRebind must be a mapping")
+        if settings_rebind is not None:
+            try:
+                settings_rebind = validate_settings_rebind_payload(settings_rebind)
+            except SettingsRebindError as exc:
+                raise RegistryError(str(exc)) from exc
         default_binding_id, default_provenance = _read_default_from_frontmatter(
             frontmatter, registrations, extensions
         )

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -1035,10 +1035,12 @@ class VaultRegistryStore:
                     persisted = validate_settings_rebind_payload(current.settings_rebind)
                 except SettingsRebindError as exc:  # defensive: load recovery must not weaken writes
                     raise RegistryError(str(exc)) from exc
-                persisted_desired = int(persisted["desiredRevision"])
-                persisted_applied = int(persisted["appliedRevision"])
-                incoming_desired = int(validated["desiredRevision"])
-                incoming_applied = int(validated["appliedRevision"])
+                persisted_record = SettingsRebindRecord.from_payload(persisted)
+                incoming_record = SettingsRebindRecord.from_payload(validated)
+                persisted_desired = persisted_record.desired_revision
+                persisted_applied = persisted_record.applied_revision
+                incoming_desired = incoming_record.desired_revision
+                incoming_applied = incoming_record.applied_revision
                 if (
                     incoming_desired < persisted_desired
                     or incoming_applied < persisted_applied

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -35,6 +35,7 @@ from app.instance.settings_rebind import (
     MINIMUM_SETTINGS_REBIND_RUNTIME,
     MINIMUM_SETTINGS_REBIND_RUNTIME_KEY,
     SettingsRebindError,
+    SettingsRebindRecord,
     validate_settings_rebind_payload,
 )
 
@@ -974,33 +975,42 @@ class VaultRegistryStore:
             _capability=_capability,
         )
 
-    def record_settings_rebind_floor(
+    def install_settings_rebind_dormant(
         self,
+        value: Mapping[str, object],
         *,
         _capability: _StorageMutationCapability | None = None,
     ) -> RegistrySnapshot:
-        """Record SETTINGS-05's compatibility floor before its first record.
-
-        This is intentionally a dedicated producer: it pins the revision it
-        observed and carries sibling extension state unchanged rather than
-        making a settings record writer an unrestricted extension writer.
-        """
+        """Atomically install SETTINGS-05's floor with its first dormant record."""
         _require_storage_mutation_capability(_capability)
-        current = self.load()
-        floors = dict(current.extensions.get("runtimeFloors") or {})
-        existing = floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
-        if existing not in (None, MINIMUM_SETTINGS_REBIND_RUNTIME):
-            raise RegistryError("settings rebind runtime floor is incompatible")
-        if existing == MINIMUM_SETTINGS_REBIND_RUNTIME:
-            return current
-        floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = MINIMUM_SETTINGS_REBIND_RUNTIME
-        return self.set_extension_state(
-            principal_state=dict(current.extensions.get("principalState") or {}),
-            background_state=dict(current.extensions.get("backgroundState") or {}),
-            runtime_floors=floors,
-            expected_revision=current.revision,
-            _capability=_capability,
-        )
+        try:
+            validated = validate_settings_rebind_payload(value)
+        except SettingsRebindError as exc:
+            raise RegistryError(str(exc)) from exc
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            self._assert_settings_rebind_binding_authority(current, validated)
+            floors = dict(current.extensions.get("runtimeFloors") or {})
+            existing_floor = floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+            if existing_floor not in (None, MINIMUM_SETTINGS_REBIND_RUNTIME):
+                raise RegistryError("settings rebind runtime floor is incompatible")
+            if current.settings_rebind is not None:
+                if existing_floor != MINIMUM_SETTINGS_REBIND_RUNTIME:
+                    raise RegistryError("settings rebind record requires its runtime floor")
+                validate_settings_rebind_payload(current.settings_rebind)
+                return current
+            floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = MINIMUM_SETTINGS_REBIND_RUNTIME
+            extensions = copy.deepcopy(current.extensions)
+            extensions["runtimeFloors"] = floors
+            updated = self._with_registrations(current, dict(current.registrations))
+            updated = replace(
+                updated,
+                extensions=extensions,
+                settings_rebind=copy.deepcopy(validated),
+            )
+            self._write_locked(updated)
+            return updated
 
     def set_settings_rebind_state(
         self,
@@ -1019,6 +1029,31 @@ class VaultRegistryStore:
             self._assert_no_scalar_rollback_session_locked()
             current = self._read_current_locked(recover=True)
             self._assert_revision(current, expected_revision)
+            self._assert_settings_rebind_binding_authority(current, validated)
+            if current.settings_rebind is not None:
+                try:
+                    persisted = validate_settings_rebind_payload(current.settings_rebind)
+                except SettingsRebindError as exc:  # defensive: load recovery must not weaken writes
+                    raise RegistryError(str(exc)) from exc
+                persisted_desired = int(persisted["desiredRevision"])
+                persisted_applied = int(persisted["appliedRevision"])
+                incoming_desired = int(validated["desiredRevision"])
+                incoming_applied = int(validated["appliedRevision"])
+                if (
+                    incoming_desired < persisted_desired
+                    or incoming_applied < persisted_applied
+                ):
+                    raise RegistryError(
+                        "settings rebind desired/applied revisions must be monotonic"
+                    )
+                if (
+                    incoming_desired == persisted_desired
+                    and incoming_applied == persisted_applied
+                    and validated != persisted
+                ):
+                    raise RegistryError(
+                        "settings rebind state cannot change without a revision advance"
+                    )
             floors = current.extensions.get("runtimeFloors") or {}
             if floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY) != MINIMUM_SETTINGS_REBIND_RUNTIME:
                 raise RegistryError("settings rebind runtime floor must precede the record")
@@ -1476,7 +1511,15 @@ class VaultRegistryStore:
         try:
             _assert_private(self.path, directory=False)
             document = _read_document(self.path)
-            return self._snapshot_from_frontmatter(document.frontmatter)
+            try:
+                return self._snapshot_from_frontmatter(document.frontmatter)
+            except RegistryError:
+                upgraded = self._upgrade_current_schema_settings_rebind_locked(
+                    document.frontmatter
+                )
+                if upgraded is None:
+                    raise
+                return upgraded
         except RegistrySecurityError:
             raise
         except (OSError, RegistryParseError, RegistryError) as exc:
@@ -1489,6 +1532,69 @@ class VaultRegistryStore:
             _atomic_private_write(self.path, payload)
             _atomic_private_write(self.rollback_export_path, self._rollback_export_payload(snapshot))
             return snapshot
+
+    def _upgrade_current_schema_settings_rebind_locked(
+        self, frontmatter: Mapping[str, Any]
+    ) -> RegistrySnapshot | None:
+        """Upgrade the provisional pre-SETTINGS record only while holding its writer lock."""
+        if _optional_str(frontmatter.get("schema")) != CURRENT_REGISTRY_SCHEMA:
+            return None
+        raw_rebind = frontmatter.get("settingsRebind")
+        if not isinstance(raw_rebind, Mapping):
+            return None
+        provisional_schema = _optional_str(raw_rebind.get("schema"))
+        if provisional_schema not in (None, "settings_rebind.v1"):
+            return None
+        if "desiredRevision" in raw_rebind or "appliedRevision" in raw_rebind:
+            return None
+        if not any(key in raw_rebind for key in ("prior", "candidate", "applied")):
+            return None
+        provisional_ids = {
+            _optional_str(value.get("vaultBindingId"))
+            for key in ("prior", "candidate", "applied")
+            if isinstance((value := raw_rebind.get(key)), Mapping)
+            and _optional_str(value.get("vaultBindingId")) is not None
+        }
+        if len(provisional_ids) > 1:
+            raise RegistryError("legacy settings rebind references multiple binding identities")
+        without_rebind = copy.deepcopy(dict(frontmatter))
+        without_rebind["settingsRebind"] = None
+        extensions = dict(without_rebind.get("runtimeFloors") or {})
+        existing_floor = extensions.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+        if existing_floor not in (None, MINIMUM_SETTINGS_REBIND_RUNTIME):
+            raise RegistryError("legacy settings rebind runtime floor is incompatible")
+        without_rebind["runtimeFloors"] = extensions
+        current = self._snapshot_from_frontmatter(without_rebind)
+        binding_id = next(iter(provisional_ids), None)
+        if binding_id is not None and binding_id not in (
+            set(current.registrations) | set(current.removal_tombstones)
+        ):
+            raise RegistryError("legacy settings rebind binding is outside registry authority")
+
+        extensions[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = MINIMUM_SETTINGS_REBIND_RUNTIME
+        updated_extensions = copy.deepcopy(current.extensions)
+        updated_extensions["runtimeFloors"] = extensions
+        updated = replace(
+            self._with_registrations(current, dict(current.registrations)),
+            extensions=updated_extensions,
+            settings_rebind=SettingsRebindRecord.dormant(
+                binding_id=binding_id
+            ).as_payload(),
+        )
+        self._write_locked(updated)
+        return updated
+
+    @staticmethod
+    def _assert_settings_rebind_binding_authority(
+        current: RegistrySnapshot, payload: Mapping[str, object]
+    ) -> None:
+        record = SettingsRebindRecord.from_payload(payload)
+        known_ids = set(current.registrations) | set(current.removal_tombstones)
+        for binding_id in (record.prior_binding_id, record.candidate_binding_id):
+            if binding_id is not None and binding_id not in known_ids:
+                raise RegistryError(
+                    "settings rebind record names a binding outside registry authority"
+                )
 
     def _restore_or_initialize_missing_locked(self) -> RegistrySnapshot:
         recovered = self._load_verified_snapshot_locked()
@@ -1928,12 +2034,20 @@ class VaultRegistryStore:
             ):
                 raise RegistryError("active registry scalar rollback floor is invalid")
         settings_rebind = frontmatter.get("settingsRebind")
+        floors = extensions.get("runtimeFloors") or {}
+        if not isinstance(floors, dict):
+            raise RegistryError("runtime floors are invalid")
+        if (
+            floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+            == MINIMUM_SETTINGS_REBIND_RUNTIME
+            and settings_rebind is None
+        ):
+            raise RegistryError("settings rebind runtime floor requires its dormant record")
         if settings_rebind is not None:
             try:
                 settings_rebind = validate_settings_rebind_payload(settings_rebind)
             except SettingsRebindError as exc:
                 raise RegistryError(str(exc)) from exc
-            floors = extensions.get("runtimeFloors") or {}
             if floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY) != MINIMUM_SETTINGS_REBIND_RUNTIME:
                 raise RegistryError("settings rebind record requires its runtime floor")
         default_binding_id, default_provenance = _read_default_from_frontmatter(

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -211,7 +211,8 @@ acquire_channel_mutation_lock
 current_sha="$(read_pin "${pin_file}" 2>/dev/null || true)"
 target_sha="$(resolve_target_sha "${target_sha}")"
 scalar_rollback=0
-if [ "${action}" = "rollback" ] && \
+settings_rebind_floor_marker="${INSTANCE_OWNERSHIP_HOST_STATE_DIR:-}/settings-rebind-runtime-floor-${channel}.json"
+if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ] && \
   { ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null \
     || ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/settings_rebind.py" 2>/dev/null; }; then
   scalar_rollback=1
@@ -700,7 +701,8 @@ rollback_failed_startup() {
     return 0
   fi
   if [ -n "${current_sha}" ]; then
-    if ! git -C "${ROOT}" cat-file -e "${current_sha}:app/instance/settings_rebind.py" 2>/dev/null; then
+    if [ -f "${settings_rebind_floor_marker}" ] && \
+      ! git -C "${ROOT}" cat-file -e "${current_sha}:app/instance/settings_rebind.py" 2>/dev/null; then
       echo "${reason} (status ${original_status}); automatic rollback is blocked because previous pin ${current_sha} cannot satisfy the persisted settings rebind runtime floor" >&2
       return 0
     fi

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -212,7 +212,8 @@ current_sha="$(read_pin "${pin_file}" 2>/dev/null || true)"
 target_sha="$(resolve_target_sha "${target_sha}")"
 scalar_rollback=0
 if [ "${action}" = "rollback" ] && \
-  ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null; then
+  { ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null \
+    || ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/settings_rebind.py" 2>/dev/null; }; then
   scalar_rollback=1
 fi
 
@@ -699,6 +700,10 @@ rollback_failed_startup() {
     return 0
   fi
   if [ -n "${current_sha}" ]; then
+    if ! git -C "${ROOT}" cat-file -e "${current_sha}:app/instance/settings_rebind.py" 2>/dev/null; then
+      echo "${reason} (status ${original_status}); automatic rollback is blocked because previous pin ${current_sha} cannot satisfy the persisted settings rebind runtime floor" >&2
+      return 0
+    fi
     echo "${reason} (status ${original_status}); attempting rollback to previous pin" >&2
     if ! write_pin "${pin_file}" "${current_sha}"; then
       echo "rollback pin restore failed for previous pin ${current_sha}" >&2

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -211,12 +211,6 @@ acquire_channel_mutation_lock
 current_sha="$(read_pin "${pin_file}" 2>/dev/null || true)"
 target_sha="$(resolve_target_sha "${target_sha}")"
 scalar_rollback=0
-settings_rebind_floor_marker="${INSTANCE_OWNERSHIP_HOST_STATE_DIR:-}/settings-rebind-runtime-floor-${channel}.json"
-if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ] && \
-  { ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null \
-    || ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/settings_rebind.py" 2>/dev/null; }; then
-  scalar_rollback=1
-fi
 
 prepare_scalar_rollback_environment() {
   if [ -z "${current_sha}" ]; then
@@ -1096,11 +1090,16 @@ if ! scripts/companion_ui_postdeploy_smoke.sh preflight; then
   exit 86
 fi
 
+prepare_instance_ownership_host_state_dir
+settings_rebind_floor_marker="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ] && \
+  { ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null \
+    || ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/settings_rebind.py" 2>/dev/null; }; then
+  scalar_rollback=1
+fi
 if [ "${scalar_rollback}" = "1" ]; then
   prepare_scalar_rollback_environment || exit $?
 fi
-
-prepare_instance_ownership_host_state_dir
 
 if [ "${action}" = "rollback" ]; then
   INSTANCE_STATE_LEGACY_ROLLBACK=1

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -385,6 +385,22 @@ prepare_instance_state_deployment() {
       "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
+  # This host-global receipt is written only after the atomic protected record
+  # commit succeeds. Rollback admission consumes its existence, not image age,
+  # so installations which never crossed SETTINGS-05A retain generic rollback.
+  ( umask 077
+    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
+    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s"}\n' "${channel}" > "${marker_tmp}" &&
+      mv -f -- "${marker_tmp}" "${marker_path}"
+  )
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
 
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
     python -m app.instance.runtime deployment-prove \

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -75,6 +75,52 @@ _instance_state_deployment_host_ownership_path() {
   esac
 }
 
+# The SETTINGS runtime floor crosses two durable stores.  The host receipt is
+# therefore authority, not telemetry: each replacement fsyncs its content and
+# then the containing directory before either protected-store commit can rely
+# on it.  A failed installed replacement deliberately leaves a durable pending
+# receipt, which fences an old image until an idempotent deployment reconciles.
+_write_settings_rebind_floor_receipt() {
+  local channel="${1:?channel required}"
+  local phase="${2:?phase required}"
+  python3 - "${INSTANCE_OWNERSHIP_HOST_STATE_DIR}" "${channel}" "${phase}" <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+root, channel, phase = sys.argv[1:]
+if phase not in {"pending", "installed"}:
+    raise SystemExit("invalid settings rebind floor receipt phase")
+name = f"settings-rebind-runtime-floor-{channel}.json"
+path = os.path.join(root, name)
+fd, temporary = tempfile.mkstemp(prefix=f".{name}.", dir=root)
+try:
+    os.fchmod(fd, 0o600)
+    payload = json.dumps(
+        {"schema": "settings-rebind-floor-receipt.v1", "channel": channel, "phase": phase},
+        separators=(",", ":"),
+    ).encode() + b"\n"
+    os.write(fd, payload)
+    os.fsync(fd)
+    os.close(fd)
+    fd = -1
+    os.replace(temporary, path)
+    directory = os.open(root, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+finally:
+    if fd >= 0:
+        os.close(fd)
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+PY
+}
+
 # Explicit operator recovery for exactly one missing active ownership lease.
 # This is deliberately not called by deploy/start: the failed deployment must
 # already have left its host-global restart fence and proved quiescence in
@@ -402,11 +448,7 @@ prepare_instance_state_deployment() {
 
   # Install pending authority after the proved stopped window and before either
   # protected-store commit; replaying this idempotent deployment reconciles it.
-  ( umask 077
-    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
-    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
-    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s","phase":"pending"}\n' "${channel}" > "${marker_tmp}" && mv -f -- "${marker_tmp}" "${marker_path}"
-  ) || return $?
+  _write_settings_rebind_floor_receipt "${channel}" pending || return $?
 
   # Re-read every owner/config producer after all writers are stopped and the
   # lease-bound quiescence proof is durable. Any missing or changed source
@@ -599,12 +641,7 @@ prepare_instance_state_deployment() {
   # Publish the host receipt only after both deployment proof and the atomic
   # SETTINGS record/floor commit succeeded. A crash before this point leaves no
   # rollback fence; a crash after it has the complete protected state.
-  ( umask 077
-    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
-    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
-    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s","phase":"installed"}\n' "${channel}" > "${marker_tmp}" &&
-      mv -f -- "${marker_tmp}" "${marker_path}"
-  )
+  _write_settings_rebind_floor_receipt "${channel}" installed
   inventory_rc=$?
   if [ "${inventory_rc}" -ne 0 ]; then
     _release_abandoned_instance_state_deployment_lease \

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -385,23 +385,6 @@ prepare_instance_state_deployment() {
       "${controller_pid}" "${controller_start_token}"
     return "${inventory_rc}"
   fi
-  # This host-global receipt is written only after the atomic protected record
-  # commit succeeds. Rollback admission consumes its existence, not image age,
-  # so installations which never crossed SETTINGS-05A retain generic rollback.
-  ( umask 077
-    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
-    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
-    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s"}\n' "${channel}" > "${marker_tmp}" &&
-      mv -f -- "${marker_tmp}" "${marker_path}"
-  )
-  inventory_rc=$?
-  if [ "${inventory_rc}" -ne 0 ]; then
-    _release_abandoned_instance_state_deployment_lease \
-      "${compose_function}" "${channel}" "${runtime_user}" \
-      "${controller_pid}" "${controller_start_token}"
-    return "${inventory_rc}"
-  fi
-
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
     python -m app.instance.runtime deployment-prove \
       --channel "${channel}" \
@@ -596,6 +579,23 @@ prepare_instance_state_deployment() {
       --registry-path /app/instance-state/agentic-pkm/vault-registry.md \
       --host-global-root /app/instance-ownership \
       --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
+
+  # Publish the host receipt only after both deployment proof and the atomic
+  # SETTINGS record/floor commit succeeded. A crash before this point leaves no
+  # rollback fence; a crash after it has the complete protected state.
+  ( umask 077
+    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
+    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s"}\n' "${channel}" > "${marker_tmp}" &&
+      mv -f -- "${marker_tmp}" "${marker_path}"
+  )
   inventory_rc=$?
   if [ "${inventory_rc}" -ne 0 ]; then
     _release_abandoned_instance_state_deployment_lease \

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -571,6 +571,23 @@ prepare_instance_state_deployment() {
     return "${inventory_rc}"
   fi
 
+  # SETTINGS-05A installs only the dormant record/floor while the same proved
+  # stopped window that seals MVR-05 is still live. This is the production and
+  # existing-install producer; API, picker, and watcher activation remain sealed.
+  "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
+    python -m app.instance.runtime settings-rebind-install-dormant \
+      --channel "${channel}" \
+      --registry-path /app/instance-state/agentic-pkm/vault-registry.md \
+      --host-global-root /app/instance-ownership \
+      --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
+
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
     python -m app.instance.runtime deployment-finish \
       "${finish_args[@]}"

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -201,6 +201,7 @@ prepare_instance_state_deployment() {
   if [ "${inventory_rc}" -ne 0 ]; then
     return "${inventory_rc}"
   fi
+
   python3 "${inventory_helper}" produce-legacy-owners \
     --repo-root "${repo_root}" \
     --active-channel "${channel}" \
@@ -399,6 +400,14 @@ prepare_instance_state_deployment() {
     return "${inventory_rc}"
   fi
 
+  # Install pending authority after the proved stopped window and before either
+  # protected-store commit; replaying this idempotent deployment reconciles it.
+  ( umask 077
+    marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
+    marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s","phase":"pending"}\n' "${channel}" > "${marker_tmp}" && mv -f -- "${marker_tmp}" "${marker_path}"
+  ) || return $?
+
   # Re-read every owner/config producer after all writers are stopped and the
   # lease-bound quiescence proof is durable. Any missing or changed source
   # aborts while the durable fence remains installed; only an exact match may
@@ -593,7 +602,7 @@ prepare_instance_state_deployment() {
   ( umask 077
     marker_tmp="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/.settings-rebind-runtime-floor-${channel}-${controller_pid}.tmp"
     marker_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
-    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s"}\n' "${channel}" > "${marker_tmp}" &&
+    printf '{"schema":"settings-rebind-floor-receipt.v1","channel":"%s","phase":"installed"}\n' "${channel}" > "${marker_tmp}" &&
       mv -f -- "${marker_tmp}" "${marker_path}"
   )
   inventory_rc=$?

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -1,19 +1,49 @@
 from __future__ import annotations
 
-from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from pathlib import Path
+
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _python_sources(*roots: str) -> dict[str, str]:
+    return {
+        str(path.relative_to(REPO_ROOT)): path.read_text(encoding="utf-8")
+        for root in roots
+        for path in sorted((REPO_ROOT / root).rglob("*.py"))
+    }
+
 
 def test_all_producers_match_production_rebind_schema_and_activation_seal(tmp_path) -> None:
+    """Inventory every current producer, including the deliberately empty activation set."""
     runtime = InstanceRegistryRuntime.for_paths(
         InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
     )
     record = runtime.open_settings_rebind_store().install_dormant()
     snapshot = runtime.registry.load()
+    sources = _python_sources("app", "scripts")
 
     assert snapshot.settings_rebind == record.as_payload()
     assert snapshot.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
-    assert not hasattr(runtime, "select_rebind_binding")
-    assert not hasattr(runtime, "prepare_rebind")
-    assert _STORAGE_MUTATION_CAPABILITY is not None
+    direct_writers = {
+        path
+        for path, source in sources.items()
+        if ".set_settings_rebind_state(" in source
+    }
+    assert direct_writers == {"app/instance/settings_rebind.py"}
+    assert "settings rebind runtime floor must precede the record" in sources[
+        "app/instance/vault_registry.py"
+    ]
+    assert "expected_revision=current.revision" in sources["app/instance/settings_rebind.py"]
+    assert not any(
+        "settingsRebind" in source
+        for path, source in sources.items()
+        if path.startswith("app/api/")
+    )
+    assert not any(
+        "settingsRebind" in source
+        for path, source in sources.items()
+        if path.startswith("app/watcher/")
+    )

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -67,11 +67,13 @@ def test_floor_receipt_is_published_only_after_proof_and_dormant_install() -> No
         encoding="utf-8"
     )
     proof = deployment.index("python -m app.instance.runtime deployment-prove")
+    pending = deployment.index('_write_settings_rebind_floor_receipt "${channel}" pending')
+    mvr_floor = deployment.index("mvr05-record-floor")
     install = deployment.index("python -m app.instance.runtime settings-rebind-install-dormant")
-    receipt = deployment.index("settings-rebind-runtime-floor-${channel}.json")
+    installed = deployment.index('_write_settings_rebind_floor_receipt "${channel}" installed')
     finish = deployment.rindex("deployment-finish")
 
-    assert proof < install < receipt < finish
+    assert proof < pending < mvr_floor < install < installed < finish
 
 
 def test_floor_receipt_path_uses_resolved_default_and_explicit_host_root(tmp_path) -> None:
@@ -106,3 +108,14 @@ def test_rollback_reads_floor_receipt_only_after_host_root_preparation() -> None
     admission = deploy.index('if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ]')
 
     assert prepared < marker < admission
+
+
+def test_pristine_pre_floor_rollback_remains_unfenced() -> None:
+    deploy = (REPO_ROOT / "scripts/deploy_channel.sh").read_text(encoding="utf-8")
+    admission = 'if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ]'
+    assert admission in deploy
+    # A missing receipt is the durable proof that no SETTINGS floor transition
+    # began; generic scalar rollback must therefore retain its pre-floor path.
+    assert deploy.index(admission) < deploy.index(
+        'if [ "${scalar_rollback}" = "1" ]', deploy.index(admission)
+    )

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
+import subprocess
 
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
@@ -58,3 +60,49 @@ def test_all_producers_match_production_rebind_schema_and_activation_seal(tmp_pa
         for path, source in sources.items()
         if path.startswith("app/watcher/")
     )
+
+
+def test_floor_receipt_is_published_only_after_proof_and_dormant_install() -> None:
+    deployment = (REPO_ROOT / "scripts/lib/instance_state_deployment.sh").read_text(
+        encoding="utf-8"
+    )
+    proof = deployment.index("python -m app.instance.runtime deployment-prove")
+    install = deployment.index("python -m app.instance.runtime settings-rebind-install-dormant")
+    receipt = deployment.index("settings-rebind-runtime-floor-${channel}.json")
+    finish = deployment.rindex("deployment-finish")
+
+    assert proof < install < receipt < finish
+
+
+def test_floor_receipt_path_uses_resolved_default_and_explicit_host_root(tmp_path) -> None:
+    library = REPO_ROOT / "scripts/lib/instance_ownership_host_state.sh"
+    default_state = tmp_path / "xdg-state"
+    explicit_state = tmp_path / "explicit-state"
+    base_env = os.environ | {"HOME": str(tmp_path / "home")}
+
+    default = subprocess.run(
+        ["bash", "-c", f'source "{library}"; resolve_instance_ownership_host_state_dir; printf %s "$INSTANCE_OWNERSHIP_HOST_STATE_DIR"'],
+        env=base_env | {"XDG_STATE_HOME": str(default_state)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    explicit = subprocess.run(
+        ["bash", "-c", f'source "{library}"; resolve_instance_ownership_host_state_dir; printf %s "$INSTANCE_OWNERSHIP_HOST_STATE_DIR"'],
+        env=base_env | {"INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(explicit_state)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert default.stdout == str(default_state / "agentic-pkm" / "instance-ownership")
+    assert explicit.stdout == str(explicit_state)
+
+
+def test_rollback_reads_floor_receipt_only_after_host_root_preparation() -> None:
+    deploy = (REPO_ROOT / "scripts/deploy_channel.sh").read_text(encoding="utf-8")
+    prepared = deploy.index("prepare_instance_ownership_host_state_dir")
+    marker = deploy.index('settings_rebind_floor_marker="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}')
+    admission = deploy.index('if [ "${action}" = "rollback" ] && [ -f "${settings_rebind_floor_marker}" ]')
+
+    assert prepared < marker < admission

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -32,11 +32,22 @@ def test_all_producers_match_production_rebind_schema_and_activation_seal(tmp_pa
         for path, source in sources.items()
         if ".set_settings_rebind_state(" in source
     }
-    assert direct_writers == {"app/instance/settings_rebind.py"}
+    assert direct_writers == set()
     assert "settings rebind runtime floor must precede the record" in sources[
         "app/instance/vault_registry.py"
     ]
-    assert "expected_revision=current.revision" in sources["app/instance/settings_rebind.py"]
+    assert "install_settings_rebind_dormant" in sources["app/instance/settings_rebind.py"]
+    assert ".install_settings_rebind_dormant(" in sources["app/instance/settings_rebind.py"]
+    assert "Atomically install SETTINGS-05's floor" in sources["app/instance/vault_registry.py"]
+    deployment = (REPO_ROOT / "scripts/lib/instance_state_deployment.sh").read_text(
+        encoding="utf-8"
+    )
+    deploy = (REPO_ROOT / "scripts/deploy_channel.sh").read_text(encoding="utf-8")
+    assert "settings-rebind-install-dormant" in deployment
+    assert deployment.index("settings-rebind-install-dormant") < deployment.rindex(
+        "deployment-finish"
+    )
+    assert "${target_sha}:app/instance/settings_rebind.py" in deploy
     assert not any(
         "settingsRebind" in source
         for path, source in sources.items()

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime
+
+
+def test_all_producers_match_production_rebind_schema_and_activation_seal(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    record = runtime.open_settings_rebind_store().install_dormant()
+    snapshot = runtime.registry.load()
+
+    assert snapshot.settings_rebind == record.as_payload()
+    assert snapshot.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
+    assert not hasattr(runtime, "select_rebind_binding")
+    assert not hasattr(runtime, "prepare_rebind")
+    assert _STORAGE_MUTATION_CAPABILITY is not None

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -559,6 +559,39 @@ def test_deploy_channel_rolls_back_when_embedding_provider_preflight_fails(
     assert "embedding provider configuration preflight failed" in result.stderr
 
 
+def test_automatic_rollback_does_not_restart_a_pre_settings_floor_image(
+    tmp_path: Path,
+) -> None:
+    """A failed capable deploy retains its pin rather than recreating an old image."""
+    root, env, old_sha = _deploy_harness(tmp_path)
+    (root / "config/deploy/dev.env").write_text(
+        f"APP_IMAGE_REPOSITORY=example.invalid/pkm-app\nAPP_IMAGE_TAG={old_sha}\n",
+        encoding="utf-8",
+    )
+    marker = root / "app/instance/settings_rebind.py"
+    marker.write_text('"""SETTINGS-05 capable target marker."""\n', encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "app/instance/settings_rebind.py"], cwd=root, check=True
+    )
+    subprocess.run(["git", "commit", "-qm", "settings capable target"], cwd=root, check=True)
+    target_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    env["FAKE_DOCKER_FAIL_MATCH"] = "exec -T api python -m app.cli settings validate --json"
+    env["FAKE_SHA"] = target_sha
+
+    result = _run_deploy(root, env, target_sha)
+
+    assert result.returncode == 24
+    assert "automatic rollback is blocked" in result.stderr
+    assert f"APP_IMAGE_TAG={target_sha}" in (root / "config/deploy/dev.env").read_text(
+        encoding="utf-8"
+    )
+    assert f"APP_IMAGE_TAG={old_sha}" in (root / "config/deploy/dev.previous.env").read_text(
+        encoding="utf-8"
+    )
+
+
 def _wait_for_path_or_process_exit(
     process: subprocess.Popen[str],
     path: Path,

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -577,6 +577,12 @@ def test_automatic_rollback_does_not_restart_a_pre_settings_floor_image(
     target_sha = subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
+    host_state = Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+    host_state.mkdir(parents=True, exist_ok=True)
+    (host_state / "settings-rebind-runtime-floor-dev.json").write_text(
+        '{"schema":"settings-rebind-floor-receipt.v1","channel":"dev"}\n',
+        encoding="utf-8",
+    )
     env["FAKE_DOCKER_FAIL_MATCH"] = "exec -T api python -m app.cli settings validate --json"
     env["FAKE_SHA"] = target_sha
 

--- a/tests/instance/test_vault_registry_migration.py
+++ b/tests/instance/test_vault_registry_migration.py
@@ -235,8 +235,10 @@ def test_settings_rebind_provisional_ids_are_adopted_atomically(tmp_path) -> Non
     migrated = VaultRegistryStore(path).load_or_migrate()
     assert set(migrated.registrations) == {"provisional-a"}
     assert migrated.settings_rebind is not None
-    for key in ("prior", "candidate", "applied"):
-        assert migrated.settings_rebind[key]["vaultBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["priorBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["candidateBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["phase"] == "dormant"
+    assert migrated.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
 
     alias_path = tmp_path / "alias.md"
     _write_legacy(
@@ -260,7 +262,7 @@ def test_settings_rebind_provisional_ids_are_adopted_atomically(tmp_path) -> Non
     )
     alias_migration = VaultRegistryStore(alias_path).load_or_migrate()
     assert set(alias_migration.registrations) == {"provisional-alias"}
-    assert alias_migration.settings_rebind["candidate"]["ref"] == "alias:/vault/a"
+    assert alias_migration.settings_rebind["candidateBindingId"] == "provisional-alias"
 
     physical_alias_path = tmp_path / "physical-alias.md"
     _write_legacy(

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -4,7 +4,9 @@ from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
 from app.instance.settings_rebind import SettingsRebindRecord
+from app.instance.vault_registry import VaultRegistration
 import pytest
+import yaml
 
 
 def test_api_and_watcher_startup_share_one_dormant_rebind_revision(tmp_path) -> None:
@@ -70,3 +72,73 @@ def test_invalid_phase_revision_relation_fails_before_record_write() -> None:
     record = SettingsRebindRecord(3, 2, "committed", "watcher", "binding-a", "binding-b")
     with pytest.raises(Exception, match="committed"):
         SettingsRebindRecord.from_payload(record.as_payload())
+
+
+def test_delayed_writer_cannot_regress_durable_desired_or_applied_revision(tmp_path) -> None:
+    """The registry lock, not a caller-supplied revision, owns monotonicity."""
+    layout = InstanceStateLayout.for_channel(tmp_path / "state", "test")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host")
+    store = runtime.open_settings_rebind_store()
+    for binding_id in ("binding-a", "binding-b"):
+        runtime.registry.register(
+            VaultRegistration(binding_id, f"path:/{binding_id}", f"/{binding_id}"),
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+    before = runtime.registry.load().revision
+    store.install_dormant()
+    installed = runtime.registry.load()
+    assert installed.revision == before + 1
+    assert installed.settings_rebind is not None
+    assert installed.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
+    advanced = SettingsRebindRecord(1, 1, "committed", "watcher", "binding-a", "binding-b")
+    runtime.registry.set_settings_rebind_state(
+        advanced.as_payload(), _capability=_STORAGE_MUTATION_CAPABILITY
+    )
+
+    with pytest.raises(Exception, match="monotonic"):
+        runtime.registry.set_settings_rebind_state(
+            SettingsRebindRecord.dormant().as_payload(),
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+
+    assert store.read() == advanced
+
+
+def test_record_cannot_mint_a_binding_outside_registry_authority(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    runtime.open_settings_rebind_store().install_dormant()
+    forged = SettingsRebindRecord(1, 1, "committed", "watcher", "forged", "forged")
+
+    with pytest.raises(Exception, match="outside registry authority"):
+        runtime.registry.set_settings_rebind_state(
+            forged.as_payload(), _capability=_STORAGE_MUTATION_CAPABILITY
+        )
+
+
+def test_current_schema_provisional_record_upgrades_atomically_on_first_read(tmp_path) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "state", "test")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host")
+    registry = runtime.registry
+    registered = registry.register(
+        VaultRegistration("binding-a", "path:/vault-a", "/vault-a"),
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    frontmatter = registry._frontmatter_from_snapshot(registered)
+    frontmatter["settingsRebind"] = {
+        "schema": "settings_rebind.v1",
+        "prior": {"vaultBindingId": "binding-a"},
+    }
+    registry.path.write_text(
+        "---\n" + yaml.safe_dump(frontmatter, sort_keys=False) + "---\n",
+        encoding="utf-8",
+    )
+
+    upgraded = registry.load()
+
+    assert upgraded.revision == registered.revision + 1
+    assert upgraded.settings_rebind == SettingsRebindRecord.dormant(
+        binding_id="binding-a"
+    ).as_payload()
+    assert upgraded.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime
+
+
+def test_api_and_watcher_startup_share_one_dormant_rebind_revision(tmp_path) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "state", "test")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host")
+    api = runtime.open_settings_rebind_store()
+    record = api.install_dormant()
+    watcher = runtime.open_settings_rebind_store()
+
+    assert watcher.read() == record
+    assert watcher.read().phase == "dormant"
+    assert watcher.read().desired_revision == watcher.read().applied_revision == 0
+
+
+def test_production_startup_recovers_every_dormant_record_phase_fail_closed(tmp_path) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "state", "test")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host")
+    store = runtime.open_settings_rebind_store()
+    store.install_dormant()
+    payload = runtime.registry.load().settings_rebind
+    assert payload is not None
+    payload = dict(payload)
+    payload["checksum"] = "not-a-checksum"
+
+    try:
+        runtime.registry.set_settings_rebind_state(
+            payload, _capability=_STORAGE_MUTATION_CAPABILITY
+        )
+    except Exception as error:
+        assert "checksum" in str(error)
+    else:  # pragma: no cover - the assertion documents the fail-closed path
+        raise AssertionError("invalid rebind state was accepted")
+
+    assert store.read().phase == "dormant"
+
+
+def test_startup_restores_last_complete_record_after_on_disk_checksum_corruption(tmp_path) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "state", "test")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host")
+    store = runtime.open_settings_rebind_store()
+    expected = store.install_dormant().as_payload()
+    rendered = runtime.registry.path.read_text(encoding="utf-8")
+    runtime.registry.path.write_text(
+        rendered.replace(str(expected["checksum"]), "0" * 64), encoding="utf-8"
+    )
+
+    assert runtime.open_settings_rebind_store().read().as_payload() == expected

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
+from app.instance.settings_rebind import SettingsRebindRecord
+import pytest
 
 
 def test_api_and_watcher_startup_share_one_dormant_rebind_revision(tmp_path) -> None:
@@ -50,3 +52,21 @@ def test_startup_restores_last_complete_record_after_on_disk_checksum_corruption
     )
 
     assert runtime.open_settings_rebind_store().read().as_payload() == expected
+
+
+@pytest.mark.parametrize(
+    ("phase", "posture", "desired", "applied"),
+    [("dormant", "dormant", 2, 2), ("prepared", "watcher", 3, 2),
+     ("committed", "watcher", 3, 3), ("no_lifecycle", "no_lifecycle", 3, 3)],
+)
+def test_each_persisted_phase_has_a_deterministic_revision_relation(
+    phase, posture, desired, applied
+) -> None:
+    record = SettingsRebindRecord(desired, applied, phase, posture, "binding-a", "binding-b")
+    assert SettingsRebindRecord.from_payload(record.as_payload()) == record
+
+
+def test_invalid_phase_revision_relation_fails_before_record_write() -> None:
+    record = SettingsRebindRecord(3, 2, "committed", "watcher", "binding-a", "binding-b")
+    with pytest.raises(Exception, match="committed"):
+        SettingsRebindRecord.from_payload(record.as_payload())

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -1999,6 +1999,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
     python.write_text(
         "#!/usr/bin/env bash\n"
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
+        'if [ "${1:-}" = - ]; then exec "${REAL_PYTHON:?}" "$@"; fi\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
         '    while [ "$#" -gt 0 ]; do\n'
@@ -2052,6 +2053,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
         env={
             **os.environ,
             "EVENT_LOG": str(event_log),
+            "REAL_PYTHON": sys.executable,
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
         },
@@ -2071,6 +2073,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
     validate_index = next(i for i, event in enumerate(events) if "validate-legacy-owners" in event)
     finish_index = next(i for i, event in enumerate(events) if "deployment-finish" in event)
     assert produce_index < begin_index < stop_index < proof_index < validate_index < finish_index
+    assert sum(event.startswith("python:- ") for event in events) == 2
 
 
 def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
@@ -2085,6 +2088,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
     python.write_text(
         "#!/usr/bin/env bash\n"
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
+        'if [ "${1:-}" = - ]; then exec "${REAL_PYTHON:?}" "$@"; fi\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
         '    while [ "$#" -gt 0 ]; do\n'
@@ -2139,6 +2143,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
         env={
             **os.environ,
             "EVENT_LOG": str(event_log),
+            "REAL_PYTHON": sys.executable,
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "MVR01C_ROLLBACK_VAULT_BINDING_ID": "binding-selected",
             "MVR01C_ROLLBACK_VAULT_ROOT": selected_root,
@@ -2159,6 +2164,8 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
     assert "--rollback-vault-binding-id binding-selected" in cutover
     assert "--selected-root /app/selected-vault" in cutover
     assert "--native-launcher /app/scripts/scalar_rollback_native.sh" in cutover
+    events = event_log.read_text(encoding="utf-8").splitlines()
+    assert sum(event.startswith("python:- ") for event in events) == 2
 
 
 def _legacy_owner_source_fixture(tmp_path: Path) -> tuple[Path, dict[str, Path]]:

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -144,15 +144,22 @@ def _wrapper_run(
     verify_cutover: int = 1,
     fail_mvr_floor: int = 0,
     fail_settings_install: int = 0,
+    fail_receipt_write: str = "",
+    explicit_root: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    tmp_path.mkdir(parents=True)
+    tmp_path.mkdir(parents=True, exist_ok=True)
     event_log = tmp_path / "events.log"
     fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
+    fake_bin.mkdir(exist_ok=True)
     python = fake_bin / "python3"
     python.write_text(
         "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = - ]; then\n'
+        '  count_file="${RECEIPT_CALLS:?}"; count=$(cat "$count_file" 2>/dev/null || printf 0); count=$((count + 1)); printf %s "$count" > "$count_file"\n'
+        '  [ "${FAIL_RECEIPT_WRITE:-}" = "$count" ] && exit 91\n'
+        'fi\n'
         'if [ "${1:-}" = -c ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+        'if [ "${1:-}" = - ]; then exec "$REAL_PYTHON" "$@"; fi\n'
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
@@ -201,23 +208,31 @@ def _wrapper_run(
         "  esac\n"
         "  return 0\n"
         "}\n"
+        "prepare_instance_ownership_host_state_dir\n"
         "prepare_instance_state_deployment fake_compose prod\n",
         encoding="utf-8",
     )
     harness.chmod(0o755)
-    ownership_root = tmp_path / "instance-ownership"
-    ownership_root.mkdir()
+    ownership_root = tmp_path / "instance-ownership" if explicit_root else tmp_path / "xdg" / "agentic-pkm" / "instance-ownership"
+    ownership_root.mkdir(parents=True, exist_ok=True)
     env = {
         **os.environ,
         "EVENT_LOG": str(event_log),
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
-        "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
+        "RECEIPT_CALLS": str(tmp_path / "receipt-calls"),
         "FAIL_CUTOVER": str(fail_cutover),
         "VERIFY_CUTOVER": str(verify_cutover),
         "FAIL_MVR_FLOOR": str(fail_mvr_floor),
         "FAIL_SETTINGS_INSTALL": str(fail_settings_install),
+        "FAIL_RECEIPT_WRITE": fail_receipt_write,
         "REAL_PYTHON": sys.executable,
     }
+    if explicit_root:
+        env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"] = str(ownership_root)
+    else:
+        env["XDG_STATE_HOME"] = str(tmp_path / "xdg")
+        env["HOME"] = str(tmp_path / "home")
+        env.pop("INSTANCE_OWNERSHIP_HOST_STATE_DIR", None)
     env.pop("MVR03_PRINCIPAL_CUTOVER", None)
     env.pop("MVR03_PRINCIPAL_LOOPBACK_LISTENER", None)
     if cutover:
@@ -230,7 +245,7 @@ def _wrapper_run(
         text=True,
         check=False,
     )
-    return result, event_log.read_text(encoding="utf-8").splitlines()
+    return result, event_log.read_text(encoding="utf-8").splitlines() if event_log.exists() else []
 
 
 def test_settings_floor_receipt_pending_and_installed_matrix(tmp_path: Path) -> None:
@@ -251,6 +266,24 @@ def test_settings_floor_receipt_pending_and_installed_matrix(tmp_path: Path) -> 
     installed_marker = tmp_path / "installed" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json"
     assert installed.returncode == 0
     assert '"phase":"installed"' in installed_marker.read_text(encoding="utf-8")
+
+    installed_write_failure, _ = _wrapper_run(
+        tmp_path / "installed-write-failure", cutover=False, fail_receipt_write="4"
+    )
+    failed_marker = tmp_path / "installed-write-failure" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json"
+    assert installed_write_failure.returncode == 91
+    assert '"phase":"pending"' in failed_marker.read_text(encoding="utf-8")
+
+    replay_root = tmp_path / "same-root-replay"
+    failed, _ = _wrapper_run(replay_root, cutover=False, fail_settings_install=1)
+    assert failed.returncode == 1
+    replayed, _ = _wrapper_run(replay_root, cutover=False)
+    assert replayed.returncode == 0
+    assert '"phase":"installed"' in (replay_root / "instance-ownership" / "settings-rebind-runtime-floor-prod.json").read_text(encoding="utf-8")
+
+    default_root, _ = _wrapper_run(tmp_path / "default-root", cutover=False, explicit_root=False)
+    assert default_root.returncode == 0
+    assert (tmp_path / "default-root" / "xdg" / "agentic-pkm" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json").is_file()
 
 
 def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> None:

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -142,6 +142,8 @@ def _wrapper_run(
     loopback: str = "0",
     fail_cutover: int = 0,
     verify_cutover: int = 1,
+    fail_mvr_floor: int = 0,
+    fail_settings_install: int = 0,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     tmp_path.mkdir(parents=True)
     event_log = tmp_path / "events.log"
@@ -192,6 +194,8 @@ def _wrapper_run(
         "    printf '%s\\n' 'services: {api: {depends_on: [db], labels: {com.agentic-pkm.mvr05.db-role: client}}, db: {labels: {com.agentic-pkm.mvr05.db-role: server}}, instance-state-init: {labels: {com.agentic-pkm.mvr05.db-role: fence-controller}}, migrate: {command: [/app/scripts/run_migrations.sh], depends_on: [db], labels: {com.agentic-pkm.mvr05.db-role: migration-runner}}}' > \"$DEPLOY_COMPOSE_FENCE_CONFIG_OUTPUT\"\n"
         "  fi\n"
         "  case \" $* \" in\n"
+        "    *' mvr05-record-floor '*) return \"${FAIL_MVR_FLOOR:-0}\" ;;\n"
+        "    *' settings-rebind-install-dormant '*) return \"${FAIL_SETTINGS_INSTALL:-0}\" ;;\n"
         "    *' principal-verify-cutover-clean-failure '*) return \"${VERIFY_CUTOVER:-1}\" ;;\n"
         "    *' principal-cutover '*) return \"${FAIL_CUTOVER:-0}\" ;;\n"
         "  esac\n"
@@ -210,6 +214,8 @@ def _wrapper_run(
         "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
         "FAIL_CUTOVER": str(fail_cutover),
         "VERIFY_CUTOVER": str(verify_cutover),
+        "FAIL_MVR_FLOOR": str(fail_mvr_floor),
+        "FAIL_SETTINGS_INSTALL": str(fail_settings_install),
         "REAL_PYTHON": sys.executable,
     }
     env.pop("MVR03_PRINCIPAL_CUTOVER", None)
@@ -225,6 +231,26 @@ def _wrapper_run(
         check=False,
     )
     return result, event_log.read_text(encoding="utf-8").splitlines()
+
+
+def test_settings_floor_receipt_pending_and_installed_matrix(tmp_path: Path) -> None:
+    """The production wrapper fences failures after proof, but not pristine hosts."""
+    mvr_failure, _ = _wrapper_run(tmp_path / "mvr-failure", cutover=False, fail_mvr_floor=1)
+    mvr_marker = tmp_path / "mvr-failure" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json"
+    assert mvr_failure.returncode == 1
+    assert '"phase":"pending"' in mvr_marker.read_text(encoding="utf-8")
+
+    settings_failure, _ = _wrapper_run(
+        tmp_path / "settings-failure", cutover=False, fail_settings_install=1
+    )
+    settings_marker = tmp_path / "settings-failure" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json"
+    assert settings_failure.returncode == 1
+    assert '"phase":"pending"' in settings_marker.read_text(encoding="utf-8")
+
+    installed, _ = _wrapper_run(tmp_path / "installed", cutover=False)
+    installed_marker = tmp_path / "installed" / "instance-ownership" / "settings-rebind-runtime-floor-prod.json"
+    assert installed.returncode == 0
+    assert '"phase":"installed"' in installed_marker.read_text(encoding="utf-8")
 
 
 def test_wrapper_runs_the_cutover_inside_the_stopped_window(tmp_path: Path) -> None:

--- a/tests/ops/test_settings_rebind_runtime_floor.py
+++ b/tests/ops/test_settings_rebind_runtime_floor.py
@@ -28,6 +28,16 @@ def test_rebind_floor_blocks_every_legacy_writer_after_cutover(tmp_path) -> None
     assert runtime.registry.load().extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
 
 
+def test_rebind_floor_blocks_legacy_rollback_preflight_before_old_image_starts(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    runtime.open_settings_rebind_store().install_dormant()
+
+    with pytest.raises(CapabilityNotReadyError, match="legacy scalar"):
+        _require_runtime_floor(runtime.registry.load(), scalar_runtime=True)
+
+
 def test_complete_record_without_floor_fails_closed_on_protected_store_read(tmp_path) -> None:
     runtime = InstanceRegistryRuntime.for_paths(
         InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
@@ -37,4 +47,16 @@ def test_complete_record_without_floor_fails_closed_on_protected_store_read(tmp_
     malformed["settingsRebind"] = SettingsRebindRecord.dormant().as_payload()
 
     with pytest.raises(Exception, match="requires its runtime floor"):
+        runtime.registry._snapshot_from_frontmatter(malformed)
+
+
+def test_floor_only_state_fails_closed_before_runtime_startup(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    snapshot = runtime.registry.load()
+    malformed = runtime.registry._frontmatter_from_snapshot(snapshot)
+    malformed["runtimeFloors"] = {"minimum_settings_rebind_runtime": "1"}
+
+    with pytest.raises(Exception, match="requires its dormant record"):
         runtime.registry._snapshot_from_frontmatter(malformed)

--- a/tests/ops/test_settings_rebind_runtime_floor.py
+++ b/tests/ops/test_settings_rebind_runtime_floor.py
@@ -5,6 +5,7 @@ import pytest
 from app.instance._storage_boundary import CapabilityNotReadyError
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime, _require_runtime_floor
+from app.instance.settings_rebind import SettingsRebindRecord
 
 
 def test_rebind_floor_blocks_incompatible_api_and_watcher_before_start(tmp_path) -> None:
@@ -25,3 +26,15 @@ def test_rebind_floor_blocks_every_legacy_writer_after_cutover(tmp_path) -> None
     store = runtime.open_settings_rebind_store()
     store.install_dormant()
     assert runtime.registry.load().extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
+
+
+def test_complete_record_without_floor_fails_closed_on_protected_store_read(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    snapshot = runtime.registry.load()
+    malformed = runtime.registry._frontmatter_from_snapshot(snapshot)
+    malformed["settingsRebind"] = SettingsRebindRecord.dormant().as_payload()
+
+    with pytest.raises(Exception, match="requires its runtime floor"):
+        runtime.registry._snapshot_from_frontmatter(malformed)

--- a/tests/ops/test_settings_rebind_runtime_floor.py
+++ b/tests/ops/test_settings_rebind_runtime_floor.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from app.instance._storage_boundary import CapabilityNotReadyError
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime, _require_runtime_floor
+
+
+def test_rebind_floor_blocks_incompatible_api_and_watcher_before_start(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    snapshot = runtime.registry.load()
+    snapshot.extensions["runtimeFloors"] = {"minimum_settings_rebind_runtime": "2"}
+
+    with pytest.raises(CapabilityNotReadyError, match="settings rebind"):
+        _require_runtime_floor(snapshot, scalar_runtime=False)
+
+
+def test_rebind_floor_blocks_every_legacy_writer_after_cutover(tmp_path) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"), tmp_path / "host"
+    )
+    store = runtime.open_settings_rebind_store()
+    store.install_dormant()
+    assert runtime.registry.load().extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -478,15 +478,15 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2503): (
+    ("app/instance/vault_registry.py", 2597): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2597 "
         "(site unchanged); re-pinned after directly related MVR-05A6 (#4580) inserted "
         "the validated binding-effect lease producer earlier in vault_registry.py. "
-        "MVR-05A6 adds no new "
+        "MVR-05A6/SETTINGS-05A add no new "
         "write_frontmatter site: like MVR-02/MVR-04, it writes the registry through "
         "_atomic_private_write, "
         "not the vault-content seam."

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -478,12 +478,12 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2597): (
+    ("app/instance/vault_registry.py", 2713): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2597 "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2597 -> 2713 "
         "(site unchanged); re-pinned after directly related MVR-05A6 (#4580) inserted "
         "the validated binding-effect lease producer earlier in vault_registry.py. "
         "MVR-05A6/SETTINGS-05A add no new "


### PR DESCRIPTION
Governing-Issue: #4967

Fixes #4967

Final-Review-Rounds: 1

## Summary
Adds a checksum-validated, dormant `settings_rebind.v1` record to protected registry state with a floor-before-record compatibility gate and legacy-record migration.

Picker, API initiation, and watcher activation remain sealed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: implementation delivery evidence remains on the governing Issue and PR.

## Notes
Validation: focused record/producer/floor/migration and write-seam tests passed (17 total); ruff and scoped mypy passed. Full `not pg` ran under host lease: 13,615 passed; five unrelated baseline/host failures remain evidenced in `/tmp/issue4967-pytest-not-pg.HfGTSw/pytest.log`.

SBS Impact: Product/Runtime WSP durable protected instance-local state; no activation boundary crossed. Owner-doc writeback: none (SETTINGS-05C owns activation).