### PR TITLE
Add portable YouTube source bundles

### DIFF
--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -38,7 +38,7 @@ directly, the same two names the outbox module itself documents as the override.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Mapping, Sequence
 
 # Production extractor wiring: importing the extractors package registers every extractor
@@ -67,6 +67,11 @@ from app.knowledge_acquisition.normalize import STAGE_NAME as NORMALIZE_STAGE
 from app.knowledge_acquisition.normalize import STAGE_VERSION as NORMALIZE_STAGE_VERSION
 from app.knowledge_acquisition.normalize import NormalizeError, normalize
 from app.knowledge_acquisition.replay import CANDIDATE_STAGE, CANDIDATE_STAGE_VERSION
+from app.knowledge_acquisition.source_bundle import (
+    DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    SourceBundleError,
+    materialize_youtube_source_bundle,
+)
 from app.knowledge_acquisition.stage_events import (
     emit_stage_completed,
     emit_stage_dead_letter,
@@ -263,6 +268,7 @@ def acquire_youtube(
     conn: Any = None,
     env: Mapping[str, str] | None = None,
     fetch_fn: Callable[[str], youtube_plugin.FetchOutcome] | None = None,
+    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
 ) -> AcquisitionReceipt:
     """Acquire a NEW YouTube URL end-to-end: fetch -> persist raw -> normalize -> extract ->
     assemble_candidate -> write_candidate_note, emitting one KA-06 stage event per transition.
@@ -461,6 +467,14 @@ def acquire_youtube(
             normalized_artifact_id=normalized_artifact.object_id,
             optional_failures=optional_failures,
         )
+        bundle = materialize_youtube_source_bundle(
+            candidate,
+            normalized_artifact,
+            vault_context=vault_context,
+            write_guard=write_guard,
+            youtube_attachment_root=youtube_attachment_root,
+        )
+        candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
         write_result: CandidateWriteResult = write_candidate_note(
             candidate,
             vault_context=vault_context,
@@ -470,7 +484,7 @@ def acquire_youtube(
             # and must become a companion when the canonical candidate already exists.
             proposal_on_existing=any(not result.replayed for result in report.successes),
         )
-    except (CandidateAssemblyError, CandidateWritebackError) as exc:
+    except (CandidateAssemblyError, CandidateWritebackError, SourceBundleError) as exc:
         emit_stage_dead_letter(
             stage=CANDIDATE_STAGE,
             stage_version=CANDIDATE_STAGE_VERSION,

--- a/app/knowledge_acquisition/candidate_writeback.py
+++ b/app/knowledge_acquisition/candidate_writeback.py
@@ -111,6 +111,7 @@ class Candidate:
     normalized_artifact_id: str | None = None
     extraction_artifact_ids: tuple[str, ...] = ()
     optional_failures: tuple["ExtractionFailure", ...] = ()
+    derived_transcript_link: str | None = None
 
     def summary_text(self) -> str | None:
         for extraction in self.extractions:
@@ -317,6 +318,7 @@ def render_candidate_note(candidate: Candidate) -> str:
                     f"extractions={','.join(candidate.extraction_artifact_ids) or 'none'}"
                 ),
             ),
+            ("Derived transcript", candidate.derived_transcript_link or "not materialized"),
             (
                 "Materialization status",
                 (
@@ -356,6 +358,17 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
                         f"Rerun handle: `{failure.rerun_handle}`."
                     )
                     for failure in candidate.optional_failures
+                ),
+            )
+        )
+    if candidate.derived_transcript_link:
+        sections.append(
+            ProposalSection(
+                module_id="derived-transcript",
+                title="Derived transcript",
+                content=(
+                    "Derived transcript reference (never replay input): "
+                    f"[[{candidate.derived_transcript_link}]]"
                 ),
             )
         )

--- a/app/knowledge_acquisition/replay.py
+++ b/app/knowledge_acquisition/replay.py
@@ -49,7 +49,7 @@ flag additionally makes the CLI surface the guarantee explicitly in the printed 
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Mapping, Sequence
 from uuid import UUID
 
@@ -80,6 +80,11 @@ from app.knowledge_acquisition.normalize import STAGE_NAME as NORMALIZE_STAGE
 from app.knowledge_acquisition.normalize import STAGE_VERSION as NORMALIZE_STAGE_VERSION
 from app.knowledge_acquisition.normalize import NormalizeError, normalize
 from app.knowledge_acquisition.raw_record import RawRecordIntegrityError, get_raw_record
+from app.knowledge_acquisition.source_bundle import (
+    DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    SourceBundleError,
+    materialize_youtube_source_bundle,
+)
 from app.knowledge_acquisition.stage_events import (
     STAGE_EVENT_SOURCE,
     emit_stage_completed,
@@ -244,6 +249,7 @@ def run_replay(
     assert_no_source_egress: bool = True,
     trace_id: str | None = None,
     conn: Any = None,
+    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
 ) -> ReplayReceipt:
     """Replay every derived level from an existing `raw` record and return a typed receipt.
 
@@ -448,13 +454,21 @@ def run_replay(
                     normalized_artifact_id=normalized_artifact.object_id,
                     optional_failures=optional_failures,
                 )
+                bundle = materialize_youtube_source_bundle(
+                    candidate,
+                    normalized_artifact,
+                    vault_context=vault_context,
+                    write_guard=write_guard,
+                    youtube_attachment_root=youtube_attachment_root,
+                )
+                candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
                 write_result = write_candidate_note(
                     candidate,
                     vault_context=vault_context,
                     write_guard=write_guard,
                     proposal_on_existing=True,
                 )
-            except (CandidateAssemblyError, CandidateWritebackError) as exc:
+            except (CandidateAssemblyError, CandidateWritebackError, SourceBundleError) as exc:
                 emit_stage_dead_letter(
                     stage=CANDIDATE_STAGE,
                     stage_version=CANDIDATE_STAGE_VERSION,

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -1,0 +1,132 @@
+"""Portable, immutable vault projection for one YouTube source version (YSNV2-06)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from app.knowledge.write_ops import create_candidate_note_once
+from app.knowledge_acquisition.candidate_writeback import Candidate
+from app.knowledge_acquisition.extraction_persistence import PersistedTranscript
+from app.vault.manager import VaultContext
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+DEFAULT_YOUTUBE_ATTACHMENT_ROOT = "Sources/YouTube/_attachments"
+SOURCE_BUNDLE_WRITE_ACTION = "knowledge_acquisition.youtube_source_bundle"
+
+
+class SourceBundleError(RuntimeError):
+    """The derived portable bundle could not be safely materialized."""
+
+
+@dataclass(frozen=True)
+class SourceBundleResult:
+    source_folder: str
+    bundle_folder: str
+    transcript_path: str
+    manifest_path: str
+    status: str
+
+
+def validate_youtube_attachment_root(value: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT) -> str:
+    """Accept only a normalized, portable path relative to the selected vault."""
+    if not isinstance(value, str) or not value or "\\" in value or "\x00" in value:
+        raise SourceBundleError("youtube_attachment_root must be a portable vault-relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value or any(part in {"", ".", ".."} for part in path.parts):
+        raise SourceBundleError("youtube_attachment_root must stay vault-relative")
+    return path.as_posix()
+
+
+def materialize_youtube_source_bundle(
+    candidate: Candidate,
+    transcript: PersistedTranscript,
+    *,
+    vault_context: VaultContext,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+) -> SourceBundleResult:
+    """Create immutable transcript and manifest members beneath a stable source folder."""
+    root = validate_youtube_attachment_root(youtube_attachment_root)
+    vault_root = _vault_root(vault_context)
+    source_key = _source_key(candidate.item_ref)
+    version_key = _version_key(candidate.content_identity, transcript.extensions.get("stage_version"))
+    source_folder = (PurePosixPath(root) / source_key).as_posix()
+    bundle_folder = (PurePosixPath(source_folder) / version_key).as_posix()
+    transcript_path = (PurePosixPath(bundle_folder) / "transcript.md").as_posix()
+    manifest_path = (PurePosixPath(bundle_folder) / "source.json").as_posix()
+    manifest = _manifest(candidate, transcript, source_folder, bundle_folder, transcript_path)
+    try:
+        transcript_status = create_candidate_note_once(
+            transcript_path, _render_transcript(candidate, transcript), vault_root=vault_root,
+            action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
+        )
+        manifest_status = create_candidate_note_once(
+            manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n", vault_root=vault_root,
+            action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
+        )
+    except WritesBlockedError as exc:
+        raise SourceBundleError(f"source bundle write blocked: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise SourceBundleError(f"source bundle materialization failed: {exc}") from exc
+    return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")
+
+
+def _source_key(item_ref: str) -> str:
+    if not isinstance(item_ref, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", item_ref):
+        raise SourceBundleError("YouTube source identity must be a safe stable item_ref")
+    return f"yt-{item_ref}"
+
+
+def _version_key(content_identity: str, stage_version: Any) -> str:
+    if not isinstance(content_identity, str) or not content_identity:
+        raise SourceBundleError("content_identity is required for immutable bundle versioning")
+    payload = re.sub(r"[^A-Za-z0-9]+", "-", content_identity.split(":", 1)[-1]).strip("-")
+    if not payload:
+        payload = hashlib.sha256(content_identity.encode("utf-8")).hexdigest()
+    if not isinstance(stage_version, int) or stage_version < 1:
+        raise SourceBundleError("transcript stage_version is required for immutable bundle versioning")
+    return f"content-{payload}-v{stage_version}"
+
+
+def _manifest(candidate: Candidate, transcript: PersistedTranscript, source_folder: str, bundle_folder: str, transcript_path: str) -> dict[str, Any]:
+    metadata = dict(transcript.metadata_bundle)
+    metadata.update({
+        "object_id": f"bundle:{candidate.content_identity}:{transcript.object_id}",
+        "object_type": "projection",
+        "source_role": "external_source",
+        "authority_state": "derived",
+        "evidence_role": "reference",
+        "created_by": "app:knowledge_acquisition.source_bundle",
+        "derived_from": [transcript.object_id, *transcript.derived_from],
+        "provenance_event_ids": [f"bundle:{transcript.object_id}"],
+        "scope_binding": {"bound": "unbound"},
+        "extensions": {
+            "artifact_kind": "youtube_source_bundle", "stable_source_folder": source_folder,
+            "immutable_bundle_folder": bundle_folder, "content_identity": candidate.content_identity,
+            "stage_version": transcript.extensions["stage_version"], "transcript_path": transcript_path,
+            "transcript_anchors": list(transcript.anchors), "replay_input": "machine_side_raw_only",
+        },
+    })
+    return metadata
+
+
+def _render_transcript(candidate: Candidate, transcript: PersistedTranscript) -> str:
+    lines = ["# Transcript (derived)", "", "This is a derived/rebuildable reference and is never replay input; replay reads machine-side raw evidence.", "", f"Content identity: `{candidate.content_identity}`", f"Normalized transcript: `{transcript.object_id}`", ""]
+    for segment in transcript.extensions.get("segments", []):
+        if isinstance(segment, dict):
+            lines.append(f"- `{segment.get('anchor')}` {segment.get('text', '')}")
+    return "\n".join(lines) + "\n"
+
+
+def _vault_root(context: VaultContext) -> Path:
+    if not context.active_vault_path:
+        raise SourceBundleError("vault_context.active_vault_path is required")
+    return Path(context.active_vault_path).expanduser().resolve()
+
+
+__all__ = ["DEFAULT_YOUTUBE_ATTACHMENT_ROOT", "SOURCE_BUNDLE_WRITE_ACTION", "SourceBundleError", "SourceBundleResult", "materialize_youtube_source_bundle", "validate_youtube_attachment_root"]

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -69,8 +69,10 @@ def materialize_youtube_source_bundle(
             manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n", vault_root=vault_root,
             action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
         )
-    except WritesBlockedError as exc:
-        raise SourceBundleError(f"source bundle write blocked: {exc}") from exc
+    except WritesBlockedError:
+        return SourceBundleResult(
+            source_folder, bundle_folder, transcript_path, manifest_path, "blocked"
+        )
     except Exception as exc:  # noqa: BLE001
         raise SourceBundleError(f"source bundle materialization failed: {exc}") from exc
     return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")

--- a/docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md
+++ b/docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md
@@ -127,6 +127,14 @@ companion rather than overwrite the original candidate or human-authored content
 deliveries do not ship the later v2 modules, change title-bearing paths or persistence, alter
 D1–D6, or introduce ProfileAgent behavior.
 
+The portable-source-bundle delivery adds a derived, rebuildable vault transcript and `source.json`
+under the YouTube attachment root (`Sources/YouTube/_attachments` by default). The stable
+`yt-<video-id>` folder contains immutable content-identity/stage-version members, so a later
+acquisition cannot retarget prior candidate evidence. Its manifest carries the resolved
+metadata-bundle envelope (including object-form `scope_binding`); replay still reads only
+machine-side raw evidence. New candidates link the transcript, while an existing candidate receives
+that link only in its D5 versioned proposal companion.
+
 ## Phase 2 vertical slice (TCD milestone)
 
 One explicit URL, end to end, nothing more — no discovery, no scheduling, no UI, one extractor.

--- a/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
+++ b/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
@@ -23,6 +23,12 @@ renderer while preserving owner-authored bytes, omitting empty optional modules,
 candidate terminality behind successful note materialization. This is the YSNV2-03 rendering seam,
 not delivery of the later evidence, bundle, module, profile, frame, or evaluation slices.
 
+YSNV2-06 materializes the portable source bundle through the delivered transcript/extraction seam:
+the flat candidate note remains in place while a configured vault-relative attachment root holds a
+stable `yt-<video-id>` folder and immutable content-identity/version members. Each member contains
+a derived/rebuildable `transcript.md` and schema-valid `source.json`; replay continues from
+machine-side raw evidence, and existing candidate upgrades use a D5 versioned proposal companion.
+
 The following are V1 limitations or deliberate choices, not retroactive defects: process-local extraction results, fixed rendering, and title-bearing paths. V2 may replace those choices only through the task contracts below. The brief's metadata-bundle examples are not adopted. Every usable bundle resolves the schema-required fields at the top level: identity (`object_id`, `object_type`), scope (`scope_id`), semantic standing (`source_role`, `authority_state`, `evidence_role`, `sensitivity`, `suppression_state`), provenance (`created_by`, `created_at`, `provenance_event_ids`), and episode binding (`episode_ref`). `scope_binding`, when present, is the object defined by the shared schema rather than a string or nested substitute. Conditional schema requirements such as `derived_from` for derived types and `authority_receipt_ref` for canonical standing remain in force.
 
 ## Capability boundary

--- a/tests/architecture/test_obsidian_port_boundaries.py
+++ b/tests/architecture/test_obsidian_port_boundaries.py
@@ -400,6 +400,10 @@ def test_create_once_stays_behind_knowledge_service_boundary() -> None:
             "_write_versioned_proposal",
         ),
         ("app/knowledge_acquisition/candidate_writeback.py", "write_candidate_note"),
+        # Portable source bundles (#4113): transcript and manifest are separate immutable,
+        # no-clobber derived members under the same governed write service.
+        ("app/knowledge_acquisition/source_bundle.py", "materialize_youtube_source_bundle"),
+        ("app/knowledge_acquisition/source_bundle.py", "materialize_youtube_source_bundle"),
     ]
     writeback_path = app_root / "knowledge_acquisition" / "candidate_writeback.py"
     imports = [

--- a/tests/fixtures/youtube_source_bundle_manifest.json
+++ b/tests/fixtures/youtube_source_bundle_manifest.json
@@ -1,0 +1,26 @@
+{
+  "object_id": "bundle:fixture",
+  "object_type": "projection",
+  "scope_id": "scope:external/unresolved",
+  "scope_binding": {"bound": "unbound"},
+  "source_role": "external_source",
+  "authority_state": "derived",
+  "evidence_role": "reference",
+  "sensitivity": "internal",
+  "suppression_state": "visible",
+  "created_by": "app:knowledge_acquisition.source_bundle",
+  "created_at": "2026-08-17T00:00:00Z",
+  "derived_from": ["normalized:fixture"],
+  "provenance_event_ids": ["bundle:normalized:fixture"],
+  "episode_ref": "unbound",
+  "extensions": {
+    "artifact_kind": "youtube_source_bundle",
+    "stable_source_folder": "Sources/YouTube/_attachments/yt-dQw4w9WgXcQ",
+    "immutable_bundle_folder": "Sources/YouTube/_attachments/yt-dQw4w9WgXcQ/content-fixture-v1",
+    "content_identity": "sha256:fixture",
+    "stage_version": 1,
+    "transcript_path": "Sources/YouTube/_attachments/yt-dQw4w9WgXcQ/content-fixture-v1/transcript.md",
+    "transcript_anchors": ["t000000000-t000002000-s0000"],
+    "replay_input": "machine_side_raw_only"
+  }
+}

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -220,8 +220,14 @@ def test_acquire_youtube_end_to_end_writes_candidate_and_emits_events(
     assert candidate_stage.artifact_path
 
     notes = list((tmp_path / "vault").rglob("*.md"))
-    assert len(notes) == 1
-    assert notes[0].read_text(encoding="utf-8")  # candidate note has content
+    assert len(notes) == 2
+    candidate_path = Path(vault.active_vault_path) / str(candidate_stage.artifact_path)
+    candidate_body = candidate_path.read_text(encoding="utf-8")
+    transcript = next(path for path in notes if path.name == "transcript.md")
+    manifest = transcript.with_name("source.json")
+    transcript_rel = transcript.relative_to(vault.active_vault_path).as_posix()
+    assert f"[[{transcript_rel}]]" in candidate_body
+    assert manifest.exists()
 
     # One stage.completed event per real transition (normalize, extracted, candidate).
     completed = conn.rows_for(STAGE_COMPLETED_TOPIC)
@@ -278,7 +284,7 @@ def test_acquire_youtube_rerun_is_idempotent_dedup_noop(
     assert note_path.read_bytes() == bytes_first
 
     notes = list((tmp_path / "vault").rglob("*.md"))
-    assert len(notes) == 1  # no duplicate note written
+    assert len(notes) == 2  # no duplicate candidate or derived transcript written
 
     # Stage-completed events deduped: re-running an unchanged item does not mint new rows.
     completed = conn.rows_for(STAGE_COMPLETED_TOPIC)

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -208,7 +208,8 @@ def test_same_video_two_sources_single_request_merged_provenance(
     discovered = conn.payloads_for(YOUTUBE_SOURCE_DISCOVERED_TOPIC)
     assert {d["binding_id"] for d in discovered} == {BINDING_INBOX, BINDING_OWNED}
 
-    # End-to-end through the (stubbed-egress) production pipeline: one candidate.
+    # End-to-end through the (stubbed-egress) production pipeline: one candidate plus
+    # its portable derived transcript.
     vault = _vault(tmp_path / "vault")
     claimed = q.claim_batch(1, conn=conn)
     assert [c.request_id for c in claimed] == [r1.request_id]
@@ -217,7 +218,7 @@ def test_same_video_two_sources_single_request_merged_provenance(
     assert result.content_identity
     assert result.artifact_path
     notes = list((tmp_path / "vault").rglob("*.md"))
-    assert len(notes) == 1
+    assert len(notes) == 2
 
     # Converged: nothing left to claim.
     assert q.claim_batch(5, conn=conn) == []
@@ -447,7 +448,7 @@ def test_writeguard_block_reported_and_retryable_at_call_site(
     assert [r.request_id for r in reclaimed] == [row.request_id]
     done = drain_one(reclaimed[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
     assert done.status == "completed"
-    assert len(list((tmp_path / "vault").rglob("*.md"))) == 1
+    assert len(list((tmp_path / "vault").rglob("*.md"))) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/knowledge_acquisition/test_replay.py
+++ b/tests/knowledge_acquisition/test_replay.py
@@ -219,9 +219,10 @@ def test_replay_fresh_write_not_equivalent_then_preserved(tmp_path: Path) -> Non
     assert stages["candidate"].status == "proposal_written"
     assert stages["candidate"].equivalence == "versioned_proposal_original_preserved"
 
-    # The original candidate plus one proposal companion exist; the candidate is untouched.
+    # The original candidate plus one proposal companion and its derived transcript exist;
+    # the candidate is untouched.
     notes = list((tmp_path / "vault").rglob("*.md"))
-    assert len(notes) == 2
+    assert len(notes) == 3
     assert len([path for path in notes if path.name.endswith(".meta.md")]) == 1
 
     # Stage events were emitted on the outbox for normalize + extracted + candidate.

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -1,0 +1,123 @@
+"""YSNV2-06 portable, immutable YouTube source-bundle contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.knowledge_acquisition.candidate_writeback import assemble_candidate, write_candidate_note
+from app.knowledge_acquisition.extraction_persistence import persist_normalized_transcript
+from app.knowledge_acquisition.normalize import normalize
+from app.knowledge_acquisition.raw_record import persist_raw_record
+from app.knowledge_acquisition.source_bundle import (
+    DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    SourceBundleError,
+    materialize_youtube_source_bundle,
+)
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+from tests.invariants._helpers import assert_validates
+from tests.knowledge_acquisition.test_replay import RAW_PAYLOAD
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext("selected", "vault-test", "Vault Test", str(root))
+
+
+def _guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _source_material(tmp_path: Path, *, item_ref: str = "dQw4w9WgXcQ", identity: str | None = None):
+    raw = {**RAW_PAYLOAD, "item_ref": item_ref}
+    if identity is not None:
+        raw["content_identity"] = identity
+    persisted = persist_raw_record(
+        source_kind="youtube_url", item_ref=item_ref,
+        content_identity=str(raw["content_identity"]), payload=raw, source_ref="test:bundle",
+    )
+    normalized = normalize(dict(persisted.record))
+    transcript = persist_normalized_transcript(
+        raw_record_id=str(persisted.object_id), raw_record=persisted.record, normalized=normalized,
+    )
+    candidate = assemble_candidate(
+        persisted.record, normalized=normalized, raw_record_id=str(persisted.object_id),
+        normalized_artifact_id=transcript.object_id, extraction_results=(),
+    )
+    return persisted, transcript, candidate
+
+
+def test_configured_attachment_root_is_source_identity_keyed_and_note_is_non_destructive(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _raw, transcript, candidate = _source_material(tmp_path)
+    note = write_candidate_note(candidate, vault_context=vault, write_guard=_guard())
+    before = (Path(vault.active_vault_path) / str(note.artifact_path)).read_bytes()
+    bundle = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard(), youtube_attachment_root="Sources/YouTube/Attachments")
+    assert bundle.source_folder == "Sources/YouTube/Attachments/yt-dQw4w9WgXcQ"
+    assert (Path(vault.active_vault_path) / str(note.artifact_path)).read_bytes() == before
+
+
+def test_bundle_members_are_immutable_and_versioned_by_content_identity(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _raw, transcript, candidate = _source_material(tmp_path)
+    first = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    _, newer_transcript, newer = _source_material(tmp_path, identity="sha256:new-content")
+    second = materialize_youtube_source_bundle(newer, newer_transcript, vault_context=vault, write_guard=_guard())
+    assert first.bundle_folder != second.bundle_folder
+    assert Path(vault.active_vault_path, first.transcript_path).read_text(encoding="utf-8")
+
+
+def test_youtube_attachment_root_is_configurable_and_vault_relative(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    result = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    assert result.source_folder.startswith(f"{DEFAULT_YOUTUBE_ATTACHMENT_ROOT}/")
+    for unsafe in ("/tmp/escape", "Sources/../escape"):
+        with pytest.raises(SourceBundleError):
+            materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard(), youtube_attachment_root=unsafe)
+
+
+def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    result = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    body = Path(vault.active_vault_path, result.transcript_path).read_text(encoding="utf-8")
+    assert "derived/rebuildable reference" in body
+    assert "never replay input" in body
+    assert "t000000000-t000002000-s0000" in body
+
+
+def test_note_links_derived_transcript_from_synthesis_and_lineage(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    bundle = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    linked = candidate.__class__(**{**candidate.__dict__, "derived_transcript_link": bundle.transcript_path})
+    note = write_candidate_note(linked, vault_context=vault, write_guard=_guard())
+    assert f"[[{bundle.transcript_path}]]" in Path(vault.active_vault_path, str(note.artifact_path)).read_text(encoding="utf-8")
+
+
+def test_bundle_manifest_validates_resolved_metadata_bundle(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    bundle = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    manifest = json.loads(Path(vault.active_vault_path, bundle.manifest_path).read_text(encoding="utf-8"))
+    assert isinstance(manifest["scope_binding"], dict)
+    assert manifest["object_type"] == "projection"
+    assert_validates(manifest, "metadata-bundle.schema.json")
+
+
+def test_existing_candidate_bundle_upgrade_uses_versioned_companion_without_note_mutation(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    original = write_candidate_note(candidate, vault_context=vault, write_guard=_guard())
+    original_path = Path(vault.active_vault_path, str(original.artifact_path))
+    before = original_path.read_bytes()
+    bundle = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    linked = candidate.__class__(**{**candidate.__dict__, "derived_transcript_link": bundle.transcript_path, "extraction_artifact_ids": ("extract-1",)})
+    proposal = write_candidate_note(linked, vault_context=vault, write_guard=_guard(), proposal_on_existing=True)
+    assert proposal.status == "proposal_written"
+    assert original_path.read_bytes() == before
+    assert f"[[{bundle.transcript_path}]]" in Path(vault.active_vault_path, str(proposal.artifact_path)).read_text(encoding="utf-8")


### PR DESCRIPTION
Governing-Issue: #4113

Fixes #4113

Final-Review-Rounds: 1

## Summary
Materializes immutable, source-identity-keyed YouTube attachment bundles with derived transcripts and resolved metadata manifests in both new acquisition and replay. New candidates link the bundle transcript; existing candidates preserve their bytes and receive the link only through a D5 versioned proposal companion.

## BuilderOps Routing
- Records/projections/receipts: AgentWorklog awl_20260817213741_f9845df2; LearningSignal lrn_20260817215111_5b438993
- Reason: implementation evidence and a review-discovered production-path test gap were recorded before closure.

## Notes
Validation: pytest -q tests/knowledge_acquisition/test_acquire.py tests/knowledge_acquisition/test_youtube_source_bundle.py tests/knowledge_acquisition/test_extraction_persistence.py tests/knowledge_acquisition/test_replay.py tests/architecture/test_obsidian_port_boundaries.py::test_create_once_stays_behind_knowledge_service_boundary (52 passed); ruff check app tests; git diff --check; DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py. The jsonschema CLI cannot resolve the schema canonical local reference; the focused test validates generated manifests via the repository local schema registry.
