### PR TITLE
Clarify cross-repo governance skill targets

### DIFF
--- a/.codex/skills/capture-learning/SKILL.md
+++ b/.codex/skills/capture-learning/SKILL.md
@@ -16,6 +16,16 @@ Product/Runtime truth requires the explicit Product System authority path named 
 `docs/learning-log.md` is historical/compatibility material after #1506. Do not treat it as the
 primary operational learning store.
 
+## Cross-repository capture
+
+Learning from constituent-repository work uses the same BuilderOps `LearningSignal` path. Set
+`REPO` to the repository that produced the observation and qualify GitHub provenance as
+`github_issue:${REPO}#<issue>`; qualify a repo-local upstream artifact as
+`repo_doc:${REPO}:<path>`. The source ref preserves origin only: it neither moves GitHub tracking
+to the hub nor transfers repo authority. The BuilderOps store accepts these repository-qualified
+references as provenance under `docs/builderops/BUILDEROPS_VAULT_STORE.md :: Repository-qualified
+learning provenance`.
+
 ## When to invoke
 
 Invoke only when:
@@ -56,8 +66,8 @@ Source: <skill name or human>
 Diverged: <one sentence>
 Upstream artifact: <path or section>" \
   --signal-type workflow_divergence \
-  --source-ref "github_issue:#<issue>" \
-  --source-ref "repo_doc:<upstream-artifact-path>" \
+  --source-ref "github_issue:${REPO}#<issue>" \
+  --source-ref "repo_doc:${REPO}:<upstream-artifact-path>" \
   --created-by "<agent-id>" \
   --idempotency-key "learning:<YYYY-MM-DD>:<issue-or-context>:<short-slug>" \
   --json

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -7,6 +7,13 @@ description: "Break a docs-defined capability into a specification directory wit
 
 Use this skill when a docs-defined capability is too large for one implementation issue or when the work needs post-merge validation before owner docs should claim it as supported.
 
+## Repository target
+
+Set `REPO` to the intended `owner/repo` before creating or updating GitHub issues. A specification
+directory may be maintained in the hub while implementation issues target a constituent repository;
+the repository named by the governing contract, not the current checkout, owns that lifecycle. Use
+`gh issue create --repo "$REPO"` (and the same explicit target for follow-up reads and edits).
+
 Do not use this skill for:
 
 - a single already-bounded implementation issue
@@ -299,7 +306,11 @@ Recommended habit:
 
 ## Publication discipline
 
-This lane writes specification directories and creates issues in the shared repo. When you commit and push those spec docs, route the branch / commit / push / PR actions through `.codex/skills/publish-pr/SKILL.md` — do not run an ad hoc commit/push from this skill. `publish-pr` owns the branch-truth gate.
+This lane writes specification directories and creates issues in the explicitly selected repository.
+When a hub specification governs a constituent-repository delivery, name both repositories and keep
+each lifecycle action targeted to its owner. When you commit and push those spec docs, route the
+branch / commit / push / PR actions through `.codex/skills/publish-pr/SKILL.md` — do not run an ad
+hoc commit/push from this skill. `publish-pr` owns the branch-truth gate.
 
 Branch-truth gate (mandatory, same canonical gate as every lane) [branch-truth-gate]: run `.codex/skills/_shared/BRANCH_TRUTH_GATE.md :: Procedure` — dedicated worktree preferred, capture `EXPECTED_BRANCH`/`EXPECTED_WORKTREE` at branch creation, hardened preflight with `--allow-dirty` before commit and again before push.
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -15,6 +15,13 @@ That includes PR lifecycle truth, not only Issue lifecycle truth.
 This is a cold-path maintenance role, not a hot-path implementation routine.
 Use `docs/development/PR_HOT_PATH.md` for normal PR delivery and `docs/development/PARENT_ISSUE_CLOSURE.md` when a delivered parent issue actually needs closure.
 
