### PR TITLE
Require duplicate search before governance issue filing

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -50,6 +50,12 @@ data, or any artefact that is not reproducible from the checked-in repo plus pub
 body, linked PR, owner doc) before authoring the Issue that depends on it. If the material cannot be
 promoted, the Issue should not depend on it.
 
+Before creating or normalizing a governance or contract Issue, search for the same artifact or
+symptom in open Issues, recently merged PRs, and closed Issues. Use GitHub CLI/REST search; do not
+require GraphQL or ProjectV2 operations. If an open match exists, add the evidence there rather
+than creating a duplicate. If a closed Issue or merged PR matches, verify whether the work is
+already delivered before filing a new contract.
+
 ### Admission claims must match the named production seam
 
 An Issue that asserts local admission, proxying, or forwarded-identity behavior must name the

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -37,6 +37,17 @@ def test_canonical_agents_entrypoint_routes_to_repo_skill_index() -> None:
     assert "Known Defects registry Issue #4172" in text
 
 
+def test_shared_issue_contract_requires_duplicate_search_before_issue_creation() -> None:
+    contract = _read(".codex/skills/_shared/ISSUE_CONTRACT.md")
+    self_sufficiency = " ".join(
+        _section_between(contract, "## Issue self-sufficiency rule", "## Child to parent reference").split()
+    )
+
+    assert "Before creating or normalizing a governance or contract Issue" in self_sufficiency
+    assert "open Issues, recently merged PRs, and closed Issues" in self_sufficiency
+    assert "do not require GraphQL or ProjectV2 operations" in self_sufficiency
+
+
 def test_bug_delivery_transition_policy_is_linked_across_workflows() -> None:
     canonical = "AGENTS.md :: Transition-period bug-delivery policy"
     for path in (


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4154

## Linked Issue
Closes #4154

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): GitHub issue governance
- Write class: governance/docs/process
- Persistence impact: GitHub Issue bodies only
- Derived/rebuildable impact: none
- New or changed contract: shared issue-authoring pre-filing search rule
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: none

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require duplicate searches before governance and contract issue filing.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The learning signal is already represented by the governing issue; no new operational record or divergence was produced.

## Notes
Validation: pytest -q tests/architecture/test_agent_skill_entrypoints.py::test_shared_issue_contract_requires_duplicate_search_before_issue_creation; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py.