### PR TITLE
Update live environment baseline for Linux host split

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,7 +130,7 @@ ports, gateways) — this table references, and does not duplicate, either.
 | `app/`, `mimer_runtime/`, contracts/schemas, companion-note surface | in-repo runtime code | SoI component |
 | `db` (Postgres/pgvector, `docker-compose.yaml:2-14`) | compose service | COTS system element |
 | `ollama` (`docker-compose.yaml:16-31`) | local fallback compose service | COTS system element |
-| Mac mini Ollama reached from the Linux runtime | Tailscale-reachable remote provider | External system |
+| Dedicated Ollama host reached from the Linux runtime | Tailscale-reachable remote provider | External system |
 | `api` (`docker-compose.yaml:37-99`) | compose service (SoI component runtime, containerized) | SoI component |
 | `worker` (`docker-compose.yaml:101-142`) | compose service (SoI component runtime, containerized) | SoI component |
 | `watcher` (`docker-compose.yaml:144-188`) | compose service (SoI component runtime, containerized) | SoI component |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,12 +114,14 @@ In the current v5.5 baseline, the implemented center of gravity is still the Mim
 ### Deployed infrastructure classification (current reality)
 
 This subsection is **non-SBS-owned**: it is a current-reality infrastructure classification, not a
-boundary allocation, and it does not create a new allocation table. It applies the four-class
+boundary allocation, and it does not create a new allocation table. The Compose rows describe the
+local fallback; the live product runtime is the Linux/Tailscale host split recorded in
+`docs/ENVIRONMENTS.md`. It applies the four-class
 lifecycle-role rule from `docs/architecture/system-context-overlay.md` (SBI-1) — SoI component /
 COTS system element (deployed configuration) / enabling system / external system — to every
 `docker-compose.yaml` service and every host process listed in
-`docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md :: Environment matrix :: Current reality (verified
-2026-06-29)`. For module/host detail, see `docs/architecture/SBS_BOUNDARY_REGISTER.md` (target SBS
+`docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md :: Environment matrix :: Local Compose fallback
+matrix (verified 2026-07-06)`. For module/host detail, see `docs/architecture/SBS_BOUNDARY_REGISTER.md` (target SBS
 boundary maturity) and `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md` (deploy topology,
 ports, gateways) — this table references, and does not duplicate, either.
 
@@ -127,8 +129,8 @@ ports, gateways) — this table references, and does not duplicate, either.
 | --- | --- | --- |
 | `app/`, `mimer_runtime/`, contracts/schemas, companion-note surface | in-repo runtime code | SoI component |
 | `db` (Postgres/pgvector, `docker-compose.yaml:2-14`) | compose service | COTS system element |
-| `ollama` (`docker-compose.yaml:16-31`) | compose service | COTS system element |
-| Ollama reached as a host/remote LLM or embedding provider (`docs/ARCHITECTURE.md:109`) | host/remote service, not the compose service | External system |
+| `ollama` (`docker-compose.yaml:16-31`) | local fallback compose service | COTS system element |
+| Mac mini Ollama reached from the Linux runtime | Tailscale-reachable remote provider | External system |
 | `api` (`docker-compose.yaml:37-99`) | compose service (SoI component runtime, containerized) | SoI component |
 | `worker` (`docker-compose.yaml:101-142`) | compose service (SoI component runtime, containerized) | SoI component |
 | `watcher` (`docker-compose.yaml:144-188`) | compose service (SoI component runtime, containerized) | SoI component |
@@ -147,10 +149,9 @@ above because they are two distinct bindings, never both at once for a given dep
 
 This table classifies lifecycle role only; it does not resolve the dual-role hazard (infrastructure
 as both enabling system and a domain of interest the SoI observes/actuates), which is deferred to
-the companion thread named in `docs/architecture/system-context-overlay.md`. It does not reflect a
-post-#2655 pinned-image topology: deployment epic #2655 (S5/S7) is still open, so the classification
-above is verified against the current `docker-compose.yaml` and the "Current reality (verified
-2026-06-29)" row of the environment matrix, not the "Target" row.
+the companion thread named in `docs/architecture/system-context-overlay.md`. The Compose entries are
+the local fallback classification; live new-host deployment remains unqualified until the authoritative
+deployment handoff, immutable artifact identity, and host isolation proofs exist.
 
 The host-global ownership ledger is an additional deployment-boundary guard:
 ledger schema v2 stores the selected vault's primary filesystem identity and

--- a/docs/DEV_TEST_PROD_STARTUP_REDESIGN/README.md
+++ b/docs/DEV_TEST_PROD_STARTUP_REDESIGN/README.md
@@ -1,4 +1,8 @@
 State: Filed capability specification. P1 is active under #4914; later slices remain dependency-blocked. It does not claim a running deployment model.
+Current-state note (2026-08-22): the live topology is now intended to be Mac mini = Ollama only plus
+Linux/Tailscale `ygg-dev` / `ygg-test` / `ygg-prod` runtime hosts. The redesign contract is not yet
+implemented as a remote-host deployment path; `ygg-test` and immutable live artifact identity remain
+gates before staged promotion.
 Doc role: Capability specification directory (Product/Runtime + Builder System release boundary)
 Owning SoT: `docs/ENVIRONMENTS.md`, `docs/RELEASE_CHANNELS/README.md`, and `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md`
 

--- a/docs/DEV_TEST_PROD_STARTUP_REDESIGN/README.md
+++ b/docs/DEV_TEST_PROD_STARTUP_REDESIGN/README.md
@@ -1,5 +1,5 @@
 State: Filed capability specification. P1 is active under #4914; later slices remain dependency-blocked. It does not claim a running deployment model.
