### PR TITLE
Prevent skipped duplicates from masking required CI

### DIFF
--- a/.codex/skills/_shared/CI_WAIT_CONTRACT.md
+++ b/.codex/skills/_shared/CI_WAIT_CONTRACT.md
@@ -34,13 +34,16 @@ drains GraphQL to zero and stalls every other agent's reads — a recurring, sys
 6. **Use the shared helper, preferably through the blessed script.** Do not hand-roll CI or Codex
    wait loops; `scripts/await_pr_checks.sh` delegates shared backoff/verdict behavior to
    `app.dispatcher.poll_backoff`.
-7. **Dedupe check-runs by latest record per name before classifying.** GitHub keeps every check-run
-   record for a head SHA, so a re-run after a body/config fix leaves both the stale failed record
-   and the newer successful one for the same check name on one SHA (observed on PR #2915 and
-   #2924's `pr-contract` check). `scripts/await_pr_checks.sh` keeps only the latest record per
-   check-run name (ranked by `started_at`, falling back to run id) before green/red classification;
-   `epic-run-state lifecycle-plan` reuses that shared latest-record selector for terminal dry-runs.
-   A genuinely failed latest record still fails closed.
+7. **Dedupe check-runs by authoritative replacement per name before classifying.** GitHub keeps
+   every check-run record for a head SHA, so a re-run after a body/config fix leaves both the stale
+   failed record and the newer successful one for the same check name on one SHA (observed on PR
+   #2915 and #2924's `pr-contract` check). `scripts/await_pr_checks.sh` keeps the latest
+   non-skipped record per check-run name (ranked by `started_at`, falling back to run id); it falls
+   back to the latest skipped record only when that name has no execution. A skipped duplicate from
+   an inapplicable event therefore cannot hide a running or failed required execution, while a
+   later executed success still replaces an earlier failure. `epic-run-state lifecycle-plan` reuses
+   that shared selector for terminal dry-runs. A genuinely failed retained record still fails
+   closed.
 8. **A dirty PR schedules no pull_request workflows — absence of a required check is never
    success.** (#4605, LearningSignal `lrn_20260729154323_f134857a`, seen on PR #4354.) When a PR
    is `mergeable_state=dirty`, GitHub cannot compute `refs/pull/<n>/merge`, so the repo's

--- a/scripts/await_pr_checks.sh
+++ b/scripts/await_pr_checks.sh
@@ -144,12 +144,20 @@ sleep "$INITIAL_WAIT"
 # for the same check NAME on the same SHA. Classifying on the raw list fails closed on a check that
 # has already gone green on its latest run (observed live on PR #2915 and #2924: `pr-contract`
 # failure+success on one SHA). Before pending/conclusion classification, keep only the LATEST
-# record per check-run `name` — ranked by `started_at` (fallback `id` on a tie/missing timestamp) —
-# and classify off that deduped set only. A genuinely failed LATEST record still fails closed.
+# record per check-run `name` — ranked by `started_at` (fallback `id` on a tie/missing timestamp).
+# A later `skipped` record is not an executed replacement: when a name has any non-skipped record,
+# retain its latest non-skipped record instead. This keeps a required running or failed execution
+# authoritative while preserving the normal failure-to-success rerun replacement. Classify only off
+# that deduped set. A genuinely failed retained record still fails closed.
 DEDUPE_LATEST_PER_NAME='
   [.check_runs[]]
   | group_by(.name)
-  | map(sort_by([(.started_at // ""), .id]) | last)
+  | map(
+      sort_by([(.started_at // ""), .id])
+      | . as $runs
+      | ($runs | map(select(.conclusion != "skipped"))) as $executed
+      | if ($executed | length) > 0 then $executed[-1] else $runs[-1] end
+    )
 '
 
 # Fetch check-runs once per iteration into a single guarded response, then derive BOTH the

--- a/tests/fixtures/await_pr_checks/required_failure_then_skipped_duplicate.json
+++ b/tests/fixtures/await_pr_checks/required_failure_then_skipped_duplicate.json
@@ -1,0 +1,19 @@
+{
+  "total_count": 2,
+  "check_runs": [
+    {
+      "id": 201,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "failure",
+      "started_at": "2026-08-29T10:00:00Z"
+    },
+    {
+      "id": 202,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "skipped",
+      "started_at": "2026-08-29T10:01:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/await_pr_checks/required_failure_then_successful_rerun.json
+++ b/tests/fixtures/await_pr_checks/required_failure_then_successful_rerun.json
@@ -1,0 +1,19 @@
+{
+  "total_count": 2,
+  "check_runs": [
+    {
+      "id": 301,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "failure",
+      "started_at": "2026-08-29T10:00:00Z"
+    },
+    {
+      "id": 302,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2026-08-29T10:01:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/await_pr_checks/required_running_then_skipped_duplicate.json
+++ b/tests/fixtures/await_pr_checks/required_running_then_skipped_duplicate.json
@@ -1,0 +1,19 @@
+{
+  "total_count": 2,
+  "check_runs": [
+    {
+      "id": 101,
+      "name": "Unit tests (not pg)",
+      "status": "in_progress",
+      "conclusion": null,
+      "started_at": "2026-08-29T10:00:00Z"
+    },
+    {
+      "id": 102,
+      "name": "Unit tests (not pg)",
+      "status": "completed",
+      "conclusion": "skipped",
+      "started_at": "2026-08-29T10:01:00Z"
+    }
+  ]
+}

--- a/tests/scripts/test_await_pr_checks_dedupe.py
+++ b/tests/scripts/test_await_pr_checks_dedupe.py
@@ -57,7 +57,9 @@ def _make_fake_gh(tmp_path: Path) -> Path:
     return bin_dir
 
 
-def _run_await_script(tmp_path: Path, fixture_name: str) -> subprocess.CompletedProcess[str]:
+def _run_await_script(
+    tmp_path: Path, fixture_name: str, *, timeout: int = 30
+) -> subprocess.CompletedProcess[str]:
     fake_bin_dir = _make_fake_gh(tmp_path)
     fixture_path = FIXTURES_DIR / fixture_name
     assert fixture_path.exists(), f"missing fixture: {fixture_path}"
@@ -80,7 +82,7 @@ def _run_await_script(tmp_path: Path, fixture_name: str) -> subprocess.Completed
             "--interval",
             "60",
             "--timeout",
-            "30",
+            str(timeout),
         ],
         cwd=REPO_ROOT,
         env=env,
@@ -103,3 +105,32 @@ def test_genuine_latest_failure_still_fails_closed(tmp_path: Path) -> None:
     result = _run_await_script(tmp_path, "pr2915_genuine_latest_failure.json")
     assert result.returncode == 1, result.stdout + result.stderr
     assert "CHECKS FAILED: pr-contract: failure" in result.stderr
+
+
+def test_required_check_running_is_not_masked_by_later_skipped_duplicate(
+    tmp_path: Path,
+) -> None:
+    result = _run_await_script(
+        tmp_path,
+        "required_running_then_skipped_duplicate.json",
+        timeout=0,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "still running: Unit tests (not pg)" in result.stdout
+
+
+def test_required_check_failure_is_not_masked_by_later_skipped_duplicate(
+    tmp_path: Path,
+) -> None:
+    result = _run_await_script(tmp_path, "required_failure_then_skipped_duplicate.json")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "CHECKS FAILED: Unit tests (not pg): failure" in result.stderr
+
+
+def test_executed_successful_rerun_supersedes_earlier_failure(tmp_path: Path) -> None:
+    result = _run_await_script(tmp_path, "required_failure_then_successful_rerun.json")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "all required checks passed" in result.stdout


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5167

## Linked Issue
Closes #5167

## SBS Impact
- Primary subsystem: Builder System / CI governance
- Secondary subsystem(s): verification and closure; PR hot path
- Write class: governance/tooling
- Persistence impact: none
- Derived/rebuildable impact: waiter result remains derived from live GitHub check runs
- New or changed contract: Skipped same-name duplicates cannot supersede an executing or failed required check.
- Owner-doc impact: updated in this PR: CI wait replacement rule
- Transition debt impact: removes a false-green merge-gate path
- Boundary risk: An inapplicable skipped event must not hide required current-head CI.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Preserve running and failed required checks when a later same-name check is skipped.
- Keep genuine executed failure-to-success reruns as valid replacements.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue and this PR fully capture the bounded delivery; no separate BuilderOps operational record is needed.

## Notes
Validation: focused waiter suite (9 passed), all three acceptance tests, ruff check app tests, mypy app, docs guard, skills consistency, bash syntax, and diff check passed. Independent review is explicitly required before merge by the governing user request.