### PR TITLE
Harden local BuilderOps WAL deployment contract

### DIFF
--- a/config/builderops/postgresql.conf
+++ b/config/builderops/postgresql.conf
@@ -17,3 +17,4 @@ max_wal_senders = 3
 # are guardrails for a rebuildable projection, not a backup/PITR claim.
 max_wal_size = '2GB'
 min_wal_size = '256MB'
+max_slot_wal_keep_size = '2GB'

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -11,6 +11,25 @@ Last verified against: `docker-compose.yaml`, `docker-compose.{dev,test,prod}.ym
 
 ## Why this document exists
 
+## BuilderOps local rebuildable deployment contract
+
+The BuilderOps control plane is a separate deployment boundary from the Product channels. Its API
+binds only to loopback; authenticated private ingress is supplied separately and does not turn the
+local port into a public endpoint. Its local PostgreSQL posture is explicitly rebuildable: archive
+mode is disabled, the archive command is empty, and the Compose project declares no recovery-egress
+network, WAL archive credential, recovery target, backup service, or recovery secret.
+
+This posture is deliberately not a backup, point-in-time recovery, or restore claim. The local WAL
+guard refuses archive drift, WAL growth above 2 GiB, and excessive data-volume use; PostgreSQL also
+pins `max_slot_wal_keep_size` to 2 GiB. The retained WAL-G/restore tooling belongs only to the
+separate independent-recovery path and must not be enabled by a local rebuildable deployment.
+
+The deployment wrapper preserves the previous source and image pins as rollback material and records
+both current and previous immutable image identities. A rollback changes the selected release but
+does not restore an older database snapshot. Setup-specific placement, qualification evidence, disk
+headroom, and Linux alert installation belong in a deployment profile such as
+`docs/deployment/profiles/TARS_PROXMOX.md`; they are not generic deployment facts.
+
 ## Current live runtime posture
 
 The intended live split is now: a dedicated Ollama host for Ollama only, and the product runtime on isolated Linux

--- a/docs/deployment/profiles/TARS_PROXMOX.md
+++ b/docs/deployment/profiles/TARS_PROXMOX.md
@@ -1,0 +1,70 @@
+---
+name: TARS / Proxmox Deployment Profile
+description: Setup-specific BuilderOps placement and qualification posture for TARS/Proxmox
+type: deployment-profile
+authority: Reference for one infrastructure setup; it does not override environment, channel, or deployment contracts
+source_of_truth: Fresh qualification input and deployment receipts
+---
+
+State: Setup-specific deployment profile. It is not a live host qualification or deployment receipt.
+Doc role: Reference (deployment profile)
+Authority: Records only the TARS/Proxmox-specific posture that the generic deployment contract must
+not absorb. It does not qualify a host or authorize a deployment, and it does not define environments.
+Owner: Platform and Operations System, with the BuilderOps deployment owner
+Temporal class: operational
+Review cadence: before a TARS BuilderOps deployment and whenever host, VM, network, or disk posture changes
+Source of truth: a fresh qualification input and deployment receipts
+Last reviewed: 2026-08-29
+Last verified against: repository deployment contract only; no live TARS/Proxmox readback in this slice
+
+# TARS / Proxmox Deployment Profile
+
+## Purpose
+
+This profile isolates one TARS/Proxmox setup from the portable BuilderOps deployment contract.
+Alternative hosts, hypervisors, VM layouts, container runtimes, and alerting mechanisms may satisfy
+the generic contract with equivalent evidence.
+
+## BuilderOps placement boundary
+
+The TARS qualification contract identifies VM 102 (`builder-system`) as the intended isolated
+BuilderOps candidate. That is a candidate-policy identifier, not a live deployment assertion. The
+candidate must remain separate from Product Runtime: it must not host a `pkm-*` Product Compose
+project or carry Product production credentials, vault references, or network identities. See
+`docs/BUILDEROPS_CONTROL_PLANE/README.md :: TARS qualification contract` for the owner contract.
+
+## Disk and WAL headroom policy
+
+No current VM disk capacity, used-space value, or free-space value is asserted here. Before a TARS
+deployment or operational change, a fresh qualification input (no more than 24 hours old and
+fingerprint-verifiable) must establish the relevant disk and volume facts. Only that fresh
+qualification input may bind this setup-specific profile to current disk/headroom evidence.
+
+For the rebuildable local BuilderOps posture, PostgreSQL keeps both `max_wal_size` and
+`max_slot_wal_keep_size` at 2 GiB. The local database health guard refuses WAL growth above 2 GiB
+or a data-volume usage at or above its configured threshold. These are bounded local-disk guardrails,
+not backup, point-in-time recovery, or restore evidence. The generic deployment contract owns the
+portable policy; this profile only names its TARS qualification input.
+
+## Probe and alerting posture
+
+The repository contains a macOS launchd BuilderOps outage probe under
+`ops/host-setup/mac-mini/`. It is not a Linux probe and does not prove a Linux installation. A
+Linux service/timer that checks the BuilderOps readiness endpoint and local database health guard,
+then sends the configured outage/recovery alert, is a required-but-not-yet-installed live
+prerequisite for any TARS BuilderOps deployment receipt. Installation, credential binding, schedule,
+and live alert delivery require their own fresh operational evidence and are outside this repository
+slice.
+
+## Inherited generic contract
+
+This profile inherits, without redefining:
+
+- environment selection and path scoping from `docs/ENVIRONMENTS.md`;
+- channel identity, promotion, and rollback from `docs/RELEASE_CHANNELS/README.md`;
+- portable BuilderOps deployment, loopback exposure, authenticated private ingress, and health-gate
+  policy from `docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md`; and
+- TARS candidate policy from `docs/BUILDEROPS_CONTROL_PLANE/README.md`.
+
+A fresh qualification result, a passing repository test, or this profile never proves a live host
+mutation, backup/restore result, network reachability, or authority cutover.

--- a/scripts/builderops/local_wal_guard.sh
+++ b/scripts/builderops/local_wal_guard.sh
@@ -11,7 +11,7 @@ disk_limit_percent="${BUILDEROPS_LOCAL_DISK_MAX_USED_PERCENT:-85}"
 archive_mode="$(psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}" -Atqc 'SHOW archive_mode')"
 archive_command="$(psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}" -Atqc 'SHOW archive_command')"
 
-if [[ "$archive_mode" != "off" || -n "$archive_command" ]]; then
+if [[ "$archive_mode" != "off" && "$archive_mode" != "(disabled)" ]] || [[ -n "$archive_command" ]]; then
   echo "local BuilderOps WAL archive drift: archive_mode=$archive_mode archive_command=${archive_command:+set}" >&2
   exit 70
 fi

--- a/tests/ops/test_builderops_deploy_contract.py
+++ b/tests/ops/test_builderops_deploy_contract.py
@@ -6,8 +6,146 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+class _ComposeLoader(yaml.SafeLoader):
+    """Load the Compose-only !override tag as its wrapped value for contract checks."""
+
+
+def _construct_compose_override(
+    loader: _ComposeLoader, node: yaml.nodes.SequenceNode
+) -> object:
+    return loader.construct_sequence(node)
+
+
+_ComposeLoader.add_constructor("!override", _construct_compose_override)
+
+
+def _run_local_wal_guard(
+    tmp_path: Path, *, archive_mode: str, archive_command: str = ""
+) -> subprocess.CompletedProcess[str]:
+    pgdata = tmp_path / "pgdata"
+    (pgdata / "pg_wal").mkdir(parents=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "psql",
+        """#!/usr/bin/env bash
+set -eu
+case "$*" in
+  *'SHOW archive_mode'*) printf '%s\\n' "$TEST_ARCHIVE_MODE" ;;
+  *'SHOW archive_command'*) printf '%s\\n' "$TEST_ARCHIVE_COMMAND" ;;
+  *) exit 2 ;;
+esac
+""",
+    )
+    _write_executable(
+        bin_dir / "du",
+        """#!/usr/bin/env bash
+printf '0\\t%s\\n' "$2"
+""",
+    )
+    _write_executable(
+        bin_dir / "df",
+        """#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'
+printf 'tmpfs 100 10 90 10%% /tmp\\n'
+""",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "PGDATA": str(pgdata),
+            "TEST_ARCHIVE_MODE": archive_mode,
+            "TEST_ARCHIVE_COMMAND": archive_command,
+        }
+    )
+    return subprocess.run(
+        ["bash", str(ROOT / "scripts/builderops/local_wal_guard.sh")],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_local_wal_guard_accepts_postgresql_disabled_archive_mode(tmp_path: Path) -> None:
+    result = _run_local_wal_guard(tmp_path, archive_mode="(disabled)")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_local_wal_guard_refuses_enabled_or_unexpected_archive_configuration(
+    tmp_path: Path,
+) -> None:
+    enabled = _run_local_wal_guard(tmp_path / "enabled", archive_mode="on")
+    unexpected = _run_local_wal_guard(
+        tmp_path / "unexpected", archive_mode="off", archive_command="wal-g wal-push %p"
+    )
+
+    assert enabled.returncode == 70
+    assert "archive drift" in enabled.stderr
+    assert unexpected.returncode == 70
+    assert "archive_command=set" in unexpected.stderr
+
+
+def test_postgres_wal_limits_are_pinned() -> None:
+    config = (ROOT / "config/builderops/postgresql.conf").read_text(encoding="utf-8")
+
+    assert "max_wal_size = '2GB'" in config
+    assert "max_slot_wal_keep_size = '2GB'" in config
+    assert "max_slot_wal_keep_size = '1GB'" not in config
+    assert "max_slot_wal_keep_size = '0'" not in config
+
+
+def test_tars_profile_is_setup_specific_and_probe_truthful() -> None:
+    profile = (ROOT / "docs/deployment/profiles/TARS_PROXMOX.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_profile = " ".join(profile.split())
+
+    assert "does not qualify a host or authorize a deployment" in normalized_profile
+    assert "fresh qualification input" in normalized_profile
+    assert "required-but-not-yet-installed live prerequisite" in normalized_profile
+    assert "macOS launchd" in normalized_profile
+    assert "does not prove a Linux installation" in normalized_profile
+
+
+def test_effective_builderops_compose_has_no_recovery_egress_or_wal_secrets() -> None:
+    compose = (ROOT / "docker-compose.builderops.yml").read_text(encoding="utf-8")
+    effective = yaml.load(compose, Loader=_ComposeLoader)
+    deploy = (ROOT / "scripts/deploy_builderops.sh").read_text(encoding="utf-8")
+
+    assert effective["networks"]["builderops-internal"]["internal"] is True
+    services = effective["services"]
+    assert all(
+        service["networks"] == ["builderops-internal"]
+        for service in services.values()
+    )
+    assert services["api"]["ports"] == [
+        "127.0.0.1:${BUILDEROPS_API_PORT:-18100}:8000"
+    ]
+    assert all(
+        name == "api" or "ports" not in service
+        for name, service in services.items()
+    )
+    declared_secrets = effective["secrets"]
+    assert not any(
+        token in secret.lower()
+        for secret in declared_secrets
+        for token in ("wal", "archive", "recovery")
+    )
+    assert "recovery-target" not in compose
+    assert 'BUILDEROPS_LOCAL_DURABILITY_MODE=rebuildable' in (
+        ROOT / "config/deploy/builderops.env"
+    ).read_text(encoding="utf-8")
+    assert '"source_sha": os.environ["SOURCE_SHA"]' in deploy
+    assert '"previous_image_digest": os.environ["PREVIOUS_DIGEST"]' in deploy
 
 
 def _write_executable(path: Path, body: str) -> None:

--- a/tests/ops/test_builderops_deploy_contract.py
+++ b/tests/ops/test_builderops_deploy_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -83,24 +84,41 @@ def test_local_wal_guard_accepts_postgresql_disabled_archive_mode(tmp_path: Path
 def test_local_wal_guard_refuses_enabled_or_unexpected_archive_configuration(
     tmp_path: Path,
 ) -> None:
-    enabled = _run_local_wal_guard(tmp_path / "enabled", archive_mode="on")
+    for archive_mode in ("on", "always", "unknown"):
+        enabled = _run_local_wal_guard(
+            tmp_path / archive_mode, archive_mode=archive_mode
+        )
+
+        assert enabled.returncode == 70
+        assert "archive drift" in enabled.stderr
     unexpected = _run_local_wal_guard(
         tmp_path / "unexpected", archive_mode="off", archive_command="wal-g wal-push %p"
     )
 
-    assert enabled.returncode == 70
-    assert "archive drift" in enabled.stderr
     assert unexpected.returncode == 70
     assert "archive_command=set" in unexpected.stderr
+
+
+def _slot_wal_keep_size_assignments(config: str) -> list[str]:
+    return re.findall(
+        r"^\s*max_slot_wal_keep_size\s*=\s*['\"]?([^\s'#]+)['\"]?\s*(?:#.*)?$",
+        config,
+        flags=re.MULTILINE,
+    )
 
 
 def test_postgres_wal_limits_are_pinned() -> None:
     config = (ROOT / "config/builderops/postgresql.conf").read_text(encoding="utf-8")
 
     assert "max_wal_size = '2GB'" in config
-    assert "max_slot_wal_keep_size = '2GB'" in config
-    assert "max_slot_wal_keep_size = '1GB'" not in config
-    assert "max_slot_wal_keep_size = '0'" not in config
+    assert _slot_wal_keep_size_assignments(config) == ["2GB"]
+    for drifted_value in ("1GB", "0", "3GB"):
+        assert _slot_wal_keep_size_assignments(
+            config.replace("max_slot_wal_keep_size = '2GB'", f"max_slot_wal_keep_size = '{drifted_value}'")
+        ) != ["2GB"]
+    assert _slot_wal_keep_size_assignments(
+        config + "\nmax_slot_wal_keep_size = '3GB'\n"
+    ) != ["2GB"]
 
 
 def test_tars_profile_is_setup_specific_and_probe_truthful() -> None:


### PR DESCRIPTION
Governing-Issue: #5168

Fixes #5168

Final-Review-Rounds: 1

## Summary
Accept PostgreSQL 16's `(disabled)` archive-mode representation while retaining fail-closed archive drift and 2 GiB local WAL controls. Pin slot WAL retention, add regression coverage for guard/config/Compose/receipt boundaries, and document the portable rebuildable posture plus the TARS/Proxmox-specific qualification and Linux-probe prerequisite.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue and this PR contain the bounded repository contract; no new BuilderOps operational record was produced and live TARS qualification remains a separately gated phase.

## SBS Impact
- Builder System / CES boundary: local BuilderOps durability and deployment-contract hardening only; no Product Runtime, host, credential, recovery, or authority-cutover mutation.

## Notes
Validation: `pytest -q tests/ops/test_builderops_deploy_contract.py` (12 passed); `bash -n scripts/builderops/local_wal_guard.sh`; `ruff check app tests`; `mypy app`; `python3 scripts/docs_guard.py --language-only`.

Anchor drift: `docs/deployment/profiles/TARS_PROXMOX.md` was absent on the base; this PR introduces the bounded profile from Issue #5168's clear scope, without claiming live qualification.