+## Repository target
+
+Set `REPO` to the explicitly intended `owner/repo` before reading or mutating GitHub state. Never
+infer the hub as the target merely because this skill is available from a hub checkout. Every
+direct `gh issue` command below uses `--repo "$REPO"`; use the constituent repository for its own
+Issue lifecycle and retain a hub issue only when its contract explicitly owns cross-repo tracking.
+
 See `.codex/skills/README.md :: Workflow map` for the canonical chain: issue maintenance sits on the
 conditional path (`Issue maintenance -> Agent`), not the hot path.
 
@@ -144,15 +151,15 @@ Impact` unparseable.
    ```bash
    set -euo pipefail
    body_file="$(mktemp)"
-   gh issue view <N> --repo <owner/repo> --json body --jq .body >"$body_file"
+   gh issue view <N> --repo "$REPO" --json body --jq .body >"$body_file"
    # Edit "$body_file" while preserving real newlines.
-   gh issue edit <N> --repo <owner/repo> --body-file "$body_file"
+   gh issue edit <N> --repo "$REPO" --body-file "$body_file"
    ```
 2. Re-read the authoritative GitHub body into a fresh file after the mutation. Do not validate the
    pre-write local copy as evidence that GitHub stored the intended newlines:
    ```bash
    verified_body_file="$(mktemp)"
-   gh issue view <N> --repo <owner/repo> --json body --jq .body >"$verified_body_file"
+   gh issue view <N> --repo "$REPO" --json body --jq .body >"$verified_body_file"
    python3 scripts/validate_issue_readiness.py \
      --body-file "$verified_body_file" \
      --issue-number <N> \
@@ -187,12 +194,12 @@ If an Issue is closed (already delivered):
 
 1. **Remove all agent labels:**
    ```bash
-   gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
    ```
 
 2. **Verify authoritative state:**
    ```bash
-   gh issue view #<N> --json state,labels
+   gh issue view #<N> --repo "$REPO" --json state,labels
    ```
 
 3. **Optional Project repair:** when explicitly in scope, apply and verify the `Done` projection.
@@ -203,19 +210,19 @@ If an open issue is no longer the truthful backlog item because an equivalent sl
 
 1. **Leave a maintenance receipt comment:**
    ```bash
-   gh issue comment #<N> --body "Maintenance reconciliation: this issue is superseded by delivered canonical issue #<M> / PR #<P> ..."
+   gh issue comment #<N> --repo "$REPO" --body "Maintenance reconciliation: this issue is superseded by delivered canonical issue #<M> / PR #<P> ..."
    ```
 
 2. **Close the stale issue:**
    ```bash
-   gh issue close #<N> --reason completed
+   gh issue close #<N> --repo "$REPO" --reason completed
    ```
 
 3. **Re-check terminal truth and strip lingering agent labels if needed:**
    ```bash
-   gh issue view #<N> --json state,labels
-   gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
-   gh issue view #<N> --json state,labels
+   gh issue view #<N> --repo "$REPO" --json state,labels
+   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   gh issue view #<N> --repo "$REPO" --json state,labels
    ```
 
 4. **Only then treat the dedupe as complete.**
@@ -226,7 +233,7 @@ If an open implementation Issue is malformed, stale, or no longer safely executa
 
 1. **Add needs-human label:**
    ```bash
-   gh issue edit #<N> --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+   gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
    ```
 
 2. **Post comment with the required action.**
@@ -253,7 +260,7 @@ Parent feature issues are validation hubs, not direct pickup issues. Unless expl
 
 1. **Keep them non-active:**
    ```bash
-   gh issue edit #<PARENT> --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
+   gh issue edit #<PARENT> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
    ```
 
 2. **Use them to track child slice delivery** in comments and body updates, including validation receipts posted by each delivered child
@@ -330,7 +337,7 @@ Lead with the human summary; include later sections only when they have content 
 Use this when the user asks for a maintenance run across everything not done.
 
 1. Resolve repo:
-   - If repo not given, ask for `owner/repo`.
+   - If repo not given, ask for `owner/repo` and set it as `REPO`.
    - If user says they are the owner, resolve the username via `gh api user --jq .login` or infer it from `git remote` (prefer the GitHub app account resolver when available, but do not depend on it).
 2. **Optional Project-state audit.** Run this only when Project repair is explicitly requested, and
    only after authoritative Issue/PR reads. It never gates label edits or pickup. If in scope, query
