### PR TITLE
Add historical affected-test selector replay

### DIFF
--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -129,3 +129,22 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - Direct repair PRs are classified by the surfaces they touch, not by whether they carry a governing issue.
 - Failing required checks must be classified, not ignored as out-of-scope.
 - A required check that is stale, missing, or unrelated to the current head SHA is a blocking classification problem, not a silent pass.
+
+## Historical selector replay
+
+`scripts/replay_pr_test_selection.py` measures how the current affected-test selector classifies
+historical accepted-main deltas without changing CI or creating a second subsystem-policy source.
+It walks a bounded first-parent sample, fingerprints `scripts/select_pr_tests.py`, and emits the
+changed paths, selected subsystems and targets, plus aggregate full-suite, unowned-path, and
+multi-subsystem rates:
+
+```bash
+python3 scripts/replay_pr_test_selection.py --ref origin/main --limit 100 --json
+```
+
+The report is a rebuildable observation, never delivery authority. It applies the selector at the
+current checkout to historical changed-file sets; it does not reconstruct the selector revision
+that existed at each merge. Git history alone also cannot establish historical failing-test recall,
+CI duration or runner cost, review effort, or escaped-defect frequency. Those measurements require
+separately attributable CI and delivery evidence and must remain `not observable` when that evidence
+is unavailable rather than being inferred from this replay.