-Current-state note (2026-08-22): the live topology is now intended to be Mac mini = Ollama only plus
+Current-state note (2026-08-22): the live topology is now intended to be a dedicated Ollama host plus
 Linux/Tailscale `ygg-dev` / `ygg-test` / `ygg-prod` runtime hosts. The redesign contract is not yet
 implemented as a remote-host deployment path; `ygg-test` and immutable live artifact identity remain
 gates before staged promotion.

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -5,7 +5,8 @@ Doc role: Core SoT
 Authority: Canonical environment contract for the current baseline and forward-line work; defines what `dev`, `test`, and `prod` mean, what must remain invariant, and what may vary. Architecture, operations, testing, status, and component docs should reference this document instead of restating environment policy. Release-channel semantics (channel identity, DB-per-channel, promotion, rollback) are owned by `docs/RELEASE_CHANNELS/README.md`.
 Temporal class: operational
 Review cadence: as environment/channel posture changes
-Last reviewed: 2026-07-18
+Last reviewed: 2026-08-22
+Last live runtime verification: 2026-08-22 (Tailscale hosts `ygg-dev` and `ygg-prod`; `ygg-test` was not present/reachable)
 Last verified against: docs/RELEASE_CHANNELS/README.md, docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md, docker-compose.full-host-vault.yml, scripts/lib/deploy_channel_compose.sh, docs/STATUS.md (§Cognitive Expansion — activation status), ops/promotions/2026-06-13-cc3ce65d.md
 
 ## Overview
@@ -17,6 +18,23 @@ The purpose of this document is to make environment boundaries explicit and ensu
 Reading rule:
 - Use this document when a change touches environment-specific behavior, storage boundaries, runtime topology, write safety, rollout posture, or local bootstrap expectations.
 - Use `docs/ARCHITECTURE.md` for system structure, `docs/OPERATIONS.md` for operator procedure, `docs/TESTING.md` for verification layers, and `docs/STATUS.md` for current rollout posture.
+
+## Current live runtime topology
+
+The live product runtime is now intended to run on the new Linux/Tailscale hosts. The Mac mini is an
+Ollama/model host only; its legacy `pkm-*` Compose stacks are not evidence that the product runtime is
+deployed there. The following is the verified live baseline as of 2026-08-22:
+
+| Environment | Live endpoint evidence | Current state | Artifact identity |
+| --- | --- | --- | --- |
+| `dev` (`ygg-dev`) | API `:18001` and Companion UI `:8111` respond | API required checks pass, but runtime is degraded: watcher paused and two dead-lettered events; LLM provider is `mock` | `/version` reports `git_sha=unknown`, `built_at` empty |
+| `test` | No `ygg-test` peer or reachable test API/UI endpoint was found | Not deployed/available for staged verification | No candidate identity available |
+| `prod` (`ygg-prod`) | API liveness `:18000` responds; UI `:8113` unavailable | Functional health is failing: stale/paused watcher and no worker heartbeat | `/version` reports `git_sha=unknown`, `built_at` empty |
+
+This table is runtime evidence, not a replacement for the environment contract below. Promotion is
+blocked until the new host deployment path is authoritative, the candidate has an exact immutable
+identity, `test` is reachable, and the test verification receipt is green. Until then, local Compose
+commands are a fallback for development/testing only and must not be reported as promotion evidence.
 
 ## Vault terminology
 
@@ -341,28 +359,18 @@ Environment separation MUST be explicit across the following surfaces.
 
 <a id="prod-ollama-topology"></a>
 
-### Production Ollama topology
+### Ollama topology
 
-Production's API and worker use the `ollama` service in the `pkm-prod` Compose project at
-`http://ollama:11434`. The production overlay starts that service before API/worker readiness and
-does **not** publish port `11434` to the macOS host. This avoids relying on
-`host.docker.internal` and prevents a collision with any host-local Ollama process.
+The live host boundary reserves the Mac mini for Ollama/model serving only. The product runtime must
+reach that service through an explicitly configured Tailscale-reachable endpoint; it must not assume a
+co-resident Compose sidecar, `host.docker.internal`, or a local `ollama` service name on the Linux
+runtime host. The exact endpoint, authentication posture, model inventory, and embedding identity are
+deployment inputs that still require host-side qualification.
 
-The provider cache is the project-scoped `pkm-prod_ollama` volume inherited from the base Compose
-file. It is persistent across normal recreate/redeploy operations, but Compose never downloads a
-model implicitly. Before enabling Ollama-backed work, the operator must confirm that this cache
-contains the configured models — currently `nomic-embed-text:latest` (768 dimensions) and the
-configured chat model — without changing the existing embedding provider/model/dimension identity.
-
-The Mac mini's shared Colima budget remains 4 GB. A sidecar restores transport; it does not make
-the co-resident embedding and chat models fit more memory. Keep embedding work serial and do not
-start a rebuild or download models as part of a transport-only redeploy. Inspect model/cache disk
-usage and the running container memory before any later rebuild.
-
-To roll back this topology, redeploy the previous committed production revision (where the
-production API/worker point at the prior provider route) using the same `pkm-prod` project. The
-named cache volume is preserved; do not remove it unless an operator intentionally accepts losing
-the cached models.
+The local Compose overlays retain an Ollama sidecar as a fallback for local development/testing. That
+fallback is not the live production topology and its project-scoped cache is not evidence that the Mac
+mini or a new Linux host has the required models. Never change the provider/model/dimension identity or
+start a rebuild/download as part of a transport-only runtime repair.
 
 ## Runtime Control Surface
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -1,9 +1,11 @@
-State: SoT v5.5 baseline (descriptive, ops-oriented). If a detail drifts, prefer scripts/compose and update this doc.
+State: SoT v5.5 baseline (descriptive, ops-oriented). Local Compose is the fallback runtime; the live
+product topology is the new Linux/Tailscale host split recorded below. If a detail drifts, prefer live
+host evidence and the deployment contract, then update this doc.
 
 Documentation hierarchy: `docs/YGGDRASIL_PLATFORM_AND_OPERATIONS_SYSTEM/README.md` owns the
