### PR TITLE
Apply migration reversibility to active prod promotion

### DIFF
--- a/docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md
+++ b/docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md
@@ -28,14 +28,21 @@ This task produces the migration-reversibility contract as a docs artifact under
 
 ## Concretely
 
-This is a **target-state, unshipped** contract for the planned per-channel DB split. Until that split lands, current production uses the single `app` DB under compose project `pkm-prod`.
+This contract applies now to the active production promotion path: migrations promoted to the
+single `app` DB under compose project `pkm-prod` must carry and be consumed with an explicit
+reversibility classification. The planned per-channel DB split remains future state; when that
+split lands, the same classification contract will apply to each channel database, but the
+contract does not wait for that split.
 
 - **Reversible migration**: the migration has an authored reverse step that restores the prior schema/data shape when executed. The reverse step is versioned alongside the forward step and runs as part of `rollback-promotion` if invoked.
 - **Forward-only migration**: the migration does not have a reverse step, either because reversal is impossible (e.g. dropped data) or because reversal is not worth authoring. Forward-only migrations are allowed but must be flagged.
 - **Declaration surface**: the reversibility marker lives in the migration file itself (frontmatter, comment, or tool-native metadata, as the migration tool allows). It is mandatory; a migration with no marker fails a pre-promotion check.
 - **Consumption**: `prepare-promotion` reads the markers across the migration delta and emits them into the promotion plan's migration-delta section.
 - **Operator acknowledgment**: forward-only migrations require a distinct operator acknowledgment in the plan. Reversible migrations do not.
-- **Scope**: applies to migrations that run against `pkm_prod`. Dev-side migrations run against `pkm_dev` and are not bound by this contract during development; the contract engages at promotion time.
+- **Scope**: applies to migrations that run against the active production `app` DB in compose
+  project `pkm-prod` at promotion time. Dev-side migrations run against `pkm_dev` and are not
+  bound by this contract during development. The future per-channel database split may introduce
+  channel-specific database names, but does not narrow or defer the active production contract.
 
 ## Why This Matters
 
@@ -51,8 +58,9 @@ Without this classification, rollback is a guess. The operator discovers at roll
   Verify: `rg -n "operator acknowledgment|forward-only" docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`.
 - [ ] The contract specifies that reversible migrations carry a machine-readable reversal step.
   Verify: `rg -n "reversal step|machine-readable" docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`.
-- [ ] The contract scopes its applicability to migrations running against `pkm_prod`.
-  Verify: `rg -n "pkm_prod|at promotion time|applicability" docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`.
+- [ ] The contract scopes its applicability to migrations running against the active production
+  `app` DB under compose project `pkm-prod`, while keeping the per-channel split future state.
+  Verify: `rg -n "app|pkm-prod|at promotion time|future state" docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`.
 - [ ] The contract states that classification is about reversal-path existence, not about migration success.
   Verify: `rg -n "not a guarantee|success|reversal path" docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`.
 - [ ] The contract does not prescribe a specific migration tool.

--- a/tests/docs/test_migration_reversibility_contract.py
+++ b/tests/docs/test_migration_reversibility_contract.py
@@ -1,0 +1,35 @@
+"""Keep migration reversibility documentation aligned with active promotion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLASSIFICATION = (
+    REPO_ROOT
+    / "docs"
+    / "RELEASE_CHANNELS"
+    / "DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md"
+)
+PROMOTION_PLAN = (
+    REPO_ROOT / "docs" / "RELEASE_CHANNELS" / "DEFINE_PROMOTION_PLAN_CONTRACT.md"
+)
+PREPARE_PROMOTION = (
+    REPO_ROOT / ".codex" / "skills" / "prepare-promotion" / "SKILL.md"
+)
+
+
+def test_active_promotion_path_is_covered_by_reversibility_contract() -> None:
+    classification = CLASSIFICATION.read_text(encoding="utf-8")
+    promotion_plan = PROMOTION_PLAN.read_text(encoding="utf-8")
+    prepare_promotion = PREPARE_PROMOTION.read_text(encoding="utf-8")
+
+    assert "active production promotion path" in classification
+    assert "`app` DB" in classification
+    assert "`pkm-prod`" in classification
+    assert "planned per-channel DB split remains future state" in classification
+    assert "`app` DB, compose project `pkm-prod`" in promotion_plan
+    assert "`app` DB, compose project `pkm-prod`, port 15432" in prepare_promotion
+    scope = classification.split("- **Scope**:", 1)[1].split("\n\n", 1)[0]
+    assert "pkm_prod" not in scope


### PR DESCRIPTION
Governing-Issue: #4326

Closes #4326

Final-Review-Rounds: 1

## Summary
Reconciles the migration reversibility contract with the active `app`/`pkm-prod` promotion path while preserving the planned per-channel split as future state. Adds a focused doc-truth test for the active applicability boundary.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): OEF / release-channel promotion governance
- Write class: governance/docs/process
- Persistence impact: none; no migration or database mutation performed
- Derived/rebuildable impact: doc-truth test reads the checked-in promotion contracts
- New or changed contract: active `app`/`pkm-prod` migration reversibility applicability
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces promotion-safety contract drift
- Boundary risk: future per-channel split remains explicitly future state

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR: `docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md :: Concretely`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No operational BuilderOps record or promotion was created; this is a bounded contract/doc correction with focused verification.

## Notes
Validation: `pytest -q tests/docs/test_migration_reversibility_contract.py`; `python3 scripts/docs_guard.py`; `ruff check app tests`; `mypy app`; `git diff --check`; high-risk migration review-before-CI gate.