### PR TITLE
bug: harden registry reconciliation authority and crash safety

### DIFF
--- a/.codex/skills/bug-to-issue/scripts/known_defects.py
+++ b/.codex/skills/bug-to-issue/scripts/known_defects.py
@@ -968,6 +968,23 @@ def _reconciliation_entries(
         if not blocks:
             _validate_schema_comment(comment)
             continue
+        # A legacy multi-entry comment is eligible for repair only when its
+        # schema starts at the comment boundary.  Treating an embedded marker
+        # as an entry would let reconciliation rewrite an owner note into
+        # registry authority.
+        lines = body.splitlines()
+        if not lines or not lines[0].startswith("<!-- known-defect-entry:"):
+            raise KnownDefectsError(
+                f"comment #{comment.get('id')} contains an entry marker after "
+                "a non-empty preamble"
+            )
+        association = str(comment.get("author_association") or "").upper()
+        if association not in TRUSTED_AUTHOR_ASSOCIATIONS:
+            raise KnownDefectsError(
+                f"schema comment #{comment.get('id')} has untrusted author association "
+                f"{association or '<missing>'}"
+            )
+        _comment_reservation_order(comment)
         for index, block in enumerate(blocks):
             parsed = _entry_marker_from_comment(block)
             if parsed is None:
@@ -1004,11 +1021,19 @@ def reconcile_registry(
     by_comment: dict[int, list[tuple[str, str, int]]] = {}
     for comment, block, defect_id, index in entries:
         if (int(comment["id"]), index) in canonical:
+            parsed = _entry_marker_from_comment(block)
+            assert parsed is not None
+            # Pending reservations are durable but non-authoritative.  The
+            # earliest reservation remains canonical; reconciliation commits
+            # it before it can remove a later final duplicate.
+            if parsed[1] == "pending":
+                block = block.replace(" phase=pending -->", " phase=final -->", 1)
             by_comment.setdefault(int(comment["id"]), []).append(
                 (defect_id, block, index)
             )
 
-    actions: list[dict[str, Any]] = []
+    additive_actions: list[dict[str, Any]] = []
+    destructive_actions: list[dict[str, Any]] = []
     for comment in sorted(
         {id(comment): comment for comment, *_ in entries}.values(),
         key=lambda item: _comment_reservation_order(item),
@@ -1016,11 +1041,11 @@ def reconcile_registry(
         comment_id = int(comment["id"])
         kept = by_comment.get(comment_id, [])
         if not kept:
-            actions.append({"action": "delete", "comment_id": comment_id})
+            destructive_actions.append({"action": "delete", "comment_id": comment_id})
             continue
         first_block = kept[0][1]
         if len(kept) > 1 or (comment.get("body") or "").strip() != first_block:
-            actions.append(
+            destructive_actions.append(
                 {
                     "action": "update",
                     "comment_id": comment_id,
@@ -1028,7 +1053,7 @@ def reconcile_registry(
                 }
             )
         for defect_id, block, _index in kept[1:]:
-            actions.append(
+            additive_actions.append(
                 {
                     "action": "add",
                     "registry_issue": registry_issue,
@@ -1037,6 +1062,7 @@ def reconcile_registry(
                 }
             )
 
+    actions = additive_actions + destructive_actions
     report = {
         "schema": "known-defect-reconciliation.v1",
         "status": "planned" if not apply else "reconciled",
@@ -1054,13 +1080,65 @@ def reconcile_registry(
     if not apply:
         return report
 
-    for action in actions:
+    preexisting_comment_ids = {
+        int(comment.get("id") or 0)
+        for comment in gateway.list_comments(registry_issue)
+    }
+    added_comment_bodies: dict[int, str] = {}
+    for action in additive_actions:
+        created = gateway.add_comment(action["registry_issue"], action["body"])
+        _validate_schema_comment(created)
+        created_id = int(created.get("id") or 0)
+        created_body = str(created.get("body") or "")
+        if created_body != action["body"]:
+            raise KnownDefectsError(
+                "reconciliation additive comment response does not match the "
+                "planned schema body"
+            )
+        if created_id in preexisting_comment_ids:
+            raise KnownDefectsError(
+                "reconciliation additive comment response replayed an existing "
+                "comment ID"
+            )
+        if created_id in added_comment_bodies:
+            raise KnownDefectsError(
+                "reconciliation additive comment response reused a comment ID"
+            )
+        added_comment_bodies[created_id] = created_body
+
+    # GitHub has no transaction spanning a new comment and a destructive
+    # source update.  Re-read each exact POST response ID before the
+    # irreversible half of the plan; an older same-body duplicate cannot
+    # stand in for a lost newly-created split comment.
+    if added_comment_bodies:
+        observed_by_id = {
+            int(comment.get("id") or 0): comment
+            for comment in gateway.list_comments(registry_issue)
+        }
+        for comment_id, expected_body in added_comment_bodies.items():
+            observed = observed_by_id.get(comment_id)
+            if observed is None:
+                raise KnownDefectsError(
+                    "reconciliation additive comment verification failed before "
+                    "destructive update"
+                )
+            _validate_schema_comment(observed)
+            if str(observed.get("body") or "") != expected_body:
+                raise KnownDefectsError(
+                    "reconciliation additive comment changed before destructive "
+                    "update"
+                )
+        if len(added_comment_bodies) != len(additive_actions):
+            raise KnownDefectsError(
+                "reconciliation additive comments did not retain distinct "
+                "creation authority"
+            )
+
+    for action in destructive_actions:
         if action["action"] == "delete":
             gateway.delete_comment(action["comment_id"])
-        elif action["action"] == "update":
-            gateway.update_comment(action["comment_id"], action["body"])
         else:
-            gateway.add_comment(action["registry_issue"], action["body"])
+            gateway.update_comment(action["comment_id"], action["body"])
 
     verified = _reconciliation_entries(gateway, registry_issue)
     verified_ids = {entry[2] for entry in verified}
@@ -1073,6 +1151,8 @@ def reconcile_registry(
         raise KnownDefectsError(
             "reconciliation did not produce one comment per unique defect ID"
         )
+    if any(_entry_marker_from_comment(entry[1])[1] != "final" for entry in verified):
+        raise KnownDefectsError("reconciliation left a pending canonical entry")
     report["verified_comment_count"] = len(verified_comments)
     return report
 

--- a/.codex/skills/bug-to-issue/scripts/known_defects.py
+++ b/.codex/skills/bug-to-issue/scripts/known_defects.py
@@ -1145,11 +1145,11 @@ def reconcile_registry(
     verified_comments = {int(entry[0]["id"]) for entry in verified}
     if (
         len(verified) != len(by_id)
-        or len(verified_ids) != len(by_id)
+        or verified_ids != set(by_id)
         or len(verified_comments) != len(by_id)
     ):
         raise KnownDefectsError(
-            "reconciliation did not produce one comment per unique defect ID"
+            "reconciliation did not preserve exactly one comment per expected defect ID"
         )
     if any(_entry_marker_from_comment(entry[1])[1] != "final" for entry in verified):
         raise KnownDefectsError("reconciliation left a pending canonical entry")

--- a/tests/governance/test_known_defects_registry.py
+++ b/tests/governance/test_known_defects_registry.py
@@ -1320,6 +1320,49 @@ def test_reconcile_replayed_addition_id_cannot_use_existing_duplicate_before_upd
     assert gateway.operations == []
 
 
+def test_reconcile_rejects_replaced_defect_id_at_final_readback() -> None:
+    class ReplacedFinalReadbackGateway(FakeGateway):
+        def __init__(self) -> None:
+            super().__init__()
+            self.replacement: dict[str, Any] | None = None
+
+        def list_comments(self, issue_number: int) -> list[dict[str, Any]]:
+            comments = super().list_comments(issue_number)
+            if self.replacement is not None:
+                comments[0]["body"] = self.replacement["body"]
+            return comments
+
+        def update_comment(self, comment_id: int, body: str) -> dict[str, Any]:
+            result = super().update_comment(comment_id, body)
+            self.replacement = {"body": replacement.render_entry()}
+            return result
+
+    gateway = ReplacedFinalReadbackGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    original = _defect()
+    second = _defect(
+        source_pr=4322,
+        source_sha="b" * 40,
+        review_url="https://github.com/RasmusTho/agentic-pkm-mvp/pull/4322#discussion_r124",
+    )
+    replacement = _defect(
+        source_pr=4323,
+        source_sha="c" * 40,
+        review_url="https://github.com/RasmusTho/agentic-pkm-mvp/pull/4323#discussion_r125",
+    )
+    gateway.add_comment(
+        issue["number"],
+        original.render_entry() + "\n\n" + second.render_entry(),
+    )
+
+    with pytest.raises(
+        known_defects.KnownDefectsError,
+        match="exactly one comment per expected defect ID",
+    ):
+        known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+
+
 def test_schema_comment_requires_stable_creation_authority() -> None:
     gateway = FakeGateway()
     issue = gateway.create_registry_issue()

--- a/tests/governance/test_known_defects_registry.py
+++ b/tests/governance/test_known_defects_registry.py
@@ -1167,6 +1167,159 @@ def test_registry_reconciliation_rejects_malformed_entry_before_mutation() -> No
     assert len(gateway.comments[issue["number"]]) == 1
 
 
+def test_reconcile_rejects_untrusted_source_author() -> None:
+    gateway = FakeGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    comment = gateway.add_comment(issue["number"], _defect().render_entry())
+    comment["author_association"] = "CONTRIBUTOR"
+
+    with pytest.raises(known_defects.KnownDefectsError, match="untrusted author"):
+        known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+    assert len(gateway.comments[issue["number"]]) == 1
+
+
+def test_reconcile_preserves_pending_phase_and_finalizes_earliest_reservation() -> None:
+    gateway = FakeGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    defect = _defect()
+    pending = gateway.add_comment(issue["number"], defect.render_entry(phase="pending"))
+    later_final = gateway.add_comment(issue["number"], defect.render_entry())
+
+    plan = known_defects.reconcile_registry(gateway, issue["number"])
+    assert [action["action"] for action in plan["actions"]] == ["update", "delete"]
+    receipt = known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+
+    assert receipt["status"] == "reconciled"
+    assert [item["id"] for item in gateway.comments[issue["number"]]] == [pending["id"]]
+    assert "phase=final" in pending["body"].splitlines()[0]
+    assert later_final["id"] not in [item["id"] for item in gateway.comments[issue["number"]]]
+
+
+def test_reconcile_rejects_marker_after_preamble() -> None:
+    gateway = FakeGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    original = "Owner note: preserve this text.\n\n" + _defect().render_entry()
+    gateway.add_comment(issue["number"], original)
+
+    with pytest.raises(known_defects.KnownDefectsError, match="non-empty preamble"):
+        known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+    assert gateway.comments[issue["number"]][0]["body"] == original
+
+
+def test_reconcile_adds_split_comments_before_destructive_update() -> None:
+    class OrderedGateway(FakeGateway):
+        def __init__(self) -> None:
+            super().__init__()
+            self.operations: list[str] = []
+
+        def add_comment(self, issue_number: int, body: str) -> dict[str, Any]:
+            self.operations.append("add")
+            return super().add_comment(issue_number, body)
+
+        def update_comment(self, comment_id: int, body: str) -> dict[str, Any]:
+            self.operations.append("update")
+            return super().update_comment(comment_id, body)
+
+        def delete_comment(self, comment_id: int) -> None:
+            self.operations.append("delete")
+            super().delete_comment(comment_id)
+
+    gateway = OrderedGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    first = _defect()
+    second = _defect(source_pr=4322, source_sha="b" * 40, review_url="https://github.com/RasmusTho/agentic-pkm-mvp/pull/4322#discussion_r124")
+    gateway.add_comment(issue["number"], first.render_entry() + "\n\n" + second.render_entry())
+    gateway.operations.clear()
+
+    known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+
+    assert gateway.operations == ["add", "update"]
+
+
+def test_reconcile_lost_addition_cannot_use_existing_duplicate_before_update() -> None:
+    class LostSplitAddGateway(FakeGateway):
+        def __init__(self) -> None:
+            super().__init__()
+            self.drop_next_add = False
+            self.operations: list[str] = []
+
+        def add_comment(self, issue_number: int, body: str) -> dict[str, Any]:
+            if self.drop_next_add:
+                self.drop_next_add = False
+                return {
+                    "id": 999,
+                    "created_at": "2026-07-27T00:00:59Z",
+                    "body": body,
+                    "author_association": "OWNER",
+                }
+            return super().add_comment(issue_number, body)
+
+        def update_comment(self, comment_id: int, body: str) -> dict[str, Any]:
+            self.operations.append("update")
+            return super().update_comment(comment_id, body)
+
+        def delete_comment(self, comment_id: int) -> None:
+            self.operations.append("delete")
+            super().delete_comment(comment_id)
+
+    gateway = LostSplitAddGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    first = _defect()
+    second = _defect(source_pr=4322, source_sha="b" * 40, review_url="https://github.com/RasmusTho/agentic-pkm-mvp/pull/4322#discussion_r124")
+    gateway.add_comment(issue["number"], first.render_entry() + "\n\n" + second.render_entry())
+    # This same-body duplicate would have hidden a lost POST under the prior
+    # body-set reread; it must not authorize truncating the legacy source.
+    gateway.add_comment(issue["number"], second.render_entry())
+    gateway.drop_next_add = True
+
+    with pytest.raises(known_defects.KnownDefectsError, match="additive comment verification"):
+        known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+    assert gateway.operations == []
+
+
+def test_reconcile_replayed_addition_id_cannot_use_existing_duplicate_before_update() -> None:
+    class ReplayedSplitAddGateway(FakeGateway):
+        def __init__(self) -> None:
+            super().__init__()
+            self.replay_id: int | None = None
+            self.operations: list[str] = []
+
+        def add_comment(self, issue_number: int, body: str) -> dict[str, Any]:
+            if self.replay_id is not None:
+                return next(
+                    comment
+                    for comment in self.comments[issue_number]
+                    if int(comment["id"]) == self.replay_id
+                )
+            return super().add_comment(issue_number, body)
+
+        def update_comment(self, comment_id: int, body: str) -> dict[str, Any]:
+            self.operations.append("update")
+            return super().update_comment(comment_id, body)
+
+        def delete_comment(self, comment_id: int) -> None:
+            self.operations.append("delete")
+            super().delete_comment(comment_id)
+
+    gateway = ReplayedSplitAddGateway()
+    issue = gateway.create_registry_issue()
+    gateway.lock_registry_issue(issue["number"])
+    first = _defect()
+    second = _defect(source_pr=4322, source_sha="b" * 40, review_url="https://github.com/RasmusTho/agentic-pkm-mvp/pull/4322#discussion_r124")
+    gateway.add_comment(issue["number"], first.render_entry() + "\n\n" + second.render_entry())
+    existing = gateway.add_comment(issue["number"], second.render_entry())
+    gateway.replay_id = int(existing["id"])
+
+    with pytest.raises(known_defects.KnownDefectsError, match="replayed an existing"):
+        known_defects.reconcile_registry(gateway, issue["number"], apply=True)
+    assert gateway.operations == []
+
+
 def test_schema_comment_requires_stable_creation_authority() -> None:
     gateway = FakeGateway()
     issue = gateway.create_registry_issue()


### PR DESCRIPTION
Governing-Issue: #5009

Fixes #5009

Final-Review-Rounds: 1

## Summary
Hardens Known Defects reconciliation against untrusted source authority, embedded markers, pending/final reservation loss, and destructive split ordering.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260821234937_a9c0d2e6`; P1 exact-ID readback repair is on current head ff32487342cac643275c11c9e65cc81cd1518651; fresh independent review is required before merge.
- Reason: #5009 repaired protected registry authority and multi-writer durability findings before publication.

## Notes
Validation: `PYTHONPATH=. python3 -m pytest -q tests/governance/test_known_defects_registry.py` (181 passed); `ruff check app tests`; `python3 scripts/lint_skills_consistency.py`; `python3 scripts/docs_guard.py`; `git diff --check`.
Convergence: trusted first-line schema authoring; earliest reservation finalization; add/verify exact fresh comment IDs before destructive changes; final one-comment-per-defect readback.
---