-target operational-platform boundary. This document remains the current local Docker/Colima runtime
-description; it does not claim that the target platform boundary is already a separately delivered
-implementation.
+target operational-platform boundary. This document owns the local Docker/Colima fallback description
+and records the verified live host boundary; it does not claim that the new-host deployment handoff is
+already a separately delivered implementation.
 
 ## v5.5 Baseline Delta (Current Reality)
 - Registry watcher is the runtime default; legacy snapshot watcher is dev-only.
@@ -11,11 +13,24 @@ implementation.
 - Watcher auto-run defaults on (`WATCHER_AUTO_EXEC=1`); set `WATCHER_AUTO_EXEC=0` for emit-only mode. LangGraph/Reasoning rollout remains opt-in.
 - See `docs/STATUS.md` and `docs/ARCHITECTURE.md` for the current baseline and forward line.
 
-# Infrastructure — Local Runtime (Docker + Colima)
+# Infrastructure — Local Fallback and New-Host Runtime
 
-This document describes the current local runtime for the Agentic PKM stack. It mirrors the active docker-compose setup and the supporting scripts.
+This document describes the local Docker + Colima fallback and the current live host boundary for the
+Agentic PKM stack. It does not claim that local Compose is the live product deployment.
 
-## Stack Overview
+## Current live host boundary (verified 2026-08-22)
+
+- Mac mini: Ollama/model serving only; no product API, worker, watcher, database, or Companion UI.
+- `ygg-dev`: Linux/Tailscale dev runtime, API `:18001`, Companion UI `:8111`; reachable but degraded.
+- `ygg-test`: intended isolated test runtime; no reachable host or endpoint was found.
+- `ygg-prod`: Linux/Tailscale prod runtime, API `:18000`; liveness responds but functional health is
+  failing and Companion UI `:8113` is unavailable.
+- Both live APIs report `git_sha=unknown`; promotion cannot use them as immutable artifact evidence.
+
+The repository still documents and supports local Compose commands for fallback development and
+verification. Those commands do not deploy the new hosts and are not promotion evidence.
+
+## Local fallback stack overview
 - Host: macOS
 - Container runtime: Colima provides the Docker daemon.
 - Orchestration: Docker Compose in repo root.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -20,7 +20,7 @@ Agentic PKM stack. It does not claim that local Compose is the live product depl
 
 ## Current live host boundary (verified 2026-08-22)
 
-- Mac mini: Ollama/model serving only; no product API, worker, watcher, database, or Companion UI.
+- Dedicated Ollama host: Ollama/model serving only; no product API, worker, watcher, database, or Companion UI.
 - `ygg-dev`: Linux/Tailscale dev runtime, API `:18001`, Companion UI `:8111`; reachable but degraded.
 - `ygg-test`: intended isolated test runtime; no reachable host or endpoint was found.
 - `ygg-prod`: Linux/Tailscale prod runtime, API `:18000`; liveness responds but functional health is

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,11 +1,12 @@
-State: SoT v5.5 Reality-MVP baseline locked; v5.6 delivery line closed; this is the top-level operations entrypoint for the current runtime while v6.0 seams are shipped in bounded form and broader v6.1+ consumption remains planned.
+State: SoT v5.5 Reality-MVP baseline locked; v5.6 delivery line closed; this is the top-level operations entrypoint for the current runtime while v6.0 seams are shipped in bounded form and broader v6.1+ consumption remains planned. The live host split was re-verified on 2026-08-22: Mac mini is Ollama-only and product runtime belongs on the new Linux/Tailscale hosts.
 Doc role: Core SoT
 Authority: Top-level operator guidance for the current runtime; delegates specialized operational detail to linked companion docs but remains the main operational entrypoint.
 Owner: Runtime / operator playbook
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: mixed
-Last reviewed: 2026-07-29
+Last reviewed: 2026-08-22
+Last live runtime verification: 2026-08-22 (see `docs/ENVIRONMENTS.md`)
 Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/HEALTH.md, docs/INFRASTRUCTURE.md, docs/ENVIRONMENTS.md, docs/OBSERVABILITY.md, docs/ASK_PROVENANCE_MANIFEST/README.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, app/agent_memory/ask_provenance_manifest.py, app/relevance/now_surface.py, tests/agent_memory/test_ask_provenance_manifest.py, tests/relevance/test_vault_native_moments.py, Makefile, docker-compose.test.yml, docker-compose.legacy-vault.yml, docker-compose.test-vault.yml, scripts/start_full_system.sh, scripts/verify_runtime_stack.sh, merged PRs #1948/#1977/#2115/#2119/#2127/#2128/#2129/#2131/#2135/#2140/#2142, and current repo state on 2026-07-15
 # Operations Playbook
 
@@ -374,7 +375,8 @@ Companion docs:
   operator-visible failures rather than generic vault setup prompts.
 - Companion TTS is a local-first runtime surface: configured local voices can be selected for clean
   Markdown read-back, mixed-language segments may route to different voices, and production
-  deployment still depends on the Mac mini/local model health path.
+  deployment depends on an explicitly configured, Tailscale-reachable external Ollama endpoint; the
+  Mac mini is model-serving infrastructure only.
 - Governed channel deploys obtain `TTS_ENABLED` and `TTS_HOST_ROOT` only from the selected generated
   runtime-env snapshot. The canonical exporter publishes that file atomically; deploy preflight
   fail-closes unreadable, malformed, duplicate, or invalid enabled configuration before migration,

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -18,12 +18,26 @@ Doc role: Core SoT for the release-channels capability
 Owner: `docs/ROADMAP.md`
 Temporal class: strategic
 Review cadence: biweekly
