### PR TITLE
Add hazard-safe calibration projection rebuild

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -908,6 +908,12 @@ jobs:
               - 'app/episodes/segmenter.py'
               - 'app/receipts/outcome_receipt_log.py'
               - 'app/receipts/outcome_receipt_projection.py'
+              # CAL-04 (#3322): a doctor-before-truncate rebuild is only safe
+              # when its real PostgreSQL refusal and interleaving proofs run
+              # on the PR head rather than waiting for the nightly lane.
+              - 'app/jobs/calibration_projection.py'
+              - 'tests/jobs/test_calibration_projection_rebuild.py'
+              - 'tests/integration/test_calibration_rebuild_from_log_only.py'
               - 'tests/migrations/test_multi_vault_ingest_projection_keys.py'
               - 'tests/store/test_membership_store.py'
               - 'tests/migrations/test_ingest_schema_parity.py'
@@ -1054,6 +1060,8 @@ jobs:
             tests/jobs/test_decisions_export.py \
             tests/jobs/test_decisions_projection_rebuild.py \
             tests/jobs/test_multi_vault_decisions_rebuild_scope.py \
+            tests/jobs/test_calibration_projection_rebuild.py \
+            tests/integration/test_calibration_rebuild_from_log_only.py \
             tests/stores/test_decisions_fk_semantics.py \
             tests/stores/test_ensure_tables_assert_only.py \
             tests/stores/test_multi_vault_store_reset_scope.py \

--- a/.github/workflows/integration-nightly.yaml
+++ b/.github/workflows/integration-nightly.yaml
@@ -265,6 +265,8 @@ jobs:
             tests/jobs/test_decisions_export.py \
             tests/jobs/test_decisions_projection_rebuild.py \
             tests/jobs/test_multi_vault_decisions_rebuild_scope.py \
+            tests/jobs/test_calibration_projection_rebuild.py \
+            tests/integration/test_calibration_rebuild_from_log_only.py \
             tests/stores/test_decisions_fk_semantics.py \
             tests/stores/test_ensure_tables_assert_only.py \
             tests/stores/test_multi_vault_store_reset_scope.py \

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -35,6 +35,7 @@ from app.cli.builderops import builderops as builderops_cli
 from app.cli.vault import vault as vault_cli
 from app.cli.ops import ops as ops_cli
 from app.cli.decisions import decisions as decisions_cli
+from app.cli.calibration import calibration as calibration_cli
 from app.cli.briefing import briefing_group
 from app.cli.journaling import journaling_group
 from app.cli.youtube_inbox_dev import youtube_inbox_dev
@@ -324,6 +325,7 @@ cli.add_command(builderops_cli, name="builderops")
 cli.add_command(vault_cli, name="vault")
 cli.add_command(ops_cli, name="ops")
 cli.add_command(decisions_cli, name="decisions")
+cli.add_command(calibration_cli, name="calibration")
 cli.add_command(youtube_inbox_dev)
 
 # ---------------------------------------------------------------------------

