### PR TITLE
Migrate legacy YouTube OAuth credentials

### DIFF
--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -36,6 +36,7 @@ import json
 import os
 import stat
 import threading
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -44,7 +45,7 @@ from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from app.config.environment import active_environment
+from app.config.environment import ENV_DEV, active_environment
 from app.config.paths import resolve_runtime_artifact_path
 
 KEY_ENV_VAR = "YOUTUBE_TOKEN_STORE_KEY"
@@ -56,6 +57,8 @@ _SCHEMA = "youtube-token-store.v1"
 _STATE_DIRECTORY = "knowledge_acquisition"
 _TOKEN_STORE_FILENAME = "youtube_token_store.enc"
 _WRITER_LOCK_FILENAME = "youtube_oauth_writer.lock"
+_LEGACY_DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
+_MIGRATION_STAGE_FILENAME = f".{_TOKEN_STORE_FILENAME}.migration-stage"
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -70,6 +73,10 @@ class TokenStoreKeyMissingError(RuntimeError):
 
 class OAuthStateBoundaryError(RuntimeError):
     """The private channel OAuth state boundary is absent or unsafe."""
+
+
+class OAuthStateMigrationError(OAuthStateBoundaryError):
+    """Legacy and channel-rooted OAuth state cannot converge safely."""
 
 
 class OAuthWriterAdmissionError(RuntimeError):
@@ -171,6 +178,86 @@ def default_token_store_path() -> Path:
     return _token_store_path(canonical_oauth_state_root())
 
 
+def _legacy_default_token_store_paths() -> tuple[Path, ...]:
+    """Resolve every bounded checkout/CWD location used by the old producer.
+
+    The former default was process-CWD-relative.  The product producer was
+    dev-only and normally launched from a repository checkout, so upgrade
+    discovery covers the current launch CWD, this module's checkout, the
+    canonical shared checkout, and every linked worktree registered there.
+    Multiple surviving stores are ambiguous and are refused by the migration
+    preflight rather than guessed or merged.
+    """
+
+    roots = [Path.cwd(), _REPO_ROOT]
+    try:
+        canonical_root = _canonical_repository_root()
+    except OAuthStateBoundaryError:
+        canonical_root = None
+    if canonical_root is not None:
+        roots.append(canonical_root)
+        worktrees_root = canonical_root / ".git" / "worktrees"
+        try:
+            entries = tuple(worktrees_root.iterdir())
+        except FileNotFoundError:
+            entries = ()
+        except OSError as exc:
+            raise OAuthStateMigrationError(
+                "registered legacy YouTube OAuth locations are unavailable"
+            ) from exc
+        for entry in entries:
+            gitdir_marker = entry / "gitdir"
+            try:
+                marker = gitdir_marker.read_text(encoding="utf-8").strip()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise OAuthStateMigrationError(
+                    "registered legacy YouTube OAuth location is unavailable"
+                ) from exc
+            if marker:
+                roots.append(Path(marker).expanduser().parent)
+
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        candidate = Path(os.path.abspath(root / _LEGACY_DEFAULT_REL_PATH))
+        if candidate not in seen:
+            seen.add(candidate)
+            candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _normalized_path_identities(path: Path) -> frozenset[str]:
+    """Path spellings that collapse on the default developer filesystem."""
+
+    absolute = os.path.abspath(path)
+    canonical = os.path.realpath(absolute)
+    return frozenset(
+        unicodedata.normalize("NFC", spelling).casefold()
+        for spelling in (absolute, canonical)
+    )
+
+
+def _paths_alias(first: Path, second: Path) -> bool:
+    """Detect lexical, case/Unicode, symlink, hard-link, and bind-mount aliases."""
+
+    if _normalized_path_identities(first) & _normalized_path_identities(second):
+        return True
+    try:
+        if os.path.samefile(first, second):
+            return True
+    except OSError:
+        pass
+    try:
+        return os.path.samefile(first.parent, second.parent) and (
+            unicodedata.normalize("NFC", first.name).casefold()
+            == unicodedata.normalize("NFC", second.name).casefold()
+        )
+    except OSError:
+        return False
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -266,16 +353,36 @@ class YouTubeTokenStore:
 
     def __init__(self, path: Path | str | None = None) -> None:
         if path is None:
+            configured_path = (os.environ.get(PATH_ENV_VAR) or "").strip()
             state_root = canonical_oauth_state_root()
             self._path = _token_store_path(state_root)
             self._channel_runtime_root: Path | None = state_root.parent
+            migrate_legacy_default = (
+                active_environment() == ENV_DEV
+                and not configured_path
+            )
+            if (
+                not configured_path
+                and any(
+                    _paths_alias(self._path, legacy_path)
+                    for legacy_path in _legacy_default_token_store_paths()
+                )
+            ):
+                raise OAuthStateBoundaryError(
+                    "channel-rooted YouTube OAuth state aliases the unscoped legacy default"
+                )
         else:
             explicit = Path(path).expanduser()
             if not explicit.is_absolute():
                 raise OAuthStateBoundaryError("explicit OAuth state path must be absolute")
             self._path = Path(os.path.abspath(explicit))
             self._channel_runtime_root = None
+            migrate_legacy_default = False
         self._lock = threading.Lock()
+        if migrate_legacy_default:
+            self._migrate_legacy_default()
+        if path is None and not configured_path:
+            self._preflight_existing_default_target()
 
     def __repr__(self) -> str:
         return "YouTubeTokenStore(path=***)"