-Last reviewed: 2026-06-29
+Last reviewed: 2026-08-22
+Last live runtime verification: 2026-08-22 (new-host topology; `ygg-test` unavailable)
 Last verified against: docs/ENVIRONMENTS.md, docs/ARCHITECTURE.md, docs/STATUS.md, docs/OPERATIONS.md, docs/DB_SCHEMA.md, docs/adr/ADR-0040-prod-promotion-ref-main-interim.md
 
 # Release Channels Specification
 
-This directory specifies the capability that lets a **stable build run in prod against the real vault** while **new feature work continues in dev on the same machine**, without dev churn destabilizing prod and without prod freeze blocking dev.
+## Current live posture
+
+The operator's current topology is Mac mini = Ollama only; the product runtime belongs on the new
+Linux/Tailscale hosts. The live baseline is incomplete: `ygg-dev` answers on API `:18001` and UI
+`:8111` but is degraded and uses the `mock` LLM provider; `ygg-test` is not available; `ygg-prod`
+answers API liveness on `:18000` but fails functional health and has no reachable UI on `:8113`.
+Both live APIs report an unknown build identity. The old single-host Compose model described in this
+specification is therefore a local fallback/reference model, not current live topology.
+
+The promotion chain remains `dev → test → prod`, but it cannot start until the candidate identity is
+immutable and observable, the new-host deployment handoff is authoritative, `test` is reachable, and
+test verification produces a durable PASS receipt. A liveness response alone is not a promotion gate.
+
+This directory specifies the capability that lets a **stable build run in prod against the real vault** while **new feature work continues in dev across the same governed runtime fleet**, without dev churn destabilizing prod and without prod freeze blocking dev.
 
 This is the capability that turns the existing `dev` / `test` / `prod` environment model into something the operator can actually *use* day-to-day. [ENVIRONMENTS.md](../ENVIRONMENTS.md) today defines environment selection and artifact path scoping, but it explicitly leaves deployment automation, schema separation between long-lived environments, and cross-channel safety out of scope. That gap is what blocks running a stable operator-facing system while active development continues — and therefore what this capability closes.
 
@@ -347,7 +361,7 @@ This capability is docs-authoring at this stage. Task-level verification lives i
 Capability-level acceptance — the point at which the operator can honestly claim the system is usable — requires the following observable conditions, not a single test:
 
 - A **stable build** is running against the real vault and has run unsupervised for a bounded soak window (measured, not asserted).
-- A **dev session** on the same machine has exercised schema change, vault reset, and runtime restart without altering prod state.
+- A **dev session** on its isolated runtime host has exercised schema change, vault reset, and runtime restart without altering prod state.
 - A **promotion** has been performed end-to-end (prepare → execute → verify → accept) with a recorded plan and verification receipt.
 - A **rollback** has been performed at least once in a controlled setting, with the migration reversal path exercised.
 

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -26,7 +26,7 @@ Last verified against: docs/ENVIRONMENTS.md, docs/ARCHITECTURE.md, docs/STATUS.m
 
 ## Current live posture
 
-The operator's current topology is Mac mini = Ollama only; the product runtime belongs on the new
+The operator's current topology is a dedicated Ollama host only; the product runtime belongs on the new
 Linux/Tailscale hosts. The live baseline is incomplete: `ygg-dev` answers on API `:18001` and UI
 `:8111` but is degraded and uses the `mock` LLM provider; `ygg-test` is not available; `ygg-prod`
 answers API liveness on `:18000` but fails functional health and has no reachable UI on `:8113`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,8 +5,18 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-08-09
+Last reviewed: 2026-08-22
+Last live runtime verification: 2026-08-22 (new-host topology; see `docs/ENVIRONMENTS.md`)
 Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/OPERATIONS.md, docs/HUMAN-FLOWS.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, docs/CONCEPTS/MOMENT_ARTIFACT_CONTRACT.md, docs/CONCEPTS/RELEVANCE_EVALUATOR_CONTRACT.md, docs/CONCEPTS/REACHOUT_AND_SCARCITY_GATE_CONTRACT.md, docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md, docs/plans/CONTEXTUAL_RELEVANCE_ENGINE.md, docs/CKM_COCKPIT_DIRECTION_B/README.md, docs/BUILDEROPS_CONTROL_PLANE/DEMERZEL_REVIEW_MERGE_ORCHESTRATION.md, app/agent_memory/provisional_recall.py, app/agents/ask/graph.py, app/relevance/evaluator.py, app/relevance/materialization.py, app/relevance/attention_loop.py, app/relevance/now_surface.py, app/instance/filesystem_identity.py, app/instance/vault_registry.py, app/dispatcher/verification_api.py, app/dispatcher/verification_runtime.py, scripts/select_pr_tests.py, companion-ui/companion-app/companion_ui/workspace/now_surface.py, tests/agent_memory/test_provisional_memory_recall.py, tests/agent_memory/test_provisional_memory_call_sites.py, tests/relevance/test_vault_native_moments.py, tests/relevance/test_attention_loop_runtime.py, merged PRs #1948/#1977/#2092/#2097/#2098/#2115/#2119/#2127/#2128/#2129/#2131/#2133/#2135/#2137/#2140/#2142/#2636/#2642/#2643/#2645/#2656/#2678/#2686/#2689/#2692/#3730/#4224/#4244/#4420/#4424, issue #3720, PRs #3743/#4416, closed parent issue #4080, live issue #3603, and current repo state at `origin/main` `f0bafe6e79f3cc1a087b2c2fcbe40450c8302da2` on 2026-07-30
