### PR TITLE
Split Project backlog lifecycle lanes

### DIFF
--- a/.codex/skills/_shared/LABEL_TAXONOMY.md
+++ b/.codex/skills/_shared/LABEL_TAXONOMY.md
@@ -26,6 +26,8 @@ own copies.
 Rules:
 
 - Every new implementation Issue leaves creation with exactly one truthful agent-state label.
+- A successful pickup atomically normalizes `agent:*` labels to exactly `agent:in-progress`, preserving
+  every non-agent label; this is the authoritative active-claim transition.
 - `agent:blocked` and `agent:needs-human` belong on non-active work. When Project repair is in
   scope, non-parent `agent:blocked` projects to `Blocked` and non-parent `agent:needs-human`
   projects to `Needs Human`; durable epic/parent evidence projects to `Epic / Parent` first.

--- a/.codex/skills/_shared/LABEL_TAXONOMY.md
+++ b/.codex/skills/_shared/LABEL_TAXONOMY.md
@@ -12,12 +12,15 @@ own copies.
 | `type:task` | default for bounded implementation or maintenance work |
 | `type:bug` | confirmed defect or regression |
 | `type:refactor` | code structure change with no behavior change |
+| `type:epic` | parent delivery or validation hub |
+| `type:feature` | parent feature or validation hub |
 | `prio:high` | blocks other work or has active regression |
 | `prio:med` | normal delivery priority |
 | `prio:low` | nice-to-have, no urgency |
 | `agent:ready` | bounded, testable, unblocked, and strictly validated — safe for agent pickup without requiring Project Status |
 | `agent:blocked` | dependency unresolved, including parent validation hubs waiting on child slices |
 | `agent:needs-human` | requires a named human decision, tradeoff, missing input, or authority question |
+| `agent:in-progress` | active implementation work under a current claim or delivery handoff |
 | `state:known-defect` | rolling registry Issue containing confirmed deferred P2 defect entries; never an implementation pickup label |
 
 Rules:
@@ -31,7 +34,8 @@ Rules:
 - Closed or delivered Issues must not retain any `agent:*` label.
 - `state:known-defect` belongs only on the locked rolling Known Defects registry Issue. That
   container also carries `type:bug`, is not an implementation Issue, carries no `agent:*` label,
-  remains in `Backlog` if projected, and must never carry `agent:ready`.
+  remains in `Backlog` if projected, and must never carry `agent:ready`. During explicit Project
+  reconciliation, the open registry derives `Backlog` before the generic unmapped-issue fallthrough.
 - Registry entries are schema-marked Issue comments, not labels or child Issues. When an entry is
   selected for implementation, create/link a normal bounded `type:bug` Issue with exactly one
   priority, exactly one truthful normal agent state, the canonical contract, ACs, and `Verify:`

--- a/.codex/skills/_shared/LABEL_TAXONOMY.md
+++ b/.codex/skills/_shared/LABEL_TAXONOMY.md
@@ -23,8 +23,11 @@ own copies.
 Rules:
 
 - Every new implementation Issue leaves creation with exactly one truthful agent-state label.
-- `agent:blocked` and `agent:needs-human` belong on non-active work. A Project may mirror them as
-  `Backlog`, but that projection does not control pickup.
+- `agent:blocked` and `agent:needs-human` belong on non-active work. When Project repair is in
+  scope, non-parent `agent:blocked` projects to `Blocked` and non-parent `agent:needs-human`
+  projects to `Needs Human`; durable epic/parent evidence projects to `Epic / Parent` first.
+  An existing explicit open-Issue `Review` projection is retained. None of these projections
+  controls pickup.
 - Closed or delivered Issues must not retain any `agent:*` label.
 - `state:known-defect` belongs only on the locked rolling Known Defects registry Issue. That
   container also carries `type:bug`, is not an implementation Issue, carries no `agent:*` label,

--- a/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
+++ b/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
@@ -18,6 +18,7 @@ reconciliation.
 |---------|---------------|-------------------------|
 | Issue | CLOSED | `Done` |
 | Issue | OPEN + existing explicit `Review` projection | `Review` |
+| Issue | OPEN + `state:known-defect` registry | `Backlog` |
 | Issue | OPEN + `type:epic`, `type:feature`, or non-empty GitHub sub-issue set | `Epic / Parent` |
 | Issue | OPEN + `agent:needs-human` | `Needs Human` |
 | Issue | OPEN + `agent:blocked` | `Blocked` |

--- a/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
+++ b/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
@@ -44,6 +44,8 @@ operator projection; reconciliation must preserve it without inferring a PR rela
 
 - `agent:ready` is the pickup qualifier after strict validation. `Status=Ready` is its preferred
   legacy board projection, not a precondition or collision guard.
+- Successful pickup atomically normalizes `agent:*` labels to exactly `agent:in-progress`; a
+  subsequent explicit Project repair therefore projects the active Issue to `In Progress`.
 - Outside an explicit Project-repair run, absence from the Project is not drift and requires no
   read or mutation.
 - GitHub Issue state, agent labels, linked PR state, and merge/delivery reality outrank Project

--- a/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
+++ b/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
@@ -10,16 +10,20 @@ reconciliation.
 
 ## Allowed Project statuses
 
-`Backlog`, `Ready`, `In Progress`, `Review`, `Done`
+`Backlog`, `Epic / Parent`, `Blocked`, `Needs Human`, `Ready`, `In Progress`, `Review`, `Done`
 
 ## Matrix
 
 | Content | Content state | Projected Status |
 |---------|---------------|-------------------------|
 | Issue | CLOSED | `Done` |
-| Issue | OPEN + `agent:ready` | `Ready` |
-| Issue | OPEN + `agent:blocked` | `Backlog` |
-| Issue | OPEN + `agent:needs-human` | `Backlog` |
+| Issue | OPEN + existing explicit `Review` projection | `Review` |
+| Issue | OPEN + `type:epic`, `type:feature`, or non-empty GitHub sub-issue set | `Epic / Parent` |
+| Issue | OPEN + `agent:needs-human` | `Needs Human` |
+| Issue | OPEN + `agent:blocked` | `Blocked` |
+| Issue | OPEN + valid `agent:ready` | `Ready` |
+| Issue | OPEN + `agent:in-progress` | `In Progress` |
+| Issue | OPEN + no derived status | retain current projection (new Issue automation initially uses `Backlog`) |
 | PR | MERGED | `Done` |
 | PR | CLOSED (unmerged) | `Done` |
 | PR | OPEN + Draft | `In Progress` |
@@ -32,7 +36,8 @@ reconciliation.
 `Review` is the Project handoff state for open non-draft PRs. The shipped Project automation maps
 `opened`, `reopened`, and `ready_for_review` non-draft PR events to `Review`; draft PRs remain
 `In Progress` until they are marked ready. Maintenance runs must not treat a normal open non-draft
-PR card in `Review` as drift.
+PR card in `Review` as drift. An existing open Issue card in `Review` is likewise an explicit
+operator projection; reconciliation must preserve it without inferring a PR relationship.
 
 ## Binding rules
 
@@ -42,3 +47,5 @@ PR card in `Review` as drift.
   read or mutation.
 - GitHub Issue state, agent labels, linked PR state, and merge/delivery reality outrank Project
   state when they disagree; correct the projection to match the harder truth.
+- Parent evidence is limited to `type:epic`, `type:feature`, or a non-empty GitHub sub-issue set;
+  title prose alone is not sufficient.

--- a/.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md
+++ b/.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md
@@ -39,8 +39,9 @@ An empty `projectItems` list means the item is not in the Project yet — add it
 
 ## Set Project Status
 
