### PR TITLE
Add retained-source archival adapter

### DIFF
--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -42,6 +42,9 @@ from app.archival.transition import FaultStage, TransitionConflict, TransitionFa
 
 ADAPTER_ID = "retained_source"
 _MEDIA_TYPE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$")
+_MEDIA_TOP_LEVEL_TYPES = frozenset({
+    "application", "audio", "font", "example", "haptics", "image", "message", "model", "multipart", "text", "video",
+})
 
 
 class RetainedSourceKind(str, Enum):
@@ -121,7 +124,8 @@ class RetainedSourceAdmission:
             raise ValueError("restore destination must be a typed opaque reference")
         if self.restore_destination.namespace != "retained-source-destination":
             raise ValueError("restore destination must be owner-native retained-source authority")
-        if not isinstance(self.format, str) or not _MEDIA_TYPE.fullmatch(self.format):
+        media_type = self.format.split("/", 1)[0].lower() if isinstance(self.format, str) else ""
+        if not isinstance(self.format, str) or not _MEDIA_TYPE.fullmatch(self.format) or media_type not in _MEDIA_TOP_LEVEL_TYPES:
             raise ValueError("retained source format must be a non-location format identifier")
         descriptor = self.descriptor
         if (
@@ -214,13 +218,7 @@ class RetainedSourceAdapter:
             artifact.provenance_refs,
             (representation,),
         )
-        self._store.record_restore_receipt(receipt)
-        loaded = self._store.read_restore(artifact, representation)
-        if loaded != receipt:
-            raise TransitionFailure(
-                FaultStage.READBACK, "retained-source restore receipt readback is unavailable"
-            )
-        return loaded
+        return self._record_restore_receipt(artifact, representation, receipt)
 
     def enumerate(self, artifact: ArtifactIdentity) -> Sequence[Representation]:
         return self._store.enumerate(artifact) if artifact == self.artifact.identity else ()
@@ -290,7 +288,8 @@ class RetainedSourceAdapter:
         self._require_artifact(artifact)
         self.authorize_read(artifact, authority)
         self._require_active_representation(artifact, representation)
-        return self._store.restore(artifact, authority, representation)
+        receipt = self._store.restore(artifact, authority, representation)
+        return self._record_restore_receipt(artifact, representation, receipt)
 
     def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None:
         self._require_artifact(artifact)
@@ -334,6 +333,20 @@ class RetainedSourceAdapter:
             raise TransitionConflict("restore generation differs from owner-native representation")
         if resolved.stage is not TransitionStage.ACTIVE or resolved.liveness.state is not LivenessState.ACTIVE:
             raise TransitionConflict("restore representation is not active")
+
+    def _record_restore_receipt(
+        self,
+        artifact: ArtifactDescriptor,
+        representation: RepresentationRef,
+        receipt: ArchivalReceipt,
+    ) -> ArchivalReceipt:
+        self._store.record_restore_receipt(receipt)
+        loaded = self._store.read_restore(artifact, representation)
+        if loaded != receipt:
+            raise TransitionFailure(
+                FaultStage.READBACK, "retained-source restore receipt readback is unavailable"
+            )
+        return loaded
 
     def _verify_content(self, payload: bytes) -> None:
         content_refs = [ref.reference.token for ref in self.artifact.provenance_refs if ref.kind == "content" and ref.reference.namespace == "content-sha256"]

--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -149,6 +149,8 @@ class RetainedSourceStorePort(Protocol):
     def resolve(self, reference: RepresentationRef) -> Representation: ...
     def authorize_read(self, artifact: ArtifactDescriptor, authority: AccessAuthority) -> ArchivalReceipt: ...
     def bind_operation(self, binding: OperationBinding) -> OperationRecord: ...
+    def validate_admission(self, admission: RetainedSourceAdmission) -> None: ...
+    def authorize_retirement(self, decision: RetainedSourceRetirement) -> None: ...
     def read_operation(self, idempotency_key: str) -> OperationRecord | None: ...
     def reserve(self, binding: OperationBinding) -> RepresentationReservation: ...
     def copy(self, binding: OperationBinding, reservation: RepresentationReservation) -> None: ...
@@ -165,6 +167,7 @@ class RetainedSourceStorePort(Protocol):
     def read_bytes(self, reference: RepresentationRef) -> bytes: ...
     def copy_bytes(self, source: RepresentationRef, target: RepresentationRef) -> None: ...
     def write_restored(self, destination: OpaqueReference, payload: bytes, *, generation: Generation, format: str) -> None: ...
+    def record_restore_receipt(self, receipt: ArchivalReceipt) -> None: ...
     def record_retained_source_receipt(self, receipt: ArchivalReceipt, metadata: RetainedSourceReceiptMetadata) -> None: ...
 
 
@@ -178,8 +181,8 @@ class RetainedSourceAdapter:
             raise ValueError("retained source storage must be a PDM StorePort binding")
         self.admission = admission
         self._store = store_port
+        self._store.validate_admission(admission)
         self._retirement: RetainedSourceRetirement | None = None
-        self._restore_receipts: dict[tuple[ArtifactIdentity, RepresentationRef], ArchivalReceipt] = {}
 
     @property
     def artifact(self) -> ArtifactDescriptor:
@@ -188,6 +191,7 @@ class RetainedSourceAdapter:
     def authorize_retirement(self, decision: RetainedSourceRetirement) -> None:
         if decision.artifact != self.artifact.identity or decision.generation != self.artifact.generation:
             raise TransitionConflict("retained-source retirement differs from exact owner generation")
