### PR TITLE
Fail closed on opaque TARS credential evidence

### DIFF
--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -26,6 +26,9 @@ _ROOT = Path(__file__).resolve().parents[2]
 _SECRET_KEY = re.compile(r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)", re.I)
 _SECRET_VALUE = re.compile(r"(?:bearer\s+|gh[pousr]_[A-Za-z0-9_]|pve[ta]=|-----BEGIN [A-Z ]+PRIVATE KEY-----)", re.I)
 _OPAQUE_CREDENTIAL_KEYS = frozenset({"database_url", "dsn", "passwd", "session_cookie"})
+_SECRET_REFERENCE = re.compile(
+    r"^(?:keychain:(?://)?[A-Za-z0-9][A-Za-z0-9._/-]*|\$\{SECRET:[A-Za-z0-9][A-Za-z0-9._/-]*\})$"
+)
 _FINGERPRINT = re.compile(r"^[a-f0-9]{64}$")
 
 # The baseline is intentionally limited to builder-system.  It has no GPU or
@@ -77,7 +80,28 @@ def _key_is_secret(key: str) -> bool:
     )
 
 
+def _reference_cardinality(key: str) -> str | None:
+    normalized = key.lower().replace("-", "_")
+    if normalized.endswith("_refs"):
+        return "many"
+    if normalized.endswith("_ref"):
+        return "one"
+    return None
+
+
+def _is_valid_secret_reference(value: Any) -> bool:
+    return isinstance(value, str) and _SECRET_REFERENCE.fullmatch(value) is not None
+
+
 def _contains_secret(value: Any, *, key: str | None = None) -> bool:
+    if key is not None:
+        reference_cardinality = _reference_cardinality(key)
+        if reference_cardinality == "one":
+            return not _is_valid_secret_reference(value)
+        if reference_cardinality == "many":
+            return not isinstance(value, list) or any(
+                not _is_valid_secret_reference(item) for item in value
+            )
     if key is not None and _key_is_secret(key):
         if key.lower().replace("-", "_") in _OPAQUE_CREDENTIAL_KEYS:
             return True
@@ -92,6 +116,14 @@ def _contains_secret(value: Any, *, key: str | None = None) -> bool:
 
 
 def _redact(value: Any, *, key: str | None = None) -> Any:
+    if key is not None:
+        reference_cardinality = _reference_cardinality(key)
+        if reference_cardinality == "one":
+            return value if _is_valid_secret_reference(value) else "[REDACTED]"
+        if reference_cardinality == "many":
+            if not isinstance(value, list):
+                return "[REDACTED]"
+            return [item if _is_valid_secret_reference(item) else "[REDACTED]" for item in value]
     if key is not None and _key_is_secret(key):
         return "[REDACTED]"
     if isinstance(value, str):

--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -30,7 +30,8 @@ _SECRET_VALUE = re.compile(
     r"gh[pousr]_[A-Za-z0-9_]+|"
     r"pve[ta]=|"
     r"-----BEGIN [A-Z ]+PRIVATE KEY-----|"
-    r"[A-Za-z][A-Za-z0-9+.-]*://[^\s/@:]+(?::[^\s/@]*)?@|"
+    r"[A-Za-z][A-Za-z0-9+.-]*://[^\s@]+@|"
+    r"(?:^|[\s;])[^\s;:@]+:[^\s;@]+@|"
     r"(?:password|passwd|pwd|secret|token|api[_-]?key)\s*=\s*(?!\[REDACTED\])\S+"
     r")",
     re.I,
@@ -42,6 +43,7 @@ _SECRET_REFERENCE = re.compile(
     r"^(?:keychain:(?://)?[A-Za-z0-9][A-Za-z0-9._/-]*|\$\{SECRET:[A-Za-z0-9][A-Za-z0-9._/-]*\})$"
 )
 _FINGERPRINT = re.compile(r"^[a-f0-9]{64}$")
+_CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 
 # The baseline is intentionally limited to builder-system.  It has no GPU or
 # test-tailnet vector; neither is a prerequisite for this qualification slice.
@@ -83,17 +85,28 @@ def _loads_schema(name: str) -> Mapping[str, Any]:
     return json.loads((_ROOT / "config" / "platform" / name).read_text(encoding="utf-8"))
 
 
+def _normalize_key(key: str) -> str:
+    return _CAMEL_CASE_BOUNDARY.sub("_", key).lower().replace("-", "_")
+
+
+def _is_opaque_credential_key(key: str) -> bool:
+    normalized = _normalize_key(key)
+    return normalized in _OPAQUE_CREDENTIAL_KEYS or any(
+        normalized.endswith(f"_{candidate}") for candidate in _OPAQUE_CREDENTIAL_KEYS
+    )
+
+
 def _key_is_secret(key: str) -> bool:
-    normalized = key.lower().replace("-", "_")
+    normalized = _normalize_key(key)
     return (
         not normalized.endswith("_ref")
         and not normalized.endswith("_refs")
-        and (normalized in _OPAQUE_CREDENTIAL_KEYS or _SECRET_KEY.search(normalized) is not None)
+        and (_is_opaque_credential_key(key) or _SECRET_KEY.search(normalized) is not None)
     )
 
 
 def _reference_cardinality(key: str) -> str | None:
-    normalized = key.lower().replace("-", "_")
+    normalized = _normalize_key(key)
     if normalized.endswith("_refs"):
         return "many"
     if normalized.endswith("_ref"):
@@ -115,8 +128,6 @@ def _contains_secret(value: Any, *, key: str | None = None) -> bool:
                 not _is_valid_secret_reference(item) for item in value
             )
     if key is not None and _key_is_secret(key):
