### PR TITLE
Allow fresh BuilderOps hosts to bootstrap cutover evidence

### DIFF
--- a/app/builderops/cutover_evidence.py
+++ b/app/builderops/cutover_evidence.py
@@ -19,6 +19,7 @@ from typing import Any, Mapping
 from uuid import NAMESPACE_OID, UUID, uuid5
 
 from app.builderops.config import validate_db_path_outside_vault
+from app.builderops.store import SqliteBuilderOpsStore
 
 
 RECEIPT_SCHEMA = "builderops.host-store-cutover.v2"
@@ -67,7 +68,10 @@ def _utc(value: str) -> datetime:
 
 
 def _regular(path: Path) -> os.stat_result:
-    entry = path.lstat()
+    try:
+        entry = path.lstat()
+    except OSError as exc:
+        raise CutoverEvidenceError("cutover evidence contains a non-regular path") from exc
     if stat.S_ISLNK(entry.st_mode) or not stat.S_ISREG(entry.st_mode):
         raise CutoverEvidenceError("cutover evidence contains a non-regular path")
     return entry
@@ -125,8 +129,8 @@ def _records(path: Path) -> list[dict[str, str]]:
     return [{"id": str(row[0]), "payload_sha256": hashlib.sha256(str(row[1]).encode()).hexdigest()} for row in rows]
 
 
-def inspect_target(db_path: Path) -> dict[str, Any]:
-    """Inspect an existing target without creating or initializing it."""
+def inspect_target(db_path: Path, *, allow_empty: bool = False) -> dict[str, Any]:
+    """Inspect an initialized target, optionally admitting a zero-record bootstrap."""
     entry = _regular(db_path)
     if entry.st_size == 0:
         raise CutoverEvidenceError("target store is empty")
@@ -137,7 +141,7 @@ def inspect_target(db_path: Path) -> dict[str, Any]:
             marker = connection.execute("SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'").fetchone()
     except sqlite3.Error as exc:
         raise CutoverEvidenceError("target store is not an initialized BuilderOps database") from exc
-    if not isinstance(count, int) or count <= 0:
+    if not isinstance(count, int) or (count <= 0 and not allow_empty):
         raise CutoverEvidenceError("target store is empty")
     # The target necessarily changes after cutover as normal BuilderOps records
     # are appended.  Bind its identity and prove it was non-empty at receipt
@@ -198,7 +202,7 @@ def _reconciliation(
 
 
 def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, actor: str) -> dict[str, Any]:
-    """Build a receipt only after a real, non-empty target has been reconciled."""
+    """Build a receipt after reconciliation, or bootstrap a proven-empty host."""
     target_path = state_dir / _LEGACY_DB
     validate_db_path_outside_vault(target_path)
     if not isinstance(actor, str) or not actor.strip():
@@ -208,8 +212,16 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     inventory = discover_legacy_stores(participant_list)
     if any(item["mtime_ns"] > int(cutoff.timestamp() * 1_000_000_000) for item in inventory):
         raise CutoverEvidenceError("legacy store changed during reconciliation inventory")