@@ -306,6 +413,32 @@ class YouTubeTokenStore:
         ):
             raise OAuthStateBoundaryError(
                 "YouTube OAuth state file must be a current-user-owned mode-0600 regular file"
+            )
+
+    @staticmethod
+    def _assert_legacy_directory(metadata: os.stat_result) -> None:
+        """Accept the old mkdir-produced directory without accepting writable peers."""
+
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_mode & 0o022
+            or metadata.st_uid != os.geteuid()
+        ):
+            raise OAuthStateMigrationError(
+                "legacy YouTube OAuth state directory is not safely current-user-owned"
+            )
+
+    @staticmethod
+    def _assert_legacy_file(metadata: os.stat_result) -> None:
+        """Accept old umask-derived read bits, but never another writer."""
+
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_mode & 0o022
+            or metadata.st_uid != os.geteuid()
+        ):
+            raise OAuthStateMigrationError(
+                "legacy YouTube OAuth state file is not a safe current-user-owned regular file"
             )
 
     @staticmethod
@@ -382,13 +515,21 @@ class YouTubeTokenStore:
             except OAuthStateBoundaryError:
                 os.close(runtime_fd)
                 raise
+            descriptor = -1
             try:
                 try:
                     os.mkdir(_STATE_DIRECTORY, mode=0o700, dir_fd=runtime_fd)
                 except FileExistsError:
                     pass
                 descriptor = os.open(_STATE_DIRECTORY, flags, dir_fd=runtime_fd)
+                # The credential file cannot become authoritative until the
+                # private directory's entry is durable in its parent.  Fsync
+                # even when the directory pre-existed so a retry after an
+                # indeterminate earlier fsync closes that crash window.
+                os.fsync(runtime_fd)
             except OSError:
+                if descriptor >= 0:
+                    os.close(descriptor)
                 raise OAuthStateBoundaryError(
                     "private YouTube OAuth state directory is unavailable"
                 ) from None
@@ -426,19 +567,412 @@ class YouTubeTokenStore:
             raise
         return descriptor
 
