### PR TITLE
Accept PostgreSQL disabled archive sentinel

### DIFF
--- a/scripts/builderops/local_wal_guard.sh
+++ b/scripts/builderops/local_wal_guard.sh
@@ -11,7 +11,9 @@ disk_limit_percent="${BUILDEROPS_LOCAL_DISK_MAX_USED_PERCENT:-85}"
 archive_mode="$(psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}" -Atqc 'SHOW archive_mode')"
 archive_command="$(psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}" -Atqc 'SHOW archive_command')"
 
-if [[ "$archive_mode" != "off" && "$archive_mode" != "(disabled)" ]] || [[ -n "$archive_command" ]]; then
+if [[ "$archive_mode" != "off" && "$archive_mode" != "(disabled)" ]] || {
+  [[ -n "$archive_command" && ( "$archive_mode" != "off" || "$archive_command" != "(disabled)" ) ]];
+}; then
   echo "local BuilderOps WAL archive drift: archive_mode=$archive_mode archive_command=${archive_command:+set}" >&2
   exit 70
 fi

--- a/tests/ops/test_builderops_deploy_contract.py
+++ b/tests/ops/test_builderops_deploy_contract.py
@@ -75,8 +75,18 @@ printf 'tmpfs 100 10 90 10%% /tmp\\n'
     )
 
 
-def test_local_wal_guard_accepts_postgresql_disabled_archive_mode(tmp_path: Path) -> None:
-    result = _run_local_wal_guard(tmp_path, archive_mode="(disabled)")
+def test_local_wal_guard_accepts_postgresql_disabled_archive_command(
+    tmp_path: Path,
+) -> None:
+    result = _run_local_wal_guard(
+        tmp_path, archive_mode="off", archive_command="(disabled)"
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_local_wal_guard_accepts_empty_archive_command(tmp_path: Path) -> None:
+    result = _run_local_wal_guard(tmp_path, archive_mode="off")
 
     assert result.returncode == 0, result.stdout + result.stderr
 


### PR DESCRIPTION
Governing-Issue: #5197
Fixes #5197
Final-Review-Rounds: 0

## Summary
Accept PostgreSQL's exact `archive_mode=off` and `archive_command=(disabled)` sentinel while preserving the empty-command posture and fail-closed rejection of enabled or real archiving.

## Changes
- Add direct regression coverage for PostgreSQL's disabled archive-command sentinel and the empty command.
- Narrow the local WAL guard exception to the exact disabled pair.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python3 -m pytest -q tests/ops/test_builderops_deploy_contract.py tests/ops/test_builderops_compose_contract.py`
- `ruff check app tests companion-ui/companion-app`
- `bash -n scripts/builderops/local_wal_guard.sh`
- `git diff --check`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded guard/test correction; no new BuilderOps operational record or projection is required.