--- a/app/cli/calibration.py
+++ b/app/cli/calibration.py
@@ -1,0 +1,47 @@
+"""Operator entrypoint for the derived decision-calibration profile."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from app.jobs.calibration_projection import (
+    CalibrationProjectionHazardError,
+    rebuild_calibration_projection,
+)
+
+
+@click.group(name="calibration", help="Decision-calibration projection maintenance.")
+def calibration() -> None:
+    """Commands for derived decision-calibration views."""
+
+
+@calibration.group(name="profile", help="Generated calibration-profile maintenance.")
+def profile() -> None:
+    """The profile is generated from vault-canonical outcome receipts."""
+
+
+@profile.command("rebuild", help="Hazard-safe rebuild from the canonical outcome JSONL log.")
+@click.option("--vault-root", type=click.Path(path_type=Path, exists=False), default=None)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def rebuild(vault_root: Path | None, as_json: bool) -> None:
+    """Rebuild only when no database-only outcome receipt would be lost."""
+    try:
+        summary = rebuild_calibration_projection(vault_root)
+    except CalibrationProjectionHazardError as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload = {
+        "total_receipts": summary.total_receipts,
+        "inserted": summary.inserted,
+        "markdown_written": summary.markdown_written,
+        "rollup": summary.rollup,
+        "confidence_rollup": summary.confidence_rollup,
+    }
+    if as_json:
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        click.echo(
+            f"total_receipts={summary.total_receipts} inserted={summary.inserted} "
+            f"markdown_written={summary.markdown_written}"
+        )

--- a/app/jobs/calibration_projection.py
+++ b/app/jobs/calibration_projection.py
@@ -1,0 +1,282 @@
+"""Hazard-safe rebuild of the derived decision-calibration projection.
+
+Outcome JSONL is canonical.  ``decision_outcomes`` and the generated markdown
+profile are rebuildable views only.  In particular, a rebuild refuses before
+deleting anything when the database has an outcome the canonical log cannot
+explain; this prevents the historical Postgres-only-row data loss from being
+repeated for calibration.
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.config.paths import resolve_optional_vault_root
+from app.db.db import conn_rw
+from app.db.replay_projection_schema import assert_replay_projection_schema
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
+from app.receipts.outcome_receipt_log import OutcomeReceipt, iter_outcome_receipts
+from app.vault.paths import NoVaultSelectedError, resolve_vault_system_dir_rel_or_default
+from app.write_guard import DEFAULT_WRITE_GUARD
+from scripts.yaml_roundtrip import load_frontmatter
+
+CALIBRATION_PROFILE_WRITE_ACTION = "decision.calibration_profile"
+_OUTCOMES = ("held", "partly_held", "did_not_hold", "unknown_yet")
+
+
+class CalibrationProjectionHazardError(RuntimeError):
+    """A rebuild would discard a database-only outcome receipt."""
+
+
+@dataclass
+class CalibrationRebuildSummary:
+    total_receipts: int = 0
+    inserted: int = 0
+    markdown_written: bool = False
+    rollup: dict[str, dict[str, Any]] = field(default_factory=dict)
+    confidence_rollup: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass
+class CalibrationDoctorReport:
+    ok: bool
+    db_rows: int
+    log_rows: int
+    missing_in_db: list[dict[str, Any]] = field(default_factory=list)
+    extra_in_db: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _root(vault_root: Path | None) -> Path:
+    root = vault_root if vault_root is not None else resolve_optional_vault_root()
+    if root is None:
+        raise NoVaultSelectedError("calibration projection requires a selected vault; VAULT_ROOT is unset")
+    return root.expanduser()
+
+
+def calibration_profile_path(vault_root: Path | None = None) -> Path:
+    root = _root(vault_root)
+    return root / resolve_vault_system_dir_rel_or_default(root) / "calibration" / "calibration-profile.md"
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _receipt_rows(vault_root: Path | None) -> list[tuple[str, str, int, str, str | None, str]]:
+    rows: list[tuple[str, str, int, str, str | None, str]] = []
+    for raw in iter_outcome_receipts(vault_root):
+        receipt = OutcomeReceipt.model_validate(raw)
+        rows.append(
+            (
+                str(receipt.decision_object_id),
+                str(receipt.decision_uuid),
+                receipt.rung_index,
+                receipt.outcome,
+                receipt.note,
+                _timestamp(receipt.created_at),
+            )
+        )
+    return sorted(rows)
+
+
+def _db_rows_from_cursor(
+    cur: Any, *, vault_binding_id: str = COMPATIBILITY_BINDING_ID
+) -> list[tuple[str, str, int, str, str | None, str]]:
+    rows: list[tuple[str, str, int, str, str | None, str]] = []
+    cur.execute(
+        "SELECT decision_object_id, decision_uuid, rung_index, outcome, note, created_at "
+        "FROM decision_outcomes WHERE vault_binding_id = %s",
+        (vault_binding_id,),
+    )
+    for row in cur.fetchall():
+        get = row.__getitem__
+        rows.append((str(get("decision_object_id") if isinstance(row, dict) else get(0)),
+                     str(get("decision_uuid") if isinstance(row, dict) else get(1)),
+                     int(get("rung_index") if isinstance(row, dict) else get(2)),
+                     str(get("outcome") if isinstance(row, dict) else get(3)),
+                     (get("note") if isinstance(row, dict) else get(4)),
+                     _timestamp(get("created_at") if isinstance(row, dict) else get(5))))
+    return sorted(rows)
+
+
+def _db_rows(*, vault_binding_id: str) -> list[tuple[str, str, int, str, str | None, str]]:
+    with conn_rw() as conn:
+        assert_replay_projection_schema(conn, "decision_outcomes")
+        with conn.cursor() as cur:
+            return _db_rows_from_cursor(cur, vault_binding_id=vault_binding_id)
+
+
+def _row_dict(row: tuple[str, str, int, str, str | None, str]) -> dict[str, Any]:
+    return {
+        "decision_object_id": row[0], "decision_uuid": row[1], "rung_index": row[2],
+        "outcome": row[3], "note": row[4], "created_at": row[5],
+    }
+
+
+def doctor_calibration_projection(
+    vault_root: Path | None = None, *, vault_binding_id: str = COMPATIBILITY_BINDING_ID
+) -> CalibrationDoctorReport:
+    """Compare the derived table to the vault-canonical receipt log exactly."""
+    log_rows = _receipt_rows(vault_root)
+    db_rows = _db_rows(vault_binding_id=vault_binding_id)
+    return _doctor_report(log_rows, db_rows)
+
+
+def _doctor_report(
+    log_rows: list[tuple[str, str, int, str, str | None, str]],
+    db_rows: list[tuple[str, str, int, str, str | None, str]],
+) -> CalibrationDoctorReport:
+    log_counter, db_counter = Counter(log_rows), Counter(db_rows)
+    missing = list((log_counter - db_counter).elements())
+    extra = list((db_counter - log_counter).elements())
+    return CalibrationDoctorReport(
+        ok=not missing and not extra,
+        db_rows=len(db_rows), log_rows=len(log_rows),
+        missing_in_db=[_row_dict(row) for row in missing],
+        extra_in_db=[_row_dict(row) for row in extra],
+    )
+
+
+def _decision_frontmatter(vault_root: Path, decision_uuid: str) -> dict[str, Any]:
+    """Read only owner-authored decision notes; never read the generated profile."""
+    for path in vault_root.rglob("*.md"):
+        if path == calibration_profile_path(vault_root):
+            continue
+        try:
+            frontmatter, _ = load_frontmatter(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if str(frontmatter.get("uuid") or "") == decision_uuid:
+            return frontmatter
+    return {}
+
+
+def _labels(frontmatter: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for dimension in ("area", "project"):
+        value = frontmatter.get(dimension)
+        if value not in (None, ""):
+            labels.append(f"{dimension}:{value}")
+    tags = frontmatter.get("tags")
+    if isinstance(tags, str) and tags.strip():
+        labels.append(f"tag:{tags.strip()}")
+    elif isinstance(tags, list):
+        labels.extend(f"tag:{tag}" for tag in tags if str(tag).strip())
+    return labels or ["ungrouped"]
+
+
+def _counts_template() -> dict[str, int]:
+    return {outcome: 0 for outcome in _OUTCOMES}
+
+
+def _rollup_bucket(counts: dict[str, int]) -> dict[str, Any]:
+    total = sum(counts.values())
+    return {
+        "total": total,
+        "counts": dict(counts),
+        "rates": {outcome: (counts[outcome] / total if total else 0.0) for outcome in _OUTCOMES},
+    }
+
+
+def _compute_rollup(vault_root: Path, rows: list[tuple[str, str, int, str, str | None, str]]) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    grouped: defaultdict[str, dict[str, int]] = defaultdict(_counts_template)
+    confidence: defaultdict[str, dict[str, int]] = defaultdict(_counts_template)
+    for _object_id, decision_uuid, _rung, outcome, _note, _created in rows:
+        frontmatter = _decision_frontmatter(vault_root, decision_uuid)
+        for label in _labels(frontmatter):
+            grouped[label][outcome] += 1
+        stated_confidence = frontmatter.get("confidence")
+        if stated_confidence not in (None, ""):
+            confidence[str(stated_confidence)][outcome] += 1
+    return (
+        {label: _rollup_bucket(counts) for label, counts in sorted(grouped.items())},
+        {label: _rollup_bucket(counts) for label, counts in sorted(confidence.items())},
+    )
+
+
+def _markdown(rollup: dict[str, dict[str, Any]], confidence_rollup: dict[str, dict[str, Any]]) -> str:
+    lines = ["# Decision Calibration Profile", "", "_Generated — do not edit by hand._", "", "## By decision signal"]
+    for label, bucket in rollup.items():
+        counts, rates, total = bucket["counts"], bucket["rates"], bucket["total"]
+        rendered = ", ".join(
+            f"{outcome.replace('_', '-')} {counts[outcome]} ({rates[outcome]:.0%})"
+            for outcome in _OUTCOMES if counts[outcome]
+        )
+        lines.append(f"- {label}: {total} outcomes ({rendered})")
+    if confidence_rollup:
+        lines.extend(["", "## By stated confidence"])
+        for value, bucket in confidence_rollup.items():
+            counts, rates, total = bucket["counts"], bucket["rates"], bucket["total"]
+            rendered = ", ".join(
+                f"{outcome.replace('_', '-')} {counts[outcome]} ({rates[outcome]:.0%})"
+                for outcome in _OUTCOMES if counts[outcome]
+            )
+            lines.append(f"- {value}: {total} outcomes ({rendered})")
+    return "\n".join(lines) + "\n"
+
+
+def _write_markdown(vault_root: Path, rollup: dict[str, dict[str, Any]], confidence_rollup: dict[str, dict[str, Any]]) -> None:
+    target = calibration_profile_path(vault_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_markdown(rollup, confidence_rollup), encoding="utf-8")
+
+
+def rebuild_calibration_projection(
+    vault_root: Path | None = None, *, vault_binding_id: str = COMPATIBILITY_BINDING_ID
+) -> CalibrationRebuildSummary:
+    """Rebuild the derived outcome table and markdown only after hazard refusal.
+
+    Log-only rows are expected after a projection outage and are replayed.  The
+    table lock, exact parity check, delete, and replay share one transaction so
+    an outcome inserted by a concurrent projection writer cannot slip between
+    doctor and delete.
+    """
+    root = _root(vault_root)
+    # Check the generated-note write authority before changing either derived
+    # surface, so a blocked write cannot leave a half-completed rebuild behind.
+    DEFAULT_WRITE_GUARD.assert_writes_allowed(CALIBRATION_PROFILE_WRITE_ACTION)
+    summary = CalibrationRebuildSummary()
+    with conn_rw() as conn:
+        assert_replay_projection_schema(conn, "decision_outcomes")
+        with conn.cursor() as cur:
+            # INSERT/UPDATE/DELETE take ROW EXCLUSIVE.  SHARE ROW EXCLUSIVE
+            # conflicts with that lock, so concurrent projection writers wait
+            # until this parity-checked delete/replay has committed.
+            cur.execute("LOCK TABLE decision_outcomes IN SHARE ROW EXCLUSIVE MODE")
+            rows = _receipt_rows(root)
+            report = _doctor_report(rows, _db_rows_from_cursor(cur, vault_binding_id=vault_binding_id))
+            if report.extra_in_db:
+                raise CalibrationProjectionHazardError(
+                    "calibration projection rebuild refused: Postgres has "
+                    f"{len(report.extra_in_db)} outcome row(s) with no matching vault-canonical receipt"
+                )
+            summary.total_receipts = len(rows)
+            cur.execute("DELETE FROM decision_outcomes WHERE vault_binding_id = %s", (vault_binding_id,))
+            for object_id, decision_uuid, rung_index, outcome, note, created_at in rows:
+                cur.execute(
+                    "INSERT INTO decision_outcomes "
+                    "(vault_binding_id, decision_object_id, decision_uuid, rung_index, outcome, note, created_at) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    (vault_binding_id, object_id, decision_uuid, rung_index, outcome, note, created_at),
+                )
+                summary.inserted += 1
+    summary.rollup, summary.confidence_rollup = _compute_rollup(root, rows)
+    _write_markdown(root, summary.rollup, summary.confidence_rollup)
+    summary.markdown_written = True
+    return summary
+
+
+__all__ = [
+    "CALIBRATION_PROFILE_WRITE_ACTION", "CalibrationDoctorReport", "CalibrationProjectionHazardError",
+    "CalibrationRebuildSummary", "calibration_profile_path", "doctor_calibration_projection",
+    "rebuild_calibration_projection",
+]

--- a/tests/architecture/durable_table_classification.json
+++ b/tests/architecture/durable_table_classification.json
@@ -111,7 +111,7 @@
     },
     "decision_outcomes": {
       "classification": "binding-scoped",
-      "reason": "The `decision_outcomes` receipt projection now stamps every judgment with vault_binding_id; its per-binding decision/rung uniqueness prevents one vault's receipt from colliding with another.",
+      "reason": "The `decision_outcomes` receipt projection now stamps every judgment with vault_binding_id; its per-binding decision/rung uniqueness prevents one vault's receipt from colliding with another. CAL-04's calibration rebuild locks the table and replaces only the selected binding after exact canonical-log parity.",
       "owning_revision": "b1c2d3e4f5a6",
       "declaring_revisions": [
         "b1c2d3e4f5a6",
@@ -123,6 +123,13 @@
         {
           "module": "app/receipts/outcome_receipt_projection.py",
           "operations": [
+            "insert"
+          ]
+        },
+        {
+          "module": "app/jobs/calibration_projection.py",
+          "operations": [
+            "delete",
             "insert"
           ]
         }

--- a/tests/guard/test_no_direct_db_imports.py
+++ b/tests/guard/test_no_direct_db_imports.py
@@ -35,6 +35,11 @@ ALLOW_FILES = (
     # for app/services/decisions.py and app/jobs/backfill.py above.
     'app/receipts/decision_receipt_log.py',
     'app/jobs/decisions_projection.py',
+    # Decision Calibration CAL-04 (#3322): the vault-canonical outcome log's
+    # bounded rebuild/doctor pair owns the decision_outcomes projection.  It
+    # must inspect DB-vs-log parity before its binding-scoped DELETE, so this
+    # job uses the same explicit conn_rw exception as decisions_projection.py.
+    'app/jobs/calibration_projection.py',
     # Slice 4 (#2973): one-time DB->log export of historical decision rows.
     # Same bounded pattern as decisions_projection.py above: reads the
     # `decisions` projection table directly through conn_rw to find rows not

--- a/tests/integration/test_calibration_rebuild_from_log_only.py
+++ b/tests/integration/test_calibration_rebuild_from_log_only.py
@@ -1,0 +1,120 @@
+"""CAL-04 integration guarantees over the vault-canonical outcome log."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.receipts.outcome_receipt_log import append_outcome_receipt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def scratch_db(monkeypatch: pytest.MonkeyPatch):
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        probe = psycopg.connect(admin_dsn, connect_timeout=2)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    probe.close()
+    name = f"scratch_calibration_integration_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{name}"')
+        conn.execute(f"ALTER DATABASE \"{name}\" SET lc_messages = 'C'")
+    base, _, _ = admin_dsn.rpartition("/")
+    dsn = f"{base}/{name}"
+    from alembic import command
+    from alembic.config import Config
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_BACKEND", "pg")
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    command.upgrade(cfg, "head")
+    yield dsn
+    try:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    except Exception:
+        pass
+
+
+def _allow_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.jobs.calibration_projection as projection
+    import app.receipts.outcome_receipt_log as receipts
+
+    monkeypatch.setattr(receipts.DEFAULT_WRITE_GUARD, "assert_writes_allowed", lambda _: None)
+    monkeypatch.setattr(projection.DEFAULT_WRITE_GUARD, "assert_writes_allowed", lambda _: None)
+
+
+def _write_decision(vault: Path, note_uuid: str, **frontmatter: object) -> None:
+    fields = {"uuid": note_uuid, "title": frontmatter.pop("title", "Decision"), **frontmatter}
+    path = vault / "decisions" / f"{note_uuid}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(["---", *(f"{key}: {value}" for key, value in fields.items()), "---", ""]),
+        encoding="utf-8",
+    )
+
+
+def _append(vault: Path, object_id: str, decision_uuid: str, rung: int, outcome: str) -> None:
+    from datetime import datetime, timezone
+
+    append_outcome_receipt(
+        decision_object_id=object_id,
+        decision_uuid=decision_uuid,
+        rung_index=rung,
+        outcome=outcome,  # type: ignore[arg-type]
+        created_at=datetime(2026, 8, 25, 12, rung, tzinfo=timezone.utc),
+        vault_root=vault,
+    )
+
+
+@pytest.mark.pg
+def test_rebuild_from_log_only_matches_populated_rebuild(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.jobs.calibration_projection import doctor_calibration_projection, rebuild_calibration_projection
+    import psycopg
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    decision_uuid = str(uuid.uuid4())
+    _write_decision(vault, decision_uuid, area="architecture")
+    _append(vault, str(uuid.uuid4()), decision_uuid, 0, "held")
+    first = rebuild_calibration_projection(vault)
+    with psycopg.connect(scratch_db, autocommit=True) as conn:
+        conn.execute("TRUNCATE decision_outcomes")
+    second = rebuild_calibration_projection(vault)
+    assert second.rollup == first.rollup
+    assert doctor_calibration_projection(vault).ok
+
+
+@pytest.mark.pg
+def test_answer_survives_projection_outage(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.jobs.calibration_projection import rebuild_calibration_projection
+    import app.receipts.outcome_receipt_log as receipts
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    decision_uuid = str(uuid.uuid4())
+    _write_decision(vault, decision_uuid, project="recovery")
+    monkeypatch.setattr(receipts, "_insert_projection", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("down")))
+    with pytest.raises(RuntimeError, match="down"):
+        _append(vault, str(uuid.uuid4()), decision_uuid, 0, "held")
+    summary = rebuild_calibration_projection(vault)
+    assert summary.inserted == 1

--- a/tests/jobs/test_calibration_projection_rebuild.py
+++ b/tests/jobs/test_calibration_projection_rebuild.py
@@ -1,0 +1,234 @@
+"""CAL-04: hazard-safe rebuild of the derived calibration projection."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Event, Thread
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.instance.binding_ids import COMPATIBILITY_BINDING_ID
+from app.receipts.outcome_receipt_log import append_outcome_receipt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def scratch_db(monkeypatch: pytest.MonkeyPatch):
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        probe = psycopg.connect(admin_dsn, connect_timeout=2)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    probe.close()
+    name = f"scratch_calibration_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{name}"')
+        conn.execute(f"ALTER DATABASE \"{name}\" SET lc_messages = 'C'")
+    base, _, _ = admin_dsn.rpartition("/")
+    dsn = f"{base}/{name}"
+    from alembic import command
+    from alembic.config import Config
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_BACKEND", "pg")
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    command.upgrade(cfg, "head")
+    yield dsn
+    try:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    except Exception:
+        pass
+
+
+def _allow_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.jobs.calibration_projection as projection
+    import app.receipts.outcome_receipt_log as receipts
+
+    monkeypatch.setattr(receipts.DEFAULT_WRITE_GUARD, "assert_writes_allowed", lambda _: None)
+    monkeypatch.setattr(projection.DEFAULT_WRITE_GUARD, "assert_writes_allowed", lambda _: None)
+
+
+def _write_decision(vault: Path, note_uuid: str, **frontmatter: object) -> None:
+    fields = {"uuid": note_uuid, "title": frontmatter.pop("title", "Decision"), **frontmatter}
+    lines = ["---", *(f"{key}: {value}" for key, value in fields.items()), "---", ""]
+    path = vault / "decisions" / f"{note_uuid}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _append(vault: Path, object_id: str, decision_uuid: str, rung: int, outcome: str) -> None:
+    append_outcome_receipt(
+        decision_object_id=object_id,
+        decision_uuid=decision_uuid,
+        rung_index=rung,
+        outcome=outcome,  # type: ignore[arg-type]
+        created_at=datetime(2026, 8, 25, 12, rung, tzinfo=timezone.utc),
+        vault_root=vault,
+    )
+
+
+@pytest.mark.pg
+def test_rollup_groups_by_available_kind_and_confidence(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.jobs.calibration_projection import rebuild_calibration_projection
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    architecture = str(uuid.uuid4())
+    product = str(uuid.uuid4())
+    ungrouped = str(uuid.uuid4())
+    _write_decision(vault, architecture, area="architecture", confidence="high")
+    _write_decision(vault, product, project="product")
+    _write_decision(vault, ungrouped)
+    _append(vault, str(uuid.uuid4()), architecture, 0, "held")
+    _append(vault, str(uuid.uuid4()), product, 0, "partly_held")
+    _append(vault, str(uuid.uuid4()), ungrouped, 0, "unknown_yet")
+
+    summary = rebuild_calibration_projection(vault)
+    architecture_bucket = summary.rollup["area:architecture"]
+    assert architecture_bucket["total"] == 1
+    assert architecture_bucket["counts"]["held"] == 1
+    assert architecture_bucket["rates"]["held"] == 1.0
+    assert architecture_bucket["rates"]["did_not_hold"] == 0.0
+    assert summary.rollup["project:product"]["counts"]["partly_held"] == 1
+    assert summary.rollup["ungrouped"]["counts"]["unknown_yet"] == 1
+    assert summary.confidence_rollup["high"]["counts"]["held"] == 1
+    assert summary.confidence_rollup["high"]["rates"]["held"] == 1.0
+
+
+@pytest.mark.pg
+def test_rebuild_replays_log_into_projection(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.jobs.calibration_projection import doctor_calibration_projection, rebuild_calibration_projection
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    decision_uuid = str(uuid.uuid4())
+    _write_decision(vault, decision_uuid, area="architecture")
+    _append(vault, str(uuid.uuid4()), decision_uuid, 0, "held")
+    with psycopg.connect(scratch_db, autocommit=True) as conn:
+        conn.execute("TRUNCATE decision_outcomes")
+    summary = rebuild_calibration_projection(vault)
+    assert summary.total_receipts == summary.inserted == 1
+    assert doctor_calibration_projection(vault).ok
+
+
+@pytest.mark.pg
+def test_rebuild_refuses_when_db_has_unaccountable_rows(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real DB-only row survives: doctor runs before the rebuild DELETE."""
+    from app.jobs.calibration_projection import (
+        CalibrationProjectionHazardError,
+        rebuild_calibration_projection,
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    stray_decision = str(uuid.uuid4())
+    with psycopg.connect(scratch_db, autocommit=True) as conn:
+        conn.execute(
+            "INSERT INTO decision_outcomes "
+            "(vault_binding_id, decision_object_id, decision_uuid, rung_index, outcome, created_at) "
+            "VALUES (%s, %s, %s, 0, 'held', now())",
+            (COMPATIBILITY_BINDING_ID, str(uuid.uuid4()), stray_decision),
+        )
+    with pytest.raises(CalibrationProjectionHazardError, match="refused"):
+        rebuild_calibration_projection(vault)
+    with psycopg.connect(scratch_db, autocommit=True) as conn:
+        count = conn.execute("SELECT count(*) FROM decision_outcomes").fetchone()
+        assert count is not None and count[0] == 1
+
+
+@pytest.mark.pg
+def test_rebuild_locks_out_interleaving_db_only_write(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A projection writer cannot insert between parity check and DELETE."""
+    import app.jobs.calibration_projection as projection
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    decision_uuid = str(uuid.uuid4())
+    _write_decision(vault, decision_uuid, area="architecture")
+    _append(vault, str(uuid.uuid4()), decision_uuid, 0, "held")
+
+    entered, release = Event(), Event()
+    original = projection._db_rows_from_cursor
+
+    def pause_after_parity_read(
+        cur: Any, *, vault_binding_id: str = COMPATIBILITY_BINDING_ID
+    ) -> list[tuple[str, str, int, str, str | None, str]]:
+        rows = original(cur, vault_binding_id=vault_binding_id)
+        entered.set()
+        assert release.wait(timeout=5)
+        return rows
+
+    monkeypatch.setattr(projection, "_db_rows_from_cursor", pause_after_parity_read)
+    failures: list[BaseException] = []
+
+    def run_rebuild() -> None:
+        try:
+            projection.rebuild_calibration_projection(vault)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failures.append(exc)
+
+    thread = Thread(target=run_rebuild)
+    thread.start()
+    assert entered.wait(timeout=5)
+    try:
+        with psycopg.connect(scratch_db, autocommit=True) as conn:
+            conn.execute("SET lock_timeout = '250ms'")
+            with pytest.raises(psycopg.errors.LockNotAvailable):
+                conn.execute(
+                    "INSERT INTO decision_outcomes "
+                    "(vault_binding_id, decision_object_id, decision_uuid, rung_index, outcome, created_at) "
+                    "VALUES (%s, %s, %s, 0, 'held', now())",
+                    (COMPATIBILITY_BINDING_ID, str(uuid.uuid4()), str(uuid.uuid4())),
+                )
+    finally:
+        release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert not failures
+    with psycopg.connect(scratch_db, autocommit=True) as conn:
+        count = conn.execute("SELECT count(*) FROM decision_outcomes").fetchone()
+        assert count is not None and count[0] == 1
+
+
+@pytest.mark.pg
+def test_markdown_profile_written_on_rebuild(
+    scratch_db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.jobs.calibration_projection import calibration_profile_path, rebuild_calibration_projection
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _allow_writes(monkeypatch)
+    decision_uuid = str(uuid.uuid4())
+    _write_decision(vault, decision_uuid, area="architecture")
+    _append(vault, str(uuid.uuid4()), decision_uuid, 0, "did_not_hold")
+    rebuild_calibration_projection(vault)
+    profile = calibration_profile_path(vault)
+    assert profile.exists()
+    assert "# Decision Calibration Profile" in profile.read_text(encoding="utf-8")
+    assert "did-not-hold 1 (100%)" in profile.read_text(encoding="utf-8")

--- a/tests/jobs/test_calibration_projection_rebuild.py
+++ b/tests/jobs/test_calibration_projection_rebuild.py
@@ -96,15 +96,17 @@ def test_rollup_groups_by_available_kind_and_confidence(
     _write_decision(vault, product, project="product")
     _write_decision(vault, ungrouped)
     _append(vault, str(uuid.uuid4()), architecture, 0, "held")
+    _append(vault, str(uuid.uuid4()), architecture, 1, "did_not_hold")
     _append(vault, str(uuid.uuid4()), product, 0, "partly_held")
     _append(vault, str(uuid.uuid4()), ungrouped, 0, "unknown_yet")
 
     summary = rebuild_calibration_projection(vault)
     architecture_bucket = summary.rollup["area:architecture"]
-    assert architecture_bucket["total"] == 1
+    assert architecture_bucket["total"] == 2
     assert architecture_bucket["counts"]["held"] == 1
-    assert architecture_bucket["rates"]["held"] == 1.0
-    assert architecture_bucket["rates"]["did_not_hold"] == 0.0
+    assert architecture_bucket["counts"]["did_not_hold"] == 1
+    assert architecture_bucket["rates"]["held"] == 0.5
+    assert architecture_bucket["rates"]["did_not_hold"] == 0.5
     assert summary.rollup["project:product"]["counts"]["partly_held"] == 1
     assert summary.rollup["ungrouped"]["counts"]["unknown_yet"] == 1
     assert summary.confidence_rollup["high"]["counts"]["held"] == 1

--- a/tests/jobs/test_calibration_projection_rebuild.py
+++ b/tests/jobs/test_calibration_projection_rebuild.py
@@ -110,7 +110,7 @@ def test_rollup_groups_by_available_kind_and_confidence(
     assert summary.rollup["project:product"]["counts"]["partly_held"] == 1
     assert summary.rollup["ungrouped"]["counts"]["unknown_yet"] == 1
     assert summary.confidence_rollup["high"]["counts"]["held"] == 1
-    assert summary.confidence_rollup["high"]["rates"]["held"] == 1.0
+    assert summary.confidence_rollup["high"]["rates"]["held"] == 0.5
 
 
 @pytest.mark.pg


### PR DESCRIPTION
Governing-Issue: #3322

Fixes #3322

Final-Review-Rounds: 1

## Summary
CAL-04 rebuilds the vault-canonical decision-outcome projection and generated calibration profile. The rebuild holds a PostgreSQL `SHARE ROW EXCLUSIVE` lock across parity verification, deletion, and replay; the profile renders count plus denominator-based rates.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The Issue/PR lifecycle is the authoritative delivery record; this bounded repair produced no separate BuilderOps material.

## Notes
Validation: `ruff check app tests`, `mypy app`, and `tests/guard/test_no_direct_db_imports.py tests/governance/test_issue_pr_governance.py` (107 passed) are green. PG CAL-04 tests are present but locally skipped fail-closed because no explicit non-production DATABASE_URL/DB_DSN is configured; current-head CI must provide the PostgreSQL proof. The mixed-outcome rate assertion covers 50%/50%, and the existing adversarial test confirms a DB-only writer cannot interleave between parity read and delete.
Review: independent Sol/xhigh convergence review clean on `fd243780141f1cda3c31602f4f4285a7c1a42375`.
BuilderOps routing checkpoint: none; no plan divergence record is needed because the repair and stronger verification stay within the governing Issue.
---