### PR TITLE
Admit Builder Vault working artifacts with provenance

### DIFF
--- a/app/builderops/boundary.py
+++ b/app/builderops/boundary.py
@@ -17,6 +17,7 @@ AUTONOMOUS_AGENT_SAFE_OPERATIONS = frozenset({
     "list_records",
     "read_record",
     "create_agent_worklog",
+    "create_working_artifact",
     "create_learning_signal",
     "create_promotion_intent",
     "append_receipt",
@@ -34,6 +35,7 @@ BUILDEROPS_MCP_TOOL_NAMES = frozenset({
     f"{BUILDEROPS_MCP_TOOL_PREFIX}list_records",
     f"{BUILDEROPS_MCP_TOOL_PREFIX}read_record",
     f"{BUILDEROPS_MCP_TOOL_PREFIX}create_worklog",
+    f"{BUILDEROPS_MCP_TOOL_PREFIX}create_working_artifact",
     f"{BUILDEROPS_MCP_TOOL_PREFIX}create_learning_signal",
     f"{BUILDEROPS_MCP_TOOL_PREFIX}create_promotion_intent",
     f"{BUILDEROPS_MCP_TOOL_PREFIX}append_receipt",
@@ -97,6 +99,9 @@ class BuilderOpsBoundary:
     def create_agent_worklog(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         return self._store.create_agent_worklog(**dict(payload))
 
+    def create_working_artifact(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        return self._store.create_working_artifact(**dict(payload))
+
     def create_learning_signal(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         return self._store.create_learning_signal(**dict(payload))
 
@@ -129,6 +134,8 @@ def execute_builderops_mcp_tool(
         return {"status": "ok", "record": boundary.read_record(str(args["record_id"]))}
     if tool_name == f"{BUILDEROPS_MCP_TOOL_PREFIX}create_worklog":
         return {"status": "ok", "record": boundary.create_agent_worklog(args)}
+    if tool_name == f"{BUILDEROPS_MCP_TOOL_PREFIX}create_working_artifact":
+        return {"status": "ok", "record": boundary.create_working_artifact(args)}
     if tool_name == f"{BUILDEROPS_MCP_TOOL_PREFIX}create_learning_signal":
         return {"status": "ok", "record": boundary.create_learning_signal(args)}
     if tool_name == f"{BUILDEROPS_MCP_TOOL_PREFIX}create_promotion_intent":

--- a/app/builderops/models.py
+++ b/app/builderops/models.py
@@ -93,6 +93,7 @@ PROMOTION_TARGET_ALIASES: dict[str, str] = {
 
 OBJECT_PREFIXES = {
     "AgentWorklog": "awl",
+    "BuilderVaultWorkingArtifact": "work",
     "LearningSignal": "lrn",
     "RetroCluster": "retro",
     "BuilderDecision": "dec",
@@ -108,6 +109,12 @@ OBJECT_DEFAULTS: dict[str, JsonDict] = {
         "lifecycle_state": "active",
         "promotion_status": "none",
         "task_context": {},
+        "receipt_refs": [],
+    },
+    "BuilderVaultWorkingArtifact": {
+        "authority_class": "raw",
+        "lifecycle_state": "active",
+        "promotion_status": "none",
         "receipt_refs": [],
     },
     "LearningSignal": {
@@ -156,6 +163,7 @@ OBJECT_DEFAULTS: dict[str, JsonDict] = {
 
 ALLOWED_AUTHORITY_BY_TYPE: dict[str, frozenset[str]] = {
     "AgentWorklog": frozenset({"raw", "operational"}),
+    "BuilderVaultWorkingArtifact": frozenset({"raw", "analytical"}),
     "LearningSignal": frozenset({"operational", "analytical"}),
     "RetroCluster": frozenset({"analytical"}),
     "BuilderDecision": frozenset({"decision"}),
@@ -170,6 +178,16 @@ ALLOWED_LIFECYCLE_BY_TYPE: dict[str, frozenset[str]] = {
         "draft",
         "active",
         "review_pending",
+        "promoted",
+        "archived",
+        "discarded",
+        "superseded",
+    }),
+    "BuilderVaultWorkingArtifact": frozenset({
+        "draft",
+        "active",
+        "review_pending",
+        "accepted",
         "promoted",
         "archived",
         "discarded",
@@ -247,6 +265,27 @@ REQUIRED_FIELDS: dict[str, frozenset[str]] = {
         "summary",
         "body",
         "task_context",
+        "receipt_refs",
+    }),
+    "BuilderVaultWorkingArtifact": frozenset({
+        "id",
+        "object_type",
+        "authority_class",
+        "lifecycle_state",
+        "promotion_status",
+        "created_at",
+        "updated_at",
+        "created_by",
+        "source_refs",
+        "summary",
+        "body",
+        "authority_standing",
+        "derivation_role",
+        "durability_posture",
+        "working_lifecycle_stage",
+        "promotion_posture",
+        "location_context",
+        "provenance",
         "receipt_refs",
     }),
     "LearningSignal": frozenset({
@@ -389,6 +428,31 @@ SOURCE_REF_LIST_FIELDS = frozenset({
 # "handled" while the underlying defect stays unrepaired.
 TERMINAL_SIGNAL_LIFECYCLE_STATES = frozenset({"discarded", "superseded"})
 SUCCESSOR_REF_TYPES = frozenset({"github_issue", "github_pr", "promotion_intent"})
+WORKING_ARTIFACT_TERMINAL_STATES = frozenset({"archived", "discarded", "superseded"})
+WORKING_ARTIFACT_CLASSIFICATION_VALUES = {
+    "derivation_role": frozenset({"source", "derived", "projection", "unknown"}),
+    "durability_posture": frozenset({"durable", "ephemeral", "rebuildable", "unknown"}),
+    "working_lifecycle_stage": frozenset({
+        "capture", "explore", "synthesize", "propose", "promote", "implement", "verify",
+        "supersede_retire", "unknown",
+    }),
+    "promotion_posture": frozenset({
+        "not_promoted", "proposed", "promoted", "superseded", "retired", "unknown",
+    }),
+}
+WORKING_ARTIFACT_PROVENANCE_FIELDS = frozenset({
+    "source_refs",
+    "derived_from",
+    "transformation",
+    "actor_or_process",
+    "observed_at",
+    "source_versions_or_watermarks",
+    "review_or_decision_ref",
+    "promotion_ref",
+    "supersedes_refs",
+    "receipt_refs",
+    "limitations",
+})
 
 
 class BuilderOpsValidationError(ValueError):
@@ -514,6 +578,7 @@ def normalize_record(record: Mapping[str, Any]) -> JsonDict:
             validate_nonempty_list(data[field], field)
     validate_source_refs(data["source_refs"])
     validate_terminal_signal_successor(data)
+    validate_working_artifact(data)
     return data
 
 
@@ -548,3 +613,55 @@ def validate_terminal_signal_successor(record: Mapping[str, Any]) -> None:
             f"'{record.get('lifecycle_state')}' requires at least one "
             f"successor_refs entry with ref_type in: {allowed}"
         )
+
+
+def validate_working_artifact(record: Mapping[str, Any]) -> None:
+    """Keep Builder Vault working material explicitly non-authoritative and traceable."""
+
+    if record.get("object_type") != "BuilderVaultWorkingArtifact":
+        return
+    if record.get("authority_standing") != "non_normative":
+        raise BuilderOpsValidationError(
+            "BuilderVaultWorkingArtifact authority_standing must be non_normative"
+        )
+    for field, allowed in WORKING_ARTIFACT_CLASSIFICATION_VALUES.items():
+        if record.get(field) not in allowed:
+            raise BuilderOpsValidationError(
+                f"BuilderVaultWorkingArtifact {field} must be one of: {', '.join(sorted(allowed))}"
+            )
+    if not isinstance(record.get("location_context"), str) or not record["location_context"].strip():
+        raise BuilderOpsValidationError(
+            "BuilderVaultWorkingArtifact location_context must be explicit"
+        )
+    provenance = record.get("provenance")
+    if not isinstance(provenance, Mapping):
+        raise BuilderOpsValidationError("BuilderVaultWorkingArtifact provenance must be an object")
+    missing = sorted(
+        field for field in WORKING_ARTIFACT_PROVENANCE_FIELDS
+        if field not in provenance or provenance[field] in (None, "")
+    )
+    if missing:
+        raise BuilderOpsValidationError(
+            "BuilderVaultWorkingArtifact provenance missing required field(s): "
+            + ", ".join(missing)
+        )
+    for field in ("source_refs", "derived_from"):
+        value = provenance[field]
+        if value != ["unknown"]:
+            validate_source_refs(value, f"provenance.{field}")
+    for field in ("source_versions_or_watermarks", "supersedes_refs", "receipt_refs", "limitations"):
+        value = provenance[field]
+        if not isinstance(value, list) or not value:
+            raise BuilderOpsValidationError(
+                f"BuilderVaultWorkingArtifact provenance.{field} must be a non-empty list or explicit unknown"
+            )
+    terminal = record.get("lifecycle_state") in WORKING_ARTIFACT_TERMINAL_STATES
+    rejected = record.get("promotion_status") == "rejected"
+    if terminal or rejected:
+        successors = record.get("successor_refs")
+        if not isinstance(successors, list) or not successors:
+            raise BuilderOpsValidationError(
+                "BuilderVaultWorkingArtifact terminal or rejected-promotion disposition "
+                "requires successor_refs with the successor or outcome evidence"
+            )
+        validate_source_refs(successors, "successor_refs")

--- a/app/builderops/models.py
+++ b/app/builderops/models.py
@@ -188,7 +188,6 @@ ALLOWED_LIFECYCLE_BY_TYPE: dict[str, frozenset[str]] = {
         "active",
         "review_pending",
         "accepted",
-        "promoted",
         "archived",
         "discarded",
         "superseded",
@@ -437,7 +436,7 @@ WORKING_ARTIFACT_CLASSIFICATION_VALUES = {
         "supersede_retire", "unknown",
     }),
     "promotion_posture": frozenset({
-        "not_promoted", "proposed", "promoted", "superseded", "retired", "unknown",
+        "not_promoted", "proposed", "superseded", "retired", "unknown",
     }),
 }
 WORKING_ARTIFACT_PROVENANCE_FIELDS = frozenset({
@@ -623,6 +622,15 @@ def validate_working_artifact(record: Mapping[str, Any]) -> None:
     if record.get("authority_standing") != "non_normative":
         raise BuilderOpsValidationError(
             "BuilderVaultWorkingArtifact authority_standing must be non_normative"
+        )
+    if (
+        record.get("lifecycle_state") == "promoted"
+        or record.get("promotion_status") == "promoted"
+        or record.get("promotion_posture") == "promoted"
+    ):
+        raise BuilderOpsValidationError(
+            "BuilderVaultWorkingArtifact cannot claim promotion; create a PromotionIntent "
+            "and use the promotion gateway with target, review, and receipt evidence"
         )
     for field, allowed in WORKING_ARTIFACT_CLASSIFICATION_VALUES.items():
         if record.get(field) not in allowed:

--- a/app/builderops/store.py
+++ b/app/builderops/store.py
@@ -177,6 +177,9 @@ class SqliteBuilderOpsStore:
     def create_agent_worklog(self, **fields: Any) -> dict[str, Any]:
         return self.create_record({"object_type": "AgentWorklog", **fields})
 
+    def create_working_artifact(self, **fields: Any) -> dict[str, Any]:
+        return self.create_record({"object_type": "BuilderVaultWorkingArtifact", **fields})
+
     def create_learning_signal(self, **fields: Any) -> dict[str, Any]:
         return self.create_record({"object_type": "LearningSignal", **fields})
 
@@ -578,6 +581,30 @@ class SqliteBuilderOpsStore:
 def _minimal_probe_fields(object_type: str) -> dict[str, Any]:
     if object_type == "AgentWorklog":
         return {"body": "probe", "task_context": {}}
+    if object_type == "BuilderVaultWorkingArtifact":
+        probe_ref = {"ref_type": "builderops_object", "ref": "probe"}
+        return {
+            "body": "probe",
+            "authority_standing": "non_normative",
+            "derivation_role": "derived",
+            "durability_posture": "ephemeral",
+            "working_lifecycle_stage": "capture",
+            "promotion_posture": "not_promoted",
+            "location_context": "builder_vault",
+            "provenance": {
+                "source_refs": [probe_ref],
+                "derived_from": [probe_ref],
+                "transformation": "probe",
+                "actor_or_process": "probe",
+                "observed_at": "2026-06-01T00:00:00Z",
+                "source_versions_or_watermarks": ["unknown"],
+                "review_or_decision_ref": "unknown",
+                "promotion_ref": "unknown",
+                "supersedes_refs": ["unknown"],
+                "receipt_refs": ["unknown"],
+                "limitations": ["unknown"],
+            },
+        }
     if object_type == "LearningSignal":
         return {"content": "probe", "signal_type": "probe"}
     if object_type == "RetroCluster":

--- a/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
+++ b/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
@@ -212,6 +212,48 @@ authority-surface references.
 
 ## Object Types
 
+### Builder Vault working-artifact admission
+
+`BuilderVaultWorkingArtifact` is the bounded BuilderOps admission seam for Builder Vault research,
+agent drafts, design explorations, and intermediate products. It uses the existing validated
+BuilderOps envelope and store; it is not a second vault, source registry, authority-bearing mirror,
+or promotion executor.
+
+**Authority boundary:** every admitted record has `authority_standing: non_normative`. Its
+`location_context` is routing context only and cannot establish authority. It may use BuilderOps
+`raw` or `analytical` authority classes, but it never becomes Product/Runtime, PKM, repo, GitHub,
+or DevUI truth merely by storage, indexing, readback, display, lifecycle state, or recency.
+
+**Required classification:** `authority_standing`, `derivation_role`, `durability_posture`,
+`working_lifecycle_stage`, `promotion_posture`, and `location_context` are explicit. The
+classification uses the cross-plane overlay without collapsing its axes: derivation is
+`source|derived|projection|unknown`; durability is `durable|ephemeral|rebuildable|unknown`; the
+working stage is `capture|explore|synthesize|propose|promote|implement|verify|supersede_retire|unknown`;
+and promotion posture is `not_promoted|proposed|promoted|superseded|retired|unknown`. Unknowns are
+stored explicitly rather than inferred from a path, timestamp, Git state, model identity, or UI.
+
+**Required provenance:** the `provenance` object preserves source refs, derivation inputs and
+transformation, actor/process/time, source versions or watermarks, review/decision and promotion
+refs, supersession and receipt refs, and limitations. Known source refs use the existing `SourceRef`
+shape; unavailable evidence is represented as explicit `unknown`, never silently omitted.
+
+**Lifecycle and promotion:** `archived` (retirement), `discarded`, `superseded`, and a rejected
+promotion require `successor_refs` naming successor or outcome evidence. The existing source refs
+and transition receipt remain attached; the record is not deleted or rewritten. Any authority
+crossing is proposal-only through a separately created `PromotionIntent` and the existing promotion
+gateway. That gateway requires an explicit target, review decision, and receipt/result evidence; it
+does not directly mutate repo, GitHub, Product/Runtime, or PKM authority.
+
+**Required fields:** common envelope fields, including `id`, `source_refs`, `created_by`, `summary`,
+`body`, and `receipt_refs`; `authority_standing: non_normative`; the five remaining classification
+fields; and `provenance` with every field in the minimum provenance envelope above.
+
+**Lifecycle states:** `draft`, `active`, `review_pending`, `accepted`, `promoted`, `archived`,
+`discarded`, and `superseded`.
+
+**Must not do:** infer or execute a promotion; create an Issue or PR; write a repo document; or
+mutate Product/Runtime or PKM authority.
+
 ### Gated target-state boundary: temporal-intention lifecycle evidence
 
 ADR-0065 owns the future temporal-intention authority and lifecycle semantics. This contract reserves

--- a/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
+++ b/docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md
@@ -229,7 +229,7 @@ or DevUI truth merely by storage, indexing, readback, display, lifecycle state, 
 classification uses the cross-plane overlay without collapsing its axes: derivation is
 `source|derived|projection|unknown`; durability is `durable|ephemeral|rebuildable|unknown`; the
 working stage is `capture|explore|synthesize|propose|promote|implement|verify|supersede_retire|unknown`;
-and promotion posture is `not_promoted|proposed|promoted|superseded|retired|unknown`. Unknowns are
+and promotion posture is `not_promoted|proposed|superseded|retired|unknown`. Unknowns are
 stored explicitly rather than inferred from a path, timestamp, Git state, model identity, or UI.
 
 **Required provenance:** the `provenance` object preserves source refs, derivation inputs and
@@ -243,6 +243,11 @@ and transition receipt remain attached; the record is not deleted or rewritten. 
 crossing is proposal-only through a separately created `PromotionIntent` and the existing promotion
 gateway. That gateway requires an explicit target, review decision, and receipt/result evidence; it
 does not directly mutate repo, GitHub, Product/Runtime, or PKM authority.
+
+The source working artifact cannot mark itself `promoted` through the generic store transition.
+Promotion is represented by the separately stored `PromotionIntent`, its gateway receipt, and the
+resulting target evidence; the controlled `BuilderOpsBoundary` and its
+`mcp.builderops.create_working_artifact` intake operation preserve this validation path.
 
 **Required fields:** common envelope fields, including `id`, `source_refs`, `created_by`, `summary`,
 `body`, and `receipt_refs`; `authority_standing: non_normative`; the five remaining classification

--- a/tests/builderops/test_builderops_working_artifact_intake.py
+++ b/tests/builderops/test_builderops_working_artifact_intake.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from app.builderops.models import BuilderOpsValidationError
+from app.builderops.boundary import BuilderOpsBoundary, execute_builderops_mcp_tool
 from app.builderops.promotion_gateway import BuilderOpsPromotionError, BuilderOpsPromotionGateway
 from app.builderops.store import SqliteBuilderOpsStore
 
@@ -89,6 +90,35 @@ def test_working_artifact_uses_existing_builderops_store(
 
     assert store.list_records("BuilderVaultWorkingArtifact") == [created]
     assert store.get_record(created["id"]) == created
+
+
+def test_working_artifact_is_admitted_through_controlled_builderops_boundary(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "builderops.sqlite3"
+    result = execute_builderops_mcp_tool(
+        tool_name="mcp.builderops.create_working_artifact",
+        tool_args=_working_artifact_fields(),
+        settings={"builderops_db_path": str(db_path)},
+    )
+    created = result["record"]
+    boundary = BuilderOpsBoundary.from_path(db_path)
+
+    assert result["status"] == "ok"
+    assert boundary.read_record(created["id"]) == created
+
+
+def test_working_artifact_cannot_claim_gateway_promotion_directly(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    fields = _working_artifact_fields()
+    fields.update({
+        "promotion_status": "promoted",
+        "promotion_posture": "promoted",
+    })
+
+    with pytest.raises(BuilderOpsValidationError, match="cannot claim promotion"):
+        store.create_working_artifact(**fields)
 
 
 def test_working_artifact_promotion_requires_explicit_target_and_receipt(

--- a/tests/builderops/test_builderops_working_artifact_intake.py
+++ b/tests/builderops/test_builderops_working_artifact_intake.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.builderops.models import BuilderOpsValidationError
+from app.builderops.promotion_gateway import BuilderOpsPromotionError, BuilderOpsPromotionGateway
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+def _actor() -> dict[str, str]:
+    return {"actor_type": "agent", "id": "test-agent"}
+
+
+def _source_refs() -> list[dict[str, str]]:
+    return [
+        {
+            "ref_type": "github_issue",
+            "ref": "#4984",
+            "authority_surface": "github",
+        }
+    ]
+
+
+def _working_artifact_fields(record_id: str = "work_4984_001") -> dict[str, object]:
+    return {
+        "id": record_id,
+        "summary": "Working artifact for admission-contract validation",
+        "body": "A bounded Builder Vault research draft.",
+        "source_refs": _source_refs(),
+        "created_by": _actor(),
+        "authority_standing": "non_normative",
+        "derivation_role": "derived",
+        "durability_posture": "rebuildable",
+        "working_lifecycle_stage": "synthesize",
+        "promotion_posture": "not_promoted",
+        "location_context": "builder_vault",
+        "provenance": {
+            "source_refs": _source_refs(),
+            "derived_from": _source_refs(),
+            "transformation": "Compare source contract with existing BuilderOps envelope.",
+            "actor_or_process": "test-agent",
+            "observed_at": "2026-08-18T00:00:00Z",
+            "source_versions_or_watermarks": ["issue-4984@2026-08-18"],
+            "review_or_decision_ref": "unknown",
+            "promotion_ref": "unknown",
+            "supersedes_refs": ["unknown"],
+            "receipt_refs": ["unknown"],
+            "limitations": ["Not authority outside BuilderOps."],
+        },
+        "receipt_refs": [],
+    }
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SqliteBuilderOpsStore:
+    result = SqliteBuilderOpsStore(tmp_path / "builderops.sqlite3")
+    result.initialize()
+    return result
+
+
+def test_working_artifact_round_trip_preserves_classification_and_provenance(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    created = store.create_working_artifact(**_working_artifact_fields())
+
+    read_back = store.get_record(created["id"])
+
+    assert read_back is not None
+    for field in (
+        "authority_standing",
+        "derivation_role",
+        "durability_posture",
+        "working_lifecycle_stage",
+        "promotion_posture",
+        "location_context",
+        "provenance",
+    ):
+        assert read_back[field] == created[field]
+    assert read_back["authority_standing"] == "non_normative"
+    assert read_back["provenance"]["review_or_decision_ref"] == "unknown"
+
+
+def test_working_artifact_uses_existing_builderops_store(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    created = store.create_working_artifact(**_working_artifact_fields())
+
+    assert store.list_records("BuilderVaultWorkingArtifact") == [created]
+    assert store.get_record(created["id"]) == created
+
+
+def test_working_artifact_promotion_requires_explicit_target_and_receipt(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    artifact = store.create_working_artifact(**_working_artifact_fields())
+    intent = store.create_promotion_intent(
+        id="prom_4984_001",
+        summary="Propose the working artifact for owner-doc writeback",
+        source_refs=[
+            {
+                "ref_type": "builderops_object",
+                "ref": artifact["id"],
+                "authority_surface": "builderops",
+            }
+        ],
+        target_authority_surface="owner_doc_writeback_proposal",
+        target_action="propose",
+        target_ref="docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md",
+        target_authority_class="decision",
+        intended_output="A reviewed owner-document proposal.",
+        receipt_refs=[],
+    )
+    gateway = BuilderOpsPromotionGateway(store)
+    lease = store.acquire_lease(intent["id"], actor=_actor())
+
+    with pytest.raises(BuilderOpsPromotionError, match="accepted before promoted"):
+        gateway.transition_intent(
+            intent["id"],
+            decision="promoted",
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="promote-before-review",
+            rationale="Must not promote without review.",
+        )
+
+    accepted = gateway.transition_intent(
+        intent["id"],
+        decision="accepted",
+        actor=_actor(),
+        lease_id=lease["lease_id"],
+        idempotency_key="accept-working-artifact-proposal",
+        rationale="The explicit target and review outcome are recorded.",
+    )
+    assert accepted["receipt"]["event_type"] == "state_transition"
+
+    with pytest.raises(BuilderOpsPromotionError, match="requires result_refs"):
+        gateway.transition_intent(
+            intent["id"],
+            decision="promoted",
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="promote-without-receipt-evidence",
+            rationale="A target receipt/equivalent is required.",
+        )
+
+    promoted = gateway.transition_intent(
+        intent["id"],
+        decision="promoted",
+        actor=_actor(),
+        lease_id=lease["lease_id"],
+        idempotency_key="promote-with-target-receipt",
+        rationale="Target authority evidence is explicit.",
+        result_refs=[
+            {
+                "ref_type": "github_pr",
+                "ref": "#5000",
+                "authority_surface": "github",
+            }
+        ],
+    )
+    assert promoted["record"]["promotion_status"] == "promoted"
+    assert promoted["receipt"]["result_refs"][0]["ref"] == "#5000"
+
+
+def test_working_artifact_terminal_transition_preserves_lineage(
+    store: SqliteBuilderOpsStore,
+) -> None:
+    artifact = store.create_working_artifact(**_working_artifact_fields())
+    lease = store.acquire_lease(artifact["id"], actor=_actor())
+
+    with pytest.raises(BuilderOpsValidationError, match="requires successor_refs"):
+        store.transition_record_state(
+            artifact["id"],
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="retire-without-lineage",
+            source_refs=_source_refs(),
+            summary="Retire working artifact",
+            action="retire",
+            receipt_body="Must retain terminal provenance.",
+            lifecycle_state="archived",
+        )
+
+    retired = store.transition_record_state(
+        artifact["id"],
+        actor=_actor(),
+        lease_id=lease["lease_id"],
+        idempotency_key="retire-with-lineage",
+        source_refs=_source_refs(),
+        summary="Retire working artifact",
+        action="retire",
+        receipt_body="Retired with a governed outcome reference.",
+        lifecycle_state="archived",
+        successor_refs=[
+            {
+                "ref_type": "promotion_intent",
+                "ref": "prom_4984_001",
+                "authority_surface": "builderops",
+            }
+        ],
+    )
+
+    assert retired["record"]["source_refs"] == _source_refs()
+    assert retired["record"]["successor_refs"][0]["ref"] == "prom_4984_001"
+    assert retired["receipt"]["source_refs"] == _source_refs()
+    assert retired["receipt"]["id"] in retired["record"]["receipt_refs"]
+
+    for disposition, lifecycle_state, promotion_status in (
+        ("supersede", "superseded", None),
+        ("discard", "discarded", None),
+        ("reject-promotion", None, "rejected"),
+    ):
+        candidate = store.create_working_artifact(
+            **_working_artifact_fields(f"work_4984_{disposition}")
+        )
+        candidate_lease = store.acquire_lease(candidate["id"], actor=_actor())
+        result = store.transition_record_state(
+            candidate["id"],
+            actor=_actor(),
+            lease_id=candidate_lease["lease_id"],
+            idempotency_key=f"{disposition}-with-lineage",
+            source_refs=_source_refs(),
+            summary=f"{disposition} working artifact",
+            action=disposition,
+            receipt_body="Terminal outcome preserves source lineage and receipt evidence.",
+            lifecycle_state=lifecycle_state,
+            promotion_status=promotion_status,
+            successor_refs=[
+                {
+                    "ref_type": "promotion_intent",
+                    "ref": "prom_4984_001",
+                    "authority_surface": "builderops",
+                }
+            ],
+        )
+        assert result["record"]["successor_refs"][0]["ref"] == "prom_4984_001"
+        assert result["receipt"]["source_refs"] == _source_refs()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #4984

## Linked Issue
Closes #4984

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): BuilderOps operating plane
- Write class: mechanical
- Persistence impact: durable BuilderOps working record; no Product/Runtime persistence
- Derived/rebuildable impact: classification and provenance readback remains rebuildable from stored record and source refs
- New or changed contract: Builder Vault working-artifact admission and provenance envelope
- Owner-doc impact: updated docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md :: Builder Vault working-artifact admission
- Transition debt impact: closes the bounded admission gap without widening promotion authority
- Boundary risk: stored working artifacts remain non-normative; promotion stays proposal-only through PromotionIntent

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds a validated BuilderVaultWorkingArtifact envelope for non-normative Builder Vault working material.
- Preserves explicit classification and provenance, terminal lineage, and proposal-only PromotionIntent handoff.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No operational BuilderOps record was created; code-level admission and receipt behavior is verified by focused tests.

## Notes
Validation: pytest -q tests/builderops/test_builderops_working_artifact_intake.py; pytest -q tests/builderops/test_builderops_promotion_gateway.py; ruff check app tests; mypy app; python3 scripts/docs_guard.py; git diff --check.