### PR TITLE
Repair anchored synthesis validation

### DIFF
--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -75,7 +75,7 @@ from app.events.types import (
     YOUTUBE_SOURCE_DISCOVERED,
 )
 from app.knowledge_acquisition.source_registry import VALID_PRIORITIES as _registry_priorities
-from app.knowledge_acquisition.pipeline_defaults import DEFAULT_EXTRACTOR_IDS
+from app.knowledge_acquisition.pipeline_defaults import DEFAULT_EXTRACTOR_IDS, resolve_extractor_ids
 from app.services.outbox import derive_idempotency_key, write_outbox_event
 
 # --- Contract vocab ----------------------------------------------------------
@@ -1017,7 +1017,9 @@ class AcquisitionRequests:
                     "policy_snapshot.extractor_requirements must map non-empty extractor ids "
                     "to a required/optional materialization classification"
                 )
-            selected = tuple(extractor_ids or ("summary",))
+            selected = resolve_extractor_ids(
+                tuple(extractor_ids or DEFAULT_EXTRACTOR_IDS), extractor_requirements
+            )
             if set(extractor_requirements) != set(selected):
                 raise AcquisitionRequestValidationError(
                     "policy_snapshot.extractor_requirements must classify every selected "

--- a/app/knowledge_acquisition/evidence_synthesis.py
+++ b/app/knowledge_acquisition/evidence_synthesis.py
@@ -9,8 +9,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
-import re
 from typing import Any, Mapping, Sequence
+
+from lingua import Language, LanguageDetectorBuilder
+
+
+_D6_LANGUAGES = {"en": Language.ENGLISH, "sv": Language.SWEDISH}
+_LANGUAGE_DETECTOR = LanguageDetectorBuilder.from_all_languages_without(Language.LATIN).build()
+_NORDIC_LANGUAGE_DETECTOR = LanguageDetectorBuilder.from_languages(
+    Language.ENGLISH, Language.SWEDISH
+).build()
+_NORDIC_NEIGHBORS = {Language.BOKMAL, Language.DANISH, Language.NYNORSK}
 
 
 @dataclass(frozen=True)
@@ -47,31 +56,29 @@ def caption_quality_confidence_cap(acquisition_method: object) -> float:
     return 0.5
 
 
-_ENGLISH_MARKERS = frozenset(
-    "a an and are as about by can claim claims contains describes demonstrates evidence "
-    "for from has have in indicates is it its makes may of on provides source supports "
-    "that the their this to with".split()
-)
-_NON_ENGLISH_MARKERS = frozenset(
-    "avec cette dans des est et la le les une que sont ce der die das ein eine ist mit "
-    "el las los una es son con del y het een van zijn".split()
-)
-_TOKEN_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
-
-
 def validate_generated_language(text: str, expected_language: str) -> bool:
-    """Apply a conservative, deterministic D6 gate to generated prose."""
+    """Accept only D6's detected generated-prose language.
 
-    tokens = {token.casefold() for token in _TOKEN_RE.findall(text)}
-    if not tokens:
+    A language identifier handles ordinary prose without coupling the gate to a
+    small, hand-maintained set of marker words. Detection failures fail closed.
+    """
+
+    if expected_language not in {"en", "sv"} or not text.strip():
         return False
-    if expected_language == "sv":
-        return bool(tokens & {"och", "att", "som", "för", "inte", "är", "på", "med"}) or bool(
-            set(text) & {"å", "ä", "ö", "Å", "Ä", "Ö"}
-        )
-    if tokens & _NON_ENGLISH_MARKERS:
+    expected = _D6_LANGUAGES.get(expected_language)
+    if expected is None or not text.strip():
         return False
-    return bool(tokens & _ENGLISH_MARKERS)
+    detected = _LANGUAGE_DETECTOR.detect_language_of(text)
+    if detected == expected:
+        return True
+    # Short Swedish prose can be indistinguishable from its Nordic neighbors
+    # to a broad detector. Resolve only that bounded ambiguity with the D6
+    # language set; every other language remains a fail-closed refusal.
+    return (
+        expected == Language.SWEDISH
+        and detected in _NORDIC_NEIGHBORS
+        and _NORDIC_LANGUAGE_DETECTOR.detect_language_of(text) == Language.SWEDISH
+    )
 
 
 def render_evidence_anchored(

--- a/app/knowledge_acquisition/extractors/synthesis_extractor.py
+++ b/app/knowledge_acquisition/extractors/synthesis_extractor.py
@@ -126,7 +126,7 @@ def run(normalized: Mapping[str, Any], *, complete: CompletionFn | None = None) 
                 version=EXTRACTOR_VERSION,
                 reason="synthesis sentence language is not allowed by D6",
             )
-        if not any(
+        if not all(
             validate_resolvable_anchor(anchor, segments) for anchor in sentence["anchors"]
         ):
             raise ExtractionError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ iniconfig==2.1.0
 jsonpatch==1.33
 jsonschema==4.23.0
 jsonpointer==3.0.0
+lingua-language-detector==2.1.1
 rfc3339-validator==0.1.4
 six==1.17.0
 langchain-core==1.3.3

--- a/tests/knowledge_acquisition/test_acquire.py
+++ b/tests/knowledge_acquisition/test_acquire.py
@@ -16,11 +16,17 @@ import json
 from pathlib import Path
 import threading
 from typing import Any
+import uuid
 
 import pytest
 
 from app import objects as object_store_module
 from app.knowledge_acquisition import youtube_plugin as plugin
+from app.knowledge_acquisition import acquisition_requests as request_module
+from app.knowledge_acquisition.acquisition_requests import (
+    AcquisitionRequests,
+    reset_memory_acquisition_requests,
+)
 from app.knowledge_acquisition.acquire import (
     AcquisitionError,
     DatabaseNotConfiguredError,
@@ -31,10 +37,20 @@ from app.knowledge.write_ops import write_note_relative
 from app.knowledge_acquisition.candidate_writeback import Candidate, write_candidate_note
 from app.knowledge_acquisition.extraction_registry import clear_registry
 from app.knowledge_acquisition.extractors import claims_extractor, summary_extractor, synthesis_extractor
+from app.knowledge_acquisition.playlist_discovery import poll_source
+from app.knowledge_acquisition.source_registry import (
+    SourceRegistry,
+    reset_memory_source_registry,
+)
 from app.knowledge_acquisition.stage_events import (
     STAGE_COMPLETED_TOPIC,
     STAGE_DEAD_LETTERED_TOPIC,
 )
+from app.knowledge_acquisition.youtube_api_client import (
+    PlaylistItem,
+    PlaylistItemsPage,
+)
+from app.services.outbox import write_outbox_event
 from app.stores import reset_store_backends
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard
@@ -212,6 +228,76 @@ def _denying_guard() -> WriteGuard:
     `WritesBlockedError` for the (non-bootstrap) candidate-write action — the real
     reachable state a degraded runtime produces."""
     return WriteGuard(lambda: {"state": "safe_mode", "reason": "runtime degraded (test)"})
+
+
+def test_anchored_policy_defaults_enqueue_through_playlist_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_memory_source_registry()
+    reset_memory_acquisition_requests()
+    outbox = FakeOutboxConn()
+
+    def emit(event: Any, conn: Any = None, *, idempotency_key: str) -> str:
+        del conn
+        return write_outbox_event(event, conn=outbox, idempotency_key=idempotency_key)
+
+    monkeypatch.setattr(request_module, "write_outbox_event", emit)
+    try:
+        account = str(uuid.uuid4())
+        registry = SourceRegistry.for_runtime()
+        row = registry.register(
+            collection_kind="inbox_playlist",
+            collection_ref="PL_anchored_default",
+            title="Anchored default policy",
+            account_binding_id=account,
+            acquisition_policy={
+                "extractor_requirements": {
+                    "synthesis": "required_for_materialization",
+                    "claims": "required_for_materialization",
+                }
+            },
+        )
+        binding = registry.set_inbox(account, row.binding_id)
+        page = PlaylistItemsPage(
+            items=(
+                PlaylistItem(
+                    playlist_item_id="pli-anchored-default",
+                    video_id=VIDEO_ID,
+                    position=0,
+                    published_at="2026-08-20T00:00:00Z",
+                    title="Anchored default fixture",
+                ),
+            ),
+            next_page_token=None,
+            etag='"anchored-default"',
+            pagination_truncated=False,
+        )
+
+        class Api:
+            def list_playlist_items(self, *_args: Any, **_kwargs: Any) -> PlaylistItemsPage:
+                return page
+
+            def quota_status(self) -> dict[str, int | bool]:
+                return {"spent_today": 1, "budget": 10_000, "exhausted": False}
+
+        result = poll_source(
+            binding,
+            api_client=Api(),
+            requests=AcquisitionRequests.for_runtime(),
+            registry=registry,
+        )
+
+        queued = AcquisitionRequests.for_runtime().list_all()
+        assert result.enqueued == 1
+        assert len(queued) == 1
+        assert queued[0].policy_snapshot["extractor_ids"] == []
+        assert queued[0].policy_snapshot["extractor_requirements"] == {
+            "synthesis": "required_for_materialization",
+            "claims": "required_for_materialization",
+        }
+    finally:
+        reset_memory_source_registry()
+        reset_memory_acquisition_requests()
 
 
 def test_normal_acquisition_produces_anchored_synthesis(

--- a/tests/knowledge_acquisition/test_claims_extractor.py
+++ b/tests/knowledge_acquisition/test_claims_extractor.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.knowledge_acquisition.extraction_registry import ExtractionError
 from app.knowledge_acquisition.extractors.claims_extractor import run
+from app.knowledge_acquisition.extractors.synthesis_extractor import run as run_synthesis
 
 
 NORMALIZED = {
@@ -48,3 +49,19 @@ def test_non_swedish_paraphrase_language_is_rejected() -> None:
 
     with pytest.raises(ExtractionError, match="system_paraphrase language"):
         run(NORMALIZED, complete=_completion(json.dumps(payload)))
+
+
+def test_synthesis_rejects_any_invalid_anchor_before_persistence() -> None:
+    payload = {
+        "synthesis_sentences": [{
+            "text": "Cats sleep frequently.",
+            "anchors": [
+                {"segment_index": 0, "start": 0.0, "end": 2.0},
+                {"segment_index": 0, "start": 2.0, "end": 3.0},
+            ],
+        }],
+        "model_confidence": 0.8,
+    }
+
+    with pytest.raises(ExtractionError, match="synthesis anchor is not resolvable"):
+        run_synthesis({**NORMALIZED, "language": "en"}, complete=_completion(json.dumps(payload)))

--- a/tests/knowledge_acquisition/test_evidence_synthesis.py
+++ b/tests/knowledge_acquisition/test_evidence_synthesis.py
@@ -1,6 +1,9 @@
 """Contract tests for evidence-anchored synthesis rendering (YSNV2-05)."""
 
-from app.knowledge_acquisition.evidence_synthesis import render_evidence_anchored
+from app.knowledge_acquisition.evidence_synthesis import (
+    render_evidence_anchored,
+    validate_generated_language,
+)
 
 
 NORMALIZED = {
@@ -9,6 +12,13 @@ NORMALIZED = {
     "segments": [{"start": 0.0, "end": 2.0, "text": "Original source wording."}],
 }
 ANCHOR = {"segment_index": 0, "start": 0.0, "end": 2.0}
+
+
+def test_language_validation_rejects_invalid_d6_output() -> None:
+    assert validate_generated_language("Cats sleep frequently.", "en")
+    assert validate_generated_language("Katter sover ofta.", "sv")
+    assert not validate_generated_language("Bonjour a Paris.", "en")
+    assert not validate_generated_language("Cats sleep frequently.", "sv")
 
 
 def test_renderer_drops_anchorless_claims_and_synthesis_sentences() -> None:


### PR DESCRIPTION
Governing-Issue: #5012

Fixes #5012

Final-Review-Rounds: 0

## Summary
Align acquisition queue validation with anchored extractor defaults while preserving explicit legacy-summary policies, replace marker-word language checks with bounded language identification, and reject synthesis output when any anchor is invalid.

## SBS Impact
- Primary subsystem: Product/Runtime HKA knowledge acquisition
- Write class: code/tests
- Persistence impact: invalid derived synthesis is refused before persistence or rendering.
- Owner-doc writeback: not required; existing D6 and refinement-pipeline contracts remain unchanged.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No builder-operations material or plan divergence was produced by this bounded runtime repair.

## Notes
Validation: `python3 -m pytest -q tests/knowledge_acquisition/test_acquisition_requests.py::test_enqueue_accepts_summary_requirements_when_extractor_ids_are_omitted tests/knowledge_acquisition/test_acquire.py tests/knowledge_acquisition/test_evidence_synthesis.py tests/knowledge_acquisition/test_claims_extractor.py` (30 passed); `ruff check app tests`; `mypy app`; `git diff --check`.

CI status: prior required run exposed and repaired the legacy-summary regression. It also failed an unrelated `tests/properties/test_guard_at_seam.py` census mismatch for existing `app/knowledge_acquisition/source_bundle.py` call sites; current-head CI remains required before merge.
---