### PR TITLE
Align terminal unknown reconciliation evidence

### DIFF
--- a/app/builderops/control_plane/api_models.py
+++ b/app/builderops/control_plane/api_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AuthorityEnvelopeInput(BaseModel):
@@ -176,18 +176,44 @@ class RowDerivedPostEffectPendingRequest(BaseModel):
     minimum_fencing_token: int = Field(ge=1)
 
 
-class RowDerivedPostEffectEvidence(BaseModel):
-    """Closed readback vocabulary; claim/LSN authority never enters evidence."""
+class RowDerivedReadbackEvidence(BaseModel):
+    """Closed ordinary readback vocabulary; claim/LSN authority never enters evidence."""
 
     model_config = ConfigDict(extra="forbid")
     readback: Literal["found", "not-found", "unknown"]
     relaunch_performed: bool | None = None
 
 
+class TerminalUnknownModelEvidence(BaseModel):
+    """Exact pre-session model-effect evidence for a terminal unknown result."""
+
+    model_config = ConfigDict(extra="forbid")
+    head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+    outcome: Literal["indeterminate_pre_session_model_effect"]
+    provider_session_id: None
+    relaunch_performed: Literal[False]
+
+
+RowDerivedPostEffectEvidence = (
+    RowDerivedReadbackEvidence | TerminalUnknownModelEvidence
+)
+
+
 class RowDerivedPostEffectReconcileRequest(RowDerivedPostEffectPendingRequest):
     observed_applied: bool
     terminal_unknown: bool = False
     evidence: RowDerivedPostEffectEvidence
