### PR TITLE
bug: bind workflow-risk evidence to merge-base diff

### DIFF
--- a/scripts/workflow_review_risk.py
+++ b/scripts/workflow_review_risk.py
@@ -53,10 +53,11 @@ def infer_workflow_risks(before: str | None, after: str | None) -> set[str]:
 def workflow_risk_evidence_from_git(
     repo: Path, *, base: str = "origin/main", head: str = "HEAD"
 ) -> WorkflowRiskEvidence:
-    """Inspect every workflow path in Git's real diff, rather than caller input."""
+    """Inspect the candidate diff from its merge base, rather than moving endpoints."""
 
-    base_sha = _git(repo, "rev-parse", "--verify", base).strip()
+    requested_base_sha = _git(repo, "rev-parse", "--verify", base).strip()
     head_sha = _git(repo, "rev-parse", "--verify", head).strip()
+    base_sha = _git(repo, "merge-base", requested_base_sha, head_sha).strip()
     paths = tuple(
         dict.fromkeys(
             path

--- a/tests/governance/test_workflow_risk_moving_base.py
+++ b/tests/governance/test_workflow_risk_moving_base.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.workflow_review_risk import workflow_risk_evidence_from_git
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=repo, check=True)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for command in (
+        ("init", "-q"),
+        ("config", "user.email", "test@example.invalid"),
+        ("config", "user.name", "test"),
+    ):
+        subprocess.run(["git", *command], cwd=repo, check=True)
+    return repo
+
+
+def test_moving_base_does_not_invent_candidate_changes(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    workflow = repo / ".github/workflows/check.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: check\n'on': push\n", encoding="utf-8")
+    merge_base = _commit(repo, "base")
+
+    _git(repo, "checkout", "-qb", "candidate")
+    (repo / "candidate.txt").write_text("candidate\n", encoding="utf-8")
+    candidate = _commit(repo, "candidate change")
+
+    _git(repo, "checkout", "-q", merge_base)
+    workflow.write_text("name: check\n'on': pull_request\n", encoding="utf-8")
+    moving_base = _commit(repo, "upstream workflow change")
+
+    evidence = workflow_risk_evidence_from_git(repo, base=moving_base, head=candidate)
+
+    assert evidence.base_sha == merge_base
+    assert evidence.workflow_paths == ()
+    assert evidence.risks == ()
+
+
+def test_workflow_risk_digest_binds_candidate_diff(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    workflow = repo / ".github/workflows/check.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: check\n'on': push\n", encoding="utf-8")
+    merge_base = _commit(repo, "base")
+
+    _git(repo, "checkout", "-qb", "candidate")
+    workflow.write_text("name: check\n'on': push\nconcurrency: first\n", encoding="utf-8")
+    first_candidate = _commit(repo, "first candidate workflow change")
+    first = workflow_risk_evidence_from_git(repo, base=merge_base, head=first_candidate)
+
+    workflow.write_text("name: check\n'on': push\nconcurrency: second\n", encoding="utf-8")
+    second_candidate = _commit(repo, "second candidate workflow change")
+    second = workflow_risk_evidence_from_git(repo, base=merge_base, head=second_candidate)
+
+    assert first.base_sha == second.base_sha == merge_base
+    assert first.diff_digest != second.diff_digest
+
+
+def test_real_workflow_change_remains_risky(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    workflow = repo / ".github/workflows/check.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: check\n'on': push\n", encoding="utf-8")
+    base = _commit(repo, "base")
+
+    workflow.write_text("name: check\n'on': pull_request\n", encoding="utf-8")
+    candidate = _commit(repo, "candidate workflow change")
+
+    evidence = workflow_risk_evidence_from_git(repo, base=base, head=candidate)
+
+    assert evidence.workflow_paths == (".github/workflows/check.yml",)
+    assert evidence.risks == ("state-machine",)


### PR DESCRIPTION
Governing-Issue: #5026

Fixes #5026

Final-Review-Rounds: 0

## Summary
Derive workflow-risk paths and digest from the candidate commit relative to its resolved merge base, preventing upstream-only workflow changes from appearing in candidate evidence.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded Tier 2 implementation produced no BuilderOps operational material or delivery divergence.

## Notes
Validation: `pytest -q tests/governance/test_workflow_risk_moving_base.py tests/ops/test_review_before_ci_workflow_risk.py tests/ops/test_review_before_ci_gate.py` (78 passed); `pytest -q tests/governance` (573 passed); `ruff check app tests companion-ui/companion-app`; `git diff --check`; `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` (owner-doc impact is follow-up-issue; no current-state doc claim changed).