### PR TITLE
fix: preserve Alembic ownership of Heimdal reject-mutation triggers

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -997,6 +997,7 @@ jobs:
               - 'app/alembic/versions/e7b4c9d2a6f1_heimdal_raw_representation.py'
               - 'app/alembic/versions/c5d8a1e4f2b7_heimdal_raw_liveness.py'
               - 'tests/heimdal/test_local_archive_migration.py'
+              - 'tests/heimdal/test_trigger_ownership_pg.py'
               - 'tests/migrations/test_heimdal_raw_representation_migration.py'
               - 'tests/migrations/test_heimdal_raw_liveness_migration.py'
               - '.github/workflows/ci-smoke.yaml'
@@ -1069,6 +1070,7 @@ jobs:
             tests/instance/test_file_state_binding_key.py \
             tests/services/test_vault_sync_binding_scope.py \
             tests/integration/test_single_vault_compatibility.py \
+            tests/heimdal/test_trigger_ownership_pg.py \
             tests/migrations/test_heimdal_raw_representation_migration.py \
             tests/migrations/test_heimdal_raw_liveness_migration.py \
             --tb=short \

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -990,12 +990,23 @@ jobs:
               # migration-owned representation registry. Its rollback,
               # resume/read-continuity and bootstrap-parity proofs require
               # real PostgreSQL and therefore must be attached to the PR path.
+              - 'app/heimdal/trigger_ownership.py'
+              - 'app/heimdal/consent_ledger.py'
+              - 'app/heimdal/media_receipts.py'
+              - 'app/heimdal/observation_log.py'
               - 'app/heimdal/raw_store.py'
               - 'app/heimdal/raw_liveness.py'
               - 'app/heimdal/raw_read_gate.py'
               - 'app/heimdal/retention.py'
+              - 'app/alembic/versions/8b21e6a1f0c4_heim_observation_log_and_cursor.py'
+              - 'app/alembic/versions/a3f9d1c6e2b8_heim_retention_deletion_receipt_v0.py'
+              - 'app/alembic/versions/c4f7a1b2d9e3_heim_consent_ledger_v0.py'
               - 'app/alembic/versions/e7b4c9d2a6f1_heimdal_raw_representation.py'
               - 'app/alembic/versions/c5d8a1e4f2b7_heimdal_raw_liveness.py'
+              - 'app/alembic/versions/d5a8e2f1b6c3_heim_raw_record_v0.py'
+              - 'app/alembic/versions/e2f3a4b5c6d7_heimdal_cold_cleanup_reconciliation.py'
+              - 'app/alembic/versions/e3c1a7f5d2b8_heim_media_receipt_v0.py'
+              - 'app/alembic/versions/f1c7e2a9b4d6_heim_raw_read_receipt_v0.py'
               - 'tests/heimdal/test_local_archive_migration.py'
               - 'tests/heimdal/test_trigger_ownership_pg.py'
               - 'tests/migrations/test_heimdal_raw_representation_migration.py'

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -246,6 +246,7 @@ jobs:
             tests/migrations/test_entity_review_operation_journal_schema_parity.py \
             tests/migrations/test_file_state_adoption.py \
             tests/migrations/test_objects_adoption.py \
+            tests/heimdal/test_trigger_ownership_pg.py \
             tests/migrations/test_heimdal_raw_representation_migration.py \
             tests/migrations/test_legacy_objects_fk_migration.py \
             tests/migrations/test_store_schema_parity.py \

--- a/app/heimdal/consent_ledger.py
+++ b/app/heimdal/consent_ledger.py
@@ -422,6 +422,17 @@ def _assert_pg_schema(conn: Any) -> None:
     oid = row[0] if row else None
     if not oid:
         raise ConsentLedgerSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+    from app.heimdal.trigger_ownership import (
+        CONSENT_GRANT_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        CONSENT_GRANT_TRIGGER,
+        error_type=ConsentLedgerSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
 
 
 def _bootstrap_pg(conn: Any) -> None:
@@ -429,55 +440,60 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            id uuid PRIMARY KEY,
-            grant_ref text NOT NULL,
-            basis text NOT NULL,
-            scope text NOT NULL,
-            granted_by text NOT NULL,
-            granted_at timestamptz NOT NULL,
-            expiry timestamptz,
-            capture_profile jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            third_party_policy text NOT NULL DEFAULT 'degrade',
-            vad_gate jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            third_party jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            retention jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            erasure jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            revokes_grant_ref text,
-            payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            sequence bigserial NOT NULL
-        )
-        """
+    table_groups = (
+        (
+            _TABLE,
+            (
+                "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+                f"""
+                CREATE TABLE {_TABLE} (
+                    id uuid PRIMARY KEY,
+                    grant_ref text NOT NULL,
+                    basis text NOT NULL,
+                    scope text NOT NULL,
+                    granted_by text NOT NULL,
+                    granted_at timestamptz NOT NULL,
+                    expiry timestamptz,
+                    capture_profile jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    third_party_policy text NOT NULL DEFAULT 'degrade',
+                    vad_gate jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    third_party jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    retention jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    erasure jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    revokes_grant_ref text,
+                    payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    created_at timestamptz NOT NULL DEFAULT now(),
+                    sequence bigserial NOT NULL
+                )
+                """,
+                f"CREATE INDEX heimdal_consent_grant_seq_idx ON {_TABLE} (sequence)",
+                f"CREATE INDEX heimdal_consent_grant_grant_ref_idx ON {_TABLE} (grant_ref)",
+                f"CREATE INDEX heimdal_consent_grant_scope_idx ON {_TABLE} (scope)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_consent_grant_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_consent_grant is append-only (HEIM-1): % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_consent_grant_no_update
+                BEFORE UPDATE OR DELETE ON {_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_consent_grant_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_consent_grant_seq_idx ON {_TABLE} (sequence)")
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_consent_grant_grant_ref_idx ON {_TABLE} (grant_ref)")
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_consent_grant_scope_idx ON {_TABLE} (scope)")
-    # Append-only enforcement at the DB level (HEIM-1): a trigger rejects any
-    # UPDATE/DELETE against the ledger table, independent of which role or
-    # code path issues the statement. Defense in depth on top of "there is no
-    # update/delete method in this module's Python API".
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_consent_grant_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_consent_grant is append-only (HEIM-1): % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(f"DROP TRIGGER IF EXISTS heimdal_consent_grant_no_update ON {_TABLE}")
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_consent_grant_no_update
-        BEFORE UPDATE OR DELETE ON {_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_consent_grant_reject_mutation()
-        """
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
     # Seed every standing grant (idempotent), from the same builder tuple the
     # memory backend uses -- a standing grant cannot land in one in-process
     # producer and not the other.

