### PR TITLE
governance: reconcile release and CI review residuals

### DIFF
--- a/.github/workflows/app-image-build.yml
+++ b/.github/workflows/app-image-build.yml
@@ -44,13 +44,13 @@ jobs:
           echo "BUILT_AT=${built_at}" >> "${GITHUB_ENV}"
           echo "image=${image}" >> "${GITHUB_OUTPUT}"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build app image (PR validation)
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -89,7 +89,7 @@ jobs:
             BUILT_AT=${{ env.BUILT_AT }}
 
       - name: Verify image runtime version
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         shell: bash
         run: |
           set -euo pipefail
@@ -99,7 +99,7 @@ jobs:
             -c 'from app.version import get_runtime_version; import os; version = get_runtime_version(); assert version["git_sha"] == os.environ["VCS_REF"], version; assert version["built_at"] == os.environ["BUILT_AT"], version'
 
       - name: Probe TTS engines in PR image
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         shell: bash
         run: |
           set -euo pipefail

--- a/app/release_channels/cutover_readiness.py
+++ b/app/release_channels/cutover_readiness.py
@@ -117,7 +117,7 @@ class _ComposeModel:
 class _MigrationDelta:
     pending: tuple[MigrationInfo, ...] = ()
     forward_only: tuple[MigrationInfo, ...] = ()
-    head_revision: str | None = None
+    head_revisions: tuple[str, ...] = ()
     unreachable_detail: str | None = None
 
 
@@ -451,14 +451,13 @@ def _load_migrations(migrations_dir: Path) -> dict[str, MigrationInfo]:
     return migrations
 
 
-def _head_revision(migrations: Mapping[str, MigrationInfo]) -> str | None:
+def _head_revisions(migrations: Mapping[str, MigrationInfo]) -> tuple[str, ...]:
     down_revisions = {
         down_revision
         for info in migrations.values()
         for down_revision in info.down_revisions
     }
