### PR TITLE
Add machine-routable blocker actions

### DIFF
--- a/.codex/skills/_shared/BLOCKER_ACTION_CONTRACT.md
+++ b/.codex/skills/_shared/BLOCKER_ACTION_CONTRACT.md
@@ -1,0 +1,23 @@
+State: Shared contract. Canonical next-action receipt for non-active Issues.
+
+# Blocker Action Contract
+
+Use this contract whenever a workflow creates, repairs, blocks, escalates, verifies, or closes an
+Issue. Lifecycle state and action subtype are separate: labels are routing metadata, while the
+Issue comment is durable evidence. This contract does not make Project, Cockpit, or a watcher an
+authority and does not authorize pickup of blocked work.
+
+```yaml
+receipt: blocker_action.v1
+action: action:repair-contract
+owner: builder|owner|external:<name>
+next_action: concise executable next action
+unblocks_when: observable condition
+dependency_refs: []
+review_at: null
+last_verified_at: RFC3339 timestamp
+```
+
+Open `agent:blocked` uses exactly one blocked `action:*`; open `agent:needs-human` uses exactly
+one human `action:*`. Before `agent:ready`, re-read the evidence, remove the action label, and do
+not infer a cause from a legacy coarse state. On terminal closure remove every `action:*` label.

--- a/.codex/skills/_shared/BLOCKER_ACTION_CONTRACT.md
+++ b/.codex/skills/_shared/BLOCKER_ACTION_CONTRACT.md
@@ -18,6 +18,10 @@ review_at: null
 last_verified_at: RFC3339 timestamp
 ```
 
+`owner` is exactly `builder`, `owner`, or `external:<name>`, where `<name>` is a non-empty lowercase
+identifier matching `[a-z0-9][a-z0-9._-]*`. Consumers reject every other value rather than projecting
+unverified action evidence.
+
 Open `agent:blocked` uses exactly one blocked `action:*`; open `agent:needs-human` uses exactly
 one human `action:*`. Before `agent:ready`, re-read the evidence, remove the action label, and do
 not infer a cause from a legacy coarse state. On terminal closure remove every `action:*` label.

--- a/.codex/skills/_shared/LABEL_TAXONOMY.md
+++ b/.codex/skills/_shared/LABEL_TAXONOMY.md
@@ -20,6 +20,16 @@ own copies.
 | `agent:ready` | bounded, testable, unblocked, and strictly validated — safe for agent pickup without requiring Project Status |
 | `agent:blocked` | dependency unresolved, including parent validation hubs waiting on child slices |
 | `agent:needs-human` | requires a named human decision, tradeoff, missing input, or authority question |
+| `action:repair-contract` | blocked: next action is truthful contract/maintenance repair, not an inferred cause |
+| `action:wait-dependency` | blocked: wait for named dependency evidence |
+| `action:restore-environment` | blocked: restore a named local/host/service environment |
+| `action:wait-external` | blocked: wait for a named external system or party |
+| `action:review-at` | blocked: re-evaluate at a named review trigger |
+| `action:human-decision` | needs human: owner decision required |
+| `action:human-authorization` | needs human: authorization required |
+| `action:human-access` | needs human: access grant or credential action required |
+| `action:human-operation` | needs human: operator action required |
+| `action:human-acceptance` | needs human: acceptance observation required |
 | `agent:in-progress` | active implementation work under a current claim or delivery handoff |
 | `state:known-defect` | rolling registry Issue containing confirmed deferred P2 defect entries; never an implementation pickup label |
 
@@ -34,6 +44,13 @@ Rules:
   An existing explicit open-Issue `Review` projection is retained. None of these projections
   controls pickup.
 - Closed or delivered Issues must not retain any `agent:*` label.
+- An open `agent:blocked` Issue carries exactly one `action:repair-contract`,
+  `action:wait-dependency`, `action:restore-environment`, `action:wait-external`, or
+  `action:review-at` label. An open `agent:needs-human` Issue carries exactly one
+  `action:human-*` label. Other and terminal states carry no `action:*` label.
+- The durable comment receipt is `blocker_action.v1` with `action`, `owner`,
+  `next_action`, `unblocks_when`, `dependency_refs`, optional `review_at`, and
+  `last_verified_at`. Labels route; the receipt names the evidence and never grants a claim.
 - `state:known-defect` belongs only on the locked rolling Known Defects registry Issue. That
   container also carries `type:bug`, is not an implementation Issue, carries no `agent:*` label,
   remains in `Backlog` if projected, and must never carry `agent:ready`. During explicit Project

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -5,6 +5,9 @@ description: "Route confirmed bugs to a bounded GitHub Issue or the deterministi
 
 # Bug To Issue
 
+If a bug cannot be ready, pair `agent:blocked` or `agent:needs-human` with exactly one compatible
+`action:*` label and `blocker_action.v1` receipt from `_shared/BLOCKER_ACTION_CONTRACT.md`.
+
 ## Overview
 
 Turn a discovered bug into either:

--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -5,6 +5,9 @@ description: "Review, plan, make ready, and deliver an epic, parent feature issu
 
 # Deliver Issue Set
 
+Blocked and needs-human candidates must carry the compatible `action:*` subtype and
+`blocker_action.v1` receipt defined in `_shared/BLOCKER_ACTION_CONTRACT.md`; they remain non-pickup.
+
 Use this skill when asked to review, plan, make ready, or deliver an epic, parent feature issue, Kanban/Project lane, or larger set of issues that should move through agent pickup.
 
 The goal is to produce an executable implementation plan and, when requested, deliver the full epic or all in-scope Kanban/Project issues that can truthfully be delivered. When the ready pool is too small, repair or create bounded ready issues using the repo's existing backlog workflows.

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -5,6 +5,9 @@ description: "Convert active repo documentation into bounded GitHub Issues witho
 
 # Docs To Issue
 
+Non-ready Issue creation uses the compatible `action:*` subtype and `blocker_action.v1` receipt
+defined by `_shared/BLOCKER_ACTION_CONTRACT.md`; lifecycle state alone is insufficient.
+
 You are a repository backlog-orchestration agent for a repo-first, docs-as-code software system.
 
 Your job is to convert active documentation into bounded GitHub Issues without inventing strategy.

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -5,6 +5,9 @@ description: "Break a docs-defined capability into a specification directory wit
 
 # Feature Breakdown
 
+When a generated child is non-active, assign its compatible `action:*` subtype and
+`blocker_action.v1` receipt from `_shared/BLOCKER_ACTION_CONTRACT.md`, never a coarse state alone.
+
 Use this skill when a docs-defined capability is too large for one implementation issue or when the work needs post-merge validation before owner docs should claim it as supported.
 
 ## Repository target

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -5,6 +5,10 @@ description: "Keep GitHub Issues, PRs, labels, and optional Project projection t
 
 # Issue Maintenance: Change Control
 
+When setting or repairing `agent:blocked` / `agent:needs-human`, apply exactly one compatible
+`action:*` label and a `blocker_action.v1` receipt per `_shared/BLOCKER_ACTION_CONTRACT.md`; remove
+action labels on ready or terminal transitions.
+
 You are an Issue maintenance and lifecycle-correction agent for a repo-first, docs-as-code software system.
 
 ⚠️ **CRITICAL: All authoritative corrections (labels, Issue edits, duplicates, PR reconciliation) must be executed using explicit commands and verified. Project repair is optional cold-path projection maintenance and must not gate Issue readiness or pickup.**

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -301,8 +301,10 @@ If work becomes blocked before or during implementation:
    gh issue view #<N> --repo "$REPO" --json state,labels,comments
    ```
 
-**Use `agent:blocked`** when blocked by dependency or setup.  
-**Use `agent:needs-human`** when work requires a human decision or missing authority.
+Use `agent:blocked` with exactly one blocked `action:*` label when dependency or setup blocks work.
+Use `agent:needs-human` with exactly one human `action:*` label only for a real authority boundary.
+Post the `blocker_action.v1` receipt from `_shared/BLOCKER_ACTION_CONTRACT.md`; terminal closure
+removes every action label.
 
 ### Action: Open Draft PR (Work In Progress)
 

--- a/.codex/skills/learning-to-issue/SKILL.md
+++ b/.codex/skills/learning-to-issue/SKILL.md
@@ -5,6 +5,9 @@ description: "Convert retrospective learnings from BuilderOps LearningSignal rec
 
 # Learning To Issue
 
+When an intake is blocked or needs human, add one compatible `action:*` label and the
+`blocker_action.v1` receipt from `_shared/BLOCKER_ACTION_CONTRACT.md`.
+
 Convert retrospective learnings into bounded, verifiable GitHub Issues that match the repo's canonical issue contract.
 
 This is the maintenance-learning intake lane. It is distinct from `docs-to-issue` (which converts active SoT docs into product-feature backlog) and from `capture-learning` (which creates a BuilderOps `LearningSignal`).

--- a/.codex/skills/owner-decision-brief/SKILL.md
+++ b/.codex/skills/owner-decision-brief/SKILL.md
@@ -5,6 +5,9 @@ description: "Yggdrasil profile for owner escalations: use the repo-local decisi
 
 # Owner Decision Brief
 
+An owner escalation applies exactly one compatible `action:human-*` label and the shared
+`blocker_action.v1` receipt (`_shared/BLOCKER_ACTION_CONTRACT.md`); it is not a generic blocker.
+
 This is a thin Yggdrasil profile for the repo-local `decision-quality` skill. It applies whenever a
 repository workflow is about to ask the owner for a decision: an `agent:needs-human` label, an
 operator acknowledgment, an inline question, or an open question in an Issue or PR.

--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -10,6 +10,10 @@ You are invoked at the end of `verification-and-closure`, after a PR has merged.
 You act on the answer. You do not ask the user to classify, attest, or unblock.
 This is a cold-path maintenance check, not a hot-path implementation step.
 
+If a post-merge follow-up is ever classified as `agent:blocked` or `agent:needs-human`, apply
+`_shared/BLOCKER_ACTION_CONTRACT.md`: use one compatible canonical `action:*` label and a valid
+`blocker_action.v1` receipt. This skill does not assign either lifecycle by default.
+
 ## The one question
 
 For the merged PR, read:

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -5,6 +5,9 @@ description: "Verify delivered slice work against its governing contract, merge 
 
 # Verification and Closure
 
+Before readiness or terminal closure, apply `_shared/BLOCKER_ACTION_CONTRACT.md`: re-read blocker
+evidence before removing an action label, and remove all action labels from a closed Issue.
+
 You are the delivery verification and feedback-loop agent for repo-first, docs-as-code work.
 
 Use [`docs/development/PR_HOT_PATH.md`](../../../docs/development/PR_HOT_PATH.md) for the default PR delivery shape.

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -39,6 +39,17 @@ labels:
     - agent:blocked
     - agent:needs-human
     - agent:in-progress
+  action:
+    - action:repair-contract
+    - action:wait-dependency
+    - action:restore-environment
+    - action:wait-external
+    - action:review-at
+    - action:human-decision
+    - action:human-authorization
+    - action:human-access
+    - action:human-operation
+    - action:human-acceptance
   state:
     - state:known-defect
   lane:

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -22,6 +22,9 @@ jobs:
             const issue = context.payload.issue;
             const labels = (issue.labels || []).map(label => label.name);
             const agentLabels = labels.filter(name => name.startsWith("agent:"));
+            const actionLabels = labels.filter(name => name.startsWith("action:"));
+            const blockedActions = new Set(["action:repair-contract", "action:wait-dependency", "action:restore-environment", "action:wait-external", "action:review-at"]);
+            const humanActions = new Set(["action:human-decision", "action:human-authorization", "action:human-access", "action:human-operation", "action:human-acceptance"]);
             if (agentLabels.length > 1) {
               core.setFailed(`Issue must not carry more than one agent label at once: ${agentLabels.join(", ")}`);
               return;
@@ -35,6 +38,23 @@ jobs:
                   name,
                 });
               }
