### PR TITLE
Add durable dormant settings rebind recovery

### DIFF
--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -54,6 +54,11 @@ from app.instance.local_operator_principal import (
     PRINCIPAL_RECORD_FILENAME,
     PrincipalPreflightError,
 )
+from app.instance.settings_rebind import (
+    MINIMUM_SETTINGS_REBIND_RUNTIME,
+    MINIMUM_SETTINGS_REBIND_RUNTIME_KEY,
+    SettingsRebindStore,
+)
 from app.instance.vault_registry import (
     AppLocalSettings,
     AppLocalSettingsStore,
@@ -141,6 +146,17 @@ class InstanceRegistryRuntime:
             layout,
             OwnershipLedger(Path(host_global_root).resolve(strict=False)),
             initialize_layout=initialize_layout,
+        )
+
+    def open_settings_rebind_store(self) -> SettingsRebindStore:
+        """Open the dormant record only after this image passes its floor."""
+
+        _require_runtime_floor(self.registry.load(), scalar_runtime=False)
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        return SettingsRebindStore(
+            self.registry,
+            capability=_STORAGE_MUTATION_CAPABILITY,
         )
 
     def bootstrap_env_binding(
@@ -873,6 +889,18 @@ def _require_runtime_floor(snapshot: RegistrySnapshot, *, scalar_runtime: bool) 
             "minimum runtime principal blocks a credential-only scalar image; use a "
             "compatible roll-forward image instead of scalar rollback"
         )
+    settings_rebind_floor = str(
+        floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY) or ""
+    ).strip()
+    if settings_rebind_floor:
+        if settings_rebind_floor != MINIMUM_SETTINGS_REBIND_RUNTIME:
+            raise CapabilityNotReadyError(
+                "settings rebind runtime floor blocks this API/watcher image before start"
+            )
+        if scalar_runtime:
+            raise CapabilityNotReadyError(
+                "settings rebind runtime floor blocks every legacy scalar writer"
+            )
 
 
 def _preflight_scalar_rollback(
@@ -3901,6 +3929,13 @@ def main(argv: list[str] | None = None) -> int:
     mvr05_floor.add_argument("--host-global-root", type=Path, required=True)
     mvr05_floor.add_argument("--quiescence-proof-path", type=Path, required=True)
     mvr05_floor.add_argument("--fence-plan", type=Path, required=True)
+    rebind_install = subparsers.add_parser("settings-rebind-install-dormant")
+    rebind_install.add_argument("--channel", required=True)
+    rebind_install.add_argument("--registry-path", type=Path, required=True)
+    rebind_install.add_argument("--host-global-root", type=Path, required=True)
+    rebind_install.add_argument(
+        "--quiescence-proof-path", type=Path, required=True
+    )
     for name in ("default-vault-get", "default-vault-set", "default-vault-clear"):
         command = subparsers.add_parser(name)
         command.add_argument("--registry-path", type=Path, required=True)
@@ -4027,6 +4062,39 @@ def main(argv: list[str] | None = None) -> int:
                     _capability=local_operator_storage_capability(),
                 )
         print(json.dumps({"ok": True, "registry_revision": result.revision}, sort_keys=True))
