### PR TITLE
governance: reconcile BuilderOps review residuals

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -175,7 +175,12 @@ def _load_json_value_file(path: Path | None, *, field: str) -> Any:
 def _merge_json_objects(*objects: dict[str, Any]) -> dict[str, Any]:
     merged: dict[str, Any] = {}
     for item in objects:
-        merged.update(item)
+        for key, value in item.items():
+            previous = merged.get(key)
+            if isinstance(previous, dict) and isinstance(value, dict):
+                merged[key] = _merge_json_objects(previous, value)
+            else:
+                merged[key] = value
     return merged
 
 

--- a/app/builderops/evidence_bridge.py
+++ b/app/builderops/evidence_bridge.py
@@ -55,7 +55,10 @@ def build_evidence_bridge_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
         allowed_kinds=UNKNOWN_EVIDENCE_KINDS,
         require_source_refs=False,
     )
-    evidence_ids = {item["id"] for item in [*observed, *unknown]}
+    evidence_items = [*observed, *unknown]
+    evidence_ids = {item["id"] for item in evidence_items}
+    if len(evidence_ids) != len(evidence_items):
+        raise EvidenceBridgeError("duplicate evidence id across observed and unknown buckets")
     candidate = _normalize_candidates(
         evidence.get("candidate", evidence.get("candidates", [])),
         evidence_ids=evidence_ids,
@@ -151,9 +154,9 @@ def _normalize_candidates(
             f"candidate[{index}].upstream_artifact",
         )
         unknown_for_retro = bool(item.get("unknown_for_retro", False))
-        if not upstream_artifact and not unknown_for_retro:
+        if not upstream_artifact and (not unknown_for_retro or route != "discard"):
             raise EvidenceBridgeError(
-                f"candidate[{index}] requires upstream_artifact or unknown_for_retro"
+                f"candidate[{index}] requires upstream_artifact unless it is an unknown-for-retro discard"
             )
         raw_ids = item.get("evidence_ids")
         if not isinstance(raw_ids, list) or not raw_ids:

--- a/app/builderops/pattern_routing.py
+++ b/app/builderops/pattern_routing.py
@@ -127,13 +127,17 @@ def _required_string(value: Any, field: str) -> str:
 
 def _receipt_body(patterns: list[dict[str, Any]]) -> str:
     routes = ", ".join(
-        f"{item['id']}={item['route']}:{item['terminal_outcome']}"
+        f"{item['id']}={item['route']}"
+        for item in patterns
+    )
+    terminal_outcomes = ", ".join(
+        f"{item['id']}={item['terminal_outcome']}"
         for item in patterns
     )
     return (
         "Repeated-pattern routing observe-only report: "
         f"patterns={len(patterns)}"
-        + (f"; routes: {routes}." if routes else ".")
+        + (f"; routes: {routes}; terminal_outcomes: {terminal_outcomes}." if routes else ".")
     )
 
 

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -5,6 +5,7 @@ Thin service layer for mutations not covered by queue or leases modules.
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -80,6 +81,8 @@ def move_task(
             "use complete instead"
         )
     previous_status = task.status
+    if next_status == "review" and task.lease_id is not None:
+        return _handoff_leased_task_to_review(store, task_id, actor, note)
     task.status = next_status
     if next_status != "blocked":
         task.blocked_reason = None
@@ -103,6 +106,108 @@ def move_task(
     ))
 
     return task