-        if key.lower().replace("-", "_") in _OPAQUE_CREDENTIAL_KEYS:
-            return True
         return True
     if isinstance(value, str):
         return value == "[REDACTED]" or _SECRET_VALUE.search(value) is not None

--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -24,7 +24,17 @@ POLICY_VERSION = "tars-builder-system-baseline.v1"
 MAX_EVIDENCE_AGE = timedelta(hours=24)
 _ROOT = Path(__file__).resolve().parents[2]
 _SECRET_KEY = re.compile(r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)", re.I)
-_SECRET_VALUE = re.compile(r"(?:bearer\s+|gh[pousr]_[A-Za-z0-9_]|pve[ta]=|-----BEGIN [A-Z ]+PRIVATE KEY-----)", re.I)
+_SECRET_VALUE = re.compile(
+    r"(?:"
+    r"bearer\s+|"
+    r"gh[pousr]_[A-Za-z0-9_]+|"
+    r"pve[ta]=|"
+    r"-----BEGIN [A-Z ]+PRIVATE KEY-----|"
+    r"[A-Za-z][A-Za-z0-9+.-]*://[^\s/@:]+(?::[^\s/@]*)?@|"
+    r"(?:password|passwd|pwd|secret|token|api[_-]?key)\s*=\s*(?!\[REDACTED\])\S+"
+    r")",
+    re.I,
+)
 _OPAQUE_CREDENTIAL_KEYS = frozenset(
     {"connection_string", "database_url", "dsn", "passwd", "session_cookie"}
 )
@@ -107,9 +117,9 @@ def _contains_secret(value: Any, *, key: str | None = None) -> bool:
     if key is not None and _key_is_secret(key):
         if key.lower().replace("-", "_") in _OPAQUE_CREDENTIAL_KEYS:
             return True
-        return value != "[REDACTED]"
+        return True
     if isinstance(value, str):
-        return value != "[REDACTED]" and _SECRET_VALUE.search(value) is not None
+        return value == "[REDACTED]" or _SECRET_VALUE.search(value) is not None
     if isinstance(value, Mapping):
         return any(_contains_secret(item, key=str(child_key)) for child_key, item in value.items())
     if isinstance(value, list):

--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -25,7 +25,9 @@ MAX_EVIDENCE_AGE = timedelta(hours=24)
 _ROOT = Path(__file__).resolve().parents[2]
 _SECRET_KEY = re.compile(r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)", re.I)
 _SECRET_VALUE = re.compile(r"(?:bearer\s+|gh[pousr]_[A-Za-z0-9_]|pve[ta]=|-----BEGIN [A-Z ]+PRIVATE KEY-----)", re.I)