-The single canonical mutation; pass the option ID for the target status (`Backlog`, `Ready`,
-`In Progress`, `Review`, `Done` — see `LIFECYCLE_TRUTH_MATRIX.md`):
+The single canonical mutation; pass the option ID for the target status (`Backlog`,
+`Epic / Parent`, `Blocked`, `Needs Human`, `Ready`, `In Progress`, `Review`, `Done` — see
+`LIFECYCLE_TRUTH_MATRIX.md`):
 
 Before setting an Issue item to `Ready`, first run strict executable-contract validation on the
 exact Issue body that will be paired with `agent:ready`:

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -94,11 +94,12 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
 The canonical optional projection matrix lives at `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`. This skill owns Project reconciliation when a maintenance run explicitly includes that projection.
 
 For open Issue cards, retain an existing explicit `Review` projection. Otherwise apply the
-canonical precedence: durable epic/parent evidence (`type:epic`, `type:feature`, or a non-empty
-GitHub sub-issue set) → `Epic / Parent`; `agent:needs-human` → `Needs Human`; `agent:blocked` →
-`Blocked`; valid `agent:ready` → `Ready`; `agent:in-progress` → `In Progress`. An otherwise
-unmapped open Issue retains its current Project status; new-Issue automation initially uses
-`Backlog`. Do not infer parenthood from title prose or infer a PR relationship to preserve Review.
+canonical precedence: the `state:known-defect` registry → `Backlog`; durable epic/parent evidence
+(`type:epic`, `type:feature`, or a non-empty GitHub sub-issue set) → `Epic / Parent`;
+`agent:needs-human` → `Needs Human`; `agent:blocked` → `Blocked`; valid `agent:ready` → `Ready`;
+`agent:in-progress` → `In Progress`. An otherwise unmapped open Issue retains its current Project
+status; new-Issue automation initially uses `Backlog`. Do not infer parenthood from title prose or
+infer a PR relationship to preserve Review.
 
 ### Drift patterns that must be flagged explicitly
 
@@ -427,8 +428,9 @@ Use this when the user asks for a maintenance run across everything not done.
    - **Optionally execute Project state reconciliation** only when projection repair is in scope and after labels are corrected and
      strict validation has passed for any `Ready` target: run the Set Project Status mutation from
      `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md` — validated `agent:ready` → `Ready`
-     option ID; parent evidence → `Epic / Parent`; `agent:needs-human` → `Needs Human`; and
-     `agent:blocked` → `Blocked`, after preserving an existing explicit open-Issue `Review`.
+     option ID; open `state:known-defect` registry → `Backlog`; parent evidence → `Epic / Parent`;
+     `agent:needs-human` → `Needs Human`; and `agent:blocked` → `Blocked`, after preserving an
+     existing explicit open-Issue `Review`.
      - If the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
 5. **Execute Deduplication:**
    - If duplicate issues have the same scope/contract:

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -93,6 +93,13 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
 
 The canonical optional projection matrix lives at `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`. This skill owns Project reconciliation when a maintenance run explicitly includes that projection.
 
+For open Issue cards, retain an existing explicit `Review` projection. Otherwise apply the
+canonical precedence: durable epic/parent evidence (`type:epic`, `type:feature`, or a non-empty
+GitHub sub-issue set) → `Epic / Parent`; `agent:needs-human` → `Needs Human`; `agent:blocked` →
+`Blocked`; valid `agent:ready` → `Ready`; `agent:in-progress` → `In Progress`. An otherwise
+unmapped open Issue retains its current Project status; new-Issue automation initially uses
+`Backlog`. Do not infer parenthood from title prose or infer a PR relationship to preserve Review.
+
 ### Drift patterns that must be flagged explicitly
 
 These are the high-frequency drift patterns that are easy to miss. Audit authoritative items on
@@ -238,7 +245,8 @@ If an open implementation Issue is malformed, stale, or no longer safely executa
 
 2. **Post comment with the required action.**
 
-3. **Optional Project repair:** when explicitly in scope, apply and verify the `Backlog` projection.
+3. **Optional Project repair:** when explicitly in scope, apply and verify the derived projection
+   (`Needs Human` unless a retained `Review` or higher-precedence epic/parent condition applies).
 
 ### Maintenance path versus hot path
 
@@ -264,7 +272,9 @@ Parent feature issues are validation hubs, not direct pickup issues. Unless expl
    ```
 
 2. **Use them to track child slice delivery** in comments and body updates, including validation receipts posted by each delivered child
-3. **When the parent is fully repo-verifiable and only future observation remains, close it and move that observation to a BuilderOps `LearningSignal`, `PromotionIntent`, discard/supersession receipt, or a follow-up GitHub Issue when it is executable work**
+3. **Optional Project repair:** when explicitly in scope, project durable parent evidence to
+   `Epic / Parent`; do not overwrite an existing explicit `Review` card.
+4. **When the parent is fully repo-verifiable and only future observation remains, close it and move that observation to a BuilderOps `LearningSignal`, `PromotionIntent`, discard/supersession receipt, or a follow-up GitHub Issue when it is executable work**
 
 ### Child Slice Issues
 
@@ -281,10 +291,10 @@ Child slice issues may become `agent:ready` only when their executable contract 
 | Condition | Action | Issue Labels | Issue Status | Notes |
 |-----------|--------|-------------|-------------|-------|
 | Issue closed | Execute Close Delivered | -agent:* | Done | Remove all agent labels |
-| Malformed/stale open | Execute Malformed/Stale | +agent:needs-human | Backlog | Non-active state |
-| Delivered but open | Execute Delivered Open | +agent:needs-human | Backlog | Comment explaining next step |
-| Parent feature | Keep non-active | +agent:blocked | Backlog | Validation hub, waiting on child chain |
-| Child with spec in PR | Keep non-active | +agent:blocked | Backlog | Wait for spec merge |
+| Malformed/stale open | Execute Malformed/Stale | +agent:needs-human | Needs Human | Retain explicit Review; parent evidence still wins |
+| Delivered but open | Execute Delivered Open | +agent:needs-human | Needs Human | Retain explicit Review; comment explaining next step |
+| Parent feature | Keep non-active | +agent:blocked | Epic / Parent | Validation hub, waiting on child chain |
+| Child with spec in PR | Keep non-active | +agent:blocked | Blocked | Retain explicit Review; wait for spec merge |
 | Child with concrete contract | Can label ready | +agent:ready | Optional projection: Ready | Only when merged, clear, and strict readiness validation passes |
 
 ## When splitting
@@ -417,7 +427,8 @@ Use this when the user asks for a maintenance run across everything not done.
    - **Optionally execute Project state reconciliation** only when projection repair is in scope and after labels are corrected and
      strict validation has passed for any `Ready` target: run the Set Project Status mutation from
      `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md` — validated `agent:ready` → `Ready`
-     option ID; `agent:blocked` or `agent:needs-human` → `Backlog` option ID.
+     option ID; parent evidence → `Epic / Parent`; `agent:needs-human` → `Needs Human`; and
+     `agent:blocked` → `Blocked`, after preserving an existing explicit open-Issue `Review`.
      - If the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
 5. **Execute Deduplication:**
    - If duplicate issues have the same scope/contract:

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -84,7 +84,7 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
 
 - Open implementation Issues should normally carry exactly one truthful agent-state label.
 - Active implementation work should not remain `Ready`.
-- Closed Issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`.
+- Closed Issues must not retain any `agent:*` label, including `agent:in-progress`.
 - If repo reality satisfies the Issue, its Issue/PR state and labels must reflect that.
 - When Project repair is explicitly included, reconcile its projection after authoritative
   Issue/PR correction; missing Project cards are not lifecycle failures outside that scope.

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -202,7 +202,7 @@ If an Issue is closed (already delivered):
 
 1. **Remove all agent labels:**
    ```bash
-   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human --remove-label agent:in-progress
    ```
 
 2. **Verify authoritative state:**
