### PR TITLE
Publish Builder Thread command artifacts atomically

### DIFF
--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -179,6 +179,7 @@ class SerializedThreadWriter:
         self._request_results: dict[str, BuilderThread] = {}
         self._capture_index: dict[str, str] = {}
         self._accepted_mutation_count = 0
+        self._persistence_unavailable = False
         self._lock = threading.RLock()
         self._verify_external_root()
         self._restore_external_state()
@@ -204,6 +205,10 @@ class SerializedThreadWriter:
 
             if self._accepted_mutation_count >= _MAX_TOTAL_ENTRIES:
                 raise BuilderThreadError("serialized writer contribution bound reached")
+            if self._persistence_unavailable:
+                raise WriterUnavailableError("serialized writer persistence is unavailable")
+            threads_before_write = self._threads.copy()
+            capture_index_before_write = self._capture_index.copy()
             if command.kind == "create":
                 thread = self._create(command)
             else:
@@ -215,7 +220,9 @@ class SerializedThreadWriter:
                     sequence=self._accepted_mutation_count + 1,
                 )
             except OSError as exc:
-                self._restore_external_state()
+                self._threads = threads_before_write
+                self._capture_index = capture_index_before_write
+                self._persistence_unavailable = True
                 raise WriterUnavailableError("serialized writer persistence is unavailable") from exc
             self._record(command, request_digest, thread)
             return ThreadMutationResult(thread=thread, replayed=False)
@@ -345,15 +352,16 @@ class SerializedThreadWriter:
                 payload = json.loads(path.read_text(encoding="utf-8"))
                 sequence = payload["sequence"]
                 command = _command_from_record(payload, vault_id=self._vault_id)
+                if path.name != f"{command.request_id}.json":
+                    raise ValueError("invalid writer entry identity")
                 digest = payload["request_digest"]
                 if not isinstance(sequence, int) or isinstance(sequence, bool):
                     raise ValueError("invalid writer sequence")
                 if not isinstance(digest, str) or digest != _command_digest(command):
                     raise ValueError("invalid writer digest")
                 _validate_command(command)
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-                self._quarantine_incomplete_entry(path)
-                continue
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise BuilderThreadError("external writer entry is invalid") from exc
             records.append((sequence, command, digest))
         if len(records) > _MAX_TOTAL_ENTRIES:
             raise BuilderThreadError("external writer contribution bound exceeded")
@@ -379,17 +387,11 @@ class SerializedThreadWriter:
         temporary_path = self._entries_root / f".{path.name}.{uuid.uuid4().hex}.tmp"
         with temporary_path.open("xb") as handle:
             handle.write(_canonical_json(payload))
-        if path.exists():
-            raise FileExistsError(path)
-        os.replace(temporary_path, path)
-
-    def _quarantine_incomplete_entry(self, path: Path) -> None:
-        """Retain a malformed legacy final artifact without treating it as committed."""
-        quarantine_path = path.with_name(f"{path.name}.quarantine-{uuid.uuid4().hex}")
+        os.link(temporary_path, path)
         try:
-            os.replace(path, quarantine_path)
-        except OSError as exc:
-            raise BuilderThreadError("external writer entry is invalid") from exc
+            temporary_path.unlink()
+        except OSError:
+            pass
 
     def _record(
         self, command: ThreadMutation, request_digest: str, thread: BuilderThread

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -337,32 +337,33 @@ class SerializedThreadWriter:
         self._request_results = {}
         self._capture_index = {}
         self._accepted_mutation_count = 0
-        paths = tuple(self._entries_root.glob("*.json"))
-        if len(paths) > _MAX_TOTAL_ENTRIES:
-            raise BuilderThreadError("external writer contribution bound exceeded")
-        records: list[tuple[int, Any]] = []
-        for path in paths:
+        records: list[tuple[int, ThreadMutation, str]] = []
+        for path in self._entries_root.glob("*.json"):
             if path.is_symlink():
                 raise BuilderThreadError("external writer entry is unavailable")
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
                 sequence = payload["sequence"]
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-                raise BuilderThreadError("external writer entry is invalid") from exc
-            if not isinstance(sequence, int) or isinstance(sequence, bool):
-                raise BuilderThreadError("external writer entry is invalid")
-            records.append((sequence, payload))
-        for expected_sequence, (sequence, payload) in enumerate(sorted(records), start=1):
+                command = _command_from_record(payload, vault_id=self._vault_id)
+                digest = payload["request_digest"]
+                if not isinstance(sequence, int) or isinstance(sequence, bool):
+                    raise ValueError("invalid writer sequence")
+                if not isinstance(digest, str) or digest != _command_digest(command):
+                    raise ValueError("invalid writer digest")
+                _validate_command(command)
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                self._quarantine_incomplete_entry(path)
+                continue
+            records.append((sequence, command, digest))
+        if len(records) > _MAX_TOTAL_ENTRIES:
+            raise BuilderThreadError("external writer contribution bound exceeded")
+        for expected_sequence, (sequence, command, digest) in enumerate(
+            sorted(records, key=lambda record: record[0]), start=1
+        ):
             if sequence != expected_sequence:
                 raise BuilderThreadError("external writer entry order conflicts")
-            try:
-                command = _command_from_record(payload, vault_id=self._vault_id)
-                digest = str(payload["request_digest"])
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-                raise BuilderThreadError("external writer entry is invalid") from exc
-            if digest != _command_digest(command) or command.request_id in self._request_digests:
+            if command.request_id in self._request_digests:
                 raise BuilderThreadError("external writer entry conflicts")
-            _validate_command(command)
             thread = self._create(command) if command.kind == "create" else self._append(command)
             self._record(command, digest, thread)
 
@@ -375,8 +376,20 @@ class SerializedThreadWriter:
             "schema": "builder-thread-command.v1",
             "vault_id": self._vault_id,
         }
