### PR TITLE
test: prove support-free artifact survivability

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -905,6 +905,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ),
     ),
     (
+        # Quality Wave is the non-blocking acceptance surface for seeded and
+        # cold-rebuild scenarios. A direct edit to one of its tests must run
+        # the suite rather than fail closed as an unowned path before pytest
+        # can exercise the added evidence.
+        "quality_wave",
+        ("tests/quality_wave/",),
+        ("tests/quality_wave",),
+    ),
+    (
         "ops",
         ("app/ops/", "tests/ops/"),
         ("tests/ops",),

--- a/tests/quality_wave/test_cold_rebuild.py
+++ b/tests/quality_wave/test_cold_rebuild.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -111,6 +112,38 @@ class TestColdStartPrecondition:
     def test_store_starts_empty(self) -> None:
         object_store_module._MEMORY_STORE.clear()
         assert len(object_store_module._MEMORY_STORE) == 0
+
+
+def test_support_free_copied_root_remains_human_intelligible(tmp_path: Path) -> None:
+    """Scenario 12 non-blocking acceptance evidence for Markdown-only inspection."""
+    source_root = tmp_path / "source"
+    artifact_source = source_root / "artifacts"
+    artifact_source.mkdir(parents=True)
+    representative_artifacts = {
+        "evergreen-strategy.md": ("# Evergreen Strategy", "sustainable knowledge loop"),
+        "reflection-journal.md": ("# Reflection Journal", "LangGraph-based agents"),
+    }
+    for source_name in representative_artifacts:
+        shutil.copy2(GOLDEN_DIR / source_name.replace(".md", ".golden.md"), artifact_source / source_name)
+
+    # These derived/runtime artifacts deliberately remain outside the copied root.
+    (source_root / "index.json").write_text('{"derived": true}', encoding="utf-8")
+    (source_root / "cache").mkdir()
+    (source_root / "runtime-metadata.json").write_text('{"runtime": true}', encoding="utf-8")
+
+    support_free_root = tmp_path / "support-free-copy"
+    support_free_root.mkdir()
+    for artifact_name in representative_artifacts:
+        shutil.copy2(artifact_source / artifact_name, support_free_root / artifact_name)
+
+    assert sorted(path.name for path in support_free_root.iterdir()) == sorted(representative_artifacts)
+    assert not (support_free_root / "index.json").exists()
+    assert not (support_free_root / "cache").exists()
+    assert not (support_free_root / "runtime-metadata.json").exists()
+    for artifact_name, (heading, meaning) in representative_artifacts.items():
+        content = (support_free_root / artifact_name).read_text(encoding="utf-8")
+        assert heading in content
+        assert meaning in content
 
 
 class TestColdRebuildMatchesGolden:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -173,6 +173,18 @@ def test_builder_system_architecture_fitness_test_has_ci_owner() -> None:
     assert path in selection.targets
 
 
+def test_quality_wave_tests_have_ci_owner() -> None:
+    path = "tests/quality_wave/test_cold_rebuild.py"
+
+    selection = select_tests([path])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("quality_wave",)
+    assert selection.unowned_paths == ()
+    assert "tests/quality_wave" in selection.targets
+    assert path in selection.targets
+
+
 def test_proxmox_inventory_boundary_has_builder_system_ci_owner() -> None:
     selection = select_tests(["app/proxmox/inventory.py"])
 


### PR DESCRIPTION
Governing-Issue: #5144

Fixes #5144

Final-Review-Rounds: 0

## Summary

Adds Scenario 12 non-blocking acceptance evidence that representative Markdown artifacts remain intelligible after a Markdown-only copy to an isolated root, and assigns the existing quality-wave test surface a CI selector owner.

The test leaves index, cache, and runtime metadata outside the copied root, then verifies directly readable headings and meaningful content without invoking runtime support.

## Acceptance Criteria / Verify Evidence

- AC1 — PASS: `tests/quality_wave/test_cold_rebuild.py::test_support_free_copied_root_remains_human_intelligible` copies representative core Markdown artifacts and asserts readable headings plus meaningful text.
- AC2 — PASS: the same test creates source-side `index.json`, `cache/`, and `runtime-metadata.json`, then proves none is present in the support-free copy.
- AC3 — PASS: `docs/plans/SCENARIO_ACCEPTANCE_MATRIX.md :: 12. Keep central artifacts understandable if the system changes or dies` continues to declare `partial` implementation posture and `non-blocking acceptance` test posture; this PR does not alter that boundary.
- AC4 — PASS: `tests/scripts/test_select_pr_tests.py::test_quality_wave_tests_have_ci_owner` proves the selector assigns the cold-rebuild quality-wave test a deterministic owner and includes `tests/quality_wave` in its targets.

## Validation

- PASS — `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/quality_wave/test_cold_rebuild.py -m not_pg` (11 passed)
- PASS — `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/scripts/test_select_pr_tests.py` (99 passed)
- PASS — `python3 scripts/select_pr_tests.py --base-ref origin/main --head-ref HEAD` selects `quality_wave,ops_deploy`, including `tests/quality_wave`.
- PASS — `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` (no shipped behavior or current-state doc changed)
- PASS — `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests`
- PASS — `git diff --check`

## SBS Impact

- Product SBS / artifact and vault durability; Builder System / quality-wave UAT and CI test selection.
- Mechanical test evidence and deterministic selector routing only; no runtime, persistence, or ArtifactContract change.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: This bounded Tier 2 test slice produced no BuilderOps operational state or delivery divergence.

## Notes

Scenario 12 remains non-blocking acceptance evidence and does not claim runtime-death recovery or owner acceptance. The Issue contract was amended after CI exposed the unowned quality-wave path; this PR head supersedes the earlier failed CI evidence.
