### PR TITLE
Wire anchored synthesis into acquisition and replay

### DIFF
--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -66,6 +66,10 @@ from app.knowledge_acquisition.extraction_registry import (
 from app.knowledge_acquisition.normalize import STAGE_NAME as NORMALIZE_STAGE
 from app.knowledge_acquisition.normalize import STAGE_VERSION as NORMALIZE_STAGE_VERSION
 from app.knowledge_acquisition.normalize import NormalizeError, normalize
+from app.knowledge_acquisition.pipeline_defaults import (
+    DEFAULT_EXTRACTOR_IDS,
+    resolve_extractor_ids,
+)
 from app.knowledge_acquisition.replay import CANDIDATE_STAGE, CANDIDATE_STAGE_VERSION
 from app.knowledge_acquisition.source_bundle import (
     DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
@@ -261,7 +265,7 @@ def acquire_youtube(
     url_or_id: str,
     *,
     vault_context: VaultContext,
-    extractor_ids: Sequence[str] = ("summary",),
+    extractor_ids: Sequence[str] = DEFAULT_EXTRACTOR_IDS,
     extractor_requirements: Mapping[str, str] | None = None,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
     trace_id: str | None = None,
@@ -340,11 +344,14 @@ def acquire_youtube(
 
     normalized_dict = normalized.as_dict()
     raw_record_id = str(outcome.object_id)
+    selected_extractor_ids = resolve_extractor_ids(
+        extractor_ids, extractor_requirements
+    )
     try:
         resolved_requirements = resolve_extractor_requirements(
-            extractor_ids, extractor_requirements
+            selected_extractor_ids, extractor_requirements
         )
-        validate_registered_extractors(list(extractor_ids))
+        validate_registered_extractors(list(selected_extractor_ids))
     except (ValueError, UnknownExtractorError) as exc:
         raise TerminalAcquisitionError(
             f"invalid extractor materialization plan: {exc}"
@@ -386,7 +393,7 @@ def acquire_youtube(
     # --- extracted -------------------------------------------------------------------
     report = run_extractors(
         normalized_dict,
-        extractor_ids=extractor_ids,
+        extractor_ids=selected_extractor_ids,
         extractor_requirements=resolved_requirements,
         raw_record_id=raw_record_id,
         normalized_artifact_id=normalized_artifact.object_id,

--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -75,6 +75,7 @@ from app.events.types import (
     YOUTUBE_SOURCE_DISCOVERED,
 )
 from app.knowledge_acquisition.source_registry import VALID_PRIORITIES as _registry_priorities
+from app.knowledge_acquisition.pipeline_defaults import DEFAULT_EXTRACTOR_IDS
 from app.services.outbox import derive_idempotency_key, write_outbox_event
 
 # --- Contract vocab ----------------------------------------------------------
@@ -1470,7 +1471,7 @@ def drain_one(
             now=now,
             conn=conn,
         )
-    extractor_ids = tuple(raw_extractor_ids) or ("summary",)
+    extractor_ids = tuple(raw_extractor_ids) or DEFAULT_EXTRACTOR_IDS
     raw_extractor_requirements = policy.get("extractor_requirements")
     if raw_extractor_requirements is not None and not isinstance(
         raw_extractor_requirements, dict

--- a/app/knowledge_acquisition/candidate_writeback.py
+++ b/app/knowledge_acquisition/candidate_writeback.py
@@ -400,9 +400,9 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
 
     summary = candidate.summary_text()
     confidence = candidate.summary_confidence()
-    sections: list[ProposalSection] = []
+    summary_sections: list[ProposalSection] = []
     if summary is not None and confidence is not None and candidate.transcript_segment_count > 0:
-        sections.append(
+        summary_sections.append(
             ProposalSection(
                 module_id="summary",
                 title="Summary",
@@ -412,7 +412,7 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
             )
         )
     if candidate.optional_failures:
-        sections.append(
+        summary_sections.append(
             ProposalSection(
                 module_id="extraction-gaps",
                 title="Degraded extraction status",
@@ -426,7 +426,7 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
             )
         )
     if candidate.derived_transcript_link:
-        sections.append(
+        summary_sections.append(
             ProposalSection(
                 module_id="derived-transcript",
                 title="Derived transcript",
@@ -436,7 +436,7 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
                 ),
             )
         )
-    return tuple(sections)
+    return tuple(summary_sections)
 
 
 def _render_anchored_evidence(

--- a/app/knowledge_acquisition/candidate_writeback.py
+++ b/app/knowledge_acquisition/candidate_writeback.py
@@ -54,6 +54,10 @@ from app.knowledge.write_ops import (
     create_candidate_note_once,
 )
 from app.knowledge_acquisition.extraction_registry import ExtractionResult, run_extractor
+from app.knowledge_acquisition.evidence_synthesis import (
+    RenderedEvidence,
+    render_evidence_anchored,
+)
 from app.knowledge_acquisition.note_renderer import (
     NoteRenderError,
     ProposalSection,
@@ -112,6 +116,7 @@ class Candidate:
     extraction_artifact_ids: tuple[str, ...] = ()
     optional_failures: tuple["ExtractionFailure", ...] = ()
     derived_transcript_link: str | None = None
+    rendered_evidence: RenderedEvidence | None = None
 
     def summary_text(self) -> str | None:
         for extraction in self.extractions:
@@ -201,6 +206,11 @@ def assemble_candidate(
                     f"content_identity={content_identity!r}: {exc}"
                 ) from exc
 
+    rendered_evidence = _render_anchored_evidence(
+        normalized=normalized_dict,
+        extractions=extractions,
+    )
+
     return Candidate(
         content_identity=content_identity,
         source_kind=str(source_kind),
@@ -219,6 +229,7 @@ def assemble_candidate(
             result.artifact_id for result in extractions if result.artifact_id is not None
         ),
         optional_failures=tuple(optional_failures),
+        rendered_evidence=rendered_evidence,
     )
 
 
@@ -288,7 +299,14 @@ def render_candidate_note(candidate: Candidate) -> str:
 
     proposal_sections = _candidate_proposal_sections(candidate)
     coverage = (
-        f"{candidate.transcript_segment_count}/{candidate.transcript_segment_count} "
+        (
+            f"{candidate.rendered_evidence.coverage:.1%} transcript segments covered; "
+            f"model confidence {candidate.rendered_evidence.model_confidence:g}; "
+            f"evidence confidence {candidate.rendered_evidence.evidence_confidence:g}; "
+            f"final confidence {candidate.rendered_evidence.confidence:g}"
+        )
+        if candidate.rendered_evidence is not None
+        else f"{candidate.transcript_segment_count}/{candidate.transcript_segment_count} "
         "normalized segments (100%; complete transcript)"
         if candidate.transcript_available and candidate.transcript_segment_count > 0
         else "0 normalized segments; no transcript evidence"
@@ -334,6 +352,52 @@ def render_candidate_note(candidate: Candidate) -> str:
 
 def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection, ...]:
     """Render reviewable extraction outputs without assigning them authority."""
+    if candidate.rendered_evidence is not None:
+        sections: list[ProposalSection] = []
+        if candidate.rendered_evidence.synthesis_sentences:
+            evidence = candidate.rendered_evidence
+            sections.append(
+                ProposalSection(
+                    module_id="evidence-anchored-synthesis",
+                    title="Evidence-anchored synthesis",
+                    content=(
+                        f"**Model confidence (non-authoritative):** {evidence.model_confidence:g}\n\n"
+                        f"**Evidence confidence (non-authoritative):** {evidence.evidence_confidence:g}\n\n"
+                        + "\n".join(f"- {sentence}" for sentence in evidence.synthesis_sentences)
+                    ),
+                )
+            )
+        if candidate.rendered_evidence.claims:
+            claim_lines = ["**Source-bound claims (non-authoritative):**"]
+            for claim in candidate.rendered_evidence.claims:
+                claim_lines.extend(
+                    (
+                        f"- **Source wording:** {claim['source_wording']}",
+                        f"  **System paraphrase:** {claim['system_paraphrase']}",
+                        f"  **Anchors:** {claim['anchors']}",
+                    )
+                )
+            sections.append(
+                ProposalSection(
+                    module_id="evidence-anchored-claims",
+                    title="Evidence-anchored claims",
+                    content="\n".join(claim_lines),
+                )
+            )
+        if candidate.rendered_evidence.dropped:
+            sections.append(
+                ProposalSection(
+                    module_id="evidence-gaps",
+                    title="Unsupported evidence omitted",
+                    content=(
+                        "The following generated assertions were omitted because their evidence "
+                        "anchors were not resolvable: "
+                        + ", ".join(candidate.rendered_evidence.dropped)
+                    ),
+                )
+            )
+        return tuple(sections)
+
     summary = candidate.summary_text()
     confidence = candidate.summary_confidence()
     sections: list[ProposalSection] = []
@@ -373,6 +437,32 @@ def _candidate_proposal_sections(candidate: Candidate) -> tuple[ProposalSection,
             )
         )
     return tuple(sections)
+
+
+def _render_anchored_evidence(
+    *, normalized: Mapping[str, Any], extractions: Sequence[ExtractionResult]
+) -> RenderedEvidence | None:
+    synthesis = next(
+        (result.output for result in extractions if result.extractor_id == "synthesis"),
+        None,
+    )
+    claims = next(
+        (result.output for result in extractions if result.extractor_id == "claims"),
+        None,
+    )
+    if synthesis is None and claims is None:
+        return None
+    synthesis_sentences = (
+        synthesis.get("synthesis_sentences", []) if synthesis is not None else []
+    )
+    claim_items = claims.get("claims", []) if claims is not None else []
+    model_confidence = synthesis.get("model_confidence", 0.0) if synthesis is not None else 0.0
+    return render_evidence_anchored(
+        synthesis_sentences=synthesis_sentences,
+        claims=claim_items,
+        normalized=normalized,
+        model_confidence=model_confidence,
+    )
 
 
 def write_candidate_note(

--- a/app/knowledge_acquisition/evidence_synthesis.py
+++ b/app/knowledge_acquisition/evidence_synthesis.py
@@ -8,6 +8,8 @@ content only after checking that every assertion names a resolvable transcript s
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
+import re
 from typing import Any, Mapping, Sequence
 
 
@@ -19,6 +21,8 @@ class RenderedEvidence:
     claims: tuple[Mapping[str, Any], ...]
     dropped: tuple[str, ...]
     coverage: float
+    model_confidence: float
+    evidence_confidence: float
     confidence: float
     system_language: str
 
@@ -39,8 +43,35 @@ def caption_quality_confidence_cap(acquisition_method: object) -> float:
     if method == "captions_auto":
         return 0.75
     if method == "asr":
-        return 0.6
+        return 0.85
     return 0.5
+
+
+_ENGLISH_MARKERS = frozenset(
+    "a an and are as about by can claim claims contains describes demonstrates evidence "
+    "for from has have in indicates is it its makes may of on provides source supports "
+    "that the their this to with".split()
+)
+_NON_ENGLISH_MARKERS = frozenset(
+    "avec cette dans des est et la le les une que sont ce der die das ein eine ist mit "
+    "el las los una es son con del y het een van zijn".split()
+)
+_TOKEN_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+
+def validate_generated_language(text: str, expected_language: str) -> bool:
+    """Apply a conservative, deterministic D6 gate to generated prose."""
+
+    tokens = {token.casefold() for token in _TOKEN_RE.findall(text)}
+    if not tokens:
+        return False
+    if expected_language == "sv":
+        return bool(tokens & {"och", "att", "som", "för", "inte", "är", "på", "med"}) or bool(
+            set(text) & {"å", "ä", "ö", "Å", "Ä", "Ö"}
+        )
+    if tokens & _NON_ENGLISH_MARKERS:
+        return False
+    return bool(tokens & _ENGLISH_MARKERS)
 
 
 def render_evidence_anchored(
@@ -77,16 +108,22 @@ def render_evidence_anchored(
         else:
             dropped.append("claim")
 
-    asserted = len(synthesis_sentences) + len(claims)
-    retained = len(rendered_sentences) + len(rendered_claims)
-    coverage = retained / asserted if asserted else 0.0
+    covered_segments: set[int] = set()
+    for item in (*synthesis_sentences, *claims):
+        if isinstance(item, Mapping) and _has_resolvable_anchor(item, segments):
+            covered_segments.update(_covered_segment_indices(item))
+    coverage = len(covered_segments) / len(segments) if segments else 0.0
     cap = caption_quality_confidence_cap(normalized.get("acquisition_method"))
-    confidence = min(_finite_unit_interval(model_confidence), cap)
+    bounded_model_confidence = _finite_unit_interval(model_confidence)
+    evidence_confidence = min(cap, coverage)
+    confidence = min(bounded_model_confidence, evidence_confidence)
     return RenderedEvidence(
         synthesis_sentences=tuple(rendered_sentences),
         claims=tuple(rendered_claims),
         dropped=tuple(dropped),
         coverage=coverage,
+        model_confidence=bounded_model_confidence,
+        evidence_confidence=evidence_confidence,
         confidence=confidence,
         system_language=system_language_for(normalized.get("language")),
     )
@@ -111,9 +148,27 @@ def _has_resolvable_anchor(item: Mapping[str, Any], segments: Sequence[object]) 
         segment_start, segment_end = segment.get("start"), segment.get("end")
         if not isinstance(segment_start, (int, float)) or not isinstance(segment_end, (int, float)):
             return False
+        if not math.isfinite(float(start)) or not math.isfinite(float(end)):
+            return False
         if start < segment_start or end > segment_end:
             return False
     return True
+
+
+def validate_resolvable_anchor(anchor: Mapping[str, Any], segments: Sequence[object]) -> bool:
+    """Validate one transcript anchor against its referenced segment bounds."""
+
+    return _has_resolvable_anchor({"anchors": [anchor]}, segments)
+
+
+def _covered_segment_indices(item: Mapping[str, Any]) -> set[int]:
+    return {
+        int(anchor["segment_index"])
+        for anchor in item.get("anchors", ())
+        if isinstance(anchor, Mapping)
+        and isinstance(anchor.get("segment_index"), int)
+        and not isinstance(anchor.get("segment_index"), bool)
+    }
 
 
 def _claim_is_structurally_distinct(claim: Mapping[str, Any]) -> bool:

--- a/app/knowledge_acquisition/extractors/__init__.py
+++ b/app/knowledge_acquisition/extractors/__init__.py
@@ -15,5 +15,6 @@ new module plus one import line here, never a change to the registry or the pipe
 
 from __future__ import annotations
 
-from app.knowledge_acquisition.extractors import summary_extractor as summary_extractor  # noqa: F401
 from app.knowledge_acquisition.extractors import claims_extractor as claims_extractor  # noqa: F401
+from app.knowledge_acquisition.extractors import summary_extractor as summary_extractor  # noqa: F401
+from app.knowledge_acquisition.extractors import synthesis_extractor as synthesis_extractor  # noqa: F401

--- a/app/knowledge_acquisition/extractors/claims_extractor.py
+++ b/app/knowledge_acquisition/extractors/claims_extractor.py
@@ -7,7 +7,11 @@ from typing import Any, Mapping
 from app.components.llm.constrained import CompletionFn, ConstrainedCompletionError, constrained_completion, register_schema
 from app.components.llm.fabric import LLMTaskIntent
 from app.components.llm.router import LLMRouter
-from app.knowledge_acquisition.evidence_synthesis import system_language_for
+from app.knowledge_acquisition.evidence_synthesis import (
+    system_language_for,
+    validate_generated_language,
+    validate_resolvable_anchor,
+)
 from app.knowledge_acquisition.extraction_registry import ExtractionError, ExtractorSpec, register_extractor
 
 EXTRACTOR_ID = "claims"
@@ -56,12 +60,14 @@ def run(normalized: Mapping[str, Any], *, complete: CompletionFn | None = None) 
     except ConstrainedCompletionError as exc:
         raise ExtractionError(extractor_id=EXTRACTOR_ID, version=EXTRACTOR_VERSION, reason=exc.reason) from exc
     segments = normalized["segments"]
+    expected_language = system_language_for(normalized.get("language"))
     for claim in payload["claims"]:
         if claim["source_wording"].strip() == claim["system_paraphrase"].strip():
             raise ExtractionError(extractor_id=EXTRACTOR_ID, version=EXTRACTOR_VERSION, reason="source_wording and system_paraphrase must remain distinct")
+        if not validate_generated_language(claim["system_paraphrase"], expected_language):
+            raise ExtractionError(extractor_id=EXTRACTOR_ID, version=EXTRACTOR_VERSION, reason="system_paraphrase language is not allowed by D6")
         for anchor in claim["anchors"]:
-            index = anchor["segment_index"]
-            if index >= len(segments) or anchor["start"] > anchor["end"]:
+            if not validate_resolvable_anchor(anchor, segments):
                 raise ExtractionError(extractor_id=EXTRACTOR_ID, version=EXTRACTOR_VERSION, reason="claim anchor is not resolvable")
     return payload
 

--- a/app/knowledge_acquisition/extractors/synthesis_extractor.py
+++ b/app/knowledge_acquisition/extractors/synthesis_extractor.py
@@ -1,0 +1,158 @@
+"""Schema-gated, evidence-anchored synthesis extractor for YouTube Source Note v2."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+from app.components.llm.constrained import (
+    CompletionFn,
+    ConstrainedCompletionError,
+    constrained_completion,
+    register_schema,
+)
+from app.components.llm.fabric import LLMTaskIntent
+from app.components.llm.router import LLMRouter
+from app.knowledge_acquisition.evidence_synthesis import (
+    system_language_for,
+    validate_generated_language,
+    validate_resolvable_anchor,
+)
+from app.knowledge_acquisition.extraction_registry import (
+    ExtractionError,
+    ExtractorSpec,
+    register_extractor,
+)
+
+EXTRACTOR_ID = "synthesis"
+EXTRACTOR_VERSION = 1
+TASK_KIND = "extract.synthesis"
+SYNTHESIS_SCHEMA_REF = "knowledge_acquisition.extract.synthesis.v1"
+
+_ANCHOR_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "segment_index": {"type": "integer", "minimum": 0},
+        "start": {"type": "number"},
+        "end": {"type": "number"},
+    },
+    "required": ["segment_index", "start", "end"],
+    "additionalProperties": False,
+}
+_SYNTHESIS_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "synthesis_sentences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string", "minLength": 1},
+                    "anchors": {"type": "array", "minItems": 1, "items": _ANCHOR_SCHEMA},
+                },
+                "required": ["text", "anchors"],
+                "additionalProperties": False,
+            },
+        },
+        "model_confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+    },
+    "required": ["synthesis_sentences", "model_confidence"],
+    "additionalProperties": False,
+}
+register_schema(SYNTHESIS_SCHEMA_REF, _SYNTHESIS_SCHEMA)
+
+
+def _prompt(normalized: Mapping[str, Any]) -> tuple[str, str]:
+    segments = normalized.get("segments")
+    if not isinstance(segments, list) or not segments:
+        raise ExtractionError(
+            extractor_id=EXTRACTOR_ID,
+            version=EXTRACTOR_VERSION,
+            reason="normalized.segments must be a non-empty list",
+        )
+    language = system_language_for(normalized.get("language"))
+    lines: list[str] = []
+    for index, segment in enumerate(segments):
+        if not isinstance(segment, Mapping) or not isinstance(segment.get("text"), str):
+            raise ExtractionError(
+                extractor_id=EXTRACTOR_ID,
+                version=EXTRACTOR_VERSION,
+                reason=f"normalized.segments[{index}] must contain text",
+            )
+        lines.append(f"[{index} {segment.get('start')}..{segment.get('end')}] {segment['text']}")
+    system = (
+        "Return only JSON. Produce concise source-bound synthesis sentences. "
+        f"Generated prose must be in {language}. Every sentence requires one or more exact "
+        "segment_index/start/end anchors contained by the cited transcript segments."
+    )
+    return system, "Transcript:\n" + "\n".join(lines)
+
+
+def run(normalized: Mapping[str, Any], *, complete: CompletionFn | None = None) -> dict[str, Any]:
+    system, user = _prompt(normalized)
+    try:
+        payload = constrained_completion(
+            SYNTHESIS_SCHEMA_REF,
+            system=system,
+            user=user,
+            task_kind=TASK_KIND,
+            complete=complete,
+        )
+    except ConstrainedCompletionError as exc:
+        raise ExtractionError(
+            extractor_id=EXTRACTOR_ID,
+            version=EXTRACTOR_VERSION,
+            reason=exc.reason,
+        ) from exc
+
+    confidence = payload.get("model_confidence")
+    if (
+        not isinstance(confidence, (int, float))
+        or isinstance(confidence, bool)
+        or not math.isfinite(confidence)
+    ):
+        raise ExtractionError(
+            extractor_id=EXTRACTOR_ID,
+            version=EXTRACTOR_VERSION,
+            reason="model_confidence must be a finite number between 0.0 and 1.0",
+        )
+    segments = normalized["segments"]
+    expected_language = system_language_for(normalized.get("language"))
+    for sentence in payload["synthesis_sentences"]:
+        if not validate_generated_language(sentence["text"], expected_language):
+            raise ExtractionError(
+                extractor_id=EXTRACTOR_ID,
+                version=EXTRACTOR_VERSION,
+                reason="synthesis sentence language is not allowed by D6",
+            )
+        if not any(
+            validate_resolvable_anchor(anchor, segments) for anchor in sentence["anchors"]
+        ):
+            raise ExtractionError(
+                extractor_id=EXTRACTOR_ID,
+                version=EXTRACTOR_VERSION,
+                reason="synthesis anchor is not resolvable",
+            )
+    return payload
+
+
+def _model_identity() -> dict[str, str]:
+    route = LLMRouter().route(LLMTaskIntent(task_kind=TASK_KIND, json_schema_required=True))
+    return {"provider": route.provider, "model": route.model}
+
+
+def register(*, complete: CompletionFn | None = None) -> None:
+    register_extractor(
+        ExtractorSpec(
+            extractor_id=EXTRACTOR_ID,
+            version=EXTRACTOR_VERSION,
+            input_content_type="transcript",
+            output_schema_ref=SYNTHESIS_SCHEMA_REF,
+            run=lambda normalized: run(normalized, complete=complete),
+            model_identity=_model_identity,
+        )
+    )
+
+
+register()

--- a/app/knowledge_acquisition/pipeline_defaults.py
+++ b/app/knowledge_acquisition/pipeline_defaults.py
@@ -1,0 +1,28 @@
+"""Shared production defaults for the evidence-bound acquisition pipeline."""
+
+from __future__ import annotations
+
+
+# The old ``summary`` extractor remains available for explicit legacy callers, but production
+# acquisition and replay must not silently publish its free-text output.
+DEFAULT_EXTRACTOR_IDS: tuple[str, ...] = ("synthesis", "claims")
+
+
+def resolve_extractor_ids(
+    extractor_ids: tuple[str, ...] | list[str],
+    extractor_requirements: dict[str, str] | None,
+) -> tuple[str, ...]:
+    """Preserve the pre-anchored shorthand for explicit summary policies.
+
+    Before anchored synthesis became the production default, callers could provide only
+    ``extractor_requirements={"summary": ...}`` and rely on the summary default implicitly.
+    Keep that persisted-policy shape readable while making every unqualified call anchored.
+    """
+    selected = tuple(extractor_ids)
+    if selected == DEFAULT_EXTRACTOR_IDS and extractor_requirements is not None:
+        if set(extractor_requirements) == {"summary"}:
+            return ("summary",)
+    return selected
+
+
+__all__ = ["DEFAULT_EXTRACTOR_IDS", "resolve_extractor_ids"]

--- a/app/knowledge_acquisition/pipeline_defaults.py
+++ b/app/knowledge_acquisition/pipeline_defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 
 # The old ``summary`` extractor remains available for explicit legacy callers, but production
 # acquisition and replay must not silently publish its free-text output.
@@ -9,8 +10,8 @@ DEFAULT_EXTRACTOR_IDS: tuple[str, ...] = ("synthesis", "claims")
 
 
 def resolve_extractor_ids(
-    extractor_ids: tuple[str, ...] | list[str],
-    extractor_requirements: dict[str, str] | None,
+    extractor_ids: Sequence[str],
+    extractor_requirements: Mapping[str, str] | None,
 ) -> tuple[str, ...]:
     """Preserve the pre-anchored shorthand for explicit summary policies.
 

--- a/app/knowledge_acquisition/replay.py
+++ b/app/knowledge_acquisition/replay.py
@@ -79,6 +79,10 @@ from app.knowledge_acquisition.extraction_registry import (
 from app.knowledge_acquisition.normalize import STAGE_NAME as NORMALIZE_STAGE
 from app.knowledge_acquisition.normalize import STAGE_VERSION as NORMALIZE_STAGE_VERSION
 from app.knowledge_acquisition.normalize import NormalizeError, normalize
+from app.knowledge_acquisition.pipeline_defaults import (
+    DEFAULT_EXTRACTOR_IDS,
+    resolve_extractor_ids,
+)
 from app.knowledge_acquisition.raw_record import RawRecordIntegrityError, get_raw_record
 from app.knowledge_acquisition.source_bundle import (
     DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
@@ -243,7 +247,7 @@ def run_replay(
     raw_record_id: str | UUID,
     *,
     vault_context: VaultContext,
-    extractor_ids: Sequence[str] = ("summary",),
+    extractor_ids: Sequence[str] = DEFAULT_EXTRACTOR_IDS,
     extractor_requirements: Mapping[str, str] | None = None,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
     assert_no_source_egress: bool = True,
@@ -315,11 +319,14 @@ def run_replay(
                 f"{content_identity!r}: {exc}"
             ) from exc
         normalized_dict = normalized.as_dict()
+        selected_extractor_ids = resolve_extractor_ids(
+            extractor_ids, extractor_requirements
+        )
         try:
             resolved_requirements = resolve_extractor_requirements(
-                extractor_ids, extractor_requirements
+                selected_extractor_ids, extractor_requirements
             )
-            validate_registered_extractors(list(extractor_ids))
+            validate_registered_extractors(list(selected_extractor_ids))
         except (ValueError, UnknownExtractorError) as exc:
             raise ReplayError(f"invalid extractor materialization plan: {exc}") from exc
         try:
@@ -365,7 +372,7 @@ def run_replay(
         # --- extracted: schema + lineage equivalence -----------------------------------
         report = run_extractors(
             normalized_dict,
-            extractor_ids=extractor_ids,
+                extractor_ids=selected_extractor_ids,
             trace_id=trace_id,
             conn=conn,
             extractor_requirements=resolved_requirements,

--- a/app/knowledge_acquisition/source_registry.py
+++ b/app/knowledge_acquisition/source_registry.py
@@ -63,6 +63,8 @@ from __future__ import annotations
 
 import json
 import math
+
+from app.knowledge_acquisition.pipeline_defaults import DEFAULT_EXTRACTOR_IDS
 import os
 import threading
 import uuid
@@ -367,7 +369,7 @@ def _build_acquisition_policy(collection_kind: str, override: dict[str, Any] | N
         merged["media"] = merged_media
     requirements = merged.get("extractor_requirements")
     if requirements is not None:
-        selected = tuple(merged.get("extractor_ids") or ("summary",))
+        selected = tuple(merged.get("extractor_ids") or DEFAULT_EXTRACTOR_IDS)
         if set(requirements) != set(selected):
             raise SourceRegistryValidationError(
                 "acquisition_policy.extractor_requirements must classify every selected "

--- a/docs/KNOWLEDGE_ACQUISITION/CANDIDATE_WRITEBACK.md
+++ b/docs/KNOWLEDGE_ACQUISITION/CANDIDATE_WRITEBACK.md
@@ -25,8 +25,10 @@ pipeline ends here; triage is human territory.
   `Proposals (non-authoritative)` wrapper, and deterministic evidence/lineage — through
   WriteGuard and the candidate-only create-once knowledge helper (mechanical durable,
   non-authority-bearing write). A durable existing-target probe stays before render and WriteGuard.
-- Composes the delivered `summary@2` result through a pure proposal-section seam. Empty optional
-  modules are omitted; a no-proposals marker replaces empty module headings.
+- Composes production `synthesis@1` and `claims@1` results through pure proposal-section seams.
+  Both outputs are evidence-anchored; invalid language and unresolvable anchors fail before
+  rendering. The legacy `summary@2` extractor remains available for explicit persisted policies.
+  Empty optional modules are omitted; a no-proposals marker replaces empty module headings.
 - Parses generated Markdown before assembly and fails closed when visible prose falsely claims the
   note owner's belief, decision, takeaway, or approval, or when a visible heading impersonates one
   of the three authority bands. Invisible link destinations and valid reference definitions are not
@@ -63,11 +65,11 @@ pipeline ends here; triage is human territory.
 ## Concretely
 
 ```
-candidate(raw=…, extractions=[summary@2]) → vault: Sources/<title>.md
+candidate(raw=…, extractions=[synthesis@1, claims@1]) → vault: Sources/<title>.md
 frontmatter: artifact_class=youtube_source_note, requires_review=true, provenance{…},
 transcript_available=true
 body: Owner notes{Takeaways, Open threads}
-      / Proposals (non-authoritative){Summary when present}
+      / Proposals (non-authoritative){anchored synthesis and claims when present}
       / Evidence and lineage{source URL, content identity, acquisition method,
                              transcript status, deterministic coverage}
 ```

--- a/docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md
+++ b/docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md
@@ -158,6 +158,7 @@ definitive list**):
 | Extractor | Output shape it proves |
 | --- | --- |
 | `summary` | free-text with confidence |
+| `synthesis` | source-bound sentences with transcript-segment anchors and model confidence |
 | `claims` | list of statements with source-position anchors (timestamps) |
 | `entities` | typed references (people, works, technologies) for later SIP linking |
 | `action_items` | task-shaped candidates that must NOT become tasks without triage |

--- a/docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md
+++ b/docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md
@@ -1,4 +1,4 @@
-State: Partially implemented source specification. The explicit-URL fetch/refinement/writeback path is delivered by KA-01..06, including evidence-derived transcript availability, rendered summary confidence, complete normalized-transcript summary input, and authority-banded review-required proposal rendering. Pragmatic discovery V1 is delivered by #3915/#3920: one OAuth account, one ordinary owned playlist selected as Inbox, explicit manual sync, sanitized status, and review-required draft candidates. Liked Videos, multi-playlist product sync, scheduling, subscriptions/RSS/Takeout, backfill, analytics, broad CLI/UI, and full-media work remain target state and are not shipped claims.
+State: Partially implemented source specification. The explicit-URL fetch/refinement/writeback path is delivered by KA-01..06, including evidence-derived transcript availability, anchored synthesis and claims bound to retained transcript segments, deterministic coverage/confidence reporting, and authority-banded review-required proposal rendering. Pragmatic discovery V1 is delivered by #3915/#3920: one OAuth account, one ordinary owned playlist selected as Inbox, explicit manual sync, sanitized status, and review-required draft candidates. Liked Videos, multi-playlist product sync, scheduling, subscriptions/RSS/Takeout, backfill, analytics, broad CLI/UI, and full-media work remain target state and are not shipped claims.
 Doc role: Source instance specification
 Authority: Instantiates `SOURCE_PLUGIN_CONTRACT.md` for YouTube. Mechanism choices are grounded in `RESEARCH_2026-07.md` (mid-2026 verification). The triage flow for the resulting artifacts is owned by `docs/CONTEXTUALIZATION_LAYER/INGESTION_AND_TRIAGE_POLICY.md` §4.3; the artifact class by `LIFE_WIDE_ARTIFACT_TAXONOMY.md` (`youtube_source_note`).
 
@@ -83,8 +83,9 @@ The candidate stage writes a `youtube_source_note` companion artifact based on t
 template (`docs/examples/vault-templates/youtube-source-note.md`). Metadata, provenance, and
 `transcript_available` remain in frontmatter. The body has exactly three authority bands:
 owner-authored takeaways/open threads, one `Proposals (non-authoritative)` wrapper for registered
-extraction output, and deterministic evidence/lineage. The delivered `summary@2` output is the
-only current proposal module; blank optional modules are omitted. Generated content never enters
+extraction output, and deterministic evidence/lineage. Production acquisition renders anchored
+`synthesis@1` and `claims@1` modules; explicit legacy `summary@2` policies remain supported.
+Generated content never enters
 the owner band, and first-write-wins replay leaves every byte of an existing note unchanged.
 
 Every runtime candidate carrying generated content receives the initial non-authoritative posture
@@ -108,9 +109,10 @@ The shipped candidate writeback now corrects the three confirmed V1 truth defect
 - `transcript_available` is derived from usable normalized segments; a valid empty ASR result
   renders `false` and does not run transcript-dependent summary extraction. Captionless acquisition
   remains a loud normalization failure.
-- each rendered summary shows its schema-validated model confidence as non-authoritative.
-- summary input contains every normalized segment, and the rendered note reports the complete
-  segment count rather than hiding a partial window.
+- anchored synthesis shows schema-validated model confidence plus deterministic evidence
+  confidence derived from referenced transcript segments.
+- synthesis and claims input contains every normalized segment; coverage counts unique referenced
+  transcript segments, and unsupported anchorless output is omitted before rendering.
 
 The delivered YSNV2-03 renderer replaces the fixed About/Summary/Takeaways body with the three
 authority bands above. It fails closed when visible generated Markdown claims the owner's belief,
@@ -149,8 +151,8 @@ Acceptance criteria (each needs a concrete `Verify:` target when issues are file
       (dedup), not a duplicate.
 - [ ] `normalized` transcript: deduplicated rolling cues, timestamps preserved, language detected
       and marked as detected.
-- [ ] One extractor (e.g. `summary`) produces schema-valid output registered per the extraction
-      registry; schema mismatch fails loudly.
+- [x] Anchored `synthesis` and `claims` extractors produce schema-valid output registered per the
+      extraction registry; language and anchor violations fail loudly.
 - [ ] Candidate written back as a `youtube_source_note` companion artifact with the mandated
       non-authoritative posture markers (`requires_review: true` + `review_state: draft` — see
       §Writeback, including the template-frontmatter extension shipped in the same slice) and full

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -30,7 +30,7 @@ from app.knowledge_acquisition.acquire import (
 from app.knowledge.write_ops import write_note_relative
 from app.knowledge_acquisition.candidate_writeback import Candidate, write_candidate_note
 from app.knowledge_acquisition.extraction_registry import clear_registry
-from app.knowledge_acquisition.extractors import summary_extractor
+from app.knowledge_acquisition.extractors import claims_extractor, summary_extractor, synthesis_extractor
 from app.knowledge_acquisition.stage_events import (
     STAGE_COMPLETED_TOPIC,
     STAGE_DEAD_LETTERED_TOPIC,
@@ -104,9 +104,33 @@ def _reset_registry():
             json.dumps({"summary": "A deterministic test summary.", "confidence": 0.75})
         )
     )
+    synthesis_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "synthesis_sentences": [{
+                    "text": "The transcript describes a deterministic test.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }],
+                "model_confidence": 0.8,
+            })
+        )
+    )
+    claims_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "claims": [{
+                    "source_wording": "Hello world",
+                    "system_paraphrase": "The source opens with a greeting.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }]
+            })
+        )
+    )
     yield
     clear_registry()
     summary_extractor.register()
+    synthesis_extractor.register()
+    claims_extractor.register()
 
 
 @pytest.fixture(autouse=True)
@@ -190,9 +214,28 @@ def _denying_guard() -> WriteGuard:
     return WriteGuard(lambda: {"state": "safe_mode", "reason": "runtime degraded (test)"})
 
 
+def test_normal_acquisition_produces_anchored_synthesis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_caption_fetch(monkeypatch)
+    receipt = acquire_youtube(
+        FAKE_URL,
+        vault_context=_vault(tmp_path / "vault"),
+        write_guard=_allowing_guard(),
+        conn=FakeOutboxConn(),
+    )
+
+    assert receipt.ok is True
+    note = next((tmp_path / "vault").rglob("*.md")).read_text(encoding="utf-8")
+    assert "### Evidence-anchored synthesis" in note
+    assert "### Evidence-anchored claims" in note
+    assert "### Summary" not in note
+    assert "The transcript describes a deterministic test." in note
+
+
 # ---------------------------------------------------------------------------
 # AC1: end-to-end new-URL acquisition — fetch -> persist raw -> normalize ->
-# extract(summary) -> candidate note written, one stage event per transition.
+# extract(synthesis + claims) -> candidate note written, one stage event per transition.
 # ---------------------------------------------------------------------------
 
 
@@ -213,7 +256,7 @@ def test_acquire_youtube_end_to_end_writes_candidate_and_emits_events(
     assert receipt.is_new_raw is True
 
     stage_names = [s.stage for s in receipt.stages]
-    assert stage_names == ["raw", "normalize", "extracted", "candidate"]
+    assert stage_names == ["raw", "normalize", "extracted", "extracted", "candidate"]
 
     candidate_stage = next(s for s in receipt.stages if s.stage == "candidate")
     assert candidate_stage.status == "written"
@@ -226,14 +269,14 @@ def test_acquire_youtube_end_to_end_writes_candidate_and_emits_events(
     transcript = next(path for path in notes if path.name == "transcript.md")
     manifest = transcript.with_name("source.json")
     transcript_rel = transcript.relative_to(vault.active_vault_path).as_posix()
-    assert f"[[{transcript_rel}]]" in candidate_body
+    assert f"- **Derived transcript:** {transcript_rel}" in candidate_body
     assert manifest.exists()
 
-    # One stage.completed event per real transition (normalize, extracted, candidate).
+    # One stage.completed event per real transition (normalize, each extractor, candidate).
     completed = conn.rows_for(STAGE_COMPLETED_TOPIC)
     stages_seen = {json.loads(r["payload"])["payload"]["stage"] for r in completed}
     assert stages_seen == {"normalize", "extracted", "candidate"}
-    assert len(completed) == 3  # exactly one per transition, no duplicates
+    assert len(completed) == 4  # exactly one per transition, no duplicates
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +331,7 @@ def test_acquire_youtube_rerun_is_idempotent_dedup_noop(
 
     # Stage-completed events deduped: re-running an unchanged item does not mint new rows.
     completed = conn.rows_for(STAGE_COMPLETED_TOPIC)
-    assert len(completed) == 3  # still exactly 3: normalize + extracted + candidate, deduped
+    assert len(completed) == 4  # normalize + synthesis + claims + candidate, deduped
 
 
 def test_acquire_youtube_asr_dedup_skips_reacquisition(
@@ -456,6 +499,7 @@ def test_acquire_valid_empty_asr_blocks_candidate_when_summary_is_required(
     receipt = acquire_youtube(
         FAKE_URL,
         vault_context=vault,
+        extractor_ids=("summary",),
         write_guard=_allowing_guard(),
         conn=conn,
         fetch_fn=lambda _url: outcome,
@@ -508,6 +552,7 @@ def test_acquire_valid_empty_asr_materializes_degraded_when_summary_is_optional(
 
     receipt = acquire_youtube(
         FAKE_URL,
+        extractor_ids=("summary",),
         vault_context=vault,
         extractor_requirements={"summary": "optional_for_materialization"},
         write_guard=_allowing_guard(),
@@ -837,6 +882,7 @@ def test_ordinary_extractor_version_upgrade_writes_proposal_without_overwrite(
     )
     upgraded = acquire_youtube(
         FAKE_URL,
+        extractor_ids=("summary",),
         vault_context=vault,
         write_guard=_allowing_guard(),
         conn=conn,

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -41,7 +41,11 @@ from app.knowledge_acquisition.acquisition_requests import (
     reset_memory_acquisition_requests,
 )
 from app.knowledge_acquisition.extraction_registry import clear_registry
-from app.knowledge_acquisition.extractors import summary_extractor
+from app.knowledge_acquisition.extractors import (
+    claims_extractor,
+    summary_extractor,
+    synthesis_extractor,
+)
 from app.services.outbox import write_outbox_event
 from app.events.models import new_event
 from app.vault.manager import VaultContext
@@ -77,9 +81,33 @@ _VALID_SUMMARY = json.dumps({"summary": "A deterministic test summary.", "confid
 def _reset_registry():
     clear_registry()
     summary_extractor.register(complete=_stub_completion(_VALID_SUMMARY))
+    synthesis_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "synthesis_sentences": [{
+                    "text": "The transcript describes a deterministic test.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }],
+                "model_confidence": 0.8,
+            })
+        )
+    )
+    claims_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "claims": [{
+                    "source_wording": "Hello world",
+                    "system_paraphrase": "The source opens with a greeting.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }]
+            })
+        )
+    )
     yield
     clear_registry()
     summary_extractor.register()
+    synthesis_extractor.register()
+    claims_extractor.register()
 
 
 @pytest.fixture(autouse=True)
@@ -290,7 +318,11 @@ def test_drain_one_requeues_private_youtube_plugin_failure(
     """Expected inaccessible-source failures never strand a claimed request."""
     conn = FakeOutboxConn()
     q = _queue()
-    _enqueue(q, conn)
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "extractor_ids": ["summary"]},
+    )
     claimed = q.claim_batch(1, conn=conn)
 
     monkeypatch.setattr(
@@ -326,7 +358,11 @@ def test_drain_one_sanitizes_transient_youtube_plugin_failure(
     """Transient caption egress is retryable and stores no provider detail."""
     conn = FakeOutboxConn()
     q = _queue()
-    _enqueue(q, conn)
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "extractor_ids": ["summary"]},
+    )
     claimed = q.claim_batch(1, conn=conn)
     _stub_caption_fetch(monkeypatch)
     monkeypatch.setattr(
@@ -400,7 +436,11 @@ def test_drain_one_maps_pipeline_dead_letter(
     summary_extractor.register(complete=_stub_completion("not json at all"))
     conn = FakeOutboxConn()
     q = _queue()
-    _enqueue(q, conn)
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "extractor_ids": ["summary"]},
+    )
     claimed = q.claim_batch(1, conn=conn)
 
     result = drain_one(
@@ -468,7 +508,12 @@ def test_dead_letter_item_scoped_and_attempts_exhaustion(
     _stub_caption_fetch(monkeypatch)
     clear_registry()
     summary_extractor.register(complete=_stub_completion("not json at all"))
-    row_a = _enqueue(q, conn, item=VIDEO_ID)
+    row_a = _enqueue(
+        q,
+        conn,
+        item=VIDEO_ID,
+        policy_snapshot={"policy_version": 1, "extractor_ids": ["summary"]},
+    )
     claimed = q.claim_batch(1, conn=conn)
     dead = drain_one(claimed[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
     assert dead.status == "dead_lettered"
@@ -482,7 +527,14 @@ def test_dead_letter_item_scoped_and_attempts_exhaustion(
     monkeypatch.setattr(plugin, "yt_dlp_extract_info", lambda url: info_b)
     clear_registry()
     summary_extractor.register(complete=_stub_completion(_VALID_SUMMARY))
-    row_b = _enqueue(q, conn, item="lmnopqrstuv", binding=BINDING_OWNED, kind="owned_playlist")
+    row_b = _enqueue(
+        q,
+        conn,
+        item="lmnopqrstuv",
+        binding=BINDING_OWNED,
+        kind="owned_playlist",
+        policy_snapshot={"policy_version": 1, "extractor_ids": ["summary"]},
+    )
     assert q.get(row_b.request_id).status == "pending"
     claimed_b = q.claim_batch(1, conn=conn)
     assert [c.request_id for c in claimed_b] == [row_b.request_id]

--- a/tests/knowledge_acquisition/test_claims_extractor.py
+++ b/tests/knowledge_acquisition/test_claims_extractor.py
@@ -35,3 +35,16 @@ def test_claim_wording_and_paraphrase_are_structurally_distinct() -> None:
     payload["claims"][0]["system_paraphrase"] = "Le texte source."
     with pytest.raises(ExtractionError, match="must remain distinct"):
         run(NORMALIZED, complete=_completion(json.dumps(payload)))
+
+
+def test_non_swedish_paraphrase_language_is_rejected() -> None:
+    payload = {
+        "claims": [{
+            "source_wording": "The source wording.",
+            "system_paraphrase": "Le texte source est important.",
+            "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+        }]
+    }
+
+    with pytest.raises(ExtractionError, match="system_paraphrase language"):
+        run(NORMALIZED, complete=_completion(json.dumps(payload)))

--- a/tests/knowledge_acquisition/test_evidence_synthesis.py
+++ b/tests/knowledge_acquisition/test_evidence_synthesis.py
@@ -30,16 +30,30 @@ def test_renderer_drops_anchorless_claims_and_synthesis_sentences() -> None:
     assert rendered.dropped == ("synthesis_sentence", "claim")
 
 
-def test_synthesis_reports_coverage_and_caption_quality_confidence_cap() -> None:
+def test_synthesis_coverage_uses_transcript_evidence_spans() -> None:
+    normalized = {
+        **NORMALIZED,
+        "segments": [
+            {"start": float(index), "end": float(index + 1), "text": f"Segment {index}."}
+            for index in range(100)
+        ],
+    }
     rendered = render_evidence_anchored(
-        normalized=NORMALIZED,
+        normalized=normalized,
         model_confidence=0.95,
-        synthesis_sentences=({"text": "Anchored.", "anchors": [ANCHOR]},),
+        synthesis_sentences=(
+            {
+                "text": "Anchored.",
+                "anchors": [{"segment_index": 0, "start": 0.0, "end": 1.0}],
+            },
+        ),
         claims=(),
     )
 
-    assert rendered.coverage == 1.0
-    assert rendered.confidence == 0.75
+    assert rendered.coverage == 0.01
+    assert rendered.model_confidence == 0.95
+    assert rendered.evidence_confidence == 0.01
+    assert rendered.confidence == 0.01
 
 
 def test_synthesis_language_policy_uses_english_unless_source_is_swedish_and_preserves_quotes() -> None:

--- a/tests/knowledge_acquisition/test_extraction_persistence.py
+++ b/tests/knowledge_acquisition/test_extraction_persistence.py
@@ -25,7 +25,11 @@ from app.knowledge_acquisition.extraction_registry import (
     clear_registry,
     run_extractor,
 )
-from app.knowledge_acquisition.extractors import summary_extractor
+from app.knowledge_acquisition.extractors import (
+    claims_extractor,
+    summary_extractor,
+    synthesis_extractor,
+)
 from app.knowledge_acquisition.normalize import normalize
 from app.knowledge_acquisition.raw_record import persist_raw_record
 from app.knowledge_acquisition.replay import run_replay
@@ -55,9 +59,29 @@ def _isolated_runtime(monkeypatch: pytest.MonkeyPatch):
     summary_extractor.register(
         complete=_completion({"summary": "Durable summary.", "confidence": 0.8})
     )
+    synthesis_extractor.register(
+        complete=_completion({
+            "synthesis_sentences": [{
+                "text": "The transcript describes a durable test.",
+                "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+            }],
+            "model_confidence": 0.8,
+        })
+    )
+    claims_extractor.register(
+        complete=_completion({
+            "claims": [{
+                "source_wording": "Hello world",
+                "system_paraphrase": "The source opens with a greeting.",
+                "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+            }]
+        })
+    )
     yield
     clear_registry()
     summary_extractor.register()
+    synthesis_extractor.register()
+    claims_extractor.register()
     object_store_module._MEMORY_STORE.clear()
     reset_store_backends()
 
@@ -254,7 +278,9 @@ def test_reextraction_writes_versioned_proposal_companion_without_overwriting_ca
     assert candidate_stage.status == "proposal_written"
     assert candidate_stage.artifact_path is not None
     first_proposal = Path(vault.active_vault_path) / candidate_stage.artifact_path
-    assert "Durable summary." in first_proposal.read_text(encoding="utf-8")
+    assert "The transcript describes a durable test." in first_proposal.read_text(
+        encoding="utf-8"
+    )
 
     assert candidate_stage.artifact_path is not None
     proposal = Path(vault.active_vault_path) / candidate_stage.artifact_path

--- a/tests/knowledge_acquisition/test_playlist_discovery.py
+++ b/tests/knowledge_acquisition/test_playlist_discovery.py
@@ -26,7 +26,11 @@ from app.knowledge_acquisition.acquisition_requests import (
     reset_memory_acquisition_requests,
 )
 from app.knowledge_acquisition.extraction_registry import clear_registry
-from app.knowledge_acquisition.extractors import summary_extractor
+from app.knowledge_acquisition.extractors import (
+    claims_extractor,
+    summary_extractor,
+    synthesis_extractor,
+)
 from app.knowledge_acquisition.playlist_discovery import (
     SourcePollPersistenceError,
     V1InboxConfigurationError,
@@ -182,12 +186,33 @@ def _memory_backends(monkeypatch: pytest.MonkeyPatch):
     reset_memory_acquisition_requests()
     object_store_module._MEMORY_STORE.clear()
     clear_registry()
+    synthesis_extractor.register(
+        complete=lambda **_kwargs: json.dumps({
+            "synthesis_sentences": [{
+                "text": "The transcript describes a deterministic test.",
+                "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+            }],
+            "model_confidence": 0.8,
+        })
+    )
+    claims_extractor.register(
+        complete=lambda **_kwargs: json.dumps({
+            "claims": [{
+                "source_wording": "Hello world",
+                "system_paraphrase": "The source opens with a greeting.",
+                "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+            }]
+        })
+    )
     yield
     clear_registry()
     reset_store_backends()
     reset_memory_source_registry()
     reset_memory_acquisition_requests()
     object_store_module._MEMORY_STORE.clear()
+    synthesis_extractor.register()
+    claims_extractor.register()
+    summary_extractor.register()
 
 
 @pytest.fixture

--- a/tests/knowledge_acquisition/test_replay.py
+++ b/tests/knowledge_acquisition/test_replay.py
@@ -31,7 +31,7 @@ from app.knowledge_acquisition.candidate_writeback import (
     write_candidate_note,
 )
 from app.knowledge_acquisition.extraction_registry import clear_registry
-from app.knowledge_acquisition.extractors import summary_extractor
+from app.knowledge_acquisition.extractors import claims_extractor, summary_extractor, synthesis_extractor
 from app.knowledge_acquisition.normalize import normalize
 from app.knowledge_acquisition.raw_record import (
     persist_raw_record,
@@ -139,9 +139,33 @@ def _reset_registry():
             json.dumps({"summary": "A deterministic test summary.", "confidence": 0.75})
         )
     )
+    synthesis_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "synthesis_sentences": [{
+                    "text": "The transcript describes a deterministic test.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }],
+                "model_confidence": 0.8,
+            })
+        )
+    )
+    claims_extractor.register(
+        complete=_stub_completion(
+            json.dumps({
+                "claims": [{
+                    "source_wording": "Hello world",
+                    "system_paraphrase": "The source opens with a greeting.",
+                    "anchors": [{"segment_index": 0, "start": 0.0, "end": 2.0}],
+                }]
+            })
+        )
+    )
     yield
     clear_registry()
     summary_extractor.register()
+    synthesis_extractor.register()
+    claims_extractor.register()
 
 
 def _vault(root: Path) -> VaultContext:
@@ -200,7 +224,8 @@ def test_replay_fresh_write_not_equivalent_then_preserved(tmp_path: Path) -> Non
     assert second.source_egress == 0
     assert second.equivalent is True
 
-    stages = {s.stage: s for s in second.stages}
+    stages = {s.stage: s for s in second.stages if s.stage != "extracted"}
+    extracted = [s for s in second.stages if s.stage == "extracted"]
 
     # normalize: byte-identical equivalence, asserted deterministic.
     assert stages["normalize"].equivalence == "byte_identical"
@@ -211,9 +236,9 @@ def test_replay_fresh_write_not_equivalent_then_preserved(tmp_path: Path) -> Non
     assert n1 == n2
 
     # extracted: schema + lineage equivalence (NOT byte-identical text).
-    assert stages["extracted"].equivalence == "schema_and_lineage"
-    assert stages["extracted"].extractor_id == "summary"
-    assert stages["extracted"].extractor_version == 2
+    assert {s.extractor_id for s in extracted} == {"synthesis", "claims"}
+    assert all(s.equivalence == "schema_and_lineage" for s in extracted)
+    assert {s.extractor_version for s in extracted} == {1}
 
     # candidate: first-write-wins, with the fresh re-extraction surfaced as a companion proposal.
     assert stages["candidate"].status == "proposal_written"
@@ -344,6 +369,7 @@ def test_replay_valid_empty_asr_blocks_candidate_when_summary_is_required(
     receipt = run_replay(
         str(persisted.object_id),
         vault_context=vault,
+        extractor_ids=("summary",),
         write_guard=_allowing_guard(),
         conn=conn,
     )


### PR DESCRIPTION
Governing-Issue: #4994

Fixes #4994

Final-Review-Rounds: 0

## Summary
Normal YouTube acquisition and replay now use evidence-anchored synthesis and claims by default. Transcript-segment coverage, confidence, language, and anchor validity are enforced before candidate persistence/rendering, while explicit legacy summary policies remain supported.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was routed; the issue and PR are the canonical delivery surfaces.

## Notes
Validation: `python3 -m pytest -q tests/knowledge_acquisition` (331 passed, 4 database-marked skips); exact issue verification targets (3 passed); `ruff check app/knowledge_acquisition tests/knowledge_acquisition`; `git diff --check`; `python3 scripts/docs_guard.py`.

Owner-doc truth surfaces updated: `CANDIDATE_WRITEBACK.md`, `YOUTUBE_SOURCE_SPEC.md`, and `REFINEMENT_PIPELINE_CONTRACT.md`.
---