### PR TITLE
Add Linux containment for BuilderOps verification

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -1214,8 +1214,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Required allowlisted whole-process-tree containment profile; "
-            "installed-main currently supports "
-            "darwin-launchd-resource-coalition-v1"
+            "installed-main supports darwin-launchd-resource-coalition-v1 "
+            "or linux-systemd-cgroup-v2-scope-v1"
         ),
     )
     p.add_argument("--json", action="store_true")

--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -426,6 +426,8 @@ _PUBLIC_VERIFICATION_CYCLE_OPTIONAL_KEYS = frozenset({"containment"})
 
 def _public_verification_cycle_receipt(
     receipt: Mapping[str, object],
+    *,
+    containment_receipt_required: bool = False,
 ) -> dict[str, object]:
     """Return only the exact, secret-free BCP-05 receipt contract."""
 
@@ -437,6 +439,7 @@ def _public_verification_cycle_receipt(
         )
         or receipt.get("contract") != "bcp05_demerzel_cycle.v1"
         or receipt.get("raw_secret_count") != 0
+        or (containment_receipt_required and "containment" not in receipt)
         or not isinstance(receipt.get("readback"), Mapping)
         or not isinstance(receipt.get("merge_authority"), Mapping)
     ):
@@ -784,6 +787,7 @@ def _build_host_fenced_verification_cycle(
             consumer,
             executor,
             holder=holder,
+            containment_receipt_required=containment_receipt_required,
         )
     except Exception:
         repository_authority.close()
@@ -878,7 +882,13 @@ def _cmd_verification_cycle(
             1,
         )
     try:
