### PR TITLE
Harden cross-container vault rollback admission

### DIFF
--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -769,6 +769,7 @@ class OwnershipLedger:
             self._assert_no_collision(
                 current,
                 candidate,
+                key=key,
                 allow_same_channel_nested=allow_same_channel_nested,
             )
             leases = dict(current.leases)
@@ -841,7 +842,9 @@ class OwnershipLedger:
                 key=key,
                 state="active",
             )
-            self._assert_no_collision(current, active, allow_same_channel_nested=True)
+            self._assert_no_collision(
+                current, active, key=key, allow_same_channel_nested=True
+            )
             leases = dict(current.leases)
             leases[vault_binding_id] = active
             self._write_ledger_locked(self._replace(current, leases=leases), key)
@@ -995,7 +998,9 @@ class OwnershipLedger:
                     key=key,
                     state="active",
                 )
-                self._assert_no_collision(staged, candidate, allow_same_channel_nested=True)
+                self._assert_no_collision(
+                    staged, candidate, key=key, allow_same_channel_nested=True
+                )
                 leases[candidate.vault_binding_id] = candidate
                 staged = self._replace(staged, leases=leases)
             staged = self._replace(staged, legacy_bootstrap_complete=True)
@@ -1120,6 +1125,7 @@ class OwnershipLedger:
         current: LedgerSnapshot,
         candidate: OwnershipLease,
         *,
+        key: _KeyMaterial,
         allow_same_channel_nested: bool,
     ) -> None:
         leases = list(current.leases.values()) + list(current.tombstones.values())
@@ -1142,6 +1148,19 @@ class OwnershipLedger:
                 or candidate.root_fingerprint in lease.ancestor_fingerprints
                 or lease.root_fingerprint in candidate.ancestor_fingerprints
             )
+            if not overlap:
+                try:
+                    candidate_root = Path(self._open_root(candidate.sealed_root, key))
+                    lease_root = Path(self._open_root(lease.sealed_root, key))
+                    overlap = (
+                        candidate_root != lease_root
+                        and (
+                            candidate_root.is_relative_to(lease_root)
+                            or lease_root.is_relative_to(candidate_root)
+                        )
+                    )
+                except (LedgerError, OSError, ValueError):
+                    overlap = False
             if not overlap or lease.vault_binding_id == candidate.vault_binding_id:
                 continue
             if (
@@ -1469,12 +1488,12 @@ def _identity_material(root: Path) -> tuple[str, tuple[str, ...]]:
     )
     ancestors: list[str] = []
     for ancestor in resolved.parents:
-        ancestor_identity = resolve_filesystem_root_identity(ancestor)
-        ancestors.append(
-            f"inode:{ancestor_identity.device}:{ancestor_identity.inode}"
-            if ancestor_identity.materialized
-            else f"path:{ancestor_identity.canonical_path}"
-        )
+        # Parent directories can be bind-mount roots whose device/inode
+        # identity belongs to the current container mount namespace rather
+        # than to the selected vault. Persisting those inode values makes an
+        # otherwise identical vault fail cross-container verification. The
+        # vault itself remains inode-bound; its parent chain is path-bound.
+        ancestors.append(f"path:{ancestor}")
     return primary, tuple(ancestors)
 
 

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -25,7 +25,8 @@ from app.instance.filesystem_identity import (
 )
 
 
-LEDGER_SCHEMA = "agentic-pkm.host-ownership-ledger.v1"
+LEGACY_LEDGER_SCHEMA = "agentic-pkm.host-ownership-ledger.v1"
+LEDGER_SCHEMA = "agentic-pkm.host-ownership-ledger.v2"
 KEY_SCHEMA = "agentic-pkm.host-ownership-key.v1"
 ROTATION_SCHEMA = "agentic-pkm.host-ownership-key-rotation.v1"
 
@@ -1382,7 +1383,12 @@ class OwnershipLedger:
         _assert_private_file(self.path)
         try:
             value = json.loads(self.path.read_text(encoding="utf-8"))