+    @staticmethod
+    def _entry_exists(path: Path, *, label: str) -> bool:
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            raise OAuthStateMigrationError(f"{label} state is unavailable") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise OAuthStateMigrationError(f"{label} state must not be a symlink")
+        return True
+
+    def _open_legacy_directory(self, legacy_path: Path) -> int | None:
+        parent = legacy_path.parent
+        try:
+            parent_metadata = parent.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise OAuthStateMigrationError(
+                "legacy YouTube OAuth state directory is unavailable"
+            ) from exc
+        self._assert_no_symlink_ancestry(parent, allow_missing_leaf=False)
+        self._assert_legacy_directory(parent_metadata)
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(parent, flags)
+        except OSError as exc:
+            raise OAuthStateMigrationError(
+                "legacy YouTube OAuth state directory is unavailable"
+            ) from exc
+        try:
+            self._assert_legacy_directory(os.fstat(descriptor))
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+
+    def _open_checked_store_entry(
+        self,
+        directory_fd: int,
+        name: str,
+        *,
+        legacy: bool,
+        label: str,
+    ) -> int | None:
+        try:
+            metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise OAuthStateMigrationError(f"{label} state is unavailable") from exc
+        if legacy:
+            self._assert_legacy_file(metadata)
+        else:
+            self._assert_private_file(metadata)
+        try:
+            descriptor = os.open(
+                name,
+                os.O_RDONLY
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_NONBLOCK", 0),
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise OAuthStateMigrationError(f"{label} state is unavailable") from exc
+        try:
+            metadata = os.fstat(descriptor)
+            if legacy:
+                self._assert_legacy_file(metadata)
+            else:
+                self._assert_private_file(metadata)
+        except BaseException:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            raise
+        return descriptor
+
+    def _read_store_entry(
+        self,
+        directory_fd: int,
+        name: str,
+        *,
+        legacy: bool,
+        label: str,
+    ) -> bytes | None:
+        descriptor = self._open_checked_store_entry(
+            directory_fd,
+            name,
+            legacy=legacy,
+            label=label,
+        )
+        if descriptor is None:
+            return None
+        with os.fdopen(descriptor, "rb") as handle:
+            payload = handle.read()
+        self._validate_migration_payload(payload, label=label)
+        return payload
+
+    def _preflight_existing_default_target(self) -> None:
+        """Refuse an unsafe implicit target before status/refresh receives the store."""
+
+        if not self._entry_exists(self._path, label="channel-rooted"):
+            return
+        directory_fd = self._open_state_directory()
+        try:
+            payload = self._read_store_entry(
+                directory_fd,
+                self._path.name,
+                legacy=False,
+                label="channel-rooted",
+            )
+            assert payload is not None
+        finally:
+            os.close(directory_fd)
+
+    @staticmethod
+    def _validate_migration_payload(payload: bytes, *, label: str) -> None:
+        """Validate only encrypted structure; migration never decrypts or falls back."""
+
+        try:
+            data = json.loads(payload.decode("utf-8"))
+            if not isinstance(data, dict) or data.get("schema") != _SCHEMA:
+                raise ValueError("unexpected schema")
+            records = data.get("records")
+            if not isinstance(records, dict):
+                raise ValueError("records must be an object")
+            for binding_id, record in records.items():
+                if not isinstance(binding_id, str) or not binding_id:
+                    raise ValueError("invalid binding id")
+                if not isinstance(record, dict):
+                    raise ValueError("invalid encrypted record")
+                ciphertext = record.get("ciphertext")
+                nonce = record.get("nonce")
+                if not isinstance(ciphertext, str) or not isinstance(nonce, str):
+                    raise ValueError("invalid encrypted record fields")
+                decoded_ciphertext = base64.b64decode(ciphertext, validate=True)
+                decoded_nonce = base64.b64decode(nonce, validate=True)
+                if len(decoded_nonce) != _NONCE_BYTES or len(decoded_ciphertext) < 16:
+                    raise ValueError("invalid AES-GCM record")
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise OAuthStateMigrationError(
+                f"{label} encrypted YouTube token store failed migration preflight"
+            ) from exc
+
+    def _acquire_migration_admission(self) -> OAuthWriterAdmission:
+        directory_fd = self._open_state_directory()
+        try:
+            descriptor = os.open(
+                _WRITER_LOCK_FILENAME,
+                os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=directory_fd,
+            )
+            try:
+                self._assert_private_file(os.fstat(descriptor))
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            except BaseException:
+                os.close(descriptor)
+                raise
+            return OAuthWriterAdmission(descriptor)
+        finally:
+            os.close(directory_fd)
+
+    @staticmethod
+    def _assert_equal_payloads(first: bytes, second: bytes, *, states: str) -> None:
+        if first != second:
+            raise OAuthStateMigrationError(
+                f"ambiguous encrypted YouTube token stores exist in {states}"
+            )
+
+    def _remove_migration_entry(self, directory_fd: int, name: str, *, label: str) -> None:
+        try:
+            os.unlink(name, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except OSError as exc:
+            raise OAuthStateMigrationError(f"{label} failed") from exc
+
+    def _publish_migration_payload(
+        self,
+        directory_fd: int,
+        payload: bytes,
+        *,
+        staged_payload: bytes | None,
+    ) -> bytes:
+        # Rollback owns only entries created by this attempt.  A pre-existing
+        # stage is independent recovery evidence and must survive any refusal.
+        stage_created = False
+        target_created = False
+        try:
+            if staged_payload is None:
+                descriptor = os.open(
+                    _MIGRATION_STAGE_FILENAME,
+                    os.O_WRONLY
+                    | os.O_CREAT
+                    | os.O_EXCL
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                    dir_fd=directory_fd,
+                )
+                stage_created = True
+                with os.fdopen(descriptor, "wb") as handle:
+                    handle.write(payload)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                staged_payload = self._read_store_entry(
+                    directory_fd,
+                    _MIGRATION_STAGE_FILENAME,
+                    legacy=False,
+                    label="staged migration",
+                )
+                assert staged_payload is not None
+            self._assert_equal_payloads(
+                payload, staged_payload, states="legacy and staged state"
+            )
+            os.link(
+                _MIGRATION_STAGE_FILENAME,
+                self._path.name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            target_created = True
+            os.fsync(directory_fd)
+            published = self._read_store_entry(
+                directory_fd,
+                self._path.name,
+                legacy=False,
+                label="channel-rooted",
+            )
+            assert published is not None
+            self._assert_equal_payloads(payload, published, states="legacy and channel state")
+            self._remove_migration_entry(
+                directory_fd,
+                _MIGRATION_STAGE_FILENAME,
+                label="staged migration cleanup",
+            )
+            stage_created = False
+            return published
+        except Exception as exc:
+            rollback_error: OSError | None = None
+            if target_created:
+                try:
+                    os.unlink(self._path.name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+                except OSError as rollback_exc:
+                    rollback_error = rollback_exc
+            if stage_created:
+                try:
+                    os.unlink(_MIGRATION_STAGE_FILENAME, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+                except OSError as cleanup_exc:
+                    rollback_error = rollback_error or cleanup_exc
+            if rollback_error is not None:
+                raise OAuthStateMigrationError(
+                    "target publication failed and rollback could not be verified"
+                ) from exc
+            if (
+                not target_created
+                and not stage_created
+                and isinstance(exc, OAuthStateMigrationError)
+            ):
+                raise
+            raise OAuthStateMigrationError(
+                "target publication failed; encrypted legacy state was preserved"
+            ) from exc
+
+    def _migrate_legacy_default(self) -> None:
+        """Converge the old default into this channel before any credential read."""
+
+        legacy_candidates = _legacy_default_token_store_paths()
+        if any(_paths_alias(self._path, path) for path in legacy_candidates):
+            raise OAuthStateBoundaryError(
+                "channel-rooted YouTube OAuth state aliases the unscoped legacy default"
+            )
+        legacy_paths = tuple(
+            path
+            for path in legacy_candidates
+            if self._entry_exists(path, label="legacy")
+        )
+        if len(legacy_paths) > 1:
+            raise OAuthStateMigrationError(
+                "ambiguous encrypted YouTube token stores exist in multiple legacy locations"
+            )
+        legacy_path = legacy_paths[0] if legacy_paths else None
+        stage_path = self._path.with_name(_MIGRATION_STAGE_FILENAME)
+        stage_exists = self._entry_exists(stage_path, label="staged migration")
+        if legacy_path is None and not stage_exists:
+            return
+
+        admission = self._acquire_migration_admission()
+        legacy_fd: int | None = None
+        target_fd: int | None = None
+        try:
+            legacy_fd = (
+                self._open_legacy_directory(legacy_path)
+                if legacy_path is not None
+                else None
+            )
+            legacy = (
+                self._read_store_entry(
+                    legacy_fd,
+                    _TOKEN_STORE_FILENAME,
+                    legacy=True,
+                    label="legacy",
+                )
+                if legacy_fd is not None
+                else None
+            )
+            target_fd = self._open_state_directory()
+            target = self._read_store_entry(
+                target_fd,
+                self._path.name,
+                legacy=False,
+                label="channel-rooted",
+            )
+            stage = self._read_store_entry(
+                target_fd,
+                _MIGRATION_STAGE_FILENAME,
+                legacy=False,
+                label="staged migration",
+            )
+
+            if legacy is None and stage is not None and target is None:
+                raise OAuthStateMigrationError(
+                    "orphaned staged migration has no legacy or channel authority"
+                )
+            if legacy is None:
+                assert target is not None
+                if stage is not None:
+                    self._assert_equal_payloads(
+                        target, stage, states="channel and staged state"
+                    )
+                    self._remove_migration_entry(
+                        target_fd,
+                        _MIGRATION_STAGE_FILENAME,
+                        label="staged migration cleanup",
+                    )
+                return
+            if target is None:
+                target = self._publish_migration_payload(
+                    target_fd,
+                    legacy,
+                    staged_payload=stage,
+                )
+            else:
+                self._assert_equal_payloads(
+                    legacy, target, states="legacy and channel-rooted state"
+                )
+                if stage is not None:
+                    self._assert_equal_payloads(
+                        target, stage, states="channel and staged state"
+                    )
+                    self._remove_migration_entry(
+                        target_fd,
+                        _MIGRATION_STAGE_FILENAME,
+                        label="staged migration cleanup",
+                    )
+            try:
+                # A visible target from an interrupted publication is not yet
+                # authority proof.  Re-establish its directory-link durability
+                # on every retry before the legacy authority can be removed.
+                os.fsync(target_fd)
+            except OSError as exc:
+                raise OAuthStateMigrationError(
+                    "channel-rooted durability verification failed"
+                ) from exc
+            assert legacy_fd is not None
+            current_legacy = self._read_store_entry(
+                legacy_fd,
+                _TOKEN_STORE_FILENAME,
+                legacy=True,
+                label="legacy",
+            )
+            assert current_legacy is not None
+            self._assert_equal_payloads(
+                target, current_legacy, states="channel and final legacy state"
+            )
+            self._remove_migration_entry(
+                legacy_fd,
+                _TOKEN_STORE_FILENAME,
+                label="legacy finalization",
+            )
+        finally:
+            if target_fd is not None:
+                os.close(target_fd)
+            if legacy_fd is not None:
+                os.close(legacy_fd)
+            admission.release()
+
     def _load_file(self) -> dict[str, Any]:
         directory_fd = self._open_state_directory()
         try:
-            try:
-                descriptor = os.open(
-                    self._path.name,
-                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
-                    dir_fd=directory_fd,
-                )
-            except FileNotFoundError:
+            descriptor = self._open_checked_store_entry(
+                directory_fd,
+                self._path.name,
+                legacy=False,
+                label="channel-rooted",
+            )
+            if descriptor is None:
                 return {"schema": _SCHEMA, "records": {}}
             try:
-                self._assert_private_file(os.fstat(descriptor))
                 with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
                     raw = handle.read()
             except BaseException:
@@ -459,19 +993,14 @@ class YouTubeTokenStore:
         temporary_name = f".{self._path.name}.{uuid.uuid4().hex}.tmp"
         descriptor: int | None = None
         try:
-            try:
-                existing = os.open(
-                    self._path.name,
-                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
-                    dir_fd=directory_fd,
-                )
-            except FileNotFoundError:
-                existing = None
+            existing = self._open_checked_store_entry(
+                directory_fd,
+                self._path.name,
+                legacy=False,
+                label="channel-rooted",
+            )
             if existing is not None:
-                try:
-                    self._assert_private_file(os.fstat(existing))
-                finally:
-                    os.close(existing)
+                os.close(existing)
             descriptor = os.open(
                 temporary_name,
                 os.O_WRONLY
@@ -590,6 +1119,7 @@ class YouTubeTokenStore:
 __all__ = [
     "KEY_ENV_VAR",
     "OAuthStateBoundaryError",
+    "OAuthStateMigrationError",
     "OAuthWriterAdmission",
     "OAuthWriterAdmissionError",
     "PATH_ENV_VAR",

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -115,6 +115,24 @@ non-current-user-owned/non-`0700` private directories, and non-current-user-owne
 files before credential or admission effects. The shipped sticky `1777` channel scratch mount is a
 container/bootstrap boundary only; credential and admission state stays in its private child.
 
+When `YOUTUBE_TOKEN_STORE_PATH` is unset, the first dev-channel default-bound open after an upgrade
+preflights the former process-CWD-relative
+`runtime/knowledge_acquisition/youtube_token_store.enc` locations associated with the launch CWD,
+canonical checkout, and registered linked worktrees before reading status or refreshing credentials.
+The former producer was dev-only, so test/prod never claim or delete that unscoped legacy state;
+multiple surviving legacy locations fail loud as ambiguous. A safe current-user-owned legacy ciphertext file is
+copied byte-for-byte through a mode-`0600`, fsynced stage into the active channel's mode-`0700`
+private directory whose parent link is also fsynced, atomically published without overwriting an existing target, re-read and
+verified, and only then removed. An interruption leaves the legacy file, an equal durable target,
+or both; retry converges those states. Divergent legacy/new ciphertext, symlinks, unsafe ownership
+or writable peer permissions fail loud without deleting any authority or pre-existing stage. Explicit path overrides
+remain explicit and never trigger this default-path migration. Migration validates encrypted
+structure only and never decrypts, rewrites, or falls back to plaintext. A channel runtime authority
+whose default target would alias the unscoped legacy path is refused in every channel; wrong-type
+leaves such as FIFOs are checked without a blocking open and fail loud both during default
+construction and through ordinary status/refresh reads. Alias identity includes physical inode,
+canonical, case-folded, and Unicode-normalized path spellings rather than lexical equality alone.
+
 V1 admits one connect or reconnect transition at a time across processes and permits at most one
 durable YouTube account binding. Admission happens before provider egress and remains held through
 token and binding persistence. Tokens remain the first durable write, but only a matching durable

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -4,7 +4,7 @@ Authority: Owns the YouTube source-sync capability design — account binding, s
 Owner: Architecture / knowledge acquisition
 Temporal class: strategic
 Review cadence: event-driven (task merge, YouTube API surface change)
-Last reviewed: 2026-07-21
+Last reviewed: 2026-08-22
 
 # YouTube Source Sync
 
@@ -160,7 +160,10 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   manual call and does not claim lease or concurrent-run reconciliation.
 - **INV-YSS-7 — channel isolation.** dev/test/prod never share OAuth state, registry rows, cursors,
   or queues: DB-per-channel isolates the tables; token stores are per-channel app-local paths.
-  Environment selection never bypasses these boundaries (`docs/ENVIRONMENTS.md`).
+  Environment selection never bypasses these boundaries (`docs/ENVIRONMENTS.md`). Before a
+  dev-channel rooted default is first used after upgrade, a fail-loud existing-resource migration
+  durably verifies the former dev-only encrypted default before deleting it; test/prod never claim
+  that unscoped state, and explicit path overrides remain outside the migration.
 - **INV-YSS-8 — posture markers unconditional.** Every candidate written via this capability
   carries `authority.requires_review: true` + `review_state: draft` and enters triage at
   `captured` — inherited from KA-05 and never overridable by any sync policy or setting.

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -245,6 +245,15 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   binding (default under the channel runtime dir; never the vault, never the repo), key from
   `YOUTUBE_TOKEN_STORE_KEY` (32 bytes, same provisioning boundary). Missing key with an existing
   binding ⇒ `auth_key_missing` degraded state — never a plaintext fallback (fail closed).
+- A default-path upgrade migrates the dev-only former process-CWD-relative encrypted store into the
+  dev channel root before status/refresh reads. Discovery covers the launch CWD, canonical checkout,
+  and registered linked worktrees; test/prod never claim the unscoped legacy authority. The migration
+  is permission-checked and fsyncs both file content and the target directory's parent link,
+  atomically published without replacement, byte-verified before legacy deletion, and retry-safe
+  across interrupted equal dual states. Multiple legacy locations, divergent or unsafe states fail loud and preserve every
+  encrypted copy; a default target that aliases the unscoped legacy path is refused in every
+  channel using physical and normalized path identity, and an explicit `YOUTUBE_TOKEN_STORE_PATH`
+  is never auto-migrated. Wrong-type leaves fail without blocking migration, status, or refresh.
 - Redaction: all sync surfaces route through redaction-aware serialization; field names carry
   `token`/`secret`/`credential` tokens so existing key-name redactors match. Exception text from
   the OAuth/HTTP layer is sanitized (status + class, never response bodies that may echo tokens).

--- a/tests/knowledge_acquisition/test_youtube_oauth_durability.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth_durability.py
@@ -28,6 +28,7 @@ class _OAuthClient:
         self.channel_id = channel_id
         self.starts = 0
         self.polls = 0
+        self.refreshes = 0
 
     def start_device_flow(self) -> oauth.DeviceFlowHandle:
         self.starts += 1
@@ -45,6 +46,16 @@ class _OAuthClient:
         return oauth.TokenBundle(
             access_token=f"synthetic-access-{self.channel_id}",
             refresh_token=f"synthetic-refresh-{self.channel_id}",
+            expires_in=3600,
+            scope=oauth.SCOPE,
+            token_type="Bearer",
+        )
+
+    def refresh(self, _refresh_token: str) -> oauth.TokenBundle:
+        self.refreshes += 1
+        return oauth.TokenBundle(
+            access_token=f"synthetic-refreshed-access-{self.channel_id}",
+            refresh_token=f"synthetic-refreshed-refresh-{self.channel_id}",
             expires_in=3600,
             scope=oauth.SCOPE,
             token_type="Bearer",
@@ -89,6 +100,34 @@ def _token(channel_id: str = CHANNEL_A) -> tokstore.StoredToken:
         obtained_at="2026-08-12T00:00:00+00:00",
         provider_channel_id=channel_id,
     )
+
+
+def _bind_repository_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, name: str = "primary-checkout"
+) -> Path:
+    repository_root = tmp_path / name
+    (repository_root / ".git").mkdir(parents=True)
+    (repository_root / "tmp-dev").mkdir(mode=0o700)
+    monkeypatch.setattr(tokstore, "_REPO_ROOT", repository_root)
+    monkeypatch.chdir(repository_root)
+    monkeypatch.delenv("INDEX_OUTBOX_PATH", raising=False)
+    return repository_root
+
+
+def _legacy_store_path(repository_root: Path) -> Path:
+    return (
+        repository_root
+        / "runtime"
+        / "knowledge_acquisition"
+        / "youtube_token_store.enc"
+    )
+
+
+def _write_store(path: Path, binding_id: str, token: tokstore.StoredToken) -> bytes:
+    path.parent.mkdir(parents=True, mode=0o700)
+    path.parent.chmod(0o700)
+    tokstore.YouTubeTokenStore(path).put(binding_id, token)
+    return path.read_bytes()
 
 
 def test_default_oauth_state_is_channel_bound_and_hardened(
@@ -193,6 +232,386 @@ def test_default_oauth_state_is_channel_bound_and_hardened(
     with pytest.raises(tokstore.OAuthStateBoundaryError):
         tokstore.default_token_store_path()
     assert not (tmp_path / "escaped.enc").exists()
+
+
+def test_legacy_default_token_store_migrates_before_new_path_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository_root = _bind_repository_root(tmp_path, monkeypatch)
+    binding_id = "legacy-binding"
+    legacy_checkout = tmp_path / "legacy-linked-checkout"
+    legacy_checkout.mkdir()
+    legacy_worktree_metadata = repository_root / ".git" / "worktrees" / "legacy-linked"
+    legacy_worktree_metadata.mkdir(parents=True)
+    (legacy_worktree_metadata / "gitdir").write_text(
+        f"{legacy_checkout / '.git'}\n", encoding="utf-8"
+    )
+    legacy_path = _legacy_store_path(legacy_checkout)
+    legacy_payload = _write_store(
+        legacy_path, binding_id, _token().with_expired_access()
+    )
+    legacy_path.chmod(0o644)  # the old Path.write_text producer honored the host umask
+    restart_working_root = tmp_path / "upgraded-process-cwd"
+    restart_working_root.mkdir()
+    monkeypatch.chdir(restart_working_root)
+    explicit_path = (
+        repository_root
+        / "tmp-dev"
+        / "knowledge_acquisition"
+        / "explicit-token-store.enc"
+    )
+    monkeypatch.setenv(tokstore.PATH_ENV_VAR, str(explicit_path))
+    overridden = tokstore.YouTubeTokenStore()
+    assert overridden.path == explicit_path
+    assert legacy_path.read_bytes() == legacy_payload
+    assert explicit_path.exists() is False
+    monkeypatch.delenv(tokstore.PATH_ENV_VAR)
+
+    bindings = yab.AccountBindingStore.for_runtime()
+    bindings.create(
+        provider_channel_id=CHANNEL_A,
+        display_label="Legacy channel",
+        scopes=[oauth.SCOPE],
+        account_binding_id=binding_id,
+    )
+
+    migrated = tokstore.YouTubeTokenStore()
+    assert migrated.path.read_bytes() == legacy_payload
+    binder = _binder(_OAuthClient(), migrated, bindings)
+    assert binder.status(binding_id) == {
+        "status": "connected",
+        "reason_code": None,
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+
+    client = _OAuthClient()
+    access_token = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=migrated,
+        oauth_client=client,  # type: ignore[arg-type]
+        binding_store=bindings,
+    ).get_access_token()
+    assert access_token == f"synthetic-refreshed-access-{CHANNEL_A}"
+    assert client.refreshes == 1
+    assert migrated.get(binding_id).refresh_token == (
+        f"synthetic-refreshed-refresh-{CHANNEL_A}"
+    )
+    assert legacy_path.exists() is False
+    assert migrated.path == (
+        repository_root
+        / "tmp-dev"
+        / "knowledge_acquisition"
+        / "youtube_token_store.enc"
+    )
+    assert migrated.path.parent.stat().st_mode & 0o777 == 0o700
+    assert migrated.path.stat().st_mode & 0o777 == 0o600
+    assert legacy_payload != migrated.path.read_bytes()
+    assert b"synthetic-refresh" not in migrated.path.read_bytes()
+
+
+def test_token_store_migration_is_crash_convergent_and_channel_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository_root = _bind_repository_root(tmp_path, monkeypatch)
+    binding_id = "crash-window-binding"
+    legacy_path = _legacy_store_path(repository_root)
+    legacy_payload = _write_store(legacy_path, binding_id, _token())
+    target_path = tokstore.default_token_store_path()
+
+    # The historical producer was dev-only.  A test/prod process that starts
+    # first must neither capture nor delete its unscoped legacy credential.
+    for environment, runtime_name in (("test", "tmp-test"), ("prod", "tmp")):
+        monkeypatch.setenv("PKM_ENVIRONMENT", environment)
+        (repository_root / runtime_name).mkdir(mode=0o700)
+        isolated = tokstore.YouTubeTokenStore()
+        assert isolated.binding_ids() == ()
+        assert legacy_path.read_bytes() == legacy_payload
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+
+    # Refuse before legacy deletion when the target directory's link cannot be
+    # durably committed in the channel runtime root.
+    real_fsync = os.fsync
+    runtime_metadata = (repository_root / "tmp-dev").stat()
+
+    def fail_runtime_directory_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        if (metadata.st_dev, metadata.st_ino) == (
+            runtime_metadata.st_dev,
+            runtime_metadata.st_ino,
+        ):
+            raise OSError("synthetic runtime-directory fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(tokstore.os, "fsync", fail_runtime_directory_fsync)
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        tokstore.YouTubeTokenStore()
+    assert legacy_path.read_bytes() == legacy_payload
+    assert target_path.exists() is False
+    monkeypatch.setattr(tokstore.os, "fsync", real_fsync)
+
+    real_link = os.link
+
+    def fail_publication(*_args: object, **_kwargs: object) -> None:
+        raise OSError("synthetic target publication failure")
+
+    monkeypatch.setattr(tokstore.os, "link", fail_publication)
+    with pytest.raises(
+        tokstore.OAuthStateMigrationError,
+        match="target publication failed",
+    ):
+        tokstore.YouTubeTokenStore()
+    assert legacy_path.read_bytes() == legacy_payload
+    assert target_path.exists() is False
+
+    monkeypatch.setattr(tokstore.os, "link", real_link)
+    real_unlink = os.unlink
+
+    def fail_legacy_finalize(
+        path: str,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        if path == legacy_path.name:
+            raise OSError("synthetic legacy finalization failure")
+        real_unlink(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(tokstore.os, "unlink", fail_legacy_finalize)
+    with pytest.raises(
+        tokstore.OAuthStateMigrationError,
+        match="legacy finalization failed",
+    ):
+        tokstore.YouTubeTokenStore()
+    assert legacy_path.read_bytes() == legacy_payload
+    assert target_path.read_bytes() == legacy_payload
+
+    target_directory_metadata = target_path.parent.stat()
+
+    def fail_target_directory_fsync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        if (metadata.st_dev, metadata.st_ino) == (
+            target_directory_metadata.st_dev,
+            target_directory_metadata.st_ino,
+        ):
+            raise OSError("synthetic target-directory fsync failure")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(tokstore.os, "fsync", fail_target_directory_fsync)
+    with pytest.raises(
+        tokstore.OAuthStateMigrationError,
+        match="durability verification failed",
+    ):
+        tokstore.YouTubeTokenStore()
+    assert legacy_path.read_bytes() == legacy_payload
+    assert target_path.read_bytes() == legacy_payload
+
+    monkeypatch.setattr(tokstore.os, "fsync", real_fsync)
+    monkeypatch.setattr(tokstore.os, "unlink", real_unlink)
+    migrated = tokstore.YouTubeTokenStore()
+    assert migrated.get(binding_id) == _token()
+    assert legacy_path.exists() is False
+    assert target_path.stat().st_mode & 0o777 == 0o600
+    assert b"synthetic-refresh" not in target_path.read_bytes()
+
+    monkeypatch.setenv("PKM_ENVIRONMENT", "test")
+    isolated_test_store = tokstore.YouTubeTokenStore()
+    assert isolated_test_store.path == (
+        repository_root
+        / "tmp-test"
+        / "knowledge_acquisition"
+        / "youtube_token_store.enc"
+    )
+    assert isolated_test_store.binding_ids() == ()
+    assert migrated.get(binding_id) == _token()
+
+
+def test_token_store_migration_preflight_fails_loud_on_ambiguity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repository_root = _bind_repository_root(tmp_path, monkeypatch)
+    legacy_path = _legacy_store_path(repository_root)
+    legacy_payload = _write_store(legacy_path, "legacy-binding", _token(CHANNEL_A))
+    target_path = tokstore.default_token_store_path()
+    target_payload = _write_store(target_path, "new-binding", _token(CHANNEL_B))
+
+    with pytest.raises(tokstore.OAuthStateMigrationError, match="ambiguous"):
+        tokstore.YouTubeTokenStore()
+
+    assert legacy_path.read_bytes() == legacy_payload
+    assert target_path.read_bytes() == target_payload
+    assert legacy_path.exists() is True
+    assert target_path.exists() is True
+
+    multiple_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="multiple-legacy-checkout"
+    )
+    canonical_legacy_path = _legacy_store_path(multiple_root)
+    canonical_legacy_payload = _write_store(
+        canonical_legacy_path, "canonical-legacy-binding", _token(CHANNEL_A)
+    )
+    alternate_launch_root = tmp_path / "alternate-legacy-cwd"
+    alternate_launch_root.mkdir()
+    alternate_legacy_path = _legacy_store_path(alternate_launch_root)
+    alternate_legacy_payload = _write_store(
+        alternate_legacy_path, "alternate-legacy-binding", _token(CHANNEL_B)
+    )
+    monkeypatch.chdir(alternate_launch_root)
+    with pytest.raises(tokstore.OAuthStateMigrationError, match="multiple legacy"):
+        tokstore.YouTubeTokenStore()
+    assert canonical_legacy_path.read_bytes() == canonical_legacy_payload
+    assert alternate_legacy_path.read_bytes() == alternate_legacy_payload
+
+    stage_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="divergent-stage-checkout"
+    )
+    stage_legacy_path = _legacy_store_path(stage_root)
+    stage_legacy_payload = _write_store(
+        stage_legacy_path, "stage-legacy-binding", _token(CHANNEL_A)
+    )
+    stage_path = (
+        stage_root
+        / "tmp-dev"
+        / "knowledge_acquisition"
+        / tokstore._MIGRATION_STAGE_FILENAME
+    )
+    stage_payload = _write_store(
+        stage_path, "stage-newer-binding", _token(CHANNEL_B)
+    )
+    with pytest.raises(tokstore.OAuthStateMigrationError, match="ambiguous"):
+        tokstore.YouTubeTokenStore()
+    assert stage_legacy_path.read_bytes() == stage_legacy_payload
+    assert stage_path.read_bytes() == stage_payload
+    assert tokstore.default_token_store_path().exists() is False
+
+    alias_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="legacy-alias-checkout"
+    )
+    alias_legacy_path = _legacy_store_path(alias_root)
+    alias_legacy_payload = _write_store(
+        alias_legacy_path, "alias-binding", _token(CHANNEL_A)
+    )
+    alias_legacy_path.chmod(0o644)
+    monkeypatch.setenv(
+        "INDEX_OUTBOX_PATH", str(alias_root / "runtime" / "index-outbox.jsonl")
+    )
+    for environment in ("test", "prod", "dev"):
+        monkeypatch.setenv("PKM_ENVIRONMENT", environment)
+        with pytest.raises(tokstore.OAuthStateBoundaryError, match="aliases"):
+            tokstore.YouTubeTokenStore()
+        assert alias_legacy_path.read_bytes() == alias_legacy_payload
+
+    normalized_alias_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="normalized-alias-checkout"
+    )
+    normalized_legacy_path = _legacy_store_path(normalized_alias_root)
+    normalized_legacy_payload = _write_store(
+        normalized_legacy_path, "normalized-alias-binding", _token(CHANNEL_A)
+    )
+    monkeypatch.setenv(
+        "INDEX_OUTBOX_PATH",
+        str(normalized_alias_root / "RUNTIME" / "index-outbox.jsonl"),
+    )
+    with pytest.raises(tokstore.OAuthStateBoundaryError, match="aliases"):
+        tokstore.YouTubeTokenStore()
+    assert normalized_legacy_path.read_bytes() == normalized_legacy_payload
+
+    realpath_alias_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="realpath-alias-checkout"
+    )
+    realpath_legacy_path = _legacy_store_path(realpath_alias_root)
+    realpath_legacy_payload = _write_store(
+        realpath_legacy_path, "realpath-alias-binding", _token(CHANNEL_A)
+    )
+    runtime_link = realpath_alias_root / "runtime-link"
+    runtime_link.symlink_to(realpath_alias_root / "runtime", target_is_directory=True)
+    monkeypatch.setenv(
+        "INDEX_OUTBOX_PATH", str(runtime_link / "index-outbox.jsonl")
+    )
+    with pytest.raises(tokstore.OAuthStateBoundaryError, match="aliases"):
+        tokstore.YouTubeTokenStore()
+    assert realpath_legacy_path.read_bytes() == realpath_legacy_payload
+
+    physical_alias_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="physical-alias-checkout"
+    )
+    physical_legacy_path = _legacy_store_path(physical_alias_root)
+    physical_legacy_payload = _write_store(
+        physical_legacy_path, "physical-alias-binding", _token(CHANNEL_A)
+    )
+    physical_legacy_path.chmod(0o600)
+    physical_target_path = (
+        physical_alias_root
+        / "runtime-bind"
+        / "knowledge_acquisition"
+        / "youtube_token_store.enc"
+    )
+    real_samefile = os.path.samefile
+
+    def same_physical_parent(first: object, second: object) -> bool:
+        pair = {Path(first), Path(second)}
+        if pair == {physical_legacy_path.parent, physical_target_path.parent}:
+            return True
+        return real_samefile(first, second)
+
+    monkeypatch.setattr(tokstore.os.path, "samefile", same_physical_parent)
+    monkeypatch.setenv(
+        "INDEX_OUTBOX_PATH",
+        str(physical_alias_root / "runtime-bind" / "index-outbox.jsonl"),
+    )
+    with pytest.raises(tokstore.OAuthStateBoundaryError, match="aliases"):
+        tokstore.YouTubeTokenStore()
+    assert physical_legacy_path.read_bytes() == physical_legacy_payload
+    monkeypatch.setattr(tokstore.os.path, "samefile", real_samefile)
+
+    for state_kind in ("legacy", "stage", "target", "target-only"):
+        fifo_root = _bind_repository_root(
+            tmp_path, monkeypatch, name=f"fifo-{state_kind}-checkout"
+        )
+        fifo_legacy_path = _legacy_store_path(fifo_root)
+        fifo_target_path = tokstore.default_token_store_path()
+        if state_kind == "legacy":
+            fifo_path = fifo_legacy_path
+        else:
+            if state_kind != "target-only":
+                _write_store(
+                    fifo_legacy_path,
+                    f"fifo-{state_kind}-binding",
+                    _token(CHANNEL_A),
+                )
+            fifo_path = (
+                fifo_target_path.with_name(tokstore._MIGRATION_STAGE_FILENAME)
+                if state_kind == "stage"
+                else fifo_target_path
+            )
+        fifo_path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        fifo_path.parent.chmod(0o700)
+        os.mkfifo(fifo_path, mode=0o600)
+        with pytest.raises(tokstore.OAuthStateBoundaryError):
+            tokstore.YouTubeTokenStore()
+        assert fifo_path.exists() is True
+        if state_kind in {"stage", "target"}:
+            assert fifo_legacy_path.exists() is True
+
+    direct_fifo_root = tmp_path / "direct-consumer-fifo"
+    direct_fifo_root.mkdir(mode=0o700)
+    direct_fifo_path = direct_fifo_root / "tokens.enc"
+    direct_store = tokstore.YouTubeTokenStore(direct_fifo_path)
+    os.mkfifo(direct_fifo_path, mode=0o600)
+    with pytest.raises(tokstore.OAuthStateBoundaryError):
+        direct_store.binding_ids()
+
+    unsafe_root = _bind_repository_root(
+        tmp_path, monkeypatch, name="unsafe-primary-checkout"
+    )
+    unsafe_legacy_path = _legacy_store_path(unsafe_root)
+    _write_store(unsafe_legacy_path, "unsafe-binding", _token())
+    unsafe_legacy_path.chmod(0o622)
+    with pytest.raises(
+        tokstore.OAuthStateMigrationError,
+        match="not a safe current-user-owned regular file",
+    ):
+        tokstore.YouTubeTokenStore()
+    assert unsafe_legacy_path.exists() is True
 
 
 def test_concurrent_connect_converges_to_one_binding_and_credential(tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4863

## Linked Issue
Closes #4863

## SBS Impact
- Primary subsystem: Product/Runtime System — Evidence-Bearing Flow (EBF) YouTube source sync
- Secondary subsystem(s): Persistence/Durable Memory (PDM), Operational Execution (OEF), and release-channel runtime artifacts
- Write class: Mechanical encrypted-credential migration during default token-store construction
- Persistence impact: Moves an existing AES-256-GCM store from the legacy CWD-relative path to the active channel-rooted authority without decrypting or writing plaintext
- Derived/rebuildable impact: The mode-0600 migration stage is rebuildable while legacy ciphertext remains; the published target becomes durable credential authority
- New or changed contract: The implicit dev default must converge or fail loud before status/refresh; legacy admission is dev-only and all channel targets remain isolated
- Owner-doc impact: Updated the YouTube OAuth binding guide, source-sync contract, and subsystem README
- Transition debt impact: Removes the credential-loss/auth_missing transition debt introduced by the default-path move in PR #4837
- Boundary risk: Credential deletion, divergent authority, unsafe file types or permissions, crash ordering, aliasing, and channel bleed are fail-closed and regression-tested

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Migrates the former CWD-relative encrypted YouTube OAuth token store into the active dev channel root before any default status or refresh read.
- Fails loud on ambiguous or unsafe state, preserves ciphertext through atomic crash-convergent retries, and keeps explicit overrides plus test/prod channels isolated.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Planned Issue-backed Product/Runtime implementation; no BuilderOps operational material or delivery divergence required routing.

## Notes
Validation on ae24f7de4: 25 focused OAuth tests passed; ruff check app tests, mypy app/knowledge_acquisition, docs language guard, and git diff --check passed. Rebased byte-identically to 1782653023 over incoming 243fe3ba2..2e3204db9 (stable patch ID 968cfc7ad766032f9f411972c931977d6e68f211; no delivery-path overlap); all three Issue Verify targets plus changed-file ruff/docs/diff checks passed on the rebased head. Pre-CI Sol/xhigh convergence review: CLEAN after five rounds, all ten prior P1 findings/proof gaps resolved, no additional P0/P1. No production rollout is part of this PR.