+
+### Live environment baseline (2026-08-22)
+
+The Mac mini is now an Ollama/model host only. Product runtime evidence is on the new Linux/Tailscale
+hosts: `ygg-dev` is reachable but degraded, `ygg-test` is not available, and `ygg-prod` has API
+liveness but failing functional health (stale watcher/no worker heartbeat; Companion UI unavailable).
+Both new-host APIs report unknown build identity. The promotion chain is therefore not yet executable;
+the missing test host, immutable artifact identity, and authoritative deployment handoff are explicit
+follow-up gates rather than implied by local Compose or old Mac mini state.
 
 Status snapshot now includes SoT baseline + release-line fields and intent/event counters (`promote.intent.created`, `panel.intent.executed`, `watcher.run`, ingest runs by plane). Code still exposes `sot_forward_line_version` / `feature_line_version` as the v5.6 release-line marker, but GitHub issue truth treats v5.6 as delivered rather than active. `watcher_runs` now counts watcher audit events from the registry watcher as well as the legacy snapshot watcher, while runtime health still relies on heartbeat + tick logs.
 

--- a/docs/adr/ADR-0040-prod-promotion-ref-main-interim.md
+++ b/docs/adr/ADR-0040-prod-promotion-ref-main-interim.md
@@ -1,4 +1,8 @@
 State: Accepted (operator decision, 2026-06-29). Records the interim prod promotion ref and the reproducibility invariant that backs it. The gated `stable` model in docs/RELEASE_CHANNELS/README.md §"Promotion contract" is unchanged and remains the target; this ADR does not relax it.
+Applicability note (2026-08-22): this ADR remains the decision record for the legacy/local Compose
+promotion baseline. The observed move of runtime services toward new Linux/Tailscale hosts does not
+supersede it, because no authoritative remote deployment path, immutable artifact identity, or live
+test channel has been established yet. A new ADR is required when that promotion authority is chosen.
 Doc role: Decision record (ADR)
 Authority: Authoritative for the *decision* that prod tracks `main` as the interim promotion ref, that `origin/stable` is dormant and must not be treated as the prod source-of-truth until restored, and that the prod runtime must equal the promotion ref with a clean working tree (reproducible from git alone). Channel identity, isolation invariants, and the target four-phase gated promotion contract remain owned by `docs/RELEASE_CHANNELS/README.md`; this ADR reconciles that doc with prod reality and points at it, it does not redefine it.
 Owner: Release channels / deployment governance

--- a/docs/architecture/inv-ef1-register.json
+++ b/docs/architecture/inv-ef1-register.json
@@ -2275,6 +2275,41 @@
       "why_load_bearing": "The serialized-writer tests retain the designated host identity only as a synthetic vault identifier for contract coverage.",
       "disposition": "stay",
       "issue": "#4708"
+    },
+    {
+      "artifact": "docs/DEV_TEST_PROD_STARTUP_REDESIGN/README.md",
+      "category": "iii",
+      "why_load_bearing": "The startup redesign records the designated Ollama-only model host and the separate Linux runtime-host boundary.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/INFRASTRUCTURE.md",
+      "category": "iii",
+      "why_load_bearing": "The infrastructure owner document records the designated Ollama-only model host and the separate Linux runtime-host boundary.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/RELEASE_CHANNELS/README.md",
+      "category": "iii",
+      "why_load_bearing": "The release-channel specification records the designated Ollama-only model host and the separate promotion-host boundary.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md",
+      "category": "iii",
+      "why_load_bearing": "The deployment owner document records the designated Ollama-only model host and the separate Linux runtime-host boundary.",
+      "disposition": "stay",
+      "issue": "#2892"
+    },
+    {
+      "artifact": "docs/ARCHITECTURE.md",
+      "category": "iii",
+      "why_load_bearing": "The architecture owner document records the designated remote Ollama provider and the separate Linux runtime-host boundary.",
+      "disposition": "stay",
+      "issue": "#2892"
     }
   ]
 }

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -5,10 +5,26 @@ Doc role: Core SoT (deployment)
 Authority: Canonical deployment + environment-separation contract. `docs/ENVIRONMENTS.md` owns environment *selection* and *path scoping* (what data/config each channel touches); `docs/RELEASE_CHANNELS/README.md` owns *channel identity, per-channel DB isolation, promotion-plan contract, migration reversibility classification, and rollback semantics*. `docs/YGGDRASIL_PLATFORM_AND_OPERATIONS_SYSTEM/README.md` owns the target ecosystem boundary for the operational platform; it does not replace this current deployment contract. This document owns *how a deploy physically happens*: image build/promote, managed gateways, deploy/rollback runbook, health gates, and the proxy-trust topology. Operations, runbooks, and component docs should reference this document instead of restating deployment procedure.
 Temporal class: operational
 Review cadence: as deployment topology, build pipeline, or channel ports change
-Last reviewed: 2026-07-19
+Last reviewed: 2026-08-22
+Last live runtime verification: 2026-08-22 (new-host topology; no authoritative SSH/deploy path was available from this workstation)
 Last verified against: `docker-compose.yaml`, `docker-compose.{dev,test,prod}.yml`, `docker-compose.{full-host-vault,legacy-vault,test-vault}.yml`, `Makefile`, `Dockerfile`, `scripts/lib/companion_ui_startup.sh`, `scripts/lib/instance_ownership_host_state.sh`, `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`, `serve_production_page.py`, `app/auth.py`, `app/version.py`, `app/api/routes/health_contract.py`, `app/activation/ask_synthesis.py`
 
 ## Why this document exists