+
+
+def _handoff_leased_task_to_review(
+    store: SqliteStore,
+    task_id: str,
+    actor: str,
+    note: str | None,
+) -> TaskRecord:
+    """Atomically release an owned lease while moving its task to review."""
+
+    now = _utc_now()
+    with store._connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        task = conn.execute(
+            "SELECT * FROM dispatcher_tasks WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        if task is None:
+            raise ValueError(f"Task {task_id} not found")
+        lease_id = task["lease_id"]
+        if lease_id is None:
+            raise ValueError(f"Task {task_id} has no active lease for review handoff")
+        lease = conn.execute(
+            "SELECT * FROM dispatcher_leases WHERE lease_id = ?", (lease_id,)
+        ).fetchone()
+        if lease is None or lease["released_at"] is not None:
+            raise ValueError(f"Task {task_id} has no active lease for review handoff")
+        if lease["holder"] != actor:
+            raise ValueError(
+                f"Cannot move task {task_id} to review: lease {lease_id} is held by {lease['holder']}, not {actor}"
+            )
+
+        released = conn.execute(
+            """
+            UPDATE dispatcher_leases
+            SET released_at = ?, release_reason = 'review_handoff'
+            WHERE lease_id = ? AND released_at IS NULL
+            """,
+            (now, lease_id),
+        )
+        if released.rowcount != 1:
+            raise ValueError(f"Cannot move task {task_id} to review: lease changed concurrently")
+
+        moved = conn.execute(
+            """
+            UPDATE dispatcher_tasks
+            SET status = 'review', blocked_reason = NULL, lease_id = NULL,
+                claimed_by = NULL, last_heartbeat_at = NULL, lease_expires_at = NULL,
+                updated_at = ?
+            WHERE task_id = ? AND lease_id = ?
+            """,
+            (now, task_id, lease_id),
+        )
+        if moved.rowcount != 1:
+            raise ValueError(f"Cannot move task {task_id} to review: task changed concurrently")
+
+        release_event = EventRecord(
+            event_id=_make_event_id(),
+            timestamp=now,
+            task_id=task_id,
+            event_type="task.released",
+            actor=actor,
+            lease_id=lease_id,
+            payload={"reason": "review_handoff"},
+        )
+        move_payload: dict[str, str] = {"from_status": task["status"], "to_status": "review"}
+        if note is not None:
+            move_payload["note"] = note
+        move_event = EventRecord(
+            event_id=_make_event_id(),
+            timestamp=now,
+            task_id=task_id,
+            event_type="task.moved",
+            actor=actor,
+            payload=move_payload,
+        )
+        for event in (release_event, move_event):
+            conn.execute(
+                """
+                INSERT INTO dispatcher_events (
+                    event_id, timestamp, task_id, event_type, actor, lease_id, payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.timestamp,
+                    event.task_id,
+                    event.event_type,
+                    event.actor,
+                    event.lease_id,
+                    json.dumps(event.payload, sort_keys=True, ensure_ascii=False)
+                    if event.payload is not None
+                    else None,
+                ),
+            )
+        conn.commit()
+
+    if store._event_writer is not None:
+        store._event_writer.append(release_event)
+        store._event_writer.append(move_event)
+    moved_task = store.get_task(task_id)
+    assert moved_task is not None
+    return moved_task
 
 
 def link_pr(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -861,6 +861,11 @@ python -m app.dispatcher block github-issue-123 --reason "waiting for owner deci
 python -m app.dispatcher export-signboard --json
 ```
 
+Moving a claimed task to `review` is a terminal handoff for its pickup lease:
+the dispatcher atomically releases the current holder's lease while preserving
+the `review` status. A released review task cannot later be reclaimed as an
+expired ready task.
+
 The generated Markdown frontmatter is projection state only. Do not patch generated Signboard cards
 as the source of a claim, heartbeat, or lifecycle transition.
 

--- a/tests/builderops/test_pattern_routing.py
+++ b/tests/builderops/test_pattern_routing.py
@@ -86,7 +86,8 @@ def test_repeated_failure_can_route_to_debt_or_fitness_with_source_refs() -> Non
     assert by_id["pat-debt"]["target_ref"] == "docs/architecture/SBS_TRANSITION_DEBT.md::D12"
     assert by_id["pat-debt"]["source_refs"]
     assert by_id["pat-fitness"]["route"] == "fitness_rule_candidate"
-    assert "pat-fitness=fitness_rule_candidate:debt_or_fitness_recorded" in report["receipt_body"]
+    assert "pat-fitness=fitness_rule_candidate" in report["receipt_body"]
+    assert "pat-fitness=debt_or_fitness_recorded" in report["receipt_body"]
 
 
 def test_one_off_signal_can_be_discarded_with_receipt_target() -> None:

--- a/tests/builderops/test_review_comment_residuals.py
+++ b/tests/builderops/test_review_comment_residuals.py
@@ -1,0 +1,164 @@
+"""Regression coverage for the bounded #3309 review-comment residuals."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.__main__ import _root as builderops_root
+from app.builderops.completeness_report import _terminal_outcomes_from_receipt
+from app.builderops.evidence_bridge import EvidenceBridgeError, build_evidence_bridge_report
+from app.builderops.pattern_routing import build_pattern_routing_report
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.leases import claim, reclaim_expired_leases
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.services import move_task
+from app.dispatcher.store import SqliteStore
+from scripts.select_pr_tests import select_tests
+
+
+def _source_ref(ref: str = "#3309") -> dict[str, str]:
+    return {"ref_type": "github_issue", "ref": ref}
+
+
+def _dispatcher_store(tmp_path: Path) -> SqliteStore:
+    store = SqliteStore(tmp_path / "dispatcher.sqlite3", JsonlEventWriter(tmp_path / "events.jsonl"))
+    store.initialize()
+    store.upsert_task(
+        TaskRecord(
+            task_id="review-residual",
+            issue_number=5099,
+            title="Review residual",
+            status="ready",
+            priority="high",
+            source_anchor_refs=["#3309"],
+            created_at="2026-08-25T00:00:00+00:00",
+            updated_at="2026-08-25T00:00:00+00:00",
+        )
+    )
+    return store
+
+
+def test_pattern_routing_and_dispatcher_review_handoff_residuals(tmp_path: Path) -> None:
+    report = build_pattern_routing_report(
+        {
+            "patterns": [
+                {
+                    "id": "pattern-5099",
+                    "route": "issue_candidate",
+                    "summary": "A bounded repeated review finding.",
+                    "repeat_count": 2,
+                    "source_refs": [_source_ref()],
+                    "target_ref": "#5099",
+                    "terminal_outcome": "issue_created",
+                    "recommendation": "Create the bounded follow-up issue.",
+                }
+            ]
+        }
+    )
+    outcomes = _terminal_outcomes_from_receipt(
+        {
+            "target_refs": [{"ref_type": "builderops_object", "ref": "pattern-5099"}],
+            "receipt_body": report["receipt_body"],
+        }
+    )
+    assert outcomes == {"pattern-5099": "issue_created"}
+
+    store = _dispatcher_store(tmp_path)
+    _, lease = claim(store, "review-residual", "agent-5099", ttl_minutes=1)
+    with pytest.raises(ValueError, match="held by agent-5099"):
+        move_task(store, "review-residual", "review", "other-agent")
+    moved = move_task(store, "review-residual", "review", "agent-5099")
+
+    assert moved.status == "review"
+    assert moved.lease_id is None
+    assert moved.claimed_by is None
+    assert moved.lease_expires_at is None
+    assert store.get_lease(lease.lease_id).released_at is not None  # type: ignore[union-attr]
+    assert reclaim_expired_leases(store, actor="dispatcher") == []
+
+
+def test_evidence_index_and_run_state_residuals(tmp_path: Path) -> None:
+    duplicate_across_buckets = {
+        "observed": [
+            {
+                "id": "same-evidence",
+                "kind": "review_finding",
+                "summary": "Observed finding.",
+                "source_refs": [_source_ref()],
+            }
+        ],
+        "unknown": [
+            {
+                "id": "same-evidence",
+                "kind": "unknown_for_retro",
+                "summary": "Ambiguous duplicate.",
+            }
+        ],
+        "candidate": [],
+    }
+    with pytest.raises(EvidenceBridgeError, match="duplicate evidence id"):
+        build_evidence_bridge_report(duplicate_across_buckets)
+
+    unknown_actionable = {
+        "observed": [],
+        "unknown": [
+            {
+                "id": "unknown-5099",
+                "kind": "unknown_for_retro",
+                "summary": "Artifact still unknown.",
+            }
+        ],
+        "candidate": [
+            {
+                "id": "candidate-5099",
+                "route": "issue_candidate",
+                "summary": "This would otherwise be actionable without an owner.",
+                "evidence_ids": ["unknown-5099"],
+                "source_refs": [_source_ref()],
+                "unknown_for_retro": True,
+                "recommendation": "Do not create an unanchored issue.",
+            }
+        ],
+    }
+    with pytest.raises(EvidenceBridgeError, match="upstream_artifact"):
+        build_evidence_bridge_report(unknown_actionable)
+
+    selection = select_tests(["app/index/rules.py"])
+    assert "memory_retrieval" in selection.subsystems
+    assert "tests/index" in selection.targets
+
+    update_file = tmp_path / "bulk-update.json"
+    update_file.write_text(
+        json.dumps({"issue_mappings": {"5099": {"branch": "codex/issue-5099"}}}),
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(
+        builderops_root,
+        [
+            "builderops",
+            "epic-run-state",
+            "record",
+            "--epic-issue-number",
+            "3309",
+            "--run-id",
+            "review-residuals",
+            "--root",
+            str(tmp_path),
+            "--update-file",
+            str(update_file),
+            "--update-json",
+            json.dumps({"issue_mappings": {"5099": {"pr_number": 5100}}}),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    state = json.loads(result.output)["state"]
+    assert state["issue_mappings"]["5099"] == {
+        "branch": "codex/issue-5099",
+        "pr_number": 5100,
+    }


### PR DESCRIPTION
Governing-Issue: #5099

Fixes #5099

Final-Review-Rounds: 1

## Summary
Repairs the bounded BuilderOps and dispatcher review residuals from #3309, including parseable terminal outcomes, atomic review lease release, evidence ambiguity refusal, and run-state input preservation. Adds the six-mechanism regression coverage required by the issue.

## SBS Impact
- Primary subsystem: Builder System helper and evidence handling
- Secondary subsystem(s): dispatcher; index CI selection; CLI run-state persistence
- Write class: governance/tooling correction
- Persistence impact: existing BuilderOps/run-state artifacts only
- Derived/rebuildable impact: preserves evidence rather than silently discarding it
- New or changed contract: each cited helper mechanism has a focused regression proof
- Owner-doc impact: updated `docs/AGENT_ISSUE_DISPATCHER.md :: Manual lifecycle changes` for review-handoff lease semantics
- Transition debt impact: reduces stale review closure debt
- Boundary risk: review-thread replies rely on exact merged evidence only

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Existing GitHub issue and PR provide the durable delivery authority; this slice creates no separate BuilderOps operational record.

## Notes
Validation: `pytest -q tests/builderops/test_review_comment_residuals.py` (2 passed); focused BuilderOps (46 passed) and dispatcher (61 passed) suites; `ruff check app tests`; `python3 scripts/docs_guard.py --language-only`; review-before-CI gate. The broader selector collectability test is environment-blocked because the local Python 3.14 interpreter cannot install the declared `lingua-language-detector==2.1.1` dependency.
