### PR TITLE
Add governed journal review acceptance

### DIFF
--- a/app/cli/journaling.py
+++ b/app/cli/journaling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+import json
 from pathlib import Path
 import select
 import sys
@@ -10,6 +11,10 @@ import sys
 import click
 
 from app.journaling.day_context import assemble_day_context
+from app.journaling.review import (
+    process_journal_reviews_tick,
+    project_journal_review,
+)
 from app.chat.reflection_conversation import ReflectionConversationService
 from app.vault.manager import VaultContext
 
@@ -60,6 +65,82 @@ def reflect(
     click.echo(f"Transcript: {conversation.session.log_path}")
 
 
+@journaling_group.command(name="review-status")
+@click.option("--vault-root", type=click.Path(path_type=Path), required=True)
+@click.option("--date", "for_date", type=click.DateTime(formats=["%Y-%m-%d"]))
+@click.option("--json", "as_json", is_flag=True, help="Emit one JSON result.")
+def review_status(
+    *, vault_root: Path, for_date: datetime | None, as_json: bool
+) -> None:
+    """Project one journal candidate's durable review state without writing."""
+
+    target_date = for_date.date() if for_date is not None else date.today()
+    projection = project_journal_review(
+        vault_context=_vault_context(vault_root), for_date=target_date
+    )
+    payload = {
+        "state": projection.state.value,
+        "date": target_date.isoformat(),
+        "candidate_path": projection.candidate_path,
+        "canonical_path": projection.canonical_path,
+        "status_message": projection.status_message,
+    }
+    click.echo(
+        json.dumps(payload, ensure_ascii=False)
+        if as_json
+        else json.dumps(payload, ensure_ascii=False, indent=2)
+    )
+
+
+@journaling_group.command(name="review-tick")
+@click.option("--vault-root", type=click.Path(path_type=Path), required=True)
+@click.option("--date", "for_date", type=click.DateTime(formats=["%Y-%m-%d"]))
+@click.option("--outbox-path", type=click.Path(path_type=Path), default=None)
+@click.option("--json", "as_json", is_flag=True, help="Emit one JSON result.")
+def review_tick(
+    *,
+    vault_root: Path,
+    for_date: datetime | None,
+    outbox_path: Path | None,
+    as_json: bool,
+) -> None:
+    """Observe checked journal actions and retry durable pending intent."""
+
+    result = process_journal_reviews_tick(
+        vault_context=_vault_context(vault_root),
+        outbox_path=outbox_path,
+        only_date=for_date.date() if for_date is not None else None,
+    )
+    payload = {
+        "scanned_dates": list(result.scanned_dates),
+        "materialized": result.materialized,
+        "pending": result.pending,
+        "results": [
+            {
+                "state": item.state.value,
+                "action": item.action,
+                "candidate_path": item.candidate_path,
+                "canonical_path": item.canonical_path,
+                "receipt_id": item.receipt_id,
+                "status_message": item.status_message,
+            }
+            for item in result.results
+        ],
+    }
+    click.echo(
+        json.dumps(payload, ensure_ascii=False)
+        if as_json
+        else json.dumps(payload, ensure_ascii=False, indent=2)
+    )
+
+
+def _vault_context(vault_root: Path) -> VaultContext:
+    root = vault_root.expanduser().resolve()
+    if not root.is_dir():
+        raise click.UsageError("--vault-root must name an existing directory")
+    return VaultContext(status="selected", active_vault_path=str(root))
+
+
 def _read_owner_turn(timeout_seconds: int) -> str | None:
     click.echo("Owner (/stop to finish): ", nl=False)
     ready, _, _ = select.select([sys.stdin], [], [], timeout_seconds)
@@ -72,4 +153,4 @@ def _read_owner_turn(timeout_seconds: int) -> str | None:
     return line.rstrip("\n")
 
 
-__all__ = ["journaling_group"]
+__all__ = ["journaling_group", "review_status", "review_tick"]

--- a/app/heimdal/interest_steering.py
+++ b/app/heimdal/interest_steering.py
@@ -77,18 +77,12 @@ onboarding beyond writing the `sources/*.md` filter notes.
 
 from __future__ import annotations
 
-from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass, replace
+from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
-import fcntl
-import hashlib
 import json
-import os
 from pathlib import Path
 import re
-import stat
-import tempfile
-import threading
 from typing import Any, Literal, Optional
 from collections.abc import Iterator
 import yaml
@@ -106,16 +100,10 @@ from app.heimdal.settings_notes import (
     render_note,
     write_settings_note,
 )
-from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.write_ops import (
     _AtomicAppendAuthority,
-    _bind_host_append_route,
-    _mark_host_atomic_append_indeterminate,
-    _open_atomic_append_authority,
-    _open_durable_host_fence_root,
-    _require_host_append_route_live,
-    _require_no_host_indeterminate_fence,
     append_note_relative,
+    locked_atomic_append_authority,
 )
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 from scripts.yaml_roundtrip import dump_frontmatter
@@ -133,8 +121,6 @@ POSTHOC_STEERING_WRITE_ACTION = "heimdal.interest_steering.posthoc_append"
 INTEREST_WEIGHT_WRITE_ACTION = "heimdal.interest_steering.interest_update"
 SOURCE_FILTER_WRITE_ACTION = "heimdal.interest_steering.source_filter_update"
 _STEERING_OPERATION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
-_STEERING_LOCKS_GUARD = threading.Lock()
-_STEERING_LOCKS: dict[str, threading.RLock] = {}
 
 # The two in-flow steering targets (J2/J3): "watch this" -> watchlist.md,
 # "never this" -> never.md. Kept as a closed Literal so a caller cannot
@@ -469,111 +455,8 @@ def _build_steering_log_transaction(
 def _locked_steering_log(vault_root: Path) -> Iterator[_AtomicAppendAuthority]:
     """Serialize one inode and lexical resource across remaps and aliases."""
     relative = note_rel_path(STEERING_LOG)
-    with _open_atomic_append_authority(vault_root, relative) as authority:
-        lock_keys = sorted(authority.coordination_keys)
-        with _STEERING_LOCKS_GUARD:
-            process_locks = [
-                _STEERING_LOCKS.setdefault(key, threading.RLock())
-                for key in lock_keys
-            ]
-
-        lock_root = Path(tempfile.gettempdir()) / "agentic-pkm-heimdal-locks"
-        with ExitStack() as stack:
-            for process_lock in process_locks:
-                stack.enter_context(process_lock)
-            directory_flags = (
-                os.O_RDONLY
-                | getattr(os, "O_DIRECTORY", 0)
-                | getattr(os, "O_NOFOLLOW", 0)
-                | getattr(os, "O_CLOEXEC", 0)
-            )
-            lock_parent_fd = os.open(lock_root.parent, directory_flags)
-            stack.callback(os.close, lock_parent_fd)
-            try:
-                os.mkdir(lock_root.name, mode=0o700, dir_fd=lock_parent_fd)
-            except FileExistsError:
-                pass
-            os.fsync(lock_parent_fd)
-            lock_root_fd = os.open(
-                lock_root.name,
-                directory_flags,
-                dir_fd=lock_parent_fd,
-            )
-            stack.callback(os.close, lock_root_fd)
-            os.fsync(lock_root_fd)
-            lock_fds: list[int] = []
-            for key in lock_keys:
-                name = f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.lock"
-                file_flags = (
-                    os.O_RDWR
-                    | getattr(os, "O_NOFOLLOW", 0)
-                    | getattr(os, "O_CLOEXEC", 0)
-                )
-                try:
-                    lock_fd = os.open(
-                        name,
-                        file_flags | os.O_CREAT | os.O_EXCL,
-                        0o600,
-                        dir_fd=lock_root_fd,
-                    )
-                except FileExistsError:
-                    lock_fd = os.open(
-                        name,
-                        file_flags,
-                        dir_fd=lock_root_fd,
-                    )
-                stack.callback(os.close, lock_fd)
-                observed = os.fstat(lock_fd)
-                if not stat.S_ISREG(observed.st_mode) or observed.st_nlink != 1:
-                    raise KnowledgeWriteConflict(
-                        "steering log host lock must be one regular file"
-                    )
-                lock_fds.append(lock_fd)
-            os.fsync(lock_root_fd)
-            for lock_fd in lock_fds:
-                fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            host_state_fd = _open_durable_host_fence_root(authority)
-            lock_fd_by_key = {
-                key: lock_fd for key, lock_fd in zip(lock_keys, lock_fds, strict=True)
-            }
-            bound_authority = replace(
-                authority,
-                host_state_fd=host_state_fd,
-                host_state_stat=os.fstat(host_state_fd),
-                host_witness_root_path=lock_root,
-                host_witness_root_fd=lock_root_fd,
-                host_witness_root_stat=os.fstat(lock_root_fd),
-                host_witness_fds=tuple(
-                    (key, lock_fd_by_key[key]) for key in authority.coordination_keys
-                ),
-            )
-            try:
-                bound_authority.assert_live()
-                bound_authority.assert_host_state_live()
-                bound_authority.assert_host_witness_live()
-                _bind_host_append_route(bound_authority)
-                _require_no_host_indeterminate_fence(bound_authority)
-                yield bound_authority
-                try:
-                    bound_authority.assert_live()
-                    bound_authority.assert_host_state_live()
-                    bound_authority.assert_host_witness_live()
-                    _require_no_host_indeterminate_fence(bound_authority)
-                    _require_host_append_route_live(bound_authority)
-                except KnowledgeWriteConflict:
-                    try:
-                        _mark_host_atomic_append_indeterminate(
-                            bound_authority,
-                            "post-transaction-authority-check",
-                            "root or host authority changed before lock release",
-                        )
-                    except BaseException:
-                        pass
-                    raise
-            finally:
-                os.close(host_state_fd)
-                for lock_fd in reversed(lock_fds):
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    with locked_atomic_append_authority(vault_root, relative) as authority:
+        yield authority
 
 
 @dataclass(frozen=True)

--- a/app/journaling/draft.py
+++ b/app/journaling/draft.py
@@ -36,6 +36,12 @@ from app.journaling.day_context import (
     DayContextItem,
     assemble_day_context,
 )
+from app.journaling.lifecycle import (
+    JournalCandidateType,
+    JournalCandidateContractError,
+    checked_journal_action,
+    journal_decline_finding_id,
+)
 from app.journaling.transcript_protocol import ROLE_MESSAGE_FORMAT_BLOCKQUOTE_V1
 from app.knowledge_acquisition.candidate_writeback import ARTIFACT_CLASS
 from app.knowledge_compilation.proposal_builders import (
@@ -54,6 +60,7 @@ from app.reasoning.multi import (
     run_multi_note_reasoning,
 )
 from app.reasoning.schema import ReasoningOutput
+from app.proposals.declined_ledger import DeclinedLedger, default_declined_ledger
 from app.vault.manager import VaultContext
 from app.vault.paths import get_vault_system_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
@@ -171,6 +178,7 @@ def draft_journal_entry(
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
     activation_posture: ActivationPosture | None = None,
     reasoning_fn: ReasoningFunction = run_multi_note_reasoning,
+    declined_ledger: DeclinedLedger | None = None,
     now: datetime | None = None,
     staleness_days: int = DEFAULT_STALENESS_DAYS,
 ) -> JournalDraftResult:
@@ -183,6 +191,7 @@ def draft_journal_entry(
     """
 
     vault_root = _vault_root(vault_context)
+    ledger = declined_ledger or default_declined_ledger()
     if not session_id.strip():
         raise ValueError("draft_journal_entry requires a non-empty session_id")
     if staleness_days <= 0:
@@ -205,7 +214,7 @@ def draft_journal_entry(
     # preventing same-day lost updates rather than merely preventing torn bytes.
     write_guard.assert_writes_allowed(JOURNAL_DRAFT_WRITE_ACTION)
     with _locked_draft(vault_root, draft_rel) as (directory_fd, filename):
-        # Acceptance and drafting share this per-candidate lock. A draft run
+        # Acceptance and drafting share this per-day lock. A draft run
         # may have selected the primary path immediately before JRNL-04
         # materialized the day's canonical entry. Re-check after acquiring the
         # lock so that stale run refuses and retries onto the addendum path;
@@ -215,9 +224,34 @@ def draft_journal_entry(
                 "journal acceptance state changed before staging; retry the draft "
                 "so the canonical primary/addendum path is resolved again"
             )
-        existing_frontmatter = _load_existing_draft_frontmatter_at(
+        primary_name = f"{for_date.isoformat()}.md"
+        addendum_name = f"{for_date.isoformat()}-addendum.md"
+        other_name = primary_name if is_addendum else addendum_name
+        if _candidate_or_retirement_exists_at(directory_fd, other_name):
+            raise JournalDraftBlockedError(
+                "journal review transition is still pending; retire the existing "
+                "candidate before staging another same-day proposal"
+            )
+        existing_frontmatter, existing_body = _load_existing_draft_at(
             directory_fd, filename
         )
+        if existing_frontmatter:
+            candidate_type: JournalCandidateType = (
+                "addendum" if is_addendum else "primary"
+            )
+            try:
+                pending_action = checked_journal_action(
+                    existing_body, candidate_type=candidate_type
+                )
+            except JournalCandidateContractError as exc:
+                raise JournalDraftBlockedError(
+                    "existing journal candidate review state is malformed"
+                ) from exc
+            if pending_action is not None:
+                raise JournalDraftBlockedError(
+                    f"journal candidate has durable pending {pending_action} intent; "
+                    "draft generation cannot replace it"
+                )
         previous_session_ids = (
             _session_ids(
                 existing_frontmatter.get("sources"),
@@ -373,6 +407,17 @@ def draft_journal_entry(
         note_text = dump_frontmatter(frontmatter, compilation.body or "") + _review_actions(
             is_addendum=is_addendum
         )
+        finding_id = journal_decline_finding_id(
+            candidate_type="addendum" if is_addendum else "primary",
+            for_date=for_date.isoformat(),
+            frontmatter=frontmatter,
+            body=(compilation.body or "") + _review_actions(is_addendum=is_addendum),
+        )
+        if ledger.is_declined(finding_id):
+            raise JournalDraftBlockedError(
+                "unchanged journal proposal was previously dismissed; a changed "
+                "content/source basis is required before reproposal"
+            )
 
         # Re-resolve inside the same serialized transaction immediately before
         # replace so a removed or newly blocked source cannot be laundered into
@@ -435,9 +480,10 @@ def _draft_relative_path(
 def _locked_draft(
     vault_root: Path, relative_path: Path
 ) -> Iterator[tuple[int, str]]:
-    """Open a no-follow staging directory and hold the per-draft lock."""
+    """Open a no-follow staging directory and hold the per-day lock."""
 
-    lock_key = f"{vault_root}:{relative_path}"
+    day_key = _journal_day_key(relative_path.name)
+    lock_key = f"{vault_root}:{relative_path.parent}:{day_key}"
     with _PROCESS_LOCKS_GUARD:
         process_lock = _PROCESS_LOCKS.setdefault(lock_key, threading.RLock())
     with process_lock:
@@ -464,6 +510,7 @@ def _locked_draft_process_safe(
             symlink_message="journal draft bootstrap lock path is a symlink",
         )
         fcntl.flock(bootstrap_fd, fcntl.LOCK_EX)
+        _require_open_lock_at(root_fd, ".journal-draft-bootstrap.lock", bootstrap_fd)
         for component in relative_path.parent.parts:
             try:
                 next_fd = os.open(
@@ -496,7 +543,7 @@ def _locked_draft_process_safe(
                 os.close(current_fd)
             current_fd = next_fd
 
-        lock_name = f".{relative_path.name}.lock"
+        lock_name = f".{_journal_day_key(relative_path.name)}.journal-day.lock"
         lock_fd = _open_lock_at(
             current_fd,
             lock_name,
@@ -504,6 +551,7 @@ def _locked_draft_process_safe(
         )
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            _require_open_lock_at(current_fd, lock_name, lock_fd)
             fcntl.flock(bootstrap_fd, fcntl.LOCK_UN)
             os.close(bootstrap_fd)
             bootstrap_fd = None
@@ -548,33 +596,44 @@ def _open_lock_at(
         raise
 
     try:
-        opened = os.fstat(descriptor)
-        named = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
-        if not stat.S_ISREG(opened.st_mode) or not stat.S_ISREG(named.st_mode):
-            raise ValueError("journal draft lock path is not a regular file")
-        if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
-            raise ValueError("journal draft lock path changed while opening")
+        _require_open_lock_at(directory_fd, filename, descriptor)
     except BaseException:
         os.close(descriptor)
         raise
     return descriptor
 
 
-def _load_existing_draft_frontmatter_at(
+def _require_open_lock_at(
+    directory_fd: int, filename: str, descriptor: int
+) -> None:
+    opened = os.fstat(descriptor)
+    named = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or opened.st_nlink != 1
+        or not stat.S_ISREG(named.st_mode)
+        or named.st_nlink != 1
+    ):
+        raise ValueError("journal draft lock path is not one regular file")
+    if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+        raise ValueError("journal draft lock path changed while opening")
+
+
+def _load_existing_draft_at(
     directory_fd: int, filename: str
-) -> dict[str, object]:
+) -> tuple[dict[str, object], str]:
     try:
         descriptor = os.open(
             filename, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd
         )
     except FileNotFoundError:
-        return {}
+        return {}, ""
     except OSError as exc:
         if exc.errno == errno.ELOOP:
             raise ValueError("existing journal draft target is a symlink") from exc
         raise
     with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
-        frontmatter, _body = load_frontmatter(handle.read())
+        frontmatter, body = load_frontmatter(handle.read())
     if (
         frontmatter.get("kind") != "journal-draft"
         or frontmatter.get("authority_state") != "proposal"
@@ -583,7 +642,29 @@ def _load_existing_draft_frontmatter_at(
         raise ValueError(
             f"existing journal draft at {filename} has an incompatible contract"
         )
-    return frontmatter
+    return frontmatter, body
+
+
+def _journal_day_key(filename: str) -> str:
+    name = filename
+    if name.startswith(".") and ".journal-retire-" in name:
+        name = name[1:].split(".journal-retire-", 1)[0]
+    stem = Path(name).stem
+    return stem.removesuffix("-addendum")
+
+
+def _candidate_or_retirement_exists_at(directory_fd: int, filename: str) -> bool:
+    retirement_prefix = f".{filename}.journal-retire-"
+    for entry in os.listdir(directory_fd):
+        if entry != filename and not entry.startswith(retirement_prefix):
+            continue
+        observed = os.stat(entry, dir_fd=directory_fd, follow_symlinks=False)
+        if not stat.S_ISREG(observed.st_mode):
+            raise JournalDraftBlockedError(
+                "journal candidate lifecycle path must be a regular file"
+            )
+        return True
+    return False
 
 
 def _session_ids(

--- a/app/journaling/draft.py
+++ b/app/journaling/draft.py
@@ -205,6 +205,16 @@ def draft_journal_entry(
     # preventing same-day lost updates rather than merely preventing torn bytes.
     write_guard.assert_writes_allowed(JOURNAL_DRAFT_WRITE_ACTION)
     with _locked_draft(vault_root, draft_rel) as (directory_fd, filename):
+        # Acceptance and drafting share this per-candidate lock. A draft run
+        # may have selected the primary path immediately before JRNL-04
+        # materialized the day's canonical entry. Re-check after acquiring the
+        # lock so that stale run refuses and retries onto the addendum path;
+        # it must never recreate a primary candidate beside accepted content.
+        if accepted_path.exists() != is_addendum:
+            raise JournalDraftBlockedError(
+                "journal acceptance state changed before staging; retry the draft "
+                "so the canonical primary/addendum path is resolved again"
+            )
         existing_frontmatter = _load_existing_draft_frontmatter_at(
             directory_fd, filename
         )

--- a/app/journaling/lifecycle.py
+++ b/app/journaling/lifecycle.py
@@ -1,0 +1,121 @@
+"""Shared JRNL-03/JRNL-04 journal-candidate lifecycle semantics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+
+from app.agents.panel_agent.parser import find_panels, parse_panel
+
+
+PRIMARY_ACCEPT_LABEL = "Accept this draft as today's journal entry"
+ADDENDUM_ACCEPT_LABEL = "Accept and append this addendum to today's journal"
+DISMISS_LABEL = "Dismiss this journal candidate"
+
+JournalCandidateType = Literal["primary", "addendum"]
+JournalCandidateAction = Literal["accept", "dismiss"]
+
+
+class JournalCandidateContractError(ValueError):
+    """The candidate's durable Panel or proposal identity is ambiguous."""
+
+
+def checked_journal_action(
+    body: str, *, candidate_type: JournalCandidateType
+) -> JournalCandidateAction | None:
+    """Return the sole checked action from the exact JRNL Panel contract."""
+
+    expected_accept = (
+        ADDENDUM_ACCEPT_LABEL
+        if candidate_type == "addendum"
+        else PRIMARY_ACCEPT_LABEL
+    )
+    matching_actions: list[tuple[str, bool]] = []
+    for panel in find_panels(body):
+        parsed = parse_panel(panel.raw_block, panel.panel_id)
+        for action in parsed.actions:
+            if action.label in {expected_accept, DISMISS_LABEL}:
+                matching_actions.append((action.label, action.checked))
+
+    labels = [label for label, _checked in matching_actions]
+    if labels.count(expected_accept) != 1 or labels.count(DISMISS_LABEL) != 1:
+        raise JournalCandidateContractError(
+            "journal candidate must carry exactly one accept and one dismiss "
+            "action in a valid AI-åtgärder Panel"
+        )
+    checked = {label for label, is_checked in matching_actions if is_checked}
+    if len(checked) > 1:
+        raise JournalCandidateContractError(
+            "journal candidate has both accept and dismiss checked"
+        )
+    if expected_accept in checked:
+        return "accept"
+    if DISMISS_LABEL in checked:
+        return "dismiss"
+    return None
+
+
+def strip_journal_review_panel(body: str) -> str:
+    """Remove exactly one JRNL review Panel from the candidate body."""
+
+    rendered = body
+    removed = 0
+    for panel in find_panels(body):
+        parsed = parse_panel(panel.raw_block, panel.panel_id)
+        labels = {action.label for action in parsed.actions}
+        if DISMISS_LABEL in labels and labels.intersection(
+            {PRIMARY_ACCEPT_LABEL, ADDENDUM_ACCEPT_LABEL}
+        ):
+            rendered = rendered.replace(panel.raw_block, "", 1)
+            removed += 1
+    if removed != 1:
+        raise JournalCandidateContractError(
+            "journal candidate review Panel is missing or ambiguous"
+        )
+    return rendered.strip() + "\n"
+
+
+def journal_decline_finding_id(
+    *,
+    candidate_type: JournalCandidateType,
+    for_date: str,
+    frontmatter: dict[str, Any],
+    body: str,
+) -> str:
+    """Bind decline suppression to proposal content and source basis.
+
+    Volatile proposal ids, timestamps, and activation receipts are excluded so
+    an unchanged JRNL-03 rerun remains suppressed. Any body or source-basis
+    change mints a new id and is therefore independently reviewable.
+    """
+
+    sources = frontmatter.get("sources")
+    occurrences = frontmatter.get("source_occurrences")
+    basis = {
+        "candidate_type": candidate_type,
+        "for_date": for_date,
+        "sources": sources if isinstance(sources, list) else [],
+        "source_occurrences": occurrences if isinstance(occurrences, list) else [],
+        "body": strip_journal_review_panel(body),
+    }
+    encoded = json.dumps(
+        basis,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "journal-candidate-" + hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "ADDENDUM_ACCEPT_LABEL",
+    "DISMISS_LABEL",
+    "JournalCandidateAction",
+    "JournalCandidateContractError",
+    "JournalCandidateType",
+    "PRIMARY_ACCEPT_LABEL",
+    "checked_journal_action",
+    "journal_decline_finding_id",
+    "strip_journal_review_panel",
+]

--- a/app/journaling/review.py
+++ b/app/journaling/review.py
@@ -32,9 +32,9 @@ from app.journaling.lifecycle import (
     journal_decline_finding_id,
     strip_journal_review_panel,
 )
-from app.knowledge.adapters import _atomic_rename_noreplace_at
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.write_ops import (
+    _atomic_rename_noreplace_at,
     append_note_relative,
     locked_atomic_append_authority,
 )

--- a/app/journaling/review.py
+++ b/app/journaling/review.py
@@ -428,6 +428,7 @@ def _accept_candidate(
             current_raw: bytes | None, proposed: bytes
         ) -> tuple[bytes, bytes]:
             nonlocal materialized_at
+            _assert_candidate_unchanged_at(directory_fd, candidate)
             if current_raw is not None:
                 current_frontmatter, _current_body = _load_raw_frontmatter(current_raw)
                 if (
@@ -479,6 +480,7 @@ def _accept_candidate(
             current_raw: bytes | None, proposed: bytes
         ) -> tuple[bytes, bytes]:
             nonlocal materialized_at
+            _assert_candidate_unchanged_at(directory_fd, candidate)
             if current_raw is None:
                 raise JournalAcceptedEntryExistsError(
                     "an addendum requires an existing accepted journal entry"
@@ -916,6 +918,30 @@ def _load_raw_frontmatter(raw: bytes) -> tuple[dict[str, Any], bytes]:
             "canonical journal frontmatter/body boundary is not stable UTF-8"
         )
     return frontmatter, body_bytes
+
+
+def _assert_candidate_unchanged_at(directory_fd: int, candidate: _Candidate) -> None:
+    """Reject publication if the owner changed the checked candidate meanwhile.
+
+    This runs inside the canonical write transaction, so the body stamped into the
+    accepted note is the same body that the owner actually approved.
+    """
+    try:
+        current = _read_candidate_at(
+            directory_fd,
+            candidate.storage_filename,
+            relative_path=candidate.relative_path,
+            candidate_type=candidate.candidate_type,
+            for_date=date.fromisoformat(str(candidate.frontmatter["for_date"])),
+        )
+    except FileNotFoundError:
+        raise JournalReviewConflictError(
+            "journal candidate disappeared during canonical acceptance; the owner must retry"
+        ) from None
+    if current.identity != candidate.identity or current.raw != candidate.raw:
+        raise JournalReviewConflictError(
+            "journal candidate changed before canonical acceptance; the current edited draft remains available"
+        )
 
 
 def _retire_candidate_if_unchanged(

--- a/app/journaling/review.py
+++ b/app/journaling/review.py
@@ -15,21 +15,34 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import stat
 from typing import Any
+from uuid import uuid4
 
-from app.agents.panel_agent.parser import find_panels, parse_panel
 from app.journaling.draft import (
     CANONICAL_JOURNAL_SUBDIR,
     _draft_relative_path,
     _locked_draft,
 )
+from app.journaling.lifecycle import (
+    JournalCandidateType,
+    JournalCandidateContractError,
+    checked_journal_action,
+    journal_decline_finding_id,
+    strip_journal_review_panel,
+)
+from app.knowledge.adapters import _atomic_rename_noreplace_at
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.write_ops import (
     append_note_relative,
     locked_atomic_append_authority,
 )
-from app.proposals.declined_ledger import DeclinedLedger, default_declined_ledger
+from app.proposals.declined_ledger import (
+    DECLINED_LEDGER_WRITE_ACTION,
+    DeclinedLedger,
+    default_declined_ledger,
+)
 from app.services.outbox import serialize_outbox_record
 from app.vault.manager import VaultContext
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
@@ -40,10 +53,13 @@ JOURNAL_ENTRY_ACCEPT_WRITE_ACTION = "journal.entry.accept"
 JOURNAL_ENTRY_ACCEPTED_EVENT = "journal.entry.accepted"
 JOURNAL_ENTRY_DECLINED_EVENT = "journal.entry.declined"
 JOURNAL_REVIEW_EVENT_SOURCE = "app.journaling.review"
+DEFAULT_JOURNAL_REVIEW_OUTBOX_PATH = Path("runtime/journal-review-outbox.jsonl")
 
-_PRIMARY_ACCEPT_LABEL = "Accept this draft as today's journal entry"
-_ADDENDUM_ACCEPT_LABEL = "Accept and append this addendum to today's journal"
-_DISMISS_LABEL = "Dismiss this journal candidate"
+_RETIREMENT_MARKER = ".journal-retire-"
+_RETIRED_MARKER = ".journal-retired-"
+_CANDIDATE_NAME_RE = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})(?P<addendum>-addendum)?\.md$"
+)
 
 
 class JournalReviewError(RuntimeError):
@@ -89,15 +105,40 @@ class JournalReviewResult:
 
 
 @dataclass(frozen=True)
+class JournalReviewTickResult:
+    scanned_dates: tuple[str, ...]
+    results: tuple[JournalReviewResult, ...]
+
+    @property
+    def materialized(self) -> int:
+        return sum(
+            result.state is JournalReviewState.FULLY_MATERIALIZED
+            for result in self.results
+        )
+
+    @property
+    def pending(self) -> int:
+        return sum(
+            result.state
+            in {
+                JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION,
+                JournalReviewState.DISMISSAL_PENDING,
+            }
+            for result in self.results
+        )
+
+
+@dataclass(frozen=True)
 class _Candidate:
     relative_path: Path
-    candidate_type: str
+    candidate_type: JournalCandidateType
     draft_id: str
     frontmatter: dict[str, Any]
     body: str
     raw: bytes
     identity: os.stat_result
     action: str | None
+    storage_filename: str
 
 
 def journal_draft_relative_path(
@@ -132,6 +173,36 @@ def project_journal_review(
                 rendered_body=None,
                 status_message="Saved",
             )
+        retired = _retired_candidates(vault_root, for_date)
+        if retired:
+            for relative_path, candidate_type, storage_path in retired:
+                candidate = _read_candidate_path(
+                    vault_root,
+                    storage_path,
+                    relative_path=relative_path,
+                    candidate_type=candidate_type,
+                    for_date=for_date,
+                )
+                if candidate.action != "dismiss":
+                    raise JournalReviewConflictError(
+                        "accepted candidate archive exists without its canonical journal"
+                    )
+                expected_name = (
+                    f".{relative_path.name}{_RETIRED_MARKER}"
+                    f"{_decline_receipt_id(candidate)}"
+                )
+                if storage_path.name != expected_name:
+                    raise JournalReviewConflictError(
+                        "dismissed candidate archive is not bound to its exact receipt"
+                    )
+            return JournalReviewProjection(
+                state=JournalReviewState.DISMISSED,
+                canonical_path=canonical_rel.as_posix(),
+                candidate_path=None,
+                candidate_type=None,
+                rendered_body=None,
+                status_message="Dismissed",
+            )
         return JournalReviewProjection(
             state=JournalReviewState.NOT_YET_REVIEWED,
             canonical_path=canonical_rel.as_posix(),
@@ -141,9 +212,13 @@ def project_journal_review(
             status_message="Not yet reviewed",
         )
 
-    relative_path, candidate_type = selected
+    relative_path, candidate_type, storage_path = selected
     candidate = _read_candidate_path(
-        vault_root, relative_path, candidate_type=candidate_type, for_date=for_date
+        vault_root,
+        storage_path,
+        relative_path=relative_path,
+        candidate_type=candidate_type,
+        for_date=for_date,
     )
     state, message = _projection_state(candidate.action)
     return JournalReviewProjection(
@@ -173,24 +248,28 @@ def process_journal_review(
 
     vault_root = _vault_root(vault_context)
     canonical_rel = _canonical_relative_path(for_date)
-    selected = _select_candidate(vault_root, for_date)
-    if selected is None:
-        projection = project_journal_review(
-            vault_context=vault_context, for_date=for_date
-        )
-        return JournalReviewResult(
-            state=projection.state,
-            action=None,
-            canonical_path=projection.canonical_path,
-            candidate_path=None,
-            candidate_type=None,
-            receipt_id=None,
-            decision_token_ref=None,
-            status_message=projection.status_message,
-        )
+    primary_rel = journal_draft_relative_path(
+        vault_root, for_date, is_addendum=False
+    )
+    with _locked_draft(vault_root, primary_rel) as (directory_fd, _primary_name):
+        selected = _select_candidate_at(directory_fd, for_date)
+        if selected is None:
+            projection = project_journal_review(
+                vault_context=vault_context, for_date=for_date
+            )
+            return JournalReviewResult(
+                state=projection.state,
+                action=None,
+                canonical_path=projection.canonical_path,
+                candidate_path=None,
+                candidate_type=None,
+                receipt_id=None,
+                decision_token_ref=None,
+                status_message=projection.status_message,
+            )
 
-    candidate_rel, candidate_type = selected
-    with _locked_draft(vault_root, candidate_rel) as (directory_fd, filename):
+        logical_name, candidate_type, filename = selected
+        candidate_rel = primary_rel.parent / logical_name
         try:
             candidate = _read_candidate_at(
                 directory_fd,
@@ -200,19 +279,9 @@ def process_journal_review(
                 for_date=for_date,
             )
         except FileNotFoundError:
-            projection = project_journal_review(
-                vault_context=vault_context, for_date=for_date
-            )
-            return JournalReviewResult(
-                state=projection.state,
-                action=None,
-                canonical_path=projection.canonical_path,
-                candidate_path=projection.candidate_path,
-                candidate_type=projection.candidate_type,
-                receipt_id=None,
-                decision_token_ref=None,
-                status_message=projection.status_message,
-            )
+            raise JournalReviewConflictError(
+                "journal candidate disappeared while its per-day lifecycle lock was held"
+            ) from None
 
         if candidate.action is None:
             return _result(
@@ -226,7 +295,6 @@ def process_journal_review(
             return _dismiss_candidate(
                 candidate,
                 directory_fd=directory_fd,
-                filename=filename,
                 canonical_rel=canonical_rel,
                 outbox_path=Path(outbox_path),
                 declined_ledger=declined_ledger or default_declined_ledger(),
@@ -253,11 +321,77 @@ def process_journal_review(
             vault_root=vault_root,
             canonical_rel=canonical_rel,
             directory_fd=directory_fd,
-            filename=filename,
             outbox_path=Path(outbox_path),
             write_guard=write_guard,
             now=_aware_now(now),
         )
+
+
+def process_journal_reviews_tick(
+    *,
+    vault_context: VaultContext,
+    outbox_path: Path | None = None,
+    declined_ledger: DeclinedLedger | None = None,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    now: datetime | None = None,
+    only_date: date | None = None,
+) -> JournalReviewTickResult:
+    """Observe durable candidates and advance checked actions once per tick.
+
+    This is the production retry seam. A checked accept remains in the vault
+    when WriteGuard blocks; a later healthy invocation rediscovers and
+    materializes it without another human action.
+    """
+
+    dates = (only_date,) if only_date is not None else _candidate_dates(vault_context)
+    receipt_path = outbox_path or default_journal_review_outbox_path()
+    results = tuple(
+        process_journal_review(
+            vault_context=vault_context,
+            for_date=for_date,
+            outbox_path=receipt_path,
+            declined_ledger=declined_ledger,
+            write_guard=write_guard,
+            now=now,
+        )
+        for for_date in dates
+    )
+    return JournalReviewTickResult(
+        scanned_dates=tuple(item.isoformat() for item in dates),
+        results=results,
+    )
+
+
+def default_journal_review_outbox_path() -> Path:
+    override = os.getenv("JOURNAL_REVIEW_OUTBOX_PATH", "").strip()
+    return Path(override).expanduser() if override else DEFAULT_JOURNAL_REVIEW_OUTBOX_PATH
+
+
+def _candidate_dates(vault_context: VaultContext) -> tuple[date, ...]:
+    vault_root = _vault_root(vault_context)
+    primary = journal_draft_relative_path(
+        vault_root, date.min, is_addendum=False
+    )
+    directory = vault_root / primary.parent
+    try:
+        names = os.listdir(directory)
+    except FileNotFoundError:
+        return ()
+    dates: set[date] = set()
+    for name in names:
+        logical_name = name
+        if name.startswith(".") and _RETIREMENT_MARKER in name:
+            logical_name = name[1:].split(_RETIREMENT_MARKER, 1)[0]
+        match = _CANDIDATE_NAME_RE.fullmatch(logical_name)
+        if match is None:
+            continue
+        observed = (directory / name).lstat()
+        if stat.S_ISLNK(observed.st_mode) or not stat.S_ISREG(observed.st_mode):
+            raise JournalReviewConflictError(
+                "journal candidate lifecycle path must be a regular file"
+            )
+        dates.add(date.fromisoformat(match.group("date")))
+    return tuple(sorted(dates))
 
 
 def _accept_candidate(
@@ -266,7 +400,6 @@ def _accept_candidate(
     vault_root: Path,
     canonical_rel: Path,
     directory_fd: int,
-    filename: str,
     outbox_path: Path,
     write_guard: WriteGuard,
     now: datetime,
@@ -335,14 +468,12 @@ def _accept_candidate(
         action = "accept"
         transform = primary_transform
     else:
-        marker = (
-            f"<!-- journal:addendum_receipt_id={receipt_id} "
-            f"draft_id={candidate.draft_id} -->"
+        proposed_append = _render_addendum_block(
+            receipt_id=receipt_id,
+            draft_id=candidate.draft_id,
+            accepted_at=accepted_at,
+            materialized_body=materialized_body,
         )
-        proposed_append = (
-            f"\n## Addendum — {accepted_at}\n\n"
-            f"{materialized_body.rstrip()}\n\n{marker}\n"
-        ).encode("utf-8")
 
         def addendum_transform(
             current_raw: bytes | None, proposed: bytes
@@ -356,11 +487,24 @@ def _accept_candidate(
             _require_accepted_frontmatter(
                 current_frontmatter, canonical_rel.as_posix()
             )
-            marker_bytes = marker.encode("utf-8")
-            if marker_bytes in current_body:
-                materialized_at = _accepted_addendum_timestamp(
-                    current_body, marker_bytes
+            recovered = _recover_addendum_block(
+                current_body,
+                receipt_id=receipt_id,
+                draft_id=candidate.draft_id,
+                materialized_body=materialized_body,
+            )
+            if recovered is not None:
+                materialized_at = recovered
+                expected = _render_addendum_block(
+                    receipt_id=receipt_id,
+                    draft_id=candidate.draft_id,
+                    accepted_at=materialized_at,
+                    materialized_body=materialized_body,
                 )
+                if not current_body.endswith(expected):
+                    raise JournalReviewConflictError(
+                        "accepted addendum block is no longer the exact journal suffix"
+                    )
                 return current_raw, b""
             return current_raw + proposed, proposed
 
@@ -405,8 +549,10 @@ def _accept_candidate(
         timestamp=materialized_at,
         payload=payload,
     )
-    _unlink_candidate_if_unchanged(
-        directory_fd, filename, candidate.identity, candidate.raw
+    _retire_candidate_if_unchanged(
+        directory_fd,
+        candidate,
+        receipt_id=receipt_id,
     )
     return _result(
         state=JournalReviewState.FULLY_MATERIALIZED,
@@ -423,42 +569,72 @@ def _dismiss_candidate(
     candidate: _Candidate,
     *,
     directory_fd: int,
-    filename: str,
     canonical_rel: Path,
     outbox_path: Path,
     declined_ledger: DeclinedLedger,
     write_guard: WriteGuard,
     now: datetime,
 ) -> JournalReviewResult:
-    timestamp = _iso(now)
-    receipt_id = "journal-decline-" + hashlib.sha256(
-        (
-            f"{candidate.draft_id}\x1f{candidate.candidate_type}\x1f"
-            f"{hashlib.sha256(candidate.raw).hexdigest()}"
-        ).encode("utf-8")
-    ).hexdigest()[:24]
-    declined_ledger.record_decline(
-        candidate.draft_id,
+    # Reading/reconciling the receipt creates its lock file on first use, so
+    # assert the shared decline action before any dismissal-owned filesystem
+    # mutation. DeclinedLedger asserts the same action again at its write port.
+    write_guard.assert_writes_allowed(DECLINED_LEDGER_WRITE_ACTION)
+    finding_id = journal_decline_finding_id(
+        candidate_type=candidate.candidate_type,
+        for_date=str(candidate.frontmatter["for_date"]),
+        frontmatter=candidate.frontmatter,
+        body=candidate.body,
+    )
+    receipt_id = _decline_receipt_id(candidate)
+    existing_event = _read_event(outbox_path, receipt_id)
+    ledger_receipt = declined_ledger.get_receipt(finding_id)
+    event_timestamp = (
+        _normalized_timestamp(
+            existing_event.get("timestamp"), description="journal decline event"
+        )
+        if existing_event is not None
+        else None
+    )
+    ledger_timestamp = (
+        _normalized_timestamp(
+            ledger_receipt.declined_at, description="journal decline ledger receipt"
+        )
+        if ledger_receipt is not None and ledger_receipt.declined_at is not None
+        else None
+    )
+    if event_timestamp and ledger_timestamp and event_timestamp != ledger_timestamp:
+        raise JournalReviewConflictError(
+            "journal dismissal ledger and event carry different timestamps"
+        )
+    timestamp = event_timestamp or ledger_timestamp or _iso(now)
+    durable_decline = declined_ledger.record_decline(
+        finding_id,
         finding_class="journal.candidate",
         reason="human_dismissed",
         declined_at=timestamp,
         write_guard=write_guard,
     )
+    if durable_decline.declined_at != timestamp:
+        raise JournalReviewConflictError(
+            "journal dismissal ledger changed evidence under a stable finding id"
+        )
     _emit_event_once(
         outbox_path,
         event=JOURNAL_ENTRY_DECLINED_EVENT,
         event_id=receipt_id,
-        trace_id=candidate.draft_id,
+        trace_id=finding_id,
         timestamp=timestamp,
         payload={
-            "draft_id": candidate.draft_id,
+            "finding_id": finding_id,
             "candidate_type": candidate.candidate_type,
             "sources": list(_sources(candidate.frontmatter)),
             "reason": "human_dismissed",
         },
     )
-    _unlink_candidate_if_unchanged(
-        directory_fd, filename, candidate.identity, candidate.raw
+    _retire_candidate_if_unchanged(
+        directory_fd,
+        candidate,
+        receipt_id=receipt_id,
     )
     return _result(
         state=JournalReviewState.DISMISSED,
@@ -470,36 +646,121 @@ def _dismiss_candidate(
     )
 
 
+def _decline_receipt_id(candidate: _Candidate) -> str:
+    finding_id = journal_decline_finding_id(
+        candidate_type=candidate.candidate_type,
+        for_date=str(candidate.frontmatter["for_date"]),
+        frontmatter=candidate.frontmatter,
+        body=candidate.body,
+    )
+    return "journal-decline-" + hashlib.sha256(
+        f"journal-decline\x1f{finding_id}".encode("utf-8")
+    ).hexdigest()[:24]
+
+
 def _select_candidate(
     vault_root: Path, for_date: date
-) -> tuple[Path, str] | None:
+) -> tuple[Path, JournalCandidateType, Path] | None:
     primary = journal_draft_relative_path(
         vault_root, for_date, is_addendum=False
     )
-    addendum = journal_draft_relative_path(
-        vault_root, for_date, is_addendum=True
-    )
-    primary_exists = _path_exists_no_symlink(vault_root / primary)
-    addendum_exists = _path_exists_no_symlink(vault_root / addendum)
-    if primary_exists and addendum_exists:
+    parent = vault_root / primary.parent
+    try:
+        names = os.listdir(parent)
+    except FileNotFoundError:
+        return None
+    selection = _select_candidate_names(names, for_date)
+    if selection is None:
+        return None
+    logical_name, candidate_type, storage_name = selection
+    storage_path = primary.parent / storage_name
+    mode = (vault_root / storage_path).lstat().st_mode
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
         raise JournalReviewConflictError(
-            "both primary and addendum candidates exist for the same day"
+            "journal candidate lifecycle path must be a regular non-symlink file"
         )
-    if addendum_exists:
-        return addendum, "addendum"
-    if primary_exists:
-        return primary, "primary"
-    return None
+    return primary.parent / logical_name, candidate_type, storage_path
+
+
+def _retired_candidates(
+    vault_root: Path, for_date: date
+) -> tuple[tuple[Path, JournalCandidateType, Path], ...]:
+    primary = journal_draft_relative_path(
+        vault_root, for_date, is_addendum=False
+    )
+    parent = vault_root / primary.parent
+    try:
+        names = os.listdir(parent)
+    except FileNotFoundError:
+        return ()
+    candidates: tuple[tuple[str, JournalCandidateType], ...] = (
+        (f"{for_date.isoformat()}.md", "primary"),
+        (f"{for_date.isoformat()}-addendum.md", "addendum"),
+    )
+    retired: list[tuple[Path, JournalCandidateType, Path]] = []
+    for logical_name, candidate_type in candidates:
+        prefix = f".{logical_name}{_RETIRED_MARKER}"
+        for storage_name in names:
+            if not storage_name.startswith(prefix):
+                continue
+            storage_path = primary.parent / storage_name
+            mode = (vault_root / storage_path).lstat().st_mode
+            if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+                raise JournalReviewConflictError(
+                    "journal candidate archive must be a regular non-symlink file"
+                )
+            retired.append(
+                (primary.parent / logical_name, candidate_type, storage_path)
+            )
+    return tuple(retired)
+
+
+def _select_candidate_at(
+    directory_fd: int, for_date: date
+) -> tuple[str, JournalCandidateType, str] | None:
+    selection = _select_candidate_names(os.listdir(directory_fd), for_date)
+    if selection is None:
+        return None
+    logical_name, candidate_type, storage_name = selection
+    observed = os.stat(storage_name, dir_fd=directory_fd, follow_symlinks=False)
+    if not stat.S_ISREG(observed.st_mode):
+        raise JournalReviewConflictError(
+            "journal candidate lifecycle path must be a regular file"
+        )
+    return logical_name, candidate_type, storage_name
+
+
+def _select_candidate_names(
+    names: list[str], for_date: date
+) -> tuple[str, JournalCandidateType, str] | None:
+    primary_name = f"{for_date.isoformat()}.md"
+    addendum_name = f"{for_date.isoformat()}-addendum.md"
+    matches: list[tuple[str, JournalCandidateType, str]] = []
+    candidates: tuple[tuple[str, JournalCandidateType], ...] = (
+        (primary_name, "primary"),
+        (addendum_name, "addendum"),
+    )
+    for logical_name, candidate_type in candidates:
+        retirement_prefix = f".{logical_name}{_RETIREMENT_MARKER}"
+        for name in names:
+            if name == logical_name or name.startswith(retirement_prefix):
+                matches.append((logical_name, candidate_type, name))
+    if len(matches) > 1:
+        raise JournalReviewConflictError(
+            "multiple primary/addendum/retiring candidates exist for the same day"
+        )
+    return matches[0] if matches else None
 
 
 def _read_candidate_path(
     vault_root: Path,
-    relative_path: Path,
+    storage_path: Path,
     *,
-    candidate_type: str,
+    relative_path: Path,
+    candidate_type: JournalCandidateType,
     for_date: date,
 ) -> _Candidate:
-    parent = vault_root / relative_path.parent
+    parent = vault_root / storage_path.parent
     parent_fd = os.open(
         parent,
         os.O_RDONLY
@@ -509,7 +770,7 @@ def _read_candidate_path(
     try:
         return _read_candidate_at(
             parent_fd,
-            relative_path.name,
+            storage_path.name,
             relative_path=relative_path,
             candidate_type=candidate_type,
             for_date=for_date,
@@ -523,7 +784,7 @@ def _read_candidate_at(
     filename: str,
     *,
     relative_path: Path,
-    candidate_type: str,
+    candidate_type: JournalCandidateType,
     for_date: date,
 ) -> _Candidate:
     descriptor = os.open(
@@ -538,6 +799,8 @@ def _read_candidate_at(
             not stat.S_ISREG(opened.st_mode)
             or not stat.S_ISREG(named.st_mode)
             or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
+            or opened.st_nlink != 1
+            or named.st_nlink != 1
         ):
             raise JournalReviewConflictError(
                 "journal candidate must be one stable regular file"
@@ -581,58 +844,29 @@ def _read_candidate_at(
         raw=raw,
         identity=opened,
         action=action,
+        storage_filename=filename,
     )
 
 
-def _checked_action(body: str, *, candidate_type: str) -> str | None:
-    expected_accept = (
-        _ADDENDUM_ACCEPT_LABEL if candidate_type == "addendum" else _PRIMARY_ACCEPT_LABEL
-    )
-    matching_actions: list[tuple[str, bool]] = []
-    for panel in find_panels(body):
-        parsed = parse_panel(panel.raw_block, panel.panel_id)
-        for action in parsed.actions:
-            if action.label in {expected_accept, _DISMISS_LABEL}:
-                matching_actions.append((action.label, action.checked))
-
-    labels = [label for label, _checked in matching_actions]
-    if labels.count(expected_accept) != 1 or labels.count(_DISMISS_LABEL) != 1:
-        raise JournalReviewConflictError(
-            "journal candidate must carry exactly one accept and one dismiss "
-            "action in a valid AI-åtgärder Panel"
+def _checked_action(body: str, *, candidate_type: JournalCandidateType) -> str | None:
+    try:
+        return checked_journal_action(
+            body,
+            candidate_type=candidate_type,
         )
-    checked = {label for label, is_checked in matching_actions if is_checked}
-    if len(checked) > 1:
-        raise JournalReviewConflictError(
-            "journal candidate has both accept and dismiss checked"
-        )
-    if expected_accept in checked:
-        return "accept"
-    if _DISMISS_LABEL in checked:
-        return "dismiss"
-    return None
+    except JournalCandidateContractError as exc:
+        raise JournalReviewConflictError(str(exc)) from exc
 
 
 def _strip_review_panel(body: str) -> str:
-    rendered = body
-    removed = 0
-    for panel in find_panels(body):
-        parsed = parse_panel(panel.raw_block, panel.panel_id)
-        labels = {action.label for action in parsed.actions}
-        if _DISMISS_LABEL in labels and labels.intersection(
-            {_PRIMARY_ACCEPT_LABEL, _ADDENDUM_ACCEPT_LABEL}
-        ):
-            rendered = rendered.replace(panel.raw_block, "", 1)
-            removed += 1
-    if removed != 1:
-        raise JournalReviewConflictError(
-            "journal candidate review Panel is missing or ambiguous"
-        )
-    return rendered.strip() + "\n"
+    try:
+        return strip_journal_review_panel(body)
+    except JournalCandidateContractError as exc:
+        raise JournalReviewConflictError(str(exc)) from exc
 
 
 def _require_candidate_frontmatter(
-    frontmatter: dict[str, Any], *, candidate_type: str, for_date: date
+    frontmatter: dict[str, Any], *, candidate_type: JournalCandidateType, for_date: date
 ) -> None:
     expected = {
         "kind": "journal-draft",
@@ -684,32 +918,52 @@ def _load_raw_frontmatter(raw: bytes) -> tuple[dict[str, Any], bytes]:
     return frontmatter, body_bytes
 
 
-def _unlink_candidate_if_unchanged(
+def _retire_candidate_if_unchanged(
     directory_fd: int,
-    filename: str,
-    expected: os.stat_result,
-    expected_raw: bytes,
+    candidate: _Candidate,
+    *,
+    receipt_id: str,
 ) -> None:
-    try:
-        current = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
-    except FileNotFoundError:
-        return
-    if (
-        not stat.S_ISREG(current.st_mode)
-        or (current.st_dev, current.st_ino) != (expected.st_dev, expected.st_ino)
-        or current.st_size != expected.st_size
-        or current.st_mtime_ns != expected.st_mtime_ns
-        or current.st_ctime_ns != expected.st_ctime_ns
-    ):
+    logical_name = candidate.relative_path.name
+    retirement_name = f".{logical_name}{_RETIREMENT_MARKER}{receipt_id}"
+    retired_name = f".{logical_name}{_RETIRED_MARKER}{receipt_id}"
+    moved = candidate.storage_filename == logical_name
+    if moved:
+        try:
+            os.stat(retirement_name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise JournalReviewConflictError(
+                "journal candidate retirement path already exists"
+            )
+        try:
+            _atomic_rename_noreplace_at(
+                directory_fd,
+                candidate.storage_filename,
+                directory_fd,
+                retirement_name,
+            )
+        except FileExistsError as exc:
+            raise JournalReviewConflictError(
+                "journal candidate retirement path appeared concurrently"
+            ) from exc
+        os.fsync(directory_fd)
+    elif candidate.storage_filename != retirement_name:
         raise JournalReviewConflictError(
-            "journal candidate changed after materialization; it was preserved for review"
+            "journal candidate retirement evidence does not match its receipt"
         )
+
     descriptor = os.open(
-        filename,
+        retirement_name,
         os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
         dir_fd=directory_fd,
     )
     try:
+        opened = os.fstat(descriptor)
+        named = os.stat(
+            retirement_name, dir_fd=directory_fd, follow_symlinks=False
+        )
         current_raw = b""
         while True:
             chunk = os.read(descriptor, 1024 * 1024)
@@ -718,12 +972,108 @@ def _unlink_candidate_if_unchanged(
             current_raw += chunk
     finally:
         os.close(descriptor)
-    if current_raw != expected_raw:
+
+    matches = (
+        stat.S_ISREG(opened.st_mode)
+        and stat.S_ISREG(named.st_mode)
+        and opened.st_nlink == 1
+        and named.st_nlink == 1
+        and (opened.st_dev, opened.st_ino)
+        == (candidate.identity.st_dev, candidate.identity.st_ino)
+        and (named.st_dev, named.st_ino) == (opened.st_dev, opened.st_ino)
+        and opened.st_size == candidate.identity.st_size
+        and opened.st_mtime_ns == candidate.identity.st_mtime_ns
+        and current_raw == candidate.raw
+    )
+    if not matches:
+        if moved:
+            try:
+                os.stat(logical_name, dir_fd=directory_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                try:
+                    _atomic_rename_noreplace_at(
+                        directory_fd,
+                        retirement_name,
+                        directory_fd,
+                        logical_name,
+                    )
+                except FileExistsError:
+                    pass
+                os.fsync(directory_fd)
         raise JournalReviewConflictError(
-            "journal candidate content changed after materialization; it was preserved"
+            "journal candidate changed during conditional retirement; the "
+            "replacement was preserved"
         )
-    os.unlink(filename, dir_fd=directory_fd)
+    try:
+        _atomic_rename_noreplace_at(
+            directory_fd,
+            retirement_name,
+            directory_fd,
+            retired_name,
+        )
+    except FileExistsError as exc:
+        raise JournalReviewConflictError(
+            "journal candidate retired archive already exists for this receipt"
+        ) from exc
     os.fsync(directory_fd)
+
+    # Re-read the inert archive after publication. It is intentionally retained
+    # as receipt-bound recovery evidence: no unlink-by-name window can delete a
+    # concurrently substituted file, and JRNL-03/JRNL-04 ignore retired names.
+    archived = _read_stable_named_bytes(directory_fd, retired_name)
+    if archived != candidate.raw:
+        try:
+            _atomic_rename_noreplace_at(
+                directory_fd,
+                retired_name,
+                directory_fd,
+                logical_name,
+            )
+        except FileExistsError:
+            pass
+        os.fsync(directory_fd)
+        raise JournalReviewConflictError(
+            "journal candidate changed during final retirement; the replacement "
+            "was preserved"
+        )
+
+
+def _read_stable_named_bytes(directory_fd: int, filename: str) -> bytes:
+    descriptor = os.open(
+        filename,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=directory_fd,
+    )
+    try:
+        opened = os.fstat(descriptor)
+        named = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or not stat.S_ISREG(named.st_mode)
+            or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
+        ):
+            raise JournalReviewConflictError(
+                "journal candidate archive must be one stable regular file"
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+        if (
+            after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+        ):
+            raise JournalReviewConflictError(
+                "journal candidate archive changed while it was verified"
+            )
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
 
 
 def _emit_event_once(
@@ -748,92 +1098,329 @@ def _emit_event_once(
     )
     if record is None:
         raise JournalReviewError("journal review receipt could not be serialized")
-    outbox_path.parent.mkdir(parents=True, exist_ok=True)
-    flags = (
-        os.O_RDWR
-        | os.O_APPEND
-        | os.O_CREAT
-        | getattr(os, "O_NOFOLLOW", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-    )
+    parent_fd, lock_fd = _lock_outbox(outbox_path)
     try:
-        descriptor = os.open(outbox_path, flags, 0o600)
+        raw, records = _read_outbox_at(parent_fd, outbox_path.name)
+        exact = [row for row in records if row.get("event_id") == event_id]
+        if len(exact) > 1:
+            raise JournalReviewConflictError(
+                "journal review receipt id appears more than once"
+            )
+        if exact and exact[0] != record:
+            raise JournalReviewConflictError(
+                "journal review receipt id already exists with different "
+                "transition evidence"
+            )
+        normalized = _normalized_outbox_bytes(raw)
+        desired = normalized
+        if not exact:
+            desired += (json.dumps(record, ensure_ascii=False) + "\n").encode(
+                "utf-8"
+            )
+        if desired != raw:
+            _atomic_replace_at(parent_fd, outbox_path.name, desired)
+        _fsync_named_file(parent_fd, outbox_path.name)
+        os.fsync(parent_fd)
+        _raw_after, records_after = _read_outbox_at(parent_fd, outbox_path.name)
+        proved = [row for row in records_after if row.get("event_id") == event_id]
+        if proved != [record]:
+            raise JournalReviewError(
+                "journal review receipt was not durably re-readable after publish"
+            )
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+        os.close(parent_fd)
+
+
+def _read_event(outbox_path: Path, event_id: str) -> dict[str, Any] | None:
+    parent_fd, lock_fd = _lock_outbox(outbox_path)
+    try:
+        _raw, records = _read_outbox_at(parent_fd, outbox_path.name)
+        exact = [row for row in records if row.get("event_id") == event_id]
+        if len(exact) > 1:
+            raise JournalReviewConflictError(
+                "journal review receipt id appears more than once"
+            )
+        return exact[0] if exact else None
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+        os.close(parent_fd)
+
+
+def _lock_outbox(outbox_path: Path) -> tuple[int, int]:
+    try:
+        parent_fd = os.open(
+            outbox_path.parent,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
     except OSError as exc:
         raise JournalReviewError(
-            f"journal review receipt store cannot be opened safely: {exc}"
+            "journal review receipt parent must already exist as a durable directory"
         ) from exc
+    lock_name = f".{outbox_path.name}.journal-review.lock"
+    lock_fd: int | None = None
+    try:
+        lock_fd = os.open(
+            lock_name,
+            os.O_RDWR
+            | os.O_CREAT
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+            dir_fd=parent_fd,
+        )
+        opened = os.fstat(lock_fd)
+        named = os.stat(lock_name, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or not stat.S_ISREG(named.st_mode)
+            or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
+        ):
+            raise JournalReviewError(
+                "journal review receipt lock must be one stable regular file"
+            )
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        named_after_lock = os.stat(
+            lock_name, dir_fd=parent_fd, follow_symlinks=False
+        )
+        opened_after_lock = os.fstat(lock_fd)
+        if (
+            not stat.S_ISREG(named_after_lock.st_mode)
+            or named_after_lock.st_nlink != 1
+            or opened_after_lock.st_nlink != 1
+            or (opened_after_lock.st_dev, opened_after_lock.st_ino)
+            != (named_after_lock.st_dev, named_after_lock.st_ino)
+        ):
+            raise JournalReviewError(
+                "journal review receipt lock changed during acquisition"
+            )
+    except BaseException:
+        if lock_fd is not None:
+            os.close(lock_fd)
+        os.close(parent_fd)
+        raise
+    assert lock_fd is not None
+    return parent_fd, lock_fd
+
+
+def _read_outbox_at(
+    parent_fd: int, filename: str
+) -> tuple[bytes, list[dict[str, Any]]]:
+    try:
+        descriptor = os.open(
+            filename,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_fd,
+        )
+    except FileNotFoundError:
+        return b"", []
     try:
         observed = os.fstat(descriptor)
-        if not stat.S_ISREG(observed.st_mode):
-            raise JournalReviewError("journal review receipt store must be regular")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        try:
-            os.lseek(descriptor, 0, os.SEEK_SET)
-            raw = b""
-            while True:
-                chunk = os.read(descriptor, 1024 * 1024)
-                if not chunk:
-                    break
-                raw += chunk
-            for line in raw.splitlines():
-                try:
-                    existing = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if existing.get("event_id") == event_id:
-                    if existing != record:
-                        raise JournalReviewConflictError(
-                            "journal review receipt id already exists with different "
-                            "transition evidence"
-                        )
-                    return
-
-            encoded = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
-            written = 0
-            while written < len(encoded):
-                written += os.write(descriptor, encoded[written:])
-            os.fsync(descriptor)
-            named = outbox_path.lstat()
-            after = os.fstat(descriptor)
-            if (
-                stat.S_ISLNK(named.st_mode)
-                or not stat.S_ISREG(named.st_mode)
-                or (named.st_dev, named.st_ino) != (after.st_dev, after.st_ino)
-            ):
-                raise JournalReviewError(
-                    "journal review receipt path changed during durable append"
-                )
-            parent_fd = os.open(
-                outbox_path.parent,
-                os.O_RDONLY
-                | getattr(os, "O_DIRECTORY", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
+        named = os.stat(filename, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(observed.st_mode)
+            or observed.st_nlink != 1
+            or not stat.S_ISREG(named.st_mode)
+            or (observed.st_dev, observed.st_ino) != (named.st_dev, named.st_ino)
+        ):
+            raise JournalReviewError(
+                "journal review receipt store must be one stable regular file"
             )
+        raw = b""
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            raw += chunk
+        observed_after = os.fstat(descriptor)
+        named_after = os.stat(filename, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            observed_after.st_size != observed.st_size
+            or observed_after.st_mtime_ns != observed.st_mtime_ns
+            or observed_after.st_ctime_ns != observed.st_ctime_ns
+            or (observed_after.st_dev, observed_after.st_ino)
+            != (named_after.st_dev, named_after.st_ino)
+        ):
+            raise JournalReviewError(
+                "journal review receipt store changed while it was read"
+            )
+    finally:
+        os.close(descriptor)
+    normalized = _normalized_outbox_bytes(raw)
+    records: list[dict[str, Any]] = []
+    for line in normalized.splitlines():
+        if not line:
+            continue
+        parsed = json.loads(line)
+        if not isinstance(parsed, dict):
+            raise JournalReviewError("journal review receipt line must be an object")
+        records.append(parsed)
+    return raw, records
+
+
+def _normalized_outbox_bytes(raw: bytes) -> bytes:
+    if not raw:
+        return b""
+    normalized = bytearray()
+    lines = raw.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        terminated = line.endswith(b"\n")
+        content = line[:-1] if terminated else line
+        if content:
             try:
-                os.fsync(parent_fd)
-            finally:
-                os.close(parent_fd)
-        finally:
-            fcntl.flock(descriptor, fcntl.LOCK_UN)
+                parsed = json.loads(content)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                if index == len(lines) - 1 and not terminated:
+                    break
+                raise JournalReviewError(
+                    "journal review receipt store contains non-tail corruption"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise JournalReviewError(
+                    "journal review receipt line must be a JSON object"
+                )
+        normalized.extend(content)
+        normalized.extend(b"\n")
+    return bytes(normalized)
+
+
+def _atomic_replace_at(parent_fd: int, filename: str, content: bytes) -> None:
+    temp_name = f".{filename}.{uuid4().hex}.tmp"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            temp_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_fd,
+        )
+        written = 0
+        while written < len(content):
+            count = os.write(descriptor, content[written:])
+            if count <= 0:
+                raise OSError("journal review receipt write made no progress")
+            written += count
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(
+            temp_name,
+            filename,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        os.fsync(parent_fd)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            os.unlink(temp_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+
+
+def _fsync_named_file(parent_fd: int, filename: str) -> None:
+    descriptor = os.open(
+        filename,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        os.fsync(descriptor)
     finally:
         os.close(descriptor)
 
 
-def _accepted_addendum_timestamp(body: bytes, marker: bytes) -> str:
-    marker_index = body.find(marker)
-    heading = body[:marker_index].rsplit("## Addendum — ".encode("utf-8"), 1)
-    if len(heading) != 2:
+def _render_addendum_block(
+    *, receipt_id: str, draft_id: str, accepted_at: str, materialized_body: str
+) -> bytes:
+    digest = hashlib.sha256(materialized_body.encode("utf-8")).hexdigest()
+    metadata = json.dumps(
+        {
+            "accepted_at": accepted_at,
+            "body_sha256": digest,
+            "draft_id": draft_id,
+            "receipt_id": receipt_id,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return (
+        f"\n<!-- journal:addendum:start {metadata} -->\n"
+        f"## Addendum — {accepted_at}\n\n"
+        f"{materialized_body.rstrip()}\n"
+        f"<!-- journal:addendum:end receipt_id={receipt_id} -->\n"
+    ).encode("utf-8")
+
+
+def _recover_addendum_block(
+    body: bytes,
+    *,
+    receipt_id: str,
+    draft_id: str,
+    materialized_body: str,
+) -> str | None:
+    prefix = b"<!-- journal:addendum:start "
+    matches: list[tuple[dict[str, Any], int]] = []
+    cursor = 0
+    while True:
+        start = body.find(prefix, cursor)
+        if start < 0:
+            break
+        line_end = body.find(b" -->\n", start)
+        if line_end < 0:
+            raise JournalReviewConflictError(
+                "accepted addendum metadata is truncated"
+            )
+        raw_metadata = body[start + len(prefix) : line_end]
+        try:
+            metadata = json.loads(raw_metadata)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise JournalReviewConflictError(
+                "accepted addendum metadata is malformed"
+            ) from exc
+        if isinstance(metadata, dict) and metadata.get("receipt_id") == receipt_id:
+            matches.append((metadata, start))
+        cursor = line_end + 5
+    if not matches:
+        return None
+    if len(matches) != 1:
         raise JournalReviewConflictError(
-            "accepted addendum receipt is missing its materialization timestamp"
+            "accepted addendum receipt appears more than once"
         )
-    raw_timestamp = heading[1].splitlines()[0]
-    try:
-        timestamp = raw_timestamp.decode("utf-8")
-    except UnicodeDecodeError as exc:
+    metadata, _start = matches[0]
+    if metadata.get("draft_id") != draft_id:
         raise JournalReviewConflictError(
-            "accepted addendum receipt has an invalid materialization timestamp"
-        ) from exc
-    return _normalized_timestamp(timestamp, description="accepted addendum receipt")
+            "accepted addendum receipt is bound to a different draft"
+        )
+    accepted_at = _normalized_timestamp(
+        metadata.get("accepted_at"), description="accepted addendum receipt"
+    )
+    expected_digest = hashlib.sha256(materialized_body.encode("utf-8")).hexdigest()
+    if metadata.get("body_sha256") != expected_digest:
+        raise JournalReviewConflictError(
+            "accepted addendum receipt body digest does not match the candidate"
+        )
+    expected = _render_addendum_block(
+        receipt_id=receipt_id,
+        draft_id=draft_id,
+        accepted_at=accepted_at,
+        materialized_body=materialized_body,
+    )
+    if body.count(expected) != 1:
+        raise JournalReviewConflictError(
+            "accepted addendum receipt does not bind one exact append block"
+        )
+    return accepted_at
 
 
 def _normalized_timestamp(value: object, *, description: str) -> str:
@@ -931,13 +1518,17 @@ __all__ = [
     "JOURNAL_ENTRY_ACCEPT_WRITE_ACTION",
     "JOURNAL_ENTRY_ACCEPTED_EVENT",
     "JOURNAL_ENTRY_DECLINED_EVENT",
+    "DEFAULT_JOURNAL_REVIEW_OUTBOX_PATH",
     "JournalAcceptedEntryExistsError",
     "JournalReviewConflictError",
     "JournalReviewError",
     "JournalReviewProjection",
     "JournalReviewResult",
     "JournalReviewState",
+    "JournalReviewTickResult",
+    "default_journal_review_outbox_path",
     "journal_draft_relative_path",
     "process_journal_review",
+    "process_journal_reviews_tick",
     "project_journal_review",
 ]

--- a/app/journaling/review.py
+++ b/app/journaling/review.py
@@ -108,6 +108,7 @@ class JournalReviewResult:
 class JournalReviewTickResult:
     scanned_dates: tuple[str, ...]
     results: tuple[JournalReviewResult, ...]
+    errors: tuple[str, ...] = ()
 
     @property
     def materialized(self) -> int:
@@ -283,6 +284,18 @@ def process_journal_review(
                 "journal candidate disappeared while its per-day lifecycle lock was held"
             ) from None
 
+        current_now = _aware_now(now)
+        if candidate.action is None and _candidate_expired(candidate, current_now):
+            return _dismiss_candidate(
+                candidate,
+                directory_fd=directory_fd,
+                canonical_rel=canonical_rel,
+                outbox_path=Path(outbox_path),
+                declined_ledger=declined_ledger or default_declined_ledger(),
+                write_guard=write_guard,
+                now=current_now,
+                reason="expired",
+            )
         if candidate.action is None:
             return _result(
                 state=JournalReviewState.NOT_YET_REVIEWED,
@@ -345,20 +358,27 @@ def process_journal_reviews_tick(
 
     dates = (only_date,) if only_date is not None else _candidate_dates(vault_context)
     receipt_path = outbox_path or default_journal_review_outbox_path()
-    results = tuple(
-        process_journal_review(
-            vault_context=vault_context,
-            for_date=for_date,
-            outbox_path=receipt_path,
-            declined_ledger=declined_ledger,
-            write_guard=write_guard,
-            now=now,
-        )
-        for for_date in dates
-    )
+    results_list: list[JournalReviewResult] = []
+    errors: list[str] = []
+    for for_date in dates:
+        try:
+            results_list.append(
+                process_journal_review(
+                    vault_context=vault_context,
+                    for_date=for_date,
+                    outbox_path=receipt_path,
+                    declined_ledger=declined_ledger,
+                    write_guard=write_guard,
+                    now=now,
+                )
+            )
+        except JournalReviewConflictError as exc:
+            errors.append(f"{for_date.isoformat()}: {exc}")
+    results = tuple(results_list)
     return JournalReviewTickResult(
         scanned_dates=tuple(item.isoformat() for item in dates),
         results=results,
+        errors=tuple(errors),
     )
 
 
@@ -576,6 +596,7 @@ def _dismiss_candidate(
     declined_ledger: DeclinedLedger,
     write_guard: WriteGuard,
     now: datetime,
+    reason: str = "human_dismissed",
 ) -> JournalReviewResult:
     # Reading/reconciling the receipt creates its lock file on first use, so
     # assert the shared decline action before any dismissal-owned filesystem
@@ -612,7 +633,7 @@ def _dismiss_candidate(
     durable_decline = declined_ledger.record_decline(
         finding_id,
         finding_class="journal.candidate",
-        reason="human_dismissed",
+        reason=reason,
         declined_at=timestamp,
         write_guard=write_guard,
     )
@@ -630,7 +651,7 @@ def _dismiss_candidate(
             "finding_id": finding_id,
             "candidate_type": candidate.candidate_type,
             "sources": list(_sources(candidate.frontmatter)),
-            "reason": "human_dismissed",
+            "reason": reason,
         },
     )
     _retire_candidate_if_unchanged(
@@ -1481,6 +1502,23 @@ def _sources(frontmatter: dict[str, Any]) -> tuple[str, ...]:
     if not isinstance(raw, list):
         return ()
     return tuple(str(item) for item in raw if str(item).strip())
+
+
+def _candidate_expired(candidate: _Candidate, now: datetime) -> bool:
+    raw_expires = candidate.frontmatter.get("expires")
+    if raw_expires is None:
+        return False
+    try:
+        expires = datetime.fromisoformat(str(raw_expires).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise JournalReviewConflictError(
+            "journal candidate has an invalid expires timestamp"
+        ) from exc
+    if expires.tzinfo is None:
+        raise JournalReviewConflictError(
+            "journal candidate expires timestamp must carry a timezone"
+        )
+    return expires.astimezone(timezone.utc) <= now
 
 
 def _projection_state(action: str | None) -> tuple[JournalReviewState, str]:

--- a/app/journaling/review.py
+++ b/app/journaling/review.py
@@ -1,0 +1,943 @@
+"""Governed review and materialization of staged journal candidates (JRNL-04).
+
+The vault-visible Panel checkbox is the sole acceptance input.  A checked
+accept action is durable pending intent; this module never needs an in-memory
+approval object or a second tap after a transient WriteGuard refusal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+from typing import Any
+
+from app.agents.panel_agent.parser import find_panels, parse_panel
+from app.journaling.draft import (
+    CANONICAL_JOURNAL_SUBDIR,
+    _draft_relative_path,
+    _locked_draft,
+)
+from app.knowledge.errors import KnowledgeWriteConflict
+from app.knowledge.write_ops import (
+    append_note_relative,
+    locked_atomic_append_authority,
+)
+from app.proposals.declined_ledger import DeclinedLedger, default_declined_ledger
+from app.services.outbox import serialize_outbox_record
+from app.vault.manager import VaultContext
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
+
+
+JOURNAL_ENTRY_ACCEPT_WRITE_ACTION = "journal.entry.accept"
+JOURNAL_ENTRY_ACCEPTED_EVENT = "journal.entry.accepted"
+JOURNAL_ENTRY_DECLINED_EVENT = "journal.entry.declined"
+JOURNAL_REVIEW_EVENT_SOURCE = "app.journaling.review"
+
+_PRIMARY_ACCEPT_LABEL = "Accept this draft as today's journal entry"
+_ADDENDUM_ACCEPT_LABEL = "Accept and append this addendum to today's journal"
+_DISMISS_LABEL = "Dismiss this journal candidate"
+
+
+class JournalReviewError(RuntimeError):
+    """Base class for fail-loud review refusals."""
+
+
+class JournalReviewConflictError(JournalReviewError):
+    """The durable review state is malformed, ambiguous, or changed."""
+
+
+class JournalAcceptedEntryExistsError(JournalReviewError):
+    """A primary candidate cannot replace an existing canonical daily note."""
+
+
+class JournalReviewState(str, Enum):
+    NOT_YET_REVIEWED = "not_yet_reviewed"
+    ACCEPTED_PENDING_MATERIALIZATION = "accepted_pending_materialization"
+    FULLY_MATERIALIZED = "fully_materialized"
+    DISMISSAL_PENDING = "dismissal_pending"
+    DISMISSED = "dismissed"
+
+
+@dataclass(frozen=True)
+class JournalReviewProjection:
+    state: JournalReviewState
+    canonical_path: str
+    candidate_path: str | None
+    candidate_type: str | None
+    rendered_body: str | None
+    status_message: str
+
+
+@dataclass(frozen=True)
+class JournalReviewResult:
+    state: JournalReviewState
+    action: str | None
+    canonical_path: str
+    candidate_path: str | None
+    candidate_type: str | None
+    receipt_id: str | None
+    decision_token_ref: str | None
+    status_message: str
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    relative_path: Path
+    candidate_type: str
+    draft_id: str
+    frontmatter: dict[str, Any]
+    body: str
+    raw: bytes
+    identity: os.stat_result
+    action: str | None
+
+
+def journal_draft_relative_path(
+    vault_root: Path, for_date: date, *, is_addendum: bool
+) -> Path:
+    """Return JRNL-03's canonical candidate location for review callers."""
+
+    return _draft_relative_path(
+        Path(vault_root).expanduser().resolve(),
+        for_date,
+        is_addendum=is_addendum,
+    )
+
+
+def project_journal_review(
+    *, vault_context: VaultContext, for_date: date
+) -> JournalReviewProjection:
+    """Render the current review state without mutating any durable surface."""
+
+    vault_root = _vault_root(vault_context)
+    canonical_rel = _canonical_relative_path(for_date)
+    canonical = vault_root / canonical_rel
+    selected = _select_candidate(vault_root, for_date)
+    if selected is None:
+        if _path_exists_no_symlink(canonical):
+            _require_accepted_canonical(canonical.read_bytes(), canonical_rel.as_posix())
+            return JournalReviewProjection(
+                state=JournalReviewState.FULLY_MATERIALIZED,
+                canonical_path=canonical_rel.as_posix(),
+                candidate_path=None,
+                candidate_type=None,
+                rendered_body=None,
+                status_message="Saved",
+            )
+        return JournalReviewProjection(
+            state=JournalReviewState.NOT_YET_REVIEWED,
+            canonical_path=canonical_rel.as_posix(),
+            candidate_path=None,
+            candidate_type=None,
+            rendered_body=None,
+            status_message="Not yet reviewed",
+        )
+
+    relative_path, candidate_type = selected
+    candidate = _read_candidate_path(
+        vault_root, relative_path, candidate_type=candidate_type, for_date=for_date
+    )
+    state, message = _projection_state(candidate.action)
+    return JournalReviewProjection(
+        state=state,
+        canonical_path=canonical_rel.as_posix(),
+        candidate_path=relative_path.as_posix(),
+        candidate_type=candidate_type,
+        rendered_body=_strip_review_panel(candidate.body),
+        status_message=message,
+    )
+
+
+def process_journal_review(
+    *,
+    vault_context: VaultContext,
+    for_date: date,
+    outbox_path: Path,
+    declined_ledger: DeclinedLedger | None = None,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    now: datetime | None = None,
+) -> JournalReviewResult:
+    """Process the checked action on the current staged journal candidate.
+
+    No approval flag, destination, or accepted body is accepted from callers.
+    The current on-disk candidate and its exact Panel action are authoritative.
+    """
+
+    vault_root = _vault_root(vault_context)
+    canonical_rel = _canonical_relative_path(for_date)
+    selected = _select_candidate(vault_root, for_date)
+    if selected is None:
+        projection = project_journal_review(
+            vault_context=vault_context, for_date=for_date
+        )
+        return JournalReviewResult(
+            state=projection.state,
+            action=None,
+            canonical_path=projection.canonical_path,
+            candidate_path=None,
+            candidate_type=None,
+            receipt_id=None,
+            decision_token_ref=None,
+            status_message=projection.status_message,
+        )
+
+    candidate_rel, candidate_type = selected
+    with _locked_draft(vault_root, candidate_rel) as (directory_fd, filename):
+        try:
+            candidate = _read_candidate_at(
+                directory_fd,
+                filename,
+                relative_path=candidate_rel,
+                candidate_type=candidate_type,
+                for_date=for_date,
+            )
+        except FileNotFoundError:
+            projection = project_journal_review(
+                vault_context=vault_context, for_date=for_date
+            )
+            return JournalReviewResult(
+                state=projection.state,
+                action=None,
+                canonical_path=projection.canonical_path,
+                candidate_path=projection.candidate_path,
+                candidate_type=projection.candidate_type,
+                receipt_id=None,
+                decision_token_ref=None,
+                status_message=projection.status_message,
+            )
+
+        if candidate.action is None:
+            return _result(
+                state=JournalReviewState.NOT_YET_REVIEWED,
+                action=None,
+                canonical_rel=canonical_rel,
+                candidate=candidate,
+                status_message="Not yet reviewed",
+            )
+        if candidate.action == "dismiss":
+            return _dismiss_candidate(
+                candidate,
+                directory_fd=directory_fd,
+                filename=filename,
+                canonical_rel=canonical_rel,
+                outbox_path=Path(outbox_path),
+                declined_ledger=declined_ledger or default_declined_ledger(),
+                write_guard=write_guard,
+                now=_aware_now(now),
+            )
+
+        try:
+            # Assert before any acceptance-owned lock, parent creation, recovery
+            # artifact, or canonical mutation. append_note_relative asserts the
+            # same named action again at the production vault port.
+            write_guard.assert_writes_allowed(JOURNAL_ENTRY_ACCEPT_WRITE_ACTION)
+        except WritesBlockedError:
+            return _result(
+                state=JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION,
+                action="accept",
+                canonical_rel=canonical_rel,
+                candidate=candidate,
+                status_message="Accepted — waiting to save",
+            )
+
+        return _accept_candidate(
+            candidate,
+            vault_root=vault_root,
+            canonical_rel=canonical_rel,
+            directory_fd=directory_fd,
+            filename=filename,
+            outbox_path=Path(outbox_path),
+            write_guard=write_guard,
+            now=_aware_now(now),
+        )
+
+
+def _accept_candidate(
+    candidate: _Candidate,
+    *,
+    vault_root: Path,
+    canonical_rel: Path,
+    directory_fd: int,
+    filename: str,
+    outbox_path: Path,
+    write_guard: WriteGuard,
+    now: datetime,
+) -> JournalReviewResult:
+    candidate_digest = hashlib.sha256(candidate.raw).hexdigest()
+    decision_token_ref = "dtok-" + hashlib.sha256(
+        (
+            f"journal-human-checkbox\x1f{candidate.draft_id}\x1f"
+            f"{candidate.candidate_type}\x1f{candidate_digest}"
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    receipt_id = "journal-accept-" + hashlib.sha256(
+        (
+            f"{decision_token_ref}\x1f{canonical_rel.as_posix()}\x1f"
+            f"{candidate.candidate_type}"
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    accepted_at = _iso(now)
+    materialized_at = accepted_at
+    materialized_body = _strip_review_panel(candidate.body).rstrip() + "\n"
+
+    if candidate.candidate_type == "primary":
+        proposed_append = materialized_body.encode("utf-8")
+
+        def primary_transform(
+            current_raw: bytes | None, proposed: bytes
+        ) -> tuple[bytes, bytes]:
+            nonlocal materialized_at
+            if current_raw is not None:
+                current_frontmatter, _current_body = _load_raw_frontmatter(current_raw)
+                if (
+                    current_frontmatter.get("authority_state") == "accepted"
+                    and current_frontmatter.get("acceptance_receipt_id") == receipt_id
+                    and current_frontmatter.get("accepted_draft_id")
+                    == candidate.draft_id
+                    and current_frontmatter.get("decision_token_ref")
+                    == decision_token_ref
+                ):
+                    _require_accepted_frontmatter(
+                        current_frontmatter, canonical_rel.as_posix()
+                    )
+                    materialized_at = _normalized_timestamp(
+                        current_frontmatter["accepted_at"],
+                        description="accepted journal entry",
+                    )
+                    return current_raw, b""
+                raise JournalAcceptedEntryExistsError(
+                    "the canonical daily note already exists; a primary candidate "
+                    "can never replace its body"
+                )
+            accepted_frontmatter = dict(candidate.frontmatter)
+            accepted_frontmatter["authority_state"] = "accepted"
+            accepted_frontmatter["accepted_by"] = "human"
+            accepted_frontmatter["accepted_at"] = accepted_at
+            accepted_frontmatter["acceptance_receipt_id"] = receipt_id
+            accepted_frontmatter["decision_token_ref"] = decision_token_ref
+            accepted_frontmatter["accepted_draft_id"] = candidate.draft_id
+            accepted_frontmatter.pop("kind", None)
+            accepted_frontmatter.pop("journal_candidate_type", None)
+            accepted_frontmatter.pop("expires", None)
+            replacement = dump_frontmatter(
+                accepted_frontmatter, proposed.decode("utf-8")
+            ).encode("utf-8")
+            return replacement, proposed
+
+        action = "accept"
+        transform = primary_transform
+    else:
+        marker = (
+            f"<!-- journal:addendum_receipt_id={receipt_id} "
+            f"draft_id={candidate.draft_id} -->"
+        )
+        proposed_append = (
+            f"\n## Addendum — {accepted_at}\n\n"
+            f"{materialized_body.rstrip()}\n\n{marker}\n"
+        ).encode("utf-8")
+
+        def addendum_transform(
+            current_raw: bytes | None, proposed: bytes
+        ) -> tuple[bytes, bytes]:
+            nonlocal materialized_at
+            if current_raw is None:
+                raise JournalAcceptedEntryExistsError(
+                    "an addendum requires an existing accepted journal entry"
+                )
+            current_frontmatter, current_body = _load_raw_frontmatter(current_raw)
+            _require_accepted_frontmatter(
+                current_frontmatter, canonical_rel.as_posix()
+            )
+            marker_bytes = marker.encode("utf-8")
+            if marker_bytes in current_body:
+                materialized_at = _accepted_addendum_timestamp(
+                    current_body, marker_bytes
+                )
+                return current_raw, b""
+            return current_raw + proposed, proposed
+
+        action = "accept_addendum"
+        transform = addendum_transform
+
+    try:
+        with locked_atomic_append_authority(
+            vault_root, canonical_rel.as_posix()
+        ) as authority:
+            append_note_relative(
+                canonical_rel.as_posix(),
+                proposed_append.decode("utf-8"),
+                vault_root=vault_root,
+                action=JOURNAL_ENTRY_ACCEPT_WRITE_ACTION,
+                write_guard=write_guard,
+                _atomic_transform=transform,
+                _atomic_authority=authority,
+            )
+    except KnowledgeWriteConflict as exc:
+        raise JournalReviewConflictError(
+            "the canonical journal entry changed during acceptance; the durable "
+            "checked candidate remains available for a safe retry"
+        ) from exc
+
+    payload = {
+        "draft_id": candidate.draft_id,
+        "candidate_type": candidate.candidate_type,
+        "final_note_path": canonical_rel.as_posix(),
+        "sources": list(_sources(candidate.frontmatter)),
+        "decision_token_ref": decision_token_ref,
+        "authority_receipt_id": receipt_id,
+        "accepted_by": "human",
+        "accepted_at": materialized_at,
+        "operation": action,
+    }
+    _emit_event_once(
+        outbox_path,
+        event=JOURNAL_ENTRY_ACCEPTED_EVENT,
+        event_id=receipt_id,
+        trace_id=candidate.draft_id,
+        timestamp=materialized_at,
+        payload=payload,
+    )
+    _unlink_candidate_if_unchanged(
+        directory_fd, filename, candidate.identity, candidate.raw
+    )
+    return _result(
+        state=JournalReviewState.FULLY_MATERIALIZED,
+        action=action,
+        canonical_rel=canonical_rel,
+        candidate=candidate,
+        receipt_id=receipt_id,
+        decision_token_ref=decision_token_ref,
+        status_message="Saved",
+    )
+
+
+def _dismiss_candidate(
+    candidate: _Candidate,
+    *,
+    directory_fd: int,
+    filename: str,
+    canonical_rel: Path,
+    outbox_path: Path,
+    declined_ledger: DeclinedLedger,
+    write_guard: WriteGuard,
+    now: datetime,
+) -> JournalReviewResult:
+    timestamp = _iso(now)
+    receipt_id = "journal-decline-" + hashlib.sha256(
+        (
+            f"{candidate.draft_id}\x1f{candidate.candidate_type}\x1f"
+            f"{hashlib.sha256(candidate.raw).hexdigest()}"
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    declined_ledger.record_decline(
+        candidate.draft_id,
+        finding_class="journal.candidate",
+        reason="human_dismissed",
+        declined_at=timestamp,
+        write_guard=write_guard,
+    )
+    _emit_event_once(
+        outbox_path,
+        event=JOURNAL_ENTRY_DECLINED_EVENT,
+        event_id=receipt_id,
+        trace_id=candidate.draft_id,
+        timestamp=timestamp,
+        payload={
+            "draft_id": candidate.draft_id,
+            "candidate_type": candidate.candidate_type,
+            "sources": list(_sources(candidate.frontmatter)),
+            "reason": "human_dismissed",
+        },
+    )
+    _unlink_candidate_if_unchanged(
+        directory_fd, filename, candidate.identity, candidate.raw
+    )
+    return _result(
+        state=JournalReviewState.DISMISSED,
+        action="dismiss",
+        canonical_rel=canonical_rel,
+        candidate=candidate,
+        receipt_id=receipt_id,
+        status_message="Dismissed",
+    )
+
+
+def _select_candidate(
+    vault_root: Path, for_date: date
+) -> tuple[Path, str] | None:
+    primary = journal_draft_relative_path(
+        vault_root, for_date, is_addendum=False
+    )
+    addendum = journal_draft_relative_path(
+        vault_root, for_date, is_addendum=True
+    )
+    primary_exists = _path_exists_no_symlink(vault_root / primary)
+    addendum_exists = _path_exists_no_symlink(vault_root / addendum)
+    if primary_exists and addendum_exists:
+        raise JournalReviewConflictError(
+            "both primary and addendum candidates exist for the same day"
+        )
+    if addendum_exists:
+        return addendum, "addendum"
+    if primary_exists:
+        return primary, "primary"
+    return None
+
+
+def _read_candidate_path(
+    vault_root: Path,
+    relative_path: Path,
+    *,
+    candidate_type: str,
+    for_date: date,
+) -> _Candidate:
+    parent = vault_root / relative_path.parent
+    parent_fd = os.open(
+        parent,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        return _read_candidate_at(
+            parent_fd,
+            relative_path.name,
+            relative_path=relative_path,
+            candidate_type=candidate_type,
+            for_date=for_date,
+        )
+    finally:
+        os.close(parent_fd)
+
+
+def _read_candidate_at(
+    directory_fd: int,
+    filename: str,
+    *,
+    relative_path: Path,
+    candidate_type: str,
+    for_date: date,
+) -> _Candidate:
+    descriptor = os.open(
+        filename,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=directory_fd,
+    )
+    try:
+        opened = os.fstat(descriptor)
+        named = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not stat.S_ISREG(named.st_mode)
+            or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
+        ):
+            raise JournalReviewConflictError(
+                "journal candidate must be one stable regular file"
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+        after = os.fstat(descriptor)
+        if (
+            after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+        ):
+            raise JournalReviewConflictError(
+                "journal candidate changed while the review action was read"
+            )
+    finally:
+        os.close(descriptor)
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise JournalReviewConflictError(
+            "journal candidate must be valid UTF-8 Markdown"
+        ) from exc
+    frontmatter, body = load_frontmatter(text)
+    _require_candidate_frontmatter(
+        frontmatter, candidate_type=candidate_type, for_date=for_date
+    )
+    action = _checked_action(body, candidate_type=candidate_type)
+    return _Candidate(
+        relative_path=relative_path,
+        candidate_type=candidate_type,
+        draft_id=str(frontmatter["uuid"]),
+        frontmatter=frontmatter,
+        body=body,
+        raw=raw,
+        identity=opened,
+        action=action,
+    )
+
+
+def _checked_action(body: str, *, candidate_type: str) -> str | None:
+    expected_accept = (
+        _ADDENDUM_ACCEPT_LABEL if candidate_type == "addendum" else _PRIMARY_ACCEPT_LABEL
+    )
+    matching_actions: list[tuple[str, bool]] = []
+    for panel in find_panels(body):
+        parsed = parse_panel(panel.raw_block, panel.panel_id)
+        for action in parsed.actions:
+            if action.label in {expected_accept, _DISMISS_LABEL}:
+                matching_actions.append((action.label, action.checked))
+
+    labels = [label for label, _checked in matching_actions]
+    if labels.count(expected_accept) != 1 or labels.count(_DISMISS_LABEL) != 1:
+        raise JournalReviewConflictError(
+            "journal candidate must carry exactly one accept and one dismiss "
+            "action in a valid AI-åtgärder Panel"
+        )
+    checked = {label for label, is_checked in matching_actions if is_checked}
+    if len(checked) > 1:
+        raise JournalReviewConflictError(
+            "journal candidate has both accept and dismiss checked"
+        )
+    if expected_accept in checked:
+        return "accept"
+    if _DISMISS_LABEL in checked:
+        return "dismiss"
+    return None
+
+
+def _strip_review_panel(body: str) -> str:
+    rendered = body
+    removed = 0
+    for panel in find_panels(body):
+        parsed = parse_panel(panel.raw_block, panel.panel_id)
+        labels = {action.label for action in parsed.actions}
+        if _DISMISS_LABEL in labels and labels.intersection(
+            {_PRIMARY_ACCEPT_LABEL, _ADDENDUM_ACCEPT_LABEL}
+        ):
+            rendered = rendered.replace(panel.raw_block, "", 1)
+            removed += 1
+    if removed != 1:
+        raise JournalReviewConflictError(
+            "journal candidate review Panel is missing or ambiguous"
+        )
+    return rendered.strip() + "\n"
+
+
+def _require_candidate_frontmatter(
+    frontmatter: dict[str, Any], *, candidate_type: str, for_date: date
+) -> None:
+    expected = {
+        "kind": "journal-draft",
+        "journal_candidate_type": candidate_type,
+        "for_date": for_date.isoformat(),
+        "derived_by": "conversation",
+        "authority_state": "proposal",
+    }
+    for key, value in expected.items():
+        if frontmatter.get(key) != value:
+            raise JournalReviewConflictError(
+                f"journal candidate has invalid {key!r}; expected {value!r}"
+            )
+    if not str(frontmatter.get("uuid") or "").strip():
+        raise JournalReviewConflictError("journal candidate requires a durable uuid")
+    if not _sources(frontmatter):
+        raise JournalReviewConflictError(
+            "journal candidate requires permanent source provenance"
+        )
+
+
+def _require_accepted_canonical(raw: bytes, path: str) -> None:
+    frontmatter, _body = _load_raw_frontmatter(raw)
+    _require_accepted_frontmatter(frontmatter, path)
+
+
+def _require_accepted_frontmatter(frontmatter: dict[str, Any], path: str) -> None:
+    if (
+        frontmatter.get("authority_state") != "accepted"
+        or frontmatter.get("accepted_by") != "human"
+        or frontmatter.get("derived_by") != "conversation"
+        or not frontmatter.get("acceptance_receipt_id")
+        or not frontmatter.get("accepted_at")
+        or not frontmatter.get("decision_token_ref")
+    ):
+        raise JournalAcceptedEntryExistsError(
+            f"canonical journal target {path} exists but is not a JRNL-04 accepted entry"
+        )
+
+
+def _load_raw_frontmatter(raw: bytes) -> tuple[dict[str, Any], bytes]:
+    text = raw.decode("utf-8")
+    frontmatter, body = load_frontmatter(text)
+    body_bytes = body.encode("utf-8")
+    if not raw.endswith(body_bytes):
+        raise JournalReviewConflictError(
+            "canonical journal frontmatter/body boundary is not stable UTF-8"
+        )
+    return frontmatter, body_bytes
+
+
+def _unlink_candidate_if_unchanged(
+    directory_fd: int,
+    filename: str,
+    expected: os.stat_result,
+    expected_raw: bytes,
+) -> None:
+    try:
+        current = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if (
+        not stat.S_ISREG(current.st_mode)
+        or (current.st_dev, current.st_ino) != (expected.st_dev, expected.st_ino)
+        or current.st_size != expected.st_size
+        or current.st_mtime_ns != expected.st_mtime_ns
+        or current.st_ctime_ns != expected.st_ctime_ns
+    ):
+        raise JournalReviewConflictError(
+            "journal candidate changed after materialization; it was preserved for review"
+        )
+    descriptor = os.open(
+        filename,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=directory_fd,
+    )
+    try:
+        current_raw = b""
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            current_raw += chunk
+    finally:
+        os.close(descriptor)
+    if current_raw != expected_raw:
+        raise JournalReviewConflictError(
+            "journal candidate content changed after materialization; it was preserved"
+        )
+    os.unlink(filename, dir_fd=directory_fd)
+    os.fsync(directory_fd)
+
+
+def _emit_event_once(
+    outbox_path: Path,
+    *,
+    event: str,
+    event_id: str,
+    trace_id: str,
+    timestamp: str,
+    payload: dict[str, Any],
+) -> None:
+    record = serialize_outbox_record(
+        {
+            "event": event,
+            "event_id": event_id,
+            "trace_id": trace_id,
+            "source": JOURNAL_REVIEW_EVENT_SOURCE,
+            "timestamp": timestamp,
+            "payload": payload,
+        },
+        default_source=JOURNAL_REVIEW_EVENT_SOURCE,
+    )
+    if record is None:
+        raise JournalReviewError("journal review receipt could not be serialized")
+    outbox_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = (
+        os.O_RDWR
+        | os.O_APPEND
+        | os.O_CREAT
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        descriptor = os.open(outbox_path, flags, 0o600)
+    except OSError as exc:
+        raise JournalReviewError(
+            f"journal review receipt store cannot be opened safely: {exc}"
+        ) from exc
+    try:
+        observed = os.fstat(descriptor)
+        if not stat.S_ISREG(observed.st_mode):
+            raise JournalReviewError("journal review receipt store must be regular")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            raw = b""
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                raw += chunk
+            for line in raw.splitlines():
+                try:
+                    existing = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if existing.get("event_id") == event_id:
+                    if existing != record:
+                        raise JournalReviewConflictError(
+                            "journal review receipt id already exists with different "
+                            "transition evidence"
+                        )
+                    return
+
+            encoded = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
+            written = 0
+            while written < len(encoded):
+                written += os.write(descriptor, encoded[written:])
+            os.fsync(descriptor)
+            named = outbox_path.lstat()
+            after = os.fstat(descriptor)
+            if (
+                stat.S_ISLNK(named.st_mode)
+                or not stat.S_ISREG(named.st_mode)
+                or (named.st_dev, named.st_ino) != (after.st_dev, after.st_ino)
+            ):
+                raise JournalReviewError(
+                    "journal review receipt path changed during durable append"
+                )
+            parent_fd = os.open(
+                outbox_path.parent,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+            try:
+                os.fsync(parent_fd)
+            finally:
+                os.close(parent_fd)
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def _accepted_addendum_timestamp(body: bytes, marker: bytes) -> str:
+    marker_index = body.find(marker)
+    heading = body[:marker_index].rsplit("## Addendum — ".encode("utf-8"), 1)
+    if len(heading) != 2:
+        raise JournalReviewConflictError(
+            "accepted addendum receipt is missing its materialization timestamp"
+        )
+    raw_timestamp = heading[1].splitlines()[0]
+    try:
+        timestamp = raw_timestamp.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise JournalReviewConflictError(
+            "accepted addendum receipt has an invalid materialization timestamp"
+        ) from exc
+    return _normalized_timestamp(timestamp, description="accepted addendum receipt")
+
+
+def _normalized_timestamp(value: object, *, description: str) -> str:
+    try:
+        timestamp = str(value)
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise JournalReviewConflictError(
+            f"{description} has an invalid materialization timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise JournalReviewConflictError(
+            f"{description} timestamp must carry a timezone"
+        )
+    return _iso(parsed.astimezone(timezone.utc))
+
+
+def _path_exists_no_symlink(path: Path) -> bool:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return False
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+        raise JournalReviewConflictError(
+            f"journal review path {path} must be a regular non-symlink file"
+        )
+    return True
+
+
+def _sources(frontmatter: dict[str, Any]) -> tuple[str, ...]:
+    raw = frontmatter.get("sources")
+    if not isinstance(raw, list):
+        return ()
+    return tuple(str(item) for item in raw if str(item).strip())
+
+
+def _projection_state(action: str | None) -> tuple[JournalReviewState, str]:
+    if action == "accept":
+        return (
+            JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION,
+            "Accepted — waiting to save",
+        )
+    if action == "dismiss":
+        return JournalReviewState.DISMISSAL_PENDING, "Dismissal pending"
+    return JournalReviewState.NOT_YET_REVIEWED, "Not yet reviewed"
+
+
+def _result(
+    *,
+    state: JournalReviewState,
+    action: str | None,
+    canonical_rel: Path,
+    candidate: _Candidate,
+    status_message: str,
+    receipt_id: str | None = None,
+    decision_token_ref: str | None = None,
+) -> JournalReviewResult:
+    return JournalReviewResult(
+        state=state,
+        action=action,
+        canonical_path=canonical_rel.as_posix(),
+        candidate_path=candidate.relative_path.as_posix(),
+        candidate_type=candidate.candidate_type,
+        receipt_id=receipt_id,
+        decision_token_ref=decision_token_ref,
+        status_message=status_message,
+    )
+
+
+def _canonical_relative_path(for_date: date) -> Path:
+    return CANONICAL_JOURNAL_SUBDIR / f"{for_date.isoformat()}.md"
+
+
+def _vault_root(context: VaultContext) -> Path:
+    if context.status != "selected" or not context.active_vault_path:
+        raise ValueError("journal review requires a selected active vault")
+    root = Path(context.active_vault_path).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError("journal review requires an existing active vault")
+    return root
+
+
+def _aware_now(value: datetime | None) -> datetime:
+    selected = value or datetime.now(timezone.utc)
+    if selected.tzinfo is None:
+        selected = selected.replace(tzinfo=timezone.utc)
+    return selected.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+__all__ = [
+    "JOURNAL_ENTRY_ACCEPT_WRITE_ACTION",
+    "JOURNAL_ENTRY_ACCEPTED_EVENT",
+    "JOURNAL_ENTRY_DECLINED_EVENT",
+    "JournalAcceptedEntryExistsError",
+    "JournalReviewConflictError",
+    "JournalReviewError",
+    "JournalReviewProjection",
+    "JournalReviewResult",
+    "JournalReviewState",
+    "journal_draft_relative_path",
+    "process_journal_review",
+    "project_journal_review",
+]

--- a/app/knowledge/write_ops.py
+++ b/app/knowledge/write_ops.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import errno
 import ctypes
-from contextlib import contextmanager
-from dataclasses import dataclass
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass, replace
 import fcntl
 import hashlib
 import json
@@ -12,6 +12,8 @@ from pathlib import Path, PurePosixPath
 import re
 import stat
 import sys
+import tempfile
+import threading
 from typing import TYPE_CHECKING, Callable, Iterator, Literal
 import uuid
 
@@ -66,6 +68,8 @@ _ATOMIC_APPEND_STAGE_RE = re.compile(
 _ATOMIC_APPEND_RECOVERY_TEMP_RE = re.compile(
     r"^\.atomic-append-recovery-[0-9a-f]{32}-[a-z]+-[0-9a-f]{32}\.tmp$"
 )
+_ATOMIC_APPEND_PROCESS_LOCKS_GUARD = threading.Lock()
+_ATOMIC_APPEND_PROCESS_LOCKS: dict[str, threading.RLock] = {}
 
 
 @dataclass(frozen=True)
@@ -253,6 +257,126 @@ def _open_atomic_append_authority(
         yield authority
     finally:
         os.close(root_fd)
+
+
+@contextmanager
+def locked_atomic_append_authority(
+    vault_root: Path | str,
+    note_rel_path: str,
+) -> Iterator[_AtomicAppendAuthority]:
+    """Bind the hardened atomic-append mechanism to one live path authority.
+
+    The atomic publisher needs both in-process/resource locks and independent
+    host witnesses before it may interpret or advance recovery state.  This
+    public wrapper supplies that authority for consumers beyond Heimdal while
+    keeping one lock namespace for each resolved target.
+    """
+
+    with _open_atomic_append_authority(vault_root, note_rel_path) as authority:
+        lock_keys = sorted(authority.coordination_keys)
+        with _ATOMIC_APPEND_PROCESS_LOCKS_GUARD:
+            process_locks = [
+                _ATOMIC_APPEND_PROCESS_LOCKS.setdefault(key, threading.RLock())
+                for key in lock_keys
+            ]
+
+        lock_root = Path(tempfile.gettempdir()) / "agentic-pkm-atomic-append-locks"
+        with ExitStack() as stack:
+            for process_lock in process_locks:
+                stack.enter_context(process_lock)
+            directory_flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0)
+            )
+            lock_parent_fd = os.open(lock_root.parent, directory_flags)
+            stack.callback(os.close, lock_parent_fd)
+            try:
+                os.mkdir(lock_root.name, mode=0o700, dir_fd=lock_parent_fd)
+            except FileExistsError:
+                pass
+            os.fsync(lock_parent_fd)
+            lock_root_fd = os.open(
+                lock_root.name,
+                directory_flags,
+                dir_fd=lock_parent_fd,
+            )
+            stack.callback(os.close, lock_root_fd)
+            os.fsync(lock_root_fd)
+
+            lock_fds: list[int] = []
+            for key in lock_keys:
+                name = f"{hashlib.sha256(key.encode('utf-8')).hexdigest()}.lock"
+                file_flags = (
+                    os.O_RDWR
+                    | getattr(os, "O_NOFOLLOW", 0)
+                    | getattr(os, "O_CLOEXEC", 0)
+                )
+                try:
+                    lock_fd = os.open(
+                        name,
+                        file_flags | os.O_CREAT | os.O_EXCL,
+                        0o600,
+                        dir_fd=lock_root_fd,
+                    )
+                except FileExistsError:
+                    lock_fd = os.open(name, file_flags, dir_fd=lock_root_fd)
+                stack.callback(os.close, lock_fd)
+                observed = os.fstat(lock_fd)
+                if not stat.S_ISREG(observed.st_mode) or observed.st_nlink != 1:
+                    raise KnowledgeWriteConflict(
+                        "atomic append host lock must be one regular file"
+                    )
+                lock_fds.append(lock_fd)
+            os.fsync(lock_root_fd)
+            for lock_fd in lock_fds:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+            host_state_fd = _open_durable_host_fence_root(authority)
+            lock_fd_by_key = {
+                key: lock_fd
+                for key, lock_fd in zip(lock_keys, lock_fds, strict=True)
+            }
+            bound_authority = replace(
+                authority,
+                host_state_fd=host_state_fd,
+                host_state_stat=os.fstat(host_state_fd),
+                host_witness_root_path=lock_root,
+                host_witness_root_fd=lock_root_fd,
+                host_witness_root_stat=os.fstat(lock_root_fd),
+                host_witness_fds=tuple(
+                    (key, lock_fd_by_key[key])
+                    for key in authority.coordination_keys
+                ),
+            )
+            try:
+                bound_authority.assert_live()
+                bound_authority.assert_host_state_live()
+                bound_authority.assert_host_witness_live()
+                _bind_host_append_route(bound_authority)
+                _require_no_host_indeterminate_fence(bound_authority)
+                yield bound_authority
+                try:
+                    bound_authority.assert_live()
+                    bound_authority.assert_host_state_live()
+                    bound_authority.assert_host_witness_live()
+                    _require_no_host_indeterminate_fence(bound_authority)
+                    _require_host_append_route_live(bound_authority)
+                except KnowledgeWriteConflict:
+                    try:
+                        _mark_host_atomic_append_indeterminate(
+                            bound_authority,
+                            "post-transaction-authority-check",
+                            "root or host authority changed before lock release",
+                        )
+                    except BaseException:
+                        pass
+                    raise
+            finally:
+                os.close(host_state_fd)
+                for lock_fd in reversed(lock_fds):
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
 
 @dataclass(frozen=True)
@@ -4579,6 +4703,7 @@ __all__ = [
     "candidate_note_exists_durable",
     "create_candidate_note_once",
     "default_vault_root_for_path",
+    "locked_atomic_append_authority",
     "read_note_text_with_version",
     "write_note_from_absolute",
     "write_note_relative",

--- a/app/proposals/declined_ledger.py
+++ b/app/proposals/declined_ledger.py
@@ -40,7 +40,8 @@ ADR):
   the id scheme it consumes.
 - **Idempotent decline recording.** Recording the same ``finding_id`` as
   declined twice is a no-op (one ledger line survives per finding_id, keeping
-  the newest receipt); it never raises and never duplicates suppression.
+  the first durable receipt); it never changes evidence under a stable id and
+  never duplicates suppression.
 - **WriteGuard-gated, named action.** :data:`DECLINED_LEDGER_WRITE_ACTION`
   (``proposals.declined_ledger.record``) is asserted before any file I/O,
   matching the dotted ``<module>.<verb>`` convention used elsewhere
@@ -53,8 +54,14 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass
+import fcntl
 from pathlib import Path
+import stat
+import threading
+from typing import Iterator
+from uuid import uuid4
 
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 
@@ -65,6 +72,8 @@ DECLINED_LEDGER_WRITE_ACTION = "proposals.declined_ledger.record"
 # app.relevance.attention_loop.DEFAULT_REACHOUT_RECEIPTS_PATH and siblings
 # (runtime/<module>/*.jsonl, gitignored, safe to delete wholesale).
 DEFAULT_DECLINED_LEDGER_PATH = Path("runtime/proposals/declined.jsonl")
+_PROCESS_LOCKS_GUARD = threading.Lock()
+_PROCESS_LOCKS: dict[str, threading.RLock] = {}
 
 
 @dataclass(frozen=True)
@@ -155,6 +164,11 @@ class DeclinedLedger:
         """
         return finding_id in self._read_all()
 
+    def get_receipt(self, finding_id: str) -> DeclineReceipt | None:
+        """Return the first durable receipt for one suppression identity."""
+
+        return self._read_all().get(finding_id)
+
     def record_decline(
         self,
         finding_id: str,
@@ -163,25 +177,116 @@ class DeclinedLedger:
         reason: str | None = None,
         declined_at: str | None = None,
         write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    ) -> None:
+    ) -> DeclineReceipt:
         """Record *finding_id* as declined. Idempotent: re-recording the same
-        finding_id replaces its single ledger line rather than duplicating
-        it (rewrite-on-write keeps the store O(distinct finding_ids), not
-        O(decline events))."""
+        finding_id preserves its first durable receipt rather than changing
+        evidence under a stable identity. The complete read/merge/replace is
+        serialized across threads and processes and published atomically."""
         write_guard.assert_writes_allowed(DECLINED_LEDGER_WRITE_ACTION)
 
-        receipts = self._read_all()
-        receipts[finding_id] = DeclineReceipt(
+        proposed = DeclineReceipt(
             finding_id=finding_id,
             finding_class=finding_class,
             reason=reason,
             declined_at=declined_at,
         )
+        with self._locked_store():
+            receipts = self._read_all()
+            receipt = receipts.get(finding_id) or proposed
+            receipts[finding_id] = receipt
+            self._atomic_replace(receipts)
+            return receipt
+
+    @contextmanager
+    def _locked_store(self) -> Iterator[None]:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        lines = [receipt.to_json_line() for receipt in receipts.values()]
-        self._path.write_text(
-            "\n".join(lines) + ("\n" if lines else ""), encoding="utf-8"
+        key = os.path.abspath(os.fspath(self._path))
+        with _PROCESS_LOCKS_GUARD:
+            process_lock = _PROCESS_LOCKS.setdefault(key, threading.RLock())
+        with process_lock:
+            lock_path = self._path.with_name(f".{self._path.name}.lock")
+            descriptor = os.open(
+                lock_path,
+                os.O_RDWR
+                | os.O_CREAT
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            try:
+                observed = os.fstat(descriptor)
+                named = lock_path.lstat()
+                if (
+                    not stat.S_ISREG(observed.st_mode)
+                    or observed.st_nlink != 1
+                    or not stat.S_ISREG(named.st_mode)
+                    or (observed.st_dev, observed.st_ino)
+                    != (named.st_dev, named.st_ino)
+                ):
+                    raise RuntimeError("declined ledger lock must be one stable file")
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+                named_after_lock = lock_path.lstat()
+                opened_after_lock = os.fstat(descriptor)
+                if (
+                    not stat.S_ISREG(named_after_lock.st_mode)
+                    or named_after_lock.st_nlink != 1
+                    or opened_after_lock.st_nlink != 1
+                    or (opened_after_lock.st_dev, opened_after_lock.st_ino)
+                    != (named_after_lock.st_dev, named_after_lock.st_ino)
+                ):
+                    raise RuntimeError(
+                        "declined ledger lock changed during acquisition"
+                    )
+                yield
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+
+    def _atomic_replace(self, receipts: dict[str, DeclineReceipt]) -> None:
+        lines = [receipts[key].to_json_line() for key in sorted(receipts)]
+        encoded = ("\n".join(lines) + ("\n" if lines else "")).encode("utf-8")
+        parent_fd = os.open(
+            self._path.parent,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
         )
+        temp_name = f".{self._path.name}.{uuid4().hex}.tmp"
+        temp_fd: int | None = None
+        try:
+            temp_fd = os.open(
+                temp_name,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=parent_fd,
+            )
+            written = 0
+            while written < len(encoded):
+                count = os.write(temp_fd, encoded[written:])
+                if count <= 0:
+                    raise OSError("declined ledger atomic write made no progress")
+                written += count
+            os.fsync(temp_fd)
+            os.close(temp_fd)
+            temp_fd = None
+            os.replace(
+                temp_name,
+                self._path.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.fsync(parent_fd)
+        finally:
+            if temp_fd is not None:
+                os.close(temp_fd)
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
 
     def suppressed_count(self, finding_ids: list[str]) -> int:
         """Count how many of *finding_ids* are currently declined -- a small

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -27,6 +27,7 @@ from app.events.types import INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
 from app.knowledge.errors import KnowledgeWriteConflict
 from app.knowledge.write_ops import read_note_text_with_version
 from app.knowledge.write_ops import write_note_from_absolute
+from app.journaling.review import process_journal_reviews_tick
 from app.objects import resolve_canonical_object_id
 from app.services.note_uuid import ensure_note_uuid
 from app.services.outbox import (
@@ -1651,6 +1652,7 @@ def run_registry_once(config_path: Path) -> dict[str, dict[str, object]]:
         now=now,
         cadence=BriefingTickCadence(),
     )
+    summaries["journal_review"] = _run_journal_review_tick(cfg)
     enqueue_failures_total = sum(state.enqueue_failures_total for state in states.values())
     write_registry_heartbeat(
         path=cfg.heartbeat_path,
@@ -1707,6 +1709,7 @@ def run_registry_forever(config_path: Path, *, max_ticks: int | None = None) -> 
             now=now,
             cadence=briefing_cadence,
         )
+        summaries["journal_review"] = _run_journal_review_tick(cfg)
         enqueue_failures_total = sum(state.enqueue_failures_total for state in states.values())
         write_registry_heartbeat(
             path=cfg.heartbeat_path,
@@ -1775,6 +1778,44 @@ def _run_briefing_tick(
     except Exception as exc:
         logger.exception("daily briefing scheduled tick failed")
         return {"triggered": False, "reason": "generation_failed", "error": str(exc)}
+
+
+def _run_journal_review_tick(cfg: RegistryConfig) -> dict[str, object]:
+    """Advance durable checked journal intent on every production watcher cycle."""
+
+    if not cfg.enable:
+        return {"scanned": 0, "reason": "watcher_disabled"}
+    if cfg.stop_file.exists():
+        return {"scanned": 0, "reason": "watcher_paused"}
+    try:
+        context = VaultManager().validate_vault(cfg.vault_path)
+        override = os.getenv("JOURNAL_REVIEW_OUTBOX_PATH", "").strip()
+        receipt_path = (
+            Path(override).expanduser()
+            if override
+            else cfg.state_dir / "journal-review-outbox.jsonl"
+        )
+        result = process_journal_reviews_tick(
+            vault_context=context,
+            outbox_path=receipt_path,
+        )
+        return {
+            "scanned": len(result.scanned_dates),
+            "materialized": result.materialized,
+            "pending": result.pending,
+            "reason": "processed",
+        }
+    except Exception as exc:
+        # The checked candidate remains the pending authority. Surface the
+        # failure and let the next production watcher cycle retry it.
+        logger.exception("journal review production tick failed")
+        return {
+            "scanned": 0,
+            "materialized": 0,
+            "pending": 1,
+            "reason": "processing_failed",
+            "error": str(exc),
+        }
 
 
 __all__ = [

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1789,6 +1789,8 @@ def _run_journal_review_tick(cfg: RegistryConfig) -> dict[str, object]:
         return {"scanned": 0, "reason": "watcher_paused"}
     try:
         context = VaultManager().validate_vault(cfg.vault_path)
+        if context.status != "selected" or not context.active_vault_path:
+            return {"scanned": 0, "reason": "vault_not_selected"}
         override = os.getenv("JOURNAL_REVIEW_OUTBOX_PATH", "").strip()
         receipt_path = (
             Path(override).expanduser()

--- a/docs/CONVERSATIONAL_JOURNALING/REVIEW_ACCEPT_JOURNAL.md
+++ b/docs/CONVERSATIONAL_JOURNALING/REVIEW_ACCEPT_JOURNAL.md
@@ -25,6 +25,17 @@ JRNL-03 stages a candidate; nobody has looked at it yet. This task is the review
 6. **Acceptance intent survives a blocked write path.** If WriteGuard is unhealthy/blocked at the moment of promotion, the checked box itself is already durable (it lives in the staged draft file, on disk, independent of promotion succeeding). The review surface must show an honest **"accepted, pending materialization"** state — distinct from both "not yet reviewed" and "fully materialized" — and a retry path re-attempts promotion without requiring the owner to re-click; the acceptance intent is never silently dropped.
 7. **Every action is a tap/click affordance.** Accept, dismiss, and expand/read all require zero typing; only the optional edit-before-accept step introduces free text, and it is never required.
 
+The canonical production registry watcher invokes
+`app.journaling.review.process_journal_reviews_tick` on every cycle. It scans the vault-durable
+journal candidate queue, processes checked actions, and automatically retries them; a checked
+accept blocked by WriteGuard is rediscovered by a later healthy watcher tick without another tap.
+`python -m app.cli journaling review-tick` exposes the same deterministic processor for an explicit
+operator run, while `journaling review-status` projects one date without mutation. Authority
+receipts use a dedicated `journal-review-outbox.jsonl` under the watcher state directory in
+production (or `JOURNAL_REVIEW_OUTBOX_PATH` when configured), separate from the runtime index audit
+log. Standalone callers default to `runtime/journal-review-outbox.jsonl` and must provision its
+parent directory durably.
+
 ## Concretely
 
 ```
@@ -81,7 +92,7 @@ Assembling day context (JRNL-01), leading the conversation (JRNL-02), and genera
 
 ## Restart / Durability Posture
 
-The staged draft, the checked/unchecked state of its acceptance checkbox, and any already-accepted journal note are all vault-durable — a restart at any point (before, during, or after a tap) loses none of this. The one non-durable element is an in-flight *promotion attempt* itself (the process of moving/writing the accepted note if it was interrupted mid-write): the promotion write is atomic-or-absent, so a restart mid-promotion leaves either the pre-acceptance staged state (checkbox still shows checked, note not yet at its final location — surfaced as "accepted, pending materialization") or a complete accepted note, never a half-written one. The owner experiences, at worst, a slightly delayed materialization after a restart — never a lost acceptance and never a corrupted note.
+The staged draft, the checked/unchecked state of its acceptance checkbox, and any already-accepted journal note are all vault-durable — a restart at any point (before, during, or after a tap) loses none of this. JRNL-03 and JRNL-04 share one per-day lifecycle lock across the primary candidate, addendum candidate, canonical transition, and receipt-bound candidate retirement, so draft regeneration cannot erase checked intent or stage an addendum while primary acceptance is still reconciling. Canonical publication is atomic-or-absent; deterministic canonical/addendum evidence reconciles a receipt interrupted after publication; the receipt is atomically replaced, fsynced, reread, and proven before the candidate is conditionally moved from its visible queue name to a receipt-bound, scanner-inert archive. The archive is retained as recovery evidence instead of being unlinked through a replacement race. A restart therefore resumes from the checked or receipt-bound queue item and never requires a second owner action.
 
 ## Related Docs
 

--- a/docs/FRONTMATTER.md
+++ b/docs/FRONTMATTER.md
@@ -129,8 +129,13 @@ Conversational Journaling's JRNL-03 staging path (`app/journaling/draft.py`) use
 posture without extending Create's closed output-kind enum: it writes `derived_by: conversation`,
 `authority_state: proposal`, and a `sources` list containing the reflection-session id plus every
 day-context provenance reference folded into the draft. These fields do not make the draft human
-knowledge or authorize promotion. JRNL-04's separate, explicit acceptance path owns any later move
-to `authority_state: accepted`. JRNL-03 also writes `activation_receipt_id` plus an
+knowledge or authorize promotion. JRNL-04's separate acceptance path (`app/journaling/review.py`)
+owns the only move to `authority_state: accepted`: it reads the checked in-note Panel action as the
+human decision, preserves `derived_by`/`sources`, and stamps `accepted_by: human`, `accepted_at`,
+`acceptance_receipt_id`, and `decision_token_ref`. A checked action remains a durable pending intent
+when WriteGuard blocks materialization; a later healthy retry needs no second approval. Accepted
+primary entries are never replaced, while independently accepted addenda append under their own
+receipt marker. JRNL-03 also writes `activation_receipt_id` plus an
 `activation_receipts` list of content-free gate records into the same atomically replaced proposal;
 the current id and retained earlier same-day ids therefore remain resolvable after restart without a
 separate receipt write that could diverge from the draft.

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -819,8 +819,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         "journaling",
         (
             "app/journaling/",
+            "app/cli/journaling.py",
             "app/activation/journal_draft.py",
             "app/knowledge_compilation/proposal_builders.py",
+            "app/proposals/declined_ledger.py",
             "tests/journaling/",
             "docs/CONVERSATIONAL_JOURNALING/",
         ),

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -830,6 +830,8 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/journaling",
             "tests/activation/test_journal_draft_activation.py",
             "tests/knowledge_compilation/test_proposal_builders.py",
+            "tests/proposals/test_declined_ledger.py",
+            "tests/cli/test_journaling_review_cli.py",
         ),
     ),
     (

--- a/tests/cli/test_journaling_review_cli.py
+++ b/tests/cli/test_journaling_review_cli.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from app.cli.journaling import journaling_group
+from app.journaling.review import (
+    JournalReviewState,
+    JournalReviewTickResult,
+)
+
+
+def test_review_tick_cli_invokes_production_observer(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    observed: dict[str, object] = {}
+
+    def fake_tick(**kwargs: object) -> JournalReviewTickResult:
+        observed.update(kwargs)
+        return JournalReviewTickResult(scanned_dates=("2026-07-15",), results=())
+
+    monkeypatch.setattr("app.cli.journaling.process_journal_reviews_tick", fake_tick)
+    result = CliRunner().invoke(
+        journaling_group,
+        [
+            "review-tick",
+            "--vault-root",
+            str(vault),
+            "--date",
+            "2026-07-15",
+            "--outbox-path",
+            str(tmp_path / "outbox.jsonl"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed["only_date"] == date(2026, 7, 15)
+    assert '"scanned_dates": ["2026-07-15"]' in result.output
+
+
+def test_review_status_cli_projects_without_processing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    class Projection:
+        state = JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION
+        candidate_path = "draft.md"
+        canonical_path = "daily.md"
+        status_message = "Accepted — waiting to save"
+
+    monkeypatch.setattr(
+        "app.cli.journaling.project_journal_review",
+        lambda **_kwargs: Projection(),
+    )
+    result = CliRunner().invoke(
+        journaling_group,
+        [
+            "review-status",
+            "--vault-root",
+            str(vault),
+            "--date",
+            "2026-07-15",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"state": "accepted_pending_materialization"' in result.output

--- a/tests/heimdal/test_interest_steering.py
+++ b/tests/heimdal/test_interest_steering.py
@@ -34,9 +34,11 @@ from datetime import datetime, timedelta, timezone
 import errno
 import json
 import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
 import os
 from pathlib import Path
 import queue
+import threading
 import re
 import stat
 import subprocess
@@ -80,7 +82,7 @@ def _isolated_atomic_append_host_fence(
     host_temp_root = tmp_path / "host-temp"
     host_temp_root.mkdir()
     monkeypatch.setattr(
-        steering_module.tempfile,
+        write_ops_module.tempfile,
         "gettempdir",
         lambda: os.fspath(host_temp_root),
     )
@@ -95,8 +97,8 @@ def _host_fence_root() -> Path:
 
 
 def _host_witness_paths(vault_root: Path) -> tuple[Path, ...]:
-    lock_root = Path(steering_module.tempfile.gettempdir()) / (
-        "agentic-pkm-heimdal-locks"
+    lock_root = Path(write_ops_module.tempfile.gettempdir()) / (
+        "agentic-pkm-atomic-append-locks"
     )
     with write_ops_module._open_atomic_append_authority(
         vault_root,
@@ -104,20 +106,20 @@ def _host_witness_paths(vault_root: Path) -> tuple[Path, ...]:
     ) as authority:
         return tuple(
             lock_root
-            / f"{steering_module.hashlib.sha256(key.encode('utf-8')).hexdigest()}.lock"
+            / f"{write_ops_module.hashlib.sha256(key.encode('utf-8')).hexdigest()}.lock"
             for key in authority.host_state_keys
         )
 
 
 def _host_route_paths(vault_root: Path) -> tuple[Path, Path, Path]:
-    lock_root = Path(steering_module.tempfile.gettempdir()) / (
-        "agentic-pkm-heimdal-locks"
+    lock_root = Path(write_ops_module.tempfile.gettempdir()) / (
+        "agentic-pkm-atomic-append-locks"
     )
     with write_ops_module._open_atomic_append_authority(
         vault_root,
         note_rel_path(STEERING_LOG),
     ) as authority:
-        token = steering_module.hashlib.sha256(
+        token = write_ops_module.hashlib.sha256(
             authority.route_key.encode("utf-8")
         ).hexdigest()
     return (
@@ -735,6 +737,38 @@ def test_concurrent_steering_log_appends_preserve_all_entries_and_bookkeeping(
     assert note.values["entry_count"] == writer_count
     last_entry = [line for line in body.splitlines() if '"operation_id":' in line][-1]
     assert note.values["last_appended"] == last_entry.split("]", 1)[0].removeprefix("- [")
+
+
+def test_generic_atomic_authority_and_heimdal_delegate_share_one_lock_namespace(
+    tmp_path: Path,
+) -> None:
+    vault_root = _vault(tmp_path)
+    relative = note_rel_path(STEERING_LOG)
+    generic_acquired = threading.Event()
+    release_generic = threading.Event()
+    heimdal_acquired = threading.Event()
+
+    def hold_generic() -> None:
+        with write_ops_module.locked_atomic_append_authority(
+            vault_root, relative
+        ):
+            generic_acquired.set()
+            assert release_generic.wait(timeout=5)
+
+    def acquire_heimdal() -> None:
+        assert generic_acquired.wait(timeout=5)
+        with steering_module._locked_steering_log(vault_root):
+            heimdal_acquired.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(hold_generic)
+        second = executor.submit(acquire_heimdal)
+        assert generic_acquired.wait(timeout=5)
+        assert not heimdal_acquired.wait(timeout=0.1)
+        release_generic.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+    assert heimdal_acquired.is_set()
 
 
 def test_steering_log_retry_recovers_interrupted_states(
@@ -2485,12 +2519,12 @@ def test_steering_log_cross_key_unrelated_clean_cohort_blocks_unchanged(
             json.dumps(foreign_clean, ensure_ascii=True, sort_keys=True) + "\n"
         ).encode()
         state_path.write_bytes(foreign_raw)
-        witness_token = steering_module.hashlib.sha256(
+        witness_token = write_ops_module.hashlib.sha256(
             changed_key.encode("utf-8")
         ).hexdigest()
         witness_path = (
-            Path(steering_module.tempfile.gettempdir())
-            / "agentic-pkm-heimdal-locks"
+            Path(write_ops_module.tempfile.gettempdir())
+            / "agentic-pkm-atomic-append-locks"
             / f"{witness_token}.lock"
         )
         witness_path.write_bytes(foreign_raw)
@@ -2909,12 +2943,12 @@ def test_steering_log_impossible_cross_key_frontier_blocks_unchanged(
     later_state_path = state_paths[1]
     later_swap_path = later_state_path.with_suffix(".swap")
     later_key = json.loads(later_state_path.read_text())["path_lock_key"]
-    witness_token = steering_module.hashlib.sha256(
+    witness_token = write_ops_module.hashlib.sha256(
         later_key.encode("utf-8")
     ).hexdigest()
     later_witness_path = (
-        Path(steering_module.tempfile.gettempdir())
-        / "agentic-pkm-heimdal-locks"
+        Path(write_ops_module.tempfile.gettempdir())
+        / "agentic-pkm-atomic-append-locks"
         / f"{witness_token}.lock"
     )
     active = json.loads(later_witness_path.read_text())
@@ -3130,10 +3164,10 @@ def test_steering_log_cross_key_phase_barriers_block_unchanged(
 def test_steering_log_clean_state_recovers_after_temporary_witness_loss(
     tmp_path: Path,
 ) -> None:
-    isolated_temp_root = Path(steering_module.tempfile.gettempdir())
+    isolated_temp_root = Path(write_ops_module.tempfile.gettempdir())
     assert isolated_temp_root == tmp_path / "host-temp"
     unrelated_lock_root = tmp_path / "unrelated-host-temp" / (
-        "agentic-pkm-heimdal-locks"
+        "agentic-pkm-atomic-append-locks"
     )
     unrelated_lock_root.mkdir(parents=True)
     unrelated_sentinel = unrelated_lock_root / "unrelated-live-resource.lock"

--- a/tests/journaling/test_draft_journal_entry.py
+++ b/tests/journaling/test_draft_journal_entry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import date, datetime, timezone
 import hashlib
 import json
@@ -10,6 +12,7 @@ import threading
 
 import pytest
 
+import app.journaling.draft as draft_module
 from app.chat.session_log import SessionLogWriter
 from app.journaling.day_context import DayContextBundle, DayContextItem, assemble_day_context
 from app.journaling.draft import (
@@ -2094,3 +2097,37 @@ def test_draft_after_acceptance_produces_addendum_not_overwrite(tmp_path: Path) 
     assert frontmatter["journal_candidate_type"] == "addendum"
     assert "Addendum candidate" in body
     assert accepted.read_bytes() == before
+
+
+def test_acceptance_winning_route_race_blocks_stale_primary_candidate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root, context, session_id, _capture = _seed_inputs(tmp_path)
+    accepted = root / "1_Calendar" / "Daily" / "2026-07-15.md"
+    real_locked_draft = draft_module._locked_draft
+
+    @contextmanager
+    def acceptance_wins_before_lock(
+        vault_root: Path, relative_path: Path
+    ) -> Iterator[tuple[int, str]]:
+        accepted.parent.mkdir(parents=True)
+        accepted.write_text(
+            "---\nauthority_state: accepted\naccepted_by: human\n---\n\n"
+            "Human-owned text.\n",
+            encoding="utf-8",
+        )
+        with real_locked_draft(vault_root, relative_path) as locked:
+            yield locked
+
+    monkeypatch.setattr(draft_module, "_locked_draft", acceptance_wins_before_lock)
+
+    with pytest.raises(JournalDraftBlockedError, match="acceptance state changed"):
+        draft_journal_entry(
+            vault_context=context,
+            for_date=DAY,
+            session_id=session_id,
+            write_guard=_allowing_guard(),
+        )
+
+    assert accepted.read_text(encoding="utf-8").endswith("Human-owned text.\n")
+    assert not list(root.glob("**/drafts/journal/*.md"))

--- a/tests/journaling/test_draft_journal_entry.py
+++ b/tests/journaling/test_draft_journal_entry.py
@@ -23,6 +23,7 @@ from app.journaling.draft import (
     resolve_journal_draft_activation_receipt,
 )
 from app.knowledge_acquisition.candidate_writeback import ARTIFACT_CLASS, DEFAULT_SOURCES_DIR
+from app.proposals.declined_ledger import DeclinedLedger
 from app.reasoning.schema import Claim, Inference, ReasoningOutput
 from app.vault.manager import VaultContext
 from app.write_guard import WriteGuard, WritesBlockedError
@@ -371,7 +372,7 @@ def test_symlinked_per_draft_lock_is_rejected_without_touching_target(
     outside.write_text("owner content", encoding="utf-8")
     journal_dir = root / get_vault_system_dir_rel(root) / "drafts" / "journal"
     journal_dir.mkdir(parents=True)
-    (journal_dir / ".2026-07-15.md.lock").symlink_to(outside)
+    (journal_dir / ".2026-07-15.journal-day.lock").symlink_to(outside)
 
     with pytest.raises(ValueError, match="journal draft lock path is a symlink"):
         draft_journal_entry(
@@ -2131,3 +2132,140 @@ def test_acceptance_winning_route_race_blocks_stale_primary_candidate(
 
     assert accepted.read_text(encoding="utf-8").endswith("Human-owned text.\n")
     assert not list(root.glob("**/drafts/journal/*.md"))
+
+
+@pytest.mark.parametrize(
+    ("checked_text", "expected_action"),
+    (("- [x] Accept", "accept"), ("- [x] Dismiss", "dismiss")),
+)
+def test_draft_cannot_replace_checked_pending_review_intent(
+    tmp_path: Path, checked_text: str, expected_action: str
+) -> None:
+    root, context, session_id, _capture = _seed_inputs(tmp_path)
+    first = draft_journal_entry(
+        vault_context=context,
+        for_date=DAY,
+        session_id=session_id,
+        write_guard=_allowing_guard(),
+    )
+    candidate = root / first.path
+    text = candidate.read_text(encoding="utf-8")
+    if expected_action == "accept":
+        changed = text.replace("- [ ] Accept", checked_text)
+    else:
+        changed = text.replace("- [ ] Dismiss", checked_text)
+    candidate.write_text(changed, encoding="utf-8")
+    durable = candidate.read_bytes()
+
+    with pytest.raises(
+        JournalDraftBlockedError, match=f"pending {expected_action} intent"
+    ):
+        draft_journal_entry(
+            vault_context=context,
+            for_date=DAY,
+            session_id=session_id,
+            write_guard=_allowing_guard(),
+        )
+    assert candidate.read_bytes() == durable
+
+
+def test_primary_receipt_pending_forbids_addendum_staging(tmp_path: Path) -> None:
+    root, context, session_id, _capture = _seed_inputs(tmp_path)
+    first = draft_journal_entry(
+        vault_context=context,
+        for_date=DAY,
+        session_id=session_id,
+        write_guard=_allowing_guard(),
+    )
+    primary = root / first.path
+    primary.write_text(
+        primary.read_text(encoding="utf-8").replace(
+            "- [ ] Accept", "- [x] Accept"
+        ),
+        encoding="utf-8",
+    )
+    canonical = root / "1_Calendar" / "Daily" / f"{DAY.isoformat()}.md"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text(
+        "---\nauthority_state: accepted\naccepted_by: human\n---\n\n"
+        "Receipt pending.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(JournalDraftBlockedError, match="transition is still pending"):
+        draft_journal_entry(
+            vault_context=context,
+            for_date=DAY,
+            session_id=session_id,
+            write_guard=_allowing_guard(),
+        )
+    assert primary.exists()
+    assert not primary.with_name(f"{DAY.isoformat()}-addendum.md").exists()
+
+
+def test_unchanged_dismissed_basis_is_suppressed_but_changed_basis_reopens(
+    tmp_path: Path,
+) -> None:
+    root, context, session_id, _capture = _seed_inputs(tmp_path)
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    real_atomic_write = draft_module._atomic_write_at
+    first_note: str | None = None
+
+    def capture_first_write(directory_fd: int, filename: str, content: str) -> None:
+        nonlocal first_note
+        first_note = content
+        real_atomic_write(directory_fd, filename, content)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(draft_module, "_atomic_write_at", capture_first_write)
+    try:
+        result = draft_journal_entry(
+            vault_context=context,
+            for_date=DAY,
+            session_id=session_id,
+            write_guard=_allowing_guard(),
+            declined_ledger=ledger,
+        )
+    finally:
+        monkeypatch.undo()
+    assert first_note is not None
+    path = root / result.path
+    frontmatter, body = load_frontmatter(first_note)
+    from app.journaling.lifecycle import journal_decline_finding_id
+
+    finding_id = journal_decline_finding_id(
+        candidate_type="primary",
+        for_date=DAY.isoformat(),
+        frontmatter=frontmatter,
+        body=body,
+    )
+    ledger.record_decline(
+        finding_id,
+        finding_class="journal.candidate",
+        declined_at="2026-07-15T20:30:00Z",
+        write_guard=_allowing_guard(),
+    )
+    path.unlink()
+
+    with pytest.raises(JournalDraftBlockedError, match="previously dismissed"):
+        draft_journal_entry(
+            vault_context=context,
+            for_date=DAY,
+            session_id=session_id,
+            write_guard=_allowing_guard(),
+            declined_ledger=ledger,
+        )
+
+    transcript = next((root / ".chats" / "reflection").glob("*.md"))
+    transcript.write_text(
+        transcript.read_text(encoding="utf-8") + "\n> owner: Changed reflection.\n",
+        encoding="utf-8",
+    )
+    reopened = draft_journal_entry(
+        vault_context=context,
+        for_date=DAY,
+        session_id=session_id,
+        write_guard=_allowing_guard(),
+        declined_ledger=ledger,
+    )
+    assert (root / reopened.path).exists()

--- a/tests/journaling/test_review_accept_journal.py
+++ b/tests/journaling/test_review_accept_journal.py
@@ -7,9 +7,11 @@ accepted text, a destination, or a separate approval flag.
 
 from __future__ import annotations
 
+import ast
 from datetime import date, datetime, timezone
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,15 +21,18 @@ from app.journaling.review import (
     JOURNAL_ENTRY_ACCEPTED_EVENT,
     JOURNAL_ENTRY_DECLINED_EVENT,
     JournalAcceptedEntryExistsError,
+    JournalReviewConflictError,
     JournalReviewError,
     JournalReviewState,
     journal_draft_relative_path,
     process_journal_review,
+    process_journal_reviews_tick,
     project_journal_review,
 )
+from app.journaling.lifecycle import journal_decline_finding_id
 from app.proposals.declined_ledger import DeclinedLedger
 from app.vault.manager import VaultContext
-from app.write_guard import WriteGuard
+from app.write_guard import WriteGuard, WritesBlockedError
 from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
 
 
@@ -160,7 +165,13 @@ def test_dismiss_records_declined_ledger_entry(tmp_path: Path) -> None:
     root.mkdir()
     candidate = _stage_candidate(root, dismiss_checked=True)
     draft_frontmatter, _body = load_frontmatter(candidate.read_text(encoding="utf-8"))
-    draft_id = str(draft_frontmatter["uuid"])
+    _frontmatter, draft_body = load_frontmatter(candidate.read_text(encoding="utf-8"))
+    finding_id = journal_decline_finding_id(
+        candidate_type="primary",
+        for_date=DAY.isoformat(),
+        frontmatter=draft_frontmatter,
+        body=draft_body,
+    )
     ledger = DeclinedLedger(tmp_path / "declined.jsonl")
     outbox = tmp_path / "outbox.jsonl"
 
@@ -175,10 +186,39 @@ def test_dismiss_records_declined_ledger_entry(tmp_path: Path) -> None:
 
     assert result.action == "dismiss"
     assert result.state is JournalReviewState.DISMISSED
-    assert ledger.is_declined(draft_id)
+    assert ledger.is_declined(finding_id)
     assert not candidate.exists()
     assert not (root / "1_Calendar/Daily/2026-07-15.md").exists()
     assert [row["event"] for row in _outbox(outbox)] == [JOURNAL_ENTRY_DECLINED_EVENT]
+    assert (
+        project_journal_review(vault_context=_context(root), for_date=DAY).state
+        is JournalReviewState.DISMISSED
+    )
+
+
+def test_blocked_dismissal_mutates_no_receipt_or_ledger_surface(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, dismiss_checked=True)
+    ledger_path = tmp_path / "derived" / "declined.jsonl"
+    outbox = tmp_path / "outbox.jsonl"
+
+    with pytest.raises(WritesBlockedError):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            declined_ledger=DeclinedLedger(ledger_path),
+            write_guard=WriteGuard(
+                lambda: {"state": "safe_mode", "reason": "operator hold"}
+            ),
+            now=NOW,
+        )
+
+    assert candidate.exists()
+    assert not ledger_path.parent.exists()
+    assert not outbox.exists()
+    assert not (tmp_path / ".outbox.jsonl.journal-review.lock").exists()
 
 
 def test_acceptance_asserts_guard_and_stamps_receipt_fields(tmp_path: Path) -> None:
@@ -341,7 +381,7 @@ def test_addendum_acceptance_appends_not_replaces(tmp_path: Path) -> None:
     assert "Later reflection that may only be appended." in current_body
     assert current_body.count("Original accepted reflection.") == 1
     assert current_body.count("Later reflection that may only be appended.") == 1
-    assert f"journal:addendum_receipt_id={second.receipt_id}" in current_body
+    assert f"receipt_id={second.receipt_id}" in current_body
 
 
 def test_primary_retry_reconciles_materialization_before_receipt(
@@ -446,3 +486,531 @@ def test_addendum_retry_reconciles_append_before_receipt(
     addendum_row = next(row for row in accepted_rows if row["event_id"] == retried.receipt_id)
     assert addendum_row["timestamp"] == "2026-07-15T22:30:00Z"
     assert addendum_row["payload"]["accepted_at"] == "2026-07-15T22:30:00Z"
+
+
+def test_production_tick_observes_checked_intent_and_retries_automatically(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+
+    blocked = process_journal_reviews_tick(
+        vault_context=_context(root),
+        outbox_path=outbox,
+        write_guard=WriteGuard(
+            lambda: {"state": "safe_mode", "reason": "operator hold"}
+        ),
+        now=NOW,
+    )
+    assert blocked.scanned_dates == (DAY.isoformat(),)
+    assert blocked.pending == 1
+    assert candidate.exists()
+
+    healthy = process_journal_reviews_tick(
+        vault_context=_context(root),
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW.replace(hour=21),
+    )
+    assert healthy.materialized == 1
+    assert not candidate.exists()
+    assert (root / "1_Calendar/Daily/2026-07-15.md").exists()
+
+
+def test_production_registry_retries_checked_intent_automatically(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import app.watcher.registry as registry
+
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    state_dir = tmp_path / "watcher-state"
+    state_dir.mkdir()
+    cfg = SimpleNamespace(
+        enable=True,
+        stop_file=tmp_path / "WATCHER_STOP",
+        vault_path=root,
+        state_dir=state_dir,
+    )
+    manager = SimpleNamespace(validate_vault=lambda _root: _context(root))
+    monkeypatch.setattr(registry, "VaultManager", lambda: manager)
+    real_tick = review_module.process_journal_reviews_tick
+    health = {"state": "safe_mode", "reason": "maintenance"}
+
+    def governed_tick(**kwargs: object) -> object:
+        return real_tick(
+            **kwargs,
+            write_guard=WriteGuard(lambda: health),
+            now=NOW,
+        )
+
+    monkeypatch.setattr(registry, "process_journal_reviews_tick", governed_tick)
+    blocked = registry._run_journal_review_tick(cfg)
+    assert blocked["pending"] == 1
+    assert candidate.exists()
+
+    health["state"] = "healthy"
+    retried = registry._run_journal_review_tick(cfg)
+    assert retried["materialized"] == 1
+    assert not candidate.exists()
+    assert (root / "1_Calendar/Daily/2026-07-15.md").exists()
+    assert (state_dir / "journal-review-outbox.jsonl").exists()
+
+
+def test_production_registry_entrypoints_call_journal_retry_tick() -> None:
+    tree = ast.parse(Path("app/watcher/registry.py").read_text(encoding="utf-8"))
+    for function_name in ("run_registry_once", "run_registry_forever"):
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == function_name
+        )
+        assert any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_run_journal_review_tick"
+            for node in ast.walk(function)
+        )
+
+
+def test_torn_outbox_tail_is_repaired_before_candidate_cleanup(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_bytes(b'{"event":"crash-torn"')
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    assert not candidate.exists()
+    rows = _outbox(outbox)
+    assert rows == [
+        next(row for row in rows if row["event_id"] == result.receipt_id)
+    ]
+
+
+def test_candidate_retirement_recovers_after_crash_before_inert_archive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    real_noreplace = review_module._atomic_rename_noreplace_at
+
+    def crash_before_archive(
+        source_dir_fd: int,
+        source_name: str,
+        destination_dir_fd: int,
+        destination_name: str,
+    ) -> None:
+        if ".journal-retired-" in destination_name:
+            raise OSError("simulated crash before inert archive")
+        real_noreplace(
+            source_dir_fd,
+            source_name,
+            destination_dir_fd,
+            destination_name,
+        )
+
+    monkeypatch.setattr(
+        review_module, "_atomic_rename_noreplace_at", crash_before_archive
+    )
+    with pytest.raises(OSError, match="before inert archive"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+    directory = _candidate_path(root).parent
+    assert not _candidate_path(root).exists()
+    assert len(list(directory.glob(".*.journal-retire-*"))) == 1
+
+    monkeypatch.setattr(
+        review_module, "_atomic_rename_noreplace_at", real_noreplace
+    )
+    recovered = process_journal_reviews_tick(
+        vault_context=_context(root),
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW.replace(hour=21),
+    )
+    assert recovered.materialized == 1
+    assert not list(directory.glob(".*.journal-retire-*"))
+    assert len(list(directory.glob(".*.journal-retired-*"))) == 1
+    assert len(_outbox(outbox)) == 1
+
+
+def test_candidate_replacement_during_retirement_is_preserved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    real_noreplace = review_module._atomic_rename_noreplace_at
+    replaced = False
+
+    def replace_before_retirement(
+        source_dir_fd: int,
+        source_name: str,
+        destination_dir_fd: int,
+        destination_name: str,
+    ) -> None:
+        nonlocal replaced
+        if (
+            source_name == candidate.name
+            and ".journal-retire-" in destination_name
+            and not replaced
+        ):
+            candidate.write_text("external replacement\n", encoding="utf-8")
+            replaced = True
+        real_noreplace(
+            source_dir_fd,
+            source_name,
+            destination_dir_fd,
+            destination_name,
+        )
+
+    monkeypatch.setattr(
+        review_module, "_atomic_rename_noreplace_at", replace_before_retirement
+    )
+    with pytest.raises(JournalReviewConflictError, match="replacement was preserved"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+
+    assert candidate.read_text(encoding="utf-8") == "external replacement\n"
+
+
+def test_candidate_replacement_before_final_archive_is_restored(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    real_noreplace = review_module._atomic_rename_noreplace_at
+    replaced = False
+
+    def replace_after_verification(
+        source_dir_fd: int,
+        source_name: str,
+        destination_dir_fd: int,
+        destination_name: str,
+    ) -> None:
+        nonlocal replaced
+        if ".journal-retired-" in destination_name and not replaced:
+            descriptor = review_module.os.open(
+                source_name,
+                review_module.os.O_WRONLY | review_module.os.O_TRUNC,
+                dir_fd=source_dir_fd,
+            )
+            try:
+                review_module.os.write(descriptor, b"external replacement\n")
+                review_module.os.fsync(descriptor)
+            finally:
+                review_module.os.close(descriptor)
+            replaced = True
+        real_noreplace(
+            source_dir_fd,
+            source_name,
+            destination_dir_fd,
+            destination_name,
+        )
+
+    monkeypatch.setattr(
+        review_module, "_atomic_rename_noreplace_at", replace_after_verification
+    )
+    with pytest.raises(JournalReviewConflictError, match="replacement was preserved"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+
+    assert candidate.read_text(encoding="utf-8") == "external replacement\n"
+
+
+def test_hardlinked_candidate_is_rejected_before_materialization(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    alias = tmp_path / "candidate-alias.md"
+    alias.hardlink_to(candidate)
+
+    with pytest.raises(JournalReviewConflictError, match="stable regular file"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=tmp_path / "outbox.jsonl",
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+    assert candidate.exists()
+    assert alias.exists()
+    assert not (root / "1_Calendar/Daily/2026-07-15.md").exists()
+
+
+def test_dismiss_retry_reuses_first_timestamp_and_receipt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, dismiss_checked=True)
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    outbox = tmp_path / "outbox.jsonl"
+    real_retire = review_module._retire_candidate_if_unchanged
+
+    def interrupt_cleanup(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash before dismissal cleanup")
+
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", interrupt_cleanup
+    )
+    with pytest.raises(JournalReviewError, match="simulated crash"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            declined_ledger=ledger,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+    assert candidate.exists()
+
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", real_retire
+    )
+    retried = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        declined_ledger=ledger,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW.replace(hour=23),
+    )
+    rows = _outbox(outbox)
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == retried.receipt_id
+    assert rows[0]["timestamp"] == "2026-07-15T20:30:00Z"
+    assert not candidate.exists()
+
+
+def test_dismiss_retry_after_ledger_before_event_keeps_first_timestamp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, dismiss_checked=True)
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    outbox = tmp_path / "outbox.jsonl"
+    real_emit = review_module._emit_event_once
+
+    def interrupt_event(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash after decline ledger")
+
+    monkeypatch.setattr(review_module, "_emit_event_once", interrupt_event)
+    with pytest.raises(JournalReviewError, match="after decline ledger"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            declined_ledger=ledger,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+    assert candidate.exists()
+    assert _outbox(outbox) == []
+
+    monkeypatch.setattr(review_module, "_emit_event_once", real_emit)
+    process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        declined_ledger=ledger,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW.replace(hour=23),
+    )
+    assert _outbox(outbox)[0]["timestamp"] == "2026-07-15T20:30:00Z"
+    assert not candidate.exists()
+
+
+def test_addendum_recovery_refuses_body_marker_divergence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    _stage_candidate(root, accept_checked=True)
+    primary = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    candidate = _stage_candidate(
+        root,
+        addendum=True,
+        body="Exact addendum content.\n",
+        accept_checked=True,
+    )
+    canonical = root / primary.canonical_path
+    real_retire = review_module._retire_candidate_if_unchanged
+
+    def interrupt_cleanup(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash before addendum cleanup")
+
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", interrupt_cleanup
+    )
+    with pytest.raises(JournalReviewError):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=22),
+        )
+    canonical.write_text(
+        canonical.read_text(encoding="utf-8").replace(
+            "Exact addendum content.", "Human changed the append."
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", real_retire
+    )
+
+    with pytest.raises(JournalReviewConflictError, match="exact append block"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=23),
+        )
+    assert candidate.exists()
+
+
+def test_addendum_body_heading_does_not_confuse_exact_recovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    _stage_candidate(root, accept_checked=True)
+    process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    candidate = _stage_candidate(
+        root,
+        addendum=True,
+        body="## Addendum — quoted owner heading\n\nStill candidate content.\n",
+        accept_checked=True,
+    )
+    real_emit = review_module._emit_event_once
+
+    def interrupt_receipt(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated receipt interruption")
+
+    monkeypatch.setattr(review_module, "_emit_event_once", interrupt_receipt)
+    with pytest.raises(JournalReviewError):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=22),
+        )
+    monkeypatch.setattr(review_module, "_emit_event_once", real_emit)
+    recovered = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW.replace(hour=23),
+    )
+    assert recovered.state is JournalReviewState.FULLY_MATERIALIZED
+    assert not candidate.exists()
+
+
+def test_addendum_recovery_refuses_duplicate_receipt_blocks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    _stage_candidate(root, accept_checked=True)
+    primary = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    candidate = _stage_candidate(
+        root,
+        addendum=True,
+        body="Duplicate-block candidate.\n",
+        accept_checked=True,
+    )
+    canonical = root / primary.canonical_path
+    real_retire = review_module._retire_candidate_if_unchanged
+
+    def interrupt_cleanup(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash before addendum cleanup")
+
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", interrupt_cleanup
+    )
+    with pytest.raises(JournalReviewError):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=22),
+        )
+    raw = canonical.read_bytes()
+    block_start = raw.rfind(b"\n<!-- journal:addendum:start ")
+    assert block_start >= 0
+    canonical.write_bytes(raw + raw[block_start:])
+    monkeypatch.setattr(
+        review_module, "_retire_candidate_if_unchanged", real_retire
+    )
+
+    with pytest.raises(JournalReviewConflictError, match="appears more than once"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=23),
+        )
+    assert candidate.exists()

--- a/tests/journaling/test_review_accept_journal.py
+++ b/tests/journaling/test_review_accept_journal.py
@@ -1,0 +1,448 @@
+"""JRNL-04: governed review and acceptance of journal candidates.
+
+These tests exercise the production review seam with vault-durable candidate
+files.  The checked Panel action is the authority input; callers never pass
+accepted text, a destination, or a separate approval flag.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import json
+from pathlib import Path
+
+import pytest
+
+import app.journaling.review as review_module
+from app.journaling.review import (
+    JOURNAL_ENTRY_ACCEPT_WRITE_ACTION,
+    JOURNAL_ENTRY_ACCEPTED_EVENT,
+    JOURNAL_ENTRY_DECLINED_EVENT,
+    JournalAcceptedEntryExistsError,
+    JournalReviewError,
+    JournalReviewState,
+    journal_draft_relative_path,
+    process_journal_review,
+    project_journal_review,
+)
+from app.proposals.declined_ledger import DeclinedLedger
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
+
+
+DAY = date(2026, 7, 15)
+NOW = datetime(2026, 7, 15, 20, 30, tzinfo=timezone.utc)
+
+
+class _RecordingGuard(WriteGuard):
+    def __init__(self, snapshot: dict[str, object]) -> None:
+        super().__init__(lambda: snapshot)
+        self.actions: list[str] = []
+
+    def assert_writes_allowed(self, action: str) -> None:
+        self.actions.append(action)
+        super().assert_writes_allowed(action)
+
+
+def _context(root: Path) -> VaultContext:
+    return VaultContext(status="selected", active_vault_path=str(root))
+
+
+def _candidate_path(root: Path, *, addendum: bool = False) -> Path:
+    return root / journal_draft_relative_path(root, DAY, is_addendum=addendum)
+
+
+def _stage_candidate(
+    root: Path,
+    *,
+    addendum: bool = False,
+    body: str = "I reflected on the day from the generated draft.\n",
+    accept_checked: bool = False,
+    dismiss_checked: bool = False,
+) -> Path:
+    path = _candidate_path(root, addendum=addendum)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    draft_id = f"journal-{DAY.isoformat()}{'-addendum' if addendum else ''}"
+    frontmatter = {
+        "uuid": draft_id,
+        "kind": "journal-draft",
+        "journal_candidate_type": "addendum" if addendum else "primary",
+        "for_date": DAY.isoformat(),
+        "derived_by": "conversation",
+        "authority_state": "proposal",
+        "sources": ["session:session-abc", "Sources/capture-one.md"],
+    }
+    accept_label = (
+        "Accept and append this addendum to today's journal"
+        if addendum
+        else "Accept this draft as today's journal entry"
+    )
+    review = (
+        "\n%% AI:Start %%\n"
+        "## AI-åtgärder\n\n"
+        f"- [{'x' if accept_checked else ' '}] {accept_label}\n"
+        f"- [{'x' if dismiss_checked else ' '}] Dismiss this journal candidate\n"
+        "%% AI:End %%\n"
+    )
+    path.write_text(dump_frontmatter(frontmatter, body) + review, encoding="utf-8")
+    return path
+
+
+def _check_accept(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    checked = text.replace("- [ ] Accept", "- [x] Accept")
+    assert checked != text
+    path.write_text(checked, encoding="utf-8")
+
+
+def _outbox(path: Path) -> list[dict[str, object]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_accept_requires_no_typing(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+
+    projection = project_journal_review(vault_context=_context(root), for_date=DAY)
+    assert projection.state is JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION
+    assert projection.candidate_path == candidate.relative_to(root).as_posix()
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    assert result.state is JournalReviewState.FULLY_MATERIALIZED
+    assert result.action == "accept"
+    assert result.canonical_path == "1_Calendar/Daily/2026-07-15.md"
+    assert not candidate.exists()
+    assert (root / result.canonical_path).is_file()
+
+
+def test_edit_then_accept_promotes_edited_text(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, body="Generated text that I will replace.\n")
+    human_edit = "HUMAN EDIT: this is the text I chose to own."
+    text = candidate.read_text(encoding="utf-8")
+    text = text.replace("Generated text that I will replace.", human_edit)
+    candidate.write_text(text.replace("- [ ] Accept", "- [x] Accept"), encoding="utf-8")
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=tmp_path / "outbox.jsonl",
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    _frontmatter, accepted_body = load_frontmatter(
+        (root / result.canonical_path).read_text(encoding="utf-8")
+    )
+    assert human_edit in accepted_body
+    assert "Generated text that I will replace." not in accepted_body
+
+
+def test_dismiss_records_declined_ledger_entry(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, dismiss_checked=True)
+    draft_frontmatter, _body = load_frontmatter(candidate.read_text(encoding="utf-8"))
+    draft_id = str(draft_frontmatter["uuid"])
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    outbox = tmp_path / "outbox.jsonl"
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        declined_ledger=ledger,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    assert result.action == "dismiss"
+    assert result.state is JournalReviewState.DISMISSED
+    assert ledger.is_declined(draft_id)
+    assert not candidate.exists()
+    assert not (root / "1_Calendar/Daily/2026-07-15.md").exists()
+    assert [row["event"] for row in _outbox(outbox)] == [JOURNAL_ENTRY_DECLINED_EVENT]
+
+
+def test_acceptance_asserts_guard_and_stamps_receipt_fields(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    candidate_frontmatter, _body = load_frontmatter(candidate.read_text(encoding="utf-8"))
+    outbox = tmp_path / "outbox.jsonl"
+    guard = _RecordingGuard({"state": "healthy"})
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+
+    assert guard.actions and set(guard.actions) == {JOURNAL_ENTRY_ACCEPT_WRITE_ACTION}
+    accepted_frontmatter, accepted_body = load_frontmatter(
+        (root / result.canonical_path).read_text(encoding="utf-8")
+    )
+    assert accepted_frontmatter["authority_state"] == "accepted"
+    assert accepted_frontmatter["accepted_by"] == "human"
+    assert accepted_frontmatter["accepted_at"] == "2026-07-15T20:30:00Z"
+    assert accepted_frontmatter["acceptance_receipt_id"] == result.receipt_id
+    assert accepted_frontmatter["decision_token_ref"] == result.decision_token_ref
+    assert accepted_frontmatter["derived_by"] == "conversation"
+    assert accepted_frontmatter["sources"] == candidate_frontmatter["sources"]
+    assert "AI-åtgärder" not in accepted_body
+
+    accepted_events = [
+        row for row in _outbox(outbox) if row["event"] == JOURNAL_ENTRY_ACCEPTED_EVENT
+    ]
+    assert len(accepted_events) == 1
+    payload = accepted_events[0]["payload"]
+    assert payload["draft_id"] == candidate_frontmatter["uuid"]
+    assert payload["final_note_path"] == result.canonical_path
+    assert payload["sources"] == candidate_frontmatter["sources"]
+    assert payload["authority_receipt_id"] == result.receipt_id
+
+
+def test_engine_cannot_overwrite_accepted_entry(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    _stage_candidate(root, body="The human-owned primary entry.\n", accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    first = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    canonical = root / first.canonical_path
+    accepted_bytes = canonical.read_bytes()
+
+    primary_again = _stage_candidate(
+        root,
+        body="Machine replacement that must never land.\n",
+        accept_checked=True,
+    )
+    with pytest.raises(JournalAcceptedEntryExistsError):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW,
+        )
+    assert canonical.read_bytes() == accepted_bytes
+    assert primary_again.exists()
+
+    primary_again.unlink()
+    addendum = _stage_candidate(root, addendum=True, body="A distinct later candidate.\n")
+    projection = project_journal_review(vault_context=_context(root), for_date=DAY)
+    assert projection.candidate_type == "addendum"
+    assert projection.candidate_path == addendum.relative_to(root).as_posix()
+    assert canonical.read_bytes() == accepted_bytes
+
+
+def test_blocked_write_path_preserves_acceptance_intent_and_retries(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+
+    blocked = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=WriteGuard(
+            lambda: {"state": "safe_mode", "reason": "operator hold"}
+        ),
+        now=NOW,
+    )
+
+    assert blocked.state is JournalReviewState.ACCEPTED_PENDING_MATERIALIZATION
+    assert blocked.status_message == "Accepted — waiting to save"
+    assert candidate.exists()
+    assert "- [x] Accept" in candidate.read_text(encoding="utf-8")
+    assert not (root / "1_Calendar/Daily/2026-07-15.md").exists()
+    assert _outbox(outbox) == []
+
+    # Simulate a later healthy process: the durable checked action is enough;
+    # no second tap or in-memory pending object is supplied.
+    retried = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+    assert retried.state is JournalReviewState.FULLY_MATERIALIZED
+    assert not candidate.exists()
+    assert (root / retried.canonical_path).exists()
+
+
+def test_addendum_acceptance_appends_not_replaces(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    _stage_candidate(root, body="Original accepted reflection.\n", accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    first = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    canonical = root / first.canonical_path
+    original_frontmatter, original_body = load_frontmatter(
+        canonical.read_text(encoding="utf-8")
+    )
+
+    _stage_candidate(
+        root,
+        addendum=True,
+        body="Later reflection that may only be appended.\n",
+        accept_checked=True,
+    )
+    second = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW.replace(hour=22),
+    )
+
+    current_frontmatter, current_body = load_frontmatter(
+        canonical.read_text(encoding="utf-8")
+    )
+    assert second.action == "accept_addendum"
+    assert current_frontmatter == original_frontmatter
+    assert current_body.startswith(original_body)
+    assert "Later reflection that may only be appended." in current_body
+    assert current_body.count("Original accepted reflection.") == 1
+    assert current_body.count("Later reflection that may only be appended.") == 1
+    assert f"journal:addendum_receipt_id={second.receipt_id}" in current_body
+
+
+def test_primary_retry_reconciles_materialization_before_receipt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    real_emit = review_module._emit_event_once
+
+    def interrupt_receipt(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash before receipt")
+
+    monkeypatch.setattr(review_module, "_emit_event_once", interrupt_receipt)
+    with pytest.raises(JournalReviewError, match="simulated crash"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW,
+        )
+
+    canonical = root / "1_Calendar/Daily/2026-07-15.md"
+    materialized = canonical.read_bytes()
+    assert candidate.exists()
+
+    monkeypatch.setattr(review_module, "_emit_event_once", real_emit)
+    retried = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW.replace(hour=21),
+    )
+
+    assert canonical.read_bytes() == materialized
+    assert not candidate.exists()
+    rows = _outbox(outbox)
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == retried.receipt_id
+    assert rows[0]["timestamp"] == "2026-07-15T20:30:00Z"
+    assert rows[0]["payload"]["accepted_at"] == "2026-07-15T20:30:00Z"
+
+
+def test_addendum_retry_reconciles_append_before_receipt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    outbox = tmp_path / "outbox.jsonl"
+    guard = WriteGuard(lambda: {"state": "healthy"})
+    _stage_candidate(root, accept_checked=True)
+    primary = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW,
+    )
+    candidate = _stage_candidate(
+        root,
+        addendum=True,
+        body="The append that survives receipt interruption.\n",
+        accept_checked=True,
+    )
+    canonical = root / primary.canonical_path
+    real_emit = review_module._emit_event_once
+
+    def interrupt_receipt(*_args: object, **_kwargs: object) -> None:
+        raise JournalReviewError("simulated crash before receipt")
+
+    monkeypatch.setattr(review_module, "_emit_event_once", interrupt_receipt)
+    with pytest.raises(JournalReviewError, match="simulated crash"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=guard,
+            now=NOW.replace(hour=22),
+        )
+    materialized = canonical.read_bytes()
+    assert candidate.exists()
+
+    monkeypatch.setattr(review_module, "_emit_event_once", real_emit)
+    retried = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        write_guard=guard,
+        now=NOW.replace(hour=23),
+    )
+
+    assert canonical.read_bytes() == materialized
+    assert not candidate.exists()
+    accepted_rows = [
+        row for row in _outbox(outbox) if row["event"] == JOURNAL_ENTRY_ACCEPTED_EVENT
+    ]
+    assert len(accepted_rows) == 2
+    addendum_row = next(row for row in accepted_rows if row["event_id"] == retried.receipt_id)
+    assert addendum_row["timestamp"] == "2026-07-15T22:30:00Z"
+    assert addendum_row["payload"]["accepted_at"] == "2026-07-15T22:30:00Z"

--- a/tests/journaling/test_review_accept_journal.py
+++ b/tests/journaling/test_review_accept_journal.py
@@ -698,6 +698,41 @@ def test_candidate_replacement_during_retirement_is_preserved(
     assert candidate.read_text(encoding="utf-8") == "external replacement\n"
 
 
+def test_candidate_replacement_before_canonical_write_is_not_materialized(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+    real_append = review_module.append_note_relative
+    replaced = False
+
+    def replace_before_transform(*args: object, **kwargs: object) -> object:
+        nonlocal replaced
+        if not replaced:
+            candidate.write_text(
+                candidate.read_text(encoding="utf-8") + "\nexternal replacement\n",
+                encoding="utf-8",
+            )
+            replaced = True
+        return real_append(*args, **kwargs)
+
+    monkeypatch.setattr(review_module, "append_note_relative", replace_before_transform)
+    with pytest.raises(JournalReviewConflictError, match="changed before canonical acceptance"):
+        process_journal_review(
+            vault_context=_context(root),
+            for_date=DAY,
+            outbox_path=outbox,
+            write_guard=WriteGuard(lambda: {"state": "healthy"}),
+            now=NOW,
+        )
+
+    assert candidate.read_text(encoding="utf-8").endswith("external replacement\n")
+    assert not (root / "1_Calendar/Daily/2026-07-15.md").exists()
+    assert not outbox.exists()
+
+
 def test_candidate_replacement_before_final_archive_is_restored(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/journaling/test_review_accept_journal.py
+++ b/tests/journaling/test_review_accept_journal.py
@@ -61,19 +61,20 @@ def _candidate_path(root: Path, *, addendum: bool = False) -> Path:
 def _stage_candidate(
     root: Path,
     *,
+    for_date: date = DAY,
     addendum: bool = False,
     body: str = "I reflected on the day from the generated draft.\n",
     accept_checked: bool = False,
     dismiss_checked: bool = False,
 ) -> Path:
-    path = _candidate_path(root, addendum=addendum)
+    path = root / journal_draft_relative_path(root, for_date, is_addendum=addendum)
     path.parent.mkdir(parents=True, exist_ok=True)
-    draft_id = f"journal-{DAY.isoformat()}{'-addendum' if addendum else ''}"
+    draft_id = f"journal-{for_date.isoformat()}{'-addendum' if addendum else ''}"
     frontmatter = {
         "uuid": draft_id,
         "kind": "journal-draft",
         "journal_candidate_type": "addendum" if addendum else "primary",
-        "for_date": DAY.isoformat(),
+        "for_date": for_date.isoformat(),
         "derived_by": "conversation",
         "authority_state": "proposal",
         "sources": ["session:session-abc", "Sources/capture-one.md"],
@@ -194,6 +195,64 @@ def test_dismiss_records_declined_ledger_entry(tmp_path: Path) -> None:
         project_journal_review(vault_context=_context(root), for_date=DAY).state
         is JournalReviewState.DISMISSED
     )
+
+
+def test_unreviewed_expired_candidate_is_declined_via_shared_ledger(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    candidate = _stage_candidate(root)
+    text = candidate.read_text(encoding="utf-8")
+    frontmatter, body = load_frontmatter(text)
+    frontmatter["expires"] = "2026-07-15T20:29:59Z"
+    candidate.write_text(dump_frontmatter(frontmatter, body), encoding="utf-8")
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    outbox = tmp_path / "outbox.jsonl"
+
+    result = process_journal_review(
+        vault_context=_context(root),
+        for_date=DAY,
+        outbox_path=outbox,
+        declined_ledger=ledger,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    assert result.state is JournalReviewState.DISMISSED
+    assert result.action == "dismiss"
+    assert not candidate.exists()
+    rows = _outbox(outbox)
+    assert rows[-1]["payload"]["reason"] == "expired"
+
+
+def test_tick_isolates_one_conflicting_date_from_later_candidates(tmp_path: Path) -> None:
+    root = tmp_path / "vault"
+    root.mkdir()
+    conflicting = _stage_candidate(root)
+    conflict_text = conflicting.read_text(encoding="utf-8")
+    conflicting.write_text(
+        conflict_text.replace("- [ ] Accept", "- [x] Accept").replace(
+            "- [ ] Dismiss", "- [x] Dismiss"
+        ),
+        encoding="utf-8",
+    )
+    later = date(2026, 7, 16)
+    valid = _stage_candidate(root, for_date=later, accept_checked=True)
+    outbox = tmp_path / "outbox.jsonl"
+
+    tick = process_journal_reviews_tick(
+        vault_context=_context(root),
+        outbox_path=outbox,
+        write_guard=WriteGuard(lambda: {"state": "healthy"}),
+        now=NOW,
+    )
+
+    assert tick.scanned_dates == (DAY.isoformat(), later.isoformat())
+    assert len(tick.errors) == 1
+    assert tick.materialized == 1
+    assert not valid.exists()
+    assert conflicting.exists()
 
 
 def test_blocked_dismissal_mutates_no_receipt_or_ledger_surface(tmp_path: Path) -> None:

--- a/tests/proposals/test_declined_ledger.py
+++ b/tests/proposals/test_declined_ledger.py
@@ -17,6 +17,8 @@ Covers every behavioral Acceptance Criterion from the issue:
 from __future__ import annotations
 
 import ast
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
 from pathlib import Path
 
 import pytest
@@ -238,6 +240,72 @@ def test_recording_the_same_decline_twice_is_idempotent(tmp_path: Path) -> None:
     lines = (tmp_path / "declined.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert ledger.is_declined("fid-1") is True
+
+
+def test_concurrent_different_declines_do_not_lose_records(tmp_path: Path) -> None:
+    path = tmp_path / "declined.jsonl"
+    finding_ids = [f"fid-{index}" for index in range(20)]
+
+    def record(finding_id: str) -> None:
+        DeclinedLedger(path).record_decline(
+            finding_id,
+            finding_class="journal.candidate",
+            declined_at="2026-07-15T20:30:00Z",
+            write_guard=_allow_all_guard(),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(record, finding_ids))
+
+    ledger = DeclinedLedger(path)
+    assert all(ledger.is_declined(finding_id) for finding_id in finding_ids)
+    assert len(path.read_text(encoding="utf-8").splitlines()) == len(finding_ids)
+
+
+def test_cross_process_different_declines_do_not_lose_records(tmp_path: Path) -> None:
+    path = tmp_path / "declined.jsonl"
+    context = multiprocessing.get_context("fork")
+    start = context.Barrier(6)
+
+    def record(index: int) -> None:
+        start.wait(timeout=5)
+        DeclinedLedger(path).record_decline(
+            f"process-fid-{index}",
+            finding_class="journal.candidate",
+            declined_at="2026-07-15T20:30:00Z",
+            write_guard=_allow_all_guard(),
+        )
+
+    processes = [context.Process(target=record, args=(index,)) for index in range(6)]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+    assert all(process.exitcode == 0 for process in processes)
+    ledger = DeclinedLedger(path)
+    assert all(ledger.is_declined(f"process-fid-{index}") for index in range(6))
+
+
+def test_idempotent_decline_preserves_first_durable_timestamp(tmp_path: Path) -> None:
+    ledger = DeclinedLedger(tmp_path / "declined.jsonl")
+    first = ledger.record_decline(
+        "fid-1",
+        finding_class="journal.candidate",
+        declined_at="2026-07-15T20:30:00Z",
+        write_guard=_allow_all_guard(),
+    )
+    second = ledger.record_decline(
+        "fid-1",
+        finding_class="journal.candidate",
+        declined_at="2026-07-15T23:30:00Z",
+        write_guard=_allow_all_guard(),
+    )
+
+    assert second == first
+    assert ledger.get_receipt("fid-1") == first
 
 
 def test_record_decline_is_write_guard_gated(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #3351

Fixes #3351

Final-Review-Rounds: 2

## Summary
Implements governed review, accept, dismiss, addendum, and retry handling for staged conversational journal drafts. Revalidates candidate bytes in the canonical write transaction so concurrent owner edits cannot materialize stale text.

## SBS Impact
Primary subsystem: GOV; secondary subsystems: HIX and HKA. This is a Product/Runtime acceptance path that promotes a human-disposed journal candidate through WriteGuard into a human-owned note; it introduces no channel, deployment, or migration change.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Normal implementation delivery; lifecycle and review evidence remain on the governing Issue and PR.

## Notes
Validation on exact head 4b4963f3087a0a661476b870bff87571c001ccf9: ruff check app tests; mypy app; 142 focused tests; affected validation 1602 passed, 3 skipped, 2 deselected; exact-head GitHub checks green including Unit tests (not pg). The prior Sol/xhigh P1 findings were repaired across queue failure isolation, expiry dismissal through the shared declined ledger, and selector test-target coverage. Fresh independent Sol/xhigh convergence review ACCEPTED this exact head with no P0/P1/P2 findings.