@@ -229,7 +229,7 @@ If an open issue is no longer the truthful backlog item because an equivalent sl
 3. **Re-check terminal truth and strip lingering agent labels if needed:**
    ```bash
    gh issue view #<N> --repo "$REPO" --json state,labels
-   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   gh issue edit #<N> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human --remove-label agent:in-progress
    gh issue view #<N> --repo "$REPO" --json state,labels
    ```
 
@@ -241,7 +241,7 @@ If an open implementation Issue is malformed, stale, or no longer safely executa
 
 1. **Add needs-human label:**
    ```bash
-   gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+   gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked --remove-label agent:in-progress
    ```
 
 2. **Post comment with the required action.**
@@ -269,7 +269,7 @@ Parent feature issues are validation hubs, not direct pickup issues. Unless expl
 
 1. **Keep them non-active:**
    ```bash
-   gh issue edit #<PARENT> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
+   gh issue edit #<PARENT> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human --remove-label agent:in-progress
    ```
 
 2. **Use them to track child slice delivery** in comments and body updates, including validation receipts posted by each delivered child
@@ -412,11 +412,11 @@ Use this when the user asks for a maintenance run across everything not done.
    - **Execute label corrections** from established issue/PR truth before any Project reconciliation:
      ```bash
      # Example: set to ready if criteria are concrete
-     gh issue edit #<N> --repo "$REPO" --add-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     gh issue edit #<N> --repo "$REPO" --add-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human --remove-label agent:in-progress
      # OR: set to needs-human if ambiguous or boundary move
-     gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+     gh issue edit #<N> --repo "$REPO" --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked --remove-label agent:in-progress
      # OR: set to blocked if external dependency exists
-     gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
+     gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human --remove-label agent:in-progress
      ```
      - Add `agent:ready` only if Scope/Constraints/Acceptance Criteria are concrete and no ambiguity remains.
      - Do not add or preserve `agent:ready` when any AC lacks a resolvable `Verify:` marker.
@@ -440,7 +440,7 @@ Use this when the user asks for a maintenance run across everything not done.
      ```
    - Remove all agent labels from closed duplicate:
      ```bash
-     gh issue edit #<DUPLICATE> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     gh issue edit #<DUPLICATE> --repo "$REPO" --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human --remove-label agent:in-progress
      ```
 
 6. **When Project repair is in scope, reconcile terminal work stuck in non-terminal status**:

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -282,7 +282,7 @@ If work becomes blocked before or during implementation:
 
 1. **Add blocker label:**
    ```bash
-   gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready
+   gh issue edit #<N> --repo "$REPO" --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human --remove-label agent:in-progress
    ```
 
 2. **Add a blocking comment to the Issue with the explicit reason and next unblock condition.**

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -145,7 +145,7 @@ Treat every canonical Issue contract section (`.codex/skills/_shared/ISSUE_CONTR
 - GitHub Project `Agent Delivery Control Plane` is an optional legacy lifecycle projection.
 - Project Status is an optional projection; its repair is a cold-path maintenance concern and is
   not part of selection, pickup, claim, blocked-state, or review-handoff flow.
-- Do not leave actively worked Issues labeled `agent:ready`.
+- Successful pickup atomically replaces all `agent:*` state labels with exactly `agent:in-progress`, while preserving non-agent labels.
 - Do not leave blocked Issues in `In Progress`.
 - Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.
 - Treat dispatcher lease acquisition plus removal of `agent:ready` as the fast claim handshake.
@@ -223,7 +223,8 @@ The wrapper runs workspace preflight and `dispatcher status`, derives the exact 
 override), and does not substitute a candidate returned by `dispatcher next`. When the
 dispatcher is available, it executes `dispatcher claim` for that exact task and verifies the returned
 task id, issue number, status, owner, lease id, lease resource, holder, expiry, and unreleased state
-before removing `agent:ready`. Database or singleton existence alone never produces a
+before atomically replacing all `agent:*` state labels with exactly `agent:in-progress`. The replacement preserves
+non-agent labels (including `type:*`, `prio:*`, and `lane:*`). Database or singleton existence alone never produces a
 dispatcher-backed pickup receipt.
 
 Rescue-stash notes, stale local pickup plans, and prior-session handoffs are
@@ -239,7 +240,7 @@ contains `task_id`, `lease_id`, `holder`, and `evidence=verified-dispatcher-leas
 
 When dispatcher status selects degraded mode, the same wrapper posts a durable claimant-intent
 comment containing agent, session, branch, worktree, `coordination_mode`, and `fallback_reason`
-before removing `agent:ready`. Explicit fallback can be selected with:
+before the same atomic `agent:*` → exactly `agent:in-progress` transition. Explicit fallback can be selected with:
 
 ```bash
 scripts/issue_pickup_claim.sh \
@@ -310,7 +311,7 @@ the authority. Project automation may mirror that state; manual Project repair b
 
 | When | Authoritative Issue state | Authoritative PR state |
 |------|---------------------------|------------------------|
-| Start work | open, `agent:ready` removed | — |
+| Start work | open, exactly `agent:in-progress` (atomically replacing `agent:*`) | — |
 | Blocked mid-work | open, `agent:blocked` | — |
 | Open draft PR | open, active claim retained | draft |
 | Request review | open, active claim retained | non-draft / review requested |
@@ -416,7 +417,7 @@ When continuing through anchor drift:
 1. Select the Issue according to priority and readiness rules.
 2. Run mandatory pickup claim wrapper before any lifecycle mutation:
    - `scripts/issue_pickup_claim.sh --issue <N> --repo "$REPO" --agent <agent_id> --session <session_id>`
-   - This wrapper enforces workspace isolation preflight before removing `agent:ready`.
+   - This wrapper enforces workspace isolation preflight before atomically replacing `agent:*` labels with exactly `agent:in-progress`.
    - If preflight fails, stop and resolve branch/worktree collisions before claiming.
    - After a successful claim, register the dedicated checkout without switching the shared root:
      `python3 scripts/agent_worktree.py --cwd <repo-or-worktree> register --worktree <absolute-worktree> --owner <session_id>`.

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -28,6 +28,8 @@ labels:
     - type:task
     - type:bug
     - type:refactor
+    - type:epic
+    - type:feature
   priority:
     - prio:high
     - prio:med
@@ -36,6 +38,7 @@ labels:
     - agent:ready
     - agent:blocked
     - agent:needs-human
+    - agent:in-progress
   state:
     - state:known-defect
   lane:
@@ -44,6 +47,7 @@ labels:
     agent:ready: strictly validated queue-eligible work; Project Status is optional projection, never a pickup, claim, blocked-state, or review-handoff gate
     agent:blocked: blocked by dependency or setup; projected to Blocked unless durable epic/parent evidence takes precedence
     agent:needs-human: blocked on human decision or missing authority; projected to Needs Human unless durable epic/parent evidence takes precedence
+    agent:in-progress: active implementation work; projected to In Progress when no higher-precedence condition applies
     state:known-defect: rolling confirmed-defect registry container; Backlog, no agent-state label, never pickup-eligible
     lane:governance: narrow additive label for governance-lane Issues and PRs
 project:

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -42,8 +42,8 @@ labels:
     - lane:governance
   interpretation:
     agent:ready: strictly validated queue-eligible work; Project Status is optional projection, never a pickup, claim, blocked-state, or review-handoff gate
-    agent:blocked: blocked by dependency or setup; normally non-active backlog work
-    agent:needs-human: blocked on human decision or missing authority; normally non-active backlog work
+    agent:blocked: blocked by dependency or setup; projected to Blocked unless durable epic/parent evidence takes precedence
+    agent:needs-human: blocked on human decision or missing authority; projected to Needs Human unless durable epic/parent evidence takes precedence
     state:known-defect: rolling confirmed-defect registry container; Backlog, no agent-state label, never pickup-eligible
     lane:governance: narrow additive label for governance-lane Issues and PRs
 project:
@@ -52,6 +52,9 @@ project:
   fields:
     Status:
       - Backlog