--- a/app/heimdal/entity_review_operation_journal.py
+++ b/app/heimdal/entity_review_operation_journal.py
@@ -363,10 +363,17 @@ def ensure_journal_schema(conn: Any) -> None:
     holds byte-parity with the Alembic revision.
     """
     if _schema_autocreate_enabled():
-        _exec(conn, _TABLE_DDL)
-        _exec(conn, _ACTIVE_ENTRY_INDEX_DDL)
-        conn.commit()
-        return
+        table_groups = ((JOURNAL_TABLE, (_TABLE_DDL, _ACTIVE_ENTRY_INDEX_DDL)),)
+        for table_name, statements in table_groups:
+            cur = _exec(conn, "SELECT to_regclass(%s) AS oid", (table_name,))
+            row = cur.fetchone() if hasattr(cur, "fetchone") else None
+            table_present = bool(_col(row, 0, "oid")) if row is not None else False
+            if table_present:
+                continue
+            for statement in statements:
+                _exec(conn, statement)
+            conn.commit()
+            return
     cur = _exec(conn, "SELECT to_regclass(%s) AS oid", (JOURNAL_TABLE,))
     row = cur.fetchone() if hasattr(cur, "fetchone") else None
     oid = _col(row, 0, "oid") if row is not None else None

--- a/app/heimdal/media_receipts.py
+++ b/app/heimdal/media_receipts.py
@@ -222,6 +222,17 @@ def _assert_pg_schema(conn: Any) -> None:
     oid = row[0] if row else None
     if not oid:
         raise MediaReceiptSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+    from app.heimdal.trigger_ownership import (
+        MEDIA_RECEIPT_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        MEDIA_RECEIPT_TRIGGER,
+        error_type=MediaReceiptSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
 
 
 def _bootstrap_pg(conn: Any) -> None:
@@ -229,45 +240,52 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            receipt_id text PRIMARY KEY,
-            capture_id text NOT NULL,
-            content_sha256 text NOT NULL,
-            raw_ref text NOT NULL,
-            kind text NOT NULL,
-            lane text NOT NULL,
-            admitted_at timestamptz NOT NULL DEFAULT now(),
-            trace_id text NOT NULL DEFAULT '',
-            payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            sequence bigserial NOT NULL
-        )
-        """
+    table_groups = (
+        (
+            _TABLE,
+            (
+                "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+                f"""
+                CREATE TABLE {_TABLE} (
+                    receipt_id text PRIMARY KEY,
+                    capture_id text NOT NULL,
+                    content_sha256 text NOT NULL,
+                    raw_ref text NOT NULL,
+                    kind text NOT NULL,
+                    lane text NOT NULL,
+                    admitted_at timestamptz NOT NULL DEFAULT now(),
+                    trace_id text NOT NULL DEFAULT '',
+                    payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    sequence bigserial NOT NULL
+                )
+                """,
+                f"CREATE INDEX heimdal_media_receipt_seq_idx ON {_TABLE} (sequence)",
+                f"CREATE INDEX heimdal_media_receipt_capture_id_idx ON {_TABLE} (capture_id)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_media_receipt_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_media_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_media_receipt_no_update
+                BEFORE UPDATE OR DELETE ON {_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_media_receipt_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_media_receipt_seq_idx ON {_TABLE} (sequence)")
-    cur.execute(
-        f"CREATE INDEX IF NOT EXISTS heimdal_media_receipt_capture_id_idx ON {_TABLE} (capture_id)"
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_media_receipt_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_media_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(f"DROP TRIGGER IF EXISTS heimdal_media_receipt_no_update ON {_TABLE}")
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_media_receipt_no_update
-        BEFORE UPDATE OR DELETE ON {_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_media_receipt_reject_mutation()
-        """
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 _SELECT_COLUMNS = (

--- a/app/heimdal/meeting_blocks.py
+++ b/app/heimdal/meeting_blocks.py
@@ -510,7 +510,25 @@ class _PgBlockStore:
         conn = _pg_connect()
         try:
             if _schema_autocreate_enabled():
-                conn.cursor().execute(_PG_AUTOCREATE_DDL)
+                cur = conn.cursor()
+                tables = (_BLOCK_TABLE, _NOTE_REVISION_TABLE, _REFUSAL_TABLE)
+                cur.execute(
+                    "SELECT " + ", ".join("to_regclass(%s)" for _ in tables),
+                    tables,
+                )
+                existing = cur.fetchone()
+                if existing and any(existing):
+                    _assert_pg_schema(conn)
+                else:
+                    table_groups = ((_BLOCK_TABLE, (_PG_AUTOCREATE_DDL,)),)
+                    for table_name, statements in table_groups:
+                        cur.execute("SELECT to_regclass(%s)", (table_name,))
+                        row = cur.fetchone()
+                        table_present = bool(row and row[0])
+                        if table_present:
+                            continue
+                        for statement in statements:
+                            cur.execute(statement)
             else:
                 _assert_pg_schema(conn)
         finally:

--- a/app/heimdal/meeting_ledger.py
+++ b/app/heimdal/meeting_ledger.py
@@ -522,7 +522,25 @@ class _PgLedgerStore:
         conn = _pg_connect()
         try:
             if _schema_autocreate_enabled():
-                conn.cursor().execute(_PG_AUTOCREATE_DDL)
+                cur = conn.cursor()
+                tables = (_SESSION_TABLE, _SEGMENT_TABLE, _CONFLICT_TABLE)
+                cur.execute(
+                    "SELECT " + ", ".join("to_regclass(%s)" for _ in tables),
+                    tables,
+                )
+                existing = cur.fetchone()
+                if existing and any(existing):
+                    _assert_pg_schema(conn)
+                else:
+                    table_groups = ((_SESSION_TABLE, (_PG_AUTOCREATE_DDL,)),)
+                    for table_name, statements in table_groups:
+                        cur.execute("SELECT to_regclass(%s)", (table_name,))
+                        row = cur.fetchone()
+                        table_present = bool(row and row[0])
+                        if table_present:
+                            continue
+                        for statement in statements:
+                            cur.execute(statement)
             else:
                 _assert_pg_schema(conn)
         finally:

--- a/app/heimdal/meeting_projection.py
+++ b/app/heimdal/meeting_projection.py
@@ -601,7 +601,25 @@ class _PgProjectionStore:
         conn = _pg_connect()
         try:
             if _schema_autocreate_enabled():
-                conn.cursor().execute(_PG_AUTOCREATE_DDL)
+                cur = conn.cursor()
+                tables = (_DERIVATION_TABLE, _REVISION_TABLE)
+                cur.execute(
+                    "SELECT " + ", ".join("to_regclass(%s)" for _ in tables),
+                    tables,
+                )
+                existing = cur.fetchone()
+                if existing and any(existing):
+                    _assert_pg_schema(conn)
+                else:
+                    table_groups = ((_DERIVATION_TABLE, (_PG_AUTOCREATE_DDL,)),)
+                    for table_name, statements in table_groups:
+                        cur.execute("SELECT to_regclass(%s)", (table_name,))
+                        row = cur.fetchone()
+                        table_present = bool(row and row[0])
+                        if table_present:
+                            continue
+                        for statement in statements:
+                            cur.execute(statement)
             else:
                 _assert_pg_schema(conn)
         finally:

--- a/app/heimdal/observation_log.py
+++ b/app/heimdal/observation_log.py
@@ -168,6 +168,17 @@ def _assert_pg_schema(conn: Any) -> None:
     oid = row[0] if row else None
     if not oid:
         raise ObservationLogSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+    from app.heimdal.trigger_ownership import (
+        OBSERVATION_LOG_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        OBSERVATION_LOG_TRIGGER,
+        error_type=ObservationLogSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
 
 
 def _bootstrap_pg(conn: Any) -> None:
@@ -175,42 +186,47 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            id uuid PRIMARY KEY,
-            topic text NOT NULL,
-            payload jsonb NOT NULL,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            sequence bigserial NOT NULL
-        )
-        """
+    table_groups = (
+        (
+            _TABLE,
+            (
+                "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+                f"""
+                CREATE TABLE {_TABLE} (
+                    id uuid PRIMARY KEY,
+                    topic text NOT NULL,
+                    payload jsonb NOT NULL,
+                    created_at timestamptz NOT NULL DEFAULT now(),
+                    sequence bigserial NOT NULL
+                )
+                """,
+                f"CREATE INDEX heimdal_observation_log_seq_idx ON {_TABLE} (sequence)",
+                f"CREATE INDEX heimdal_observation_log_topic_idx ON {_TABLE} (topic)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_observation_log_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_observation_log is append-only (HEIM-1): % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_observation_log_no_update
+                BEFORE UPDATE OR DELETE ON {_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_observation_log_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_observation_log_seq_idx ON {_TABLE} (sequence)")
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_observation_log_topic_idx ON {_TABLE} (topic)")
-    # Append-only enforcement at the DB level (HEIM-1): a trigger rejects any
-    # UPDATE/DELETE against the log table, independent of which role or code
-    # path issues the statement. This is defense in depth on top of "there is
-    # no update/delete method in this module's Python API".
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_observation_log_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_observation_log is append-only (HEIM-1): % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(f"DROP TRIGGER IF EXISTS heimdal_observation_log_no_update ON {_TABLE}")
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_observation_log_no_update
-        BEFORE UPDATE OR DELETE ON {_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_observation_log_reject_mutation()
-        """
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 class _PgObservationLog:

--- a/app/heimdal/raw_liveness.py
+++ b/app/heimdal/raw_liveness.py
@@ -696,6 +696,17 @@ def _assert_pg_schema(conn: Any) -> None:
             "Raw-liveness/deletion columns do not match the migration-owned schema. "
             + _MIGRATION_HINT
         )
+    from app.heimdal.trigger_ownership import (
+        RAW_DELETION_RECEIPT_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        RAW_DELETION_RECEIPT_TRIGGER,
+        error_type=RawLivenessSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
     cur.execute(
         """
         SELECT trigger_name
@@ -862,6 +873,7 @@ def _bootstrap_pg(conn: Any) -> None:
         return
     cur = conn.cursor()
     fixture_tables = (
+        _DELETION_RECEIPT_TABLE,
         _GENERATION_TABLE,
         _TOMBSTONE_TABLE,
         _LEASE_TABLE,
@@ -882,94 +894,93 @@ def _bootstrap_pg(conn: Any) -> None:
             "Test autocreate refuses to invent liveness generations for existing raw rows. "
             + _MIGRATION_HINT
         )
-    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_DELETION_RECEIPT_TABLE} (
-            id uuid PRIMARY KEY,
-            record_id uuid NOT NULL,
-            content_identity text NOT NULL,
-            reason text NOT NULL,
-            retention_window_days integer NOT NULL,
-            deleted_at timestamptz NOT NULL DEFAULT now(),
-            payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            sequence bigserial NOT NULL
-        )
-        """
+    deletion_receipt_groups = (
+        (
+            _DELETION_RECEIPT_TABLE,
+            (
+                "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+                f"""
+                CREATE TABLE {_DELETION_RECEIPT_TABLE} (
+                    id uuid PRIMARY KEY,
+                    record_id uuid NOT NULL,
+                    content_identity text NOT NULL,
+                    reason text NOT NULL,
+                    retention_window_days integer NOT NULL,
+                    deleted_at timestamptz NOT NULL DEFAULT now(),
+                    payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    sequence bigserial NOT NULL
+                )
+                """,
+                f"CREATE INDEX heimdal_raw_deletion_receipt_seq_idx "
+                f"ON {_DELETION_RECEIPT_TABLE} (sequence)",
+                f"CREATE INDEX heimdal_raw_deletion_receipt_record_id_idx "
+                f"ON {_DELETION_RECEIPT_TABLE} (record_id)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_raw_cleanup_queue_is_subsequence(
+                    old_payload jsonb, new_payload jsonb
+                ) RETURNS boolean AS $$
+                DECLARE
+                    old_refs text[] := ARRAY(
+                        SELECT jsonb_array_elements_text(COALESCE(old_payload, '[]'::jsonb))
+                    );
+                    new_ref text;
+                    old_index integer := 1;
+                    old_length integer := COALESCE(array_length(old_refs, 1), 0);
+                BEGIN
+                    FOR new_ref IN SELECT jsonb_array_elements_text(COALESCE(new_payload, '[]'::jsonb)) LOOP
+                        WHILE old_index <= old_length AND old_refs[old_index] <> new_ref LOOP
+                            old_index := old_index + 1;
+                        END LOOP;
+                        IF old_index > old_length THEN
+                            RETURN false;
+                        END IF;
+                        old_index := old_index + 1;
+                    END LOOP;
+                    RETURN true;
+                END;
+                $$ LANGUAGE plpgsql IMMUTABLE STRICT
+                """,
+                f"""
+                CREATE OR REPLACE FUNCTION heimdal_raw_deletion_receipt_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    IF TG_OP = 'UPDATE'
+                       AND current_setting('{_RETENTION_RECONCILE_GUARD_SETTING}', true) = 'true'
+                       AND NEW.id IS NOT DISTINCT FROM OLD.id
+                       AND NEW.record_id IS NOT DISTINCT FROM OLD.record_id
+                       AND NEW.content_identity IS NOT DISTINCT FROM OLD.content_identity
+                       AND NEW.reason IS NOT DISTINCT FROM OLD.reason
+                       AND NEW.retention_window_days IS NOT DISTINCT FROM OLD.retention_window_days
+                       AND NEW.deleted_at IS NOT DISTINCT FROM OLD.deleted_at
+                       AND NEW.sequence IS NOT DISTINCT FROM OLD.sequence
+                       AND (NEW.payload - 'cold_cleanup_location_refs')
+                           IS NOT DISTINCT FROM (OLD.payload - 'cold_cleanup_location_refs')
+                       AND heimdal_raw_cleanup_queue_is_subsequence(
+                           OLD.payload->'cold_cleanup_location_refs',
+                           NEW.payload->'cold_cleanup_location_refs'
+                       ) THEN
+                        RETURN NEW;
+                    END IF;
+                    RAISE EXCEPTION 'heimdal_raw_deletion_receipt is append-only: % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_deletion_receipt_no_update
+                BEFORE UPDATE OR DELETE ON {_DELETION_RECEIPT_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_deletion_receipt_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(
-        f"CREATE INDEX IF NOT EXISTS heimdal_raw_deletion_receipt_seq_idx "
-        f"ON {_DELETION_RECEIPT_TABLE} (sequence)"
-    )
-    cur.execute(
-        f"CREATE INDEX IF NOT EXISTS heimdal_raw_deletion_receipt_record_id_idx "
-        f"ON {_DELETION_RECEIPT_TABLE} (record_id)"
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_cleanup_queue_is_subsequence(
-            old_payload jsonb, new_payload jsonb
-        ) RETURNS boolean AS $$
-        DECLARE
-            old_refs text[] := ARRAY(
-                SELECT jsonb_array_elements_text(COALESCE(old_payload, '[]'::jsonb))
-            );
-            new_ref text;
-            old_index integer := 1;
-            old_length integer := COALESCE(array_length(old_refs, 1), 0);
-        BEGIN
-            FOR new_ref IN SELECT jsonb_array_elements_text(COALESCE(new_payload, '[]'::jsonb)) LOOP
-                WHILE old_index <= old_length AND old_refs[old_index] <> new_ref LOOP
-                    old_index := old_index + 1;
-                END LOOP;
-                IF old_index > old_length THEN
-                    RETURN false;
-                END IF;
-                old_index := old_index + 1;
-            END LOOP;
-            RETURN true;
-        END;
-        $$ LANGUAGE plpgsql IMMUTABLE STRICT
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE OR REPLACE FUNCTION heimdal_raw_deletion_receipt_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            IF TG_OP = 'UPDATE'
-               AND current_setting('{_RETENTION_RECONCILE_GUARD_SETTING}', true) = 'true'
-               AND NEW.id IS NOT DISTINCT FROM OLD.id
-               AND NEW.record_id IS NOT DISTINCT FROM OLD.record_id
-               AND NEW.content_identity IS NOT DISTINCT FROM OLD.content_identity
-               AND NEW.reason IS NOT DISTINCT FROM OLD.reason
-               AND NEW.retention_window_days IS NOT DISTINCT FROM OLD.retention_window_days
-               AND NEW.deleted_at IS NOT DISTINCT FROM OLD.deleted_at
-               AND NEW.sequence IS NOT DISTINCT FROM OLD.sequence
-               AND (NEW.payload - 'cold_cleanup_location_refs')
-                   IS NOT DISTINCT FROM (OLD.payload - 'cold_cleanup_location_refs')
-               AND heimdal_raw_cleanup_queue_is_subsequence(
-                   OLD.payload->'cold_cleanup_location_refs',
-                   NEW.payload->'cold_cleanup_location_refs'
-               ) THEN
-                RETURN NEW;
-            END IF;
-            RAISE EXCEPTION 'heimdal_raw_deletion_receipt is append-only: % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"DROP TRIGGER IF EXISTS heimdal_raw_deletion_receipt_no_update "
-        f"ON {_DELETION_RECEIPT_TABLE}"
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_deletion_receipt_no_update
-        BEFORE UPDATE OR DELETE ON {_DELETION_RECEIPT_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_deletion_receipt_reject_mutation()
-        """
-    )
+    for receipt_table_name, receipt_statements in deletion_receipt_groups:
+        cur.execute("SELECT to_regclass(%s)", (receipt_table_name,))
+        receipt_row = cur.fetchone()
+        receipt_table_present = bool(receipt_row and receipt_row[0])
+        if receipt_table_present:
+            continue
+        for receipt_statement in receipt_statements:
+            cur.execute(receipt_statement)
     generation_table_groups = (
         (
             _GENERATION_TABLE,
@@ -1089,96 +1100,173 @@ def _bootstrap_pg(conn: Any) -> None:
                 END;
                 $$ LANGUAGE plpgsql
                 """,
-                "DROP TRIGGER IF EXISTS heimdal_raw_representation_no_mutation "
-                "ON heimdal_raw_representation",
+                f"CREATE INDEX heimdal_raw_liveness_generation_record_idx "
+                f"ON {_GENERATION_TABLE} (record_id)",
                 """
-                CREATE TRIGGER heimdal_raw_representation_no_mutation
-                BEFORE INSERT OR UPDATE OR DELETE ON heimdal_raw_representation
-                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_representation_reject_mutation()
+                CREATE OR REPLACE FUNCTION heimdal_raw_liveness_generation_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_raw_liveness_generation is append-only: % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_liveness_generation_no_mutation
+                BEFORE UPDATE OR DELETE ON {_GENERATION_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_liveness_generation_reject_mutation()
                 """,
             ),
         ),
     )
-    for table_name, statements in generation_table_groups:
-        cur.execute("SELECT to_regclass(%s)", (table_name,))
-        table_present_row = cur.fetchone()
-        table_present = bool(table_present_row and table_present_row[0])
-        if table_present:
+    for generation_table_name, generation_statements in generation_table_groups:
+        cur.execute("SELECT to_regclass(%s)", (generation_table_name,))
+        generation_table_row = cur.fetchone()
+        generation_table_present = bool(generation_table_row and generation_table_row[0])
+        if generation_table_present:
             continue
-        for statement in statements:
-            cur.execute(statement)
-    cur.execute(
-        f"CREATE INDEX heimdal_raw_liveness_generation_record_idx "
-        f"ON {_GENERATION_TABLE} (record_id)"
+        for generation_statement in generation_statements:
+            cur.execute(generation_statement)
+    authority_table_groups = (
+        (
+            _TOMBSTONE_TABLE,
+            (
+                f"""
+                CREATE TABLE {_TOMBSTONE_TABLE} (
+                    id uuid PRIMARY KEY,
+                    content_identity text NOT NULL,
+                    generation integer NOT NULL,
+                    record_id uuid NOT NULL UNIQUE,
+                    raw_ref text NOT NULL UNIQUE,
+                    deletion_receipt_id uuid NOT NULL UNIQUE
+                        REFERENCES {_DELETION_RECEIPT_TABLE}(id) ON DELETE RESTRICT,
+                    reason text NOT NULL,
+                    erased_at timestamptz NOT NULL,
+                    sequence bigserial NOT NULL,
+                    FOREIGN KEY (content_identity, generation)
+                        REFERENCES {_GENERATION_TABLE}(content_identity, generation)
+                        ON DELETE RESTRICT
+                )
+                """,
+                f"CREATE INDEX heimdal_raw_deletion_tombstone_identity_idx "
+                f"ON {_TOMBSTONE_TABLE} (content_identity, generation)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_raw_deletion_tombstone_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_raw_deletion_tombstone is append-only: % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_deletion_tombstone_no_mutation
+                BEFORE UPDATE OR DELETE ON {_TOMBSTONE_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_deletion_tombstone_reject_mutation()
+                """,
+            ),
+        ),
+        (
+            _LEASE_TABLE,
+            (
+                f"""
+                CREATE TABLE {_LEASE_TABLE} (
+                    lease_id uuid PRIMARY KEY,
+                    content_identity text NOT NULL,
+                    generation integer NOT NULL,
+                    record_id uuid NOT NULL,
+                    raw_ref text NOT NULL,
+                    issued_at timestamptz NOT NULL,
+                    expires_at timestamptz NOT NULL CHECK (expires_at > issued_at),
+                    sequence bigserial NOT NULL,
+                    FOREIGN KEY (content_identity, generation)
+                        REFERENCES {_GENERATION_TABLE}(content_identity, generation)
+                        ON DELETE RESTRICT
+                )
+                """,
+                f"CREATE INDEX heimdal_raw_response_lease_active_idx "
+                f"ON {_LEASE_TABLE} (record_id, expires_at)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_raw_response_lease_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_raw_response_lease is append-only: % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_response_lease_no_mutation
+                BEFORE UPDATE OR DELETE ON {_LEASE_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_response_lease_reject_mutation()
+                """,
+                f"""
+                CREATE OR REPLACE FUNCTION heimdal_raw_response_lease_reject_retiring()
+                RETURNS trigger AS $$
+                BEGIN
+                    PERFORM pg_advisory_xact_lock(hashtextextended(NEW.content_identity, 0));
+                    IF EXISTS (
+                        SELECT 1 FROM {_RETENTION_CLAIM_TABLE}
+                        WHERE record_id = NEW.record_id
+                    ) THEN
+                        RAISE EXCEPTION
+                            'heimdal_raw_response_lease cannot be issued for a retiring raw generation';
+                    END IF;
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_response_lease_reject_retiring
+                BEFORE INSERT ON {_LEASE_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_response_lease_reject_retiring()
+                """,
+            ),
+        ),
+        (
+            _RETENTION_CLAIM_TABLE,
+            (
+                f"""
+                CREATE TABLE {_RETENTION_CLAIM_TABLE} (
+                    id uuid PRIMARY KEY,
+                    content_identity text NOT NULL,
+                    generation integer NOT NULL,
+                    record_id uuid NOT NULL UNIQUE,
+                    raw_ref text NOT NULL UNIQUE,
+                    reason text NOT NULL,
+                    retention_window_days integer NOT NULL,
+                    claimed_at timestamptz NOT NULL,
+                    drain_after timestamptz NOT NULL,
+                    payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    sequence bigserial NOT NULL,
+                    FOREIGN KEY (content_identity, generation)
+                        REFERENCES {_GENERATION_TABLE}(content_identity, generation)
+                        ON DELETE RESTRICT
+                )
+                """,
+                f"CREATE INDEX heimdal_raw_retention_claim_record_idx "
+                f"ON {_RETENTION_CLAIM_TABLE} (record_id)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_raw_retention_claim_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_raw_retention_claim is append-only: % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_retention_claim_no_mutation
+                BEFORE UPDATE OR DELETE ON {_RETENTION_CLAIM_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_retention_claim_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(
-        f"""
-        CREATE TABLE {_TOMBSTONE_TABLE} (
-            id uuid PRIMARY KEY,
-            content_identity text NOT NULL,
-            generation integer NOT NULL,
-            record_id uuid NOT NULL UNIQUE,
-            raw_ref text NOT NULL UNIQUE,
-            deletion_receipt_id uuid NOT NULL UNIQUE
-                REFERENCES {_DELETION_RECEIPT_TABLE}(id) ON DELETE RESTRICT,
-            reason text NOT NULL,
-            erased_at timestamptz NOT NULL,
-            sequence bigserial NOT NULL,
-            FOREIGN KEY (content_identity, generation)
-                REFERENCES {_GENERATION_TABLE}(content_identity, generation)
-                ON DELETE RESTRICT
-        )
-        """
-    )
-    cur.execute(
-        f"CREATE INDEX heimdal_raw_deletion_tombstone_identity_idx "
-        f"ON {_TOMBSTONE_TABLE} (content_identity, generation)"
-    )
-    cur.execute(
-        f"""
-        CREATE TABLE {_LEASE_TABLE} (
-            lease_id uuid PRIMARY KEY,
-            content_identity text NOT NULL,
-            generation integer NOT NULL,
-            record_id uuid NOT NULL,
-            raw_ref text NOT NULL,
-            issued_at timestamptz NOT NULL,
-            expires_at timestamptz NOT NULL CHECK (expires_at > issued_at),
-            sequence bigserial NOT NULL,
-            FOREIGN KEY (content_identity, generation)
-                REFERENCES {_GENERATION_TABLE}(content_identity, generation)
-                ON DELETE RESTRICT
-        )
-        """
-    )
-    cur.execute(
-        f"CREATE INDEX heimdal_raw_response_lease_active_idx "
-        f"ON {_LEASE_TABLE} (record_id, expires_at)"
-    )
-    cur.execute(
-        f"""
-        CREATE TABLE {_RETENTION_CLAIM_TABLE} (
-            id uuid PRIMARY KEY,
-            content_identity text NOT NULL,
-            generation integer NOT NULL,
-            record_id uuid NOT NULL UNIQUE,
-            raw_ref text NOT NULL UNIQUE,
-            reason text NOT NULL,
-            retention_window_days integer NOT NULL,
-            claimed_at timestamptz NOT NULL,
-            drain_after timestamptz NOT NULL,
-            payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            sequence bigserial NOT NULL,
-            FOREIGN KEY (content_identity, generation)
-                REFERENCES {_GENERATION_TABLE}(content_identity, generation)
-                ON DELETE RESTRICT
-        )
-        """
-    )
-    cur.execute(
-        f"CREATE INDEX heimdal_raw_retention_claim_record_idx "
-        f"ON {_RETENTION_CLAIM_TABLE} (record_id)"
-    )
+    for authority_table_name, authority_statements in authority_table_groups:
+        cur.execute("SELECT to_regclass(%s)", (authority_table_name,))
+        authority_row = cur.fetchone()
+        authority_table_present = bool(authority_row and authority_row[0])
+        if authority_table_present:
+            continue
+        for authority_statement in authority_statements:
+            cur.execute(authority_statement)
     consent_association_table_groups = (
         (
             _CONSENT_ASSOCIATION_TABLE,
@@ -1268,117 +1356,6 @@ def _bootstrap_pg(conn: Any) -> None:
             continue
         for statement in consent_statements:
             cur.execute(statement)
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_liveness_generation_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_raw_liveness_generation is append-only: % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_liveness_generation_no_mutation
-        BEFORE UPDATE OR DELETE ON {_GENERATION_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_liveness_generation_reject_mutation()
-        """
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_deletion_tombstone_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_raw_deletion_tombstone is append-only: % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_deletion_tombstone_no_mutation
-        BEFORE UPDATE OR DELETE ON {_TOMBSTONE_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_deletion_tombstone_reject_mutation()
-        """
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_response_lease_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_raw_response_lease is append-only: % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_response_lease_no_mutation
-        BEFORE UPDATE OR DELETE ON {_LEASE_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_response_lease_reject_mutation()
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE OR REPLACE FUNCTION heimdal_raw_response_lease_reject_retiring()
-        RETURNS trigger AS $$
-        BEGIN
-            PERFORM pg_advisory_xact_lock(hashtextextended(NEW.content_identity, 0));
-            IF EXISTS (
-                SELECT 1 FROM {_RETENTION_CLAIM_TABLE}
-                WHERE record_id = NEW.record_id
-            ) THEN
-                RAISE EXCEPTION
-                    'heimdal_raw_response_lease cannot be issued for a retiring raw generation';
-            END IF;
-            RETURN NEW;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_response_lease_reject_retiring
-        BEFORE INSERT ON {_LEASE_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_response_lease_reject_retiring()
-        """
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_retention_claim_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_raw_retention_claim is append-only: % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_retention_claim_no_mutation
-        BEFORE UPDATE OR DELETE ON {_RETENTION_CLAIM_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_retention_claim_reject_mutation()
-        """
-    )
-    cur.execute(
-        f"""
-        CREATE OR REPLACE FUNCTION heimdal_raw_record_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            IF TG_OP = 'DELETE'
-               AND current_setting('{_RETENTION_GUARD_SETTING}', true) = 'true'
-               AND EXISTS (
-                   SELECT 1 FROM {_TOMBSTONE_TABLE} WHERE record_id = OLD.id
-               ) THEN
-                RETURN OLD;
-            END IF;
-            RAISE EXCEPTION 'heimdal_raw_record is append-only: % is not permitted '
-                'outside the governed tombstone transaction', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
     _assert_pg_schema(conn)
 
 

--- a/app/heimdal/raw_liveness.py
+++ b/app/heimdal/raw_liveness.py
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import threading
+import textwrap
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Iterable, Iterator, Literal, Mapping, Optional
@@ -65,6 +66,12 @@ _MIGRATION_HINT = (
     "database. See revisions c5d8a1e4f2b7, e2f3a4b5c6d7, f4b6c8d0e2a1, "
     "and a9d7c5e3b1f0."
 )
+
+
+def _migration_fixture_sql(sql: str) -> str:
+    """Render test-fixture function SQL with Alembic's stored body indentation."""
+
+    return textwrap.indent(textwrap.dedent(sql), "        ")
 
 _RECEIPT_TRIGGER_BODY = (
     "if tg_op = 'update' and current_setting('app.heimdal_retention_reconcile', true) = 'true' "
@@ -915,7 +922,7 @@ def _bootstrap_pg(conn: Any) -> None:
                 f"ON {_DELETION_RECEIPT_TABLE} (sequence)",
                 f"CREATE INDEX heimdal_raw_deletion_receipt_record_id_idx "
                 f"ON {_DELETION_RECEIPT_TABLE} (record_id)",
-                """
+                _migration_fixture_sql("""
                 CREATE OR REPLACE FUNCTION heimdal_raw_cleanup_queue_is_subsequence(
                     old_payload jsonb, new_payload jsonb
                 ) RETURNS boolean AS $$
@@ -939,8 +946,8 @@ def _bootstrap_pg(conn: Any) -> None:
                     RETURN true;
                 END;
                 $$ LANGUAGE plpgsql IMMUTABLE STRICT
-                """,
-                f"""
+                """),
+                _migration_fixture_sql(f"""
                 CREATE OR REPLACE FUNCTION heimdal_raw_deletion_receipt_reject_mutation()
                 RETURNS trigger AS $$
                 BEGIN
@@ -964,7 +971,7 @@ def _bootstrap_pg(conn: Any) -> None:
                     RAISE EXCEPTION 'heimdal_raw_deletion_receipt is append-only: % is not permitted', TG_OP;
                 END;
                 $$ LANGUAGE plpgsql
-                """,
+                """),
                 f"""
                 CREATE TRIGGER heimdal_raw_deletion_receipt_no_update
                 BEFORE UPDATE OR DELETE ON {_DELETION_RECEIPT_TABLE}

--- a/app/heimdal/raw_read_gate.py
+++ b/app/heimdal/raw_read_gate.py
@@ -236,6 +236,17 @@ def _assert_pg_schema(conn: Any) -> None:
     oid = row[0] if row else None
     if not oid:
         raise RawReadReceiptSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+    from app.heimdal.trigger_ownership import (
+        RAW_READ_RECEIPT_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        RAW_READ_RECEIPT_TRIGGER,
+        error_type=RawReadReceiptSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
 
 
 def _bootstrap_pg(conn: Any) -> None:
@@ -243,43 +254,50 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            id uuid PRIMARY KEY,
-            raw_ref text NOT NULL,
-            content_identity text NOT NULL,
-            reader text NOT NULL,
-            purpose text NOT NULL,
-            read_at timestamptz NOT NULL DEFAULT now(),
-            payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-            sequence bigserial NOT NULL
-        )
-        """
+    table_groups = (
+        (
+            _TABLE,
+            (
+                "CREATE EXTENSION IF NOT EXISTS pgcrypto",
+                f"""
+                CREATE TABLE {_TABLE} (
+                    id uuid PRIMARY KEY,
+                    raw_ref text NOT NULL,
+                    content_identity text NOT NULL,
+                    reader text NOT NULL,
+                    purpose text NOT NULL,
+                    read_at timestamptz NOT NULL DEFAULT now(),
+                    payload jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+                    sequence bigserial NOT NULL
+                )
+                """,
+                f"CREATE INDEX heimdal_raw_read_receipt_seq_idx ON {_TABLE} (sequence)",
+                f"CREATE INDEX heimdal_raw_read_receipt_raw_ref_idx ON {_TABLE} (raw_ref)",
+                """
+                CREATE OR REPLACE FUNCTION heimdal_raw_read_receipt_reject_mutation()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'heimdal_raw_read_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
+                END;
+                $$ LANGUAGE plpgsql
+                """,
+                f"""
+                CREATE TRIGGER heimdal_raw_read_receipt_no_update
+                BEFORE UPDATE OR DELETE ON {_TABLE}
+                FOR EACH ROW EXECUTE FUNCTION heimdal_raw_read_receipt_reject_mutation()
+                """,
+            ),
+        ),
     )
-    cur.execute(f"CREATE INDEX IF NOT EXISTS heimdal_raw_read_receipt_seq_idx ON {_TABLE} (sequence)")
-    cur.execute(
-        f"CREATE INDEX IF NOT EXISTS heimdal_raw_read_receipt_raw_ref_idx ON {_TABLE} (raw_ref)"
-    )
-    cur.execute(
-        """
-        CREATE OR REPLACE FUNCTION heimdal_raw_read_receipt_reject_mutation()
-        RETURNS trigger AS $$
-        BEGIN
-            RAISE EXCEPTION 'heimdal_raw_read_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
-        END;
-        $$ LANGUAGE plpgsql
-        """
-    )
-    cur.execute(f"DROP TRIGGER IF EXISTS heimdal_raw_read_receipt_no_update ON {_TABLE}")
-    cur.execute(
-        f"""
-        CREATE TRIGGER heimdal_raw_read_receipt_no_update
-        BEFORE UPDATE OR DELETE ON {_TABLE}
-        FOR EACH ROW EXECUTE FUNCTION heimdal_raw_read_receipt_reject_mutation()
-        """
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 def _row_from_db(row: tuple) -> RawReadReceipt:

--- a/app/heimdal/raw_store.py
+++ b/app/heimdal/raw_store.py
@@ -2048,6 +2048,17 @@ def _assert_pg_schema(conn: Any, *, allow_legacy_reconciliation: bool = False) -
         raise RawStoreSchemaMissingError(
             "Missing raw identity or representation table. " + _MIGRATION_HINT
         )
+    from app.heimdal.trigger_ownership import (
+        RAW_RECORD_TRIGGER,
+        assert_migration_owned_reject_mutation_trigger,
+    )
+
+    assert_migration_owned_reject_mutation_trigger(
+        conn,
+        RAW_RECORD_TRIGGER,
+        error_type=RawStoreSchemaMissingError,
+        migration_hint=_MIGRATION_HINT,
+    )
 
     cur.execute(
         """
@@ -2443,11 +2454,15 @@ def _bootstrap_pg(conn: Any) -> None:
                 RETURNS trigger AS $$
                 BEGIN
                     IF TG_OP = 'DELETE'
-                       AND current_setting('{_RETENTION_GUARD_SETTING}', true) = 'true' THEN
+                       AND current_setting('{_RETENTION_GUARD_SETTING}', true) = 'true'
+                       AND EXISTS (
+                           SELECT 1 FROM {_TOMBSTONE_TABLE}
+                           WHERE record_id = OLD.id
+                       ) THEN
                         RETURN OLD;
                     END IF;
                     RAISE EXCEPTION 'heimdal_raw_record is append-only (HEIM-1): % is not permitted '
-                        'outside the governed hard-retention job (D-RETENTION)', TG_OP;
+                        'outside the governed tombstone transaction', TG_OP;
                 END;
                 $$ LANGUAGE plpgsql
                 """,

--- a/app/heimdal/trigger_ownership.py
+++ b/app/heimdal/trigger_ownership.py
@@ -1,0 +1,216 @@
+"""Read-only authentication for Alembic-owned append-only triggers.
+
+Runtime code may create these objects only while producing a genuinely absent
+test-fixture table.  Once the table exists, Alembic is the sole DDL owner and
+the runtime's only authority is to authenticate the catalog shape or fail.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RejectMutationTrigger:
+    table: str
+    trigger: str
+    function: str
+    body: str
+
+
+_CATALOG_SQL = """
+SELECT
+    table_ns.nspname,
+    table_class.relname,
+    trigger.tgname,
+    trigger.tgtype,
+    trigger.tgenabled,
+    trigger.tgattr::text,
+    trigger.tgqual IS NULL,
+    function_ns.nspname = table_ns.nspname,
+    function.proname,
+    function.prokind,
+    function.prorettype = 'trigger'::regtype,
+    function.pronargs,
+    function.proargtypes::text,
+    language.lanname,
+    function.provolatile,
+    function.proisstrict,
+    function.prosecdef,
+    function.proleakproof,
+    function.proparallel,
+    function.proconfig,
+    function.prosrc
+FROM pg_trigger AS trigger
+JOIN pg_class AS table_class ON table_class.oid = trigger.tgrelid
+JOIN pg_namespace AS table_ns ON table_ns.oid = table_class.relnamespace
+JOIN pg_proc AS function ON function.oid = trigger.tgfoid
+JOIN pg_namespace AS function_ns ON function_ns.oid = function.pronamespace
+JOIN pg_language AS language ON language.oid = function.prolang
+WHERE trigger.tgrelid = to_regclass(%s)
+  AND table_ns.nspname = current_schema()
+  AND trigger.tgname = %s
+  AND NOT trigger.tgisinternal
+"""
+
+
+def _canonical_body(value: object) -> str:
+    """Remove only wrapper indentation; preserve every body character.
+
+    Collapsing SQL whitespace is unsafe because whitespace inside a quoted
+    string is data. PostgreSQL preserves the dollar-quoted ``prosrc`` text, so
+    dedenting the common Python/migration wrapper and normalizing line endings
+    is sufficient while keeping literals and statement layout exact.
+    """
+
+    body = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    return textwrap.dedent(body).strip()
+
+
+def assert_migration_owned_reject_mutation_trigger(
+    conn: Any,
+    spec: RejectMutationTrigger,
+    *,
+    error_type: type[RuntimeError],
+    migration_hint: str,
+) -> None:
+    """Authenticate one exact row-level BEFORE UPDATE OR DELETE trigger.
+
+    ``tgenabled`` admits PostgreSQL's two origin-active modes (``O`` and
+    ``A``).  Every other trigger and function attribute, including the full
+    ``prosrc`` body modulo insignificant whitespace, is exact.
+    """
+
+    cur = conn.cursor()
+    cur.execute(_CATALOG_SQL, (spec.table, spec.trigger))
+    rows = cur.fetchall()
+    expected = (
+        "public",
+        spec.table,
+        spec.trigger,
+        27,  # ROW | BEFORE | DELETE | UPDATE
+        "",
+        True,
+        True,
+        spec.function,
+        "f",
+        True,
+        0,
+        "",
+        "plpgsql",
+        "v",
+        False,
+        False,
+        False,
+        "u",
+        None,
+    )
+    valid = False
+    if len(rows) == 1:
+        row = rows[0]
+        valid = (
+            tuple(row[:4]) == expected[:4]
+            and row[4] in {"O", "A"}
+            and tuple(row[5:20]) == expected[4:]
+            and _canonical_body(row[20]) == _canonical_body(spec.body)
+        )
+    if not valid:
+        raise error_type(
+            f"Trigger '{spec.trigger}' on '{spec.table}' does not match its "
+            f"Alembic-owned definition. {migration_hint}"
+        )
+
+
+CONSENT_GRANT_TRIGGER = RejectMutationTrigger(
+    table="heimdal_consent_grant",
+    trigger="heimdal_consent_grant_no_update",
+    function="heimdal_consent_grant_reject_mutation",
+    body="""
+    BEGIN
+        RAISE EXCEPTION 'heimdal_consent_grant is append-only (HEIM-1): % is not permitted', TG_OP;
+    END;
+    """,
+)
+
+MEDIA_RECEIPT_TRIGGER = RejectMutationTrigger(
+    table="heimdal_media_receipt",
+    trigger="heimdal_media_receipt_no_update",
+    function="heimdal_media_receipt_reject_mutation",
+    body="""
+    BEGIN
+        RAISE EXCEPTION 'heimdal_media_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
+    END;
+    """,
+)
+
+OBSERVATION_LOG_TRIGGER = RejectMutationTrigger(
+    table="heimdal_observation_log",
+    trigger="heimdal_observation_log_no_update",
+    function="heimdal_observation_log_reject_mutation",
+    body="""
+    BEGIN
+        RAISE EXCEPTION 'heimdal_observation_log is append-only (HEIM-1): % is not permitted', TG_OP;
+    END;
+    """,
+)
+
+RAW_READ_RECEIPT_TRIGGER = RejectMutationTrigger(
+    table="heimdal_raw_read_receipt",
+    trigger="heimdal_raw_read_receipt_no_update",
+    function="heimdal_raw_read_receipt_reject_mutation",
+    body="""
+    BEGIN
+        RAISE EXCEPTION 'heimdal_raw_read_receipt is append-only (HEIM-1): % is not permitted', TG_OP;
+    END;
+    """,
+)
+
+RAW_DELETION_RECEIPT_TRIGGER = RejectMutationTrigger(
+    table="heimdal_raw_deletion_receipt",
+    trigger="heimdal_raw_deletion_receipt_no_update",
+    function="heimdal_raw_deletion_receipt_reject_mutation",
+    body="""
+    BEGIN
+        IF TG_OP = 'UPDATE'
+           AND current_setting('app.heimdal_retention_reconcile', true) = 'true'
+           AND NEW.id IS NOT DISTINCT FROM OLD.id
+           AND NEW.record_id IS NOT DISTINCT FROM OLD.record_id
+           AND NEW.content_identity IS NOT DISTINCT FROM OLD.content_identity
+           AND NEW.reason IS NOT DISTINCT FROM OLD.reason
+           AND NEW.retention_window_days IS NOT DISTINCT FROM OLD.retention_window_days
+           AND NEW.deleted_at IS NOT DISTINCT FROM OLD.deleted_at
+           AND NEW.sequence IS NOT DISTINCT FROM OLD.sequence
+           AND (NEW.payload - 'cold_cleanup_location_refs')
+               IS NOT DISTINCT FROM (OLD.payload - 'cold_cleanup_location_refs')
+           AND heimdal_raw_cleanup_queue_is_subsequence(
+               OLD.payload->'cold_cleanup_location_refs',
+               NEW.payload->'cold_cleanup_location_refs'
+           ) THEN
+            RETURN NEW;
+        END IF;
+        RAISE EXCEPTION 'heimdal_raw_deletion_receipt is append-only: % is not permitted', TG_OP;
+    END;
+    """,
+)
+
+RAW_RECORD_TRIGGER = RejectMutationTrigger(
+    table="heimdal_raw_record",
+    trigger="heimdal_raw_record_no_update",
+    function="heimdal_raw_record_reject_mutation",
+    body="""
+    BEGIN
+        IF TG_OP = 'DELETE'
+           AND current_setting('app.heimdal_retention_bypass', true) = 'true'
+           AND EXISTS (
+               SELECT 1 FROM heimdal_raw_deletion_tombstone
+               WHERE record_id = OLD.id
+           ) THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION 'heimdal_raw_record is append-only (HEIM-1): % is not permitted '
+            'outside the governed tombstone transaction', TG_OP;
+    END;
+    """,
+)

--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -592,42 +592,52 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            request_id TEXT PRIMARY KEY,
-            source_kind TEXT NOT NULL,
-            item_ref TEXT NOT NULL,
-            source_ref TEXT NOT NULL,
-            status TEXT NOT NULL DEFAULT 'pending',
-            priority TEXT NOT NULL DEFAULT 'normal',
-            requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-            completed_at TIMESTAMPTZ,
-            attempts INTEGER NOT NULL DEFAULT 0,
-            next_attempt_at TIMESTAMPTZ,
-            last_failure JSONB,
-            discovery_triggers JSONB NOT NULL DEFAULT '[]'::jsonb,
-            policy_snapshot JSONB NOT NULL DEFAULT '{{}}'::jsonb,
-            policy_version INTEGER NOT NULL DEFAULT 1,
-            trace_id TEXT,
-            content_identity TEXT,
-            artifact_path TEXT,
-            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-            CONSTRAINT acquisition_requests_status_chk CHECK (
-                status IN ('pending', 'in_progress', 'completed', 'dead_lettered')
+    table_groups = (
+        (
+            _TABLE,
+            (
+                f"""
+                CREATE TABLE {_TABLE} (
+                    request_id TEXT PRIMARY KEY,
+                    source_kind TEXT NOT NULL,
+                    item_ref TEXT NOT NULL,
+                    source_ref TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    priority TEXT NOT NULL DEFAULT 'normal',
+                    requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    completed_at TIMESTAMPTZ,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at TIMESTAMPTZ,
+                    last_failure JSONB,
+                    discovery_triggers JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    policy_snapshot JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+                    policy_version INTEGER NOT NULL DEFAULT 1,
+                    trace_id TEXT,
+                    content_identity TEXT,
+                    artifact_path TEXT,
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    CONSTRAINT acquisition_requests_status_chk CHECK (
+                        status IN ('pending', 'in_progress', 'completed', 'dead_lettered')
+                    ),
+                    CONSTRAINT acquisition_requests_priority_chk CHECK (priority IN ('high', 'normal'))
+                )
+                """,
+                f"CREATE INDEX acquisition_requests_drain_idx ON {_TABLE} "
+                "(status, priority, requested_at)",
+                f"CREATE UNIQUE INDEX acquisition_requests_identity_uq ON {_TABLE} "
+                "(source_kind, item_ref, policy_version)",
             ),
-            CONSTRAINT acquisition_requests_priority_chk CHECK (priority IN ('high', 'normal'))
-        )
-        """
+        ),
     )
-    cur.execute(
-        f"CREATE INDEX IF NOT EXISTS acquisition_requests_drain_idx "
-        f"ON {_TABLE} (status, priority, requested_at)"
-    )
-    cur.execute(
-        f"CREATE UNIQUE INDEX IF NOT EXISTS acquisition_requests_identity_uq "
-        f"ON {_TABLE} (source_kind, item_ref, policy_version)"
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 def _iso_or_none(value: Any) -> str | None:

--- a/app/knowledge_acquisition/source_registry.py
+++ b/app/knowledge_acquisition/source_registry.py
@@ -786,9 +786,12 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
+    table_groups = (
+        (
+            _TABLE,
+            (
+                f"""
+                CREATE TABLE {_TABLE} (
             binding_id TEXT PRIMARY KEY,
             account_binding_id TEXT,
             collection_kind TEXT NOT NULL,
@@ -829,23 +832,28 @@ def _bootstrap_pg(conn: Any) -> None:
                 account_binding_id IS NULL OR account_binding_id ~
                 '^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$'
             )
-        )
-        """
+                )
+                """,
+                "CREATE UNIQUE INDEX acquisition_source_registry_binding_triple_uq "
+                f"ON {_TABLE} (collection_kind, collection_ref, "
+                f"COALESCE(account_binding_id, '{_NULL_ACCOUNT_SENTINEL}'))",
+                "CREATE UNIQUE INDEX acquisition_source_registry_single_inbox_uq "
+                f"ON {_TABLE} (COALESCE(account_binding_id, '{_NULL_ACCOUNT_SENTINEL}')) "
+                "WHERE collection_kind = 'inbox_playlist' AND enabled = true",
+                f"CREATE INDEX acquisition_source_registry_account_idx ON {_TABLE} "
+                "(account_binding_id)",
+            ),
+        ),
     )
-    cur.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS acquisition_source_registry_binding_triple_uq "
-        f"ON {_TABLE} (collection_kind, collection_ref, "
-        f"COALESCE(account_binding_id, '{_NULL_ACCOUNT_SENTINEL}'))"
-    )
-    cur.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS acquisition_source_registry_single_inbox_uq "
-        f"ON {_TABLE} (COALESCE(account_binding_id, '{_NULL_ACCOUNT_SENTINEL}')) "
-        "WHERE collection_kind = 'inbox_playlist' AND enabled = true"
-    )
-    cur.execute(
-        "CREATE INDEX IF NOT EXISTS acquisition_source_registry_account_idx "
-        f"ON {_TABLE} (account_binding_id)"
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 def _row_to_binding(row: tuple[Any, ...]) -> SourceBinding:

--- a/app/knowledge_acquisition/youtube_account_binding.py
+++ b/app/knowledge_acquisition/youtube_account_binding.py
@@ -242,30 +242,42 @@ def _bootstrap_pg(conn: Any) -> None:
         _assert_pg_schema(conn)
         return
     cur = conn.cursor()
-    cur.execute(
-        f"""
-        CREATE TABLE IF NOT EXISTS {_TABLE} (
-            account_binding_id TEXT PRIMARY KEY,
-            provider TEXT NOT NULL,
-            provider_channel_id TEXT NOT NULL,
-            display_label TEXT NOT NULL,
-            state TEXT NOT NULL,
-            reason_code TEXT,
-            scopes JSONB NOT NULL,
-            obtained_at TIMESTAMPTZ NOT NULL,
-            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-            CONSTRAINT youtube_account_binding_state_chk CHECK (state IN ('connected', 'degraded')),
-            CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
-                state <> 'connected' OR reason_code IS NULL
-            )
-        )
-        """
+    table_groups = (
+        (
+            _TABLE,
+            (
+                f"""
+                CREATE TABLE {_TABLE} (
+                    account_binding_id TEXT PRIMARY KEY,
+                    provider TEXT NOT NULL,
+                    provider_channel_id TEXT NOT NULL,
+                    display_label TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    reason_code TEXT,
+                    scopes JSONB NOT NULL,
+                    obtained_at TIMESTAMPTZ NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    CONSTRAINT youtube_account_binding_state_chk CHECK (state IN ('connected', 'degraded')),
+                    CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
+                        state <> 'connected' OR reason_code IS NULL
+                    )
+                )
+                """,
+                f"CREATE UNIQUE INDEX youtube_account_binding_channel_uq ON {_TABLE} "
+                "(provider, provider_channel_id)",
+            ),
+        ),
     )
-    cur.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS youtube_account_binding_channel_uq "
-        f"ON {_TABLE} (provider, provider_channel_id)"
-    )
+    for table_name, statements in table_groups:
+        cur.execute("SELECT to_regclass(%s)", (table_name,))
+        row = cur.fetchone()
+        table_present = bool(row and row[0])
+        if table_present:
+            continue
+        for statement in statements:
+            cur.execute(statement)
+    _assert_pg_schema(conn)
 
 
 def _iso(value: Any) -> str | None:

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -327,26 +327,46 @@ def bootstrap(conn: Any = None) -> None:
         # No longer swallowed (KERNEL-05, #2850): a failure here must surface,
         # not silently mask a broken connection/legacy-schema seam.
         ensure_schema(conn)  # type: ignore[arg-type]
+        cur = _exec(conn, "SELECT to_regclass('outbox') AS oid")
+        row = cur.fetchone() if hasattr(cur, "fetchone") else None
+        oid = row.get("oid") if isinstance(row, dict) else (row[0] if row else None)
+        if oid:
+            _assert_outbox_schema(conn)
+            return
         if not _outbox_schema_autocreate_enabled():
             _assert_outbox_schema(conn)
             return
-        _exec(conn, "create extension if not exists pgcrypto")
-        _exec(
-            conn,
-            """
-        create table if not exists outbox (
-            id uuid primary key default gen_random_uuid(),
-            topic text not null,
-            payload jsonb not null,
-            created_at timestamptz not null default now(),
-            delivered_at timestamptz,
-            attempts int not null default 0,
-            vault_binding_id text not null default 'legacy-compatibility-binding',
-            legacy_key uuid
-        )""",
+        table_groups = (
+            (
+                "outbox",
+                (
+                    "create extension if not exists pgcrypto",
+                    """
+                    create table outbox (
+                        id uuid primary key default gen_random_uuid(),
+                        topic text not null,
+                        payload jsonb not null,
+                        created_at timestamptz not null default now(),
+                        delivered_at timestamptz,
+                        attempts int not null default 0,
+                        vault_binding_id text not null default 'legacy-compatibility-binding',
+                        legacy_key uuid
+                    )""",
+                    "create index outbox_created_idx on outbox (created_at)",
+                    "create index outbox_delivered_idx on outbox (delivered_at)",
+                ),
+            ),
         )
-        _exec(conn, "create index if not exists outbox_created_idx on outbox (created_at)")
-        _exec(conn, "create index if not exists outbox_delivered_idx on outbox (delivered_at)")
+        for table_name, statements in table_groups:
+            cur = _exec(conn, "SELECT to_regclass(%s) AS oid", (table_name,))
+            row = cur.fetchone() if hasattr(cur, "fetchone") else None
+            table_present = bool(
+                row.get("oid") if isinstance(row, dict) else (row[0] if row else None)
+            )
+            if table_present:
+                continue
+            for statement in statements:
+                _exec(conn, statement)
     finally:
         if close:
             conn.close()

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -114,18 +114,17 @@ Last verified against: app/stores/pg.py + app/alembic/versions/e6c4a2b8d1f3_mvr0
   against objects *attached to* a durable table (indexes, triggers, rules) as well as the table
   itself, because an index or trigger dropped and recreated against a migration-owned table is the
   same drop-and-re-add mechanism MVR-05A1 removed from `objects_pkey`.
-- **Forty-five attached-object statements across fourteen modules run without an existence probe,
-  and are recorded rather than fixed** (MVR-05A2, #4576).
-  `tests/architecture/durable_table_classification.py::RECORDED_ATTACHED_DDL_DEBT` pins them by
-  (module, verb, table) with a count. **It is a measurement, not a clean bill of health.** Six of
-  the fourteen modules issue a `DROP TRIGGER` / `CREATE TRIGGER` pair against a table whose trigger
-  a migration already owns — `app/heimdal/raw_read_gate.py`'s own docstring records that
-  `f1c7e2a9b4d6` installs an identical reject-mutation trigger. MVR-05A2's acceptance criteria ask
-  for the existence probe in exactly one place (`app/stores/pg.py`, delivered), so repairing the
-  rest and shrinking that mapping is owned by
-  [#4598](https://github.com/RasmusTho/agentic-pkm-mvp/issues/4598). A statement that retires must
-  come off the pin; a statement that appears is in neither the pin nor the exclusion and fails the
-  guard.
+- **Runtime attached-object DDL debt is zero** (#4598). Every test-fixture autocreate group probes
+  its table with `to_regclass` and skips the complete attached-DDL group once that table exists;
+  create-on-demand is only for a genuinely absent fixture table. Alembic remains the sole owner of
+  durable indexes, triggers, and trigger functions. The six Heimdal append-only seams authenticate
+  the existing catalog shape read-only — exact table/trigger/function binding, origin-active
+  enablement, row-level `BEFORE UPDATE OR DELETE`, function attributes, and complete body — and fail
+  closed with migration guidance on drift. Runtime code never drops, recreates, installs, or repairs
+  those objects on an existing table. The raw-record trigger admits only its migration-owned,
+  session-local governed `DELETE` exception (with the matching tombstone); the current
+  deletion-receipt reconciliation body is likewise authenticated exactly. The zero-valued
+  `RECORDED_ATTACHED_DDL_DEBT` map is a regression tripwire.
 - **`app/db/sql/relations_init.sql` is deleted** (MVR-05A2, #4576). It declared a primary-key-less
   `relations` shape disagreeing with its Alembic owner
   (`202510241200_sot41_amg_core.py`) and had zero readers repo-wide; its absence and the absence of

--- a/tests/architecture/durable_table_classification.py
+++ b/tests/architecture/durable_table_classification.py
@@ -1567,104 +1567,10 @@ def _statement_sites(*, durable_source: bool) -> tuple[str, ...]:
 # 6. Recorded attached-object DDL debt (owned by #4598)
 # --------------------------------------------------------------------------- #
 
-#: Durable DDL against an object *attached to* a migration-owned table —
-#: indexes, triggers — that runs behind the `STORE_SCHEMA_AUTOCREATE` opt-in but
-#: without an existence probe, so it re-runs against an already-migrated table
-#: on every boot of the fixture path.
-#:
-#: This is **recorded debt, not a clean bill.** MVR-05A2 widened the scan's
-#: vocabulary past table-level DDL and this is what the wider vocabulary found;
-#: MVR-05A2's own AC-5 asks for the existence probe in exactly one place
-#: (`app/stores/pg.py`, delivered), so retiring these belongs to
-#: https://github.com/RasmusTho/agentic-pkm-mvp/issues/4598, which owns both the
-#: repair and shrinking this mapping as statements retire.
-#:
-#: The load-bearing entries are the five `drop trigger` / `create trigger` pairs.
-#: `app/heimdal/raw_read_gate.py`'s own module docstring records that migration
-#: `f1c7e2a9b4d6` installs an identical reject-mutation trigger — so a migration
-#: owns the object and the runtime drops and recreates it, which is structurally
-#: the mechanism MVR-05A1 (#4560) removed from `objects_pkey`.
-#:
-#: Keyed by (module, verb, table) with a count, so retiring one statement of a
-#: kind shows up as a number that must come down. A *new* attached-object
-#: statement is not in this mapping at all and fails the gate outright.
-RECORDED_ATTACHED_DDL_DEBT: Mapping[tuple[str, str, str], int] = MappingProxyType(
-    {
-        ("app/heimdal/consent_ledger.py", "create index", "heimdal_consent_grant"): 3,
-        ("app/heimdal/consent_ledger.py", "create trigger", "heimdal_consent_grant"): 1,
-        ("app/heimdal/consent_ledger.py", "drop trigger", "heimdal_consent_grant"): 1,
-        (
-            "app/heimdal/entity_review_operation_journal.py",
-            "create index",
-            "entity_review_operations",
-        ): 3,
-        ("app/heimdal/media_receipts.py", "create index", "heimdal_media_receipt"): 2,
-        ("app/heimdal/media_receipts.py", "create trigger", "heimdal_media_receipt"): 1,
-        ("app/heimdal/media_receipts.py", "drop trigger", "heimdal_media_receipt"): 1,
-        ("app/heimdal/meeting_blocks.py", "create index", "heimdal_meeting_block"): 1,
-        ("app/heimdal/meeting_blocks.py", "create index", "heimdal_meeting_block_refusal"): 1,
-        ("app/heimdal/meeting_ledger.py", "create index", "heimdal_meeting_segment"): 1,
-        ("app/heimdal/meeting_ledger.py", "create index", "heimdal_meeting_segment_conflict"): 1,
-        (
-            "app/heimdal/meeting_projection.py",
-            "create index",
-            "heimdal_meeting_analysis_revision",
-        ): 1,
-        ("app/heimdal/observation_log.py", "create index", "heimdal_observation_log"): 2,
-        ("app/heimdal/observation_log.py", "create trigger", "heimdal_observation_log"): 1,
-        ("app/heimdal/observation_log.py", "drop trigger", "heimdal_observation_log"): 1,
-        ("app/heimdal/raw_read_gate.py", "create index", "heimdal_raw_read_receipt"): 2,
-        ("app/heimdal/raw_read_gate.py", "create trigger", "heimdal_raw_read_receipt"): 1,
-        ("app/heimdal/raw_read_gate.py", "drop trigger", "heimdal_raw_read_receipt"): 1,
-        ("app/heimdal/raw_liveness.py", "create index", "heimdal_raw_deletion_receipt"): 2,
-        ("app/heimdal/raw_liveness.py", "create index", "heimdal_raw_deletion_tombstone"): 1,
-        ("app/heimdal/raw_liveness.py", "create index", "heimdal_raw_liveness_generation"): 1,
-        ("app/heimdal/raw_liveness.py", "create index", "heimdal_raw_response_lease"): 1,
-        ("app/heimdal/raw_liveness.py", "create index", "heimdal_raw_retention_claim"): 1,
-        (
-            "app/heimdal/raw_liveness.py",
-            "create trigger",
-            "heimdal_raw_deletion_receipt",
-        ): 1,
-        (
-            "app/heimdal/raw_liveness.py",
-            "create trigger",
-            "heimdal_raw_liveness_generation",
-        ): 1,
-        (
-            "app/heimdal/raw_liveness.py",
-            "create trigger",
-            "heimdal_raw_deletion_tombstone",
-        ): 1,
-        (
-            "app/heimdal/raw_liveness.py",
-            "create trigger",
-            "heimdal_raw_response_lease",
-        ): 2,
-        (
-            "app/heimdal/raw_liveness.py",
-            "create trigger",
-            "heimdal_raw_retention_claim",
-        ): 1,
-        ("app/heimdal/raw_liveness.py", "drop trigger", "heimdal_raw_deletion_receipt"): 1,
-        (
-            "app/knowledge_acquisition/acquisition_requests.py",
-            "create index",
-            "acquisition_requests",
-        ): 2,
-        (
-            "app/knowledge_acquisition/source_registry.py",
-            "create index",
-            "acquisition_source_registry",
-        ): 3,
-        (
-            "app/knowledge_acquisition/youtube_account_binding.py",
-            "create index",
-            "youtube_account_binding",
-        ): 1,
-        ("app/services/outbox.py", "create index", "outbox"): 6,
-    }
-)
+#: Attached-object DDL that still lacks the per-table existence probe.  #4598
+#: retired the recorded inventory; a future entry is a regression, not a new
+#: baseline to accept casually.
+RECORDED_ATTACHED_DDL_DEBT: Mapping[tuple[str, str, str], int] = MappingProxyType({})
 
 
 def observed_attached_ddl_debt(

--- a/tests/architecture/test_durable_table_ownership.py
+++ b/tests/architecture/test_durable_table_ownership.py
@@ -782,6 +782,23 @@ PG_LANES = (
         "durable table ownership PG surface",
     ),
 )
+HEIMDAL_TRIGGER_OWNERSHIP_SOURCES = (
+    "app/heimdal/trigger_ownership.py",
+    "app/heimdal/consent_ledger.py",
+    "app/heimdal/media_receipts.py",
+    "app/heimdal/observation_log.py",
+    "app/heimdal/raw_read_gate.py",
+    "app/heimdal/raw_liveness.py",
+    "app/heimdal/raw_store.py",
+    "app/alembic/versions/8b21e6a1f0c4_heim_observation_log_and_cursor.py",
+    "app/alembic/versions/a3f9d1c6e2b8_heim_retention_deletion_receipt_v0.py",
+    "app/alembic/versions/c4f7a1b2d9e3_heim_consent_ledger_v0.py",
+    "app/alembic/versions/c5d8a1e4f2b7_heimdal_raw_liveness.py",
+    "app/alembic/versions/d5a8e2f1b6c3_heim_raw_record_v0.py",
+    "app/alembic/versions/e2f3a4b5c6d7_heimdal_cold_cleanup_reconciliation.py",
+    "app/alembic/versions/e3c1a7f5d2b8_heim_media_receipt_v0.py",
+    "app/alembic/versions/f1c7e2a9b4d6_heim_raw_read_receipt_v0.py",
+)
 DURABLE_OWNERSHIP_PG_TARGETS = (
     # #4598: restricted-role read-only authentication and continuous
     # append-only enforcement must run against the migrated catalog.
@@ -923,6 +940,7 @@ def test_the_pr_path_pg_lane_is_triggered_by_the_sources_it_guards() -> None:
         "app/store/membership_store.py",
         "app/objects/relation_types.py",
         "app/stores/postgres.py",
+        *HEIMDAL_TRIGGER_OWNERSHIP_SOURCES,
         "tests/architecture/durable_table_classification.py",
         "tests/architecture/test_durable_table_ownership.py",
         "tests/architecture/test_multi_vault_projection_inventory.py",

--- a/tests/architecture/test_durable_table_ownership.py
+++ b/tests/architecture/test_durable_table_ownership.py
@@ -617,29 +617,7 @@ def test_no_durable_ddl_executes_outside_the_revision_chain() -> None:
 
 
 def test_the_attached_object_ddl_debt_is_exactly_what_is_recorded() -> None:
-    """The recorded attached-object DDL debt is a measurement, not a waiver.
-
-    MVR-05A2 widened this scan's vocabulary past table-level DDL, because an
-    index or trigger dropped and recreated against a migration-owned table is
-    the same drop-and-re-add mechanism MVR-05A1 (#4560) removed from
-    `objects_pkey`. Forty-one such statements across thirteen modules already
-    run without an existence probe, including five
-    `DROP TRIGGER` / `CREATE TRIGGER` pairs —
-    `app/heimdal/raw_read_gate.py`'s own docstring records that migration
-    `f1c7e2a9b4d6` installs an identical trigger, so a migration owns the object
-    and the runtime recreates it.
-
-    MVR-05A2's AC-5 asks for the existence probe in exactly one place
-    (`app/stores/pg.py`, delivered), so repairing the rest belongs to
-    https://github.com/RasmusTho/agentic-pkm-mvp/issues/4598, which owns both
-    the repair and shrinking this mapping as statements retire. Pinning the
-    count is what keeps it evidence: a statement that goes away must come off
-    the pin, and a statement that appears is in neither the pin nor the
-    exclusion and fails the guard above.
-
-    **This mapping is not a clean bill of health.** Reading it as one is the
-    mistake it exists to prevent.
-    """
+    """The #4598 attached-object DDL debt stays exactly zero."""
     observed = observed_attached_ddl_debt(discover_runtime_ddl_seams(discover_durable_tables()))
     assert dict(observed) == dict(RECORDED_ATTACHED_DDL_DEBT), (
         "the recorded attached-object DDL debt no longer matches the tree.\n"

--- a/tests/architecture/test_durable_table_ownership.py
+++ b/tests/architecture/test_durable_table_ownership.py
@@ -783,6 +783,9 @@ PG_LANES = (
     ),
 )
 DURABLE_OWNERSHIP_PG_TARGETS = (
+    # #4598: restricted-role read-only authentication and continuous
+    # append-only enforcement must run against the migrated catalog.
+    "tests/heimdal/test_trigger_ownership_pg.py",
     "tests/migrations/test_file_state_adoption.py",
     "tests/migrations/test_objects_adoption.py",
     # Both were pg-marked and in no lane at all before #4560, and both guard the

--- a/tests/heimdal/test_trigger_ownership.py
+++ b/tests/heimdal/test_trigger_ownership.py
@@ -1,0 +1,267 @@
+"""Production-path proof for migration-owned Heimdal mutation triggers (#4598)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.heimdal import (
+    consent_ledger,
+    media_receipts,
+    observation_log,
+    raw_read_gate,
+)
+from app.heimdal.trigger_ownership import (
+    CONSENT_GRANT_TRIGGER,
+    MEDIA_RECEIPT_TRIGGER,
+    OBSERVATION_LOG_TRIGGER,
+    RAW_DELETION_RECEIPT_TRIGGER,
+    RAW_READ_RECEIPT_TRIGGER,
+    RAW_RECORD_TRIGGER,
+    RejectMutationTrigger,
+    assert_migration_owned_reject_mutation_trigger,
+)
+from tests.architecture.durable_table_classification import (
+    RECORDED_ATTACHED_DDL_DEBT,
+    discover_durable_tables,
+    discover_runtime_ddl_seams,
+    observed_attached_ddl_debt,
+)
+
+pytestmark = pytest.mark.not_pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRIGGER_SPECS = (
+    CONSENT_GRANT_TRIGGER,
+    MEDIA_RECEIPT_TRIGGER,
+    OBSERVATION_LOG_TRIGGER,
+    RAW_READ_RECEIPT_TRIGGER,
+    RAW_DELETION_RECEIPT_TRIGGER,
+    RAW_RECORD_TRIGGER,
+)
+SIMPLE_TRIGGER_SEAMS = (
+    (consent_ledger, CONSENT_GRANT_TRIGGER),
+    (media_receipts, MEDIA_RECEIPT_TRIGGER),
+    (observation_log, OBSERVATION_LOG_TRIGGER),
+    (raw_read_gate, RAW_READ_RECEIPT_TRIGGER),
+)
+
+
+class _PresentCursor:
+    def __init__(self, conn: "_PresentConnection") -> None:
+        self._conn = conn
+        self._row: tuple[str, ...] = ()
+
+    def execute(self, statement: str, params: object = None) -> None:
+        sql = str(statement)
+        self._conn.executed.append(sql)
+        if "FROM pg_trigger AS trigger" in sql:
+            assert params == (self._conn.spec.table, self._conn.spec.trigger)
+            self._rows = [_catalog_row(self._conn.spec)]
+            self._row = ()
+        else:
+            count = sql.lower().count("to_regclass")
+            self._row = tuple("present" for _ in range(count))
+            self._rows = []
+
+    def fetchone(self) -> tuple[str, ...]:
+        return self._row
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class _PresentConnection:
+    def __init__(self, spec: RejectMutationTrigger) -> None:
+        self.executed: list[str] = []
+        self.spec = spec
+
+    def cursor(self) -> _PresentCursor:
+        return _PresentCursor(self)
+
+
+class _CatalogCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def execute(self, statement: str, params: object = None) -> None:
+        assert "FROM pg_trigger AS trigger" in statement
+        assert params is not None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class _CatalogConnection:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def cursor(self) -> _CatalogCursor:
+        return _CatalogCursor(self._rows)
+
+
+def _catalog_row(
+    spec: RejectMutationTrigger,
+    *,
+    enabled: str = "O",
+) -> tuple[Any, ...]:
+    return (
+        "public",
+        spec.table,
+        spec.trigger,
+        27,
+        enabled,
+        "",
+        True,
+        True,
+        spec.function,
+        "f",
+        True,
+        0,
+        "",
+        "plpgsql",
+        "v",
+        False,
+        False,
+        False,
+        "u",
+        None,
+        spec.body,
+    )
+
+
+def _assert_catalog(spec: RejectMutationTrigger, rows: list[tuple[Any, ...]]) -> None:
+    assert_migration_owned_reject_mutation_trigger(
+        _CatalogConnection(rows),
+        spec,
+        error_type=RuntimeError,
+        migration_hint="run alembic upgrade head",
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "spec"),
+    SIMPLE_TRIGGER_SEAMS,
+    ids=lambda value: value.__name__ if hasattr(value, "__name__") else value.table,
+)
+def test_present_trigger_is_not_dropped_and_recreated(
+    module: Any,
+    spec: RejectMutationTrigger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production bootstrap authenticates, but never mutates, an existing trigger."""
+
+    conn = _PresentConnection(spec)
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+
+    module._bootstrap_pg(conn)
+
+    assert any("FROM pg_trigger AS trigger" in sql for sql in conn.executed)
+    assert all(not re.match(r"\s*(?:CREATE|ALTER|DROP)\b", sql, re.I) for sql in conn.executed)
+
+
+def test_each_reject_mutation_trigger_has_one_owner() -> None:
+    """Alembic owns all six objects; runtime fixture DDL is existence-fenced."""
+
+    assert len({spec.table for spec in TRIGGER_SPECS}) == 6
+    assert len({spec.trigger for spec in TRIGGER_SPECS}) == 6
+    assert len({spec.function for spec in TRIGGER_SPECS}) == 6
+    seams = discover_runtime_ddl_seams(discover_durable_tables())
+    governed_tables = {spec.table for spec in TRIGGER_SPECS}
+    runtime_trigger_creates = [
+        seam
+        for seam in seams
+        if seam.verb == "create trigger" and seam.table in governed_tables
+    ]
+    assert runtime_trigger_creates
+    assert all(seam.autocreate_gated and seam.existence_probed for seam in runtime_trigger_creates)
+    runtime = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((REPO_ROOT / "app" / "heimdal").glob("*.py"))
+    )
+    assert "DROP TRIGGER" not in runtime.upper()
+
+
+def test_seam_issues_no_ddl_when_objects_are_present() -> None:
+    """Every currently discovered attached-object group has the skip guard."""
+
+    observed = observed_attached_ddl_debt(discover_runtime_ddl_seams(discover_durable_tables()))
+    assert dict(observed) == {}
+    assert dict(RECORDED_ATTACHED_DDL_DEBT) == {}
+
+
+def test_append_only_enforcement_has_no_window() -> None:
+    """The accepted catalog modes stay continuously active and exact."""
+
+    for spec in TRIGGER_SPECS:
+        _assert_catalog(spec, [_catalog_row(spec, enabled="O")])
+        _assert_catalog(spec, [_catalog_row(spec, enabled="A")])
+
+    body = RAW_RECORD_TRIGGER.body
+    assert "TG_OP = 'DELETE'" in body
+    assert "TG_OP = 'UPDATE'" not in body
+    assert "current_setting('app.heimdal_retention_bypass', true) = 'true'" in body
+    assert "heimdal_raw_deletion_tombstone" in body
+    liveness_source = (REPO_ROOT / "app/heimdal/raw_liveness.py").read_text(encoding="utf-8")
+    assert "SELECT set_config(%s, 'true', true)" in liveness_source
+
+
+@pytest.mark.parametrize(
+    ("index", "drifted"),
+    (
+        (0, "other_schema"),
+        (1, "other_table"),
+        (2, "other_trigger"),
+        (3, 19),
+        (4, "D"),
+        (5, "1"),
+        (6, False),
+        (7, False),
+        (8, "other_function"),
+        (9, "p"),
+        (10, False),
+        (11, 1),
+        (12, "23"),
+        (13, "sql"),
+        (14, "s"),
+        (15, True),
+        (16, True),
+        (17, True),
+        (18, "s"),
+        (19, ["search_path=public"]),
+        (20, "BEGIN RETURN NEW; END;"),
+    ),
+)
+def test_structural_trigger_authentication_rejects_drift_matrix(
+    index: int,
+    drifted: object,
+) -> None:
+    """Every catalog identity, attribute, binding, and body field is load-bearing."""
+
+    row = list(_catalog_row(RAW_RECORD_TRIGGER))
+    row[index] = drifted
+    with pytest.raises(RuntimeError, match="Alembic-owned definition"):
+        _assert_catalog(RAW_RECORD_TRIGGER, [tuple(row)])
+
+    with pytest.raises(RuntimeError, match="Alembic-owned definition"):
+        _assert_catalog(RAW_RECORD_TRIGGER, [])
+    with pytest.raises(RuntimeError, match="Alembic-owned definition"):
+        _assert_catalog(
+            RAW_RECORD_TRIGGER,
+            [_catalog_row(RAW_RECORD_TRIGGER), _catalog_row(RAW_RECORD_TRIGGER)],
+        )
+
+
+def test_function_body_authentication_preserves_literal_whitespace() -> None:
+    """Whitespace inside SQL literals cannot collapse to the accepted body."""
+
+    row = list(_catalog_row(RAW_RECORD_TRIGGER))
+    row[20] = RAW_RECORD_TRIGGER.body.replace(
+        "outside the governed tombstone transaction",
+        "outside  the governed tombstone transaction",
+    )
+    with pytest.raises(RuntimeError, match="Alembic-owned definition"):
+        _assert_catalog(RAW_RECORD_TRIGGER, [tuple(row)])

--- a/tests/heimdal/test_trigger_ownership_pg.py
+++ b/tests/heimdal/test_trigger_ownership_pg.py
@@ -72,6 +72,10 @@ def migrated_scratch_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[str, 
         with psycopg.connect(admin_dsn, autocommit=True) as conn:
             conn.execute(f'CREATE DATABASE "{database_name}"')
             conn.execute(f'CREATE ROLE "{role_name}" NOLOGIN')
+        # An early migration declares `embedding VECTOR` unconditionally, so
+        # every scratch database must install pgvector before Alembic runs.
+        with psycopg.connect(scratch_dsn, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
         monkeypatch.setenv("DATABASE_URL", scratch_dsn)
         monkeypatch.delenv("DB_DSN", raising=False)
         config = Config(str(REPO_ROOT / "alembic.ini"))

--- a/tests/heimdal/test_trigger_ownership_pg.py
+++ b/tests/heimdal/test_trigger_ownership_pg.py
@@ -1,0 +1,217 @@
+"""Real-Postgres proof for Heimdal migration-owned trigger seams (#4598)."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from app.heimdal import (
+    consent_ledger,
+    media_receipts,
+    observation_log,
+    raw_liveness,
+    raw_read_gate,
+    raw_store,
+)
+
+pytestmark = pytest.mark.pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SEAMS = (
+    consent_ledger,
+    media_receipts,
+    observation_log,
+    raw_read_gate,
+    raw_liveness,
+    raw_store,
+)
+TABLE_KEYS = {
+    "heimdal_consent_grant": "id",
+    "heimdal_media_receipt": "receipt_id",
+    "heimdal_observation_log": "id",
+    "heimdal_raw_read_receipt": "id",
+    "heimdal_raw_deletion_receipt": "id",
+    "heimdal_raw_record": "id",
+}
+
+
+def _configured_admin_dsn() -> str:
+    from app.db.dsn import resolve_dsn
+
+    dsn = resolve_dsn()
+    if dsn:
+        return dsn
+    message = (
+        "real-PG trigger-ownership proof unavailable: configure an explicit "
+        "non-production DATABASE_URL/DB_DSN"
+    )
+    if os.getenv("REQUIRE_REAL_PG_TRIGGER_PROOF") == "1":
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+@pytest.fixture
+def migrated_scratch_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[str, str]]:
+    psycopg = pytest.importorskip("psycopg")
+    from alembic import command
+    from alembic.config import Config
+
+    admin_dsn = _configured_admin_dsn()
+    database_name = f"scratch_trigger_owner_{secrets.token_hex(6)}"
+    role_name = f"trigger_reader_{secrets.token_hex(6)}"
+    base, separator, _database = admin_dsn.rpartition("/")
+    if not separator:
+        pytest.fail("real-PG proof requires a database-qualified non-production DSN")
+    scratch_dsn = f"{base}/{database_name}"
+    try:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'CREATE DATABASE "{database_name}"')
+            conn.execute(f'CREATE ROLE "{role_name}" NOLOGIN')
+        monkeypatch.setenv("DATABASE_URL", scratch_dsn)
+        monkeypatch.delenv("DB_DSN", raising=False)
+        config = Config(str(REPO_ROOT / "alembic.ini"))
+        config.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+        command.upgrade(config, "head")
+        with psycopg.connect(scratch_dsn, autocommit=True) as conn:
+            conn.execute(f'GRANT USAGE ON SCHEMA public TO "{role_name}"')
+            conn.execute(
+                f'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "{role_name}"'
+            )
+            conn.execute(
+                f'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "{role_name}"'
+            )
+            conn.execute(f'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "{role_name}"')
+        yield scratch_dsn, role_name
+    finally:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+            conn.execute(f'DROP ROLE IF EXISTS "{role_name}"')
+
+
+def _catalog_snapshot(conn: object) -> list[tuple[object, ...]]:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT c.relname, t.tgname, t.oid, p.proname, p.oid, t.tgtype,
+               t.tgenabled, t.tgattr::text, t.tgqual, p.prosrc
+        FROM pg_trigger AS t
+        JOIN pg_class AS c ON c.oid = t.tgrelid
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_proc AS p ON p.oid = t.tgfoid
+        WHERE n.nspname = 'public'
+          AND c.relname = ANY(%s)
+          AND NOT t.tgisinternal
+        ORDER BY c.relname, t.tgname
+        """,
+        (list(TABLE_KEYS),),
+    )
+    return list(cur.fetchall())
+
+
+def _insert_enforcement_rows(conn: object) -> dict[str, object]:
+    values: dict[str, object] = {}
+    cur = conn.cursor()
+    cur.execute("SELECT id FROM heimdal_consent_grant ORDER BY sequence LIMIT 1")
+    values["heimdal_consent_grant"] = cur.fetchone()[0]
+
+    values["heimdal_media_receipt"] = f"receipt-{uuid.uuid4()}"
+    cur.execute(
+        """INSERT INTO heimdal_media_receipt
+           (receipt_id, capture_id, content_sha256, raw_ref, kind, lane)
+           VALUES (%s, %s, %s, %s, 'audio', 'test')""",
+        (values["heimdal_media_receipt"], str(uuid.uuid4()), "a" * 64, "raw:test"),
+    )
+    for table in ("heimdal_observation_log", "heimdal_raw_read_receipt"):
+        values[table] = uuid.uuid4()
+    cur.execute(
+        "INSERT INTO heimdal_observation_log (id, topic, payload) VALUES (%s, 'test', '{}'::jsonb)",
+        (values["heimdal_observation_log"],),
+    )
+    cur.execute(
+        """INSERT INTO heimdal_raw_read_receipt
+           (id, raw_ref, content_identity, reader, purpose, payload)
+           VALUES (%s, 'raw:test', %s, 'test', 'proof', '{}'::jsonb)""",
+        (values["heimdal_raw_read_receipt"], "b" * 64),
+    )
+    values["heimdal_raw_record"] = uuid.uuid4()
+    cur.execute(
+        """INSERT INTO heimdal_raw_record
+           (id, content_identity, capture_chain, sensor, consent, source_path, payload)
+           VALUES (%s, %s, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '/proof', '{}'::jsonb)""",
+        (values["heimdal_raw_record"], "c" * 64),
+    )
+    values["heimdal_raw_deletion_receipt"] = uuid.uuid4()
+    cur.execute(
+        """INSERT INTO heimdal_raw_deletion_receipt
+           (id, record_id, content_identity, reason, retention_window_days, payload)
+           VALUES (%s, %s, %s, 'proof', 1, '{}'::jsonb)""",
+        (values["heimdal_raw_deletion_receipt"], uuid.uuid4(), "d" * 64),
+    )
+    return values
+
+
+def test_real_pg_seams_issue_zero_ddl_and_append_only_has_no_window(
+    migrated_scratch_db: tuple[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restricted production seams stay read-only and live triggers reject mutations."""
+
+    psycopg = pytest.importorskip("psycopg")
+    scratch_dsn, role_name = migrated_scratch_db
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    with psycopg.connect(scratch_dsn, autocommit=True) as admin:
+        before = _catalog_snapshot(admin)
+        with psycopg.connect(scratch_dsn, autocommit=True) as runtime:
+            runtime.execute(f'SET ROLE "{role_name}"')
+            for seam in SEAMS:
+                seam._bootstrap_pg(runtime)
+        after = _catalog_snapshot(admin)
+        assert after == before
+
+        rows = _insert_enforcement_rows(admin)
+        with psycopg.connect(scratch_dsn, autocommit=True) as runtime:
+            runtime.execute(f'SET ROLE "{role_name}"')
+            for table, key_column in TABLE_KEYS.items():
+                with pytest.raises(Exception, match="append-only"):
+                    runtime.execute(
+                        f"UPDATE {table} SET {key_column} = {key_column} WHERE {key_column} = %s",
+                        (rows[table],),
+                    )
+                with pytest.raises(Exception, match="append-only"):
+                    runtime.execute(
+                        f"DELETE FROM {table} WHERE {key_column} = %s",
+                        (rows[table],),
+                    )
+
+
+def test_real_pg_catalog_drift_fails_closed_without_runtime_repair(
+    migrated_scratch_db: tuple[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled migration trigger is detected and remains disabled."""
+
+    psycopg = pytest.importorskip("psycopg")
+    scratch_dsn, role_name = migrated_scratch_db
+    monkeypatch.setenv("STORE_SCHEMA_AUTOCREATE", "1")
+    with psycopg.connect(scratch_dsn, autocommit=True) as admin:
+        admin.execute(
+            "ALTER TABLE heimdal_observation_log DISABLE TRIGGER heimdal_observation_log_no_update"
+        )
+        with psycopg.connect(scratch_dsn, autocommit=True) as runtime:
+            runtime.execute(f'SET ROLE "{role_name}"')
+            with pytest.raises(
+                observation_log.ObservationLogSchemaMissingError,
+                match="Alembic-owned definition",
+            ):
+                observation_log._bootstrap_pg(runtime)
+        row = admin.execute(
+            """SELECT tgenabled FROM pg_trigger
+               WHERE tgrelid = 'heimdal_observation_log'::regclass
+                 AND tgname = 'heimdal_observation_log_no_update'"""
+        ).fetchone()
+        assert row == ("D",)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4598

## Linked Issue
Closes #4598

## SBS Impact
- Primary subsystem: Product/Runtime — Heimdal durable persistence seams
- Secondary subsystem(s): PDM migration authority; OEF/architecture fitness; knowledge-acquisition and outbox durable seams
- Write class: Current-state correction to runtime DDL and catalog-authentication behavior
- Persistence impact: Existing migration-owned tables/triggers/functions are authenticated read-only at startup; no runtime mutation on present tables
- Derived/rebuildable impact: None; durable authority objects remain Alembic-owned
- New or changed contract: Present tables skip their complete attached-DDL group; six append-only triggers fail closed on exact structural/function drift
- Owner-doc impact: docs/DB_SCHEMA.md updated; existing DOCS_INDEX ownership registration remains valid
- Transition debt impact: RECORDED_ATTACHED_DDL_DEBT reduced from 33 recorded keys to zero
- Boundary risk: High-risk migration/data/authority boundary; no prod/stable/host mutation and no production DSN used

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Stop all 14 recorded runtime attached-object setup groups from issuing attached DDL when their tables already exist; autocreation remains limited to absent test-fixture tables.
- Authenticate all six Alembic-owned append-only trigger/function contracts from the PostgreSQL catalog and fail closed on drift without runtime drop, recreate, repair, or install.
- Set RECORDED_ATTACHED_DDL_DEBT to zero and document the shipped migration-ownership/authentication rule.
- Repair the real-PG proof selection: the restricted-role migrated-catalog tests now run in both explicit PG lanes and CI paths-filter coverage is pinned.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded GitHub Issue and PR are the delivery authority; no BuilderOps record, projection, or receipt was required.

## Notes
Classification: Product/Runtime current-state correction with PDM/migration ownership and Builder/OEF fitness impact.

Mechanism convergence: heimdal-migration-trigger-ownership:v1. Fresh independent Sol/xhigh reviews were clean for the preceding 49fc0a5 repair and for the current exact head 9ec2bbf04e35738f16131a75aee62eea3576a4dc (complete 22-file digest 1cec309eb3bae122989dc2fd9aa05d8db586c71a2da957996a538f9a60d33dbc). The repair preserves the historical 2+2 accounting. After the new PG selection exposed a missing scratch-DB pgvector preflight, the owner explicitly authorized one additional fixture-only third repair round; the historical count is not reset.

Focused validation: 31 passed for the ownership selection and trigger-authentication suite; durable-ownership architecture suite 9 passed; mypy app passed (930 files); Ruff on changed code/tests passed; both workflows parse; public_seam_lint gate passed. docs_guard reported no temporal-doc writeback requirement.

Real PostgreSQL: unavailable/skipped. DATABASE_URL/DB_DSN is unset; tests/heimdal/test_trigger_ownership_pg.py collected as 2 skipped with the explicit non-production-DSN banner. No real-PG proof is claimed.

CI: pending on this exact head.