+
+## Current live runtime posture
+
+The intended live split is now: Mac mini for Ollama only, and the product runtime on isolated Linux
+hosts reached through Tailscale. On 2026-08-22, `ygg-dev` served API `:18001` and UI `:8111`,
+`ygg-prod` served API liveness on `:18000` while its UI `:8113` was unavailable, and no `ygg-test`
+host or endpoint was available. Dev and prod both reported `git_sha=unknown`; prod functional health
+was failing because the watcher was stale/paused and the worker had no heartbeat. These observations
+are the current baseline and do not prove a deployable promotion chain.
+
+The repository does not yet contain an authoritative deployment/startup handoff for these new hosts,
+and this workstation has no usable SSH/deploy authority for them. Do not use the old Mac mini Compose
+projects or the local Compose matrix below as evidence for the new-host runtime. The required sequence
+remains exact candidate identity → dev verification → test deployment and verification → prod promotion
+and verification.
 
 RCA on 2026-06-29 (BuilderOps LearningSignal `lrn_20260629093241_59713bc1`) found that the system had **no deployment source-of-truth**. The observed reality:
 
@@ -27,9 +43,12 @@ This document is the canonical spec that epic #2655 (deployment + environment-se
 
 ## Environment matrix
 
-Three channels run in parallel on one host: `dev`, `test`, `prod`. They are isolated by DB name, vault binding, ports, and runtime-artifact paths — see `docs/ENVIRONMENTS.md` for the environment-selection contract these values implement.
+The contract spans three channels: `dev`, `test`, and `prod`. The local Compose fallback can run them in
+parallel on one host; the intended live topology assigns them to isolated Linux/Tailscale hosts. They
+are isolated by DB name, vault binding, ports, and runtime-artifact paths — see `docs/ENVIRONMENTS.md`
+for the environment-selection contract these values implement.
 
-### Current reality (verified 2026-07-06)
+### Local Compose fallback matrix (verified 2026-07-06; not the live Product Runtime)
 
 | Surface | dev | test | prod |
 | --- | --- | --- | --- |

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -13,7 +13,7 @@ Last verified against: `docker-compose.yaml`, `docker-compose.{dev,test,prod}.ym
 
 ## Current live runtime posture
 
-The intended live split is now: Mac mini for Ollama only, and the product runtime on isolated Linux
+The intended live split is now: a dedicated Ollama host for Ollama only, and the product runtime on isolated Linux
 hosts reached through Tailscale. On 2026-08-22, `ygg-dev` served API `:18001` and UI `:8111`,
 `ygg-prod` served API liveness on `:18000` while its UI `:8113` was unavailable, and no `ygg-test`
 host or endpoint was available. Dev and prod both reported `git_sha=unknown`; prod functional health
@@ -21,7 +21,7 @@ was failing because the watcher was stale/paused and the worker had no heartbeat
 are the current baseline and do not prove a deployable promotion chain.
 
 The repository does not yet contain an authoritative deployment/startup handoff for these new hosts,
-and this workstation has no usable SSH/deploy authority for them. Do not use the old Mac mini Compose
+and this workstation has no usable SSH/deploy authority for them. Do not use the old local Compose
 projects or the local Compose matrix below as evidence for the new-host runtime. The required sequence
 remains exact candidate identity → dev verification → test deployment and verification → prod promotion
 and verification.

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -8,6 +8,14 @@ Reading note:
 - not the full target-state architecture,
 - and not a claim that the current compose/runtime wiring is the permanent system decomposition.
 
+## New-host boundary (verified 2026-08-22)
+
+This runbook's `make` and Compose commands operate the local fallback runtime. They do not deploy or
+verify the new Linux/Tailscale hosts. The Mac mini is reserved for Ollama/model serving only. Do not
+use the old Mac mini `pkm-*` containers, or a local Compose health check, as evidence for promotion to
+the new `ygg-dev`, `ygg-test`, or `ygg-prod` runtime. Promotion requires the exact-host deployment
+handoff and a durable test verification receipt.
+
 ## Concept map: startup vs verification vs promotion vs rollback
 
 These are four separate operations with different goals, risks, and rollback surfaces. Do not conflate them.

--- a/ops/host-setup/README.md
+++ b/ops/host-setup/README.md
@@ -111,17 +111,15 @@ until the change receipt is accepted.
 
 ## How the routing works
 
-- Yggdrasil talks to **one** endpoint: the `llm-gateway` on the mini
-  (`OLLAMA_URL=http://127.0.0.1:11500`). The runtime's own LLM fabric doesn't
-  load-balance (see `docs/LLM_ROUTING.md`), so the gateway does it.
-- **Embeddings always stay on the mini** — moving them would change embedding
-  identity and force a full vector-index rebuild. The gateway enforces this pin.
-- **Chat/reasoning** goes to the gaming PC **only when `gpu-warden` says the GPU is
-  free** (no listed game running and GPU utilization below the threshold).
-  Otherwise it serves from the mini's small model. When it does burst, the gateway
-  **rewrites the request to the gaming host's model** (`GAMING_CHAT_MODEL`) so the
-  two boxes can run different models; if the gaming box disappears mid-request or
-  rejects it (e.g. model-not-found), the gateway degrades to the mini automatically.
+- The current Linux/Tailscale runtime binds to one explicit Ollama endpoint. The
+  dedicated Ollama host provides model service only; it does not run the Yggdrasil
+  API, watcher, or an `llm-gateway`.
+- Keep the embedding model identity stable. A runtime change of embedding provider
+  or model requires the repository's explicit index-rebuild decision; it is not an
+  automatic routing fallback.
+- Chat and reasoning use the selected runtime's declared provider binding. Do not
+  infer a second host, gaming-PC burst route, or gateway fallback from this
+  playbook. Local Compose remains a separate fallback/reference environment.
 
 ## Tuning & options
 

--- a/ops/host-setup/README.md
+++ b/ops/host-setup/README.md
@@ -1,17 +1,22 @@
-# Yggdrasil two-box host setup
+# Yggdrasil Ollama host setup
 
