### PR TITLE
Repair retained-source restore fencing

### DIFF
--- a/app/archival/adapters/retained_source.py
+++ b/app/archival/adapters/retained_source.py
@@ -170,7 +170,16 @@ class RetainedSourceStorePort(Protocol):
     def doctor(self) -> Sequence[DoctorFinding]: ...
     def read_bytes(self, reference: RepresentationRef) -> bytes: ...
     def copy_bytes(self, source: RepresentationRef, target: RepresentationRef) -> None: ...
-    def write_restored(self, destination: OpaqueReference, payload: bytes, *, generation: Generation, format: str) -> None: ...
+    def restore_bytes_if_generation_current(
+        self,
+        destination: OpaqueReference,
+        payload: bytes,
+        *,
+        generation: Generation,
+        format: str,
+    ) -> None:
+        """Atomically restore only when no newer generation owns destination."""
+        ...
     def record_restore_receipt(self, receipt: ArchivalReceipt) -> None: ...
     def record_retained_source_receipt(self, receipt: ArchivalReceipt, metadata: RetainedSourceReceiptMetadata) -> None: ...
 
@@ -202,19 +211,41 @@ class RetainedSourceAdapter:
         self._require_artifact(artifact)
         if destination != self.admission.restore_destination:
             raise TransitionConflict("restore destination differs from the owner gate")
-        self._require_active_representation(artifact, representation)
         authority = AccessAuthority(OwnerAuthority.CLASS_ADAPTER, OpaqueReference("retained-source-owner", destination.token))
         self.authorize_read(artifact, authority)
+        return self._restore_retained_bytes(artifact, representation)
+
+    def _restore_retained_bytes(
+        self,
+        artifact: ArtifactDescriptor,
+        representation: RepresentationRef,
+    ) -> ArchivalReceipt:
+        """Perform the generation-fenced StorePort byte recovery and readback."""
+        self._require_active_representation(artifact, representation)
         payload = self._store.read_bytes(representation)
         self._verify_content(payload)
-        self._store.write_restored(destination, payload, generation=artifact.generation, format=self.admission.format)
+        self._store.restore_bytes_if_generation_current(
+            self.admission.restore_destination,
+            payload,
+            generation=artifact.generation,
+            format=self.admission.format,
+        )
         receipt = ArchivalReceipt(
-            OpaqueReference("retained-source-receipt", f"restore-{destination.token}"),
+            OpaqueReference(
+                "retained-source-receipt",
+                f"restore-{self.admission.restore_destination.token}",
+            ),
             artifact.identity,
             artifact.generation,
             TransitionStage.RESTORED,
             artifact.policy_profile,
-            Liveness(LivenessState.ACTIVE, OpaqueReference("retained-source-liveness", f"restored-{destination.token}")),
+            Liveness(
+                LivenessState.ACTIVE,
+                OpaqueReference(
+                    "retained-source-liveness",
+                    f"restored-{self.admission.restore_destination.token}",
+                ),
+            ),
             artifact.provenance_refs,
             (representation,),
         )
@@ -287,9 +318,7 @@ class RetainedSourceAdapter:
     def restore(self, artifact: ArtifactDescriptor, authority: AccessAuthority, representation: RepresentationRef) -> ArchivalReceipt:
         self._require_artifact(artifact)
         self.authorize_read(artifact, authority)
-        self._require_active_representation(artifact, representation)
-        receipt = self._store.restore(artifact, authority, representation)
-        return self._record_restore_receipt(artifact, representation, receipt)
+        return self._restore_retained_bytes(artifact, representation)
 
     def read_restore(self, artifact: ArtifactDescriptor, representation: RepresentationRef) -> ArchivalReceipt | None:
         self._require_artifact(artifact)

--- a/tests/archival/test_retained_source_adapter.py
+++ b/tests/archival/test_retained_source_adapter.py
@@ -46,6 +46,7 @@ class _StorePort(DurableFakeAdapter):
         super().__init__()
         self.payloads = {source: payload}
         self.restored: dict[OpaqueReference, bytes] = {}
+        self.restored_generations: dict[OpaqueReference, Generation] = {}
         self.receipt_metadata = {}
         self.restore_receipts = {}
         self.admissions = {"keep-42"}
@@ -58,7 +59,7 @@ class _StorePort(DurableFakeAdapter):
         self.read_calls += 1
         return self.payloads[reference]
 
-    def write_restored(
+    def restore_bytes_if_generation_current(
         self,
         destination: OpaqueReference,
         payload: bytes,
@@ -66,8 +67,12 @@ class _StorePort(DurableFakeAdapter):
         generation: Generation,
         format: str,
     ) -> None:
+        current_generation = self.restored_generations.get(destination)
+        if current_generation is not None and current_generation.value > generation.value:
+            raise TransitionConflict("restore destination has a newer generation")
         self.write_calls += 1
         self.restored[destination] = payload
+        self.restored_generations[destination] = generation
 
     def copy_bytes(self, source: RepresentationRef, target: RepresentationRef) -> None:
         self.payloads[target] = self.payloads[source]
@@ -239,6 +244,14 @@ def test_retained_source_restore_is_gated_and_generation_bound() -> None:
     )
     protocol_restored = ArchivalTransitionKernel(adapter).restore(descriptor, owner_gate, source)
     assert protocol_restored.receipt == store.read_restore(descriptor, source)
+    assert store.restored[_owner_gate()] == store.payloads[source]
+
+    store.restored_generations[_owner_gate()] = Generation(8)
+    stale_destination = ArchivalTransitionKernel(adapter).restore(
+        descriptor, owner_gate, source
+    )
+    assert stale_destination.stage is TransitionStage.CONFLICT
+    assert store.restored_generations[_owner_gate()] == Generation(8)
 
     foreign = RepresentationRef(
         "retained_source", OpaqueReference("retained-source-representation", "foreign-42")


### PR DESCRIPTION
Governing-Issue: #5066

Fixes #5066

Final-Review-Rounds: 1

## Summary
Repairs the two retained-source P1 review findings from #5091. The shared archival kernel now performs retained-byte recovery through the PDM StorePort, with payload verification, receipt readback, and an atomic StorePort generation fence that rejects overwriting a newer owner destination.

## Verification
- `pytest -q tests/archival/test_retained_source_adapter.py tests/stores/test_store_port.py tests/architecture/test_governed_archival_contract.py` (12 passed)
- `ruff check app/archival/adapters/retained_source.py tests/archival/test_retained_source_adapter.py`
- `mypy app`

## TCD
- Capability: gpt-5.6-terra/high, serial issue repair, helper budget 0.
- Full path: post-merge P1 repair, current-head CI, and independent review.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This is a bounded repair of GitHub-visible review feedback; GitHub Issue/PR, dispatcher, and worktree lifecycle records are authoritative.
