### PR TITLE
Add authority-aware DevUI discovery projection

### DIFF
--- a/app/builderops/devui_discovery.py
+++ b/app/builderops/devui_discovery.py
@@ -142,15 +142,16 @@ def _item(value: Any, *, index: int) -> dict[str, Any]:
     _keys(
         item,
         allowed={
-            "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
+            "provider", "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
             "provenance", "freshness", "limitations", "navigation",
         },
         required={
-            "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
+            "provider", "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
             "provenance", "freshness", "limitations", "navigation",
         },
         label=label,
     )
+    item["provider"] = _string(item["provider"], label=f"{label}.provider")
     item["source_ref"] = _source_ref(item["source_ref"], label=f"{label}.source_ref")
     if item["source_role"] not in _SOURCE_ROLES:
         raise DiscoveryContractError(f"{label}.source_role is unsupported")
@@ -273,7 +274,19 @@ def compose_discovery_projection(*, composition: Mapping[str, Any], items: Seque
     for index, declaration in enumerate(items):
         item = _item(declaration, index=index)
         state = item["freshness"]["state"]
-        item["claim_status"] = "available" if state == "fresh" else "withdrawn"
+        provider = envelope["providers"].get(item["provider"])
+        if provider is None:
+            raise DiscoveryContractError(
+                f"items[{index}].provider is not declared by the composition"
+            )
+        if provider["status"] == "refused":
+            item["claim_status"] = "withdrawn"
+            item["limitations"] = [
+                *item["limitations"],
+                f"Provider {item['provider']!r} refused the composition read.",
+            ]
+        else:
+            item["claim_status"] = "available" if state == "fresh" else "withdrawn"
         item["presentation"] = {
             "non_normative": item["authority_class"] == "non-normative",
             "ephemeral_or_rebuildable": item["source_ref"]["source_type"] == "builder_vault",

--- a/app/builderops/devui_discovery.py
+++ b/app/builderops/devui_discovery.py
@@ -243,8 +243,16 @@ def _validated_composition(value: Mapping[str, Any]) -> dict[str, Any]:
                 raise DiscoveryContractError(f"composition.providers.{name} available provider lacks a snapshot")
             if provider.get("refusal") is not None:
                 raise DiscoveryContractError(f"composition.providers.{name} available provider cannot carry refusal evidence")
-        elif provider["authority"] is None or provider.get("refusal") is None:
-            raise DiscoveryContractError(f"composition.providers.{name} refused provider lacks typed refusal evidence")
+        else:
+            if provider["authority"] is None or provider.get("refusal") is None:
+                raise DiscoveryContractError(f"composition.providers.{name} refused provider lacks typed refusal evidence")
+            if any(
+                provider[field] is not None
+                for field in ("captured_at", "snapshot", "completeness")
+            ) or "payload" in provider:
+                raise DiscoveryContractError(
+                    f"composition.providers.{name} refused provider cannot carry available-read evidence"
+                )
     envelope["providers"] = providers
     return envelope
 

--- a/app/builderops/devui_discovery.py
+++ b/app/builderops/devui_discovery.py
@@ -199,7 +199,54 @@ def _item(value: Any, *, index: int) -> dict[str, Any]:
 
     if item["source_ref"]["source_type"] == "builder_vault" and item["authority_class"] != "non-normative":
         raise DiscoveryContractError("Builder Vault items must remain non-normative")
+    if (
+        item["source_role"] == "working" or item["artifact_class"] == "proposal"
+    ) and item["authority_class"] == "normative":
+        raise DiscoveryContractError(
+            "working material and proposals cannot claim normative authority"
+        )
     return item
+
+
+def _validated_composition(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the public composition envelope before deriving any claim."""
+
+    envelope = _mapping(value, label="composition")
+    _keys(
+        envelope,
+        allowed={"contract_version", "authority", "captured_at", "providers"},
+        required={"contract_version", "authority", "captured_at", "providers"},
+        label="composition",
+    )
+    if envelope["contract_version"] != "devui.composition.v1" or envelope["authority"] != "projection_only":
+        raise DiscoveryContractError("composition must be the existing projection-only devUI envelope")
+    envelope["captured_at"] = _timestamp(envelope["captured_at"], label="composition.captured_at")
+    providers = _mapping(envelope["providers"], label="composition.providers")
+    for name, value in providers.items():
+        _string(name, label="composition provider name")
+        provider = _mapping(value, label=f"composition.providers.{name}")
+        _keys(
+            provider,
+            allowed={"provider", "status", "authority", "captured_at", "snapshot", "completeness", "refusal", "payload"},
+            required={"provider", "status", "authority", "captured_at", "snapshot", "completeness"},
+            label=f"composition.providers.{name}",
+        )
+        _string(provider["provider"], label=f"composition.providers.{name}.provider")
+        if provider["status"] not in {"available", "refused"}:
+            raise DiscoveryContractError(f"composition.providers.{name}.status is unsupported")
+        if provider["captured_at"] is not None:
+            _timestamp(provider["captured_at"], label=f"composition.providers.{name}.captured_at")
+        if provider["status"] == "available":
+            if provider["authority"] is None or provider["completeness"] is None:
+                raise DiscoveryContractError(f"composition.providers.{name} available provider lacks authority evidence")
+            if provider["snapshot"] is None and provider["captured_at"] is None:
+                raise DiscoveryContractError(f"composition.providers.{name} available provider lacks a snapshot")
+            if provider.get("refusal") is not None:
+                raise DiscoveryContractError(f"composition.providers.{name} available provider cannot carry refusal evidence")
+        elif provider["authority"] is None or provider.get("refusal") is None:
+            raise DiscoveryContractError(f"composition.providers.{name} refused provider lacks typed refusal evidence")
+    envelope["providers"] = providers
+    return envelope
 
 
 def compose_discovery_projection(*, composition: Mapping[str, Any], items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -209,12 +256,8 @@ def compose_discovery_projection(*, composition: Mapping[str, Any], items: Seque
     no provider payload is copied or elevated into a discovery authority.
     """
 
-    envelope = _mapping(composition, label="composition")
-    if envelope.get("contract_version") != "devui.composition.v1" or envelope.get("authority") != "projection_only":
-        raise DiscoveryContractError("composition must be the existing projection-only devUI envelope")
-    captured_at = _timestamp(envelope.get("captured_at"), label="composition.captured_at")
-    if not isinstance(envelope.get("providers"), Mapping):
-        raise DiscoveryContractError("composition.providers must be an object")
+    envelope = _validated_composition(composition)
+    captured_at = envelope["captured_at"]
     if isinstance(items, (str, bytes)) or not isinstance(items, Sequence):
         raise DiscoveryContractError("items must be a list")
 

--- a/app/builderops/devui_discovery.py
+++ b/app/builderops/devui_discovery.py
@@ -1,0 +1,240 @@
+"""Pure authority-aware discovery projection for the existing devUI envelope.
+
+The caller supplies already-read, source-owned item declarations.  This module
+does not discover sources, persist a registry, infer links, or execute routes;
+it only validates and detaches a read-time projection.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+
+CONTRACT_VERSION = "devui.discovery-projection.v1"
+_SOURCE_ROLES = frozenset({"owner", "evidence", "working", "projection", "receipt"})
+_AUTHORITY_CLASSES = frozenset(
+    {"normative", "non-normative", "operational", "projection", "receipt", "unknown"}
+)
+_ARTIFACT_CLASSES = frozenset(
+    {"source", "derived", "proposal", "implementation", "mirror", "unknown"}
+)
+_STAGES = frozenset(
+    {
+        "capture",
+        "explore",
+        "synthesize",
+        "propose",
+        "promote",
+        "implement",
+        "verify",
+        "supersede_retire",
+        "unknown",
+    }
+)
+_LIFECYCLE_STATES = frozenset(
+    {"draft", "active", "accepted", "superseded", "retired", "unknown"}
+)
+_SOURCE_STATES = frozenset(
+    {
+        "fresh",
+        "stale",
+        "unknown",
+        "unavailable",
+        "unread",
+        "refused",
+        "unlinked",
+        "missing",
+        "ambiguous",
+        "partial",
+    }
+)
+_RFC3339 = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-[0-9]{2}T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]"
+    r"(?:\.[0-9]+)?(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])\Z",
+    re.ASCII,
+)
+
+
+class DiscoveryContractError(ValueError):
+    """Raised when a declaration would overstate source-owned discovery truth."""
+
+
+def _detached(value: Any, *, label: str) -> Any:
+    try:
+        return copy.deepcopy(value)
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        raise DiscoveryContractError(f"{label} must be copyable") from exc
+
+
+def _mapping(value: Any, *, label: str) -> dict[str, Any]:
+    copied = _detached(value, label=label)
+    if not isinstance(copied, dict) or any(not isinstance(key, str) for key in copied):
+        raise DiscoveryContractError(f"{label} must be an object with string keys")
+    return copied
+
+
+def _string(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DiscoveryContractError(f"{label} must be a non-empty string")
+    return value
+
+
+def _timestamp(value: Any, *, label: str) -> str:
+    text = _string(value, label=label)
+    if _RFC3339.fullmatch(text) is None:
+        raise DiscoveryContractError(f"{label} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise DiscoveryContractError(f"{label} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise DiscoveryContractError(f"{label} must be an RFC3339 timestamp")
+    return text
+
+
+def _keys(value: Mapping[str, Any], *, allowed: set[str], required: set[str], label: str) -> None:
+    unknown = set(value) - allowed
+    missing = required - set(value)
+    if unknown:
+        raise DiscoveryContractError(f"{label} has unknown fields: {sorted(unknown)}")
+    if missing:
+        raise DiscoveryContractError(f"{label} is missing fields: {sorted(missing)}")
+
+
+def _source_ref(value: Any, *, label: str) -> dict[str, Any]:
+    ref = _mapping(value, label=label)
+    _keys(
+        ref,
+        allowed={"source_type", "source_id", "version", "snapshot", "content_hash", "locator"},
+        required={"source_type", "source_id", "locator"},
+        label=label,
+    )
+    for field in ("source_type", "source_id", "locator"):
+        _string(ref[field], label=f"{label}.{field}")
+    if all(ref.get(field) is None for field in ("version", "snapshot", "content_hash")):
+        raise DiscoveryContractError(f"{label} requires a version, snapshot, or content hash")
+    for field in ("version", "snapshot", "content_hash"):
+        if ref.get(field) is not None:
+            _string(ref[field], label=f"{label}.{field}")
+    return ref
+
+
+def _refs(value: Any, *, label: str) -> list[dict[str, Any]]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise DiscoveryContractError(f"{label} must be a list")
+    return [_source_ref(item, label=f"{label}[{index}]") for index, item in enumerate(value)]
+
+
+def _limitations(value: Any, *, label: str) -> list[str]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise DiscoveryContractError(f"{label} must be a list")
+    return [_string(item, label=f"{label}[{index}]") for index, item in enumerate(value)]
+
+
+def _item(value: Any, *, index: int) -> dict[str, Any]:
+    label = f"items[{index}]"
+    item = _mapping(value, label=label)
+    _keys(
+        item,
+        allowed={
+            "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
+            "provenance", "freshness", "limitations", "navigation",
+        },
+        required={
+            "source_ref", "source_role", "authority_class", "artifact_class", "lifecycle",
+            "provenance", "freshness", "limitations", "navigation",
+        },
+        label=label,
+    )
+    item["source_ref"] = _source_ref(item["source_ref"], label=f"{label}.source_ref")
+    if item["source_role"] not in _SOURCE_ROLES:
+        raise DiscoveryContractError(f"{label}.source_role is unsupported")
+    if item["authority_class"] not in _AUTHORITY_CLASSES:
+        raise DiscoveryContractError(f"{label}.authority_class is unsupported")
+    if item["artifact_class"] not in _ARTIFACT_CLASSES:
+        raise DiscoveryContractError(f"{label}.artifact_class is unsupported")
+
+    lifecycle = _mapping(item["lifecycle"], label=f"{label}.lifecycle")
+    _keys(lifecycle, allowed={"stage", "state"}, required={"stage", "state"}, label=f"{label}.lifecycle")
+    if lifecycle["stage"] not in _STAGES or lifecycle["state"] not in _LIFECYCLE_STATES:
+        raise DiscoveryContractError(f"{label}.lifecycle is unsupported")
+    item["lifecycle"] = lifecycle
+
+    provenance = _mapping(item["provenance"], label=f"{label}.provenance")
+    _keys(
+        provenance,
+        allowed={"source_refs", "derived_from", "review_or_promotion_ref", "receipt_refs"},
+        required={"source_refs", "derived_from", "review_or_promotion_ref", "receipt_refs"},
+        label=f"{label}.provenance",
+    )
+    provenance["source_refs"] = _refs(provenance["source_refs"], label=f"{label}.provenance.source_refs")
+    provenance["derived_from"] = _refs(provenance["derived_from"], label=f"{label}.provenance.derived_from")
+    promotion = provenance["review_or_promotion_ref"]
+    provenance["review_or_promotion_ref"] = None if promotion is None else _source_ref(promotion, label=f"{label}.provenance.review_or_promotion_ref")
+    provenance["receipt_refs"] = _refs(provenance["receipt_refs"], label=f"{label}.provenance.receipt_refs")
+    item["provenance"] = provenance
+
+    freshness = _mapping(item["freshness"], label=f"{label}.freshness")
+    _keys(freshness, allowed={"observed_at", "watermark", "state"}, required={"observed_at", "watermark", "state"}, label=f"{label}.freshness")
+    freshness["observed_at"] = _timestamp(freshness["observed_at"], label=f"{label}.freshness.observed_at")
+    if freshness["watermark"] is not None:
+        _string(freshness["watermark"], label=f"{label}.freshness.watermark")
+    if freshness["state"] not in _SOURCE_STATES:
+        raise DiscoveryContractError(f"{label}.freshness.state is unsupported")
+    item["freshness"] = freshness
+    item["limitations"] = _limitations(item["limitations"], label=f"{label}.limitations")
+    if freshness["state"] != "fresh" and not item["limitations"]:
+        raise DiscoveryContractError(f"{label} degraded source state requires a typed limitation")
+
+    navigation = _mapping(item["navigation"], label=f"{label}.navigation")
+    _keys(navigation, allowed={"inspect_ref", "governed_route_ref"}, required={"inspect_ref", "governed_route_ref"}, label=f"{label}.navigation")
+    for field in ("inspect_ref", "governed_route_ref"):
+        navigation[field] = None if navigation[field] is None else _source_ref(navigation[field], label=f"{label}.navigation.{field}")
+    item["navigation"] = navigation
+
+    if item["source_ref"]["source_type"] == "builder_vault" and item["authority_class"] != "non-normative":
+        raise DiscoveryContractError("Builder Vault items must remain non-normative")
+    return item
+
+
+def compose_discovery_projection(*, composition: Mapping[str, Any], items: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return a detached, source-bound discovery projection.
+
+    ``composition`` is accepted only as the existing read-time envelope identity;
+    no provider payload is copied or elevated into a discovery authority.
+    """
+
+    envelope = _mapping(composition, label="composition")
+    if envelope.get("contract_version") != "devui.composition.v1" or envelope.get("authority") != "projection_only":
+        raise DiscoveryContractError("composition must be the existing projection-only devUI envelope")
+    captured_at = _timestamp(envelope.get("captured_at"), label="composition.captured_at")
+    if not isinstance(envelope.get("providers"), Mapping):
+        raise DiscoveryContractError("composition.providers must be an object")
+    if isinstance(items, (str, bytes)) or not isinstance(items, Sequence):
+        raise DiscoveryContractError("items must be a list")
+
+    rendered = []
+    for index, declaration in enumerate(items):
+        item = _item(declaration, index=index)
+        state = item["freshness"]["state"]
+        item["claim_status"] = "available" if state == "fresh" else "withdrawn"
+        item["presentation"] = {
+            "non_normative": item["authority_class"] == "non-normative",
+            "ephemeral_or_rebuildable": item["source_ref"]["source_type"] == "builder_vault",
+        }
+        rendered.append(item)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "authority": "projection_only",
+        "composition_ref": {"contract_version": "devui.composition.v1", "captured_at": captured_at},
+        "navigation_mode": "source_bound_read_only",
+        "items": rendered,
+    }
+
+
+__all__ = ["CONTRACT_VERSION", "DiscoveryContractError", "compose_discovery_projection"]

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -669,9 +669,9 @@ Delivered now:
   independent Cockpit and CKM authority, snapshots, completeness, and typed refusals without
   persistence or mutation;
 - `devui.discovery-projection.v1`, a pure source-declared discovery composer over the existing
-  composition envelope that preserves authority, provenance, lifecycle, typed degraded-source
-  limitations, and source-bound read-only navigation without source I/O, a local registry, UI, or
-  promotion action, delivered by #4985;
+  composition envelope that binds every item to its declared provider and preserves authority,
+  provenance, lifecycle, typed degraded-source limitations, and source-bound read-only navigation
+  without source I/O, a local registry, UI, or promotion action, delivered by #4985;
 - `FocusView.v1` / `focus-view.v1`, a pure subject-centred projection with explicit correlation,
   delivered by #4694 / PR #4703;
 - admitted local GET `/api/devui/focus` for one stable governed GitHub Issue, rebuilding the

--- a/docs/DEVUI.md
+++ b/docs/DEVUI.md
@@ -668,6 +668,10 @@ Delivered now:
 - `devui.composition.v1` at GET `/api/devui/composition`, a per-request projection that preserves
   independent Cockpit and CKM authority, snapshots, completeness, and typed refusals without
   persistence or mutation;
+- `devui.discovery-projection.v1`, a pure source-declared discovery composer over the existing
+  composition envelope that preserves authority, provenance, lifecycle, typed degraded-source
+  limitations, and source-bound read-only navigation without source I/O, a local registry, UI, or
+  promotion action, delivered by #4985;
 - `FocusView.v1` / `focus-view.v1`, a pure subject-centred projection with explicit correlation,
   delivered by #4694 / PR #4703;
 - admitted local GET `/api/devui/focus` for one stable governed GitHub Issue, rebuilding the

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -31,6 +31,10 @@ Concept anchors: layering, portability, archive exposure, trust semantics, event
   no source I/O, persistence, mutation, task/session operation, inferred correlation, or browser
   classification. Producer enrichment, a local Overview route, and every visual or command surface
   remain undelivered.
+- The pure `devui.discovery-projection.v1` composer derives detached discovery items from the
+  existing composition envelope and caller-declared source records. It preserves authority,
+  provenance, lifecycle, source-state limitations, and source-bound read-only navigation; it adds
+  no source I/O, registry, UI, task state, Builder Vault authority, or promotion action (#4985).
 
 Roadmap reset note: `docs/plans/MAJOR_ROADMAP_RESET_2026_06_04.md` is the accepted strategic reset
 input for sequencing, not a runtime-promotion document. This status file remains the current-state

--- a/docs/architecture/DEVUI_DISCOVERY_ARCHITECTURE.md
+++ b/docs/architecture/DEVUI_DISCOVERY_ARCHITECTURE.md
@@ -182,9 +182,11 @@ implementation delivered or bypass their readiness gates.
 - Process-health semantics remain in #4980 and are not part of discovery authority.
 - Source-lineage/evidence-independence remains in #4906 and is a Product/Runtime semantic track,
   not a DevUI source registry.
-- The remaining discovery implementation gap is a bounded, read-only projection over existing
-  authoritative sources with explicit artifact standing and navigation. It is recorded in blocked
-  #4985 and must remain blocked until this review is merged and reconciled with #4982.
+- The bounded, nonvisual read-only discovery composer is delivered by #4985. It preserves declared
+  source authority, artifact standing, provenance, degraded source state, and source-bound
+  navigation over the existing composition envelope; it delivers no UI, route, Builder Vault
+  discovery surface, or promotion execution. The unified owner-facing architecture and UX handoff
+  remains separately owned by #4982.
 
 ## Related documents
 

--- a/docs/plans/DEVUI_IMPLEMENTATION.md
+++ b/docs/plans/DEVUI_IMPLEMENTATION.md
@@ -85,6 +85,7 @@ it. See `docs/audits/BUILDER_SYSTEM_INTENT_EVIDENCE_GOVERNANCE_2026-08-10.md`.
 | Work/freshness | `build_registry`, Cockpit chain predicates, source-state model | Delivered read-only |
 | Queue/claim/lease activity | Dispatcher store and Signboard API contracts | Delivered operational source; standalone Signboard is not devUI navigation |
 | Unified read composition | `devui.composition.v1`, GET `/api/devui/composition` | Delivered per-request projection; no cache, mutation, or visual shell |
+| Authority-aware discovery | `devui.discovery-projection.v1` over declared source items | Pure nonvisual composer delivered by #4985; no source registry, UI, Builder Vault surface, or promotion execution |
 | Overview zones | `DevuiOverviewView.v1` over the composition envelope | Pure server-side composer delivered; it withdraws unsupported Needs you and Ready to try classifications until producer-authority enrichment exists |
 | Subject focus | `FocusView.v1` over existing read sources | Pure read-only composer delivered by PR #4703; Focus route/UI not delivered |
 | External conversation | `conversation-context-pack.v1` and explicit external adapter boundary | Nonvisual pack/export/disposition composer delivered by PR #4704; provider opening, embedded runtime, and session integration not delivered |

--- a/tests/builderops/test_devui_discovery.py
+++ b/tests/builderops/test_devui_discovery.py
@@ -150,3 +150,13 @@ def test_discovery_rejects_malformed_or_refusal_less_provider_envelopes() -> Non
     refused["providers"]["work"]["refusal"] = None
     with pytest.raises(DiscoveryContractError, match="lacks typed refusal evidence"):
         compose_discovery_projection(composition=refused, items=[])
+
+
+def test_discovery_rejects_refused_provider_that_carries_available_read_evidence() -> None:
+    refused = _composition()
+    provider = refused["providers"]["work"]
+    provider["status"] = "refused"
+    provider["refusal"] = {"code": "unavailable"}
+
+    with pytest.raises(DiscoveryContractError, match="cannot carry available-read evidence"):
+        compose_discovery_projection(composition=refused, items=[_item()])

--- a/tests/builderops/test_devui_discovery.py
+++ b/tests/builderops/test_devui_discovery.py
@@ -39,6 +39,7 @@ def _composition() -> dict:
 
 def _item() -> dict:
     return {
+        "provider": "work",
         "source_ref": _ref("4985"),
         "source_role": "working",
         "authority_class": "non-normative",
@@ -160,3 +161,44 @@ def test_discovery_rejects_refused_provider_that_carries_available_read_evidence
 
     with pytest.raises(DiscoveryContractError, match="cannot carry available-read evidence"):
         compose_discovery_projection(composition=refused, items=[_item()])
+
+
+def test_refused_provider_withdraws_only_the_items_bound_to_that_provider() -> None:
+    composition = _composition()
+    composition["providers"]["capabilities"] = {
+        "provider": "ckm",
+        "status": "available",
+        "authority": {"status": "derived_projection", "authoritative": False},
+        "captured_at": None,
+        "snapshot": {"epoch": "fixture"},
+        "completeness": {"complete": True},
+    }
+    composition["providers"]["work"] = {
+        "provider": "builderops_cockpit",
+        "status": "refused",
+        "authority": "read_time_join",
+        "captured_at": None,
+        "snapshot": None,
+        "completeness": None,
+        "refusal": {"code": "provider_unavailable"},
+    }
+    refused_item = _item()
+    available_item = _item()
+    available_item["provider"] = "capabilities"
+
+    result = compose_discovery_projection(
+        composition=composition, items=[refused_item, available_item]
+    )
+
+    assert result["items"][0]["claim_status"] == "withdrawn"
+    assert result["items"][0]["freshness"]["state"] == "fresh"
+    assert result["items"][0]["limitations"][-1] == "Provider 'work' refused the composition read."
+    assert result["items"][1]["claim_status"] == "available"
+
+
+def test_item_provider_must_be_declared_by_the_composition() -> None:
+    item = _item()
+    item["provider"] = "invented-provider"
+
+    with pytest.raises(DiscoveryContractError, match="not declared by the composition"):
+        compose_discovery_projection(composition=_composition(), items=[item])

--- a/tests/builderops/test_devui_discovery.py
+++ b/tests/builderops/test_devui_discovery.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from app.builderops.devui_discovery import compose_discovery_projection
+import pytest
+
+from app.builderops.devui_discovery import DiscoveryContractError, compose_discovery_projection
 
 
 NOW = "2026-08-25T12:00:00+00:00"
@@ -127,3 +129,24 @@ def test_discovery_navigation_is_source_bound_and_read_only() -> None:
     assert result["items"] is not source_items
     source_items[0]["limitations"].append("mutation after composition")
     assert "mutation after composition" not in result["items"][0]["limitations"]
+
+
+def test_working_proposals_cannot_claim_normative_authority_without_promotion() -> None:
+    item = _item()
+    item["authority_class"] = "normative"
+
+    with pytest.raises(DiscoveryContractError, match="cannot claim normative authority"):
+        compose_discovery_projection(composition=_composition(), items=[item])
+
+
+def test_discovery_rejects_malformed_or_refusal_less_provider_envelopes() -> None:
+    malformed = _composition()
+    malformed["providers"] = {"work": "not a provider envelope"}
+    with pytest.raises(DiscoveryContractError, match="must be an object"):
+        compose_discovery_projection(composition=malformed, items=[])
+
+    refused = _composition()
+    refused["providers"]["work"]["status"] = "refused"
+    refused["providers"]["work"]["refusal"] = None
+    with pytest.raises(DiscoveryContractError, match="lacks typed refusal evidence"):
+        compose_discovery_projection(composition=refused, items=[])

--- a/tests/builderops/test_devui_discovery.py
+++ b/tests/builderops/test_devui_discovery.py
@@ -1,0 +1,129 @@
+"""Contract tests for the authority-aware devUI discovery projection (#4985)."""
+
+from __future__ import annotations
+
+from app.builderops.devui_discovery import compose_discovery_projection
+
+
+NOW = "2026-08-25T12:00:00+00:00"
+
+
+def _ref(source_id: str) -> dict[str, str]:
+    return {
+        "source_type": "github_issue",
+        "source_id": source_id,
+        "version": "updated-at:2026-08-25T12:00:00+00:00",
+        "locator": f"https://example.test/{source_id}",
+    }
+
+
+def _composition() -> dict:
+    return {
+        "contract_version": "devui.composition.v1",
+        "authority": "projection_only",
+        "captured_at": NOW,
+        "providers": {
+            "work": {
+                "provider": "builderops_cockpit",
+                "status": "available",
+                "authority": "read_time_join",
+                "captured_at": NOW,
+                "snapshot": {"watermark": "work:42"},
+                "completeness": {"claim": {"kind": "counted"}},
+            }
+        },
+    }
+
+
+def _item() -> dict:
+    return {
+        "source_ref": _ref("4985"),
+        "source_role": "working",
+        "authority_class": "non-normative",
+        "artifact_class": "proposal",
+        "lifecycle": {"stage": "explore", "state": "draft"},
+        "provenance": {
+            "source_refs": [_ref("owner-doc")],
+            "derived_from": [_ref("research")],
+            "review_or_promotion_ref": None,
+            "receipt_refs": [],
+        },
+        "freshness": {"observed_at": NOW, "watermark": "vault:42", "state": "fresh"},
+        "limitations": ["Working material is not an accepted owner document."],
+        "navigation": {
+            "inspect_ref": _ref("4985"),
+            "governed_route_ref": _ref("promotion-intent"),
+        },
+    }
+
+
+def test_discovery_projection_preserves_source_authority_and_provenance() -> None:
+    item = _item()
+
+    result = compose_discovery_projection(composition=_composition(), items=[item])
+
+    projected = result["items"][0]
+    assert result["authority"] == "projection_only"
+    assert projected["source_ref"] == item["source_ref"]
+    assert projected["source_role"] == "working"
+    assert projected["authority_class"] == "non-normative"
+    assert projected["artifact_class"] == "proposal"
+    assert projected["lifecycle"] == item["lifecycle"]
+    assert projected["provenance"] == item["provenance"]
+    assert projected["freshness"] == item["freshness"]
+    assert projected["limitations"] == item["limitations"]
+
+
+def test_builder_vault_items_remain_non_normative_when_projected() -> None:
+    item = _item()
+    item["source_ref"] = {
+        **_ref("vault-draft"),
+        "source_type": "builder_vault",
+    }
+    item["artifact_class"] = "derived"
+
+    result = compose_discovery_projection(composition=_composition(), items=[item])
+
+    projected = result["items"][0]
+    assert projected["authority_class"] == "non-normative"
+    assert projected["presentation"] == {
+        "non_normative": True,
+        "ephemeral_or_rebuildable": True,
+    }
+    assert projected["provenance"]["source_refs"] == item["provenance"]["source_refs"]
+
+
+def test_discovery_withdraws_only_claims_with_degraded_source_state() -> None:
+    healthy = _item()
+    degraded = _item()
+    degraded["source_ref"] = _ref("unread-source")
+    degraded["freshness"] = {
+        "observed_at": NOW,
+        "watermark": None,
+        "state": "unread",
+    }
+    degraded["limitations"] = ["The source has not been read for this composition."]
+
+    result = compose_discovery_projection(
+        composition=_composition(), items=[healthy, degraded]
+    )
+
+    assert result["items"][0]["claim_status"] == "available"
+    assert result["items"][1]["claim_status"] == "withdrawn"
+    assert result["items"][1]["freshness"]["state"] == "unread"
+    assert result["items"][1]["limitations"] == degraded["limitations"]
+
+
+def test_discovery_navigation_is_source_bound_and_read_only() -> None:
+    item = _item()
+    source_items = [item]
+
+    result = compose_discovery_projection(
+        composition=_composition(), items=source_items
+    )
+
+    assert result["navigation_mode"] == "source_bound_read_only"
+    assert result["items"][0]["navigation"] == item["navigation"]
+    assert result["items"] is not source_items
+    source_items[0]["limitations"].append("mutation after composition")
+    assert "mutation after composition" not in result["items"][0]["limitations"]


### PR DESCRIPTION
Governing-Issue: #4985

Fixes #4985

Final-Review-Rounds: 0

## Summary
Adds a pure, source-declared read-time discovery projection over the existing `devui.composition.v1` envelope. It preserves authority, provenance, lifecycle, degraded-source limitations, and typed read-only navigation without creating a source registry or UI.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): OEF/devUI read projection
- Write class: derived
- Persistence impact: none
- Derived/rebuildable impact: per-read detached projection only
- Owner-doc impact: updated `docs/architecture/DEVUI_DISCOVERY_ARCHITECTURE.md :: Implementation gaps and issue reconciliation`
- Boundary risk: no source discovery, mutation, promotion, task state, graph authority, or runtime/UI route

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: this pure read-time projection creates no BuilderOps operational record or authority transition.

## Notes
Validation: `pytest -q tests/builderops/test_devui_discovery.py`; `pytest -q tests/architecture/test_devui_builder_system_control_spec.py tests/architecture/test_docs_index.py`; `ruff check app tests`; `mypy app/builderops/devui_discovery.py`; `python3 scripts/docs_guard.py`; `git diff --check`; review-before-CI gate (no high-risk surface).