### PR TITLE
governance: reconcile admission claims before readiness

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -50,6 +50,16 @@ data, or any artefact that is not reproducible from the checked-in repo plus pub
 body, linked PR, owner doc) before authoring the Issue that depends on it. If the material cannot be
 promoted, the Issue should not depend on it.
 
+### Admission claims must match the named production seam
+
+An Issue that asserts local admission, proxying, or forwarded-identity behavior must name the
+production admission seam (for example, a direct loopback endpoint or gateway) in its `Scope`,
+`Constraints`, or `Source Anchors`. Readiness wording must agree with that seam: an explicit
+no-forwarded-identity/direct-loopback seam cannot be paired with an assertion that identity is
+forwarded or trusted through a proxy. The readiness validator rejects contradictory or unnamed
+admission claims before `agent:ready` is applied. This is a Builder System contract check; it does
+not establish or change Product/Runtime admission behavior.
+
 ## Child to parent reference
 
 A child slice governed by a parent feature issue declares that edge with exactly one line, on its

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -68,6 +68,10 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
   ```
   Do not use `--observe-only` for a Ready mutation. If validation fails, remove or avoid
   `agent:ready`.
+- For Issues asserting local admission, proxying, or forwarded-identity behavior, verify that the
+  body names the production admission seam and that its wording agrees with the seam. The shared
+  readiness validator rejects an unnamed seam or a forwarded-identity assertion paired with an
+  explicit no-forwarding/direct-loopback seam.
 
 ## Canonical lifecycle expectations
 

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -50,8 +50,41 @@ READINESS_CLASSES: tuple[str, ...] = (
     "malformed_parent_reference",
     "ambiguous_intent",
     "authority_risk",
+    "admission_contract_conflict",
     "not_agentable",
     "unknown",
+)
+
+ADMISSION_CLAIM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\blocal admission\b",
+        r"\b(?:admission|request) proxy(?:ing)?\b",
+        r"\bforwarded[- ]identity\b",
+        r"\bforwarded[- ](?:for|host|proto)\b",
+        r"\bforward(?:ed|ing)? identity\b",
+        r"\bproxy(?:ing|ed)?\b",
+    )
+)
+PRODUCTION_SEAM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bnamed production seam\b",
+        r"\bproduction seam\b",
+        r"\bdirect loopback\b",
+        r"\bloopback endpoint\b",
+        r"\b(?:gateway|ingress|reverse proxy)\b",
+    )
+)
+NO_FORWARDED_IDENTITY_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bno forwarded identity\b",
+        r"\bwithout forwarded identity\b",
+        r"\bmust not forward identity\b",
+        r"\bdoes not forward identity\b",
+        r"\bno forwarded[- ](?:for|host|proto)\b",
+    )
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -399,6 +432,28 @@ def _contains_any(patterns: Sequence[re.Pattern[str]], text: str) -> bool:
     return any(pattern.search(text) for pattern in patterns)
 
 
+def admission_contract_problem(body: str) -> str | None:
+    """Reject readiness claims that lack or contradict their production seam."""
+
+    if not _contains_any(ADMISSION_CLAIM_PATTERNS, body):
+        return None
+    if not _contains_any(PRODUCTION_SEAM_PATTERNS, body):
+        return "admission/proxy/forwarded-identity claim has no named production seam"
+    if _contains_any(NO_FORWARDED_IDENTITY_PATTERNS, body):
+        forwarded_assertion = re.search(
+            r"\b(?:forward|preserve|accept|trust|use|require)[a-z -]{0,24}"
+            r"(?:forwarded[- ](?:identity|for|host|proto)|forward(?:ed|ing)? identity)\b",
+            body,
+            re.IGNORECASE,
+        )
+        forwarded_assertion = forwarded_assertion or re.search(
+            r"\bforward identity\b", body, re.IGNORECASE
+        )
+        if forwarded_assertion is not None:
+            return "forwarded-identity assertion contradicts the named no-forwarding seam"
+    return None
+
+
 def _unknown_body(body: str, present: Sequence[str]) -> bool:
     stripped = body.strip()
     if not stripped:
@@ -452,6 +507,8 @@ def classify_issue_body(
         classification = "missing_verify_file_paths"
     elif _parent_reference_problem(body) is not None:
         classification = "malformed_parent_reference"
+    elif admission_contract_problem(body) is not None:
+        classification = "admission_contract_conflict"
     elif _contains_any(AUTHORITY_RISK_PATTERNS, body):
         classification = "authority_risk"
         human_exception_required = True
@@ -504,6 +561,11 @@ def repair_guidance(
         return [
             "Resolve the named authority question before agent execution.",
             "Split irreversible, Project/label mutation, branch-protection, auto-merge, prod, or strategic-decision work behind an explicit human decision.",
+        ]
+    if classification == "admission_contract_conflict":
+        return [
+            "Name the production admission seam (for example, direct loopback or gateway) in the Issue.",
+            "Rewrite readiness claims so forwarded-identity and proxy behavior agree with that seam.",
         ]
     if classification == "ambiguous_intent":
         return [

--- a/tests/governance/test_issue_readiness_admission_contract.py
+++ b/tests/governance/test_issue_readiness_admission_contract.py
@@ -1,0 +1,59 @@
+"""Readiness must keep admission claims aligned with their production seam."""
+
+from scripts.validate_issue_readiness import classify_issue_body
+
+
+def _issue_body(*, scope: str, constraints: str) -> str:
+    return f"""\
+## Context
+Governance contract test.
+
+## Scope
+{scope}
+
+## Source Anchors
+- `.codex/skills/_shared/ISSUE_CONTRACT.md :: Issue self-sufficiency rule`
+
+## SBS Impact
+- Primary subsystem: Builder System / CES boundary
+- Secondary subsystem(s): readiness
+- Write class: governance/docs/process
+- Persistence impact: none
+- Derived/rebuildable impact: none
+- New or changed contract: readiness admission claims
+- Owner-doc impact: none
+- Transition debt impact: reduces
+- Boundary risk: no runtime admission changes
+
+## Constraints
+{constraints}
+
+## Acceptance Criteria
+- [ ] Admission wording is validated.
+  - Verify: `tests/governance/test_issue_readiness_admission_contract.py::test_ready_issue_admission_wording_matches_named_production_seam`
+
+## Out of Scope
+- Product/runtime changes.
+
+## Suggested Validation
+- `python3 -m pytest -q tests/governance/test_issue_readiness_admission_contract.py`
+
+## Source Docs
+- `.codex/skills/_shared/ISSUE_CONTRACT.md`
+"""
+
+
+def test_ready_issue_admission_wording_matches_named_production_seam():
+    contradictory = _issue_body(
+        scope="Require the direct loopback production seam, but forward identity through the proxy.",
+        constraints="The production seam has no forwarded identity.",
+    )
+    report = classify_issue_body(contradictory, labels=("agent:ready",))
+    assert report.readiness_classification == "admission_contract_conflict"
+
+    matching = _issue_body(
+        scope="Require local admission through the named production seam: direct loopback endpoint.",
+        constraints="The direct loopback seam has no forwarded identity.",
+    )
+    report = classify_issue_body(matching, labels=("agent:ready",))
+    assert report.readiness_classification == "ready_candidate"


### PR DESCRIPTION
## Summary
- require admission/proxy/forwarded-identity claims to name a production seam
- reject contradictory forwarded-identity wording before `agent:ready`
- add focused governance coverage

Governing-Issue: #4973
Fixes #4973

## SBS Impact
- Builder System / CES boundary only; no Product/Runtime admission behavior changed.

## Verification
- `python3 -m pytest -q tests/governance/test_issue_readiness_admission_contract.py`
- `python3 -m pytest -q tests/governance/test_verify_target_contract_parity.py tests/governance/test_project_pickup_deprecation.py tests/governance/test_skills_consistency_lint.py`
- `python3 scripts/lint_skills_consistency.py`
- `python3 scripts/docs_guard.py`
- `scripts/agent_workspace_preflight.sh --allow-dirty`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded repo-governed realization of LearningSignal `lrn_20260811185254_787ae965`; no new operational record was needed.

Final-Review-Rounds: 0
Pickup-Claim: issue=4973 branch=codex/issue-4973-admission-readiness worktree=/Users/rasmusthornberg/.codex/worktrees/1a1d/agentic-pkm-mvp coordination_mode=github-label-only-fallback fallback_reason=dispatcher-claim-unavailable evidence=github-comment:5313908324

