### PR TITLE
Enforce scope isolation for promoted ASK recall

### DIFF
--- a/app/agent_memory/candidate.py
+++ b/app/agent_memory/candidate.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, model_validator
+
+MEMORY_SCOPE_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
+MEMORY_SCOPE_ID_MAX_LENGTH = 128
+_MEMORY_SCOPE_ID_RE = re.compile(MEMORY_SCOPE_ID_PATTERN)
+
+
+def validated_memory_scope_id(value: object) -> str | None:
+    """Return one explicit valid scope binding; never infer or coerce authority."""
+
+    if (
+        not isinstance(value, str)
+        or len(value) > MEMORY_SCOPE_ID_MAX_LENGTH
+        or _MEMORY_SCOPE_ID_RE.fullmatch(value) is None
+    ):
+        return None
+    return value
 
 
 class ReviewState(str, Enum):
@@ -74,6 +91,12 @@ class MemoryCandidate(BaseModel):
     source_refs: list[str] = Field(default_factory=list)
     derived_from: Optional[str] = None
     generated_by: Optional[str] = None
+    scope_id: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=MEMORY_SCOPE_ID_MAX_LENGTH,
+        pattern=MEMORY_SCOPE_ID_PATTERN,
+    )
 
     content: Optional[str] = None
     confidence: Optional[str] = None

--- a/app/agent_memory/candidate.py
+++ b/app/agent_memory/candidate.py
@@ -9,13 +9,18 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, model_validator
 
 MEMORY_SCOPE_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
+MEMORY_SCOPE_ID_MAX_LENGTH = 128
 _MEMORY_SCOPE_ID_RE = re.compile(MEMORY_SCOPE_ID_PATTERN)
 
 
 def validated_memory_scope_id(value: object) -> str | None:
     """Return one explicit valid scope binding; never infer or coerce authority."""
 
-    if not isinstance(value, str) or _MEMORY_SCOPE_ID_RE.fullmatch(value) is None:
+    if (
+        not isinstance(value, str)
+        or len(value) > MEMORY_SCOPE_ID_MAX_LENGTH
+        or _MEMORY_SCOPE_ID_RE.fullmatch(value) is None
+    ):
         return None
     return value
 
@@ -89,7 +94,7 @@ class MemoryCandidate(BaseModel):
     scope_id: Optional[str] = Field(
         default=None,
         min_length=1,
-        max_length=128,
+        max_length=MEMORY_SCOPE_ID_MAX_LENGTH,
         pattern=MEMORY_SCOPE_ID_PATTERN,
     )
 

--- a/app/agent_memory/candidate.py
+++ b/app/agent_memory/candidate.py
@@ -74,6 +74,12 @@ class MemoryCandidate(BaseModel):
     source_refs: list[str] = Field(default_factory=list)
     derived_from: Optional[str] = None
     generated_by: Optional[str] = None
+    scope_id: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+    )
 
     content: Optional[str] = None
     confidence: Optional[str] = None

--- a/app/agent_memory/candidate.py
+++ b/app/agent_memory/candidate.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, model_validator
+
+MEMORY_SCOPE_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
+_MEMORY_SCOPE_ID_RE = re.compile(MEMORY_SCOPE_ID_PATTERN)
+
+
+def validated_memory_scope_id(value: object) -> str | None:
+    """Return one explicit valid scope binding; never infer or coerce authority."""
+
+    if not isinstance(value, str) or _MEMORY_SCOPE_ID_RE.fullmatch(value) is None:
+        return None
+    return value
 
 
 class ReviewState(str, Enum):
@@ -78,7 +90,7 @@ class MemoryCandidate(BaseModel):
         default=None,
         min_length=1,
         max_length=128,
-        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+        pattern=MEMORY_SCOPE_ID_PATTERN,
     )
 
     content: Optional[str] = None

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -10,8 +10,11 @@ from uuid import uuid4
 
 import yaml
 
-from app.agent_memory.candidate import MemoryType
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.candidate import MemoryType, validated_memory_scope_id
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+)
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry, ReviewStatus
 from app.events.types import PROMOTION_TRANSITION_APPLIED
 from app.knowledge.write_ops import write_note_relative
