### PR TITLE
Update YSNV2-06 owner delivery state

### DIFF
--- a/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
+++ b/docs/YOUTUBE_SOURCE_NOTE_V2/README.md
@@ -1,4 +1,4 @@
-State: Target-state capability specification with active parent Issue #4107 and child Issues #4108–#4119. YSNV2-01 through YSNV2-03 are delivered; later slices remain outstanding, and neither the complete v2 runtime nor ProfileAgent is claimed shipped.
+State: Target-state capability specification with active parent Issue #4107 and child Issues #4108–#4119. YSNV2-01 through YSNV2-03 are delivered; YSNV2-04 is implemented and YSNV2-06 is delivered, while later slices remain outstanding, and neither the complete v2 runtime nor ProfileAgent is claimed shipped.
 Doc role: Capability specification directory
 Authority: Defines the YouTube Source Note v2 target boundary, task graph, cross-task invariants, and acceptance path. Current behavior remains owned by `docs/KNOWLEDGE_ACQUISITION/*` and implementation evidence.
 
@@ -119,7 +119,7 @@ This stable heading is retained because parent Issue #4107 uses it as an accepta
 | 3 | `COMPOSE_REVIEW_REQUIRED_PROPOSAL_NOTE` | [#4110](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4110) — delivered by PR #4142 | task 2 |
 | 4 | `PERSIST_ANCHORED_TRANSCRIPT_AND_EXTRACTIONS` | [#4111](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4111) — implemented | durable transcript/extraction lineage, partial-failure policy, and D5 versioned companions; #4132 prerequisite delivered |
 | 5 | `PRODUCE_EVIDENCE_ANCHORED_SYNTHESIS_AND_CLAIMS` | [#4112](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4112) — governed implementation record | task 4; D6 resolved |
-| 6 | `MATERIALIZE_PORTABLE_YOUTUBE_SOURCE_BUNDLE` | [#4113](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4113) — `agent:blocked` | task 4; D2/D3 resolved; D5 companion seam required |
+| 6 | `MATERIALIZE_PORTABLE_YOUTUBE_SOURCE_BUNDLE` | [#4113](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4113) — delivered by PR #4991 | task 4; D2/D3 resolved; D5 companion seam required |
 | 7 | `ROUTE_CONTENT_AND_RENDER_INITIAL_MODULES` | [#4114](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4114) — `agent:blocked` | tasks 3/5 |
 | 8 | `EXTRACT_GATED_ONTOLOGY_PROPOSALS` | [#4115](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4115) — `agent:blocked` | task 5 |
 | 9 | `SELECT_TIMESTAMPED_KEY_MOMENTS` | [#4116](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4116) — `agent:blocked` | task 5 |
@@ -133,7 +133,7 @@ Child PRs resolve their own `Verify:` targets and post a concise validation rece
 
 ## Relationship to GitHub Issues
 
-Parent feature Issue [#4107](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4107) is the live validation hub. Child Issues [#4108](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4108) through [#4119](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4119) were filed from the validated task templates and linked through native dependencies. #4108 through #4110 are delivered; #4132 delivered the canonical atomic governed KnowledgePort create-if-absent boundary, and #4111 implements the dependent durable extraction/proposal-companion slice. Later children remain governed by their recorded predecessors; #4117 additionally needs its separate authoritative vault-wide profile contract, which also gates #4119 and parent completion.
+Parent feature Issue [#4107](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4107) is the live validation hub. Child Issues [#4108](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4108) through [#4119](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4119) were filed from the validated task templates and linked through native dependencies. #4108 through #4110 are delivered; #4132 delivered the canonical atomic governed KnowledgePort create-if-absent boundary, #4111 is implemented, and #4113 was delivered by PR #4991 with the portable source-bundle slice. Later children remain governed by their recorded predecessors; #4117 additionally needs its separate authoritative vault-wide profile contract, which also gates #4119 and parent completion.
 
 ## Related Docs
 

--- a/tests/architecture/test_docs_index.py
+++ b/tests/architecture/test_docs_index.py
@@ -114,7 +114,7 @@ def test_ysnv2_owner_doc_delivery_state_matches_index() -> None:
     index_text = DOCS_INDEX.read_text(encoding="utf-8")
 
     owner_state = owner_doc.splitlines()[0]
-    assert "YSNV2-06" in owner_state and "delivered" in owner_state.lower()
+    assert "YSNV2-06 is delivered" in owner_state
 
     index_row = next(
         (

--- a/tests/architecture/test_docs_index.py
+++ b/tests/architecture/test_docs_index.py
@@ -106,6 +106,28 @@ def test_index_paths_exist() -> None:
     )
 
 
+def test_ysnv2_owner_doc_delivery_state_matches_index() -> None:
+    """Keep the YSNV2-06 owner state aligned with its canonical index row."""
+    owner_doc = (DOCS_ROOT / "YOUTUBE_SOURCE_NOTE_V2" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    index_text = DOCS_INDEX.read_text(encoding="utf-8")
+
+    owner_state = owner_doc.splitlines()[0]
+    assert "YSNV2-06" in owner_state and "delivered" in owner_state.lower()
+
+    index_row = next(
+        (
+            line
+            for line in index_text.splitlines()
+            if line.startswith("| docs/YOUTUBE_SOURCE_NOTE_V2/README.md |")
+        ),
+        None,
+    )
+    assert index_row is not None, "YSNV2 owner README must have a canonical index row."
+    assert "YSNV2-06 delivered" in index_row
+
+
 def _heading_to_anchor(heading: str) -> str:
     """Convert a Markdown heading text to a GitHub-style anchor slug."""
     slug = heading.strip().lower()


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5010

## Linked Issue
Closes #5010

## SBS Impact
- Primary subsystem: Builder System / documentation authority
- Secondary subsystem(s): HKA YouTube source-note capability
- Write class: governance/docs/tests
- Persistence impact: none
- Derived/rebuildable impact: canonical routing and current-state projection
- New or changed contract: owner doc and index agree on YSNV2-06 delivery
- Owner-doc impact: updated
- Transition debt impact: reduces current-state authority drift
- Boundary risk: no product/runtime authority change

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reconcile the YSNV2-06 owner README delivery state with the canonical docs index and add a focused parity regression test.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record needed; this is a repo-governed docs/test reconciliation with no operational-state output.

## Notes
Validation: `python3 -m pytest -q tests/architecture/test_docs_index.py` (5 passed); `python3 scripts/docs_guard.py`; `git diff --check`.
