### PR TITLE
Document merge-base workflow-risk receipt semantics

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -187,6 +187,12 @@ review of the local publishable SHA before the selected expensive validation; se
 repair with no declared high-risk surface must bypass this local gate, use `--bypass-reason` and name
 the bypass in the PR/issue receipt. A declared high-risk surface is never bypassable.
 
+When workflow-risk inference requires `--workflow-review-receipt`, receipt producers must bind
+`base_sha` to the resolved merge base (`git merge-base <requested-base> <candidate-head>`), not to
+the requested base ref or endpoint. `head_sha` remains the distinct candidate head, and workflow
+paths, risks, and digest must describe the resolved-merge-base-relative candidate diff. This local
+receipt preserves ordering evidence only; it does not replace hosted current-head CI or final review.
+
 ```bash
 PR_LANE="<implementation|docs-authoring|governance|direct-repair>"
 TCD_RISK_SURFACES="<space-separated applicable surfaces, or empty>"

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -137,14 +137,18 @@ governance/contract review should run before CI waiting becomes the main feedbac
 replace required GitHub checks, branch protection, or final review triage.
 
 For actual `.github/workflows/*.yml` or `.yaml` changes, the gate derives risk from the Git diff
-between its resolved base and head; callers cannot suppress that inference by omitting a changed
-file or risk flag. The bounded structural interpretation covers root `concurrency` (including
-quoted keys and block scalars), `pull_request` trigger forms, and direct `jobs.<job>.if` admission
-only. Step conditions and nested reusable-workflow input names are not admission. When inference
-finds a high-risk form, supply `--workflow-review-receipt <ignored-json-path>`: it must bind the
-resolved base SHA, head SHA, workflow-diff digest, inferred risk set, a pass verdict, reviewer, and
-scenario-matrix completion. This is local ordering evidence; hosted current-head CI and final
-independent review remain the merge authorities.
+between its resolved merge base and candidate head; callers cannot suppress that inference by
+omitting a changed file or risk flag. The bounded structural interpretation covers root
+`concurrency` (including quoted keys and block scalars), `pull_request` trigger forms, and direct
+`jobs.<job>.if` admission only. Step conditions and nested reusable-workflow input names are not
+admission. The requested base ref is only an input that resolves to a moving endpoint; it is not the
+receipt's `base_sha`. The gate resolves `base_sha` as `git merge-base <requested-base> <candidate-head>`.
+The candidate head is separately recorded as `head_sha`, and the workflow paths, inferred risk set,
+and digest are all derived from that resolved-merge-base-relative candidate diff. When inference
+finds a high-risk form, supply `--workflow-review-receipt <ignored-json-path>`: it must bind that
+resolved `base_sha`, the distinct candidate `head_sha`, workflow-diff digest, inferred risk set, a
+pass verdict, reviewer, and scenario-matrix completion. This is local ordering evidence; hosted
+current-head CI and final independent review remain the merge authorities.
 
 An emergency direct repair may bypass the local gate only after an explicit completed risk
 assessment finds no high-risk surface. A declared high-risk surface is never bypassable:

--- a/tests/ops/test_review_before_ci_workflow_risk.py
+++ b/tests/ops/test_review_before_ci_workflow_risk.py
@@ -140,6 +140,65 @@ def test_structural_forms_require_exact_bound_receipt_from_actual_diff(tmp_path:
         validate_workflow_review_receipt(json.dumps(receipt), evidence)
 
 
+def test_moving_base_does_not_invent_candidate_changes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "test@example.invalid"],
+        ["git", "config", "user.name", "test"],
+    ):
+        subprocess.run(command, cwd=repo, check=True)
+    workflow = repo / ".github/workflows/check.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: check\n'on': push\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+    requested_base_branch = subprocess.check_output(
+        ["git", "symbolic-ref", "--short", "HEAD"], cwd=repo, text=True
+    ).strip()
+    merge_base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+
+    subprocess.run(["git", "checkout", "-qb", "candidate"], cwd=repo, check=True)
+    workflow.write_text("name: check\n'on': pull_request\n", encoding="utf-8")
+    subprocess.run(["git", "commit", "-am", "candidate", "-q"], cwd=repo, check=True)
+    candidate_head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+
+    subprocess.run(["git", "checkout", "-q", requested_base_branch], cwd=repo, check=True)
+    (repo / "unrelated.txt").write_text("moving endpoint\n", encoding="utf-8")
+    subprocess.run(["git", "add", "unrelated.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "moving base"], cwd=repo, check=True)
+    requested_base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+
+    evidence = workflow_risk_evidence_from_git(
+        repo, base=requested_base, head=candidate_head
+    )
+    assert evidence.base_sha == merge_base
+    assert evidence.base_sha != requested_base
+    assert evidence.head_sha == candidate_head
+
+    receipt = {
+        "version": 1,
+        "base_sha": evidence.base_sha,
+        "head_sha": evidence.head_sha,
+        "diff_digest": evidence.diff_digest,
+        "risks": list(evidence.risks),
+        "verdict": "pass",
+        "reviewer": "independent reviewer",
+        "scenario_matrix_complete": True,
+    }
+    assert validate_workflow_review_receipt(json.dumps(receipt), evidence) == receipt
+    receipt["base_sha"] = requested_base
+    with pytest.raises(WorkflowReviewRiskError, match="base_sha"):
+        validate_workflow_review_receipt(json.dumps(receipt), evidence)
+
+
 def test_review_gate_consumes_actual_workflow_risk_and_requires_exact_receipt(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5047

## Linked Issue
Closes #5047

## SBS Impact
- Primary subsystem: Builder System / publication review-gate evidence
- Secondary subsystem(s): workflow-risk receipt producers and current-head verification
- Write class: governance/docs/process
- Persistence impact: review receipts retain the exact resolved merge-base identity
- Derived/rebuildable impact: workflow paths, inferred risks, and digest remain derived from the merge-base-relative candidate diff
- New or changed contract: base_sha names the resolved merge base, not the requested moving endpoint
- Owner-doc impact: updated: docs/development/PR_HOT_PATH.md :: Review-Before-CI
- Transition debt impact: reduces receipt/documentation contract drift
- Boundary risk: a moving endpoint receipt must not be accepted as evidence for a different candidate diff

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Document that workflow-risk receipts bind the resolved merge-base-relative candidate diff.
- Add contract coverage proving a moving requested base cannot become receipt base_sha.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The Issue and PR provide the required delivery evidence; no BuilderOps operational record or divergence was produced.

## Notes
Validation: PYTHONPATH=. python3 -m pytest -q tests/ops/test_review_before_ci_workflow_risk.py tests/ops/test_review_before_ci_gate.py (76 passed); python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py --language-only; git diff --check; review_before_ci_gate satisfied.