@@ -374,7 +381,7 @@ Use this when the user asks for a maintenance run across everything not done.
 
 3. List open issues:
    - Prefer GitHub app for structured data when possible.
-   - For bulk edits, use `gh issue list --state open --json number,title,labels,body,comments` for full bodies and blocker context.
+   - For bulk edits, use `gh issue list --repo "$REPO" --state open --json number,title,labels,body,comments` for full bodies and blocker context.
 4. For each open issue:
    - Establish issue/PR truth before deciding labels:
      - inspect recent comments for acceptance failures, blocker receipts, and follow-up issue links
@@ -394,11 +401,11 @@ Use this when the user asks for a maintenance run across everything not done.
    - **Execute label corrections** from established issue/PR truth before any Project reconciliation:
      ```bash
      # Example: set to ready if criteria are concrete
-     gh issue edit #<N> --add-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     gh issue edit #<N> --repo "$REPO" --add-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
      # OR: set to needs-human if ambiguous or boundary move
-     gh issue edit #<N> --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+     gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
      # OR: set to blocked if external dependency exists
-     gh issue edit #<N> --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
+     gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
      ```
      - Add `agent:ready` only if Scope/Constraints/Acceptance Criteria are concrete and no ambiguity remains.
      - Do not add or preserve `agent:ready` when any AC lacks a resolvable `Verify:` marker.
@@ -415,12 +422,12 @@ Use this when the user asks for a maintenance run across everything not done.
 5. **Execute Deduplication:**
    - If duplicate issues have the same scope/contract:
      ```bash
-     gh issue comment #<DUPLICATE> --body "Duplicate of #<CANONICAL>. Closing in favor of canonical issue."
-     gh issue close #<DUPLICATE>
+     gh issue comment #<DUPLICATE> --repo "$REPO" --body "Duplicate of #<CANONICAL>. Closing in favor of canonical issue."
+     gh issue close #<DUPLICATE> --repo "$REPO"
      ```
    - Remove all agent labels from closed duplicate:
      ```bash
-     gh issue edit #<DUPLICATE> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     gh issue edit #<DUPLICATE> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
      ```
 
 6. **When Project repair is in scope, reconcile terminal work stuck in non-terminal status**:

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -12,8 +12,8 @@ You are a builder agent implementing GitHub backlog work in a repo-first, docs-a
 Set `REPO` to the explicitly intended `owner/repo` before any GitHub lifecycle command. A
 checkout remote is only a convenience for deriving that value; it is not authority to act on the
 hub by default. Every direct `gh issue` command in this skill carries `--repo "$REPO"`. For
-constituent-surface work such as Bifrost, use that constituent repository for its Issue and PR
-lifecycle while preserving a hub Issue only when the governing contract explicitly names it.
+constituent-surface work, use that constituent repository for its Issue and PR lifecycle while
+preserving a hub Issue only when the governing contract explicitly names it.
 
 ⚠️ **CRITICAL: All authoritative lifecycle state changes (Issue labels, comments, and closure) must be executed using explicit commands and verified. Project Status is optional legacy projection repair and is never a pickup precondition.**
 

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -7,6 +7,14 @@ description: "Implement a bounded GitHub slice issue as the canonical task contr
 
 You are a builder agent implementing GitHub backlog work in a repo-first, docs-as-code software system.
 
+## Repository target
+
+Set `REPO` to the explicitly intended `owner/repo` before any GitHub lifecycle command. A
+checkout remote is only a convenience for deriving that value; it is not authority to act on the
+hub by default. Every direct `gh issue` command in this skill carries `--repo "$REPO"`. For
+constituent-surface work such as Bifrost, use that constituent repository for its Issue and PR
+lifecycle while preserving a hub Issue only when the governing contract explicitly names it.
+
 ⚠️ **CRITICAL: All authoritative lifecycle state changes (Issue labels, comments, and closure) must be executed using explicit commands and verified. Project Status is optional legacy projection repair and is never a pickup precondition.**
 
 Your governing rule:
@@ -273,14 +281,14 @@ If work becomes blocked before or during implementation:
 
 1. **Add blocker label:**
    ```bash
-   gh issue edit #<N> --add-label agent:blocked --remove-label agent:ready
+   gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready
    ```
 
 2. **Add a blocking comment to the Issue with the explicit reason and next unblock condition.**
 
 3. **Verify authoritative state:**
    ```bash
-   gh issue view #<N> --json state,labels,comments
+   gh issue view #<N> --repo "$REPO" --json state,labels,comments
    ```
 
 **Use `agent:blocked`** when blocked by dependency or setup.  

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -34,6 +34,15 @@ identity. It validates supported `object_type` values and required fields before
 The #1502 safety layer is intentionally local and minimal. It does not provide distributed locking
 across machines, but it does serialize local SQLite writes and gives agents explicit failure modes.
 
+### Repository-qualified learning provenance
+
+`LearningSignal` creation is usable from every governed repository. When a signal cites a GitHub
+issue or repo-local upstream artifact, its `source_refs` must preserve the producing repository:
+`github_issue:<owner/repo>#<issue>` and `repo_doc:<owner/repo>:<path>`. These are provenance
+identities, not a cross-repository lifecycle command or a transfer of GitHub/repo authority. The
+same BuilderOps store may retain the signal; the originating repository remains the authority for
+its Issue, PR, and docs.
+
 ### Agent identity
 
 Every created record still carries `created_by`. Lease acquisition and state transitions require an

--- a/tests/governance/test_cross_repo_skill_contract.py
+++ b/tests/governance/test_cross_repo_skill_contract.py
@@ -1,0 +1,39 @@
+"""Regression coverage for the cross-repo skill contract promised by #3174."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS = REPO_ROOT / ".codex" / "skills"
+
+
+def test_issue_skills_declare_repo_target_or_single_repo_precondition() -> None:
+    issue_to_code = (SKILLS / "issue-to-code" / "SKILL.md").read_text(encoding="utf-8")
+    maintenance = (SKILLS / "issue-maintenance-change-control" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    breakdown = (SKILLS / "feature-breakdown" / "SKILL.md").read_text(encoding="utf-8")
+
+    for skill in (issue_to_code, maintenance, breakdown):
+        assert "## Repository target" in skill
+        assert 'REPO` to the explicitly intended `owner/repo`' in skill or (
+            'REPO` to the intended `owner/repo`' in skill
+        )
+
+    for line in (*issue_to_code.splitlines(), *maintenance.splitlines()):
+        if line.lstrip().startswith("gh issue "):
+            assert '--repo "$REPO"' in line
+
+    assert 'gh issue create --repo "$REPO"' in breakdown
+
+
+def test_capture_learning_declares_cross_repo_path() -> None:
+    capture_learning = (SKILLS / "capture-learning" / "SKILL.md").read_text(encoding="utf-8")
+    store_contract = (REPO_ROOT / "docs/builderops/BUILDEROPS_VAULT_STORE.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Cross-repository capture" in capture_learning
+    assert "github_issue:${REPO}#<issue>" in capture_learning
+    assert "repo_doc:${REPO}:<upstream-artifact-path>" in capture_learning
+    assert "### Repository-qualified learning provenance" in store_contract


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #3174

## Linked Issue
Fixes #3174

## SBS Impact
- Primary subsystem: Builder System skill layer
- Secondary subsystem(s): BuilderOps store provenance
- Write class: governance/docs/process
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: explicit repository target for cross-repo skill execution and learning provenance
- Owner-doc impact: updated docs/builderops/BUILDEROPS_VAULT_STORE.md
- Transition debt impact: reduces D19 cross-repo repo-parametrization debt
- Boundary risk: provenance does not transfer GitHub or repository authority

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make Issue lifecycle examples target an explicit owner/repo instead of the checkout remote.
- Define Bifrost-compatible learning provenance and add regression coverage for the contract.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This PR documents the existing LearningSignal path; it creates no operational record.

## Notes
Validation: `python3 -m pytest -q tests/governance/test_cross_repo_skill_contract.py` (2 passed); `python3 scripts/lint_skills_consistency.py`; `python3 scripts/docs_guard.py --language-only`; `git diff --check`; review-before-CI gate passed with no high-risk surfaces.