+        self._store.authorize_retirement(decision)
         self._retirement = decision
 
     def restore_to(self, artifact: ArtifactDescriptor, representation: RepresentationRef, destination: OpaqueReference) -> ArchivalReceipt:
@@ -210,7 +214,7 @@ class RetainedSourceAdapter:
             artifact.provenance_refs,
             (representation,),
         )
-        self._restore_receipts[(artifact.identity, representation)] = receipt
+        self._store.record_restore_receipt(receipt)
         return receipt
 
     def enumerate(self, artifact: ArtifactIdentity) -> Sequence[Representation]:
@@ -285,7 +289,7 @@ class RetainedSourceAdapter:
 
     def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None:
         self._require_artifact(artifact)
-        return self._restore_receipts.get((artifact.identity, representation)) or self._store.read_restore(artifact, representation)
+        return self._store.read_restore(artifact, representation)
 
     def cleanup(self, artifact: ArtifactDescriptor) -> CleanupProof:
         self._require_artifact(artifact)

--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 import hashlib
+import re
 from typing import Protocol, Sequence
 
 from app.archival.contracts import (
@@ -40,6 +41,7 @@ from app.archival.transition import FaultStage, TransitionConflict, TransitionFa
 
 
 ADAPTER_ID = "retained_source"
+_MEDIA_TYPE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$")
 
 
 class RetainedSourceKind(str, Enum):
@@ -119,7 +121,7 @@ class RetainedSourceAdmission:
             raise ValueError("restore destination must be a typed opaque reference")
         if self.restore_destination.namespace != "retained-source-destination":
             raise ValueError("restore destination must be owner-native retained-source authority")
-        if not isinstance(self.format, str) or not self.format or self.format.startswith("/"):
+        if not isinstance(self.format, str) or not _MEDIA_TYPE.fullmatch(self.format):
             raise ValueError("retained source format must be a non-location format identifier")
         descriptor = self.descriptor
         if (
@@ -192,11 +194,7 @@ class RetainedSourceAdapter:
         self._require_artifact(artifact)
         if destination != self.admission.restore_destination:
             raise TransitionConflict("restore destination differs from the owner gate")
-        resolved = self.resolve(representation)
-        if resolved.generation != artifact.generation:
-            raise TransitionConflict("restore generation differs from owner-native representation")
-        if resolved.stage is not TransitionStage.ACTIVE or resolved.liveness.state is not LivenessState.ACTIVE:
-            raise TransitionConflict("restore representation is not active")
+        self._require_active_representation(artifact, representation)
         authority = AccessAuthority(OwnerAuthority.CLASS_ADAPTER, OpaqueReference("retained-source-owner", destination.token))
         self.authorize_read(artifact, authority)
         payload = self._store.read_bytes(representation)
@@ -225,7 +223,8 @@ class RetainedSourceAdapter:
 
     def authorize_read(self, artifact: ArtifactDescriptor, authority: AccessAuthority) -> ArchivalReceipt:
         self._require_artifact(artifact)
-        if authority.issuer is not OwnerAuthority.CLASS_ADAPTER or authority.grant_ref.namespace != "retained-source-owner":
+        expected = OpaqueReference("retained-source-owner", self.admission.restore_destination.token)
+        if authority.issuer is not OwnerAuthority.CLASS_ADAPTER or authority.grant_ref != expected:
             raise TransitionConflict("retained-source restore requires the owner gate")
         return self._store.authorize_read(artifact, authority)
 
@@ -281,6 +280,7 @@ class RetainedSourceAdapter:
     def restore(self, artifact: ArtifactDescriptor, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt:
         self._require_artifact(artifact)
         self.authorize_read(artifact, authority)
+        self._require_active_representation(artifact, representation)
         return self._store.restore(artifact, authority, representation)
 
     def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None:
@@ -314,6 +314,15 @@ class RetainedSourceAdapter:
             or binding.target.adapter != ADAPTER_ID
         ):
             raise TransitionConflict("retained-source operation differs from explicit owner admission")
+
+    def _require_active_representation(
+        self, artifact: ArtifactDescriptor, representation: RepresentationRef
+    ) -> None:
+        resolved = self.resolve(representation)
+        if resolved.generation != artifact.generation:
+            raise TransitionConflict("restore generation differs from owner-native representation")
+        if resolved.stage is not TransitionStage.ACTIVE or resolved.liveness.state is not LivenessState.ACTIVE:
+            raise TransitionConflict("restore representation is not active")
 
     def _verify_content(self, payload: bytes) -> None:
         content_refs = [ref.reference.token for ref in self.artifact.provenance_refs if ref.kind == "content" and ref.reference.namespace == "content-sha256"]

--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -215,7 +215,12 @@ class RetainedSourceAdapter:
             (representation,),
         )
         self._store.record_restore_receipt(receipt)
-        return receipt
+        loaded = self._store.read_restore(artifact, representation)
+        if loaded != receipt:
+            raise TransitionFailure(
+                FaultStage.READBACK, "retained-source restore receipt readback is unavailable"
+            )
+        return loaded
 
     def enumerate(self, artifact: ArtifactIdentity) -> Sequence[Representation]:
         return self._store.enumerate(artifact) if artifact == self.artifact.identity else ()
@@ -323,6 +328,8 @@ class RetainedSourceAdapter:
         self, artifact: ArtifactDescriptor, representation: RepresentationRef
     ) -> None:
         resolved = self.resolve(representation)
+        if resolved.artifact != artifact.identity:
+            raise TransitionConflict("restore representation differs from owner-native artifact identity")
         if resolved.generation != artifact.generation:
             raise TransitionConflict("restore generation differs from owner-native representation")
         if resolved.stage is not TransitionStage.ACTIVE or resolved.liveness.state is not LivenessState.ACTIVE:

--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -1,0 +1,321 @@
+"""Explicit-owner retained-source adapter for the governed archival kernel.
+
+This adapter owns admission and policy checks only.  Its injected PDM StorePort
+remains the sole persistence and byte-transfer seam; locations, DSNs, paths,
+and companion notes are deliberately absent from this surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+from typing import Protocol, Sequence
+
+from app.archival.contracts import (
+    AccessAuthority,
+    ArchivalReceipt,
+    ArtifactClass,
+    ArtifactDescriptor,
+    ArtifactIdentity,
+    CleanupProof,
+    DerivationClass,
+    DoctorFinding,
+    DurabilityClass,
+    Generation,
+    Liveness,
+    LivenessState,
+    OpaqueReference,
+    OperationBinding,
+    OperationRecord,
+    OwnerAuthority,
+    PolicyProfile,
+    Representation,
+    RepresentationRef,
+    RepresentationReservation,
+    TransitionStage,
+    VerificationResult,
+)
+from app.archival.transition import FaultStage, TransitionConflict, TransitionFailure
+
+
+ADAPTER_ID = "retained_source"
+
+
+class RetainedSourceKind(str, Enum):
+    """Only post-curation source roles are eligible for this adapter."""
+
+    MEDIA_ORIGINAL = "media_original"
+    DOCUMENT_ORIGINAL = "document_original"
+    EXTERNAL_RAW = "external_raw"
+    COMPANION_NOTE = "companion_note"
+
+
+@dataclass(frozen=True)
+class OwnerKeepDecision:
+    """An opaque owner-native admission decision, never a file or note pointer."""
+
+    reference: OpaqueReference
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reference, OpaqueReference):
+            raise ValueError("owner keep decision must be a typed opaque reference")
+        if self.reference.namespace != "retained-source-admission":
+            raise ValueError("owner keep decision must be retained-source admission authority")
+
+
+@dataclass(frozen=True)
+class RetainedSourceRetirement:
+    """Exact owner authorization for policy-specific physical retirement."""
+
+    artifact: ArtifactIdentity
+    generation: Generation
+    reference: OpaqueReference
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.artifact, ArtifactIdentity) or not isinstance(self.generation, Generation):
+            raise ValueError("retirement must bind typed artifact identity and generation")
+        if not isinstance(self.reference, OpaqueReference):
+            raise ValueError("retirement must carry a typed opaque reference")
+        if self.reference.namespace != "retained-source-retirement":
+            raise ValueError("retirement must use retained-source owner policy")
+
+
+@dataclass(frozen=True)
+class RetainedSourceReceiptMetadata:
+    """Owner-native durable receipt fields omitted from the provider-free receipt."""
+
+    identity: ArtifactIdentity
+    provenance_refs: tuple
+    policy_profile: PolicyProfile
+    format: str
+    generation: Generation
+    representation_refs: tuple[RepresentationRef, ...]
+
+
+@dataclass(frozen=True)
+class RetainedSourceAdmission:
+    """Stable descriptor plus the explicit owner decision that admits it."""
+
+    descriptor: ArtifactDescriptor
+    source: RepresentationRef
+    kind: RetainedSourceKind
+    format: str
+    keep_decision: OwnerKeepDecision
+    restore_destination: OpaqueReference
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.descriptor, ArtifactDescriptor):
+            raise ValueError("retained source requires an owner-native descriptor")
+        if not isinstance(self.source, RepresentationRef):
+            raise ValueError("retained source representation must be a typed opaque reference")
+        if not isinstance(self.kind, RetainedSourceKind):
+            raise ValueError("retained source kind must be explicit")
+        if self.kind in {RetainedSourceKind.EXTERNAL_RAW, RetainedSourceKind.COMPANION_NOTE}:
+            raise ValueError("external_raw or companion note is not a retained-source admission")
+        if not isinstance(self.keep_decision, OwnerKeepDecision):
+            raise ValueError("retained source requires an explicit owner keep decision")
+        if not isinstance(self.restore_destination, OpaqueReference):
+            raise ValueError("restore destination must be a typed opaque reference")
+        if self.restore_destination.namespace != "retained-source-destination":
+            raise ValueError("restore destination must be owner-native retained-source authority")
+        if not isinstance(self.format, str) or not self.format or self.format.startswith("/"):
+            raise ValueError("retained source format must be a non-location format identifier")
+        descriptor = self.descriptor
+        if (
+            descriptor.artifact_class is not ArtifactClass.SOURCE
+            or descriptor.derivation is not DerivationClass.SOURCE
+            or descriptor.durability is not DurabilityClass.DURABLE
+            or descriptor.policy_profile is not PolicyProfile.RETAINED_SOURCE
+            or descriptor.identity.owner is not OwnerAuthority.CLASS_ADAPTER
+            or descriptor.identity.owner_namespace != ADAPTER_ID
+            or self.source.adapter != ADAPTER_ID
+        ):
+            raise ValueError("retained-source admission must preserve the retained-source owner policy")
+        provenance_kinds = {item.kind for item in descriptor.provenance_refs}
+        if not {"content", "origin"}.issubset(provenance_kinds):
+            raise ValueError("retained-source admission requires content and origin provenance")
+
+
+class RetainedSourceStorePort(Protocol):
+    """Narrow PDM binding; implementations own bytes, metadata, and journals."""
+
+    contract: str
+    owner_subsystem: str
+
+    def enumerate(self, artifact: ArtifactIdentity) -> Sequence[Representation]: ...
+    def resolve(self, reference: RepresentationRef) -> Representation: ...
+    def authorize_read(self, artifact: ArtifactDescriptor, authority: AccessAuthority) -> ArchivalReceipt: ...
+    def bind_operation(self, binding: OperationBinding) -> OperationRecord: ...
+    def read_operation(self, idempotency_key: str) -> OperationRecord | None: ...
+    def reserve(self, binding: OperationBinding) -> RepresentationReservation: ...
+    def copy(self, binding: OperationBinding, reservation: RepresentationReservation) -> None: ...
+    def verify(self, binding: OperationBinding, reservation: RepresentationReservation) -> VerificationResult: ...
+    def durable_receipt(self, binding: OperationBinding, reservation: RepresentationReservation, verification: VerificationResult) -> ArchivalReceipt: ...
+    def activate(self, binding: OperationBinding, reservation: RepresentationReservation, verification: VerificationResult, receipt: ArchivalReceipt) -> None: ...
+    def retire(self, binding: OperationBinding, representation: Representation, receipt: ArchivalReceipt) -> None: ...
+    def complete_operation(self, binding: OperationBinding, receipt: ArchivalReceipt) -> ArchivalReceipt: ...
+    def restore(self, artifact: ArtifactDescriptor, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt: ...
+    def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None: ...
+    def cleanup(self, artifact: ArtifactDescriptor) -> CleanupProof: ...
+    def read_cleanup(self, artifact: ArtifactDescriptor) -> CleanupProof | None: ...
+    def doctor(self) -> Sequence[DoctorFinding]: ...
+    def read_bytes(self, reference: RepresentationRef) -> bytes: ...
+    def copy_bytes(self, source: RepresentationRef, target: RepresentationRef) -> None: ...
+    def write_restored(self, destination: OpaqueReference, payload: bytes, *, generation: Generation, format: str) -> None: ...
+    def record_retained_source_receipt(self, receipt: ArchivalReceipt, metadata: RetainedSourceReceiptMetadata) -> None: ...
+
+
+class RetainedSourceAdapter:
+    """Policy and admission guard around an owner-native PDM StorePort binding."""
+
+    def __init__(self, admission: RetainedSourceAdmission, store_port: RetainedSourceStorePort) -> None:
+        if not isinstance(admission, RetainedSourceAdmission):
+            raise ValueError("retained source requires explicit admission")
+        if getattr(store_port, "contract", None) != "StorePort" or getattr(store_port, "owner_subsystem", None) != "PDM":
+            raise ValueError("retained source storage must be a PDM StorePort binding")
+        self.admission = admission
+        self._store = store_port
+        self._retirement: RetainedSourceRetirement | None = None
+        self._restore_receipts: dict[tuple[ArtifactIdentity, RepresentationRef], ArchivalReceipt] = {}
+
+    @property
+    def artifact(self) -> ArtifactDescriptor:
+        return self.admission.descriptor
+
+    def authorize_retirement(self, decision: RetainedSourceRetirement) -> None:
+        if decision.artifact != self.artifact.identity or decision.generation != self.artifact.generation:
+            raise TransitionConflict("retained-source retirement differs from exact owner generation")
+        self._retirement = decision
+
+    def restore_to(self, artifact: ArtifactDescriptor, representation: RepresentationRef, destination: OpaqueReference) -> ArchivalReceipt:
+        self._require_artifact(artifact)
+        if destination != self.admission.restore_destination:
+            raise TransitionConflict("restore destination differs from the owner gate")
+        resolved = self.resolve(representation)
+        if resolved.generation != artifact.generation:
+            raise TransitionConflict("restore generation differs from owner-native representation")
+        if resolved.stage is not TransitionStage.ACTIVE or resolved.liveness.state is not LivenessState.ACTIVE:
+            raise TransitionConflict("restore representation is not active")
+        authority = AccessAuthority(OwnerAuthority.CLASS_ADAPTER, OpaqueReference("retained-source-owner", destination.token))
+        self.authorize_read(artifact, authority)
+        payload = self._store.read_bytes(representation)
+        self._verify_content(payload)
+        self._store.write_restored(destination, payload, generation=artifact.generation, format=self.admission.format)
+        receipt = ArchivalReceipt(
+            OpaqueReference("retained-source-receipt", f"restore-{destination.token}"),
+            artifact.identity,
+            artifact.generation,
+            TransitionStage.RESTORED,
+            artifact.policy_profile,
+            Liveness(LivenessState.ACTIVE, OpaqueReference("retained-source-liveness", f"restored-{destination.token}")),
+            artifact.provenance_refs,
+            (representation,),
+        )
+        self._restore_receipts[(artifact.identity, representation)] = receipt
+        return receipt
+
+    def enumerate(self, artifact: ArtifactIdentity) -> Sequence[Representation]:
+        return self._store.enumerate(artifact) if artifact == self.artifact.identity else ()
+
+    def resolve(self, reference: RepresentationRef) -> Representation:
+        if reference.adapter != ADAPTER_ID:
+            raise TransitionConflict("representation is not owned by retained-source adapter")
+        return self._store.resolve(reference)
+
+    def authorize_read(self, artifact: ArtifactDescriptor, authority: AccessAuthority) -> ArchivalReceipt:
+        self._require_artifact(artifact)
+        if authority.issuer is not OwnerAuthority.CLASS_ADAPTER or authority.grant_ref.namespace != "retained-source-owner":
+            raise TransitionConflict("retained-source restore requires the owner gate")
+        return self._store.authorize_read(artifact, authority)
+
+    def bind_operation(self, binding: OperationBinding) -> OperationRecord:
+        self._require_binding(binding)
+        return self._store.bind_operation(binding)
+
+    def read_operation(self, idempotency_key: str) -> OperationRecord | None:
+        return self._store.read_operation(idempotency_key)
+
+    def reserve(self, binding: OperationBinding) -> RepresentationReservation:
+        self._require_binding(binding)
+        return self._store.reserve(binding)
+
+    def copy(self, binding: OperationBinding, reservation: RepresentationReservation) -> None:
+        self._require_binding(binding)
+        self._store.copy_bytes(binding.source, binding.target)
+        self._store.copy(binding, reservation)
+
+    def verify(self, binding: OperationBinding, reservation: RepresentationReservation) -> VerificationResult:
+        self._require_binding(binding)
+        self._verify_content(self._store.read_bytes(binding.target))
+        return self._store.verify(binding, reservation)
+
+    def durable_receipt(self, binding: OperationBinding, reservation: RepresentationReservation, verification: VerificationResult) -> ArchivalReceipt:
+        self._require_binding(binding)
+        receipt = self._store.durable_receipt(binding, reservation, verification)
+        self._store.record_retained_source_receipt(
+            receipt,
+            RetainedSourceReceiptMetadata(
+                self.artifact.identity,
+                self.artifact.provenance_refs,
+                self.artifact.policy_profile,
+                self.admission.format,
+                self.artifact.generation,
+                receipt.representation_refs,
+            ),
+        )
+        return receipt
+
+    def activate(self, binding: OperationBinding, reservation: RepresentationReservation, verification: VerificationResult, receipt: ArchivalReceipt) -> None:
+        self._require_binding(binding)
+        self._store.activate(binding, reservation, verification, receipt)
+
+    def retire(self, binding: OperationBinding, representation: Representation, receipt: ArchivalReceipt) -> None:
+        self._require_binding(binding)
+        self._store.retire(binding, representation, receipt)
+
+    def complete_operation(self, binding: OperationBinding, receipt: ArchivalReceipt) -> ArchivalReceipt:
+        self._require_binding(binding)
+        return self._store.complete_operation(binding, receipt)
+
+    def restore(self, artifact: ArtifactDescriptor, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt:
+        self._require_artifact(artifact)
+        self.authorize_read(artifact, authority)
+        return self._store.restore(artifact, authority, representation)
+
+    def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None:
+        self._require_artifact(artifact)
+        return self._restore_receipts.get((artifact.identity, representation)) or self._store.read_restore(artifact, representation)
+
+    def cleanup(self, artifact: ArtifactDescriptor) -> CleanupProof:
+        self._require_artifact(artifact)
+        if self._retirement is None:
+            raise TransitionFailure(FaultStage.CLEANUP, "retained-source retirement is not owner-authorized")
+        return self._store.cleanup(artifact)
+
+    def read_cleanup(self, artifact: ArtifactDescriptor) -> CleanupProof | None:
+        self._require_artifact(artifact)
+        return self._store.read_cleanup(artifact)
+
+    def doctor(self) -> Sequence[DoctorFinding]:
+        return self._store.doctor()
+
+    def _require_artifact(self, artifact: ArtifactDescriptor) -> None:
+        if artifact != self.artifact:
+            raise TransitionConflict("retained-source artifact or generation differs from owner admission")
+
+    def _require_binding(self, binding: OperationBinding) -> None:
+        if (
+            binding.artifact != self.artifact.identity
+            or binding.generation != self.artifact.generation
+            or binding.policy is not PolicyProfile.RETAINED_SOURCE
+            or binding.source != self.admission.source
+            or binding.source.adapter != ADAPTER_ID
+            or binding.target.adapter != ADAPTER_ID
+        ):
+            raise TransitionConflict("retained-source operation differs from explicit owner admission")
+
+    def _verify_content(self, payload: bytes) -> None:
+        content_refs = [ref.reference.token for ref in self.artifact.provenance_refs if ref.kind == "content" and ref.reference.namespace == "content-sha256"]
+        if len(content_refs) != 1 or hashlib.sha256(payload).hexdigest() != content_refs[0]:
+            raise TransitionConflict("retained-source content identity differs from owner provenance")

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -185,7 +185,7 @@ def test_retained_source_admission_requires_owner_keep_decision() -> None:
             descriptor, "/private/source.jpg", RetainedSourceKind.MEDIA_ORIGINAL, "image/jpeg",
             OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-path")), _owner_gate(),
         )
-    for location_like_format in ("file:///private/source", r"C:\\private\\source.pdf", "/private/source.pdf"):
+    for location_like_format in ("file:///private/source", r"C:\\private\\source.pdf", "/private/source.pdf", "private/source.pdf"):
         with pytest.raises(ValueError, match="non-location format"):
             RetainedSourceAdmission(
                 descriptor, source, RetainedSourceKind.MEDIA_ORIGINAL, location_like_format,
@@ -232,6 +232,13 @@ def test_retained_source_restore_is_gated_and_generation_bound() -> None:
     )
     with pytest.raises(TransitionConflict, match="owner gate"):
         ArchivalTransitionKernel(adapter).restore(descriptor, forged_gate, source)
+
+    owner_gate = AccessAuthority(
+        OwnerAuthority.CLASS_ADAPTER,
+        OpaqueReference("retained-source-owner", _owner_gate().token),
+    )
+    protocol_restored = ArchivalTransitionKernel(adapter).restore(descriptor, owner_gate, source)
+    assert protocol_restored.receipt == store.read_restore(descriptor, source)
 
     foreign = RepresentationRef(
         "retained_source", OpaqueReference("retained-source-representation", "foreign-42")

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -223,6 +223,7 @@ def test_retained_source_restore_is_gated_and_generation_bound() -> None:
 
     restored = adapter.restore_to(descriptor, source, _owner_gate())
     assert restored.stage is TransitionStage.RESTORED
+    assert restored == store.read_restore(descriptor, source)
     assert store.write_calls == 1
 
     forged_gate = AccessAuthority(
@@ -231,6 +232,24 @@ def test_retained_source_restore_is_gated_and_generation_bound() -> None:
     )
     with pytest.raises(TransitionConflict, match="owner gate"):
         ArchivalTransitionKernel(adapter).restore(descriptor, forged_gate, source)
+
+    foreign = RepresentationRef(
+        "retained_source", OpaqueReference("retained-source-representation", "foreign-42")
+    )
+    foreign_identity = ArtifactIdentity(
+        OwnerAuthority.CLASS_ADAPTER,
+        OpaqueReference("retained-source", "foreign-owner-kept-42"),
+        "retained_source",
+    )
+    store.payloads[foreign] = store.payloads[source]
+    store.register_source(
+        Representation(
+            foreign_identity, foreign, descriptor.generation, TransitionStage.ACTIVE,
+            Liveness(LivenessState.ACTIVE, OpaqueReference("retained-source-liveness", "foreign-live")),
+        )
+    )
+    with pytest.raises(TransitionConflict, match="artifact identity"):
+        adapter.restore_to(descriptor, foreign, _owner_gate())
 
 
 def test_retained_source_policy_does_not_inherit_raw_ttl() -> None:

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -1,0 +1,219 @@
+"""GAF-04 production-path contract tests for curated retained sources."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from app.archival import (
+    ArchivalTransitionKernel,
+    ArtifactClass,
+    ArtifactDescriptor,
+    ArtifactIdentity,
+    DerivationClass,
+    DurableFakeAdapter,
+    DurabilityClass,
+    Generation,
+    Liveness,
+    LivenessState,
+    OpaqueReference,
+    OwnerAuthority,
+    PolicyProfile,
+    ProvenanceRef,
+    Representation,
+    RepresentationRef,
+    TransitionStage,
+)
+from app.archival.adapters.retained_source import (
+    OwnerKeepDecision,
+    RetainedSourceAdmission,
+    RetainedSourceAdapter,
+    RetainedSourceKind,
+    RetainedSourceRetirement,
+)
+from app.archival.transition import TransitionConflict, TransitionFailure
+
+
+class _StorePort(DurableFakeAdapter):
+    """Authorized PDM test binding; it exposes no DSN or filesystem location."""
+
+    contract = "StorePort"
+    owner_subsystem = "PDM"
+
+    def __init__(self, source: RepresentationRef, payload: bytes) -> None:
+        super().__init__()
+        self.payloads = {source: payload}
+        self.restored: dict[OpaqueReference, bytes] = {}
+        self.receipt_metadata = {}
+        self.read_calls = 0
+        self.write_calls = 0
+        self.fail_cleanup = False
+
+    def read_bytes(self, reference: RepresentationRef) -> bytes:
+        self.read_calls += 1
+        return self.payloads[reference]
+
+    def write_restored(
+        self,
+        destination: OpaqueReference,
+        payload: bytes,
+        *,
+        generation: Generation,
+        format: str,
+    ) -> None:
+        self.write_calls += 1
+        self.restored[destination] = payload
+
+    def copy_bytes(self, source: RepresentationRef, target: RepresentationRef) -> None:
+        self.payloads[target] = self.payloads[source]
+
+    def record_retained_source_receipt(self, receipt, metadata) -> None:  # type: ignore[no-untyped-def]
+        self.receipt_metadata[receipt.receipt_ref] = metadata
+
+    def cleanup(self, artifact: ArtifactDescriptor):  # type: ignore[no-untyped-def]
+        if self.fail_cleanup:
+            raise TransitionFailure("cleanup", "physical cleanup pending")
+        return super().cleanup(artifact)
+
+
+def _fixture(
+    *,
+    kind: RetainedSourceKind = RetainedSourceKind.MEDIA_ORIGINAL,
+    format: str = "image/jpeg",
+    payload: bytes = b"\x89JPEG-curated-original",
+) -> tuple[RetainedSourceAdapter, _StorePort, ArtifactDescriptor, RepresentationRef, RepresentationRef]:
+    identity = ArtifactIdentity(
+        OwnerAuthority.CLASS_ADAPTER,
+        OpaqueReference("retained-source", "owner-kept-42"),
+        "retained_source",
+    )
+    descriptor = ArtifactDescriptor(
+        identity=identity,
+        artifact_class=ArtifactClass.SOURCE,
+        derivation=DerivationClass.SOURCE,
+        durability=DurabilityClass.DURABLE,
+        owner=OwnerAuthority.CLASS_ADAPTER,
+        generation=Generation(7),
+        provenance_refs=(
+            ProvenanceRef("content", OpaqueReference("content-sha256", hashlib.sha256(payload).hexdigest())),
+            ProvenanceRef("origin", OpaqueReference("owner-provenance", "catalog-entry-42")),
+        ),
+        policy_profile=PolicyProfile.RETAINED_SOURCE,
+    )
+    source = RepresentationRef("retained_source", OpaqueReference("retained-source-representation", "primary-42"))
+    target = RepresentationRef("retained_source", OpaqueReference("retained-source-representation", "archive-42"))
+    store = _StorePort(source, payload)
+    store.register_source(
+        Representation(
+            identity,
+            source,
+            descriptor.generation,
+            TransitionStage.ACTIVE,
+            Liveness(LivenessState.ACTIVE, OpaqueReference("retained-source-liveness", "source-live")),
+        )
+    )
+    admission = RetainedSourceAdmission(
+        descriptor=descriptor,
+        source=source,
+        kind=kind,
+        format=format,
+        keep_decision=OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-42")),
+        restore_destination=_owner_gate(),
+    )
+    return RetainedSourceAdapter(admission, store), store, descriptor, source, target
+
+
+def _owner_gate() -> OpaqueReference:
+    return OpaqueReference("retained-source-destination", "reader-42")
+
+
+def test_retained_source_round_trip_preserves_identity_and_provenance() -> None:
+    for kind, format, payload in (
+        (RetainedSourceKind.MEDIA_ORIGINAL, "image/jpeg", b"\x89JPEG-curated-original"),
+        (RetainedSourceKind.DOCUMENT_ORIGINAL, "application/pdf", b"%PDF-curated-document"),
+    ):
+        adapter, store, descriptor, source, target = _fixture(kind=kind, format=format, payload=payload)
+
+        archived = ArchivalTransitionKernel(adapter).archive(descriptor, source, target, f"archive-{kind.value}")
+        restored = adapter.restore_to(descriptor, target, _owner_gate())
+
+        assert archived.stage is TransitionStage.RETIRED
+        assert archived.receipt is not None
+        assert archived.receipt.artifact == descriptor.identity
+        assert archived.receipt.generation == descriptor.generation
+        assert archived.receipt.policy_profile is PolicyProfile.RETAINED_SOURCE
+        assert store.receipt_metadata[archived.receipt.receipt_ref].provenance_refs == descriptor.provenance_refs
+        assert restored.provenance_refs == descriptor.provenance_refs
+        assert store.receipt_metadata[archived.receipt.receipt_ref].format == format
+        assert store.restored[_owner_gate()] == payload
+
+
+def test_retained_source_admission_requires_owner_keep_decision() -> None:
+    _adapter, _store, descriptor, source, _target = _fixture()
+
+    invalid = (
+        (RetainedSourceKind.EXTERNAL_RAW, OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-raw"))),
+        (RetainedSourceKind.COMPANION_NOTE, OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-note"))),
+        (RetainedSourceKind.MEDIA_ORIGINAL, None),
+    )
+    for kind, decision in invalid:
+        with pytest.raises(ValueError, match="explicit owner keep decision|not a retained-source admission"):
+            RetainedSourceAdmission(descriptor, source, kind, "image/jpeg", decision, _owner_gate())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="typed opaque reference"):
+        RetainedSourceAdmission(  # type: ignore[arg-type]
+            descriptor, "/private/source.jpg", RetainedSourceKind.MEDIA_ORIGINAL, "image/jpeg",
+            OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-path")), _owner_gate(),
+        )
+
+
+def test_retained_source_uses_store_port_and_redacted_receipts() -> None:
+    adapter, store, descriptor, source, target = _fixture()
+
+    archived = ArchivalTransitionKernel(adapter).archive(descriptor, source, target, "store-port")
+    restored = adapter.restore_to(descriptor, target, _owner_gate())
+
+    assert archived.receipt is not None and archived.receipt.redacted
+    assert restored.redacted
+    assert store.read_calls == 2  # archive verification plus gated restore
+    assert store.write_calls == 1
+    assert all("/" not in reference.opaque_id.token for reference in archived.receipt.representation_refs)
+
+
+def test_retained_source_restore_is_gated_and_generation_bound() -> None:
+    adapter, store, descriptor, source, _target = _fixture()
+
+    stale = ArtifactDescriptor(
+        descriptor.identity, descriptor.artifact_class, descriptor.derivation, descriptor.durability,
+        descriptor.owner, Generation(8), descriptor.provenance_refs, descriptor.policy_profile,
+    )
+    with pytest.raises(TransitionConflict, match="generation"):
+        adapter.restore_to(stale, source, _owner_gate())
+    assert store.write_calls == 0
+
+    with pytest.raises(TransitionConflict, match="destination"):
+        adapter.restore_to(descriptor, source, OpaqueReference("retained-source-destination", "other-destination"))
+    assert store.write_calls == 0
+
+    restored = adapter.restore_to(descriptor, source, _owner_gate())
+    assert restored.stage is TransitionStage.RESTORED
+    assert store.write_calls == 1
+
+
+def test_retained_source_policy_does_not_inherit_raw_ttl() -> None:
+    adapter, store, descriptor, source, target = _fixture()
+    kernel = ArchivalTransitionKernel(adapter)
+    kernel.archive(descriptor, source, target, "retire-policy")
+
+    pending = kernel.cleanup(descriptor)
+    assert pending.liveness.state is LivenessState.ERASURE_PENDING
+
+    adapter.authorize_retirement(RetainedSourceRetirement(descriptor.identity, descriptor.generation, OpaqueReference("retained-source-retirement", "retire-42")))
+    store.fail_cleanup = True
+    pending_on_failure = kernel.cleanup(descriptor)
+    assert pending_on_failure.liveness.state is LivenessState.ERASURE_PENDING
+    assert not pending_on_failure.terminal
+
+    store.fail_cleanup = False
+    assert kernel.cleanup(descriptor).stage is TransitionStage.ERASED

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -7,6 +7,7 @@ import hashlib
 import pytest
 
 from app.archival import (
+    AccessAuthority,
     ArchivalTransitionKernel,
     ArtifactClass,
     ArtifactDescriptor,
@@ -166,6 +167,12 @@ def test_retained_source_admission_requires_owner_keep_decision() -> None:
             descriptor, "/private/source.jpg", RetainedSourceKind.MEDIA_ORIGINAL, "image/jpeg",
             OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-path")), _owner_gate(),
         )
+    for location_like_format in ("file:///private/source", r"C:\\private\\source.pdf", "/private/source.pdf"):
+        with pytest.raises(ValueError, match="non-location format"):
+            RetainedSourceAdmission(
+                descriptor, source, RetainedSourceKind.MEDIA_ORIGINAL, location_like_format,
+                OwnerKeepDecision(OpaqueReference("retained-source-admission", "keep-format")), _owner_gate(),
+            )
 
 
 def test_retained_source_uses_store_port_and_redacted_receipts() -> None:
@@ -199,6 +206,13 @@ def test_retained_source_restore_is_gated_and_generation_bound() -> None:
     restored = adapter.restore_to(descriptor, source, _owner_gate())
     assert restored.stage is TransitionStage.RESTORED
     assert store.write_calls == 1
+
+    forged_gate = AccessAuthority(
+        OwnerAuthority.CLASS_ADAPTER,
+        OpaqueReference("retained-source-owner", "forged-destination"),
+    )
+    with pytest.raises(TransitionConflict, match="owner gate"):
+        ArchivalTransitionKernel(adapter).restore(descriptor, forged_gate, source)
 
 
 def test_retained_source_policy_does_not_inherit_raw_ttl() -> None:

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -47,6 +47,9 @@ class _StorePort(DurableFakeAdapter):
         self.payloads = {source: payload}
         self.restored: dict[OpaqueReference, bytes] = {}
         self.receipt_metadata = {}
+        self.restore_receipts = {}
+        self.admissions = {"keep-42"}
+        self.retirements = {"retire-42"}
         self.read_calls = 0
         self.write_calls = 0
         self.fail_cleanup = False
@@ -71,6 +74,20 @@ class _StorePort(DurableFakeAdapter):
 
     def record_retained_source_receipt(self, receipt, metadata) -> None:  # type: ignore[no-untyped-def]
         self.receipt_metadata[receipt.receipt_ref] = metadata
+
+    def validate_admission(self, admission) -> None:  # type: ignore[no-untyped-def]
+        if admission.keep_decision.reference.token not in self.admissions:
+            raise TransitionConflict("retained-source admission is not owner-issued")
+
+    def authorize_retirement(self, decision) -> None:  # type: ignore[no-untyped-def]
+        if decision.reference.token not in self.retirements:
+            raise TransitionConflict("retained-source retirement is not owner-issued")
+
+    def record_restore_receipt(self, receipt) -> None:  # type: ignore[no-untyped-def]
+        self.restore_receipts[(receipt.artifact, receipt.representation_refs[0])] = receipt
+
+    def read_restore(self, artifact, representation):  # type: ignore[no-untyped-def]
+        return self.restore_receipts.get((artifact.identity, representation))
 
     def cleanup(self, artifact: ArtifactDescriptor):  # type: ignore[no-untyped-def]
         if self.fail_cleanup:
@@ -148,6 +165,7 @@ def test_retained_source_round_trip_preserves_identity_and_provenance() -> None:
         assert restored.provenance_refs == descriptor.provenance_refs
         assert store.receipt_metadata[archived.receipt.receipt_ref].format == format
         assert store.restored[_owner_gate()] == payload
+        assert adapter.read_restore(descriptor, target) == restored
 
 
 def test_retained_source_admission_requires_owner_keep_decision() -> None:
@@ -224,6 +242,10 @@ def test_retained_source_policy_does_not_inherit_raw_ttl() -> None:
     assert pending.liveness.state is LivenessState.ERASURE_PENDING
 
     adapter.authorize_retirement(RetainedSourceRetirement(descriptor.identity, descriptor.generation, OpaqueReference("retained-source-retirement", "retire-42")))
+    with pytest.raises(TransitionConflict, match="not owner-issued"):
+        adapter.authorize_retirement(
+            RetainedSourceRetirement(descriptor.identity, descriptor.generation, OpaqueReference("retained-source-retirement", "forged-retire"))
+        )
     store.fail_cleanup = True
     pending_on_failure = kernel.cleanup(descriptor)
     assert pending_on_failure.liveness.state is LivenessState.ERASURE_PENDING


### PR DESCRIPTION
Governing-Issue: #5066

Fixes #5066

Final-Review-Rounds: 1

## Summary
Adds the GAF-04 explicit-owner retained-source adapter over the existing archival transition kernel. It admits only curated media/PDF originals, delegates persistence and byte movement to PDM StorePort, and keeps raw-evidence TTL/consent semantics out of retained-source retirement.

## Verification
- `pytest -q tests/archival/test_retained_source_adapter.py tests/stores/test_store_port.py tests/architecture/test_governed_archival_contract.py` (12 passed)
- `ruff check app tests`
- `mypy app`

## TCD
- Capability: gpt-5.6-terra/high, serial fresh issue agent, helper budget 0.
- Full path: data-surface mechanism review and one independent exact-head review before merge.

## Claim receipt
- task_id: `github-RasmusTho--agentic-pkm-mvp-issue-5066`
- lease_id: `lease-8eb1e7ef`
- holder: `codex-gpt-5.6-terra-high`
- evidence: `verified-dispatcher-lease`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No delivery divergence or BuilderOps operational artifact was produced; GitHub Issue/PR and dispatcher/worktree receipts remain their authoritative lifecycle surfaces.