### PR TITLE
Add read-only Proxmox inventory adapter

### DIFF
--- a/app/proxmox/inventory.py
+++ b/app/proxmox/inventory.py
@@ -1,0 +1,232 @@
+"""Narrow, read-only PVE inventory boundary.
+
+This module intentionally has no generic request method.  Adding one would turn a
+capability-scoped inventory token into an arbitrary PVE proxy.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from typing import Any, Callable, Mapping, Protocol, Sequence
+from urllib.parse import urlparse
+
+
+TARS_NODE = "TARS"
+ALLOWED_VM_IDS = frozenset({100, 101, 102, 104})
+ALLOWED_STORAGES = frozenset({"local", "local-lvm"})
+RECEIPT_VERSION = "proxmox.inventory.receipt.v1"
+MCP_DESCRIPTOR_ID = "mcp.proxmox.inventory.v1"
+
+
+class ProxmoxInventoryError(RuntimeError):
+    """Raised when the inventory boundary refuses a request."""
+
+
+class PVETransport(Protocol):
+    """A transport that reports the TLS identity observed for every response."""
+
+    def get(self, *, endpoint: str, path: str, token: str) -> tuple[Mapping[str, Any], str]: ...
+
+
+SecretResolver = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class InventoryPolicy:
+    node: str = TARS_NODE
+    vm_ids: frozenset[int] = ALLOWED_VM_IDS
+    storage_names: frozenset[str] = ALLOWED_STORAGES
+
+    def __post_init__(self) -> None:
+        if self.node != TARS_NODE:
+            raise ProxmoxInventoryError("unknown Proxmox node")
+        if not self.vm_ids.issubset(ALLOWED_VM_IDS):
+            raise ProxmoxInventoryError("VM allowlist exceeds TARS inventory policy")
+        if not self.storage_names.issubset(ALLOWED_STORAGES):
+            raise ProxmoxInventoryError("storage allowlist exceeds TARS inventory policy")
+
+
+@dataclass(frozen=True)
+class InventoryConfig:
+    endpoint_secret_ref: str
+    token_secret_ref: str
+    token_fingerprint: str
+    tls_fingerprint: str
+    principal_scope_digest: str
+    policy: InventoryPolicy = InventoryPolicy()
+
+    def __post_init__(self) -> None:
+        if not self.endpoint_secret_ref or not self.token_secret_ref:
+            raise ProxmoxInventoryError("endpoint and token secret references are required")
+        if not self.token_fingerprint or not self.tls_fingerprint:
+            raise ProxmoxInventoryError("token and TLS fingerprints are required")
+        if not self.principal_scope_digest:
+            raise ProxmoxInventoryError("principal/scope digest is required")
+
+
+@dataclass(frozen=True)
+class InventoryReceipt:
+    version: str
+    endpoint_identity: str
+    tls_fingerprint: str
+    principal_scope_digest: str
+    allowlist_policy: Mapping[str, Any]
+    operation: str
+    outcome: str
+    result_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InventoryResult:
+    result: Mapping[str, Any]
+    receipt: InventoryReceipt
+
+
+@dataclass(frozen=True)
+class ProxmoxInventoryDescriptor:
+    """Explicit local-only descriptor; deliberately absent from remote MCP registry."""
+
+    id: str = MCP_DESCRIPTOR_ID
+    admission: str = "local_typed_executor_only"
+    operations: tuple[str, ...] = (
+        "health_check",
+        "get_cluster_summary",
+        "list_allowed_vms",
+        "get_vm_status",
+        "get_storage_status",
+        "list_recent_tasks",
+    )
+
+
+class LocalProxmoxInventoryExecutor:
+    """Admission seam for a loopback-only, typed local caller.
+
+    The executor is intentionally not a RemoteMCPProvider and does not accept an
+    operation name/path supplied by a remote caller.
+    """
+
+    descriptor = ProxmoxInventoryDescriptor()
+
+    def __init__(self, client: "ProxmoxInventoryClient") -> None:
+        self._client = client
+
+    def execute(self, *, caller_host: str, operation: str, identifier: int | str | None = None) -> InventoryResult:
+        if caller_host not in {"127.0.0.1", "::1"}:
+            raise ProxmoxInventoryError("only direct loopback callers are admitted")
+        methods: Mapping[str, Callable[..., InventoryResult]] = {
+            "health_check": self._client.health_check,
+            "get_cluster_summary": self._client.get_cluster_summary,
+            "list_allowed_vms": self._client.list_allowed_vms,
+            "get_vm_status": self._client.get_vm_status,
+            "get_storage_status": self._client.get_storage_status,
+            "list_recent_tasks": self._client.list_recent_tasks,
+        }
+        method = methods.get(operation)
+        if method is None:
+            raise ProxmoxInventoryError("operation is not admitted")
+        if operation == "get_vm_status":
+            return method(identifier)  # type: ignore[misc]
+        if operation == "get_storage_status":
+            return method(identifier)  # type: ignore[misc]
+        return method()
+
+
+class ProxmoxInventoryClient:
+    """Typed PVE read-only client with deny-before-transport enforcement."""
+
+    def __init__(self, *, config: InventoryConfig, resolve_secret: SecretResolver, transport: PVETransport) -> None:
+        self._config = config
+        self._resolve_secret = resolve_secret
+        self._transport = transport
+
+    def health_check(self) -> InventoryResult:
+        return self._read("health_check", "/api2/json/version")
+
+    def get_cluster_summary(self) -> InventoryResult:
+        return self._read("get_cluster_summary", "/api2/json/cluster/status")
+
+    def list_allowed_vms(self) -> InventoryResult:
+        result = self._read("list_allowed_vms", f"/api2/json/nodes/{self._config.policy.node}/qemu")
+        rows = result.result.get("data", [])
+        if not isinstance(rows, Sequence):
+            rows = []
+        filtered = [row for row in rows if isinstance(row, Mapping) and row.get("vmid") in self._config.policy.vm_ids]
+        return self._result("list_allowed_vms", {"data": filtered})
+
+    def get_vm_status(self, vm_id: int | object) -> InventoryResult:
+        if not isinstance(vm_id, int) or vm_id not in self._config.policy.vm_ids:
+            raise ProxmoxInventoryError("unknown VMID")
+        return self._read("get_vm_status", f"/api2/json/nodes/{self._config.policy.node}/qemu/{vm_id}/status/current")
+
+    def get_storage_status(self, storage: str | object) -> InventoryResult:
+        if not isinstance(storage, str) or storage not in self._config.policy.storage_names:
+            raise ProxmoxInventoryError("unknown storage")
+        return self._read("get_storage_status", f"/api2/json/nodes/{self._config.policy.node}/storage/{storage}/status")
+
+    def list_recent_tasks(self) -> InventoryResult:
+        return self._read("list_recent_tasks", f"/api2/json/nodes/{self._config.policy.node}/tasks")
+
+    def _read(self, operation: str, path: str) -> InventoryResult:
+        endpoint = self._endpoint()
+        token = self._resolve_secret(self._config.token_secret_ref)
+        if not isinstance(token, str) or not token:
+            raise ProxmoxInventoryError("token secret reference did not resolve")
+        if sha256(token.encode("utf-8")).hexdigest() != self._config.token_fingerprint:
+            raise ProxmoxInventoryError("token fingerprint mismatch")
+        payload, observed_fingerprint = self._transport.get(endpoint=endpoint, path=path, token=token)
+        if observed_fingerprint != self._config.tls_fingerprint:
+            raise ProxmoxInventoryError("TLS certificate fingerprint mismatch")
+        return self._result(operation, payload)
+
+    def _endpoint(self) -> str:
+        endpoint = self._resolve_secret(self._config.endpoint_secret_ref)
+        parsed = urlparse(endpoint)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+            raise ProxmoxInventoryError("PVE endpoint must be a bare HTTPS authority")
+        return endpoint.rstrip("/")
+
+    def _result(self, operation: str, payload: Mapping[str, Any]) -> InventoryResult:
+        safe_payload = dict(payload)
+        digest = sha256(_canonical_bytes(safe_payload)).hexdigest()
+        endpoint_identity = sha256(self._config.endpoint_secret_ref.encode()).hexdigest()
+        receipt = InventoryReceipt(
+            version=RECEIPT_VERSION,
+            endpoint_identity=endpoint_identity,
+            tls_fingerprint=self._config.tls_fingerprint,
+            principal_scope_digest=self._config.principal_scope_digest,
+            allowlist_policy={
+                "node": self._config.policy.node,
+                "vm_ids": sorted(self._config.policy.vm_ids),
+                "storage_names": sorted(self._config.policy.storage_names),
+            },
+            operation=operation,
+            outcome="ok",
+            result_digest=digest,
+        )
+        return InventoryResult(result=safe_payload, receipt=receipt)
+
+
+def _canonical_bytes(value: Mapping[str, Any]) -> bytes:
+    import json
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+__all__ = [
+    "ALLOWED_STORAGES",
+    "ALLOWED_VM_IDS",
+    "InventoryConfig",
+    "InventoryPolicy",
+    "InventoryReceipt",
+    "InventoryResult",
+    "LocalProxmoxInventoryExecutor",
+    "MCP_DESCRIPTOR_ID",
+    "PVETransport",
+    "ProxmoxInventoryClient",
+    "ProxmoxInventoryDescriptor",
+    "ProxmoxInventoryError",
+    "TARS_NODE",
+]

--- a/app/proxmox/inventory.py
+++ b/app/proxmox/inventory.py
@@ -154,7 +154,7 @@ class ProxmoxInventoryClient:
         if not isinstance(rows, Sequence):
             rows = []
         filtered = [row for row in rows if isinstance(row, Mapping) and row.get("vmid") in self._config.policy.vm_ids]
-        return self._result("list_allowed_vms", {"data": filtered})
+        return self._result("list_allowed_vms", {"data": filtered}, endpoint_identity=result.receipt.endpoint_identity)
 
     def get_vm_status(self, vm_id: int | object) -> InventoryResult:
         if not isinstance(vm_id, int) or vm_id not in self._config.policy.vm_ids:
@@ -179,7 +179,7 @@ class ProxmoxInventoryClient:
         payload, observed_fingerprint = self._transport.get(endpoint=endpoint, path=path, token=token)
         if observed_fingerprint != self._config.tls_fingerprint:
             raise ProxmoxInventoryError("TLS certificate fingerprint mismatch")
-        return self._result(operation, payload)
+        return self._result(operation, payload, endpoint_identity=sha256(endpoint.encode("utf-8")).hexdigest())
 
     def _endpoint(self) -> str:
         endpoint = self._resolve_secret(self._config.endpoint_secret_ref)
@@ -188,13 +188,18 @@ class ProxmoxInventoryClient:
             raise ProxmoxInventoryError("PVE endpoint must be a bare HTTPS authority")
         return endpoint.rstrip("/")
 
-    def _result(self, operation: str, payload: Mapping[str, Any]) -> InventoryResult:
+    def _result(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        *,
+        endpoint_identity: str | None = None,
+    ) -> InventoryResult:
         safe_payload = dict(payload)
         digest = sha256(_canonical_bytes(safe_payload)).hexdigest()
-        endpoint_identity = sha256(self._config.endpoint_secret_ref.encode()).hexdigest()
         receipt = InventoryReceipt(
             version=RECEIPT_VERSION,
-            endpoint_identity=endpoint_identity,
+            endpoint_identity=endpoint_identity or sha256(self._config.endpoint_secret_ref.encode()).hexdigest(),
             tls_fingerprint=self._config.tls_fingerprint,
             principal_scope_digest=self._config.principal_scope_digest,
             allowlist_policy={

--- a/app/proxmox/inventory.py
+++ b/app/proxmox/inventory.py
@@ -24,12 +24,21 @@ class ProxmoxInventoryError(RuntimeError):
     """Raised when the inventory boundary refuses a request."""
 
 
+class PVEAuthenticatedReadSession(Protocol):
+    """Capability for reads on the same connection that passed pin verification."""
+
+    def get(self, *, path: str, token: str) -> Mapping[str, Any]: ...
+
+
 class PVETransport(Protocol):
-    """Transport with certificate pin admission before credential transmission."""
+    """Opens one connection-bound, pin-verified read session."""
 
-    def verify_tls(self, *, endpoint: str, expected_fingerprint: str) -> None: ...
-
-    def get(self, *, endpoint: str, path: str, token: str) -> Mapping[str, Any]: ...
+    def open_pinned_session(
+        self,
+        *,
+        endpoint: str,
+        expected_fingerprint: str,
+    ) -> PVEAuthenticatedReadSession: ...
 
 
 SecretResolver = Callable[[str], str]
@@ -183,10 +192,14 @@ class ProxmoxInventoryClient:
         if sha256(token.encode("utf-8")).hexdigest() != self._config.token_fingerprint:
             raise ProxmoxInventoryError("token fingerprint mismatch")
         self._validate_inventory_scope()
-        # The transport must complete certificate-pin verification before it is
-        # given a credential, not report a mismatch after the request is sent.
-        self._transport.verify_tls(endpoint=endpoint, expected_fingerprint=self._config.tls_fingerprint)
-        payload = self._transport.get(endpoint=endpoint, path=path, token=token)
+        # `session` is an object capability bound to the same connection whose
+        # certificate pin was verified.  There is deliberately no token-bearing
+        # transport-level `get` that could reconnect after verification.
+        session = self._transport.open_pinned_session(
+            endpoint=endpoint,
+            expected_fingerprint=self._config.tls_fingerprint,
+        )
+        payload = session.get(path=path, token=token)
         return self._result(operation, payload, endpoint_identity=sha256(endpoint.encode("utf-8")).hexdigest())
 
     def _endpoint(self) -> str:
@@ -268,6 +281,7 @@ __all__ = [
     "LocalProxmoxInventoryExecutor",
     "MCP_DESCRIPTOR_ID",
     "PVETransport",
+    "PVEAuthenticatedReadSession",
     "ProxmoxInventoryClient",
     "ProxmoxInventoryDescriptor",
     "ProxmoxInventoryError",

--- a/app/proxmox/inventory.py
+++ b/app/proxmox/inventory.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from hashlib import sha256
+import json
 from typing import Any, Callable, Mapping, Protocol, Sequence
 from urllib.parse import urlparse
 
@@ -16,6 +17,7 @@ ALLOWED_VM_IDS = frozenset({100, 101, 102, 104})
 ALLOWED_STORAGES = frozenset({"local", "local-lvm"})
 RECEIPT_VERSION = "proxmox.inventory.receipt.v1"
 MCP_DESCRIPTOR_ID = "mcp.proxmox.inventory.v1"
+INVENTORY_SCOPE_CAPABILITY = "inventory-read-only"
 
 
 class ProxmoxInventoryError(RuntimeError):
@@ -23,9 +25,11 @@ class ProxmoxInventoryError(RuntimeError):
 
 
 class PVETransport(Protocol):
-    """A transport that reports the TLS identity observed for every response."""
+    """Transport with certificate pin admission before credential transmission."""
 
-    def get(self, *, endpoint: str, path: str, token: str) -> tuple[Mapping[str, Any], str]: ...
+    def verify_tls(self, *, endpoint: str, expected_fingerprint: str) -> None: ...
+
+    def get(self, *, endpoint: str, path: str, token: str) -> Mapping[str, Any]: ...
 
 
 SecretResolver = Callable[[str], str]
@@ -50,18 +54,20 @@ class InventoryPolicy:
 class InventoryConfig:
     endpoint_secret_ref: str
     token_secret_ref: str
+    principal_scope_secret_ref: str
     token_fingerprint: str
+    endpoint_identity: str
     tls_fingerprint: str
     principal_scope_digest: str
     policy: InventoryPolicy = InventoryPolicy()
 
     def __post_init__(self) -> None:
-        if not self.endpoint_secret_ref or not self.token_secret_ref:
-            raise ProxmoxInventoryError("endpoint and token secret references are required")
+        if not self.endpoint_secret_ref or not self.token_secret_ref or not self.principal_scope_secret_ref:
+            raise ProxmoxInventoryError("endpoint, token, and scope secret references are required")
         if not self.token_fingerprint or not self.tls_fingerprint:
             raise ProxmoxInventoryError("token and TLS fingerprints are required")
-        if not self.principal_scope_digest:
-            raise ProxmoxInventoryError("principal/scope digest is required")
+        if not self.endpoint_identity or not self.principal_scope_digest:
+            raise ProxmoxInventoryError("endpoint identity and principal/scope digest are required")
 
 
 @dataclass(frozen=True)
@@ -176,9 +182,11 @@ class ProxmoxInventoryClient:
             raise ProxmoxInventoryError("token secret reference did not resolve")
         if sha256(token.encode("utf-8")).hexdigest() != self._config.token_fingerprint:
             raise ProxmoxInventoryError("token fingerprint mismatch")
-        payload, observed_fingerprint = self._transport.get(endpoint=endpoint, path=path, token=token)
-        if observed_fingerprint != self._config.tls_fingerprint:
-            raise ProxmoxInventoryError("TLS certificate fingerprint mismatch")
+        self._validate_inventory_scope()
+        # The transport must complete certificate-pin verification before it is
+        # given a credential, not report a mismatch after the request is sent.
+        self._transport.verify_tls(endpoint=endpoint, expected_fingerprint=self._config.tls_fingerprint)
+        payload = self._transport.get(endpoint=endpoint, path=path, token=token)
         return self._result(operation, payload, endpoint_identity=sha256(endpoint.encode("utf-8")).hexdigest())
 
     def _endpoint(self) -> str:
@@ -186,7 +194,37 @@ class ProxmoxInventoryClient:
         parsed = urlparse(endpoint)
         if parsed.scheme != "https" or not parsed.netloc or parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
             raise ProxmoxInventoryError("PVE endpoint must be a bare HTTPS authority")
-        return endpoint.rstrip("/")
+        if parsed.username or parsed.password:
+            raise ProxmoxInventoryError("PVE endpoint must not contain user credentials")
+        normalized = endpoint.rstrip("/")
+        if sha256(normalized.encode("utf-8")).hexdigest() != self._config.endpoint_identity:
+            raise ProxmoxInventoryError("PVE endpoint does not match fixed TARS endpoint identity")
+        return normalized
+
+    def _validate_inventory_scope(self) -> None:
+        raw_scope = self._resolve_secret(self._config.principal_scope_secret_ref)
+        try:
+            scope = json.loads(raw_scope)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ProxmoxInventoryError("inventory token scope is not valid JSON") from exc
+        if not isinstance(scope, Mapping):
+            raise ProxmoxInventoryError("inventory token scope is not an object")
+        if sha256(_canonical_bytes(scope)).hexdigest() != self._config.principal_scope_digest:
+            raise ProxmoxInventoryError("principal/scope digest mismatch")
+        operations = scope.get("operations")
+        vm_ids = scope.get("vm_ids")
+        storage_names = scope.get("storage_names")
+        if (
+            scope.get("capability") != INVENTORY_SCOPE_CAPABILITY
+            or scope.get("node") != self._config.policy.node
+            or not isinstance(operations, list)
+            or set(operations) != set(ProxmoxInventoryDescriptor().operations)
+            or not isinstance(vm_ids, list)
+            or not set(vm_ids).issubset(self._config.policy.vm_ids)
+            or not isinstance(storage_names, list)
+            or not set(storage_names).issubset(self._config.policy.storage_names)
+        ):
+            raise ProxmoxInventoryError("token scope is broader than inventory policy")
 
     def _result(
         self,

--- a/app/proxmox/inventory.py
+++ b/app/proxmox/inventory.py
@@ -6,8 +6,10 @@ capability-scoped inventory token into an arbitrary PVE proxy.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from enum import Enum
 from hashlib import sha256
 import json
+from types import MappingProxyType
 from typing import Any, Callable, Mapping, Protocol, Sequence
 from urllib.parse import urlparse
 
@@ -18,6 +20,27 @@ ALLOWED_STORAGES = frozenset({"local", "local-lvm"})
 RECEIPT_VERSION = "proxmox.inventory.receipt.v1"
 MCP_DESCRIPTOR_ID = "mcp.proxmox.inventory.v1"
 INVENTORY_SCOPE_CAPABILITY = "inventory-read-only"
+
+
+class _InventoryOperation(Enum):
+    HEALTH_CHECK = "health_check"
+    GET_CLUSTER_SUMMARY = "get_cluster_summary"
+    LIST_ALLOWED_VMS = "list_allowed_vms"
+    GET_VM_STATUS = "get_vm_status"
+    GET_STORAGE_STATUS = "get_storage_status"
+    LIST_RECENT_TASKS = "list_recent_tasks"
+
+
+_READ_PATH_TEMPLATES: Mapping[_InventoryOperation, str] = MappingProxyType(
+    {
+        _InventoryOperation.HEALTH_CHECK: "/api2/json/version",
+        _InventoryOperation.GET_CLUSTER_SUMMARY: "/api2/json/cluster/status",
+        _InventoryOperation.LIST_ALLOWED_VMS: "/api2/json/nodes/{node}/qemu",
+        _InventoryOperation.GET_VM_STATUS: "/api2/json/nodes/{node}/qemu/{identifier}/status/current",
+        _InventoryOperation.GET_STORAGE_STATUS: "/api2/json/nodes/{node}/storage/{identifier}/status",
+        _InventoryOperation.LIST_RECENT_TASKS: "/api2/json/nodes/{node}/tasks",
+    }
+)
 
 
 class ProxmoxInventoryError(RuntimeError):
@@ -158,13 +181,13 @@ class ProxmoxInventoryClient:
         self._transport = transport
 
     def health_check(self) -> InventoryResult:
-        return self._read("health_check", "/api2/json/version")
+        return self._read(_InventoryOperation.HEALTH_CHECK)
 
     def get_cluster_summary(self) -> InventoryResult:
-        return self._read("get_cluster_summary", "/api2/json/cluster/status")
+        return self._read(_InventoryOperation.GET_CLUSTER_SUMMARY)
 
     def list_allowed_vms(self) -> InventoryResult:
-        result = self._read("list_allowed_vms", f"/api2/json/nodes/{self._config.policy.node}/qemu")
+        result = self._read(_InventoryOperation.LIST_ALLOWED_VMS)
         rows = result.result.get("data", [])
         if not isinstance(rows, Sequence):
             rows = []
@@ -172,19 +195,16 @@ class ProxmoxInventoryClient:
         return self._result("list_allowed_vms", {"data": filtered}, endpoint_identity=result.receipt.endpoint_identity)
 
     def get_vm_status(self, vm_id: int | object) -> InventoryResult:
-        if not isinstance(vm_id, int) or vm_id not in self._config.policy.vm_ids:
-            raise ProxmoxInventoryError("unknown VMID")
-        return self._read("get_vm_status", f"/api2/json/nodes/{self._config.policy.node}/qemu/{vm_id}/status/current")
+        return self._read(_InventoryOperation.GET_VM_STATUS, identifier=vm_id)
 
     def get_storage_status(self, storage: str | object) -> InventoryResult:
-        if not isinstance(storage, str) or storage not in self._config.policy.storage_names:
-            raise ProxmoxInventoryError("unknown storage")
-        return self._read("get_storage_status", f"/api2/json/nodes/{self._config.policy.node}/storage/{storage}/status")
+        return self._read(_InventoryOperation.GET_STORAGE_STATUS, identifier=storage)
 
     def list_recent_tasks(self) -> InventoryResult:
-        return self._read("list_recent_tasks", f"/api2/json/nodes/{self._config.policy.node}/tasks")
+        return self._read(_InventoryOperation.LIST_RECENT_TASKS)
 
-    def _read(self, operation: str, path: str) -> InventoryResult:
+    def _read(self, operation: _InventoryOperation, *, identifier: object | None = None) -> InventoryResult:
+        path = self._path_for_operation(operation, identifier=identifier)
         endpoint = self._endpoint()
         token = self._resolve_secret(self._config.token_secret_ref)
         if not isinstance(token, str) or not token:
@@ -200,7 +220,23 @@ class ProxmoxInventoryClient:
             expected_fingerprint=self._config.tls_fingerprint,
         )
         payload = session.get(path=path, token=token)
-        return self._result(operation, payload, endpoint_identity=sha256(endpoint.encode("utf-8")).hexdigest())
+        return self._result(operation.value, payload, endpoint_identity=sha256(endpoint.encode("utf-8")).hexdigest())
+
+    def _path_for_operation(self, operation: _InventoryOperation, *, identifier: object | None) -> str:
+        if not isinstance(operation, _InventoryOperation):
+            raise ProxmoxInventoryError("operation is not admitted")
+        if operation is _InventoryOperation.GET_VM_STATUS:
+            if not isinstance(identifier, int) or identifier not in self._config.policy.vm_ids:
+                raise ProxmoxInventoryError("unknown VMID")
+        elif operation is _InventoryOperation.GET_STORAGE_STATUS:
+            if not isinstance(identifier, str) or identifier not in self._config.policy.storage_names:
+                raise ProxmoxInventoryError("unknown storage")
+        elif identifier is not None:
+            raise ProxmoxInventoryError("operation does not accept an identifier")
+        return _READ_PATH_TEMPLATES[operation].format(
+            node=self._config.policy.node,
+            identifier=identifier,
+        )
 
     def _endpoint(self) -> str:
         endpoint = self._resolve_secret(self._config.endpoint_secret_ref)

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -231,6 +231,12 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         (
             "app/builderops/",
             "app/dispatcher/",
+            # The TARS inventory boundary is Builder System/CES machinery.
+            # It carries an inventory-only PVE token and its direct proof
+            # lives in tests/proxmox; leaving this new app prefix unowned
+            # fails the required selector before its deny-before-HTTP tests
+            # can run.
+            "app/proxmox/",
             # Static Builder surfaces (signboard, cockpit) render dispatcher/
             # BuilderOps state; their regressions live in tests/dispatcher and
             # tests/builderops. companion_ui co-owns this prefix because the
@@ -238,6 +244,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "app/web/",
             "tests/builderops/",
             "tests/dispatcher/",
+            "tests/proxmox/",
             "tests/governance/",
             # BuilderOps store-access inventory fitness. Keep this exact file
             # owned without widening builder_system to all architecture tests.
@@ -262,6 +269,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         (
             "tests/builderops",
             "tests/dispatcher",
+            "tests/proxmox",
             "tests/governance",
             "tests/architecture/test_builderops_store_boundary.py",
             "tests/architecture/test_pr_hot_path_governance.py",

--- a/tests/proxmox/test_inventory_adapter.py
+++ b/tests/proxmox/test_inventory_adapter.py
@@ -17,17 +17,38 @@ from app.proxmox.inventory import (
 
 class Transport:
     def __init__(self, fingerprint: str = "sha256:certificate") -> None:
-        self.calls: list[tuple[str, str, str]] = []
-        self.verifications: list[tuple[str, str]] = []
+        self.calls: list[tuple[int, str, str]] = []
+        self.sessions: list[Session] = []
         self.fingerprint = fingerprint
+        self._active_connection_id = 0
 
-    def verify_tls(self, *, endpoint: str, expected_fingerprint: str) -> None:
-        self.verifications.append((endpoint, expected_fingerprint))
+    def open_pinned_session(self, *, endpoint: str, expected_fingerprint: str) -> "Session":
         if self.fingerprint != expected_fingerprint:
             raise ProxmoxInventoryError("TLS certificate fingerprint mismatch")
+        self._active_connection_id += 1
+        session = Session(
+            transport=self,
+            connection_id=self._active_connection_id,
+            endpoint=endpoint,
+            expected_fingerprint=expected_fingerprint,
+        )
+        self.sessions.append(session)
+        return session
 
-    def get(self, *, endpoint: str, path: str, token: str):
-        self.calls.append((endpoint, path, token))
+
+class Session:
+    def __init__(self, *, transport: Transport, connection_id: int, endpoint: str, expected_fingerprint: str) -> None:
+        self._transport = transport
+        self._connection_id = connection_id
+        self._endpoint = endpoint
+        self._expected_fingerprint = expected_fingerprint
+
+    def get(self, *, path: str, token: str):
+        if self._transport.fingerprint != self._expected_fingerprint:
+            raise ProxmoxInventoryError("session pin was not verified")
+        if self._connection_id != self._transport._active_connection_id:  # noqa: SLF001
+            raise ProxmoxInventoryError("session is no longer the verified connection")
+        self._transport.calls.append((self._connection_id, self._endpoint, path))
         return {"data": [{"vmid": 100}, {"vmid": 999}]}
 
 
@@ -70,8 +91,8 @@ def test_named_inventory_operations_are_allowlisted() -> None:
     assert client.get_vm_status(100).receipt.operation == "get_vm_status"
     assert client.get_storage_status("local").receipt.operation == "get_storage_status"
     assert client.list_recent_tasks().receipt.operation == "list_recent_tasks"
-    assert all("/nodes/TARS/" in path or path == "/api2/json/version" or path == "/api2/json/cluster/status" for _, path, _ in transport.calls)
-    assert len(transport.verifications) == len(transport.calls)
+    assert all("/nodes/TARS/" in path or path == "/api2/json/version" or path == "/api2/json/cluster/status" for _, _, path in transport.calls)
+    assert len(transport.sessions) == len(transport.calls)
 
 
 def test_forbidden_requests_fail_before_http() -> None:
@@ -87,14 +108,14 @@ def test_forbidden_requests_fail_before_http() -> None:
         with pytest.raises(ProxmoxInventoryError):
             invalid_call()
     assert transport.calls == []
-    assert transport.verifications == []
+    assert transport.sessions == []
 
 
 def test_scope_or_tls_refusals_happen_before_http() -> None:
     transport = Transport(fingerprint="sha256:wrong")
     with pytest.raises(ProxmoxInventoryError, match="TLS"):
         _client(transport).health_check()
-    assert transport.verifications == [("https://tars.internal", "sha256:certificate")]
+    assert transport.sessions == []
     assert transport.calls == []
 
     scope_transport = Transport()
@@ -105,8 +126,31 @@ def test_scope_or_tls_refusals_happen_before_http() -> None:
     }[ref]
     with pytest.raises(ProxmoxInventoryError, match="scope"):
         client.health_check()
-    assert scope_transport.verifications == []
+    assert scope_transport.sessions == []
     assert scope_transport.calls == []
+
+
+def test_token_read_uses_the_same_pinned_session() -> None:
+    transport = Transport()
+
+    _client(transport).health_check()
+
+    assert not hasattr(transport, "get")
+    assert len(transport.sessions) == 1
+    assert transport.calls == [(1, "https://tars.internal", "/api2/json/version")]
+    assert transport.sessions[0]._connection_id == transport.calls[0][0]  # noqa: SLF001
+    assert transport.sessions[0]._endpoint == transport.calls[0][1]  # noqa: SLF001
+
+
+def test_token_read_is_refused_after_transport_reconnect() -> None:
+    transport = Transport()
+    first = transport.open_pinned_session(endpoint="https://tars.internal", expected_fingerprint="sha256:certificate")
+    transport.open_pinned_session(endpoint="https://tars.internal", expected_fingerprint="sha256:certificate")
+
+    with pytest.raises(ProxmoxInventoryError, match="verified connection"):
+        first.get(path="/api2/json/version", token="PVEAPIToken=never-transmitted")
+
+    assert transport.calls == []
 
 
 def test_receipts_never_persist_raw_credentials() -> None:

--- a/tests/proxmox/test_inventory_adapter.py
+++ b/tests/proxmox/test_inventory_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from app.orchestrator.mcp_tool_provider import MCPToolProvider
+from app.proxmox.inventory import (
+    InventoryConfig,
+    LocalProxmoxInventoryExecutor,
+    MCP_DESCRIPTOR_ID,
+    ProxmoxInventoryClient,
+    ProxmoxInventoryError,
+)
+
+
+class Transport:
+    def __init__(self, fingerprint: str = "sha256:certificate") -> None:
+        self.calls: list[tuple[str, str, str]] = []
+        self.fingerprint = fingerprint
+
+    def get(self, *, endpoint: str, path: str, token: str):
+        self.calls.append((endpoint, path, token))
+        return {"data": [{"vmid": 100}, {"vmid": 999}]}, self.fingerprint
+
+
+def _client(transport: Transport, endpoint: str = "https://tars.internal") -> ProxmoxInventoryClient:
+    refs = {"keychain:pve-endpoint": endpoint, "keychain:pve-token": "PVEAPIToken=never-receipt"}
+    return ProxmoxInventoryClient(
+        config=InventoryConfig(
+            endpoint_secret_ref="keychain:pve-endpoint",
+            token_secret_ref="keychain:pve-token",
+            token_fingerprint="37b5e65338de4c500502f4c424ba0785f3d8178afbdf468103e560e27eee41f7",
+            tls_fingerprint="sha256:certificate",
+            principal_scope_digest="sha256:scope",
+        ),
+        resolve_secret=refs.__getitem__,
+        transport=transport,
+    )
+
+
+def test_named_inventory_operations_are_allowlisted() -> None:
+    transport = Transport()
+    client = _client(transport)
+
+    assert client.health_check().receipt.operation == "health_check"
+    assert client.get_cluster_summary().receipt.operation == "get_cluster_summary"
+    assert client.list_allowed_vms().result == {"data": [{"vmid": 100}]}
+    assert client.get_vm_status(100).receipt.operation == "get_vm_status"
+    assert client.get_storage_status("local").receipt.operation == "get_storage_status"
+    assert client.list_recent_tasks().receipt.operation == "list_recent_tasks"
+    assert all("/nodes/TARS/" in path or path == "/api2/json/version" or path == "/api2/json/cluster/status" for _, path, _ in transport.calls)
+
+
+def test_forbidden_requests_fail_before_http() -> None:
+    transport = Transport()
+    client = _client(transport)
+    for invalid_call in (
+        lambda: client.get_vm_status(103),
+        lambda: client.get_storage_status("zfs"),
+        lambda: _client(transport, "http://tars.internal").health_check(),
+        lambda: _client(transport, "https://tars.internal/api2/json/nodes/TARS/qemu/100/status/start").health_check(),
+    ):
+        with pytest.raises(ProxmoxInventoryError):
+            invalid_call()
+    assert transport.calls == []
+
+
+def test_receipts_never_persist_raw_credentials() -> None:
+    result = _client(Transport()).health_check()
+    receipt = repr(result.receipt.to_dict())
+    assert "PVEAPIToken" not in receipt
+    assert "keychain:pve-token" not in receipt
+    assert "Authorization" not in receipt
+    assert result.receipt.endpoint_identity != "keychain:pve-endpoint"
+
+
+def test_mcp_admission_requires_explicit_descriptor() -> None:
+    transport = Transport()
+    executor = LocalProxmoxInventoryExecutor(_client(transport))
+    assert executor.descriptor.id == MCP_DESCRIPTOR_ID
+    assert executor.descriptor.admission == "local_typed_executor_only"
+    assert MCP_DESCRIPTOR_ID not in MCPToolProvider().list_descriptors({"mcp_remote_multiplex_enable": True})
+    with pytest.raises(ProxmoxInventoryError, match="loopback"):
+        executor.execute(caller_host="10.0.0.2", operation="health_check")
+    assert executor.execute(caller_host="127.0.0.1", operation="health_check").receipt.operation == "health_check"

--- a/tests/proxmox/test_inventory_adapter.py
+++ b/tests/proxmox/test_inventory_adapter.py
@@ -111,6 +111,22 @@ def test_forbidden_requests_fail_before_http() -> None:
     assert transport.sessions == []
 
 
+def test_arbitrary_path_cannot_reach_transport() -> None:
+    transport = Transport()
+    client = _client(transport)
+
+    with pytest.raises(TypeError):
+        client._read(  # type: ignore[call-arg]  # noqa: SLF001
+            "health_check",
+            "/api2/json/nodes/TARS/qemu/100/status/start",
+        )
+    with pytest.raises(ProxmoxInventoryError, match="operation"):
+        client._read("/api2/json/nodes/TARS/qemu/100/status/start")  # type: ignore[arg-type]  # noqa: SLF001
+
+    assert transport.sessions == []
+    assert transport.calls == []
+
+
 def test_scope_or_tls_refusals_happen_before_http() -> None:
     transport = Transport(fingerprint="sha256:wrong")
     with pytest.raises(ProxmoxInventoryError, match="TLS"):

--- a/tests/proxmox/test_inventory_adapter.py
+++ b/tests/proxmox/test_inventory_adapter.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from hashlib import sha256
+
 import pytest
 
 from app.orchestrator.mcp_tool_provider import MCPToolProvider
@@ -15,22 +18,42 @@ from app.proxmox.inventory import (
 class Transport:
     def __init__(self, fingerprint: str = "sha256:certificate") -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self.verifications: list[tuple[str, str]] = []
         self.fingerprint = fingerprint
+
+    def verify_tls(self, *, endpoint: str, expected_fingerprint: str) -> None:
+        self.verifications.append((endpoint, expected_fingerprint))
+        if self.fingerprint != expected_fingerprint:
+            raise ProxmoxInventoryError("TLS certificate fingerprint mismatch")
 
     def get(self, *, endpoint: str, path: str, token: str):
         self.calls.append((endpoint, path, token))
-        return {"data": [{"vmid": 100}, {"vmid": 999}]}, self.fingerprint
+        return {"data": [{"vmid": 100}, {"vmid": 999}]}
 
 
 def _client(transport: Transport, endpoint: str = "https://tars.internal") -> ProxmoxInventoryClient:
-    refs = {"keychain:pve-endpoint": endpoint, "keychain:pve-token": "PVEAPIToken=never-receipt"}
+    scope = {
+        "capability": "inventory-read-only",
+        "node": "TARS",
+        "operations": ["health_check", "get_cluster_summary", "list_allowed_vms", "get_vm_status", "get_storage_status", "list_recent_tasks"],
+        "vm_ids": [100, 101, 102, 104],
+        "storage_names": ["local", "local-lvm"],
+    }
+    scope_json = json.dumps(scope, sort_keys=True, separators=(",", ":"))
+    refs = {
+        "keychain:pve-endpoint": endpoint,
+        "keychain:pve-token": "PVEAPIToken=never-receipt",
+        "keychain:pve-scope": scope_json,
+    }
     return ProxmoxInventoryClient(
         config=InventoryConfig(
             endpoint_secret_ref="keychain:pve-endpoint",
             token_secret_ref="keychain:pve-token",
+            principal_scope_secret_ref="keychain:pve-scope",
             token_fingerprint="37b5e65338de4c500502f4c424ba0785f3d8178afbdf468103e560e27eee41f7",
+            endpoint_identity=sha256(b"https://tars.internal").hexdigest(),
             tls_fingerprint="sha256:certificate",
-            principal_scope_digest="sha256:scope",
+            principal_scope_digest=sha256(scope_json.encode("utf-8")).hexdigest(),
         ),
         resolve_secret=refs.__getitem__,
         transport=transport,
@@ -48,6 +71,7 @@ def test_named_inventory_operations_are_allowlisted() -> None:
     assert client.get_storage_status("local").receipt.operation == "get_storage_status"
     assert client.list_recent_tasks().receipt.operation == "list_recent_tasks"
     assert all("/nodes/TARS/" in path or path == "/api2/json/version" or path == "/api2/json/cluster/status" for _, path, _ in transport.calls)
+    assert len(transport.verifications) == len(transport.calls)
 
 
 def test_forbidden_requests_fail_before_http() -> None:
@@ -58,10 +82,31 @@ def test_forbidden_requests_fail_before_http() -> None:
         lambda: client.get_storage_status("zfs"),
         lambda: _client(transport, "http://tars.internal").health_check(),
         lambda: _client(transport, "https://tars.internal/api2/json/nodes/TARS/qemu/100/status/start").health_check(),
+        lambda: _client(transport, "https://untrusted.internal").health_check(),
     ):
         with pytest.raises(ProxmoxInventoryError):
             invalid_call()
     assert transport.calls == []
+    assert transport.verifications == []
+
+
+def test_scope_or_tls_refusals_happen_before_http() -> None:
+    transport = Transport(fingerprint="sha256:wrong")
+    with pytest.raises(ProxmoxInventoryError, match="TLS"):
+        _client(transport).health_check()
+    assert transport.verifications == [("https://tars.internal", "sha256:certificate")]
+    assert transport.calls == []
+
+    scope_transport = Transport()
+    client = _client(scope_transport)
+    client._resolve_secret = lambda ref: "{}" if ref == "keychain:pve-scope" else {  # noqa: SLF001
+        "keychain:pve-endpoint": "https://tars.internal",
+        "keychain:pve-token": "PVEAPIToken=never-receipt",
+    }[ref]
+    with pytest.raises(ProxmoxInventoryError, match="scope"):
+        client.health_check()
+    assert scope_transport.verifications == []
+    assert scope_transport.calls == []
 
 
 def test_receipts_never_persist_raw_credentials() -> None:

--- a/tests/proxmox/test_inventory_receipt.py
+++ b/tests/proxmox/test_inventory_receipt.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from app.proxmox.inventory import InventoryReceipt, RECEIPT_VERSION
+
+
+def test_proxmox_adapter_receipt_v1_round_trip() -> None:
+    receipt = InventoryReceipt(
+        version=RECEIPT_VERSION,
+        endpoint_identity="sha256:endpoint",
+        tls_fingerprint="sha256:tls",
+        principal_scope_digest="sha256:scope",
+        allowlist_policy={"node": "TARS", "vm_ids": [100, 101, 102, 104], "storage_names": ["local", "local-lvm"]},
+        operation="health_check",
+        outcome="ok",
+        result_digest="sha256:result",
+    )
+    payload = receipt.to_dict()
+    assert payload["version"] == "proxmox.inventory.receipt.v1"
+    assert InventoryReceipt(**payload) == receipt

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -156,6 +156,15 @@ def test_builder_system_architecture_fitness_test_has_ci_owner() -> None:
     assert path in selection.targets
 
 
+def test_proxmox_inventory_boundary_has_builder_system_ci_owner() -> None:
+    selection = select_tests(["app/proxmox/inventory.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("builder_system",)
+    assert selection.unowned_paths == ()
+    assert "tests/proxmox" in selection.targets
+
+
 def test_model_access_kernel_change_selects_contract_and_boundary_coverage() -> None:
     selection = select_tests(["llm_contract/__init__.py"])
 


### PR DESCRIPTION
Governing-Issue: #5053

Fixes #5053

Final-Review-Rounds: 1

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: authority-bearing / mechanical
- Persistence impact: versioned, secret-safe inventory receipts only
- Derived/rebuildable impact: inventory observations are rebuildable
- New or changed contract: named PVE inventory operations and deny-before-transport policy
- Owner-doc impact: no owner-doc change implied; parent acceptance remains pending
- Transition debt impact: reduces
- Boundary risk: adapter must not become an arbitrary PVE shell, REST proxy, or mutation path

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a standalone typed PVE inventory boundary with fixed TARS, VM, and storage allowlists.
- Require secret references, token/TLS fingerprints, local loopback admission, and versioned secret-safe receipts.
- Keep the adapter outside the remote MCP multiplexer and expose no generic request or mutation surface.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing GitHub Issue and this PR carry the bounded delivery evidence; no separate operational record was produced.

## Notes
Validation: Proxmox receipt/adapter plus selector tests (106 passed); `ruff check app tests companion-ui/companion-app` (passed); `mypy app` (917 source files, passed); `python3 scripts/docs_guard.py` (passed); selector maps `app/proxmox/**` to Builder System and `tests/proxmox`; `git diff --check` (passed). Repair: authenticated read paths are now derived from a closed named-operation mapping; arbitrary-path attempts create no session or HTTP. Risk assessment: security, external-api, and credential-durability; independent pre-push convergence review found no P0/P1 at `97bc5703e`; fresh post-push current-head verification remains required before merge.