+            }
+            if (issue.state === "closed" && actionLabels.length) {
+              for (const name of actionLabels) {
+                await github.rest.issues.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, name});
+              }
+              return;
+            }
+            if (issue.state !== "closed") {
+              const lifecycle = labels.filter(name => name === "agent:blocked" || name === "agent:needs-human");
+              if (lifecycle.length === 1 && actionLabels.length !== 1) {
+                core.setFailed("Open blocked/needs-human Issue must carry exactly one action:* label"); return;
+              }
+              if (lifecycle.length === 0 && actionLabels.length) {
+                core.setFailed("action:* labels require agent:blocked or agent:needs-human"); return;
+              }
+              if (lifecycle[0] === "agent:blocked" && actionLabels.length === 1 && !blockedActions.has(actionLabels[0])) core.setFailed("agent:blocked requires a canonical blocked action:* label");
+              if (lifecycle[0] === "agent:needs-human" && actionLabels.length === 1 && !humanActions.has(actionLabels[0])) core.setFailed("agent:needs-human requires a canonical human action:* label");
             }
 
   issue-shape:

--- a/app/builderops/blocker_actions.py
+++ b/app/builderops/blocker_actions.py
@@ -8,6 +8,7 @@ their own bounded, auditable write boundary.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 BLOCKED_ACTIONS = frozenset({
@@ -26,6 +27,51 @@ LEGACY_HUMAN_ACTIONS = {
     "human:operator": "action:human-operation",
     "human:acceptance": "action:human-acceptance",
 }
+
+RECEIPT_FIELDS = ("action", "owner", "next_action", "unblocks_when", "dependency_refs", "review_at", "last_verified_at")
+
+
+def _valid_timestamp(value: object) -> bool:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def parse_blocker_action_receipt(comment: object) -> dict[str, object] | None:
+    """Parse the deliberately small YAML receipt subset from one REST comment."""
+    body = comment.get("body", "") if isinstance(comment, dict) else str(comment)
+    if "receipt: blocker_action.v1" not in body:
+        return None
+    values: dict[str, object] = {"dependency_refs": []}
+    for line in body.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.strip().split(":", 1)
+        if key in RECEIPT_FIELDS or key == "receipt":
+            values[key] = value.strip()
+    if values.get("dependency_refs") == "[]":
+        values["dependency_refs"] = []
+    action = values.get("action")
+    if action not in ACTION_LABELS or any(not isinstance(values.get(key), str) or not values[key] for key in ("owner", "next_action", "unblocks_when")) or not _valid_timestamp(values.get("last_verified_at")):
+        return None
+    return values
+
+
+def latest_receipt(comments: Iterable[object]) -> dict[str, object] | None:
+    receipts = [receipt for item in comments if (receipt := parse_blocker_action_receipt(item))]
+    return receipts[-1] if receipts else None
+
+
+def receipt_for_action(action: str, *, now: datetime | None = None) -> dict[str, object]:
+    """Produce a valid, explicit maintenance receipt without inventing cause."""
+    if action not in ACTION_LABELS:
+        raise ValueError(f"unknown blocker action: {action}")
+    stamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return {"receipt": "blocker_action.v1", "action": action, "owner": "builder-system-maintenance", "next_action": "verify and repair the live Issue contract before pickup", "unblocks_when": "fresh authority evidence establishes a valid transition", "dependency_refs": [], "review_at": "null", "last_verified_at": stamp}
 
 
 def label_names(issue: dict[str, Any]) -> set[str]:
@@ -65,15 +111,21 @@ def intake(issues: Iterable[dict[str, Any]]) -> dict[str, Any]:
         if not labels & {"agent:blocked", "agent:needs-human"}:
             continue
         verdict = classify(labels, open_issue=str(issue.get("state", "open")).lower() == "open")
+        receipt = latest_receipt(issue.get("comments", []))
         item = {
             "issue_number": issue.get("number"), "title": issue.get("title"),
             "state": issue.get("state", "open"), "action": verdict.action,
-            "owner": issue.get("blocker_action", {}).get("owner") if isinstance(issue.get("blocker_action"), dict) else None,
-            "next_action": issue.get("blocker_action", {}).get("next_action") if isinstance(issue.get("blocker_action"), dict) else None,
+            "owner": receipt.get("owner") if receipt else None,
+            "next_action": receipt.get("next_action") if receipt else None,
+            "receipt_freshness": receipt.get("last_verified_at") if receipt else None,
             "claim_posture": "read-only; never claims implementation work",
         }
-        if verdict.errors:
+        if verdict.errors or receipt is None:
+            if receipt is None:
+                item.setdefault("errors", []).append("missing_or_invalid_blocker_action_receipt")
             item["errors"] = list(verdict.errors)
+            if receipt is None:
+                item["errors"].append("missing_or_invalid_blocker_action_receipt")
             drift.append(item)
         elif verdict.action:
             queues[verdict.action].append(item)

--- a/app/builderops/blocker_actions.py
+++ b/app/builderops/blocker_actions.py
@@ -41,6 +41,10 @@ def _valid_timestamp(value: object) -> bool:
     return True
 
 
+def _valid_owner(value: object) -> bool:
+    return value in {"builder", "owner"} or (isinstance(value, str) and value.startswith("external:") and len(value) > len("external:"))
+
+
 def parse_blocker_action_receipt(comment: object) -> dict[str, object] | None:
     """Parse the deliberately small YAML receipt subset from one REST comment."""
     body = comment.get("body", "") if isinstance(comment, dict) else str(comment)
@@ -56,7 +60,7 @@ def parse_blocker_action_receipt(comment: object) -> dict[str, object] | None:
     if values.get("dependency_refs") == "[]":
         values["dependency_refs"] = []
     action = values.get("action")
-    if action not in ACTION_LABELS or any(not isinstance(values.get(key), str) or not values[key] for key in ("owner", "next_action", "unblocks_when")) or not _valid_timestamp(values.get("last_verified_at")):
+    if action not in ACTION_LABELS or not _valid_owner(values.get("owner")) or any(not isinstance(values.get(key), str) or not values[key] for key in ("next_action", "unblocks_when")) or not _valid_timestamp(values.get("last_verified_at")):
         return None
     return values
 
@@ -71,7 +75,7 @@ def receipt_for_action(action: str, *, now: datetime | None = None) -> dict[str,
     if action not in ACTION_LABELS:
         raise ValueError(f"unknown blocker action: {action}")
     stamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-    return {"receipt": "blocker_action.v1", "action": action, "owner": "builder-system-maintenance", "next_action": "verify and repair the live Issue contract before pickup", "unblocks_when": "fresh authority evidence establishes a valid transition", "dependency_refs": [], "review_at": "null", "last_verified_at": stamp}
+    return {"receipt": "blocker_action.v1", "action": action, "owner": "builder", "next_action": "verify and repair the live Issue contract before pickup", "unblocks_when": "fresh authority evidence establishes a valid transition", "dependency_refs": [], "review_at": "null", "last_verified_at": stamp}
 
 
 def label_names(issue: dict[str, Any]) -> set[str]:

--- a/app/builderops/blocker_actions.py
+++ b/app/builderops/blocker_actions.py
@@ -1,0 +1,80 @@
+"""Canonical next-action classification for non-active GitHub Issues.
+
+This is deliberately a pure, read-only projection.  It never claims work or
+changes an Issue's lifecycle state; callers that mutate labels must provide
+their own bounded, auditable write boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+BLOCKED_ACTIONS = frozenset({
+    "action:repair-contract", "action:wait-dependency", "action:restore-environment",
+    "action:wait-external", "action:review-at",
+})
+HUMAN_ACTIONS = frozenset({
+    "action:human-decision", "action:human-authorization", "action:human-access",
+    "action:human-operation", "action:human-acceptance",
+})
+ACTION_LABELS = BLOCKED_ACTIONS | HUMAN_ACTIONS
+LEGACY_HUMAN_ACTIONS = {
+    "human:decision": "action:human-decision",
+    "human:authorize": "action:human-authorization",
+    "human:access": "action:human-access",
+    "human:operator": "action:human-operation",
+    "human:acceptance": "action:human-acceptance",
+}
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    return {str(item.get("name") if isinstance(item, dict) else item) for item in issue.get("labels", [])}
+
+
+@dataclass(frozen=True)
+class ActionVerdict:
+    action: str | None
+    errors: tuple[str, ...]
+
+
+def classify(labels: Iterable[str], *, open_issue: bool = True) -> ActionVerdict:
+    labels = set(labels)
+    actions = sorted(labels & ACTION_LABELS)
+    lifecycle = labels & {"agent:blocked", "agent:needs-human"}
+    if not open_issue:
+        return ActionVerdict(None, () if not actions else ("terminal_issue_has_action_label",))
+    if len(lifecycle) != 1:
+        return ActionVerdict(None, () if not actions else ("action_without_blocker_lifecycle",))
+    if len(actions) != 1:
+        return ActionVerdict(None, ("missing_action_label" if not actions else "multiple_action_labels",))
+    action = actions[0]
+    if "agent:blocked" in lifecycle and action not in BLOCKED_ACTIONS:
+        return ActionVerdict(action, ("blocked_requires_blocked_action",))
+    if "agent:needs-human" in lifecycle and action not in HUMAN_ACTIONS:
+        return ActionVerdict(action, ("needs_human_requires_human_action",))
+    return ActionVerdict(action, ())
+
+
+def intake(issues: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Return deterministic non-claim queues for supplied REST Issue objects."""
+    queues: dict[str, list[dict[str, Any]]] = {action: [] for action in sorted(ACTION_LABELS)}
+    drift: list[dict[str, Any]] = []
+    for issue in issues:
+        labels = label_names(issue)
+        if not labels & {"agent:blocked", "agent:needs-human"}:
+            continue
+        verdict = classify(labels, open_issue=str(issue.get("state", "open")).lower() == "open")
+        item = {
+            "issue_number": issue.get("number"), "title": issue.get("title"),
+            "state": issue.get("state", "open"), "action": verdict.action,
+            "owner": issue.get("blocker_action", {}).get("owner") if isinstance(issue.get("blocker_action"), dict) else None,
+            "next_action": issue.get("blocker_action", {}).get("next_action") if isinstance(issue.get("blocker_action"), dict) else None,
+            "claim_posture": "read-only; never claims implementation work",
+        }
+        if verdict.errors:
+            item["errors"] = list(verdict.errors)
+            drift.append(item)
+        elif verdict.action:
+            queues[verdict.action].append(item)
+    return {"schema": "blocker_action_intake.v1", "claim_posture": "read-only; never claims implementation work", "queues": queues, "drift": drift}

--- a/app/builderops/blocker_actions.py
+++ b/app/builderops/blocker_actions.py
@@ -74,6 +74,23 @@ def latest_receipt(comments: Iterable[object]) -> dict[str, object] | None:
     return receipts[-1] if receipts else None
 
 
+def receipt_for_context(
+    labels: Iterable[str], comments: Iterable[object], *, open_issue: bool
+) -> tuple[ActionVerdict, dict[str, object] | None]:
+    """Return receipt evidence only when it binds to the exact live action state."""
+    labels = set(labels)
+    verdict = classify(labels, open_issue=open_issue)
+    receipt = latest_receipt(comments)
+    errors = list(verdict.errors)
+    if receipt is None:
+        if labels & ({"agent:blocked", "agent:needs-human"} | ACTION_LABELS):
+            errors.append("missing_or_invalid_blocker_action_receipt")
+    elif receipt["action"] != verdict.action:
+        errors.append("receipt_action_mismatch")
+    bound_verdict = ActionVerdict(verdict.action, tuple(errors))
+    return bound_verdict, receipt if not bound_verdict.errors else None
+
+
 def receipt_for_action(action: str, *, now: datetime | None = None) -> dict[str, object]:
     """Produce a valid, explicit maintenance receipt without inventing cause."""
     if action not in ACTION_LABELS:
@@ -118,8 +135,10 @@ def intake(issues: Iterable[dict[str, Any]]) -> dict[str, Any]:
         labels = label_names(issue)
         if not labels & {"agent:blocked", "agent:needs-human"}:
             continue
-        verdict = classify(labels, open_issue=str(issue.get("state", "open")).lower() == "open")
-        receipt = latest_receipt(issue.get("comments", []))
+        verdict, receipt = receipt_for_context(
+            labels, issue.get("comments", []),
+            open_issue=str(issue.get("state", "open")).lower() == "open",
+        )
         item = {
             "issue_number": issue.get("number"), "title": issue.get("title"),
             "state": issue.get("state", "open"), "action": verdict.action,
@@ -128,12 +147,8 @@ def intake(issues: Iterable[dict[str, Any]]) -> dict[str, Any]:
             "receipt_freshness": receipt.get("last_verified_at") if receipt else None,
             "claim_posture": "read-only; never claims implementation work",
         }
-        if verdict.errors or receipt is None:
-            if receipt is None:
-                item.setdefault("errors", []).append("missing_or_invalid_blocker_action_receipt")
+        if verdict.errors:
             item["errors"] = list(verdict.errors)
-            if receipt is None:
-                item["errors"].append("missing_or_invalid_blocker_action_receipt")
             drift.append(item)
         elif verdict.action:
             queues[verdict.action].append(item)

--- a/app/builderops/blocker_actions.py
+++ b/app/builderops/blocker_actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import re
 from typing import Any, Iterable
 
 BLOCKED_ACTIONS = frozenset({
@@ -29,6 +30,7 @@ LEGACY_HUMAN_ACTIONS = {
 }
 
 RECEIPT_FIELDS = ("action", "owner", "next_action", "unblocks_when", "dependency_refs", "review_at", "last_verified_at")
+_EXTERNAL_OWNER = re.compile(r"external:[a-z0-9][a-z0-9._-]*\Z")
 
 
 def _valid_timestamp(value: object) -> bool:
@@ -42,7 +44,9 @@ def _valid_timestamp(value: object) -> bool:
 
 
 def _valid_owner(value: object) -> bool:
-    return value in {"builder", "owner"} or (isinstance(value, str) and value.startswith("external:") and len(value) > len("external:"))
+    return value in {"builder", "owner"} or (
+        isinstance(value, str) and _EXTERNAL_OWNER.fullmatch(value) is not None
+    )
 
 
 def parse_blocker_action_receipt(comment: object) -> dict[str, object] | None:

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -62,6 +62,7 @@ from app.builderops.cockpit_github_plane import (
     default_github_reader,
     fetch_github_live,
 )
+from app.builderops.blocker_actions import latest_receipt
 
 logger = logging.getLogger(__name__)
 
@@ -439,6 +440,17 @@ def _blocker_action(labels: list[str]) -> str | None:
     return actions[0] if len(actions) == 1 else None
 
 
+def _sync_blocker_receipt(sync_state: str | None) -> dict[str, object] | None:
+    if not sync_state:
+        return None
+    try:
+        payload = json.loads(sync_state)
+    except json.JSONDecodeError:
+        return None
+    comments = payload.get("comments")
+    return latest_receipt(comments) if isinstance(comments, list) else None
+
+
 def _sync_url(sync_state: str | None) -> str | None:
     if not sync_state:
         return None
@@ -685,6 +697,7 @@ def _build_item(
     now: datetime | None = None,
 ) -> dict[str, Any]:
     labels = _sync_labels(task.get("sync_state"))
+    blocker_receipt = _sync_blocker_receipt(task.get("sync_state"))
     mirror_url = _sync_url(task.get("sync_state"))
     mirror_watermark = _sync_last_pull_at(task.get("sync_state"))
     issue_number = task.get("issue_number")
@@ -760,9 +773,9 @@ def _build_item(
         "claimed_by": task.get("claimed_by"),
         "linked_pr": linked_pr,
         "labels": labels,
-        "blocker_action": _blocker_action(labels),
-        "next_action": None,
-        "next_action_evidence": "issue comment blocker_action.v1; read-only projection",
+        "blocker_action": blocker_receipt.get("action") if blocker_receipt else _blocker_action(labels),
+        "next_action": blocker_receipt.get("next_action") if blocker_receipt else None,
+        "next_action_evidence": "issue comment blocker_action.v1" if blocker_receipt else "receipt unavailable; read-only projection",
         # BOPS-COCKPIT-03 (#4450, decision Q5): labels/url are mirror-derived
         # fields; they name the mirror's own `sync_state.last_pull_at`
         # watermark here, never the dispatcher-store SQLite read instant the

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -62,7 +62,7 @@ from app.builderops.cockpit_github_plane import (
     default_github_reader,
     fetch_github_live,
 )
-from app.builderops.blocker_actions import latest_receipt
+from app.builderops.blocker_actions import receipt_for_context
 
 logger = logging.getLogger(__name__)
 
@@ -447,8 +447,15 @@ def _sync_blocker_receipt(sync_state: str | None) -> dict[str, object] | None:
         payload = json.loads(sync_state)
     except json.JSONDecodeError:
         return None
+    labels = payload.get("labels")
     comments = payload.get("comments")
-    return latest_receipt(comments) if isinstance(comments, list) else None
+    if not isinstance(labels, list) or not isinstance(comments, list):
+        return None
+    _, receipt = receipt_for_context(
+        (str(label) for label in labels), comments,
+        open_issue=str(payload.get("state", "open")).lower() == "open",
+    )
+    return receipt
 
 
 def _sync_url(sync_state: str | None) -> str | None:

--- a/app/builderops/cockpit_registry.py
+++ b/app/builderops/cockpit_registry.py
@@ -89,6 +89,7 @@ BANDS: tuple[tuple[str, str], ...] = (
 # that used to live here is gone, because "ready" is not "forgotten" — a fresh
 # unclaimed ready issue is in progress, and forgotten requires a stall.
 _NEEDS_HUMAN_LABEL = "agent:needs-human"
+_ACTION_PREFIX = "action:"
 
 # Locked rung order for the evidence spine.
 RUNG_ORDER: tuple[str, ...] = (
@@ -432,6 +433,12 @@ def _sync_labels(sync_state: str | None) -> list[str]:
     return []
 
 
+def _blocker_action(labels: list[str]) -> str | None:
+    """Expose a subtype only; the live Issue remains its authority."""
+    actions = sorted(label for label in labels if label.startswith(_ACTION_PREFIX))
+    return actions[0] if len(actions) == 1 else None
+
+
 def _sync_url(sync_state: str | None) -> str | None:
     if not sync_state:
         return None
@@ -753,6 +760,9 @@ def _build_item(
         "claimed_by": task.get("claimed_by"),
         "linked_pr": linked_pr,
         "labels": labels,
+        "blocker_action": _blocker_action(labels),
+        "next_action": None,
+        "next_action_evidence": "issue comment blocker_action.v1; read-only projection",
         # BOPS-COCKPIT-03 (#4450, decision Q5): labels/url are mirror-derived
         # fields; they name the mirror's own `sync_state.last_pull_at`
         # watermark here, never the dispatcher-store SQLite read instant the

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -17,6 +17,7 @@ import re
 import uuid
 from typing import Any, Protocol
 
+from app.builderops.blocker_actions import receipt_for_context
 from app.dispatcher.models import EventRecord, SyncState, TaskRecord
 from app.dispatcher.store import DispatcherStore
 from app.dispatcher.github_call_logger import (
@@ -367,6 +368,10 @@ def normalize_github_issue(
     # GraphQL-shaped payloads carry the browser URL as ``url``.
     html_url = payload.get("html_url") or payload.get("url") or None
 
+    comments = payload.get("comments") if isinstance(payload.get("comments"), list) else []
+    blocker_verdict, _ = receipt_for_context(
+        labels, comments, open_issue=str(payload.get("state", "open")).lower() == "open"
+    )
     sync_state = SyncState(
         last_pull_at=now,
         source_version=payload.get("updatedAt") or payload.get("updated_at"),
@@ -374,11 +379,13 @@ def normalize_github_issue(
         sync_note=None,
         extra={
             "labels": labels,
+            "state": payload.get("state", "open"),
             "url": str(html_url) if html_url is not None else None,
             # A caller that obtained the bounded REST comment projection may
             # pass it through unchanged. The normal ready-only dispatcher does
             # not fetch blocker comments and remains a strict pickup path.
-            "comments": payload.get("comments") if isinstance(payload.get("comments"), list) else [],
+            "comments": comments,
+            "blocker_action_drift": list(blocker_verdict.errors),
         },
     )
 

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -373,6 +373,10 @@ def normalize_github_issue(
         extra={
             "labels": labels,
             "url": str(html_url) if html_url is not None else None,
+            # A caller that obtained the bounded REST comment projection may
+            # pass it through unchanged. The normal ready-only dispatcher does
+            # not fetch blocker comments and remains a strict pickup path.
+            "comments": payload.get("comments") if isinstance(payload.get("comments"), list) else [],
         },
     )
 

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -283,6 +283,8 @@ _LABEL_PRIORITY: dict[str, str] = {
 _LABEL_STATUS: dict[str, str] = {
     "agent:ready": "ready",
     "agent:blocked": "blocked",
+    "agent:needs-human": "blocked",
+    "agent:in-progress": "in_progress",
 }
 
 
@@ -651,7 +653,11 @@ class GhCliIssueSource:
         page = 1
         while page <= OPEN_ISSUES_MAX_PAGES:
             raw_page = self._fetch_open_issues_raw_page(owner, name, page)
-            issues.extend(self._normalize_open_issue_node(node) for node in raw_page if not node.get("pull_request"))
+            for node in raw_page:
+                if node.get("pull_request"):
+                    continue
+                issue = self._normalize_open_issue_node(node)
+                issues.append(issue)
             if len(raw_page) < OPEN_ISSUES_PAGE_SIZE:
                 return issues
             page += 1
@@ -711,6 +717,19 @@ class GhCliIssueSource:
         if not isinstance(payload, list):
             raise RuntimeError("gh api open issues returned a non-list payload")
         return payload
+
+    def fetch_blocker_comments(self, repo: str, issue_number: int) -> list[dict[str, Any]]:
+        """Fetch bounded REST comments only for non-active action projection."""
+        import json
+        import subprocess
+        owner, _, name = repo.partition("/")
+        result = subprocess.run(["gh", "api", f"repos/{owner}/{name}/issues/{issue_number}/comments", "--method", "GET", "-F", "per_page=100"], capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"gh api blocker comments failed: {result.stderr}")
+        comments = json.loads(result.stdout)
+        if not isinstance(comments, list):
+            raise RuntimeError("gh api blocker comments returned a non-list payload")
+        return comments
 
     @staticmethod
     def _normalize_open_issue_node(node: dict[str, Any]) -> dict[str, Any]:
@@ -900,6 +919,27 @@ class PullSyncAdapter:
                     ready_issue_numbers.add(number)
             except Exception as exc:
                 skipped.append(f"issue={issue.get('number', '?')}: {exc}")
+
+        # Non-active action records feed Cockpit and read-only maintenance
+        # projection only. They never enter ready_issue_numbers or pickup.
+        if open_issues_available:
+            comment_reader = getattr(self._source, "fetch_blocker_comments", None)
+            for issue in open_issues:
+                labels = set(_label_names(issue))
+                if not labels & {"agent:blocked", "agent:needs-human"}:
+                    continue
+                try:
+                    if callable(comment_reader):
+                        comments = comment_reader(repo, int(issue["number"]))
+                        if isinstance(comments, list):
+                            issue = {**issue, "comments": comments}
+                    task = normalize_github_issue(issue, repo, now=pull_at)
+                    existing = self._store.get_task(task.task_id)
+                    if existing is not None and existing.status in {"claimed", "in_progress"}:
+                        continue
+                    self._store.upsert_task(task)
+                except Exception as exc:
+                    skipped.append(f"blocker issue={issue.get('number', '?')}: {exc}")
 
         reconciled = self._reconcile_stale_ready(
             repo=repo,

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -368,7 +368,10 @@ def normalize_github_issue(
     # GraphQL-shaped payloads carry the browser URL as ``url``.
     html_url = payload.get("html_url") or payload.get("url") or None
 
-    comments = payload.get("comments") if isinstance(payload.get("comments"), list) else []
+    comments: list[object] = []
+    comments_payload = payload.get("comments")
+    if isinstance(comments_payload, list):
+        comments.extend(comments_payload)
     blocker_verdict, _ = receipt_for_context(
         labels, comments, open_issue=str(payload.get("state", "open")).lower() == "open"
     )

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,8 +5,13 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-08-29
+Last reviewed: 2026-08-30
 Last live runtime verification: 2026-08-22 (new-host topology; see `docs/ENVIRONMENTS.md`)
+Last verified against (blocker-action projection candidate): PR #5206,
+`app/dispatcher/sync_github.py`, `app/builderops/cockpit_registry.py`,
+`scripts/reconcile_blocker_actions.py`, and focused local validation on 2026-08-30; current-head CI
+and merge remain pending.
+
 Last verified against (SQ-04 candidate): PR #5174, `app/standing_questions/evidence_matching.py`,
 `app/standing_questions/answer_refresh.py`, and focused Standing Questions tests on 2026-08-29;
 live test-channel and owner-UAT evidence remain absent.
@@ -732,11 +737,12 @@ Platform-side governance applied:
   `scripts/issue_pickup_claim.sh` routes a missing-task claim failure after such a sync to
   explicit GitHub-label-only fallback guidance (see
   `docs/AGENT_ISSUE_DISPATCHER.md :: Kill-Switch Partial Sync (#4606)`)
-- Blocked/needs-human action intake is a separate bounded REST read path: it fetches only those
-  Issues' comments, accepts a latest valid `blocker_action.v1` receipt as projection evidence, and
-  keeps normal implementation pickup strictly `agent:ready` only. The matching targeted migration
-  re-reads each Issue before a narrow label write, verifies label and receipt readback, and fails
-  closed on claim or lifecycle drift; no action intake has claim authority.
+- Candidate PR #5206 defines a separate bounded REST action-intake path for blocked/needs-human
+  Issues: it fetches only those Issues' comments and accepts a latest valid `blocker_action.v1`
+  receipt as projection evidence. Current implementation pickup remains strictly `agent:ready` only.
+  The candidate's targeted migration re-reads each Issue before a narrow label write, verifies label
+  and receipt readback, and fails closed on claim or lifecycle drift; no action intake has claim
+  authority. It is not shipped until current-head CI and merge complete.
 - the verification-dispatch integration line now fails closed on exact-head, authoritative
   `github-actions` required-check evidence, preserves review/repair budgets across restart, and
   rejects ambiguous legacy active-plus-terminal authority chains. Host rollout remains disabled

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -732,6 +732,11 @@ Platform-side governance applied:
   `scripts/issue_pickup_claim.sh` routes a missing-task claim failure after such a sync to
   explicit GitHub-label-only fallback guidance (see
   `docs/AGENT_ISSUE_DISPATCHER.md :: Kill-Switch Partial Sync (#4606)`)
+- Blocked/needs-human action intake is a separate bounded REST read path: it fetches only those
+  Issues' comments, accepts a latest valid `blocker_action.v1` receipt as projection evidence, and
+  keeps normal implementation pickup strictly `agent:ready` only. The matching targeted migration
+  re-reads each Issue before a narrow label write, verifies label and receipt readback, and fails
+  closed on claim or lifecycle drift; no action intake has claim authority.
 - the verification-dispatch integration line now fails closed on exact-head, authoritative
   `github-actions` required-check evidence, preserves review/repair budgets across restart, and
   rejects ambiguous legacy active-plus-terminal authority chains. Host rollout remains disabled

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -354,6 +354,11 @@ L2 subprocess; it does not waive CI, review, verification, release, or safety ga
 canonical authority conditions applies, use `agent:blocked` or the workflow's technical recovery
 state rather than `agent:needs-human`.
 
+Every non-active lifecycle state also names exactly one canonical `action:*` next-action subtype
+and a `blocker_action.v1` receipt. The subtype routes maintenance, dependency, environment,
+external, review-trigger, and human queues without claiming implementation work; it never replaces
+the Human Exception authority classifier.
+
 ### View 3 — information, evidence, and representation architecture
 
 This view classifies artifacts and state; it is not a fourth process hierarchy. These surfaces must

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -62,6 +62,16 @@ Keep only these labels for the delivery control plane taxonomy:
 - `agent:blocked`
 - `agent:needs-human`
 - `agent:in-progress`
+- `action:repair-contract`
+- `action:wait-dependency`
+- `action:restore-environment`
+- `action:wait-external`
+- `action:review-at`
+- `action:human-decision`
+- `action:human-authorization`
+- `action:human-access`
+- `action:human-operation`
+- `action:human-acceptance`
 - `state:known-defect`
 - `lane:governance`
 
@@ -79,6 +89,11 @@ second registry to orphan committed defect authority.
 `lane:governance` is the one additive lane label. Apply it to governance-lane Issues and PRs in
 addition to their canonical type, priority, and agent-state labels; never apply it to the Known
 Defects registry container itself.
+
+An open `agent:blocked` Issue must have exactly one blocked `action:*` label; an open
+`agent:needs-human` Issue must have exactly one human `action:*` label. The corresponding
+`blocker_action.v1` Issue comment names owner, next action, evidence, unblock condition and optional
+review trigger. Status remains a projection; action labels never make an Issue pickup eligible.
 
 ## Project contract
 

--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -62,12 +62,25 @@ CANONICAL_LABELS = [
     "type:task",
     "type:bug",
     "type:refactor",
+    "type:epic",
+    "type:feature",
     "prio:high",
     "prio:med",
     "prio:low",
     "agent:ready",
     "agent:blocked",
     "agent:needs-human",
+    "agent:in-progress",
+    "action:repair-contract",
+    "action:wait-dependency",
+    "action:restore-environment",
+    "action:wait-external",
+    "action:review-at",
+    "action:human-decision",
+    "action:human-authorization",
+    "action:human-access",
+    "action:human-operation",
+    "action:human-acceptance",
 ]
 
 # Backticked kebab-case tokens that are not skill names. A token not listed
@@ -104,7 +117,7 @@ RETIRED_PHRASE = "Do not batch to end of task"
 
 KEBAB_TOKEN_RE = re.compile(r"`([a-z][a-z0-9]*(?:-[a-z0-9]+)+)`")
 ROUTING_ENTRY_RE = re.compile(r"^- `([a-z][a-z0-9-]+)`\s*$", re.MULTILINE)
-LABEL_ITEM_RE = re.compile(r"^\s*[-*]\s+`((?:type|prio|agent):[a-z-]+)`\s*\|?\s*$")
+LABEL_ITEM_RE = re.compile(r"^\s*[-*]\s+`((?:type|prio|agent|action):[a-z-]+)`\s*\|?\s*$")
 BLOCK_SCALAR_DESCRIPTION_RE = re.compile(r"^[|>](?:[+-]?\d*|\d+[+-]?)$")
 BASH_FENCE_RE = re.compile(r"^\s*```(?:bash|sh)\s*$", re.IGNORECASE)
 BASH4_ONLY_CONSTRUCTS: tuple[tuple[str, re.Pattern[str]], ...] = (

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Report or boundedly reconcile canonical blocker-action labels via GitHub REST."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any
+
+from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names
+
+
+def plan(issue: dict[str, Any]) -> dict[str, Any]:
+    labels = label_names(issue)
+    desired = set(labels)
+    changes: list[dict[str, str]] = []
+    for old, new in LEGACY_HUMAN_ACTIONS.items():
+        if old in desired:
+            desired.remove(old); desired.add(new); changes.append({"remove": old, "add": new})
+    lifecycle = labels & {"agent:blocked", "agent:needs-human"}
+    if labels & ACTION_LABELS and not lifecycle:
+        for action in labels & ACTION_LABELS:
+            desired.remove(action); changes.append({"remove": action, "add": ""})
+    elif lifecycle == {"agent:blocked"} and not labels & ACTION_LABELS:
+        desired.add("action:repair-contract"); changes.append({"remove": "", "add": "action:repair-contract"})
+    verdict = classify(desired, open_issue=str(issue.get("state", "open")).lower() == "open")
+    return {"issue": issue.get("number"), "before": sorted(labels), "after": sorted(desired), "changes": changes, "errors": list(verdict.errors)}
+
+
+def _api(repo: str, endpoint: str, *, method: str = "GET", payload: Any = None) -> Any:
+    cmd = ["gh", "api", endpoint, "--method", method]
+    if payload is not None:
+        cmd += ["--input", "-"]
+    result = subprocess.run(cmd, input=json.dumps(payload) if payload is not None else None, text=True, capture_output=True, check=False)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip())
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True); parser.add_argument("--issue", type=int, action="append", default=[])
+    parser.add_argument("--apply", action="store_true"); parser.add_argument("--limit", type=int, default=5)
+    args = parser.parse_args()
+    if args.limit < 1 or args.limit > 5: parser.error("--limit must be 1..5")
+    if len(args.issue) > args.limit: parser.error("issue set exceeds bounded --limit")
+    owner, name = args.repo.split("/", 1)
+    issues = [_api(args.repo, f"repos/{owner}/{name}/issues/{number}") for number in args.issue]
+    plans = [plan(issue) for issue in issues]
+    if args.apply:
+        # Label creation is deterministic and idempotent.  It is intentionally
+        # limited to the canonical family; no legacy or unrelated label is deleted.
+        existing = _api(args.repo, f"repos/{owner}/{name}/labels?per_page=100")
+        existing_names = {str(label.get("name")) for label in existing}
+        for label in sorted(ACTION_LABELS - existing_names):
+            _api(args.repo, f"repos/{owner}/{name}/labels", method="POST", payload={"name": label, "color": "bfdadc", "description": "Canonical next action for a non-active Issue"})
+        for item in plans:
+            if item["errors"]: raise RuntimeError(f"refusing drifted issue #{item['issue']}: {item['errors']}")
+            _api(args.repo, f"repos/{owner}/{name}/issues/{item['issue']}", method="PATCH", payload={"labels": item["after"]})
+            if item["changes"]:
+                action = next((label for label in item["after"] if label.startswith("action:")), "none")
+                _api(args.repo, f"repos/{owner}/{name}/issues/{item['issue']}/comments", method="POST", payload={"body": "```yaml\nreceipt: blocker_action.v1\naction: " + action + "\nowner: unknown\nnext_action: verify and repair the live Issue contract before pickup\nunblocks_when: fresh authority evidence establishes a valid transition\ndependency_refs: []\nreview_at: null\nlast_verified_at: migration apply readback\n```\n\nBounded migration receipt; it does not infer an underlying blocker cause or claim implementation work."})
+    print(json.dumps({"mode": "apply" if args.apply else "report", "plans": plans}, indent=2, sort_keys=True))
+    return 0
+
+if __name__ == "__main__": raise SystemExit(main())

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names, parse_blocker_action_receipt, receipt_for_action
+from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names, receipt_for_action, receipt_for_context
 
 
 def plan(issue: dict[str, Any]) -> dict[str, Any]:
@@ -102,8 +102,12 @@ def apply_plan(repo: str, owner: str, name: str, item: dict[str, Any]) -> dict[s
         created = _api(repo, f"{endpoint}/comments", method="POST", payload={"body": _receipt_text(receipt)})
         comments = _api(repo, f"{endpoint}/comments?per_page=100")
         created_id = created.get("id") if isinstance(created, dict) else None
-        exact_receipt = next((parse_blocker_action_receipt(comment) for comment in comments if isinstance(comment, dict) and comment.get("id") == created_id), None)
-        if exact_receipt != receipt:
+        exact_comment = next((comment for comment in comments if isinstance(comment, dict) and comment.get("id") == created_id), None)
+        receipt_verdict, exact_receipt = receipt_for_context(
+            _labels(final), [exact_comment] if exact_comment else [],
+            open_issue=str(final.get("state", "")).lower() == "open",
+        )
+        if exact_receipt != receipt or receipt_verdict.errors:
             raise RuntimeError(f"receipt readback mismatch for issue #{item['issue']}")
         terminal = _api(repo, endpoint)
         terminal_open = str(terminal.get("state", "")).lower() == "open"
@@ -111,7 +115,7 @@ def apply_plan(repo: str, owner: str, name: str, item: dict[str, Any]) -> dict[s
         if (
             terminal_open != final_open
             or _labels(terminal) != _labels(final)
-            or classify(_labels(terminal), open_issue=terminal_open).errors
+            or receipt_for_context(_labels(terminal), [exact_comment] if exact_comment else [], open_issue=terminal_open)[0].errors
         ):
             raise RuntimeError(f"post-receipt lifecycle/action drift for issue #{item['issue']}")
     return {"issue": item["issue"], "labels": sorted(_labels(final)), "action": final_verdict.action}

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names
+from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names, receipt_for_action
 
 
 def plan(issue: dict[str, Any]) -> dict[str, Any]:
@@ -22,7 +22,8 @@ def plan(issue: dict[str, Any]) -> dict[str, Any]:
     changes: list[dict[str, str]] = []
     for old, new in LEGACY_HUMAN_ACTIONS.items():
         if old in desired:
-            desired.remove(old); desired.add(new); changes.append({"remove": old, "add": new})
+            desired.remove(old); desired.add(new)
+            changes.extend(({"remove": "", "add": new}, {"remove": old, "add": ""}))
     lifecycle = labels & {"agent:blocked", "agent:needs-human"}
     if labels & ACTION_LABELS and not lifecycle:
         for action in labels & ACTION_LABELS:
@@ -43,6 +44,65 @@ def _api(repo: str, endpoint: str, *, method: str = "GET", payload: Any = None) 
     return json.loads(result.stdout) if result.stdout.strip() else None
 
 
+def _labels(issue: dict[str, Any]) -> set[str]:
+    return label_names(issue)
+
+
+def _mutate_label(repo: str, endpoint: str, *, add: str | None = None, remove: str | None = None) -> None:
+    """Use GitHub's narrow label endpoints, never a whole-array PATCH."""
+    if bool(add) == bool(remove):
+        raise ValueError("exactly one narrow label mutation is required")
+    if add:
+        _api(repo, f"{endpoint}/labels", method="POST", payload={"labels": [add]})
+    else:
+        _api(repo, f"{endpoint}/labels/{remove}", method="DELETE")
+
+
+def _receipt_text(action: str) -> str:
+    receipt = receipt_for_action(action)
+    lines = ["```yaml"] + [f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()] + ["```", "", "Bounded migration receipt; it does not infer an underlying blocker cause or claim implementation work."]
+    return "\n".join(lines)
+
+
+def apply_plan(repo: str, owner: str, name: str, item: dict[str, Any]) -> dict[str, Any]:
+    """Re-read, validate and apply one plan with narrow mutations and readback."""
+    endpoint = f"repos/{owner}/{name}/issues/{item['issue']}"
+    live = _api(repo, endpoint)
+    if _labels(live) != set(item["before"]) or str(live.get("state", "open")).lower() != "open":
+        raise RuntimeError(f"refusing stale snapshot for issue #{item['issue']}")
+    if item["errors"]:
+        raise RuntimeError(f"refusing drifted issue #{item['issue']}: {item['errors']}")
+    expected_labels = set(item["before"])
+    for change in item["changes"]:
+        # Immediate re-read closes stale observation before every authority write.
+        current = _api(repo, endpoint)
+        current_labels = _labels(current)
+        if str(current.get("state", "open")).lower() != "open" or current_labels != expected_labels:
+            raise RuntimeError(f"refusing terminal drift for issue #{item['issue']}")
+        if change["remove"] and change["remove"] not in current_labels:
+            raise RuntimeError(f"refusing label drift for issue #{item['issue']}")
+        if change["add"] and change["add"] in current_labels:
+            raise RuntimeError(f"refusing duplicate mutation for issue #{item['issue']}")
+        _mutate_label(repo, endpoint, add=change["add"] or None, remove=change["remove"] or None)
+        expected_labels.discard(change["remove"])
+        if change["add"]:
+            expected_labels.add(change["add"])
+        readback = _api(repo, endpoint)
+        if _labels(readback) != expected_labels:
+            raise RuntimeError(f"post-mutation label drift for issue #{item['issue']}")
+        verdict = classify(_labels(readback), open_issue=True)
+        if verdict.errors:
+            raise RuntimeError(f"post-mutation lifecycle/action drift for issue #{item['issue']}: {verdict.errors}")
+    final = _api(repo, endpoint)
+    final_verdict = classify(_labels(final), open_issue=True)
+    if final_verdict.errors:
+        raise RuntimeError(f"post-apply drift for issue #{item['issue']}: {final_verdict.errors}")
+    if item["changes"]:
+        action = final_verdict.action or "action:repair-contract"
+        _api(repo, f"{endpoint}/comments", method="POST", payload={"body": _receipt_text(action)})
+    return {"issue": item["issue"], "labels": sorted(_labels(final)), "action": final_verdict.action}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True); parser.add_argument("--issue", type=int, action="append", default=[])
@@ -61,11 +121,7 @@ def main() -> int:
         for label in sorted(ACTION_LABELS - existing_names):
             _api(args.repo, f"repos/{owner}/{name}/labels", method="POST", payload={"name": label, "color": "bfdadc", "description": "Canonical next action for a non-active Issue"})
         for item in plans:
-            if item["errors"]: raise RuntimeError(f"refusing drifted issue #{item['issue']}: {item['errors']}")
-            _api(args.repo, f"repos/{owner}/{name}/issues/{item['issue']}", method="PATCH", payload={"labels": item["after"]})
-            if item["changes"]:
-                action = next((label for label in item["after"] if label.startswith("action:")), "none")
-                _api(args.repo, f"repos/{owner}/{name}/issues/{item['issue']}/comments", method="POST", payload={"body": "```yaml\nreceipt: blocker_action.v1\naction: " + action + "\nowner: unknown\nnext_action: verify and repair the live Issue contract before pickup\nunblocks_when: fresh authority evidence establishes a valid transition\ndependency_refs: []\nreview_at: null\nlast_verified_at: migration apply readback\n```\n\nBounded migration receipt; it does not infer an underlying blocker cause or claim implementation work."})
+            apply_plan(args.repo, owner, name, item)
     print(json.dumps({"mode": "apply" if args.apply else "report", "plans": plans}, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -106,7 +106,13 @@ def apply_plan(repo: str, owner: str, name: str, item: dict[str, Any]) -> dict[s
         if exact_receipt != receipt:
             raise RuntimeError(f"receipt readback mismatch for issue #{item['issue']}")
         terminal = _api(repo, endpoint)
-        if _labels(terminal) != _labels(final) or classify(_labels(terminal), open_issue=True).errors:
+        terminal_open = str(terminal.get("state", "")).lower() == "open"
+        final_open = str(final.get("state", "")).lower() == "open"
+        if (
+            terminal_open != final_open
+            or _labels(terminal) != _labels(final)
+            or classify(_labels(terminal), open_issue=terminal_open).errors
+        ):
             raise RuntimeError(f"post-receipt lifecycle/action drift for issue #{item['issue']}")
     return {"issue": item["issue"], "labels": sorted(_labels(final)), "action": final_verdict.action}
 

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
+from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names
 

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -20,10 +20,20 @@ def plan(issue: dict[str, Any]) -> dict[str, Any]:
     labels = label_names(issue)
     desired = set(labels)
     changes: list[dict[str, str]] = []
+    errors: list[str] = []
     for old, new in LEGACY_HUMAN_ACTIONS.items():
         if old in desired:
-            desired.remove(old); desired.add(new)
-            changes.extend(({"remove": "", "add": new}, {"remove": old, "add": ""}))
+            live_actions = desired & ACTION_LABELS
+            if new in desired:
+                # A prior partial apply already established the exact successor.
+                desired.remove(old)
+                changes.append({"remove": old, "add": ""})
+            elif live_actions:
+                # Never add a second successor over a conflicting live action.
+                errors.append("legacy_successor_conflict")
+            else:
+                desired.remove(old); desired.add(new)
+                changes.extend(({"remove": "", "add": new}, {"remove": old, "add": ""}))
     lifecycle = labels & {"agent:blocked", "agent:needs-human"}
     if labels & ACTION_LABELS and not lifecycle:
         for action in labels & ACTION_LABELS:
@@ -31,7 +41,7 @@ def plan(issue: dict[str, Any]) -> dict[str, Any]:
     elif lifecycle == {"agent:blocked"} and not labels & ACTION_LABELS:
         desired.add("action:repair-contract"); changes.append({"remove": "", "add": "action:repair-contract"})
     verdict = classify(desired, open_issue=str(issue.get("state", "open")).lower() == "open")
-    return {"issue": issue.get("number"), "before": sorted(labels), "after": sorted(desired), "changes": changes, "errors": list(verdict.errors)}
+    return {"issue": issue.get("number"), "before": sorted(labels), "after": sorted(desired), "changes": changes, "errors": errors + list(verdict.errors)}
 
 
 def _api(repo: str, endpoint: str, *, method: str = "GET", payload: Any = None) -> Any:

--- a/scripts/reconcile_blocker_actions.py
+++ b/scripts/reconcile_blocker_actions.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names, receipt_for_action
+from app.builderops.blocker_actions import ACTION_LABELS, LEGACY_HUMAN_ACTIONS, classify, label_names, parse_blocker_action_receipt, receipt_for_action
 
 
 def plan(issue: dict[str, Any]) -> dict[str, Any]:
@@ -58,8 +58,7 @@ def _mutate_label(repo: str, endpoint: str, *, add: str | None = None, remove: s
         _api(repo, f"{endpoint}/labels/{remove}", method="DELETE")
 
 
-def _receipt_text(action: str) -> str:
-    receipt = receipt_for_action(action)
+def _receipt_text(receipt: dict[str, object]) -> str:
     lines = ["```yaml"] + [f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()] + ["```", "", "Bounded migration receipt; it does not infer an underlying blocker cause or claim implementation work."]
     return "\n".join(lines)
 
@@ -99,7 +98,16 @@ def apply_plan(repo: str, owner: str, name: str, item: dict[str, Any]) -> dict[s
         raise RuntimeError(f"post-apply drift for issue #{item['issue']}: {final_verdict.errors}")
     if item["changes"]:
         action = final_verdict.action or "action:repair-contract"
-        _api(repo, f"{endpoint}/comments", method="POST", payload={"body": _receipt_text(action)})
+        receipt = receipt_for_action(action)
+        created = _api(repo, f"{endpoint}/comments", method="POST", payload={"body": _receipt_text(receipt)})
+        comments = _api(repo, f"{endpoint}/comments?per_page=100")
+        created_id = created.get("id") if isinstance(created, dict) else None
+        exact_receipt = next((parse_blocker_action_receipt(comment) for comment in comments if isinstance(comment, dict) and comment.get("id") == created_id), None)
+        if exact_receipt != receipt:
+            raise RuntimeError(f"receipt readback mismatch for issue #{item['issue']}")
+        terminal = _api(repo, endpoint)
+        if _labels(terminal) != _labels(final) or classify(_labels(terminal), open_issue=True).errors:
+            raise RuntimeError(f"post-receipt lifecycle/action drift for issue #{item['issue']}")
     return {"issue": item["issue"], "labels": sorted(_labels(final)), "action": final_verdict.action}
 
 

--- a/scripts/report_blocker_actions.py
+++ b/scripts/report_blocker_actions.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from app.builderops.blocker_actions import intake
 

--- a/scripts/report_blocker_actions.py
+++ b/scripts/report_blocker_actions.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Read-only REST intake for the canonical blocked-action queues."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+from app.builderops.blocker_actions import intake
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+    if not 1 <= args.limit <= 100:
+        parser.error("--limit must be 1..100")
+    owner, name = args.repo.split("/", 1)
+    command = ["gh", "api", f"repos/{owner}/{name}/issues", "--method", "GET", "-f", "state=open", "-F", f"per_page={args.limit}"]
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip())
+    print(json.dumps(intake(json.loads(result.stdout)), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_blocker_actions.py
+++ b/scripts/report_blocker_actions.py
@@ -27,7 +27,15 @@ def main() -> int:
     result = subprocess.run(command, text=True, capture_output=True, check=False)
     if result.returncode:
         raise RuntimeError(result.stderr.strip())
-    print(json.dumps(intake(json.loads(result.stdout)), indent=2, sort_keys=True))
+    issues = json.loads(result.stdout)
+    for issue in issues:
+        labels = {str(label.get("name") if isinstance(label, dict) else label) for label in issue.get("labels", [])}
+        if labels & {"agent:blocked", "agent:needs-human"}:
+            comments = subprocess.run(["gh", "api", f"repos/{owner}/{name}/issues/{issue['number']}/comments", "--method", "GET", "-F", "per_page=100"], text=True, capture_output=True, check=False)
+            if comments.returncode:
+                raise RuntimeError(comments.stderr.strip())
+            issue["comments"] = json.loads(comments.stdout)
+    print(json.dumps(intake(issues), indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/builderops/test_blocker_action_intake.py
+++ b/tests/builderops/test_blocker_action_intake.py
@@ -1,9 +1,13 @@
-from app.builderops.blocker_actions import intake
+from app.builderops.blocker_actions import intake, receipt_for_action
 
 
 def test_intake_routes_every_canonical_action_without_claiming() -> None:
     actions = ["action:repair-contract", "action:wait-dependency", "action:restore-environment", "action:wait-external", "action:review-at", "action:human-decision", "action:human-authorization", "action:human-access", "action:human-operation", "action:human-acceptance"]
-    issues = [{"number": index, "title": action, "state": "open", "labels": ["agent:blocked" if "human" not in action else "agent:needs-human", action]} for index, action in enumerate(actions, 1)]
+    issues = []
+    for index, action in enumerate(actions, 1):
+        receipt = receipt_for_action(action)
+        comment = {"body": "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"}
+        issues.append({"number": index, "title": action, "state": "open", "labels": ["agent:blocked" if "human" not in action else "agent:needs-human", action], "comments": [comment]})
     payload = intake(issues)
     assert not payload["drift"]
     assert set(payload["queues"]) == set(actions)

--- a/tests/builderops/test_blocker_action_intake.py
+++ b/tests/builderops/test_blocker_action_intake.py
@@ -1,3 +1,7 @@
+import json
+import subprocess
+import sys
+
 from app.builderops.blocker_actions import intake, receipt_for_action
 
 
@@ -19,3 +23,29 @@ def test_report_surface_is_rest_oriented_and_read_only() -> None:
     script = (Path(__file__).resolve().parents[2] / "scripts/report_blocker_actions.py").read_text()
     assert '"gh", "api"' in script
     assert "claim" not in script.lower().replace("read-only", "")
+
+
+def test_report_entrypoint_rejects_noncanonical_owner_receipts(monkeypatch, capsys) -> None:
+    from scripts import report_blocker_actions
+
+    invalid = """```yaml
+receipt: blocker_action.v1
+action: action:wait-dependency
+owner: builder-system-maintenance
+next_action: wait
+unblocks_when: dependency closes
+dependency_refs: []
+review_at: null
+last_verified_at: 2026-08-30T11:00:00Z
+```"""
+    responses = iter([
+        subprocess.CompletedProcess([], 0, json.dumps([{"number": 71, "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}]}]), ""),
+        subprocess.CompletedProcess([], 0, json.dumps([{"body": invalid}]), ""),
+    ])
+    monkeypatch.setattr(report_blocker_actions.subprocess, "run", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(sys, "argv", ["report_blocker_actions.py", "--repo", "o/r"])
+
+    assert report_blocker_actions.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["drift"][0]["owner"] is None
+    assert payload["drift"][0]["next_action"] is None

--- a/tests/builderops/test_blocker_action_intake.py
+++ b/tests/builderops/test_blocker_action_intake.py
@@ -5,6 +5,14 @@ import sys
 from app.builderops.blocker_actions import intake, receipt_for_action
 
 
+def _comment(action: str) -> dict[str, str]:
+    receipt = receipt_for_action(action)
+    return {"body": "```yaml\n" + "\n".join(
+        f"{key}: {value if key != 'dependency_refs' else '[]'}"
+        for key, value in receipt.items()
+    ) + "\n```"}
+
+
 def test_intake_routes_every_canonical_action_without_claiming() -> None:
     actions = ["action:repair-contract", "action:wait-dependency", "action:restore-environment", "action:wait-external", "action:review-at", "action:human-decision", "action:human-authorization", "action:human-access", "action:human-operation", "action:human-acceptance"]
     issues = []
@@ -49,3 +57,35 @@ last_verified_at: 2026-08-30T11:00:00Z
     payload = json.loads(capsys.readouterr().out)
     assert payload["drift"][0]["owner"] is None
     assert payload["drift"][0]["next_action"] is None
+
+
+def test_intake_rejects_receipts_that_do_not_bind_to_live_action_context() -> None:
+    cases = [
+        (["agent:blocked", "action:wait-dependency"], "action:human-decision", "receipt_action_mismatch"),
+        (["agent:blocked", "action:wait-dependency"], "action:repair-contract", "receipt_action_mismatch"),
+        (["agent:blocked", "action:wait-dependency", "action:wait-external"], "action:wait-dependency", "multiple_action_labels"),
+        (["agent:blocked"], "action:wait-dependency", "missing_action_label"),
+        (["agent:blocked", "agent:needs-human", "action:wait-dependency"], "action:wait-dependency", "action_without_blocker_lifecycle"),
+    ]
+    for labels, receipt_action, expected_error in cases:
+        payload = intake([{"number": 71, "state": "open", "labels": labels, "comments": [_comment(receipt_action)]}])
+        item = payload["drift"][0]
+        assert expected_error in item["errors"]
+        assert item["owner"] is None and item["next_action"] is None
+        assert not any(payload["queues"].values())
+
+
+def test_report_entrypoint_keeps_mismatched_receipt_out_of_label_queue(monkeypatch, capsys) -> None:
+    from scripts import report_blocker_actions
+
+    responses = iter([
+        subprocess.CompletedProcess([], 0, json.dumps([{"number": 72, "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}]}]), ""),
+        subprocess.CompletedProcess([], 0, json.dumps([_comment("action:human-decision")]), ""),
+    ])
+    monkeypatch.setattr(report_blocker_actions.subprocess, "run", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(sys, "argv", ["report_blocker_actions.py", "--repo", "o/r"])
+
+    assert report_blocker_actions.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert not payload["queues"]["action:wait-dependency"]
+    assert payload["drift"][0]["errors"] == ["receipt_action_mismatch"]

--- a/tests/builderops/test_blocker_action_intake.py
+++ b/tests/builderops/test_blocker_action_intake.py
@@ -1,0 +1,17 @@
+from app.builderops.blocker_actions import intake
+
+
+def test_intake_routes_every_canonical_action_without_claiming() -> None:
+    actions = ["action:repair-contract", "action:wait-dependency", "action:restore-environment", "action:wait-external", "action:review-at", "action:human-decision", "action:human-authorization", "action:human-access", "action:human-operation", "action:human-acceptance"]
+    issues = [{"number": index, "title": action, "state": "open", "labels": ["agent:blocked" if "human" not in action else "agent:needs-human", action]} for index, action in enumerate(actions, 1)]
+    payload = intake(issues)
+    assert not payload["drift"]
+    assert set(payload["queues"]) == set(actions)
+    assert all(item["claim_posture"].startswith("read-only") for queue in payload["queues"].values() for item in queue)
+
+
+def test_report_surface_is_rest_oriented_and_read_only() -> None:
+    from pathlib import Path
+    script = (Path(__file__).resolve().parents[2] / "scripts/report_blocker_actions.py").read_text()
+    assert '"gh", "api"' in script
+    assert "claim" not in script.lower().replace("read-only", "")

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -14,6 +14,7 @@ from app.builderops.cockpit_github_plane import fetch_github_live
 from app.builderops.cockpit_registry import BANDS, RUNG_ORDER, build_registry
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.store import SqliteStore
+from app.dispatcher.sync_github import normalize_github_issue
 
 
 def _now() -> str:
@@ -126,12 +127,22 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
 
 def test_registry_exposes_canonical_blocker_action_without_promoting_authority(tmp_path: Path) -> None:
     store, db_path = _make_store(tmp_path)
-    store.upsert_task(_task(status="blocked", issue_number=71, sync_state={"labels": ["agent:blocked", "action:wait-dependency"]}))
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait for Issue #72\nunblocks_when: Issue #72 closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    store.upsert_task(_task(status="blocked", issue_number=71, sync_state={"labels": ["agent:blocked", "action:wait-dependency"], "comments": [{"body": receipt}]}))
     payload = _registry(db_path, tmp_path)
     item = _band(payload, "working")["items"][0]
     assert item["blocker_action"] == "action:wait-dependency"
-    assert item["next_action"] is None
-    assert item["next_action_evidence"] == "issue comment blocker_action.v1; read-only projection"
+    assert item["next_action"] == "wait for Issue #72"
+    assert item["next_action_evidence"] == "issue comment blocker_action.v1"
+
+
+def test_registry_uses_dispatcher_rest_comment_projection(tmp_path: Path) -> None:
+    store, db_path = _make_store(tmp_path)
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait for dependency\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    task = normalize_github_issue({"number": 72, "title": "blocked", "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}], "comments": [{"body": receipt}]}, "RasmusTho/agentic-pkm-mvp")
+    store.upsert_task(task)
+    item = _band(_registry(db_path, tmp_path), "working")["items"][0]
+    assert item["next_action"] == "wait for dependency"
 
 
 def test_chain_derivation_failure_does_not_expose_exception_details(

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -145,6 +145,16 @@ def test_registry_uses_dispatcher_rest_comment_projection(tmp_path: Path) -> Non
     assert item["next_action"] == "wait for dependency"
 
 
+def test_registry_rejects_noncanonical_receipt_owner(tmp_path: Path) -> None:
+    store, db_path = _make_store(tmp_path)
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait for dependency\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    task = normalize_github_issue({"number": 73, "title": "blocked", "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}], "comments": [{"body": receipt}]}, "RasmusTho/agentic-pkm-mvp")
+    store.upsert_task(task)
+    item = _band(_registry(db_path, tmp_path), "working")["items"][0]
+    assert item["next_action"] is None
+    assert item["next_action_evidence"] == "receipt unavailable; read-only projection"
+
+
 def test_chain_derivation_failure_does_not_expose_exception_details(
     tmp_path: Path,
     monkeypatch,

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -124,6 +124,16 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
     assert flawed_item["why_now"] == "blocked: upstream"
 
 
+def test_registry_exposes_canonical_blocker_action_without_promoting_authority(tmp_path: Path) -> None:
+    store, db_path = _make_store(tmp_path)
+    store.upsert_task(_task(status="blocked", issue_number=71, sync_state={"labels": ["agent:blocked", "action:wait-dependency"]}))
+    payload = _registry(db_path, tmp_path)
+    item = _band(payload, "working")["items"][0]
+    assert item["blocker_action"] == "action:wait-dependency"
+    assert item["next_action"] is None
+    assert item["next_action_evidence"] == "issue comment blocker_action.v1; read-only projection"
+
+
 def test_chain_derivation_failure_does_not_expose_exception_details(
     tmp_path: Path,
     monkeypatch,

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -127,7 +127,7 @@ def test_band_derivation_fail_closed(tmp_path: Path) -> None:
 
 def test_registry_exposes_canonical_blocker_action_without_promoting_authority(tmp_path: Path) -> None:
     store, db_path = _make_store(tmp_path)
-    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait for Issue #72\nunblocks_when: Issue #72 closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder\nnext_action: wait for Issue #72\nunblocks_when: Issue #72 closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
     store.upsert_task(_task(status="blocked", issue_number=71, sync_state={"labels": ["agent:blocked", "action:wait-dependency"], "comments": [{"body": receipt}]}))
     payload = _registry(db_path, tmp_path)
     item = _band(payload, "working")["items"][0]
@@ -138,7 +138,7 @@ def test_registry_exposes_canonical_blocker_action_without_promoting_authority(t
 
 def test_registry_uses_dispatcher_rest_comment_projection(tmp_path: Path) -> None:
     store, db_path = _make_store(tmp_path)
-    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait for dependency\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder\nnext_action: wait for dependency\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
     task = normalize_github_issue({"number": 72, "title": "blocked", "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}], "comments": [{"body": receipt}]}, "RasmusTho/agentic-pkm-mvp")
     store.upsert_task(task)
     item = _band(_registry(db_path, tmp_path), "working")["items"][0]

--- a/tests/builderops/test_cockpit_registry.py
+++ b/tests/builderops/test_cockpit_registry.py
@@ -155,6 +155,17 @@ def test_registry_rejects_noncanonical_receipt_owner(tmp_path: Path) -> None:
     assert item["next_action_evidence"] == "receipt unavailable; read-only projection"
 
 
+def test_registry_rejects_cross_family_receipt_action(tmp_path: Path) -> None:
+    store, db_path = _make_store(tmp_path)
+    receipt = "```yaml\nreceipt: blocker_action.v1\naction: action:human-decision\nowner: builder\nnext_action: ask owner\nunblocks_when: owner decides\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"
+    task = normalize_github_issue({"number": 74, "title": "blocked", "state": "open", "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}], "comments": [{"body": receipt}]}, "RasmusTho/agentic-pkm-mvp")
+    store.upsert_task(task)
+    item = _band(_registry(db_path, tmp_path), "working")["items"][0]
+    assert item["blocker_action"] == "action:wait-dependency"
+    assert item["next_action"] is None
+    assert item["next_action_evidence"] == "receipt unavailable; read-only projection"
+
+
 def test_chain_derivation_failure_does_not_expose_exception_details(
     tmp_path: Path,
     monkeypatch,

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -225,6 +225,35 @@ def test_essential_source_remains_ready_only_when_action_labels_exist() -> None:
     assert task.status == "ready"
 
 
+def test_pull_sync_projects_blocker_comment_records_without_making_them_pickable(tmp_store: SqliteStore) -> None:
+    receipt = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
+    blocked = {**SAMPLE_ISSUE_BLOCKED, "comments": [receipt], "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}]}
+    source = _mock_source([SAMPLE_ISSUE_HIGH], open_issues=[blocked])
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+    upserted = adapter.pull(REPO)
+    assert [task.issue_number for task in upserted] == [101]
+    projected = tmp_store.get_task(_tid(104))
+    assert projected is not None and projected.status == "blocked"
+    assert projected.sync_state["comments"] == [receipt]
+
+
+def test_rest_open_issue_source_fetches_comments_only_for_nonactive_actions(monkeypatch) -> None:
+    import json
+    source = GhCliIssueSource()
+    calls: list[str] = []
+    def fake_run(command, **kwargs):
+        endpoint = command[2]
+        calls.append(endpoint)
+        payload = ([{"number": 1, "title": "blocked", "state": "open", "labels": [{"name": "agent:blocked"}]}, {"number": 2, "title": "ready", "state": "open", "labels": [{"name": "agent:ready"}]}] if endpoint.endswith("/issues") else [])
+        return MagicMock(returncode=0, stdout=json.dumps(payload), stderr="")
+    monkeypatch.setattr("subprocess.run", fake_run)
+    source.list_open_issues(REPO)
+    comments = source.fetch_blocker_comments(REPO, 1)
+    assert comments == []
+    assert "issues/1/comments" in calls[-1]
+    assert all("issues/2/comments" not in call for call in calls)
+
+
 def test_normalize_github_issue_low_priority() -> None:
     task = normalize_github_issue(SAMPLE_ISSUE_LOW, REPO)
     assert task.priority == "low"

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -166,7 +166,7 @@ def test_sync_state_carries_labels_and_url() -> None:
 
 
 def test_normalize_carries_rest_comment_projection_without_changing_ready_pickup() -> None:
-    comment = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
+    comment = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
     task = normalize_github_issue({**SAMPLE_ISSUE_BLOCKED, "comments": [comment]}, REPO)
     assert task.sync_state["comments"] == [comment]
     assert task.status == "blocked"
@@ -226,7 +226,7 @@ def test_essential_source_remains_ready_only_when_action_labels_exist() -> None:
 
 
 def test_pull_sync_projects_blocker_comment_records_without_making_them_pickable(tmp_store: SqliteStore) -> None:
-    receipt = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
+    receipt = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
     blocked = {**SAMPLE_ISSUE_BLOCKED, "comments": [receipt], "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}]}
     source = _mock_source([SAMPLE_ISSUE_HIGH], open_issues=[blocked])
     adapter = PullSyncAdapter(store=tmp_store, source=source)

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -237,6 +237,18 @@ def test_pull_sync_projects_blocker_comment_records_without_making_them_pickable
     assert projected.sync_state["comments"] == [receipt]
 
 
+def test_pull_sync_records_receipt_action_drift_for_cockpit_without_pickup(tmp_store: SqliteStore) -> None:
+    receipt = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:human-decision\nowner: builder\nnext_action: ask owner\nunblocks_when: owner decides\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
+    blocked = {**SAMPLE_ISSUE_BLOCKED, "comments": [receipt], "labels": [{"name": "agent:blocked"}, {"name": "action:wait-dependency"}]}
+    source = _mock_source([SAMPLE_ISSUE_HIGH], open_issues=[blocked])
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+
+    assert [task.issue_number for task in adapter.pull(REPO)] == [101]
+    projected = tmp_store.get_task(_tid(104))
+    assert projected is not None
+    assert projected.sync_state["blocker_action_drift"] == ["receipt_action_mismatch"]
+
+
 def test_rest_open_issue_source_fetches_comments_only_for_nonactive_actions(monkeypatch) -> None:
     import json
     source = GhCliIssueSource()

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -165,6 +165,13 @@ def test_sync_state_carries_labels_and_url() -> None:
     assert bare.sync_state["url"] is None
 
 
+def test_normalize_carries_rest_comment_projection_without_changing_ready_pickup() -> None:
+    comment = {"body": "```yaml\nreceipt: blocker_action.v1\naction: action:wait-dependency\nowner: builder-system-maintenance\nnext_action: wait\nunblocks_when: dependency closes\ndependency_refs: []\nreview_at: null\nlast_verified_at: 2026-08-30T11:00:00Z\n```"}
+    task = normalize_github_issue({**SAMPLE_ISSUE_BLOCKED, "comments": [comment]}, REPO)
+    assert task.sync_state["comments"] == [comment]
+    assert task.status == "blocked"
+
+
 def test_github_issue_task_id_single_source_format_pinned() -> None:
     """The repo-qualified task id has exactly one implementation with a pinned
     byte format, including the doubled ``--`` owner/repo separator that keeps

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -211,6 +211,13 @@ def test_normalize_github_issue_blocked_status() -> None:
     assert task.priority == "med"
 
 
+def test_essential_source_remains_ready_only_when_action_labels_exist() -> None:
+    source = inspect.getsource(GhCliIssueSource.list_issues)
+    assert "labels=agent:ready" in source
+    task = normalize_github_issue({**SAMPLE_ISSUE_HIGH, "labels": [{"name": "agent:ready"}, {"name": "action:wait-dependency"}]}, REPO)
+    assert task.status == "ready"
+
+
 def test_normalize_github_issue_low_priority() -> None:
     task = normalize_github_issue(SAMPLE_ISSUE_LOW, REPO)
     assert task.priority == "low"

--- a/tests/governance/test_blocker_action_contract.py
+++ b/tests/governance/test_blocker_action_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from app.builderops.blocker_actions import ACTION_LABELS, BLOCKED_ACTIONS, HUMAN_ACTIONS
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_operational_skills_reference_canonical_blocker_action_contract() -> None:
+    for skill in ("issue-to-code", "issue-maintenance-change-control", "owner-decision-brief", "deliver-issue-set", "feature-breakdown", "bug-to-issue", "docs-to-issue", "learning-to-issue", "verification-and-closure"):
+        text = (ROOT / ".codex" / "skills" / skill / "SKILL.md").read_text()
+        assert "BLOCKER_ACTION_CONTRACT.md" in text
+
+
+def test_canonical_action_labels_and_receipt_schema_are_complete() -> None:
+    taxonomy = (ROOT / ".codex/skills/_shared/LABEL_TAXONOMY.md").read_text()
+    receipt = (ROOT / ".codex/skills/_shared/BLOCKER_ACTION_CONTRACT.md").read_text()
+    assert len(ACTION_LABELS) == 10 and len(BLOCKED_ACTIONS) == len(HUMAN_ACTIONS) == 5
+    for label in ACTION_LABELS:
+        assert label in taxonomy
+    for key in ("receipt: blocker_action.v1", "action:", "owner:", "next_action:", "unblocks_when:", "dependency_refs:", "last_verified_at:"):
+        assert key in receipt

--- a/tests/governance/test_blocker_action_contract.py
+++ b/tests/governance/test_blocker_action_contract.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_operational_skills_reference_canonical_blocker_action_contract() -> None:
-    for skill in ("issue-to-code", "issue-maintenance-change-control", "owner-decision-brief", "deliver-issue-set", "feature-breakdown", "bug-to-issue", "docs-to-issue", "learning-to-issue", "verification-and-closure"):
+    for skill in ("issue-to-code", "issue-maintenance-change-control", "owner-decision-brief", "deliver-issue-set", "feature-breakdown", "bug-to-issue", "docs-to-issue", "learning-to-issue", "post-merge-owner-doc", "verification-and-closure"):
         text = (ROOT / ".codex" / "skills" / skill / "SKILL.md").read_text()
         assert "BLOCKER_ACTION_CONTRACT.md" in text
 

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -209,6 +209,20 @@ def _read_workflow() -> str:
     )
 
 
+def test_issue_agent_label_guard_enforces_blocker_action_compatibility() -> None:
+    workflow = _read_workflow()
+    assert "Open blocked/needs-human Issue must carry exactly one action:* label" in workflow
+    assert "agent:blocked requires a canonical blocked action:* label" in workflow
+    assert "agent:needs-human requires a canonical human action:* label" in workflow
+
+
+def test_issue_agent_label_guard_removes_terminal_action_labels() -> None:
+    workflow = _read_workflow()
+    assert 'name.startsWith("action:")' in workflow
+    assert 'issue.state === "closed" && actionLabels.length' in workflow
+    assert "await github.rest.issues.removeLabel" in workflow
+
+
 def _sbs_impact_warnings(body: str, changed_files: list[str]) -> list[str]:
     workflow = _read_workflow()
     checker = workflow.split("// sbs-impact-consistency:start", 1)[1].split(

--- a/tests/governance/test_skills_consistency_lint.py
+++ b/tests/governance/test_skills_consistency_lint.py
@@ -71,6 +71,12 @@ def test_skills_consistency_lint_passes() -> None:
     assert errors == [], "skills consistency lint reported errors:\n" + "\n".join(errors)
 
 
+def test_blocker_action_taxonomy_is_linted() -> None:
+    from scripts.lint_skills_consistency import CANONICAL_LABELS
+    assert "action:human-acceptance" in CANONICAL_LABELS
+    assert "action:repair-contract" in CANONICAL_LABELS
+
+
 def test_seeded_clean_tree_passes(tmp_path: Path) -> None:
     assert run_lint(_seed_tree(tmp_path)) == []
 

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -137,6 +137,14 @@ def test_intake_parses_real_comment_receipt_and_rejects_invalid_placeholder() ->
 
 def test_receipt_parser_rejects_noncanonical_owner() -> None:
     receipt = receipt_for_action("action:wait-dependency")
-    receipt["owner"] = "builder-system-maintenance"
+    for owner in ("", "builder-system-maintenance", "external:", "external:bad name", "external:UPPER"):
+        receipt["owner"] = owner
+        body = "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"
+        assert parse_blocker_action_receipt({"body": body}) is None
+
+
+def test_receipt_parser_accepts_canonical_external_owner() -> None:
+    receipt = receipt_for_action("action:wait-dependency")
+    receipt["owner"] = "external:github-bot_1"
     body = "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"
-    assert parse_blocker_action_receipt({"body": body}) is None
+    assert parse_blocker_action_receipt({"body": body}) == receipt

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -1,0 +1,20 @@
+from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS
+from scripts.reconcile_blocker_actions import plan
+
+
+def test_report_and_apply_are_bounded_idempotent_and_exact() -> None:
+    issue = {"number": 1, "state": "open", "labels": ["agent:blocked"]}
+    first = plan(issue)
+    assert first["after"] == ["action:repair-contract", "agent:blocked"]
+    assert plan({**issue, "labels": first["after"]})["changes"] == []
+
+
+def test_legacy_human_labels_map_to_canonical_successors() -> None:
+    for old, new in LEGACY_HUMAN_ACTIONS.items():
+        result = plan({"number": 1, "state": "open", "labels": ["agent:needs-human", old]})
+        assert new in result["after"] and old not in result["after"]
+
+
+def test_unclassified_blocked_routes_to_repair_contract_without_cause_inference() -> None:
+    result = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    assert result["after"] == ["action:repair-contract", "agent:blocked"]

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -1,4 +1,4 @@
-from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS, intake, receipt_for_action
+from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS, intake, parse_blocker_action_receipt, receipt_for_action
 from scripts.reconcile_blocker_actions import apply_plan, plan
 import subprocess
 import sys
@@ -130,6 +130,13 @@ def test_intake_parses_real_comment_receipt_and_rejects_invalid_placeholder() ->
     comment = {"body": "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"}
     payload = intake([{"number": 1, "state": "open", "labels": ["agent:blocked", "action:wait-dependency"], "comments": [comment]}])
     item = payload["queues"]["action:wait-dependency"][0]
-    assert item["owner"] == "builder-system-maintenance"
+    assert item["owner"] == "builder"
     assert item["next_action"]
     assert not payload["drift"]
+
+
+def test_receipt_parser_rejects_noncanonical_owner() -> None:
+    receipt = receipt_for_action("action:wait-dependency")
+    receipt["owner"] = "builder-system-maintenance"
+    body = "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"
+    assert parse_blocker_action_receipt({"body": body}) is None

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -98,6 +98,31 @@ def test_apply_aborts_when_posted_receipt_cannot_be_read_back(monkeypatch) -> No
         apply_plan("o/r", "o", "r", item)
 
 
+def test_apply_aborts_when_posted_receipt_action_mismatches_live_label(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    reads = iter([
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+    ])
+    wrong = receipt_for_action("action:human-decision")
+    wrong_body = "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in wrong.items()) + "\n```"
+
+    def fake_api(repo, endpoint, *, method="GET", payload=None):
+        if method == "POST" and endpoint.endswith("/comments"):
+            return {"id": 9}
+        if method == "POST" and endpoint.endswith("/labels"):
+            return None
+        if method == "GET" and "comments?" in endpoint:
+            return [{"id": 9, "body": wrong_body}]
+        return next(reads)
+
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
+    with pytest.raises(RuntimeError, match="receipt readback mismatch"):
+        apply_plan("o/r", "o", "r", item)
+
+
 def test_apply_aborts_when_terminal_lifecycle_drifts_after_receipt(monkeypatch) -> None:
     item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
     reads = iter([

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -23,6 +23,19 @@ def test_legacy_human_labels_map_to_canonical_successors() -> None:
         assert new in result["after"] and old not in result["after"]
 
 
+def test_plan_removes_only_legacy_label_when_exact_successor_is_already_live() -> None:
+    result = plan({"number": 1, "state": "open", "labels": ["agent:needs-human", "human:decision", "action:human-decision"]})
+    assert result["after"] == ["action:human-decision", "agent:needs-human"]
+    assert result["changes"] == [{"remove": "human:decision", "add": ""}]
+    assert not result["errors"]
+
+
+def test_plan_fails_closed_for_legacy_label_with_other_live_successor() -> None:
+    result = plan({"number": 1, "state": "open", "labels": ["agent:needs-human", "human:decision", "action:human-authorization"]})
+    assert result["changes"] == []
+    assert "legacy_successor_conflict" in result["errors"]
+
+
 def test_unclassified_blocked_routes_to_repair_contract_without_cause_inference() -> None:
     result = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
     assert result["after"] == ["action:repair-contract", "agent:blocked"]
@@ -75,6 +88,36 @@ def test_apply_uses_narrow_writes_and_verifies_readback(monkeypatch) -> None:
     assert result["action"] == "action:repair-contract"
     assert any(method == "POST" and endpoint.endswith("/labels") for endpoint, method, _ in calls)
     assert not any(method == "PATCH" for _, method, _ in calls)
+
+
+def test_apply_retries_partial_legacy_migration_with_only_safe_removal(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:needs-human", "human:decision", "action:human-decision"]})
+    reads = iter([
+        {"number": 1, "state": "open", "labels": item["before"]},
+        {"number": 1, "state": "open", "labels": item["before"]},
+        {"number": 1, "state": "open", "labels": item["after"]},
+        {"number": 1, "state": "open", "labels": item["after"]},
+        {"number": 1, "state": "open", "labels": item["after"]},
+    ])
+    calls = []
+    posted_body = None
+
+    def fake_api(repo, endpoint, *, method="GET", payload=None):
+        nonlocal posted_body
+        calls.append((endpoint, method, payload))
+        if method == "DELETE":
+            return None
+        if method == "POST" and endpoint.endswith("/comments"):
+            posted_body = payload["body"]
+            return {"id": 9}
+        if method == "GET" and "comments?" in endpoint:
+            return [{"id": 9, "body": posted_body}]
+        return next(reads)
+
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
+    assert apply_plan("o/r", "o", "r", item)["action"] == "action:human-decision"
+    assert any(method == "DELETE" and endpoint.endswith("/labels/human:decision") for endpoint, method, _ in calls)
+    assert not any(method == "POST" and endpoint.endswith("/labels") for endpoint, method, _ in calls)
 
 
 def test_apply_aborts_when_posted_receipt_cannot_be_read_back(monkeypatch) -> None:

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -1,8 +1,10 @@
-from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS
-from scripts.reconcile_blocker_actions import plan
+from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS, intake, receipt_for_action
+from scripts.reconcile_blocker_actions import apply_plan, plan
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -33,3 +35,44 @@ def test_script_entrypoints_execute_from_repo_root() -> None:
             cwd=ROOT, text=True, capture_output=True, check=False,
         )
         assert result.returncode == 0, result.stderr
+
+
+def test_apply_re_reads_before_each_narrow_mutation_and_aborts_on_claim_drift(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    reads = iter([
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:in-progress"]},
+    ])
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", lambda *args, **kwargs: next(reads))
+    with pytest.raises(RuntimeError, match="drift"):
+        apply_plan("o/r", "o", "r", item)
+
+
+def test_apply_uses_narrow_writes_and_verifies_readback(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    calls = []
+    reads = iter([
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+    ])
+    def fake_api(repo, endpoint, *, method="GET", payload=None):
+        calls.append((endpoint, method, payload))
+        if method == "GET": return next(reads)
+        return None
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
+    result = apply_plan("o/r", "o", "r", item)
+    assert result["action"] == "action:repair-contract"
+    assert any(method == "POST" and endpoint.endswith("/labels") for endpoint, method, _ in calls)
+    assert not any(method == "PATCH" for _, method, _ in calls)
+
+
+def test_intake_parses_real_comment_receipt_and_rejects_invalid_placeholder() -> None:
+    receipt = receipt_for_action("action:wait-dependency")
+    comment = {"body": "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"}
+    payload = intake([{"number": 1, "state": "open", "labels": ["agent:blocked", "action:wait-dependency"], "comments": [comment]}])
+    item = payload["queues"]["action:wait-dependency"][0]
+    assert item["owner"] == "builder-system-maintenance"
+    assert item["next_action"]
+    assert not payload["drift"]

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -98,6 +98,33 @@ def test_apply_aborts_when_posted_receipt_cannot_be_read_back(monkeypatch) -> No
         apply_plan("o/r", "o", "r", item)
 
 
+def test_apply_aborts_when_terminal_lifecycle_drifts_after_receipt(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    reads = iter([
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "closed", "labels": ["agent:blocked", "action:repair-contract"]},
+    ])
+    posted_body = None
+
+    def fake_api(repo, endpoint, *, method="GET", payload=None):
+        nonlocal posted_body
+        if method == "POST" and endpoint.endswith("/labels"):
+            return None
+        if method == "POST" and endpoint.endswith("/comments"):
+            posted_body = payload["body"]
+            return {"id": 9}
+        if method == "GET" and "comments?" in endpoint:
+            return [{"id": 9, "body": posted_body}]
+        return next(reads)
+
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
+    with pytest.raises(RuntimeError, match="post-receipt lifecycle/action drift"):
+        apply_plan("o/r", "o", "r", item)
+
+
 def test_intake_parses_real_comment_receipt_and_rejects_invalid_placeholder() -> None:
     receipt = receipt_for_action("action:wait-dependency")
     comment = {"body": "```yaml\n" + "\n".join(f"{key}: {value if key != 'dependency_refs' else '[]'}" for key, value in receipt.items()) + "\n```"}

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -56,9 +56,18 @@ def test_apply_uses_narrow_writes_and_verifies_readback(monkeypatch) -> None:
         {"number": 1, "state": "open", "labels": ["agent:blocked"]},
         {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
         {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
     ])
+    posted_body = None
     def fake_api(repo, endpoint, *, method="GET", payload=None):
+        nonlocal posted_body
         calls.append((endpoint, method, payload))
+        if method == "POST" and endpoint.endswith("/comments"):
+            posted_body = payload["body"]
+            return {"id": 9}
+        if method == "GET" and "comments?" in endpoint:
+            return [{"id": 9, "body": posted_body}]
         if method == "GET": return next(reads)
         return None
     monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
@@ -66,6 +75,27 @@ def test_apply_uses_narrow_writes_and_verifies_readback(monkeypatch) -> None:
     assert result["action"] == "action:repair-contract"
     assert any(method == "POST" and endpoint.endswith("/labels") for endpoint, method, _ in calls)
     assert not any(method == "PATCH" for _, method, _ in calls)
+
+
+def test_apply_aborts_when_posted_receipt_cannot_be_read_back(monkeypatch) -> None:
+    item = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
+    reads = iter([
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+        {"number": 1, "state": "open", "labels": ["agent:blocked", "action:repair-contract"]},
+    ])
+    def fake_api(repo, endpoint, *, method="GET", payload=None):
+        if method == "POST" and endpoint.endswith("/comments"):
+            return {"id": 9}
+        if method == "POST" and endpoint.endswith("/labels"):
+            return None
+        if method == "GET" and "comments?" in endpoint:
+            return []
+        return next(reads)
+    monkeypatch.setattr("scripts.reconcile_blocker_actions._api", fake_api)
+    with pytest.raises(RuntimeError, match="receipt readback mismatch"):
+        apply_plan("o/r", "o", "r", item)
 
 
 def test_intake_parses_real_comment_receipt_and_rejects_invalid_placeholder() -> None:

--- a/tests/scripts/test_reconcile_blocker_actions.py
+++ b/tests/scripts/test_reconcile_blocker_actions.py
@@ -1,5 +1,11 @@
 from app.builderops.blocker_actions import LEGACY_HUMAN_ACTIONS
 from scripts.reconcile_blocker_actions import plan
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_report_and_apply_are_bounded_idempotent_and_exact() -> None:
@@ -18,3 +24,12 @@ def test_legacy_human_labels_map_to_canonical_successors() -> None:
 def test_unclassified_blocked_routes_to_repair_contract_without_cause_inference() -> None:
     result = plan({"number": 1, "state": "open", "labels": ["agent:blocked"]})
     assert result["after"] == ["action:repair-contract", "agent:blocked"]
+
+
+def test_script_entrypoints_execute_from_repo_root() -> None:
+    for script in ("reconcile_blocker_actions.py", "report_blocker_actions.py"):
+        result = subprocess.run(
+            [sys.executable, f"scripts/{script}", "--help"],
+            cwd=ROOT, text=True, capture_output=True, check=False,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Governing-Issue: #5204

Fixes #5204

Final-Review-Rounds: 0

## Summary
Adds a canonical action-label and blocker receipt contract for blocked and needs-human Issues, with lifecycle enforcement, read-only intake, Cockpit projection, and a bounded idempotent migration path.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The PR changes Builder System contracts and projections; it creates no BuilderOps Vault record.

## Notes
Local focused validation and declared CLI entrypoint smokes were run on the current head. Current-head CI, independent review, and closure remain pending; this PR body does not claim a passing CI gate.
