### PR TITLE
Harden readiness admission assertion parsing

### DIFF
--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -456,6 +456,8 @@ def admission_contract_problem(body: str) -> str | None:
         return None
     if not _contains_any(PRODUCTION_SEAM_PATTERNS, body):
         return "admission/proxy/forwarded-identity claim has no named production seam"
+    if _contains_any(NO_FORWARDED_IDENTITY_PATTERNS, body) and _affirmative_forwarded_identity_claim(body):
+        return "forwarded-identity assertion contradicts the named no-forwarding seam"
     if _contains_any((re.compile(r"\bdirect loopback\b", re.IGNORECASE),
                       re.compile(r"\bloopback endpoint\b", re.IGNORECASE)), body) and _affirmative_forwarded_identity_claim(body):
         return "forwarded-identity assertion contradicts the direct-loopback seam"

--- a/scripts/validate_issue_readiness.py
+++ b/scripts/validate_issue_readiness.py
@@ -69,8 +69,6 @@ ADMISSION_CLAIM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
 PRODUCTION_SEAM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
     re.compile(pattern, re.IGNORECASE)
     for pattern in (
-        r"\bnamed production seam\b",
-        r"\bproduction seam\b",
         r"\bdirect loopback\b",
         r"\bloopback endpoint\b",
         r"\b(?:gateway|ingress|reverse proxy)\b",
@@ -432,6 +430,25 @@ def _contains_any(patterns: Sequence[re.Pattern[str]], text: str) -> bool:
     return any(pattern.search(text) for pattern in patterns)
 
 
+def _affirmative_forwarded_identity_claim(body: str) -> bool:
+    """Return whether the body positively requires or trusts forwarded identity."""
+
+    affirmative_patterns = (
+        r"\b(?:forward|preserve|accept|trust|use|require|allow|receive)[a-z -]{0,24}"
+        r"(?:forwarded[- ](?:identity|for|host|proto)|forward(?:ed|ing)? identity)\b",
+        r"\bforward identity\b",
+        r"\b(?:forwarded[- ](?:identity|for|host|proto)|forward(?:ed|ing)? identity)"
+        r"\s+(?:is|must be|should be|remains?)\s+(?:trusted|accepted|required|used)\b",
+        r"\btrusted forwarded[- ]identity\b",
+    )
+    for pattern in affirmative_patterns:
+        for match in re.finditer(pattern, body, re.IGNORECASE):
+            prefix = body[max(0, match.start() - 24) : match.start()]
+            if not re.search(r"(?:no|not|without|never)\s*$", prefix, re.IGNORECASE):
+                return True
+    return False
+
+
 def admission_contract_problem(body: str) -> str | None:
     """Reject readiness claims that lack or contradict their production seam."""
 
@@ -439,18 +456,9 @@ def admission_contract_problem(body: str) -> str | None:
         return None
     if not _contains_any(PRODUCTION_SEAM_PATTERNS, body):
         return "admission/proxy/forwarded-identity claim has no named production seam"
-    if _contains_any(NO_FORWARDED_IDENTITY_PATTERNS, body):
-        forwarded_assertion = re.search(
-            r"\b(?:forward|preserve|accept|trust|use|require)[a-z -]{0,24}"
-            r"(?:forwarded[- ](?:identity|for|host|proto)|forward(?:ed|ing)? identity)\b",
-            body,
-            re.IGNORECASE,
-        )
-        forwarded_assertion = forwarded_assertion or re.search(
-            r"\bforward identity\b", body, re.IGNORECASE
-        )
-        if forwarded_assertion is not None:
-            return "forwarded-identity assertion contradicts the named no-forwarding seam"
+    if _contains_any((re.compile(r"\bdirect loopback\b", re.IGNORECASE),
+                      re.compile(r"\bloopback endpoint\b", re.IGNORECASE)), body) and _affirmative_forwarded_identity_claim(body):
+        return "forwarded-identity assertion contradicts the direct-loopback seam"
     return None
 
 

--- a/tests/governance/test_issue_readiness_admission_contract.py
+++ b/tests/governance/test_issue_readiness_admission_contract.py
@@ -57,3 +57,34 @@ def test_ready_issue_admission_wording_matches_named_production_seam():
     )
     report = classify_issue_body(matching, labels=("agent:ready",))
     assert report.readiness_classification == "ready_candidate"
+
+
+def test_forwarded_identity_requires_concrete_production_seam():
+    body = _issue_body(
+        scope="Require forwarded identity at the production seam.",
+        constraints="The forwarded identity is trusted by the admission check.",
+    )
+    report = classify_issue_body(body, labels=("agent:ready",))
+    assert report.readiness_classification == "admission_contract_conflict"
+
+
+def test_direct_loopback_rejects_forwarded_identity_claim():
+    body = _issue_body(
+        scope="Require direct loopback endpoint admission with trusted forwarded identity.",
+        constraints="The direct loopback endpoint is the production seam.",
+    )
+    report = classify_issue_body(body, labels=("agent:ready",))
+    assert report.readiness_classification == "admission_contract_conflict"
+
+
+def test_negated_or_unrelated_proxy_text_is_not_an_affirmative_admission_claim():
+    negative = _issue_body(
+        scope="Require direct loopback endpoint admission.",
+        constraints="The direct loopback endpoint has no forwarded identity.",
+    )
+    unrelated = _issue_body(
+        scope="Document the reverse proxy used by the deployment.",
+        constraints="The readiness claim does not require forwarded identity.",
+    )
+    assert classify_issue_body(negative, labels=("agent:ready",)).readiness_classification == "ready_candidate"
+    assert classify_issue_body(unrelated, labels=("agent:ready",)).readiness_classification == "ready_candidate"

--- a/tests/governance/test_issue_readiness_admission_contract.py
+++ b/tests/governance/test_issue_readiness_admission_contract.py
@@ -77,6 +77,15 @@ def test_direct_loopback_rejects_forwarded_identity_claim():
     assert report.readiness_classification == "admission_contract_conflict"
 
 
+def test_explicit_no_forwarding_conflict_remains_rejected():
+    body = _issue_body(
+        scope="Require gateway admission to accept forwarded identity.",
+        constraints="The gateway has no forwarded identity.",
+    )
+    report = classify_issue_body(body, labels=("agent:ready",))
+    assert report.readiness_classification == "admission_contract_conflict"
+
+
 def test_negated_or_unrelated_proxy_text_is_not_an_affirmative_admission_claim():
     negative = _issue_body(
         scope="Require direct loopback endpoint admission.",


### PR DESCRIPTION
Governing-Issue: #4992

Fixes #4992

Final-Review-Rounds: 0

- [x] Governance lane

## Summary
Require concrete production seams for forwarded-identity admission claims and reject forwarded identity paired with direct-loopback admission.

## Changes
- Remove generic `production seam` wording as sufficient admission evidence.
- Detect affirmative forwarded-identity assertions, including trusted identity wording, while preserving negated and unrelated proxy text.
- Add regression coverage for both false-green paths and valid negative/unrelated cases.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No operational learning, freshness, roadmap, promotion, or authority-crossing material was produced.

## Notes
Validation: `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py`; `python3 -m pytest -q tests/governance/test_issue_readiness_admission_contract.py`; `ruff check scripts/validate_issue_readiness.py tests/governance/test_issue_readiness_admission_contract.py`; `git diff --check`.
---