### PR TITLE
Fix mount-blind deployment backup binding

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -1007,11 +1007,25 @@ class InstanceStateBackup:
                     "canonical global live-owner inventory is invalid: "
                     f"owners[{index}].root is missing or not absolute"
                 )
+            root = Path(raw_root).expanduser().resolve(strict=False)
             if not require_materialized_owner_roots and not binding_id:
-                raise InstanceStatePreflightError(
-                    "canonical global live-owner inventory is invalid: "
-                    f"owners[{index}].vault_binding_id is missing"
-                )
+                # Deployment-finish verifies a host-produced receipt in a
+                # mount-blind scratch namespace. Recover a binding only from
+                # one exact normalized path match in the staged registry;
+                # aliases and ambiguity remain fail-closed.
+                normalized_root = str(root)
+                matches = [
+                    registration.vault_binding_id
+                    for registration in registry.registrations.values()
+                    if str(Path(registration.path).expanduser().resolve(strict=False))
+                    == normalized_root
+                ]
+                if len(matches) != 1:
+                    raise InstanceStatePreflightError(
+                        "canonical global live-owner inventory is invalid: "
+                        f"owners[{index}].vault_binding_id is missing or path is ambiguous"
+                    )
+                binding_id = matches[0]
             # Owner-root materialization is not re-checked here (#4371): the
             # host-side inventory producer proved every root twice and the
             # receipt is digest-bound to the deployment lease, while this
@@ -1022,7 +1036,6 @@ class InstanceStateBackup:
             # was materialized — such an owner therefore resolves to no lease
             # and is handled by the unadopted-candidate rule in
             # resolve_live_owner_bindings below.
-            root = Path(raw_root).expanduser().resolve(strict=False)
             if (
                 require_materialized_owner_roots
                 and channel_id == self.layout.channel_id

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2960,7 +2960,11 @@ def _finish_instance_state_deployment_locked(
         backup_root,
         quiescence_proof=quiescence_proof,
         owner_receipt_path=inventory_path,
-        require_materialized_owner_roots=not scalar_roll_forward_merged,
+        # Host-side quiescence has already proven materialized roots. The
+        # backup verifier stages bytes in a mount-blind scratch namespace, so
+        # retain exact receipt-to-registry binding without recomputing inode
+        # identity there.
+        require_materialized_owner_roots=False,
     )
     result: dict[str, object] = {
         "channel": channel,

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -5012,6 +5012,36 @@ def test_staged_backup_preserves_adopted_active_lease_across_mount_namespace(
     assert dev_registration.vault_binding_id in prod.ledger.load().leases
 
 
+def test_staged_backup_binds_materialized_owner_after_root_leaves_scratch_view(
+    tmp_path,
+) -> None:
+    """A proof-bound owner path may be absent from verifier scratch state."""
+
+    layout = InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod")
+    runtime = InstanceRegistryRuntime.for_paths(layout, tmp_path / "host-global")
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=vault_root,
+        watcher_vault_path=vault_root,
+    )
+    payloads = runtime.ledger.capture_backup_artifacts(
+        capture_registry_artifacts=runtime.registry.capture_backup_artifacts,
+    )
+    shutil.rmtree(vault_root)
+
+    staged_ledger, owners = InstanceStateBackup(
+        layout, runtime.ledger
+    )._verify_staged_backup(
+        payloads=payloads,
+        owner_payload={"owners": [{"channel_id": "prod", "root": str(vault_root)}]},
+        require_materialized_owner_roots=False,
+    )
+
+    assert staged_ledger.leases[registration.vault_binding_id].state == "active"
+    assert owners[0].vault_binding_id == registration.vault_binding_id
+
+
 def test_staged_backup_rejects_ambiguous_adopted_lease_identity(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #4371
Fixes #4371

Final-Review-Rounds: 0

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded repository repair; no BuilderOps record is required
