### PR TITLE
Implement verified archival transition kernel

### DIFF
--- a/app/archival/__init__.py
+++ b/app/archival/__init__.py
@@ -9,10 +9,22 @@ from app.archival.contracts import (
     DerivationClass,
     DurabilityClass,
     Generation,
+    Liveness,
+    LivenessState,
     OwnerAuthority,
     OpaqueReference,
     PolicyProfile,
+    ProvenanceRef,
+    Representation,
     RepresentationRef,
+    TransitionStage,
+)
+from app.archival.transition import (
+    ArchivalTransitionKernel,
+    DurableFakeAdapter,
+    FaultStage,
+    TransitionFailure,
+    TransitionResult,
 )
 
 __all__ = [
@@ -24,8 +36,18 @@ __all__ = [
     "DerivationClass",
     "DurabilityClass",
     "Generation",
+    "Liveness",
+    "LivenessState",
     "OwnerAuthority",
     "OpaqueReference",
     "PolicyProfile",
+    "ProvenanceRef",
+    "Representation",
     "RepresentationRef",
+    "TransitionStage",
+    "ArchivalTransitionKernel",
+    "DurableFakeAdapter",
+    "FaultStage",
+    "TransitionFailure",
+    "TransitionResult",
 ]

--- a/app/archival/contracts.py
+++ b/app/archival/contracts.py
@@ -87,6 +87,8 @@ class TransitionStage(str, Enum):
     ERASE_PENDING = "erase_pending"
     ERASED = "erased"
     REFUSED = "refused"
+    CONFLICT = "conflict"
+    RESTORE_PENDING = "restore_pending"
 
 
 class LivenessState(str, Enum):
@@ -96,6 +98,11 @@ class LivenessState(str, Enum):
     MISSING = "missing"
     ERASED = "erased"
     REFUSED = "refused"
+    TRANSITION_PENDING = "transition_pending"
+    RESTORE_PENDING = "restore_pending"
+    ERASURE_PENDING = "erasure_pending"
+    UNAVAILABLE = "unavailable"
+    CONFLICT = "conflict"
 
 
 _OPAQUE_NAMESPACE = re.compile(r"^[a-z][a-z0-9_-]*$")

--- a/app/archival/transition.py
+++ b/app/archival/transition.py
@@ -1,0 +1,244 @@
+"""Receipt-first, provider-neutral archival transition ordering."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Protocol
+
+from app.archival.contracts import (
+    AccessAuthority, ArtifactDescriptor, ArtifactIdentity, ArchivalReceipt,
+    Generation, Liveness, LivenessState, OpaqueReference, PolicyProfile,
+    Representation, RepresentationRef, RepresentationReservation, TransitionStage,
+    VerificationResult,
+)
+
+
+class FaultStage(str, Enum):
+    RESERVATION = "reservation"
+    BYTES = "bytes"
+    VERIFICATION = "verification"
+    RECEIPT = "receipt"
+    ACTIVATION = "activation"
+    ACTIVATION_AFTER_EFFECT = "activation_after_effect"
+    RETIREMENT = "retirement"
+    COMPLETION = "completion"
+    CLEANUP = "cleanup"
+
+
+class TransitionFailure(RuntimeError):
+    def __init__(self, stage: FaultStage, message: str) -> None:
+        super().__init__(message)
+        self.stage = stage
+
+
+@dataclass(frozen=True)
+class OperationRecord:
+    idempotency_key: str
+    artifact: ArtifactIdentity
+    generation: Generation
+    policy: PolicyProfile
+    source: RepresentationRef
+    target: RepresentationRef
+    reservation: RepresentationReservation
+    receipt: ArchivalReceipt
+    activated: bool = False
+    retired: bool = False
+
+
+class TransitionAdapter(Protocol):
+    """Owner-native durability and access seams; the kernel owns no state."""
+    def source(self, reference: RepresentationRef) -> Representation: ...
+    def reserve(self, artifact: ArtifactDescriptor, target: RepresentationRef) -> RepresentationReservation: ...
+    def persist(self, reservation: RepresentationReservation) -> None: ...
+    def verify(self, reservation: RepresentationReservation) -> VerificationResult: ...
+    def durable_receipt(self, key: str, source: RepresentationRef, reservation: RepresentationReservation, verification: VerificationResult) -> ArchivalReceipt: ...
+    def activate(self, key: str, reservation: RepresentationReservation, receipt: ArchivalReceipt) -> None: ...
+    def retire(self, source: Representation, receipt: ArchivalReceipt) -> None: ...
+    def authorize_read(self, artifact: ArtifactIdentity, authority: AccessAuthority) -> ArchivalReceipt: ...
+    def restore(self, artifact: ArtifactIdentity, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt: ...
+    def cleanup(self, artifact: ArtifactIdentity, generation: Generation, policy: PolicyProfile) -> OpaqueReference: ...
+    def find_operation(self, key: str) -> OperationRecord | None: ...
+    def complete(self, key: str, receipt: ArchivalReceipt) -> None: ...
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    stage: TransitionStage
+    liveness: Liveness
+    receipt: ArchivalReceipt | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return self.liveness.is_terminal or self.stage in {TransitionStage.RETIRED, TransitionStage.RESTORED}
+
+
+def _evidence(token: str) -> OpaqueReference:
+    return OpaqueReference("archival-kernel", token)
+
+
+class ArchivalTransitionKernel:
+    """Resume durable operation records; never infer completion from process state."""
+    def __init__(self, adapter: TransitionAdapter) -> None:
+        self._adapter = adapter
+
+    def transition(self, artifact: ArtifactDescriptor, source: RepresentationRef, target: RepresentationRef, idempotency_key: str) -> TransitionResult:
+        if not isinstance(idempotency_key, str) or not idempotency_key:
+            raise ValueError("idempotency_key is required")
+        existing = self._adapter.find_operation(idempotency_key)
+        if existing is not None:
+            if (existing.artifact != artifact.identity or existing.generation != artifact.generation
+                    or existing.policy is not artifact.policy_profile or existing.source != source
+                    or existing.target != target):
+                return self._refused("idempotency-binding-conflict")
+            if existing.retired:
+                return TransitionResult(existing.receipt.stage, existing.receipt.liveness, existing.receipt)
+            reservation = existing.reservation
+            current_source = self._adapter.source(source)
+            if current_source.artifact != artifact.identity or current_source.generation != artifact.generation:
+                return self._refused("stale-generation-or-source-binding")
+            if not existing.activated:
+                self._adapter.activate(idempotency_key, reservation, existing.receipt)
+            if current_source.stage is not TransitionStage.RETIRED:
+                self._adapter.retire(current_source, existing.receipt)
+            self._adapter.complete(idempotency_key, existing.receipt)
+            return TransitionResult(TransitionStage.RETIRED, existing.receipt.liveness, existing.receipt)
+        source_rep = self._adapter.source(source)
+        if source_rep.artifact != artifact.identity or source_rep.generation != artifact.generation:
+            return self._refused("stale-generation-or-source-binding")
+        try:
+            reservation = self._adapter.reserve(artifact, target)
+            self._adapter.persist(reservation)
+            verification = self._adapter.verify(reservation)
+            if not verification.verified or verification.generation != artifact.generation:
+                return self._refused("destination-verification-failed")
+            receipt = self._adapter.durable_receipt(idempotency_key, source, reservation, verification)
+            self._adapter.activate(idempotency_key, reservation, receipt)
+            self._adapter.retire(source_rep, receipt)
+            self._adapter.complete(idempotency_key, receipt)
+            return TransitionResult(TransitionStage.RETIRED, receipt.liveness, receipt)
+        except TransitionFailure as failure:
+            return TransitionResult(
+                TransitionStage.REFUSED if failure.stage is FaultStage.RESERVATION else TransitionStage.RESERVED,
+                Liveness(LivenessState.TRANSITION_PENDING, _evidence(f"pending-{idempotency_key}")),
+            )
+
+    archive = transition
+
+    def restore(self, artifact: ArtifactDescriptor, authority: AccessAuthority, representation: RepresentationRef) -> TransitionResult:
+        gate = self._adapter.authorize_read(artifact.identity, authority)
+        if representation not in gate.representation_refs:
+            return TransitionResult(TransitionStage.CONFLICT, Liveness(LivenessState.CONFLICT, _evidence("restore-representation-mismatch")), gate)
+        try:
+            receipt = self._adapter.restore(artifact.identity, authority, representation)
+        except TransitionFailure:
+            return TransitionResult(TransitionStage.RESTORE_PENDING, Liveness(LivenessState.RESTORE_PENDING, _evidence("restore-pending")), gate)
+        if receipt.artifact != artifact.identity or receipt.generation != artifact.generation or representation not in receipt.representation_refs:
+            return TransitionResult(TransitionStage.CONFLICT, Liveness(LivenessState.CONFLICT, _evidence("restore-receipt-mismatch")), receipt)
+        return TransitionResult(TransitionStage.RESTORED, receipt.liveness, receipt)
+
+    def cleanup(self, artifact: ArtifactDescriptor) -> TransitionResult:
+        try:
+            evidence = self._adapter.cleanup(artifact.identity, artifact.generation, artifact.policy_profile)
+        except TransitionFailure:
+            return TransitionResult(TransitionStage.ERASE_PENDING, Liveness(LivenessState.ERASURE_PENDING, _evidence("erasure-pending")))
+        return TransitionResult(TransitionStage.ERASED, Liveness(LivenessState.ERASED, evidence))
+
+    @staticmethod
+    def _refused(reason: str) -> TransitionResult:
+        return TransitionResult(TransitionStage.REFUSED, Liveness(LivenessState.REFUSED, _evidence(reason)))
+
+
+class DurableFakeAdapter:
+    """Test-only durable double. Production adapters are intentionally unwired."""
+    def __init__(self) -> None:
+        self.representations: dict[RepresentationRef, Representation] = {}
+        self.reservations: dict[OpaqueReference, RepresentationReservation] = {}
+        self.operations: dict[str, OperationRecord] = {}
+        self._policies: dict[RepresentationRef, PolicyProfile] = {}
+        self.fault: FaultStage | None = None
+        self.source_retired = False
+        self.access_gate_called = False
+
+    def register_source(self, representation: Representation) -> None:
+        self.representations[representation.ref] = representation
+
+    def fail_once(self, stage: FaultStage) -> None:
+        self.fault = stage
+
+    def _fault(self, stage: FaultStage) -> None:
+        if self.fault is stage:
+            self.fault = None
+            raise TransitionFailure(stage, f"injected failure at {stage.value}")
+
+    def source(self, reference: RepresentationRef) -> Representation:
+        return self.representations[reference]
+
+    def reserve(self, artifact: ArtifactDescriptor, target: RepresentationRef) -> RepresentationReservation:
+        self._fault(FaultStage.RESERVATION)
+        existing = self.representations.get(target)
+        if existing is not None and (existing.artifact != artifact.identity or existing.generation != artifact.generation):
+            raise TransitionFailure(FaultStage.RESERVATION, "destination binding is stale")
+        old_policy = self._policies.get(target)
+        if old_policy is not None and old_policy is not artifact.policy_profile:
+            raise TransitionFailure(FaultStage.RESERVATION, "destination policy binding changed")
+        self._policies[target] = artifact.policy_profile
+        reservation = RepresentationReservation(artifact.identity, target, artifact.generation, OpaqueReference("reservation", f"r-{len(self.reservations)+1}"))
+        self.reservations[reservation.reservation_ref] = reservation
+        return reservation
+
+    def persist(self, reservation: RepresentationReservation) -> None:
+        self._fault(FaultStage.BYTES)
+        self.representations[reservation.target] = Representation(reservation.artifact, reservation.target, reservation.generation, TransitionStage.VERIFIED, Liveness(LivenessState.TRANSITION_PENDING, _evidence(reservation.reservation_ref.token)))
+
+    def verify(self, reservation: RepresentationReservation) -> VerificationResult:
+        self._fault(FaultStage.VERIFICATION)
+        representation = self.representations.get(reservation.target)
+        if representation is None or representation.generation != reservation.generation:
+            raise TransitionFailure(FaultStage.VERIFICATION, "destination is not durable")
+        return VerificationResult(reservation.target, reservation.generation, True, _evidence(f"verified-{reservation.reservation_ref.token}"))
+
+    def durable_receipt(self, key: str, source: RepresentationRef, reservation: RepresentationReservation, verification: VerificationResult) -> ArchivalReceipt:
+        self._fault(FaultStage.RECEIPT)
+        receipt = ArchivalReceipt(OpaqueReference("receipt", reservation.reservation_ref.token), reservation.artifact, reservation.generation, TransitionStage.VERIFIED, self._policies[reservation.target], Liveness(LivenessState.ACTIVE, _evidence(f"receipt-{reservation.reservation_ref.token}")), (), (reservation.target,))
+        self.operations[key] = OperationRecord(key, reservation.artifact, reservation.generation, self._policies[reservation.target], source, reservation.target, reservation, receipt)
+        return receipt
+
+    def activate(self, key: str, reservation: RepresentationReservation, receipt: ArchivalReceipt) -> None:
+        self._fault(FaultStage.ACTIVATION)
+        representation = self.representations[reservation.target]
+        self.representations[reservation.target] = replace(representation, stage=TransitionStage.ACTIVE, liveness=receipt.liveness)
+        if self.fault is FaultStage.ACTIVATION_AFTER_EFFECT:
+            self.fault = None
+            raise TransitionFailure(FaultStage.ACTIVATION_AFTER_EFFECT, "activation committed before progress receipt")
+        operation = self.operations.get(key)
+        if operation is not None:
+            self.operations[key] = replace(operation, activated=True)
+
+    def retire(self, source: Representation, receipt: ArchivalReceipt) -> None:
+        self._fault(FaultStage.RETIREMENT)
+        self.source_retired = True
+        self.representations[source.ref] = replace(source, stage=TransitionStage.RETIRED, liveness=receipt.liveness)
+
+    def find_operation(self, key: str) -> OperationRecord | None:
+        return self.operations.get(key)
+
+    def complete(self, key: str, receipt: ArchivalReceipt) -> None:
+        self._fault(FaultStage.COMPLETION)
+        operation = self.operations[key]
+        self.operations[key] = replace(operation, receipt=replace(receipt, stage=TransitionStage.RETIRED), activated=True, retired=True)
+
+    def authorize_read(self, artifact: ArtifactIdentity, authority: AccessAuthority) -> ArchivalReceipt:
+        self.access_gate_called = True
+        refs = tuple(ref for ref, rep in self.representations.items() if rep.artifact == artifact and rep.stage is not TransitionStage.RETIRED)
+        generation = next((rep.generation for rep in self.representations.values() if rep.artifact == artifact), Generation(0))
+        return ArchivalReceipt(OpaqueReference("access-receipt", "read-1"), artifact, generation, TransitionStage.ACTIVE, PolicyProfile.HKA_RECOVERY, Liveness(LivenessState.ACTIVE, _evidence("access-granted")), (), refs)
+
+    def restore(self, artifact: ArtifactIdentity, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt:
+        self._fault(FaultStage.VERIFICATION)
+        if representation not in self.representations:
+            raise TransitionFailure(FaultStage.VERIFICATION, "exact representation is unavailable")
+        return ArchivalReceipt(OpaqueReference("restore-receipt", representation.opaque_id.token), artifact, self.representations[representation].generation, TransitionStage.RESTORED, PolicyProfile.HKA_RECOVERY, Liveness(LivenessState.ACTIVE, _evidence("restored")), (), (representation,))
+
+    def cleanup(self, artifact: ArtifactIdentity, generation: Generation, policy: PolicyProfile) -> OpaqueReference:
+        self._fault(FaultStage.CLEANUP)
+        return _evidence("cleanup-proven")

--- a/tests/architecture/test_governed_archival_contract.py
+++ b/tests/architecture/test_governed_archival_contract.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import inspect
+
+from app.archival.transition import ArchivalTransitionKernel
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -30,3 +33,10 @@ def test_normative_contract_and_invariant_registry_match() -> None:
     ):
         assert identifier in contract
         assert identifier in registry
+
+
+def test_transition_kernel_has_no_private_persistence_or_content_store() -> None:
+    source = inspect.getsource(ArchivalTransitionKernel)
+    assert "dict[" not in source
+    assert "bytes" not in source
+    assert "registry" not in source.lower()

--- a/tests/archival/test_transition_kernel.py
+++ b/tests/archival/test_transition_kernel.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from app.archival import (
+    ArchivalTransitionKernel,
+    ArtifactClass,
+    ArtifactDescriptor,
+    ArtifactIdentity,
+    DerivationClass,
+    DurableFakeAdapter,
+    DurabilityClass,
+    FaultStage,
+    Generation,
+    LivenessState,
+    OpaqueReference,
+    OwnerAuthority,
+    PolicyProfile,
+    ProvenanceRef,
+    Representation,
+    RepresentationRef,
+    TransitionStage,
+)
+from app.archival.contracts import AccessAuthority, Liveness
+
+
+def _fixture() -> tuple[ArtifactDescriptor, RepresentationRef, RepresentationRef, DurableFakeAdapter, ArchivalTransitionKernel]:
+    identity = ArtifactIdentity(OwnerAuthority.CLASS_ADAPTER, OpaqueReference("fixture", "source-1"), "fixture")
+    descriptor = ArtifactDescriptor(
+        identity, ArtifactClass.SOURCE, DerivationClass.SOURCE, DurabilityClass.DURABLE,
+        OwnerAuthority.CLASS_ADAPTER, Generation(3),
+        (ProvenanceRef("origin", OpaqueReference("fixture", "origin-1")),), PolicyProfile.RETAINED_SOURCE,
+    )
+    source = RepresentationRef("fixture", OpaqueReference("fixture", "source-1"))
+    target = RepresentationRef("fixture", OpaqueReference("fixture", "archive-1"))
+    adapter = DurableFakeAdapter()
+    adapter.register_source(Representation(
+        identity, source, Generation(3), TransitionStage.ACTIVE,
+        Liveness(LivenessState.ACTIVE, OpaqueReference("fixture", "live")),
+    ))
+    return descriptor, source, target, adapter, ArchivalTransitionKernel(adapter)
+
+
+def test_verified_transition_is_durable_before_source_retirement() -> None:
+    descriptor, source, target, adapter, kernel = _fixture()
+    result = kernel.transition(descriptor, source, target, "op-1")
+    assert result.stage is TransitionStage.RETIRED
+    assert adapter.representations[target].stage is TransitionStage.ACTIVE
+    assert adapter.source_retired
+
+
+def test_crash_matrix_preserves_source_and_retry_authority() -> None:
+    for stage in FaultStage:
+        if stage is FaultStage.CLEANUP:
+            continue
+        descriptor, source, target, adapter, kernel = _fixture()
+        adapter.fail_once(stage)
+        failed = kernel.transition(descriptor, source, target, f"op-{stage.value}")
+        assert failed.liveness.state in {LivenessState.TRANSITION_PENDING, LivenessState.REFUSED}
+        retried = kernel.transition(descriptor, source, target, f"op-{stage.value}")
+        assert retried.liveness.state is not LivenessState.ERASED
+
+
+def test_retry_reuses_durable_reservation_and_source_binding() -> None:
+    descriptor, source, target, adapter, kernel = _fixture()
+    adapter.fail_once(FaultStage.ACTIVATION)
+    pending = kernel.transition(descriptor, source, target, "op-resume")
+    assert pending.liveness.state is LivenessState.TRANSITION_PENDING
+    reservation = adapter.find_operation("op-resume").reservation  # type: ignore[union-attr]
+    result = kernel.transition(descriptor, source, target, "op-resume")
+    assert result.stage is TransitionStage.RETIRED
+    assert adapter.find_operation("op-resume").reservation == reservation  # type: ignore[union-attr]
+
+
+def test_restore_failure_is_typed_pending() -> None:
+    descriptor, source, _target, adapter, kernel = _fixture()
+    adapter.fail_once(FaultStage.VERIFICATION)
+    result = kernel.restore(descriptor, AccessAuthority(OwnerAuthority.GOV, OpaqueReference("grant", "r1")), source)
+    assert result.liveness.state is LivenessState.RESTORE_PENDING
+    assert not result.terminal
+
+
+def test_post_retirement_crash_reconciles_without_duplicate_retirement() -> None:
+    descriptor, source, target, adapter, kernel = _fixture()
+    adapter.fail_once(FaultStage.COMPLETION)
+    pending = kernel.transition(descriptor, source, target, "op-post-effect")
+    assert pending.liveness.state is LivenessState.TRANSITION_PENDING
+    assert adapter.source(source).stage is TransitionStage.RETIRED
+    result = kernel.transition(descriptor, source, target, "op-post-effect")
+    assert result.stage is TransitionStage.RETIRED
+    assert adapter.source_retired
+
+
+def test_post_activation_crash_retries_idempotently() -> None:
+    descriptor, source, target, adapter, kernel = _fixture()
+    adapter.fail_once(FaultStage.ACTIVATION_AFTER_EFFECT)
+    pending = kernel.transition(descriptor, source, target, "op-activation-effect")
+    assert pending.liveness.state is LivenessState.TRANSITION_PENDING
+    result = kernel.transition(descriptor, source, target, "op-activation-effect")
+    assert result.stage is TransitionStage.RETIRED
+    assert adapter.representations[target].stage is TransitionStage.ACTIVE
+
+
+def test_stale_generation_and_binding_fail_closed_before_effect() -> None:
+    descriptor, source, target, adapter, kernel = _fixture()
+    stale = ArtifactDescriptor(
+        descriptor.identity, descriptor.artifact_class, descriptor.derivation, descriptor.durability,
+        descriptor.owner, Generation(4), descriptor.provenance_refs, descriptor.policy_profile,
+    )
+    result = kernel.transition(stale, source, target, "stale")
+    assert result.stage is TransitionStage.REFUSED
+    assert target not in adapter.representations
+
+
+def test_restore_requires_owner_access_gate_and_exact_representation() -> None:
+    descriptor, source, _target, adapter, kernel = _fixture()
+    result = kernel.restore(descriptor, AccessAuthority(OwnerAuthority.GOV, OpaqueReference("grant", "r1")), source)
+    assert result.stage is TransitionStage.RESTORED
+    assert adapter.access_gate_called
+
+
+def test_cleanup_failure_cannot_project_terminal_erasure() -> None:
+    descriptor, _source, _target, adapter, kernel = _fixture()
+    adapter.fail_once(FaultStage.CLEANUP)
+    assert kernel.cleanup(descriptor).liveness.state is LivenessState.ERASURE_PENDING
+    assert kernel.cleanup(descriptor).liveness.state is LivenessState.ERASED


### PR DESCRIPTION
Governing-Issue: #5064

Fixes #5064

Final-Review-Rounds: 1

## Summary
Implement the provider-neutral verified archival transition kernel with durable receipt-first ordering, crash-safe idempotent retry, generation/policy/destination fencing, governed restore access, and typed cleanup liveness. Production adapters remain unwired; the durable fake adapter and fault matrix provide the executable proof.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260822210401_eb7bccbc` and `lrn_20260822220717_19904065`; pickup receipt `github-comment:5382859814`.
- Reason: Delivery resumed after readiness drift and reconciled a duplicate archival PR before continuing with GAF-02.

## Notes
Validation: 17 focused archival/architecture tests passed; `ruff check app/archival tests/archival`; `mypy app/archival`; independent issue-local Sol review PASS on exact SHA `ab6cd594a`.