-    heads = sorted(set(migrations) - down_revisions)
-    return heads[-1] if heads else None
+    return tuple(sorted(set(migrations) - down_revisions))
 
 
 def _ancestor_revisions(
@@ -522,37 +521,71 @@ def _postorder_to_revision(
     return ordered
 
 
-def _pending_migration_delta(migrations_dir: Path, db_revision: str | None) -> _MigrationDelta:
+def _current_revisions(db_revision: str | Sequence[str] | None) -> tuple[str, ...]:
+    if db_revision is None:
+        return ()
+    if isinstance(db_revision, str):
+        return (db_revision,)
+    return tuple(dict.fromkeys(revision for revision in db_revision if revision))
+
+
+def _pending_migration_delta(
+    migrations_dir: Path,
+    db_revision: str | Sequence[str] | None,
+) -> _MigrationDelta:
     migrations = _load_migrations(migrations_dir)
-    head = _head_revision(migrations)
-    if head is None:
-        return _MigrationDelta(head_revision=None)
+    heads = _head_revisions(migrations)
+    if not heads:
+        return _MigrationDelta()
 
-    head_ancestors = _ancestor_revisions(migrations, head)
-    ordered_to_head = _postorder_to_revision(migrations, head)
-    if head_ancestors is None or ordered_to_head is None:
+    head_ancestors: set[str] = set()
+    ordered_to_heads: list[MigrationInfo] = []
+    emitted: set[str] = set()
+    for head in heads:
+        ancestors = _ancestor_revisions(migrations, head)
+        ordered = _postorder_to_revision(migrations, head)
+        if ancestors is None or ordered is None:
+            return _MigrationDelta(
+                head_revisions=heads,
+                unreachable_detail="migration graph is incomplete or cyclic",
+            )
+        head_ancestors.update(ancestors)
+        for info in ordered:
+            if info.revision not in emitted:
+                emitted.add(info.revision)
+                ordered_to_heads.append(info)
+    if not head_ancestors:
         return _MigrationDelta(
-            head_revision=head,
+            head_revisions=heads,
             unreachable_detail="migration graph is incomplete or cyclic",
         )
-    if db_revision not in head_ancestors:
+    current_revisions = _current_revisions(db_revision)
+    if not current_revisions:
         return _MigrationDelta(
-            head_revision=head,
-            unreachable_detail=(
-                f"DB revision {db_revision} is not reachable from selected Alembic head {head}"
-            ),
+            head_revisions=heads,
+            unreachable_detail="DB revision unavailable",
         )
 
-    db_ancestors = _ancestor_revisions(migrations, db_revision)
-    if db_ancestors is None:
-        return _MigrationDelta(
-            head_revision=head,
-            unreachable_detail="migration graph is incomplete or cyclic",
-        )
+    applied_revisions: set[str] = set()
+    for revision in current_revisions:
+        if revision not in head_ancestors:
+            return _MigrationDelta(
+                head_revisions=heads,
+                unreachable_detail=(
+                    f"DB revision {revision} is not reachable from selected Alembic head(s) {', '.join(heads)}"
+                ),
+            )
+        ancestors = _ancestor_revisions(migrations, revision)
+        if ancestors is None:
+            return _MigrationDelta(
+                head_revisions=heads,
+                unreachable_detail="migration graph is incomplete or cyclic",
+            )
+        applied_revisions.update(ancestors)
 
-    pending_revisions = head_ancestors - db_ancestors
+    pending_revisions = head_ancestors - applied_revisions
     pending = tuple(
-        info for info in ordered_to_head if info.revision in pending_revisions
+        info for info in ordered_to_heads if info.revision in pending_revisions
     )
 
     forward_only = [
@@ -561,29 +594,35 @@ def _pending_migration_delta(migrations_dir: Path, db_revision: str | None) -> _
     return _MigrationDelta(
         pending=pending,
         forward_only=tuple(forward_only),
-        head_revision=head,
+        head_revisions=heads,
     )
 
 
-def _resolve_db_revision(root: Path, runner: CommandRunner) -> str | None:
+def _resolve_db_revision(root: Path, runner: CommandRunner) -> tuple[str, ...] | None:
     env_revision = os.environ.get("CUTOVER_DB_REVISION")
     if env_revision:
-        return env_revision
+        return tuple(part for part in env_revision.split(",") if part)
     completed = runner(["alembic", "-c", "alembic.ini", "current"], root)
     if completed.returncode != 0:
         return None
-    for token in completed.stdout.replace("(", " ").replace(")", " ").split():
-        if re.fullmatch(r"[0-9A-Za-z_]+", token):
-            return token
-    return None
+    revisions = tuple(
+        dict.fromkeys(
+            revision
+            for line in completed.stdout.splitlines()
+            for revision in line.split("(", 1)[0].replace(",", " ").split()
+            if re.fullmatch(r"[0-9A-Za-z_]+", revision)
+        )
+    )
+    return revisions or None
 
 
 def _check_migration_state(
     root: Path,
-    db_revision: str | None,
+    db_revision: str | Sequence[str] | None,
     ack_forward_only: bool,
 ) -> tuple[ReadinessCheck, _MigrationDelta]:
-    if db_revision is None:
+    current_revisions = _current_revisions(db_revision)
+    if not current_revisions:
         return (
             ReadinessCheck(
                 "migration-state",
@@ -607,7 +646,7 @@ def _check_migration_state(
             ReadinessCheck(
                 "migration-state",
                 True,
-                f"DB revision {db_revision} is at alembic head {delta.head_revision}",
+                f"DB revision(s) {', '.join(current_revisions)} are at Alembic head(s) {', '.join(delta.head_revisions)}",
             ),
             delta,
         )
@@ -635,7 +674,7 @@ def check_cutover_readiness(
     target_sha: str,
     *,
     root: Path | str = Path("."),
-    db_revision: str | None = None,
+    db_revision: str | Sequence[str] | None = None,
     ack_forward_only: bool = False,
     image_repository: str = DEFAULT_IMAGE_REPOSITORY,
     promotion_ref: str = DEFAULT_PROMOTION_REF,

--- a/docs/LLM.md
+++ b/docs/LLM.md
@@ -84,9 +84,7 @@ Embeddings are currently dispatched from `app/llm/embeddings.py` (superseded as 
 
 ## Timeouts, retries, breakers
 
-- `LLM_TIMEOUT` applies to every HTTP call.
-  - chat defaults to 120s
-  - embeddings and other adapter calls default to 60s
+- `LLM_TIMEOUT` applies to every HTTP call and defaults to 60s when unset.
 - `/api/ask` fails loud with the documented ASK timeout contract when the backend raises
   `LLMBackendTimeout` (the current Ollama socket-timeout path). The HTTP response is
   `504 Gateway Timeout` with the FastAPI error body also documented in
@@ -97,7 +95,7 @@ Embeddings are currently dispatched from `app/llm/embeddings.py` (superseded as 
     "detail": {
       "error": "llm_backend_timeout",
       "provider": "<provider>",
-      "timeout_seconds": 120.0,
+      "timeout_seconds": 60.0,
       "trace_id": "<trace id>",
       "message": "<backend timeout detail>"
     }

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -240,6 +240,11 @@ acknowledgement receipt. Those mechanisms belong to the deferred gated-`stable` 
 they make the existing active applicability enforceable and auditable, rather than changing which
 production database the classification protects.
 
+The read-only `cutover_readiness` preflight is local/CI evidence only, not a deployment or migration
+receipt. When Alembic reports more than one current head, it treats the union of their ancestor
+sets as already applied; only revisions outside that union are pending. It therefore does not
+misclassify an already-applied merge parent as pending.
+
 `origin/stable` (`e2892b18`) is **dormant** and does **not** reflect what prod runs: as of 2026-06-29 it is not an ancestor of `origin/main` (hundreds of commits of divergence under squash-merge history). It must not be treated as the prod source-of-truth until it is restored as a gated ref. The promotion **skills** (`prepare-promotion`, `execute-promotion`, `verify-promotion`, `promote-test-to-prod`) describe the target gated model and remain valid for that future; they do not describe the current `main`-tracking baseline.
 
 **Reproducibility invariant.** Prod must be reconstructible from git alone. The prod runtime HEAD must equal the promotion ref and the working tree must be clean — no uncommitted, machine-local state as durable truth (the Issue #2527 finding was a prod checkout dirty with tracked modifications that existed nowhere in git). The read-only guard `app/release_channels/prod_ref_fitness.py` (Issue #2527 AC3) flags a prod checkout that diverges from the promotion ref or runs a dirty tree; the operator runs it on the prod host to produce the clean-tree receipt:

--- a/tests/deploy/test_ci_image_build.py
+++ b/tests/deploy/test_ci_image_build.py
@@ -37,7 +37,7 @@ def test_ci_builds_sha_tagged_image() -> None:
     assert "context: ." in workflow
     assert "file: Dockerfile" in workflow
     assert "tags: ${{ steps.build-identity.outputs.image }}" in workflow
-    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "if: github.event_name != 'push' || github.ref != 'refs/heads/main'" in workflow
     assert "platforms: linux/amd64" in workflow
     assert "Publish the exact restore-proved BuilderOps images" in workflow
     assert 'docker push "${{ steps.images.outputs.control_plane }}"' in workflow
@@ -62,7 +62,7 @@ def test_built_image_version_reports_build_sha(monkeypatch) -> None:
     assert "get_runtime_version" in workflow
     assert 'version["git_sha"] == os.environ["VCS_REF"]' in workflow
     assert 'version["built_at"] == os.environ["BUILT_AT"]' in workflow
-    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "if: github.event_name != 'push' || github.ref != 'refs/heads/main'" in workflow
     assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in workflow
     assert "docker buildx imagetools inspect" in workflow
     assert 'manifest_json="$(mktemp)"' in workflow
@@ -84,7 +84,7 @@ def test_single_image_artifact_per_commit() -> None:
 
     assert "strategy:" not in product_image_job
     assert product_image_job.count("uses: docker/build-push-action@") == 2
-    assert product_image_job.count("if: github.event_name == 'pull_request'") == 3
+    assert product_image_job.count("if: github.event_name != 'push' || github.ref != 'refs/heads/main'") == 3
     assert (
         product_image_job.count("if: github.event_name == 'push' && github.ref == 'refs/heads/main'")
         >= 1

--- a/tests/deploy/test_cutover_readiness.py
+++ b/tests/deploy/test_cutover_readiness.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 from app.release_channels.cutover_readiness import (
+    _resolve_db_revision,
     check_cutover_readiness,
 )
 
@@ -336,6 +337,34 @@ def test_merge_revision_lists_shared_pending_parent_once(tmp_path: Path) -> None
 
     assert result.ok, result.summary()
     assert result.pending_migrations == ("002_shared.py", "left.py", "right.py", "merge.py")
+
+
+def test_multiple_current_heads_are_all_treated_as_applied(tmp_path: Path) -> None:
+    _write_base_fixture(tmp_path)
+    versions = tmp_path / "app" / "alembic" / "versions"
+    for child in versions.iterdir():
+        child.unlink()
+    _write_migration(tmp_path, filename="left.py", revision="left", down_revision=None, reversibility="reversible")
+    _write_migration(tmp_path, filename="right.py", revision="right", down_revision=None, reversibility="reversible")
+
+    result = check_cutover_readiness(
+        "prod",
+        TARGET_SHA,
+        root=tmp_path,
+        db_revision=("left", "right"),
+        runner=_runner,
+    )
+
+    assert result.ok, result.summary()
+    assert result.pending_migrations == ()
+
+
+def test_alembic_current_annotations_are_not_parsed_as_revisions(tmp_path: Path) -> None:
+    def annotated_runner(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        assert args == ["alembic", "-c", "alembic.ini", "current"]
+        return subprocess.CompletedProcess(args, 0, "left (head)\nright (head)\n", "")
+
+    assert _resolve_db_revision(tmp_path, annotated_runner) == ("left", "right")
 
 
 def test_unreachable_db_revision_fails_migration_state(tmp_path: Path) -> None:

--- a/tests/governance/test_review_comment_residuals.py
+++ b/tests/governance/test_review_comment_residuals.py
@@ -1,0 +1,53 @@
+"""Focused regression proof for the seven #5100 / #3309 review residuals."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.release_channels.cutover_readiness import _pending_migration_delta
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_migration(
+    versions: Path,
+    filename: str,
+    revision: str,
+    down_revision: str | tuple[str, ...] | None,
+) -> None:
+    versions.mkdir(parents=True, exist_ok=True)
+    (versions / filename).write_text(
+        f"revision = {revision!r}\ndown_revision = {down_revision!r}\nreversibility = 'reversible'\n",
+        encoding="utf-8",
+    )
+
+
+def test_release_ci_checkout_and_transcript_residuals(tmp_path: Path) -> None:
+    workflow = (ROOT / ".github/workflows/app-image-build.yml").read_text(encoding="utf-8")
+    assert workflow.index("Set up QEMU") < workflow.index("Set up Docker Buildx")
+    assert "github.event_name != 'push' || github.ref != 'refs/heads/main'" in workflow
+
+    fleet_guard = (ROOT / "app/release_channels/fleet_model_fitness.py").read_text(encoding="utf-8")
+    assert 'APP_CODE_SERVICES = ("api", "worker", "watcher", "heimdal-capture-watch")' in fleet_guard
+
+    versions = tmp_path / "versions"
+    _write_migration(versions, "001.py", "001", None)
+    _write_migration(versions, "left.py", "left", "001")
+    _write_migration(versions, "right.py", "right", "001")
+    _write_migration(versions, "merge.py", "merge", ("left", "right"))
+    delta = _pending_migration_delta(versions, ("left", "right"))
+    assert [migration.revision for migration in delta.pending] == ["merge"]
+    release_channels = (ROOT / "docs/RELEASE_CHANNELS/README.md").read_text(encoding="utf-8")
+    assert "union of their ancestor" in release_channels
+
+    transcript_readme = ROOT / "docs/research/builder-system-skill-review-2026-07-09/transcripts/README.md"
+    docs_index = (ROOT / "docs/DOCS_INDEX.md").read_text(encoding="utf-8")
+    assert transcript_readme.exists()
+    assert str(transcript_readme.relative_to(ROOT)) in docs_index
+
+
+def test_ask_timeout_documentation_residual() -> None:
+    llm_doc = (ROOT / "docs/LLM.md").read_text(encoding="utf-8")
+    assert "defaults to 60s when unset" in llm_doc
+    assert '"timeout_seconds": 60.0' in llm_doc


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5100

## Linked Issue
Closes #5100

## SBS Impact
- Primary subsystem: Builder System release and CI governance
- Secondary subsystem(s): release image workflow; checkout/migration readiness; documentation/index coverage
- Write class: governance/tooling/docs/process
- Persistence impact: workflow docs and test contract only
- Derived/rebuildable impact: CI and transcript indexes remain derived from checked-in inputs
- New or changed contract: each cited release docs CI mechanism has focused regression proof
- Owner-doc impact: updated docs/RELEASE_CHANNELS/README.md and docs/LLM.md
- Transition debt impact: reduces stale review closure debt
- Boundary risk: no deployment, production receipt, migration execution, or image publication

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Restore manual image-validation coverage, make the read-only cutover preflight multi-head aware, and align the documented ASK timeout with the single current default.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue, PR, and review-thread replies are the durable delivery record; no separate BuilderOps material was produced.

## Notes
Validation: current-head CI green on 4f63fd25a33df104415bcd68278dcbd8f80d598d; focused local pytest (25 passed); independent review PASS on the same SHA; ruff check app tests; YAML parse; docs_guard with explicit temporal-skip. No deployment, production receipt, migration execution, or image publication.