### PR TITLE
Fence Builder Thread sequence allocation

### DIFF
--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -7,15 +7,17 @@ no client filesystem API and deliberately never discovers a vault path.
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
 import re
 import threading
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Iterator, Literal, Protocol, cast
 
 
 PRIVACY_CLASS: Literal["shared_non_sensitive"] = "shared_non_sensitive"
@@ -48,6 +50,9 @@ _ENTRY_DIRECTORY = "builder-thread-entries"
 _REPOSITORY_VAULT_ROOT = (Path(__file__).resolve().parents[2] / "vault").resolve()
 _WRITER_ROOT_ENV = "BUILDEROPS_THREAD_WRITER_ROOT"
 _WRITER_VAULT_ID_ENV = "BUILDEROPS_THREAD_WRITER_VAULT_ID"
+_SEQUENCE_RESERVATION = ".builder-thread-sequence.lock"
+_ROOT_RESERVATION_GUARD = threading.Lock()
+_ROOT_RESERVATIONS: dict[Path, threading.Lock] = {}
 
 
 class BuilderThreadError(ValueError):
@@ -72,6 +77,32 @@ class RequestReplayConflictError(BuilderThreadError):
 
 class ThreadAlreadyRepresentedError(BuilderThreadError):
     """The create capture key already has a durable Builder Thread."""
+
+
+@contextmanager
+def _external_mutation_reservation(entries_root: Path) -> Iterator[None]:
+    """Reserve one durable sequence allocation across writer hosts on this filesystem."""
+    lock_path = (entries_root / _SEQUENCE_RESERVATION).resolve()
+    with _ROOT_RESERVATION_GUARD:
+        process_lock = _ROOT_RESERVATIONS.setdefault(lock_path, threading.Lock())
+    if not process_lock.acquire(blocking=False):
+        raise WriterUnavailableError("serialized writer overlap is unavailable")
+
+    descriptor: int | None = None
+    try:
+        try:
+            descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise WriterUnavailableError("serialized writer overlap is unavailable") from exc
+        yield
+    finally:
+        if descriptor is not None:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        process_lock.release()
 
 
 def initialize_external_writer_root(root: Path, *, vault_id: str) -> None:
@@ -192,40 +223,46 @@ class SerializedThreadWriter:
         """Validate and apply exactly one command in the designated process."""
         with self._lock:
             _validate_command(command)
-            request_digest = _command_digest(command)
-            previous_digest = self._request_digests.get(command.request_id)
-            if previous_digest is not None:
-                if previous_digest != request_digest:
-                    raise RequestReplayConflictError(
-                        "request id reuse conflicts with accepted semantics"
-                    )
-                return ThreadMutationResult(
-                    thread=self._request_results[command.request_id], replayed=True
-                )
-
-            if self._accepted_mutation_count >= _MAX_TOTAL_ENTRIES:
-                raise BuilderThreadError("serialized writer contribution bound reached")
             if self._persistence_unavailable:
                 raise WriterUnavailableError("serialized writer persistence is unavailable")