+      - Epic / Parent
+      - Blocked
+      - Needs Human
       - Ready
       - In Progress
       - Review
@@ -89,6 +92,8 @@ project:
   interpretation:
     status_is_projection_of_issue_and_pr_truth: true
     ready_requires_agent_ready: true
+    epic_parent_precedes_blocker_labels: true
+    explicit_open_issue_review_is_preserved: true
     in_progress_covers_draft_or_rework_prs: true
     review_covers_open_non_draft_prs: true
     done_requires_closed_issue_or_terminal_pr_card: true

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -104,7 +104,7 @@ Lifecycle guardrails:
 - active implementation must not remain `Ready`
 - issues should not move to `Review` only because a PR exists; issue state remains claim/execution truth
 - normal open PRs should default to `Review`; draft is opt-in and should be used only with an explicit reason
-- closed issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`
+- closed issues must not retain any `agent:*` label, including `agent:in-progress`
 - when optional Project repair is in scope, merged or otherwise closed terminal PR items should
   reconcile to `Done`
 - parent feature issues are validation hubs, not direct pickup issues; while child slices remain outstanding they normally project to `Epic / Parent` even if they carry `agent:blocked`

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -20,12 +20,15 @@ Keep only these labels for the delivery control plane taxonomy:
 - `type:task`
 - `type:bug`
 - `type:refactor`
+- `type:epic`
+- `type:feature`
 - `prio:high`
 - `prio:med`
 - `prio:low`
 - `agent:ready`
 - `agent:blocked`
 - `agent:needs-human`
+- `agent:in-progress`
 - `state:known-defect`
 - `lane:governance`
 
@@ -67,6 +70,7 @@ Agent-label meanings:
 - `agent:ready`: strictly validated queue-eligible work; Project Status is not a pickup precondition
 - `agent:blocked`: blocked by dependency waiting; normally pair with `Blocked` unless durable epic/parent evidence takes precedence
 - `agent:needs-human`: blocked on a named human decision, tradeoff, missing input, or authority question; normally pair with `Needs Human` unless durable epic/parent evidence takes precedence
+- `agent:in-progress`: active implementation work; normally pair with `In Progress` unless a higher-precedence projection condition applies
 - open implementation Issues should normally carry exactly one truthful agent-state label
 - `state:known-defect`: one locked rolling registry Issue for confirmed deferred P2 entries;
   keep it in `Backlog`, with `type:bug`, without an agent-state label, and never treat it as
@@ -112,7 +116,7 @@ Projection rule:
 - When Project state disagrees with Issue state, PR state, or merged delivery reality, treat the Issue/PR state as authoritative and correct the Project opportunistically.
 - Do not block delivery solely because a personal Project v2 card could not be updated by repo automation.
 - An existing open Issue card explicitly placed in `Review` is an operator projection override and is retained; reconciliation does not infer a PR link or move it back into a split backlog lane.
-- Otherwise, Issue projection precedence is closed → `Done`; epic/parent evidence → `Epic / Parent`; `agent:needs-human` → `Needs Human`; `agent:blocked` → `Blocked`; valid `agent:ready` → `Ready`; `agent:in-progress` → `In Progress`. An otherwise-unmapped open Issue retains its current Project status.
+- Otherwise, Issue projection precedence is closed → `Done`; open `state:known-defect` registry → `Backlog`; epic/parent evidence → `Epic / Parent`; `agent:needs-human` → `Needs Human`; `agent:blocked` → `Blocked`; valid `agent:ready` → `Ready`; `agent:in-progress` → `In Progress`. An otherwise-unmapped open Issue retains its current Project status.
 
 ## Shared operational lease boundary
 

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -50,11 +50,14 @@ Project name:
 - `Agent Delivery Control Plane`
 
 Required fields:
-- `Status`: `Backlog`, `Ready`, `In Progress`, `Review`, `Done`
+- `Status`: `Backlog`, `Epic / Parent`, `Blocked`, `Needs Human`, `Ready`, `In Progress`, `Review`, `Done`
 - `Agent State`: `Idle`, `Running`, `Waiting`
 
 Status meanings:
-- `Backlog`: tracked work that is not yet ready for agent execution or has been moved out of active execution
+- `Backlog`: residual tracked work with no more-specific lifecycle projection; new Issue automation initially places new work here
+- `Epic / Parent`: validation hub evidenced by `type:epic`, `type:feature`, or a non-empty GitHub sub-issue set
+- `Blocked`: an open non-parent Issue labeled `agent:blocked`
+- `Needs Human`: an open non-parent Issue labeled `agent:needs-human`
 - `Ready`: bounded, testable, unblocked work that is eligible for pickup and labeled `agent:ready`
 - `In Progress`: active implementation issue state; on PR items this covers draft PRs and open non-draft PRs without a requested review
 - `Review`: explicit review-handoff state for PR/project items, entered when review is requested — not a default for open PRs (see the lifecycle truth matrix in `.codex/skills/issue-maintenance-change-control/SKILL.md`)
@@ -62,8 +65,8 @@ Status meanings:
 
 Agent-label meanings:
 - `agent:ready`: strictly validated queue-eligible work; Project Status is not a pickup precondition
-- `agent:blocked`: blocked by dependency waiting, including parent validation hubs waiting on child slices; normally pair with a non-active status such as `Backlog`
-- `agent:needs-human`: blocked on a named human decision, tradeoff, missing input, or authority question; normally pair with a non-active status such as `Backlog`
+- `agent:blocked`: blocked by dependency waiting; normally pair with `Blocked` unless durable epic/parent evidence takes precedence
+- `agent:needs-human`: blocked on a named human decision, tradeoff, missing input, or authority question; normally pair with `Needs Human` unless durable epic/parent evidence takes precedence
 - open implementation Issues should normally carry exactly one truthful agent-state label
 - `state:known-defect`: one locked rolling registry Issue for confirmed deferred P2 entries;
   keep it in `Backlog`, with `type:bug`, without an agent-state label, and never treat it as
@@ -100,7 +103,7 @@ Lifecycle guardrails:
 - closed issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`
 - when optional Project repair is in scope, merged or otherwise closed terminal PR items should
   reconcile to `Done`
-- parent feature issues are validation hubs, not direct pickup issues; while child slices remain outstanding they normally live in `Backlog` with `agent:blocked`
+- parent feature issues are validation hubs, not direct pickup issues; while child slices remain outstanding they normally project to `Epic / Parent` even if they carry `agent:blocked`
 - use `agent:needs-human` only when the blocker is a named human decision, tradeoff, missing input, or authority question
 - the `state:known-defect` registry is not an implementation Issue; promotion creates a separate
   canonical `type:bug` Issue and links it back to the registry entry
@@ -108,6 +111,8 @@ Lifecycle guardrails:
 Projection rule:
 - When Project state disagrees with Issue state, PR state, or merged delivery reality, treat the Issue/PR state as authoritative and correct the Project opportunistically.
 - Do not block delivery solely because a personal Project v2 card could not be updated by repo automation.
+- An existing open Issue card explicitly placed in `Review` is an operator projection override and is retained; reconciliation does not infer a PR link or move it back into a split backlog lane.
+- Otherwise, Issue projection precedence is closed → `Done`; epic/parent evidence → `Epic / Parent`; `agent:needs-human` → `Needs Human`; `agent:blocked` → `Blocked`; valid `agent:ready` → `Ready`; `agent:in-progress` → `In Progress`. An otherwise-unmapped open Issue retains its current Project status.
 
 ## Shared operational lease boundary
 

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -62,8 +62,8 @@ Status meanings:
 - `Blocked`: an open non-parent Issue labeled `agent:blocked`
 - `Needs Human`: an open non-parent Issue labeled `agent:needs-human`
 - `Ready`: bounded, testable, unblocked work that is eligible for pickup and labeled `agent:ready`