-            if value.get("schema") != LEDGER_SCHEMA:
+            schema = value.get("schema")
+            if schema == LEGACY_LEDGER_SCHEMA:
+                raise LedgerError(
+                    "ownership ledger format v1 requires explicit scratch/rebootstrap reset"
+                )
+            if schema != LEDGER_SCHEMA:
                 raise ValueError
             leases = {
                 binding: OwnershipLease(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -735,7 +735,9 @@ class OwnershipLedger:
                 key=key,
                 state="active",
             )
-            self._assert_no_collision(current, candidate, allow_same_channel_nested=False)
+            self._assert_no_collision(
+                current, candidate, key=key, allow_same_channel_nested=False
+            )
             self._write_ledger_locked(
                 self._replace(current, leases={vault_binding_id: candidate}), key
             )

--- a/app/instance/scalar_rollback_guard.py
+++ b/app/instance/scalar_rollback_guard.py
@@ -202,13 +202,18 @@ def _validate_compose_model(base_model: object, overlay_model: object) -> None:
     gateway = services["scalar-rollback-gateway"]
     if not all(isinstance(value, dict) for value in (init, api, guard, gateway)):
         raise RegistryError("scalar rollback service definitions are invalid")
-    init_targets = _volume_targets(init.get("volumes"))
-    if not {
-        "/run/scalar-rollback-policy/docker-compose.yaml",
-        "/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml",
-        "/run/scalar-rollback-policy/nginx.conf",
-    }.issubset(init_targets):
-        raise RegistryError("scalar rollback init policy/source mounts are incomplete")
+    expected_init_mounts = {
+        "./docker-compose.yaml:/run/scalar-rollback-policy/docker-compose.yaml:ro",
+        "./docker-compose.scalar-rollback.yml:/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml:ro",
+        "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro",
+    }
+    init_volumes = init.get("volumes")
+    if (
+        not isinstance(init_volumes, list)
+        or not all(isinstance(mount, str) for mount in init_volumes)
+        or set(init_volumes) != expected_init_mounts
+    ):
+        raise RegistryError("scalar rollback init policy/source mounts are invalid")
     if api.get("ports") != [] or set((api.get("depends_on") or {})) != {
         "scalar-rollback-guard"
     }:

--- a/app/instance/scalar_rollback_guard.py
+++ b/app/instance/scalar_rollback_guard.py
@@ -185,6 +185,7 @@ def _validate_compose_model(base_model: object, overlay_model: object) -> None:
     base_services = base_model["services"]
     services = overlay_model["services"]
     required = {
+        "instance-state-init",
         "scalar-rollback-guard",
         "api",
         "scalar-rollback-gateway",
@@ -196,10 +197,18 @@ def _validate_compose_model(base_model: object, overlay_model: object) -> None:
     if set(services) != required:
         raise RegistryError("scalar rollback overlay service set is invalid")
     api = services["api"]
+    init = services["instance-state-init"]
     guard = services["scalar-rollback-guard"]
     gateway = services["scalar-rollback-gateway"]
-    if not all(isinstance(value, dict) for value in (api, guard, gateway)):
+    if not all(isinstance(value, dict) for value in (init, api, guard, gateway)):
         raise RegistryError("scalar rollback service definitions are invalid")
+    init_targets = _volume_targets(init.get("volumes"))
+    if not {
+        "/run/scalar-rollback-policy/docker-compose.yaml",
+        "/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml",
+        "/run/scalar-rollback-policy/nginx.conf",
+    }.issubset(init_targets):
+        raise RegistryError("scalar rollback init policy/source mounts are incomplete")
     if api.get("ports") != [] or set((api.get("depends_on") or {})) != {
         "scalar-rollback-guard"
     }:

--- a/docker-compose.full-host-vault.yml
+++ b/docker-compose.full-host-vault.yml
@@ -7,7 +7,23 @@
 x-requires-explicit-full-host-vault: "${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}"
 
 services:
+  # The deployment fence validates drained legacy-owner roots from inside the
+  # instance-state-init container. On Linux hosts the selected vault is an
+  # absolute host path outside /Users and /Volumes, so expose that same path
+  # to the fence controller as well as to the runtime consumers.
+  instance-state-init:
+    volumes:
+      - type: bind
+        source: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        target: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        read_only: true
+
   api:
+    volumes:
+      - type: bind
+        source: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        target: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        read_only: true
     environment:
       VAULT_ROOT: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
       VAULT_ROOT_DEV: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
@@ -15,6 +31,11 @@ services:
       WATCHER_VAULT_PATH: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
 
   worker:
+    volumes:
+      - type: bind
+        source: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        target: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        read_only: true
     environment:
       VAULT_ROOT: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
       VAULT_ROOT_DEV: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
@@ -22,6 +43,11 @@ services:
       WATCHER_VAULT_PATH: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
 
   watcher:
+    volumes:
+      - type: bind
+        source: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        target: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
+        read_only: true
     environment:
       VAULT_ROOT: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}
       VAULT_ROOT_DEV: ${DEPLOY_VAULT_CONTAINER_ROOT:?DEPLOY_VAULT_CONTAINER_ROOT must be set for a full-host vault binding}

--- a/docker-compose.scalar-rollback.yml
+++ b/docker-compose.scalar-rollback.yml
@@ -1,5 +1,11 @@
 # MVR-01C only: constrain a supported previous scalar image to one validated binding.
 services:
+  instance-state-init:
+    volumes:
+      - "./docker-compose.yaml:/run/scalar-rollback-policy/docker-compose.yaml:ro"
+      - "./docker-compose.scalar-rollback.yml:/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml:ro"
+      - "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro"
+
   scalar-rollback-guard:
     image: ${SCALAR_ROLLBACK_GUARD_IMAGE:?current guard image is required}
     user: "${LOCAL_UID:-0}:${LOCAL_GID:-0}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,13 @@ post-#2655 pinned-image topology: deployment epic #2655 (S5/S7) is still open, s
 above is verified against the current `docker-compose.yaml` and the "Current reality (verified
 2026-06-29)" row of the environment matrix, not the "Target" row.
 
