### PR TITLE
Require isolated rescue-stash replay evidence

### DIFF
--- a/.codex/skills/resume-work/SKILL.md
+++ b/.codex/skills/resume-work/SKILL.md
@@ -90,8 +90,14 @@ but do not replay rescue-stash material on the strength of a cached ref alone.
 If the rescue material no longer matches the current contract, do not apply it
 blindly. Reconstruct the needed bounded delta from current `origin/main`, or
 escalate through the normal contract/SoT ambiguity path when the intended
-delta cannot be determined safely. Never apply or delete a rescue stash merely
-to make recovery look complete.
+delta cannot be determined safely. Before a rescue candidate is treated as
+rebase-ready, replay its exact stash hash in an isolated disposable worktree
+using a dry-run that does not apply or delete the stash. Record a conflict
+inventory from that replay: a replay-safe candidate has no conflicts and no
+deleted or stale paths, while any deleted, stale, or conflicting path keeps the
+candidate out of the rebase-ready state until its bounded delta is reconstructed
+from current `origin/main`. Never apply or delete a rescue stash merely to make
+recovery look complete.
 
 For an interrupted `type:bug` implementation from a larger bug set, resume only its original
 dedicated Codex task/session and worktree. Do not absorb another bug into that session; the serial

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -720,6 +720,7 @@ jobs:
               "tests/governance/test_issue_pr_governance.py",
               "tests/governance/test_known_defects_registry.py",
               "tests/governance/test_ci_smoke_docs_only_gate.py",
+              "tests/governance/test_resume_work_contract.py",
               "tests/governance/test_skills_consistency_lint.py",
               "tests/ops/test_project_status_reconcile.py",
               "tests/ops/test_review_before_ci_gate.py",

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -376,6 +376,7 @@ Use this lane only when:
   - `tests/governance/test_ci_smoke_docs_only_gate.py`
   - `tests/governance/test_issue_pr_governance.py`
   - `tests/governance/test_known_defects_registry.py`
+  - `tests/governance/test_resume_work_contract.py`
   - `tests/governance/test_skills_consistency_lint.py`
   - `tests/ops/test_project_status_reconcile.py`
   - `tests/ops/test_review_before_ci_gate.py`

--- a/tests/governance/test_resume_work_contract.py
+++ b/tests/governance/test_resume_work_contract.py
@@ -1,0 +1,23 @@
+"""Regression guards for isolated rescue-stash replay evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rescue_stash_requires_exact_hash_dry_run_and_conflict_inventory() -> None:
+    """Only a clean isolated replay can make a rescue candidate rebase-ready."""
+    resume_work = (REPO_ROOT / ".codex/skills/resume-work/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    contract = " ".join(resume_work.split())
+
+    assert "replay its exact stash hash" in contract
+    assert "isolated disposable worktree" in contract
+    assert "dry-run that does not apply or delete the stash" in contract
+    assert "conflict inventory" in contract
+    assert "replay-safe candidate has no conflicts and no deleted or stale paths" in contract
+    assert "deleted, stale, or conflicting path keeps the candidate out of the rebase-ready state" in contract


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4974

## Linked Issue
Closes #4974

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): interrupted-work recovery
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: recovery evidence remains reproducible from Git refs
- New or changed contract: rescue candidates need isolated exact-hash dry-run replay evidence
- Owner-doc impact: docs/development/DEV_WORKFLOW.md governance lane allowlist updated
- Transition debt impact: reduces unsafe stale-work replay
- Boundary risk: do not promote rescue material into claim or Issue authority

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require an isolated exact-hash dry-run replay and conflict inventory before marking rescue material rebase-ready.
- Add focused coverage that rejects deleted, stale, and conflicting replay paths.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: #4974 applies LearningSignal lrn_20260811190752_5a71f3a8; this delivery produced no new BuilderOps material.

## Notes
Validation: pytest targeted governance tests (106 passed); skill-consistency lint; docs guard; ruff; review-before-CI gate.