### PR TITLE
Harden terminal closure evidence

### DIFF
--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -103,10 +103,13 @@ include raw paths, vault names, environment values, DSNs, secrets, or raw startu
   Project repair remains an explicit cold-path action.
 - Verify review-feedback repairs are present on the target base branch before treating them as closed; a side branch or intermediate PR is not enough unless the fixing commit is reachable from the final merge target. [base-branch-truth]
 - Run GitHub GraphQL `reviewThreads` closure checks only when a review-thread closure trigger is present: a review-fix or direct-repair PR, a PR body or source anchor that names prior review feedback, a terminal issue/PR closure audit, or known unresolved review feedback. Preserve the lightweight hot path for ordinary PRs with no trigger. [review-thread-closure]
-- When a review-thread closure trigger applies, reply on and resolve or explicitly disposition the
-  original review thread before final closure: P0/P1 repairs name the fixing PR or merge commit, P2
-  deferrals name their durable defect Issue, and P3 observations may be closed as informational.
-  [review-thread-closure]
+- When a review-thread closure trigger applies, preserve the original actionable thread node IDs and
+  reply on and resolve or explicitly disposition every one before final closure: P0/P1 repairs name
+  the fixing PR or merge commit, P2 deferrals name their durable defect Issue, and P3 observations
+  record an informational disposition. Immediately before the terminal receipt, re-read those same
+  original thread IDs through `reviewThreads` and require a final resolved state plus the matching
+  reply or disposition evidence for each; missing, substituted, or still-unresolved original-thread
+  evidence fails closure. Record that final readback in the delivery receipt. [review-thread-closure]
 - On resume or recovery, re-check branch, `origin/main`, relevant merged PRs, and expected implementation files before continuing publication, reimplementation, or closure. [post-resume-current-state-gate]
 - If the work is a slice under a larger feature, keep post-merge validation evidence on the parent issue
 - If post-merge validation advanced but acceptance is still pending, record the new evidence on the parent issue body or comments
@@ -635,8 +638,18 @@ this block.
 
 ## Dependent Issue Unblocking
 
-After merging and delivering work, scan for issues blocked by the delivered Issue.
-Only unblock issues whose actual dependency is truly satisfied.
+Before a terminal delivery receipt, read current dispatcher status and the exact issue task state
+(`python3 -m app.dispatcher status --json` and `python3 -m app.dispatcher show <task-id> --json` when
+the task exists). Record the readback and require it to agree with the merged Issue/PR and label
+state; unavailable, stale, or contradictory dispatcher evidence is a terminal-closure block, not a
+reason to infer completion from an earlier lease or receipt.
+
+After merging and delivering work, scan for issues blocked by the delivered Issue. Before unblocking
+each dependent, re-read its live Issue body, state, labels, and dependency evidence; run the strict
+issue-readiness validation against that current body and labels; and verify that this delivery
+actually satisfied the named dependency. Only then make the explicit lifecycle mutation and read it
+back. Do not unblock from a stale dependency graph, an earlier readiness report, or a successful
+merge alone.
 
 ## Optional Project Projection
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -638,18 +638,22 @@ this block.
 
 ## Dependent Issue Unblocking
 
-Before a terminal delivery receipt, read current dispatcher status and the exact issue task state
-(`python3 -m app.dispatcher status --json` and `python3 -m app.dispatcher show <task-id> --json` when
-the task exists). Record the readback and require it to agree with the merged Issue/PR and label
-state; unavailable, stale, or contradictory dispatcher evidence is a terminal-closure block, not a
-reason to infer completion from an earlier lease or receipt.
+Before a terminal delivery receipt, obtain current coordination evidence. For a verified
+dispatcher-backed pickup, read current dispatcher status and the exact issue task state
+(`python3 -m app.dispatcher status --json` and `python3 -m app.dispatcher show <task-id> --json`),
+record the readback, and require it to agree with the merged Issue/PR and label state; unavailable,
+stale, or contradictory dispatcher evidence is a terminal-closure block. For a verified
+GitHub-label-only fallback, instead preserve the claimant fallback receipt and re-read the current
+Issue, PR, and labels; dispatcher unavailability or a missing dispatcher task does not invalidate
+that fallback. Never infer either mode from an earlier lease, database existence, or receipt alone.
 
 After merging and delivering work, scan for issues blocked by the delivered Issue. Before unblocking