+The host-global ownership ledger is an additional deployment-boundary guard:
+ledger schema v2 stores the selected vault's primary filesystem identity and
+canonical parent-chain identities for cross-container verification. A persisted
+v1 ledger is incompatible with that semantic change and must fail closed until
+an explicitly operator-controlled scratch/rebootstrap reset has been completed;
+the application does not perform that reset implicitly.
+
 ## Artifact surfaces (current reading, forward-line aligned)
 
 Read the current architecture through three artifact surfaces:

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -33,6 +33,27 @@ macOS host
 ```
 API and worker share the same Python image built from the repo.
 
+## Cross-container vault and scalar-rollback contract
+
+The full-host-vault overlay binds the selected host vault read-only into
+`instance-state-init`, `api`, `worker`, and `watcher`. The init container must
+see the same selected root as the runtime consumers so deployment admission can
+validate drained legacy-owner roots from inside its container namespace.
+
+The scalar-rollback overlay also exposes the repo-owned policy sources
+read-only to `instance-state-init` at:
+
+- `/run/scalar-rollback-policy/docker-compose.yaml`
+- `/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml`
+- `/run/scalar-rollback-policy/nginx.conf`
+
+The rollback guard fails closed unless that init service and all three policy
+mounts are present. The ownership ledger keeps the selected vault's primary
+identity inode-bound, while parent-chain identities are canonical-path-bound so
+the same vault remains verifiable across container bind mounts. Nested-root
+collision checks still compare authenticated sealed roots by resolved path when
+their persisted parent identities cannot be compared directly.
+
 ## Feasibility: capacity-managed dev/test runtime
 
 **Status:** Advisory feasibility snapshot, 2026-08-17. This section describes a

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -54,6 +54,16 @@ the same vault remains verifiable across container bind mounts. Nested-root
 collision checks still compare authenticated sealed roots by resolved path when
 their persisted parent identities cannot be compared directly.
 
+### Scratch/rebootstrap boundary
+
+The path-bound parent-chain identity is persisted under ledger schema v2. A
+schema-v1 ownership ledger is not migrated or silently interpreted under the
+new identity semantics; established v1 state fails closed with an explicit
+`scratch/rebootstrap reset` error. Rebootstrap is an operator-controlled
+replacement of the host-global ownership state after the external backup,
+writer-drain, and deployment-quiescence proofs are complete. This repository
+change does not perform that destructive reset.
+
 ## Feasibility: capacity-managed dev/test runtime
 
 **Status:** Advisory feasibility snapshot, 2026-08-17. This section describes a

--- a/tests/ops/test_mvr05_mixed_version_fence.py
+++ b/tests/ops/test_mvr05_mixed_version_fence.py
@@ -20,7 +20,7 @@ from app.instance.mvr05_cutover import (
     Mvr05CutoverError,
     discover_db_producer_fence,
 )
-from app.instance.ownership_ledger import LedgerKeyError, OwnershipLedger
+from app.instance.ownership_ledger import LedgerError, LedgerKeyError, OwnershipLedger
 from app.instance.vault_registry import VaultRegistration, VaultRegistryStore
 from app.services import outbox
 from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
@@ -228,6 +228,41 @@ def test_floor_producer_preserves_established_ledger_identity(tmp_path, monkeypa
     after = OwnershipLedger(host_global_root).require_existing()
     assert (after.key_id, after.generation) == (before.key_id, before.generation)
     assert VaultRegistryStore(registry_path).load().revision == 1
+
+
+def test_recover_missing_active_uses_authenticated_key_for_collision_check(tmp_path) -> None:
+    ownership_root = tmp_path / "host-global"
+    ownership_root.mkdir(mode=0o700)
+    root = tmp_path / "recovered-vault"
+    root.mkdir()
+    ledger = OwnershipLedger(ownership_root)
+    ledger.load()
+
+    recovered = ledger.recover_missing_active(
+        channel_id="dev",
+        vault_binding_id="binding-recovered",
+        root=root,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    assert recovered.state == "active"
+    assert ledger.require_existing().leases["binding-recovered"] == recovered
+
+
+def test_v1_ledger_requires_explicit_scratch_rebootstrap(tmp_path) -> None:
+    ownership_root = tmp_path / "host-global"
+    ownership_root.mkdir(mode=0o700)
+    ledger = OwnershipLedger(ownership_root)
+    ledger.load()
+    payload = json.loads(ledger.path.read_text(encoding="utf-8"))
+    payload["schema"] = "agentic-pkm.host-ownership-ledger.v1"
+    ledger.path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        LedgerError,
+        match="ownership ledger format v1 requires explicit scratch/rebootstrap reset",
+    ):
+        ledger.require_existing()
 
 
 @pytest.mark.parametrize("missing_artifact", ["ledger", "key"])

--- a/tests/ops/test_scalar_rollback_guard.py
+++ b/tests/ops/test_scalar_rollback_guard.py
@@ -310,6 +310,16 @@ def test_rollback_gateway_and_mounts_enforce_selected_binding(
         ),
         Loader=_ComposeLoader,
     )
+    rollback_init = rollback_compose["services"]["instance-state-init"]
+    assert {
+        mount.split(":", 2)[1]
+        for mount in rollback_init["volumes"]
+        if isinstance(mount, str)
+    } == {
+        "/run/scalar-rollback-policy/docker-compose.yaml",
+        "/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml",
+        "/run/scalar-rollback-policy/nginx.conf",
+    }
     assert rollback_compose["services"]["api"]["environment"] | {
         "VAULT_ROOT": "/app/selected-vault",
         "VAULT_ROOT_DEV": "/app/selected-vault",

--- a/tests/ops/test_scalar_rollback_guard.py
+++ b/tests/ops/test_scalar_rollback_guard.py
@@ -263,6 +263,35 @@ def test_rollback_gateway_and_mounts_enforce_selected_binding(
     gateway_config.write_bytes(
         (REPO_ROOT / "ops/scalar-rollback/nginx.conf").read_bytes()
     )
+    canonical_overlay = (REPO_ROOT / "docker-compose.scalar-rollback.yml").read_text(
+        encoding="utf-8"
+    )
+    for replacement in (
+        (
+            "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro",
+            "./wrong-policy.conf:/run/scalar-rollback-policy/nginx.conf:ro",
+        ),
+        (
+            "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro",
+            "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:rw",
+        ),
+    ):
+        compose_overlay.write_text(
+            canonical_overlay.replace(*replacement), encoding="utf-8"
+        )
+        with pytest.raises(
+            RegistryError,
+            match="scalar rollback init policy/source mounts are invalid",
+        ):
+            preflight_scalar_rollback_guard(
+                compose_base=compose_base,
+                compose_overlay=compose_overlay,
+                gateway_config=gateway_config,
+                native_launcher=REPO_ROOT / "scripts/scalar_rollback_native.sh",
+                rollback_vault_binding_id=registration.vault_binding_id,
+                selected_root=root,
+            )
+    compose_overlay.write_text(canonical_overlay, encoding="utf-8")
     compose_overlay.write_text(
         (REPO_ROOT / "docker-compose.scalar-rollback.yml")
         .read_text(encoding="utf-8")
@@ -311,14 +340,10 @@ def test_rollback_gateway_and_mounts_enforce_selected_binding(
         Loader=_ComposeLoader,
     )
     rollback_init = rollback_compose["services"]["instance-state-init"]
-    assert {
-        mount.split(":", 2)[1]
-        for mount in rollback_init["volumes"]
-        if isinstance(mount, str)
-    } == {
-        "/run/scalar-rollback-policy/docker-compose.yaml",
-        "/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml",
-        "/run/scalar-rollback-policy/nginx.conf",
+    assert set(rollback_init["volumes"]) == {
+        "./docker-compose.yaml:/run/scalar-rollback-policy/docker-compose.yaml:ro",
+        "./docker-compose.scalar-rollback.yml:/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml:ro",
+        "./ops/scalar-rollback/nginx.conf:/run/scalar-rollback-policy/nginx.conf:ro",
     }
     assert rollback_compose["services"]["api"]["environment"] | {
         "VAULT_ROOT": "/app/selected-vault",


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4517

## Linked Issue
Closes #4517

## SBS Impact
- Primary subsystem: Product/Runtime host-global ownership and deployment boundary
- Secondary subsystem(s): instance-state init, scalar rollback, vault registry
- Write class: authority-bearing guard and durable ledger validation
- Persistence impact: Ledger v2; v1 fails closed and is never silently migrated
- Derived/rebuildable impact: Compose policy mounts and validation are rebuildable
- New or changed contract: Cross-container selected-root verification, exact rollback policy mounts, and explicit scratch/rebootstrap boundary
- Owner-doc impact: updated in PR
- Transition debt impact: Closes cross-container admission drift without destructive reset
- Boundary risk: Fail-closed nested-root, format, and policy-mount validation

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Harden cross-container vault rollback admission, require explicit ledger-v2 rebootstrap, and document the bind-mount contract.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No new BuilderOps record; bounded repo implementation/test change.

## Notes
Validation: 163 passed, 3 skipped in extended vault/rollback suite; 34 passed in v2/rebootstrap suite; ruff, mypy, docs_guard, and git diff --check passed. No host reset was performed. The PR intentionally excludes unrelated local untracked files.