### PR TITLE
Verify rendered scalar rollback policy mounts

### DIFF
--- a/tests/deploy/test_deploy_channel_vault_overlays.py
+++ b/tests/deploy/test_deploy_channel_vault_overlays.py
@@ -358,6 +358,21 @@ def test_scalar_rollback_overrides_full_host_environment_selectors(
     )
     assert _mount_source(api, "/Users") is None
     assert api.get("ports", []) == []
+    init = services["instance-state-init"]
+    expected_policy_mounts = {
+        "/run/scalar-rollback-policy/docker-compose.yaml": (
+            REPO_ROOT / "docker-compose.yaml"
+        ),
+        "/run/scalar-rollback-policy/docker-compose.scalar-rollback.yml": (
+            REPO_ROOT / "docker-compose.scalar-rollback.yml"
+        ),
+        "/run/scalar-rollback-policy/nginx.conf": (
+            REPO_ROOT / "ops/scalar-rollback/nginx.conf"
+        ),
+    }
+    for target, source in expected_policy_mounts.items():
+        assert _mount_source(init, target) == str(source)
+        assert _mount_is_read_only(init, target)
     gateway_ports = services["scalar-rollback-gateway"]["ports"]
     assert isinstance(gateway_ports, list)
     assert gateway_ports[0]["host_ip"] == "127.0.0.1"


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: PR #5051 merged before independent review identified that the positive test inspected raw overlay YAML instead of rendered Compose output.
Validation: Static scalar rollback contract passed; Docker-rendered assertion is attached to the existing Docker-required deploy-compose test and will execute in CI.
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Product/Runtime deployment verification
- Secondary subsystem(s): scalar rollback and instance-state init
- Write class: test-only contract assertion
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: no runtime change; verifies merged Compose output
- Owner-doc impact: none
- Transition debt impact: closes review evidence gap from PR 5051
- Boundary risk: false green if rendered mount semantics drift

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Verify scalar rollback policy mounts against the fully rendered deployment Compose model.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Test-only direct repair; no BuilderOps material was produced.

## Notes
Local validation: 1 passed, 1 skipped because docker is not installed on this Mac; Ruff, docs_guard, and git diff --check passed.