-        with path.open("xb") as handle:
+        temporary_path = self._entries_root / f".{path.name}.{uuid.uuid4().hex}.tmp"
+        with temporary_path.open("xb") as handle:
             handle.write(_canonical_json(payload))
+        if path.exists():
+            raise FileExistsError(path)
+        os.replace(temporary_path, path)
+
+    def _quarantine_incomplete_entry(self, path: Path) -> None:
+        """Retain a malformed legacy final artifact without treating it as committed."""
+        quarantine_path = path.with_name(f"{path.name}.quarantine-{uuid.uuid4().hex}")
+        try:
+            os.replace(path, quarantine_path)
+        except OSError as exc:
+            raise BuilderThreadError("external writer entry is invalid") from exc
 
     def _record(
         self, command: ThreadMutation, request_digest: str, thread: BuilderThread

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -289,6 +289,15 @@ and the writer at 100 total contributions, keeping reads bounded. An unavailable
 writer returns a typed degraded failure and never enables direct client filesystem
 fallback.
 
+Each command envelope is written to a same-directory temporary pathname, then
+atomically published at its final JSON pathname only after the complete payload
+is written. Interrupted temporary writes are not committed state. Recovery reads
+only validated final envelopes in sequence order; a malformed legacy partial
+final envelope is retained under a quarantine name and excluded from replay, so
+the last valid artifact remains the recovery authority. A failed publication
+returns the existing typed writer-unavailable signal, and an exact retry may
+then publish the command without duplicating an accepted mutation.
+
 This boundary is deliberately not a distributed filesystem protocol. It has no
 vault-global claims, slot reservations, cross-device locks, hard-link/fsync race
 recovery, SQLite state, or iCloud convergence semantics. PR #4706 is superseded

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -293,14 +293,14 @@ Each command envelope is written to a same-directory temporary pathname, then
 atomically published at its final JSON pathname only after the complete payload
 is written. Interrupted temporary writes are not committed state. Recovery reads
 only validated final envelopes in sequence order; a malformed legacy partial
-final envelope is retained under a quarantine name and excluded from replay, so
-the last valid artifact remains the recovery authority. A failed publication
-returns the existing typed writer-unavailable signal, and an exact retry may
-then publish the command without duplicating an accepted mutation.
+final envelope is retained and fails recovery closed rather than being replayed
+or silently discarded. A failed publication latches the existing typed
+writer-unavailable signal until a clean restart; an exact retry after a valid
+restart may then publish the command without duplicating an accepted mutation.
 
 This boundary is deliberately not a distributed filesystem protocol. It has no
-vault-global claims, slot reservations, cross-device locks, hard-link/fsync race
-recovery, SQLite state, or iCloud convergence semantics. PR #4706 is superseded
+vault-global claims, slot reservations, cross-device locks, fsync-based recovery,
+SQLite state, or iCloud convergence semantics. PR #4706 is superseded
 multi-writer evidence only; it is not merged or used as the operational contract.
 
 Threads and their inbox/devUI projections are non-authoritative discussion

--- a/tests/builderops/test_builder_threads_serialized.py
+++ b/tests/builderops/test_builder_threads_serialized.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 from pathlib import Path
 
 from app.builderops.builder_threads_serialized import (
+    BuilderThreadError,
     BuilderThreadClient,
     BuilderThreadWriterHost,
     InProcessWriterEndpoint,
@@ -455,7 +454,7 @@ def test_failed_write_preserves_last_valid_artifact(
     def fail_publication(_source: object, _destination: object) -> None:
         raise OSError("simulated publication failure")
 
-    monkeypatch.setattr("app.builderops.builder_threads_serialized.os.replace", fail_publication)
+    monkeypatch.setattr("app.builderops.builder_threads_serialized.os.link", fail_publication)
     with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
         client.create(
             request_id="atomic-failure-5023",
@@ -469,6 +468,56 @@ def test_failed_write_preserves_last_valid_artifact(
     assert (entries / "atomic-baseline-5023.json").read_bytes() == baseline
     assert not (entries / "atomic-failure-5023.json").exists()
     assert writer.read_thread(created.thread.thread_id) == created.thread
+
+
+def test_atomic_publication_does_not_overwrite_competing_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = _writer(tmp_path)
+    client = BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+    entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
+    created = client.create(
+        request_id="competing-baseline-5023",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Competing baseline",
+        content="This valid envelope must not become another request's authority.",
+        source_refs=("github:5023",),
+    )
+    competing = (entries / "competing-baseline-5023.json").read_bytes()
+
+    def simulate_competing_publication(_source: object, destination: object) -> None:
+        Path(destination).write_bytes(competing)
+        raise FileExistsError(destination)
+
+    monkeypatch.setattr(
+        "app.builderops.builder_threads_serialized.os.link", simulate_competing_publication
+    )
+    with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
+        client.create(
+            request_id="competing-publication-5023",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Competing publication",
+            content="The writer must not replace an existing immutable envelope.",
+            source_refs=("github:5023",),
+        )
+
+    assert (entries / "competing-publication-5023.json").read_bytes() == competing
+    assert writer.read_thread(created.thread.thread_id) == created.thread
+    with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
+        client.create(
+            request_id="competing-follow-up-5023",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Competing follow-up",
+            content="A failed publication latches the writer unavailable.",
+            source_refs=("github:5023",),
+        )
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        _writer(tmp_path)
 
 
 def test_restart_recovers_after_interrupted_write(tmp_path: Path) -> None:
@@ -521,28 +570,13 @@ def test_partial_artifact_is_quarantined_with_failure_signal(
         source_refs=("github:5023",),
     )
     entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
-    original_replace = os.replace
+    partial = entries / "partial-final-5023.json"
+    partial.write_text('{"command":', encoding="utf-8")
 
-    def leave_partial_final(_source: object, destination: object) -> None:
-        destination_path = Path(destination)
-        if destination_path.name == "partial-final-5023.json":
-            destination_path.write_text('{"command":', encoding="utf-8")
-            raise OSError("simulated interrupted publication")
-        original_replace(_source, destination)
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        _writer(tmp_path)
 
-    monkeypatch.setattr("app.builderops.builder_threads_serialized.os.replace", leave_partial_final)
-    with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
-        client.create(
-            request_id="partial-final-5023",
-            actor="codex:desktop",
-            recipient="claude:mac",
-            subject="Partial final artifact",
-            content="This partial final artifact cannot authorize a mutation.",
-            source_refs=("github:5023",),
-        )
-
-    assert not (entries / "partial-final-5023.json").exists()
-    assert list(entries.glob("partial-final-5023.json.quarantine-*"))
+    assert partial.read_text(encoding="utf-8") == '{"command":'
     assert writer.read_thread(created.thread.thread_id) == created.thread
 
 

--- a/tests/builderops/test_builder_threads_serialized.py
+++ b/tests/builderops/test_builder_threads_serialized.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 from pathlib import Path
 
@@ -430,6 +432,118 @@ def test_external_writer_state_survives_restart_and_replays_exact_request(tmp_pa
     )
     assert restarted.read(created.thread.thread_id).thread_id == created.thread.thread_id
     assert restarted.create(**request).replayed is True
+
+
+def test_failed_write_preserves_last_valid_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = _writer(tmp_path)
+    client = BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+    created = client.create(
+        request_id="atomic-baseline-5023",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Atomic baseline",
+        content="This committed artifact must remain readable.",
+        source_refs=("github:5023",),
+    )
+    entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
+    baseline = (entries / "atomic-baseline-5023.json").read_bytes()
+
+    def fail_publication(_source: object, _destination: object) -> None:
+        raise OSError("simulated publication failure")
+
+    monkeypatch.setattr("app.builderops.builder_threads_serialized.os.replace", fail_publication)
+    with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
+        client.create(
+            request_id="atomic-failure-5023",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Atomic failure",
+            content="This failed write must not replace committed state.",
+            source_refs=("github:5023",),
+        )
+
+    assert (entries / "atomic-baseline-5023.json").read_bytes() == baseline
+    assert not (entries / "atomic-failure-5023.json").exists()
+    assert writer.read_thread(created.thread.thread_id) == created.thread
+
+
+def test_restart_recovers_after_interrupted_write(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    client = BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+    created = client.create(
+        request_id="interrupted-create-5023",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Interrupted restart",
+        content="A completed command remains available after interruption.",
+        source_refs=("github:5023",),
+    )
+    entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
+    (entries / ".interrupted-reply-5023.json.interrupted.tmp").write_text(
+        '{"command":', encoding="utf-8"
+    )
+
+    restarted = BuilderThreadClient(
+        InProcessWriterEndpoint(_writer(tmp_path), client_id="claude:mac"), client_id="claude:mac"
+    )
+    retried = restarted.reply(
+        request_id="interrupted-reply-5023",
+        thread_id=created.thread.thread_id,
+        actor="claude:mac",
+        recipient="codex:desktop",
+        content="The retry commits exactly once after restart.",
+        source_refs=("github:5023",),
+    )
+
+    assert retried.replayed is False
+    assert len(restarted.read(created.thread.thread_id).entries) == 2
+
+
+def test_partial_artifact_is_quarantined_with_failure_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = _writer(tmp_path)
+    client = BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+    created = client.create(
+        request_id="partial-baseline-5023",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Partial artifact baseline",
+        content="The last valid command must remain authoritative.",
+        source_refs=("github:5023",),
+    )
+    entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
+    original_replace = os.replace
+
+    def leave_partial_final(_source: object, destination: object) -> None:
+        destination_path = Path(destination)
+        if destination_path.name == "partial-final-5023.json":
+            destination_path.write_text('{"command":', encoding="utf-8")
+            raise OSError("simulated interrupted publication")
+        original_replace(_source, destination)
+
+    monkeypatch.setattr("app.builderops.builder_threads_serialized.os.replace", leave_partial_final)
+    with pytest.raises(WriterUnavailableError, match="persistence is unavailable"):
+        client.create(
+            request_id="partial-final-5023",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Partial final artifact",
+            content="This partial final artifact cannot authorize a mutation.",
+            source_refs=("github:5023",),
+        )
+
+    assert not (entries / "partial-final-5023.json").exists()
+    assert list(entries.glob("partial-final-5023.json.quarantine-*"))
+    assert writer.read_thread(created.thread.thread_id) == created.thread
 
 
 def test_external_writer_restores_causal_order_not_request_id_order(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #5023

Refs #5023

Final-Review-Rounds: 2

## Summary
Publishes serialized Builder Thread command envelopes by writing a same-directory temporary file and atomically linking it into the immutable final pathname without replacement. Publication failure preserves prior in-memory and committed state, then latches the existing writer-unavailable signal until restart.

Restart recovery accepts only validated committed envelopes. Interrupted temporary writes are not committed; malformed or integrity-corrupt final envelopes fail recovery closed rather than being replayed or silently discarded. Builder Thread delivery, approval, receipt, backlog, and promotion boundaries remain unchanged.

## BuilderOps Routing
- Records/projections/receipts: dispatcher claim receipt `lease-b7573838`
- Reason: The implementation produced no separate BuilderOps operational record; the governing Issue and dispatcher-backed pickup receipt provide delivery traceability.

## Notes
- Owner-doc writeback: updated `docs/BUILDEROPS/BUILDEROPS_VAULT_STORE.md` at Builder Thread artifact exchange.
- Validation: current-head AC tests (3 passed); full serialized writer file (37 passed); `ruff check app/builderops tests/builderops`; `mypy app/builderops`; `git diff --check`; required and changed-surface CI green on `d0c7e9a7e2b09917d8b04fcf507cb63741d5d53f`.
- Review repair: protected P1 findings remain bound to failure_domain `lease/concurrency` and mechanism_id `serialized-envelope-publication-recovery-v1`; the active convergence circuit breaker requires two clean independent final rounds.
Verified-Closing-Issues: #5023