### PR TITLE
test: verify Builder Vault promotion authority boundaries

### DIFF
--- a/tests/builderops/test_builderops_promotion_gateway.py
+++ b/tests/builderops/test_builderops_promotion_gateway.py
@@ -268,6 +268,69 @@ def test_repo_doc_and_adr_promotions_are_proposal_only(
     assert "## Source Anchors" in proposal["body"]
 
 
+def test_working_artifact_promotion_stays_proposal_only(
+    store: SqliteBuilderOpsStore,
+    gateway: BuilderOpsPromotionGateway,
+) -> None:
+    artifact = store.create_working_artifact(
+        id="work_proposal_only_001",
+        summary="Builder working artifact remains non-normative",
+        body="A bounded artifact that may only produce a proposal.",
+        source_refs=[
+            {
+                "ref_type": "github_issue",
+                "ref": "#5013",
+                "authority_surface": "github",
+            }
+        ],
+        created_by=_actor(),
+        authority_standing="non_normative",
+        derivation_role="derived",
+        durability_posture="ephemeral",
+        working_lifecycle_stage="propose",
+        promotion_posture="proposed",
+        location_context="builder_vault",
+        provenance={
+            "source_refs": [
+                {
+                    "ref_type": "github_issue",
+                    "ref": "#5013",
+                    "authority_surface": "github",
+                }
+            ],
+            "derived_from": [
+                {
+                    "ref_type": "github_issue",
+                    "ref": "#5013",
+                    "authority_surface": "github",
+                }
+            ],
+            "transformation": "Prepare a proposal through the promotion gateway.",
+            "actor_or_process": "test-agent",
+            "observed_at": "2026-08-22T00:00:00Z",
+            "source_versions_or_watermarks": ["issue-5013@2026-08-22"],
+            "review_or_decision_ref": "unknown",
+            "promotion_ref": "unknown",
+            "supersedes_refs": ["unknown"],
+            "receipt_refs": ["unknown"],
+            "limitations": ["Cannot mutate target authority."],
+        },
+        receipt_refs=[],
+    )
+    intent = _create_intent(
+        store,
+        intent_id="prom_working_artifact_001",
+        target_surface="github_issue",
+        target_ref="pending",
+    )
+    proposal = gateway.render_proposal(intent["id"])
+
+    assert artifact["promotion_status"] == "none"
+    assert artifact["promotion_posture"] == "proposed"
+    assert proposal["would_mutate_authority"] is False
+    assert proposal["target_authority_surface"] == "github_issue"
+
+
 def test_repo_skill_and_workflow_doc_target_renders_as_writeback_proposal(
     store: SqliteBuilderOpsStore,
     gateway: BuilderOpsPromotionGateway,

--- a/tests/builderops/test_builderops_working_artifact_intake.py
+++ b/tests/builderops/test_builderops_working_artifact_intake.py
@@ -92,7 +92,7 @@ def test_working_artifact_uses_existing_builderops_store(
     assert store.get_record(created["id"]) == created
 
 
-def test_working_artifact_is_admitted_through_controlled_builderops_boundary(
+def test_working_artifact_is_reachable_through_supported_boundary(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "builderops.sqlite3"
@@ -108,17 +108,30 @@ def test_working_artifact_is_admitted_through_controlled_builderops_boundary(
     assert boundary.read_record(created["id"]) == created
 
 
-def test_working_artifact_cannot_claim_gateway_promotion_directly(
+def test_promoted_working_artifact_requires_gateway_evidence_at_every_transition(
     store: SqliteBuilderOpsStore,
 ) -> None:
     fields = _working_artifact_fields()
-    fields.update({
-        "promotion_status": "promoted",
-        "promotion_posture": "promoted",
-    })
+    fields["promotion_status"] = "promoted"
 
     with pytest.raises(BuilderOpsValidationError, match="cannot claim promotion"):
         store.create_working_artifact(**fields)
+
+    artifact = store.create_working_artifact(**_working_artifact_fields())
+    lease = store.acquire_lease(artifact["id"], actor=_actor())
+
+    with pytest.raises(BuilderOpsValidationError, match="cannot claim promotion"):
+        store.transition_record_state(
+            artifact["id"],
+            actor=_actor(),
+            lease_id=lease["lease_id"],
+            idempotency_key="working-artifact-direct-promotion",
+            source_refs=_source_refs(),
+            summary="Attempt unsupported direct promotion",
+            action="promote",
+            receipt_body="A working artifact cannot self-promote.",
+            promotion_status="promoted",
+        )
 
 
 def test_working_artifact_promotion_requires_explicit_target_and_receipt(


### PR DESCRIPTION
Governing-Issue: #5013

Fixes #5013

Final-Review-Rounds: 1

## SBS Impact
- Primary subsystem: Builder System / BuilderOps operating plane
- Secondary subsystem(s): promotion gateway and controlled agent boundary
- Write class: tests
- Persistence impact: verifies existing non-normative working records cannot self-promote through either admission or generic transition.
- Boundary risk: authority remains proposal-only through PromotionIntent and the existing gateway.

## Summary
- Adds the issue-contract verification targets for promotion refusal, supported-boundary reachability, and proposal-only gateway behavior.
- Covers both direct persistence admission and generic state transition so an unknown-provenance working artifact cannot self-promote.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The claimed GitHub issue and this PR fully represent the bounded test-only delivery; no operational BuilderOps record or authority crossing was created.

## Mechanism Convergence
- Mechanism: BuilderVaultWorkingArtifact admission and generic state transition.
- Invariant: working artifacts remain non-normative and cannot set promoted lifecycle/status/posture; only a separate PromotionIntent can produce a proposal and the gateway records outcome evidence.
- Writers: SqliteBuilderOpsStore.create_working_artifact and transition_record_state; supported MCP boundary delegates to the same store.
- Ordering/recovery: validation runs before the transaction commits the updated record/receipt, so refusal writes neither claimed promotion nor receipt; per-record leases serialize generic transitions.
- Proof: the three governing Verify targets plus existing PromotionIntent gateway transition tests.

## Notes
Validation: python3 -m pytest -q tests/builderops/test_builderops_working_artifact_intake.py tests/builderops/test_builderops_promotion_gateway.py; ruff check app tests; mypy app; python3 scripts/docs_guard.py; git diff --check; review_before_ci_gate.py --lane implementation --risk-surface state-machine.