### PR TITLE
Harden unit-test execution contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,11 @@ test:
 		PYTEST_PLUGIN_ARGS="$$PYTEST_PLUGIN_ARGS -p anyio.pytest_plugin"; \
 	fi; \
 	export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1; \
+	export PATH="$$(dirname "$(PYTHON)"):$${PATH}"; \
 	GIT_SHA="$$(git rev-parse --short HEAD)"; \
 	python3 scripts/run_with_host_lease.py --resource pytest-not-pg \
 		--execution-id "make-test:$$GIT_SHA:$$$$" --wait-seconds 900 -- \
-		$(PYTHON) -m pytest $$PYTEST_PLUGIN_ARGS -q -c /dev/null --import-mode=importlib
+		$(PYTHON) -m pytest $$PYTEST_PLUGIN_ARGS -q --import-mode=importlib
 
 eval:
 	$(PYTHON) -m app.eval.run

--- a/tests/api/test_active_context_resolution.py
+++ b/tests/api/test_active_context_resolution.py
@@ -67,6 +67,16 @@ def client() -> TestClient:
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def reset_global_vault_manager(monkeypatch: pytest.MonkeyPatch):
+    """Keep this request-scoped API suite independent of VaultManager state."""
+
+    import app.vault.manager as vault_manager_module
+
+    monkeypatch.setattr(vault_manager_module, "_GLOBAL_MANAGER", None)
+    yield
+
+
 def _create(client: TestClient, binding_ids: list[str]) -> dict:
     response = client.post(SELECTION_URL, json={"vault_binding_ids": binding_ids})
     assert response.status_code == 201, response.text

--- a/tests/heimdal/test_media_ingress.py
+++ b/tests/heimdal/test_media_ingress.py
@@ -1810,10 +1810,11 @@ def test_preflight_logs_the_remedy_matching_the_failing_precondition(
     def _unreadable(**_kwargs: Any):
         raise ConsentLedgerSchemaMissingError("Missing table 'heimdal_consent_grant'.")
 
-    monkeypatch.setattr(ingress_preflight, "resolve_active_grant", _unreadable)
-    ingress_preflight.reset_ingress_preflight()
-    with caplog.at_level(logging.ERROR, logger="app.heimdal.ingress_preflight"):
-        ingress_preflight.run_ingress_preflight()
+    with monkeypatch.context() as isolated_patch:
+        isolated_patch.setattr(ingress_preflight, "resolve_active_grant", _unreadable)
+        ingress_preflight.reset_ingress_preflight()
+        with caplog.at_level(logging.ERROR, logger="app.heimdal.ingress_preflight"):
+            ingress_preflight.run_ingress_preflight()
     unreadable_log = caplog.text
     assert "could not be read at all" in unreadable_log
     assert "c4f7a1b2d9e3" in unreadable_log, "must name the table-owning migration"
@@ -1821,7 +1822,6 @@ def test_preflight_logs_the_remedy_matching_the_failing_precondition(
 
     # 2. Readable ledger, no active grant -> point at *this* slice's migration
     #    and at re-granting.
-    monkeypatch.undo()
     caplog.clear()
     revoke_consent(grant_ref=MEDIA_CAPTURE_GRANT_REF, revoked_by="test-operator")
     ingress_preflight.reset_ingress_preflight()

--- a/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
+++ b/tests/migrations/test_heimdal_media_capture_grant_seed_parity.py
@@ -53,6 +53,7 @@ from app.heimdal.consent_ledger import (
     list_active_grants,
     reset_memory_consent_ledger,
 )
+from app.heimdal.trigger_ownership import CONSENT_GRANT_TRIGGER
 
 pytestmark = pytest.mark.not_pg
 
@@ -179,12 +180,51 @@ class _RecordingCursor:
 
     def __init__(self) -> None:
         self.executed: list[tuple[str, tuple]] = []
+        self._last_query = ""
+        self._table_created = False
+        self._trigger_created = False
 
     def execute(self, sql: str, params: tuple | None = None) -> None:
+        self._last_query = sql
+        if "CREATE TABLE heimdal_consent_grant" in sql:
+            self._table_created = True
+        if "CREATE TRIGGER heimdal_consent_grant_no_update" in sql:
+            self._trigger_created = True
         self.executed.append((sql, params or ()))
 
-    def fetchone(self) -> None:
+    def fetchone(self) -> tuple[str] | None:
+        if "to_regclass" in self._last_query:
+            return ("heimdal_consent_grant",) if self._table_created else None
         return None
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        if "FROM pg_trigger" not in self._last_query or not self._trigger_created:
+            return []
+        return [
+            (
+                "public",
+                "heimdal_consent_grant",
+                "heimdal_consent_grant_no_update",
+                27,
+                "O",
+                "",
+                True,
+                True,
+                "heimdal_consent_grant_reject_mutation",
+                "f",
+                True,
+                0,
+                "",
+                "plpgsql",
+                "v",
+                False,
+                False,
+                False,
+                "u",
+                None,
+                CONSENT_GRANT_TRIGGER.body,
+            )
+        ]
 
     def seeded_identities(self) -> set[tuple[str, str, str]]:
         """`(grant_ref, basis, scope)` of every row this bootstrap INSERTed.

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -3518,6 +3518,15 @@ def test_host_global_bind_source_resolves_identically_across_checkouts_and_chann
     resolved = []
     for checkout in (tmp_path / "checkout-a", tmp_path / "checkout-b"):
         checkout.mkdir()
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "XDG_STATE_HOME": "",
+        }
+        # The Makefile exports this as a host-global value. The resolver must
+        # still derive the path from the subprocess' HOME when no explicit
+        # value is supplied, so do not let the parent test runner pre-seed it.
+        env.pop("INSTANCE_OWNERSHIP_HOST_STATE_DIR", None)
         result = subprocess.run(
             [
                 "/bin/bash",
@@ -3525,7 +3534,7 @@ def test_host_global_bind_source_resolves_identically_across_checkouts_and_chann
                 f"source '{resolver}'; prepare_instance_ownership_host_state_dir; printf %s \"$INSTANCE_OWNERSHIP_HOST_STATE_DIR\"",
             ],
             cwd=checkout,
-            env={**os.environ, "HOME": str(home), "XDG_STATE_HOME": ""},
+            env=env,
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Bounded repair of the repository unit-test runner and its contract-test fixtures after the complete local suite exposed order-dependent state, subprocess interpreter, and bootstrap-stub isolation failures.
Validation: Targeted regression 185 passed and 4 skipped; `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py`; full `make test` completed with 14,053 passed, 556 skipped, 24 xfailed, and 8 failures caused by preserved local artifacts or unavailable Docker.
Issue required: no

Final-Review-Rounds: 0

## Summary
Keep the repository unit-test runner on the configured interpreter and compatible pytest import mode, isolate process-global test state, and make the consent/bootstrap and host-state contract fixtures hermetic under the full suite.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded validation repair; no BuilderOps material was routed.

## Notes
No product runtime behavior or deployment state is changed by this PR. Existing untracked and ignored workspace artifacts were preserved.