### PR TITLE
governance: clarify Project pickup deprecation

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -135,7 +135,8 @@ Treat every canonical Issue contract section (`.codex/skills/_shared/ISSUE_CONTR
 
 - GitHub Issue is the canonical implementation task contract.
 - GitHub Project `Agent Delivery Control Plane` is an optional legacy lifecycle projection.
-- Project repair is a cold-path maintenance concern and is not part of selection or claim.
+- Project Status is an optional projection; its repair is a cold-path maintenance concern and is
+  not part of selection, pickup, claim, blocked-state, or review-handoff flow.
 - Do not leave actively worked Issues labeled `agent:ready`.
 - Do not leave blocked Issues in `In Progress`.
 - Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -41,7 +41,7 @@ labels:
   lane:
     - lane:governance
   interpretation:
-    agent:ready: strictly validated queue-eligible work; Project Status is optional projection
+    agent:ready: strictly validated queue-eligible work; Project Status is optional projection, never a pickup, claim, blocked-state, or review-handoff gate
     agent:blocked: blocked by dependency or setup; normally non-active backlog work
     agent:needs-human: blocked on human decision or missing authority; normally non-active backlog work
     state:known-defect: rolling confirmed-defect registry container; Backlog, no agent-state label, never pickup-eligible
@@ -164,7 +164,7 @@ rules:
   docs_authoring_prs_must_be_docs_only: true
   governance_lane_prs_may_skip_issue_reference: true
   governance_lane_prs_must_be_limited_to_repo_governance_surfaces: true
-  agents_only_pick: strictly validated label:agent:ready; Project Status is optional projection
+  agents_only_pick: strictly validated label:agent:ready; Project Status is optional projection, never a pickup, claim, blocked-state, or review-handoff gate
   agents_must_follow_issue_constraints: true
   agents_must_satisfy_acceptance: true
   no_free_form_tasks: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,4 +532,5 @@ The dispatcher is an optional collision guard for issue pickup, not lifecycle au
   GitHub-label-only fallback.
 - Heartbeat, complete, block, release, fallback receipts, TTL, and recovery semantics are owned by
   `.codex/skills/issue-to-code/SKILL.md` and `docs/AGENT_ISSUE_DISPATCHER.md`.
-- Project Status is not part of claim and never gates pickup.
+- Project Status is an optional projection, not part of the authoritative Issue/PR lifecycle,
+  claim, blocked-state, or review-handoff flow, and never gates pickup.

--- a/docs/architecture/SBS_OPERATING_MODEL.md
+++ b/docs/architecture/SBS_OPERATING_MODEL.md
@@ -455,7 +455,7 @@ An SBS-relevant PR is Done only when:
 
 - SBS-relevant work uses `.github/ISSUE_TEMPLATE/task.yml`. The `SBS Impact` section is a required section per `.github/github-governance.yml`.
 - Issues carry `agent:ready` only when the Definition of Ready (§5) holds; otherwise `agent:needs-human` or `agent:blocked`.
-- Project Status is a projection of issue/PR truth (governance config): opened → Backlog; ready → Ready; PR open → Review; merged/closed → Done. Do not hand-edit Status to mask issue state.
+- Project Status is an optional projection of issue/PR truth (governance config): opened → Backlog; ready → Ready; PR open → Review; merged/closed → Done. It is not a pickup, claim, blocked-state, or review-handoff gate. Do not hand-edit Status to mask issue state.
 - Larger SBS work hangs off the tracking issue `#2337` (Operationalize Target SBS) and the delivery parent `#2355`. New initiative-level SBS work should reference the relevant `docs/architecture/SBS_ROADMAP.md` phase.
 
 ## 8. PR lifecycle expectations

--- a/tests/governance/test_project_pickup_deprecation.py
+++ b/tests/governance/test_project_pickup_deprecation.py
@@ -36,7 +36,7 @@ def _signboard_imports(source: str, *, filename: str = "<source>") -> set[str]:
     return imports
 
 
-def test_active_pickup_contract_is_label_only() -> None:
+def test_project_status_is_not_a_hot_path_pickup_gate() -> None:
     agents = _read("AGENTS.md")
     issue_to_code = _read(".codex/skills/issue-to-code/SKILL.md")
     deliver_issue_set = _read(".codex/skills/deliver-issue-set/SKILL.md")
@@ -51,6 +51,11 @@ def test_active_pickup_contract_is_label_only() -> None:
     assert "Project Status is not a pickup gate" in dev_workflow
     assert "without requiring Project Status" in labels
     assert "label removal + claimant receipt" in issue_to_code
+
+    for contract in (agents, issue_to_code, _read("docs/architecture/SBS_OPERATING_MODEL.md"), _read(".github/github-governance.yml")):
+        assert "optional projection" in contract
+        assert "blocked-state" in contract
+        assert "review-handoff" in contract
 
     canonical_pickup_contracts = (
         agents,


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5098

## Linked Issue
Closes #5098

## SBS Impact
- Primary subsystem: Builder System delivery governance
- Secondary subsystem(s): GitHub Project projection
- Write class: governance/docs/process
- Persistence impact: Repository guidance and GitHub review-thread replies only
- Derived/rebuildable impact: none
- New or changed contract: Project Status is not a pickup, claim, blocked-state, or review-handoff gate.
- Owner-doc impact: Updated SBS operating-model owner guidance in this PR.
- Transition debt impact: Resolves the Project hot-path ambiguity recorded by #3309.
- Boundary risk: Project projection does not gain authority over Issue or PR lifecycle truth.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Makes the four named governance surfaces explicitly treat Project Status as optional and non-gating.
- Restores the exact Verify selector for the Project-pickup contract test.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 governance slice; no BuilderOps material was produced.

## Notes
Validation: focused Verify target, skill consistency lint, docs language guard, diff check, and local review-before-CI gate passed.