+        return 0
+    if args.command == "settings-rebind-install-dormant":
+        layout = InstanceStateLayout(
+            root=args.registry_path.parent,
+            channel_id=args.channel,
+            registry_path=args.registry_path,
+        )
+        layout.require_existing()
+        with _deployment_admission_locked(args.host_global_root):
+            with _producer_transition_locked(layout):
+                proof = json.loads(
+                    args.quiescence_proof_path.read_text(encoding="utf-8")
+                )
+                _require_proved_deployment_lease(
+                    host_global_root=args.host_global_root,
+                    channel=args.channel,
+                    nonce=proof.get("nonce"),
+                )
+                record = SettingsRebindStore(
+                    VaultRegistryStore(args.registry_path),
+                    capability=local_operator_storage_capability(),  # type: ignore[arg-type]
+                ).install_dormant()
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "desired_revision": record.desired_revision,
+                    "applied_revision": record.applied_revision,
+                    "phase": record.phase,
+                },
+                sort_keys=True,
+            )
+        )
         return 0
     if args.command == "preflight":
         return _preflight_runtime(

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -152,12 +152,7 @@ class InstanceRegistryRuntime:
         """Open the dormant record only after this image passes its floor."""
 
         _require_runtime_floor(self.registry.load(), scalar_runtime=False)
-        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
-
-        return SettingsRebindStore(
-            self.registry,
-            capability=_STORAGE_MUTATION_CAPABILITY,
-        )
+        return SettingsRebindStore(self.registry)
 
     def bootstrap_env_binding(
         self,
@@ -4064,6 +4059,8 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps({"ok": True, "registry_revision": result.revision}, sort_keys=True))
         return 0
     if args.command == "settings-rebind-install-dormant":
+        from app.instance.settings_rebind import _install_dormant_settings_rebind
+
         layout = InstanceStateLayout(
             root=args.registry_path.parent,
             channel_id=args.channel,
@@ -4080,10 +4077,10 @@ def main(argv: list[str] | None = None) -> int:
                     channel=args.channel,
                     nonce=proof.get("nonce"),
                 )
-                record = SettingsRebindStore(
+                record = _install_dormant_settings_rebind(
                     VaultRegistryStore(args.registry_path),
-                    capability=local_operator_storage_capability(),  # type: ignore[arg-type]
-                ).install_dormant()
+                    _capability=local_operator_storage_capability(),  # type: ignore[arg-type]
+                )
         print(
             json.dumps(
                 {

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Mapping
+
+from app.instance._storage_boundary import (
+    RegistryError,
+    _StorageMutationCapability,
+)
+
+if TYPE_CHECKING:
+    from app.instance.vault_registry import VaultRegistryStore
+
+
+SETTINGS_REBIND_SCHEMA = "settings_rebind.v1"
+SETTINGS_REBIND_SCHEMA_REVISION = 1
+MINIMUM_SETTINGS_REBIND_RUNTIME_KEY = "minimum_settings_rebind_runtime"
+MINIMUM_SETTINGS_REBIND_RUNTIME = "1"
+
+_FIELDS = {
+    "schema",
+    "schemaRevision",
+    "desiredRevision",
+    "appliedRevision",
+    "phase",
+    "lifecyclePosture",
+    "priorBindingId",
+    "candidateBindingId",
+    "checksum",
+}
+_PHASE_POSTURES = {
+    "dormant": "dormant",
+    "prepared": "watcher",
+    "committed": "watcher",
+    "no_lifecycle": "no_lifecycle",
+}
+
+
+def _checksum(payload: Mapping[str, object]) -> str:
+    canonical = json.dumps(
+        dict(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _revision(value: object, *, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise RegistryError(f"settings rebind {name} must be a non-negative integer")
+    return value
+
+
+def _binding(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise RegistryError(f"settings rebind {name} must be a non-blank binding id")
+    return value
+
+
+@dataclass(frozen=True)
+class SettingsRebindRecord:
+    schema_revision: int = SETTINGS_REBIND_SCHEMA_REVISION
+    desired_revision: int = 0
+    applied_revision: int = 0
+    phase: str = "dormant"
+    lifecycle_posture: str = "dormant"
+    prior_binding_id: str | None = None
+    candidate_binding_id: str | None = None
+
+    @classmethod
+    def dormant(cls, *, binding_id: str | None = None) -> SettingsRebindRecord:
+        return cls(prior_binding_id=binding_id, candidate_binding_id=binding_id)
+
+    def as_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": SETTINGS_REBIND_SCHEMA,
+            "schemaRevision": self.schema_revision,
+            "desiredRevision": self.desired_revision,
+            "appliedRevision": self.applied_revision,
+            "phase": self.phase,
+            "lifecyclePosture": self.lifecycle_posture,
+            "priorBindingId": self.prior_binding_id,
+            "candidateBindingId": self.candidate_binding_id,
+        }
+        payload["checksum"] = _checksum(payload)
+        return payload
+
+    @classmethod
+    def from_payload(cls, value: object) -> SettingsRebindRecord:
+        if not isinstance(value, dict) or set(value) != _FIELDS:
+            raise RegistryError("settings rebind record has an invalid shape")
+        if value.get("schema") != SETTINGS_REBIND_SCHEMA:
+            raise RegistryError("settings rebind record has an invalid schema")
+        schema_revision = _revision(value.get("schemaRevision"), name="schema revision")
+        if schema_revision != SETTINGS_REBIND_SCHEMA_REVISION:
+            raise RegistryError("settings rebind record has an incompatible schema revision")
+        desired = _revision(value.get("desiredRevision"), name="desired revision")
+        applied = _revision(value.get("appliedRevision"), name="applied revision")
+        if applied > desired:
+            raise RegistryError("settings rebind applied revision exceeds desired revision")
+        phase = value.get("phase")
+        posture = value.get("lifecyclePosture")
+        if not isinstance(phase, str) or phase not in _PHASE_POSTURES:
+            raise RegistryError("settings rebind record has an invalid phase")
+        if posture != _PHASE_POSTURES[phase]:
+            raise RegistryError("settings rebind phase and lifecycle posture disagree")
+        if phase == "dormant" and (desired != 0 or applied != 0):
+            raise RegistryError("dormant settings rebind revisions must be zero")
+        if phase == "prepared" and not (desired > applied):
+            raise RegistryError("prepared settings rebind requires unapplied desired revision")
+        if phase in {"committed", "no_lifecycle"} and desired != applied:
+            raise RegistryError("completed settings rebind revisions must match")
+        prior = _binding(value.get("priorBindingId"), name="prior binding")
+        candidate = _binding(value.get("candidateBindingId"), name="candidate binding")
+        supplied_checksum = value.get("checksum")
+        if (
+            not isinstance(supplied_checksum, str)
+            or len(supplied_checksum) != 64
+            or supplied_checksum != _checksum({key: value[key] for key in value if key != "checksum"})
+        ):
+            raise RegistryError("settings rebind checksum is invalid")
+        return cls(
+            schema_revision=schema_revision,
+            desired_revision=desired,
+            applied_revision=applied,
+            phase=phase,
+            lifecycle_posture=posture,
+            prior_binding_id=prior,
+            candidate_binding_id=candidate,
+        )
+
+
+def provisional_binding_id(value: object) -> str | None:
+    """Validate the only pre-floor legacy form and return its stable binding id."""
+
+    if not isinstance(value, dict) or value.get("schema") != SETTINGS_REBIND_SCHEMA:
+        raise RegistryError("settings rebind record has an invalid pre-floor shape")
+    allowed = {"schema", "prior", "candidate", "applied"}
+    if not set(value).issubset(allowed):
+        raise RegistryError("settings rebind record has an invalid pre-floor shape")
+    binding_ids: set[str] = set()
+    for name in ("prior", "candidate", "applied"):
+        entry = value.get(name)
+        if entry is None:
+            continue
+        if not isinstance(entry, dict):
+            raise RegistryError(f"settings rebind {name} must be a mapping")
+        binding_id = _binding(entry.get("vaultBindingId"), name=f"{name} binding")
+        if binding_id is None:
+            raise RegistryError(f"settings rebind {name} has no provisional binding id")
+        binding_ids.add(binding_id)
+    if len(binding_ids) > 1:
+        raise RegistryError("settings rebind provisional bindings disagree")
+    return next(iter(binding_ids), None)
+
+
+class SettingsRebindStore:
+    """Sealed facade for the durable dormant SETTINGS-05A record."""
+
+    def __init__(
+        self,
+        registry: VaultRegistryStore,
+        *,
+        capability: _StorageMutationCapability,
+    ) -> None:
+        self._registry = registry
+        self._capability = capability
+
+    def install_dormant(self, *, binding_id: str | None = None) -> SettingsRebindRecord:
+        snapshot = self._registry.install_settings_rebind_dormant(
+            binding_id=binding_id,
+            _capability=self._capability,
+        )
+        return SettingsRebindRecord.from_payload(snapshot.settings_rebind)
+
+    def read(self) -> SettingsRebindRecord:
+        value = self._registry.load().settings_rebind
+        if value is None:
+            raise RegistryError("settings rebind record is not installed")
+        return SettingsRebindRecord.from_payload(value)

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -160,26 +160,28 @@ def provisional_binding_id(value: object) -> str | None:
 
 
 class SettingsRebindStore:
-    """Sealed facade for the durable dormant SETTINGS-05A record."""
+    """Read-only facade for the durable dormant SETTINGS-05A record."""
 
-    def __init__(
-        self,
-        registry: VaultRegistryStore,
-        *,
-        capability: _StorageMutationCapability,
-    ) -> None:
+    def __init__(self, registry: VaultRegistryStore) -> None:
         self._registry = registry
-        self._capability = capability
-
-    def install_dormant(self, *, binding_id: str | None = None) -> SettingsRebindRecord:
-        snapshot = self._registry.install_settings_rebind_dormant(
-            binding_id=binding_id,
-            _capability=self._capability,
-        )
-        return SettingsRebindRecord.from_payload(snapshot.settings_rebind)
 
     def read(self) -> SettingsRebindRecord:
         value = self._registry.load().settings_rebind
         if value is None:
             raise RegistryError("settings rebind record is not installed")
         return SettingsRebindRecord.from_payload(value)
+
+
+def _install_dormant_settings_rebind(
+    registry: VaultRegistryStore,
+    *,
+    binding_id: str | None = None,
+    _capability: _StorageMutationCapability,
+) -> SettingsRebindRecord:
+    """Install only from the proved deployment producer or an explicit test fixture."""
+
+    snapshot = registry.install_settings_rebind_dormant(
+        binding_id=binding_id,
+        _capability=_capability,
+    )
+    return SettingsRebindRecord.from_payload(snapshot.settings_rebind)

--- a/app/instance/settings_rebind_runtime_capability.json
+++ b/app/instance/settings_rebind_runtime_capability.json
@@ -1,0 +1,10 @@
+{
+  "capability": "settings-rebind-runtime-floor",
+  "preserves": [
+    "settings_rebind.v1",
+    "minimum_settings_rebind_runtime=1"
+  ],
+  "revision": 1,
+  "rollbackPosture": "reject-incompatible-writer",
+  "schema": "agentic-pkm.runtime-capability-attestation.v1"
+}

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -31,6 +31,12 @@ from app.instance.filesystem_identity import (
     same_filesystem_root,
 )
 from app.receipts.settings_write import emit_settings_write_receipts_for_changes
+from app.instance.settings_rebind import (
+    MINIMUM_SETTINGS_REBIND_RUNTIME,
+    MINIMUM_SETTINGS_REBIND_RUNTIME_KEY,
+    SettingsRebindRecord,
+    provisional_binding_id,
+)
 
 if TYPE_CHECKING:
     from app.instance.runtime import InstanceRegistryRuntime
@@ -387,6 +393,158 @@ class VaultRegistryStore:
             if not self.path.exists():
                 return self._restore_or_initialize_missing_locked()
             return self._read_current_locked(recover=True)
+
+    def install_settings_rebind_dormant(
+        self,
+        *,
+        binding_id: str | None = None,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Install the complete dormant record and its runtime floor atomically."""
+
+        _require_storage_mutation_capability(_capability)
+        requested_binding = _optional_str(binding_id)
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = (
+                self._read_current_locked(recover=True)
+                if self.path.exists()
+                else self._restore_or_initialize_missing_locked()
+            )
+            floors = current.extensions.get("runtimeFloors") or {}
+            if not isinstance(floors, dict):
+                raise RegistryError("runtime floors are invalid")
+            existing_floor = _optional_str(
+                floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+            )
+            if existing_floor is not None:
+                if existing_floor != MINIMUM_SETTINGS_REBIND_RUNTIME:
+                    raise RegistryError("settings rebind runtime floor is incompatible")
+                installed = SettingsRebindRecord.from_payload(current.settings_rebind)
+                if requested_binding is not None and requested_binding not in {
+                    installed.prior_binding_id,
+                    installed.candidate_binding_id,
+                }:
+                    raise RegistryError(
+                        "installed settings rebind record does not match the requested binding"
+                    )
+                return current
+
+            provisional_binding: str | None = None
+            if current.settings_rebind is not None:
+                provisional_binding = provisional_binding_id(current.settings_rebind)
+            if (
+                requested_binding is not None
+                and provisional_binding is not None
+                and requested_binding != provisional_binding
+            ):
+                raise RegistryError("settings rebind provisional binding cannot be replaced")
+            selected_binding = (
+                provisional_binding
+                or requested_binding
+                or current.default_vault_binding_id
+            )
+            self._validate_settings_rebind_binding(current, selected_binding)
+            record = SettingsRebindRecord.dormant(
+                binding_id=selected_binding
+            ).as_payload()
+            extensions = copy.deepcopy(current.extensions)
+            next_floors = copy.deepcopy(floors)
+            next_floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = (
+                MINIMUM_SETTINGS_REBIND_RUNTIME
+            )
+            extensions["runtimeFloors"] = next_floors
+            next_revision = current.revision + 1
+            if current.authority == REGISTRY_AUTHORITY_ACTIVE:
+                scalar_floor = extensions.get("scalarRollback")
+                if not isinstance(scalar_floor, dict):
+                    raise RegistryError("active registry scalar rollback floor is invalid")
+                extensions["scalarRollback"] = {
+                    **scalar_floor,
+                    "forkRegistryRevision": next_revision,
+                }
+            updated = replace(
+                current,
+                revision=next_revision,
+                settings_rebind=record,
+                extensions=extensions,
+            )
+            self._write_locked(updated)
+            return updated
+
+    def set_settings_rebind_state(
+        self,
+        payload: Mapping[str, object],
+        *,
+        expected_revision: int | None = None,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Commit one checksum-valid monotonic rebind state generation."""
+
+        _require_storage_mutation_capability(_capability)
+        requested = SettingsRebindRecord.from_payload(dict(payload))
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            self._assert_revision(current, expected_revision)
+            floors = current.extensions.get("runtimeFloors") or {}
+            if (
+                not isinstance(floors, dict)
+                or floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+                != MINIMUM_SETTINGS_REBIND_RUNTIME
+            ):
+                raise RegistryError("settings rebind runtime floor is not installed")
+            existing = SettingsRebindRecord.from_payload(current.settings_rebind)
+            if (
+                requested.desired_revision < existing.desired_revision
+                or requested.applied_revision < existing.applied_revision
+            ):
+                raise RegistryError("settings rebind revisions must be monotonic")
+            if (
+                requested.desired_revision == existing.desired_revision
+                and requested.applied_revision == existing.applied_revision
+                and requested != existing
+            ):
+                raise RegistryError(
+                    "settings rebind state cannot change without a revision advance"
+                )
+            if requested == existing:
+                return current
+            self._validate_settings_rebind_binding(current, requested.prior_binding_id)
+            self._validate_settings_rebind_binding(
+                current, requested.candidate_binding_id
+            )
+            next_revision = current.revision + 1
+            extensions = copy.deepcopy(current.extensions)
+            if current.authority == REGISTRY_AUTHORITY_ACTIVE:
+                scalar_floor = extensions.get("scalarRollback")
+                if not isinstance(scalar_floor, dict):
+                    raise RegistryError("active registry scalar rollback floor is invalid")
+                extensions["scalarRollback"] = {
+                    **scalar_floor,
+                    "forkRegistryRevision": next_revision,
+                }
+            updated = replace(
+                current,
+                revision=next_revision,
+                settings_rebind=requested.as_payload(),
+                extensions=extensions,
+            )
+            self._write_locked(updated)
+            return updated
+
+    @staticmethod
+    def _validate_settings_rebind_binding(
+        snapshot: RegistrySnapshot,
+        binding_id: str | None,
+    ) -> None:
+        if binding_id is None:
+            return
+        if (
+            binding_id not in snapshot.registrations
+            and binding_id not in snapshot.removal_tombstones
+        ):
+            raise RegistryError("settings rebind record names an unknown binding")
 
     def require_no_scalar_rollback_session(self) -> None:
         """Fail current-runtime startup while an authenticated old image is live."""
@@ -954,11 +1112,32 @@ class VaultRegistryStore:
         current = self.load()
         self._assert_revision(current, expected_revision)
         extensions = copy.deepcopy(current.extensions)
+        next_runtime_floors = copy.deepcopy(dict(runtime_floors))
+        current_runtime_floors = current.extensions.get("runtimeFloors") or {}
+        if not isinstance(current_runtime_floors, dict):
+            raise RegistryError("runtime floors are invalid")
+        current_rebind_floor = current_runtime_floors.get(
+            MINIMUM_SETTINGS_REBIND_RUNTIME_KEY
+        )
+        incoming_rebind_floor = next_runtime_floors.get(
+            MINIMUM_SETTINGS_REBIND_RUNTIME_KEY
+        )
+        if current_rebind_floor is not None:
+            if (
+                incoming_rebind_floor is not None
+                and incoming_rebind_floor != current_rebind_floor
+            ):
+                raise RegistryError(
+                    "settings rebind runtime floor cannot be changed by a legacy extension writer"
+                )
+            next_runtime_floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = (
+                current_rebind_floor
+            )
         extensions.update(
             {
                 "principalState": copy.deepcopy(dict(principal_state)),
                 "backgroundState": copy.deepcopy(dict(background_state)),
-                "runtimeFloors": copy.deepcopy(dict(runtime_floors)),
+                "runtimeFloors": next_runtime_floors,
             }
         )
         return self.commit_state(
@@ -1871,6 +2050,39 @@ class VaultRegistryStore:
         settings_rebind = frontmatter.get("settingsRebind")
         if settings_rebind is not None and not isinstance(settings_rebind, dict):
             raise RegistryError("settingsRebind must be a mapping")
+        runtime_floors = extensions.get("runtimeFloors") or {}
+        if not isinstance(runtime_floors, dict):
+            raise RegistryError("runtime floors are invalid")
+        settings_floor = _optional_str(
+            runtime_floors.get(MINIMUM_SETTINGS_REBIND_RUNTIME_KEY)
+        )
+        if settings_floor is None:
+            if settings_rebind is not None:
+                if "schemaRevision" in settings_rebind:
+                    SettingsRebindRecord.from_payload(settings_rebind)
+                    raise RegistryError(
+                        "settings rebind record requires its runtime floor; "
+                        "settings rebind runtime floor must precede the record"
+                    )
+                provisional_binding_id(settings_rebind)
+        else:
+            if settings_floor != MINIMUM_SETTINGS_REBIND_RUNTIME:
+                raise RegistryError("settings rebind runtime floor is incompatible")
+            if settings_rebind is None or "schemaRevision" not in settings_rebind:
+                raise RegistryError(
+                    "settings rebind runtime floor requires its dormant record"
+                )
+            parsed_rebind = SettingsRebindRecord.from_payload(settings_rebind)
+            for rebind_binding_id in (
+                parsed_rebind.prior_binding_id,
+                parsed_rebind.candidate_binding_id,
+            ):
+                if (
+                    rebind_binding_id is not None
+                    and rebind_binding_id not in registrations
+                    and rebind_binding_id not in removal_tombstones
+                ):
+                    raise RegistryError("settings rebind record names an unknown binding")
         default_binding_id, default_provenance = _read_default_from_frontmatter(
             frontmatter, registrations, extensions
         )
@@ -1994,6 +2206,36 @@ class VaultRegistryStore:
             default_provenance = (
                 DEFAULT_PROVENANCE_LEGACY_MIGRATION if default_binding_id else None
             )
+        migrated_rebind: dict[str, Any] | None = None
+        if rewritten_rebind is not None:
+            # The legacy payload carried stable binding identity but no
+            # checksum/revision contract. Convert it during the same one-time
+            # schema migration transaction; never publish a provisional v1
+            # record without its compatibility floor.
+            try:
+                migrated_binding_id = provisional_binding_id(rewritten_rebind)
+            except RegistryError as exc:
+                raise RegistryMigrationError(str(exc)) from exc
+            migrated_rebind = SettingsRebindRecord.dormant(
+                binding_id=migrated_binding_id
+            ).as_payload()
+            runtime_floors = copy.deepcopy(extensions.get("runtimeFloors") or {})
+            if not isinstance(runtime_floors, dict):
+                raise RegistryMigrationError("legacy runtime floors must be a mapping")
+            existing_rebind_floor = runtime_floors.get(
+                MINIMUM_SETTINGS_REBIND_RUNTIME_KEY
+            )
+            if existing_rebind_floor not in (
+                None,
+                MINIMUM_SETTINGS_REBIND_RUNTIME,
+            ):
+                raise RegistryMigrationError(
+                    "legacy settings rebind runtime floor is incompatible"
+                )
+            runtime_floors[MINIMUM_SETTINGS_REBIND_RUNTIME_KEY] = (
+                MINIMUM_SETTINGS_REBIND_RUNTIME
+            )
+            extensions["runtimeFloors"] = runtime_floors
         # No separate "migration applied" marker: this branch runs only for an
         # `APP_LOCAL_SCHEMA` document, and the schema transition it performs is
         # itself the once-only guarantee. `default_vault_provenance` already
@@ -2005,7 +2247,7 @@ class VaultRegistryStore:
             app_install_id=app_install_id,
             last_active_vault_ref=last_active_vault_ref,
             registrations=registrations,
-            settings_rebind=rewritten_rebind,
+            settings_rebind=migrated_rebind,
             extensions=extensions,
             default_vault_binding_id=default_binding_id,
             default_vault_provenance=default_provenance,

--- a/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
+++ b/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
@@ -105,23 +105,23 @@ deliveries precisely because production initiation stays fail-closed until C.
 
 ## Acceptance Criteria
 
-- [ ] **SETTINGS-05A:** API and watcher startup use the production protected-store resolver to read
+- [x] **SETTINGS-05A:** API and watcher startup use the production protected-store resolver to read
       the same complete `settings_rebind.v1` revision; atomic write/restart preserves stable binding
       IDs, monotonic desired/applied revisions, phase, lifecycle posture, and checksum.
   - Verify: `tests/integration/test_settings_rebind_record.py::test_api_and_watcher_startup_share_one_dormant_rebind_revision`
-- [ ] **SETTINGS-05A:** Interrupted record writes and every persisted phase recover through the
+- [x] **SETTINGS-05A:** Interrupted record writes and every persisted phase recover through the
       production store/startup path to the last complete revision, never a guessed binding or partial
       record; invalid checksum/revision fails before watcher root resolution.
   - Verify: `tests/integration/test_settings_rebind_record.py::test_production_startup_recovers_every_dormant_record_phase_fail_closed`
-- [ ] **SETTINGS-05A:** Init/bootstrap, migration, no-lifecycle setup, and runtime fixtures produce the
+- [x] **SETTINGS-05A:** Init/bootstrap, migration, no-lifecycle setup, and runtime fixtures produce the
       same current schema, while production picker/API and direct initiation calls remain sealed and
       cannot change selection or watcher behavior before SETTINGS-05C.
   - Verify: `tests/architecture/test_settings_rebind_producers.py::test_all_producers_match_production_rebind_schema_and_activation_seal`
-- [ ] **SETTINGS-05A:** The rollout records `minimum_settings_rebind_runtime=1` before the first
+- [x] **SETTINGS-05A:** The rollout records `minimum_settings_rebind_runtime=1` before the first
       authoritative v1 record; host-side and process startup guards reject incompatible API/watcher
       capability before protected-state access or root resolution.
   - Verify: `tests/ops/test_settings_rebind_runtime_floor.py::test_rebind_floor_blocks_incompatible_api_and_watcher_before_start`
-- [ ] **SETTINGS-05A:** Every CLI, bootstrap/reconciliation, compiler/delta, fixture, and direct
+- [x] **SETTINGS-05A:** Every CLI, bootstrap/reconciliation, compiler/delta, fixture, and direct
       store/manager producer is migrated in the same slice and fails before protected-state mutation
       when it cannot preserve the v1 floor and revision.
   - Verify: `tests/ops/test_settings_rebind_runtime_floor.py::test_rebind_floor_blocks_every_legacy_writer_after_cutover`

--- a/importlinter.ini
+++ b/importlinter.ini
@@ -170,5 +170,6 @@ allowed_importers =
     app.instance.ownership_ledger
     app.instance.runtime
     app.instance.scalar_binding_runtime
+    app.instance.settings_rebind
     app.instance.vault_registry
 as_packages = False

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -211,10 +211,178 @@ acquire_channel_mutation_lock
 current_sha="$(read_pin "${pin_file}" 2>/dev/null || true)"
 target_sha="$(resolve_target_sha "${target_sha}")"
 scalar_rollback=0
-if [ "${action}" = "rollback" ] && \
-  ! git -C "${ROOT}" cat-file -e "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null; then
-  scalar_rollback=1
-fi
+
+target_attests_settings_rebind_runtime() {
+  local sha="${1:?sha required}"
+  local capability_payload=""
+  capability_payload="$(
+    git -C "${ROOT}" show \
+      "${sha}:app/instance/settings_rebind_runtime_capability.json" 2>/dev/null
+  )" || return 1
+  SETTINGS_REBIND_CAPABILITY_PAYLOAD="${capability_payload}" "${PYTHON}" - <<'PY'
+import json
+import os
+
+value = json.loads(os.environ["SETTINGS_REBIND_CAPABILITY_PAYLOAD"])
+expected = {
+    "schema": "agentic-pkm.runtime-capability-attestation.v1",
+    "capability": "settings-rebind-runtime-floor",
+    "revision": 1,
+    "preserves": [
+        "settings_rebind.v1",
+        "minimum_settings_rebind_runtime=1",
+    ],
+    "rollbackPosture": "reject-incompatible-writer",
+}
+if value != expected:
+    raise SystemExit("settings rebind runtime capability attestation is invalid")
+PY
+}
+
+settings_rebind_floor_capability_state() {
+  local sha="${1:?sha required}"
+  local inspection_rc=0 runtime_payload="" tree_paths=""
+  local has_module=0 has_runtime=0 path=""
+  # This is deliberately broader than the exact compatibility attestation.
+  # Historical SETTINGS-05A candidates could commit the durable floor before
+  # the attestation file existed, and abandoned module-only candidates are
+  # likewise ambiguous after host-receipt loss. Either runtime surface means
+  # absence cannot prove the channel is still pre-floor. A successful tree
+  # inspection is required to prove absence; transport/object/read failures
+  # are an unknown state, never a pre-floor result.
+  if tree_paths="$(
+    git -C "${ROOT}" ls-tree -r --name-only "${sha}" -- \
+      app/instance/settings_rebind.py app/instance/runtime.py 2>/dev/null
+  )"; then
+    :
+  else
+    inspection_rc=$?
+    return "${inspection_rc}"
+  fi
+  while IFS= read -r path; do
+    case "${path}" in
+      app/instance/settings_rebind.py) has_module=1 ;;
+      app/instance/runtime.py) has_runtime=1 ;;
+    esac
+  done <<< "${tree_paths}"
+  if [ "${has_module}" = "1" ]; then
+    printf '%s\n' floor-capable
+    return 0
+  fi
+  if [ "${has_runtime}" = "1" ]; then
+    if runtime_payload="$(
+      git -C "${ROOT}" show "${sha}:app/instance/runtime.py" 2>/dev/null
+    )"; then
+      :
+    else
+      inspection_rc=$?
+      return "${inspection_rc}"
+    fi
+    case "${runtime_payload}" in
+      *settings-rebind-install-dormant*)
+        printf '%s\n' floor-capable
+        return 0
+        ;;
+    esac
+  fi
+  printf '%s\n' pre-floor
+}
+
+read_settings_rebind_floor_phase() {
+  local receipt_path
+  receipt_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+  [ -e "${receipt_path}" ] || return 1
+  "${PYTHON}" - "${receipt_path}" "${channel}" <<'PY'
+import json
+import os
+import stat
+import sys
+
+path, channel = sys.argv[1:]
+metadata = os.lstat(path)
+if (
+    not stat.S_ISREG(metadata.st_mode)
+    or metadata.st_uid != os.geteuid()
+    or stat.S_IMODE(metadata.st_mode) != 0o600
+):
+    raise SystemExit("settings rebind runtime floor receipt is not private")
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+expected = {
+    "schema",
+    "channel",
+    "phase",
+    "minimum_settings_rebind_runtime",
+}
+if (
+    not isinstance(value, dict)
+    or set(value) != expected
+    or value.get("schema") != "agentic-pkm.settings-rebind-runtime-floor.v1"
+    or value.get("channel") != channel
+    or value.get("phase") not in {"pending", "installed"}
+    or value.get("minimum_settings_rebind_runtime") != "1"
+):
+    raise SystemExit("settings rebind runtime floor receipt is invalid")
+print(value["phase"])
+PY
+}
+
+classify_rollback_runtime() {
+  local floor_phase=""
+  local receipt_path=""
+  local current_floor_state="pre-floor" inspection_rc=0 target_floor_state=""
+  [ "${action}" = "rollback" ] || return 0
+  receipt_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+  if [ -e "${receipt_path}" ]; then
+    floor_phase="$(read_settings_rebind_floor_phase)" || return $?
+  fi
+  if target_attests_settings_rebind_runtime "${target_sha}"; then
+    return 0
+  fi
+  if [ -n "${floor_phase}" ]; then
+    if [ "${floor_phase}" = "pending" ]; then
+      echo "rollback blocked: settings rebind floor installation is pending; use a compatible roll-forward image" >&2
+      return 78
+    fi
+    scalar_rollback=1
+    return 0
+  fi
+  # Any current or target image with the module/installer may already have
+  # committed the registry floor, including historical images from before the
+  # exact compatibility attestation existed. Losing its host receipt cannot
+  # authorize an older writer: absence is ambiguous, not proof of pre-floor
+  # state. The MVR-05 compatibility fallback below is reserved for channels
+  # whose current and target images demonstrably both predate SETTINGS-05A.
+  if target_floor_state="$(
+    settings_rebind_floor_capability_state "${target_sha}"
+  )"; then
+    :
+  else
+    inspection_rc=$?
+    echo "rollback blocked: settings rebind floor capability inspection failed for target ${target_sha}" >&2
+    return "${inspection_rc}"
+  fi
+  if [ -n "${current_sha}" ]; then
+    if current_floor_state="$(
+      settings_rebind_floor_capability_state "${current_sha}"
+    )"; then
+      :
+    else
+      inspection_rc=$?
+      echo "rollback blocked: settings rebind floor capability inspection failed for current ${current_sha}" >&2
+      return "${inspection_rc}"
+    fi
+  fi
+  if [ "${target_floor_state}" = "floor-capable" ] || \
+    [ "${current_floor_state}" = "floor-capable" ]; then
+    echo "rollback blocked: settings rebind runtime floor receipt is absent for an incompatible target; use a compatible roll-forward image" >&2
+    return 78
+  fi
+  if ! git -C "${ROOT}" cat-file -e \
+    "${target_sha}:app/instance/mvr05_cutover.py" 2>/dev/null; then
+    scalar_rollback=1
+  fi
+}
 
 prepare_scalar_rollback_environment() {
   if [ -z "${current_sha}" ]; then
@@ -675,6 +843,7 @@ apply_changed_migrations() {
 
 rollback_failed_startup() {
   local reason="$1" original_status="$2" forward_only_count="0"
+  local current_floor_state="" inspection_rc=0 target_floor_state=""
   if [ "${scalar_rollback}" = "1" ]; then
     echo "${reason} (status ${original_status}); retaining the current guard pin and scalar rollback target for a fail-closed retry" >&2
     return 0
@@ -697,6 +866,44 @@ rollback_failed_startup() {
       echo "${reason} (status ${original_status}); forward-only migration execution started and its commit state is ambiguous; the target pin is retained until unchanged database revision is proven or a compatible forward fix is applied" >&2
     fi
     return 0
+  fi
+  if [ -n "${current_sha}" ] && \
+    ! target_attests_settings_rebind_runtime "${current_sha}"; then
+    local settings_rebind_floor_phase="" settings_rebind_receipt_path=""
+    if current_floor_state="$(
+      settings_rebind_floor_capability_state "${current_sha}"
+    )"; then
+      :
+    else
+      inspection_rc=$?
+      echo "${reason} (status ${original_status}); settings rebind floor capability inspection failed for the previous pin (status ${inspection_rc}), retaining the target pin" >&2
+      return 0
+    fi
+    if target_floor_state="$(
+      settings_rebind_floor_capability_state "${target_sha}"
+    )"; then
+      :
+    else
+      inspection_rc=$?
+      echo "${reason} (status ${original_status}); settings rebind floor capability inspection failed for the target (status ${inspection_rc}), retaining the target pin" >&2
+      return 0
+    fi
+    if [ "${current_floor_state}" = "pre-floor" ] && \
+      [ "${target_floor_state}" = "pre-floor" ]; then
+      :
+    else
+      settings_rebind_receipt_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+      if [ ! -e "${settings_rebind_receipt_path}" ]; then
+        echo "${reason} (status ${original_status}); settings rebind floor receipt is absent, retaining the compatible target pin instead of restarting an older writer" >&2
+        return 0
+      fi
+      settings_rebind_floor_phase="$(read_settings_rebind_floor_phase)" || {
+        echo "${reason} (status ${original_status}); settings rebind floor receipt is invalid, retaining the compatible target pin" >&2
+        return 0
+      }
+      echo "${reason} (status ${original_status}); settings rebind floor is ${settings_rebind_floor_phase}, retaining the compatible target pin instead of restarting an older writer" >&2
+      return 0
+    fi
   fi
   if [ -n "${current_sha}" ]; then
     echo "${reason} (status ${original_status}); attempting rollback to previous pin" >&2
@@ -1094,11 +1301,12 @@ if [ "${action}" = "deploy" ] && [ "${channel}" = "prod" ]; then
     "${ROOT}/docker-compose.prod.yml" || exit $?
 fi
 
+prepare_instance_ownership_host_state_dir
+classify_rollback_runtime || exit $?
+
 if [ "${scalar_rollback}" = "1" ]; then
   prepare_scalar_rollback_environment || exit $?
 fi
-
-prepare_instance_ownership_host_state_dir
 
 if [ "${action}" = "rollback" ]; then
   INSTANCE_STATE_LEGACY_ROLLBACK=1

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -75,6 +75,62 @@ _instance_state_deployment_host_ownership_path() {
   esac
 }
 
+_write_settings_rebind_floor_receipt() {
+  local channel="${1:?channel required}"
+  local phase="${2:?phase required}"
+  local receipt_path
+  case "${phase}" in
+    pending|installed) ;;
+    *)
+      echo "instance state deployment: invalid settings rebind floor phase" >&2
+      return 78
+      ;;
+  esac
+  receipt_path="${INSTANCE_OWNERSHIP_HOST_STATE_DIR}/settings-rebind-runtime-floor-${channel}.json"
+  python3 - "${receipt_path}" "${channel}" "${phase}" <<'PY'
+import json
+import os
+import stat
+import sys
+import tempfile
+
+path, channel, phase = sys.argv[1:]
+directory = os.path.dirname(path)
+metadata = os.lstat(directory)
+if (
+    not stat.S_ISDIR(metadata.st_mode)
+    or metadata.st_uid != os.geteuid()
+    or stat.S_IMODE(metadata.st_mode) != 0o700
+):
+    raise SystemExit("settings rebind receipt directory is not private")
+payload = {
+    "schema": "agentic-pkm.settings-rebind-runtime-floor.v1",
+    "channel": channel,
+    "phase": phase,
+    "minimum_settings_rebind_runtime": "1",
+}
+descriptor, temporary = tempfile.mkstemp(
+    prefix=os.path.basename(path) + ".tmp.", dir=directory
+)
+try:
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+    directory_fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+}
+
 # Explicit operator recovery for exactly one missing active ownership lease.
 # This is deliberately not called by deploy/start: the failed deployment must
 # already have left its host-global restart fence and proved quiescence in
@@ -400,6 +456,18 @@ prepare_instance_state_deployment() {
     return "${inventory_rc}"
   fi
 
+  # Durable host-side compatibility evidence begins before the first possible
+  # registry-floor commit. If this stopped-window attempt crashes, rollback
+  # classification must still know that an older writer cannot safely start.
+  _write_settings_rebind_floor_receipt "${channel}" pending
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
+
   # Re-read every owner/config producer after all writers are stopped and the
   # lease-bound quiescence proof is durable. Any missing or changed source
   # aborts while the durable fence remains installed; only an exact match may
@@ -564,6 +632,31 @@ prepare_instance_state_deployment() {
       --fence-plan "/app/instance-ownership/mvr05-fence-plan-${controller_pid}.json"
   inventory_rc=$?
   rm -f -- "${mvr05_fence_plan_host_path}"
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
+
+  # SETTINGS-05A uses the same proved, writer-stopped deployment window but a
+  # dedicated producer: generic deployment finalization and older test fixtures
+  # must not silently acquire this compatibility floor.
+  "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
+    python -m app.instance.runtime settings-rebind-install-dormant \
+      --channel "${channel}" \
+      --registry-path /app/instance-state/agentic-pkm/vault-registry.md \
+      --host-global-root /app/instance-ownership \
+      --quiescence-proof-path /app/instance-ownership/deployment-quiescence-proof.json
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
+  _write_settings_rebind_floor_receipt "${channel}" installed
+  inventory_rc=$?
   if [ "${inventory_rc}" -ne 0 ]; then
     _release_abandoned_instance_state_deployment_lease \
       "${compose_function}" "${channel}" "${runtime_user}" \

--- a/scripts/lib/instance_state_deployment.sh
+++ b/scripts/lib/instance_state_deployment.sh
@@ -456,18 +456,6 @@ prepare_instance_state_deployment() {
     return "${inventory_rc}"
   fi
 
-  # Durable host-side compatibility evidence begins before the first possible
-  # registry-floor commit. If this stopped-window attempt crashes, rollback
-  # classification must still know that an older writer cannot safely start.
-  _write_settings_rebind_floor_receipt "${channel}" pending
-  inventory_rc=$?
-  if [ "${inventory_rc}" -ne 0 ]; then
-    _release_abandoned_instance_state_deployment_lease \
-      "${compose_function}" "${channel}" "${runtime_user}" \
-      "${controller_pid}" "${controller_start_token}"
-    return "${inventory_rc}"
-  fi
-
   # Re-read every owner/config producer after all writers are stopped and the
   # lease-bound quiescence proof is durable. Any missing or changed source
   # aborts while the durable fence remains installed; only an exact match may
@@ -642,6 +630,18 @@ prepare_instance_state_deployment() {
   # SETTINGS-05A uses the same proved, writer-stopped deployment window but a
   # dedicated producer: generic deployment finalization and older test fixtures
   # must not silently acquire this compatibility floor.
+  # Write pending only after every caught pre-install check has succeeded and
+  # immediately before the installer may commit the floor. A crash or an
+  # ambiguous installer failure preserves pending; a proven earlier failure
+  # never creates compatibility evidence for a floor that could not exist.
+  _write_settings_rebind_floor_receipt "${channel}" pending
+  inventory_rc=$?
+  if [ "${inventory_rc}" -ne 0 ]; then
+    _release_abandoned_instance_state_deployment_lease \
+      "${compose_function}" "${channel}" "${runtime_user}" \
+      "${controller_pid}" "${controller_start_token}"
+    return "${inventory_rc}"
+  fi
   "${compose_function}" run --rm --no-deps -T --user "${runtime_user}" instance-state-init \
     python -m app.instance.runtime settings-rebind-install-dormant \
       --channel "${channel}" \

--- a/tests/architecture/test_import_boundary.py
+++ b/tests/architecture/test_import_boundary.py
@@ -308,14 +308,15 @@ def test_instance_storage_mutation_import_contract_is_complete() -> None:
     # instance-state writer must be a named, reviewed entry. MVR-03 (#3857) added
     # `local_operator_principal`; MVR-05A6 (#4580) adds the per-binding effect lease;
     # MVR-05A8 (#4582) adds the scalar compatibility resolver that assembles the
-    # ownership fence and effect lease. All write under the same boundary and take
-    # the same seal.
+    # ownership fence and effect lease. SETTINGS-05A (#4967) adds the sealed dormant
+    # record transaction. All write under the same boundary and take the same seal.
     assert _module_list(capability_section["allowed_importers"]) == {
         "app.instance.binding_effect_lease",
         "app.instance.local_operator_principal",
         "app.instance.ownership_ledger",
         "app.instance.runtime",
         "app.instance.scalar_binding_runtime",
+        "app.instance.settings_rebind",
         "app.instance.vault_registry",
     }
     runtime_module = importlib.import_module("app.instance.runtime")

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -52,7 +52,10 @@ def test_all_producers_match_production_rebind_schema_and_activation_seal(
         )
         == 0
     )
-    record = runtime.open_settings_rebind_store().read()
+    reader = runtime.open_settings_rebind_store()
+    record = reader.read()
+    assert not hasattr(reader, "install_dormant")
+    assert not hasattr(reader, "_capability")
     snapshot = runtime.registry.load()
     app_sources = _sources("app")
     script_sources = _sources("scripts")
@@ -94,6 +97,14 @@ def test_all_producers_match_production_rebind_schema_and_activation_seal(
     assert not any(
         "settings-rebind-initiate" in source for source in script_sources.values()
     )
+    assert sorted(
+        path
+        for path, source in app_sources.items()
+        if "_install_dormant_settings_rebind" in source
+    ) == [
+        "app/instance/runtime.py",
+        "app/instance/settings_rebind.py",
+    ]
 
     deployment = (REPO_ROOT / "scripts/lib/instance_state_deployment.sh").read_text(
         encoding="utf-8"

--- a/tests/architecture/test_settings_rebind_producers.py
+++ b/tests/architecture/test_settings_rebind_producers.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import app.instance.runtime as runtime_module
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _sources(root: str) -> dict[str, str]:
+    return {
+        str(path.relative_to(REPO_ROOT)): path.read_text(encoding="utf-8")
+        for path in sorted((REPO_ROOT / root).rglob("*.py"))
+    }
+
+
+def test_all_producers_match_production_rebind_schema_and_activation_seal(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    ownership_root = tmp_path / "ownership"
+    ownership_root.mkdir(mode=0o700)
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"),
+        ownership_root,
+    )
+    runtime.registry.load()
+    proof_path = ownership_root / "deployment-quiescence-proof.json"
+    proof_path.write_text(json.dumps({"nonce": "proved-test-window"}), encoding="utf-8")
+    monkeypatch.setattr(
+        runtime_module,
+        "_require_proved_deployment_lease",
+        lambda **_kwargs: None,
+    )
+    assert (
+        runtime_module.main(
+            [
+                "settings-rebind-install-dormant",
+                "--channel",
+                "test",
+                "--registry-path",
+                str(runtime.layout.registry_path),
+                "--host-global-root",
+                str(ownership_root),
+                "--quiescence-proof-path",
+                str(proof_path),
+            ]
+        )
+        == 0
+    )
+    record = runtime.open_settings_rebind_store().read()
+    snapshot = runtime.registry.load()
+    app_sources = _sources("app")
+    script_sources = _sources("scripts")
+
+    assert snapshot.settings_rebind == record.as_payload()
+    assert record.schema_revision == 1
+    assert snapshot.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
+    assert "install_settings_rebind_dormant" in app_sources[
+        "app/instance/settings_rebind.py"
+    ]
+    assert "install_dormant" in app_sources["app/instance/runtime.py"]
+    assert "settings rebind runtime floor must precede the record" in app_sources[
+        "app/instance/vault_registry.py"
+    ]
+    capability = json.loads(
+        (
+            REPO_ROOT
+            / "app/instance/settings_rebind_runtime_capability.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert capability == {
+        "schema": "agentic-pkm.runtime-capability-attestation.v1",
+        "capability": "settings-rebind-runtime-floor",
+        "revision": 1,
+        "preserves": [
+            "settings_rebind.v1",
+            "minimum_settings_rebind_runtime=1",
+        ],
+        "rollbackPosture": "reject-incompatible-writer",
+    }
+    assert not any(
+        "set_settings_rebind_state" in source or "install_dormant" in source
+        for path, source in app_sources.items()
+        if path.startswith(("app/api/", "app/watcher/"))
+    )
+    assert not any(
+        "settings-rebind-initiate" in source for source in app_sources.values()
+    )
+    assert not any(
+        "settings-rebind-initiate" in source for source in script_sources.values()
+    )
+
+    deployment = (REPO_ROOT / "scripts/lib/instance_state_deployment.sh").read_text(
+        encoding="utf-8"
+    )
+    pending = deployment.index(
+        '_write_settings_rebind_floor_receipt "${channel}" pending'
+    )
+    producer = deployment.index(
+        "python -m app.instance.runtime settings-rebind-install-dormant"
+    )
+    installed = deployment.index(
+        '_write_settings_rebind_floor_receipt "${channel}" installed'
+    )
+    finish = deployment.index("python -m app.instance.runtime deployment-finish")
+    assert pending < producer < installed < finish
+
+
+def test_provisional_migration_is_replaced_only_by_the_fenced_producer(
+    tmp_path: Path,
+) -> None:
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "state", "test"),
+        tmp_path / "ownership",
+    )
+    snapshot = runtime.registry.load()
+    frontmatter = runtime.registry._frontmatter_from_snapshot(snapshot)
+    frontmatter["settingsRebind"] = {
+        "schema": "settings_rebind.v1",
+        "prior": {"vaultBindingId": "provisional-a"},
+    }
+
+    provisional = runtime.registry._snapshot_from_frontmatter(frontmatter)
+    assert provisional.settings_rebind == frontmatter["settingsRebind"]
+    assert "minimum_settings_rebind_runtime" not in provisional.extensions.get(
+        "runtimeFloors", {}
+    )

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -20,8 +20,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _MACOS_MALLOC_STACK_LOGGING_PREFIX = "MallocStackLogging"
 _DEPLOY_READINESS_TIMEOUT_SECONDS = 30
 _DEPLOY_CLEANUP_TIMEOUT_SECONDS = 5
-_PREFLOOR_MAIN_SHA = "a5df4ffa30150ac76ac96ae9ab88c4e96ffab4d4"
-_PREATTESTATION_FLOOR_SHA = "5c30e8cb034fead9b5776a3754e7fe97778488cc"
 
 
 def _without_macos_malloc_stack_logging(
@@ -561,24 +559,17 @@ def _settings_rebind_unsafe_and_safe_heads(root: Path) -> tuple[str, str]:
     return unsafe_sha, safe_sha
 
 
-def _historical_prefloor_and_preattestation_floor_heads(
+def _prefloor_and_preattestation_floor_heads(
     root: Path,
 ) -> tuple[str, str]:
-    """Materialize the real a5df -> 5c30 runtime transition in the harness."""
-
-    def historical_blob(sha: str, path: str) -> str:
-        return subprocess.check_output(
-            ["git", "show", f"{sha}:{path}"],
-            cwd=REPO_ROOT,
-            text=True,
-        )
+    """Materialize a self-contained pre-floor -> pre-attestation transition."""
 
     runtime_path = root / "app/instance/runtime.py"
     module_path = root / "app/instance/settings_rebind.py"
     capability_path = root / "app/instance/settings_rebind_runtime_capability.json"
 
     runtime_path.write_text(
-        historical_blob(_PREFLOOR_MAIN_SHA, "app/instance/runtime.py"),
+        "# Runtime before the dormant settings-rebind installer.\n",
         encoding="utf-8",
     )
     module_path.unlink(missing_ok=True)
@@ -589,7 +580,7 @@ def _historical_prefloor_and_preattestation_floor_heads(
         check=True,
     )
     subprocess.run(
-        ["git", "commit", "-qm", f"fixture pre-floor {_PREFLOOR_MAIN_SHA[:8]}"],
+        ["git", "commit", "-qm", "fixture pre-floor runtime"],
         cwd=root,
         check=True,
     )
@@ -598,14 +589,11 @@ def _historical_prefloor_and_preattestation_floor_heads(
     ).strip()
 
     runtime_path.write_text(
-        historical_blob(_PREATTESTATION_FLOOR_SHA, "app/instance/runtime.py"),
+        "# Runtime with settings-rebind-install-dormant support.\n",
         encoding="utf-8",
     )
     module_path.write_text(
-        historical_blob(
-            _PREATTESTATION_FLOOR_SHA,
-            "app/instance/settings_rebind.py",
-        ),
+        "# Dormant settings-rebind module before capability attestation.\n",
         encoding="utf-8",
     )
     capability_path.unlink(missing_ok=True)
@@ -619,7 +607,7 @@ def _historical_prefloor_and_preattestation_floor_heads(
             "git",
             "commit",
             "-qm",
-            f"fixture pre-attestation floor {_PREATTESTATION_FLOOR_SHA[:8]}",
+            "fixture pre-attestation floor runtime",
         ],
         cwd=root,
         check=True,
@@ -740,11 +728,11 @@ def test_absent_settings_floor_receipt_blocks_module_only_predecessor(
     assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
 
 
-def test_absent_receipt_blocks_real_preattestation_floor_to_prefloor_rollback(
+def test_absent_receipt_blocks_preattestation_floor_to_prefloor_rollback(
     tmp_path: Path,
 ) -> None:
     root, env, _ = _deploy_harness(tmp_path)
-    prefloor_sha, floor_sha = _historical_prefloor_and_preattestation_floor_heads(
+    prefloor_sha, floor_sha = _prefloor_and_preattestation_floor_heads(
         root
     )
     (root / "config/deploy/dev.env").write_text(
@@ -760,11 +748,11 @@ def test_absent_receipt_blocks_real_preattestation_floor_to_prefloor_rollback(
     assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
 
 
-def test_floor_capability_inspection_failure_blocks_manual_historical_rollback(
+def test_floor_capability_inspection_failure_blocks_manual_transition_rollback(
     tmp_path: Path,
 ) -> None:
     root, env, _ = _deploy_harness(tmp_path)
-    prefloor_sha, floor_sha = _historical_prefloor_and_preattestation_floor_heads(
+    prefloor_sha, floor_sha = _prefloor_and_preattestation_floor_heads(
         root
     )
     (root / "config/deploy/dev.env").write_text(
@@ -1609,11 +1597,11 @@ def test_missing_settings_floor_receipt_never_auto_restarts_module_only_predeces
     assert strict_recreates == []
 
 
-def test_missing_receipt_never_auto_rolls_real_floor_candidate_back_to_prefloor(
+def test_missing_receipt_never_auto_rolls_floor_candidate_back_to_prefloor(
     tmp_path: Path,
 ) -> None:
     root, env, _ = _deploy_harness(tmp_path)
-    previous_sha, sha = _historical_prefloor_and_preattestation_floor_heads(root)
+    previous_sha, sha = _prefloor_and_preattestation_floor_heads(root)
     env["FAKE_SHA"] = sha
     pin_path = root / "config/deploy/dev.env"
     pin_path.write_text(
@@ -1642,11 +1630,11 @@ def test_missing_receipt_never_auto_rolls_real_floor_candidate_back_to_prefloor(
     )
 
 
-def test_floor_capability_inspection_failure_retains_historical_deploy_candidate(
+def test_floor_capability_inspection_failure_retains_deploy_candidate(
     tmp_path: Path,
 ) -> None:
     root, env, _ = _deploy_harness(tmp_path)
-    previous_sha, sha = _historical_prefloor_and_preattestation_floor_heads(root)
+    previous_sha, sha = _prefloor_and_preattestation_floor_heads(root)
     env["FAKE_SHA"] = sha
     pin_path = root / "config/deploy/dev.env"
     pin_path.write_text(

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -20,6 +20,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _MACOS_MALLOC_STACK_LOGGING_PREFIX = "MallocStackLogging"
 _DEPLOY_READINESS_TIMEOUT_SECONDS = 30
 _DEPLOY_CLEANUP_TIMEOUT_SECONDS = 5
+_PREFLOOR_MAIN_SHA = "a5df4ffa30150ac76ac96ae9ab88c4e96ffab4d4"
+_PREATTESTATION_FLOOR_SHA = "5c30e8cb034fead9b5776a3754e7fe97778488cc"
 
 
 def _without_macos_malloc_stack_logging(
@@ -335,6 +337,9 @@ case "$*" in
   *"/api/health"*) printf '{"ok":true,"required_ok":true,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}" ;;
   *"/healthz"*)
     if [ "${FAKE_API_LIVENESS:-pass}" = "fail" ]; then
+      if [ -n "${FAKE_REMOVE_SETTINGS_REBIND_RECEIPT:-}" ]; then
+        rm -f -- "${FAKE_REMOVE_SETTINGS_REBIND_RECEIPT}"
+      fi
       exit 22
     fi
     printf '{"ok":true}\\n'
@@ -507,6 +512,124 @@ def _run_rollback(
     )
 
 
+def _settings_rebind_unsafe_and_safe_heads(root: Path) -> tuple[str, str]:
+    """Create an abandoned module-only predecessor and one attested successor."""
+
+    module_path = root / "app/instance/settings_rebind.py"
+    module_path.write_text(
+        '"""Unsafe predecessor: module presence was not compatibility proof."""\n',
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", "app/instance/settings_rebind.py"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-qm", "fixture unsafe settings predecessor"],
+        cwd=root,
+        check=True,
+    )
+    unsafe_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+    shutil.copy2(REPO_ROOT / "app/instance/settings_rebind.py", module_path)
+    capability_path = root / "app/instance/settings_rebind_runtime_capability.json"
+    shutil.copy2(
+        REPO_ROOT / "app/instance/settings_rebind_runtime_capability.json",
+        capability_path,
+    )
+    subprocess.run(
+        [
+            "git",
+            "add",
+            "app/instance/settings_rebind.py",
+            "app/instance/settings_rebind_runtime_capability.json",
+        ],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-qm", "fixture attested settings runtime"],
+        cwd=root,
+        check=True,
+    )
+    safe_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    return unsafe_sha, safe_sha
+
+
+def _historical_prefloor_and_preattestation_floor_heads(
+    root: Path,
+) -> tuple[str, str]:
+    """Materialize the real a5df -> 5c30 runtime transition in the harness."""
+
+    def historical_blob(sha: str, path: str) -> str:
+        return subprocess.check_output(
+            ["git", "show", f"{sha}:{path}"],
+            cwd=REPO_ROOT,
+            text=True,
+        )
+
+    runtime_path = root / "app/instance/runtime.py"
+    module_path = root / "app/instance/settings_rebind.py"
+    capability_path = root / "app/instance/settings_rebind_runtime_capability.json"
+
+    runtime_path.write_text(
+        historical_blob(_PREFLOOR_MAIN_SHA, "app/instance/runtime.py"),
+        encoding="utf-8",
+    )
+    module_path.unlink(missing_ok=True)
+    capability_path.unlink(missing_ok=True)
+    subprocess.run(
+        ["git", "add", "-A", "app/instance"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-qm", f"fixture pre-floor {_PREFLOOR_MAIN_SHA[:8]}"],
+        cwd=root,
+        check=True,
+    )
+    prefloor_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+    runtime_path.write_text(
+        historical_blob(_PREATTESTATION_FLOOR_SHA, "app/instance/runtime.py"),
+        encoding="utf-8",
+    )
+    module_path.write_text(
+        historical_blob(
+            _PREATTESTATION_FLOOR_SHA,
+            "app/instance/settings_rebind.py",
+        ),
+        encoding="utf-8",
+    )
+    capability_path.unlink(missing_ok=True)
+    subprocess.run(
+        ["git", "add", "-A", "app/instance"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "-qm",
+            f"fixture pre-attestation floor {_PREATTESTATION_FLOOR_SHA[:8]}",
+        ],
+        cwd=root,
+        check=True,
+    )
+    floor_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    return prefloor_sha, floor_sha
+
+
 def test_archive_preflight_blocks_deploy_but_never_gates_rollback(tmp_path: Path) -> None:
     root, env, sha = _deploy_harness(tmp_path)
     pin_path = root / "config/deploy/dev.env"
@@ -525,6 +648,159 @@ def test_archive_preflight_blocks_deploy_but_never_gates_rollback(tmp_path: Path
     rollback = _run_rollback(root, env, sha)
     assert rollback.returncode == 0, rollback.stdout + rollback.stderr
     assert not any(event.startswith("archive-preflight") for event in _deploy_events(env))
+
+
+def test_pending_settings_rebind_floor_blocks_older_rollback_before_compose(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    unsafe_sha, safe_sha = _settings_rebind_unsafe_and_safe_heads(root)
+    pin_path = root / "config/deploy/dev.env"
+    pin_path.write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n" f"APP_IMAGE_TAG={safe_sha}\n",
+        encoding="utf-8",
+    )
+    ownership_root = Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+    ownership_root.mkdir(mode=0o700)
+    receipt = ownership_root / "settings-rebind-runtime-floor-dev.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-pkm.settings-rebind-runtime-floor.v1",
+                "channel": "dev",
+                "phase": "pending",
+                "minimum_settings_rebind_runtime": "1",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    receipt.chmod(0o600)
+
+    result = _run_rollback(root, env, unsafe_sha)
+
+    assert result.returncode == 78
+    assert "settings rebind floor installation is pending" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
+
+
+def test_installed_settings_floor_routes_module_only_predecessor_to_legacy_guard(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    unsafe_sha, safe_sha = _settings_rebind_unsafe_and_safe_heads(root)
+    (root / "config/deploy/dev.env").write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={safe_sha}\n",
+        encoding="utf-8",
+    )
+    ownership_root = Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+    ownership_root.mkdir(mode=0o700)
+    receipt = ownership_root / "settings-rebind-runtime-floor-dev.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "schema": "agentic-pkm.settings-rebind-runtime-floor.v1",
+                "channel": "dev",
+                "phase": "installed",
+                "minimum_settings_rebind_runtime": "1",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    receipt.chmod(0o600)
+
+    result = _run_rollback(root, env, unsafe_sha)
+
+    assert result.returncode == 78
+    assert "scalar rollback requires SCALAR_ROLLBACK_VAULT_BINDING_ID" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
+
+
+def test_absent_settings_floor_receipt_blocks_module_only_predecessor(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    unsafe_sha, safe_sha = _settings_rebind_unsafe_and_safe_heads(root)
+    (root / "config/deploy/dev.env").write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={safe_sha}\n",
+        encoding="utf-8",
+    )
+
+    result = _run_rollback(root, env, unsafe_sha)
+
+    assert result.returncode == 78
+    assert "settings rebind runtime floor receipt is absent" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
+
+
+def test_absent_receipt_blocks_real_preattestation_floor_to_prefloor_rollback(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    prefloor_sha, floor_sha = _historical_prefloor_and_preattestation_floor_heads(
+        root
+    )
+    (root / "config/deploy/dev.env").write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={floor_sha}\n",
+        encoding="utf-8",
+    )
+
+    result = _run_rollback(root, env, prefloor_sha)
+
+    assert result.returncode == 78
+    assert "settings rebind runtime floor receipt is absent" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
+
+
+def test_floor_capability_inspection_failure_blocks_manual_historical_rollback(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    prefloor_sha, floor_sha = _historical_prefloor_and_preattestation_floor_heads(
+        root
+    )
+    (root / "config/deploy/dev.env").write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={floor_sha}\n",
+        encoding="utf-8",
+    )
+    env["FAKE_GIT_FAIL_MATCH"] = f"ls-tree -r --name-only {floor_sha}"
+    env["FAKE_GIT_FAIL_RC"] = "87"
+
+    result = _run_rollback(root, env, prefloor_sha)
+
+    assert result.returncode == 87
+    assert "floor capability inspection failed for current" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
+
+
+def test_malformed_settings_rebind_floor_receipt_blocks_rollback_before_compose(
+    tmp_path: Path,
+) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    (root / "config/deploy/dev.env").write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n" f"APP_IMAGE_TAG={sha}\n",
+        encoding="utf-8",
+    )
+    ownership_root = Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+    ownership_root.mkdir(mode=0o700)
+    receipt = ownership_root / "settings-rebind-runtime-floor-dev.json"
+    receipt.write_text("{}\n", encoding="utf-8")
+    receipt.chmod(0o600)
+
+    result = _run_rollback(root, env, sha)
+
+    assert result.returncode != 0
+    assert "settings rebind runtime floor receipt is invalid" in result.stderr
+    assert not Path(env["FAKE_DEPLOY_EVENT_LOG"]).exists()
 
 
 def test_prod_archive_preflight_precedes_keychain_lookup(tmp_path: Path) -> None:
@@ -1266,11 +1542,12 @@ def test_unacknowledged_deploy_keeps_strict_compose_startup(tmp_path: Path) -> N
     assert not any("--no-deps companion-ui" in event for event in events)
 
 
-def test_acknowledged_embedding_cutover_liveness_failure_rolls_back_candidate(
+def test_acknowledged_embedding_cutover_liveness_failure_retains_floored_candidate(
     tmp_path: Path,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "1" * 40
+    root, env, _ = _deploy_harness(tmp_path)
+    previous_sha, sha = _settings_rebind_unsafe_and_safe_heads(root)
+    env["FAKE_SHA"] = sha
     pin_path = root / "config/deploy/dev.env"
     pin_path.write_text(
         "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n" f"APP_IMAGE_TAG={previous_sha}\n",
@@ -1282,13 +1559,14 @@ def test_acknowledged_embedding_cutover_liveness_failure_rolls_back_candidate(
 
     assert result.returncode == 1
     assert "service recreate/liveness gate failed" in result.stderr
-    assert f"APP_IMAGE_TAG={previous_sha}" in pin_path.read_text(encoding="utf-8")
+    assert f"APP_IMAGE_TAG={sha}" in pin_path.read_text(encoding="utf-8")
+    assert "settings rebind floor is installed" in result.stderr
     events = _deploy_events(env)
     assert any(
         event.endswith("up -d --force-recreate api worker watcher heimdal-capture-watch")
         for event in events
     )
-    assert any(
+    assert not any(
         event.endswith(
             "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"
         )
@@ -1296,11 +1574,115 @@ def test_acknowledged_embedding_cutover_liveness_failure_rolls_back_candidate(
     )
 
 
-def test_acknowledged_embedding_cutover_gateway_failure_rolls_back_candidate(
+def test_missing_settings_floor_receipt_never_auto_restarts_module_only_predecessor(
     tmp_path: Path,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "2" * 40
+    root, env, _ = _deploy_harness(tmp_path)
+    previous_sha, sha = _settings_rebind_unsafe_and_safe_heads(root)
+    env["FAKE_SHA"] = sha
+    pin_path = root / "config/deploy/dev.env"
+    pin_path.write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={previous_sha}\n",
+        encoding="utf-8",
+    )
+    receipt = (
+        Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+        / "settings-rebind-runtime-floor-dev.json"
+    )
+    env["FAKE_REMOVE_SETTINGS_REBIND_RECEIPT"] = str(receipt)
+    env["FAKE_API_LIVENESS"] = "fail"
+
+    result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
+
+    assert result.returncode == 1
+    assert not receipt.exists()
+    assert "settings rebind floor receipt is absent" in result.stderr
+    assert f"APP_IMAGE_TAG={sha}" in pin_path.read_text(encoding="utf-8")
+    strict_recreates = [
+        event
+        for event in _deploy_events(env)
+        if event.endswith(
+            "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"
+        )
+    ]
+    assert strict_recreates == []
+
+
+def test_missing_receipt_never_auto_rolls_real_floor_candidate_back_to_prefloor(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    previous_sha, sha = _historical_prefloor_and_preattestation_floor_heads(root)
+    env["FAKE_SHA"] = sha
+    pin_path = root / "config/deploy/dev.env"
+    pin_path.write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={previous_sha}\n",
+        encoding="utf-8",
+    )
+    receipt = (
+        Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+        / "settings-rebind-runtime-floor-dev.json"
+    )
+    env["FAKE_REMOVE_SETTINGS_REBIND_RECEIPT"] = str(receipt)
+    env["FAKE_API_LIVENESS"] = "fail"
+
+    result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
+
+    assert result.returncode == 1
+    assert not receipt.exists()
+    assert "settings rebind floor receipt is absent" in result.stderr
+    assert f"APP_IMAGE_TAG={sha}" in pin_path.read_text(encoding="utf-8")
+    assert not any(
+        event.endswith(
+            "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"
+        )
+        for event in _deploy_events(env)
+    )
+
+
+def test_floor_capability_inspection_failure_retains_historical_deploy_candidate(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    previous_sha, sha = _historical_prefloor_and_preattestation_floor_heads(root)
+    env["FAKE_SHA"] = sha
+    pin_path = root / "config/deploy/dev.env"
+    pin_path.write_text(
+        "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n"
+        f"APP_IMAGE_TAG={previous_sha}\n",
+        encoding="utf-8",
+    )
+    receipt = (
+        Path(env["INSTANCE_OWNERSHIP_HOST_STATE_DIR"])
+        / "settings-rebind-runtime-floor-dev.json"
+    )
+    env["FAKE_REMOVE_SETTINGS_REBIND_RECEIPT"] = str(receipt)
+    env["FAKE_API_LIVENESS"] = "fail"
+    env["FAKE_GIT_FAIL_MATCH"] = f"ls-tree -r --name-only {sha}"
+    env["FAKE_GIT_FAIL_RC"] = "87"
+
+    result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
+
+    assert result.returncode == 1
+    assert not receipt.exists()
+    assert "floor capability inspection failed for the target (status 87)" in result.stderr
+    assert f"APP_IMAGE_TAG={sha}" in pin_path.read_text(encoding="utf-8")
+    assert not any(
+        event.endswith(
+            "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"
+        )
+        for event in _deploy_events(env)
+    )
+
+
+def test_acknowledged_embedding_cutover_gateway_failure_retains_floored_candidate(
+    tmp_path: Path,
+) -> None:
+    root, env, _ = _deploy_harness(tmp_path)
+    previous_sha, sha = _settings_rebind_unsafe_and_safe_heads(root)
+    env["FAKE_SHA"] = sha
     pin_path = root / "config/deploy/dev.env"
     pin_path.write_text(
         "APP_IMAGE_REPOSITORY=example.invalid/pkm-app\n" f"APP_IMAGE_TAG={previous_sha}\n",
@@ -1312,10 +1694,11 @@ def test_acknowledged_embedding_cutover_gateway_failure_rolls_back_candidate(
 
     assert result.returncode == 24
     assert "service recreate/liveness gate failed" in result.stderr
-    assert f"APP_IMAGE_TAG={previous_sha}" in pin_path.read_text(encoding="utf-8")
+    assert f"APP_IMAGE_TAG={sha}" in pin_path.read_text(encoding="utf-8")
+    assert "settings rebind floor is installed" in result.stderr
     events = _deploy_events(env)
     assert any("--no-deps companion-ui" in event for event in events)
-    assert any(
+    assert not any(
         event.endswith(
             "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"
         )

--- a/tests/deploy/test_deploy_channel_compose_stdin.py
+++ b/tests/deploy/test_deploy_channel_compose_stdin.py
@@ -163,7 +163,7 @@ def _fake_compose_harness(tmp_path: Path, extra_env: dict[str, str]) -> tuple[su
     _install_writer_inventory_fixture(fake_bin, event_log)
 
     ownership_root = tmp_path / "instance-ownership"
-    ownership_root.mkdir()
+    ownership_root.mkdir(mode=0o700)
 
     harness = tmp_path / "harness.sh"
     _write_executable(
@@ -268,7 +268,7 @@ def test_producer_fails_closed_on_empty_inventory(tmp_path: Path) -> None:
         quiescence_inventory_content="",
     )
     ownership_root_empty = tmp_path_empty / "instance-ownership"
-    ownership_root_empty.mkdir()
+    ownership_root_empty.mkdir(mode=0o700)
     harness = tmp_path_empty / "harness.sh"
     _write_executable(
         harness,

--- a/tests/deploy/test_deploy_channel_compose_stdin.py
+++ b/tests/deploy/test_deploy_channel_compose_stdin.py
@@ -13,13 +13,13 @@ These tests exercise the fix at both levels named in the issue:
 - `deploy_channel_compose` itself must not consume a caller's stdin for its
   own override document (test 1).
 - The real deployment producer, `prepare_instance_state_deployment`, must
-  deliver non-empty, privately-owned inventories to their consumer paths
-  (tests 2-4), and must still fail closed when a source inventory is empty
-  or missing (test 5).
+  deliver non-empty, privately-owned inventories, fail closed on invalid
+  sources, and keep SETTINGS floor evidence aligned with installer ambiguity.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import stat
@@ -133,6 +133,7 @@ def _install_writer_inventory_fixture(
         "      done\n"
         "      exit 2 ;;\n"
         "    *' validate-legacy-owners '*)\n"
+        '      if [ "${FAIL_VALIDATE_LEGACY_OWNERS:-0}" = 1 ]; then exit 73; fi\n'
         '      while [ "$#" -gt 0 ]; do\n'
         '        if [ "$1" = --output ]; then '
         f"printf '{owner_inventory_content}' > \"$2\"; exit 0; fi\n"
@@ -176,6 +177,7 @@ def _fake_compose_harness(tmp_path: Path, extra_env: dict[str, str]) -> tuple[su
         "  if [ \"${1:-}\" = config ] && [ -n \"${DEPLOY_COMPOSE_FENCE_CONFIG_OUTPUT:-}\" ]; then\n"
         "    printf '%s\\n' 'services: {api: {depends_on: [db], labels: {com.agentic-pkm.mvr05.db-role: client}}, db: {labels: {com.agentic-pkm.mvr05.db-role: server}}, instance-state-init: {labels: {com.agentic-pkm.mvr05.db-role: fence-controller}}, migrate: {command: [/app/scripts/run_migrations.sh], depends_on: [db], labels: {com.agentic-pkm.mvr05.db-role: migration-runner}}}' > \"$DEPLOY_COMPOSE_FENCE_CONFIG_OUTPUT\"\n"
         "  fi\n"
+        "  if [[ \" $* \" == *' settings-rebind-install-dormant '* ]] && [ \"${FAIL_SETTINGS_REBIND_INSTALL:-0}\" = 1 ]; then return 74; fi\n"
         "  return 0\n"
         "}\n"
         "prepare_instance_state_deployment fake_compose prod\n",
@@ -225,6 +227,37 @@ def test_producer_delivers_owner_inventory_with_content(tmp_path: Path) -> None:
     content = delivered.read_text(encoding="utf-8")
     assert content.strip() != ""
     assert "legacy-owner" in content
+
+
+def test_preinstall_validation_failure_never_creates_settings_floor_receipt(
+    tmp_path: Path,
+) -> None:
+    result, ownership_root = _fake_compose_harness(
+        tmp_path,
+        {"FAIL_VALIDATE_LEGACY_OWNERS": "1"},
+    )
+
+    assert result.returncode == 73
+    assert not (
+        ownership_root / "settings-rebind-runtime-floor-prod.json"
+    ).exists()
+
+
+def test_ambiguous_settings_installer_failure_preserves_pending_receipt(
+    tmp_path: Path,
+) -> None:
+    result, ownership_root = _fake_compose_harness(
+        tmp_path,
+        {"FAIL_SETTINGS_REBIND_INSTALL": "1"},
+    )
+
+    assert result.returncode == 74
+    receipt = json.loads(
+        (
+            ownership_root / "settings-rebind-runtime-floor-prod.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert receipt["phase"] == "pending"
 
 
 def test_delivered_inventories_are_private(tmp_path: Path) -> None:

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -589,6 +589,19 @@ def _seed_previous_pin(root: Path, previous_sha: str, *, channel: str = "dev") -
     return pin_path
 
 
+def _commit_prefloor_successor(root: Path, label: str) -> str:
+    """Create a readable second pre-SETTINGS-05A ref for rollback fixtures."""
+
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-qm", f"fixture {label}"],
+        cwd=root,
+        check=True,
+    )
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
 def _run_rollback(
     root: Path, env: dict[str, str], sha: str, *, channel: str = "dev"
 ) -> subprocess.CompletedProcess[str]:
@@ -605,8 +618,9 @@ def _run_rollback(
 def test_postdeploy_smoke_failure_rolls_back_previous_pin_and_services(
     tmp_path: Path,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "1" * 40
+    root, env, previous_sha = _deploy_harness(tmp_path)
+    sha = _commit_prefloor_successor(root, "postdeploy-smoke target")
+    env["FAKE_SHA"] = sha
     pin_path = _seed_previous_pin(root, previous_sha)
     env["FAKE_POSTDEPLOY_SMOKE"] = "fail"
     env["FAKE_POSTDEPLOY_SMOKE_RC"] = "73"
@@ -686,8 +700,9 @@ def test_every_postmutation_gate_has_fail_closed_terminal_handling(
     diagnostic: str,
     expected_recreate_attempts: int,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "2" * 40
+    root, env, previous_sha = _deploy_harness(tmp_path)
+    sha = _commit_prefloor_successor(root, "postmutation-gate target")
+    env["FAKE_SHA"] = sha
     pin_path = _seed_previous_pin(root, previous_sha)
     env[failure_env] = failure_value
 
@@ -706,8 +721,7 @@ def test_every_postmutation_gate_has_fail_closed_terminal_handling(
 def test_failed_postmutation_gate_preserves_forward_only_rollback_limitations(
     tmp_path: Path,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "3" * 40
+    root, env, previous_sha = _deploy_harness(tmp_path)
     pin_path = _seed_previous_pin(root, previous_sha)
     migration = root / "app/alembic/versions/999_forward_only.py"
     migration.write_text('reversibility = "forward-only"\n', encoding="utf-8")
@@ -730,7 +744,7 @@ def test_failed_manual_rollback_retains_the_known_good_rollback_target(
     tmp_path: Path,
 ) -> None:
     root, env, rollback_sha = _deploy_harness(tmp_path)
-    pre_rollback_sha = "4" * 40
+    pre_rollback_sha = _commit_prefloor_successor(root, "pre-manual-rollback pin")
     pin_path = _seed_previous_pin(root, pre_rollback_sha)
     env["FAKE_POSTDEPLOY_SMOKE"] = "fail"
 
@@ -747,7 +761,7 @@ def test_failed_manual_rollback_retains_the_known_good_rollback_target(
 
 def test_manual_rollback_never_runs_target_forward_migration_authority(tmp_path: Path) -> None:
     root, env, rollback_sha = _deploy_harness(tmp_path)
-    pre_rollback_sha = "7" * 40
+    pre_rollback_sha = _commit_prefloor_successor(root, "migration-free rollback pin")
     pin_path = _seed_previous_pin(root, pre_rollback_sha)
     migration = root / "app/alembic/versions/reversible_current_only.py"
     migration.write_text(
@@ -776,7 +790,7 @@ def test_prod_rollback_ensures_external_volume_without_instance_state_authority(
     tmp_path: Path,
 ) -> None:
     root, env, rollback_sha = _deploy_harness(tmp_path)
-    pre_rollback_sha = "8" * 40
+    pre_rollback_sha = _commit_prefloor_successor(root, "prod rollback pin")
     pin_path = _seed_previous_pin(root, pre_rollback_sha, channel="prod")
 
     result = _run_rollback(root, env, rollback_sha, channel="prod")
@@ -797,7 +811,7 @@ def test_failed_manual_rollback_before_recreate_restores_pre_rollback_state(
     tmp_path: Path,
 ) -> None:
     root, env, rollback_sha = _deploy_harness(tmp_path)
-    pre_rollback_sha = "6" * 40
+    pre_rollback_sha = _commit_prefloor_successor(root, "failed rollback pin")
     pin_path = _seed_previous_pin(root, pre_rollback_sha)
     env["FAKE_DOCKER_FAIL_MATCH"] = " pull "
 
@@ -814,8 +828,9 @@ def test_failed_manual_rollback_before_recreate_restores_pre_rollback_state(
 def test_prod_promotion_receipt_failure_does_not_publish_latest_receipt(
     tmp_path: Path,
 ) -> None:
-    root, env, sha = _deploy_harness(tmp_path)
-    previous_sha = "5" * 40
+    root, env, previous_sha = _deploy_harness(tmp_path)
+    sha = _commit_prefloor_successor(root, "prod receipt target")
+    env["FAKE_SHA"] = sha
     pin_path = _seed_previous_pin(root, previous_sha, channel="prod")
     _configure_prod_retry_preflight(root, env, tmp_path, rows=[])
     env["FAKE_PROMOTION_RECEIPT_COPY"] = "fail"

--- a/tests/instance/test_vault_registry_migration.py
+++ b/tests/instance/test_vault_registry_migration.py
@@ -235,8 +235,13 @@ def test_settings_rebind_provisional_ids_are_adopted_atomically(tmp_path) -> Non
     migrated = VaultRegistryStore(path).load_or_migrate()
     assert set(migrated.registrations) == {"provisional-a"}
     assert migrated.settings_rebind is not None
-    for key in ("prior", "candidate", "applied"):
-        assert migrated.settings_rebind[key]["vaultBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["priorBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["candidateBindingId"] == "provisional-a"
+    assert migrated.settings_rebind["phase"] == "dormant"
+    assert (
+        migrated.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"]
+        == "1"
+    )
 
     alias_path = tmp_path / "alias.md"
     _write_legacy(
@@ -260,7 +265,7 @@ def test_settings_rebind_provisional_ids_are_adopted_atomically(tmp_path) -> Non
     )
     alias_migration = VaultRegistryStore(alias_path).load_or_migrate()
     assert set(alias_migration.registrations) == {"provisional-alias"}
-    assert alias_migration.settings_rebind["candidate"]["ref"] == "alias:/vault/a"
+    assert alias_migration.settings_rebind["candidateBindingId"] == "provisional-alias"
 
     physical_alias_path = tmp_path / "physical-alias.md"
     _write_legacy(

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -7,7 +7,10 @@ import pytest
 from app.instance._storage_boundary import RegistryError
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
-from app.instance.settings_rebind import SettingsRebindRecord
+from app.instance.settings_rebind import (
+    SettingsRebindRecord,
+    _install_dormant_settings_rebind,
+)
 from app.instance.vault_registry import VaultRegistration
 from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
@@ -26,12 +29,22 @@ def _register(runtime: InstanceRegistryRuntime, binding_id: str) -> None:
     )
 
 
+def _install_dormant(
+    runtime: InstanceRegistryRuntime,
+    *,
+    binding_id: str,
+) -> SettingsRebindRecord:
+    return _install_dormant_settings_rebind(
+        runtime.registry,
+        binding_id=binding_id,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+
 def test_api_and_watcher_startup_share_one_dormant_rebind_revision(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     _register(runtime, "binding-a")
-    installed = runtime.open_settings_rebind_store().install_dormant(
-        binding_id="binding-a"
-    )
+    installed = _install_dormant(runtime, binding_id="binding-a")
 
     api_runtime = _runtime(tmp_path)
     watcher_runtime = _runtime(tmp_path)
@@ -62,8 +75,7 @@ def test_production_startup_recovers_every_dormant_record_phase_fail_closed(
 ) -> None:
     runtime = _runtime(tmp_path / phase)
     _register(runtime, "binding-a")
-    store = runtime.open_settings_rebind_store()
-    store.install_dormant(binding_id="binding-a")
+    _install_dormant(runtime, binding_id="binding-a")
     expected = SettingsRebindRecord(
         schema_revision=1,
         desired_revision=desired,
@@ -102,7 +114,7 @@ def test_delayed_writer_cannot_regress_durable_rebind_revision(tmp_path: Path) -
     runtime = _runtime(tmp_path)
     _register(runtime, "binding-a")
     store = runtime.open_settings_rebind_store()
-    store.install_dormant(binding_id="binding-a")
+    _install_dormant(runtime, binding_id="binding-a")
     committed = SettingsRebindRecord(
         schema_revision=1,
         desired_revision=1,

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.instance._storage_boundary import RegistryError
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime
+from app.instance.settings_rebind import SettingsRebindRecord
+from app.instance.vault_registry import VaultRegistration
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
+
+
+def _runtime(root: Path) -> InstanceRegistryRuntime:
+    return InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(root / "state", "test"),
+        root / "ownership",
+    )
+
+
+def _register(runtime: InstanceRegistryRuntime, binding_id: str) -> None:
+    runtime.registry.register(
+        VaultRegistration(binding_id, f"path:/{binding_id}", f"/{binding_id}"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+
+def test_api_and_watcher_startup_share_one_dormant_rebind_revision(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _register(runtime, "binding-a")
+    installed = runtime.open_settings_rebind_store().install_dormant(
+        binding_id="binding-a"
+    )
+
+    api_runtime = _runtime(tmp_path)
+    watcher_runtime = _runtime(tmp_path)
+    api_record = api_runtime.open_settings_rebind_store().read()
+    watcher_record = watcher_runtime.open_settings_rebind_store().read()
+
+    assert api_record == watcher_record == installed
+    assert api_runtime.registry.load().revision == watcher_runtime.registry.load().revision
+    assert api_record.schema_revision == 1
+    assert api_record.prior_binding_id == api_record.candidate_binding_id == "binding-a"
+
+
+@pytest.mark.parametrize(
+    ("phase", "posture", "desired", "applied"),
+    [
+        ("dormant", "dormant", 0, 0),
+        ("prepared", "watcher", 1, 0),
+        ("committed", "watcher", 1, 1),
+        ("no_lifecycle", "no_lifecycle", 1, 1),
+    ],
+)
+def test_production_startup_recovers_every_dormant_record_phase_fail_closed(
+    tmp_path: Path,
+    phase: str,
+    posture: str,
+    desired: int,
+    applied: int,
+) -> None:
+    runtime = _runtime(tmp_path / phase)
+    _register(runtime, "binding-a")
+    store = runtime.open_settings_rebind_store()
+    store.install_dormant(binding_id="binding-a")
+    expected = SettingsRebindRecord(
+        schema_revision=1,
+        desired_revision=desired,
+        applied_revision=applied,
+        phase=phase,
+        lifecycle_posture=posture,
+        prior_binding_id="binding-a",
+        candidate_binding_id="binding-a",
+    )
+    runtime.registry.set_settings_rebind_state(
+        expected.as_payload(),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    rendered = runtime.registry.path.read_text(encoding="utf-8")
+    runtime.registry.path.write_text(
+        rendered.replace(str(expected.as_payload()["checksum"]), "0" * 64),
+        encoding="utf-8",
+    )
+
+    restarted = _runtime(tmp_path / phase)
+    assert restarted.open_settings_rebind_store().read() == expected
+
+    malformed = expected.as_payload()
+    malformed["appliedRevision"] = desired + 1
+    malformed["checksum"] = "0" * 64
+    with pytest.raises(RegistryError, match="checksum|revision"):
+        runtime.registry.set_settings_rebind_state(
+            malformed,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert restarted.open_settings_rebind_store().read() == expected
+
+
+def test_delayed_writer_cannot_regress_durable_rebind_revision(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _register(runtime, "binding-a")
+    store = runtime.open_settings_rebind_store()
+    store.install_dormant(binding_id="binding-a")
+    committed = SettingsRebindRecord(
+        schema_revision=1,
+        desired_revision=1,
+        applied_revision=1,
+        phase="committed",
+        lifecycle_posture="watcher",
+        prior_binding_id="binding-a",
+        candidate_binding_id="binding-a",
+    )
+    runtime.registry.set_settings_rebind_state(
+        committed.as_payload(),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    with pytest.raises(RegistryError, match="monotonic"):
+        runtime.registry.set_settings_rebind_state(
+            SettingsRebindRecord.dormant(binding_id="binding-a").as_payload(),
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert store.read() == committed

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -2005,6 +2005,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
     python = fake_bin / "python3"
     python.write_text(
         "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = - ]; then exec "$REAL_PYTHON" "$@"; fi\n'
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
@@ -2033,8 +2034,10 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
         "      shift\n"
         "    done\n"
         "    exit 2 ;;\n"
+        "  *settings-rebind-runtime-floor-*)\n"
+        "    printf '{\"schema\":\"fixture\"}\\n' > \"$2\"; chmod 0600 \"$2\"; exit 0 ;;\n"
         "esac\n"
-        "exit 2\n",
+        'exec "$REAL_PYTHON" "$@"\n',
         encoding="utf-8",
     )
     python.chmod(0o755)
@@ -2053,7 +2056,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
     )
     harness.chmod(0o755)
     ownership_root = tmp_path / "instance-ownership"
-    ownership_root.mkdir()
+    ownership_root.mkdir(mode=0o700)
     result = subprocess.run(
         ["bash", str(harness)],
         env={
@@ -2061,6 +2064,7 @@ def test_real_deployment_wrapper_produces_owner_inventory_before_mutation_window
             "EVENT_LOG": str(event_log),
             "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
+            "REAL_PYTHON": sys.executable,
         },
         capture_output=True,
         text=True,
@@ -2091,6 +2095,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
     python = fake_bin / "python3"
     python.write_text(
         "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = - ]; then exec "$REAL_PYTHON" "$@"; fi\n'
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
@@ -2120,7 +2125,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
         "    done\n"
         "    exit 2 ;;\n"
         "esac\n"
-        "exit 2\n",
+        'exec "$REAL_PYTHON" "$@"\n',
         encoding="utf-8",
     )
     python.chmod(0o755)
@@ -2140,7 +2145,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
     harness.chmod(0o755)
     selected_root = "/srv/operator/vault"
     ownership_root = tmp_path / "instance-ownership"
-    ownership_root.mkdir()
+    ownership_root.mkdir(mode=0o700)
     result = subprocess.run(
         ["bash", str(harness)],
         env={
@@ -2150,6 +2155,7 @@ def test_real_deployment_wrapper_mounts_selected_root_at_cutover_alias(
             "MVR01C_ROLLBACK_VAULT_BINDING_ID": "binding-selected",
             "MVR01C_ROLLBACK_VAULT_ROOT": selected_root,
             "INSTANCE_OWNERSHIP_HOST_STATE_DIR": str(ownership_root),
+            "REAL_PYTHON": sys.executable,
         },
         capture_output=True,
         text=True,

--- a/tests/ops/test_mvr03_principal_cutover_wiring.py
+++ b/tests/ops/test_mvr03_principal_cutover_wiring.py
@@ -150,7 +150,7 @@ def _wrapper_run(
     python = fake_bin / "python3"
     python.write_text(
         "#!/usr/bin/env bash\n"
-        'if [ "${1:-}" = -c ]; then exec "$REAL_PYTHON" "$@"; fi\n'
+        'if [ "${1:-}" = -c ] || [ "${1:-}" = - ]; then exec "$REAL_PYTHON" "$@"; fi\n'
         'printf \'python:%s\\n\' "$*" >> "$EVENT_LOG"\n'
         'case " $* " in\n'
         "  *' produce-legacy-owners '*)\n"
@@ -177,7 +177,7 @@ def _wrapper_run(
         "      shift\n"
         "    done; exit 2 ;;\n"
         "esac\n"
-        "exit 2\n",
+        'exec "$REAL_PYTHON" "$@"\n',
         encoding="utf-8",
     )
     python.chmod(0o755)
@@ -202,7 +202,7 @@ def _wrapper_run(
     )
     harness.chmod(0o755)
     ownership_root = tmp_path / "instance-ownership"
-    ownership_root.mkdir()
+    ownership_root.mkdir(mode=0o700)
     env = {
         **os.environ,
         "EVENT_LOG": str(event_log),

--- a/tests/ops/test_settings_rebind_runtime_floor.py
+++ b/tests/ops/test_settings_rebind_runtime_floor.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from app.instance._storage_boundary import CapabilityNotReadyError, RegistryError
+from app.instance.instance_state import InstanceStateLayout
+from app.instance.runtime import InstanceRegistryRuntime, _require_runtime_floor
+from app.instance.settings_rebind import SettingsRebindRecord
+from app.instance.vault_registry import VaultRegistration
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _runtime(root: Path) -> InstanceRegistryRuntime:
+    return InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(root / "state", "test"),
+        root / "ownership",
+    )
+
+
+def test_rebind_floor_blocks_incompatible_api_and_watcher_before_start(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    snapshot = runtime.registry.load()
+    snapshot.extensions["runtimeFloors"] = {
+        "minimum_settings_rebind_runtime": "2"
+    }
+
+    with pytest.raises(CapabilityNotReadyError, match="settings rebind"):
+        _require_runtime_floor(snapshot, scalar_runtime=False)
+
+    deploy = (REPO_ROOT / "scripts/deploy_channel.sh").read_text(encoding="utf-8")
+    assert "settings-rebind-runtime-floor-${channel}.json" in deploy
+    assert "app/instance/settings_rebind_runtime_capability.json" in deploy
+
+
+def test_rebind_floor_blocks_every_legacy_writer_after_cutover(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    runtime.registry.register(
+        VaultRegistration("binding-a", "path:/binding-a", "/binding-a"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    store = runtime.open_settings_rebind_store()
+    record = store.install_dormant(binding_id="binding-a")
+
+    runtime.registry.register(
+        VaultRegistration("binding-b", "path:/binding-b", "/binding-b"),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    after = runtime.registry.load()
+    assert after.settings_rebind == record.as_payload()
+    assert after.extensions["runtimeFloors"]["minimum_settings_rebind_runtime"] == "1"
+
+    legacy_extension_write = runtime.registry.set_extension_state(
+        principal_state={},
+        background_state={},
+        runtime_floors={"minimumRuntimeSchema": "scalar"},
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    assert legacy_extension_write.settings_rebind == record.as_payload()
+    assert (
+        legacy_extension_write.extensions["runtimeFloors"]
+        ["minimum_settings_rebind_runtime"]
+        == "1"
+    )
+
+    dropped = replace(after, revision=after.revision + 1, settings_rebind=None)
+    with runtime.registry._locked():
+        with pytest.raises(RegistryError, match="requires its dormant record"):
+            runtime.registry._write_locked(dropped)
+
+    incompatible = replace(
+        after,
+        extensions={
+            **after.extensions,
+            "runtimeFloors": {"minimum_settings_rebind_runtime": "2"},
+        },
+    )
+    with pytest.raises(CapabilityNotReadyError, match="settings rebind"):
+        _require_runtime_floor(incompatible, scalar_runtime=False)
+    with pytest.raises(CapabilityNotReadyError, match="legacy scalar"):
+        _require_runtime_floor(after, scalar_runtime=True)
+
+    malformed = record.as_payload()
+    malformed["checksum"] = "0" * 64
+    with pytest.raises(RegistryError, match="checksum"):
+        runtime.registry.set_settings_rebind_state(
+            malformed,
+            _capability=STORAGE_MUTATION_CAPABILITY,
+        )
+    assert runtime.registry.load().settings_rebind == record.as_payload()
+
+
+def test_complete_record_and_floor_are_an_indivisible_registry_generation(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    snapshot = runtime.registry.load()
+    record = SettingsRebindRecord.dormant().as_payload()
+    without_floor = runtime.registry._frontmatter_from_snapshot(snapshot)
+    without_floor["settingsRebind"] = record
+    with pytest.raises(RegistryError, match="requires its runtime floor"):
+        runtime.registry._snapshot_from_frontmatter(without_floor)
+
+    floor_only = runtime.registry._frontmatter_from_snapshot(snapshot)
+    floor_only["runtimeFloors"] = {"minimum_settings_rebind_runtime": "1"}
+    with pytest.raises(RegistryError, match="requires its dormant record"):
+        runtime.registry._snapshot_from_frontmatter(floor_only)

--- a/tests/ops/test_settings_rebind_runtime_floor.py
+++ b/tests/ops/test_settings_rebind_runtime_floor.py
@@ -8,7 +8,10 @@ import pytest
 from app.instance._storage_boundary import CapabilityNotReadyError, RegistryError
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime, _require_runtime_floor
-from app.instance.settings_rebind import SettingsRebindRecord
+from app.instance.settings_rebind import (
+    SettingsRebindRecord,
+    _install_dormant_settings_rebind,
+)
 from app.instance.vault_registry import VaultRegistration
 from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
 
@@ -48,8 +51,11 @@ def test_rebind_floor_blocks_every_legacy_writer_after_cutover(
         VaultRegistration("binding-a", "path:/binding-a", "/binding-a"),
         _capability=STORAGE_MUTATION_CAPABILITY,
     )
-    store = runtime.open_settings_rebind_store()
-    record = store.install_dormant(binding_id="binding-a")
+    record = _install_dormant_settings_rebind(
+        runtime.registry,
+        binding_id="binding-a",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
 
     runtime.registry.register(
         VaultRegistration("binding-b", "path:/binding-b", "/binding-b"),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -478,15 +478,15 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2503): (
+    ("app/instance/vault_registry.py", 2745): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 "
-        "(site unchanged); re-pinned after directly related MVR-05A6 (#4580) inserted "
-        "the validated binding-effect lease producer earlier in vault_registry.py. "
-        "MVR-05A6 adds no new "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2745 "
+        "(site unchanged); re-pinned after directly related SETTINGS-05A (#4967) inserted "
+        "the durable dormant-rebind schema and producers earlier in vault_registry.py. "
+        "SETTINGS-05A adds no new "
         "write_frontmatter site: like MVR-02/MVR-04, it writes the registry through "
         "_atomic_private_write, "
         "not the vault-content seam."


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #4967

## Linked Issue
Closes #4967

## SBS Impact
- Primary subsystem: Product/Runtime System - protected instance settings spine
- Secondary subsystem(s): Release-channel rollback compatibility boundary
- Write class: Protected mechanical instance-state and host compatibility receipt
- Persistence impact: Durable versioned rebind record, last-good recovery generation, and minimum runtime floor
- Derived/rebuildable impact: Host pending/installed receipt is compatibility evidence, not product state
- New or changed contract: settings_rebind.v1 with minimum_settings_rebind_runtime=1 and exact capability attestation
- Owner-doc impact: REBIND_ON_VAULT_SELECTION owner document updated
- Transition debt impact: Dormant only; picker/API/watcher initiation remains deferred to SETTINGS-05B/05C
- Boundary risk: Older or unreadable writers fail closed; legacy fallback requires positive pre-floor proof for both refs

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add one durable checksum-valid dormant settings_rebind.v1 record and runtime floor, installed by the fenced production deployment producer.
- Recover exact last-good phases fail closed, preserve monotonic revisions across every registry writer, and block legacy writers before startup.
- Harden rollback compatibility with exact attestation plus tri-state historical floor-capability inspection, including receipt-loss and Git-inspection adversarial coverage; supersedes closed PR #4970.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Product/runtime implementation; no BuilderOps operational material was created.

## Notes
Pickup: pickup-claim-complete issue=4967 branch=codex/issue-4967-settings05a-rebuild worktree=/private/tmp/agentic-pkm-issue4967-rebuild coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-4967 lease_id=lease-e330e816 holder=codex-rebuild-issue4967 evidence=verified-dispatcher-lease. Exact-head independent review: PASS on 11ef860b804016ddbde867136342166fd387781d. Local validation: settings/migration selectors 12 passed; complete deploy surfaces 125 passed; current mechanism/import boundary selectors 14 passed; import-linter 5 contracts kept/0 broken; Ruff, mypy (932 files), bash syntax, JSON, diff check, and docs guard green. Full non-PG reviewer run on the pre-fixture head exposed 22 deterministic adjacent fixture/census failures, all repaired and revalidated; the remaining docker-not-found case was host-platform-only. Late changes: late_change_supersession_receipt.v1 prior_head=a1e8649a78e828692ca81c1fa72c01211da63bcd current_head=0f4331b90efd32745347053bdd44bcd23aedd52e authority_body=updated governing_contract=unchanged required_check_config=unchanged affected_evidence=import-contract,current-head-review reruns=lint-imports,protected-selectors,independent-review preserved_evidence=complete-deploy-surfaces,mypy,docs-guard; late_change_supersession_receipt.v1 prior_head=0f4331b90efd32745347053bdd44bcd23aedd52e current_head=ea29f1efc05ed238bf0877cd2e631c150b81043e authority_body=updated governing_contract=unchanged required_check_config=unchanged affected_evidence=hosted-non-pg-fixture,current-head-review reruns=four-ci-failed-selectors,complete-deploy-surfaces,ruff,diff-check,independent-review preserved_evidence=settings-migration-selectors,import-contract,mypy,docs-guard; late_change_supersession_receipt.v1 prior_head=ea29f1efc05ed238bf0877cd2e631c150b81043e current_head=11ef860b804016ddbde867136342166fd387781d authority_body=updated governing_contract=unchanged required_check_config=unchanged affected_evidence=public-capability-seal,pending-receipt-order,importer-census,current-head-review reruns=mechanism-selectors,import-boundary,lint-imports,ruff,bash,diff-check,independent-review preserved_evidence=complete-deploy-surfaces,settings-migration-selectors,mypy,docs-guard.