-Turn a base **Mac mini** (always-on core) + your **Windows gaming PC** (burst
-inference) + a **MacBook Air** (thin client) into the local-first host for
-Yggdrasil — with LLM routing that **prefers the gaming GPU when it's idle and
-backs off the moment you start a game**.
+State: Legacy host-setup reference; product runtime deployment is owned by `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md`.
+
+**Current boundary (2026-08-22): the Mac mini is Ollama-only.** Do not install or run the Yggdrasil
+API, database, worker, watcher, Companion UI, or gateway on it. Product runtime belongs on the new
+Linux/Tailscale `ygg-dev`, `ygg-test`, and `ygg-prod` hosts. The playbooks below predate that split and
+must not be treated as a live deployment procedure until they are reconciled with the new host handoff.
+
+The remaining supported purpose of this setup is to provide optional Ollama capacity to the product
+runtime over the private Tailscale network.
 
 ```
             Tailscale (private, MagicDNS)
-  MacBook Air ──────── Mac mini ──────── Gaming PC (Windows)
-  thin client          ALWAYS-ON         BURST INFERENCE
-  Screen Share/SSH     • runtime         • Ollama (fast MoE)
-  Moonlight            • Ollama 8B+embed • gpu-warden (/status)
-                       • llm-gateway ◀──── routes here when GPU is free
+  MacBook Air ──────── ygg-dev / ygg-test / ygg-prod
+  thin client          Linux product runtime hosts
+       │                         │
+       └──── Tailscale ──── Mac mini Ollama-only
+                              (optional Gaming PC Ollama)
 ```
 
 ## The whole operator process
@@ -22,27 +27,23 @@ each box does the rest by reading that box's playbook.
 1. **Install Tailscale on all three machines** and sign in to the same account.
    Enable **MagicDNS** in the Tailscale admin so `mac-mini` / `gaming-pc` resolve
    by name.
-2. **Install Claude Code (or Codex) on the Mac mini and the gaming PC**, and clone
-   this repo on each (the mini probably already has it).
-3. **Edit `ops/host-setup/config.env` once** (copy it from `config.example.env`):
+2. **Edit `ops/host-setup/config.env` once** (copy it from `config.example.env`):
    set `MAC_MINI_HOST`, `GAMING_PC_HOST`, and — on the gaming side —
    `WARDEN_GAME_PROCESSES` to your games' `.exe` names. Defaults for ports/models
    are fine.
-4. **On the gaming PC**, open the agent and paste:
+3. **On the gaming PC**, open the agent and paste:
    > Set up this machine. Read and execute `ops/host-setup/gaming-pc/AGENT_PLAYBOOK.md`.
-5. **On the Mac mini**, open the agent and paste:
-   > Set up this machine. Read and execute `ops/host-setup/mac-mini/AGENT_PLAYBOOK.md`.
-6. **On the MacBook Air**, follow `ops/host-setup/macbook-air/AGENT_PLAYBOOK.md`
+4. **On the MacBook Air**, follow `ops/host-setup/macbook-air/AGENT_PLAYBOOK.md`
    (mostly just Tailscale + connection shortcuts — no services).
 
-That's it. After step 5 the mini is serving the prosthesis 24/7 and routing chat
-to the gaming PC whenever it's free.
+The product hosts are separate from this optional inference setup. They must be
+deployed and verified through the governed deployment handoff.
 
 ## What each playbook does
 
 | Machine | Role | Installs |
 |---|---|---|
-| `mac-mini/` | always-on core | Ollama (`nomic-embed-text` + `llama3.1:8b`), `llm-gateway` (launchd), wires Yggdrasil's `OLLAMA_URL` |
+| `mac-mini/` | Ollama-only model host | Ollama (`nomic-embed-text` + `llama3.1:8b`); no product runtime or gateway |
 | `gaming-pc/` | burst inference | Ollama (`gpt-oss:20b`), `gpu-warden` (Scheduled Task) |
 | `macbook-air/` | thin client | nothing — Tailscale + Screen Sharing / Moonlight |
 

--- a/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
+++ b/ops/host-setup/mac-mini/AGENT_PLAYBOOK.md
@@ -1,9 +1,10 @@
 # Agent Playbook — Mac mini (macOS)
 
-You are a coding agent (Claude Code / Codex) running on the Mac mini. Set this
-machine up as the **always-on core**: Ollama (embeddings + small chat) + the
-gaming-aware `llm-gateway`, and point the Yggdrasil runtime at the gateway.
-Work top to bottom; stop and report if a step fails.
+You are an operator or host agent running on the Mac mini. The Mac mini is
+**Ollama-only**: install and verify Ollama/model serving, but do not install or
+start the Yggdrasil API, database, worker, watcher, Companion UI, or gateway.
+Those product-runtime services belong on the new Linux/Tailscale hosts. Work
+top to bottom; stop and report if a step fails.
 
 ## Preconditions (the operator did these by hand)
 - Tailscale installed and signed in (same tailnet as the gaming PC + Air).
@@ -15,36 +16,20 @@ Work top to bottom; stop and report if a step fails.
    `config.example.env`). Set `GAMING_PC_HOST` to the gaming PC's Tailscale name
    (`tailscale status` lists peers). Keep `EMBED_MODEL` as-is — it is pinned here.
 
-2. **Run the installer:** `bash ops/host-setup/mac-mini/install.sh`
-   It installs Ollama, pulls `nomic-embed-text` + `llama3.1:8b`, creates the
-   gateway venv, and loads the `com.yggdrasil.llm-gateway` launchd service.
+2. **Install and verify Ollama only.** The existing `install.sh` also provisions
+   the legacy gateway and is not an approved live-runtime installer for this
+   topology. Until that script is split, install Ollama and pull the approved
+   models through the normal host package flow without running the legacy gateway
+   setup.
 
