### PR TITLE
fix: make Signboard Review handoff lease-safe

### DIFF
--- a/app/api/routes/signboard.py
+++ b/app/api/routes/signboard.py
@@ -24,7 +24,7 @@ from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.queue import block, complete
-from app.dispatcher.services import move_task
+from app.dispatcher.services import move_task, move_unclaimed_task_to_review
 from app.dispatcher.signboard import STATUS_COLUMNS, canonical_status, column_for_status
 from app.dispatcher.store import SqliteStore
 
@@ -155,7 +155,11 @@ def move_card(task_id: str, request: MoveRequest) -> dict[str, Any]:
                 store, task_id, next_status, request.actor, request.note
             )
         else:
-            task = move_task(store, task_id, next_status, request.actor, request.note)
+            task = (
+                move_unclaimed_task_to_review(store, task_id, request.actor, request.note)
+                if next_status == "review"
+                else move_task(store, task_id, next_status, request.actor, request.note)
+            )
     except ValueError as exc:
         status_code = 404 if "not found" in str(exc).lower() else 409
         raise HTTPException(status_code=status_code, detail=str(exc)) from exc

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -70,19 +70,20 @@ def move_task(
     note: str | None = None,
 ) -> TaskRecord:
     """Move a task to a lifecycle status. Emits task.moved event."""
+    next_status = canonical_status(status)
+    if next_status == "review":
+        return _move_task_to_review(store, task_id, actor, note, allow_handoff=True)
+
     task = store.get_task(task_id)
     if task is None:
         raise ValueError(f"Task {task_id} not found")
 
-    next_status = canonical_status(status)
     if next_status == "completed" and task.lease_id is not None:
         raise ValueError(
             f"Cannot move task {task_id} to completed while lease {task.lease_id} is active; "
             "use complete instead"
         )
     previous_status = task.status
-    if next_status == "review" and task.lease_id is not None:
-        return _handoff_leased_task_to_review(store, task_id, actor, note)
     task.status = next_status
     if next_status != "blocked":
         task.blocked_reason = None
