### PR TITLE
feat: govern rebuildable derivatives with read-only doctor

### DIFF
--- a/app/archival/__init__.py
+++ b/app/archival/__init__.py
@@ -29,6 +29,16 @@ from app.archival.transition import (
     TransitionFailure,
     TransitionResult,
 )
+from app.archival.derived_disposition import (
+    DerivativeCandidate,
+    DerivativeDisposition,
+    DerivativeDispositionDoctor,
+    DerivativeDispositionResult,
+    DerivativeFinding,
+    DerivativeFindingCode,
+    OwnerAdmissionRoute,
+    RebuildRecipe,
+)
 
 __all__ = [
     "AccessAuthority",
@@ -56,4 +66,12 @@ __all__ = [
     "FaultStage",
     "TransitionFailure",
     "TransitionResult",
+    "DerivativeCandidate",
+    "DerivativeDisposition",
+    "DerivativeDispositionDoctor",
+    "DerivativeDispositionResult",
+    "DerivativeFinding",
+    "DerivativeFindingCode",
+    "OwnerAdmissionRoute",
+    "RebuildRecipe",
 ]

--- a/app/archival/derived_disposition.py
+++ b/app/archival/derived_disposition.py
@@ -1,0 +1,191 @@
+"""Read-only DRI disposition checks for rebuildable derivatives.
+
+This module intentionally owns no archive representation, receipt, deletion, or
+owner-state transition.  It evaluates only owner-native source and recipe
+readbacks supplied by its callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from app.archival.contracts import ArtifactIdentity, Generation, OpaqueReference
+
+
+class DerivativeDisposition(str, Enum):
+    """The only classifications a read-only derivative doctor may return."""
+
+    REBUILDABLE_NON_AUTHORITATIVE = "rebuildable_non_authoritative"
+    REQUIRES_OWNER_ADMISSION = "requires_owner_admission"
+    REFUSED = "refused"
+
+
+class DerivativeFindingCode(str, Enum):
+    MISSING_SOURCE_IDENTITY = "missing_source_identity"
+    MISSING_SOURCE_GENERATION = "missing_source_generation"
+    STALE_SOURCE_LINEAGE = "stale_source_lineage"
+    MISSING_REBUILD_RECIPE = "missing_rebuild_recipe"
+    UNAVAILABLE_REBUILD_RECIPE = "unavailable_rebuild_recipe"
+    DERIVATIVE_AS_ARCHIVE_AUTHORITY = "derivative_as_archive_authority"
+    OWNER_ADMISSION_REQUIRED = "owner_admission_required"
+
+
+class OwnerAdmissionRoute(str, Enum):
+    """Owner-native destinations for an explicit non-rebuildable reclassification."""
+
+    HKA = "hka"
+    RETAINED_SOURCE = "retained_source"
+
+
+@dataclass(frozen=True)
+class RebuildRecipe:
+    reference: OpaqueReference
+    version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.reference, OpaqueReference):
+            raise ValueError("recipe reference must be a typed opaque reference")
+        if not isinstance(self.version, str) or not self.version:
+            raise ValueError("recipe version must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class DerivativeCandidate:
+    """Owner-supplied derivative lineage; never inferred from paths or scans."""
+
+    identity: ArtifactIdentity
+    generation: Generation
+    source_identity: ArtifactIdentity | None
+    source_generation: Generation | None
+    recipe: RebuildRecipe | None
+    explicitly_nonrebuildable: bool = False
+    requested_owner_admission: OwnerAdmissionRoute | None = None
+    claimed_archive_authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.identity, ArtifactIdentity):
+            raise ValueError("derivative identity must be an artifact identity")
+        if not isinstance(self.generation, Generation):
+            raise ValueError("derivative generation must be a generation")
+        if self.source_identity is not None and not isinstance(
+            self.source_identity, ArtifactIdentity
+        ):
+            raise ValueError("source identity must be an artifact identity")
+        if self.source_generation is not None and not isinstance(
+            self.source_generation, Generation
+        ):
+            raise ValueError("source generation must be a generation")
+        if self.recipe is not None and not isinstance(self.recipe, RebuildRecipe):
+            raise ValueError("recipe must be a rebuild recipe")
+        if type(self.explicitly_nonrebuildable) is not bool:
+            raise ValueError("explicitly_nonrebuildable must be a bool")
+        if self.requested_owner_admission is not None and not isinstance(
+            self.requested_owner_admission, OwnerAdmissionRoute
+        ):
+            raise ValueError("requested_owner_admission must be an owner admission route")
+        if type(self.claimed_archive_authority) is not bool:
+            raise ValueError("claimed_archive_authority must be a bool")
+
+
+@dataclass(frozen=True)
+class DerivativeFinding:
+    code: DerivativeFindingCode
+    candidate: DerivativeCandidate
+
+
+@dataclass(frozen=True)
+class DerivativeDispositionResult:
+    candidate: DerivativeCandidate
+    disposition: DerivativeDisposition
+    findings: tuple[DerivativeFinding, ...]
+    owner_admission: OwnerAdmissionRoute | None = None
+
+    @property
+    def archive_authority(self) -> bool:
+        """Derivatives cannot become last-copy authority through this doctor."""
+
+        return False
+
+
+class DerivativeSourceLookup(Protocol):
+    """Read-only owner-native source lineage lookup."""
+
+    def is_current(self, identity: ArtifactIdentity, generation: Generation) -> bool: ...
+
+
+class RebuildRecipeLookup(Protocol):
+    """Read-only recipe/version availability lookup."""
+
+    def is_available(self, recipe: RebuildRecipe) -> bool: ...
+
+
+class DerivativeDispositionDoctor:
+    """Classify one supplied derivative without mutating any owner or archive state."""
+
+    def __init__(
+        self,
+        source_lookup: DerivativeSourceLookup,
+        recipe_lookup: RebuildRecipeLookup,
+    ) -> None:
+        self._source_lookup = source_lookup
+        self._recipe_lookup = recipe_lookup
+
+    def diagnose(self, candidate: DerivativeCandidate) -> DerivativeDispositionResult:
+        findings: list[DerivativeFinding] = []
+
+        if candidate.claimed_archive_authority:
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.DERIVATIVE_AS_ARCHIVE_AUTHORITY, candidate)
+            )
+
+        if candidate.explicitly_nonrebuildable:
+            if candidate.requested_owner_admission is None:
+                findings.append(
+                    DerivativeFinding(DerivativeFindingCode.OWNER_ADMISSION_REQUIRED, candidate)
+                )
+                return self._refused(candidate, findings)
+            return DerivativeDispositionResult(
+                candidate,
+                DerivativeDisposition.REQUIRES_OWNER_ADMISSION,
+                tuple(findings),
+                candidate.requested_owner_admission,
+            )
+
+        if candidate.source_identity is None:
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.MISSING_SOURCE_IDENTITY, candidate)
+            )
+        elif candidate.source_generation is None:
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.MISSING_SOURCE_GENERATION, candidate)
+            )
+        elif not self._source_lookup.is_current(
+            candidate.source_identity, candidate.source_generation
+        ):
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.STALE_SOURCE_LINEAGE, candidate)
+            )
+
+        if candidate.recipe is None:
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.MISSING_REBUILD_RECIPE, candidate)
+            )
+        elif not self._recipe_lookup.is_available(candidate.recipe):
+            findings.append(
+                DerivativeFinding(DerivativeFindingCode.UNAVAILABLE_REBUILD_RECIPE, candidate)
+            )
+
+        if findings:
+            return self._refused(candidate, findings)
+        return DerivativeDispositionResult(
+            candidate, DerivativeDisposition.REBUILDABLE_NON_AUTHORITATIVE, ()
+        )
+
+    @staticmethod
+    def _refused(
+        candidate: DerivativeCandidate,
+        findings: list[DerivativeFinding],
+    ) -> DerivativeDispositionResult:
+        return DerivativeDispositionResult(candidate, DerivativeDisposition.REFUSED, tuple(findings))

--- a/docs/contracts/GOVERNED_ARCHIVAL_FLOW.md
+++ b/docs/contracts/GOVERNED_ARCHIVAL_FLOW.md
@@ -41,6 +41,21 @@ The common vocabulary deliberately carries class-specific terminal outcomes rath
 
 No profile inherits another profile's retention, revocation, or erasure authority.
 
+## Rebuildable derivative disposition
+
+DRI owns the disposition of embeddings, indexes, OCR, thumbnails, caches, and other derived
+rebuildable artifacts. A derivative MUST NOT be accepted as last-copy archive authority. It is
+`rebuildable_non_authoritative` only when an owner-native lookup resolves its authoritative source
+identity at the declared source generation and a read-only lookup confirms its rebuild
+recipe/version. Missing source identity, source generation, recipe/version, stale lineage,
+unavailable recipe, or a source-authority claim produces a typed refusal; none is inferred from a
+path, filename, scan, or archive representation.
+
+An explicitly non-rebuildable derivative is not admitted by this contract. The read-only DRI doctor
+returns an HKA or retained-source owner-admission route; the receiving owner performs any later
+reclassification and archival admission. The doctor retains no progress state and cannot write a
+receipt, mutate owner state, delete bytes, or change the candidate's classification.
+
 ## Adapter seam
 
 `ArchivalAdapter` is the single public protocol used by both the transition kernel and later owner-native adapters; the kernel has no second private adapter seam. The adapter provides enumerate and resolve; authorize read; atomically bind and read an operation journal; reserve and copy a representation; verify; durably receipt; activate; retire; complete; restore with exact receipt readback; cleanup with all-representation proof readback; and read-only doctor/reconcile. The protocol does not select a backend, allocate a database, authorize a caller itself, or move owner state into the kernel.

--- a/tests/archival/test_derived_disposition.py
+++ b/tests/archival/test_derived_disposition.py
@@ -1,0 +1,123 @@
+"""Acceptance tests for the read-only GAF-06 derivative disposition doctor."""
+
+from __future__ import annotations
+
+from app.archival.contracts import (
+    ArtifactIdentity,
+    Generation,
+    OpaqueReference,
+    OwnerAuthority,
+)
+from app.archival.derived_disposition import (
+    DerivativeCandidate,
+    DerivativeDisposition,
+    DerivativeDispositionDoctor,
+    DerivativeFindingCode,
+    OwnerAdmissionRoute,
+    RebuildRecipe,
+)
+
+
+class FakeSourceLookup:
+    def __init__(self, resolved: bool = True) -> None:
+        self.resolved = resolved
+        self.calls: list[tuple[ArtifactIdentity, Generation]] = []
+
+    def is_current(self, identity: ArtifactIdentity, generation: Generation) -> bool:
+        self.calls.append((identity, generation))
+        return self.resolved
+
+
+class FakeRecipeLookup:
+    def __init__(self, resolved: bool = True) -> None:
+        self.resolved = resolved
+        self.calls: list[RebuildRecipe] = []
+
+    def is_available(self, recipe: RebuildRecipe) -> bool:
+        self.calls.append(recipe)
+        return self.resolved
+
+
+def _candidate(**changes: object) -> DerivativeCandidate:
+    source = ArtifactIdentity(OwnerAuthority.HKA, OpaqueReference("hka", "note-42"))
+    candidate = DerivativeCandidate(
+        identity=ArtifactIdentity(OwnerAuthority.DRI, OpaqueReference("dri", "embedding-42")),
+        generation=Generation(8),
+        source_identity=source,
+        source_generation=Generation(4),
+        recipe=RebuildRecipe(OpaqueReference("recipe", "embed-v1"), "v1"),
+    )
+    return DerivativeCandidate(**{**candidate.__dict__, **changes})
+
+
+def test_rebuildable_derivative_is_not_archive_authority() -> None:
+    source_lookup = FakeSourceLookup()
+    recipe_lookup = FakeRecipeLookup()
+
+    result = DerivativeDispositionDoctor(source_lookup, recipe_lookup).diagnose(_candidate())
+
+    assert result.disposition is DerivativeDisposition.REBUILDABLE_NON_AUTHORITATIVE
+    assert result.findings == ()
+    assert result.archive_authority is False
+    assert source_lookup.calls
+    assert recipe_lookup.calls
+
+
+def test_missing_source_or_rebuild_recipe_is_loud() -> None:
+    missing_source = DerivativeDispositionDoctor(FakeSourceLookup(False), FakeRecipeLookup()).diagnose(
+        _candidate()
+    )
+    missing_recipe = DerivativeDispositionDoctor(FakeSourceLookup(), FakeRecipeLookup(False)).diagnose(
+        _candidate(recipe=None)
+    )
+    missing_generation = DerivativeDispositionDoctor(FakeSourceLookup(), FakeRecipeLookup()).diagnose(
+        _candidate(source_generation=None)
+    )
+    authority_misuse = DerivativeDispositionDoctor(FakeSourceLookup(), FakeRecipeLookup()).diagnose(
+        _candidate(claimed_archive_authority=True)
+    )
+
+    assert missing_source.disposition is DerivativeDisposition.REFUSED
+    assert DerivativeFindingCode.STALE_SOURCE_LINEAGE in {
+        finding.code for finding in missing_source.findings
+    }
+    assert missing_recipe.disposition is DerivativeDisposition.REFUSED
+    assert DerivativeFindingCode.MISSING_REBUILD_RECIPE in {
+        finding.code for finding in missing_recipe.findings
+    }
+    assert missing_generation.disposition is DerivativeDisposition.REFUSED
+    assert DerivativeFindingCode.MISSING_SOURCE_GENERATION in {
+        finding.code for finding in missing_generation.findings
+    }
+    assert authority_misuse.disposition is DerivativeDisposition.REFUSED
+    assert DerivativeFindingCode.DERIVATIVE_AS_ARCHIVE_AUTHORITY in {
+        finding.code for finding in authority_misuse.findings
+    }
+
+
+def test_explicit_nonrebuildable_reclassification_routes_to_owner_adapter() -> None:
+    result = DerivativeDispositionDoctor(FakeSourceLookup(), FakeRecipeLookup()).diagnose(
+        _candidate(
+            explicitly_nonrebuildable=True,
+            requested_owner_admission=OwnerAdmissionRoute.RETAINED_SOURCE,
+        )
+    )
+
+    assert result.disposition is DerivativeDisposition.REQUIRES_OWNER_ADMISSION
+    assert result.owner_admission is OwnerAdmissionRoute.RETAINED_SOURCE
+    assert result.archive_authority is False
+
+
+def test_derivative_doctor_is_read_only() -> None:
+    source_lookup = FakeSourceLookup()
+    recipe_lookup = FakeRecipeLookup()
+    candidate = _candidate()
+
+    result = DerivativeDispositionDoctor(source_lookup, recipe_lookup).diagnose(candidate)
+
+    assert result.candidate is candidate
+    assert source_lookup.calls == [(candidate.source_identity, candidate.source_generation)]
+    assert recipe_lookup.calls == [candidate.recipe]
+    assert not hasattr(result, "receipt")
+    assert not hasattr(result, "delete")
+    assert not hasattr(result, "reclassify")


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5068

## Linked Issue
Closes #5068

## SBS Impact
- Primary subsystem: DRI - Derived/Rebuildable Intelligence
- Secondary subsystem(s): HKA, SIP, PDM
- Write class: none; read-only classification and diagnosis
- Persistence impact: none
- Derived/rebuildable impact: Makes source identity, generation, and recipe evidence mandatory before safe discard.
- New or changed contract: Rebuildable derivative disposition within GovernedArchivalFlow
- Owner-doc impact: updated in this PR
- Transition debt impact: Prevents stale derivatives from becoming hidden source authority.
- Boundary risk: Doctor must not mutate, delete, receipt, or reclassify owner state.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a read-only DRI doctor that refuses derivatives as last-copy archive authority unless source lineage and recipe evidence resolve.
- Return an HKA or retained-source admission route for explicit non-rebuildable reclassification without mutating owner or archive state.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps record: no plan divergence or operational state was produced.

## Notes
Validation: pytest -q tests/archival/test_derived_disposition.py; pytest -q tests/architecture/test_governed_archival_contract.py; pytest -q tests/archival; ruff check app tests; mypy app; python3 scripts/docs_guard.py --language-only.