-            threads_before_write = self._threads.copy()
-            capture_index_before_write = self._capture_index.copy()
-            if command.kind == "create":
-                thread = self._create(command)
-            else:
-                thread = self._append(command)
-            try:
-                self._persist(
-                    command,
-                    request_digest,
-                    sequence=self._accepted_mutation_count + 1,
-                )
-            except OSError as exc:
-                self._threads = threads_before_write
-                self._capture_index = capture_index_before_write
-                self._persistence_unavailable = True
-                raise WriterUnavailableError("serialized writer persistence is unavailable") from exc
-            self._record(command, request_digest, thread)
-            return ThreadMutationResult(thread=thread, replayed=False)
+            with _external_mutation_reservation(self._entries_root):
+                # A separately restored host has a stale in-memory sequence. Rebuild
+                # under the shared reservation before allocating the next durable slot.
+                self._restore_external_state()
+                request_digest = _command_digest(command)
+                previous_digest = self._request_digests.get(command.request_id)
+                if previous_digest is not None:
+                    if previous_digest != request_digest:
+                        raise RequestReplayConflictError(
+                            "request id reuse conflicts with accepted semantics"
+                        )
+                    return ThreadMutationResult(
+                        thread=self._request_results[command.request_id], replayed=True
+                    )
+
+                if self._accepted_mutation_count >= _MAX_TOTAL_ENTRIES:
+                    raise BuilderThreadError("serialized writer contribution bound reached")
+                threads_before_write = self._threads.copy()
+                capture_index_before_write = self._capture_index.copy()
+                if command.kind == "create":
+                    thread = self._create(command)
+                else:
+                    thread = self._append(command)
+                try:
+                    self._persist(
+                        command,
+                        request_digest,
+                        sequence=self._accepted_mutation_count + 1,
+                    )
+                except OSError as exc:
+                    self._threads = threads_before_write
+                    self._capture_index = capture_index_before_write
+                    self._persistence_unavailable = True
+                    raise WriterUnavailableError(
+                        "serialized writer persistence is unavailable"
+                    ) from exc
+                self._record(command, request_digest, thread)
+                return ThreadMutationResult(thread=thread, replayed=False)
 
     def read_thread(self, thread_id: str) -> BuilderThread:
         _validate_identifier(thread_id, field="thread_id")

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -376,41 +376,58 @@ class SerializedThreadWriter:
             raise BuilderThreadError("external writer root is not the pinned vault identity")
 
     def _restore_external_state(self) -> None:
-        self._threads = {}
-        self._request_digests = {}
-        self._request_results = {}
-        self._capture_index = {}
-        self._accepted_mutation_count = 0
-        records: list[tuple[int, ThreadMutation, str]] = []
-        for path in self._entries_root.glob("*.json"):
-            if path.is_symlink():
-                raise BuilderThreadError("external writer entry is unavailable")
-            try:
-                payload = json.loads(path.read_text(encoding="utf-8"))
-                sequence = payload["sequence"]
-                command = _command_from_record(payload, vault_id=self._vault_id)
-                if path.name != f"{command.request_id}.json":
-                    raise ValueError("invalid writer entry identity")
-                digest = payload["request_digest"]
-                if not isinstance(sequence, int) or isinstance(sequence, bool):
-                    raise ValueError("invalid writer sequence")
-                if not isinstance(digest, str) or digest != _command_digest(command):
-                    raise ValueError("invalid writer digest")
-                _validate_command(command)
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-                raise BuilderThreadError("external writer entry is invalid") from exc
-            records.append((sequence, command, digest))
-        if len(records) > _MAX_TOTAL_ENTRIES:
-            raise BuilderThreadError("external writer contribution bound exceeded")
-        for expected_sequence, (sequence, command, digest) in enumerate(
-            sorted(records, key=lambda record: record[0]), start=1
-        ):
-            if sequence != expected_sequence:
-                raise BuilderThreadError("external writer entry order conflicts")
-            if command.request_id in self._request_digests:
-                raise BuilderThreadError("external writer entry conflicts")
-            thread = self._create(command) if command.kind == "create" else self._append(command)
-            self._record(command, digest, thread)
+        previous_state = (
+            self._threads,
+            self._request_digests,
+            self._request_results,
+            self._capture_index,
+            self._accepted_mutation_count,
+        )
+        try:
+            self._threads = {}
+            self._request_digests = {}
+            self._request_results = {}
+            self._capture_index = {}
+            self._accepted_mutation_count = 0
+            records: list[tuple[int, ThreadMutation, str]] = []
+            for path in self._entries_root.glob("*.json"):
+                if path.is_symlink():
+                    raise BuilderThreadError("external writer entry is unavailable")
+                try:
+                    payload = json.loads(path.read_text(encoding="utf-8"))
+                    sequence = payload["sequence"]
+                    command = _command_from_record(payload, vault_id=self._vault_id)
+                    if path.name != f"{command.request_id}.json":
+                        raise ValueError("invalid writer entry identity")
+                    digest = payload["request_digest"]
+                    if not isinstance(sequence, int) or isinstance(sequence, bool):
+                        raise ValueError("invalid writer sequence")
+                    if not isinstance(digest, str) or digest != _command_digest(command):
+                        raise ValueError("invalid writer digest")
+                    _validate_command(command)
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                    raise BuilderThreadError("external writer entry is invalid") from exc
+                records.append((sequence, command, digest))
+            if len(records) > _MAX_TOTAL_ENTRIES:
+                raise BuilderThreadError("external writer contribution bound exceeded")
+            for expected_sequence, (sequence, command, digest) in enumerate(
+                sorted(records, key=lambda record: record[0]), start=1
+            ):
+                if sequence != expected_sequence:
+                    raise BuilderThreadError("external writer entry order conflicts")
+                if command.request_id in self._request_digests:
+                    raise BuilderThreadError("external writer entry conflicts")
+                thread = self._create(command) if command.kind == "create" else self._append(command)
+                self._record(command, digest, thread)
+        except Exception:
+            (
+                self._threads,
+                self._request_digests,
+                self._request_results,
+                self._capture_index,
+                self._accepted_mutation_count,
+            ) = previous_state
+            raise
 
     def _persist(self, command: ThreadMutation, request_digest: str, *, sequence: int) -> None:
         path = self._entries_root / f"{command.request_id}.json"

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -291,9 +291,19 @@ or silently discarded. A failed publication latches the existing typed
 writer-unavailable signal until a clean restart; an exact retry after a valid
 restart may then publish the command without duplicating an accepted mutation.
 