@@ -108,13 +109,34 @@ def move_task(
     return task
 
 
-def _handoff_leased_task_to_review(
+def move_unclaimed_task_to_review(
+    store: SqliteStore,
+    task_id: str,
+    actor: str,
+    note: str | None = None,
+) -> TaskRecord:
+    """Move only an unclaimed task to Review under the dispatcher write lock.
+
+    This is the Signboard boundary: a projection client has no agent identity
+    authority and therefore never performs the claimed-holder handoff.
+    """
+    return _move_task_to_review(store, task_id, actor, note, allow_handoff=False)
+
+
+def _move_task_to_review(
     store: SqliteStore,
     task_id: str,
     actor: str,
     note: str | None,
+    *,
+    allow_handoff: bool,
 ) -> TaskRecord:
-    """Atomically release an owned lease while moving its task to review."""
+    """Atomically decide and persist the complete Review transition.
+
+    The task state is intentionally not inspected before ``BEGIN IMMEDIATE``:
+    otherwise a claim that arrives between a read and a generic upsert can be
+    silently overwritten by a stale Review move.
+    """
 
     now = _utc_now()
     with store._connect() as conn:
@@ -125,51 +147,63 @@ def _handoff_leased_task_to_review(
         if task is None:
             raise ValueError(f"Task {task_id} not found")
         lease_id = task["lease_id"]
+        release_event: EventRecord | None = None
         if lease_id is None:
-            raise ValueError(f"Task {task_id} has no active lease for review handoff")
-        lease = conn.execute(
-            "SELECT * FROM dispatcher_leases WHERE lease_id = ?", (lease_id,)
-        ).fetchone()
-        if lease is None or lease["released_at"] is not None:
-            raise ValueError(f"Task {task_id} has no active lease for review handoff")
-        if lease["holder"] != actor:
-            raise ValueError(
-                f"Cannot move task {task_id} to review: lease {lease_id} is held by {lease['holder']}, not {actor}"
+            moved = conn.execute(
+                """
+                UPDATE dispatcher_tasks
+                SET status = 'review', blocked_reason = NULL, updated_at = ?
+                WHERE task_id = ? AND lease_id IS NULL
+                """,
+                (now, task_id),
             )
+        else:
+            if not allow_handoff:
+                raise ValueError(
+                    "claimed task Review handoff requires the dispatcher lease holder path"
+                )
+            lease = conn.execute(
+                "SELECT * FROM dispatcher_leases WHERE lease_id = ?", (lease_id,)
+            ).fetchone()
+            if lease is None or lease["released_at"] is not None:
+                raise ValueError(f"Task {task_id} has no active lease for review handoff")
+            if lease["holder"] != actor:
+                raise ValueError(
+                    f"Cannot move task {task_id} to review: lease {lease_id} is held by {lease['holder']}, not {actor}"
+                )
 
-        released = conn.execute(
-            """
-            UPDATE dispatcher_leases
-            SET released_at = ?, release_reason = 'review_handoff'
-            WHERE lease_id = ? AND released_at IS NULL
-            """,
-            (now, lease_id),
-        )
-        if released.rowcount != 1:
-            raise ValueError(f"Cannot move task {task_id} to review: lease changed concurrently")
+            released = conn.execute(
+                """
+                UPDATE dispatcher_leases
+                SET released_at = ?, release_reason = 'review_handoff'
+                WHERE lease_id = ? AND released_at IS NULL
+                """,
+                (now, lease_id),
+            )
+            if released.rowcount != 1:
+                raise ValueError(f"Cannot move task {task_id} to review: lease changed concurrently")
 
-        moved = conn.execute(
-            """
-            UPDATE dispatcher_tasks
-            SET status = 'review', blocked_reason = NULL, lease_id = NULL,
-                claimed_by = NULL, last_heartbeat_at = NULL, lease_expires_at = NULL,
-                updated_at = ?
-            WHERE task_id = ? AND lease_id = ?
-            """,
-            (now, task_id, lease_id),
-        )
+            moved = conn.execute(
+                """
+                UPDATE dispatcher_tasks
+                SET status = 'review', blocked_reason = NULL, lease_id = NULL,
+                    claimed_by = NULL, last_heartbeat_at = NULL, lease_expires_at = NULL,
+                    updated_at = ?
+                WHERE task_id = ? AND lease_id = ?
+                """,
+                (now, task_id, lease_id),
+            )
+            release_event = EventRecord(
+                event_id=_make_event_id(),
+                timestamp=now,
+                task_id=task_id,
+                event_type="task.released",
+                actor=actor,
+                lease_id=lease_id,
+                payload={"reason": "review_handoff"},
+            )
         if moved.rowcount != 1:
             raise ValueError(f"Cannot move task {task_id} to review: task changed concurrently")
-
-        release_event = EventRecord(
-            event_id=_make_event_id(),
-            timestamp=now,
-            task_id=task_id,
-            event_type="task.released",
-            actor=actor,
-            lease_id=lease_id,
-            payload={"reason": "review_handoff"},
-        )
         move_payload: dict[str, str] = {"from_status": task["status"], "to_status": "review"}
         if note is not None:
             move_payload["note"] = note
@@ -181,7 +215,8 @@ def _handoff_leased_task_to_review(
             actor=actor,
             payload=move_payload,
         )
-        for event in (release_event, move_event):
+        events = (move_event,) if release_event is None else (release_event, move_event)
+        for event in events:
             conn.execute(
                 """
                 INSERT INTO dispatcher_events (
@@ -203,7 +238,8 @@ def _handoff_leased_task_to_review(
         conn.commit()
 
     if store._event_writer is not None:
-        store._event_writer.append(release_event)
+        if release_event is not None:
+            store._event_writer.append(release_event)
         store._event_writer.append(move_event)
     moved_task = store.get_task(task_id)
     assert moved_task is not None

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -861,10 +861,18 @@ python -m app.dispatcher block github-issue-123 --reason "waiting for owner deci
 python -m app.dispatcher export-signboard --json
 ```
 
-Moving a claimed task to `review` is a terminal handoff for its pickup lease:
-the dispatcher atomically releases the current holder's lease while preserving
-the `review` status. A released review task cannot later be reclaimed as an
-expired ready task.
+Moving a task to `review` takes the task/lease decision, validation, release,
+and status write under one dispatcher SQLite write transaction. For a claimed
+task this is a terminal handoff for its pickup lease: only the current holder
+may move it, and the dispatcher atomically releases that holder's lease while
+preserving the `review` status. A released review task cannot later be
+reclaimed as an expired ready task.
+
+Signboard is a generic projection client, not an agent-identity authority. It
+may move an unclaimed task through its normal route, but it must refuse a
+claimed task's Review handoff even when a browser payload names `claimed_by`.
+The current holder performs that handoff through the dispatcher agent command;
+the generic Signboard route never impersonates the lease holder.
 
 The generated Markdown frontmatter is projection state only. Do not patch generated Signboard cards
 as the source of a claim, heartbeat, or lifecycle transition.

--- a/tests/api/test_signboard_api.py
+++ b/tests/api/test_signboard_api.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.api.app import app
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.leases import claim
 from app.dispatcher.models import TaskRecord
+from app.dispatcher.services import move_task
 from app.dispatcher.signboard import STATUS_COLUMNS, VALID_STATUSES
 from app.dispatcher.store import SqliteStore
 
 ROUTE_SOURCE = Path(__file__).parents[2] / "app/api/routes/signboard.py"
+SIGNBOARD_SOURCE = Path(__file__).parents[2] / "app/web/static/signboard.js"
 
 
 def _seed(store: SqliteStore, *, status: str = "ready") -> TaskRecord:
@@ -168,6 +171,70 @@ def test_move_is_visible_without_export(tmp_path: Path, monkeypatch) -> None:
     }
     assert [card["id"] for card in reread["Review"]] == [task.task_id]
     assert not board_root.exists()
+
+
+@pytest.mark.parametrize("actor", ["lease-holder", "other-actor", "signboard-ui"])
+def test_claimed_card_moves_to_review_with_lease_holder(tmp_path: Path, monkeypatch, actor: str) -> None:
+    """Signboard cannot impersonate a holder; the holder path still succeeds."""
+    store = _configure(tmp_path, monkeypatch)
+    task = _seed(store)
+    claim(store, task.task_id, "lease-holder")
+
+    response = TestClient(app).post(
+        f"/api/signboard/cards/{task.task_id}/move",
+        json={"status": "Review", "actor": actor},
+    )
+
+    assert response.status_code == 409
+    assert "requires the dispatcher lease holder path" in response.json()["detail"]
+    moved = store.get_task(task.task_id)
+    assert moved is not None
+    assert moved.status == "claimed"
+    assert moved.claimed_by == "lease-holder"
+    assert moved.lease_id is not None
+
+    moved = move_task(store, task.task_id, "Review", "lease-holder")
+    assert moved.status == "review"
+    assert moved.claimed_by is None
+    assert moved.lease_id is None
+    events = store.list_events(task.task_id)
+    handoff_events = events[-2:]
+    assert {event.event_type for event in handoff_events} == {"task.released", "task.moved"}
+    assert next(event for event in handoff_events if event.event_type == "task.released").actor == "lease-holder"
+
+    # The browser must not carry the agent identity into its generic request.
+    source = SIGNBOARD_SOURCE.read_text(encoding="utf-8")
+    assert "select.value === 'Review' || select.value === 'Done'" not in source
+    assert "column === 'Review' || column === 'Done'" not in source
+
+
+def test_signboard_review_with_matching_actor_race_is_atomic(tmp_path: Path, monkeypatch) -> None:
+    """A matching user payload cannot pass a claim made after UI observation."""
+    store = _configure(tmp_path, monkeypatch)
+    task = _seed(store)
+    observed = store.get_task(task.task_id)
+    assert observed is not None
+    assert observed.lease_id is None
+    claim(store, task.task_id, "racing-agent")
+
+    response = TestClient(app).post(
+        f"/api/signboard/cards/{task.task_id}/move",
+        json={"status": "Review", "actor": "racing-agent"},
+    )
+
+    assert response.status_code == 409
+    assert "requires the dispatcher lease holder path" in response.json()["detail"]
+    stored = store.get_task(task.task_id)
+    assert stored is not None
+    assert stored.status == "claimed"
+    assert stored.claimed_by == "racing-agent"
+    assert stored.lease_id is not None
+
+    # The Signboard path's first decision is under the write lock, so this
+    # observable race cannot be widened by an API-side preflight read.
+    source = ROUTE_SOURCE.read_text(encoding="utf-8")
+    review_branch = source[source.index('next_status == "review"'):]
+    assert "store.get_task(task_id)" not in review_branch.split("except ValueError", 1)[0]
 
 
 def test_columns_follow_dispatcher_status_columns(tmp_path: Path, monkeypatch) -> None:

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -405,6 +405,55 @@ def test_move_completed_rejects_active_lease(tmp_env, store):
     assert stored.claimed_by == "codex"
 
 
+def test_move_review_with_racing_claim_is_atomic(tmp_env, store):
+    """A claim after an observation is never erased by a stale Review move."""
+    from app.dispatcher.leases import claim
+    from app.dispatcher.services import move_task
+    from tests.dispatcher.helpers import seed_tasks
+
+    ready = next(task for task in seed_tasks(store) if task.status == "ready")
+    statements: list[str] = []
+    original_connect = store._connect
+
+    def traced_connect():
+        conn = original_connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    store._connect = traced_connect  # type: ignore[method-assign]
+    reviewed = move_task(store, ready.task_id, "Review", "reviewer")
+    assert reviewed.status == "review"
+    first_begin = next(index for index, statement in enumerate(statements) if statement == "BEGIN IMMEDIATE")
+    first_task_read = next(
+        index
+        for index, statement in enumerate(statements)
+        if "SELECT * FROM dispatcher_tasks" in statement
+    )
+    assert first_begin < first_task_read
+
+    # A later claimant cannot be overwritten by an actor that only observed the
+    # previous unclaimed state. This is the rejected-race branch of the same
+    # transaction contract.
+    store._connect = original_connect  # type: ignore[method-assign]
+    raced = next(task for task in seed_tasks(store) if task.status == "ready")
+    observed = store.get_task(raced.task_id)
+    assert observed is not None
+    assert observed.lease_id is None
+    claim(store, raced.task_id, "racing-agent")
+    code, data = _run(
+        ["move", raced.task_id, "--status", "Review", "--agent", "stale-agent", "--json"]
+    )
+
+    assert code == 1
+    assert data["ok"] is False
+    assert "held by racing-agent" in data["error"]
+    stored = store.get_task(raced.task_id)
+    assert stored is not None
+    assert stored.status == "claimed"
+    assert stored.claimed_by == "racing-agent"
+    assert stored.lease_id is not None
+
+
 def test_export_signboard_writes_markdown_columns(tmp_env, store, tmp_path: Path):
     from tests.dispatcher.helpers import seed_tasks
     tasks = seed_tasks(store)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5107

## Linked Issue
Closes #5107

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): dispatcher; Signboard API projection
- Write class: governance/tooling correction
- Persistence impact: dispatcher task and lease rows remain mutually consistent through Review handoff
- Derived/rebuildable impact: Signboard remains a dispatcher-store projection
- New or changed contract: Signboard cannot impersonate claimed_by; only the dispatcher holder path may release a claimed lease
- Owner-doc impact: docs/AGENT_ISSUE_DISPATCHER.md updated
- Transition debt impact: reduces stale review-closure debt from #3309
- Boundary risk: Signboard remains a producer, never an independent lease or agent-identity authority

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Makes Signboard reject every claimed Review handoff, including a payload that names the active holder.
- Keeps holder-only Review handoff in the dispatcher transaction and prevents stale or matching-actor races.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record was produced; the durable delivery evidence is the governing Issue, PR, dispatcher lease, and closure receipt.

## Notes
Late-change supersession: prior head 12e3329f5 and its CI/review evidence are superseded by 83e14742b30db7465dd0242e421d318ff35ef388 after two P1 repairs in dispatcher.review_handoff.v1 / lease_concurrency. Fresh independent review PASS on 83e14742. Focused tests (5), ruff, and docs_guard green; current-head CI is required again.