### PR TITLE
Add authority-loss deployment regression coverage

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -329,6 +329,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # Vault-layout hardcoded-literal fitness guard. Keep this exact
             # file owned without widening vault to all architecture tests.
             "tests/architecture/test_no_hardcoded_vault_layout.py",
+            # MVR-05 deployment finalization is a vault/ownership authority
+            # boundary. Keep its focused architecture regression owned without
+            # widening vault to all architecture tests.
+            "tests/architecture/test_mvr05_authority_recovery.py",
             # The semanticmd vault-note merge driver/resolver (#4505): cross-
             # device vault-note merging is its real job (uuid: frontmatter
             # identity, near-duplicate/"prefer concise" heuristics), so it was
@@ -348,6 +352,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/services/test_vault_sync_delete_note_policy.py",
             "tests/watcher/test_vault_watcher_delete_required_outbox.py",
             "tests/architecture/test_no_hardcoded_vault_layout.py",
+            "tests/architecture/test_mvr05_authority_recovery.py",
             "tests/agents/test_merge_resolver.py",
             "tests/agents/test_merge_resolver_repo_docs.py",
             "tests/cli/test_merge_driver.py",

--- a/tests/architecture/test_mvr05_authority_recovery.py
+++ b/tests/architecture/test_mvr05_authority_recovery.py
@@ -1,0 +1,216 @@
+"""Regression coverage for protected ownership recovery at deployment finish."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.ownership_ledger import LedgerKeyError, OwnershipLedger
+from app.instance.runtime import (
+    _begin_instance_state_deployment,
+    _deployment_lease_path,
+    _finish_instance_state_deployment,
+    _prove_instance_state_quiescence,
+)
+from app.instance.vault_registry import VaultRegistration, VaultRegistryStore
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRITER_INVENTORY_HELPER = REPO_ROOT / "scripts/instance_state_writer_inventory.py"
+pytestmark = pytest.mark.not_pg
+
+
+def _controller_token() -> str:
+    return subprocess.check_output(
+        [sys.executable, str(WRITER_INVENTORY_HELPER), "controller-token", "--pid", str(os.getpid())],
+        text=True,
+    ).strip()
+
+
+def _owner_inventory(owners: list[dict[str, str]]) -> dict[str, object]:
+    identities = []
+    for owner in owners:
+        metadata = os.stat(owner["root"])
+        identities.append(
+            {
+                "channel_id": owner["channel_id"],
+                "root": owner["root"],
+                "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+            }
+        )
+    evidence = {"docker": [], "config": [], "owners": owners, "owner_identities": identities}
+    return {
+        "schema": "agentic-pkm.legacy-owner-inventory.v1",
+        "inventory_complete": True,
+        "writers_drained": True,
+        "source_probe_count": 2,
+        "validated_after_quiescence": True,
+        "source_digest": hashlib.sha256(
+            json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+        "source_evidence": evidence,
+        "owners": owners,
+    }
+
+
+def _prove_empty_quiescence(channel: str, ownership_root: Path):
+    lease = json.loads(_deployment_lease_path(ownership_root).read_text(encoding="utf-8"))
+    domains = {domain: [] for domain in ("dev", "native", "prod", "test")}
+    digest = hashlib.sha256(
+        json.dumps(domains, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    inventory = ownership_root / "deployment-quiescence-inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-pkm.host-deployment-quiescence.v2",
+                "inventory_complete": True,
+                "all_consumers_stopped": True,
+                "probe_count": 2,
+                "controller": lease["controller"],
+                "domains": domains,
+                "snapshot_digests": [digest, digest],
+            }
+        ),
+        encoding="utf-8",
+    )
+    inventory.chmod(0o600)
+    return _prove_instance_state_quiescence(
+        channel=channel, host_global_root=ownership_root, inventory_path=inventory
+    )
+
+
+def _finish(
+    *,
+    state_root: Path,
+    ownership_root: Path,
+    backup_root: Path,
+    owners: list[dict[str, str]],
+    restore_root: Path | None = None,
+) -> dict[str, object]:
+    channel = "dev"
+    _begin_instance_state_deployment(
+        channel=channel,
+        instance_state_root=state_root,
+        host_global_root=ownership_root,
+        legacy_path=state_root / "missing-legacy.md",
+        controller_pid=os.getpid(),
+        controller_start_token=_controller_token(),
+    )
+    inventory = ownership_root / "legacy-owner-inventory.json"
+    inventory.write_text(json.dumps(_owner_inventory(owners)), encoding="utf-8")
+    inventory.chmod(0o600)
+    return _finish_instance_state_deployment(
+        channel=channel,
+        instance_state_root=state_root,
+        host_global_root=ownership_root,
+        legacy_path=state_root / "missing-legacy.md",
+        inventory_path=inventory,
+        backup_root=backup_root,
+        restore_root=restore_root,
+        quiescence_proof=_prove_empty_quiescence(channel, ownership_root),
+    )
+
+
+def _established_owner(state_root: Path, ownership_root: Path) -> tuple[dict[str, str], OwnershipLedger]:
+    layout = InstanceStateLayout.for_channel(state_root, "dev")
+    registry = VaultRegistryStore(layout.registry_path)
+    root = state_root / "content-root"
+    root.mkdir()
+    registry.register(
+        VaultRegistration("binding-a", "path:binding-a", str(root)),
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger = OwnershipLedger(ownership_root)
+    ledger.reserve(
+        channel_id="dev",
+        vault_binding_id="binding-a",
+        root=root,
+        _capability=_STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger.activate("binding-a", _capability=_STORAGE_MUTATION_CAPABILITY)
+    return ({"channel_id": "dev", "vault_binding_id": "binding-a", "root": str(root)}, ledger)
+
+
+def _fresh_and_established(tmp_path: Path) -> tuple[Path, Path, dict[str, str], OwnershipLedger]:
+    state_root = tmp_path / "instance-state"
+    ownership_root = tmp_path / "host-global"
+    state_root.mkdir()
+    ownership_root.mkdir()
+    _finish(
+        state_root=state_root,
+        ownership_root=ownership_root,
+        backup_root=tmp_path / "fresh-backup",
+        owners=[],
+    )
+    owner, ledger = _established_owner(state_root, ownership_root)
+    return state_root, ownership_root, owner, ledger
+
+
+def test_fresh_and_intact_registry_paths_preserve_authority_contract(tmp_path: Path) -> None:
+    state_root, ownership_root, owner, ledger = _fresh_and_established(tmp_path)
+    before = ledger.require_existing()
+
+    result = _finish(
+        state_root=state_root,
+        ownership_root=ownership_root,
+        backup_root=tmp_path / "intact-backup",
+        owners=[owner],
+    )
+
+    after = ledger.require_existing()
+    assert result["restart_fence_cleared"] is True
+    assert (after.key_id, after.generation) == (before.key_id, before.generation)
+
+
+def test_established_registry_missing_ownership_fails_closed(tmp_path: Path) -> None:
+    state_root, ownership_root, owner, ledger = _fresh_and_established(tmp_path)
+    registry_before = (state_root / "agentic-pkm" / "vault-registry.md").read_bytes()
+    ledger.path.unlink()
+    ledger.key_path.unlink()
+
+    with pytest.raises(LedgerKeyError):
+        _finish(
+            state_root=state_root,
+            ownership_root=ownership_root,
+            backup_root=tmp_path / "blocked-backup",
+            owners=[owner],
+        )
+
+    assert not ledger.path.exists()
+    assert not ledger.key_path.exists()
+    assert (state_root / "agentic-pkm" / "vault-registry.md").read_bytes() == registry_before
+
+
+def test_recovery_requires_explicit_fence(tmp_path: Path) -> None:
+    state_root, ownership_root, owner, ledger = _fresh_and_established(tmp_path)
+    recovery_backup = tmp_path / "recovery-backup"
+    _finish(
+        state_root=state_root,
+        ownership_root=ownership_root,
+        backup_root=recovery_backup,
+        owners=[owner],
+    )
+    before = ledger.require_existing()
+    ledger.path.unlink()
+    ledger.key_path.unlink()
+
+    result = _finish(
+        state_root=state_root,
+        ownership_root=ownership_root,
+        backup_root=tmp_path / "post-recovery-backup",
+        owners=[owner],
+        restore_root=recovery_backup,
+    )
+
+    restored = ledger.require_existing()
+    assert result["restart_fence_cleared"] is True
+    assert (restored.key_id, restored.generation) == (before.key_id, before.generation)

--- a/tests/architecture/test_mvr05_authority_recovery.py
+++ b/tests/architecture/test_mvr05_authority_recovery.py
@@ -12,10 +12,11 @@ from pathlib import Path
 import pytest
 
 from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
-from app.instance.instance_state import InstanceStateLayout
+from app.instance.instance_state import InstanceStateLayout, InstanceStatePreflightError
 from app.instance.ownership_ledger import LedgerKeyError, OwnershipLedger
 from app.instance.runtime import (
     _begin_instance_state_deployment,
+    _deployment_fence_path,
     _deployment_lease_path,
     _finish_instance_state_deployment,
     _prove_instance_state_quiescence,
@@ -95,6 +96,7 @@ def _finish(
     backup_root: Path,
     owners: list[dict[str, str]],
     restore_root: Path | None = None,
+    remove_restart_fence: bool = False,
 ) -> dict[str, object]:
     channel = "dev"
     _begin_instance_state_deployment(
@@ -108,6 +110,9 @@ def _finish(
     inventory = ownership_root / "legacy-owner-inventory.json"
     inventory.write_text(json.dumps(_owner_inventory(owners)), encoding="utf-8")
     inventory.chmod(0o600)
+    proof = _prove_empty_quiescence(channel, ownership_root)
+    if remove_restart_fence:
+        _deployment_fence_path(ownership_root, channel).unlink()
     return _finish_instance_state_deployment(
         channel=channel,
         instance_state_root=state_root,
@@ -116,7 +121,7 @@ def _finish(
         inventory_path=inventory,
         backup_root=backup_root,
         restore_root=restore_root,
-        quiescence_proof=_prove_empty_quiescence(channel, ownership_root),
+        quiescence_proof=proof,
     )
 
 
@@ -193,6 +198,30 @@ def test_established_registry_missing_ownership_fails_closed(tmp_path: Path) -> 
 def test_recovery_requires_explicit_fence(tmp_path: Path) -> None:
     state_root, ownership_root, owner, ledger = _fresh_and_established(tmp_path)
     recovery_backup = tmp_path / "recovery-backup"
+    _finish(
+        state_root=state_root,
+        ownership_root=ownership_root,
+        backup_root=recovery_backup,
+        owners=[owner],
+    )
+    before = ledger.require_existing()
+    ledger.path.unlink()
+    ledger.key_path.unlink()
+
+    with pytest.raises(InstanceStatePreflightError, match="restart fence"):
+        _finish(
+            state_root=state_root,
+            ownership_root=ownership_root,
+            backup_root=tmp_path / "unfenced-recovery-backup",
+            owners=[owner],
+            restore_root=recovery_backup,
+            remove_restart_fence=True,
+        )
+
+    fenced_root = tmp_path / "fenced"
+    fenced_root.mkdir()
+    state_root, ownership_root, owner, ledger = _fresh_and_established(fenced_root)
+    recovery_backup = tmp_path / "fenced-recovery-backup"
     _finish(
         state_root=state_root,
         ownership_root=ownership_root,

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -84,6 +84,18 @@ def test_instance_registry_change_selects_vault_coverage() -> None:
     )
 
 
+def test_mvr05_authority_recovery_architecture_test_has_vault_ci_owner() -> None:
+    path = "tests/architecture/test_mvr05_authority_recovery.py"
+
+    selection = select_tests([path])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("vault",)
+    assert selection.unowned_paths == ()
+    assert path in selection.targets
+    assert "tests/ops/test_instance_state_volume_contract.py" in selection.targets
+
+
 def test_knowledge_runtime_modules_select_vault_knowledge_and_port_coverage() -> None:
     selection = select_tests(
         [


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4971

## Linked Issue
Closes #4971

## SBS Impact
- Primary subsystem: Product/Runtime deployment authority boundary
- Secondary subsystem(s): CI test selection
- Write class: Tests and test-selection metadata only
- Persistence impact: No runtime behavior change; regression coverage protects established ownership identity.
- Derived/rebuildable impact: None
- New or changed contract: None; existing contract receives regression coverage.
- Owner-doc impact: None; current MVR documentation already states the contract.
- Transition debt impact: None
- Boundary risk: Protected authority/recovery behavior; covered by full review and exact-head CI.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds production-path regression coverage for established authority loss during deployment finalization, including fresh bootstrap, intact authority, fail-closed missing ledger/key, unfenced recovery rejection, and fenced restore.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded Issue and PR provide the delivery evidence; no operational learning, roadmap movement, promotion, or projection material was produced.

## Notes
Validation: ruff check app tests; mypy app (901 source files); architecture recovery, mixed-version fence, and selector tests (109 passed); deployment-volume contract suite (106 passed, 3 skipped); lint-imports --config importlinter.ini (5 kept); docs_guard temporal-skip (no high-risk temporal docs touched). Local full-path review on 9f2d2d1ce59390d33507d564a828c029705bfb7e: clean after repairing one recovery-fence coverage finding. The selector maps the new test and app/instance changes to the vault suite and deployment-volume contract.