--- a/scripts/replay_pr_test_selection.py
+++ b/scripts/replay_pr_test_selection.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+if __package__:
+    from .select_pr_tests import Selection, select_tests
+else:
+    from select_pr_tests import Selection, select_tests
+
+
+SCHEMA_VERSION = "affected-test-selector-replay.v1"
+INTERPRETATION = (
+    "This report replays the current selector over historical changed-file sets. "
+    "It does not reconstruct the selector version used at each commit and does not measure "
+    "historical failing-test recall, CI duration, runner cost, review effort, or escaped defects."
+)
+DEFAULT_SELECTOR_PATH = Path(__file__).with_name("select_pr_tests.py")
+DEFAULT_SELECTOR_ID = "scripts/select_pr_tests.py"
+GitRunner = Callable[..., str]
+
+
+class ReplayError(RuntimeError):
+    """Raised when a replay cannot produce truthful evidence."""
+
+
+def _run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _selection_evidence(selection: Selection) -> dict[str, Any]:
+    return {
+        "full_suite": selection.full_suite,
+        "subsystems": list(selection.subsystems),
+        "targets": list(selection.targets),
+        "reason": selection.reason,
+        "unowned_paths": list(selection.unowned_paths),
+    }
+
+
+def _rate(count: int, total: int) -> float:
+    return count / total
+
+
+def _selector_id(selector_path: Path) -> str:
+    if selector_path.resolve() == DEFAULT_SELECTOR_PATH.resolve():
+        return DEFAULT_SELECTOR_ID
+    return str(selector_path)
+
+
+def build_report(
+    *,
+    ref: str,
+    limit: int,
+    selector_path: Path = DEFAULT_SELECTOR_PATH,
+    run_git: GitRunner | None = None,
+) -> dict[str, Any]:
+    git = run_git or _run_git
+    if limit < 1:
+        raise ReplayError("limit must be a positive integer")
+    if not selector_path.is_file():
+        raise ReplayError(f"selector source does not exist: {selector_path}")
+
+    resolved_ref = git("rev-parse", "--verify", f"{ref}^{{commit}}").strip()
+    commits = [
+        line
+        for line in git(
+            "rev-list",
+            "--first-parent",
+            f"--max-count={limit}",
+            resolved_ref,
+        ).splitlines()
+        if line
+    ]
+    if not commits:
+        raise ReplayError(f"no first-parent commits found for ref {ref!r}")
+
+    deliveries: list[dict[str, Any]] = []
+    for commit in commits:
+        parent = git("rev-parse", "--verify", f"{commit}^").strip()
+        changed_files = [
+            line
+            for line in git("diff", "--name-only", parent, commit).splitlines()
+            if line
+        ]
+        selection = select_tests(changed_files)
+        deliveries.append(
+            {
+                "commit": commit,
+                "parent": parent,
+                "changed_files": changed_files,
+                "selection": _selection_evidence(selection),
+            }
+        )
+
+    total = len(deliveries)
+    full_suite_count = sum(
+        delivery["selection"]["full_suite"] is True for delivery in deliveries
+    )
+    unowned_count = sum(
+        bool(delivery["selection"]["unowned_paths"]) for delivery in deliveries
+    )
+    multi_subsystem_count = sum(
+        len(delivery["selection"]["subsystems"]) > 1 for delivery in deliveries
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "interpretation": INTERPRETATION,
+        "selector": {
+            "path": _selector_id(selector_path),
+            "sha256": hashlib.sha256(selector_path.read_bytes()).hexdigest(),
+        },
+        "ref": {"requested": ref, "resolved_sha": resolved_ref},
+        "sample": {
+            "requested_limit": limit,
+            "returned": total,
+            "newest_commit": commits[0],
+            "oldest_commit": commits[-1],
+        },
+        "metrics": {
+            "deliveries": total,
+            "full_suite": {
+                "count": full_suite_count,
+                "rate": _rate(full_suite_count, total),
+            },
+            "unowned": {
+                "count": unowned_count,
+                "rate": _rate(unowned_count, total),
+            },
+            "multi_subsystem": {
+                "count": multi_subsystem_count,
+                "rate": _rate(multi_subsystem_count, total),
+            },
+        },
+        "deliveries": deliveries,
+    }
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay the current affected-test selector over first-parent Git history."
+    )
+    parser.add_argument("--ref", default="HEAD", help="Git ref whose first-parent history is replayed.")
+    parser.add_argument(
+        "--limit",
+        default=100,
+        type=_positive_int,
+        help="Maximum number of first-parent commits to replay (default: 100).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the complete JSON evidence report.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = build_report(ref=args.ref, limit=args.limit)
+    except ReplayError as exc:
+        print(f"selector replay failed: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        print(f"selector replay failed: {detail}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        metrics = report["metrics"]
+        print(f"ref={report['ref']['resolved_sha']}")
+        print(f"deliveries={metrics['deliveries']}")
+        for name in ("full_suite", "unowned", "multi_subsystem"):
+            print(f"{name}={metrics[name]['count']} ({metrics[name]['rate']:.1%})")
+        print(f"interpretation={report['interpretation']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_replay_pr_test_selection.py
+++ b/tests/scripts/test_replay_pr_test_selection.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import scripts.replay_pr_test_selection as replay
+
+
+def _fake_history(*args: str) -> str:
+    responses = {
+        ("rev-parse", "--verify", "main^{commit}"): "head-sha\n",
+        ("rev-list", "--first-parent", "--max-count=3", "head-sha"): "c3\nc2\nc1\n",
+        ("rev-parse", "--verify", "c3^"): "p3\n",
+        ("rev-parse", "--verify", "c2^"): "p2\n",
+        ("rev-parse", "--verify", "c1^"): "p1\n",
+        ("diff", "--name-only", "p3", "c3"): "pyproject.toml\n",
+        ("diff", "--name-only", "p2", "c2"): "app/new_surface/example.py\n",
+        (
+            "diff",
+            "--name-only",
+            "p1",
+            "c1",
+        ): "companion-ui/companion-app/companion_ui/workspace/view.py\napp/instance/vault_registry.py\n",
+    }
+    return responses[args]
+
+
+def test_replay_reports_current_policy_metrics(tmp_path: Path) -> None:
+    selector_path = tmp_path / "select_pr_tests.py"
+    selector_path.write_text("current selector policy\n", encoding="utf-8")
+
+    report = replay.build_report(
+        ref="main",
+        limit=3,
+        selector_path=selector_path,
+        run_git=_fake_history,
+    )
+
+    assert report["metrics"] == {
+        "deliveries": 3,
+        "full_suite": {"count": 1, "rate": 1 / 3},
+        "unowned": {"count": 1, "rate": 1 / 3},
+        "multi_subsystem": {"count": 1, "rate": 1 / 3},
+    }
+    assert [delivery["commit"] for delivery in report["deliveries"]] == ["c3", "c2", "c1"]
+    assert report["deliveries"][0]["selection"]["full_suite"] is True
+    assert report["deliveries"][1]["selection"]["unowned_paths"] == [
+        "app/new_surface/example.py"
+    ]
+    assert len(report["deliveries"][2]["selection"]["subsystems"]) > 1
+
+
+def test_replay_binds_output_to_selector_and_ref(tmp_path: Path) -> None:
+    selector_path = tmp_path / "select_pr_tests.py"
+    selector_bytes = b"selector-version\n"
+    selector_path.write_bytes(selector_bytes)
+
+    report = replay.build_report(
+        ref="main",
+        limit=3,
+        selector_path=selector_path,
+        run_git=_fake_history,
+    )
+
+    assert report["schema_version"] == "affected-test-selector-replay.v1"
+    assert report["selector"] == {
+        "path": str(selector_path),
+        "sha256": hashlib.sha256(selector_bytes).hexdigest(),
+    }
+    assert report["ref"] == {"requested": "main", "resolved_sha": "head-sha"}
+    assert report["sample"] == {
+        "requested_limit": 3,
+        "returned": 3,
+        "newest_commit": "c3",
+        "oldest_commit": "c1",
+    }
+    assert "current selector" in report["interpretation"].lower()
+    assert "failing-test recall" in report["interpretation"].lower()
+    assert replay._selector_id(replay.DEFAULT_SELECTOR_PATH) == "scripts/select_pr_tests.py"
+
+
+def test_replay_fails_loud_on_empty_sample(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def empty_history(*args: str) -> str:
+        if args[0] == "rev-parse":
+            return "head-sha\n"
+        if args[0] == "rev-list":
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.setattr(replay, "_run_git", empty_history)
+
+    exit_code = replay.main(["--ref", "main", "--limit", "3", "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "no first-parent commits" in captured.err
+
+
+def test_git_failure_is_reported_without_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def failed_git(*args: str) -> str:
+        raise subprocess.CalledProcessError(128, ["git", *args], stderr="unknown revision")
+
+    monkeypatch.setattr(replay, "_run_git", failed_git)
+
+    exit_code = replay.main(["--ref", "missing", "--limit", "3", "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ""
+    assert "unknown revision" in captured.err
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(captured.out)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5029

## Linked Issue
Closes #5029

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): none
- Write class: governance/process tooling
- Persistence impact: none
- Derived/rebuildable impact: JSON observation rebuilt from Git history and the current selector
- New or changed contract: read-only current-policy selector replay contract
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces unmeasured selector-fit debt
- Boundary risk: replay must not become delivery authority or claim historical failing-test recall

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a deterministic current-policy replay over bounded first-parent accepted-main deltas.
- Report SHA-bound selector evidence and routing rates without changing CI authority or selection.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps operational material was produced; evidence is rebuilt directly from Git and repo policy.

## Notes
Validation: docs language guard; Ruff; mypy app (906 files); selector-scoped not-pg suite (1451 passed, 3 skipped, 2 deselected); focused replay tests (4 passed); 100-delta real replay.
