### PR TITLE
Expand capability validation coverage baseline

### DIFF
--- a/docs/audits/BUILDEROPS_CAPABILITY_AND_HUMAN_UAT_INVENTORY_2026-08-28.md
+++ b/docs/audits/BUILDEROPS_CAPABILITY_AND_HUMAN_UAT_INVENTORY_2026-08-28.md
@@ -1,4 +1,4 @@
-State: Advisory capability and acceptance inventory snapshot, 2026-08-28. Repository baseline: `origin/main` at `c4ab77a6504d6120638703e86375903883d461f5`.
+State: Advisory capability and acceptance inventory snapshot, 2026-08-28. Repository baseline: `origin/main` at `a252490dc57ad3e45bb6687d6d9b928d7b0b56aa`.
 Doc role: Reference (point-in-time inventory and reporting plan)
 Authority: Current-state claims remain owned by `docs/STATUS.md`, `docs/ARCHITECTURE.md`, capability specifications, contracts, GitHub Issues, Git, CI, and acceptance receipts. This audit creates no runtime, lifecycle, or owner-acceptance authority.
 Owner: Builder System governance
@@ -81,7 +81,78 @@ The posture labels follow `docs/plans/HUMAN_NEED_UAT_STRATEGY.md`: `baseline`, `
 `release gate` describe test gating. A `partial` scenario may be valuable UAT without being a smoke
 failure; a `baseline` scenario becomes a release gate only when current-state owner docs claim it.
 
-## 5. Test strategy by evidence class
+## 5. Full validation-coverage audit
+
+The scenario matrix is broader than the eight canonical loops: it contains fourteen human-facing
+scenarios (including 2A and 7A) and seven direct human-agent scenarios. Coverage means that every
+row has all of the following, or an explicit `unsupported`/`N/A` reason:
+
+1. a stable human-outcome source anchor;
+2. an implementation posture owned by the current-state docs;
+3. a minimum executable scenario;
+4. a named proof layer (unit/API/data/browser/system);
+5. a bounded UAT observation and disposition path;
+6. a GitHub/spec owner for executable gaps; and
+7. a separate owner-tried/owner-accepted receipt path.
+
+The audit below records coverage of the scenario definition itself. A missing executable scenario
+is a coverage gap even when the capability has a detailed prose contract or a related unit test.
+
+### Human-facing scenarios
+
+| Scenario matrix row | Scenario/prose | Executable scenario + test posture | Primary proof frame | Coverage disposition |
+| --- | --- | --- | --- | --- |
+| 1 | Capture a fleeting thought | No explicit validation posture or minimum executable scenario in the matrix | Capture contract + isolated vault/system UAT | Gap: add bounded scenario and owner route |
+| 2 | Return after interruption and recover orientation | Defined; `partial`; non-blocking acceptance → nightly; minimum scenario exists | Retrieval/context bundle + human-need UAT | Covered at scenario-definition level; implementation remains partial |
+| 2A | Use archive material without forcing it into notes | Defined; `partial`; non-blocking acceptance → nightly; minimum scenario exists | Archive/acquisition integration + provenance UAT | Covered at scenario-definition level; broader connector coverage remains open |
+| 3 | Move from source material to durable understanding | No explicit validation posture or minimum executable scenario in the matrix | Source lineage + promotion/review tests | Gap: add scenario and acceptance path |
+| 4 | Keep commitments trustworthy over time | Defined; `future`; non-blocking acceptance; minimum scenario exists | Commitment/state transition + human review | Covered as future scenario; no shipped claim |
+| 5 | Develop a creative fragment without premature closure | No explicit validation posture or minimum executable scenario in the matrix | Candidate/draft lifecycle + human review | Gap: add scenario and acceptance path |
+| 6 | Maintain a hobby or RPG world across time | No explicit validation posture or minimum executable scenario in the matrix | Context/scope separation + domain UAT | Gap: add scenario and acceptance path |
+| 7 | Understand what the system did and whether to trust it | Defined; `partial`; release gate for baseline actions, otherwise non-blocking; minimum scenario exists | Governed action/receipt + browser/readability proof | Covered at scenario-definition level; composed proof remains incomplete |
+| 7A | Decide whether watcher automation is safe to enable | Defined; `baseline`; release gate; minimum scenario exists | Settings/status/write-guard operator proof | Covered and release-gated for the bounded baseline |
+| 8 | Use the system across multiple domains without losing meaning | No explicit validation posture or minimum executable scenario in the matrix | Context/sphere separation + cross-scope UAT | Gap: add scenario and acceptance path |
+| 9 | Evolve the system without early lock-in | No explicit validation posture or minimum executable scenario in the matrix | Capability contract/replacement and migration proof | Gap: add scenario and acceptance path |
+| 10 | Work across devices while keeping local artifacts primary | No explicit validation posture or minimum executable scenario in the matrix | Device/client contract + local-first recovery proof | Gap: add scenario and owner route; likely cross-repo |
+| 11 | Preserve contextual integrity with real overlap | No explicit validation posture or minimum executable scenario in the matrix | Scope/sphere identity and isolation tests | Gap: add scenario and acceptance path |
+| 12 | Keep central artifacts understandable if the system changes or dies | No explicit validation posture or minimum executable scenario in the matrix | Artifact portability/readability + rebuild/restore proof | Gap: add scenario and acceptance path |
+
+### Direct human-agent scenarios
+
+Rows A–G have a defined need, acceptance signal, and failure posture, but the matrix explicitly
+marks them `future` and does not give each row a test posture or minimum executable scenario.
+They therefore require a separate direct-filesystem validation track; mediated-agent scenarios reuse
+the human rows above and must not be counted twice.
+
+| Rows | Capability surface | Minimum proof that must be added before implementation can be claimed | Coverage disposition |
+| --- | --- | --- | --- |
+| A–C | Declared project/draft/synthesis roots | Disposable roots, plain-Markdown output, provenance/standing checks, no out-of-root writes, and human review/promotion observation | Gap: scenario-specific contract and tests absent from the matrix |
+| D–E | Observation/classification and stale synthesis | External-agent file-change fixture, classification projection, staleness signal, proposal-not-apply assertion, restart/rebuild check | Gap: scenario-specific contract and tests absent from the matrix |
+| F | Contradictory agent outputs | Two attributed outputs, side-by-side conflict projection, explicit reversible consolidation decision | Gap: scenario-specific contract and tests absent from the matrix |
+| G | Human promotion into canonical knowledge | Explicit promotion action, citation preservation, origin trace, governed receipt, owner acceptance observation | Gap: scenario-specific contract and tests absent from the matrix |
+
+### Coverage-to-framework mapping
+
+The gaps above should be filled by existing frames, in this order:
+
+| Need | Existing frame to reuse | Boundary |
+| --- | --- | --- |
+| Human outcome and scenario semantics | `docs/HUMAN-FLOWS.md` + `docs/plans/SCENARIO_ACCEPTANCE_MATRIX.md` | No implementation claim by itself |
+| Capability contract and reusable function | `docs/CAPABILITY_CONTRACT_MODEL.md` + local capability README/spec | No universal runtime registry implied |
+| Evidence and maturity inputs | CKM/Kvasir and its provenance/freshness contracts | Projection-only; cannot choose Issues or accept work |
+| BuilderOps owner orientation | Cockpit/devUI read-time compositions | Read-only; no lifecycle or owner-acceptance authority |
+| Deterministic product/system verification | Existing unit/API/PG/invariant/recovery suites | Must use the owning capability's authority boundary |
+| Browser and interaction verification | Existing Playwright harness and post-merge browser lane | Proves rendered interaction, not persistence or authority |
+| Human UAT and acceptance | `HUMAN_NEED_UAT_STRATEGY.md`, parent Issue evidence, owner receipt | Cannot be inferred from CI, merge, deployment, or screenshot |
+| Delivery truth | Issue → PR → exact SHA → CI/review → merge → receipt workflow | Separate from product acceptance |
+
+The first implementation action after this audit is therefore not to create a new ledger. It is to
+materialize the missing scenario-level validation contracts in the owning capability specs, then
+route only executable gaps through `docs-to-issue` or `feature-breakdown`. Existing Issues remain
+the owners where they already cover the gap; a new Issue is justified only after the live duplicate
+check proves that no owner exists.
+
+## 6. Test strategy by evidence class
 
 | Claim to prove | Primary mechanism | What it must show | What it cannot show |
 | --- | --- | --- | --- |
@@ -97,7 +168,7 @@ responses, raw JSON as visual state, browser-built target URLs, or local fixture
 runtime proof. For BCP/TIA and other authority-bearing work, browser evidence is supplemental only;
 the primary proof is API/PostgreSQL/concurrency/recovery/cutover evidence.
 
-## 6. Existing backlog ownership and disposition
+## 7. Existing backlog ownership and disposition
 
 | Work surface | Existing owner | Live posture at snapshot | Disposition |
 | --- | --- | --- | --- |
@@ -109,7 +180,7 @@ the primary proof is API/PostgreSQL/concurrency/recovery/cutover evidence.
 | Temporal-intention authority | #4375 | Open and blocked | Preserve opaque-first and single-writer boundary; do not treat target spec as shipped runtime. |
 | Human-need scenario execution | `docs/plans/HUMAN_NEED_UAT_STRATEGY.md`, scenario matrix, existing UAT tests | Mixed baseline/partial/future | Add or advance scenario-specific UAT only under the owning capability Issue; avoid a catch-all epic. |
 
-## 7. Reporting template for a capability or parent Issue
+## 8. Reporting template for a capability or parent Issue
 
 Every parent validation hub or capability receipt should report one row per capability with:
 
@@ -134,7 +205,7 @@ The evidence spine belongs on the parent Issue after child delivery; stable owne
 when accepted support truth changes. CKM, Cockpit, devUI and generated projections may render this
 information at read time, but GitHub/CI/receipts and the authorized owner path remain the authority.
 
-## 8. Immediate conclusions
+## 9. Immediate conclusions
 
 - The repository already has a coherent capability/UAT strategy and several strong proof mechanisms.
 - The highest-value missing proof is not another taxonomy; it is composed, exact-SHA capability


### PR DESCRIPTION
## Change Lane
- [x] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

## Linked Issue
None — this is an issue-free docs-authoring update to the existing advisory audit snapshot.

## SBS Impact
- Primary subsystem: Builder System governance / docs-as-code
- Secondary subsystem(s): none
- Write class: analytical/reference only
- Persistence impact: none
- Derived/rebuildable impact: audit snapshot only; rebuildable from cited docs and live delivery evidence
- New or changed contract: none
- Owner-doc impact: none; current-state and capability owner docs remain authoritative
- Transition debt impact: preserves D11/D12 boundaries; no runtime authority or lifecycle mutation
- Boundary risk: none beyond documentation accuracy

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Expand the existing BuilderOps capability and human-UAT audit with explicit coverage for all 14 human-facing scenario rows and 7 direct human-agent rows.
- Map missing validation contracts to the existing CKM, UAT, Playwright, authority, and delivery frameworks without creating a parallel master registry.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 docs-authoring lane; no BuilderOps operational material was created.

## Notes
- Validation: `python3 scripts/docs_guard.py`, `python3 -m pytest -q tests/architecture/test_docs_index.py`, `git diff --check`, and branch-truth/review-before-CI gates passed.
- The audit remains advisory; it does not claim implementation, owner trial, owner acceptance, or runtime authority.
---