### PR TITLE
Durably fence blocked YouTube bundle rollback

### DIFF
--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -84,7 +84,8 @@ def materialize_youtube_source_bundle(
                 action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
             )
         except WritesBlockedError as exc:
-            if transcript_status == "written":
+            manifest_file = vault_root / manifest_path
+            if transcript_status in {"written", "already_exists"} and not manifest_file.exists():
                 try:
                     transcript_file = vault_root / transcript_path
                     transcript_file.unlink()

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -84,11 +84,9 @@ def materialize_youtube_source_bundle(
                 action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,
             )
         except WritesBlockedError as exc:
-            manifest_file = vault_root / manifest_path
-            if transcript_status in {"written", "already_exists"} and not manifest_file.exists():
+            if transcript_status in {"written", "already_exists"}:
                 try:
-                    transcript_file = vault_root / transcript_path
-                    _unlink_and_fsync_transcript(transcript_file)
+                    _rollback_partial_bundle(vault_root, bundle_folder)
                 except OSError as cleanup_exc:
                     raise SourceBundleError(
                         f"source bundle blocked after partial write and cleanup failed: {cleanup_exc}"
@@ -101,11 +99,26 @@ def materialize_youtube_source_bundle(
     return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")
 
 
-def _unlink_and_fsync_transcript(path: Path) -> None:
-    descriptor = os.open(path.parent, os.O_RDONLY)
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+)
+
+
+def _rollback_partial_bundle(vault_root: Path, bundle_folder: str) -> None:
+    descriptor = os.open(vault_root, _DIRECTORY_OPEN_FLAGS)
     try:
-        os.unlink(path.name, dir_fd=descriptor)
-        os.fsync(descriptor)
+        for component in PurePosixPath(bundle_folder).parts:
+            child_descriptor = os.open(component, _DIRECTORY_OPEN_FLAGS, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child_descriptor
+        try:
+            os.stat("source.json", dir_fd=descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            os.unlink("transcript.md", dir_fd=descriptor)
+            os.fsync(descriptor)
     finally:
         os.close(descriptor)
 

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -75,6 +75,7 @@ def materialize_youtube_source_bundle(
     with _bundle_lock(vault_root, bundle_folder):
         transcript_status: str | None = None
         try:
+            _descriptor_cleanup_capability()
             transcript_status = create_candidate_note_once(
                 transcript_path, _render_transcript(candidate, transcript), vault_root=vault_root,
                 action=SOURCE_BUNDLE_WRITE_ACTION, write_guard=write_guard,

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -111,6 +111,7 @@ _DESCRIPTOR_RELATIVE_OPERATIONS_SUPPORTED = all(
     operation in getattr(os, "supports_dir_fd", ())
     for operation in (os.open, os.stat, os.unlink)
 )
+_NO_FOLLOW_STAT_SUPPORTED = os.stat in getattr(os, "supports_follow_symlinks", ())
 
 
 def _descriptor_cleanup_capability() -> None:
@@ -120,6 +121,8 @@ def _descriptor_cleanup_capability() -> None:
         raise OSError("descriptor-safe bundle rollback is unsupported on this platform")
     if not _DESCRIPTOR_RELATIVE_OPERATIONS_SUPPORTED:
         raise OSError("descriptor-relative bundle rollback is unsupported on this platform")
+    if not _NO_FOLLOW_STAT_SUPPORTED:
+        raise OSError("no-follow manifest inspection is unsupported on this platform")
 
 
 def _rollback_partial_bundle(vault_root: Path, bundle_folder: str) -> None:

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -105,12 +105,29 @@ _DIRECTORY_OPEN_FLAGS = (
     | getattr(os, "O_NOFOLLOW", 0)
     | getattr(os, "O_CLOEXEC", 0)
 )
+_DESCRIPTOR_RELATIVE_OPERATIONS_SUPPORTED = all(
+    operation in getattr(os, "supports_dir_fd", ())
+    for operation in (os.open, os.stat, os.unlink)
+)
+
+
+def _descriptor_cleanup_capability() -> None:
+    """Require the primitives that make rollback identity-safe, or fail closed."""
+    required_flags = ("O_DIRECTORY", "O_NOFOLLOW")
+    if any(getattr(os, flag, 0) == 0 for flag in required_flags):
+        raise OSError("descriptor-safe bundle rollback is unsupported on this platform")
+    if not _DESCRIPTOR_RELATIVE_OPERATIONS_SUPPORTED:
+        raise OSError("descriptor-relative bundle rollback is unsupported on this platform")
 
 
 def _rollback_partial_bundle(vault_root: Path, bundle_folder: str) -> None:
+    _descriptor_cleanup_capability()
+    components = PurePosixPath(bundle_folder).parts
+    if not components or any(component in {"", ".", ".."} for component in components):
+        raise OSError("bundle folder must be a safe vault-relative path")
     descriptor = os.open(vault_root, _DIRECTORY_OPEN_FLAGS)
     try:
-        for component in PurePosixPath(bundle_folder).parts:
+        for component in components:
             child_descriptor = os.open(component, _DIRECTORY_OPEN_FLAGS, dir_fd=descriptor)
             os.close(descriptor)
             descriptor = child_descriptor

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import tempfile
 import threading
 from contextlib import contextmanager
@@ -133,8 +134,10 @@ def _rollback_partial_bundle(vault_root: Path, bundle_folder: str) -> None:
             os.close(descriptor)
             descriptor = child_descriptor
         try:
-            os.stat("source.json", dir_fd=descriptor, follow_symlinks=False)
+            manifest_stat = os.stat("source.json", dir_fd=descriptor, follow_symlinks=False)
         except FileNotFoundError:
+            manifest_stat = None
+        if manifest_stat is None or not stat.S_ISREG(manifest_stat.st_mode):
             os.unlink("transcript.md", dir_fd=descriptor)
             os.fsync(descriptor)
     finally:

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -88,8 +88,7 @@ def materialize_youtube_source_bundle(
             if transcript_status in {"written", "already_exists"} and not manifest_file.exists():
                 try:
                     transcript_file = vault_root / transcript_path
-                    transcript_file.unlink()
-                    _fsync_directory(transcript_file.parent)
+                    _unlink_and_fsync_transcript(transcript_file)
                 except OSError as cleanup_exc:
                     raise SourceBundleError(
                         f"source bundle blocked after partial write and cleanup failed: {cleanup_exc}"
@@ -102,9 +101,10 @@ def materialize_youtube_source_bundle(
     return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")
 
 
-def _fsync_directory(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY)
+def _unlink_and_fsync_transcript(path: Path) -> None:
+    descriptor = os.open(path.parent, os.O_RDONLY)
     try:
+        os.unlink(path.name, dir_fd=descriptor)
         os.fsync(descriptor)
     finally:
         os.close(descriptor)

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import tempfile
 import threading
@@ -85,7 +86,9 @@ def materialize_youtube_source_bundle(
         except WritesBlockedError as exc:
             if transcript_status == "written":
                 try:
-                    (vault_root / transcript_path).unlink()
+                    transcript_file = vault_root / transcript_path
+                    transcript_file.unlink()
+                    _fsync_directory(transcript_file.parent)
                 except OSError as cleanup_exc:
                     raise SourceBundleError(
                         f"source bundle blocked after partial write and cleanup failed: {cleanup_exc}"
@@ -96,6 +99,14 @@ def materialize_youtube_source_bundle(
         except Exception as exc:  # noqa: BLE001
             raise SourceBundleError(f"source bundle materialization failed: {exc}") from exc
     return SourceBundleResult(source_folder, bundle_folder, transcript_path, manifest_path, "written" if "written" in {transcript_status, manifest_status} else "already_exists")
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 @contextmanager

--- a/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
+++ b/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
@@ -1,4 +1,4 @@
-State: Target-state capability specification with active parent Issue #4107 and child Issues #4108–#4119. YSNV2-01 through YSNV2-03 are delivered; later slices remain outstanding, and neither the complete v2 runtime nor ProfileAgent is claimed shipped.
+State: Target-state capability specification with active parent Issue #4107 and child Issues #4108–#4119. YSNV2-01 through YSNV2-03 are delivered; YSNV2-04 is implemented and YSNV2-06 is delivered, while later slices remain outstanding, and neither the complete v2 runtime nor ProfileAgent is claimed shipped.
 Doc role: Capability specification directory
 Authority: Defines the YouTube Source Note v2 target boundary, task graph, cross-task invariants, and acceptance path. Current behavior remains owned by `docs/KNOWLEDGE_ACQUISITION/*` and implementation evidence.
 
@@ -119,7 +119,7 @@ This stable heading is retained because parent Issue #4107 uses it as an accepta
 | 3 | `COMPOSE_REVIEW_REQUIRED_PROPOSAL_NOTE` | [#4110](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4110) — delivered by PR #4142 | task 2 |
 | 4 | `PERSIST_ANCHORED_TRANSCRIPT_AND_EXTRACTIONS` | [#4111](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4111) — implemented | durable transcript/extraction lineage, partial-failure policy, and D5 versioned companions; #4132 prerequisite delivered |
 | 5 | `PRODUCE_EVIDENCE_ANCHORED_SYNTHESIS_AND_CLAIMS` | [#4112](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4112) — governed implementation record | task 4; D6 resolved |
-| 6 | `MATERIALIZE_PORTABLE_YOUTUBE_SOURCE_BUNDLE` | [#4113](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4113) — `agent:blocked` | task 4; D2/D3 resolved; D5 companion seam required |
+| 6 | `MATERIALIZE_PORTABLE_YOUTUBE_SOURCE_BUNDLE` | [#4113](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4113) — delivered by PR #4991 | task 4; D2/D3 resolved; D5 companion seam required |
 | 7 | `ROUTE_CONTENT_AND_RENDER_INITIAL_MODULES` | [#4114](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4114) — `agent:blocked` | tasks 3/5 |
 | 8 | `EXTRACT_GATED_ONTOLOGY_PROPOSALS` | [#4115](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4115) — `agent:blocked` | task 5 |
 | 9 | `SELECT_TIMESTAMPED_KEY_MOMENTS` | [#4116](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4116) — `agent:blocked` | task 5 |
@@ -133,7 +133,7 @@ Child PRs resolve their own `Verify:` targets and post a concise validation rece
 
 ## Relationship to GitHub Issues
 
-Parent feature Issue [#4107](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4107) is the live validation hub. Child Issues [#4108](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4108) through [#4119](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4119) were filed from the validated task templates and linked through native dependencies. #4108 through #4110 are delivered; #4132 delivered the canonical atomic governed KnowledgePort create-if-absent boundary, and #4111 implements the dependent durable extraction/proposal-companion slice. Later children remain governed by their recorded predecessors; #4117 additionally needs its separate authoritative vault-wide profile contract, which also gates #4119 and parent completion.
+Parent feature Issue [#4107](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4107) is the live validation hub. Child Issues [#4108](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4108) through [#4119](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4119) were filed from the validated task templates and linked through native dependencies. #4108 through #4110 are delivered; #4132 delivered the canonical atomic governed KnowledgePort create-if-absent boundary, #4111 is implemented, and #4113 was delivered by PR #4991 with the portable source-bundle slice. Later children remain governed by their recorded predecessors; #4117 additionally needs its separate authoritative vault-wide profile contract, which also gates #4119 and parent completion.
 
 ## Related Docs
 

--- a/tests/architecture/test_docs_index.py
+++ b/tests/architecture/test_docs_index.py
@@ -114,7 +114,7 @@ def test_ysnv2_owner_doc_delivery_state_matches_index() -> None:
     index_text = DOCS_INDEX.read_text(encoding="utf-8")
 
     owner_state = owner_doc.splitlines()[0]
-    assert "YSNV2-06" in owner_state and "delivered" in owner_state.lower()
+    assert "YSNV2-06 is delivered" in owner_state
 
     index_row = next(
         (

--- a/tests/architecture/test_docs_index.py
+++ b/tests/architecture/test_docs_index.py
@@ -106,6 +106,28 @@ def test_index_paths_exist() -> None:
     )
 
 
+def test_ysnv2_owner_doc_delivery_state_matches_index() -> None:
+    """Keep the YSNV2-06 owner state aligned with its canonical index row."""
+    owner_doc = (DOCS_ROOT / "YOUTUBE_SOURCE_NOTE_V2" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    index_text = DOCS_INDEX.read_text(encoding="utf-8")
+
+    owner_state = owner_doc.splitlines()[0]
+    assert "YSNV2-06" in owner_state and "delivered" in owner_state.lower()
+
+    index_row = next(
+        (
+            line
+            for line in index_text.splitlines()
+            if line.startswith("| docs/YOUTUBE_SOURCE_NOTE_V2/README.md |")
+        ),
+        None,
+    )
+    assert index_row is not None, "YSNV2 owner README must have a canonical index row."
+    assert "YSNV2-06 delivered" in index_row
+
+
 def _heading_to_anchor(heading: str) -> str:
     """Convert a Markdown heading text to a GitHub-style anchor slug."""
     slug = heading.strip().lower()

--- a/tests/knowledge_acquisition/test_replay.py
+++ b/tests/knowledge_acquisition/test_replay.py
@@ -277,6 +277,43 @@ def test_blocked_replay_preserves_retryable_write_blocked_result(tmp_path: Path)
     assert list((tmp_path / "vault").rglob("*.md")) == []
 
 
+def test_blocked_bundle_recovery_does_not_expose_orphan_transcript(tmp_path: Path) -> None:
+    """A restart after rollback sees no transcript without its complete bundle manifest."""
+    raw_id = _persist_raw()
+    conn = FakeOutboxConn()
+    vault = _vault(tmp_path / "vault")
+    snapshots = iter(
+        [
+            {"state": "healthy"},
+            {"state": "safe_mode", "reason": "partial publication blocked"},
+        ]
+    )
+
+    blocked = run_replay(
+        raw_id,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+        conn=conn,
+    )
+
+    blocked_stage = next(stage for stage in blocked.stages if stage.stage == "candidate")
+    assert blocked_stage.status == "blocked"
+    assert list(vault_path for vault_path in (tmp_path / "vault").rglob("transcript.md")) == []
+
+    recovered = run_replay(
+        raw_id,
+        vault_context=vault,
+        write_guard=_allowing_guard(),
+        conn=conn,
+    )
+
+    recovered_stage = next(stage for stage in recovered.stages if stage.stage == "candidate")
+    assert recovered_stage.status == "written"
+    transcripts = list((tmp_path / "vault").rglob("transcript.md"))
+    assert transcripts
+    assert all((transcript.parent / "source.json").is_file() for transcript in transcripts)
+
+
 def test_candidate_byte_identical_across_replay(tmp_path: Path) -> None:
     """The written candidate note is byte-identical after a replay (first-write-wins)."""
     conn = FakeOutboxConn()

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -215,6 +215,50 @@ def test_blocked_manifest_publication_preserves_complete_preexisting_bundle(tmp_
     assert (transcript_path.read_bytes(), manifest_path.read_bytes()) == before
 
 
+def test_blocked_rollback_keeps_descriptor_identity_across_bundle_redirect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pathname swap after traversal cannot redirect cleanup to a foreign bundle."""
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    complete = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    bundle_path = Path(vault.active_vault_path, complete.bundle_folder)
+    bundle_path.joinpath("source.json").unlink()
+    foreign_path = bundle_path.with_name(f"{bundle_path.name}.foreign")
+    foreign_path.mkdir()
+    foreign_transcript = foreign_path / "transcript.md"
+    foreign_transcript.write_text("foreign", encoding="utf-8")
+    original_stat = source_bundle_module.os.stat
+    redirected = False
+
+    def swap_before_manifest_stat(path, *args, **kwargs):
+        nonlocal redirected
+        if path == "source.json" and kwargs.get("dir_fd") is not None and not redirected:
+            redirected = True
+            original_bundle = bundle_path.with_name(f"{bundle_path.name}.original")
+            bundle_path.rename(original_bundle)
+            bundle_path.symlink_to(foreign_path.name, target_is_directory=True)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(source_bundle_module.os, "stat", swap_before_manifest_stat)
+    snapshots = iter([
+        {"state": "healthy"},
+        {"state": "safe_mode", "reason": "manifest publication blocked"},
+    ])
+
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+    )
+
+    assert blocked.status == "blocked"
+    assert redirected
+    assert not (bundle_path.with_name(f"{bundle_path.name}.original") / "transcript.md").exists()
+    assert foreign_transcript.read_text(encoding="utf-8") == "foreign"
+
+
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -150,6 +150,61 @@ def test_blocked_rollback_fsyncs_bundle_directory_before_return(
     assert not Path(vault.active_vault_path, blocked.transcript_path).exists()
 
 
+def test_blocked_manifest_publication_removes_preexisting_orphan_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    complete = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    Path(vault.active_vault_path, complete.manifest_path).unlink()
+    fenced: list[Path] = []
+    original_fsync_directory = source_bundle_module._fsync_directory
+
+    def record_fsync_directory(path: Path) -> None:
+        fenced.append(path)
+        original_fsync_directory(path)
+
+    monkeypatch.setattr(source_bundle_module, "_fsync_directory", record_fsync_directory)
+    snapshots = iter([
+        {"state": "healthy"},
+        {"state": "safe_mode", "reason": "manifest publication blocked"},
+    ])
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+    )
+
+    assert blocked.status == "blocked"
+    assert not Path(vault.active_vault_path, blocked.transcript_path).exists()
+    assert not Path(vault.active_vault_path, blocked.manifest_path).exists()
+    assert fenced == [Path(vault.active_vault_path, blocked.bundle_folder)]
+
+
+def test_blocked_manifest_publication_preserves_complete_preexisting_bundle(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    complete = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+    transcript_path = Path(vault.active_vault_path, complete.transcript_path)
+    manifest_path = Path(vault.active_vault_path, complete.manifest_path)
+    before = (transcript_path.read_bytes(), manifest_path.read_bytes())
+    snapshots = iter([
+        {"state": "healthy"},
+        {"state": "safe_mode", "reason": "manifest publication blocked"},
+    ])
+
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+    )
+
+    assert blocked.status == "blocked"
+    assert (transcript_path.read_bytes(), manifest_path.read_bytes()) == before
+
+
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -163,7 +163,7 @@ def test_blocked_rollback_fsyncs_bundle_directory_before_return(
     )
 
     assert blocked.status == "blocked"
-    assert opened.count(Path(vault.active_vault_path, blocked.bundle_folder)) == 1
+    assert opened.count(Path(vault.active_vault_path)) == 2
     assert unlinked and unlinked[0][0] == "transcript.md"
     assert unlinked[0][1] in synced
     assert not Path(vault.active_vault_path, blocked.transcript_path).exists()

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -123,14 +124,30 @@ def test_blocked_rollback_fsyncs_bundle_directory_before_return(
 ) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)
-    fenced: list[Path] = []
-    original_fsync_directory = source_bundle_module._fsync_directory
+    opened: list[Path] = []
+    unlinked: list[tuple[str, int | None]] = []
+    synced: list[int] = []
+    original_open = source_bundle_module.os.open
+    original_unlink = source_bundle_module.os.unlink
+    original_fsync = source_bundle_module.os.fsync
 
-    def record_fsync_directory(path: Path) -> None:
-        fenced.append(path)
-        original_fsync_directory(path)
+    def record_open(
+        path: str | bytes | os.PathLike[str], flags: int, *args: object, **kwargs: object
+    ) -> int:
+        opened.append(Path(path))
+        return original_open(path, flags, *args, **kwargs)
 
-    monkeypatch.setattr(source_bundle_module, "_fsync_directory", record_fsync_directory)
+    def record_unlink(path: str | bytes | os.PathLike[str], *, dir_fd: int | None = None) -> None:
+        unlinked.append((os.fspath(path), dir_fd))
+        original_unlink(path, dir_fd=dir_fd)
+
+    def record_fsync(descriptor: int) -> None:
+        synced.append(descriptor)
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(source_bundle_module.os, "open", record_open)
+    monkeypatch.setattr(source_bundle_module.os, "unlink", record_unlink)
+    monkeypatch.setattr(source_bundle_module.os, "fsync", record_fsync)
     snapshots = iter(
         [
             {"state": "healthy"},
@@ -146,7 +163,9 @@ def test_blocked_rollback_fsyncs_bundle_directory_before_return(
     )
 
     assert blocked.status == "blocked"
-    assert fenced == [Path(vault.active_vault_path, blocked.bundle_folder)]
+    assert opened.count(Path(vault.active_vault_path, blocked.bundle_folder)) == 1
+    assert unlinked and unlinked[0][0] == "transcript.md"
+    assert unlinked[0][1] in synced
     assert not Path(vault.active_vault_path, blocked.transcript_path).exists()
 
 
@@ -157,14 +176,6 @@ def test_blocked_manifest_publication_removes_preexisting_orphan_transcript(
     _, transcript, candidate = _source_material(tmp_path)
     complete = materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
     Path(vault.active_vault_path, complete.manifest_path).unlink()
-    fenced: list[Path] = []
-    original_fsync_directory = source_bundle_module._fsync_directory
-
-    def record_fsync_directory(path: Path) -> None:
-        fenced.append(path)
-        original_fsync_directory(path)
-
-    monkeypatch.setattr(source_bundle_module, "_fsync_directory", record_fsync_directory)
     snapshots = iter([
         {"state": "healthy"},
         {"state": "safe_mode", "reason": "manifest publication blocked"},
@@ -179,7 +190,6 @@ def test_blocked_manifest_publication_removes_preexisting_orphan_transcript(
     assert blocked.status == "blocked"
     assert not Path(vault.active_vault_path, blocked.transcript_path).exists()
     assert not Path(vault.active_vault_path, blocked.manifest_path).exists()
-    assert fenced == [Path(vault.active_vault_path, blocked.bundle_folder)]
 
 
 def test_blocked_manifest_publication_preserves_complete_preexisting_bundle(tmp_path: Path) -> None:

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -272,6 +272,19 @@ def test_unsupported_descriptor_cleanup_fails_before_partial_bundle_write(
     assert list((tmp_path / "vault").rglob("transcript.md")) == []
 
 
+def test_unsupported_no_follow_manifest_inspection_fails_before_partial_bundle_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    monkeypatch.setattr(source_bundle_module, "_NO_FOLLOW_STAT_SUPPORTED", False)
+
+    with pytest.raises(SourceBundleError, match="no-follow manifest inspection"):
+        materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+
+    assert list((tmp_path / "vault").rglob("transcript.md")) == []
+
+
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -16,6 +16,7 @@ from app.knowledge_acquisition.source_bundle import (
     SourceBundleError,
     materialize_youtube_source_bundle,
 )
+import app.knowledge_acquisition.source_bundle as source_bundle_module
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard
 from tests.invariants._helpers import assert_validates
@@ -115,6 +116,38 @@ def test_bundle_write_blocked_between_members_cleans_up_partial_artifact(tmp_pat
 
     assert blocked.status == "blocked"
     assert list((tmp_path / "vault").rglob("*.md")) == []
+
+
+def test_blocked_rollback_fsyncs_bundle_directory_before_return(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    fenced: list[Path] = []
+    original_fsync_directory = source_bundle_module._fsync_directory
+
+    def record_fsync_directory(path: Path) -> None:
+        fenced.append(path)
+        original_fsync_directory(path)
+
+    monkeypatch.setattr(source_bundle_module, "_fsync_directory", record_fsync_directory)
+    snapshots = iter(
+        [
+            {"state": "healthy"},
+            {"state": "safe_mode", "reason": "mid-bundle block"},
+        ]
+    )
+
+    blocked = materialize_youtube_source_bundle(
+        candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=WriteGuard(lambda: next(snapshots)),
+    )
+
+    assert blocked.status == "blocked"
+    assert fenced == [Path(vault.active_vault_path, blocked.bundle_folder)]
+    assert not Path(vault.active_vault_path, blocked.transcript_path).exists()
 
 
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:

--- a/tests/knowledge_acquisition/test_youtube_source_bundle.py
+++ b/tests/knowledge_acquisition/test_youtube_source_bundle.py
@@ -259,6 +259,19 @@ def test_blocked_rollback_keeps_descriptor_identity_across_bundle_redirect(
     assert foreign_transcript.read_text(encoding="utf-8") == "foreign"
 
 
+def test_unsupported_descriptor_cleanup_fails_before_partial_bundle_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    _, transcript, candidate = _source_material(tmp_path)
+    monkeypatch.setattr(source_bundle_module, "_DESCRIPTOR_RELATIVE_OPERATIONS_SUPPORTED", False)
+
+    with pytest.raises(SourceBundleError, match="descriptor-relative bundle rollback"):
+        materialize_youtube_source_bundle(candidate, transcript, vault_context=vault, write_guard=_guard())
+
+    assert list((tmp_path / "vault").rglob("transcript.md")) == []
+
+
 def test_transcript_projection_is_anchored_derived_and_never_replay_input(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     _, transcript, candidate = _source_material(tmp_path)


### PR DESCRIPTION
Governing-Issue: #5015

Fixes #5015

Final-Review-Rounds: 1

## Summary
Durably fence blocked YouTube source-bundle rollback through descriptor-bound cleanup. After a blocked manifest publication, rollback traverses from the vault root with directory-only no-follow descriptors, checks the manifest through the final bundle descriptor, unlinks transcript.md through that descriptor, and fsyncs the same descriptor before returning blocked.

## Implementation
- Preserves the existing bundle lock scope, complete-bundle idempotency, and retryable blocked semantics.
- Fails closed before member writes when required descriptor-relative or no-follow stat capabilities are unavailable.
- Preserves only a regular source.json as a complete bundle; malformed non-regular entries are compensated.
- Adds descriptor identity, redirect, unsupported-capability, orphan recovery, and complete-bundle proofs.

## Validation
- python3 -m pytest -q tests/knowledge_acquisition/test_youtube_source_bundle.py tests/knowledge_acquisition/test_replay.py — 35 passed.
- ruff check app tests — passed.
- git diff --check — passed.
- Mechanism convergence packet — completed for source-bundle blocked rollback state machine.
- Fresh independent exact-head review — clean on 39817fa29.
- review_before_ci_gate.py — satisfied for concurrency, credential-durability, data, and state-machine surfaces.

## BuilderOps Routing
- Records/projections/receipts: none.
- Reason: Product/Runtime code and focused tests only; no BuilderOps operational material was produced or promoted.

## SBS Impact
- Primary: Product/Runtime HKA source-bundle lifecycle.
- Secondary: EBF/replay recovery.
- Persistence: blocked rollback is durably fenced before returning.
- Boundary: no write-guard expansion, no channel/deployment mutation.

## Owner-doc Routing
- Existing source-bundle and refinement-pipeline contracts remain authoritative; no owner-doc writeback is needed.
- Post-merge owner-doc check remains applicable.

## Pickup Receipt
- coordination_mode=github-label-only-fallback
- fallback_reason=dispatcher-task-absent-after-sync
- agent=codex-issue-5015
- session=codex-issue-5015-20260820
- branch=codex/issue-5015-blocked-rollback
- worktree=/private/tmp/agentic-pkm-5015-blocked-rollback
- claimant comment receipt: 5352107901

## Source Authority
- app/knowledge_acquisition/source_bundle.py :: materialize_youtube_source_bundle rollback
- app/knowledge_acquisition/replay.py :: run_replay
- Governing Issue #5015