### PR TITLE
docs: record watcher fixture learning fallback

### DIFF
--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -235,3 +235,9 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Compatibility fallback:** BuilderOps LearningSignal write unavailable: implicit host-stable store selection was refused because the required same-user/same-host cutover acknowledgement or explicit BuilderOps state path is absent.
 
 --- retro 2026-08-03: processed 3/3 compatibility fallback entries ---
+
+## 2026-08-28 — #5145 (quality-wave watcher fixture seam)
+**Source:** capture-learning after issue-to-code / CI
+**Diverged:** The plan described a joined watcher safe-enablement receipt, but CI exposed three missing production-seam fixture assumptions before the test could validate behavior: the settings parent directory, configured tick/run receipt paths, and the canonical watcher settings path.
+**Upstream artifact:** `docs/TESTING.md :: Quality Wave acceptance harness / watcher-runtime convergence tests`
+**Compatibility fallback:** BuilderOps LearningSignal write unavailable: local CLI import failed because the pinned `lingua` dependency is unavailable; convert this entry to a `LearningSignal` when the acknowledged BuilderOps store is reachable.


### PR DESCRIPTION
## Summary

Record the compatibility fallback learning from the #5145 quality-wave watcher validation slice.

## Changes

- Add one dated `docs/learning-log.md` entry.
- Preserve the concrete CI divergence: settings directory, configured receipt paths, and canonical watcher settings path were not explicit in the fixture contract.
- Name `docs/TESTING.md` as the upstream artifact for future repair.

## BuilderOps Routing

- Records/projections/receipts: Historical compatibility fallback in `docs/learning-log.md`; no BuilderOps record was created.
- Reason: BuilderOps LearningSignal creation was attempted but the local CLI import cannot resolve the pinned `lingua` dependency; convert the fallback to a `LearningSignal` when the acknowledged store is reachable.

## Notes

- [x] Docs authoring lane
- [x] `python3 scripts/docs_guard.py`
- [x] `python3 -m pytest -q tests/architecture/test_docs_index.py`
- [x] `git diff --check`
- [x] `scripts/review_before_ci_gate.py --lane docs-authoring --changed-file docs/learning-log.md --review-gate-complete`
- [x] `scripts/agent_workspace_preflight.sh --allow-dirty`
Final-Review-Rounds: 0