+Independently restored writer hosts that share the same external-root filesystem
+reserve each mutation's sequence allocation through the writer-owned lock file.
+While holding that reservation, a host reloads the immutable envelopes before
+allocating and publishing its next sequence, so concurrent hosts either serialize
+to unique contiguous sequences or the unavailable reservation produces the typed
+writer-unavailable refusal without accepting a command. A caller retains and may
+retry the same request ID after the overlap clears; restart recovery reads the
+resulting ordered envelopes normally. This is a same-filesystem writer
+reservation, not a cross-device or iCloud coordination guarantee.
+
 This boundary is deliberately not a distributed filesystem protocol. It has no
-vault-global claims, slot reservations, cross-device locks, fsync-based recovery,
-SQLite state, or iCloud convergence semantics. PR #4706 is superseded
+vault-global claims, cross-device locks, fsync-based recovery, SQLite state, or
+iCloud convergence semantics. PR #4706 is superseded
 multi-writer evidence only; it is not merged or used as the operational contract.
 
 Threads and their inbox/devUI projections are non-authoritative discussion

--- a/tests/builderops/test_builder_threads_serialized.py
+++ b/tests/builderops/test_builder_threads_serialized.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import multiprocessing
+
 import pytest
 from pathlib import Path
 
@@ -610,6 +613,86 @@ def test_external_writer_restores_causal_order_not_request_id_order(tmp_path: Pa
         client_id="claude:mac",
     )
     assert len(restarted.read(created.thread.thread_id).entries) == 2