-_OPAQUE_CREDENTIAL_KEYS = frozenset({"database_url", "dsn", "passwd", "session_cookie"})
+_OPAQUE_CREDENTIAL_KEYS = frozenset(
+    {"connection_string", "database_url", "dsn", "passwd", "session_cookie"}
+)
 _SECRET_REFERENCE = re.compile(
     r"^(?:keychain:(?://)?[A-Za-z0-9][A-Za-z0-9._/-]*|\$\{SECRET:[A-Za-z0-9][A-Za-z0-9._/-]*\})$"
 )

--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -32,6 +32,7 @@ _SECRET_VALUE = re.compile(
     r"-----BEGIN [A-Z ]+PRIVATE KEY-----|"
     r"[A-Za-z][A-Za-z0-9+.-]*://[^\s@]+@|"
     r"(?:^|[\s;])[^\s;:@]+:[^\s;@]+@|"
+    r"(?:^|[\s;])[^\s;:@/]+/[^\s;@]+@|"
     r"(?:password|passwd|pwd|secret|token|api[_-]?key)\s*=\s*(?!\[REDACTED\])\S+"
     r")",
     re.I,
@@ -44,6 +45,7 @@ _SECRET_REFERENCE = re.compile(
 )
 _FINGERPRINT = re.compile(r"^[a-f0-9]{64}$")
 _CAMEL_CASE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_CAMEL_CASE_ACRONYM_BOUNDARY = re.compile(r"([A-Z]+)([A-Z][a-z])")
 
 # The baseline is intentionally limited to builder-system.  It has no GPU or
 # test-tailnet vector; neither is a prerequisite for this qualification slice.
@@ -86,7 +88,8 @@ def _loads_schema(name: str) -> Mapping[str, Any]:
 
 
 def _normalize_key(key: str) -> str:
-    return _CAMEL_CASE_BOUNDARY.sub("_", key).lower().replace("-", "_")
+    with_acronym_boundaries = _CAMEL_CASE_ACRONYM_BOUNDARY.sub(r"\1_\2", key)
+    return _CAMEL_CASE_BOUNDARY.sub("_", with_acronym_boundaries).lower().replace("-", "_")
 
 
 def _is_opaque_credential_key(key: str) -> bool:

--- a/app/ops/tars_qualification.py
+++ b/app/ops/tars_qualification.py
@@ -25,6 +25,7 @@ MAX_EVIDENCE_AGE = timedelta(hours=24)
 _ROOT = Path(__file__).resolve().parents[2]
 _SECRET_KEY = re.compile(r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)", re.I)
 _SECRET_VALUE = re.compile(r"(?:bearer\s+|gh[pousr]_[A-Za-z0-9_]|pve[ta]=|-----BEGIN [A-Z ]+PRIVATE KEY-----)", re.I)
+_OPAQUE_CREDENTIAL_KEYS = frozenset({"database_url", "dsn", "passwd", "session_cookie"})
 _FINGERPRINT = re.compile(r"^[a-f0-9]{64}$")
 
 # The baseline is intentionally limited to builder-system.  It has no GPU or
@@ -72,12 +73,14 @@ def _key_is_secret(key: str) -> bool:
     return (
         not normalized.endswith("_ref")
         and not normalized.endswith("_refs")
-        and _SECRET_KEY.search(normalized) is not None
+        and (normalized in _OPAQUE_CREDENTIAL_KEYS or _SECRET_KEY.search(normalized) is not None)
     )
 
 
 def _contains_secret(value: Any, *, key: str | None = None) -> bool:
     if key is not None and _key_is_secret(key):
+        if key.lower().replace("-", "_") in _OPAQUE_CREDENTIAL_KEYS:
+            return True
         return value != "[REDACTED]"
     if isinstance(value, str):
         return value != "[REDACTED]" and _SECRET_VALUE.search(value) is not None
@@ -157,7 +160,13 @@ def _baseline_refusals(evidence: Mapping[str, Any]) -> list[str]:
 
     builder_engine = builderops.get("builder_engine_id")
     product_engine = builderops.get("product_engine_id")
-    if not isinstance(builder_engine, str) or not builder_engine or builder_engine == product_engine:
+    if (
+        not isinstance(builder_engine, str)
+        or not builder_engine.strip()
+        or not isinstance(product_engine, str)
+        or not product_engine.strip()
+        or builder_engine.strip() == product_engine.strip()
+    ):
         refusals.append("VM 102 must not share the Product Docker engine")
     projects = builderops.get("compose_projects")
     if not isinstance(projects, list) or any(not isinstance(item, str) or item.startswith("pkm-") for item in projects):

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -99,6 +99,8 @@ def test_evidence_bundle_redacts_credentials_and_secrets() -> None:
 def test_opaque_credential_fields_are_refused() -> None:
     opaque_fields = {
         "connection_string": "postgresql://user:opaque@example.invalid/app",
+        "primary_connection_string": "postgresql://user:opaque@example.invalid/app",
+        "connectionString": "postgresql://user:opaque@example.invalid/app",
         "session_cookie": "opaque-session-cookie",
         "passwd": "opaque-password",
         "database_url": "postgresql://user:password@example.invalid/app",

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -96,6 +96,54 @@ def test_evidence_bundle_redacts_credentials_and_secrets() -> None:
     assert bundle["evidence"]["builderops"]["nested"]["password"] == "[REDACTED]"
 
 
+def test_opaque_credential_fields_are_refused() -> None:
+    opaque_fields = {
+        "session_cookie": "opaque-session-cookie",
+        "passwd": "opaque-password",
+        "database_url": "postgresql://user:password@example.invalid/app",
+        "dsn": "host=example.invalid user=app password=opaque",
+    }
+
+    for field, secret in opaque_fields.items():
+        evidence = _evidence()
+        evidence["builderops"][field] = secret
+        evidence["builderops"][f"{field}_ref"] = f"keychain:builderops.{field}"
+
+        bundle = emit_redacted_evidence_bundle(evidence)
+        receipt = evaluate_qualification(bundle)
+
+        assert secret not in str(bundle)
+        assert bundle["evidence"]["builderops"][field] == "[REDACTED]"
+        assert (
+            bundle["evidence"]["builderops"][f"{field}_ref"]
+            == f"keychain:builderops.{field}"
+        )
+        assert receipt["candidate_verdict"] == "fail"
+        assert any("secret-bearing" in refusal for refusal in receipt["refusals"])
+
+
+def test_product_engine_identity_is_required_for_isolation() -> None:
+    invalid_product_engine_ids: tuple[object, ...] = (None, 102, "", "   ", "engine-builder-102")
+
+    missing = _evidence()
+    del missing["builderops"]["product_engine_id"]
+    invalid_evidence = [missing]
+    for product_engine_id in invalid_product_engine_ids:
+        evidence = _evidence()
+        evidence["builderops"]["product_engine_id"] = product_engine_id
+        invalid_evidence.append(evidence)
+
+    whitespace_alias = _evidence()
+    whitespace_alias["builderops"]["product_engine_id"] = " engine-builder-102 "
+    invalid_evidence.append(whitespace_alias)
+
+    for evidence in invalid_evidence:
+        receipt = evaluate_qualification(emit_redacted_evidence_bundle(evidence))
+
+        assert receipt["candidate_verdict"] == "fail"
+        assert any("Product Docker engine" in refusal for refusal in receipt["refusals"])
+
+
 def test_qualification_policy_has_no_gpu_or_test_tailnet_prerequisite() -> None:
     serialized = str(DEFAULT_POLICY).lower()
     assert "gpu" not in serialized

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -101,6 +101,8 @@ def test_opaque_credential_fields_are_refused() -> None:
         "connection_string": "postgresql://user:opaque@example.invalid/app",
         "primary_connection_string": "postgresql://user:opaque@example.invalid/app",
         "connectionString": "postgresql://user:opaque@example.invalid/app",
+        "redisConnectionString": "redis://:opaque@example.invalid/0",
+        "mysqlDsn": "app:opaque@tcp(example.invalid:3306)/app",
         "session_cookie": "opaque-session-cookie",
         "passwd": "opaque-password",
         "database_url": "postgresql://user:password@example.invalid/app",

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -122,6 +122,57 @@ def test_opaque_credential_fields_are_refused() -> None:
         assert any("secret-bearing" in refusal for refusal in receipt["refusals"])
 
 
+def test_malformed_secret_reference_values_are_redacted_and_refused() -> None:
+    malformed_references: tuple[tuple[str, object, str], ...] = (
+        ("database_url_ref", "postgresql://user:password@example.invalid/app", "password"),
+        ("session_cookie_ref", "opaque-session-cookie", "opaque-session-cookie"),
+        ("passwd_ref", None, ""),
+        ("dsn_refs", "host=example.invalid password=opaque", "password=opaque"),
+        (
+            "database_url_refs",
+            ["keychain:builderops.primary-database", "postgresql://user:password@example.invalid/app"],
+            "password@example.invalid",
+        ),
+        ("session_cookie_refs", ["keychain:builderops.session-cookie", 42], ""),
+    )
+
+    for field, malformed_value, raw_fragment in malformed_references:
+        evidence = _evidence()
+        evidence["builderops"][field] = malformed_value
+
+        bundle = emit_redacted_evidence_bundle(evidence)
+        receipt = evaluate_qualification(bundle)
+
+        if raw_fragment:
+            assert raw_fragment not in str(bundle)
+        assert receipt["candidate_verdict"] == "fail"
+        assert any("secret-bearing" in refusal for refusal in receipt["refusals"])
+
+
+def test_valid_secret_reference_values_remain_allowed() -> None:
+    evidence = _evidence()
+    evidence["builderops"].update(
+        {
+            "database_url_ref": "keychain:builderops.primary-database",
+            "dsn_refs": ["keychain://builderops/primary-dsn"],
+            "session_cookie_ref": "${SECRET:builderops.session-cookie}",
+        }
+    )
+
+    bundle = emit_redacted_evidence_bundle(evidence)
+    receipt = evaluate_qualification(bundle)
+
+    assert bundle["evidence"]["builderops"]["database_url_ref"] == evidence["builderops"][
+        "database_url_ref"
+    ]
+    assert bundle["evidence"]["builderops"]["dsn_refs"] == evidence["builderops"]["dsn_refs"]
+    assert bundle["evidence"]["builderops"]["session_cookie_ref"] == evidence["builderops"][
+        "session_cookie_ref"
+    ]
+    assert receipt["candidate_verdict"] == "pass"
+    assert receipt["live_qualified"] is False
+
+
 def test_product_engine_identity_is_required_for_isolation() -> None:
     invalid_product_engine_ids: tuple[object, ...] = (None, 102, "", "   ", "engine-builder-102")
 

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -98,6 +98,7 @@ def test_evidence_bundle_redacts_credentials_and_secrets() -> None:
 
 def test_opaque_credential_fields_are_refused() -> None:
     opaque_fields = {
+        "connection_string": "postgresql://user:opaque@example.invalid/app",
         "session_cookie": "opaque-session-cookie",
         "passwd": "opaque-password",
         "database_url": "postgresql://user:password@example.invalid/app",

--- a/tests/platform/test_tars_qualification.py
+++ b/tests/platform/test_tars_qualification.py
@@ -103,6 +103,8 @@ def test_opaque_credential_fields_are_refused() -> None:
         "connectionString": "postgresql://user:opaque@example.invalid/app",
         "redisConnectionString": "redis://:opaque@example.invalid/0",
         "mysqlDsn": "app:opaque@tcp(example.invalid:3306)/app",
+        "oracleConnect": "app/opaque@example.invalid/service",
+        "databaseURLRef": "postgresql://user:opaque@example.invalid/app",
         "session_cookie": "opaque-session-cookie",
         "passwd": "opaque-password",
         "database_url": "postgresql://user:password@example.invalid/app",


### PR DESCRIPTION
Governing-Issue: #5072

Fixes #5072

Final-Review-Rounds: 2

## Summary
Harden the repo-side TARS qualification evidence boundary so opaque credential-bearing URI and DSN values cannot survive redaction or authorize a candidate pass. The change also normalizes camelCase and acronym-style secret-reference keys while preserving only valid secret locators.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Repo-side admission-contract repair; no live BuilderOps material was routed.

## Notes
Validation: `10 passed` in `tests/platform/test_tars_qualification.py`; Ruff and `git diff --check` passed; independent Sol/high mechanism-convergence review accepted exact head `c9f21c3c0564bad5b05c894dac889f3a54fc5d92` with packet SHA-256 `85449ad5d093fa714efa4ca5717880a08a50d934259835d124212934e30f8481`.

No TARS/Proxmox, VM, network, DNS, firewall, reboot, snapshot, restore, or cutover operation was performed.
---