-- `In Progress`: active implementation issue state; on PR items this covers draft PRs and open non-draft PRs without a requested review
-- `Review`: explicit review-handoff state for PR/project items, entered when review is requested — not a default for open PRs (see the lifecycle truth matrix in `.codex/skills/issue-maintenance-change-control/SKILL.md`)
+- `In Progress`: active implementation Issue state; on PR items this covers open draft PRs
+- `Review`: the Project state for open non-draft PRs, whether or not review was explicitly requested (see `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`)
 - `Done`: merged or otherwise fully delivered work; the Issue is closed and no `agent:*` labels remain
 
 Agent-label meanings:

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -174,9 +174,53 @@ else
   fi
 fi
 
-remove_ready_label() {
-  gh api --method DELETE \
-    "repos/$REPO/issues/$ISSUE_NUMBER/labels/agent%3Aready" >/dev/null
+replace_ready_label_with_in_progress() {
+  # GitHub's per-label DELETE would leave a successful claim with no active
+  # agent-state label. Read the current labels, then use the collection PUT
+  # endpoint for one atomic replacement that keeps every non-agent label.
+  local labels_json label_payload
+  if ! labels_json="$(gh api --method GET "repos/$REPO/issues/$ISSUE_NUMBER/labels")"; then
+    return 1
+  fi
+  if ! label_payload="$(
+    GITHUB_LABELS_JSON="$labels_json" "$JSON_PYTHON_BIN" - <<'PY'
+import json
+import os
+
+try:
+    labels = json.loads(os.environ["GITHUB_LABELS_JSON"])
+except (KeyError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"GitHub label read is not valid JSON: {exc}")
+
+if not isinstance(labels, list):
+    raise SystemExit("GitHub label read did not return a list")
+
+names = []
+for label in labels:
+    name = label.get("name") if isinstance(label, dict) else label
+    if not isinstance(name, str) or not name:
+        raise SystemExit("GitHub label read contained an invalid label")
+    if name.startswith("agent:"):
+        continue
+    if name not in names:
+        names.append(name)
+
+if "agent:ready" not in {
+    label.get("name") if isinstance(label, dict) else label for label in labels
+}:
+    raise SystemExit("GitHub label read no longer contains agent:ready")
+
+names.append("agent:in-progress")
+
+print(json.dumps({"labels": names}))
+PY
+  )"; then
+    return 1
+  fi
+
+  gh api --method PUT \
+    "repos/$REPO/issues/$ISSUE_NUMBER/labels" \
+    --input - <<<"$label_payload" >/dev/null
 }
 
 release_dispatcher_claim() {
@@ -281,11 +325,11 @@ PY
   fi
 
   read -r RECEIPT_LEASE_ID RECEIPT_HOLDER <<< "$validation"
-  if ! remove_ready_label; then
+  if ! replace_ready_label_with_in_progress; then
     if release_dispatcher_claim; then
-      echo "label-removal-failed cleanup=released task_id=$TASK_ID lease_id=$RECEIPT_LEASE_ID holder=$RECEIPT_HOLDER evidence=verified-dispatcher-release" >&2
+      echo "label-transition-failed cleanup=released task_id=$TASK_ID lease_id=$RECEIPT_LEASE_ID holder=$RECEIPT_HOLDER evidence=verified-dispatcher-release" >&2
     else
-      echo "label-removal-failed cleanup-failed task_id=$TASK_ID lease_id=$RECEIPT_LEASE_ID holder=$RECEIPT_HOLDER evidence=cleanup-failed" >&2
+      echo "label-transition-failed cleanup-failed task_id=$TASK_ID lease_id=$RECEIPT_LEASE_ID holder=$RECEIPT_HOLDER evidence=cleanup-failed" >&2
     fi
     exit 1
   fi
@@ -316,8 +360,8 @@ print(comment_id)
 PY
 )"
 
-if ! remove_ready_label; then
-  echo "GitHub label removal failed after claimant intent receipt comment=$comment_id" >&2
+if ! replace_ready_label_with_in_progress; then
+  echo "GitHub label transition failed after claimant intent receipt comment=$comment_id" >&2
   exit 1
 fi
 

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -608,7 +608,7 @@ def reconcile_issue(
     label_names = _issue_label_names(issue)
     invalid_ready_failure = (
         issue_ready_validation_failure(issue)
-        if "agent:ready" in label_names
+        if issue.get("state") != "CLOSED" and "agent:ready" in label_names
         else None
     )
     if args.status == "Ready" and invalid_ready_failure is not None:

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -28,6 +28,16 @@ from scripts.validate_issue_readiness import classify_issue_body
 
 GOVERNANCE_PATH = Path(".github/github-governance.yml")
 DEFAULT_PROJECT_NAME = "Agent Delivery Control Plane"
+PROJECT_STATUS_VALUES = (
+    "Backlog",
+    "Epic / Parent",
+    "Blocked",
+    "Needs Human",
+    "Ready",
+    "In Progress",
+    "Review",
+    "Done",
+)
 SCAN_WATERMARK_PATH = REPO_ROOT / "runtime" / "dispatcher" / "project_status_reconcile_scan_watermark.json"
 PROJECT_ITEM_LIST_INITIAL_LIMIT = 200
 PROJECT_ITEM_SCAN_PAGE_SIZE = 100
@@ -464,7 +474,7 @@ def get_issue(repo: str, number: int) -> dict[str, Any]:
             "--repo",
             repo,
             "--json",
-            "number,state,labels,url,title,body",
+            "number,state,labels,url,title,body,subIssues",
         )
     )
 
@@ -497,16 +507,34 @@ def issue_ready_validation_failure(issue: dict[str, Any]) -> str | None:
     )
 
 
-def desired_issue_status(issue: dict[str, Any]) -> str | None:
+def _has_epic_or_parent_evidence(issue: dict[str, Any]) -> bool:
+    if {"type:epic", "type:feature"} & _issue_label_names(issue):
+        return True
+    return bool((issue.get("subIssues") or {}).get("totalCount"))
+
+
+def desired_issue_status(
+    issue: dict[str, Any], current_status: str | None = None
+) -> str | None:
     if issue.get("state") == "CLOSED":
         return "Done"
+    if current_status == "Review":
+        # Existing Issue Review cards are explicit operator projections, not
+        # inferred PR links that reconciliation may overwrite.
+        return "Review"
     label_names = _issue_label_names(issue)
+    if _has_epic_or_parent_evidence(issue):
+        return "Epic / Parent"
+    if "agent:needs-human" in label_names:
+        return "Needs Human"
+    if "agent:blocked" in label_names:
+        return "Blocked"
     if "agent:ready" in label_names:
         if issue_ready_validation_failure(issue) is not None:
             return "Backlog"
         return "Ready"
-    if {"agent:blocked", "agent:needs-human"} & label_names:
-        return "Backlog"
+    if "agent:in-progress" in label_names:
+        return "In Progress"
     return None
 
 