@@ -55,6 +58,7 @@ def materialize_promoted_memory(
             entry.candidate_id,
             vault_context=vault_context,
             channel=channel,
+            expected_outcome=ReviewDecision.PROMOTE,
         )
         return MemoryMaterializationResult(
             status="not_semantic",
@@ -62,12 +66,7 @@ def materialize_promoted_memory(
             receipt_id=None,
             terminal=True,
         )
-    persisted_scope_id = _require_scope_binding(
-        entry,
-        decision_store=decision_store,
-        vault_context=vault_context,
-        channel=channel,
-    )
+    requested_scope_id = _require_scope_binding(entry)
 
     vault_root = _vault_root(vault_context)
     artifact_uuid = uuid4().hex
@@ -79,56 +78,65 @@ def materialize_promoted_memory(
     )
     trace_id = uuid4().hex
     try:
-        write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
-        write_note_relative(
-            artifact_path,
-            _render_memory_note(
-                entry,
-                artifact_uuid=artifact_uuid,
-                scope_id=persisted_scope_id,
-            ),
-            vault_root=vault_root,
-        )
-    except Exception as exc:
-        receipt_id = _append_promotion_receipt(
-            outbox_path,
-            entry=entry,
+        with decision_store.promotion_materialization_transaction(
+            entry.candidate_id,
             vault_context=vault_context,
             channel=channel,
-            artifact_uuid=artifact_uuid,
-            artifact_path=artifact_path,
-            trace_id=trace_id,
-            scope_id=persisted_scope_id,
-            status="failed",
-            error=str(exc),
-        )
-        raise MemoryMaterializationError(
-            f"memory materialization failed; receipt={receipt_id}"
-        ) from exc
+            expected_scope_id=requested_scope_id,
+        ) as persisted:
+            persisted_scope_id = persisted.scope_id
+            if persisted_scope_id is None:
+                raise MemoryMaterializationError(
+                    "persisted promote decision has no scope binding"
+                )
+            try:
+                write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
+                write_note_relative(
+                    artifact_path,
+                    _render_memory_note(
+                        entry,
+                        artifact_uuid=artifact_uuid,
+                        scope_id=persisted_scope_id,
+                    ),
+                    vault_root=vault_root,
+                )
+            except Exception as exc:
+                receipt_id = _append_promotion_receipt(
+                    outbox_path,
+                    entry=entry,
+                    vault_context=vault_context,
+                    channel=channel,
+                    artifact_uuid=artifact_uuid,
+                    artifact_path=artifact_path,
+                    trace_id=trace_id,
+                    scope_id=persisted_scope_id,
+                    status="failed",
+                    error=str(exc),
+                )
+                raise MemoryMaterializationError(
+                    f"memory materialization failed; receipt={receipt_id}"
+                ) from exc
 
-    receipt_id = _append_promotion_receipt(
-        outbox_path,
-        entry=entry,
-        vault_context=vault_context,
-        channel=channel,
-        artifact_uuid=artifact_uuid,
-        artifact_path=artifact_path,
-        trace_id=trace_id,
-        scope_id=persisted_scope_id,
-        status="applied",
-    )
-    result = query_promotion_receipts(
-        vault_root=vault_root,
-        outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
-    )
-    if not any(row.receipt_id == receipt_id for row in result.rows):
-        raise MemoryMaterializationError("materialization receipt was not queryable")
-    decision_store.mark_terminal(
-        entry.candidate_id,
-        vault_context=vault_context,
-        channel=channel,
-        expected_scope_id=persisted_scope_id,
-    )
+            receipt_id = _append_promotion_receipt(
+                outbox_path,
+                entry=entry,
+                vault_context=vault_context,
+                channel=channel,
+                artifact_uuid=artifact_uuid,
+                artifact_path=artifact_path,
+                trace_id=trace_id,
+                scope_id=persisted_scope_id,
+                status="applied",
+            )
+            result = query_promotion_receipts(
+                vault_root=vault_root,
+                outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
+            )
+            if not any(row.receipt_id == receipt_id for row in result.rows):
+                raise MemoryMaterializationError("materialization receipt was not queryable")
+    except ReviewDecisionStoreError as exc:
+        raise MemoryMaterializationError(str(exc)) from exc
+
     return MemoryMaterializationResult(
         status="materialized",
         artifact_path=artifact_path,
@@ -142,33 +150,13 @@ def _require_promoted(entry: ReviewEntry) -> None:
         raise MemoryMaterializationError("entry must carry a promote decision")
 
 
-def _require_scope_binding(
-    entry: ReviewEntry,
-    *,
-    decision_store: ReviewDecisionStore,
-    vault_context: VaultContext,
-    channel: str,
-) -> str:
-    if entry.scope_id is None:
+def _require_scope_binding(entry: ReviewEntry) -> str:
+    scope_id = validated_memory_scope_id(entry.scope_id)
+    if scope_id is None:
         raise MemoryMaterializationError(
-            "semantic memory materialization requires candidate.scope_id"
+            "semantic memory materialization requires a valid candidate.scope_id"
         )
-    persisted = decision_store.get_decision(
-        entry.candidate_id,
-        vault_context=vault_context,
-        channel=channel,
-    )
-    if persisted is None or persisted.outcome is not ReviewDecision.PROMOTE:
-        raise MemoryMaterializationError(
-            "semantic memory materialization requires a persisted promote decision"
-        )
-    if persisted.terminal:
-        raise MemoryMaterializationError("semantic memory decision is already terminal")
-    if persisted.scope_id != entry.scope_id:
-        raise MemoryMaterializationError(
-            "candidate.scope_id does not match the persisted review decision"
-        )
-    return persisted.scope_id
+    return scope_id
 
 
 def _vault_root(context: VaultContext) -> Path:

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -62,6 +62,7 @@ def materialize_promoted_memory(
             receipt_id=None,
             terminal=True,
         )
+    _require_scope_binding(entry)
 
     vault_root = _vault_root(vault_context)
     artifact_uuid = uuid4().hex
@@ -129,6 +130,13 @@ def _require_promoted(entry: ReviewEntry) -> None:
         raise MemoryMaterializationError("entry must carry a promote decision")
 
 
+def _require_scope_binding(entry: ReviewEntry) -> None:
+    if entry.scope_id is None:
+        raise MemoryMaterializationError(
+            "semantic memory materialization requires candidate.scope_id"
+        )
+
+
 def _vault_root(context: VaultContext) -> Path:
     if not context.active_vault_path:
         raise MemoryMaterializationError("vault_context.active_vault_path is required")
@@ -172,6 +180,7 @@ def _render_memory_note(entry: ReviewEntry, *, artifact_uuid: str) -> str:
         "agent_promoted": True,
         "labels": ["agent-promoted-memory"],
         "promoted_from_candidate_id": candidate.candidate_id,
+        "scope_id": candidate.scope_id,
         "source_refs": list(candidate.source_refs),
         "inferred": candidate.inferred,
         "generated_by": candidate.generated_by,
@@ -220,6 +229,7 @@ def _append_promotion_receipt(
             "source_event": f"memory-promote:{entry.candidate_id}",
             "intent_type": "agent_memory_materialization",
             "candidate_id": entry.candidate_id,
+            "scope_id": entry.scope_id,
             "inferred": entry.inferred,
             "source_refs": list(entry.source_refs),
         },

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -246,9 +246,16 @@ def _stable_materialization_id(
     vault_context: VaultContext,
     channel: str,
 ) -> str:
+    vault_identity = vault_context.active_vault_id
+    if not vault_identity:
+        if not vault_context.active_vault_path:
+            raise MemoryMaterializationError(
+                "vault identity is required for stable materialization"
+            )
+        vault_identity = f"path:{Path(vault_context.active_vault_path).expanduser().resolve()}"
     identity = (
         f"agent-memory-materialization:{kind}:"
-        f"{vault_context.active_vault_id}:{channel}:{entry.candidate_id}"
+        f"{vault_identity}:{channel}:{entry.candidate_id}"
     )
     return uuid5(NAMESPACE_URL, identity).hex
 

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -1,21 +1,30 @@
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import yaml
 
-from app.agent_memory.candidate import MemoryType
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.candidate import MemoryType, validated_memory_scope_id
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionRecord,
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+    review_candidate_digest,
+)
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry, ReviewStatus
 from app.events.types import PROMOTION_TRANSITION_APPLIED
 from app.knowledge.write_ops import write_note_relative
-from app.receipts.promotion_receipts import query_promotion_receipts
+from app.receipts.promotion_receipts import (
+    PromotionReceiptQuery,
+    PromotionReceiptRow,
+    query_promotion_receipts,
+)
+from app.services.outbox import append_jsonl_record
 from app.vault.manager import VaultContext
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 
@@ -55,6 +64,7 @@ def materialize_promoted_memory(
             entry.candidate_id,
             vault_context=vault_context,
             channel=channel,
+            expected_outcome=ReviewDecision.PROMOTE,
         )
         return MemoryMaterializationResult(
             status="not_semantic",
@@ -62,60 +72,134 @@ def materialize_promoted_memory(
             receipt_id=None,
             terminal=True,
         )
+    requested_scope_id = _require_scope_binding(entry)
 
     vault_root = _vault_root(vault_context)
-    artifact_uuid = uuid4().hex
-    artifact_path = _unique_memory_path(
-        vault_root=vault_root,
-        memory_dir=memory_dir,
-        title=entry.title,
-        candidate_id=entry.candidate_id,
-    )
-    trace_id = uuid4().hex
-    try:
-        write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
-        write_note_relative(
-            artifact_path,
-            _render_memory_note(entry, artifact_uuid=artifact_uuid),
-            vault_root=vault_root,
-        )
-    except Exception as exc:
-        receipt_id = _append_promotion_receipt(
-            outbox_path,
-            entry=entry,
-            vault_context=vault_context,
-            channel=channel,
-            artifact_uuid=artifact_uuid,
-            artifact_path=artifact_path,
-            trace_id=trace_id,
-            status="failed",
-            error=str(exc),
-        )
-        raise MemoryMaterializationError(
-            f"memory materialization failed; receipt={receipt_id}"
-        ) from exc
-
-    receipt_id = _append_promotion_receipt(
-        outbox_path,
+    receipt_id = _stable_materialization_id(
+        "receipt",
         entry=entry,
         vault_context=vault_context,
         channel=channel,
-        artifact_uuid=artifact_uuid,
-        artifact_path=artifact_path,
-        trace_id=trace_id,
-        status="applied",
     )
-    result = query_promotion_receipts(
-        vault_root=vault_root,
-        outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
-    )
-    if not any(row.receipt_id == receipt_id for row in result.rows):
-        raise MemoryMaterializationError("materialization receipt was not queryable")
-    decision_store.mark_terminal(
-        entry.candidate_id,
+    trace_id = _stable_materialization_id(
+        "trace",
+        entry=entry,
         vault_context=vault_context,
         channel=channel,
     )
+    artifact_path: str | None = None
+    try:
+        with decision_store.promotion_materialization_transaction(
+            entry.candidate_id,
+            vault_context=vault_context,
+            channel=channel,
+            expected_scope_id=requested_scope_id,
+            expected_candidate_digest=review_candidate_digest(entry),
+        ) as persisted:
+            persisted_scope_id = persisted.scope_id
+            if persisted_scope_id is None:
+                raise MemoryMaterializationError(
+                    "persisted promote decision has no scope binding"
+                )
+            recovered_receipt = _recover_applied_receipt(
+                receipt_id,
+                entry=entry,
+                vault_root=vault_root,
+                outbox_path=outbox_path,
+                scope_id=persisted_scope_id,
+                persisted=persisted,
+                vault_id=_materialization_vault_identity(vault_context),
+            )
+            if recovered_receipt is not None:
+                artifact_path = recovered_receipt.artifact_path
+            else:
+                recovered_note = _find_materialized_note(
+                    vault_root=vault_root,
+                    memory_dir=memory_dir,
+                    entry=entry,
+                    scope_id=persisted_scope_id,
+                    persisted=persisted,
+                )
+                if recovered_note is None:
+                    artifact_uuid = _stable_materialization_id(
+                        "artifact",
+                        entry=entry,
+                        vault_context=vault_context,
+                        channel=channel,
+                    )
+                    artifact_path = _unique_memory_path(
+                        vault_root=vault_root,
+                        memory_dir=memory_dir,
+                        title=entry.title,
+                        candidate_id=entry.candidate_id,
+                    )
+                    try:
+                        write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
+                        write_note_relative(
+                            artifact_path,
+                            _render_memory_note(
+                                entry,
+                                artifact_uuid=artifact_uuid,
+                                scope_id=persisted_scope_id,
+                                persisted=persisted,
+                            ),
+                            vault_root=vault_root,
+                        )
+                    except Exception as exc:
+                        failed_receipt_id = _append_promotion_receipt(
+                            outbox_path,
+                            entry=entry,
+                            vault_context=vault_context,
+                            channel=channel,
+                            artifact_uuid=artifact_uuid,
+                            artifact_path=artifact_path,
+                            trace_id=trace_id,
+                            scope_id=persisted_scope_id,
+                            status="failed",
+                            error=str(exc),
+                            decided_by=persisted.decided_by,
+                        )
+                        raise MemoryMaterializationError(
+                            f"memory materialization failed; receipt={failed_receipt_id}"
+                        ) from exc
+                else:
+                    artifact_uuid, artifact_path = recovered_note
+
+                _append_promotion_receipt(
+                    outbox_path,
+                    entry=entry,
+                    vault_context=vault_context,
+                    channel=channel,
+                    artifact_uuid=artifact_uuid,
+                    artifact_path=artifact_path,
+                    trace_id=trace_id,
+                    scope_id=persisted_scope_id,
+                    status="applied",
+                    receipt_id=receipt_id,
+                    decided_by=persisted.decided_by,
+                )
+                recovered_receipt = _recover_applied_receipt(
+                    receipt_id,
+                    entry=entry,
+                    vault_root=vault_root,
+                    outbox_path=outbox_path,
+                    scope_id=persisted_scope_id,
+                    persisted=persisted,
+                    vault_id=_materialization_vault_identity(vault_context),
+                )
+                if recovered_receipt is None:
+                    raise MemoryMaterializationError(
+                        "materialization receipt was not queryable"
+                    )
+    except ReviewDecisionStoreError as exc:
+        raise MemoryMaterializationError(str(exc)) from exc
+    except MemoryMaterializationError:
+        raise
+    except Exception as exc:
+        raise MemoryMaterializationError(
+            "memory materialization interrupted; retry will reconcile durable effects"
+        ) from exc
+
     return MemoryMaterializationResult(
         status="materialized",
         artifact_path=artifact_path,
@@ -127,6 +211,15 @@ def materialize_promoted_memory(
 def _require_promoted(entry: ReviewEntry) -> None:
     if entry.status is not ReviewStatus.PROMOTED or entry.decision is not ReviewDecision.PROMOTE:
         raise MemoryMaterializationError("entry must carry a promote decision")
+
+
+def _require_scope_binding(entry: ReviewEntry) -> str:
+    scope_id = validated_memory_scope_id(entry.scope_id)
+    if scope_id is None:
+        raise MemoryMaterializationError(
+            "semantic memory materialization requires a valid candidate.scope_id"
+        )
+    return scope_id
 
 
 def _vault_root(context: VaultContext) -> Path:
@@ -163,7 +256,180 @@ def _unique_memory_path(
     return candidate.as_posix()
 
 
-def _render_memory_note(entry: ReviewEntry, *, artifact_uuid: str) -> str:
+def _stable_materialization_id(
+    kind: str,
+    *,
+    entry: ReviewEntry,
+    vault_context: VaultContext,
+    channel: str,
+) -> str:
+    vault_identity = _materialization_vault_identity(vault_context)
+    identity = (
+        f"agent-memory-materialization:{kind}:"
+        f"{vault_identity}:{channel}:{entry.candidate_id}"
+    )
+    return uuid5(NAMESPACE_URL, identity).hex
+
+
+def _materialization_vault_identity(vault_context: VaultContext) -> str:
+    if vault_context.active_vault_id:
+        return vault_context.active_vault_id
+    if not vault_context.active_vault_path:
+        raise MemoryMaterializationError(
+            "vault identity is required for stable materialization"
+        )
+    return f"path:{Path(vault_context.active_vault_path).expanduser().resolve()}"
+
+
+def _recover_applied_receipt(
+    receipt_id: str,
+    *,
+    entry: ReviewEntry,
+    vault_root: Path,
+    outbox_path: Path | None,
+    scope_id: str,
+    persisted: ReviewDecisionRecord,
+    vault_id: str,
+) -> PromotionReceiptRow | None:
+    result = query_promotion_receipts(
+        PromotionReceiptQuery(receipt_or_source_event_id=receipt_id),
+        vault_root=vault_root,
+        outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
+    )
+    matches = [row for row in result.rows if row.receipt_id == receipt_id]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise MemoryMaterializationError(
+            "multiple applied receipts exist for one memory materialization"
+        )
+    row = matches[0]
+    if (
+        row.outcome_status != "applied"
+        or row.vault_id != vault_id
+        or row.basis.get("candidate_id") != entry.candidate_id
+        or row.basis.get("scope_id") != scope_id
+        or row.artifact_uuid is None
+        or row.artifact_path is None
+    ):
+        raise MemoryMaterializationError(
+            "persisted memory materialization receipt conflicts with review authority"
+        )
+    artifact_file = _resolve_existing_vault_path(vault_root, row.artifact_path)
+    identity = _read_materialized_note_identity(artifact_file)
+    if identity != (entry.candidate_id, scope_id, row.artifact_uuid):
+        raise MemoryMaterializationError(
+            "persisted memory materialization receipt does not match its artifact"
+        )
+    if artifact_file.read_text(encoding="utf-8") != _render_memory_note(
+        entry,
+        artifact_uuid=row.artifact_uuid,
+        scope_id=scope_id,
+        persisted=persisted,
+    ):
+        raise MemoryMaterializationError(
+            "persisted memory materialization artifact content changed"
+        )
+    return row
+
+
+def _find_materialized_note(
+    *,
+    vault_root: Path,
+    memory_dir: str,
+    entry: ReviewEntry,
+    scope_id: str,
+    persisted: ReviewDecisionRecord,
+) -> tuple[str, str] | None:
+    root = vault_root / _safe_rel_path(memory_dir)
+    if not root.exists():
+        return None
+    _resolve_existing_vault_path(vault_root, root.relative_to(vault_root).as_posix())
+    matches: list[tuple[str, str]] = []
+    for path in root.rglob("*.md"):
+        identity = _read_materialized_note_identity(path)
+        if identity is None or identity[:2] != (entry.candidate_id, scope_id):
+            continue
+        safe_path = _resolve_existing_vault_path(
+            vault_root,
+            path.relative_to(vault_root).as_posix(),
+        )
+        if safe_path.read_text(encoding="utf-8") != _render_memory_note(
+            entry,
+            artifact_uuid=identity[2],
+            scope_id=scope_id,
+            persisted=persisted,
+        ):
+            raise MemoryMaterializationError(
+                "candidate-bound recovery artifact content changed"
+            )
+        matches.append((identity[2], path.relative_to(vault_root).as_posix()))
+    if len(matches) > 1:
+        raise MemoryMaterializationError(
+            "multiple vault artifacts exist for one memory candidate"
+        )
+    return matches[0] if matches else None
+
+
+def _resolve_existing_vault_path(vault_root: Path, relative_path: str) -> Path:
+    safe_relative = _safe_rel_path(relative_path)
+    lexical_root = vault_root.resolve()
+    lexical_path = lexical_root / safe_relative
+    current = lexical_root
+    for part in PurePosixPath(safe_relative).parts:
+        current = current / part
+        if current.is_symlink():
+            raise MemoryMaterializationError(
+                "materialization recovery artifact may not traverse a symlink"
+            )
+    try:
+        resolved = lexical_path.resolve(strict=True)
+    except OSError as exc:
+        raise MemoryMaterializationError(
+            "materialization recovery artifact is missing"
+        ) from exc
+    if not resolved.is_relative_to(lexical_root):
+        raise MemoryMaterializationError(
+            "materialization recovery artifact must stay inside the vault"
+        )
+    return resolved
+
+
+def _read_materialized_note_identity(path: Path) -> tuple[str, str, str] | None:
+    try:
+        body = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    if not body.startswith("---\n"):
+        return None
+    try:
+        _, raw_frontmatter, _ = body.split("---\n", 2)
+        frontmatter = yaml.safe_load(raw_frontmatter)
+    except (ValueError, yaml.YAMLError):
+        return None
+    if not isinstance(frontmatter, dict):
+        return None
+    candidate_id = frontmatter.get("promoted_from_candidate_id")
+    scope_id = frontmatter.get("scope_id")
+    artifact_uuid = frontmatter.get("uuid")
+    if (
+        frontmatter.get("agent_promoted") is not True
+        or frontmatter.get("artifact_type") != "semantic_memory"
+        or not isinstance(candidate_id, str)
+        or not isinstance(scope_id, str)
+        or not isinstance(artifact_uuid, str)
+    ):
+        return None
+    return candidate_id, scope_id, artifact_uuid
+
+
+def _render_memory_note(
+    entry: ReviewEntry,
+    *,
+    artifact_uuid: str,
+    scope_id: str,
+    persisted: ReviewDecisionRecord,
+) -> str:
     candidate = entry.candidate
     frontmatter = {
         "uuid": artifact_uuid,
@@ -172,12 +438,13 @@ def _render_memory_note(entry: ReviewEntry, *, artifact_uuid: str) -> str:
         "agent_promoted": True,
         "labels": ["agent-promoted-memory"],
         "promoted_from_candidate_id": candidate.candidate_id,
+        "scope_id": scope_id,
         "source_refs": list(candidate.source_refs),
         "inferred": candidate.inferred,
         "generated_by": candidate.generated_by,
         "derived_from": candidate.derived_from,
-        "decided_by": entry.decided_by,
-        "decided_at": _iso(entry.decided_at),
+        "decided_by": persisted.decided_by,
+        "decided_at": _iso(persisted.decided_at),
     }
     body = candidate.content or candidate.title
     yaml_block = yaml.safe_dump(frontmatter, sort_keys=True, allow_unicode=False).strip()
@@ -193,17 +460,20 @@ def _append_promotion_receipt(
     artifact_uuid: str,
     artifact_path: str,
     trace_id: str,
+    scope_id: str,
     status: str,
     error: str | None = None,
+    receipt_id: str | None = None,
+    decided_by: str | None = None,
 ) -> str:
-    receipt_id = uuid4().hex
+    receipt_id = receipt_id or uuid4().hex
     timestamp = _iso(datetime.now(timezone.utc))
     payload: dict[str, Any] = {
         "receipt_id": receipt_id,
         "intent_event_id": f"memory-promote:{entry.candidate_id}",
         "source_event": f"memory-promote:{entry.candidate_id}",
         "trace_id": trace_id,
-        "vault_id": vault_context.active_vault_id,
+        "vault_id": _materialization_vault_identity(vault_context),
         "channel": channel,
         "artifact_uuid": artifact_uuid,
         "artifact_path": artifact_path,
@@ -214,12 +484,13 @@ def _append_promotion_receipt(
             "mode": "governed_execution",
             "component": MEMORY_MATERIALIZATION_SOURCE,
             "executor": MEMORY_MATERIALIZATION_SOURCE,
-            "requested_by": entry.decided_by,
+            "requested_by": decided_by or entry.decided_by,
         },
         "basis": {
             "source_event": f"memory-promote:{entry.candidate_id}",
             "intent_type": "agent_memory_materialization",
             "candidate_id": entry.candidate_id,
+            "scope_id": scope_id,
             "inferred": entry.inferred,
             "source_refs": list(entry.source_refs),
         },
@@ -245,9 +516,7 @@ def _append_promotion_receipt(
         "payload": payload,
     }
     path = outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+    append_jsonl_record(path, record, require_event_id=True)
     return receipt_id
 
 

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import yaml
 
@@ -18,7 +17,12 @@ from app.agent_memory.review_decision_store import (
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry, ReviewStatus
 from app.events.types import PROMOTION_TRANSITION_APPLIED
 from app.knowledge.write_ops import write_note_relative
-from app.receipts.promotion_receipts import query_promotion_receipts
+from app.receipts.promotion_receipts import (
+    PromotionReceiptQuery,
+    PromotionReceiptRow,
+    query_promotion_receipts,
+)
+from app.services.outbox import append_jsonl_record
 from app.vault.manager import VaultContext
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 
@@ -69,14 +73,19 @@ def materialize_promoted_memory(
     requested_scope_id = _require_scope_binding(entry)
 
     vault_root = _vault_root(vault_context)
-    artifact_uuid = uuid4().hex
-    artifact_path = _unique_memory_path(
-        vault_root=vault_root,
-        memory_dir=memory_dir,
-        title=entry.title,
-        candidate_id=entry.candidate_id,
+    receipt_id = _stable_materialization_id(
+        "receipt",
+        entry=entry,
+        vault_context=vault_context,
+        channel=channel,
     )
-    trace_id = uuid4().hex
+    trace_id = _stable_materialization_id(
+        "trace",
+        entry=entry,
+        vault_context=vault_context,
+        channel=channel,
+    )
+    artifact_path: str | None = None
     try:
         with decision_store.promotion_materialization_transaction(
             entry.candidate_id,
@@ -89,19 +98,66 @@ def materialize_promoted_memory(
                 raise MemoryMaterializationError(
                     "persisted promote decision has no scope binding"
                 )
-            try:
-                write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
-                write_note_relative(
-                    artifact_path,
-                    _render_memory_note(
-                        entry,
-                        artifact_uuid=artifact_uuid,
-                        scope_id=persisted_scope_id,
-                    ),
+            recovered_receipt = _recover_applied_receipt(
+                receipt_id,
+                entry=entry,
+                vault_root=vault_root,
+                outbox_path=outbox_path,
+                scope_id=persisted_scope_id,
+            )
+            if recovered_receipt is not None:
+                artifact_path = recovered_receipt.artifact_path
+            else:
+                recovered_note = _find_materialized_note(
                     vault_root=vault_root,
+                    memory_dir=memory_dir,
+                    entry=entry,
+                    scope_id=persisted_scope_id,
                 )
-            except Exception as exc:
-                receipt_id = _append_promotion_receipt(
+                if recovered_note is None:
+                    artifact_uuid = _stable_materialization_id(
+                        "artifact",
+                        entry=entry,
+                        vault_context=vault_context,
+                        channel=channel,
+                    )
+                    artifact_path = _unique_memory_path(
+                        vault_root=vault_root,
+                        memory_dir=memory_dir,
+                        title=entry.title,
+                        candidate_id=entry.candidate_id,
+                    )
+                    try:
+                        write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
+                        write_note_relative(
+                            artifact_path,
+                            _render_memory_note(
+                                entry,
+                                artifact_uuid=artifact_uuid,
+                                scope_id=persisted_scope_id,
+                            ),
+                            vault_root=vault_root,
+                        )
+                    except Exception as exc:
+                        failed_receipt_id = _append_promotion_receipt(
+                            outbox_path,
+                            entry=entry,
+                            vault_context=vault_context,
+                            channel=channel,
+                            artifact_uuid=artifact_uuid,
+                            artifact_path=artifact_path,
+                            trace_id=trace_id,
+                            scope_id=persisted_scope_id,
+                            status="failed",
+                            error=str(exc),
+                        )
+                        raise MemoryMaterializationError(
+                            f"memory materialization failed; receipt={failed_receipt_id}"
+                        ) from exc
+                else:
+                    artifact_uuid, artifact_path = recovered_note
+
+                _append_promotion_receipt(
                     outbox_path,
                     entry=entry,
                     vault_context=vault_context,
@@ -110,30 +166,20 @@ def materialize_promoted_memory(
                     artifact_path=artifact_path,
                     trace_id=trace_id,
                     scope_id=persisted_scope_id,
-                    status="failed",
-                    error=str(exc),
+                    status="applied",
+                    receipt_id=receipt_id,
                 )
-                raise MemoryMaterializationError(
-                    f"memory materialization failed; receipt={receipt_id}"
-                ) from exc
-
-            receipt_id = _append_promotion_receipt(
-                outbox_path,
-                entry=entry,
-                vault_context=vault_context,
-                channel=channel,
-                artifact_uuid=artifact_uuid,
-                artifact_path=artifact_path,
-                trace_id=trace_id,
-                scope_id=persisted_scope_id,
-                status="applied",
-            )
-            result = query_promotion_receipts(
-                vault_root=vault_root,
-                outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
-            )
-            if not any(row.receipt_id == receipt_id for row in result.rows):
-                raise MemoryMaterializationError("materialization receipt was not queryable")
+                recovered_receipt = _recover_applied_receipt(
+                    receipt_id,
+                    entry=entry,
+                    vault_root=vault_root,
+                    outbox_path=outbox_path,
+                    scope_id=persisted_scope_id,
+                )
+                if recovered_receipt is None:
+                    raise MemoryMaterializationError(
+                        "materialization receipt was not queryable"
+                    )
     except ReviewDecisionStoreError as exc:
         raise MemoryMaterializationError(str(exc)) from exc
 
@@ -193,6 +239,156 @@ def _unique_memory_path(
     return candidate.as_posix()
 
 
+def _stable_materialization_id(
+    kind: str,
+    *,
+    entry: ReviewEntry,
+    vault_context: VaultContext,
+    channel: str,
+) -> str:
+    identity = (
+        f"agent-memory-materialization:{kind}:"
+        f"{vault_context.active_vault_id}:{channel}:{entry.candidate_id}"
+    )
+    return uuid5(NAMESPACE_URL, identity).hex
+
+
+def _recover_applied_receipt(
+    receipt_id: str,
+    *,
+    entry: ReviewEntry,
+    vault_root: Path,
+    outbox_path: Path | None,
+    scope_id: str,
+) -> PromotionReceiptRow | None:
+    result = query_promotion_receipts(
+        PromotionReceiptQuery(receipt_or_source_event_id=receipt_id),
+        vault_root=vault_root,
+        outbox_path=outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
+    )
+    matches = [row for row in result.rows if row.receipt_id == receipt_id]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise MemoryMaterializationError(
+            "multiple applied receipts exist for one memory materialization"
+        )
+    row = matches[0]
+    if (
+        row.outcome_status != "applied"
+        or row.basis.get("candidate_id") != entry.candidate_id
+        or row.basis.get("scope_id") != scope_id
+        or row.artifact_uuid is None
+        or row.artifact_path is None
+    ):
+        raise MemoryMaterializationError(
+            "persisted memory materialization receipt conflicts with review authority"
+        )
+    artifact_file = _resolve_existing_vault_path(vault_root, row.artifact_path)
+    identity = _read_materialized_note_identity(artifact_file)
+    if identity != (entry.candidate_id, scope_id, row.artifact_uuid):
+        raise MemoryMaterializationError(
+            "persisted memory materialization receipt does not match its artifact"
+        )
+    if artifact_file.read_text(encoding="utf-8") != _render_memory_note(
+        entry,
+        artifact_uuid=row.artifact_uuid,
+        scope_id=scope_id,
+    ):
+        raise MemoryMaterializationError(
+            "persisted memory materialization artifact content changed"
+        )
+    return row
+
+
+def _find_materialized_note(
+    *,
+    vault_root: Path,
+    memory_dir: str,
+    entry: ReviewEntry,
+    scope_id: str,
+) -> tuple[str, str] | None:
+    root = vault_root / _safe_rel_path(memory_dir)
+    if not root.exists():
+        return None
+    _resolve_existing_vault_path(vault_root, root.relative_to(vault_root).as_posix())
+    matches: list[tuple[str, str]] = []
+    for path in root.rglob("*.md"):
+        identity = _read_materialized_note_identity(path)
+        if identity is None or identity[:2] != (entry.candidate_id, scope_id):
+            continue
+        safe_path = _resolve_existing_vault_path(
+            vault_root,
+            path.relative_to(vault_root).as_posix(),
+        )
+        if safe_path.read_text(encoding="utf-8") != _render_memory_note(
+            entry,
+            artifact_uuid=identity[2],
+            scope_id=scope_id,
+        ):
+            raise MemoryMaterializationError(
+                "candidate-bound recovery artifact content changed"
+            )
+        matches.append((identity[2], path.relative_to(vault_root).as_posix()))
+    if len(matches) > 1:
+        raise MemoryMaterializationError(
+            "multiple vault artifacts exist for one memory candidate"
+        )
+    return matches[0] if matches else None
+
+
+def _resolve_existing_vault_path(vault_root: Path, relative_path: str) -> Path:
+    safe_relative = _safe_rel_path(relative_path)
+    lexical_root = vault_root.resolve()
+    lexical_path = lexical_root / safe_relative
+    current = lexical_root
+    for part in PurePosixPath(safe_relative).parts:
+        current = current / part
+        if current.is_symlink():
+            raise MemoryMaterializationError(
+                "materialization recovery artifact may not traverse a symlink"
+            )
+    try:
+        resolved = lexical_path.resolve(strict=True)
+    except OSError as exc:
+        raise MemoryMaterializationError(
+            "materialization recovery artifact is missing"
+        ) from exc
+    if not resolved.is_relative_to(lexical_root):
+        raise MemoryMaterializationError(
+            "materialization recovery artifact must stay inside the vault"
+        )
+    return resolved
+
+
+def _read_materialized_note_identity(path: Path) -> tuple[str, str, str] | None:
+    try:
+        body = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    if not body.startswith("---\n"):
+        return None
+    try:
+        _, raw_frontmatter, _ = body.split("---\n", 2)
+        frontmatter = yaml.safe_load(raw_frontmatter)
+    except (ValueError, yaml.YAMLError):
+        return None
+    if not isinstance(frontmatter, dict):
+        return None
+    candidate_id = frontmatter.get("promoted_from_candidate_id")
+    scope_id = frontmatter.get("scope_id")
+    artifact_uuid = frontmatter.get("uuid")
+    if (
+        frontmatter.get("agent_promoted") is not True
+        or frontmatter.get("artifact_type") != "semantic_memory"
+        or not isinstance(candidate_id, str)
+        or not isinstance(scope_id, str)
+        or not isinstance(artifact_uuid, str)
+    ):
+        return None
+    return candidate_id, scope_id, artifact_uuid
+
+
 def _render_memory_note(
     entry: ReviewEntry,
     *,
@@ -232,8 +428,9 @@ def _append_promotion_receipt(
     scope_id: str,
     status: str,
     error: str | None = None,
+    receipt_id: str | None = None,
 ) -> str:
-    receipt_id = uuid4().hex
+    receipt_id = receipt_id or uuid4().hex
     timestamp = _iso(datetime.now(timezone.utc))
     payload: dict[str, Any] = {
         "receipt_id": receipt_id,
@@ -283,9 +480,7 @@ def _append_promotion_receipt(
         "payload": payload,
     }
     path = outbox_path or DEFAULT_MATERIALIZATION_RECEIPTS_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+    append_jsonl_record(path, record, require_event_id=True)
     return receipt_id
 
 

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -62,7 +62,12 @@ def materialize_promoted_memory(
             receipt_id=None,
             terminal=True,
         )
-    _require_scope_binding(entry)
+    persisted_scope_id = _require_scope_binding(
+        entry,
+        decision_store=decision_store,
+        vault_context=vault_context,
+        channel=channel,
+    )
 
     vault_root = _vault_root(vault_context)
     artifact_uuid = uuid4().hex
@@ -77,7 +82,11 @@ def materialize_promoted_memory(
         write_guard.assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION)
         write_note_relative(
             artifact_path,
-            _render_memory_note(entry, artifact_uuid=artifact_uuid),
+            _render_memory_note(
+                entry,
+                artifact_uuid=artifact_uuid,
+                scope_id=persisted_scope_id,
+            ),
             vault_root=vault_root,
         )
     except Exception as exc:
@@ -89,6 +98,7 @@ def materialize_promoted_memory(
             artifact_uuid=artifact_uuid,
             artifact_path=artifact_path,
             trace_id=trace_id,
+            scope_id=persisted_scope_id,
             status="failed",
             error=str(exc),
         )
@@ -104,6 +114,7 @@ def materialize_promoted_memory(
         artifact_uuid=artifact_uuid,
         artifact_path=artifact_path,
         trace_id=trace_id,
+        scope_id=persisted_scope_id,
         status="applied",
     )
     result = query_promotion_receipts(
@@ -116,6 +127,7 @@ def materialize_promoted_memory(
         entry.candidate_id,
         vault_context=vault_context,
         channel=channel,
+        expected_scope_id=persisted_scope_id,
     )
     return MemoryMaterializationResult(
         status="materialized",
@@ -130,11 +142,33 @@ def _require_promoted(entry: ReviewEntry) -> None:
         raise MemoryMaterializationError("entry must carry a promote decision")
 
 
-def _require_scope_binding(entry: ReviewEntry) -> None:
+def _require_scope_binding(
+    entry: ReviewEntry,
+    *,
+    decision_store: ReviewDecisionStore,
+    vault_context: VaultContext,
+    channel: str,
+) -> str:
     if entry.scope_id is None:
         raise MemoryMaterializationError(
             "semantic memory materialization requires candidate.scope_id"
         )
+    persisted = decision_store.get_decision(
+        entry.candidate_id,
+        vault_context=vault_context,
+        channel=channel,
+    )
+    if persisted is None or persisted.outcome is not ReviewDecision.PROMOTE:
+        raise MemoryMaterializationError(
+            "semantic memory materialization requires a persisted promote decision"
+        )
+    if persisted.terminal:
+        raise MemoryMaterializationError("semantic memory decision is already terminal")
+    if persisted.scope_id != entry.scope_id:
+        raise MemoryMaterializationError(
+            "candidate.scope_id does not match the persisted review decision"
+        )
+    return persisted.scope_id
 
 
 def _vault_root(context: VaultContext) -> Path:
@@ -171,7 +205,12 @@ def _unique_memory_path(
     return candidate.as_posix()
 
 
-def _render_memory_note(entry: ReviewEntry, *, artifact_uuid: str) -> str:
+def _render_memory_note(
+    entry: ReviewEntry,
+    *,
+    artifact_uuid: str,
+    scope_id: str,
+) -> str:
     candidate = entry.candidate
     frontmatter = {
         "uuid": artifact_uuid,
@@ -180,7 +219,7 @@ def _render_memory_note(entry: ReviewEntry, *, artifact_uuid: str) -> str:
         "agent_promoted": True,
         "labels": ["agent-promoted-memory"],
         "promoted_from_candidate_id": candidate.candidate_id,
-        "scope_id": candidate.scope_id,
+        "scope_id": scope_id,
         "source_refs": list(candidate.source_refs),
         "inferred": candidate.inferred,
         "generated_by": candidate.generated_by,
@@ -202,6 +241,7 @@ def _append_promotion_receipt(
     artifact_uuid: str,
     artifact_path: str,
     trace_id: str,
+    scope_id: str,
     status: str,
     error: str | None = None,
 ) -> str:
@@ -229,7 +269,7 @@ def _append_promotion_receipt(
             "source_event": f"memory-promote:{entry.candidate_id}",
             "intent_type": "agent_memory_materialization",
             "candidate_id": entry.candidate_id,
-            "scope_id": entry.scope_id,
+            "scope_id": scope_id,
             "inferred": entry.inferred,
             "source_refs": list(entry.source_refs),
         },

--- a/app/agent_memory/materialization.py
+++ b/app/agent_memory/materialization.py
@@ -11,8 +11,10 @@ import yaml
 
 from app.agent_memory.candidate import MemoryType, validated_memory_scope_id
 from app.agent_memory.review_decision_store import (
+    ReviewDecisionRecord,
     ReviewDecisionStore,
     ReviewDecisionStoreError,
+    review_candidate_digest,
 )
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry, ReviewStatus
 from app.events.types import PROMOTION_TRANSITION_APPLIED
@@ -92,6 +94,7 @@ def materialize_promoted_memory(
             vault_context=vault_context,
             channel=channel,
             expected_scope_id=requested_scope_id,
+            expected_candidate_digest=review_candidate_digest(entry),
         ) as persisted:
             persisted_scope_id = persisted.scope_id
             if persisted_scope_id is None:
@@ -104,6 +107,8 @@ def materialize_promoted_memory(
                 vault_root=vault_root,
                 outbox_path=outbox_path,
                 scope_id=persisted_scope_id,
+                persisted=persisted,
+                vault_id=_materialization_vault_identity(vault_context),
             )
             if recovered_receipt is not None:
                 artifact_path = recovered_receipt.artifact_path
@@ -113,6 +118,7 @@ def materialize_promoted_memory(
                     memory_dir=memory_dir,
                     entry=entry,
                     scope_id=persisted_scope_id,
+                    persisted=persisted,
                 )
                 if recovered_note is None:
                     artifact_uuid = _stable_materialization_id(
@@ -135,6 +141,7 @@ def materialize_promoted_memory(
                                 entry,
                                 artifact_uuid=artifact_uuid,
                                 scope_id=persisted_scope_id,
+                                persisted=persisted,
                             ),
                             vault_root=vault_root,
                         )
@@ -150,6 +157,7 @@ def materialize_promoted_memory(
                             scope_id=persisted_scope_id,
                             status="failed",
                             error=str(exc),
+                            decided_by=persisted.decided_by,
                         )
                         raise MemoryMaterializationError(
                             f"memory materialization failed; receipt={failed_receipt_id}"
@@ -168,6 +176,7 @@ def materialize_promoted_memory(
                     scope_id=persisted_scope_id,
                     status="applied",
                     receipt_id=receipt_id,
+                    decided_by=persisted.decided_by,
                 )
                 recovered_receipt = _recover_applied_receipt(
                     receipt_id,
@@ -175,6 +184,8 @@ def materialize_promoted_memory(
                     vault_root=vault_root,
                     outbox_path=outbox_path,
                     scope_id=persisted_scope_id,
+                    persisted=persisted,
+                    vault_id=_materialization_vault_identity(vault_context),
                 )
                 if recovered_receipt is None:
                     raise MemoryMaterializationError(
@@ -182,6 +193,12 @@ def materialize_promoted_memory(
                     )
     except ReviewDecisionStoreError as exc:
         raise MemoryMaterializationError(str(exc)) from exc
+    except MemoryMaterializationError:
+        raise
+    except Exception as exc:
+        raise MemoryMaterializationError(
+            "memory materialization interrupted; retry will reconcile durable effects"
+        ) from exc
 
     return MemoryMaterializationResult(
         status="materialized",
@@ -246,18 +263,22 @@ def _stable_materialization_id(
     vault_context: VaultContext,
     channel: str,
 ) -> str:
-    vault_identity = vault_context.active_vault_id
-    if not vault_identity:
-        if not vault_context.active_vault_path:
-            raise MemoryMaterializationError(
-                "vault identity is required for stable materialization"
-            )
-        vault_identity = f"path:{Path(vault_context.active_vault_path).expanduser().resolve()}"
+    vault_identity = _materialization_vault_identity(vault_context)
     identity = (
         f"agent-memory-materialization:{kind}:"
         f"{vault_identity}:{channel}:{entry.candidate_id}"
     )
     return uuid5(NAMESPACE_URL, identity).hex
+
+
+def _materialization_vault_identity(vault_context: VaultContext) -> str:
+    if vault_context.active_vault_id:
+        return vault_context.active_vault_id
+    if not vault_context.active_vault_path:
+        raise MemoryMaterializationError(
+            "vault identity is required for stable materialization"
+        )
+    return f"path:{Path(vault_context.active_vault_path).expanduser().resolve()}"
 
 
 def _recover_applied_receipt(
@@ -267,6 +288,8 @@ def _recover_applied_receipt(
     vault_root: Path,
     outbox_path: Path | None,
     scope_id: str,
+    persisted: ReviewDecisionRecord,
+    vault_id: str,
 ) -> PromotionReceiptRow | None:
     result = query_promotion_receipts(
         PromotionReceiptQuery(receipt_or_source_event_id=receipt_id),
@@ -283,6 +306,7 @@ def _recover_applied_receipt(
     row = matches[0]
     if (
         row.outcome_status != "applied"
+        or row.vault_id != vault_id
         or row.basis.get("candidate_id") != entry.candidate_id
         or row.basis.get("scope_id") != scope_id
         or row.artifact_uuid is None
@@ -301,6 +325,7 @@ def _recover_applied_receipt(
         entry,
         artifact_uuid=row.artifact_uuid,
         scope_id=scope_id,
+        persisted=persisted,
     ):
         raise MemoryMaterializationError(
             "persisted memory materialization artifact content changed"
@@ -314,6 +339,7 @@ def _find_materialized_note(
     memory_dir: str,
     entry: ReviewEntry,
     scope_id: str,
+    persisted: ReviewDecisionRecord,
 ) -> tuple[str, str] | None:
     root = vault_root / _safe_rel_path(memory_dir)
     if not root.exists():
@@ -332,6 +358,7 @@ def _find_materialized_note(
             entry,
             artifact_uuid=identity[2],
             scope_id=scope_id,
+            persisted=persisted,
         ):
             raise MemoryMaterializationError(
                 "candidate-bound recovery artifact content changed"
@@ -401,6 +428,7 @@ def _render_memory_note(
     *,
     artifact_uuid: str,
     scope_id: str,
+    persisted: ReviewDecisionRecord,
 ) -> str:
     candidate = entry.candidate
     frontmatter = {
@@ -415,8 +443,8 @@ def _render_memory_note(
         "inferred": candidate.inferred,
         "generated_by": candidate.generated_by,
         "derived_from": candidate.derived_from,
-        "decided_by": entry.decided_by,
-        "decided_at": _iso(entry.decided_at),
+        "decided_by": persisted.decided_by,
+        "decided_at": _iso(persisted.decided_at),
     }
     body = candidate.content or candidate.title
     yaml_block = yaml.safe_dump(frontmatter, sort_keys=True, allow_unicode=False).strip()
@@ -436,6 +464,7 @@ def _append_promotion_receipt(
     status: str,
     error: str | None = None,
     receipt_id: str | None = None,
+    decided_by: str | None = None,
 ) -> str:
     receipt_id = receipt_id or uuid4().hex
     timestamp = _iso(datetime.now(timezone.utc))
@@ -444,7 +473,7 @@ def _append_promotion_receipt(
         "intent_event_id": f"memory-promote:{entry.candidate_id}",
         "source_event": f"memory-promote:{entry.candidate_id}",
         "trace_id": trace_id,
-        "vault_id": vault_context.active_vault_id,
+        "vault_id": _materialization_vault_identity(vault_context),
         "channel": channel,
         "artifact_uuid": artifact_uuid,
         "artifact_path": artifact_path,
@@ -455,7 +484,7 @@ def _append_promotion_receipt(
             "mode": "governed_execution",
             "component": MEMORY_MATERIALIZATION_SOURCE,
             "executor": MEMORY_MATERIALIZATION_SOURCE,
-            "requested_by": entry.decided_by,
+            "requested_by": decided_by or entry.decided_by,
         },
         "basis": {
             "source_event": f"memory-promote:{entry.candidate_id}",

--- a/app/agent_memory/recall_activation.py
+++ b/app/agent_memory/recall_activation.py
@@ -44,6 +44,7 @@ def activate_guarded_recall(
     behavioral_claim: str | None = None,
     authority_source: str | None = None,
     source_artifact_path: Path | None = None,
+    applied_scope_id: str | None = None,
 ) -> GuardedRecall:
     decision = evaluate_memory_authority(
         promoted,
@@ -76,6 +77,7 @@ def activate_guarded_recall(
         explanation=explanation,
         requested_use_right=use_right,
         source_artifact_path=source_artifact_path,
+        applied_scope_id=applied_scope_id,
     )
     return GuardedRecall(
         memory_id=promoted.candidate.candidate_id,
@@ -97,6 +99,7 @@ def _emit_recall_receipt(
     explanation: RecallExplanation,
     requested_use_right: RecallUseRight,
     source_artifact_path: Path | None,
+    applied_scope_id: str | None,
 ) -> str:
     record = {
         "event": RECALL_RECEIPT_EVENT,
@@ -121,6 +124,7 @@ def _emit_recall_receipt(
             "source_provenance": explanation.source_provenance.model_dump(),
             "authority_limits": list(explanation.authority_limits),
             "source_artifact_path": str(source_artifact_path) if source_artifact_path else None,
+            "applied_scope_id": applied_scope_id,
         },
     }
     receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -56,6 +56,8 @@ class RecallCandidate:
     reason: str
     artifact_path: str | None = None
     receipt_id: str | None = None
+    memory_scope_id: str | None = None
+    applied_scope_id: str | None = None
 
 
 def read_promoted_memories(
@@ -96,8 +98,14 @@ def retrieve_relevant_promoted(
     outbox_path: str | Path | None = None,
     records: Iterable[dict[str, Any]] | None = None,
     memory_dir: str = DEFAULT_MEMORY_DIR,
+    active_scope_id: str | None = None,
 ) -> list[RecallCandidate]:
-    """Return a scarce, relevance-ranked subset of promoted memories for recall."""
+    """Return a scarce, relevance-ranked subset of scope-eligible promoted memories.
+
+    A bound ASK admits only memories with the same persisted scope. Missing
+    bindings fail closed when a scope is active; unbound calls preserve the
+    default behavior and consider all promoted memories.
+    """
 
     if k <= 0:
         return []
@@ -116,12 +124,15 @@ def retrieve_relevant_promoted(
     )
     candidates: list[RecallCandidate] = []
     for row in rows:
-        promoted = _promoted_from_row(
+        promoted_with_scope = _promoted_from_row_with_scope(
             row,
             vault_root=resolved_root,
             memory_dir=memory_dir,
         )
-        if promoted is None:
+        if promoted_with_scope is None:
+            continue
+        promoted, memory_scope_id = promoted_with_scope
+        if active_scope_id is not None and memory_scope_id != active_scope_id:
             continue
         score, reason = _score(promoted, query_tokens)
         if score <= 0:
@@ -133,6 +144,8 @@ def retrieve_relevant_promoted(
                 reason=reason,
                 artifact_path=row.artifact_path,
                 receipt_id=row.receipt_id,
+                memory_scope_id=memory_scope_id,
+                applied_scope_id=active_scope_id,
             )
         )
 
@@ -193,6 +206,20 @@ def _promoted_from_row(
     vault_root: Path,
     memory_dir: str,
 ) -> PromotedMemory | None:
+    promoted_with_scope = _promoted_from_row_with_scope(
+        row,
+        vault_root=vault_root,
+        memory_dir=memory_dir,
+    )
+    return promoted_with_scope[0] if promoted_with_scope is not None else None
+
+
+def _promoted_from_row_with_scope(
+    row: PromotionReceiptRow,
+    *,
+    vault_root: Path,
+    memory_dir: str,
+) -> tuple[PromotedMemory, str | None] | None:
     if not row.artifact_path:
         return None
     note_path = (vault_root / row.artifact_path).resolve()
@@ -233,14 +260,17 @@ def _promoted_from_row(
         content=content,
         observed_at=decided_at,
     )
-    return PromotedMemory(
-        promotion_id=row.receipt_id,
-        outcome=ReviewState.ACCEPTED,
-        candidate=candidate,
-        decided_by=_first_str(frontmatter.get("decided_by"), row.authority.get("requested_by")) or "unknown",
-        decided_at=decided_at,
-        decision_notes=_first_str(frontmatter.get("decision_notes")),
-        promoted_at=promoted_at,
+    return (
+        PromotedMemory(
+            promotion_id=row.receipt_id,
+            outcome=ReviewState.ACCEPTED,
+            candidate=candidate,
+            decided_by=_first_str(frontmatter.get("decided_by"), row.authority.get("requested_by")) or "unknown",
+            decided_at=decided_at,
+            decision_notes=_first_str(frontmatter.get("decision_notes")),
+            promoted_at=promoted_at,
+        ),
+        _first_str(frontmatter.get("scope_id"), frontmatter.get("domain")),
     )
 
 

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -72,6 +72,7 @@ def read_promoted_memories(
     outbox_path: str | Path | None = None,
     records: Iterable[dict[str, Any]] | None = None,
     memory_dir: str = DEFAULT_MEMORY_DIR,
+    active_vault_id: str | None = None,
 ) -> list[PromotedMemory]:
     """Read materialized promoted memories back into frozen promotion artifacts."""
 
@@ -90,6 +91,7 @@ def read_promoted_memories(
             row,
             vault_root=resolved_root,
             memory_dir=memory_dir,
+            active_vault_id=active_vault_id,
         )
         if promoted is not None:
             memories.append(promoted)
@@ -105,6 +107,7 @@ def retrieve_relevant_promoted(
     records: Iterable[dict[str, Any]] | None = None,
     memory_dir: str = DEFAULT_MEMORY_DIR,
     active_scope_id: str | None = None,
+    active_vault_id: str | None = None,
 ) -> list[RecallCandidate]:
     """Return a scarce, relevance-ranked subset of scope-eligible promoted memories.
 
@@ -117,6 +120,8 @@ def retrieve_relevant_promoted(
         return []
     query_tokens = _tokens(query)
     if not query_tokens:
+        return []
+    if active_scope_id is not None and active_vault_id is None:
         return []
 
     resolved_root = _resolve_vault_root(vault_root)
@@ -134,6 +139,7 @@ def retrieve_relevant_promoted(
             row,
             vault_root=resolved_root,
             memory_dir=memory_dir,
+            active_vault_id=active_vault_id,
         )
         if promoted_with_scope is None:
             continue
@@ -211,11 +217,13 @@ def _promoted_from_row(
     *,
     vault_root: Path,
     memory_dir: str,
+    active_vault_id: str | None,
 ) -> PromotedMemory | None:
     promoted_with_scope = _promoted_from_row_with_scope(
         row,
         vault_root=vault_root,
         memory_dir=memory_dir,
+        active_vault_id=active_vault_id,
     )
     return promoted_with_scope[0] if promoted_with_scope is not None else None
 
@@ -225,6 +233,7 @@ def _promoted_from_row_with_scope(
     *,
     vault_root: Path,
     memory_dir: str,
+    active_vault_id: str | None,
 ) -> tuple[PromotedMemory, str | None] | None:
     if not row.artifact_path:
         return None
@@ -238,15 +247,26 @@ def _promoted_from_row_with_scope(
     frontmatter, body = load_frontmatter(raw)
     if not _is_agent_promoted_memory(frontmatter, row=row, memory_dir=memory_dir):
         return None
-    title, content = _title_and_content(body, fallback=note_path.stem)
-    candidate_id = _first_str(
-        frontmatter.get("promoted_from_candidate_id"),
-        row.artifact_linkage.get("candidate_id"),
-        row.basis.get("candidate_id"),
-        row.artifact_uuid,
-    )
-    if not candidate_id:
+    if active_vault_id is not None and row.vault_id != active_vault_id:
         return None
+    note_candidate_id = _first_str(frontmatter.get("promoted_from_candidate_id"))
+    basis_candidate_id = _first_str(row.basis.get("candidate_id"))
+    linkage_candidate_id = _first_str(row.artifact_linkage.get("candidate_id"))
+    note_artifact_uuid = _first_str(frontmatter.get("uuid"))
+    if (
+        note_candidate_id is None
+        or basis_candidate_id != note_candidate_id
+        or linkage_candidate_id != note_candidate_id
+        or note_artifact_uuid is None
+        or row.artifact_uuid != note_artifact_uuid
+    ):
+        return None
+    note_scope_id = validated_memory_scope_id(frontmatter.get("scope_id"))
+    receipt_scope_id = validated_memory_scope_id(row.basis.get("scope_id"))
+    if note_scope_id != receipt_scope_id:
+        return None
+    title, content = _title_and_content(body, fallback=note_path.stem)
+    candidate_id = note_candidate_id
     decided_at = _parse_datetime(
         _first_str(frontmatter.get("decided_at"), row.timestamp)
     )
@@ -263,7 +283,7 @@ def _promoted_from_row_with_scope(
         source_refs=source_refs,
         derived_from=_first_str(frontmatter.get("derived_from")),
         generated_by=_first_str(frontmatter.get("generated_by")),
-        scope_id=validated_memory_scope_id(frontmatter.get("scope_id")),
+        scope_id=note_scope_id,
         content=content,
         observed_at=decided_at,
     )

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -9,7 +9,13 @@ from typing import Any, Iterable
 from scripts.yaml_roundtrip import load_frontmatter
 
 from app.config.paths import VaultRootMisconfiguredError, resolve_optional_vault_root
-from app.agent_memory.candidate import ActivationPolicy, MemoryCandidate, MemoryType, ReviewState
+from app.agent_memory.candidate import (
+    ActivationPolicy,
+    MemoryCandidate,
+    MemoryType,
+    ReviewState,
+    validated_memory_scope_id,
+)
 from app.agent_memory.materialization import (
     DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
     DEFAULT_MEMORY_DIR,
@@ -257,7 +263,7 @@ def _promoted_from_row_with_scope(
         source_refs=source_refs,
         derived_from=_first_str(frontmatter.get("derived_from")),
         generated_by=_first_str(frontmatter.get("generated_by")),
-        scope_id=_first_str(frontmatter.get("scope_id"), frontmatter.get("domain")),
+        scope_id=validated_memory_scope_id(frontmatter.get("scope_id")),
         content=content,
         observed_at=decided_at,
     )

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -257,6 +257,7 @@ def _promoted_from_row_with_scope(
         source_refs=source_refs,
         derived_from=_first_str(frontmatter.get("derived_from")),
         generated_by=_first_str(frontmatter.get("generated_by")),
+        scope_id=_first_str(frontmatter.get("scope_id"), frontmatter.get("domain")),
         content=content,
         observed_at=decided_at,
     )
@@ -270,7 +271,7 @@ def _promoted_from_row_with_scope(
             decision_notes=_first_str(frontmatter.get("decision_notes")),
             promoted_at=promoted_at,
         ),
-        _first_str(frontmatter.get("scope_id"), frontmatter.get("domain")),
+        candidate.scope_id,
     )
 
 

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -9,7 +9,13 @@ from typing import Any, Iterable
 from scripts.yaml_roundtrip import load_frontmatter
 
 from app.config.paths import VaultRootMisconfiguredError, resolve_optional_vault_root
-from app.agent_memory.candidate import ActivationPolicy, MemoryCandidate, MemoryType, ReviewState
+from app.agent_memory.candidate import (
+    ActivationPolicy,
+    MemoryCandidate,
+    MemoryType,
+    ReviewState,
+    validated_memory_scope_id,
+)
 from app.agent_memory.materialization import (
     DEFAULT_MATERIALIZATION_RECEIPTS_PATH,
     DEFAULT_MEMORY_DIR,
@@ -56,6 +62,8 @@ class RecallCandidate:
     reason: str
     artifact_path: str | None = None
     receipt_id: str | None = None
+    memory_scope_id: str | None = None
+    applied_scope_id: str | None = None
 
 
 def read_promoted_memories(
@@ -64,6 +72,7 @@ def read_promoted_memories(
     outbox_path: str | Path | None = None,
     records: Iterable[dict[str, Any]] | None = None,
     memory_dir: str = DEFAULT_MEMORY_DIR,
+    active_vault_id: str | None = None,
 ) -> list[PromotedMemory]:
     """Read materialized promoted memories back into frozen promotion artifacts."""
 
@@ -82,6 +91,7 @@ def read_promoted_memories(
             row,
             vault_root=resolved_root,
             memory_dir=memory_dir,
+            active_vault_id=active_vault_id,
         )
         if promoted is not None:
             memories.append(promoted)
@@ -96,13 +106,22 @@ def retrieve_relevant_promoted(
     outbox_path: str | Path | None = None,
     records: Iterable[dict[str, Any]] | None = None,
     memory_dir: str = DEFAULT_MEMORY_DIR,
+    active_scope_id: str | None = None,
+    active_vault_id: str | None = None,
 ) -> list[RecallCandidate]:
-    """Return a scarce, relevance-ranked subset of promoted memories for recall."""
+    """Return a scarce, relevance-ranked subset of scope-eligible promoted memories.
+
+    A bound ASK admits only memories with the same persisted scope. Missing
+    bindings fail closed when a scope is active; unbound calls preserve the
+    default behavior and consider all promoted memories.
+    """
 
     if k <= 0:
         return []
     query_tokens = _tokens(query)
     if not query_tokens:
+        return []
+    if active_scope_id is not None and active_vault_id is None:
         return []
 
     resolved_root = _resolve_vault_root(vault_root)
@@ -116,12 +135,16 @@ def retrieve_relevant_promoted(
     )
     candidates: list[RecallCandidate] = []
     for row in rows:
-        promoted = _promoted_from_row(
+        promoted_with_scope = _promoted_from_row_with_scope(
             row,
             vault_root=resolved_root,
             memory_dir=memory_dir,
+            active_vault_id=active_vault_id,
         )
-        if promoted is None:
+        if promoted_with_scope is None:
+            continue
+        promoted, memory_scope_id = promoted_with_scope
+        if active_scope_id is not None and memory_scope_id != active_scope_id:
             continue
         score, reason = _score(promoted, query_tokens)
         if score <= 0:
@@ -133,6 +156,8 @@ def retrieve_relevant_promoted(
                 reason=reason,
                 artifact_path=row.artifact_path,
                 receipt_id=row.receipt_id,
+                memory_scope_id=memory_scope_id,
+                applied_scope_id=active_scope_id,
             )
         )
 
@@ -192,7 +217,24 @@ def _promoted_from_row(
     *,
     vault_root: Path,
     memory_dir: str,
+    active_vault_id: str | None,
 ) -> PromotedMemory | None:
+    promoted_with_scope = _promoted_from_row_with_scope(
+        row,
+        vault_root=vault_root,
+        memory_dir=memory_dir,
+        active_vault_id=active_vault_id,
+    )
+    return promoted_with_scope[0] if promoted_with_scope is not None else None
+
+
+def _promoted_from_row_with_scope(
+    row: PromotionReceiptRow,
+    *,
+    vault_root: Path,
+    memory_dir: str,
+    active_vault_id: str | None,
+) -> tuple[PromotedMemory, str | None] | None:
     if not row.artifact_path:
         return None
     note_path = (vault_root / row.artifact_path).resolve()
@@ -205,15 +247,36 @@ def _promoted_from_row(
     frontmatter, body = load_frontmatter(raw)
     if not _is_agent_promoted_memory(frontmatter, row=row, memory_dir=memory_dir):
         return None
-    title, content = _title_and_content(body, fallback=note_path.stem)
-    candidate_id = _first_str(
-        frontmatter.get("promoted_from_candidate_id"),
-        row.artifact_linkage.get("candidate_id"),
-        row.basis.get("candidate_id"),
-        row.artifact_uuid,
-    )
-    if not candidate_id:
+    if active_vault_id is not None and row.vault_id != active_vault_id:
         return None
+    note_candidate_id = _first_str(frontmatter.get("promoted_from_candidate_id"))
+    basis_candidate_id = _first_str(row.basis.get("candidate_id"))
+    linkage_candidate_id = _first_str(row.artifact_linkage.get("candidate_id"))
+    linkage_artifact_uuid = _first_str(
+        row.artifact_linkage.get("artifact_uuid"),
+        row.artifact_linkage.get("note_uuid"),
+    )
+    linkage_artifact_path = _first_str(
+        row.artifact_linkage.get("artifact_path"),
+        row.artifact_linkage.get("note_path"),
+    )
+    note_artifact_uuid = _first_str(frontmatter.get("uuid"))
+    if (
+        note_candidate_id is None
+        or basis_candidate_id != note_candidate_id
+        or linkage_candidate_id != note_candidate_id
+        or note_artifact_uuid is None
+        or row.artifact_uuid != note_artifact_uuid
+        or linkage_artifact_uuid != row.artifact_uuid
+        or linkage_artifact_path != row.artifact_path
+    ):
+        return None
+    note_scope_id = validated_memory_scope_id(frontmatter.get("scope_id"))
+    receipt_scope_id = validated_memory_scope_id(row.basis.get("scope_id"))
+    if note_scope_id != receipt_scope_id:
+        return None
+    title, content = _title_and_content(body, fallback=note_path.stem)
+    candidate_id = note_candidate_id
     decided_at = _parse_datetime(
         _first_str(frontmatter.get("decided_at"), row.timestamp)
     )
@@ -230,17 +293,21 @@ def _promoted_from_row(
         source_refs=source_refs,
         derived_from=_first_str(frontmatter.get("derived_from")),
         generated_by=_first_str(frontmatter.get("generated_by")),
+        scope_id=note_scope_id,
         content=content,
         observed_at=decided_at,
     )
-    return PromotedMemory(
-        promotion_id=row.receipt_id,
-        outcome=ReviewState.ACCEPTED,
-        candidate=candidate,
-        decided_by=_first_str(frontmatter.get("decided_by"), row.authority.get("requested_by")) or "unknown",
-        decided_at=decided_at,
-        decision_notes=_first_str(frontmatter.get("decision_notes")),
-        promoted_at=promoted_at,
+    return (
+        PromotedMemory(
+            promotion_id=row.receipt_id,
+            outcome=ReviewState.ACCEPTED,
+            candidate=candidate,
+            decided_by=_first_str(frontmatter.get("decided_by"), row.authority.get("requested_by")) or "unknown",
+            decided_at=decided_at,
+            decision_notes=_first_str(frontmatter.get("decision_notes")),
+            promoted_at=promoted_at,
+        ),
+        candidate.scope_id,
     )
 
 

--- a/app/agent_memory/recall_retrieval.py
+++ b/app/agent_memory/recall_retrieval.py
@@ -252,6 +252,14 @@ def _promoted_from_row_with_scope(
     note_candidate_id = _first_str(frontmatter.get("promoted_from_candidate_id"))
     basis_candidate_id = _first_str(row.basis.get("candidate_id"))
     linkage_candidate_id = _first_str(row.artifact_linkage.get("candidate_id"))
+    linkage_artifact_uuid = _first_str(
+        row.artifact_linkage.get("artifact_uuid"),
+        row.artifact_linkage.get("note_uuid"),
+    )
+    linkage_artifact_path = _first_str(
+        row.artifact_linkage.get("artifact_path"),
+        row.artifact_linkage.get("note_path"),
+    )
     note_artifact_uuid = _first_str(frontmatter.get("uuid"))
     if (
         note_candidate_id is None
@@ -259,6 +267,8 @@ def _promoted_from_row_with_scope(
         or linkage_candidate_id != note_candidate_id
         or note_artifact_uuid is None
         or row.artifact_uuid != note_artifact_uuid
+        or linkage_artifact_uuid != row.artifact_uuid
+        or linkage_artifact_path != row.artifact_path
     ):
         return None
     note_scope_id = validated_memory_scope_id(frontmatter.get("scope_id"))

--- a/app/agent_memory/review_decision_store.py
+++ b/app/agent_memory/review_decision_store.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
+from app.agent_memory.candidate import validated_memory_scope_id
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry
 from app.vault.manager import VaultContext
 
@@ -62,6 +64,11 @@ class ReviewDecisionStore:
         channel = _safe_str(channel)
         if not channel:
             raise ReviewDecisionStoreError("channel is required")
+        if (
+            entry.scope_id is not None
+            and validated_memory_scope_id(entry.scope_id) is None
+        ):
+            raise ReviewDecisionStoreError("candidate scope is invalid")
 
         record = ReviewDecisionRecord(
             vault_id=vault_id,
@@ -90,6 +97,10 @@ class ReviewDecisionStore:
             ).fetchone()
             if existing_row is not None:
                 existing = _record_from_payload(json.loads(existing_row["payload"]))
+                if existing.terminal:
+                    raise ReviewDecisionStoreError(
+                        "terminal review decisions cannot be replaced"
+                    )
                 if existing.scope_id != record.scope_id:
                     raise ReviewDecisionStoreError(
                         "candidate scope cannot change across review decisions"
@@ -168,6 +179,7 @@ class ReviewDecisionStore:
         vault_context: VaultContext,
         channel: str,
         expected_scope_id: str | None | object = _UNSET,
+        expected_outcome: ReviewDecision | None = None,
     ) -> ReviewDecisionRecord:
         vault_id = _vault_id(vault_context)
         safe_channel = _safe_str(channel)
@@ -184,26 +196,17 @@ class ReviewDecisionStore:
             if row is None:
                 raise ReviewDecisionStoreError("cannot mark missing decision terminal")
             record = _record_from_payload(json.loads(row["payload"]))
+            if record.terminal:
+                raise ReviewDecisionStoreError("decision is already terminal")
             if expected_scope_id is not _UNSET and record.scope_id != expected_scope_id:
                 raise ReviewDecisionStoreError(
                     "persisted candidate scope changed before terminal transition"
                 )
-            terminal_record = ReviewDecisionRecord(
-                vault_id=record.vault_id,
-                channel=record.channel,
-                candidate_id=record.candidate_id,
-                outcome=record.outcome,
-                decided_by=record.decided_by,
-                decided_at=record.decided_at,
-                source_refs=record.source_refs,
-                scope_id=record.scope_id,
-                receipt_kind=record.receipt_kind,
-                terminal=True,
-                decision_notes=record.decision_notes,
-                revision_of=record.revision_of,
-                generated_by=record.generated_by,
-                derived_from=record.derived_from,
-            )
+            if expected_outcome is not None and record.outcome is not expected_outcome:
+                raise ReviewDecisionStoreError(
+                    "persisted decision outcome changed before terminal transition"
+                )
+            terminal_record = replace(record, terminal=True)
             conn.execute(
                 """
                 UPDATE agent_memory_review_decisions
@@ -223,6 +226,81 @@ class ReviewDecisionStore:
             )
             conn.commit()
         return terminal_record
+
+    @contextmanager
+    def promotion_materialization_transaction(
+        self,
+        candidate_id: str,
+        *,
+        vault_context: VaultContext,
+        channel: str,
+        expected_scope_id: str,
+    ) -> Iterator[ReviewDecisionRecord]:
+        """Serialize one promoted decision through artifact write and terminalization."""
+
+        vault_id = _vault_id(vault_context)
+        safe_channel = _safe_str(channel)
+        safe_candidate_id = _safe_str(candidate_id)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (vault_id, safe_channel, safe_candidate_id),
+            ).fetchone()
+            if row is None:
+                raise ReviewDecisionStoreError(
+                    "semantic memory materialization requires a persisted decision"
+                )
+            record = _record_from_payload(json.loads(row["payload"]))
+            if record.outcome is not ReviewDecision.PROMOTE:
+                raise ReviewDecisionStoreError(
+                    "semantic memory materialization requires a persisted promote decision"
+                )
+            if record.terminal:
+                raise ReviewDecisionStoreError(
+                    "semantic memory decision is already terminal"
+                )
+            if record.scope_id != expected_scope_id:
+                raise ReviewDecisionStoreError(
+                    "candidate.scope_id does not match the persisted review decision"
+                )
+
+            try:
+                yield record
+            except Exception:
+                conn.rollback()
+                raise
+
+            terminal_record = replace(record, terminal=True)
+            updated = conn.execute(
+                """
+                UPDATE agent_memory_review_decisions
+                SET terminal = 1, payload = ?
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                  AND outcome = ? AND terminal = 0
+                """,
+                (
+                    json.dumps(
+                        _record_payload(terminal_record),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    record.vault_id,
+                    record.channel,
+                    record.candidate_id,
+                    ReviewDecision.PROMOTE.value,
+                ),
+            )
+            if updated.rowcount != 1:
+                conn.rollback()
+                raise ReviewDecisionStoreError(
+                    "promote decision changed before terminal transition"
+                )
+            conn.commit()
 
     def _connect(self) -> sqlite3.Connection:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/agent_memory/review_decision_store.py
+++ b/app/agent_memory/review_decision_store.py
@@ -12,7 +12,7 @@ from app.agent_memory.review_queue import ReviewDecision, ReviewEntry
 from app.vault.manager import VaultContext
 
 REVIEW_DECISION_RECEIPT_KIND = "agent_memory.review_decision"
-REVIEW_DECISION_STORE_VERSION = 1
+REVIEW_DECISION_STORE_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -24,6 +24,7 @@ class ReviewDecisionRecord:
     decided_by: str
     decided_at: datetime
     source_refs: tuple[str, ...]
+    scope_id: str | None = None
     receipt_kind: str = REVIEW_DECISION_RECEIPT_KIND
     terminal: bool = False
     decision_notes: str | None = None
@@ -69,6 +70,7 @@ class ReviewDecisionStore:
             decided_by=entry.decided_by,
             decided_at=entry.decided_at.astimezone(timezone.utc),
             source_refs=tuple(entry.source_refs),
+            scope_id=entry.scope_id,
             terminal=entry.decision in {ReviewDecision.REJECT, ReviewDecision.REVISE},
             decision_notes=entry.decision_notes,
             revision_of=entry.revision_of,
@@ -165,6 +167,7 @@ class ReviewDecisionStore:
             decided_by=record.decided_by,
             decided_at=record.decided_at,
             source_refs=record.source_refs,
+            scope_id=record.scope_id,
             receipt_kind=record.receipt_kind,
             terminal=True,
             decision_notes=record.decision_notes,
@@ -270,6 +273,7 @@ def _record_payload(record: ReviewDecisionRecord) -> dict[str, Any]:
         "decided_at": _iso(record.decided_at),
         "terminal": record.terminal,
         "source_refs": list(record.source_refs),
+        "scope_id": record.scope_id,
         "decision_notes": record.decision_notes,
         "revision_of": record.revision_of,
         "generated_by": record.generated_by,
@@ -286,6 +290,7 @@ def _record_from_payload(payload: dict[str, Any]) -> ReviewDecisionRecord:
         decided_by=str(payload["decided_by"]),
         decided_at=_parse_iso(str(payload["decided_at"])),
         source_refs=tuple(str(ref) for ref in payload.get("source_refs", [])),
+        scope_id=payload.get("scope_id"),
         receipt_kind=str(payload.get("receipt_kind") or REVIEW_DECISION_RECEIPT_KIND),
         terminal=bool(payload.get("terminal", False)),
         decision_notes=payload.get("decision_notes"),

--- a/app/agent_memory/review_decision_store.py
+++ b/app/agent_memory/review_decision_store.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
+from app.agent_memory.candidate import validated_memory_scope_id
 from app.agent_memory.review_queue import ReviewDecision, ReviewEntry
 from app.vault.manager import VaultContext
 
 REVIEW_DECISION_RECEIPT_KIND = "agent_memory.review_decision"
-REVIEW_DECISION_STORE_VERSION = 1
+REVIEW_DECISION_STORE_VERSION = 3
+_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -24,12 +28,15 @@ class ReviewDecisionRecord:
     decided_by: str
     decided_at: datetime
     source_refs: tuple[str, ...]
+    scope_id: str | None = None
     receipt_kind: str = REVIEW_DECISION_RECEIPT_KIND
     terminal: bool = False
     decision_notes: str | None = None
     revision_of: str | None = None
     generated_by: str | None = None
     derived_from: str | None = None
+    candidate_digest: str | None = None
+    materializing: bool = False
 
 
 class ReviewDecisionStoreError(ValueError):
@@ -60,6 +67,11 @@ class ReviewDecisionStore:
         channel = _safe_str(channel)
         if not channel:
             raise ReviewDecisionStoreError("channel is required")
+        if (
+            entry.scope_id is not None
+            and validated_memory_scope_id(entry.scope_id) is None
+        ):
+            raise ReviewDecisionStoreError("candidate scope is invalid")
 
         record = ReviewDecisionRecord(
             vault_id=vault_id,
@@ -69,13 +81,47 @@ class ReviewDecisionStore:
             decided_by=entry.decided_by,
             decided_at=entry.decided_at.astimezone(timezone.utc),
             source_refs=tuple(entry.source_refs),
+            scope_id=entry.scope_id,
             terminal=entry.decision in {ReviewDecision.REJECT, ReviewDecision.REVISE},
             decision_notes=entry.decision_notes,
             revision_of=entry.revision_of,
             generated_by=entry.generated_by,
             derived_from=entry.derived_from,
+            candidate_digest=review_candidate_digest(entry),
         )
         with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing_row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (record.vault_id, record.channel, record.candidate_id),
+            ).fetchone()
+            if existing_row is not None:
+                existing = _record_from_payload(json.loads(existing_row["payload"]))
+                if existing.terminal:
+                    raise ReviewDecisionStoreError(
+                        "terminal review decisions cannot be replaced"
+                    )
+                if existing.scope_id != record.scope_id:
+                    raise ReviewDecisionStoreError(
+                        "candidate scope cannot change across review decisions"
+                    )
+                if (
+                    existing.candidate_digest is not None
+                    and existing.candidate_digest != record.candidate_digest
+                ):
+                    raise ReviewDecisionStoreError(
+                        "candidate content cannot change across review decisions"
+                    )
+                if existing.materializing:
+                    if record.outcome is ReviewDecision.PROMOTE:
+                        return existing
+                    raise ReviewDecisionStoreError(
+                        "review decision cannot change while materialization is in progress"
+                    )
             conn.execute(
                 """
                 INSERT INTO agent_memory_review_decisions (
@@ -149,30 +195,35 @@ class ReviewDecisionStore:
         *,
         vault_context: VaultContext,
         channel: str,
+        expected_scope_id: str | None | object = _UNSET,
+        expected_outcome: ReviewDecision | None = None,
     ) -> ReviewDecisionRecord:
-        record = self.get_decision(
-            candidate_id,
-            vault_context=vault_context,
-            channel=channel,
-        )
-        if record is None:
-            raise ReviewDecisionStoreError("cannot mark missing decision terminal")
-        terminal_record = ReviewDecisionRecord(
-            vault_id=record.vault_id,
-            channel=record.channel,
-            candidate_id=record.candidate_id,
-            outcome=record.outcome,
-            decided_by=record.decided_by,
-            decided_at=record.decided_at,
-            source_refs=record.source_refs,
-            receipt_kind=record.receipt_kind,
-            terminal=True,
-            decision_notes=record.decision_notes,
-            revision_of=record.revision_of,
-            generated_by=record.generated_by,
-            derived_from=record.derived_from,
-        )
+        vault_id = _vault_id(vault_context)
+        safe_channel = _safe_str(channel)
         with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (vault_id, safe_channel, _safe_str(candidate_id)),
+            ).fetchone()
+            if row is None:
+                raise ReviewDecisionStoreError("cannot mark missing decision terminal")
+            record = _record_from_payload(json.loads(row["payload"]))
+            if record.terminal:
+                raise ReviewDecisionStoreError("decision is already terminal")
+            if expected_scope_id is not _UNSET and record.scope_id != expected_scope_id:
+                raise ReviewDecisionStoreError(
+                    "persisted candidate scope changed before terminal transition"
+                )
+            if expected_outcome is not None and record.outcome is not expected_outcome:
+                raise ReviewDecisionStoreError(
+                    "persisted decision outcome changed before terminal transition"
+                )
+            terminal_record = replace(record, terminal=True)
             conn.execute(
                 """
                 UPDATE agent_memory_review_decisions
@@ -192,6 +243,134 @@ class ReviewDecisionStore:
             )
             conn.commit()
         return terminal_record
+
+    @contextmanager
+    def promotion_materialization_transaction(
+        self,
+        candidate_id: str,
+        *,
+        vault_context: VaultContext,
+        channel: str,
+        expected_scope_id: str,
+        expected_candidate_digest: str,
+    ) -> Iterator[ReviewDecisionRecord]:
+        """Serialize one promoted decision through artifact write and terminalization."""
+
+        vault_id = _vault_id(vault_context)
+        safe_channel = _safe_str(channel)
+        safe_candidate_id = _safe_str(candidate_id)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (vault_id, safe_channel, safe_candidate_id),
+            ).fetchone()
+            if row is None:
+                raise ReviewDecisionStoreError(
+                    "semantic memory materialization requires a persisted decision"
+                )
+            record = _record_from_payload(json.loads(row["payload"]))
+            if record.outcome is not ReviewDecision.PROMOTE:
+                raise ReviewDecisionStoreError(
+                    "semantic memory materialization requires a persisted promote decision"
+                )
+            if record.terminal:
+                raise ReviewDecisionStoreError(
+                    "semantic memory decision is already terminal"
+                )
+            if record.scope_id != expected_scope_id:
+                raise ReviewDecisionStoreError(
+                    "candidate.scope_id does not match the persisted review decision"
+                )
+            if record.candidate_digest != expected_candidate_digest:
+                raise ReviewDecisionStoreError(
+                    "candidate content does not match the persisted review decision"
+                )
+            if not record.materializing:
+                materializing_record = replace(record, materializing=True)
+                conn.execute(
+                    """
+                    UPDATE agent_memory_review_decisions
+                    SET payload = ?
+                    WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                      AND outcome = ? AND terminal = 0
+                    """,
+                    (
+                        json.dumps(
+                            _record_payload(materializing_record),
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        record.vault_id,
+                        record.channel,
+                        record.candidate_id,
+                        ReviewDecision.PROMOTE.value,
+                    ),
+                )
+                conn.commit()
+                conn.execute("BEGIN IMMEDIATE")
+                resumed_row = conn.execute(
+                    """
+                    SELECT payload
+                    FROM agent_memory_review_decisions
+                    WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                    """,
+                    (record.vault_id, record.channel, record.candidate_id),
+                ).fetchone()
+                if resumed_row is None:
+                    raise ReviewDecisionStoreError(
+                        "materializing review decision disappeared"
+                    )
+                record = _record_from_payload(json.loads(resumed_row["payload"]))
+                if record.terminal or record.outcome is not ReviewDecision.PROMOTE:
+                    raise ReviewDecisionStoreError(
+                        "promote decision changed before materialization resumed"
+                    )
+                if (
+                    record.scope_id != expected_scope_id
+                    or record.candidate_digest != expected_candidate_digest
+                    or not record.materializing
+                ):
+                    raise ReviewDecisionStoreError(
+                        "materialization authority changed before resume"
+                    )
+
+            try:
+                yield record
+            except Exception:
+                conn.rollback()
+                raise
+
+            terminal_record = replace(record, terminal=True, materializing=False)
+            updated = conn.execute(
+                """
+                UPDATE agent_memory_review_decisions
+                SET terminal = 1, payload = ?
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                  AND outcome = ? AND terminal = 0
+                """,
+                (
+                    json.dumps(
+                        _record_payload(terminal_record),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    record.vault_id,
+                    record.channel,
+                    record.candidate_id,
+                    ReviewDecision.PROMOTE.value,
+                ),
+            )
+            if updated.rowcount != 1:
+                conn.rollback()
+                raise ReviewDecisionStoreError(
+                    "promote decision changed before terminal transition"
+                )
+            conn.commit()
 
     def _connect(self) -> sqlite3.Connection:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -270,10 +449,13 @@ def _record_payload(record: ReviewDecisionRecord) -> dict[str, Any]:
         "decided_at": _iso(record.decided_at),
         "terminal": record.terminal,
         "source_refs": list(record.source_refs),
+        "scope_id": record.scope_id,
         "decision_notes": record.decision_notes,
         "revision_of": record.revision_of,
         "generated_by": record.generated_by,
         "derived_from": record.derived_from,
+        "candidate_digest": record.candidate_digest,
+        "materializing": record.materializing,
     }
 
 
@@ -286,13 +468,22 @@ def _record_from_payload(payload: dict[str, Any]) -> ReviewDecisionRecord:
         decided_by=str(payload["decided_by"]),
         decided_at=_parse_iso(str(payload["decided_at"])),
         source_refs=tuple(str(ref) for ref in payload.get("source_refs", [])),
+        scope_id=payload.get("scope_id"),
         receipt_kind=str(payload.get("receipt_kind") or REVIEW_DECISION_RECEIPT_KIND),
         terminal=bool(payload.get("terminal", False)),
         decision_notes=payload.get("decision_notes"),
         revision_of=payload.get("revision_of"),
         generated_by=payload.get("generated_by"),
         derived_from=payload.get("derived_from"),
+        candidate_digest=payload.get("candidate_digest"),
+        materializing=bool(payload.get("materializing", False)),
     )
+
+
+def review_candidate_digest(entry: ReviewEntry) -> str:
+    payload = entry.candidate.model_dump(mode="json")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 __all__ = [
@@ -300,4 +491,5 @@ __all__ = [
     "ReviewDecisionRecord",
     "ReviewDecisionStore",
     "ReviewDecisionStoreError",
+    "review_candidate_digest",
 ]

--- a/app/agent_memory/review_decision_store.py
+++ b/app/agent_memory/review_decision_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -14,7 +15,7 @@ from app.agent_memory.review_queue import ReviewDecision, ReviewEntry
 from app.vault.manager import VaultContext
 
 REVIEW_DECISION_RECEIPT_KIND = "agent_memory.review_decision"
-REVIEW_DECISION_STORE_VERSION = 2
+REVIEW_DECISION_STORE_VERSION = 3
 _UNSET = object()
 
 
@@ -34,6 +35,8 @@ class ReviewDecisionRecord:
     revision_of: str | None = None
     generated_by: str | None = None
     derived_from: str | None = None
+    candidate_digest: str | None = None
+    materializing: bool = False
 
 
 class ReviewDecisionStoreError(ValueError):
@@ -84,6 +87,7 @@ class ReviewDecisionStore:
             revision_of=entry.revision_of,
             generated_by=entry.generated_by,
             derived_from=entry.derived_from,
+            candidate_digest=review_candidate_digest(entry),
         )
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
@@ -104,6 +108,19 @@ class ReviewDecisionStore:
                 if existing.scope_id != record.scope_id:
                     raise ReviewDecisionStoreError(
                         "candidate scope cannot change across review decisions"
+                    )
+                if (
+                    existing.candidate_digest is not None
+                    and existing.candidate_digest != record.candidate_digest
+                ):
+                    raise ReviewDecisionStoreError(
+                        "candidate content cannot change across review decisions"
+                    )
+                if existing.materializing:
+                    if record.outcome is ReviewDecision.PROMOTE:
+                        return existing
+                    raise ReviewDecisionStoreError(
+                        "review decision cannot change while materialization is in progress"
                     )
             conn.execute(
                 """
@@ -235,6 +252,7 @@ class ReviewDecisionStore:
         vault_context: VaultContext,
         channel: str,
         expected_scope_id: str,
+        expected_candidate_digest: str,
     ) -> Iterator[ReviewDecisionRecord]:
         """Serialize one promoted decision through artifact write and terminalization."""
 
@@ -268,6 +286,58 @@ class ReviewDecisionStore:
                 raise ReviewDecisionStoreError(
                     "candidate.scope_id does not match the persisted review decision"
                 )
+            if record.candidate_digest != expected_candidate_digest:
+                raise ReviewDecisionStoreError(
+                    "candidate content does not match the persisted review decision"
+                )
+            if not record.materializing:
+                materializing_record = replace(record, materializing=True)
+                conn.execute(
+                    """
+                    UPDATE agent_memory_review_decisions
+                    SET payload = ?
+                    WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                      AND outcome = ? AND terminal = 0
+                    """,
+                    (
+                        json.dumps(
+                            _record_payload(materializing_record),
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        record.vault_id,
+                        record.channel,
+                        record.candidate_id,
+                        ReviewDecision.PROMOTE.value,
+                    ),
+                )
+                conn.commit()
+                conn.execute("BEGIN IMMEDIATE")
+                resumed_row = conn.execute(
+                    """
+                    SELECT payload
+                    FROM agent_memory_review_decisions
+                    WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                    """,
+                    (record.vault_id, record.channel, record.candidate_id),
+                ).fetchone()
+                if resumed_row is None:
+                    raise ReviewDecisionStoreError(
+                        "materializing review decision disappeared"
+                    )
+                record = _record_from_payload(json.loads(resumed_row["payload"]))
+                if record.terminal or record.outcome is not ReviewDecision.PROMOTE:
+                    raise ReviewDecisionStoreError(
+                        "promote decision changed before materialization resumed"
+                    )
+                if (
+                    record.scope_id != expected_scope_id
+                    or record.candidate_digest != expected_candidate_digest
+                    or not record.materializing
+                ):
+                    raise ReviewDecisionStoreError(
+                        "materialization authority changed before resume"
+                    )
 
             try:
                 yield record
@@ -275,7 +345,7 @@ class ReviewDecisionStore:
                 conn.rollback()
                 raise
 
-            terminal_record = replace(record, terminal=True)
+            terminal_record = replace(record, terminal=True, materializing=False)
             updated = conn.execute(
                 """
                 UPDATE agent_memory_review_decisions
@@ -384,6 +454,8 @@ def _record_payload(record: ReviewDecisionRecord) -> dict[str, Any]:
         "revision_of": record.revision_of,
         "generated_by": record.generated_by,
         "derived_from": record.derived_from,
+        "candidate_digest": record.candidate_digest,
+        "materializing": record.materializing,
     }
 
 
@@ -403,7 +475,15 @@ def _record_from_payload(payload: dict[str, Any]) -> ReviewDecisionRecord:
         revision_of=payload.get("revision_of"),
         generated_by=payload.get("generated_by"),
         derived_from=payload.get("derived_from"),
+        candidate_digest=payload.get("candidate_digest"),
+        materializing=bool(payload.get("materializing", False)),
     )
+
+
+def review_candidate_digest(entry: ReviewEntry) -> str:
+    payload = entry.candidate.model_dump(mode="json")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 __all__ = [
@@ -411,4 +491,5 @@ __all__ = [
     "ReviewDecisionRecord",
     "ReviewDecisionStore",
     "ReviewDecisionStoreError",
+    "review_candidate_digest",
 ]

--- a/app/agent_memory/review_decision_store.py
+++ b/app/agent_memory/review_decision_store.py
@@ -13,6 +13,7 @@ from app.vault.manager import VaultContext
 
 REVIEW_DECISION_RECEIPT_KIND = "agent_memory.review_decision"
 REVIEW_DECISION_STORE_VERSION = 2
+_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -78,6 +79,21 @@ class ReviewDecisionStore:
             derived_from=entry.derived_from,
         )
         with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing_row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (record.vault_id, record.channel, record.candidate_id),
+            ).fetchone()
+            if existing_row is not None:
+                existing = _record_from_payload(json.loads(existing_row["payload"]))
+                if existing.scope_id != record.scope_id:
+                    raise ReviewDecisionStoreError(
+                        "candidate scope cannot change across review decisions"
+                    )
             conn.execute(
                 """
                 INSERT INTO agent_memory_review_decisions (
@@ -151,31 +167,43 @@ class ReviewDecisionStore:
         *,
         vault_context: VaultContext,
         channel: str,
+        expected_scope_id: str | None | object = _UNSET,
     ) -> ReviewDecisionRecord:
-        record = self.get_decision(
-            candidate_id,
-            vault_context=vault_context,
-            channel=channel,
-        )
-        if record is None:
-            raise ReviewDecisionStoreError("cannot mark missing decision terminal")
-        terminal_record = ReviewDecisionRecord(
-            vault_id=record.vault_id,
-            channel=record.channel,
-            candidate_id=record.candidate_id,
-            outcome=record.outcome,
-            decided_by=record.decided_by,
-            decided_at=record.decided_at,
-            source_refs=record.source_refs,
-            scope_id=record.scope_id,
-            receipt_kind=record.receipt_kind,
-            terminal=True,
-            decision_notes=record.decision_notes,
-            revision_of=record.revision_of,
-            generated_by=record.generated_by,
-            derived_from=record.derived_from,
-        )
+        vault_id = _vault_id(vault_context)
+        safe_channel = _safe_str(channel)
         with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT payload
+                FROM agent_memory_review_decisions
+                WHERE vault_id = ? AND channel = ? AND candidate_id = ?
+                """,
+                (vault_id, safe_channel, _safe_str(candidate_id)),
+            ).fetchone()
+            if row is None:
+                raise ReviewDecisionStoreError("cannot mark missing decision terminal")
+            record = _record_from_payload(json.loads(row["payload"]))
+            if expected_scope_id is not _UNSET and record.scope_id != expected_scope_id:
+                raise ReviewDecisionStoreError(
+                    "persisted candidate scope changed before terminal transition"
+                )
+            terminal_record = ReviewDecisionRecord(
+                vault_id=record.vault_id,
+                channel=record.channel,
+                candidate_id=record.candidate_id,
+                outcome=record.outcome,
+                decided_by=record.decided_by,
+                decided_at=record.decided_at,
+                source_refs=record.source_refs,
+                scope_id=record.scope_id,
+                receipt_kind=record.receipt_kind,
+                terminal=True,
+                decision_notes=record.decision_notes,
+                revision_of=record.revision_of,
+                generated_by=record.generated_by,
+                derived_from=record.derived_from,
+            )
             conn.execute(
                 """
                 UPDATE agent_memory_review_decisions

--- a/app/agent_memory/review_queue.py
+++ b/app/agent_memory/review_queue.py
@@ -90,6 +90,10 @@ class ReviewEntry(BaseModel):
         return self.candidate.generated_by
 
     @property
+    def scope_id(self) -> Optional[str]:
+        return self.candidate.scope_id
+
+    @property
     def proposed_memory_type(self) -> MemoryType:
         return self.candidate.memory_type
 

--- a/app/agent_memory/review_queue.py
+++ b/app/agent_memory/review_queue.py
@@ -296,6 +296,27 @@ class MemoryCandidateReviewQueue:
         self._entries[candidate_id] = reverted
         return reverted
 
+    def rollback_persistence_refusal(
+        self,
+        original: ReviewEntry,
+        *,
+        revision_candidate_id: str | None = None,
+    ) -> None:
+        """Restore the pending queue state after the durable store refuses."""
+
+        current = self.get(original.candidate_id)
+        if current.status is ReviewStatus.PENDING:
+            raise ReviewQueueError(
+                f"cannot roll back a pending decision: {original.candidate_id}"
+            )
+        if original.status is not ReviewStatus.PENDING or original.decision is not None:
+            raise ReviewQueueError(
+                f"rollback authority is not pending: {original.candidate_id}"
+            )
+        self._entries[original.candidate_id] = original
+        if revision_candidate_id is not None:
+            self._entries.pop(revision_candidate_id, None)
+
     def recallable_for_working_context(self) -> list[ReviewEntry]:
         """Entries authorized for working-context recall.
 

--- a/app/agent_memory/review_queue.py
+++ b/app/agent_memory/review_queue.py
@@ -90,6 +90,10 @@ class ReviewEntry(BaseModel):
         return self.candidate.generated_by
 
     @property
+    def scope_id(self) -> Optional[str]:
+        return self.candidate.scope_id
+
+    @property
     def proposed_memory_type(self) -> MemoryType:
         return self.candidate.memory_type
 
@@ -291,6 +295,27 @@ class MemoryCandidateReviewQueue:
         )
         self._entries[candidate_id] = reverted
         return reverted
+
+    def rollback_persistence_refusal(
+        self,
+        original: ReviewEntry,
+        *,
+        revision_candidate_id: str | None = None,
+    ) -> None:
+        """Restore the pending queue state after the durable store refuses."""
+
+        current = self.get(original.candidate_id)
+        if current.status is ReviewStatus.PENDING:
+            raise ReviewQueueError(
+                f"cannot roll back a pending decision: {original.candidate_id}"
+            )
+        if original.status is not ReviewStatus.PENDING or original.decision is not None:
+            raise ReviewQueueError(
+                f"rollback authority is not pending: {original.candidate_id}"
+            )
+        self._entries[original.candidate_id] = original
+        if revision_candidate_id is not None:
+            self._entries.pop(revision_candidate_id, None)
 
     def recallable_for_working_context(self) -> list[ReviewEntry]:
         """Entries authorized for working-context recall.

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -200,9 +200,14 @@ def _recall_node(
     citation_reference: str | None = None,
 ) -> AgentState:
     vault_root = _active_recall_vault_root()
-    candidates = retrieve_relevant_promoted(state.query, k=RECALL_TOP_K, vault_root=vault_root)
     # The same scope retrieval used for this turn (#2921), under the same precedence rule.
     active_scope = _active_scope(state)
+    candidates = retrieve_relevant_promoted(
+        state.query,
+        k=RECALL_TOP_K,
+        vault_root=vault_root,
+        active_scope_id=active_scope,
+    )
     provisional = (
         retrieve_relevant_provisional(
             state.query,
@@ -239,6 +244,7 @@ def _recall_node(
             why_now=candidate.reason,
             receipt_path=receipt_path,
             source_artifact_path=_source_artifact_path(candidate, vault_root),
+            applied_scope_id=candidate.applied_scope_id,
         )
         if guarded.may_answer:
             recalled.append(guarded.explanation)

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -187,10 +187,29 @@ def _active_recall_vault_root() -> Path | None:
 def _active_recall_vault_id(vault_root: Path | None) -> str | None:
     if vault_root is None:
         return None
-    context = get_vault_manager().context
-    if context.status == "selected" and context.active_vault_id:
+    resolved_root = vault_root.expanduser().resolve()
+    manager = get_vault_manager()
+    context = manager.context
+    if (
+        context.status == "selected"
+        and context.active_vault_id
+        and context.active_vault_path
+        and Path(context.active_vault_path).expanduser().resolve() == resolved_root
+    ):
         return context.active_vault_id
-    return f"path:{vault_root.expanduser().resolve()}"
+    if context.status != "selected" and not getattr(
+        manager, _ASK_LAST_ACTIVE_LOADED_ATTR, False
+    ):
+        context = manager.load_last_active()
+        setattr(manager, _ASK_LAST_ACTIVE_LOADED_ATTR, context.status == "selected")
+        if (
+            context.status == "selected"
+            and context.active_vault_id
+            and context.active_vault_path
+            and Path(context.active_vault_path).expanduser().resolve() == resolved_root
+        ):
+            return context.active_vault_id
+    return f"path:{resolved_root}"
 
 
 def _source_artifact_path(candidate: RecallCandidate, vault_root: Path | None) -> Path | None:

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -184,6 +184,15 @@ def _active_recall_vault_root() -> Path | None:
     return None
 
 
+def _active_recall_vault_id(vault_root: Path | None) -> str | None:
+    if vault_root is None:
+        return None
+    context = get_vault_manager().context
+    if context.status == "selected" and context.active_vault_id:
+        return context.active_vault_id
+    return f"path:{vault_root.expanduser().resolve()}"
+
+
 def _source_artifact_path(candidate: RecallCandidate, vault_root: Path | None) -> Path | None:
     if not candidate.artifact_path:
         return None
@@ -202,11 +211,15 @@ def _recall_node(
     vault_root = _active_recall_vault_root()
     # The same scope retrieval used for this turn (#2921), under the same precedence rule.
     active_scope = _active_scope(state)
+    active_vault_id = (
+        _active_recall_vault_id(vault_root) if active_scope is not None else None
+    )
     candidates = retrieve_relevant_promoted(
         state.query,
         k=RECALL_TOP_K,
         vault_root=vault_root,
         active_scope_id=active_scope,
+        active_vault_id=active_vault_id,
     )
     provisional = (
         retrieve_relevant_provisional(

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -184,6 +184,34 @@ def _active_recall_vault_root() -> Path | None:
     return None
 
 
+def _active_recall_vault_id(vault_root: Path | None) -> str | None:
+    if vault_root is None:
+        return None
+    resolved_root = vault_root.expanduser().resolve()
+    manager = get_vault_manager()
+    context = manager.context
+    if (
+        context.status == "selected"
+        and context.active_vault_id
+        and context.active_vault_path
+        and Path(context.active_vault_path).expanduser().resolve() == resolved_root
+    ):
+        return context.active_vault_id
+    if context.status != "selected" and not getattr(
+        manager, _ASK_LAST_ACTIVE_LOADED_ATTR, False
+    ):
+        context = manager.load_last_active()
+        setattr(manager, _ASK_LAST_ACTIVE_LOADED_ATTR, context.status == "selected")
+        if (
+            context.status == "selected"
+            and context.active_vault_id
+            and context.active_vault_path
+            and Path(context.active_vault_path).expanduser().resolve() == resolved_root
+        ):
+            return context.active_vault_id
+    return f"path:{resolved_root}"
+
+
 def _source_artifact_path(candidate: RecallCandidate, vault_root: Path | None) -> Path | None:
     if not candidate.artifact_path:
         return None
@@ -200,9 +228,18 @@ def _recall_node(
     citation_reference: str | None = None,
 ) -> AgentState:
     vault_root = _active_recall_vault_root()
-    candidates = retrieve_relevant_promoted(state.query, k=RECALL_TOP_K, vault_root=vault_root)
     # The same scope retrieval used for this turn (#2921), under the same precedence rule.
     active_scope = _active_scope(state)
+    active_vault_id = (
+        _active_recall_vault_id(vault_root) if active_scope is not None else None
+    )
+    candidates = retrieve_relevant_promoted(
+        state.query,
+        k=RECALL_TOP_K,
+        vault_root=vault_root,
+        active_scope_id=active_scope,
+        active_vault_id=active_vault_id,
+    )
     provisional = (
         retrieve_relevant_provisional(
             state.query,
@@ -239,6 +276,7 @@ def _recall_node(
             why_now=candidate.reason,
             receipt_path=receipt_path,
             source_artifact_path=_source_artifact_path(candidate, vault_root),
+            applied_scope_id=candidate.applied_scope_id,
         )
         if guarded.may_answer:
             recalled.append(guarded.explanation)

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -5050,6 +5050,7 @@ def _memory_review_revision_candidate(
         source_refs=list(original.source_refs),
         derived_from=original.derived_from,
         generated_by=original.generated_by,
+        scope_id=original.scope_id,
         correction_of=original.candidate_id,
     )
 

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -28,7 +28,11 @@ from app.chat.reflection_conversation import (
     build_evening_reflection_offer,
     load_reflection_settings,
 )
-from app.agent_memory.candidate import MemoryCandidate, MemoryType
+from app.agent_memory.candidate import (
+    MemoryCandidate,
+    MemoryType,
+    validated_memory_scope_id,
+)
 from app.agent_memory.materialization import (
     MemoryMaterializationError,
     MemoryMaterializationResult,
@@ -5136,6 +5140,27 @@ def post_memory_review_decision(
                 "Deferred: candidate remains pending in agent_memory.review_queue; "
                 "no review decision was recorded and no receipt exists."
             ),
+        )
+
+    if (
+        req.action == "accept"
+        and entry.candidate.memory_type is MemoryType.SEMANTIC_MEMORY
+        and validated_memory_scope_id(entry.scope_id) is None
+    ):
+        # A semantic promotion without an explicit scope can never be
+        # materialized or safely admitted to bound recall. Refuse before the
+        # queue transition and durable decision write so the candidate remains
+        # actionable instead of becoming a permanently non-materializable
+        # accepted decision.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "promotion_refused",
+                "message": (
+                    "semantic promotion requires a valid candidate.scope_id; "
+                    "no review decision was recorded"
+                ),
+            },
         )
 
     vault_context = _memory_review_vault_context()

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -41,7 +41,11 @@ from app.agent_memory.promotion import (
     reject as reject_memory_candidate,
     revise as revise_memory_candidate,
 )
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionRecord,
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+)
 from app.agent_memory.review_queue import (
     MemoryCandidateReviewQueue,
     ReviewDecision,
@@ -5029,6 +5033,26 @@ def _memory_review_decide(
         ) from exc
 
 
+def _memory_review_record_decision(
+    store: ReviewDecisionStore,
+    entry: ReviewEntry,
+    *,
+    vault_context: VaultContext,
+    channel: str,
+) -> ReviewDecisionRecord:
+    try:
+        return store.record_decision(
+            entry,
+            vault_context=vault_context,
+            channel=channel,
+        )
+    except ReviewDecisionStoreError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "review_decision_conflict", "message": str(exc)},
+        ) from exc
+
+
 def _memory_review_revision_candidate(
     entry: ReviewEntry, payload: MemoryReviewRevisionPayload | None
 ) -> MemoryCandidate:
@@ -5141,12 +5165,20 @@ def post_memory_review_decision(
             reviewed_by=req.reviewed_by,
             notes=req.notes,
         )
-        decision_store.record_decision(
+        persisted_decision = _memory_review_record_decision(
+            decision_store,
             decided,
             vault_context=vault_context,
             channel=channel,
         )
-        promoted = promote_memory_candidate(decided)
+        effective_decided = decided.model_copy(
+            update={
+                "decided_by": persisted_decision.decided_by,
+                "decided_at": persisted_decision.decided_at,
+                "decision_notes": persisted_decision.decision_notes,
+            }
+        )
+        promoted = promote_memory_candidate(effective_decided)
         # Materialize the accepted candidate into the vault. For semantic
         # candidates this writes the agent-promoted artifact through WriteGuard,
         # appends the promotion receipt, and marks the stored decision terminal.
@@ -5156,7 +5188,7 @@ def post_memory_review_decision(
         # accept outright.
         try:
             materialization = materialize_promoted_memory(
-                decided,
+                effective_decided,
                 vault_context=vault_context,
                 channel=channel,
                 decision_store=decision_store,
@@ -5198,7 +5230,8 @@ def post_memory_review_decision(
             reviewed_by=req.reviewed_by,
             notes=req.notes,
         )
-        decision_store.record_decision(
+        _memory_review_record_decision(
+            decision_store,
             decided,
             vault_context=vault_context,
             channel=channel,
@@ -5221,7 +5254,8 @@ def post_memory_review_decision(
         notes=req.notes,
         revision=revision_candidate,
     )
-    decision_store.record_decision(
+    _memory_review_record_decision(
+        decision_store,
         decided,
         vault_context=vault_context,
         channel=channel,

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -5039,6 +5039,9 @@ def _memory_review_record_decision(
     *,
     vault_context: VaultContext,
     channel: str,
+    queue: MemoryCandidateReviewQueue,
+    original_entry: ReviewEntry,
+    revision_candidate_id: str | None = None,
 ) -> ReviewDecisionRecord:
     try:
         return store.record_decision(
@@ -5047,6 +5050,10 @@ def _memory_review_record_decision(
             channel=channel,
         )
     except ReviewDecisionStoreError as exc:
+        queue.rollback_persistence_refusal(
+            original_entry,
+            revision_candidate_id=revision_candidate_id,
+        )
         raise HTTPException(
             status_code=409,
             detail={"error": "review_decision_conflict", "message": str(exc)},
@@ -5170,6 +5177,8 @@ def post_memory_review_decision(
             decided,
             vault_context=vault_context,
             channel=channel,
+            queue=queue,
+            original_entry=entry,
         )
         effective_decided = decided.model_copy(
             update={
@@ -5235,6 +5244,8 @@ def post_memory_review_decision(
             decided,
             vault_context=vault_context,
             channel=channel,
+            queue=queue,
+            original_entry=entry,
         )
         rejected = reject_memory_candidate(decided)
         return MemoryReviewDecisionResponse(
@@ -5259,6 +5270,9 @@ def post_memory_review_decision(
         decided,
         vault_context=vault_context,
         channel=channel,
+        queue=queue,
+        original_entry=entry,
+        revision_candidate_id=revision_candidate.candidate_id,
     )
     revision_entry = queue.get(revision_candidate.candidate_id)
     revised = revise_memory_candidate(decided, revision_entry)

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -41,7 +41,11 @@ from app.agent_memory.promotion import (
     reject as reject_memory_candidate,
     revise as revise_memory_candidate,
 )
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionRecord,
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+)
 from app.agent_memory.review_queue import (
     MemoryCandidateReviewQueue,
     ReviewDecision,
@@ -5029,6 +5033,33 @@ def _memory_review_decide(
         ) from exc
 
 
+def _memory_review_record_decision(
+    store: ReviewDecisionStore,
+    entry: ReviewEntry,
+    *,
+    vault_context: VaultContext,
+    channel: str,
+    queue: MemoryCandidateReviewQueue,
+    original_entry: ReviewEntry,
+    revision_candidate_id: str | None = None,
+) -> ReviewDecisionRecord:
+    try:
+        return store.record_decision(
+            entry,
+            vault_context=vault_context,
+            channel=channel,
+        )
+    except ReviewDecisionStoreError as exc:
+        queue.rollback_persistence_refusal(
+            original_entry,
+            revision_candidate_id=revision_candidate_id,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "review_decision_conflict", "message": str(exc)},
+        ) from exc
+
+
 def _memory_review_revision_candidate(
     entry: ReviewEntry, payload: MemoryReviewRevisionPayload | None
 ) -> MemoryCandidate:
@@ -5050,6 +5081,7 @@ def _memory_review_revision_candidate(
         source_refs=list(original.source_refs),
         derived_from=original.derived_from,
         generated_by=original.generated_by,
+        scope_id=original.scope_id,
         correction_of=original.candidate_id,
     )
 
@@ -5140,12 +5172,22 @@ def post_memory_review_decision(
             reviewed_by=req.reviewed_by,
             notes=req.notes,
         )
-        decision_store.record_decision(
+        persisted_decision = _memory_review_record_decision(
+            decision_store,
             decided,
             vault_context=vault_context,
             channel=channel,
+            queue=queue,
+            original_entry=entry,
         )
-        promoted = promote_memory_candidate(decided)
+        effective_decided = decided.model_copy(
+            update={
+                "decided_by": persisted_decision.decided_by,
+                "decided_at": persisted_decision.decided_at,
+                "decision_notes": persisted_decision.decision_notes,
+            }
+        )
+        promoted = promote_memory_candidate(effective_decided)
         # Materialize the accepted candidate into the vault. For semantic
         # candidates this writes the agent-promoted artifact through WriteGuard,
         # appends the promotion receipt, and marks the stored decision terminal.
@@ -5155,7 +5197,7 @@ def post_memory_review_decision(
         # accept outright.
         try:
             materialization = materialize_promoted_memory(
-                decided,
+                effective_decided,
                 vault_context=vault_context,
                 channel=channel,
                 decision_store=decision_store,
@@ -5197,10 +5239,13 @@ def post_memory_review_decision(
             reviewed_by=req.reviewed_by,
             notes=req.notes,
         )
-        decision_store.record_decision(
+        _memory_review_record_decision(
+            decision_store,
             decided,
             vault_context=vault_context,
             channel=channel,
+            queue=queue,
+            original_entry=entry,
         )
         rejected = reject_memory_candidate(decided)
         return MemoryReviewDecisionResponse(
@@ -5220,10 +5265,14 @@ def post_memory_review_decision(
         notes=req.notes,
         revision=revision_candidate,
     )
-    decision_store.record_decision(
+    _memory_review_record_decision(
+        decision_store,
         decided,
         vault_context=vault_context,
         channel=channel,
+        queue=queue,
+        original_entry=entry,
+        revision_candidate_id=revision_candidate.candidate_id,
     )
     revision_entry = queue.get(revision_candidate.candidate_id)
     revised = revise_memory_candidate(decided, revision_entry)

--- a/app/knowledge_compilation/review_admission.py
+++ b/app/knowledge_compilation/review_admission.py
@@ -185,6 +185,7 @@ def route_admitted_memory_to_review_queue(
     queue: MemoryCandidateReviewQueue,
     *,
     memory_type: MemoryType,
+    scope_id: str,
     title: Optional[str] = None,
     content: Optional[str] = None,
 ) -> ReviewEntry:
@@ -215,6 +216,7 @@ def route_admitted_memory_to_review_queue(
         source_refs=_source_ids(artifact.source_refs),
         derived_from=artifact.artifact_id,
         generated_by=artifact.generated_by,
+        scope_id=scope_id,
         content=content if content is not None else _artifact_content(artifact),
         inferred=artifact.inferred,
     )

--- a/app/receipts/promotion_receipts.py
+++ b/app/receipts/promotion_receipts.py
@@ -36,6 +36,7 @@ class PromotionReceiptRow:
     timestamp: str
     artifact_uuid: str | None
     artifact_path: str | None
+    vault_id: str | None
     transition_family: str | None
     target_maturity: str | None
     review_state: str | None
@@ -189,6 +190,7 @@ def _project_transition_applied(
             timestamp=timestamp,
             artifact_uuid=artifact_uuid,
             artifact_path=artifact_path,
+            vault_id=first_str(payload.get("vault_id")),
             transition_family=first_str(payload.get("transition_family"), "promotion"),
             target_maturity=target_maturity,
             review_state=first_str(outcome.get("review_state")),

--- a/app/receipts/promotion_receipts.py
+++ b/app/receipts/promotion_receipts.py
@@ -36,6 +36,7 @@ class PromotionReceiptRow:
     timestamp: str
     artifact_uuid: str | None
     artifact_path: str | None
+    vault_id: str | None
     transition_family: str | None
     target_maturity: str | None
     review_state: str | None
@@ -144,24 +145,45 @@ def _project_transition_applied(
     if not isinstance(artifact_linkage, dict):
         return None, "missing_artifact_linkage"
 
-    artifact_uuid = first_str(
+    top_level_artifact_uuid = first_str(
         payload.get("artifact_uuid"),
         payload.get("note_uuid"),
         nested(payload, "note", "uuid"),
+    )
+    linkage_artifact_uuid = first_str(
         artifact_linkage.get("artifact_uuid"),
         artifact_linkage.get("note_uuid"),
     )
-    artifact_path = normalize_note_path(
+    if (
+        top_level_artifact_uuid
+        and linkage_artifact_uuid
+        and top_level_artifact_uuid != linkage_artifact_uuid
+    ):
+        return None, "conflicting_artifact_uuid"
+    artifact_uuid = top_level_artifact_uuid or linkage_artifact_uuid
+    top_level_artifact_path = normalize_note_path(
         first_str(
             payload.get("artifact_path"),
             payload.get("note_path"),
             payload.get("path"),
             nested(payload, "note", "path"),
+        ),
+        vault_root=vault_root,
+    )
+    linkage_artifact_path = normalize_note_path(
+        first_str(
             artifact_linkage.get("artifact_path"),
             artifact_linkage.get("note_path"),
         ),
         vault_root=vault_root,
     )
+    if (
+        top_level_artifact_path
+        and linkage_artifact_path
+        and top_level_artifact_path != linkage_artifact_path
+    ):
+        return None, "conflicting_artifact_path"
+    artifact_path = top_level_artifact_path or linkage_artifact_path
     if not artifact_uuid and not artifact_path:
         return None, "missing_artifact_identity"
 
@@ -189,6 +211,7 @@ def _project_transition_applied(
             timestamp=timestamp,
             artifact_uuid=artifact_uuid,
             artifact_path=artifact_path,
+            vault_id=first_str(payload.get("vault_id")),
             transition_family=first_str(payload.get("transition_family"), "promotion"),
             target_maturity=target_maturity,
             review_state=first_str(outcome.get("review_state")),

--- a/app/receipts/promotion_receipts.py
+++ b/app/receipts/promotion_receipts.py
@@ -145,24 +145,45 @@ def _project_transition_applied(
     if not isinstance(artifact_linkage, dict):
         return None, "missing_artifact_linkage"
 
-    artifact_uuid = first_str(
+    top_level_artifact_uuid = first_str(
         payload.get("artifact_uuid"),
         payload.get("note_uuid"),
         nested(payload, "note", "uuid"),
+    )
+    linkage_artifact_uuid = first_str(
         artifact_linkage.get("artifact_uuid"),
         artifact_linkage.get("note_uuid"),
     )
-    artifact_path = normalize_note_path(
+    if (
+        top_level_artifact_uuid
+        and linkage_artifact_uuid
+        and top_level_artifact_uuid != linkage_artifact_uuid
+    ):
+        return None, "conflicting_artifact_uuid"
+    artifact_uuid = top_level_artifact_uuid or linkage_artifact_uuid
+    top_level_artifact_path = normalize_note_path(
         first_str(
             payload.get("artifact_path"),
             payload.get("note_path"),
             payload.get("path"),
             nested(payload, "note", "path"),
+        ),
+        vault_root=vault_root,
+    )
+    linkage_artifact_path = normalize_note_path(
+        first_str(
             artifact_linkage.get("artifact_path"),
             artifact_linkage.get("note_path"),
         ),
         vault_root=vault_root,
     )
+    if (
+        top_level_artifact_path
+        and linkage_artifact_path
+        and top_level_artifact_path != linkage_artifact_path
+    ):
+        return None, "conflicting_artifact_path"
+    artifact_path = top_level_artifact_path or linkage_artifact_path
     if not artifact_uuid and not artifact_path:
         return None, "missing_artifact_identity"
 

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -25,7 +25,8 @@ existing authority path: `proposal → WriteGuard → receipt → vault artifact
 
 - is written through `app/write_guard.py` (a vault-internal write, consistent with the owner's
   "all vault-internal writes pass WriteGuard" rule) and the companion-note / knowledge write path;
-- carries provenance frontmatter (source_refs, generated_by, promoted-from candidate id, decided_by);
+- carries provenance frontmatter (source_refs, generated_by, promoted-from candidate id, decided_by)
+  plus the candidate's explicit `scope_id` binding;
 - is labeled as agent-promoted material, distinct from and never overriding human-authored notes;
 - has a corresponding promotion receipt (`app/receipts/promotion_receipts.py`) — the receipt is the
   accountability record, the note is the durable semantic surface.
@@ -41,6 +42,27 @@ promotion stays **actionable**: the candidate remains in (or returns to) the pen
 is re-attempted when writes are allowed again. A promoted candidate must never be suppressed from
 review while no artifact exists. (Non-semantic promotions need no artifact and are terminal on
 decision.)
+
+**Scope producer invariant.** A semantic candidate must carry an explicit `scope_id` before
+materialization. The materializer refuses a missing or invalid binding before any artifact or
+transition receipt is written. It serializes the persisted `PROMOTE` decision from nonterminal state
+through a durable `materializing` reservation, note and receipt creation, and the terminal
+transition. The reservation binds the immutable scope, candidate digest, and original reviewer
+authority; once it exists, reject/revise cannot replace the decision after an indeterminate external
+write. This allows one successful materializer and prevents a revoked, changed, repeated, or
+competing materializer from writing. The persisted binding is
+written to both note and receipt; legacy unscoped artifacts remain unchanged. Bound recall denies
+unscoped artifacts fail closed and requires scope, candidate, artifact UUID, and selected vault to
+match the applied receipt; unbound recall retains its existing behavior.
+The selected vault ID is trusted only when its selected path equals the root used for recall, and
+receipt top-level artifact identity must agree with its linkage fields. If a reject or revise races
+with a durable `materializing` reservation, the store refuses it and the API restores the original
+pending queue entry (including removal of any speculative revision) before returning a conflict.
+
+Late failures are resumed idempotently. The materialization identity is stable per
+vault/channel/candidate. A retry validates and reuses an existing applied receipt plus its
+candidate-bound note, or an unreceipted candidate-bound note when receipt append was interrupted.
+Conflicting or multiple recovery artifacts fail closed instead of producing another note or receipt.
 
 ## Concretely
 
@@ -80,6 +102,16 @@ receipt → durable artifact, never silent persistence") and the writing-surface
 - [ ] The materialized note carries provenance and an agent-promoted label and does not overwrite an
   existing human-authored note.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_materialized_note_preserves_provenance_and_human_authorship`
+- [ ] Semantic materialization refuses a missing or invalid candidate scope before writing, while
+  successful materialization persists the immutable decision scope into the artifact and receipt.
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_semantic_materialization_requires_scope_before_write`
+  Verify: `tests/agent_memory/test_materialization_live_path.py::test_accept_materializes_and_marks_terminal`
+- [ ] Materialization requires a current nonterminal `PROMOTE` for the same persisted scope and
+  permits only one successful materializer.
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_materialization_refuses_intervening_same_scope_rejection`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_duplicate_materializer_refuses_after_terminal_success`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_retry_reconciles_applied_receipt_after_late_query_failure`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_retry_reuses_candidate_note_after_receipt_append_failure`
 - [ ] Non-semantic promotions (episodic/working/preference) do not materialize a vault artifact.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_non_semantic_promotion_does_not_materialize`
 

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -46,11 +46,14 @@ decision.)
 **Scope producer invariant.** A semantic candidate must carry an explicit `scope_id` before
 materialization. The materializer refuses a missing or invalid binding before any artifact or
 transition receipt is written. It serializes the persisted `PROMOTE` decision from nonterminal state
-through note and receipt creation to the terminal transition, requiring the in-memory candidate and
-persisted decision to carry the same immutable scope. This allows one successful materializer and
-prevents a revoked, repeated, or competing materializer from writing. The persisted binding is
+through a durable `materializing` reservation, note and receipt creation, and the terminal
+transition. The reservation binds the immutable scope, candidate digest, and original reviewer
+authority; once it exists, reject/revise cannot replace the decision after an indeterminate external
+write. This allows one successful materializer and prevents a revoked, changed, repeated, or
+competing materializer from writing. The persisted binding is
 written to both note and receipt; legacy unscoped artifacts remain unchanged. Bound recall denies
-unscoped artifacts fail closed; unbound recall retains its existing behavior.
+unscoped artifacts fail closed and requires scope, candidate, artifact UUID, and selected vault to
+match the applied receipt; unbound recall retains its existing behavior.
 
 Late failures are resumed idempotently. The materialization identity is stable per
 vault/channel/candidate. A retry validates and reuses an existing applied receipt plus its

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -25,7 +25,8 @@ existing authority path: `proposal → WriteGuard → receipt → vault artifact
 
 - is written through `app/write_guard.py` (a vault-internal write, consistent with the owner's
   "all vault-internal writes pass WriteGuard" rule) and the companion-note / knowledge write path;
-- carries provenance frontmatter (source_refs, generated_by, promoted-from candidate id, decided_by);
+- carries provenance frontmatter (source_refs, generated_by, promoted-from candidate id, decided_by)
+  plus the candidate's explicit `scope_id` binding;
 - is labeled as agent-promoted material, distinct from and never overriding human-authored notes;
 - has a corresponding promotion receipt (`app/receipts/promotion_receipts.py`) — the receipt is the
   accountability record, the note is the durable semantic surface.
@@ -41,6 +42,12 @@ promotion stays **actionable**: the candidate remains in (or returns to) the pen
 is re-attempted when writes are allowed again. A promoted candidate must never be suppressed from
 review while no artifact exists. (Non-semantic promotions need no artifact and are terminal on
 decision.)
+
+**Scope producer invariant.** A semantic candidate must carry an explicit `scope_id` before
+materialization. The materializer refuses a missing binding before any artifact or transition
+receipt is written, persists the same binding in the note and receipt on success, and leaves legacy
+unscoped artifacts unchanged. Bound recall denies unscoped artifacts fail closed; unbound recall
+retains its existing behavior.
 
 ## Concretely
 
@@ -80,6 +87,10 @@ receipt → durable artifact, never silent persistence") and the writing-surface
 - [ ] The materialized note carries provenance and an agent-promoted label and does not overwrite an
   existing human-authored note.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_materialized_note_preserves_provenance_and_human_authorship`
+- [ ] Semantic materialization refuses a missing candidate scope before writing, while successful
+  materialization persists that scope into the artifact and receipt.
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_semantic_materialization_requires_scope_before_write`
+  Verify: `tests/agent_memory/test_materialization_live_path.py::test_accept_materializes_and_marks_terminal`
 - [ ] Non-semantic promotions (episodic/working/preference) do not materialize a vault artifact.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_non_semantic_promotion_does_not_materialize`
 

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -44,10 +44,13 @@ review while no artifact exists. (Non-semantic promotions need no artifact and a
 decision.)
 
 **Scope producer invariant.** A semantic candidate must carry an explicit `scope_id` before
-materialization. The materializer refuses a missing binding before any artifact or transition
-receipt is written, persists the same binding in the note and receipt on success, and leaves legacy
-unscoped artifacts unchanged. Bound recall denies unscoped artifacts fail closed; unbound recall
-retains its existing behavior.
+materialization. The materializer refuses a missing or invalid binding before any artifact or
+transition receipt is written. It serializes the persisted `PROMOTE` decision from nonterminal state
+through note and receipt creation to the terminal transition, requiring the in-memory candidate and
+persisted decision to carry the same immutable scope. This allows one successful materializer and
+prevents a revoked, repeated, or competing materializer from writing. The persisted binding is
+written to both note and receipt; legacy unscoped artifacts remain unchanged. Bound recall denies
+unscoped artifacts fail closed; unbound recall retains its existing behavior.
 
 ## Concretely
 
@@ -87,10 +90,14 @@ receipt → durable artifact, never silent persistence") and the writing-surface
 - [ ] The materialized note carries provenance and an agent-promoted label and does not overwrite an
   existing human-authored note.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_materialized_note_preserves_provenance_and_human_authorship`
-- [ ] Semantic materialization refuses a missing candidate scope before writing, while successful
-  materialization persists that scope into the artifact and receipt.
+- [ ] Semantic materialization refuses a missing or invalid candidate scope before writing, while
+  successful materialization persists the immutable decision scope into the artifact and receipt.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_semantic_materialization_requires_scope_before_write`
   Verify: `tests/agent_memory/test_materialization_live_path.py::test_accept_materializes_and_marks_terminal`
+- [ ] Materialization requires a current nonterminal `PROMOTE` for the same persisted scope and
+  permits only one successful materializer.
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_materialization_refuses_intervening_same_scope_rejection`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_duplicate_materializer_refuses_after_terminal_success`
 - [ ] Non-semantic promotions (episodic/working/preference) do not materialize a vault artifact.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_non_semantic_promotion_does_not_materialize`
 

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -54,6 +54,10 @@ competing materializer from writing. The persisted binding is
 written to both note and receipt; legacy unscoped artifacts remain unchanged. Bound recall denies
 unscoped artifacts fail closed and requires scope, candidate, artifact UUID, and selected vault to
 match the applied receipt; unbound recall retains its existing behavior.
+The selected vault ID is trusted only when its selected path equals the root used for recall, and
+receipt top-level artifact identity must agree with its linkage fields. If a reject or revise races
+with a durable `materializing` reservation, the store refuses it and the API restores the original
+pending queue entry (including removal of any speculative revision) before returning a conflict.
 
 Late failures are resumed idempotently. The materialization identity is stable per
 vault/channel/candidate. A retry validates and reuses an existing applied receipt plus its

--- a/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
+++ b/docs/DURABLE_MEMORY_AND_RECALL/MATERIALIZE_PROMOTED_MEMORY_TO_VAULT.md
@@ -52,6 +52,11 @@ prevents a revoked, repeated, or competing materializer from writing. The persis
 written to both note and receipt; legacy unscoped artifacts remain unchanged. Bound recall denies
 unscoped artifacts fail closed; unbound recall retains its existing behavior.
 
+Late failures are resumed idempotently. The materialization identity is stable per
+vault/channel/candidate. A retry validates and reuses an existing applied receipt plus its
+candidate-bound note, or an unreceipted candidate-bound note when receipt append was interrupted.
+Conflicting or multiple recovery artifacts fail closed instead of producing another note or receipt.
+
 ## Concretely
 
 ```
@@ -98,6 +103,8 @@ receipt → durable artifact, never silent persistence") and the writing-surface
   permits only one successful materializer.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_materialization_refuses_intervening_same_scope_rejection`
   Verify: `tests/agent_memory/test_memory_materialization.py::test_duplicate_materializer_refuses_after_terminal_success`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_retry_reconciles_applied_receipt_after_late_query_failure`
+  Verify: `tests/agent_memory/test_memory_materialization.py::test_retry_reuses_candidate_note_after_receipt_append_failure`
 - [ ] Non-semantic promotions (episodic/working/preference) do not materialize a vault artifact.
   Verify: `tests/agent_memory/test_memory_materialization.py::test_non_semantic_promotion_does_not_materialize`
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -578,6 +578,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         "memory_retrieval",
         (
             "app/memory/",
+            # Promoted and provisional agent-memory recall is consumed by the
+            # memory/retrieval suites. Keep this runtime package owned so a
+            # recall-boundary change cannot fail CI selection as unowned.
+            "app/agent_memory/",
             "app/retrieval/",
             "app/index/",
             # Index rebuild is the memory-retrieval CLI producer for the

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -601,6 +601,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         "memory_retrieval",
         (
             "app/memory/",
+            # Promoted and provisional agent-memory recall is consumed by the
+            # memory/retrieval suites. Keep this runtime package owned so a
+            # recall-boundary change cannot fail CI selection as unowned.
+            "app/agent_memory/",
+            # Review admission is the producer seam that hands an approved
+            # candidate to promoted-memory materialization. Its persisted
+            # scope/candidate authority must stay on the same acceptance
+            # surface as the consumer that later admits the memory to recall.
+            "app/knowledge_compilation/review_admission.py",
             "app/retrieval/",
             "app/index/",
             # Index rebuild is the memory-retrieval CLI producer for the
@@ -625,6 +634,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ),
         (
             "tests/agent_memory",
+            "tests/knowledge_compilation/test_review_admission_handoff.py",
             "tests/retrieval",
             "tests/index",
             "tests/indexer",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -601,6 +601,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         "memory_retrieval",
         (
             "app/memory/",
+            # Promoted and provisional agent-memory recall is consumed by the
+            # memory/retrieval suites. Keep this runtime package owned so a
+            # recall-boundary change cannot fail CI selection as unowned.
+            "app/agent_memory/",
             "app/retrieval/",
             "app/index/",
             # Index rebuild is the memory-retrieval CLI producer for the

--- a/tests/agent_memory/test_materialization.py
+++ b/tests/agent_memory/test_materialization.py
@@ -50,6 +50,7 @@ def _promoted_entry(store: ReviewDecisionStore, vault: VaultContext):
         source_refs=["note:source.md", "session:2026-06-14T10:00:00Z"],
         derived_from="vault:source.md",
         generated_by="companion_agent",
+        scope_id="scope:test/default-outbox",
     )
     queue.enqueue(candidate)
     entry = queue.decide(

--- a/tests/agent_memory/test_materialization_live_path.py
+++ b/tests/agent_memory/test_materialization_live_path.py
@@ -13,6 +13,7 @@ Source authority:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,7 @@ def _semantic_candidate(**overrides: Any) -> MemoryCandidate:
         source_refs=["note:source.md", "session:2026-06-14T09:00:00Z"],
         derived_from="vault:source.md",
         generated_by="companion_agent",
+        scope_id="scope:work/project-alpha",
     )
     fields.update(overrides)
     return MemoryCandidate(**fields)
@@ -107,7 +109,10 @@ def test_accept_materializes_and_marks_terminal(
     assert artifact.exists()
     body = artifact.read_text(encoding="utf-8")
     assert "agent-promoted-memory" in body
+    assert "scope_id: scope:work/project-alpha" in body
     assert "The user keeps design docs ahead of code." in body
+    receipt = json.loads(receipts_path.read_text(encoding="utf-8"))
+    assert receipt["payload"]["basis"]["scope_id"] == "scope:work/project-alpha"
 
     # The stored review decision is terminal.
     record = store.get_decision(

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -189,6 +189,82 @@ def test_materialization_requires_entry_scope_to_match_persisted_decision(
     assert record.terminal is False
 
 
+def test_materialization_refuses_intervening_same_scope_rejection(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate(candidate_id="candidate-revoked")
+    stale_promote = _promoted(candidate, store=store, vault=vault)
+
+    replacement_queue = MemoryCandidateReviewQueue()
+    replacement_queue.enqueue(candidate)
+    rejection = replacement_queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="companion-ui:reviewer",
+        notes="Promotion authority revoked before materialization.",
+    )
+    store.record_decision(rejection, vault_context=vault, channel="test")
+
+    with pytest.raises(MemoryMaterializationError, match="persisted promote decision"):
+        materialize_promoted_memory(
+            stale_promote,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.outcome is ReviewDecision.REJECT
+    assert record.terminal is True
+
+
+def test_duplicate_materializer_refuses_after_terminal_success(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-single-writer"),
+        store=store,
+        vault=vault,
+    )
+
+    first = materialize_promoted_memory(
+        entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+    with pytest.raises(MemoryMaterializationError, match="already terminal"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert first.artifact_path is not None
+    assert len(list(Path(vault.active_vault_path).rglob("*.md"))) == 1
+    receipts = query_promotion_receipts(
+        vault_root=Path(vault.active_vault_path),
+        outbox_path=outbox,
+    )
+    assert [row.outcome_status for row in receipts.rows] == ["applied"]
+
+
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     Path(vault.active_vault_path).mkdir()

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import app.agent_memory.materialization as materialization_module
 from app.agent_memory.candidate import MemoryCandidate, MemoryType
 from app.agent_memory.materialization import (
     MemoryMaterializationError,
@@ -263,6 +264,137 @@ def test_duplicate_materializer_refuses_after_terminal_success(tmp_path: Path) -
         outbox_path=outbox,
     )
     assert [row.outcome_status for row in receipts.rows] == ["applied"]
+
+
+def test_retry_reconciles_applied_receipt_after_late_query_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    vault_root = Path(vault.active_vault_path)
+    vault_root.mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-late-query"),
+        store=store,
+        vault=vault,
+    )
+    original_query = materialization_module.query_promotion_receipts
+    query_calls = 0
+
+    def fail_post_append_query(*args, **kwargs):
+        nonlocal query_calls
+        query_calls += 1
+        if query_calls == 2:
+            raise RuntimeError("injected post-append query failure")
+        return original_query(*args, **kwargs)
+
+    monkeypatch.setattr(
+        materialization_module,
+        "query_promotion_receipts",
+        fail_post_append_query,
+    )
+    with pytest.raises(RuntimeError, match="post-append query failure"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    assert store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    ).terminal is False
+
+    monkeypatch.setattr(
+        materialization_module,
+        "query_promotion_receipts",
+        original_query,
+    )
+    result = materialize_promoted_memory(
+        entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+
+    assert result.status == "materialized"
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    assert store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    ).terminal is True
+
+
+def test_retry_reuses_candidate_note_after_receipt_append_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    vault_root = Path(vault.active_vault_path)
+    vault_root.mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-late-append"),
+        store=store,
+        vault=vault,
+    )
+    original_append = materialization_module._append_promotion_receipt
+
+    def fail_receipt_append(*args, **kwargs):
+        raise RuntimeError("injected receipt append failure")
+
+    monkeypatch.setattr(
+        materialization_module,
+        "_append_promotion_receipt",
+        fail_receipt_append,
+    )
+    with pytest.raises(RuntimeError, match="receipt append failure"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    first_note = next(vault_root.rglob("*.md"))
+    first_body = first_note.read_text(encoding="utf-8")
+    assert not outbox.exists()
+    assert store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    ).terminal is False
+
+    monkeypatch.setattr(
+        materialization_module,
+        "_append_promotion_receipt",
+        original_append,
+    )
+    result = materialize_promoted_memory(
+        entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+
+    assert result.artifact_path == first_note.relative_to(vault_root).as_posix()
+    assert first_note.read_text(encoding="utf-8") == first_body
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    assert store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    ).terminal is True
 
 
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -149,6 +149,46 @@ def test_semantic_materialization_requires_scope_before_write(tmp_path: Path) ->
     assert record.terminal is False
 
 
+def test_materialization_requires_entry_scope_to_match_persisted_decision(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate(candidate_id="candidate-scope-cas")
+    _promoted(candidate, store=store, vault=vault)
+
+    stale_candidate = candidate.model_copy(update={"scope_id": "scope:test/other"})
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(stale_candidate)
+    stale_entry = queue.decide(
+        stale_candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+        notes="Stale in-memory review entry.",
+    )
+
+    with pytest.raises(MemoryMaterializationError, match="persisted review decision"):
+        materialize_promoted_memory(
+            stale_entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.scope_id == "scope:test/materialization"
+    assert record.terminal is False
+
+
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     Path(vault.active_vault_path).mkdir()

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -5,12 +5,16 @@ from pathlib import Path
 
 import pytest
 
+import app.agent_memory.materialization as materialization_module
 from app.agent_memory.candidate import MemoryCandidate, MemoryType
 from app.agent_memory.materialization import (
     MemoryMaterializationError,
     materialize_promoted_memory,
 )
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+)
 from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewDecision
 from app.receipts.promotion_receipts import query_promotion_receipts
 from app.vault.manager import VaultContext
@@ -41,6 +45,7 @@ def _candidate(
         source_refs=["note:source.md", "session:2026-06-13T09:00:00Z"],
         derived_from="vault:source.md",
         generated_by="companion_agent",
+        scope_id="scope:test/materialization",
     )
 
 
@@ -121,6 +126,338 @@ def test_blocked_writes_prevent_materialization(tmp_path: Path) -> None:
     assert not list(Path(vault.active_vault_path).rglob("*.md"))
 
 
+def test_semantic_materialization_requires_scope_before_write(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate().model_copy(update={"scope_id": None})
+    entry = _promoted(candidate, store=store, vault=vault)
+
+    with pytest.raises(MemoryMaterializationError, match="candidate.scope_id"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.terminal is False
+
+
+def test_materialization_requires_entry_scope_to_match_persisted_decision(
+    tmp_path: Path,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate(candidate_id="candidate-scope-cas")
+    _promoted(candidate, store=store, vault=vault)
+
+    stale_candidate = candidate.model_copy(update={"scope_id": "scope:test/other"})
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(stale_candidate)
+    stale_entry = queue.decide(
+        stale_candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+        notes="Stale in-memory review entry.",
+    )
+
+    with pytest.raises(MemoryMaterializationError, match="persisted review decision"):
+        materialize_promoted_memory(
+            stale_entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.scope_id == "scope:test/materialization"
+    assert record.terminal is False
+
+
+def test_materialization_refuses_intervening_same_scope_rejection(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate(candidate_id="candidate-revoked")
+    stale_promote = _promoted(candidate, store=store, vault=vault)
+
+    replacement_queue = MemoryCandidateReviewQueue()
+    replacement_queue.enqueue(candidate)
+    rejection = replacement_queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="companion-ui:reviewer",
+        notes="Promotion authority revoked before materialization.",
+    )
+    store.record_decision(rejection, vault_context=vault, channel="test")
+
+    with pytest.raises(MemoryMaterializationError, match="persisted promote decision"):
+        materialize_promoted_memory(
+            stale_promote,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.outcome is ReviewDecision.REJECT
+    assert record.terminal is True
+
+
+def test_duplicate_materializer_refuses_after_terminal_success(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-single-writer"),
+        store=store,
+        vault=vault,
+    )
+
+    first = materialize_promoted_memory(
+        entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+    with pytest.raises(MemoryMaterializationError, match="already terminal"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert first.artifact_path is not None
+    assert len(list(Path(vault.active_vault_path).rglob("*.md"))) == 1
+    receipts = query_promotion_receipts(
+        vault_root=Path(vault.active_vault_path),
+        outbox_path=outbox,
+    )
+    assert [row.outcome_status for row in receipts.rows] == ["applied"]
+
+
+def test_retry_reconciles_applied_receipt_after_late_query_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    vault_root = Path(vault.active_vault_path)
+    vault_root.mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-late-query"),
+        store=store,
+        vault=vault,
+    )
+    original_query = materialization_module.query_promotion_receipts
+    query_calls = 0
+
+    def fail_post_append_query(*args, **kwargs):
+        nonlocal query_calls
+        query_calls += 1
+        if query_calls == 2:
+            raise RuntimeError("injected post-append query failure")
+        return original_query(*args, **kwargs)
+
+    monkeypatch.setattr(
+        materialization_module,
+        "query_promotion_receipts",
+        fail_post_append_query,
+    )
+    with pytest.raises(MemoryMaterializationError, match="interrupted"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    interrupted = store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    )
+    assert interrupted.terminal is False
+    assert interrupted.materializing is True
+
+    changed_candidate = entry.candidate.model_copy(
+        update={"content": "Changed candidate content after restart."}
+    )
+    changed_queue = MemoryCandidateReviewQueue()
+    changed_queue.enqueue(changed_candidate)
+    changed_retry = changed_queue.decide(
+        changed_candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+    )
+    with pytest.raises(ReviewDecisionStoreError, match="content cannot change"):
+        store.record_decision(
+            changed_retry,
+            vault_context=vault,
+            channel="test",
+        )
+
+    monkeypatch.setattr(
+        materialization_module,
+        "query_promotion_receipts",
+        original_query,
+    )
+    retry_queue = MemoryCandidateReviewQueue()
+    retry_queue.enqueue(entry.candidate)
+    retry_entry = retry_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+        notes="Retry after restart.",
+    )
+    persisted_retry = store.record_decision(
+        retry_entry,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted_retry.decided_by == "companion-ui:reviewer"
+    result = materialize_promoted_memory(
+        retry_entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+
+    assert result.status == "materialized"
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    completed = store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    )
+    assert completed.terminal is True
+    assert completed.materializing is False
+
+
+def test_retry_reuses_candidate_note_after_receipt_append_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = _vault(tmp_path / "vault")
+    vault_root = Path(vault.active_vault_path)
+    vault_root.mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    entry = _promoted(
+        _candidate(candidate_id="candidate-late-append"),
+        store=store,
+        vault=vault,
+    )
+    original_append = materialization_module._append_promotion_receipt
+
+    def fail_receipt_append(*args, **kwargs):
+        raise RuntimeError("injected receipt append failure")
+
+    monkeypatch.setattr(
+        materialization_module,
+        "_append_promotion_receipt",
+        fail_receipt_append,
+    )
+    with pytest.raises(MemoryMaterializationError, match="interrupted"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    first_note = next(vault_root.rglob("*.md"))
+    first_body = first_note.read_text(encoding="utf-8")
+    assert not outbox.exists()
+    interrupted = store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    )
+    assert interrupted.terminal is False
+    assert interrupted.materializing is True
+
+    rejection_queue = MemoryCandidateReviewQueue()
+    rejection_queue.enqueue(entry.candidate)
+    rejection = rejection_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="companion-ui:restart-reviewer",
+    )
+    with pytest.raises(ReviewDecisionStoreError, match="in progress"):
+        store.record_decision(rejection, vault_context=vault, channel="test")
+
+    monkeypatch.setattr(
+        materialization_module,
+        "_append_promotion_receipt",
+        original_append,
+    )
+    retry_queue = MemoryCandidateReviewQueue()
+    retry_queue.enqueue(entry.candidate)
+    retry_entry = retry_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+        notes="Retry after restart.",
+    )
+    store.record_decision(retry_entry, vault_context=vault, channel="test")
+    result = materialize_promoted_memory(
+        retry_entry,
+        vault_context=vault,
+        channel="test",
+        decision_store=store,
+        write_guard=_allowing_guard(),
+        outbox_path=outbox,
+    )
+
+    assert result.artifact_path == first_note.relative_to(vault_root).as_posix()
+    assert first_note.read_text(encoding="utf-8") == first_body
+    assert len(list(vault_root.rglob("*.md"))) == 1
+    assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
+    completed = store.get_decision(
+        entry.candidate_id, vault_context=vault, channel="test"
+    )
+    assert completed.terminal is True
+    assert completed.materializing is False
+
+
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     Path(vault.active_vault_path).mkdir()
@@ -179,6 +516,7 @@ def test_materialized_note_preserves_provenance_and_human_authorship(tmp_path: P
     body = (vault_root / result.artifact_path).read_text(encoding="utf-8")
     assert "agent-promoted-memory" in body
     assert "promoted_from_candidate_id: candidate-" in body
+    assert "scope_id: scope:test/materialization" in body
     assert "companion-ui:reviewer" in body
     assert "note:source.md" in body
     assert "The user explicitly prefers design docs before code." in body

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -41,6 +41,7 @@ def _candidate(
         source_refs=["note:source.md", "session:2026-06-13T09:00:00Z"],
         derived_from="vault:source.md",
         generated_by="companion_agent",
+        scope_id="scope:test/materialization",
     )
 
 
@@ -121,6 +122,33 @@ def test_blocked_writes_prevent_materialization(tmp_path: Path) -> None:
     assert not list(Path(vault.active_vault_path).rglob("*.md"))
 
 
+def test_semantic_materialization_requires_scope_before_write(tmp_path: Path) -> None:
+    vault = _vault(tmp_path / "vault")
+    Path(vault.active_vault_path).mkdir()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    candidate = _candidate().model_copy(update={"scope_id": None})
+    entry = _promoted(candidate, store=store, vault=vault)
+
+    with pytest.raises(MemoryMaterializationError, match="candidate.scope_id"):
+        materialize_promoted_memory(
+            entry,
+            vault_context=vault,
+            channel="test",
+            decision_store=store,
+            write_guard=_allowing_guard(),
+            outbox_path=outbox,
+        )
+
+    assert not list(Path(vault.active_vault_path).rglob("*.md"))
+    assert not outbox.exists()
+    record = store.get_decision(
+        candidate.candidate_id, vault_context=vault, channel="test"
+    )
+    assert record is not None
+    assert record.terminal is False
+
+
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:
     vault = _vault(tmp_path / "vault")
     Path(vault.active_vault_path).mkdir()
@@ -179,6 +207,7 @@ def test_materialized_note_preserves_provenance_and_human_authorship(tmp_path: P
     body = (vault_root / result.artifact_path).read_text(encoding="utf-8")
     assert "agent-promoted-memory" in body
     assert "promoted_from_candidate_id: candidate-" in body
+    assert "scope_id: scope:test/materialization" in body
     assert "companion-ui:reviewer" in body
     assert "note:source.md" in body
     assert "The user explicitly prefers design docs before code." in body

--- a/tests/agent_memory/test_memory_materialization.py
+++ b/tests/agent_memory/test_memory_materialization.py
@@ -11,7 +11,10 @@ from app.agent_memory.materialization import (
     MemoryMaterializationError,
     materialize_promoted_memory,
 )
-from app.agent_memory.review_decision_store import ReviewDecisionStore
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionStore,
+    ReviewDecisionStoreError,
+)
 from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewDecision
 from app.receipts.promotion_receipts import query_promotion_receipts
 from app.vault.manager import VaultContext
@@ -295,7 +298,7 @@ def test_retry_reconciles_applied_receipt_after_late_query_failure(
         "query_promotion_receipts",
         fail_post_append_query,
     )
-    with pytest.raises(RuntimeError, match="post-append query failure"):
+    with pytest.raises(MemoryMaterializationError, match="interrupted"):
         materialize_promoted_memory(
             entry,
             vault_context=vault,
@@ -307,17 +310,50 @@ def test_retry_reconciles_applied_receipt_after_late_query_failure(
 
     assert len(list(vault_root.rglob("*.md"))) == 1
     assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
-    assert store.get_decision(
+    interrupted = store.get_decision(
         entry.candidate_id, vault_context=vault, channel="test"
-    ).terminal is False
+    )
+    assert interrupted.terminal is False
+    assert interrupted.materializing is True
+
+    changed_candidate = entry.candidate.model_copy(
+        update={"content": "Changed candidate content after restart."}
+    )
+    changed_queue = MemoryCandidateReviewQueue()
+    changed_queue.enqueue(changed_candidate)
+    changed_retry = changed_queue.decide(
+        changed_candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+    )
+    with pytest.raises(ReviewDecisionStoreError, match="content cannot change"):
+        store.record_decision(
+            changed_retry,
+            vault_context=vault,
+            channel="test",
+        )
 
     monkeypatch.setattr(
         materialization_module,
         "query_promotion_receipts",
         original_query,
     )
+    retry_queue = MemoryCandidateReviewQueue()
+    retry_queue.enqueue(entry.candidate)
+    retry_entry = retry_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+        notes="Retry after restart.",
+    )
+    persisted_retry = store.record_decision(
+        retry_entry,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted_retry.decided_by == "companion-ui:reviewer"
     result = materialize_promoted_memory(
-        entry,
+        retry_entry,
         vault_context=vault,
         channel="test",
         decision_store=store,
@@ -328,9 +364,11 @@ def test_retry_reconciles_applied_receipt_after_late_query_failure(
     assert result.status == "materialized"
     assert len(list(vault_root.rglob("*.md"))) == 1
     assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
-    assert store.get_decision(
+    completed = store.get_decision(
         entry.candidate_id, vault_context=vault, channel="test"
-    ).terminal is True
+    )
+    assert completed.terminal is True
+    assert completed.materializing is False
 
 
 def test_retry_reuses_candidate_note_after_receipt_append_failure(
@@ -357,7 +395,7 @@ def test_retry_reuses_candidate_note_after_receipt_append_failure(
         "_append_promotion_receipt",
         fail_receipt_append,
     )
-    with pytest.raises(RuntimeError, match="receipt append failure"):
+    with pytest.raises(MemoryMaterializationError, match="interrupted"):
         materialize_promoted_memory(
             entry,
             vault_context=vault,
@@ -370,17 +408,38 @@ def test_retry_reuses_candidate_note_after_receipt_append_failure(
     first_note = next(vault_root.rglob("*.md"))
     first_body = first_note.read_text(encoding="utf-8")
     assert not outbox.exists()
-    assert store.get_decision(
+    interrupted = store.get_decision(
         entry.candidate_id, vault_context=vault, channel="test"
-    ).terminal is False
+    )
+    assert interrupted.terminal is False
+    assert interrupted.materializing is True
+
+    rejection_queue = MemoryCandidateReviewQueue()
+    rejection_queue.enqueue(entry.candidate)
+    rejection = rejection_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="companion-ui:restart-reviewer",
+    )
+    with pytest.raises(ReviewDecisionStoreError, match="in progress"):
+        store.record_decision(rejection, vault_context=vault, channel="test")
 
     monkeypatch.setattr(
         materialization_module,
         "_append_promotion_receipt",
         original_append,
     )
+    retry_queue = MemoryCandidateReviewQueue()
+    retry_queue.enqueue(entry.candidate)
+    retry_entry = retry_queue.decide(
+        entry.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:restart-reviewer",
+        notes="Retry after restart.",
+    )
+    store.record_decision(retry_entry, vault_context=vault, channel="test")
     result = materialize_promoted_memory(
-        entry,
+        retry_entry,
         vault_context=vault,
         channel="test",
         decision_store=store,
@@ -392,9 +451,11 @@ def test_retry_reuses_candidate_note_after_receipt_append_failure(
     assert first_note.read_text(encoding="utf-8") == first_body
     assert len(list(vault_root.rglob("*.md"))) == 1
     assert len(outbox.read_text(encoding="utf-8").splitlines()) == 1
-    assert store.get_decision(
+    completed = store.get_decision(
         entry.candidate_id, vault_context=vault, channel="test"
-    ).terminal is True
+    )
+    assert completed.terminal is True
+    assert completed.materializing is False
 
 
 def test_blocked_materialization_keeps_promotion_actionable(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_recall_in_ask.py
+++ b/tests/agent_memory/test_recall_in_ask.py
@@ -51,6 +51,7 @@ def _candidate(
         source_refs=[f"note:{candidate_id}.md", "session:2026-06-13T09:00:00Z"],
         derived_from=f"vault:{candidate_id}.md",
         generated_by="companion_agent",
+        scope_id="scope:work/project-alpha",
     )
 
 

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -273,6 +273,80 @@ def test_selects_relevant_topk_and_caps(tmp_path: Path) -> None:
     )
 
 
+def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> None:
+    """A bound recall only admits promoted memories with the same persisted scope."""
+    vault_root = tmp_path / "vault"
+    memory_dir = vault_root / "Agent Memory"
+    memory_dir.mkdir(parents=True)
+    records = []
+    for candidate_id, scope_id, title in (
+        ("candidate-work", "scope-work", "Work deployment posture"),
+        ("candidate-private", "scope-private", "Private deployment posture"),
+        ("candidate-legacy", None, "Legacy deployment posture"),
+    ):
+        artifact_path = f"Agent Memory/{candidate_id}.md"
+        scope_line = f"scope_id: {scope_id}\n" if scope_id else ""
+        (vault_root / artifact_path).write_text(
+            "---\n"
+            "artifact_type: semantic_memory\n"
+            "agent_promoted: true\n"
+            f"promoted_from_candidate_id: {candidate_id}\n"
+            f"{scope_line}"
+            "decided_by: companion-ui:reviewer\n"
+            "decided_at: '2026-06-13T09:00:00Z'\n"
+            "---\n\n"
+            f"# {title}\n\nDeployment posture details.\n",
+            encoding="utf-8",
+        )
+        records.append(
+            {
+                "event": "promotion.transition.applied",
+                "event_id": f"receipt-{candidate_id}",
+                "trace_id": f"trace-{candidate_id}",
+                "timestamp": "2026-06-13T09:05:00Z",
+                "payload": {
+                    "receipt_id": f"receipt-{candidate_id}",
+                    "transition_family": "agent_memory_materialization",
+                    "target_maturity": "semantic_memory",
+                    "artifact_uuid": f"artifact-{candidate_id}",
+                    "artifact_path": artifact_path,
+                    "authority": {"requested_by": "companion-ui:reviewer"},
+                    "basis": {"candidate_id": candidate_id},
+                    "outcome": {"status": "applied", "review_state": "accepted"},
+                    "artifact_linkage": {
+                        "artifact_uuid": f"artifact-{candidate_id}",
+                        "artifact_path": artifact_path,
+                        "candidate_id": candidate_id,
+                    },
+                },
+            }
+        )
+
+    scoped = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        records=records,
+        active_scope_id="scope-work",
+    )
+
+    assert [item.promoted.candidate.candidate_id for item in scoped] == ["candidate-work"]
+    assert scoped[0].memory_scope_id == "scope-work"
+    assert scoped[0].applied_scope_id == "scope-work"
+
+    unbound = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        records=records,
+    )
+
+    assert {item.promoted.candidate.candidate_id for item in unbound} == {
+        "candidate-work",
+        "candidate-private",
+        "candidate-legacy",
+    }
+    assert {item.applied_scope_id for item in unbound} == {None}
+
+
 def test_pure_and_safe_on_empty(tmp_path: Path) -> None:
     missing_vault = tmp_path / "missing-vault"
     missing_outbox = tmp_path / "missing-outbox.jsonl"

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -159,6 +159,7 @@ def test_missing_inferred_metadata_defaults_conservatively(tmp_path: Path) -> No
         """---
 artifact_type: semantic_memory
 agent_promoted: true
+uuid: artifact-legacy
 promoted_from_candidate_id: candidate-legacy
 source_refs:
 - note:legacy-a.md
@@ -282,27 +283,31 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
     memory_dir = vault_root / "Agent Memory"
     memory_dir.mkdir(parents=True)
     records = []
-    for candidate_id, authority_line, title in (
-        ("candidate-work", "scope_id: scope-work\n", "Work deployment posture"),
+    for candidate_id, authority_line, receipt_scope, title in (
+        ("candidate-work", "scope_id: scope-work\n", "scope-work", "Work deployment posture"),
         (
             "candidate-private",
             "scope_id: scope-private\n",
+            "scope-private",
             "Private deployment posture",
         ),
-        ("candidate-legacy", "", "Legacy deployment posture"),
+        ("candidate-legacy", "", None, "Legacy deployment posture"),
         (
             "candidate-domain-only",
             "domain: scope-work\n",
+            None,
             "Domain-only deployment posture",
         ),
         (
             "candidate-invalid-scope",
             "scope_id: 'invalid scope'\n",
+            "invalid scope",
             "Invalid-scope deployment posture",
         ),
         (
             "candidate-overlength-scope",
             f"scope_id: {'s' * 129}\n",
+            "s" * 129,
             "Overlength-scope deployment posture",
         ),
     ):
@@ -311,6 +316,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
             "---\n"
             "artifact_type: semantic_memory\n"
             "agent_promoted: true\n"
+            f"uuid: artifact-{candidate_id}\n"
             f"promoted_from_candidate_id: {candidate_id}\n"
             f"{authority_line}"
             "decided_by: companion-ui:reviewer\n"
@@ -332,7 +338,11 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
                     "artifact_uuid": f"artifact-{candidate_id}",
                     "artifact_path": artifact_path,
                     "authority": {"requested_by": "companion-ui:reviewer"},
-                    "basis": {"candidate_id": candidate_id},
+                    "vault_id": "vault-a",
+                    "basis": {
+                        "candidate_id": candidate_id,
+                        **({"scope_id": receipt_scope} if receipt_scope is not None else {}),
+                    },
                     "outcome": {"status": "applied", "review_state": "accepted"},
                     "artifact_linkage": {
                         "artifact_uuid": f"artifact-{candidate_id}",
@@ -348,6 +358,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
         vault_root=vault_root,
         records=records,
         active_scope_id="scope-work",
+        active_vault_id="vault-a",
     )
 
     assert [item.promoted.candidate.candidate_id for item in scoped] == ["candidate-work"]
@@ -408,12 +419,14 @@ def test_materialized_scope_drives_bound_recall_admission(tmp_path: Path) -> Non
         vault_root=vault_root,
         outbox_path=outbox,
         active_scope_id="scope-work",
+        active_vault_id="vault-a",
     )
     denied = retrieve_relevant_promoted(
         "deployment posture",
         vault_root=vault_root,
         outbox_path=outbox,
         active_scope_id="scope-private",
+        active_vault_id="vault-a",
     )
 
     assert [item.promoted.candidate.candidate_id for item in admitted] == [
@@ -421,6 +434,75 @@ def test_materialized_scope_drives_bound_recall_admission(tmp_path: Path) -> Non
     ]
     assert admitted[0].memory_scope_id == "scope-work"
     assert denied == []
+
+
+def test_bound_recall_rejects_note_scope_tampering_against_receipt(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    artifact_path = _materialize(
+        _candidate(
+            "candidate-private-tamper",
+            title="Private deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-private",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+    note_path = vault_root / artifact_path
+    note_path.write_text(
+        note_path.read_text(encoding="utf-8").replace(
+            "scope_id: scope-private",
+            "scope_id: scope-work",
+        ),
+        encoding="utf-8",
+    )
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
+    ) == []
+
+
+def test_bound_recall_rejects_receipt_from_another_vault(tmp_path: Path) -> None:
+    source_root = tmp_path / "source-vault"
+    source_root.mkdir()
+    source_vault = _vault(source_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    artifact_path = _materialize(
+        _candidate(
+            "candidate-cross-vault",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=source_vault,
+        store=store,
+        outbox=outbox,
+    )
+    target_root = tmp_path / "target-vault"
+    target_note = target_root / artifact_path
+    target_note.parent.mkdir(parents=True)
+    target_note.write_text(
+        (source_root / artifact_path).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=target_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+        active_vault_id="vault-b",
+    ) == []
 
 
 def test_pure_and_safe_on_empty(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,7 @@ def _candidate(
     content: str,
     source_refs: list[str] | None = None,
     inferred: bool = False,
+    scope_id: str = "scope:work/project-alpha",
 ) -> MemoryCandidate:
     return MemoryCandidate(
         candidate_id=candidate_id,
@@ -47,6 +49,7 @@ def _candidate(
         source_refs=source_refs or [f"note:{candidate_id}.md", "session:2026-06-13T09:00:00Z"],
         derived_from=f"vault:{candidate_id}.md",
         generated_by="companion_agent",
+        scope_id=scope_id,
     )
 
 
@@ -101,6 +104,7 @@ def test_reads_promoted_memory_from_durable_set(tmp_path: Path) -> None:
     assert promoted.candidate.content == candidate.content
     assert promoted.candidate.source_refs == candidate.source_refs
     assert promoted.candidate.inferred is False
+    assert promoted.candidate.scope_id == candidate.scope_id
     assert promoted.decided_by == "companion-ui:reviewer"
     assert (vault_root / artifact_path).exists()
 
@@ -156,6 +160,7 @@ def test_missing_inferred_metadata_defaults_conservatively(tmp_path: Path) -> No
         """---
 artifact_type: semantic_memory
 agent_promoted: true
+uuid: artifact-legacy
 promoted_from_candidate_id: candidate-legacy
 source_refs:
 - note:legacy-a.md
@@ -271,6 +276,274 @@ def test_selects_relevant_topk_and_caps(tmp_path: Path) -> None:
         )
         == []
     )
+
+
+def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> None:
+    """A bound recall only admits promoted memories with the same persisted scope."""
+    vault_root = tmp_path / "vault"
+    memory_dir = vault_root / "Agent Memory"
+    memory_dir.mkdir(parents=True)
+    records = []
+    for candidate_id, authority_line, receipt_scope, title in (
+        ("candidate-work", "scope_id: scope-work\n", "scope-work", "Work deployment posture"),
+        (
+            "candidate-private",
+            "scope_id: scope-private\n",
+            "scope-private",
+            "Private deployment posture",
+        ),
+        ("candidate-legacy", "", None, "Legacy deployment posture"),
+        (
+            "candidate-domain-only",
+            "domain: scope-work\n",
+            None,
+            "Domain-only deployment posture",
+        ),
+        (
+            "candidate-invalid-scope",
+            "scope_id: 'invalid scope'\n",
+            "invalid scope",
+            "Invalid-scope deployment posture",
+        ),
+        (
+            "candidate-overlength-scope",
+            f"scope_id: {'s' * 129}\n",
+            "s" * 129,
+            "Overlength-scope deployment posture",
+        ),
+    ):
+        artifact_path = f"Agent Memory/{candidate_id}.md"
+        (vault_root / artifact_path).write_text(
+            "---\n"
+            "artifact_type: semantic_memory\n"
+            "agent_promoted: true\n"
+            f"uuid: artifact-{candidate_id}\n"
+            f"promoted_from_candidate_id: {candidate_id}\n"
+            f"{authority_line}"
+            "decided_by: companion-ui:reviewer\n"
+            "decided_at: '2026-06-13T09:00:00Z'\n"
+            "---\n\n"
+            f"# {title}\n\nDeployment posture details.\n",
+            encoding="utf-8",
+        )
+        records.append(
+            {
+                "event": "promotion.transition.applied",
+                "event_id": f"receipt-{candidate_id}",
+                "trace_id": f"trace-{candidate_id}",
+                "timestamp": "2026-06-13T09:05:00Z",
+                "payload": {
+                    "receipt_id": f"receipt-{candidate_id}",
+                    "transition_family": "agent_memory_materialization",
+                    "target_maturity": "semantic_memory",
+                    "artifact_uuid": f"artifact-{candidate_id}",
+                    "artifact_path": artifact_path,
+                    "authority": {"requested_by": "companion-ui:reviewer"},
+                    "vault_id": "vault-a",
+                    "basis": {
+                        "candidate_id": candidate_id,
+                        **({"scope_id": receipt_scope} if receipt_scope is not None else {}),
+                    },
+                    "outcome": {"status": "applied", "review_state": "accepted"},
+                    "artifact_linkage": {
+                        "artifact_uuid": f"artifact-{candidate_id}",
+                        "artifact_path": artifact_path,
+                        "candidate_id": candidate_id,
+                    },
+                },
+            }
+        )
+
+    scoped = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        records=records,
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
+    )
+
+    assert [item.promoted.candidate.candidate_id for item in scoped] == ["candidate-work"]
+    assert scoped[0].memory_scope_id == "scope-work"
+    assert scoped[0].promoted.candidate.scope_id == "scope-work"
+    assert scoped[0].applied_scope_id == "scope-work"
+
+    unbound = retrieve_relevant_promoted(
+        "deployment posture",
+        k=10,
+        vault_root=vault_root,
+        records=records,
+    )
+
+    assert {item.promoted.candidate.candidate_id for item in unbound} == {
+        "candidate-work",
+        "candidate-private",
+        "candidate-legacy",
+        "candidate-domain-only",
+        "candidate-invalid-scope",
+        "candidate-overlength-scope",
+    }
+    assert {item.applied_scope_id for item in unbound} == {None}
+    unbound_by_id = {
+        item.promoted.candidate.candidate_id: item
+        for item in unbound
+    }
+    for candidate_id in (
+        "candidate-legacy",
+        "candidate-domain-only",
+        "candidate-invalid-scope",
+        "candidate-overlength-scope",
+    ):
+        assert unbound_by_id[candidate_id].memory_scope_id is None
+        assert unbound_by_id[candidate_id].promoted.candidate.scope_id is None
+
+
+def test_materialized_scope_drives_bound_recall_admission(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    _materialize(
+        _candidate(
+            "candidate-work-materialized",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+
+    admitted = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
+    )
+    denied = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-private",
+        active_vault_id="vault-a",
+    )
+
+    assert [item.promoted.candidate.candidate_id for item in admitted] == [
+        "candidate-work-materialized"
+    ]
+    assert admitted[0].memory_scope_id == "scope-work"
+    assert denied == []
+
+
+def test_bound_recall_rejects_note_scope_tampering_against_receipt(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    artifact_path = _materialize(
+        _candidate(
+            "candidate-private-tamper",
+            title="Private deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-private",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+    note_path = vault_root / artifact_path
+    note_path.write_text(
+        note_path.read_text(encoding="utf-8").replace(
+            "scope_id: scope-private",
+            "scope_id: scope-work",
+        ),
+        encoding="utf-8",
+    )
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
+    ) == []
+
+
+def test_bound_recall_rejects_receipt_from_another_vault(tmp_path: Path) -> None:
+    source_root = tmp_path / "source-vault"
+    source_root.mkdir()
+    source_vault = _vault(source_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    artifact_path = _materialize(
+        _candidate(
+            "candidate-cross-vault",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=source_vault,
+        store=store,
+        outbox=outbox,
+    )
+    target_root = tmp_path / "target-vault"
+    target_note = target_root / artifact_path
+    target_note.parent.mkdir(parents=True)
+    target_note.write_text(
+        (source_root / artifact_path).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=target_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+        active_vault_id="vault-b",
+    ) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "conflicting_value"),
+    (
+        ("artifact_uuid", "conflicting-artifact-uuid"),
+        ("artifact_path", "Agent Memory/conflicting-artifact.md"),
+    ),
+)
+def test_bound_recall_rejects_conflicting_receipt_artifact_identity(
+    tmp_path: Path,
+    field: str,
+    conflicting_value: str,
+) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    _materialize(
+        _candidate(
+            "candidate-receipt-conflict",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+    record = json.loads(outbox.read_text(encoding="utf-8"))
+    record["payload"][field] = conflicting_value
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        records=[record],
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
+    ) == []
 
 
 def test_pure_and_safe_on_empty(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -300,6 +300,11 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
             "scope_id: 'invalid scope'\n",
             "Invalid-scope deployment posture",
         ),
+        (
+            "candidate-overlength-scope",
+            f"scope_id: {'s' * 129}\n",
+            "Overlength-scope deployment posture",
+        ),
     ):
         artifact_path = f"Agent Memory/{candidate_id}.md"
         (vault_root / artifact_path).write_text(
@@ -363,6 +368,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
         "candidate-legacy",
         "candidate-domain-only",
         "candidate-invalid-scope",
+        "candidate-overlength-scope",
     }
     assert {item.applied_scope_id for item in unbound} == {None}
     unbound_by_id = {
@@ -373,6 +379,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
         "candidate-legacy",
         "candidate-domain-only",
         "candidate-invalid-scope",
+        "candidate-overlength-scope",
     ):
         assert unbound_by_id[candidate_id].memory_scope_id is None
         assert unbound_by_id[candidate_id].promoted.candidate.scope_id is None

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -282,19 +282,32 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
     memory_dir = vault_root / "Agent Memory"
     memory_dir.mkdir(parents=True)
     records = []
-    for candidate_id, scope_id, title in (
-        ("candidate-work", "scope-work", "Work deployment posture"),
-        ("candidate-private", "scope-private", "Private deployment posture"),
-        ("candidate-legacy", None, "Legacy deployment posture"),
+    for candidate_id, authority_line, title in (
+        ("candidate-work", "scope_id: scope-work\n", "Work deployment posture"),
+        (
+            "candidate-private",
+            "scope_id: scope-private\n",
+            "Private deployment posture",
+        ),
+        ("candidate-legacy", "", "Legacy deployment posture"),
+        (
+            "candidate-domain-only",
+            "domain: scope-work\n",
+            "Domain-only deployment posture",
+        ),
+        (
+            "candidate-invalid-scope",
+            "scope_id: 'invalid scope'\n",
+            "Invalid-scope deployment posture",
+        ),
     ):
         artifact_path = f"Agent Memory/{candidate_id}.md"
-        scope_line = f"scope_id: {scope_id}\n" if scope_id else ""
         (vault_root / artifact_path).write_text(
             "---\n"
             "artifact_type: semantic_memory\n"
             "agent_promoted: true\n"
             f"promoted_from_candidate_id: {candidate_id}\n"
-            f"{scope_line}"
+            f"{authority_line}"
             "decided_by: companion-ui:reviewer\n"
             "decided_at: '2026-06-13T09:00:00Z'\n"
             "---\n\n"
@@ -339,6 +352,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
 
     unbound = retrieve_relevant_promoted(
         "deployment posture",
+        k=10,
         vault_root=vault_root,
         records=records,
     )
@@ -347,8 +361,21 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
         "candidate-work",
         "candidate-private",
         "candidate-legacy",
+        "candidate-domain-only",
+        "candidate-invalid-scope",
     }
     assert {item.applied_scope_id for item in unbound} == {None}
+    unbound_by_id = {
+        item.promoted.candidate.candidate_id: item
+        for item in unbound
+    }
+    for candidate_id in (
+        "candidate-legacy",
+        "candidate-domain-only",
+        "candidate-invalid-scope",
+    ):
+        assert unbound_by_id[candidate_id].memory_scope_id is None
+        assert unbound_by_id[candidate_id].promoted.candidate.scope_id is None
 
 
 def test_materialized_scope_drives_bound_recall_admission(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -37,6 +37,7 @@ def _candidate(
     content: str,
     source_refs: list[str] | None = None,
     inferred: bool = False,
+    scope_id: str = "scope:work/project-alpha",
 ) -> MemoryCandidate:
     return MemoryCandidate(
         candidate_id=candidate_id,
@@ -47,6 +48,7 @@ def _candidate(
         source_refs=source_refs or [f"note:{candidate_id}.md", "session:2026-06-13T09:00:00Z"],
         derived_from=f"vault:{candidate_id}.md",
         generated_by="companion_agent",
+        scope_id=scope_id,
     )
 
 
@@ -101,6 +103,7 @@ def test_reads_promoted_memory_from_durable_set(tmp_path: Path) -> None:
     assert promoted.candidate.content == candidate.content
     assert promoted.candidate.source_refs == candidate.source_refs
     assert promoted.candidate.inferred is False
+    assert promoted.candidate.scope_id == candidate.scope_id
     assert promoted.decided_by == "companion-ui:reviewer"
     assert (vault_root / artifact_path).exists()
 
@@ -331,6 +334,7 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
 
     assert [item.promoted.candidate.candidate_id for item in scoped] == ["candidate-work"]
     assert scoped[0].memory_scope_id == "scope-work"
+    assert scoped[0].promoted.candidate.scope_id == "scope-work"
     assert scoped[0].applied_scope_id == "scope-work"
 
     unbound = retrieve_relevant_promoted(
@@ -345,6 +349,44 @@ def test_scope_bound_promoted_recall_excludes_private_memory(tmp_path: Path) -> 
         "candidate-legacy",
     }
     assert {item.applied_scope_id for item in unbound} == {None}
+
+
+def test_materialized_scope_drives_bound_recall_admission(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    _materialize(
+        _candidate(
+            "candidate-work-materialized",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+
+    admitted = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-work",
+    )
+    denied = retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        outbox_path=outbox,
+        active_scope_id="scope-private",
+    )
+
+    assert [item.promoted.candidate.candidate_id for item in admitted] == [
+        "candidate-work-materialized"
+    ]
+    assert admitted[0].memory_scope_id == "scope-work"
+    assert denied == []
 
 
 def test_pure_and_safe_on_empty(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_recall_retrieval.py
+++ b/tests/agent_memory/test_recall_retrieval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -502,6 +503,46 @@ def test_bound_recall_rejects_receipt_from_another_vault(tmp_path: Path) -> None
         outbox_path=outbox,
         active_scope_id="scope-work",
         active_vault_id="vault-b",
+    ) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "conflicting_value"),
+    (
+        ("artifact_uuid", "conflicting-artifact-uuid"),
+        ("artifact_path", "Agent Memory/conflicting-artifact.md"),
+    ),
+)
+def test_bound_recall_rejects_conflicting_receipt_artifact_identity(
+    tmp_path: Path,
+    field: str,
+    conflicting_value: str,
+) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    vault = _vault(vault_root)
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    outbox = tmp_path / "outbox.jsonl"
+    _materialize(
+        _candidate(
+            "candidate-receipt-conflict",
+            title="Work deployment posture",
+            content="Deployment posture details.",
+            scope_id="scope-work",
+        ),
+        vault=vault,
+        store=store,
+        outbox=outbox,
+    )
+    record = json.loads(outbox.read_text(encoding="utf-8"))
+    record["payload"][field] = conflicting_value
+
+    assert retrieve_relevant_promoted(
+        "deployment posture",
+        vault_root=vault_root,
+        records=[record],
+        active_scope_id="scope-work",
+        active_vault_id="vault-a",
     ) == []
 
 

--- a/tests/agent_memory/test_recall_surfacing.py
+++ b/tests/agent_memory/test_recall_surfacing.py
@@ -50,6 +50,7 @@ def _candidate(candidate_id: str) -> MemoryCandidate:
         source_refs=[f"note:{candidate_id}.md", "session:2026-06-13T09:00:00Z"],
         derived_from=f"vault:{candidate_id}.md",
         generated_by="companion_agent",
+        scope_id="scope:work/project-alpha",
     )
 
 

--- a/tests/agent_memory/test_review_decision_store.py
+++ b/tests/agent_memory/test_review_decision_store.py
@@ -139,3 +139,73 @@ def test_decision_record_preserves_provenance(tmp_path: Path) -> None:
     assert record.generated_by == "companion_agent"
     assert record.derived_from == "conversation:abc123"
     assert record.terminal is False
+
+
+def test_persisted_candidate_scope_is_immutable(tmp_path: Path) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+
+    replacement = candidate.model_copy(update={"scope_id": "scope:work/project-a"})
+    replacement_queue = MemoryCandidateReviewQueue()
+    replacement_queue.enqueue(replacement)
+    replacement_decision = replacement_queue.decide(
+        replacement.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+
+    with pytest.raises(ReviewDecisionStoreError, match="scope cannot change"):
+        store.record_decision(
+            replacement_decision,
+            vault_context=vault,
+            channel="test",
+        )
+
+    persisted = store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted is not None
+    assert persisted.scope_id == "scope:private/personal"
+    assert persisted.terminal is False
+
+
+def test_terminal_transition_compares_persisted_scope(tmp_path: Path) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+
+    with pytest.raises(ReviewDecisionStoreError, match="scope changed"):
+        store.mark_terminal(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id="scope:work/project-a",
+        )
+
+    persisted = store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted is not None
+    assert persisted.scope_id == "scope:private/personal"
+    assert persisted.terminal is False

--- a/tests/agent_memory/test_review_decision_store.py
+++ b/tests/agent_memory/test_review_decision_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -209,3 +211,93 @@ def test_terminal_transition_compares_persisted_scope(tmp_path: Path) -> None:
     assert persisted is not None
     assert persisted.scope_id == "scope:private/personal"
     assert persisted.terminal is False
+
+
+def test_terminal_decision_cannot_be_reopened_or_terminalized_twice(
+    tmp_path: Path,
+) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+    store.mark_terminal(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+        expected_scope_id=candidate.scope_id,
+        expected_outcome=ReviewDecision.PROMOTE,
+    )
+
+    with pytest.raises(ReviewDecisionStoreError, match="cannot be replaced"):
+        store.record_decision(decided, vault_context=vault, channel="test")
+    with pytest.raises(ReviewDecisionStoreError, match="already terminal"):
+        store.mark_terminal(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_outcome=ReviewDecision.PROMOTE,
+        )
+
+
+def test_materialization_transaction_serializes_competing_writers(
+    tmp_path: Path,
+) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+    assert candidate.scope_id is not None
+    first_entered = Event()
+    release_first = Event()
+    second_started = Event()
+    second_entered = Event()
+
+    def first_writer() -> None:
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+        ):
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+
+    def competing_writer() -> None:
+        second_started.set()
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+        ):
+            second_entered.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(first_writer)
+        assert first_entered.wait(timeout=2)
+        second = executor.submit(competing_writer)
+        assert second_started.wait(timeout=2)
+        with pytest.raises(FutureTimeoutError):
+            second.result(timeout=0.1)
+        assert not second_entered.is_set()
+        release_first.set()
+        first.result(timeout=2)
+        with pytest.raises(ReviewDecisionStoreError, match="already terminal"):
+            second.result(timeout=2)
+
+    assert not second_entered.is_set()

--- a/tests/agent_memory/test_review_decision_store.py
+++ b/tests/agent_memory/test_review_decision_store.py
@@ -33,6 +33,7 @@ def _candidate(*, title: str = "Observed user preference") -> MemoryCandidate:
         source_refs=["session:2026-06-13T09:00:00Z", "note:preferences.md"],
         derived_from="conversation:abc123",
         generated_by="companion_agent",
+        scope_id="scope:private/personal",
     )
 
 
@@ -66,6 +67,7 @@ def test_decisions_survive_restart(tmp_path: Path) -> None:
     assert record.candidate_id == candidate.candidate_id
     assert record.outcome is ReviewDecision.REJECT
     assert record.terminal is True
+    assert record.scope_id == candidate.scope_id
 
 
 def test_decision_store_is_vault_scoped(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_review_decision_store.py
+++ b/tests/agent_memory/test_review_decision_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -10,6 +12,7 @@ from app.agent_memory.review_decision_store import (
     ReviewDecisionStore,
     ReviewDecisionStoreError,
     _default_db_path,
+    review_candidate_digest,
 )
 from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewDecision
 from app.vault.manager import VaultContext
@@ -33,6 +36,7 @@ def _candidate(*, title: str = "Observed user preference") -> MemoryCandidate:
         source_refs=["session:2026-06-13T09:00:00Z", "note:preferences.md"],
         derived_from="conversation:abc123",
         generated_by="companion_agent",
+        scope_id="scope:private/personal",
     )
 
 
@@ -66,6 +70,7 @@ def test_decisions_survive_restart(tmp_path: Path) -> None:
     assert record.candidate_id == candidate.candidate_id
     assert record.outcome is ReviewDecision.REJECT
     assert record.terminal is True
+    assert record.scope_id == candidate.scope_id
 
 
 def test_decision_store_is_vault_scoped(tmp_path: Path) -> None:
@@ -137,3 +142,165 @@ def test_decision_record_preserves_provenance(tmp_path: Path) -> None:
     assert record.generated_by == "companion_agent"
     assert record.derived_from == "conversation:abc123"
     assert record.terminal is False
+
+
+def test_persisted_candidate_scope_is_immutable(tmp_path: Path) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+
+    replacement = candidate.model_copy(update={"scope_id": "scope:work/project-a"})
+    replacement_queue = MemoryCandidateReviewQueue()
+    replacement_queue.enqueue(replacement)
+    replacement_decision = replacement_queue.decide(
+        replacement.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+
+    with pytest.raises(ReviewDecisionStoreError, match="scope cannot change"):
+        store.record_decision(
+            replacement_decision,
+            vault_context=vault,
+            channel="test",
+        )
+
+    persisted = store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted is not None
+    assert persisted.scope_id == "scope:private/personal"
+    assert persisted.terminal is False
+
+
+def test_terminal_transition_compares_persisted_scope(tmp_path: Path) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+
+    with pytest.raises(ReviewDecisionStoreError, match="scope changed"):
+        store.mark_terminal(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id="scope:work/project-a",
+        )
+
+    persisted = store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+    )
+    assert persisted is not None
+    assert persisted.scope_id == "scope:private/personal"
+    assert persisted.terminal is False
+
+
+def test_terminal_decision_cannot_be_reopened_or_terminalized_twice(
+    tmp_path: Path,
+) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+    store.mark_terminal(
+        candidate.candidate_id,
+        vault_context=vault,
+        channel="test",
+        expected_scope_id=candidate.scope_id,
+        expected_outcome=ReviewDecision.PROMOTE,
+    )
+
+    with pytest.raises(ReviewDecisionStoreError, match="cannot be replaced"):
+        store.record_decision(decided, vault_context=vault, channel="test")
+    with pytest.raises(ReviewDecisionStoreError, match="already terminal"):
+        store.mark_terminal(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_outcome=ReviewDecision.PROMOTE,
+        )
+
+
+def test_materialization_transaction_serializes_competing_writers(
+    tmp_path: Path,
+) -> None:
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    vault = _vault("vault-a", tmp_path / "vault-a")
+    candidate = _candidate()
+    queue = MemoryCandidateReviewQueue()
+    queue.enqueue(candidate)
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="companion-ui:reviewer",
+    )
+    store.record_decision(decided, vault_context=vault, channel="test")
+    assert candidate.scope_id is not None
+    first_entered = Event()
+    release_first = Event()
+    second_started = Event()
+    second_entered = Event()
+
+    def first_writer() -> None:
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(decided),
+        ):
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+
+    def competing_writer() -> None:
+        second_started.set()
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(decided),
+        ):
+            second_entered.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(first_writer)
+        assert first_entered.wait(timeout=2)
+        second = executor.submit(competing_writer)
+        assert second_started.wait(timeout=2)
+        with pytest.raises(FutureTimeoutError):
+            second.result(timeout=0.1)
+        assert not second_entered.is_set()
+        release_first.set()
+        first.result(timeout=2)
+        with pytest.raises(ReviewDecisionStoreError, match="already terminal"):
+            second.result(timeout=2)
+
+    assert not second_entered.is_set()

--- a/tests/agent_memory/test_review_decision_store.py
+++ b/tests/agent_memory/test_review_decision_store.py
@@ -12,6 +12,7 @@ from app.agent_memory.review_decision_store import (
     ReviewDecisionStore,
     ReviewDecisionStoreError,
     _default_db_path,
+    review_candidate_digest,
 )
 from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewDecision
 from app.vault.manager import VaultContext
@@ -273,6 +274,7 @@ def test_materialization_transaction_serializes_competing_writers(
             vault_context=vault,
             channel="test",
             expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(decided),
         ):
             first_entered.set()
             assert release_first.wait(timeout=2)
@@ -284,6 +286,7 @@ def test_materialization_transaction_serializes_competing_writers(
             vault_context=vault,
             channel="test",
             expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(decided),
         ):
             second_entered.set()
 

--- a/tests/agents/ask/test_recall_scope_enforcement.py
+++ b/tests/agents/ask/test_recall_scope_enforcement.py
@@ -1,0 +1,91 @@
+"""Production ASK wiring for scope-bound promoted-memory recall (#5019)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType, ReviewState
+from app.agent_memory.promotion import PromotedMemory
+from app.agent_memory.recall_retrieval import RecallCandidate
+from app.agent_memory.provisional_recall import ProvisionalRecallSearch
+from app.agents.ask import graph as ask_graph
+from app.agents.ask.state import AgentState
+from app.settings.models import AskSettings
+
+
+def _candidate(*, applied_scope_id: str | None = None) -> RecallCandidate:
+    promoted = PromotedMemory(
+        outcome=ReviewState.ACCEPTED,
+        candidate=MemoryCandidate(
+            candidate_id="memory-work",
+            title="Work deployment posture",
+            memory_type=MemoryType.SEMANTIC_MEMORY,
+            review_state=ReviewState.ACCEPTED,
+            inferred=False,
+            content="Deploy through the work release checklist.",
+            source_refs=["note:work.md"],
+        ),
+        decided_by="companion-ui:reviewer",
+        decided_at=datetime.now(timezone.utc),
+    )
+    return RecallCandidate(
+        promoted=promoted,
+        score=1.0,
+        reason="content matched deployment",
+        artifact_path="Agent Memory/memory-work.md",
+        memory_scope_id="scope-work",
+        applied_scope_id=applied_scope_id,
+    )
+
+
+def _prepare_recall_node(tmp_path: Path, monkeypatch, captured: dict[str, object]) -> Path:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: vault_root)
+    monkeypatch.setattr(
+        ask_graph,
+        "retrieve_relevant_provisional",
+        lambda *args, **kwargs: ProvisionalRecallSearch(candidates=(), excluded=()),
+    )
+    receipt_path = tmp_path / "runtime" / "recall.jsonl"
+    monkeypatch.setattr(ask_graph, "_recall_receipt_path", lambda: receipt_path)
+
+    def fake_retrieve(query: str, **kwargs):
+        captured["query"] = query
+        captured["active_scope_id"] = kwargs.get("active_scope_id")
+        return [_candidate(applied_scope_id=kwargs.get("active_scope_id"))]
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", fake_retrieve)
+    return receipt_path
+
+
+def test_ask_graph_enforces_scope_on_promoted_recall(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    receipt_path = _prepare_recall_node(tmp_path, monkeypatch, captured)
+
+    state = ask_graph._recall_node(
+        AgentState(query="deployment", active_scope="scope-work"),
+        ask_settings=AskSettings(),
+    )
+
+    assert captured["active_scope_id"] == "scope-work"
+    assert [item.artifact_id for item in state.recalled] == ["memory-work"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["payload"]["applied_scope_id"] == "scope-work"
+
+
+def test_unbound_ask_preserves_default_promoted_recall(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    receipt_path = _prepare_recall_node(tmp_path, monkeypatch, captured)
+    monkeypatch.setattr(ask_graph, "_resolve_domain_scope", lambda: None)
+
+    state = ask_graph._recall_node(
+        AgentState(query="deployment"),
+        ask_settings=AskSettings(),
+    )
+
+    assert captured["active_scope_id"] is None
+    assert [item.artifact_id for item in state.recalled] == ["memory-work"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["payload"]["applied_scope_id"] is None

--- a/tests/agents/ask/test_recall_scope_enforcement.py
+++ b/tests/agents/ask/test_recall_scope_enforcement.py
@@ -25,6 +25,7 @@ def _candidate(*, applied_scope_id: str | None = None) -> RecallCandidate:
             inferred=False,
             content="Deploy through the work release checklist.",
             source_refs=["note:work.md"],
+            scope_id="scope-work",
         ),
         decided_by="companion-ui:reviewer",
         decided_at=datetime.now(timezone.utc),

--- a/tests/agents/ask/test_recall_scope_enforcement.py
+++ b/tests/agents/ask/test_recall_scope_enforcement.py
@@ -1,0 +1,92 @@
+"""Production ASK wiring for scope-bound promoted-memory recall (#5019)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType, ReviewState
+from app.agent_memory.promotion import PromotedMemory
+from app.agent_memory.recall_retrieval import RecallCandidate
+from app.agent_memory.provisional_recall import ProvisionalRecallSearch
+from app.agents.ask import graph as ask_graph
+from app.agents.ask.state import AgentState
+from app.settings.models import AskSettings
+
+
+def _candidate(*, applied_scope_id: str | None = None) -> RecallCandidate:
+    promoted = PromotedMemory(
+        outcome=ReviewState.ACCEPTED,
+        candidate=MemoryCandidate(
+            candidate_id="memory-work",
+            title="Work deployment posture",
+            memory_type=MemoryType.SEMANTIC_MEMORY,
+            review_state=ReviewState.ACCEPTED,
+            inferred=False,
+            content="Deploy through the work release checklist.",
+            source_refs=["note:work.md"],
+            scope_id="scope-work",
+        ),
+        decided_by="companion-ui:reviewer",
+        decided_at=datetime.now(timezone.utc),
+    )
+    return RecallCandidate(
+        promoted=promoted,
+        score=1.0,
+        reason="content matched deployment",
+        artifact_path="Agent Memory/memory-work.md",
+        memory_scope_id="scope-work",
+        applied_scope_id=applied_scope_id,
+    )
+
+
+def _prepare_recall_node(tmp_path: Path, monkeypatch, captured: dict[str, object]) -> Path:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: vault_root)
+    monkeypatch.setattr(
+        ask_graph,
+        "retrieve_relevant_provisional",
+        lambda *args, **kwargs: ProvisionalRecallSearch(candidates=(), excluded=()),
+    )
+    receipt_path = tmp_path / "runtime" / "recall.jsonl"
+    monkeypatch.setattr(ask_graph, "_recall_receipt_path", lambda: receipt_path)
+
+    def fake_retrieve(query: str, **kwargs):
+        captured["query"] = query
+        captured["active_scope_id"] = kwargs.get("active_scope_id")
+        return [_candidate(applied_scope_id=kwargs.get("active_scope_id"))]
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", fake_retrieve)
+    return receipt_path
+
+
+def test_ask_graph_enforces_scope_on_promoted_recall(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    receipt_path = _prepare_recall_node(tmp_path, monkeypatch, captured)
+
+    state = ask_graph._recall_node(
+        AgentState(query="deployment", active_scope="scope-work"),
+        ask_settings=AskSettings(),
+    )
+
+    assert captured["active_scope_id"] == "scope-work"
+    assert [item.artifact_id for item in state.recalled] == ["memory-work"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["payload"]["applied_scope_id"] == "scope-work"
+
+
+def test_unbound_ask_preserves_default_promoted_recall(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    receipt_path = _prepare_recall_node(tmp_path, monkeypatch, captured)
+    monkeypatch.setattr(ask_graph, "_resolve_domain_scope", lambda: None)
+
+    state = ask_graph._recall_node(
+        AgentState(query="deployment"),
+        ask_settings=AskSettings(),
+    )
+
+    assert captured["active_scope_id"] is None
+    assert [item.artifact_id for item in state.recalled] == ["memory-work"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["payload"]["applied_scope_id"] is None

--- a/tests/agents/ask/test_recall_vault_and_budget.py
+++ b/tests/agents/ask/test_recall_vault_and_budget.py
@@ -188,6 +188,46 @@ def test_recall_vault_falls_back_to_env_when_no_persisted_vault(tmp_path: Path, 
     assert resolved == env_root.resolve()
 
 
+def test_recall_vault_id_loads_matching_persisted_binding_for_env_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    env_root = tmp_path / "env-vault"
+    env_root.mkdir()
+    monkeypatch.setenv("PKM_ENVIRONMENT", "prod")
+    monkeypatch.setenv("VAULT_ROOT", str(env_root))
+    manager = _RestartedVaultManager(_selected(env_root))
+    monkeypatch.setattr(ask_graph, "get_vault_manager", lambda: manager)
+
+    resolved = ask_graph._active_recall_vault_root()
+    vault_id = ask_graph._active_recall_vault_id(resolved)
+
+    assert resolved == env_root.resolve()
+    assert vault_id == "vault-persisted"
+    assert manager.load_last_active_calls == 1
+
+
+def test_recall_vault_id_rejects_stale_selected_id_for_env_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    selected_root = tmp_path / "selected-vault"
+    env_root = tmp_path / "env-vault"
+    selected_root.mkdir()
+    env_root.mkdir()
+    monkeypatch.setenv("PKM_ENVIRONMENT", "prod")
+    monkeypatch.setenv("VAULT_ROOT", str(env_root))
+
+    class _StaleSelectedManager:
+        context = _selected(selected_root)
+
+    manager = _StaleSelectedManager()
+    monkeypatch.setattr(ask_graph, "get_vault_manager", lambda: manager)
+    setattr(manager, ask_graph._ASK_LAST_ACTIVE_LOADED_ATTR, True)
+
+    vault_id = ask_graph._active_recall_vault_id(env_root)
+
+    assert vault_id == f"path:{env_root.resolve()}"
+
+
 # --------------------------------------------------------------------------- #
 # AC2: enforce the context budget after using full bodies
 # --------------------------------------------------------------------------- #

--- a/tests/api/test_memory_review_queue_api.py
+++ b/tests/api/test_memory_review_queue_api.py
@@ -62,6 +62,7 @@ def _candidate(**overrides: Any) -> MemoryCandidate:
         source_refs=["session:2026-06-01T09:00:00Z"],
         derived_from="conversation:abc123",
         generated_by="companion_agent",
+        scope_id="scope:private/personal",
     )
     fields.update(overrides)
     return MemoryCandidate(**fields)
@@ -238,6 +239,7 @@ def test_reject_and_revise_are_receipted_review_outcomes_not_promotions(
     assert revision_entry.status is ReviewStatus.PENDING
     assert revision_entry.revision_of == to_revise.candidate_id
     assert revision_entry.title == "Narrowed candidate"
+    assert revision_entry.scope_id == to_revise.scope_id
 
     # Neither reject nor revise is a promotion: nothing became recallable
     # authoritative memory.

--- a/tests/api/test_memory_review_queue_api.py
+++ b/tests/api/test_memory_review_queue_api.py
@@ -22,6 +22,10 @@ from fastapi.testclient import TestClient
 
 import app.api.routes.companion as companion_module
 from app.agent_memory.candidate import MemoryCandidate, MemoryType
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionStore,
+    review_candidate_digest,
+)
 from app.agent_memory.review_queue import (
     MemoryCandidateReviewQueue,
     ReviewDecision,
@@ -62,6 +66,7 @@ def _candidate(**overrides: Any) -> MemoryCandidate:
         source_refs=["session:2026-06-01T09:00:00Z"],
         derived_from="conversation:abc123",
         generated_by="companion_agent",
+        scope_id="scope:private/personal",
     )
     fields.update(overrides)
     return MemoryCandidate(**fields)
@@ -238,6 +243,7 @@ def test_reject_and_revise_are_receipted_review_outcomes_not_promotions(
     assert revision_entry.status is ReviewStatus.PENDING
     assert revision_entry.revision_of == to_revise.candidate_id
     assert revision_entry.title == "Narrowed candidate"
+    assert revision_entry.scope_id == to_revise.scope_id
 
     # Neither reject nor revise is a promotion: nothing became recallable
     # authoritative memory.
@@ -246,6 +252,61 @@ def test_reject_and_revise_are_receipted_review_outcomes_not_promotions(
     # The pending revision is back on the read surface for its own review.
     read = client.get("/api/companion/memory/review-queue").json()
     assert [c["candidate_id"] for c in read["candidates"]] == [revision_id]
+
+
+def test_materializing_store_conflict_restores_pending_api_queue_state(
+    client: TestClient,
+    queue: MemoryCandidateReviewQueue,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    candidate = _candidate(title="Materialization recovery candidate")
+    vault_context = companion_module._memory_review_vault_context()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    seed_queue = MemoryCandidateReviewQueue()
+    seed_queue.enqueue(candidate)
+    promoted = seed_queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="reviewer:original",
+    )
+    store.record_decision(promoted, vault_context=vault_context, channel="test")
+    with pytest.raises(RuntimeError, match="injected crash"):
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault_context,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(promoted),
+        ):
+            raise RuntimeError("injected crash")
+    assert store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault_context,
+        channel="test",
+    ).materializing is True
+    monkeypatch.setattr(companion_module, "_memory_review_decision_store", lambda: store)
+    queue.enqueue(candidate)
+
+    rejected = client.post(
+        _decision_url(candidate.candidate_id),
+        json={"action": "reject", "reviewed_by": "reviewer:restart"},
+    )
+    assert rejected.status_code == 409
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+    assert [entry.candidate_id for entry in queue.pending()] == [candidate.candidate_id]
+
+    revised = client.post(
+        _decision_url(candidate.candidate_id),
+        json={
+            "action": "revise",
+            "reviewed_by": "reviewer:restart",
+            "revision": {"title": "Unauthorized revision"},
+        },
+    )
+    assert revised.status_code == 409
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+    assert [entry.candidate_id for entry in queue.pending()] == [candidate.candidate_id]
 
 
 def test_defer_is_non_terminal_and_unreceipted(

--- a/tests/api/test_memory_review_queue_api.py
+++ b/tests/api/test_memory_review_queue_api.py
@@ -22,6 +22,10 @@ from fastapi.testclient import TestClient
 
 import app.api.routes.companion as companion_module
 from app.agent_memory.candidate import MemoryCandidate, MemoryType
+from app.agent_memory.review_decision_store import (
+    ReviewDecisionStore,
+    review_candidate_digest,
+)
 from app.agent_memory.review_queue import (
     MemoryCandidateReviewQueue,
     ReviewDecision,
@@ -248,6 +252,61 @@ def test_reject_and_revise_are_receipted_review_outcomes_not_promotions(
     # The pending revision is back on the read surface for its own review.
     read = client.get("/api/companion/memory/review-queue").json()
     assert [c["candidate_id"] for c in read["candidates"]] == [revision_id]
+
+
+def test_materializing_store_conflict_restores_pending_api_queue_state(
+    client: TestClient,
+    queue: MemoryCandidateReviewQueue,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    candidate = _candidate(title="Materialization recovery candidate")
+    vault_context = companion_module._memory_review_vault_context()
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    seed_queue = MemoryCandidateReviewQueue()
+    seed_queue.enqueue(candidate)
+    promoted = seed_queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="reviewer:original",
+    )
+    store.record_decision(promoted, vault_context=vault_context, channel="test")
+    with pytest.raises(RuntimeError, match="injected crash"):
+        with store.promotion_materialization_transaction(
+            candidate.candidate_id,
+            vault_context=vault_context,
+            channel="test",
+            expected_scope_id=candidate.scope_id,
+            expected_candidate_digest=review_candidate_digest(promoted),
+        ):
+            raise RuntimeError("injected crash")
+    assert store.get_decision(
+        candidate.candidate_id,
+        vault_context=vault_context,
+        channel="test",
+    ).materializing is True
+    monkeypatch.setattr(companion_module, "_memory_review_decision_store", lambda: store)
+    queue.enqueue(candidate)
+
+    rejected = client.post(
+        _decision_url(candidate.candidate_id),
+        json={"action": "reject", "reviewed_by": "reviewer:restart"},
+    )
+    assert rejected.status_code == 409
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+    assert [entry.candidate_id for entry in queue.pending()] == [candidate.candidate_id]
+
+    revised = client.post(
+        _decision_url(candidate.candidate_id),
+        json={
+            "action": "revise",
+            "reviewed_by": "reviewer:restart",
+            "revision": {"title": "Unauthorized revision"},
+        },
+    )
+    assert revised.status_code == 409
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+    assert [entry.candidate_id for entry in queue.pending()] == [candidate.candidate_id]
 
 
 def test_defer_is_non_terminal_and_unreceipted(

--- a/tests/api/test_memory_review_queue_api.py
+++ b/tests/api/test_memory_review_queue_api.py
@@ -188,6 +188,39 @@ def test_accept_is_governed_decision(
     assert queue.get(anonymous.candidate_id).status is ReviewStatus.PENDING
 
 
+def test_semantic_accept_without_scope_refuses_before_durable_decision(
+    client: TestClient,
+    queue: MemoryCandidateReviewQueue,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A scope-less semantic accept must not create a stranded decision."""
+
+    store = ReviewDecisionStore(tmp_path / "review_decisions.sqlite3")
+    monkeypatch.setattr(companion_module, "_memory_review_decision_store", lambda: store)
+    candidate = _candidate(
+        title="Scope-less semantic candidate",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=False,
+        scope_id=None,
+    )
+    queue.enqueue(candidate)
+
+    refused = client.post(
+        _decision_url(candidate.candidate_id),
+        json={"action": "accept", "reviewed_by": "reviewer:human"},
+    )
+
+    assert refused.status_code == 409
+    assert refused.json()["detail"]["error"] == "promotion_refused"
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+    assert store.get_decision(
+        candidate.candidate_id,
+        vault_context=companion_module._memory_review_vault_context(),
+        channel="test",
+    ) is None
+
+
 def test_reject_and_revise_are_receipted_review_outcomes_not_promotions(
     client: TestClient, queue: MemoryCandidateReviewQueue
 ) -> None:

--- a/tests/knowledge_compilation/test_review_admission_handoff.py
+++ b/tests/knowledge_compilation/test_review_admission_handoff.py
@@ -112,6 +112,7 @@ def test_handoff_routes_to_review_queue_without_promoting() -> None:
         handoff,
         queue,
         memory_type=MemoryType.EPISODIC_MEMORY,
+        scope_id="scope:work/project-alpha",
     )
 
     assert entry.status is ReviewStatus.PENDING
@@ -123,6 +124,7 @@ def test_handoff_routes_to_review_queue_without_promoting() -> None:
     assert entry.candidate.derived_from == handoff.admitted_artifact.artifact_id
     assert entry.candidate.generated_by == "knowledge_compiler"
     assert entry.candidate.source_refs == ["note:source"]
+    assert entry.candidate.scope_id == "scope:work/project-alpha"
     assert queue.pending() == [entry]
     assert queue.recallable_for_working_context() == []
 

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -145,6 +145,20 @@ def test_unknown_runtime_surface_fails_closed_until_it_has_an_owner() -> None:
     assert selection.unowned_paths == ("app/new_surface/example.py",)
 
 
+def test_agent_memory_recall_modules_select_memory_retrieval_coverage() -> None:
+    selection = select_tests(
+        [
+            "app/agent_memory/recall_retrieval.py",
+            "app/agent_memory/recall_activation.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.unowned_paths == ()
+    assert selection.subsystems == ("memory_retrieval",)
+    assert "tests/agent_memory" in selection.targets
+
+
 def test_builder_system_architecture_fitness_test_has_ci_owner() -> None:
     path = "tests/architecture/test_builderops_store_boundary.py"
 

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -162,6 +162,30 @@ def test_unknown_runtime_surface_fails_closed_until_it_has_an_owner() -> None:
     assert selection.unowned_paths == ("app/new_surface/example.py",)
 
 
+def test_agent_memory_recall_modules_select_memory_retrieval_coverage() -> None:
+    selection = select_tests(
+        [
+            "app/agent_memory/recall_retrieval.py",
+            "app/agent_memory/recall_activation.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.unowned_paths == ()
+    assert selection.subsystems == ("memory_retrieval",)
+    assert "tests/agent_memory" in selection.targets
+
+
+def test_promoted_memory_review_admission_selects_memory_retrieval_coverage() -> None:
+    selection = select_tests(["app/knowledge_compilation/review_admission.py"])
+
+    assert selection.full_suite is False
+    assert selection.unowned_paths == ()
+    assert selection.subsystems == ("memory_retrieval",)
+    assert "tests/agent_memory" in selection.targets
+    assert "tests/knowledge_compilation/test_review_admission_handoff.py" in selection.targets
+
+
 def test_builder_system_architecture_fitness_test_has_ci_owner() -> None:
     path = "tests/architecture/test_builderops_store_boundary.py"
 

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -162,6 +162,20 @@ def test_unknown_runtime_surface_fails_closed_until_it_has_an_owner() -> None:
     assert selection.unowned_paths == ("app/new_surface/example.py",)
 
 
+def test_agent_memory_recall_modules_select_memory_retrieval_coverage() -> None:
+    selection = select_tests(
+        [
+            "app/agent_memory/recall_retrieval.py",
+            "app/agent_memory/recall_activation.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.unowned_paths == ()
+    assert selection.subsystems == ("memory_retrieval",)
+    assert "tests/agent_memory" in selection.targets
+
+
 def test_builder_system_architecture_fitness_test_has_ci_owner() -> None:
     path = "tests/architecture/test_builderops_store_boundary.py"
 


### PR DESCRIPTION
Governing-Issue: #5019

Fixes #5019

Final-Review-Rounds: 1

## Summary
Thread the active ASK scope into promoted-memory recall so bound turns admit only matching persisted scopes and reject legacy unscoped memories. Materialization now persists scope and candidate authority through a serialized, restart-safe decision state; ASK and receipt linkage fail closed on scope, artifact, and vault-identity conflicts. Unbound recall remains unchanged, and the CI selector owns the affected promoted-recall runtime modules.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The issue and PR fully capture this bounded implementation and CI-selection repair; no operational state requires a BuilderOps record.

## Security convergence
- Mechanism: promoted-memory materialization and scope admission at ASK recall (`security`, `data`, `concurrency`, `state-machine`).
- Invariant: a bound ASK admits only same-scope promoted memory backed by matching durable candidate, artifact, receipt, and vault identity; absent or conflicting persisted authority is denied.
- Exact reviewed head: `f90c3f2444f1385faab18801d9e4c2ae428b6821`.
- Independent mechanism review: PASS for current head; no P0/P1/P2/P3 findings. The review-fix thread for the prior scope-propagation finding is replied to with this fixing head and resolved.

## Validation
- Issue AC plus selector regression: 4 passed on the previous exact head; current-head regression adds the scope-less semantic accept refusal proof.
- Combined affected ASK, agent-memory, API, admission, and selector suites: 312 passed on the previous exact head; current-head focused API and promotion suites: 15 passed under the isolated test environment; the broad selected suite on current head produced 4,752 passed and 36 skipped, with three unrelated local environment failures caused by missing `python`/`docker` commands in existing Heimdal/deploy tests.
- `ruff check app tests companion-ui/companion-app`: PASS on current head.
- `mypy app`: PASS (939 source files) on current head.
- `python3 scripts/docs_guard.py --language-only`: PASS on current head.
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py`: PASS on current head; no temporal current-state surface changed.
- `scripts/review_before_ci_gate.py`: PASS for the current-head implementation risk surfaces; exact PR scope was revalidated against the live PR before publication.
- `scripts/select_pr_tests.py --base-ref origin/main --head-ref HEAD`: PASS on current head with no unowned paths.
- The current-head regression proves that a semantic candidate without a valid scope returns refusal before queue transition or durable decision persistence.
- The first affected-suite collection under system Python was superseded because that interpreter lacked the declared `lingua` dependency; the identical selection passed in the isolated test environment.

Current-head GitHub CI, exact-head local gates, and final independent review are complete for merge preparation.