### PR TITLE
Add canonical duplicate-search instruction rule

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -50,11 +50,12 @@ data, or any artefact that is not reproducible from the checked-in repo plus pub
 body, linked PR, owner doc) before authoring the Issue that depends on it. If the material cannot be
 promoted, the Issue should not depend on it.
 
-Before creating or normalizing a governance or contract Issue, search for the same artifact or
-symptom in open Issues, recently merged PRs, and closed Issues. Use GitHub CLI/REST search; do not
-require GraphQL or ProjectV2 operations. If an open match exists, add the evidence there rather
-than creating a duplicate. If a closed Issue or merged PR matches, verify whether the work is
-already delivered before filing a new contract.
+Before creating or normalizing a governance or contract Issue, follow the canonical
+`AGENTS.md :: GitHub delivery governance` requirement: search for the same artifact or symptom in
+open Issues, recently merged PRs, and closed Issues. Use GitHub CLI/REST search; do not require
+GraphQL or ProjectV2 operations. If an open match exists, add the evidence there rather than
+creating a duplicate. If a closed Issue or merged PR matches, verify whether the work is already
+delivered before filing a new contract.
 
 ### Admission claims must match the named production seam
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,6 +502,7 @@ Builder-agent rules:
 - Do not treat chat-only requests as canonical implementation tasks when an Issue is expected.
 - Do not expand scope beyond the Issue without updating the task contract first.
 - Do not create new backlog work in GitHub without stable `Source Anchors` that point to the most local governing doc items.
+- Before creating or normalizing a governance or contract Issue, search GitHub for the same artifact or symptom in open Issues, recently merged PRs, and closed Issues. Use GitHub CLI/REST search; do not require GraphQL or ProjectV2 operations. Add evidence to an open match rather than creating a duplicate; for a closed Issue or merged PR, verify whether the work is already delivered before filing a new contract.
 - Prefer stable anchor IDs over prose fragments when the source doc is likely to produce multiple Issues over time.
 - Treat GitHub Issues as the canonical backlog receipt. GitHub Project is an optional legacy projection when available; inline doc markers such as `Tracked by: #...` are secondary convenience notes only.
 - Prefer Issues plus truthful agent labels, linked PR state, and CI as harder authority than Project state if they drift.

--- a/tests/architecture/test_agent_skill_entrypoints.py
+++ b/tests/architecture/test_agent_skill_entrypoints.py
@@ -48,6 +48,17 @@ def test_shared_issue_contract_requires_duplicate_search_before_issue_creation()
     assert "do not require GraphQL or ProjectV2 operations" in self_sufficiency
 
 
+def test_duplicate_search_rule_is_present_in_canonical_agent_instructions() -> None:
+    agents = _read("AGENTS.md")
+    delivery_governance = " ".join(
+        _section_between(agents, "## GitHub delivery governance", "## Dispatcher policy").split()
+    )
+
+    assert "Before creating or normalizing a governance or contract Issue" in delivery_governance
+    assert "open Issues, recently merged PRs, and closed Issues" in delivery_governance
+    assert "Use GitHub CLI/REST search; do not require GraphQL or ProjectV2 operations" in delivery_governance
+
+
 def test_shared_issue_contract_bounds_producer_and_caller_surfaces() -> None:
     contract = _read(".codex/skills/_shared/ISSUE_CONTRACT.md")
     bounded_surfaces = " ".join(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5011

## Linked Issue
Closes #5011

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): GitHub Issue authoring
- Write class: governance/docs/tests
- Persistence impact: GitHub Issue contracts only
- Derived/rebuildable impact: none
- New or changed contract: canonical entrypoint requires pre-filing duplicate search
- Owner-doc impact: none
- Transition debt impact: reduces duplicate Issue risk
- Boundary risk: no Product/Runtime authority change

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Place the mandatory governance/contract duplicate-search rule in canonical AGENTS.md.
- Keep the shared Issue contract linked to the canonical rule and protect it with focused coverage.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue fully records this normal implementation; no BuilderOps operational material or delivery divergence was produced.

## Notes
Validation: python3 scripts/docs_guard.py; python3 scripts/lint_skills_consistency.py; ruff check app tests; git diff --check; python3 -m pytest -q tests/architecture/test_agent_skill_entrypoints.py. Local review-before-CI gate: satisfied; risk surfaces: none.