@@ -586,16 +614,18 @@ def reconcile_issue(
         return 1
     if args.status is None and invalid_ready_failure is not None:
         print(f"invalid issue #{args.issue}: {invalid_ready_failure}")
-    desired = args.status or desired_issue_status(issue)
-    if not desired:
-        print(f"skip issue #{args.issue}: no derived status")
-        return 0
     try:
         items = list_project_items(owner, project["number"])
     except ProjectItemListDeferred as exc:
         print(f"skip issue #{args.issue}: {exc}")
         return 0
     item = find_item_by_number(items, "Issue", args.issue)
+    desired = args.status or desired_issue_status(
+        issue, item.get("status") if item is not None else None
+    )
+    if not desired:
+        print(f"skip issue #{args.issue}: no derived status")
+        return 0
     if item is None:
         print(f'add issue #{args.issue} to project "{project["title"]}"')
         if not args.dry_run:
@@ -710,7 +740,7 @@ def reconcile_scan(
         if kind == "Issue":
             issue = get_issue(repo, number)
             label_names = _issue_label_names(issue)
-            desired = desired_issue_status(issue)
+            desired = desired_issue_status(issue, current)
             if "agent:ready" in label_names:
                 failure = issue_ready_validation_failure(issue)
                 if failure is not None:
@@ -753,7 +783,7 @@ def main() -> int:
     parser.add_argument("--issue", type=int, help="Issue number to reconcile")
     parser.add_argument("--pr", type=int, help="Pull request number to reconcile")
     parser.add_argument("--scan", action="store_true", help="Reconcile all existing project items")
-    parser.add_argument("--status", choices=["Backlog", "Ready", "In Progress", "Review", "Done"])
+    parser.add_argument("--status", choices=PROJECT_STATUS_VALUES)
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -541,15 +541,15 @@ def desired_issue_status(
 
 
 def desired_pr_status(pr: dict[str, Any], explicit_status: str | None) -> str | None:
-    if explicit_status:
-        return explicit_status
     if pr.get("mergedAt"):
         return "Done"
+    if pr.get("state") == "CLOSED":
+        # Terminal PR truth outranks a caller's stale targeted-status request.
+        return "Done"
+    if explicit_status:
+        return explicit_status
     if pr.get("state") == "OPEN":
         return "In Progress" if pr.get("isDraft") else "Review"
-    if pr.get("state") == "CLOSED":
-        # Closed PR cards are terminal Project artifacts and must not remain blank.
-        return "Done"
     return None
 
 

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -622,8 +622,11 @@ def reconcile_issue(
         print(f"skip issue #{args.issue}: {exc}")
         return 0
     item = find_item_by_number(items, "Issue", args.issue)
-    desired = args.status or desired_issue_status(
-        issue, item.get("status") if item is not None else None
+    current_status = item.get("status") if item is not None else None
+    desired = (
+        desired_issue_status(issue, current_status)
+        if issue.get("state") == "CLOSED"
+        else args.status or desired_issue_status(issue, current_status)
     )
     if not desired:
         print(f"skip issue #{args.issue}: no derived status")

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -523,6 +523,8 @@ def desired_issue_status(
         # inferred PR links that reconciliation may overwrite.
         return "Review"
     label_names = _issue_label_names(issue)
+    if "state:known-defect" in label_names:
+        return "Backlog"
     if _has_epic_or_parent_evidence(issue):
         return "Epic / Parent"
     if "agent:needs-human" in label_names:

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -36,8 +36,13 @@ def test_open_non_draft_pr_without_review_request_matches_documented_status() ->
     matrix = Path(".codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md").read_text(
         encoding="utf-8"
     )
+    setup = Path("docs/development/GITHUB_GOVERNANCE_SETUP.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "| PR | OPEN + non-draft, no review requested | `Review` |" in matrix
+    assert "- `In Progress`: active implementation Issue state; on PR items this covers open draft PRs" in setup
+    assert "- `Review`: the Project state for open non-draft PRs, whether or not review was explicitly requested" in setup
     assert (
         desired_pr_status({"state": "OPEN", "isDraft": False, "mergedAt": None}, None)
         == "Review"

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -111,6 +111,12 @@ def test_desired_issue_status_splits_non_active_backlog_lanes() -> None:
     assert desired_issue_status({"state": "OPEN", "labels": []}) is None
 
 
+def test_successful_pickup_label_transition_projects_in_progress() -> None:
+    assert desired_issue_status(
+        {"state": "OPEN", "labels": [{"name": "agent:in-progress"}]}
+    ) == "In Progress"
+
+
 def test_desired_issue_status_projects_known_defect_registry_to_backlog() -> None:
     issue = {"state": "OPEN", "labels": [{"name": "state:known-defect"}]}
 

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -132,6 +132,21 @@ def test_reconcile_cli_accepts_split_backlog_statuses() -> None:
     }
 
 
+def test_canonical_maintenance_surfaces_document_split_lane_precedence() -> None:
+    maintenance_skill = Path(
+        ".codex/skills/issue-maintenance-change-control/SKILL.md"
+    ).read_text(encoding="utf-8")
+    label_taxonomy = Path(".codex/skills/_shared/LABEL_TAXONOMY.md").read_text(
+        encoding="utf-8"
+    )
+
+    for content in (maintenance_skill, label_taxonomy):
+        assert "Epic / Parent" in content
+        assert "Needs Human" in content
+        assert "Blocked" in content
+        assert "explicit open-Issue `Review`" in content
+
+
 def test_pr_stage_change_workflow_subscribes_to_closed_event() -> None:
     # Merge/close must be event-driven so terminal projection does not depend on
     # the best-effort hourly reconcile scan.

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -188,6 +188,25 @@ def test_desired_issue_status_preserves_explicit_review_override() -> None:
     assert desired_issue_status({**issue, "state": "CLOSED"}, "Review") == "Done"
 
 
+def test_reconcile_issue_terminal_truth_precedes_explicit_status(monkeypatch) -> None:
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "get_issue",
+        lambda *_args: {"number": 1, "state": "CLOSED", "labels": [], "url": "https://example.test/1"},
+    )
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "list_project_items",
+        lambda *_args: [{"id": "issue-1", "content": {"type": "Issue", "number": 1}, "status": "Review"}],
+    )
+    calls = []
+    monkeypatch.setattr(reconcile_project_status, "set_project_status", lambda *args: calls.append(args))
+    args = reconcile_project_status.argparse.Namespace(repo="owner/repo", issue=1, status="Review", dry_run=False)
+
+    assert reconcile_project_status.reconcile_issue(args, "owner", {"id": "project", "number": 1, "title": "P"}, "field", {"Done": "done"}) == 0
+    assert calls == [("owner", "project", "issue-1", "field", "done", False)]
+
+
 def test_get_issue_fetches_parent_projection_evidence(monkeypatch) -> None:
     commands = []
 

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -89,6 +89,49 @@ def test_desired_issue_status_requires_ready_candidate_body() -> None:
     assert desired_issue_status(invalid_issue) == "Backlog"
 
 
+def test_desired_issue_status_splits_non_active_backlog_lanes() -> None:
+    assert desired_issue_status({"state": "OPEN", "labels": [{"name": "agent:needs-human"}]}) == "Needs Human"
+    assert desired_issue_status({"state": "OPEN", "labels": [{"name": "agent:blocked"}]}) == "Blocked"
+    assert desired_issue_status({"state": "OPEN", "labels": [{"name": "agent:in-progress"}]}) == "In Progress"
+    assert desired_issue_status({"state": "OPEN", "labels": []}) is None
+
+
+def test_epic_parent_projection_precedes_blocker_projection() -> None:
+    assert desired_issue_status(
+        {"state": "OPEN", "labels": [{"name": "type:epic"}, {"name": "agent:blocked"}]}
+    ) == "Epic / Parent"
+    assert desired_issue_status(
+        {"state": "OPEN", "labels": [{"name": "agent:needs-human"}], "subIssues": {"totalCount": 1}}
+    ) == "Epic / Parent"
+
+
+def test_desired_issue_status_preserves_explicit_review_override() -> None:
+    issue = {"state": "OPEN", "labels": [{"name": "agent:blocked"}]}
+    assert desired_issue_status(issue, "Review") == "Review"
+    assert desired_issue_status({**issue, "state": "CLOSED"}, "Review") == "Done"
+
+
+def test_get_issue_fetches_parent_projection_evidence(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_gh(*args: str) -> str:
+        commands.append(args)
+        return reconcile_project_status.json.dumps({"number": 5177, "subIssues": {"totalCount": 1}})
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+
+    assert reconcile_project_status.get_issue("RasmusTho/agentic-pkm-mvp", 5177)["subIssues"]["totalCount"] == 1
+    assert commands == [
+        ("issue", "view", "5177", "--repo", "RasmusTho/agentic-pkm-mvp", "--json", "number,state,labels,url,title,body,subIssues")
+    ]
+
+
+def test_reconcile_cli_accepts_split_backlog_statuses() -> None:
+    assert set(reconcile_project_status.PROJECT_STATUS_VALUES) == {
+        "Backlog", "Epic / Parent", "Blocked", "Needs Human", "Ready", "In Progress", "Review", "Done"
+    }
+
+
 def test_pr_stage_change_workflow_subscribes_to_closed_event() -> None:
     # Merge/close must be event-driven so terminal projection does not depend on
     # the best-effort hourly reconcile scan.

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -192,7 +192,7 @@ def test_reconcile_issue_terminal_truth_precedes_explicit_status(monkeypatch) ->
     monkeypatch.setattr(
         reconcile_project_status,
         "get_issue",
-        lambda *_args: {"number": 1, "state": "CLOSED", "labels": [], "url": "https://example.test/1"},
+        lambda *_args: {"number": 1, "state": "CLOSED", "labels": [{"name": "agent:ready"}], "url": "https://example.test/1", "body": ""},
     )
     monkeypatch.setattr(
         reconcile_project_status,
@@ -201,7 +201,7 @@ def test_reconcile_issue_terminal_truth_precedes_explicit_status(monkeypatch) ->
     )
     calls = []
     monkeypatch.setattr(reconcile_project_status, "set_project_status", lambda *args: calls.append(args))
-    args = reconcile_project_status.argparse.Namespace(repo="owner/repo", issue=1, status="Review", dry_run=False)
+    args = reconcile_project_status.argparse.Namespace(repo="owner/repo", issue=1, status="Ready", dry_run=False)
 
     assert reconcile_project_status.reconcile_issue(args, "owner", {"id": "project", "number": 1, "title": "P"}, "field", {"Done": "done"}) == 0
     assert calls == [("owner", "project", "issue-1", "field", "done", False)]

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -241,6 +241,7 @@ def test_canonical_maintenance_surfaces_document_split_lane_precedence() -> None
         assert "Needs Human" in content
         assert "Blocked" in content
         assert "explicit open-Issue `Review`" in content
+    assert maintenance_skill.count("--remove-label agent:in-progress") >= 8
 
 
 def test_canonical_label_taxonomy_declares_projection_inputs() -> None:

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -96,6 +96,68 @@ def test_desired_issue_status_splits_non_active_backlog_lanes() -> None:
     assert desired_issue_status({"state": "OPEN", "labels": []}) is None
 
 
+def test_desired_issue_status_projects_known_defect_registry_to_backlog() -> None:
+    issue = {"state": "OPEN", "labels": [{"name": "state:known-defect"}]}
+
+    assert desired_issue_status(issue) == "Backlog"
+    assert desired_issue_status(issue, "Review") == "Review"
+
+
+def test_scan_projects_known_defect_registry_to_backlog(monkeypatch, tmp_path) -> None:
+    watermark_path = tmp_path / "project_status_reconcile_scan_watermark.json"
+    monkeypatch.setattr(reconcile_project_status, "SCAN_WATERMARK_PATH", watermark_path)
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "list_project_items_for_scan",
+        lambda *_args: [
+            {
+                "id": "known-defect-item",
+                "content": {
+                    "type": "Issue",
+                    "number": 4172,
+                    "updatedAt": "2026-08-29T15:00:00Z",
+                },
+                "status": "Needs Human",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "get_issue",
+        lambda *_args: {
+            "number": 4172,
+            "state": "OPEN",
+            "labels": [{"name": "state:known-defect"}],
+            "url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/4172",
+            "body": "",
+        },
+    )
+    status_calls = []
+    monkeypatch.setattr(
+        reconcile_project_status, "set_project_status", lambda *args: status_calls.append(args)
+    )
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "_scan_started_at",
+        lambda: datetime(2026, 8, 29, 16, 0, tzinfo=timezone.utc),
+    )
+
+    args = reconcile_project_status.argparse.Namespace(
+        repo="RasmusTho/agentic-pkm-mvp", dry_run=False, status=None
+    )
+    project = {"id": "project-1", "number": 1, "title": "Agent Delivery Control Plane"}
+
+    assert (
+        reconcile_project_status.reconcile_scan(
+            args, "RasmusTho", project, "field-id", {"Backlog": "backlog-id"}
+        )
+        == 0
+    )
+    assert status_calls == [
+        ("RasmusTho", "project-1", "known-defect-item", "field-id", "backlog-id", False)
+    ]
+
+
 def test_epic_parent_projection_precedes_blocker_projection() -> None:
     assert desired_issue_status(
         {"state": "OPEN", "labels": [{"name": "type:epic"}, {"name": "agent:blocked"}]}
@@ -145,6 +207,20 @@ def test_canonical_maintenance_surfaces_document_split_lane_precedence() -> None
         assert "Needs Human" in content
         assert "Blocked" in content
         assert "explicit open-Issue `Review`" in content
+
+
+def test_canonical_label_taxonomy_declares_projection_inputs() -> None:
+    governance = yaml.safe_load(
+        Path(".github/github-governance.yml").read_text(encoding="utf-8")
+    )
+    taxonomy = Path(".codex/skills/_shared/LABEL_TAXONOMY.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert {"type:epic", "type:feature"} <= set(governance["labels"]["type"])
+    assert "agent:in-progress" in governance["labels"]["agent"]
+    for label in ("type:epic", "type:feature", "agent:in-progress"):
+        assert f"| `{label}`" in taxonomy
 
 
 def test_pr_stage_change_workflow_subscribes_to_closed_event() -> None:

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -242,6 +242,8 @@ def test_canonical_maintenance_surfaces_document_split_lane_precedence() -> None
         assert "Blocked" in content
         assert "explicit open-Issue `Review`" in content
     assert maintenance_skill.count("--remove-label agent:in-progress") >= 8
+    issue_to_code = Path(".codex/skills/issue-to-code/SKILL.md").read_text(encoding="utf-8")
+    assert "--add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human --remove-label agent:in-progress" in issue_to_code
 
 
 def test_canonical_label_taxonomy_declares_projection_inputs() -> None:

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -61,10 +61,20 @@ def test_desired_pr_status_closed_unmerged_pr_is_done() -> None:
     assert desired_pr_status({"state": "CLOSED", "mergedAt": None}, None) == "Done"
 
 
-def test_desired_pr_status_explicit_status_wins() -> None:
+def test_desired_pr_status_explicit_status_applies_to_open_pr() -> None:
     assert (
-        desired_pr_status({"state": "CLOSED", "mergedAt": None}, "Review")
+        desired_pr_status({"state": "OPEN", "isDraft": True, "mergedAt": None}, "Review")
         == "Review"
+    )
+
+
+def test_desired_pr_status_terminal_truth_precedes_explicit_status() -> None:
+    assert desired_pr_status({"state": "CLOSED", "mergedAt": None}, "Review") == "Done"
+    assert (
+        desired_pr_status(
+            {"state": "CLOSED", "mergedAt": "2026-08-29T16:00:00Z"}, "Review"
+        )
+        == "Done"
     )
 
 

--- a/tests/scripts/test_issue_pickup_claim.py
+++ b/tests/scripts/test_issue_pickup_claim.py
@@ -54,7 +54,8 @@ def _make_harness(
     status_json: str,
     claim_json: str = "",
     claim_rc: int = 0,
-    label_delete_rc: int = 0,
+    label_replace_rc: int = 0,
+    labels_json: str = '[{"name":"type:task"},{"name":"prio:high"},{"name":"lane:governance"},{"name":"agent:ready"}]',
     release_json: str = '{"ok":true,"task":{"task_id":"github-RasmusTho--agentic-pkm-mvp-issue-3301","status":"ready","claimed_by":null,"lease_id":null}}',
     release_rc: int = 0,
 ) -> tuple[Path, dict[str, str]]:
@@ -94,7 +95,8 @@ set -eu
 printf 'gh %s\n' "$*" >> "$COMMAND_LOG"
 case "$*" in
   *"/comments"*) echo '{"id":9876,"html_url":"https://example.test/comment/9876"}' ;;
-  *"/labels/agent%3Aready"*) echo '[]'; exit "$FAKE_LABEL_DELETE_RC" ;;
+  *"--method GET repos/"*"/labels"*) printf '%s\n' "$FAKE_LABELS_JSON" ;;
+  *"--method PUT repos/"*"/labels"*) cat > "$FAKE_LABEL_PAYLOAD"; echo '[]'; exit "$FAKE_LABEL_REPLACE_RC" ;;
   *) echo "unexpected gh call: $*" >&2; exit 1 ;;
 esac
 """,
@@ -121,7 +123,9 @@ printf 'preflight %s\n' "$*" >> "$COMMAND_LOG"
             "FAKE_STATUS_JSON": status_json,
             "FAKE_CLAIM_JSON": claim_json,
             "FAKE_CLAIM_RC": str(claim_rc),
-            "FAKE_LABEL_DELETE_RC": str(label_delete_rc),
+            "FAKE_LABEL_REPLACE_RC": str(label_replace_rc),
+            "FAKE_LABELS_JSON": labels_json,
+            "FAKE_LABEL_PAYLOAD": str(tmp_path / "labels.json"),
             "FAKE_RELEASE_JSON": release_json,
             "FAKE_RELEASE_RC": str(release_rc),
         }
@@ -152,7 +156,7 @@ def _run(worktree: Path, env: dict[str, str], *extra: str) -> subprocess.Complet
     )
 
 
-def test_dispatcher_backed_pickup_requires_verified_lease_before_label_removal(
+def test_dispatcher_backed_pickup_replaces_ready_with_in_progress_after_verified_lease(
     tmp_path: Path,
 ) -> None:
     worktree, env = _make_harness(
@@ -177,8 +181,41 @@ def test_dispatcher_backed_pickup_requires_verified_lease_before_label_removal(
     assert "holder=codex-3301" in result.stdout
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
     assert commands.index("dispatcher -m app.dispatcher claim") < commands.index(
-        "gh api --method DELETE"
+        "gh api --method GET repos/RasmusTho/agentic-pkm-mvp/issues/3301/labels"
     )
+    assert "gh api --method PUT repos/RasmusTho/agentic-pkm-mvp/issues/3301/labels" in commands
+    assert json.loads(Path(env["FAKE_LABEL_PAYLOAD"]).read_text(encoding="utf-8")) == {
+        "labels": ["type:task", "prio:high", "lane:governance", "agent:in-progress"]
+    }
+
+
+def test_pickup_normalizes_stale_mixed_agent_labels_without_erasing_non_agent_labels(
+    tmp_path: Path,
+) -> None:
+    worktree, env = _make_harness(
+        tmp_path,
+        status_json=json.dumps(
+            {
+                "ok": True,
+                "db_exists": True,
+                "coordination_mode": "dispatcher-backed",
+                "fallback_reason": None,
+            }
+        ),
+        claim_json=_dispatcher_claim(),
+        labels_json=(
+            '[{"name":"type:task"},{"name":"prio:high"},{"name":"lane:governance"},'
+            '{"name":"agent:ready"},{"name":"agent:blocked"},'
+            '{"name":"agent:needs-human"},{"name":"agent:in-progress"}]'
+        ),
+    )
+
+    result = _run(worktree, env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(Path(env["FAKE_LABEL_PAYLOAD"]).read_text(encoding="utf-8")) == {
+        "labels": ["type:task", "prio:high", "lane:governance", "agent:in-progress"]
+    }
 
 
 def test_default_task_id_is_repo_qualified_to_match_dispatcher_pull(tmp_path: Path) -> None:
@@ -347,7 +384,7 @@ def test_dispatcher_availability_is_not_reported_as_acquired_claim(tmp_path: Pat
         assert result.returncode != 0, name
         assert "pickup-claim-complete" not in result.stdout
         commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
-        assert "gh api --method DELETE" not in commands
+        assert "gh api --method PUT repos/" not in commands
         if claim_rc == 0:
             assert "dispatcher -m app.dispatcher release github-RasmusTho--agentic-pkm-mvp-issue-3301" in commands
 
@@ -381,12 +418,15 @@ def test_label_only_fallback_emits_durable_claimant_receipt(tmp_path: Path) -> N
     assert "session=session-3301" in result.stdout
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
     comment_at = commands.index("gh api --method POST")
-    label_at = commands.index("gh api --method DELETE")
+    label_at = commands.index("gh api --method PUT repos/RasmusTho/agentic-pkm-mvp/issues/3301/labels")
     assert comment_at < label_at
     assert "agent=codex-3301" in commands
     assert "session=session-3301" in commands
     assert "fallback_reason=dispatcher_db_missing" in commands
     assert "dispatcher-backed" not in result.stdout
+    assert json.loads(Path(env["FAKE_LABEL_PAYLOAD"]).read_text(encoding="utf-8")) == {
+        "labels": ["type:task", "prio:high", "lane:governance", "agent:in-progress"]
+    }
 
 
 def test_label_delete_failure_reports_verified_dispatcher_release(tmp_path: Path) -> None:
@@ -401,7 +441,7 @@ def test_label_delete_failure_reports_verified_dispatcher_release(tmp_path: Path
             }
         ),
         claim_json=_dispatcher_claim(),
-        label_delete_rc=1,
+        label_replace_rc=1,
     )
 
     result = _run(worktree, env)
@@ -429,7 +469,7 @@ def test_label_delete_and_release_failure_reports_cleanup_failed_evidence(
             }
         ),
         claim_json=_dispatcher_claim(),
-        label_delete_rc=1,
+        label_replace_rc=1,
         release_json='{ "ok": false }',
         release_rc=1,
     )
@@ -490,7 +530,7 @@ def test_partial_sync_fallback_requires_requested_task_evidence(
     assert "--coordination-mode github-label-only-fallback" not in result.stderr
     assert "dispatcher claim failed for expected task" in result.stderr
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
-    assert "gh api --method DELETE" not in commands
+    assert "gh api --method PUT repos/" not in commands
 
 
 def test_complete_sync_missing_task_keeps_opaque_claim_failure(
@@ -530,4 +570,4 @@ def test_complete_sync_missing_task_keeps_opaque_claim_failure(
     assert "cause=kill-switch-partial-sync" not in result.stderr
     assert "dispatcher claim failed for expected task" in result.stderr
     commands = Path(env["COMMAND_LOG"]).read_text(encoding="utf-8")
-    assert "gh api --method DELETE" not in commands
+    assert "gh api --method PUT repos/" not in commands


### PR DESCRIPTION
Governing-Issue: #5185

Fixes #5185

- [x] Governance lane

Final-Review-Rounds: 0

## Summary
Splits the Project Status projection into Epic / Parent, Blocked, Needs Human, and residual Backlog while preserving explicit open Issue Review cards. Successful pickup now normalizes stale `agent:*` labels to exactly `agent:in-progress` without changing Project claim authority.

## Changes
Updates the canonical lifecycle contract, governance configuration, owner setup guide, reconciler, pickup wrapper, and focused regression coverage.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded repo-governed lifecycle projection change; no BuilderOps operational material was produced.

## Notes
Validation: pytest -q tests/scripts/test_issue_pickup_claim.py tests/ops/test_project_status_reconcile.py (57 passed); bash -n scripts/issue_pickup_claim.sh; ruff check tests/scripts/test_issue_pickup_claim.py tests/ops/test_project_status_reconcile.py; python3 scripts/lint_skills_consistency.py; python3 scripts/docs_guard.py --language-only; git diff --check. Independent P1 convergence review: PASS on e3fe736b9c726e799264c95cc018adcf7b6aaa8b.