-each dependent, re-read its live Issue body, state, labels, and dependency evidence; run the strict
-issue-readiness validation against that current body and labels; and verify that this delivery
-actually satisfied the named dependency. Only then make the explicit lifecycle mutation and read it
-back. Do not unblock from a stale dependency graph, an earlier readiness report, or a successful
-merge alone.
+each dependent, re-read its live Issue body, state, labels, and dependency evidence; do not unblock
+an Issue carrying `agent:needs-human`; form the prospective post-unblock label set by replacing
+`agent:blocked` with `agent:ready`; run the strict issue-readiness validation against that current
+body and prospective label set; and verify that this delivery actually satisfied the named
+dependency. Only then make the explicit lifecycle mutation and read it back. Do not unblock from a
+stale dependency graph, an earlier readiness report, or a successful merge alone.
 
 ## Optional Project Projection
 

--- a/tests/governance/test_verification_closure_contract.py
+++ b/tests/governance/test_verification_closure_contract.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / ".codex/skills/verification-and-closure/SKILL.md"
+
+
+def test_terminal_closure_requires_source_thread_and_dispatcher_readback() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+
+    triggered_section = text.split("[review-thread-closure]", 1)[0]
+    assert "only when a review-thread closure trigger is present" in triggered_section
+    assert "Preserve the lightweight hot path for ordinary PRs with no trigger" in triggered_section
+
+    for requirement in (
+        "original actionable thread node IDs",
+        "every one before final closure",
+        "re-read those same\n  original thread IDs through `reviewThreads`",
+        "final resolved state",
+        "matching\n  reply or disposition evidence for each",
+        "Record that final readback in the delivery receipt",
+        "python3 -m app.dispatcher status --json",
+        "python3 -m app.dispatcher show <task-id> --json",
+        "strict\nissue-readiness validation against that current body and labels",
+        "Only then make the explicit lifecycle mutation and read it\nback",
+    ):
+        assert requirement in text

--- a/tests/governance/test_verification_closure_contract.py
+++ b/tests/governance/test_verification_closure_contract.py
@@ -23,7 +23,11 @@ def test_terminal_closure_requires_source_thread_and_dispatcher_readback() -> No
         "Record that final readback in the delivery receipt",
         "python3 -m app.dispatcher status --json",
         "python3 -m app.dispatcher show <task-id> --json",
-        "strict\nissue-readiness validation against that current body and labels",
-        "Only then make the explicit lifecycle mutation and read it\nback",
+        "For a verified\nGitHub-label-only fallback",
+        "dispatcher unavailability or a missing dispatcher task does not invalidate\nthat fallback",
+        "do not unblock\nan Issue carrying `agent:needs-human`",
+        "prospective post-unblock label set by replacing\n`agent:blocked` with `agent:ready`",
+        "strict issue-readiness validation against that current\nbody and prospective label set",
+        "Only then make the explicit lifecycle mutation and read it back",
     ):
         assert requirement in text


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4972

## Linked Issue
Closes #4972

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): GitHub review and dispatcher lifecycle projection
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: terminal receipts gain verifiable source references
- New or changed contract: triggered closure requires source-thread and dispatcher terminal readback
- Owner-doc impact: none
- Transition debt impact: reduces false delivered state
- Boundary risk: does not make GraphQL review-thread sweeps mandatory for ordinary PRs

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require terminal closure receipts to include original-thread, dispatcher, and dependent-readiness readbacks.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Existing retrospective LearningSignals are the governing Issue provenance; P1 review repair stayed within the same promoted issue.

## Notes
Validation: python3 -m pytest -q tests/governance/test_verification_closure_contract.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py; git diff --check. Convergence: independent Sol/high review accepted SHA 702ee1bd1 with P0=0, P1=0, P2=0, P3=0.