+
+    @model_validator(mode="after")
+    def _terminal_unknown_uses_exact_evidence(
+        self,
+    ) -> "RowDerivedPostEffectReconcileRequest":
+        is_terminal_evidence = isinstance(self.evidence, TerminalUnknownModelEvidence)
+        if self.terminal_unknown != is_terminal_evidence:
+            raise ValueError(
+                "terminal-unknown reconciliation requires exact terminal evidence"
+            )
+        return self
 
 
 __all__ = [
@@ -203,6 +229,8 @@ __all__ = [
     "OutboxUnknownRequest",
     "RowDerivedPostEffectPendingRequest",
     "RowDerivedPostEffectEvidence",
+    "RowDerivedReadbackEvidence",
+    "TerminalUnknownModelEvidence",
     "RowDerivedPostEffectReconcileRequest",
     "PromotionCommitRequest",
     "RecordCommitRequest",

--- a/app/builderops/control_plane/store.py
+++ b/app/builderops/control_plane/store.py
@@ -40,8 +40,21 @@ def _hash(value: Mapping[str, Any]) -> str:
     return hashlib.sha256(_canonical(value).encode()).hexdigest()
 
 
-def _validate_row_derived_evidence(evidence: Mapping[str, Any]) -> None:
-    """Validate the closed dormant readback schema at the persistence boundary."""
+def _validate_row_derived_evidence(
+    evidence: Mapping[str, Any], *, terminal_unknown: bool
+) -> None:
+    """Validate the closed post-effect evidence schema at the persistence boundary."""
+    if terminal_unknown:
+        _assert_terminal_unknown_model_evidence(
+            effect_type="model.verification_coordinator",
+            effect_payload={"head_sha": evidence.get("head_sha")},
+            task_payload={
+                "contract_version": "builderops_verification_run.v1",
+                "run": {"coordinator_session_id": None, "context_pack": None},
+            },
+            evidence=evidence,
+        )
+        return
     allowed = {"readback", "relaunch_performed"}
     if not isinstance(evidence, Mapping) or not set(evidence).issubset(allowed):
         raise ValueError("row-derived readback evidence contains unknown fields")
@@ -2212,13 +2225,14 @@ class PostgresBuilderOpsStore:
         terminal_unknown: bool = False,
     ) -> Mapping[str, Any]:
         """Use the stored row-derived claim for dormant reconciliation only."""
-        _validate_row_derived_evidence(evidence)
-        readback = evidence["readback"]
-        expected_readback = "unknown" if terminal_unknown else "found" if observed_applied else "not-found"
-        if readback != expected_readback:
-            raise ValueError("readback evidence contradicts the requested outcome")
         if terminal_unknown and observed_applied:
             raise ValueError("terminal-unknown reconciliation cannot claim an applied effect")
+        _validate_row_derived_evidence(evidence, terminal_unknown=terminal_unknown)
+        if not terminal_unknown:
+            readback = evidence["readback"]
+            expected_readback = "found" if observed_applied else "not-found"
+            if readback != expected_readback:
+                raise ValueError("readback evidence contradicts the requested outcome")
         repository = canonical_repository(repository)
         with self._connect() as conn:
             row = conn.execute(

--- a/docs/BUILDEROPS_CONTROL_PLANE/POSTGRES_TRANSACTION_KERNEL.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/POSTGRES_TRANSACTION_KERNEL.md
@@ -110,7 +110,7 @@ by BuilderOps governance and remains outside Product persistence authority.
 - [x] A pre-session indeterminate verification-model effect without a provider identity becomes one
   durable `dead_letter` reconciliation and cannot be reclaimed or replayed; the PostgreSQL
   authority rejects the same terminal-unknown request for GitHub effects without mutation.
-  Verify: `tests/builderops/control_plane/test_outbox_recovery.py::test_indeterminate_effect_dead_letters_without_retry`.
+  Verify: `tests/builderops/control_plane/test_outbox_recovery.py::test_terminal_unknown_evidence_reaches_dead_letter`.
   Verify: `tests/builderops/control_plane/test_outbox_recovery.py::test_terminal_unknown_rejects_github_effect_without_mutation`.
   Verify: `tests/builderops/control_plane/test_outbox_recovery.py::test_terminal_unknown_rejects_session_bound_task_without_mutation`.
 - [x] Production construction requires a PostgreSQL DSN and never selects/creates SQLite implicitly;

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -207,6 +207,10 @@ Shortcuts are proportionate, not authority bypasses:
 | **V3.4 Verify, accept, merge, and close** | Resolve delivery tier, prove exact-head ACs/checks, run full-path independent review when required, perform the current governed explicit merge/readback, close Issue/claim, and classify owner-doc impact. | Accepted merge and closure evidence; technical verification remains distinct from owner/product validation. Disabled GitHub auto-merge is not the merge mechanism. |
 | **V3.5 Release, deploy, verify, or roll back** | Resolve the current channel model, authorize the candidate, prepare risk/migration/config delta, obtain only required operator authority, deploy the authorized SHA, prove live identity/health, run feature/owner acceptance when required, and accept or roll back with rollback verification. | Live-channel receipt or safe rollback/block; current `main`-tracking production and target gated-`stable` promotion remain distinct. |
 
+#### Delivery reconciliation
+
+Row-derived post-effect reconciliation uses a closed ordinary readback schema. Its sole terminal-unknown exception is the exact pre-session verification-model evidence (`head_sha`, the indeterminate outcome, a null provider session, and `relaunch_performed: false`). The persistence transition independently proves that the stored effect is eligible for that exception before dead-lettering it, so an unknown external effect is neither represented as success/failure nor relaunched.
+
 #### V4 Operate & Improve — L2 children
 
 | L2 ID | Child subprocess | Required output and boundary |

--- a/tests/builderops/control_plane/test_outbox_recovery.py
+++ b/tests/builderops/control_plane/test_outbox_recovery.py
@@ -499,7 +499,7 @@ def test_concurrent_identical_post_effect_reconciliation_replays_one_row_identit
     assert first["receipt_sequence"] == second["receipt_sequence"]
 
 
-def test_indeterminate_effect_dead_letters_without_retry(
+def test_terminal_unknown_evidence_reaches_dead_letter(
     control_plane_store, envelope
 ) -> None:
     result = _commit_outbox_task(
@@ -532,27 +532,37 @@ def test_indeterminate_effect_dead_letters_without_retry(
         "relaunch_performed": False,
     }
 
-    terminal = control_plane_store.reconcile_outbox(
-        claim,
+    control_plane_store.begin_post_effect_pending(
+        repository=envelope.repository,
+        operation_key=result.operation_key,
+        minimum_fencing_token=claim.fencing_token,
+        expected_principal=envelope.actor,
+    )
+    terminal = control_plane_store.reconcile_post_effect(
+        repository=envelope.repository,
+        operation_key=result.operation_key,
+        minimum_fencing_token=claim.fencing_token,
+        expected_principal=envelope.actor,
         observed_applied=False,
         terminal_unknown=True,
         evidence=evidence,
     )
-    replay = control_plane_store.reconcile_outbox(
-        claim,
+    replay = control_plane_store.reconcile_post_effect(
+        repository=envelope.repository,
+        operation_key=result.operation_key,
+        minimum_fencing_token=claim.fencing_token,
+        expected_principal=envelope.actor,
         observed_applied=False,
         terminal_unknown=True,
         evidence=evidence,
     )
 
-    assert terminal.status == "dead_letter"
-    assert replay.status == "dead_letter"
-    assert replay.replayed is True
-    receipt = control_plane_store.receipt(
-        envelope.repository, terminal.receipt_sequence
-    )
+    assert terminal["status"] == "dead_letter"
+    assert replay["status"] == "dead_letter"
+    assert replay["replayed"] is True
+    receipt = control_plane_store.receipt(envelope.repository, terminal["receipt_sequence"])
     assert receipt["event_type"] == "outbox.reconciled.dead_letter"
-    assert receipt["recovery_lsn"] == terminal.recovery_lsn
+    assert receipt["recovery_lsn"] == terminal["recovery_lsn"]
     with control_plane_store._connect() as conn:
         dead_letter = conn.execute(
             "SELECT outcome FROM builderops_dead_letters "
@@ -568,12 +578,61 @@ def test_indeterminate_effect_dead_letters_without_retry(
             worker_id="replacement-verifier",
         )
     with pytest.raises(ValueError, match="cannot claim an applied effect"):
-        control_plane_store.reconcile_outbox(
-            claim,
+        control_plane_store.reconcile_post_effect(
+            repository=envelope.repository,
+            operation_key=result.operation_key,
+            minimum_fencing_token=claim.fencing_token,
+            expected_principal=envelope.actor,
             observed_applied=True,
             terminal_unknown=True,
             evidence=evidence,
         )
+
+
+def test_terminal_unknown_rejects_incomplete_evidence(
+    control_plane_store, envelope
+) -> None:
+    result = _commit_outbox_task(
+        control_plane_store,
+        envelope,
+        task_id="task-incomplete-terminal-evidence",
+        key="incomplete-terminal-evidence",
+        effect_type="model.verification_coordinator",
+        payload={"head_sha": "a" * 40},
+        task_payload={
+            "contract_version": "builderops_verification_run.v1",
+            "run": {"coordinator_session_id": None, "context_pack": None},
+        },
+    )
+    claim = control_plane_store.claim_outbox(
+        envelope=envelope,
+        operation_key=result.operation_key,
+        worker_id="verification-host",
+    )
+    control_plane_store.mark_effect_unknown(claim, detail="readback required")
+    control_plane_store.begin_post_effect_pending(
+        repository=envelope.repository,
+        operation_key=result.operation_key,
+        minimum_fencing_token=claim.fencing_token,
+        expected_principal=envelope.actor,
+    )
+
+    with pytest.raises(StateConflict, match="exact"):
+        control_plane_store.reconcile_post_effect(
+            repository=envelope.repository,
+            operation_key=result.operation_key,
+            minimum_fencing_token=claim.fencing_token,
+            expected_principal=envelope.actor,
+            observed_applied=False,
+            terminal_unknown=True,
+            evidence={
+                "outcome": "indeterminate_pre_session_model_effect",
+                "provider_session_id": None,
+                "relaunch_performed": False,
+            },
+        )
+
+    assert control_plane_store.outbox_status(envelope.repository, result.operation_key) == "unknown"
 
 
 def test_terminal_unknown_rejects_github_effect_without_mutation(


### PR DESCRIPTION
Governing-Issue: #5022

Fixes #5022

Final-Review-Rounds: 1

## Summary
Allows the row-derived post-effect path to carry the exact terminal-unknown model evidence while retaining closed ordinary readback evidence and fail-closed effect eligibility.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded implementation changes BuilderOps runtime contracts but creates no new BuilderOps operational record.

## Notes
Validation: focused scratch-PostgreSQL acceptance tests (3 passed); ruff check app tests; mypy app; docs language guard. `pytest -q tests/builderops` completed against the scratch DB; an unrelated pre-existing replay assertion in test_outbox_recovery remains observable on origin/main.

SBS Impact: Builder System / authority-bearing durable outbox reconciliation; terminal unknown remains distinct from success, failure, and relaunch.
---
