### PR TITLE
Apply executed-run precedence to CI selectors

### DIFF
--- a/.codex/skills/_shared/CI_WAIT_CONTRACT.md
+++ b/.codex/skills/_shared/CI_WAIT_CONTRACT.md
@@ -41,9 +41,10 @@ drains GraphQL to zero and stalls every other agent's reads — a recurring, sys
    non-skipped record per check-run name (ranked by `started_at`, falling back to run id); it falls
    back to the latest skipped record only when that name has no execution. A skipped duplicate from
    an inapplicable event therefore cannot hide a running or failed required execution, while a
-   later executed success still replaces an earlier failure. `epic-run-state lifecycle-plan` reuses
-   that shared selector for terminal dry-runs. A genuinely failed retained record still fails
-   closed.
+   later executed success still replaces an earlier failure. Every production selector that consumes
+   the same check-run evidence, including CI handoff resume and stall classification, must apply this
+   executed-run precedence before deriving a verdict. `epic-run-state lifecycle-plan` reuses that
+   shared selector for terminal dry-runs. A genuinely failed retained record still fails closed.
 8. **A dirty PR schedules no pull_request workflows — absence of a required check is never
    success.** (#4605, LearningSignal `lrn_20260729154323_f134857a`, seen on PR #4354.) When a PR
    is `mergeable_state=dirty`, GitHub cannot compute `refs/pull/<n>/merge`, so the repo's

--- a/.codex/skills/_shared/CI_WAIT_CONTRACT.md
+++ b/.codex/skills/_shared/CI_WAIT_CONTRACT.md
@@ -42,9 +42,10 @@ drains GraphQL to zero and stalls every other agent's reads — a recurring, sys
    back to the latest skipped record only when that name has no execution. A skipped duplicate from
    an inapplicable event therefore cannot hide a running or failed required execution, while a
    later executed success still replaces an earlier failure. Every production selector that consumes
-   the same check-run evidence, including CI handoff resume and stall classification, must apply this
-   executed-run precedence before deriving a verdict. `epic-run-state lifecycle-plan` reuses that
-   shared selector for terminal dry-runs. A genuinely failed retained record still fails closed.
+   the same check-run evidence, including CI handoff resume, stall classification, lifecycle plans,
+   and authenticated merge authority, must apply this executed-run precedence before deriving a
+   verdict. `epic-run-state lifecycle-plan` reuses that shared selector for terminal dry-runs. A
+   genuinely failed retained record still fails closed.
 8. **A dirty PR schedules no pull_request workflows — absence of a required check is never
    success.** (#4605, LearningSignal `lrn_20260729154323_f134857a`, seen on PR #4354.) When a PR
    is `mergeable_state=dirty`, GitHub cannot compute `refs/pull/<n>/merge`, so the repo's

--- a/app/builderops/ci_handoff_state.py
+++ b/app/builderops/ci_handoff_state.py
@@ -166,15 +166,33 @@ def pending_check_summary(checks: Iterable[Mapping[str, Any]]) -> list[dict[str,
 def latest_checks_by_name(
     checks: Iterable[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Keep the newest GitHub check-run per name using stable run evidence."""
+    """Keep the newest executed check-run per name using stable run evidence.
 
-    latest: dict[str, dict[str, Any]] = {}
+    A skipped run is only a fallback when GitHub has no executed run for that
+    name. This keeps an event-inapplicable duplicate from masking a running or
+    failed execution while preserving successful executed reruns.
+    """
+
+    names: list[str] = []
+    latest_executed: dict[str, dict[str, Any]] = {}
+    latest_skipped: dict[str, dict[str, Any]] = {}
     for check in checks:
         normalized = dict(check)
-        existing = latest.get(normalized["name"])
+        name = normalized["name"]
+        if name not in names:
+            names.append(name)
+        selected = (
+            latest_skipped
+            if normalized.get("conclusion") == "skipped"
+            else latest_executed
+        )
+        existing = selected.get(name)
         if existing is None or _is_check_newer(normalized, existing):
-            latest[normalized["name"]] = normalized
-    return list(latest.values())
+            selected[name] = normalized
+    return [
+        (latest_executed.get(name) or latest_skipped[name])
+        for name in names
+    ]
 
 
 def _is_check_newer(

--- a/app/builderops/ci_handoff_state.py
+++ b/app/builderops/ci_handoff_state.py
@@ -166,15 +166,31 @@ def pending_check_summary(checks: Iterable[Mapping[str, Any]]) -> list[dict[str,
 def latest_checks_by_name(
     checks: Iterable[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Keep the newest GitHub check-run per name using stable run evidence."""
+    """Keep the newest executed check-run per name using stable run evidence.
 
-    latest: dict[str, dict[str, Any]] = {}
+    A skipped run is only a fallback when GitHub has no executed run for that
+    name. This keeps an event-inapplicable duplicate from masking a running or
+    failed execution while preserving successful executed reruns.
+    """
+
+    names: list[str] = []
+    latest_executed: dict[str, dict[str, Any]] = {}
+    latest_skipped: dict[str, dict[str, Any]] = {}
     for check in checks:
         normalized = dict(check)
-        existing = latest.get(normalized["name"])
+        name = normalized["name"]
+        if name not in names:
+            names.append(name)
+        conclusion = normalized.get("conclusion")
+        is_skipped = isinstance(conclusion, str) and conclusion.lower() == "skipped"
+        selected = latest_skipped if is_skipped else latest_executed
+        existing = selected.get(name)
         if existing is None or _is_check_newer(normalized, existing):
-            latest[normalized["name"]] = normalized
-    return list(latest.values())
+            selected[name] = normalized
+    return [
+        (latest_executed.get(name) or latest_skipped[name])
+        for name in names
+    ]
 
 
 def _is_check_newer(

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -3654,7 +3654,11 @@ def _checks_rejection(
     if not checks:
         return "missing_checks"
     required_checks = {"Unit tests (not pg)": ".github/workflows/ci-smoke.yaml"}
-    latest: dict[
+    latest_executed: dict[
+        tuple[str, str],
+        tuple[tuple[int, str, int], Mapping[str, object]],
+    ] = {}
+    latest_skipped: dict[
         tuple[str, str],
         tuple[tuple[int, str, int], Mapping[str, object]],
     ] = {}
@@ -3723,8 +3727,17 @@ def _checks_rejection(
             str(check.get("started_at") or check.get("completed_at") or ""),
             index,
         )
-        if key not in latest or rank > latest[key][0]:
-            latest[key] = (rank, check)
+        selected = (
+            latest_skipped
+            if _is_skipped_conclusion(check.get("conclusion"))
+            else latest_executed
+        )
+        if key not in selected or rank > selected[key][0]:
+            selected[key] = (rank, check)
+    latest = {
+        key: latest_executed.get(key) or latest_skipped[key]
+        for key in latest_executed.keys() | latest_skipped.keys()
+    }
     for required_name in required_checks:
         candidates = [
             check
@@ -3746,6 +3759,10 @@ def _checks_rejection(
         }:
             return "checks_not_green"
     return None
+
+
+def _is_skipped_conclusion(value: object) -> bool:
+    return isinstance(value, str) and value.lower() == "skipped"
 
 
 def _context_pack_from_authority(

--- a/app/dispatcher/verification_github.py
+++ b/app/dispatcher/verification_github.py
@@ -797,7 +797,14 @@ class GitHubProtectedRepositoryAuthority:
                 [],
             ).append(row)
         latest_checks = {
-            identity: _latest_github_result(history)
+            identity: _latest_github_result(
+                [
+                    row
+                    for row in history
+                    if not _is_skipped_conclusion(row.get("conclusion"))
+                ]
+                or history
+            )
             for identity, history in check_history.items()
         }
         authenticated_workflow_suites: set[int] = set()
@@ -967,6 +974,10 @@ class GitHubProtectedRepositoryAuthority:
             "merge_commit_message": merge_commit_message,
             "merged_at": pull.get("merged_at"),
         }
+
+
+def _is_skipped_conclusion(value: object) -> bool:
+    return isinstance(value, str) and value.lower() == "skipped"
 
 
 class HostCredentialManifestResolver:

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -175,6 +175,11 @@ python3 scripts/ci_stall_classifier.py \
   --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
+The merge wait, CI handoff resume, and stall classifier use the same per-name
+replacement rule: retain the latest non-skipped execution, and use a skipped
+record only when no execution exists for that check name. This prevents an
+event-inapplicable duplicate from producing false-green coordination evidence.
+
 Classifier output is advisory coordination evidence only:
 - `wait`: pending checks are still within the bounded threshold; keep waiting with the REST/backoff
   path.

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -175,10 +175,11 @@ python3 scripts/ci_stall_classifier.py \
   --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
-The merge wait, CI handoff resume, and stall classifier use the same per-name
-replacement rule: retain the latest non-skipped execution, and use a skipped
-record only when no execution exists for that check name. This prevents an
-event-inapplicable duplicate from producing false-green coordination evidence.
+The merge wait, CI handoff resume, stall classifier, lifecycle plan, and authenticated merge
+authority all consume the canonical per-name replacement rule in
+[`CI_WAIT_CONTRACT.md` Rule 7](../../.codex/skills/_shared/CI_WAIT_CONTRACT.md). Keep this hot path
+operational: the shared contract prevents an event-inapplicable duplicate from producing
+false-green coordination evidence.
 
 Classifier output is advisory coordination evidence only:
 - `wait`: pending checks are still within the bounded threshold; keep waiting with the REST/backoff

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -175,7 +175,8 @@ python3 scripts/ci_stall_classifier.py \
   --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
-The merge wait, CI handoff resume, and stall classifier use the same per-name
+The merge wait, CI handoff resume, stall classifier, lifecycle plan, and authenticated merge
+authority use the same per-name
 replacement rule: retain the latest non-skipped execution, and use a skipped
 record only when no execution exists for that check name. This prevents an
 event-inapplicable duplicate from producing false-green coordination evidence.

--- a/scripts/ci_stall_classifier.py
+++ b/scripts/ci_stall_classifier.py
@@ -265,12 +265,24 @@ def _normalize_check(value: Any) -> CheckRun:
 
 
 def _latest_by_name(checks: list[CheckRun]) -> list[CheckRun]:
-    latest: dict[str, CheckRun] = {}
+    names: list[str] = []
+    latest_executed: dict[str, CheckRun] = {}
+    latest_skipped: dict[str, CheckRun] = {}
     for check in checks:
-        existing = latest.get(check.name)
+        if check.name not in names:
+            names.append(check.name)
+        selected = (
+            latest_skipped
+            if check.conclusion == "skipped"
+            else latest_executed
+        )
+        existing = selected.get(check.name)
         if existing is None or _check_rank(check) >= _check_rank(existing):
-            latest[check.name] = check
-    return list(latest.values())
+            selected[check.name] = check
+    return [
+        (latest_executed.get(name) or latest_skipped[name])
+        for name in names
+    ]
 
 
 def _check_rank(check: CheckRun) -> tuple[str, int]:

--- a/tests/builderops/test_ci_handoff_state.py
+++ b/tests/builderops/test_ci_handoff_state.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from app.builderops.__main__ import _root as builderops_standalone_root
 from app.builderops.ci_handoff_state import (
     build_ci_pending_handoff,
+    latest_checks_by_name,
     plan_ci_handoff_resume,
     record_ci_pending_handoff,
 )
@@ -174,6 +175,100 @@ def test_resume_deduplicates_stale_failed_rerun_checks() -> None:
     assert plan["blocked_reasons"] == []
     check_names = [item["name"] for item in plan["closure_plan_candidate"]["checks"]]
     assert check_names == ["pr-contract", "Unit tests (not pg)"]
+    assert plan["closure_plan_candidate"]["checks"][0]["conclusion"] == "success"
+
+
+def test_plan_ci_handoff_resume_does_not_mask_running_check_with_skipped_duplicate() -> None:
+    handoff = build_ci_pending_handoff(
+        issue_number=5196,
+        pr_number=5171,
+        head_sha="abc123",
+        local_validation=["pytest -q tests/builderops/test_ci_handoff_state.py"],
+        review_state="review-comments-clear",
+        next_closure_action="wait for CI",
+    )
+
+    checks = [
+        {
+            "id": 1,
+            "name": "pr-contract",
+            "status": "in_progress",
+            "started_at": "2026-08-30T01:00:00Z",
+        },
+        {
+            "id": 2,
+            "name": "pr-contract",
+            "status": "completed",
+            "conclusion": "skipped",
+            "started_at": "2026-08-30T01:05:00Z",
+        },
+        {
+            "id": 3,
+            "name": "Unit tests (not pg)",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+
+    retained = latest_checks_by_name(checks)
+    assert retained[0]["status"] == "in_progress"
+
+    plan = plan_ci_handoff_resume(
+        handoff=handoff,
+        live_pr={"number": 5171, "headRefOid": "abc123"},
+        checks=checks,
+    )
+
+    assert plan["blocked"] is True
+    assert plan["blocked_reasons"] == ["ci-not-terminal"]
+    assert plan["closure_plan_candidate"] is None
+
+
+def test_latest_checks_by_name_prefers_latest_executed_run() -> None:
+    handoff = build_ci_pending_handoff(
+        issue_number=5196,
+        pr_number=5171,
+        head_sha="abc123",
+        local_validation=["pytest -q tests/builderops/test_ci_handoff_state.py"],
+        review_state="review-comments-clear",
+        next_closure_action="merge after green CI",
+    )
+
+    plan = plan_ci_handoff_resume(
+        handoff=handoff,
+        live_pr={"number": 5171, "headRefOid": "abc123"},
+        checks=[
+            {
+                "id": 1,
+                "name": "pr-contract",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-08-30T01:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "pr-contract",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-08-30T01:05:00Z",
+            },
+            {
+                "id": 3,
+                "name": "pr-contract",
+                "status": "completed",
+                "conclusion": "skipped",
+                "started_at": "2026-08-30T01:10:00Z",
+            },
+            {
+                "id": 4,
+                "name": "Unit tests (not pg)",
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ],
+    )
+
+    assert plan["ok"] is True
     assert plan["closure_plan_candidate"]["checks"][0]["conclusion"] == "success"
 
 

--- a/tests/builderops/test_epic_lifecycle_plan.py
+++ b/tests/builderops/test_epic_lifecycle_plan.py
@@ -248,6 +248,41 @@ def test_done_plan_uses_latest_check_run_per_name() -> None:
     ]
 
 
+def test_done_plan_skipped_duplicate_does_not_mask_running_execution() -> None:
+    plan = build_lifecycle_transition_plan(
+        transition="done",
+        issue=_issue(state="CLOSED", labels=["type:task"], project_status="Review"),
+        pull_request=_pr(state="CLOSED", merged=True, project_status="Review"),
+        checks=[
+            {
+                "id": 1,
+                "name": "unit",
+                "status": "in_progress",
+                "started_at": "2026-08-30T01:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "unit",
+                "status": "completed",
+                "conclusion": "skipped",
+                "started_at": "2026-08-30T01:05:00Z",
+            },
+        ],
+        repo="RasmusTho/agentic-pkm-mvp",
+    )
+
+    assert plan["blocked_reasons"] == ["ci-checks-not-green"]
+    assert plan["content"]["checks"] == [
+        {
+            "name": "unit",
+            "status": "IN_PROGRESS",
+            "conclusion": None,
+            "id": 1,
+            "started_at": "2026-08-30T01:00:00Z",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("status", "conclusion", "latest_started_at"),
     [

--- a/tests/dispatcher/test_verification_merge.py
+++ b/tests/dispatcher/test_verification_merge.py
@@ -1875,7 +1875,7 @@ def test_live_adapter_rejects_green_push_masking_failed_pr_check() -> None:
             return httpx.Response(
                 200,
                 json={
-                    "total_count": 6,
+                    "total_count": 7,
                     "check_runs": [
                         {
                             "id": 10,
@@ -1901,6 +1901,18 @@ def test_live_adapter_rejects_green_push_masking_failed_pr_check() -> None:
                             "status": "completed",
                             "conclusion": "failure",
                             "completed_at": "2026-07-30T10:00:00Z",
+                            "app": {
+                                "id": 7,
+                                "slug": "github-actions",
+                            },
+                            "check_suite": {"id": 70},
+                        },
+                        {
+                            "id": 16,
+                            "name": "Docs Guard",
+                            "status": "completed",
+                            "conclusion": "skipped",
+                            "completed_at": "2026-07-30T10:03:00Z",
                             "app": {
                                 "id": 7,
                                 "slug": "github-actions",

--- a/tests/dispatcher/test_verification_review_repairs_attempt6.py
+++ b/tests/dispatcher/test_verification_review_repairs_attempt6.py
@@ -910,6 +910,26 @@ def test_required_check_accepts_latest_github_actions_rerun() -> None:
     assert _checks_rejection(checks, expected_head_sha=HEAD) is None
 
 
+def test_optional_failed_execution_is_not_masked_by_skipped_duplicate() -> None:
+    optional_failed = {
+        "id": 20,
+        "name": "optional",
+        "status": "completed",
+        "conclusion": "failure",
+        "app": {"id": 999, "slug": "external"},
+    }
+    optional_skipped = {
+        **optional_failed,
+        "id": 21,
+        "conclusion": "skipped",
+    }
+
+    assert _checks_rejection(
+        [_check(check_id=12, conclusion="success"), optional_failed, optional_skipped],
+        expected_head_sha=HEAD,
+    ) == "checks_not_green"
+
+
 def test_required_check_rejects_missing_producer_identity() -> None:
     checks = [_check(check_id=11, conclusion="success", app_slug=None)]
 

--- a/tests/scripts/test_ci_stall_classifier.py
+++ b/tests/scripts/test_ci_stall_classifier.py
@@ -173,6 +173,37 @@ def test_latest_check_run_uses_numeric_id_to_break_timestamp_ties() -> None:
     assert result.checks_considered[0]["id"] == 10
 
 
+def test_skipped_duplicate_does_not_mask_running_or_failed_check() -> None:
+    for status, conclusion, expected_classification in (
+        ("in_progress", None, "wait"),
+        ("completed", "failure", "actionable_failure"),
+    ):
+        result = classify_ci_state(
+            {
+                "check_runs": [
+                    _check(
+                        "pr-contract",
+                        status=status,
+                        conclusion=conclusion,
+                        started_at="2026-08-30T01:00:00Z",
+                        check_id=1,
+                    ),
+                    _check(
+                        "pr-contract",
+                        status="completed",
+                        conclusion="skipped",
+                        started_at="2026-08-30T01:05:00Z",
+                        check_id=2,
+                    ),
+                ]
+            },
+            now="2026-08-30T01:10:00Z",
+        )
+
+        assert result.classification == expected_classification
+        assert result.checks_considered[0]["conclusion"] == conclusion
+
+
 def test_missing_expected_check_reports_missing_attachment() -> None:
     result = classify_ci_state(
         {


### PR DESCRIPTION
Governing-Issue: #5196

Fixes #5196

Final-Review-Rounds: 1

## Summary
Apply the CI wait contract's executed-run precedence to all five production check selectors. A later skipped duplicate can no longer mask a running or failed execution across CI handoff, stall classification, lifecycle planning, and authenticated merge authority; a later executed success still supersedes an earlier failure.

## Source Review
- Source P1: [PR #5171 review thread](https://github.com/RasmusTho/agentic-pkm-mvp/pull/5171#discussion_r3886278749) at exact head `54c875f1438add687ae429cc30f387a5a1ef1143`.
- Follow-up P1: [PR #5198 review thread](https://github.com/RasmusTho/agentic-pkm-mvp/pull/5198#discussion_r3888255123) at exact head `3f8cb1c3d050c17e3f2745d7130685a4903c0438`; repaired in reviewed tree `2528aefee4ce028eadbe381ca998b5f476415362`, published descendant `10212e93cc56dd3327b069f357af29d01cfbfe71`.
- Governing selector contract: `.codex/skills/_shared/CI_WAIT_CONTRACT.md`.

## SBS Impact
- Primary subsystem: Builder System / CI governance
- Secondary subsystem(s): verification and closure; PR hot path
- Write class: governance/tooling
- Persistence impact: none
- Derived/rebuildable impact: CI classification remains derived from live check-run evidence
- New or changed contract: event-inapplicable skipped duplicates cannot supersede an executing required check
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: CI helper output must not claim green closure from a skipped duplicate while an executed check remains running or failed

## BuilderOps Routing
- Records/projections/receipts: LearningSignals `lrn_20260830021413_37a32b26` and `lrn_20260830030939_4849cce5`
- Reason: The repair addresses the terminal-closure review-thread divergence and the discovered under-scoped selector inventory.

## Validation
- Host-leased focused tests for merge authority, verification consumer, CI handoff, stall classification, and lifecycle planning — 112 passed.
- `codex review --commit 2528aefee4ce028eadbe381ca998b5f476415362` — clean; published merge commit `10212e93cc56dd3327b069f357af29d01cfbfe71` is byte-identical in tree.
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — passed for the canonical-reference docs correction.
- Targeted Ruff check for changed dispatcher/test files — passed.
- `python3 scripts/review_before_ci_gate.py ...` — passed for exact candidate `10212e93cc56dd3327b069f357af29d01cfbfe71` with `external-api` and `state-machine` risk surfaces.
- `git diff --check` — passed.