### PR TITLE
fix(builderops): implement structural privacy classifier

### DIFF
--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+import idna
 import json
 import os
 import re
 import threading
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,7 +31,7 @@ _SOURCE_REF = re.compile(
 _CREDENTIAL_CONTENT = re.compile(
     r"(?im)(password|secret|credential|token|api[_-]?key|bearer\b|"
     r"^aws_(?:access_key_id|secret_access_key)\s*=|"
-    r"^authorization:\s*(?:basic|bearer)\b|^-----begin [a-z ]+private key-----|"
+    r"^authorization:\s*(?:basic|bearer)\b|^-----begin (?:[a-z ]* )?private key-----|"
     r"\bAKIA[0-9A-Z]{16}\b|\bgithub_pat_[A-Za-z0-9_]{20,}|"
     r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b)"
 )
@@ -37,7 +39,7 @@ _CODE_OR_PATCH = re.compile(
     r"(?im)^(?:diff --git |--- a/|\+\+\+ b/|@@ |```|"
     r"\s*(?:def|class|function|const|let|var|import|from|package|func)\b|"
     r"\s*console\.(?:log|error|warn)\s*\(|\s*git diff(?:\s|$)|"
-    r"\s*(?:print|return|throw|await|yield)\b\s*(?:\(|[a-z_$])|"
+    r"\s*(?:print|return|throw|await|yield)\b\s*(?:\(|[a-z0-9_$'\"\[{])|"
     r"\s*lambda\s+[^:\n]+:|\s*if\s+[^:\n]+:\s*$|"
     r"\s*[a-z_$][a-z0-9_$]*\s*=\s*(?:\([^)]*\)|[a-z_$][a-z0-9_$]*)\s*=>)"
 )
@@ -680,6 +682,11 @@ def _has_valid_percent_escapes(value: str) -> bool:
 
 
 def _classify_form(value: str) -> Literal["valid", "terminal_private", "indeterminate"]:
+    # Decoding may turn an encoded path segment into whitespace. Recognise
+    # credential/code forms at every segment boundary before lexical URI
+    # scanning terminates the candidate at that whitespace.
+    if _contains_credential_or_code(value.replace("/", "\n")):
+        return "terminal_private"
     spans = _uri_spans(value)
     remainder = list(value)
     components = 0