-        public_receipt = _public_verification_cycle_receipt(receipt)
+        public_receipt = _public_verification_cycle_receipt(
+            receipt,
+            containment_receipt_required=(
+                args.containment_profile
+                == LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+            ),
+        )
     except Exception as exc:
         return _emit_payload(
             {

--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -421,6 +421,7 @@ _PUBLIC_VERIFICATION_CYCLE_RECEIPT_KEYS = frozenset(
         "raw_secret_count",
     }
 )
+_PUBLIC_VERIFICATION_CYCLE_OPTIONAL_KEYS = frozenset({"containment"})
 
 
 def _public_verification_cycle_receipt(
@@ -429,7 +430,11 @@ def _public_verification_cycle_receipt(
     """Return only the exact, secret-free BCP-05 receipt contract."""
 
     if (
-        set(receipt) != _PUBLIC_VERIFICATION_CYCLE_RECEIPT_KEYS
+        not _PUBLIC_VERIFICATION_CYCLE_RECEIPT_KEYS.issubset(receipt)
+        or not set(receipt).issubset(
+            _PUBLIC_VERIFICATION_CYCLE_RECEIPT_KEYS
+            | _PUBLIC_VERIFICATION_CYCLE_OPTIONAL_KEYS
+        )
         or receipt.get("contract") != "bcp05_demerzel_cycle.v1"
         or receipt.get("raw_secret_count") != 0
         or not isinstance(receipt.get("readback"), Mapping)
@@ -688,6 +693,15 @@ class _InstalledMainExactHeadLauncher:
             return self.launcher.launch(bound_pack, **kwargs)
         finally:
             patch_path.unlink(missing_ok=True)
+
+    def containment_receipt(self) -> Mapping[str, object] | None:
+        """Expose the inner launch's validated host-containment evidence."""
+
+        reader = getattr(self.launcher, "containment_receipt", None)
+        if not callable(reader):
+            return None
+        candidate = reader()
+        return dict(candidate) if isinstance(candidate, Mapping) else None
 
 
 def _build_host_fenced_verification_cycle(

--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -631,6 +631,9 @@ class _InstalledMainExactHeadLauncher:
     ) -> None:
         self.launcher = launcher
         self.config = launcher.config
+        self.containment_receipt_required = bool(
+            getattr(launcher, "containment_receipt_required", False)
+        )
         self.installed_main = installed_main
         self.context_path = context_path
         self.git_runner = git_runner
@@ -712,6 +715,7 @@ def _build_host_fenced_verification_cycle(
     worktree: Path,
     context_path: Path,
     containment_factory: Callable[[], Any],
+    containment_receipt_required: bool = False,
 ) -> tuple[Any, Callable[[], None]]:
     from app.dispatcher.verification_consumer import (
         CANONICAL_RECEIPT_SCHEMA_PATH,
@@ -755,6 +759,7 @@ def _build_host_fenced_verification_cycle(
             CANONICAL_RECEIPT_SCHEMA_PATH,
             context_path,
             containment_factory=containment_factory,
+            containment_receipt_required=containment_receipt_required,
         )
         launcher = _InstalledMainExactHeadLauncher(
             raw_launcher,
@@ -833,6 +838,9 @@ def _cmd_verification_cycle(
         containment_factory = select_verification_containment(
             args.containment_profile
         )
+        from app.dispatcher.linux_containment import (
+            LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+        )
         with tempfile.TemporaryDirectory(
             prefix="yggdrasil-verification-cycle-"
         ) as scratch:
@@ -845,6 +853,10 @@ def _cmd_verification_cycle(
                         worktree=worktree,
                         context_path=Path(scratch) / "context.json",
                         containment_factory=containment_factory,
+                        containment_receipt_required=(
+                            args.containment_profile
+                            == LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+                        ),
                     )
                 )
                 try:

--- a/app/dispatcher/darwin_containment.py
+++ b/app/dispatcher/darwin_containment.py
@@ -566,11 +566,29 @@ def select_verification_containment(
     *,
     platform: str = sys.platform,
     kernel: DarwinCoalitionKernel | None = None,
+    linux_kernel: Any | None = None,
+    linux_scope_name: str | None = None,
     current_pid: int | None = None,
     sleeper: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
-) -> Callable[[], DarwinLaunchdCoalitionContainment]:
-    """Preflight and return the one allowlisted production containment factory."""
+) -> Callable[[], Any]:
+    """Preflight and return an explicitly allowlisted containment factory."""
+
+    from app.dispatcher.linux_containment import (
+        LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+        select_linux_verification_containment,
+    )
+
+    if profile == LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE:
+        if platform != "linux":
+            raise ValueError(
+                "verification containment profile is unsupported on this platform"
+            )
+        return select_linux_verification_containment(
+            kernel=linux_kernel,
+            scope_name=linux_scope_name,
+            sleeper=sleeper,
+        )
 
     if profile != DARWIN_LAUNCHD_COALITION_PROFILE:
         raise ValueError("verification containment profile is absent or unsupported")

--- a/app/dispatcher/linux_containment.py
+++ b/app/dispatcher/linux_containment.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import secrets
 import shutil
 import signal
@@ -29,6 +30,41 @@ from app.dispatcher.linux_launch_barrier import RELEASE_TOKEN
 LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE = "linux-systemd-cgroup-v2-scope-v1"
 _SCOPE_PREFIX = "yggdrasil-verification-"
 _STABLE_SNAPSHOT_ATTEMPTS = 8
+
+
+def validated_linux_containment_receipt(value: object) -> dict[str, object]:
+    """Validate the complete secret-safe Linux containment allowlist."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("verification containment receipt is malformed")
+    evidence = value.get("evidence_digests")
+    hex64 = re.compile(r"[0-9a-f]{64}")
+    scope_name = re.compile(r"yggdrasil-verification-[0-9a-f]{24}\.scope")
+    if (
+        set(value)
+        != {
+            "contract",
+            "profile_name",
+            "scope_identity",
+            "evidence_digests",
+            "outcome",
+        }
+        or value.get("contract") != "builderops_linux_containment.v1"
+        or value.get("profile_name")
+        != LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+        or not isinstance(value.get("scope_identity"), str)
+        or scope_name.fullmatch(str(value.get("scope_identity"))) is None
+        or not isinstance(evidence, Mapping)
+        or set(evidence) != {"attach", "cleanup"}
+        or any(
+            not isinstance(evidence.get(key), str)
+            or hex64.fullmatch(str(evidence.get(key))) is None
+            for key in ("attach", "cleanup")
+        )
+        or value.get("outcome") != "clean"
+    ):
+        raise ValueError("verification containment receipt is malformed")
+    return dict(value)
 
 
 @dataclass(frozen=True, order=True)
@@ -478,6 +514,7 @@ class LinuxSystemdScopeContainment:
     """Launch-scoped cleanup proven by one transient systemd scope."""
 
     profile_name = LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+    cleanup_before_direct_reap = True
 
     def __init__(
         self,
@@ -702,4 +739,5 @@ __all__ = [
     "LinuxSystemdScopeContainment",
     "SystemdCgroupV2Kernel",
     "select_linux_verification_containment",
+    "validated_linux_containment_receipt",
 ]

--- a/app/dispatcher/linux_containment.py
+++ b/app/dispatcher/linux_containment.py
@@ -1,0 +1,705 @@
+"""Fail-closed systemd/cgroup-v2 containment for verification runs.
+
+The scope name is launch-specific and allowlisted by the caller. Numeric PIDs
+never confer signal authority: every target is bound to its Linux start-time
+tick and exact cgroup-v2 scope, then revalidated through a pidfd immediately
+before signalling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from app.dispatcher.linux_launch_barrier import RELEASE_TOKEN
+
+
+LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE = "linux-systemd-cgroup-v2-scope-v1"
+_SCOPE_PREFIX = "yggdrasil-verification-"
+_STABLE_SNAPSHOT_ATTEMPTS = 8
+
+
+@dataclass(frozen=True, order=True)
+class LinuxProcessIdentity:
+    """One PID generation and its observed cgroup-v2 membership."""
+
+    pid: int
+    start_time_ticks: int
+    parent_pid: int
+    cgroup_path: str
+
+
+@dataclass(frozen=True)
+class LinuxScopeIdentity:
+    """One named transient scope bound to its cgroup filesystem object."""
+
+    unit: str
+    cgroup_path: str
+    cgroup_device: int
+    cgroup_inode: int
+
+
+class LinuxCgroupKernel(Protocol):
+    """Narrow injectable systemd/cgroup-v2 interface."""
+
+    def preflight(self) -> None: ...
+
+    def scope_command(
+        self, scope_name: str, command: Sequence[str]
+    ) -> list[str]: ...
+
+    def scope_identity(self, scope_name: str) -> LinuxScopeIdentity: ...
+
+    def inspect(self, pid: int) -> LinuxProcessIdentity | None: ...
+
+    def scope_members(
+        self, scope: LinuxScopeIdentity
+    ) -> frozenset[LinuxProcessIdentity]: ...
+
+    def signal(self, identity: LinuxProcessIdentity, sig: int) -> bool: ...
+
+    def retire_scope(self, scope: LinuxScopeIdentity) -> bool: ...
+
+
+def _parse_proc_stat(pid: int, payload: str) -> tuple[int, int]:
+    closing = payload.rfind(")")
+    if closing < 0 or not payload.startswith(f"{pid} ("):
+        raise ValueError("Linux process identity is malformed")
+    fields = payload[closing + 1 :].split()
+    if len(fields) < 20:
+        raise ValueError("Linux process identity is incomplete")
+    try:
+        parent_pid = int(fields[1])
+        start_time_ticks = int(fields[19])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Linux process identity is malformed") from exc
+    if parent_pid < 0 or start_time_ticks <= 0:
+        raise ValueError("Linux process identity is malformed")
+    return parent_pid, start_time_ticks
+
+
+def _parse_unified_cgroup(payload: str) -> str:
+    lines = [line for line in payload.splitlines() if line]
+    if len(lines) != 1:
+        raise ValueError("Linux unified cgroup membership is unavailable")
+    hierarchy, controllers, cgroup_path = lines[0].split(":", 2)
+    path = PurePosixPath(cgroup_path)
+    if (
+        hierarchy != "0"
+        or controllers
+        or not cgroup_path.startswith("/")
+        or ".." in path.parts
+    ):
+        raise ValueError("Linux unified cgroup membership is unavailable")
+    return cgroup_path
+
+
+def _parse_systemctl_properties(payload: str) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    for line in payload.splitlines():
+        key, separator, value = line.partition("=")
+        if not separator or not key or key in properties:
+            raise ValueError("Linux systemd scope identity is malformed")
+        properties[key] = value
+    return properties
+
+
+class SystemdCgroupV2Kernel:
+    """Production adapter for one user-manager transient scope."""
+
+    def __init__(
+        self,
+        *,
+        proc_root: Path = Path("/proc"),
+        cgroup_root: Path = Path("/sys/fs/cgroup"),
+        runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self._proc_root = proc_root
+        self._cgroup_root = cgroup_root
+        self._runner = runner
+        self._systemd_run: str | None = None
+        self._systemctl: str | None = None
+
+    def _invoke(self, command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            return self._runner(
+                list(command),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise ValueError("Linux systemd user manager is unavailable") from exc
+
+    def preflight(self) -> None:
+        systemd_run = shutil.which("systemd-run")
+        systemctl = shutil.which("systemctl")
+        if systemd_run is None or systemctl is None:
+            raise ValueError("Linux systemd/cgroup-v2 prerequisites are unavailable")
+        if not (self._cgroup_root / "cgroup.controllers").is_file():
+            raise ValueError("Linux cgroup-v2 unified hierarchy is unavailable")
+        try:
+            own_cgroup = (self._proc_root / "self" / "cgroup").read_text(
+                encoding="utf-8"
+            )
+        except OSError as exc:
+            raise ValueError("Linux cgroup-v2 unified hierarchy is unavailable") from exc
+        _parse_unified_cgroup(own_cgroup)
+        probe = self._invoke([systemctl, "--user", "show-environment"])
+        if probe.returncode != 0:
+            raise ValueError("Linux systemd user manager is unavailable")
+        help_probe = self._invoke([systemd_run, "--help"])
+        required = ("--scope", "--unit", "--user", "--property")
+        if help_probe.returncode != 0 or not all(
+            option in help_probe.stdout for option in required
+        ):
+            raise ValueError("Linux systemd scope attachment is unavailable")
+        if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+            raise ValueError("Linux PID-version-bound signalling is unavailable")
+        self._systemd_run = systemd_run
+        self._systemctl = systemctl
+
+    @staticmethod
+    def _validate_scope_name(scope_name: str) -> None:
+        suffix = scope_name.removeprefix(_SCOPE_PREFIX).removesuffix(".scope")
+        if (
+            not scope_name.startswith(_SCOPE_PREFIX)
+            or not scope_name.endswith(".scope")
+            or len(suffix) != 24
+            or any(character not in "0123456789abcdef" for character in suffix)
+        ):
+            raise ValueError("Linux containment scope name is invalid")
+
+    def scope_command(
+        self, scope_name: str, command: Sequence[str]
+    ) -> list[str]:
+        self._validate_scope_name(scope_name)
+        if self._systemd_run is None or not command:
+            raise ValueError("Linux containment preflight is incomplete")
+        return [
+            self._systemd_run,
+            "--user",
+            "--scope",
+            "--quiet",
+            "--unit",
+            scope_name,
+            "--property=KillMode=control-group",
+            "--property=CollectMode=inactive-or-failed",
+            "--",
+            *command,
+        ]
+
+    def _cgroup_directory(self, cgroup_path: str) -> Path:
+        relative = PurePosixPath(cgroup_path)
+        if not cgroup_path.startswith("/") or ".." in relative.parts:
+            raise ValueError("Linux cgroup path is invalid")
+        root = self._cgroup_root.resolve()
+        candidate = (root / cgroup_path.lstrip("/")).resolve()
+        if not candidate.is_relative_to(root):
+            raise ValueError("Linux cgroup path escapes the unified hierarchy")
+        return candidate
+
+    def scope_identity(self, scope_name: str) -> LinuxScopeIdentity:
+        self._validate_scope_name(scope_name)
+        if self._systemctl is None:
+            raise ValueError("Linux containment preflight is incomplete")
+        result = self._invoke(
+            [
+                self._systemctl,
+                "--user",
+                "show",
+                scope_name,
+                "--no-pager",
+                "--property=Id",
+                "--property=ControlGroup",
+                "--property=ActiveState",
+                "--property=KillMode",
+            ]
+        )
+        if result.returncode != 0:
+            raise ValueError("Linux systemd scope identity is unavailable")
+        properties = _parse_systemctl_properties(result.stdout)
+        if (
+            properties
+            != {
+                "Id": scope_name,
+                "ControlGroup": properties.get("ControlGroup", ""),
+                "ActiveState": "active",
+                "KillMode": "control-group",
+            }
+            or not properties["ControlGroup"]
+        ):
+            raise ValueError("Linux systemd scope identity is unavailable")
+        cgroup_path = properties["ControlGroup"]
+        directory = self._cgroup_directory(cgroup_path)
+        try:
+            stat_result = directory.stat()
+        except OSError as exc:
+            raise ValueError("Linux systemd scope cgroup is unavailable") from exc
+        return LinuxScopeIdentity(
+            unit=scope_name,
+            cgroup_path=cgroup_path,
+            cgroup_device=stat_result.st_dev,
+            cgroup_inode=stat_result.st_ino,
+        )
+
+    def inspect(self, pid: int) -> LinuxProcessIdentity | None:
+        if pid <= 0:
+            return None
+        directory = self._proc_root / str(pid)
+        try:
+            stat_payload = (directory / "stat").read_text(encoding="utf-8")
+            cgroup_payload = (directory / "cgroup").read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise ValueError("Linux process identity is unavailable") from exc
+        parent_pid, start_time_ticks = _parse_proc_stat(pid, stat_payload)
+        return LinuxProcessIdentity(
+            pid=pid,
+            start_time_ticks=start_time_ticks,
+            parent_pid=parent_pid,
+            cgroup_path=_parse_unified_cgroup(cgroup_payload),
+        )
+
+    @staticmethod
+    def _is_inside_scope(cgroup_path: str, scope_path: str) -> bool:
+        return cgroup_path == scope_path or cgroup_path.startswith(scope_path + "/")
+
+    def scope_members(
+        self, scope: LinuxScopeIdentity
+    ) -> frozenset[LinuxProcessIdentity]:
+        directory = self._cgroup_directory(scope.cgroup_path)
+        try:
+            current_stat = directory.stat()
+        except FileNotFoundError:
+            return frozenset()
+        except OSError as exc:
+            raise ValueError("Linux systemd scope cgroup is unavailable") from exc
+        if (current_stat.st_dev, current_stat.st_ino) != (
+            scope.cgroup_device,
+            scope.cgroup_inode,
+        ):
+            raise ValueError("Linux systemd scope identity changed")
+        pids: set[int] = set()
+        try:
+            process_files = sorted(directory.rglob("cgroup.procs"))
+            if not process_files:
+                raise ValueError("Linux cgroup membership file is unavailable")
+            for process_file in process_files:
+                for raw_pid in process_file.read_text(encoding="utf-8").splitlines():
+                    pid = int(raw_pid)
+                    if pid <= 0 or pid in pids:
+                        raise ValueError("Linux cgroup membership is malformed")
+                    pids.add(pid)
+        except (OSError, ValueError) as exc:
+            raise ValueError("Linux cgroup membership is unavailable") from exc
+        members: set[LinuxProcessIdentity] = set()
+        for pid in pids:
+            identity = self.inspect(pid)
+            if identity is None or not self._is_inside_scope(
+                identity.cgroup_path, scope.cgroup_path
+            ):
+                raise ValueError("Linux cgroup membership changed during inspection")
+            members.add(identity)
+        return frozenset(members)
+
+    def signal(self, identity: LinuxProcessIdentity, sig: int) -> bool:
+        fresh = self.inspect(identity.pid)
+        if fresh != identity:
+            return False
+        pidfd_open = getattr(os, "pidfd_open", None)
+        pidfd_send_signal = getattr(signal, "pidfd_send_signal", None)
+        if not callable(pidfd_open) or not callable(pidfd_send_signal):
+            return False
+        try:
+            pidfd = pidfd_open(identity.pid, 0)
+        except OSError:
+            return False
+        try:
+            if self.inspect(identity.pid) != identity:
+                return False
+            pidfd_send_signal(pidfd, sig)
+        except OSError:
+            return False
+        finally:
+            os.close(pidfd)
+        return True
+
+    def retire_scope(self, scope: LinuxScopeIdentity) -> bool:
+        if self.scope_members(scope):
+            return False
+        directory = self._cgroup_directory(scope.cgroup_path)
+        if not directory.exists():
+            return True
+        if self._systemctl is None:
+            return False
+        result = self._invoke([self._systemctl, "--user", "stop", scope.unit])
+        return result.returncode == 0 and not directory.exists()
+
+
+class LinuxLaunchBarrier:
+    """Hold the systemd scope command until its identity is proven."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        kernel: LinuxCgroupKernel,
+        scope_name: str,
+    ) -> None:
+        if not command:
+            raise ValueError("Linux launch barrier command is empty")
+        reader, writer = os.pipe()
+        os.set_inheritable(reader, False)
+        os.set_inheritable(writer, False)
+        self._reader: int | None = reader
+        self._writer: int | None = writer
+        self._release_lock = threading.Lock()
+        self._release_attempted = False
+        self._may_have_released = False
+        inner_command = [
+            sys.executable,
+            "-I",
+            "-S",
+            str(Path(__file__).with_name("linux_launch_barrier.py").resolve()),
+            "--release-fd",
+            str(reader),
+            "--",
+            *command,
+        ]
+        self.command = kernel.scope_command(scope_name, inner_command)
+        self.pass_fds = (reader,)
+
+    @property
+    def may_have_released(self) -> bool:
+        with self._release_lock:
+            return self._may_have_released
+
+    def after_spawn(self) -> None:
+        if self._reader is None:
+            raise ValueError("Linux launch barrier reader is unavailable")
+        os.close(self._reader)
+        self._reader = None
+
+    def release(self) -> None:
+        with self._release_lock:
+            if self._release_attempted or self._reader is not None or self._writer is None:
+                raise ValueError("Linux launch barrier is unavailable")
+            self._release_attempted = True
+            self._may_have_released = True
+            try:
+                written = os.write(self._writer, RELEASE_TOKEN)
+            except BaseException:
+                try:
+                    os.close(self._writer)
+                finally:
+                    self._writer = None
+                raise
+            try:
+                os.close(self._writer)
+            finally:
+                self._writer = None
+            if written != len(RELEASE_TOKEN):
+                raise OSError("Linux launch barrier release was partial")
+
+    def close(self) -> None:
+        for attribute in ("_reader", "_writer"):
+            descriptor = getattr(self, attribute)
+            if descriptor is None:
+                continue
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            setattr(self, attribute, None)
+
+
+def _scope_digest(
+    scope: LinuxScopeIdentity,
+    members: frozenset[LinuxProcessIdentity],
+) -> str:
+    evidence = {
+        "scope": {
+            "unit": scope.unit,
+            "cgroup_path": scope.cgroup_path,
+            "cgroup_device": scope.cgroup_device,
+            "cgroup_inode": scope.cgroup_inode,
+        },
+        "members": [
+            {
+                "pid": member.pid,
+                "start_time_ticks": member.start_time_ticks,
+                "parent_pid": member.parent_pid,
+                "cgroup_path": member.cgroup_path,
+            }
+            for member in sorted(members)
+        ],
+    }
+    return hashlib.sha256(
+        json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _ancestry_closes_at_root(
+    members: frozenset[LinuxProcessIdentity], root: LinuxProcessIdentity
+) -> bool:
+    by_pid = {member.pid: member for member in members}
+    if len(by_pid) != len(members) or by_pid.get(root.pid) != root:
+        return False
+    for member in members:
+        cursor = member
+        visited: set[int] = set()
+        while cursor.pid != root.pid:
+            if cursor.pid in visited:
+                return False
+            visited.add(cursor.pid)
+            parent = by_pid.get(cursor.parent_pid)
+            if parent is None:
+                return False
+            cursor = parent
+    return True
+
+
+class LinuxSystemdScopeContainment:
+    """Launch-scoped cleanup proven by one transient systemd scope."""
+
+    profile_name = LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+
+    def __init__(
+        self,
+        kernel: LinuxCgroupKernel,
+        *,
+        scope_name: str,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._kernel = kernel
+        self._scope_name = scope_name
+        self._sleeper = sleeper
+        self._scope: LinuxScopeIdentity | None = None
+        self._root: LinuxProcessIdentity | None = None
+        self._attach_digest: str | None = None
+        self._cleanup_digest: str | None = None
+        self._outcome = "preflight"
+        self._attached = False
+        self._lock = threading.RLock()
+
+    def environment(self, base: Mapping[str, str]) -> dict[str, str]:
+        return dict(base)
+
+    def launch_barrier(self, command: Sequence[str]) -> LinuxLaunchBarrier:
+        return LinuxLaunchBarrier(
+            command,
+            kernel=self._kernel,
+            scope_name=self._scope_name,
+        )
+
+    def _stable_members(
+        self,
+        scope: LinuxScopeIdentity,
+        *,
+        root: LinuxProcessIdentity | None,
+        require_root: bool,
+    ) -> frozenset[LinuxProcessIdentity]:
+        prior: frozenset[LinuxProcessIdentity] | None = None
+        for _attempt in range(_STABLE_SNAPSHOT_ATTEMPTS):
+            try:
+                try:
+                    current_scope = self._kernel.scope_identity(scope.unit)
+                except ValueError:
+                    if require_root:
+                        raise
+                    current_scope = None
+                members = self._kernel.scope_members(scope)
+                if current_scope is None and members:
+                    raise ValueError("Linux systemd scope identity is unavailable")
+                if current_scope is not None and current_scope != scope:
+                    raise ValueError("Linux systemd scope identity changed")
+                if require_root and (
+                    root is None
+                    or root not in members
+                    or not _ancestry_closes_at_root(members, root)
+                ):
+                    raise ValueError("Linux launch scope membership is unproven")
+            except ValueError:
+                prior = None
+            else:
+                if members == prior:
+                    return members
+                prior = members
+            self._sleeper(0.05)
+        raise ValueError("Linux scope membership did not converge")
+
+    def capture_launch_root(self, root_pid: int) -> LinuxProcessIdentity:
+        last_error: ValueError | None = None
+        for _attempt in range(_STABLE_SNAPSHOT_ATTEMPTS):
+            try:
+                scope = self._kernel.scope_identity(self._scope_name)
+                root = self._kernel.inspect(root_pid)
+                if root is None or not SystemdCgroupV2Kernel._is_inside_scope(
+                    root.cgroup_path, scope.cgroup_path
+                ):
+                    raise ValueError("Linux launch root scope membership is unavailable")
+                self._stable_members(scope, root=root, require_root=True)
+            except ValueError as exc:
+                last_error = exc
+                self._sleeper(0.05)
+                continue
+            self._scope = scope
+            return root
+        raise ValueError("Linux launch root scope membership is unavailable") from last_error
+
+    def attach(
+        self,
+        root_pid: int,
+        expected_root: LinuxProcessIdentity | None = None,
+    ) -> None:
+        with self._lock:
+            if (
+                expected_root is None
+                or expected_root.pid != root_pid
+                or self._scope is None
+            ):
+                raise ValueError("Linux containment launch identity is unavailable")
+            if self._kernel.inspect(root_pid) != expected_root:
+                raise ValueError("Linux containment launch identity changed")
+            members = self._stable_members(
+                self._scope, root=expected_root, require_root=True
+            )
+            self._root = expected_root
+            self._attach_digest = _scope_digest(self._scope, members)
+            self._outcome = "attached"
+            self._attached = True
+
+    def _wait_empty(self) -> frozenset[LinuxProcessIdentity] | None:
+        assert self._scope is not None
+        prior_empty = False
+        for _attempt in range(_STABLE_SNAPSHOT_ATTEMPTS):
+            try:
+                members = self._kernel.scope_members(self._scope)
+            except ValueError:
+                prior_empty = False
+            else:
+                if not members:
+                    if prior_empty:
+                        return members
+                    prior_empty = True
+                else:
+                    prior_empty = False
+            self._sleeper(0.05)
+        return None
+
+    def _signal_snapshot(
+        self,
+        members: frozenset[LinuxProcessIdentity],
+        sig: int,
+    ) -> bool:
+        assert self._scope is not None
+        for member in sorted(members, key=lambda item: item.pid, reverse=True):
+            fresh_scope = self._kernel.scope_identity(self._scope.unit)
+            fresh = self._kernel.inspect(member.pid)
+            if (
+                fresh_scope != self._scope
+                or fresh != member
+                or not SystemdCgroupV2Kernel._is_inside_scope(
+                    fresh.cgroup_path, self._scope.cgroup_path
+                )
+                or not self._kernel.signal(member, sig)
+            ):
+                return False
+        return True
+
+    def cleanup(self) -> bool:
+        with self._lock:
+            if not self._attached or self._scope is None:
+                self._outcome = "cleanup_refused"
+                return False
+            try:
+                members = self._stable_members(
+                    self._scope, root=None, require_root=False
+                )
+                if members and not self._signal_snapshot(members, signal.SIGTERM):
+                    self._outcome = "cleanup_refused"
+                    return False
+                empty = self._wait_empty()
+                if empty is None:
+                    members = self._stable_members(
+                        self._scope, root=None, require_root=False
+                    )
+                    if members and not self._signal_snapshot(members, signal.SIGKILL):
+                        self._outcome = "cleanup_refused"
+                        return False
+                    empty = self._wait_empty()
+                if empty is None or not self._kernel.retire_scope(self._scope):
+                    self._outcome = "cleanup_refused"
+                    return False
+                self._cleanup_digest = _scope_digest(self._scope, empty)
+                self._outcome = "clean"
+                return True
+            except Exception:
+                self._outcome = "cleanup_refused"
+                return False
+
+    def receipt(self) -> dict[str, object]:
+        with self._lock:
+            evidence = {
+                key: value
+                for key, value in (
+                    ("attach", self._attach_digest),
+                    ("cleanup", self._cleanup_digest),
+                )
+                if value is not None
+            }
+            return {
+                "contract": "builderops_linux_containment.v1",
+                "profile_name": self.profile_name,
+                "scope_identity": self._scope_name,
+                "evidence_digests": evidence,
+                "outcome": self._outcome,
+            }
+
+
+def select_linux_verification_containment(
+    *,
+    kernel: LinuxCgroupKernel | None = None,
+    scope_name: str | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> Callable[[], LinuxSystemdScopeContainment]:
+    selected_kernel = kernel or SystemdCgroupV2Kernel()
+    selected_kernel.preflight()
+    selected_scope_name = scope_name or (
+        f"{_SCOPE_PREFIX}{secrets.token_hex(12)}.scope"
+    )
+
+    def factory() -> LinuxSystemdScopeContainment:
+        return LinuxSystemdScopeContainment(
+            selected_kernel,
+            scope_name=selected_scope_name,
+            sleeper=sleeper,
+        )
+
+    return factory
+
+
+__all__ = [
+    "LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE",
+    "LinuxCgroupKernel",
+    "LinuxProcessIdentity",
+    "LinuxScopeIdentity",
+    "LinuxSystemdScopeContainment",
+    "SystemdCgroupV2Kernel",
+    "select_linux_verification_containment",
+]

--- a/app/dispatcher/linux_launch_barrier.py
+++ b/app/dispatcher/linux_launch_barrier.py
@@ -1,0 +1,48 @@
+"""One-shot exec barrier for the Linux verification containment root."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Sequence
+
+
+RELEASE_TOKEN = b"verification-linux-scope-release-v1\n"
+
+
+def _read_release(fd: int) -> bool:
+    payload = b""
+    try:
+        os.set_inheritable(fd, False)
+        while len(payload) <= len(RELEASE_TOKEN):
+            chunk = os.read(fd, len(RELEASE_TOKEN) + 1 - len(payload))
+            if not chunk:
+                break
+            payload += chunk
+    except OSError:
+        return False
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    return payload == RELEASE_TOKEN
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--release-fd", type=int, required=True)
+    parsed, command = parser.parse_known_args(argv)
+    if not command or command[0] != "--" or len(command) == 1:
+        return 1
+    if parsed.release_fd < 0 or not _read_release(parsed.release_fd):
+        return 1
+    try:
+        os.execvpe(command[1], command[1:], os.environ)
+    except OSError:
+        return 1
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through exec.
+    raise SystemExit(main())

--- a/app/dispatcher/verification_api.py
+++ b/app/dispatcher/verification_api.py
@@ -890,7 +890,12 @@ class BuilderOpsVerificationLedger:
                         raise ValueError("BuilderOps verification attempt batch is malformed")
                     result.append(dict(event))
             else:
-                result.append(dict(payload))
+                attempt = dict(payload)
+                if "containment" in attempt:
+                    validated_linux_containment_receipt(
+                        attempt["containment"]
+                    )
+                result.append(attempt)
         return result
 
     def record_attempt(
@@ -907,6 +912,7 @@ class BuilderOpsVerificationLedger:
         holder: str,
         lease_id: str,
         idempotency_key: str | None = None,
+        containment_receipt: Mapping[str, object] | None = None,
     ) -> int:
         if kind not in {*REPAIR_ATTEMPT_KINDS, "review", "verification"}:
             raise ValueError("invalid verification attempt kind")
@@ -928,6 +934,13 @@ class BuilderOpsVerificationLedger:
             )
             if replay is not None:
                 expected_receipt = dict(receipt) if receipt is not None else None
+                expected_containment = (
+                    validated_linux_containment_receipt(
+                        containment_receipt
+                    )
+                    if containment_receipt is not None
+                    else None
+                )
                 if (
                     replay.get("kind") != kind
                     or replay.get("session_id") != session_id
@@ -935,6 +948,7 @@ class BuilderOpsVerificationLedger:
                     or replay.get("reasoning_effort") != reasoning_effort
                     or replay.get("outcome") != outcome
                     or replay.get("receipt") != expected_receipt
+                    or replay.get("containment") != expected_containment
                 ):
                     raise ValueError("verification attempt replay conflicts")
                 ordinal = replay.get("ordinal")
@@ -970,6 +984,10 @@ class BuilderOpsVerificationLedger:
             "mechanism_id": mechanism_id,
             "receipt": dict(receipt) if receipt is not None else None,
         }
+        if containment_receipt is not None:
+            document["containment"] = validated_linux_containment_receipt(
+                containment_receipt
+            )
         self.client.commit_attempt(
             envelope=self.envelope,
             task_id=run_id,

--- a/app/dispatcher/verification_api.py
+++ b/app/dispatcher/verification_api.py
@@ -1251,6 +1251,29 @@ class BuilderOpsVerificationLedger:
             "repair_budget": self.repair_budget_projection(run.run_id),
         }
 
+    def _verification_containment(
+        self, run: VerificationRun
+    ) -> dict[str, object] | None:
+        """Read containment from the durable current-head model attempt."""
+
+        candidates: builtins.list[dict[str, object]] = []
+        for attempt in self.attempts(run.run_id):
+            receipt = attempt.get("receipt")
+            if (
+                attempt.get("kind") == "verification"
+                and isinstance(receipt, Mapping)
+                and receipt.get("head_sha") == run.current_head_sha
+            ):
+                candidates.append(attempt)
+        if not candidates:
+            raise ValueError(
+                "merge readiness has no current-head verification attempt"
+            )
+        containment = candidates[-1].get("containment")
+        if containment is None:
+            return None
+        return validated_linux_containment_receipt(containment)
+
     def mark_merge_ready(
         self,
         run_id: str,
@@ -1273,6 +1296,16 @@ class BuilderOpsVerificationLedger:
             )
         lease = self._assert_lease(snapshot, holder, lease_id)
         document = dict(_snapshot_payload(snapshot))
+        expected_containment = self._verification_containment(run)
+        supplied_containment = (
+            validated_linux_containment_receipt(containment_receipt)
+            if containment_receipt is not None
+            else None
+        )
+        if supplied_containment != expected_containment:
+            raise ValueError(
+                "merge-ready containment does not match durable verification"
+            )
         merge_ready_receipt: dict[str, object] = {
             "contract": "builderops_merge_ready.v1",
             "run_id": run_id,
@@ -1282,10 +1315,8 @@ class BuilderOpsVerificationLedger:
             **self._merge_ready_authority(run),
             "coordinator_receipt": dict(receipt),
         }
-        if containment_receipt is not None:
-            merge_ready_receipt["containment"] = (
-                validated_linux_containment_receipt(containment_receipt)
-            )
+        if expected_containment is not None:
+            merge_ready_receipt["containment"] = expected_containment
         document["merge_ready_receipt"] = merge_ready_receipt
         self.client.transition_task(
             envelope=self.envelope,
@@ -1328,6 +1359,7 @@ class BuilderOpsVerificationLedger:
             key: marker.get(key)
             for key in expected
         }
+        expected_containment = self._verification_containment(run)
         allowed_keys = {
             "contract",
             "run_id",
@@ -1353,6 +1385,10 @@ class BuilderOpsVerificationLedger:
             raise ValueError("BuilderOps merge-ready receipt is malformed or stale")
         if "containment" in marker:
             validated_linux_containment_receipt(marker["containment"])
+        if marker.get("containment") != expected_containment:
+            raise ValueError(
+                "BuilderOps merge-ready containment is stale or substituted"
+            )
         return dict(marker)
 
     def pending_effect_binding(

--- a/app/dispatcher/verification_api.py
+++ b/app/dispatcher/verification_api.py
@@ -44,6 +44,9 @@ from app.dispatcher.verification_dispatch import (
     _request_final_review_rounds,
     _validate_request,
 )
+from app.dispatcher.linux_containment import (
+    validated_linux_containment_receipt,
+)
 
 _TASK_PREFIX = "vrun-"
 _PAYLOAD_CONTRACT = "builderops_verification_run.v1"
@@ -1237,6 +1240,7 @@ class BuilderOpsVerificationLedger:
         *,
         holder: str,
         lease_id: str,
+        containment_receipt: Mapping[str, object] | None = None,
     ) -> VerificationRun:
         """Persist exact review-only authority before the host merge effect."""
         snapshot = self._snapshot(run_id)
@@ -1251,7 +1255,7 @@ class BuilderOpsVerificationLedger:
             )
         lease = self._assert_lease(snapshot, holder, lease_id)
         document = dict(_snapshot_payload(snapshot))
-        document["merge_ready_receipt"] = {
+        merge_ready_receipt: dict[str, object] = {
             "contract": "builderops_merge_ready.v1",
             "run_id": run_id,
             "repository": self.repository,
@@ -1260,6 +1264,11 @@ class BuilderOpsVerificationLedger:
             **self._merge_ready_authority(run),
             "coordinator_receipt": dict(receipt),
         }
+        if containment_receipt is not None:
+            merge_ready_receipt["containment"] = (
+                validated_linux_containment_receipt(containment_receipt)
+            )
+        document["merge_ready_receipt"] = merge_ready_receipt
         self.client.transition_task(
             envelope=self.envelope,
             task_id=run_id,
@@ -1301,8 +1310,19 @@ class BuilderOpsVerificationLedger:
             key: marker.get(key)
             for key in expected
         }
+        allowed_keys = {
+            "contract",
+            "run_id",
+            "repository",
+            "pr_number",
+            "head_sha",
+            "coordinator_receipt",
+            "containment",
+            *expected,
+        }
         if (
-            marker.get("contract") != "builderops_merge_ready.v1"
+            not set(marker).issubset(allowed_keys)
+            or marker.get("contract") != "builderops_merge_ready.v1"
             or marker.get("run_id") != run_id
             or marker.get("repository") != self.repository
             or marker.get("pr_number") != run.pr_number
@@ -1313,6 +1333,8 @@ class BuilderOpsVerificationLedger:
             or coordinator.get("head_sha") != run.current_head_sha
         ):
             raise ValueError("BuilderOps merge-ready receipt is malformed or stale")
+        if "containment" in marker:
+            validated_linux_containment_receipt(marker["containment"])
         return dict(marker)
 
     def pending_effect_binding(

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -33,6 +33,10 @@ from zoneinfo import ZoneInfo
 
 import jsonschema
 
+from app.dispatcher.linux_containment import (
+    validated_linux_containment_receipt,
+)
+
 from app.dispatcher.verification_dispatch import (
     CONTRACT_VERSION,
     VerificationBackoffPending,
@@ -2711,6 +2715,7 @@ class CodexExecLauncher:
         self.cleanup_tracker_factory = (
             cleanup_tracker_factory or TaggedProcessTreeCleanup
         )
+        self._last_containment_receipt: dict[str, object] | None = None
         self.adapter_path = adapter_path or worktree / ".codex/agents/verification-closer.toml"
         try:
             adapter = tomllib.loads(self.adapter_path.read_text(encoding="utf-8"))
@@ -2827,6 +2832,7 @@ class CodexExecLauncher:
         on_thread_started: Callable[[str], None] | None = None,
         on_heartbeat: Callable[[], None] | None = None,
     ) -> tuple[str, Mapping[str, object]]:
+        self._last_containment_receipt = None
         try:
             schema = json.loads(self.receipt_schema.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -2923,11 +2929,18 @@ class CodexExecLauncher:
                 except Exception:
                     pass
             try:
-                return bool(containment.cleanup())
+                clean = bool(containment.cleanup())
             except Exception:
                 return False
+            receipt_reader = getattr(containment, "receipt", None)
+            if callable(receipt_reader):
+                candidate = receipt_reader()
+                if not isinstance(candidate, Mapping):
+                    return False
+                self._last_containment_receipt = dict(candidate)
+            return clean
 
-        def reap_direct_root() -> bool:
+        def reap_direct_root(*, allow_signal: bool = True) -> bool:
             with process_lock:
                 if process is None:
                     return False
@@ -2936,6 +2949,12 @@ class CodexExecLauncher:
                         return True
                 except Exception:
                     return False
+                if not allow_signal:
+                    try:
+                        process.wait(timeout=5)
+                    except Exception:
+                        return False
+                    return True
                 try:
                     process.terminate()
                 except ProcessLookupError:
@@ -2954,10 +2973,17 @@ class CodexExecLauncher:
                     return False
                 return True
 
-        def cleanup_darwin_barrier_after_release() -> bool:
-            # In R, direct-root reaping is best effort. The audited coalition
-            # cleanup must run even if that adapter fails.
+        def cleanup_barrier_after_release() -> bool:
+            # Linux signals only through its scope/pidfd authority, then waits
+            # for the exact Popen root without sending another numeric-PID
+            # signal. Darwin retains its existing root-reap-first ordering.
             with process_lock:
+                if bool(
+                    getattr(containment, "cleanup_before_direct_reap", False)
+                ):
+                    containment_clean = cleanup_process_tree()
+                    root_reaped = reap_direct_root(allow_signal=False)
+                    return root_reaped and containment_clean
                 root_reaped = reap_direct_root()
                 try:
                     coalition_clean = bool(containment.cleanup())
@@ -2976,10 +3002,13 @@ class CodexExecLauncher:
                             barrier.close()
                         except Exception:
                             pass
+                        # Before release the coordinator cannot have entered
+                        # the target scope. Reap only this exact Popen child;
+                        # scope-owned signalling begins after release.
                         reap_direct_root()
                     else:
                         containment_proven = (
-                            cleanup_darwin_barrier_after_release()
+                            cleanup_barrier_after_release()
                             or containment_proven
                         )
                     process_group_id = None
@@ -3309,7 +3338,7 @@ class CodexExecLauncher:
                         if barrier is not None:
                             process_group_id = None
                             containment_proven = (
-                                cleanup_darwin_barrier_after_release()
+                                cleanup_barrier_after_release()
                             )
                         elif process_group_is_alive():
                             terminate_and_reap_child()
@@ -3382,6 +3411,13 @@ class CodexExecLauncher:
         if terminal is None:
             raise RuntimeError("codex exec produced no schema-valid final agent receipt")
         return thread_id, terminal
+
+    def containment_receipt(self) -> Mapping[str, object] | None:
+        """Return the last launch's bounded host-containment evidence."""
+
+        if self._last_containment_receipt is None:
+            return None
+        return dict(self._last_containment_receipt)
 
 
 def _nested(mapping: Mapping[str, object], *keys: str) -> object:
@@ -5434,11 +5470,22 @@ class VerificationConsumer:
                 raise RuntimeError(
                     "host-fenced merge receipt writer is unavailable"
                 )
+            containment_receipt = None
+            containment_receipt_reader = getattr(
+                self.launcher, "containment_receipt", None
+            )
+            if callable(containment_receipt_reader):
+                candidate = containment_receipt_reader()
+                if candidate is not None:
+                    containment_receipt = validated_linux_containment_receipt(
+                        candidate
+                    )
             return mark_merge_ready(
                 claimed.run_id,
                 dict(receipt),
                 holder=self.holder,
                 lease_id=lease_id,
+                containment_receipt=containment_receipt,
             )
         status = (
             {

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -2706,6 +2706,7 @@ class CodexExecLauncher:
         runner: ProcessRunner | None = None,
         containment_factory: Callable[[], WholeTreeContainment] | None = None,
         cleanup_tracker_factory: Callable[[], WholeTreeContainment] | None = None,
+        containment_receipt_required: bool = False,
     ) -> None:
         self.worktree = worktree
         self.receipt_schema = receipt_schema
@@ -2715,6 +2716,7 @@ class CodexExecLauncher:
         self.cleanup_tracker_factory = (
             cleanup_tracker_factory or TaggedProcessTreeCleanup
         )
+        self.containment_receipt_required = containment_receipt_required
         self._last_containment_receipt: dict[str, object] | None = None
         self.adapter_path = adapter_path or worktree / ".codex/agents/verification-closer.toml"
         try:
@@ -4895,6 +4897,10 @@ class VerificationConsumer:
             effect_operation_key = None
 
         attempt_already_durable = recovered_attempt is not None
+        containment_receipt: dict[str, object] | None = None
+        containment_required = bool(
+            getattr(self.launcher, "containment_receipt_required", False)
+        )
         try:
             resume_session_id = bounded_coordinator_session_id(
                 claimed.coordinator_session_id
@@ -4917,6 +4923,17 @@ class VerificationConsumer:
                         "durable model attempt does not match recovery authority"
                     )
                 session_id = stored_session
+                stored_containment = recovered_attempt.get("containment")
+                if stored_containment is not None:
+                    containment_receipt = (
+                        validated_linux_containment_receipt(
+                            stored_containment
+                        )
+                    )
+                if containment_required and containment_receipt is None:
+                    raise ValueError(
+                        "durable Linux containment receipt is unavailable"
+                    )
                 started(session_id)
                 receipt = load_and_validate_verification_closer_receipt(
                     stored_receipt,
@@ -4970,6 +4987,19 @@ class VerificationConsumer:
                     on_thread_started=started,
                     on_heartbeat=heartbeat,
                 )
+                containment_receipt_reader = getattr(
+                    self.launcher, "containment_receipt", None
+                )
+                if callable(containment_receipt_reader):
+                    candidate = containment_receipt_reader()
+                    if candidate is not None:
+                        containment_receipt = (
+                            validated_linux_containment_receipt(candidate)
+                        )
+                if containment_required and containment_receipt is None:
+                    raise ValueError(
+                        "Linux containment receipt is unavailable"
+                    )
                 receipt = load_and_validate_verification_closer_receipt(
                     receipt,
                     self.receipt_schema,
@@ -5182,6 +5212,7 @@ class VerificationConsumer:
                         config.reasoning_effort,
                         receipt,
                     ),
+                    containment_receipt=containment_receipt,
                 )
             except Exception:
                 abandon_effect(
@@ -5470,16 +5501,6 @@ class VerificationConsumer:
                 raise RuntimeError(
                     "host-fenced merge receipt writer is unavailable"
                 )
-            containment_receipt = None
-            containment_receipt_reader = getattr(
-                self.launcher, "containment_receipt", None
-            )
-            if callable(containment_receipt_reader):
-                candidate = containment_receipt_reader()
-                if candidate is not None:
-                    containment_receipt = validated_linux_containment_receipt(
-                        candidate
-                    )
             return mark_merge_ready(
                 claimed.run_id,
                 dict(receipt),

--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -2078,7 +2078,12 @@ class VerificationDispatchLedger:
         holder: str,
         lease_id: str,
         idempotency_key: str | None = None,
+        containment_receipt: Mapping[str, object] | None = None,
     ) -> int:
+        if containment_receipt is not None:
+            raise ValueError(
+                "local verification ledger cannot persist host containment"
+            )
         allowed = {*REPAIR_ATTEMPT_KINDS, "review", "verification"}
         if kind not in allowed:
             raise ValueError("invalid verification attempt kind")

--- a/app/dispatcher/verification_runtime.py
+++ b/app/dispatcher/verification_runtime.py
@@ -18,6 +18,9 @@ from app.dispatcher.verification_merge import (
     VerificationMergeExecutor,
     verification_authority_digest,
 )
+from app.dispatcher.linux_containment import (
+    validated_linux_containment_receipt,
+)
 from app.dispatcher.verified_merge import (
     FIXED_VERIFIED_MERGE_COMMIT_MESSAGE,
     fixed_verified_merge_commit_title,
@@ -39,6 +42,7 @@ _CYCLE_RECEIPT_KEYS = frozenset(
         "raw_secret_count",
     }
 )
+_OPTIONAL_CYCLE_RECEIPT_KEYS = frozenset({"containment"})
 _DRY_READBACK_KEYS = frozenset(
     {
         "merged",
@@ -120,7 +124,10 @@ def validated_cycle_receipt_shape(
     hex40 = re.compile(r"[0-9a-f]{40}")
     hex64 = re.compile(r"[0-9a-f]{64}")
     if (
-        set(receipt) != _CYCLE_RECEIPT_KEYS
+        not _CYCLE_RECEIPT_KEYS.issubset(receipt)
+        or not set(receipt).issubset(
+            _CYCLE_RECEIPT_KEYS | _OPTIONAL_CYCLE_RECEIPT_KEYS
+        )
         or receipt.get("contract") != "bcp05_demerzel_cycle.v1"
         or not _positive_int(receipt.get("governing_issue"))
         or receipt.get("repository") != repository
@@ -159,12 +166,20 @@ def validated_cycle_receipt_shape(
         or receipt.get("raw_secret_count") != 0
     ):
         raise ValueError("verification cycle receipt is malformed")
+    if "containment" in receipt:
+        validated_containment_receipt_shape(receipt["containment"])
     validated_dry_run_readback(
         readback,
         head_sha=receipt.get("head_sha"),
         terminal_outcome=receipt.get("terminal_outcome"),
     )
     return dict(receipt)
+
+
+def validated_containment_receipt_shape(value: object) -> dict[str, object]:
+    """Validate the Linux receipt before API replay or public output."""
+
+    return validated_linux_containment_receipt(value)
 
 
 class HostFencedVerificationCycle:
@@ -361,6 +376,13 @@ class HostFencedVerificationCycle:
             },
             "raw_secret_count": 0,
         }
+        merge_ready = self.ledger.merge_ready_receipt(run_id)
+        if not isinstance(merge_ready, Mapping):
+            raise ValueError("verification merge readiness is unavailable")
+        if "containment" in merge_ready:
+            receipt["containment"] = validated_containment_receipt_shape(
+                merge_ready["containment"]
+            )
         return self._validated_receipt(
             run,
             receipt,
@@ -472,6 +494,7 @@ class HostFencedVerificationCycle:
 
 __all__ = [
     "HostFencedVerificationCycle",
+    "validated_containment_receipt_shape",
     "validated_cycle_receipt_shape",
     "validated_dry_run_readback",
 ]

--- a/app/dispatcher/verification_runtime.py
+++ b/app/dispatcher/verification_runtime.py
@@ -248,6 +248,13 @@ class HostFencedVerificationCycle:
         pending = self.ledger.pending_effect_binding(run_id)
         merge_ready = self.ledger.merge_ready_receipt(run_id)
         if merge_ready is not None:
+            if (
+                self.containment_receipt_required
+                and "containment" not in merge_ready
+            ):
+                raise ValueError(
+                    "verification Linux containment evidence is unavailable"
+                )
             # A durable merge-ready marker means model work must not be
             # relaunched. Rebind every remaining effect and settlement to a
             # fresh task fence before touching the outbox.
@@ -300,13 +307,21 @@ class HostFencedVerificationCycle:
         self, run_id: str
     ) -> Mapping[str, object]:
         run = self.ledger.get(run_id)
+        merge_ready = self.ledger.merge_ready_receipt(run_id)
         if (
             run is None
             or run.lease_id is None
-            or self.ledger.merge_ready_receipt(run_id) is None
+            or merge_ready is None
         ):
             raise ValueError(
                 "verification cycle did not reach durable merge readiness"
+            )
+        if (
+            self.containment_receipt_required
+            and "containment" not in merge_ready
+        ):
+            raise ValueError(
+                "verification Linux containment evidence is unavailable"
             )
         merge_receipt = self.merge_executor.execute(
             run,

--- a/app/dispatcher/verification_runtime.py
+++ b/app/dispatcher/verification_runtime.py
@@ -198,6 +198,7 @@ class HostFencedVerificationCycle:
         merge_executor: VerificationMergeExecutor,
         *,
         holder: str,
+        containment_receipt_required: bool = False,
     ) -> None:
         if consumer.ledger is not ledger or not consumer.host_fenced_merge:
             raise ValueError(
@@ -218,6 +219,7 @@ class HostFencedVerificationCycle:
         self.consumer = consumer
         self.merge_executor = merge_executor
         self.holder = holder
+        self.containment_receipt_required = containment_receipt_required
 
     def run_dry_cycle(
         self, request: Mapping[str, object]
@@ -379,6 +381,13 @@ class HostFencedVerificationCycle:
         merge_ready = self.ledger.merge_ready_receipt(run_id)
         if not isinstance(merge_ready, Mapping):
             raise ValueError("verification merge readiness is unavailable")
+        if (
+            self.containment_receipt_required
+            and "containment" not in merge_ready
+        ):
+            raise ValueError(
+                "verification Linux containment evidence is unavailable"
+            )
         if "containment" in merge_ready:
             receipt["containment"] = validated_containment_receipt_shape(
                 merge_ready["containment"]
@@ -469,6 +478,13 @@ class HostFencedVerificationCycle:
             or dict(authority) != expected_authority
             or receipt.get("raw_secret_count") != 0
         ):
+            raise ValueError("verification cycle receipt is malformed")
+        if (
+            self.containment_receipt_required
+            and "containment" not in marker
+        ) or (("containment" in marker) != ("containment" in receipt)):
+            raise ValueError("verification cycle receipt is malformed")
+        if marker.get("containment") != receipt.get("containment"):
             raise ValueError("verification cycle receipt is malformed")
         return validated_cycle_receipt_shape(receipt)
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md
@@ -185,6 +185,18 @@ python -m app.dispatcher.cli verification-cycle \
   --json
 ```
 
+On an installed-main Linux host, the only admitted Linux profile is selected
+explicitly instead:
+
+```bash
+python -m app.dispatcher.cli verification-cycle \
+  <verification_dispatch_request.v3.json> \
+  --holder verification-host \
+  --worktree <installed-main-checkout> \
+  --containment-profile linux-systemd-cgroup-v2-scope-v1 \
+  --json
+```
+
 It resolves the BuilderOps API connection from `BUILDEROPS_API_URL` plus exactly one of
 `BUILDEROPS_API_TOKEN_FILE` or `BUILDEROPS_API_TOKEN`, and resolves GitHub effect credentials only
 through `BUILDEROPS_EXECUTOR_CREDENTIAL_MANIFEST_FILE`. The addressed repository must have exactly
@@ -204,12 +216,17 @@ python -m app.dispatcher.cli verification-cycle \
   --json
 ```
 
+Linux recovery uses the same explicit
+`linux-systemd-cgroup-v2-scope-v1` profile. There is no platform-derived or
+best-effort fallback between the Linux and Darwin profiles.
+
 Both forms are dry-run-safe and API/PostgreSQL-only. A successful command emits the existing
 `bcp05_demerzel_cycle.v1` receipt; repository delivery is not accepted until a real installed-main
 Demerzel invocation posts that receipt to #3603. The command itself does not satisfy that parent
 gate or activate BCP-06. Before constructing any client or effect adapter, the command requires the
 selected worktree to be clean `main` at the exact locally fetched `origin/main`; a detached, dirty,
 stale, or feature-branch checkout fails closed. It also requires the explicit
+containment profile matching the host. On Darwin this remains the unchanged
 `darwin-launchd-resource-coalition-v1` profile while running inside the dedicated launchd job whose
 resource coalition is inherited by the child-wrapper topology. Before API construction or claim,
 the profile enumerates PIDs, binds each task to its PID-version and resource-coalition identity,
@@ -240,6 +257,22 @@ whole-tree authority; raw
 PID, process-group, and Tagged-process tracking are not used for the Darwin profile. The fence
 does not grant the model child GitHub authority: the installed-main cycle remains
 `github.merge.dry_run`, and BCP-06 stays disabled.
+
+On Linux, `linux-systemd-cgroup-v2-scope-v1` fails before API construction or
+claim unless the unified cgroup-v2 hierarchy, user systemd manager, transient
+scope properties, and pidfd signalling are available. The one-shot wrapper is
+started through a uniquely named `yggdrasil-verification-*.scope`; before
+release, the executor binds that scope's unit name, cgroup filesystem identity,
+root start-time tick, complete membership, and root-closing ancestry. Cleanup
+enumerates only that exact cgroup subtree, revalidates the scope and each
+process start-time/cgroup identity, signals through pidfds, and requires bounded
+stable emptiness before retiring the scope. Its public containment receipt
+contains only the explicit profile name, scope-unit identity, attach/cleanup
+evidence digests, and outcome—never raw PIDs, cgroup paths, credentials, or
+unrelated process observations. This development-baseline profile does not by
+itself accept the Linux migration: a disposable-host check and the separately
+governed live VM receipt remain required before the parent acceptance gate can
+move.
 
 That checkout supplies the installed composition
 code only: before launching the network-fenced reviewer, the host materializes an immutable

--- a/tests/dispatcher/test_darwin_containment.py
+++ b/tests/dispatcher/test_darwin_containment.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from app.dispatcher.darwin_containment import (
+    DARWIN_LAUNCHD_COALITION_PROFILE,
+    select_verification_containment,
+)
+from app.dispatcher.linux_containment import (
+    LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+)
+
+
+def test_darwin_profile_contract_remains_fail_closed() -> None:
+    for profile, platform in (
+        (None, "darwin"),
+        ("automatic", "darwin"),
+        (LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE, "darwin"),
+        (DARWIN_LAUNCHD_COALITION_PROFILE, "linux"),
+    ):
+        with pytest.raises(ValueError):
+            select_verification_containment(profile, platform=platform)

--- a/tests/dispatcher/test_linux_containment.py
+++ b/tests/dispatcher/test_linux_containment.py
@@ -16,6 +16,9 @@ from app.dispatcher.linux_containment import (
     LinuxScopeIdentity,
     SystemdCgroupV2Kernel,
 )
+from app.dispatcher.verification_runtime import (
+    validated_containment_receipt_shape,
+)
 
 
 class FakeLinuxKernel:
@@ -23,7 +26,7 @@ class FakeLinuxKernel:
         self.available = True
         self.scope_available = True
         self.scope = LinuxScopeIdentity(
-            unit="yggdrasil-verification-test.scope",
+            unit=f"yggdrasil-verification-{'f' * 24}.scope",
             cgroup_path="/user.slice/test.scope",
             cgroup_device=7,
             cgroup_inode=11,
@@ -227,6 +230,7 @@ def test_linux_receipt_is_secret_safe() -> None:
     assert containment.cleanup() is True
 
     receipt: Mapping[str, object] = containment.receipt()
+    assert validated_containment_receipt_shape(receipt) == receipt
     assert receipt == {
         "contract": "builderops_linux_containment.v1",
         "profile_name": LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,

--- a/tests/dispatcher/test_linux_containment.py
+++ b/tests/dispatcher/test_linux_containment.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import signal
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import pytest
+
+from app.dispatcher import cli as dispatcher_cli
+from app.dispatcher import linux_containment
+from app.dispatcher.darwin_containment import select_verification_containment
+from app.dispatcher.linux_containment import (
+    LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+    LinuxProcessIdentity,
+    LinuxScopeIdentity,
+    SystemdCgroupV2Kernel,
+)
+
+
+class FakeLinuxKernel:
+    def __init__(self) -> None:
+        self.available = True
+        self.scope_available = True
+        self.scope = LinuxScopeIdentity(
+            unit="yggdrasil-verification-test.scope",
+            cgroup_path="/user.slice/test.scope",
+            cgroup_device=7,
+            cgroup_inode=11,
+        )
+        self.identities: dict[int, LinuxProcessIdentity] = {
+            200: LinuxProcessIdentity(200, 1000, 1, self.scope.cgroup_path),
+            201: LinuxProcessIdentity(201, 1001, 200, self.scope.cgroup_path),
+        }
+        self.signalled: list[tuple[LinuxProcessIdentity, int]] = []
+        self.drift_before_signal: set[int] = set()
+
+    def preflight(self) -> None:
+        if not self.available:
+            raise ValueError("systemd/cgroup-v2 prerequisites are unavailable")
+
+    def scope_command(
+        self, scope_name: str, command: Sequence[str]
+    ) -> list[str]:
+        assert scope_name == self.scope.unit
+        return ["systemd-run", "--user", "--scope", "--unit", scope_name, "--", *command]
+
+    def scope_identity(self, scope_name: str) -> LinuxScopeIdentity:
+        if scope_name != self.scope.unit or not self.scope_available:
+            raise ValueError("scope identity unavailable")
+        return self.scope
+
+    def inspect(self, pid: int) -> LinuxProcessIdentity | None:
+        return self.identities.get(pid)
+
+    def scope_members(
+        self, scope: LinuxScopeIdentity
+    ) -> frozenset[LinuxProcessIdentity]:
+        if scope != self.scope:
+            raise ValueError("scope identity changed")
+        return frozenset(
+            identity
+            for identity in self.identities.values()
+            if identity.cgroup_path == scope.cgroup_path
+        )
+
+    def signal(self, identity: LinuxProcessIdentity, sig: int) -> bool:
+        if identity.pid in self.drift_before_signal:
+            self.drift_before_signal.remove(identity.pid)
+            self.identities[identity.pid] = LinuxProcessIdentity(
+                identity.pid,
+                identity.start_time_ticks + 1,
+                1,
+                identity.cgroup_path,
+            )
+        if self.identities.get(identity.pid) != identity:
+            return False
+        self.signalled.append((identity, sig))
+        self.identities.pop(identity.pid)
+        return True
+
+    def retire_scope(self, scope: LinuxScopeIdentity) -> bool:
+        return scope == self.scope and not self.identities
+
+
+def _containment(kernel: FakeLinuxKernel):
+    factory = select_verification_containment(
+        LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+        platform="linux",
+        linux_kernel=kernel,
+        linux_scope_name=kernel.scope.unit,
+        sleeper=lambda _seconds: None,
+    )
+    return factory()
+
+
+def test_cli_requires_explicit_linux_containment_profile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    kernel = FakeLinuxKernel()
+
+    for profile in (None, "linux", "automatic", "unknown-profile"):
+        with pytest.raises(ValueError, match="absent or unsupported"):
+            select_verification_containment(
+                profile,
+                platform="linux",
+                linux_kernel=kernel,
+            )
+
+    selected = _containment(kernel)
+    assert selected.profile_name == LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE
+    with pytest.raises(SystemExit, match="0"):
+        dispatcher_cli.build_parser().parse_args(["verification-cycle", "--help"])
+    help_text = capsys.readouterr().out
+    assert "linux-systemd-" in help_text
+    assert "cgroup-v2-scope-v1" in help_text
+
+
+def test_linux_containment_binds_and_validates_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = FakeLinuxKernel()
+    containment = _containment(kernel)
+
+    assert containment.environment({"SAFE": "yes"}) == {"SAFE": "yes"}
+    root = containment.capture_launch_root(200)
+    containment.attach(200, root)
+
+    receipt = containment.receipt()
+    assert receipt["outcome"] == "attached"
+    assert receipt["scope_identity"] == kernel.scope.unit
+
+    unavailable = FakeLinuxKernel()
+    unavailable.available = False
+    with pytest.raises(ValueError, match="prerequisites"):
+        select_verification_containment(
+            LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+            platform="linux",
+            linux_kernel=unavailable,
+        )
+
+    wrong_membership = FakeLinuxKernel()
+    wrong_membership.identities[200] = LinuxProcessIdentity(
+        200, 1000, 1, "/user.slice/unrelated.scope"
+    )
+    with pytest.raises(ValueError, match="scope membership"):
+        _containment(wrong_membership).capture_launch_root(200)
+
+    proc_root = tmp_path / "proc"
+    cgroup_root = tmp_path / "cgroup"
+    scope_name = f"yggdrasil-verification-{'a' * 24}.scope"
+    scope_path = f"/user.slice/{scope_name}"
+    scope_directory = cgroup_root / scope_path.lstrip("/")
+    (proc_root / "self").mkdir(parents=True)
+    scope_directory.mkdir(parents=True)
+    (cgroup_root / "cgroup.controllers").write_text("cpu memory\n", encoding="utf-8")
+    (proc_root / "self" / "cgroup").write_text("0::/user.slice\n", encoding="utf-8")
+    process_directory = proc_root / "200"
+    process_directory.mkdir()
+    stat_fields = ["S", "1", *("0" for _ in range(17)), "1000"]
+    (process_directory / "stat").write_text(
+        f"200 (systemd-run) {' '.join(stat_fields)}\n", encoding="utf-8"
+    )
+    (process_directory / "cgroup").write_text(
+        f"0::{scope_path}\n", encoding="utf-8"
+    )
+    (scope_directory / "cgroup.procs").write_text("200\n", encoding="utf-8")
+
+    def runner(command: Sequence[str], **_kwargs: object):
+        rendered = " ".join(command)
+        if "--help" in command:
+            stdout = "--scope --unit --user --property"
+        elif "show-environment" in command:
+            stdout = ""
+        elif " show " in f" {rendered} ":
+            stdout = (
+                f"Id={scope_name}\nControlGroup={scope_path}\n"
+                "ActiveState=active\nKillMode=control-group\n"
+            )
+        else:  # pragma: no cover - this bounded fixture admits no other call.
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(linux_containment.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(linux_containment.os, "pidfd_open", lambda *_args: 9, raising=False)
+    monkeypatch.setattr(
+        linux_containment.signal,
+        "pidfd_send_signal",
+        lambda *_args: None,
+        raising=False,
+    )
+    production_kernel = SystemdCgroupV2Kernel(
+        proc_root=proc_root,
+        cgroup_root=cgroup_root,
+        runner=runner,
+    )
+    production_kernel.preflight()
+    scope = production_kernel.scope_identity(scope_name)
+    assert production_kernel.scope_members(scope) == {
+        LinuxProcessIdentity(200, 1000, 1, scope_path)
+    }
+    assert production_kernel.scope_command(scope_name, ["true"])[1:4] == [
+        "--user",
+        "--scope",
+        "--quiet",
+    ]
+
+
+def test_linux_cleanup_revalidates_scope_membership() -> None:
+    kernel = FakeLinuxKernel()
+    containment = _containment(kernel)
+    root = containment.capture_launch_root(200)
+    containment.attach(200, root)
+    kernel.drift_before_signal.add(201)
+
+    assert containment.cleanup() is False
+    assert all(identity.pid != 201 for identity, _sig in kernel.signalled)
+    assert containment.receipt()["outcome"] == "cleanup_refused"
+
+
+def test_linux_receipt_is_secret_safe() -> None:
+    kernel = FakeLinuxKernel()
+    containment = _containment(kernel)
+    root = containment.capture_launch_root(200)
+    containment.attach(200, root)
+    assert containment.cleanup() is True
+
+    receipt: Mapping[str, object] = containment.receipt()
+    assert receipt == {
+        "contract": "builderops_linux_containment.v1",
+        "profile_name": LINUX_SYSTEMD_CGROUP_V2_SCOPE_PROFILE,
+        "scope_identity": kernel.scope.unit,
+        "evidence_digests": {
+            "attach": receipt["evidence_digests"]["attach"],  # type: ignore[index]
+            "cleanup": receipt["evidence_digests"]["cleanup"],  # type: ignore[index]
+        },
+        "outcome": "clean",
+    }
+    assert all(
+        len(value) == 64 and set(value) <= set("0123456789abcdef")
+        for value in receipt["evidence_digests"].values()  # type: ignore[union-attr]
+    )
+    rendered = repr(receipt)
+    assert "token" not in rendered.lower()
+    assert "credential" not in rendered.lower()
+    assert "/user.slice" not in rendered
+    assert "200" not in rendered
+    assert kernel.signalled
+    assert all(sig != signal.SIGKILL for _identity, sig in kernel.signalled)

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -6175,6 +6175,107 @@ def test_barrier_release_failure_close_error_still_cleans_r_coalition(
     assert containment.cleanup_calls == 1
 
 
+def test_linux_post_release_cleanup_never_signals_raw_popen_pid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Barrier:
+        command = ["barrier", "coordinator"]
+        pass_fds = (71,)
+        may_have_released = False
+
+        def after_spawn(self) -> None:
+            return None
+
+        def release(self) -> None:
+            self.may_have_released = True
+            raise RuntimeError("release delivery indeterminate")
+
+        def close(self) -> None:
+            raise OSError("barrier close failed")
+
+    class LiveRootProcess(_AuthorityLossProcess):
+        pid = 42_030
+
+        def poll(self) -> int | None:
+            events.append("poll")
+            return super().poll()
+
+        def terminate(self) -> None:
+            events.append("raw-terminate")
+            super().terminate()
+
+        def kill(self) -> None:
+            events.append("raw-kill")
+            super().kill()
+
+    process = LiveRootProcess([])
+
+    class LinuxBarrierContainment(_ProvenContainment):
+        cleanup_before_direct_reap = True
+
+        def __init__(self) -> None:
+            self.cleanup_calls = 0
+
+        def launch_barrier(self, _command: list[str]) -> Barrier:
+            return Barrier()
+
+        def capture_launch_root(self, root_pid: int) -> tuple[str, int]:
+            return ("identity", root_pid)
+
+        def attach(self, root_pid: int, identity: object | None = None) -> None:
+            assert identity == ("identity", root_pid)
+            super().attach(root_pid)
+
+        def cleanup(self) -> bool:
+            events.append("scope-cleanup")
+            self.cleanup_calls += 1
+            process.returncode = -verification_consumer.signal.SIGTERM
+            return True
+
+        def receipt(self) -> Mapping[str, object]:
+            return {
+                "contract": "builderops_linux_containment.v1",
+                "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+                "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+                "evidence_digests": {
+                    "attach": "b" * 64,
+                    "cleanup": "c" * 64,
+                },
+                "outcome": "clean",
+            }
+
+    containment = LinuxBarrierContainment()
+    monkeypatch.setattr(
+        verification_consumer.subprocess,
+        "Popen",
+        lambda *args, **kwargs: process,
+    )
+    monkeypatch.setattr(
+        verification_consumer.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("Linux scope cleanup must not use PGID")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="verification coordinator setup failed"):
+        _authority_loss_launcher(
+            tmp_path,
+            containment_factory=lambda: containment,
+            cleanup_tracker_factory=_ProvenContainment,
+        ).launch({"head_sha": HEAD})
+
+    assert containment.cleanup_calls == 1
+    assert process.terminate_calls == 0
+    assert process.kill_calls == 0
+    assert "raw-terminate" not in events
+    assert "raw-kill" not in events
+    assert events.index("scope-cleanup") < events.index("poll")
+
+
 def test_barrier_release_cleanup_runs_coalition_after_direct_root_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -121,7 +121,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     ledger = SimpleNamespace(effect_outbox=outbox)
     truth = object()
     auth = object()
-    launcher = object()
+    launcher = SimpleNamespace(containment_receipt=lambda: None)
     exact_launcher = object()
     containment_factory = lambda: object()
     consumer = object()
@@ -284,6 +284,9 @@ def test_exact_head_launcher_supplies_immutable_review_patch(
             calls.append((["inner"], {**kwargs, "source": source}))
             return "session", {"verdict": "verified"}
 
+        def containment_receipt(self):
+            return {"contract": "builderops_linux_containment.v1"}
+
     def _git(command: list[str], **_kwargs: object) -> SimpleNamespace:
         if command[3:5] == ["cat-file", "-e"]:
             return SimpleNamespace(returncode=0, stdout="")
@@ -311,6 +314,9 @@ def test_exact_head_launcher_supplies_immutable_review_patch(
         b"diff --git exact\n"
     ).hexdigest()
     assert not Path(source["patch_path"]).exists()
+    assert launcher.containment_receipt() == {
+        "contract": "builderops_linux_containment.v1"
+    }
 
 
 def test_cycle_command_runs_and_recovers_dry_cycle(
@@ -553,6 +559,21 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
     }
     with pytest.raises(ValueError, match="receipt is malformed"):
         dispatcher_cli._public_verification_cycle_receipt(unsafe_authority)
+
+    unsafe_containment = _Runtime._receipt("vrun-test")
+    unsafe_containment["containment"] = {
+        "contract": "builderops_linux_containment.v1",
+        "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+        "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+        "evidence_digests": {
+            "attach": "b" * 64,
+            "cleanup": "c" * 64,
+        },
+        "outcome": "clean",
+        "credential": secret,
+    }
+    with pytest.raises(ValueError, match="containment receipt is malformed"):
+        dispatcher_cli._public_verification_cycle_receipt(unsafe_containment)
 
 
 def test_cycle_command_rejects_non_installed_main_worktree(

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -235,12 +235,20 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     monkeypatch.setattr(
         verification_runtime,
         "HostFencedVerificationCycle",
-        lambda actual_ledger, actual_consumer, actual_executor, *, holder: (
+        lambda actual_ledger,
+        actual_consumer,
+        actual_executor,
+        *,
+        holder,
+        containment_receipt_required: (
             seen.update(
                 runtime_ledger=actual_ledger,
                 consumer=actual_consumer,
                 executor=actual_executor,
                 runtime_holder=holder,
+                runtime_containment_receipt_required=(
+                    containment_receipt_required
+                ),
             )
             or runtime
         ),
@@ -272,6 +280,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     assert seen["read_token"] == "github-secret"
     assert seen["consumer_holder"] == "verification-host"
     assert seen["runtime_holder"] == "verification-host"
+    assert seen["runtime_containment_receipt_required"] is False
 
 
 def test_exact_head_launcher_supplies_immutable_review_patch(
@@ -581,6 +590,12 @@ def test_cycle_command_output_is_secret_free_and_fail_closed(
     }
     with pytest.raises(ValueError, match="containment receipt is malformed"):
         dispatcher_cli._public_verification_cycle_receipt(unsafe_containment)
+
+    with pytest.raises(ValueError, match="receipt is malformed"):
+        dispatcher_cli._public_verification_cycle_receipt(
+            _Runtime._receipt("vrun-test"),
+            containment_receipt_required=True,
+        )
 
 
 def test_cycle_command_rejects_non_installed_main_worktree(

--- a/tests/dispatcher/test_verification_cycle_cli.py
+++ b/tests/dispatcher/test_verification_cycle_cli.py
@@ -172,12 +172,18 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     monkeypatch.setattr(
         verification_consumer,
         "CodexExecLauncher",
-        lambda worktree, receipt_schema, context_path, *, containment_factory: (
+        lambda worktree,
+        receipt_schema,
+        context_path,
+        *,
+        containment_factory,
+        containment_receipt_required: (
             seen.update(
                 worktree=worktree,
                 receipt_schema=receipt_schema,
                 context_path=context_path,
                 containment_factory=containment_factory,
+                containment_receipt_required=containment_receipt_required,
             )
             or launcher
         ),
@@ -257,6 +263,7 @@ def test_cycle_command_composes_api_outbox_and_host_runtime(
     assert seen["consumer_ledger"] is ledger
     assert seen["raw_launcher"] is launcher
     assert seen["containment_factory"] is containment_factory
+    assert seen["containment_receipt_required"] is False
     assert seen["launcher"] is exact_launcher
     assert seen["executor_ledger"] is ledger
     assert seen["executor_outbox"] is outbox

--- a/tests/dispatcher/test_verification_merge.py
+++ b/tests/dispatcher/test_verification_merge.py
@@ -403,6 +403,106 @@ def claimed_run(
     return ledger, ready, outbox
 
 
+def test_merge_ready_containment_matches_durable_verification_attempt() -> None:
+    api = FakeBuilderOpsClient()
+    ledger = BuilderOpsVerificationLedger(api, repository=REPO)
+    run = ledger.ingest(request())
+    claimed = ledger.claim(run.run_id, "verification-host")
+    assert claimed.lease_id is not None
+    containment = {
+        "contract": "builderops_linux_containment.v1",
+        "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+        "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+        "evidence_digests": {
+            "attach": "b" * 64,
+            "cleanup": "c" * 64,
+        },
+        "outcome": "clean",
+    }
+    ledger.record_attempt(
+        run.run_id,
+        "verification",
+        "verification-session",
+        "gpt-5.6-sol",
+        "high",
+        {"head_sha": HEAD},
+        "passed",
+        {"head_sha": HEAD},
+        holder="verification-host",
+        lease_id=claimed.lease_id,
+        idempotency_key="contained-verification",
+        containment_receipt=containment,
+    )
+    anchor = ledger.attempts(run.run_id)[-1]["attempt_id"]
+    ledger.record_attempt(
+        run.run_id,
+        "review",
+        "independent-review-session",
+        "gpt-5.6-sol",
+        "xhigh",
+        {"head_sha": HEAD},
+        "clean",
+        {"head_sha": HEAD, "reviewed_attempt_id": anchor},
+        holder="verification-host",
+        lease_id=claimed.lease_id,
+        idempotency_key="contained-review",
+    )
+    coordinator_receipt = {
+        "verdict": "verified",
+        "head_sha": HEAD,
+        "summary": "host-fenced merge ready",
+        "receipt_ids": ["verified-review"],
+        "retry_after": None,
+        "review_events": [],
+        "human_exception": None,
+    }
+    substituted = {
+        **containment,
+        "scope_identity": f"yggdrasil-verification-{'d' * 24}.scope",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="containment does not match durable verification",
+    ):
+        ledger.mark_merge_ready(
+            run.run_id,
+            coordinator_receipt,
+            holder="verification-host",
+            lease_id=claimed.lease_id,
+            containment_receipt=substituted,
+        )
+
+    assert ledger.merge_ready_receipt(run.run_id) is None
+    ledger.mark_merge_ready(
+        run.run_id,
+        coordinator_receipt,
+        holder="verification-host",
+        lease_id=claimed.lease_id,
+        containment_receipt=containment,
+    )
+    marker = ledger.merge_ready_receipt(run.run_id)
+    assert marker is not None
+    assert marker["containment"] == containment
+    with pytest.raises(
+        ValueError,
+        match="containment does not match durable verification",
+    ):
+        ledger.mark_merge_ready(
+            run.run_id,
+            coordinator_receipt,
+            holder="verification-host",
+            lease_id=claimed.lease_id,
+            containment_receipt=substituted,
+        )
+    assert ledger.merge_ready_receipt(run.run_id) == marker
+    api.tasks[run.run_id]["payload"]["merge_ready_receipt"][
+        "containment"
+    ] = substituted
+    with pytest.raises(ValueError, match="containment is stale or substituted"):
+        ledger.merge_ready_receipt(run.run_id)
+
+
 def test_blocking_review_wins_atomic_merge_intent_race() -> None:
     api = BlockingReviewWinsIntentRaceClient()
     ledger, run, outbox = claimed_run(api=api)

--- a/tests/dispatcher/test_verification_recovery.py
+++ b/tests/dispatcher/test_verification_recovery.py
@@ -328,6 +328,32 @@ class VerifiedLauncher(Launcher):
         }
 
 
+LINUX_CONTAINMENT_RECEIPT = {
+    "contract": "builderops_linux_containment.v1",
+    "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+    "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+    "evidence_digests": {
+        "attach": "b" * 64,
+        "cleanup": "c" * 64,
+    },
+    "outcome": "clean",
+}
+
+
+class LinuxVerifiedLauncher(VerifiedLauncher):
+    containment_receipt_required = True
+
+    def containment_receipt(self):
+        return LINUX_CONTAINMENT_RECEIPT
+
+
+class RestartedLinuxLauncher(VerifiedLauncher):
+    containment_receipt_required = True
+
+    def containment_receipt(self):
+        return None
+
+
 @pytest.mark.parametrize(
     "recovery_shape", ("merged", "open-neutralized")
 )
@@ -720,7 +746,7 @@ def test_pre_thread_start_recovery_rejects_partial_session_state_without_mutatio
 def test_recovery_reconciles_durable_model_attempt_without_relaunch() -> None:
     api = FakeBuilderOpsClient()
     outbox = CrashAfterDurableAttemptOutbox(api)
-    first_launcher = VerifiedLauncher()
+    first_launcher = LinuxVerifiedLauncher()
     first = VerificationConsumer(
         BuilderOpsVerificationLedger(
             api, repository=REPO, effect_outbox=outbox
@@ -737,10 +763,14 @@ def test_recovery_reconciles_durable_model_attempt_without_relaunch() -> None:
     run_id = next(iter(api.tasks))
     task = api.tasks[run_id]
     assert len(api.attempt_rows[run_id]) == 1
+    assert (
+        api.attempt_rows[run_id][0]["payload"]["containment"]
+        == LINUX_CONTAINMENT_RECEIPT
+    )
     assert task["lease"] is not None
     task["lease"]["expires_at"] = "2000-01-01T00:00:00+00:00"
 
-    restarted_launcher = VerifiedLauncher()
+    restarted_launcher = RestartedLinuxLauncher()
     restarted = VerificationConsumer(
         BuilderOpsVerificationLedger(
             api, repository=REPO, effect_outbox=outbox
@@ -755,9 +785,50 @@ def test_recovery_reconciles_durable_model_attempt_without_relaunch() -> None:
     assert recovered.status == "running"
     assert restarted_launcher.calls == []
     assert len(first_launcher.calls) == 1
-    assert restarted.ledger.merge_ready_receipt(run_id) is not None
+    merge_ready = restarted.ledger.merge_ready_receipt(run_id)
+    assert merge_ready is not None
+    assert merge_ready["containment"] == LINUX_CONTAINMENT_RECEIPT
     assert outbox.states
     assert set(outbox.states.values()) == {"succeeded"}
+
+
+def test_recovery_requires_durable_linux_containment_without_relaunch() -> None:
+    api = FakeBuilderOpsClient()
+    outbox = CrashAfterDurableAttemptOutbox(api)
+    first = VerificationConsumer(
+        BuilderOpsVerificationLedger(
+            api, repository=REPO, effect_outbox=outbox
+        ),
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        LinuxVerifiedLauncher(),
+        holder="verification-host",
+    )
+
+    with pytest.raises(SystemExit, match="durable model attempt"):
+        first.consume(request())
+
+    run_id = next(iter(api.tasks))
+    api.attempt_rows[run_id][0]["payload"].pop("containment")
+    task = api.tasks[run_id]
+    assert task["lease"] is not None
+    task["lease"]["expires_at"] = "2000-01-01T00:00:00+00:00"
+    restarted_launcher = RestartedLinuxLauncher()
+    restarted = VerificationConsumer(
+        BuilderOpsVerificationLedger(
+            api, repository=REPO, effect_outbox=outbox
+        ),
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        restarted_launcher,
+        holder="verification-host",
+    )
+
+    recovered = restarted.recover(run_id)
+
+    assert recovered.status == "backoff"
+    assert restarted_launcher.calls == []
+    assert restarted.ledger.merge_ready_receipt(run_id) is None
 
 
 def test_succeeded_model_effect_recovery_applies_attempt_without_relaunch() -> None:

--- a/tests/dispatcher/test_verification_runtime.py
+++ b/tests/dispatcher/test_verification_runtime.py
@@ -14,7 +14,10 @@ from app.dispatcher.verification_merge import (
     MergeAuthorityError,
     VerificationMergeExecutor,
 )
-from app.dispatcher.verification_runtime import HostFencedVerificationCycle
+from app.dispatcher.verification_runtime import (
+    HostFencedVerificationCycle,
+    validated_containment_receipt_shape,
+)
 from tests.dispatcher.builderops_verification_fakes import (
     FakeBuilderOpsClient,
     FakeVerificationOutbox,
@@ -111,6 +114,73 @@ def test_host_cycle_is_api_only_and_emits_terminal_dry_run_receipt() -> None:
     with pytest.raises(ValueError, match="receipt is malformed"):
         runtime.recover_dry_cycle(str(receipt["run_id"]))
     outbox.states[operation_key] = "succeeded"
+
+
+def test_host_cycle_projects_linux_containment_into_durable_receipt() -> None:
+    api = FakeBuilderOpsClient()
+    outbox = FakeVerificationOutbox(api)
+    ledger = BuilderOpsVerificationLedger(
+        api, repository=REPO, effect_outbox=outbox
+    )
+    containment_receipt: dict[str, object] = {
+        "contract": "builderops_linux_containment.v1",
+        "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+        "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+        "evidence_digests": {
+            "attach": "b" * 64,
+            "cleanup": "c" * 64,
+        },
+        "outcome": "clean",
+    }
+
+    class LinuxVerifiedLauncher(VerifiedLauncher):
+        def containment_receipt(self):
+            return containment_receipt
+
+    consumer = VerificationConsumer(
+        ledger,
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        LinuxVerifiedLauncher(),
+        holder="verification-host",
+    )
+    runtime = HostFencedVerificationCycle(
+        ledger,
+        consumer,
+        VerificationMergeExecutor(
+            ledger, outbox, RepositoryAuthority(), Credentials()
+        ),
+        holder="verification-host",
+    )
+
+    receipt = runtime.run_dry_cycle(request())
+
+    assert receipt["containment"] == containment_receipt
+    merge_ready = ledger.merge_ready_receipt(str(receipt["run_id"]))
+    assert merge_ready is not None
+    assert merge_ready["containment"] == containment_receipt
+    terminal = api.tasks[str(receipt["run_id"])]["payload"]["run"][
+        "terminal_receipt"
+    ]
+    assert terminal["containment"] == containment_receipt
+    assert runtime.recover_dry_cycle(str(receipt["run_id"])) == receipt
+
+
+def test_containment_receipt_validator_rejects_non_allowlisted_evidence() -> None:
+    unsafe = {
+        "contract": "builderops_linux_containment.v1",
+        "profile_name": "linux-systemd-cgroup-v2-scope-v1",
+        "scope_identity": f"yggdrasil-verification-{'a' * 24}.scope",
+        "evidence_digests": {
+            "attach": "b" * 64,
+            "cleanup": "c" * 64,
+        },
+        "outcome": "clean",
+        "cgroup_path": "/user.slice/private.scope",
+    }
+
+    with pytest.raises(ValueError, match="containment receipt is malformed"):
+        validated_containment_receipt_shape(unsafe)
 
 
 def test_pending_dry_recovery_rejects_contradictory_merge_evidence() -> None:

--- a/tests/dispatcher/test_verification_runtime.py
+++ b/tests/dispatcher/test_verification_runtime.py
@@ -153,6 +153,7 @@ def test_host_cycle_projects_linux_containment_into_durable_receipt() -> None:
             ledger, outbox, RepositoryAuthority(), Credentials()
         ),
         holder="verification-host",
+        containment_receipt_required=True,
     )
 
     receipt = runtime.run_dry_cycle(request())
@@ -166,6 +167,53 @@ def test_host_cycle_projects_linux_containment_into_durable_receipt() -> None:
     ]
     assert terminal["containment"] == containment_receipt
     assert runtime.recover_dry_cycle(str(receipt["run_id"])) == receipt
+
+    terminal.pop("containment")
+    with pytest.raises(ValueError, match="receipt is malformed"):
+        runtime.recover_dry_cycle(str(receipt["run_id"]))
+    terminal["containment"] = {
+        **containment_receipt,
+        "scope_identity": f"yggdrasil-verification-{'d' * 24}.scope",
+    }
+    with pytest.raises(ValueError, match="receipt is malformed"):
+        runtime.recover_dry_cycle(str(receipt["run_id"]))
+
+
+def test_linux_cycle_requires_containment_in_merge_ready_evidence() -> None:
+    api = FakeBuilderOpsClient()
+    outbox = FakeVerificationOutbox(api)
+    ledger = BuilderOpsVerificationLedger(
+        api, repository=REPO, effect_outbox=outbox
+    )
+    consumer = VerificationConsumer(
+        ledger,
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        VerifiedLauncher(),
+        holder="verification-host",
+    )
+    runtime = HostFencedVerificationCycle(
+        ledger,
+        consumer,
+        VerificationMergeExecutor(
+            ledger, outbox, RepositoryAuthority(), Credentials()
+        ),
+        holder="verification-host",
+        containment_receipt_required=True,
+    )
+
+    with pytest.raises(
+        ValueError, match="Linux containment evidence is unavailable"
+    ):
+        runtime.run_dry_cycle(request())
+
+    run_id = next(iter(api.tasks))
+    marker = ledger.merge_ready_receipt(run_id)
+    assert marker is not None
+    assert "containment" not in marker
+    recovered = ledger.get(run_id)
+    assert recovered is not None
+    assert recovered.status == "running"
 
 
 def test_containment_receipt_validator_rejects_non_allowlisted_evidence() -> None:

--- a/tests/dispatcher/test_verification_runtime.py
+++ b/tests/dispatcher/test_verification_runtime.py
@@ -146,11 +146,13 @@ def test_host_cycle_projects_linux_containment_into_durable_receipt() -> None:
         LinuxVerifiedLauncher(),
         holder="verification-host",
     )
+    repository = RepositoryAuthority()
+    credentials = Credentials()
     runtime = HostFencedVerificationCycle(
         ledger,
         consumer,
         VerificationMergeExecutor(
-            ledger, outbox, RepositoryAuthority(), Credentials()
+            ledger, outbox, repository, credentials
         ),
         holder="verification-host",
         containment_receipt_required=True,
@@ -192,11 +194,13 @@ def test_linux_cycle_requires_containment_in_merge_ready_evidence() -> None:
         VerifiedLauncher(),
         holder="verification-host",
     )
+    repository = RepositoryAuthority()
+    credentials = Credentials()
     runtime = HostFencedVerificationCycle(
         ledger,
         consumer,
         VerificationMergeExecutor(
-            ledger, outbox, RepositoryAuthority(), Credentials()
+            ledger, outbox, repository, credentials
         ),
         holder="verification-host",
         containment_receipt_required=True,
@@ -214,6 +218,8 @@ def test_linux_cycle_requires_containment_in_merge_ready_evidence() -> None:
     recovered = ledger.get(run_id)
     assert recovered is not None
     assert recovered.status == "running"
+    assert repository.calls == []
+    assert credentials.calls == []
 
 
 def test_containment_receipt_validator_rejects_non_allowlisted_evidence() -> None:

--- a/tests/dispatcher/test_verification_runtime.py
+++ b/tests/dispatcher/test_verification_runtime.py
@@ -134,6 +134,8 @@ def test_host_cycle_projects_linux_containment_into_durable_receipt() -> None:
     }
 
     class LinuxVerifiedLauncher(VerifiedLauncher):
+        containment_receipt_required = True
+
         def containment_receipt(self):
             return containment_receipt
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5055

## Linked Issue
Closes #5055

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): delivery verification executor
- Write class: authority-bearing / mechanical
- Persistence impact: secret-safe containment evidence is durably bound to verification attempts and cycle receipts
- Derived/rebuildable impact: process identity observations remain ephemeral and rebuildable
- New or changed contract: explicit linux-systemd-cgroup-v2-scope-v1 containment profile for BCP-05
- Owner-doc impact: installed-main composition owner doc updated
- Transition debt impact: reduces Darwin-only BuilderOps executor debt
- Boundary risk: cleanup must never signal outside the launched scope and recovery must not substitute containment identity

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add explicit fail-closed Linux systemd/cgroup-v2 containment for BuilderOps verification while preserving the Darwin profile.
- Bind cleanup and secret-safe containment evidence across durable attempts, recovery, merge readiness, terminal receipts, and public output.

## BuilderOps Routing
- Records/projections/receipts: builderops_object:prom_20260822114351_1e5b3a71
- Reason: Issue source promotion intent governs this Linux containment slice.

## Notes
Validation: 5/5 exact acceptance targets; 416 affected verification/containment tests; full ruff; mypy app (919 files); docs language guard; fresh Sol/high convergence review clean at 50c63efea0f29e6645a4bfb57c6edfff71fd5028. No live systemd, TARS, Proxmox, VM, network, or host mutation was performed; disposable/live Linux acceptance remains separately governed.