+
+
+def _overlapping_writer_process(
+    start: object, outcomes: object, request_id: str, actor: str, recipient: str
+) -> None:
+    start.wait()
+    try:
+        host = BuilderThreadWriterHost.from_environment()
+        client = BuilderThreadClient(host.endpoint_for(actor), client_id=actor)
+        client.create(
+            request_id=request_id,
+            actor=actor,
+            recipient=recipient,
+            subject=f"Overlapping writer {request_id}",
+            content="Concurrent hosts must reserve durable sequence allocation.",
+            source_refs=("github:5031",),
+        )
+        outcomes.put("accepted")
+    except WriterUnavailableError:
+        outcomes.put("unavailable")
+
+
+def _overlap_writer_hosts() -> list[str]:
+    context = multiprocessing.get_context("spawn")
+    start = context.Barrier(3)
+    outcomes = context.Queue()
+    first = context.Process(
+        target=_overlapping_writer_process,
+        args=(start, outcomes, "overlap-first-5031", "codex:desktop", "claude:mac"),
+    )
+    second = context.Process(
+        target=_overlapping_writer_process,
+        args=(start, outcomes, "overlap-second-5031", "claude:mac", "codex:desktop"),
+    )
+    first.start()
+    second.start()
+    start.wait()
+    first.join()
+    second.join()
+
+    assert first.exitcode == 0
+    assert second.exitcode == 0
+    return [outcomes.get(), outcomes.get()]
+
+
+def test_overlapping_writer_hosts_cannot_publish_duplicate_sequences(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Independently restored production hosts reserve durable sequence slots."""
+    root = tmp_path / "host-owned-external-vault"
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_ROOT", str(root))
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_VAULT_ID", "builderops-mac-mini")
+    outcomes = _overlap_writer_hosts()
+
+    assert len(outcomes) == 2
+    entries = root / "builder-thread-entries"
+    sequences = sorted(
+        json.loads(path.read_text(encoding="utf-8"))["sequence"]
+        for path in entries.glob("*.json")
+    )
+    assert sequences == list(range(1, len(sequences) + 1))
+    assert len(sequences) == outcomes.count("accepted")
+
+
+def test_restart_recovers_after_overlapping_writer_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "host-owned-external-vault"
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_ROOT", str(root))
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_VAULT_ID", "builderops-mac-mini")
+    _overlap_writer_hosts()
+    restarted = SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    entries = root / "builder-thread-entries"
+    sequences = sorted(
+        json.loads(path.read_text(encoding="utf-8"))["sequence"]
+        for path in entries.glob("*.json")
+    )
+
+    assert restarted.accepted_mutation_count == len(sequences)
+    assert sequences == list(range(1, restarted.accepted_mutation_count + 1))
 
 
 def test_global_contribution_bound_applies_to_replies(tmp_path: Path) -> None:

--- a/tests/builderops/test_builder_threads_serialized.py
+++ b/tests/builderops/test_builder_threads_serialized.py
@@ -583,6 +583,36 @@ def test_partial_artifact_is_quarantined_with_failure_signal(
     assert writer.read_thread(created.thread.thread_id) == created.thread
 
 
+def test_reload_failure_preserves_live_projection(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    client = BuilderThreadClient(
+        InProcessWriterEndpoint(writer, client_id="codex:desktop"), client_id="codex:desktop"
+    )
+    created = client.create(
+        request_id="reload-baseline-5031",
+        actor="codex:desktop",
+        recipient="claude:mac",
+        subject="Reload failure baseline",
+        content="Valid durable threads remain readable after a rejected reload.",
+        source_refs=("github:5031",),
+    )
+    entries = tmp_path / "external-builderops-vault" / "builder-thread-entries"
+    (entries / "malformed-final-5031.json").write_text('{"command":', encoding="utf-8")
+
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        client.create(
+            request_id="reload-refusal-5031",
+            actor="codex:desktop",
+            recipient="claude:mac",
+            subject="Reload refusal",
+            content="The reload must reject malformed durable state.",
+            source_refs=("github:5031",),
+        )
+
+    assert client.read(created.thread.thread_id) == created.thread
+    assert client.inbox("claude:mac", limit=10).threads[0].thread_id == created.thread.thread_id
+
+
 def test_external_writer_restores_causal_order_not_request_id_order(tmp_path: Path) -> None:
     writer = _writer(tmp_path)
     first = BuilderThreadClient(


### PR DESCRIPTION
Governing-Issue: #5031

Refs #5031

Final-Review-Rounds: 1

## Summary
Reserves Builder Thread sequence allocation across independently restored writer processes sharing one external root, reloading durable state under the reservation before immutable publication. A rejected durable-state reload now preserves the prior live read projection rather than silently presenting accepted threads as absent.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The issue, PR, and owner-document contract fully represent this bounded delivery; no separate BuilderOps operational record was produced.

## Notes
Validation: `python3 -m pytest -q tests/builderops/test_builder_threads_serialized.py` (40 passed); `ruff check app/builderops tests/builderops`; `mypy app/builderops`; `git diff --check origin/main...HEAD`; `python3 scripts/docs_guard.py --language-only`. The P1 regression is covered by `test_reload_failure_preserves_live_projection`. Review-before-CI: concurrency risk assessment and stateful-fallback matrix completed; fresh independent review found no P0/P1/P2/P3 findings on the repaired diff.
Verified-Closing-Issues: #5031

