### PR TITLE
Preserve retryable blocked replay outcomes

### DIFF
--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -474,16 +474,27 @@ def acquire_youtube(
             write_guard=write_guard,
             youtube_attachment_root=youtube_attachment_root,
         )
-        candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
-        write_result: CandidateWriteResult = write_candidate_note(
-            candidate,
-            vault_context=vault_context,
-            write_guard=write_guard,
-            # An ordinary same-version restart hit has no new proposal. A fresh extractor
-            # version (or other newly executed successful extraction) is an upgrade under D5
-            # and must become a companion when the canonical candidate already exists.
-            proposal_on_existing=any(not result.replayed for result in report.successes),
-        )
+        if bundle.status == "blocked":
+            # A bundle refusal means the candidate must not claim a transcript that was
+            # never materialized. Preserve the retryable refusal even if the guard recovers
+            # before the candidate-write seam is reached.
+            write_result = CandidateWriteResult(
+                status="blocked",
+                artifact_path=None,
+                content_identity=candidate.content_identity,
+                reason=bundle.reason or "source bundle materialization blocked by write guard",
+            )
+        else:
+            candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
+            write_result: CandidateWriteResult = write_candidate_note(  # type: ignore[no-redef]
+                candidate,
+                vault_context=vault_context,
+                write_guard=write_guard,
+                # An ordinary same-version restart hit has no new proposal. A fresh extractor
+                # version (or other newly executed successful extraction) is an upgrade under D5
+                # and must become a companion when the canonical candidate already exists.
+                proposal_on_existing=any(not result.replayed for result in report.successes),
+            )
     except (CandidateAssemblyError, CandidateWritebackError, SourceBundleError) as exc:
         emit_stage_dead_letter(
             stage=CANDIDATE_STAGE,

--- a/app/knowledge_acquisition/replay.py
+++ b/app/knowledge_acquisition/replay.py
@@ -461,13 +461,24 @@ def run_replay(
                     write_guard=write_guard,
                     youtube_attachment_root=youtube_attachment_root,
                 )
-                candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
-                write_result = write_candidate_note(
-                    candidate,
-                    vault_context=vault_context,
-                    write_guard=write_guard,
-                    proposal_on_existing=True,
-                )
+                if bundle.status == "blocked":
+                    # Bundle materialization is governed by the same write guard as the
+                    # candidate note. Preserve the retryable refusal and do not write a
+                    # candidate that falsely claims to link a bundle that was not created.
+                    write_result = CandidateWriteResult(
+                        status="blocked",
+                        artifact_path=None,
+                        content_identity=candidate.content_identity,
+                        reason=bundle.reason or "source bundle materialization blocked by write guard",
+                    )
+                else:
+                    candidate = replace(candidate, derived_transcript_link=bundle.transcript_path)
+                    write_result = write_candidate_note(
+                        candidate,
+                        vault_context=vault_context,
+                        write_guard=write_guard,
+                        proposal_on_existing=True,
+                    )
             except (CandidateAssemblyError, CandidateWritebackError, SourceBundleError) as exc:
                 emit_stage_dead_letter(
                     stage=CANDIDATE_STAGE,

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import tempfile
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows local tooling fallback.
+    fcntl = None  # type: ignore[assignment]
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, Iterator
 
 from app.knowledge.write_ops import create_candidate_note_once
 from app.knowledge_acquisition.candidate_writeback import Candidate
@@ -17,6 +24,9 @@ from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 DEFAULT_YOUTUBE_ATTACHMENT_ROOT = "Sources/YouTube/_attachments"
 SOURCE_BUNDLE_WRITE_ACTION = "knowledge_acquisition.youtube_source_bundle"
+
+_THREAD_LOCKS_GUARD = threading.Lock()
+_THREAD_LOCKS: dict[str, threading.Lock] = {}
 
 
 class SourceBundleError(RuntimeError):
@@ -30,6 +40,7 @@ class SourceBundleResult:
     transcript_path: str
     manifest_path: str
     status: str
+    reason: str | None = None
 
 
 def validate_youtube_attachment_root(value: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT) -> str:
@@ -60,22 +71,49 @@ def materialize_youtube_source_bundle(
     transcript_path = (PurePosixPath(bundle_folder) / "transcript.md").as_posix()
     manifest_path = (PurePosixPath(bundle_folder) / "source.json").as_posix()
     manifest = _manifest(candidate, transcript, source_folder, bundle_folder, transcript_path)
-    try:
-        transcript_status = create_candidate_note_once(
-            transcript_path, _render_transcript(candidate, transcript), vault_root=vault_root,
-            action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
-        )
-        manifest_status = create_candidate_note_once(
-            manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n", vault_root=vault_root,
-            action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
-        )
-    except WritesBlockedError:
-        return SourceBundleResult(
-            source_folder, bundle_folder, transcript_path, manifest_path, "blocked"
-        )
-    except Exception as exc:  # noqa: BLE001
-        raise SourceBundleError(f"source bundle materialization failed: {exc}") from exc
+    with _bundle_lock(vault_root, bundle_folder):
+        transcript_status: str | None = None
+        try:
+            transcript_status = create_candidate_note_once(
+                transcript_path, _render_transcript(candidate, transcript), vault_root=vault_root,
+                action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
+            )
+            manifest_status = create_candidate_note_once(
+                manifest_path, json.dumps(manifest, indent=2, sort_keys=True) + "\n", vault_root=vault_root,
+                action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
+            )
+        except WritesBlockedError as exc:
+            if transcript_status == "written":
+                try:
+                    (vault_root / transcript_path).unlink()
+                except OSError as cleanup_exc:
+                    raise SourceBundleError(
+                        f"source bundle blocked after partial write and cleanup failed: {cleanup_exc}"
+                    ) from cleanup_exc
+            return SourceBundleResult(
+                source_folder, bundle_folder, transcript_path, manifest_path, "blocked", str(exc)
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise SourceBundleError(f"source bundle materialization failed: {exc}") from exc
     return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")
+
+
+@contextmanager
+def _bundle_lock(vault_root: Path, bundle_folder: str) -> Iterator[None]:
+    key = hashlib.sha256(f"{vault_root}:{bundle_folder}".encode("utf-8")).hexdigest()
+    if fcntl is None:
+        with _THREAD_LOCKS_GUARD:
+            lock = _THREAD_LOCKS.setdefault(key, threading.Lock())
+        with lock:
+            yield
+        return
+    lock_path = Path(tempfile.gettempdir()) / f"agentic-pkm-youtube-bundle-{key}.lock"
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _source_key(item_ref: str) -> str:

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -946,6 +946,35 @@ def test_acquire_youtube_writeguard_blocked_is_not_ok_no_note(
     assert receipt.as_dict()["ok"] is False
 
 
+def test_acquire_youtube_bundle_blocked_does_not_publish_broken_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A guard recovery between bundle members cannot publish a missing bundle link."""
+    _stub_caption_fetch(monkeypatch)
+    conn = FakeOutboxConn()
+    vault = _vault(tmp_path / "vault")
+    snapshots = iter(
+        [
+            {"state": "safe_mode", "reason": "transient bundle block"},
+            {"state": "healthy"},
+        ]
+    )
+
+    receipt = acquire_youtube(
+        FAKE_URL,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+        conn=conn,
+    )
+
+    candidate_stage = next(s for s in receipt.stages if s.stage == "candidate")
+    assert receipt.ok is False
+    assert candidate_stage.status == "blocked"
+    assert "Writes blocked" in candidate_stage.detail
+    assert conn.rows_for(STAGE_DEAD_LETTERED_TOPIC) == []
+    assert list((tmp_path / "vault").rglob("*.md")) == []
+
+
 def test_acquire_youtube_cli_exits_nonzero_on_blocked_write(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/knowledge_acquisition/test_replay.py
+++ b/tests/knowledge_acquisition/test_replay.py
@@ -231,6 +231,27 @@ def test_replay_fresh_write_not_equivalent_then_preserved(tmp_path: Path) -> Non
     assert stages_seen == {"normalize", "extracted", "candidate"}
 
 
+def test_blocked_replay_preserves_retryable_write_blocked_result(tmp_path: Path) -> None:
+    """A blocked bundle write remains retryable and never becomes a dead letter."""
+    from app.knowledge_acquisition.stage_events import STAGE_DEAD_LETTERED_TOPIC
+
+    raw_id = _persist_raw()
+    conn = FakeOutboxConn()
+    receipt = run_replay(
+        raw_id,
+        vault_context=_vault(tmp_path / "vault"),
+        write_guard=WriteGuard(lambda: {"state": "safe_mode", "reason": "test-induced block"}),
+        conn=conn,
+    )
+
+    candidate_stage = next(stage for stage in receipt.stages if stage.stage == "candidate")
+    assert candidate_stage.status == "blocked"
+    assert receipt.dead_lettered == ()
+    assert conn.rows_for(STAGE_DEAD_LETTERED_TOPIC) == []
+    assert "Writes blocked" in candidate_stage.detail
+    assert list((tmp_path / "vault").rglob("*.md")) == []
+
+
 def test_candidate_byte_identical_across_replay(tmp_path: Path) -> None:
     """The written candidate note is byte-identical after a replay (first-write-wins)."""
     conn = FakeOutboxConn()

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -80,6 +80,43 @@ def test_youtube_attachment_root_is_configurable_and_vault_relative(tmp_path: Pa
             materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard(), youtube_attachment_root=unsafe)
 
 
+def test_bundle_write_failure_remains_terminal_and_non_partial(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: {"state": "safe_mode", "reason": "test-induced block"}),
+    )
+
+    assert blocked.status == "blocked"
+    assert blocked.reason is not None
+    assert "Writes blocked" in blocked.reason
+    assert list((tmp_path / "vault").rglob("*.md")) == []
+
+
+def test_bundle_write_blocked_between_members_cleans_up_partial_artifact(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    snapshots = iter(
+        [
+            {"state": "healthy"},
+            {"state": "safe_mode", "reason": "mid-bundle block"},
+        ]
+    )
+
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+    )
+
+    assert blocked.status == "blocked"
+    assert list((tmp_path / "vault").rglob("*.md")) == []
+
+
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)


### PR DESCRIPTION
Governing-Issue: #4995

Fixes #4995

Final-Review-Rounds: 1

## Summary
- Preserve WriteGuard-blocked bundle materialization as retryable candidate outcomes in acquisition and replay.
- Prevent broken transcript links and clean up partial bundle members under a bundle-specific lock.
- Preserve denial reasons and add production-path regressions.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No operational learning, freshness, roadmap, promotion, or BuilderOps projection material was created.

## Validation
- 48 focused HKA tests passed
- ruff passed
- mypy passed for changed source modules
- git diff --check passed

## Review
- Fresh high-capability review completed on exact commit.
- One valid P2 remains non-blocking: directory fsync after rollback could strengthen crash durability; no P0/P1/protected findings remain.