### PR TITLE
fix(ci): seed vaultwide watcher ownership

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -549,7 +549,7 @@ jobs:
                   source: "$VAULT_ROOT"
                   target: "$VAULT_ROOT"
                   read_only: true
-            worker:
+            watcher:
               volumes:
                 - type: bind
                   source: "$VAULT_ROOT"
@@ -637,17 +637,17 @@ jobs:
 
           # A fresh CI volume is intentionally dormant after mechanical state
           # preparation. Register the seeded fixture through the exact runtime
-          # consumer preflight, then exercise the existing explicit MVR-01C and
+          # watcher preflight, then exercise the existing explicit MVR-01C and
           # MVR-03 production cutovers before asking the panel to emit governed
           # binding effects. This models an already-cut-over installation; it
           # does not teach ordinary deployment to infer authority activation.
           set +e
-          run_ci_compose run --rm --no-deps -T -e VAULT_ROOT="$VAULT_ROOT" worker \
+          run_ci_compose run --rm --no-deps -T -e VAULT_ROOT="$VAULT_ROOT" watcher \
             python -m app.instance.runtime preflight \
               --channel "${PKM_ENVIRONMENT:-dev}" \
               --instance-state-root /app/instance-state \
               --host-global-root /app/instance-ownership \
-              --consumer worker > "$VAULT_BINDING_RECEIPT_PATH"
+              --consumer watcher > "$VAULT_BINDING_RECEIPT_PATH"
           binding_registration_rc=$?
           set -e
           if [ "$binding_registration_rc" -ne 0 ]; then
@@ -680,7 +680,10 @@ jobs:
           export MVR03_PRINCIPAL_LOOPBACK_LISTENER=0
           prepare_ci_instance_state_deployment
 
-          docker compose $compose_files up -d --build db api watcher worker
+          # The panel verifier exercises the watcher consumer only. Starting
+          # api/worker here would create separate live global owners for this
+          # single CI fixture root, which the ownership ledger must reject.
+          docker compose $compose_files up -d --build db watcher
           LOG_PATH="$VAULTWIDE_PANEL_LOG_PATH" \
           REPORT_PATH="$VAULTWIDE_PANEL_REPORT_PATH" \
           bash scripts/verify_vaultwide_panel.sh

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -65,8 +65,9 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
   `test_staged_backup_failure_surfaces_underlying_cause`,
   `test_inconsistent_registry_ledger_still_fails_closed`), so a backup/ownership verification defect
   fails the changing PR instead of first turning `main`'s post-merge smoke red. The CI fixture seeds
-  its adopted binding through the same `/tmp` path mounted into both `worker` and
-  `instance-state-init`; `tests/architecture/test_ci_smoke_contract.py::test_vaultwide_smoke_seeds_adopted_fixture_with_same_path_identity`
+  its adopted binding through the same `/tmp` path mounted into `watcher` and
+  `instance-state-init`; the final fixture starts that same single `watcher` owner, rather than
+  additional consumers with overlapping live ownership. `tests/architecture/test_ci_smoke_contract.py::test_vaultwide_smoke_seeds_adopted_fixture_with_same_path_identity`
   protects that mount/seed contract without weakening genuine ledger inconsistency rejection. The
   docker-compose integration itself (mounts, launcher sequence, seeded vault) remains post-merge-only
   coverage.

--- a/tests/architecture/test_ci_smoke_contract.py
+++ b/tests/architecture/test_ci_smoke_contract.py
@@ -84,7 +84,7 @@ def test_vaultwide_smoke_activates_registered_fixture_through_production_cutover
     cutover_root = 'export MVR01C_ROLLBACK_VAULT_ROOT="$VAULT_ROOT"'
     principal_cutover = "export MVR03_PRINCIPAL_CUTOVER=1"
     principal_topology = "export MVR03_PRINCIPAL_LOOPBACK_LISTENER=0"
-    services = "docker compose $compose_files up -d --build db api watcher worker"
+    services = "docker compose $compose_files up -d --build db watcher"
 
     assert step.count(deployment) == 2
     first_deployment = step.index(deployment)
@@ -120,12 +120,15 @@ def test_vaultwide_smoke_seeds_adopted_fixture_with_same_path_identity() -> None
     assert 'VAULT_IDENTITY_OVERLAY_PATH="${RUNNER_TEMP}/ci-vault-identity.' in step
     assert overlay_write in step
     assert "          services:\n            instance-state-init:\n" in step
-    assert "            worker:\n              volumes:\n" in step
+    assert "            watcher:\n              volumes:\n" in step
     assert '                  source: "$VAULT_ROOT"' in step
     assert '                  target: "$VAULT_ROOT"' in step
     assert "                  read_only: true" in step
     assert seeded_compose_files in step
-    assert 'run_ci_compose run --rm --no-deps -T -e VAULT_ROOT="$VAULT_ROOT" worker \\' in step
+    assert 'run_ci_compose run --rm --no-deps -T -e VAULT_ROOT="$VAULT_ROOT" watcher \\' in step
+    assert '--consumer watcher > "$VAULT_BINDING_RECEIPT_PATH"' in step
+    assert "docker compose $compose_files up -d --build db watcher" in step
+    assert "docker compose $compose_files up -d --build db api watcher worker" not in step
     first_deployment = step.index(deployment)
     second_deployment = step.index(deployment, first_deployment + len(deployment))
     assert step.index(overlay_write) < step.index(seeded_compose_files)


### PR DESCRIPTION
Governing-Issue: #5189
Closes #5189

## Summary
- Repair the post-merge CI regression from PR #5191 by seeding and starting only the panel verifier watcher consumer at the same CI path.
- Preserve fail-closed ownership-ledger behavior; do not start additional live ownership domains for the one fixture root.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded CI fixture repair; GitHub Issue/PR and dispatcher lease are the delivery authority.

## Validation
- `python3 -m pytest tests/architecture/test_ci_smoke_contract.py tests/ops/test_instance_state_volume_contract.py tests/ops/test_ci_workflow.py -q` (140 passed, 3 skipped)
- `python3 scripts/docs_guard.py`
- `git diff --check`

Final-Review-Rounds: 1