@@ -746,14 +753,18 @@ def _classify_uri(candidate: str) -> Literal["valid", "terminal_private", "indet
             return "indeterminate"
         # The whole URI still receives credential/code recognition. Only its
         # parsed path skips local-host-path recognition.
-        if _contains_credential_or_code(candidate):
+        if _contains_credential_or_code(candidate) or _contains_credential_or_code(
+            parsed.path.replace("/", "\n")
+        ):
             return "terminal_private"
         for component in (parsed.netloc, parsed.query, parsed.fragment):
-            if _contains_private_path(component):
-                return "terminal_private"
+            outcome = _classify_form(component)
+            if outcome != "valid":
+                return outcome
         return "valid"
-    if scheme in {"file", "smb", "nfs", "ssh", "sftp"} and not (parsed.netloc or parsed.path):
-        return "indeterminate"
+    if scheme in {"file", "smb", "nfs", "ssh", "sftp"}:
+        if not candidate.startswith(f"{scheme}://") or not parsed.netloc or not parsed.path:
+            return "indeterminate"
     if _contains_credential_or_code(candidate) or _contains_private_path(candidate):
         return "terminal_private"
     return "valid"
@@ -780,11 +791,21 @@ def _valid_http_authority(authority: str) -> bool:
     except ValueError:
         pass
     try:
-        encoded = host.encode("idna").decode("ascii")
-    except UnicodeError:
+        encoded = idna.encode(host, uts46=False, std3_rules=True).decode("ascii")
+    except idna.IDNAError:
         return False
     if len(encoded) > 253:
         return False
+    for label in encoded.split("."):
+        if label.lower().startswith("xn--"):
+            try:
+                decoded_label = idna.decode(label.encode("ascii"), uts46=False, std3_rules=True)
+                if idna.encode(decoded_label, uts46=False, std3_rules=True).decode("ascii").lower() != label.lower():
+                    return False
+            except idna.IDNAError:
+                return False
+            if any(unicodedata.category(char).startswith("C") for char in decoded_label):
+                return False
     return all(
         1 <= len(label) <= 63
         and not label.startswith("-")

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -29,7 +29,7 @@ _SOURCE_REF = re.compile(
     r"^(?:builderops|conversation|doc|git|github):[A-Za-z0-9._:/#@+-]{1,255}$"
 )
 _CREDENTIAL_CONTENT = re.compile(
-    r"(?im)(password|secret|credential|token|api[_-]?key|bearer\b|"
+    r"(?im)(password|secret|credential|token|api[_-]?key|bearer|"
     r"^[ \t]*aws_(?:access_key_id|secret_access_key)\s*=|"
     r"^[ \t]*authorization:\s*(?:basic|bearer)\b|"
     r"^[ \t]*-----begin (?:[a-z ]* )?private key-----|"

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -30,18 +30,30 @@ _SOURCE_REF = re.compile(
 )
 _CREDENTIAL_CONTENT = re.compile(
     r"(?im)(password|secret|credential|token|api[_-]?key|bearer\b|"
-    r"^aws_(?:access_key_id|secret_access_key)\s*=|"
-    r"^authorization:\s*(?:basic|bearer)\b|^-----begin (?:[a-z ]* )?private key-----|"
+    r"^[ \t]*aws_(?:access_key_id|secret_access_key)\s*=|"
+    r"^[ \t]*authorization:\s*(?:basic|bearer)\b|"
+    r"^[ \t]*-----begin (?:[a-z ]* )?private key-----|"
     r"\bAKIA[0-9A-Z]{16}\b|\bgithub_pat_[A-Za-z0-9_]{20,}|"
     r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b)"
 )
 _CODE_OR_PATCH = re.compile(
-    r"(?im)^(?:diff --git |--- a/|\+\+\+ b/|@@ |```|"
-    r"\s*(?:def|class|function|const|let|var|import|from|package|func)\b|"
-    r"\s*console\.(?:log|error|warn)\s*\(|\s*git diff(?:\s|$)|"
-    r"\s*(?:print|return|throw|await|yield)\b\s*(?:\(|[a-z0-9_$'\"\[{])|"
-    r"\s*lambda\s+[^:\n]+:|\s*if\s+[^:\n]+:\s*$|"
-    r"\s*[a-z_$][a-z0-9_$]*\s*=\s*(?:\([^)]*\)|[a-z_$][a-z0-9_$]*)\s*=>)"
+    r"(?m)^[ \t]*(?:diff --git |--- a/|\+\+\+ b/|@@ |```|"
+    r"git diff(?:[ \t]|$)|"
+    r"async[ \t]+def[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*\(|"
+    r"(?:def|function)[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*\(|"
+    r"class[ \t]+[A-Za-z_][A-Za-z0-9_]*[ \t]*(?:\(|:)|"
+    r"(?:const|let|var)[ \t]+[A-Za-z_$][A-Za-z0-9_$]*[ \t]*=[ \t]*|"
+    r"from[ \t]+[A-Za-z0-9_.]+[ \t]+import(?:[ \t]|$)|"
+    r"import[ \t]+[A-Za-z0-9_.]+(?:$|,[ \t]*|[ \t]+as\b)|"
+    r"(?:package|func)[ \t]+[A-Za-z_][A-Za-z0-9_]*|"
+    r"print[ \t]*\(|"
+    r"(?:return|yield)\b[ \t]*(?:[0-9'\"(\[{])|"
+    r"throw(?:[ \t]+new[ \t]+[A-Za-z_$][A-Za-z0-9_$]*|[ \t]*\()|"
+    r"await[ \t]+(?:[A-Za-z_$][A-Za-z0-9_$]*[ \t]*\(|Promise\.)|"
+    r"lambda[ \t]+[^:\n]+:|"
+    r"if[ \t]+[^:\n]+:[ \t]*$|"
+    r"console\.(?:log|error|warn)[ \t]*\(|"
+    r"[A-Za-z_$][A-Za-z0-9_$]*[ \t]*=[ \t]*(?:\([^)]*\)|[A-Za-z_$][A-Za-z0-9_$]*)[ \t]*=>)"
 )
 _MAX_TEXT = 500
 _MAX_COMPONENTS = 64
@@ -747,7 +759,7 @@ def _classify_uri(candidate: str) -> Literal["valid", "terminal_private", "indet
     if not scheme:
         return "valid"
     if scheme in {"http", "https"}:
-        if not candidate.startswith(f"{scheme}://") or not parsed.netloc or "@" in parsed.netloc:
+        if not candidate.lower().startswith(f"{scheme}://") or not parsed.netloc or "@" in parsed.netloc:
             return "indeterminate"
         if not _valid_http_authority(parsed.netloc):
             return "indeterminate"

--- a/app/builderops/builder_threads_serialized.py
+++ b/app/builderops/builder_threads_serialized.py
@@ -8,6 +8,7 @@ no client filesystem API and deliberately never discovers a vault path.
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -16,6 +17,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast
+from urllib.parse import unquote, urlsplit
 
 
 PRIVACY_CLASS: Literal["shared_non_sensitive"] = "shared_non_sensitive"
@@ -24,9 +26,8 @@ _REQUEST_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SOURCE_REF = re.compile(
     r"^(?:builderops|conversation|doc|git|github):[A-Za-z0-9._:/#@+-]{1,255}$"
 )
-_PRIVATE_CONTENT = re.compile(
-    r"(?im)(password|secret|credential|token|api[_-]?key|bearer\s+|"
-    r"(?:~/.ssh|/(?:Users|home|private|root|etc|var|opt)/)|"
+_CREDENTIAL_CONTENT = re.compile(
+    r"(?im)(password|secret|credential|token|api[_-]?key|bearer\b|"
     r"^aws_(?:access_key_id|secret_access_key)\s*=|"
     r"^authorization:\s*(?:basic|bearer)\b|^-----begin [a-z ]+private key-----|"
     r"\bAKIA[0-9A-Z]{16}\b|\bgithub_pat_[A-Za-z0-9_]{20,}|"
@@ -41,6 +42,7 @@ _CODE_OR_PATCH = re.compile(
     r"\s*[a-z_$][a-z0-9_$]*\s*=\s*(?:\([^)]*\)|[a-z_$][a-z0-9_$]*)\s*=>)"
 )
 _MAX_TEXT = 500
+_MAX_COMPONENTS = 64
 _MAX_THREAD_ENTRIES = 32
 _MAX_TOTAL_ENTRIES = 100
 _ROOT_IDENTITY = "builder-thread-writer.json"
@@ -337,6 +339,17 @@ class SerializedThreadWriter:
             or not self._entries_root.is_dir()
         ):
             raise BuilderThreadError("external writer root is not the pinned vault identity")
+        try:
+            payload = _strict_json_loads(identity.read_text(encoding="utf-8"))
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise BuilderThreadError("external writer root is not the pinned vault identity") from exc
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {"schema", "vault_id"}
+            or payload.get("schema") != "builder-thread-writer.v1"
+            or payload.get("vault_id") != self._vault_id
+        ):
+            raise BuilderThreadError("external writer root is not the pinned vault identity")
 
     def _restore_external_state(self) -> None:
         self._threads = {}
@@ -349,7 +362,7 @@ class SerializedThreadWriter:
             if path.is_symlink():
                 raise BuilderThreadError("external writer entry is unavailable")
             try:
-                payload = json.loads(path.read_text(encoding="utf-8"))
+                payload = _strict_json_loads(path.read_text(encoding="utf-8"))
                 sequence = payload["sequence"]
                 command = _command_from_record(payload, vault_id=self._vault_id)
                 if path.name != f"{command.request_id}.json":
@@ -560,6 +573,7 @@ def _validate_command(command: ThreadMutation) -> None:
         raise BuilderThreadError("unsupported thread mutation")
     if not _REQUEST_ID.fullmatch(command.request_id):
         raise BuilderThreadError("request_id must be a filename-safe bounded identifier")
+    _validate_shared_text(command.request_id, field="request_id")
     _validate_identity(command.actor, field="actor")
     if command.kind == "create":
         if command.thread_id is not None:
@@ -586,20 +600,19 @@ def _validate_command(command: ThreadMutation) -> None:
 def _validate_identifier(value: str | None, *, field: str) -> None:
     if not isinstance(value, str) or not value or len(value) > 128:
         raise BuilderThreadError(f"{field} must be a bounded identifier")
+    _validate_shared_text(value, field=field)
 
 
 def _validate_identity(value: str | None, *, field: str) -> None:
     if not isinstance(value, str) or not _IDENTITY.fullmatch(value):
         raise BuilderThreadError(f"{field} must be a named identity")
+    _validate_shared_text(value, field=field)
 
 
 def _validate_text(value: str | None, *, field: str) -> None:
     if not isinstance(value, str) or not value.strip() or len(value) > _MAX_TEXT:
         raise BuilderThreadError(f"{field} must be bounded non-empty text")
-    if _PRIVATE_CONTENT.search(value):
-        raise BuilderThreadError(f"{field} is not shared_non_sensitive")
-    if _CODE_OR_PATCH.search(value):
-        raise BuilderThreadError(f"{field} is not shared_non_sensitive")
+    _validate_shared_text(value, field=field)
 
 
 def _validate_source_refs(source_refs: tuple[str, ...]) -> None:
@@ -608,8 +621,213 @@ def _validate_source_refs(source_refs: tuple[str, ...]) -> None:
     for source_ref in source_refs:
         if not isinstance(source_ref, str) or not _SOURCE_REF.fullmatch(source_ref):
             raise BuilderThreadError("source_ref must be typed bounded provenance")
-        if _PRIVATE_CONTENT.search(source_ref):
-            raise BuilderThreadError("source_ref is not shared_non_sensitive")
+        _validate_shared_text(source_ref, field="source_ref")
+
+
+def _validate_shared_text(value: str, *, field: str) -> None:
+    """Apply the closed structural privacy classifier without exposing input."""
+    if _classify_shared_text(value) != "valid":
+        raise BuilderThreadError(f"{field} is not shared_non_sensitive")
+
+
+def _classify_shared_text(value: str) -> Literal["valid", "terminal_private", "indeterminate"]:
+    """Classify bounded shared text with a URI-aware, fail-closed scanner.
+
+    URI parsing is deliberately separated from path scanning: only the parsed
+    path of a valid HTTP(S) URI is a resource path. Query, fragment, opaque,
+    filesystem, malformed, and ordinary text remain untrusted components.
+    """
+    if len(value) > _MAX_TEXT:
+        return "indeterminate"
+    forms = _decoded_forms(value)
+    if forms is None:
+        return "indeterminate"
+    if len(forms) > _MAX_COMPONENTS:
+        return "indeterminate"
+    for form in forms:
+        outcome = _classify_form(form)
+        if outcome != "valid":
+            return outcome
+    return "valid"
+
+
+def _decoded_forms(value: str) -> list[str] | None:
+    forms = [value]
+    current = value
+    for _ in range(2):
+        if not _has_valid_percent_escapes(current):
+            return None
+        decoded = unquote(current)
+        if decoded == current:
+            return forms
+        forms.append(decoded)
+        current = decoded
+    if not _has_valid_percent_escapes(current) or unquote(current) != current:
+        return None
+    return forms
+
+
+def _has_valid_percent_escapes(value: str) -> bool:
+    index = 0
+    while index < len(value):
+        if value[index] == "%":
+            if index + 2 >= len(value) or any(char not in "0123456789abcdefABCDEF" for char in value[index + 1:index + 3]):
+                return False
+            index += 3
+        else:
+            index += 1
+    return True
+
+
+def _classify_form(value: str) -> Literal["valid", "terminal_private", "indeterminate"]:
+    spans = _uri_spans(value)
+    remainder = list(value)
+    components = 0
+    for start, end in spans:
+        components += 1
+        if components > _MAX_COMPONENTS:
+            return "indeterminate"
+        outcome = _classify_uri(value[start:end])
+        if outcome != "valid":
+            return outcome
+        scheme = value[start:value.find(":", start)].lower()
+        if scheme in {"http", "https"}:
+            remainder[start:end] = " " * (end - start)
+    plain = "".join(remainder)
+    if _contains_credential_or_code(plain) or _contains_private_path(plain):
+        return "terminal_private"
+    return "valid"
+
+
+def _uri_spans(value: str) -> list[tuple[int, int]]:
+    """Return bounded lexical URI candidates without assigning them safety."""
+    spans: list[tuple[int, int]] = []
+    index = 0
+    terminators = set(" \t\r\n<>\"`}")
+    while index < len(value):
+        if not value[index].isalpha() or not _token_boundary(value, index):
+            index += 1
+            continue
+        cursor = index + 1
+        while cursor < len(value) and (value[cursor].isalnum() or value[cursor] in "+-."):
+            cursor += 1
+        if cursor >= len(value) or value[cursor] != ":":
+            index += 1
+            continue
+        # One-letter forms are overwhelmingly path/code punctuation; a Windows
+        # drive is handled by path scanning, not reinterpreted as a URI.
+        if cursor == index + 1:
+            index += 1
+            continue
+        end = cursor + 1
+        while end < len(value) and value[end] not in terminators:
+            end += 1
+        spans.append((index, end))
+        index = end
+    return spans
+
+
+def _token_boundary(value: str, index: int) -> bool:
+    return index == 0 or value[index - 1] not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_%+-."
+
+
+def _classify_uri(candidate: str) -> Literal["valid", "terminal_private", "indeterminate"]:
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return "indeterminate"
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        return "valid"
+    if scheme in {"http", "https"}:
+        if not candidate.startswith(f"{scheme}://") or not parsed.netloc or "@" in parsed.netloc:
+            return "indeterminate"
+        if not _valid_http_authority(parsed.netloc):
+            return "indeterminate"
+        # The whole URI still receives credential/code recognition. Only its
+        # parsed path skips local-host-path recognition.
+        if _contains_credential_or_code(candidate):
+            return "terminal_private"
+        for component in (parsed.netloc, parsed.query, parsed.fragment):
+            if _contains_private_path(component):
+                return "terminal_private"
+        return "valid"
+    if scheme in {"file", "smb", "nfs", "ssh", "sftp"} and not (parsed.netloc or parsed.path):
+        return "indeterminate"
+    if _contains_credential_or_code(candidate) or _contains_private_path(candidate):
+        return "terminal_private"
+    return "valid"
+
+
+def _valid_http_authority(authority: str) -> bool:
+    try:
+        parsed = urlsplit(f"https://{authority}")
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return False
+    if not host or "@" in authority or port is not None and not 0 <= port <= 65535:
+        return False
+    if ":" in host:
+        try:
+            ipaddress.IPv6Address(host.split("%", 1)[0])
+        except ValueError:
+            return False
+        return "%" not in host or "%25" in authority
+    try:
+        ipaddress.IPv4Address(host)
+        return True
+    except ValueError:
+        pass
+    try:
+        encoded = host.encode("idna").decode("ascii")
+    except UnicodeError:
+        return False
+    if len(encoded) > 253:
+        return False
+    return all(
+        1 <= len(label) <= 63
+        and not label.startswith("-")
+        and not label.endswith("-")
+        and all(char.isascii() and (char.isalnum() or char == "-") for char in label)
+        for label in encoded.split(".")
+    )
+
+
+def _contains_credential_or_code(value: str) -> bool:
+    return bool(_CREDENTIAL_CONTENT.search(value) or _CODE_OR_PATCH.search(value))
+
+
+def _contains_private_path(value: str) -> bool:
+    """Recognise standalone POSIX, tilde, drive, rooted, and UNC path tokens."""
+    for index, char in enumerate(value):
+        if not _token_boundary(value, index):
+            continue
+        if char == "/":
+            return True
+        if char == "~":
+            cursor = index + 1
+            while cursor < len(value) and (value[cursor].isalnum() or value[cursor] in "_.-"):
+                cursor += 1
+            if cursor == len(value) or value[cursor] in "\\/ \t\r\n)]},;!?":
+                return True
+        if char == "\\":
+            return True
+        if char.isalpha() and index + 2 < len(value) and value[index + 1] == ":" and value[index + 2] in "\\/":
+            return True
+    return False
+
+
+def _strict_json_loads(value: str) -> Any:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError("duplicate JSON key")
+            result[key] = item
+        return result
+
+    return json.loads(value, object_pairs_hook=object_pairs)
 
 
 def _capture_key(recipient: str, subject: str, source_refs: tuple[str, ...]) -> str:
@@ -653,12 +871,24 @@ def _command_record(command: ThreadMutation) -> dict[str, Any]:
 def _command_from_record(payload: Any, *, vault_id: str) -> ThreadMutation:
     if (
         not isinstance(payload, dict)
+        or set(payload) != {"command", "request_digest", "sequence", "schema", "vault_id"}
         or payload.get("schema") != "builder-thread-command.v1"
         or payload.get("vault_id") != vault_id
         or not isinstance(payload.get("command"), dict)
     ):
         raise ValueError("invalid writer command record")
     command = payload["command"]
+    if set(command) != {
+        "actor",
+        "content",
+        "kind",
+        "recipient",
+        "request_id",
+        "source_refs",
+        "subject",
+        "thread_id",
+    }:
+        raise ValueError("invalid writer command fields")
     kind = command.get("kind")
     source_refs = command.get("source_refs")
     if kind not in {"create", "reply", "close", "archive"} or not isinstance(source_refs, list):

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -447,6 +447,15 @@ approval, promotion, or receipt authority. The detailed skill contract is
 `.codex/skills/_shared/BUILDER_THREAD_CONTRACT.md`; PR #4706 remains
 superseded multi-writer evidence and is not an operational dependency.
 
+Before a command is persisted, and again before a final envelope is reconstructed
+after restart, the writer applies the structural `shared_non_sensitive`
+classifier. It fail-closes on credentials, code or patch forms, standalone host
+paths, ambiguous filesystem URI forms, malformed URI authorities, and invalid
+persisted identity or envelope structure. Only a syntactically valid HTTP(S)
+resource path receives the narrow path exemption; query, fragment, and nested
+components remain classified. A refused command creates no final envelope or
+accepted count, and a rejected final envelope is not partially reconstructed.
+
 ### Karakeep managed source service (KMA-02)
 - `docker-compose.karakeep.yml` is the repo-owned deployment for the self-hosted Karakeep
   read-later source on the mac mini (Heimdal's external source dependency; ADR-0049 §1). It pins the

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -282,6 +282,18 @@ and the writer at 100 total contributions, keeping reads bounded. An unavailable
 writer returns a typed degraded failure and never enables direct client filesystem
 fallback.
 
+Before persistence and again during recovery, the writer applies one structural
+`shared_non_sensitive` classifier to every caller-controlled or configured
+persisted value. It uses bounded decoding and URI components: only the parsed
+path of a syntactically valid HTTP(S) URL is treated as a public resource path;
+its authority, query, fragment, credentials, code/patch forms, filesystem URI
+data, malformed URI syntax, and standalone POSIX, tilde, Windows, or UNC paths
+are refused without echoing content. Root identities and command envelopes use
+closed key sets with duplicate-key rejection; recovery checks schema, vault
+identity, digest, sequence, command validity, and the same classifier before it
+reconstructs any thread state. A rejected command creates no final envelope or
+accepted count, and an unsafe final envelope fails closed before partial recovery.
+
 Each command envelope is written to a same-directory temporary pathname, then
 atomically published at its final JSON pathname only after the complete payload
 is written. Interrupted temporary writes are not committed state. Recovery reads

--- a/tests/builderops/test_builder_thread_privacy_classifier.py
+++ b/tests/builderops/test_builder_thread_privacy_classifier.py
@@ -123,6 +123,8 @@ def test_http_and_recovery_reject_all_persisted_untrusted_fields(
     (
         ("indented-authorization-5118", "https://example.test/%20authorization%3A%20basic%20dXNlcjpwYXNz"),
         ("indented-aws-5118", "https://example.test/%20aws_access_key_id%3Dvalue"),
+        ("plain-substring-5118", "bearerValue"),
+        ("plain-uppercase-substring-5118", "BEARERvalue"),
     ),
 )
 def test_indented_decoded_http_credential_path_segments_never_persist_or_recover(

--- a/tests/builderops/test_builder_thread_privacy_classifier.py
+++ b/tests/builderops/test_builder_thread_privacy_classifier.py
@@ -118,6 +118,75 @@ def test_http_and_recovery_reject_all_persisted_untrusted_fields(
     assert created.thread.thread_id
 
 
+@pytest.mark.parametrize(
+    ("request_id", "content"),
+    (
+        ("indented-authorization-5118", "https://example.test/%20authorization%3A%20basic%20dXNlcjpwYXNz"),
+        ("indented-aws-5118", "https://example.test/%20aws_access_key_id%3Dvalue"),
+    ),
+)
+def test_indented_decoded_http_credential_path_segments_never_persist_or_recover(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request_id: str, content: str
+) -> None:
+    client, root = _http_client(tmp_path, monkeypatch)
+    entries = root / "builder-thread-entries"
+
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        _create(client, request_id=request_id, content=content)
+    assert list(entries.glob("*.json")) == []
+
+    _create(client, request_id=f"recovery-{request_id}")
+    record = entries / f"recovery-{request_id}.json"
+    original_entries = {path.name: path.read_bytes() for path in entries.glob("*.json")}
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload["command"]["content"] = content
+    from app.builderops.builder_threads_serialized import ThreadMutation, _command_digest
+
+    command = ThreadMutation(
+        request_id=payload["command"]["request_id"],
+        kind=payload["command"]["kind"],
+        actor=payload["command"]["actor"],
+        recipient=payload["command"]["recipient"],
+        subject=payload["command"]["subject"],
+        content=payload["command"]["content"],
+        source_refs=tuple(payload["command"]["source_refs"]),
+    )
+    payload["request_digest"] = _command_digest(command)
+    record.write_text(json.dumps(payload), encoding="utf-8")
+    tampered_entries = {path.name: path.read_bytes() for path in entries.glob("*.json")}
+    assert set(tampered_entries) == set(original_entries)
+
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    assert {path.name: path.read_bytes() for path in entries.glob("*.json")} == tampered_entries
+
+
+@pytest.mark.parametrize(
+    ("request_id", "content"),
+    (
+        ("uppercase-http-5118", "HTTPS://example.test/home/start"),
+        ("ordinary-let-prose-5118", "Let us discuss the boundary."),
+        ("ordinary-return-prose-5118", "Return value should remain ordinary prose."),
+        ("ordinary-return-identifier-5118", "https://example.test/return1"),
+        ("ordinary-uppercase-code-prose-5118", "ASYNC DEF foo( is ordinary prose here."),
+    ),
+)
+def test_valid_case_insensitive_http_and_ordinary_prose_persist_through_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    request_id: str,
+    content: str,
+) -> None:
+    client, root = _http_client(tmp_path, monkeypatch)
+
+    accepted = _create(client, request_id=request_id, content=content)
+    assert accepted.replayed is False
+    assert len(list((root / "builder-thread-entries").glob("*.json"))) == 1
+
+    restarted = SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    assert restarted.accepted_mutation_count == 1
+
+
 def test_closed_persisted_record_and_root_identity_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/builderops/test_builder_thread_privacy_classifier.py
+++ b/tests/builderops/test_builder_thread_privacy_classifier.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app.builderops.builder_thread_endpoint import BuilderThreadEndpointHost, HttpWriterEndpoint
+from app.builderops.builder_threads_serialized import (
+    BuilderThreadClient,
+    BuilderThreadError,
+    BuilderThreadWriterHost,
+    SerializedThreadWriter,
+    initialize_external_writer_root,
+)
+
+
+def _transport(app: object) -> httpx.MockTransport:
+    client = TestClient(app)
+
+    def dispatch(request: httpx.Request) -> httpx.Response:
+        response = client.request(
+            request.method,
+            request.url.path,
+            params=request.url.params,
+            content=request.content,
+            headers=dict(request.headers),
+        )
+        return httpx.Response(
+            response.status_code,
+            headers=response.headers,
+            content=response.content,
+            request=request,
+        )
+
+    return httpx.MockTransport(dispatch)
+
+
+def _http_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, client_id: str = "codex:desktop"
+) -> tuple[BuilderThreadClient, Path]:
+    root = tmp_path / "external-vault"
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_ROOT", str(root))
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_VAULT_ID", "builderops-mac-mini")
+    host = BuilderThreadEndpointHost(
+        BuilderThreadWriterHost.from_environment(), client_tokens={client_id: "test-token"}
+    )
+    endpoint = HttpWriterEndpoint(
+        base_url="http://testserver",
+        client_id=client_id,
+        token="test-token",
+        transport=_transport(host.app()),
+    )
+    return BuilderThreadClient(endpoint, client_id=client_id), root
+
+
+def _create(
+    client: BuilderThreadClient,
+    *,
+    request_id: str = "privacy-create-5118",
+    content: str = "A bounded question.",
+    actor: str = "codex:desktop",
+    recipient: str = "claude:mac",
+    subject: str = "Structural boundary",
+    source_refs: tuple[str, ...] = ("github:5118",),
+) -> object:
+    return client.create(
+        request_id=request_id,
+        actor=actor,
+        recipient=recipient,
+        subject=subject,
+        content=content,
+        source_refs=source_refs,
+    )
+
+
+def test_http_and_recovery_reject_all_persisted_untrusted_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, root = _http_client(tmp_path, monkeypatch)
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        _create(client, content="https://example.test/ok?next=%252Fprivate%252Fhost")
+    for kwargs in (
+        {"request_id": "token-request-5118"},
+        {"recipient": "token:recipient"},
+        {"subject": "token subject"},
+        {"source_refs": ("github:token",)},
+    ):
+        with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+            _create(client, **kwargs)
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        _http_client(tmp_path / "actor", monkeypatch, client_id="token:client")
+    entries = root / "builder-thread-entries"
+    assert list(entries.glob("*.json")) == []
+
+    created = _create(client, request_id="recovery-create-5118")
+    record = entries / "recovery-create-5118.json"
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload["command"]["actor"] = "token:client"
+    from app.builderops.builder_threads_serialized import ThreadMutation, _command_digest
+
+    command = ThreadMutation(
+        request_id=payload["command"]["request_id"],
+        kind=payload["command"]["kind"],
+        actor=payload["command"]["actor"],
+        recipient=payload["command"]["recipient"],
+        subject=payload["command"]["subject"],
+        content=payload["command"]["content"],
+        source_refs=tuple(payload["command"]["source_refs"]),
+    )
+    payload["request_digest"] = _command_digest(command)
+    record.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    assert created.thread.thread_id
+
+
+def test_closed_persisted_record_and_root_identity_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, root = _http_client(tmp_path, monkeypatch)
+    _create(client)
+    record = root / "builder-thread-entries" / "privacy-create-5118.json"
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload["unexpected"] = True
+    record.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(BuilderThreadError, match="external writer entry is invalid"):
+        SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+
+    record.write_text(json.dumps({key: value for key, value in payload.items() if key != "unexpected"}), encoding="utf-8")
+    root_identity = root / "builder-thread-writer.json"
+    root_identity.write_text(
+        '{"schema":"builder-thread-writer.v1","vault_id":"builderops-mac-mini","extra":true}',
+        encoding="utf-8",
+    )
+    with pytest.raises(BuilderThreadError, match="pinned vault identity"):
+        SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+        initialize_external_writer_root(tmp_path / "unsafe-vault", vault_id="token-vault")
+
+
+def test_structural_privacy_adversarial_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, root = _http_client(tmp_path, monkeypatch)
+    accepted = _create(
+        client,
+        request_id="valid-url-5118",
+        content="https://example.test/home/start?view=summary#today",
+    )
+    assert accepted.replayed is False
+    assert len(list((root / "builder-thread-entries").glob("*.json"))) == 1
+    assert _create(
+        client,
+        request_id="valid-url-5118",
+        content="https://example.test/home/start?view=summary#today",
+    ).replayed is True
+    restarted = SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
+    assert restarted.accepted_mutation_count == 1
+    for value in (
+        "/tmp/host-only",
+        "C:\\\\Users\\\\operator",
+        "file:///private/host-only",
+        "https://example.test/ok#%252Fprivate%252Fhost",
+        "https://[invalid-zone%25?]/ok",
+    ):
+        with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
+            _create(client, request_id=f"refusal-{len(value)}-5118", content=value)
+    assert len(list((root / "builder-thread-entries").glob("*.json"))) == 1

--- a/tests/builderops/test_builder_thread_privacy_classifier.py
+++ b/tests/builderops/test_builder_thread_privacy_classifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import httpx
@@ -98,7 +99,7 @@ def test_http_and_recovery_reject_all_persisted_untrusted_fields(
     created = _create(client, request_id="recovery-create-5118")
     record = entries / "recovery-create-5118.json"
     payload = json.loads(record.read_text(encoding="utf-8"))
-    payload["command"]["actor"] = "token:client"
+    payload["command"]["content"] = "-----BEGIN PRIVATE KEY-----"
     from app.builderops.builder_threads_serialized import ThreadMutation, _command_digest
 
     command = ThreadMutation(
@@ -159,13 +160,70 @@ def test_structural_privacy_adversarial_matrix(
     ).replayed is True
     restarted = SerializedThreadWriter(vault_id="builderops-mac-mini", state_root=root)
     assert restarted.accepted_mutation_count == 1
-    for value in (
+    assert _create(
+        client,
+        request_id="nested-url-5118",
+        subject="Nested URL boundary",
+        content="https://outer.test/start?next=https%3A%2F%2Finner.test%2Fhome",
+    ).replayed is False
+    for index, value in enumerate((
         "/tmp/host-only",
         "C:\\\\Users\\\\operator",
         "file:///private/host-only",
         "https://example.test/ok#%252Fprivate%252Fhost",
         "https://[invalid-zone%25?]/ok",
-    ):
+        "file:relative",
+        "smb:server",
+        "https://xn--a/tmp/host-only",
+        "https://xn--ls8h/private/host",
+        "https://example.test/aws_access_key_id%3Dvalue",
+        "https://example.test/return%201",
+        "-----BEGIN PRIVATE KEY-----",
+    )):
         with pytest.raises(BuilderThreadError, match="shared_non_sensitive"):
-            _create(client, request_id=f"refusal-{len(value)}-5118", content=value)
-    assert len(list((root / "builder-thread-entries").glob("*.json"))) == 1
+            _create(client, request_id=f"refusal-{index}-5118", content=value)
+    assert len(list((root / "builder-thread-entries").glob("*.json"))) == 2
+
+
+def test_structural_privacy_http_lock_hides_provisional_state_and_rejects_stale_transition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "race-vault"
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_ROOT", str(root))
+    monkeypatch.setenv("BUILDEROPS_THREAD_WRITER_VAULT_ID", "builderops-mac-mini")
+    host = BuilderThreadEndpointHost(
+        BuilderThreadWriterHost.from_environment(), client_tokens={"codex:desktop": "test-token"}
+    )
+    endpoint = HttpWriterEndpoint(
+        base_url="http://testserver", client_id="codex:desktop", token="test-token", transport=_transport(host.app())
+    )
+    client = BuilderThreadClient(endpoint, client_id="codex:desktop")
+    writer = host._writer_host._writer
+    entered = threading.Event()
+    release = threading.Event()
+    mutation_done = threading.Event()
+    read_done = threading.Event()
+    original_persist = writer._persist
+
+    def paused_persist(*args: object, **kwargs: object) -> None:
+        entered.set()
+        assert release.wait(timeout=2)
+        original_persist(*args, **kwargs)
+
+    monkeypatch.setattr(writer, "_persist", paused_persist)
+    mutation = threading.Thread(target=lambda: (_create(client, request_id="race-create-5118"), mutation_done.set()))
+    mutation.start()
+    assert entered.wait(timeout=2)
+    thread_id = next(iter(writer._threads))
+    observed: list[object] = []
+    reader = threading.Thread(target=lambda: (observed.append(client.read(thread_id)), read_done.set()))
+    reader.start()
+    assert not read_done.wait(timeout=0.1)
+    release.set()
+    mutation.join(timeout=2)
+    reader.join(timeout=2)
+    assert mutation_done.is_set() and read_done.is_set() and observed
+    before = writer.accepted_mutation_count
+    with pytest.raises(BuilderThreadError, match="requires a reply"):
+        client.close(request_id="race-close-5118", thread_id=thread_id, actor="codex:desktop", reason="stale")
+    assert writer.accepted_mutation_count == before


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5118

## Linked Issue
Closes #5118

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): BuilderOps Vault privacy admission
- Write class: authority-bearing privacy boundary
- Persistence impact: Validates classified command and root-identity fields before persistence and recovery.
- Derived/rebuildable impact: Rejected records remain absent; unsafe final envelopes fail closed before reconstruction.
- New or changed contract: Structural shared-non-sensitive admission and closed persisted-record validation.
- Owner-doc impact: Updated Builder Thread artifact exchange for delivered behavior.
- Transition debt impact: Replaces the exhausted path/URI regex direction without altering the #4728/#4813 ledger.
- Boundary risk: Credentials, private paths, code, or unclassified fields crossing immutable shared artifacts.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Implement the reviewed structural shared-non-sensitive classifier at HTTP admission and recovery.
- Refuse decoded HTTP path segments with indented credential-like forms while admitting case-insensitive valid HTTP(S) resource URLs and ordinary prose.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record: this PR is the governed code and owner-doc delivery; no new operational record was produced.

## Notes
Validation: 52 focused Builder Thread tests; docs-index target; ruff; mypy; bare docs guard; diff check; fresh independent review clean at 3464be8dd4595cede58f5f08a6624741401b9883; high-risk review-before-CI gate passed on the published head.