### PR TITLE
bug: keep post-merge proofs out of closing slice contracts

### DIFF
--- a/.codex/skills/_shared/ISSUE_CONTRACT.md
+++ b/.codex/skills/_shared/ISSUE_CONTRACT.md
@@ -142,8 +142,9 @@ Acceptance Criteria must name a finite, reviewable surface. An AC that names pro
 enumerate the concrete production entrypoints in the Issue, or reference an owner-document list
 that does; an open class such as "direct-service producers" is not a reviewable surface. Include
 CI workflows when they invoke the guarded persisted-schema surface directly. If a named producer
-can only be proven after merge, name it as `unprovable-in-PR` and require its post-merge proof in
-the Issue rather than discovering it through a later review round.
+can only be proven after merge, record it as `unprovable-in-PR`; its post-merge proof must not be a
+`Verify:` target on a closing slice Issue. Route that proof to a named parent-validation authority
+that remains open, or to an explicit non-closing lifecycle with its own durable evidence target.
 
 Do not use absolute quantifiers over an open caller set (`every`, `never`, or `cannot`) as a
 stand-alone AC guarantee. Either enumerate the bounded surface or name the mechanical boundary
@@ -155,7 +156,8 @@ Concrete rewrite:
 Bad: every direct-service producer persists the schema.
 Good: `scripts/bootstrap_vault.py`, `app/api/routes/capture.py`, and
 `.github/workflows/ci-smoke.yaml` satisfy the schema preflight; the raw-compose
-smoke producer is `unprovable-in-PR` and is verified by its post-merge workflow run.
+smoke producer is `unprovable-in-PR`; its post-merge workflow proof belongs to the named
+parent-validation authority, not to this closing slice.
 ```
 
 ## Body template

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -112,6 +112,9 @@ include raw paths, vault names, environment values, DSNs, secrets, or raw startu
   reply or disposition evidence for each; missing, substituted, or still-unresolved original-thread
   evidence fails closure. Record that final readback in the delivery receipt. [review-thread-closure]
 - On resume or recovery, re-check branch, `origin/main`, relevant merged PRs, and expected implementation files before continuing publication, reimplementation, or closure. [post-resume-current-state-gate]
+- A closing slice Issue may not carry a `Verify:` target whose producer is observable only after
+  merge. Route that proof to a named parent-validation authority or explicit non-closing lifecycle;
+  the non-closing authority must remain open through that proof and retain its durable evidence.
 - If the work is a slice under a larger feature, keep post-merge validation evidence on the parent issue
 - If post-merge validation advanced but acceptance is still pending, record the new evidence on the parent issue body or comments
 - If work is incomplete, do not close the loop falsely; create a bounded follow-up Issue instead

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -215,6 +215,14 @@ bucket list cannot override this canonical routing.
 - record BuilderOps routing: records/projections/receipts created, or `none` with a short reason
 - include enough traceability to prove the current delivery state without replaying the full procedure
 
+5. Issue/PR lifecycle and post-merge proof placement
+- a closing slice Issue may require only `Verify:` evidence that is available before its PR merges;
+  do not make a producer proof that becomes observable only after merge a closing-slice target
+- route such proof to a named parent-validation authority or an explicit non-closing lifecycle;
+  that authority remains open and records the durable post-merge evidence
+- closing the slice proves only its pre-merge contract. It neither proves nor implies completion of
+  the separately routed post-merge obligation
+
 ## Default Non-Blockers
 
 These are follow-up tasks, not default PR blockers:

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -149,6 +149,32 @@ def test_pr_contract_trigger_excludes_review_requested_and_cancels_stale_runs() 
     assert "cancel-in-progress: true" in concurrency_block
 
 
+def test_post_merge_proof_cannot_be_required_by_closing_slice() -> None:
+    """A closing slice must not promise evidence that exists only after its merge."""
+    contract = (
+        REPO_ROOT / ".codex" / "skills" / "_shared" / "ISSUE_CONTRACT.md"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "must not be a `Verify:` target on a closing slice Issue"
+        in " ".join(contract.split())
+    )
+    assert "require its post-merge proof in the Issue" not in contract
+
+
+def test_post_merge_proof_uses_non_closing_validation_authority() -> None:
+    """Post-merge proof stays on a parent or explicit non-closing authority."""
+    hot_path = (REPO_ROOT / "docs" / "development" / "PR_HOT_PATH.md").read_text(
+        encoding="utf-8"
+    )
+    closure_guidance = (
+        REPO_ROOT / ".codex" / "skills" / "verification-and-closure" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "parent-validation authority or an explicit non-closing lifecycle" in hot_path
+    assert "must remain open through that proof" in closure_guidance
+
+
 def _read_workflow() -> str:
     return (REPO_ROOT / ".github/workflows/issue-pr-governance.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5048

## Linked Issue
Closes #5048

## SBS Impact
- Primary subsystem: Builder System / Issue-contract and delivery-closure governance
- Secondary subsystem(s): PR verification, parent validation, and post-merge receipts
- Write class: governance/docs/process
- Persistence impact: closing Issue evidence remains truthful across the merge boundary
- Derived/rebuildable impact: post-merge proof routing is reconstructible from Issue, PR, and receipt state
- New or changed contract: A closing slice cannot require a proof whose producer becomes observable only after merge
- Owner-doc impact: updated in this PR
- Transition debt impact: reduces closure-contract unsatisfiability
- Boundary risk: terminal Issue closure must not be used as proof that a post-merge-only producer obligation was satisfied

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Keeps closing slice contracts limited to pre-merge proof and routes post-merge producer proof to open validation authority.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Routine Tier 1 governance/doc correction produced no BuilderOps material.

## Notes
Validation: PYTHONPATH=. python3 -m pytest -q tests/governance/test_issue_pr_governance.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py --language-only; git diff --check.