-    report = _reconciliation(reconciliation, inventory, target_path, verify_migrated_target=True)
-    target = inspect_target(target_path)
+    bootstrap = not inventory
+    if bootstrap and not target_path.exists():
+        SqliteBuilderOpsStore(target_path).initialize()
+    target = inspect_target(target_path, allow_empty=bootstrap)
+    report = _reconciliation(
+        reconciliation,
+        inventory,
+        target_path,
+        verify_migrated_target=not bootstrap,
+    )
     host, user = __import__("platform").node().strip(), str(os.getuid())
     derived_epoch = _derived_epoch(host, user, participant_list, inventory, report, target["identity"])
     payload: dict[str, Any] = {
@@ -226,12 +238,17 @@ def build_receipt(*, state_dir: Path, participants: Any, reconciliation: Any, ac
     # drifted while source records were being inspected.  Re-run both source
     # discovery and reconciliation immediately before the sole write.
     final_inventory = discover_legacy_stores(participant_list)
-    final_report = _reconciliation(reconciliation, final_inventory, target_path, verify_migrated_target=True)
+    final_report = _reconciliation(
+        reconciliation,
+        final_inventory,
+        target_path,
+        verify_migrated_target=bool(final_inventory),
+    )
     if final_inventory != inventory or final_report != report:
         raise CutoverEvidenceError("legacy store inventory drifted during reconciliation")
     evidence_digest = hashlib.sha256(_canonical(_evidence_projection(payload))).hexdigest()
     _stamp_target(target_path, {"identity": target["identity"], "epoch": derived_epoch, "evidence_sha256": evidence_digest})
-    payload["target_store"] = inspect_target(target_path)
+    payload["target_store"] = inspect_target(target_path, allow_empty=bootstrap)
     payload["receipt_sha256"] = hashlib.sha256(_canonical(payload)).hexdigest()
     return payload
 
@@ -275,9 +292,10 @@ def validate_receipt(state_dir: Path, payload: Any, *, host_id: str, user_id: st
         report = _reconciliation(receipt.get("reconciliation"), inventory, state_dir / _LEGACY_DB, verify_migrated_target=False)
         if report != receipt.get("reconciliation") or hashlib.sha256(_canonical(report)).hexdigest() != receipt.get("reconciliation_sha256"):
             raise CutoverEvidenceError("cutover receipt reconciliation binding is invalid")
-        target = inspect_target(state_dir / _LEGACY_DB)
+        target = inspect_target(state_dir / _LEGACY_DB, allow_empty=not inventory)
         recorded_target = receipt.get("target_store")
-        if not isinstance(recorded_target, Mapping) or recorded_target.get("path") != target["path"] or target["identity"] != recorded_target.get("identity") or target.get("marker") != recorded_target.get("marker") or target["record_count"] < int(recorded_target.get("record_count", 1)):
+        minimum_count = 0 if not inventory else 1
+        if not isinstance(recorded_target, Mapping) or recorded_target.get("path") != target["path"] or target["identity"] != recorded_target.get("identity") or target.get("marker") != recorded_target.get("marker") or target["record_count"] < int(recorded_target.get("record_count", minimum_count)):
             raise CutoverEvidenceError("cutover target store is empty, changed, or unaccounted")
         marker = json.loads(str(target["marker"]))
         expected_epoch = _derived_epoch(host_id, user_id, participants, inventory, report, target["identity"])

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -110,7 +110,9 @@ python -m app.builderops builderops cutover-evidence generate \
 
 The ordered participant/repository/root list is the explicit inventory boundary. The producer
 recursively discovers every legacy store beneath those roots, binds its identity and disposition,
-the actual host and numeric user, one reconciliation epoch, and an already-existing non-empty target.
+the actual host and numeric user, one reconciliation epoch, and a reconciled target. When that
+inventory is empty, the producer may initialize and bind a zero-record host-stable target; when it
+is non-empty, the target must already be initialized and non-empty.
 Because this producer governs the implicit host-stable store, the group-level CLI `--db-path`
 override is rejected before inspection or mutation.
 The producer also applies the shared vault-confinement guard to the implicit target path before
@@ -217,47 +219,29 @@ selection.
 
 ### Bootstrapping the receipt on a host with no host-stable store
 
-`cutover-evidence generate` verifies an existing target; it never creates one. `build_receipt`
-inspects the implicit target with `inspect_target` and fails closed with `target store is empty`
-unless that database already exists, is an initialized BuilderOps database, and holds at least one
-record. The producer always resolves the target from the default state directory:
+`cutover-evidence generate` has one narrow fresh-host bootstrap: when the declared participant roots
+contain no legacy stores, it initializes the implicit target and binds its zero-record state in the
+receipt. `build_receipt` otherwise inspects the implicit target and fails closed with `target store
+is empty` unless the database already exists, is an initialized BuilderOps database, and holds at
+least one record. The producer always resolves the target from the default state directory:
 `BUILDEROPS_STATE_DIR` does not redirect it, and the CLI rejects `--db-path` before inspection.
 
-Because implicit selection is exactly what the guard blocks, the target cannot be created through
-the implicit path. On a host with no host-stable store yet, the receipt route is therefore
-override-first — the override is a prerequisite of the receipt, not an alternative to it:
+With an empty legacy inventory, the receipt route can bootstrap a fresh host without an override:
 
 ```bash
-# 1. Pin the store explicitly at the default state directory, because that is the only target the
-#    producer will inspect. Clear any inherited BUILDEROPS_DB_PATH first: an exact database path
-#    takes precedence over the state directory when both are set, so leaving it in place would
-#    write step 2 into the old database while the producer inspects the still-empty target.
-unset BUILDEROPS_DB_PATH
-export BUILDEROPS_STATE_DIR="$HOME/.local/state/builderops"
-
-# 2. Initialize the target and give it at least one record. An initialized but record-free
-#    database still fails with "target store is empty".
-scripts/builderops_cli.sh builderops create-worklog \
-  --summary "Host store bootstrap" \
-  --body "Initialized the host-stable target store." \
-  --source-ref repo_doc:docs/builderops/BUILDEROPS_VAULT_STORE.md \
-  --idempotency-key create:host_store_bootstrap
-
-# 3. Stop BuilderOps writers and reconcile every legacy store beneath the participant roots into
-#    that target, then generate the receipt from a working directory inside exactly one declared
-#    participant root.
+# 1. Run from a working directory inside exactly one declared participant root, then generate.
 python -m app.builderops builderops cutover-evidence generate \
   --participants-file participants.json --reconciliation-file reconciliation.json \
   --actor <operator> --json
 
-# 4. Drop the override and confirm that implicit selection now passes.
-unset BUILDEROPS_STATE_DIR
+# 2. Confirm that implicit selection now passes.
 scripts/builderops_cli.sh builderops list --json
 ```
 
-Stopping after step 2 leaves a working host-stable store under the explicit-override posture. The
-receipt only adds self-verifying implicit selection on top of it, and is worth producing only when
-the bindings in `Choosing a store posture for a host` hold.
+If any legacy store is discovered, this bootstrap does not apply: stop BuilderOps writers,
+reconcile every discovered store into an already-existing non-empty target, and then generate the
+receipt. An absent, zero-byte, uninitialized, or zero-record target still fails closed in that path.
+The receipt remains worthwhile only when the bindings in `Choosing a store posture for a host` hold.
 
 ### Shared artifact vault and advisory claim signals
 

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -106,6 +106,27 @@ def test_default_db_path_is_host_stable_and_cwd_independent(
     assert first.db_path.is_absolute()
 
 
+def test_implicit_selection_accepts_bootstrap_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = tmp_path / "host-state" / "builderops"
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(builderops_config, "default_state_dir", lambda: state_dir)
+
+    receipt = build_receipt(
+        state_dir=state_dir,
+        participants=[{"repository": "owner/repo", "root": str(root)}],
+        reconciliation=[],
+        actor="operator-test",
+    )
+    write_receipt(state_dir, receipt)
+
+    assert builderops_config.load_paths({}).db_path == state_dir / "builderops.sqlite3"
+
+
 def test_host_stable_default_still_confined_outside_vault(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/builderops/test_cutover_evidence.py
+++ b/tests/builderops/test_cutover_evidence.py
@@ -33,6 +33,76 @@ def _receipt(state_dir: Path, root: Path) -> dict[str, object]:
     return build_receipt(state_dir=state_dir, participants=participants, reconciliation=report, actor="operator")
 
 
+def test_generate_bootstraps_absent_target_when_inventory_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    receipt = build_receipt(
+        state_dir=state_dir,
+        participants=[{"repository": "owner/repo", "root": str(root)}],
+        reconciliation=[],
+        actor="operator",
+    )
+    receipt_path = write_receipt(state_dir, receipt)
+
+    assert receipt_path.stat().st_mode & 0o777 == 0o600
+    assert not receipt_path.is_symlink()
+    assert receipt["legacy_store_inventory"] == []
+    assert receipt["reconciliation"] == []
+    assert receipt["target_store"]["record_count"] == 0
+    with sqlite3.connect(f"file:{state_dir / 'builderops.sqlite3'}?mode=ro", uri=True) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM builderops_records").fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT value FROM builderops_meta WHERE key = 'host_store_cutover_v2'"
+        ).fetchone() is not None
+
+
+def test_generate_still_requires_non_empty_target_when_legacy_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    legacy = root / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy.parent.mkdir(parents=True)
+    SqliteBuilderOpsStore(legacy).initialize()
+    participants = [{"repository": "owner/repo", "root": str(root)}]
+    report = [{"path": str(legacy), "disposition": "retained"}]
+    monkeypatch.chdir(root)
+
+    with pytest.raises(CutoverEvidenceError, match="non-regular path"):
+        build_receipt(state_dir=state_dir, participants=participants, reconciliation=report, actor="operator")
+    SqliteBuilderOpsStore(state_dir / "builderops.sqlite3").initialize()
+    with pytest.raises(CutoverEvidenceError, match="target store is empty"):
+        build_receipt(state_dir=state_dir, participants=participants, reconciliation=report, actor="operator")
+
+
+def test_bootstrap_receipt_fails_on_later_legacy_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir, root = tmp_path / "state", tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+    receipt = build_receipt(
+        state_dir=state_dir,
+        participants=[{"repository": "owner/repo", "root": str(root)}],
+        reconciliation=[],
+        actor="operator",
+    )
+    legacy = root / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy.parent.mkdir(parents=True)
+    SqliteBuilderOpsStore(legacy).initialize()
+
+    with pytest.raises(CutoverEvidenceError, match="inventory is incomplete or stale"):
+        evidence.validate_receipt(
+            state_dir,
+            receipt,
+            host_id=config.current_host_id(),
+            user_id=config.current_user_id(),
+        )
+
+
 def _resign(receipt: dict[str, object]) -> None:
     receipt.pop("receipt_sha256", None)
     receipt["receipt_sha256"] = hashlib.sha256(json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()).hexdigest()


### PR DESCRIPTION
Governing-Issue: #4175

Fixes #4175

Final-Review-Rounds: 0

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: authority-bearing (guards which SQLite store BuilderOps records are written to)
- Persistence impact: durable host-local store selection and cutover receipt
- Derived/rebuildable impact: none
- New or changed contract: empty-inventory fresh-host bootstrap for builderops.host-store-cutover.v2; non-empty inventory remains fail-closed
- Owner-doc impact: updated in this PR (`docs/builderops/BUILDEROPS_VAULT_STORE.md`)
- Transition debt impact: reduces fresh-host override dependency
- Boundary risk: bootstrap must never bypass inventory/confinement/host-user receipt bindings or admit a non-empty inventory with an empty target

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Permit a proven-empty legacy inventory on a fresh host to initialize and bind the zero-record host-stable BuilderOps store.
- Validate the bootstrap receipt on implicit store load while preserving fail-closed behavior when legacy records exist.
- Add regression coverage for bootstrap, later legacy-store invalidation, and non-empty cutover requirements.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: implementation changes repo-governed BuilderOps store selection and receipt verification only; no BuilderOps operational record was created.

## Validation
- `python3 -m pytest -q tests/builderops/test_cutover_evidence.py tests/builderops/test_config_paths.py` — 28 passed
- `python3 -m pytest -q tests/builderops` — 1146 passed, 167 skipped, 1 warning
- `ruff check app/builderops/cutover_evidence.py tests/builderops/test_cutover_evidence.py tests/builderops/test_config_paths.py` — passed
- `mypy app` — passed
- `python3 scripts/docs_guard.py --language-only` — passed
- Baseline run with the new tests before implementation: all 4 new tests failed; after implementation: all 4 passed
- Required host-leased repo-wide `not pg` validation was attempted. The parallel path was blocked by missing `xdist`; the serial fallback reached collection but was blocked by missing environment dependency `lingua` (187 collection errors). No green repo-wide `not pg` result is claimed.

## Notes
- No live host or deployment state was mutated.
- The implementation is committed at `244569ac722fb6a51961392f48edcefc52efcd34`.