-3. **Verify the gateway:**
-   `curl -sS http://127.0.0.1:11500/healthz` → JSON. Check `gaming` is the
-   expected host and `gaming_available` reflects reality (start a game on the PC
-   and confirm it flips to `false`).
+3. **Verify Ollama only:** confirm the Ollama service is reachable on its
+   operator-approved host endpoint and that the approved models are present.
+   Do not verify or start the legacy gateway; it is not part of the Mac mini
+   runtime boundary anymore.
 
-4. **Wire Yggdrasil.** In the runtime's env (`.env` / `.env.<channel>.local`), set:
-   ```
-   LLM_PROVIDER=ollama
-   OLLAMA_URL=http://127.0.0.1:11500     # the gateway, not Ollama directly
-   OLLAMA_EMBED_MODEL=nomic-embed-text:latest
-   LLM_MODEL=llama3.1:8b
-   ```
-   Do **not** also set `OLLAMA_URL` to the raw `:11434` anywhere — everything must
-   go through the gateway so the embedding-identity pin and routing hold.
-
-5. **Start / restart the stack** the usual way (`make start` or
-   `scripts/start_full_system.sh`) and confirm `/api/health` reports the llm
-   router healthy and embeddings compatible (no rebuild required).
-
-6. **End-to-end check:** with a game NOT running, send a chat through Yggdrasil
-   (e.g. `/api/ask` or a panel action) and confirm via the gateway log
-   (`/tmp/yggdrasil-llm-gateway.log`) that it routed to the gaming host; start a
-   game and confirm the next chat stays local.
-
-7. **Report** to the operator: gateway `/healthz`, the env you set, and the
-   routed-vs-local check result.
+4. **Report only the Ollama endpoint and model inventory** to the operator. The
+   product-runtime host must later configure its explicit Tailscale-reachable
+   endpoint; do not start a local Yggdrasil stack from this playbook.
 
 ## BuilderOps Model Inquiry host entrypoints
 

--- a/ops/host-setup/macbook-air/AGENT_PLAYBOOK.md
+++ b/ops/host-setup/macbook-air/AGENT_PLAYBOOK.md
@@ -1,11 +1,13 @@
 # Agent Playbook — MacBook Air (thin client)
 
 The Air is just a **thin client**. No services run here; it only needs to reach
-the mini and the gaming PC over Tailscale. This is mostly manual operator setup.
+the approved Linux/Tailscale runtime hosts and the dedicated Ollama host. This
+is mostly manual operator setup.
 
 ## Steps
 1. **Tailscale** installed and signed in (same tailnet). Verify with
-   `tailscale status` that both `mac-mini` and `gaming-pc` are reachable.
+   `tailscale status` that the approved runtime and model-service peers are
+   reachable.
 
 2. **Reach the Mac mini (macOS):**
    - GUI: Finder → Go → Connect to Server → `vnc://mac-mini` (Screen Sharing).
@@ -18,9 +20,11 @@ the mini and the gaming PC over Tailscale. This is mostly manual operator setup.
      simpler alternative for casual remote desktop.
    - Note: Windows 11 **Home cannot host RDP** — use Sunshine/Moonlight or RustDesk.
 
-4. **Use the prosthesis:** open the Yggdrasil companion UI at the mini's API port
-   over Tailscale (e.g. `http://mac-mini:18000`). Everything else (LLM routing,
-   embeddings, the watcher) is handled by the mini.
+4. **Use the prosthesis:** open the Yggdrasil companion UI on the Linux runtime
+   over Tailscale, for example `http://ygg-dev:8111` for development. The
+   production UI is `http://ygg-prod:8113` only when the live readback says it is
+   available. The Ollama host provides model service only; the API, watcher, and
+   routing belong to the selected Linux runtime host.
 
 There is nothing to install as a service here. If the operator wants a one-click
 "connect" experience, create Shortcuts/bookmarks for the VNC, SSH, and companion


### PR DESCRIPTION
## Change Lane
Direct Repair — current-state documentation and host-playbook correction

Final-Review-Rounds: 0

## Linked Issue

## SBS Impact
- Primary subsystem: Platform and Operations documentation
- Secondary subsystem(s): Release channels and environment boundary
- Write class: current-state correction
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: documents the live host boundary; no runtime contract implementation
- Owner-doc impact: owner docs updated in this PR
- Transition debt impact: remote deployment handoff and test-host qualification remain open
- Boundary risk: deployment authority is explicitly not claimed or mutated

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR.

## Summary
- Record the verified Linux/Tailscale dev and prod runtime posture and missing test host.
- Keep the Mac mini Ollama-only and mark local Compose and legacy host playbooks as fallback/reference material.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: this is a bounded current-state documentation correction; no BuilderOps material was created.

## Direct Repair
Type: docs
Reason: reconcile stale environment and host-role documentation with the verified live topology while preserving fail-closed promotion gates.
Validation: python3 scripts/docs_guard.py; python3 scripts/public_seam_lint.py --mode gate; git diff --check.
Issue required: no
- Scope: environment, deployment, architecture, operations, release-channel, startup, INV-EF1 register, ADR, and Mac mini host-playbook documentation only.
- Authority: live read-only probes from 2026-08-22 plus the operator instruction that the Mac mini is Ollama-only.
- Residual risk: no remote host was mutated; promotion remains blocked until ygg-test, immutable artifact identity, and an authoritative deployment handoff exist.

## Notes
- No API, database, worker, watcher, UI, image pin, or runtime host was changed by this PR.
- Existing unrelated untracked workspace files were preserved and excluded; current-head contract re-read after ce4cfcaba.