### PR TITLE
feat: resolve Sources landing zone from vault settings

### DIFF
--- a/app/agents/panel_agent/policy.py
+++ b/app/agents/panel_agent/policy.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import Any, Mapping
 
+from app.vault.paths import get_vault_sources_dir_rel
+
 from app.knowledge.multiwriter import NoteClass, WriteOperation, classify_note
 
 AutoRunMode = str  # "manual" | "watcher" | "never"
@@ -133,9 +135,17 @@ def watcher_panel_writeback_allowed(
     relative_path: Path | str,
     *,
     vault_root: Path | str,
-    sources_root_rel: Path | str = "Sources",
+    sources_root_rel: Path | str | None = None,
 ) -> bool:
     """Limit mutation-capable watcher runs to canonical rewritten note paths."""
+
+    if sources_root_rel is None:
+        try:
+            sources_root_rel = get_vault_sources_dir_rel(Path(vault_root))
+        except Exception:
+            # A malformed Sources setting must fail closed for app-agent
+            # mutation rather than redirecting policy to the packaged default.
+            return False
 
     path = Path(relative_path)
     if path.is_absolute() or ".." in path.parts:

--- a/app/heimdal/candidate_projection.py
+++ b/app/heimdal/candidate_projection.py
@@ -71,6 +71,7 @@ from app.heimdal.quarantine import (
 )
 from app.knowledge.write_ops import write_note_relative
 from app.vault.manager import VaultContext
+from app.vault.paths import get_vault_sources_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 #: This module's OWN cursor identity in the A2 per-consumer cursor store --
@@ -359,7 +360,7 @@ def write_candidate_note(
     *,
     vault_context: VaultContext,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    candidates_dir: str = DEFAULT_CANDIDATES_DIR,
+    candidates_dir: str | None = None,
 ) -> CandidateWriteResult:
     """The governed vault-write call site for Heimdal candidates.
 
@@ -370,6 +371,8 @@ def write_candidate_note(
     a crash that loses the candidate.
     """
     vault_root = _vault_root(vault_context)
+    if candidates_dir is None:
+        candidates_dir = f"{get_vault_sources_dir_rel(vault_root)}/Heimdal"
     artifact_path = candidate_note_path(candidate, candidates_dir=candidates_dir)
 
     candidate_path = vault_root / artifact_path
@@ -659,7 +662,7 @@ def write_reading_candidate_note(
     *,
     vault_context: VaultContext,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    candidates_dir: str = DEFAULT_READING_CANDIDATES_DIR,
+    candidates_dir: str | None = None,
 ) -> CandidateWriteResult:
     """Governed WriteGuard-gated write for a reading candidate (never companion capture).
 
@@ -669,6 +672,8 @@ def write_reading_candidate_note(
     overwrite of an existing (possibly human-reviewed) note at that path.
     """
     vault_root = _vault_root(vault_context)
+    if candidates_dir is None:
+        candidates_dir = f"{get_vault_sources_dir_rel(vault_root)}/Reading/Karakeep"
     artifact_path = reading_candidate_note_path(candidate, candidates_dir=candidates_dir)
     candidate_path = vault_root / artifact_path
 
@@ -804,8 +809,8 @@ def project_pending_candidates(
     vault_context: VaultContext,
     consumer_id: str = CANDIDATE_CONSUMER_ID,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    candidates_dir: str = DEFAULT_CANDIDATES_DIR,
-    reading_candidates_dir: str = DEFAULT_READING_CANDIDATES_DIR,
+    candidates_dir: str | None = None,
+    reading_candidates_dir: str | None = None,
     limit: Optional[int] = None,
     advance: bool = True,
 ) -> List[CandidateWriteResult]:
@@ -830,7 +835,12 @@ def project_pending_candidates(
     # The cursor is a durability acknowledgement: do not begin a batch unless a
     # selected, existing vault can hold its candidates. This happens before
     # writes so a restart can replay the complete unread batch safely.
-    _vault_root(vault_context)
+    vault_root = _vault_root(vault_context)
+    sources_dir = get_vault_sources_dir_rel(vault_root)
+    if candidates_dir is None:
+        candidates_dir = f"{sources_dir}/Heimdal"
+    if reading_candidates_dir is None:
+        reading_candidates_dir = f"{sources_dir}/Reading/Karakeep"
     rows = read_observations_for_consumer(consumer_id, limit=limit)
     planned = _plan_writes(rows)
 

--- a/app/heimdal/meeting_finalization.py
+++ b/app/heimdal/meeting_finalization.py
@@ -68,6 +68,7 @@ from app.instance.scalar_binding_runtime import resolve_scalar_binding_runtime
 from app.knowledge.write_ops import create_candidate_note_once
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.services import outbox as outbox_service
+from app.vault.paths import get_vault_sources_dir_rel
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +147,13 @@ def _parse_ts(value: Any) -> datetime:
     return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
 
 
-def meetings_dir_rel() -> str:
-    return (os.environ.get(_MEETINGS_DIR_ENV) or "").strip() or MEETINGS_DIR_DEFAULT
+def meetings_dir_rel(vault_root: Path | None = None) -> str:
+    configured = (os.environ.get(_MEETINGS_DIR_ENV) or "").strip()
+    if configured:
+        return configured
+    if vault_root is not None:
+        return f"{get_vault_sources_dir_rel(vault_root)}/Meetings"
+    return MEETINGS_DIR_DEFAULT
 
 
 def resolve_vault_root() -> Optional[Path]:
@@ -739,7 +745,7 @@ def finalize_session(
     supersedes = previous.state_sha256 if previous else None
 
     short = state_sha256[:8]
-    base = f"{meetings_dir_rel()}/{_session_path_component(session_id)}"
+    base = f"{meetings_dir_rel(vault_root)}/{_session_path_component(session_id)}"
     artifact_refs = {
         "transcript": f"{base}/transcript-{short}.md",
         "analysis": f"{base}/analysis-{short}.md",

--- a/app/journaling/day_context.py
+++ b/app/journaling/day_context.py
@@ -22,7 +22,8 @@ from app.context_bundles.schema import (
     IncludedItem,
     ItemProvenance,
 )
-from app.knowledge_acquisition.candidate_writeback import ARTIFACT_CLASS, DEFAULT_SOURCES_DIR
+from app.knowledge_acquisition.candidate_writeback import ARTIFACT_CLASS
+from app.vault.paths import get_vault_sources_dir_rel
 from app.receipts.decision_receipt_log import decisions_receipts_dir, iter_decision_receipts
 from app.services.commitment_persistence import commitment_artifact_path, load_commitments
 from app.vault.manager import VaultContext
@@ -192,7 +193,7 @@ def _read_captures(
     vault_root: Path, for_date: date
 ) -> tuple[list[DayContextItem], list[IncludedItem]]:
     paired: list[tuple[DayContextItem, IncludedItem]] = []
-    sources_dir = vault_root / DEFAULT_SOURCES_DIR
+    sources_dir = vault_root / get_vault_sources_dir_rel(vault_root)
     if not sources_dir.exists():
         return [], []
     for path in sorted(sources_dir.glob("*.md")):

--- a/app/knowledge_acquisition/acquire.py
+++ b/app/knowledge_acquisition/acquire.py
@@ -72,7 +72,6 @@ from app.knowledge_acquisition.pipeline_defaults import (
 )
 from app.knowledge_acquisition.replay import CANDIDATE_STAGE, CANDIDATE_STAGE_VERSION
 from app.knowledge_acquisition.source_bundle import (
-    DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
     SourceBundleError,
     materialize_youtube_source_bundle,
 )
@@ -272,7 +271,7 @@ def acquire_youtube(
     conn: Any = None,
     env: Mapping[str, str] | None = None,
     fetch_fn: Callable[[str], youtube_plugin.FetchOutcome] | None = None,
-    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    youtube_attachment_root: str | None = None,
 ) -> AcquisitionReceipt:
     """Acquire a NEW YouTube URL end-to-end: fetch -> persist raw -> normalize -> extract ->
     assemble_candidate -> write_candidate_note, emitting one KA-06 stage event per transition.

--- a/app/knowledge_acquisition/candidate_writeback.py
+++ b/app/knowledge_acquisition/candidate_writeback.py
@@ -66,6 +66,7 @@ from app.knowledge_acquisition.note_renderer import (
 from app.knowledge_acquisition.normalize import has_usable_transcript, normalize
 from app.knowledge_acquisition.normalize import NormalizedTranscript
 from app.vault.manager import VaultContext
+from app.vault.paths import get_vault_sources_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 CANDIDATE_WRITE_ACTION = "knowledge_acquisition.candidate_writeback"
@@ -470,7 +471,7 @@ def write_candidate_note(
     *,
     vault_context: VaultContext,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    sources_dir: str = DEFAULT_SOURCES_DIR,
+    sources_dir: str | None = None,
     proposal_on_existing: bool = False,
 ) -> CandidateWriteResult:
     """The governed vault-write call site: the only place this module touches
@@ -492,6 +493,8 @@ def write_candidate_note(
     versioned proposal companion for a fresh extraction.
     """
     vault_root = _vault_root(vault_context)
+    if sources_dir is None:
+        sources_dir = get_vault_sources_dir_rel(vault_root)
     artifact_path = candidate_note_path(candidate, sources_dir=sources_dir)
 
     try:

--- a/app/knowledge_acquisition/replay.py
+++ b/app/knowledge_acquisition/replay.py
@@ -85,7 +85,6 @@ from app.knowledge_acquisition.pipeline_defaults import (
 )
 from app.knowledge_acquisition.raw_record import RawRecordIntegrityError, get_raw_record
 from app.knowledge_acquisition.source_bundle import (
-    DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
     SourceBundleError,
     materialize_youtube_source_bundle,
 )
@@ -253,7 +252,7 @@ def run_replay(
     assert_no_source_egress: bool = True,
     trace_id: str | None = None,
     conn: Any = None,
-    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    youtube_attachment_root: str | None = None,
 ) -> ReplayReceipt:
     """Replay every derived level from an existing `raw` record and return a typed receipt.
 

--- a/app/knowledge_acquisition/source_bundle.py
+++ b/app/knowledge_acquisition/source_bundle.py
@@ -22,6 +22,7 @@ from app.knowledge.write_ops import create_candidate_note_once
 from app.knowledge_acquisition.candidate_writeback import Candidate
 from app.knowledge_acquisition.extraction_persistence import PersistedTranscript
 from app.vault.manager import VaultContext
+from app.vault.paths import get_vault_sources_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 DEFAULT_YOUTUBE_ATTACHMENT_ROOT = "Sources/YouTube/_attachments"
@@ -61,11 +62,13 @@ def materialize_youtube_source_bundle(
     *,
     vault_context: VaultContext,
     write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
-    youtube_attachment_root: str = DEFAULT_YOUTUBE_ATTACHMENT_ROOT,
+    youtube_attachment_root: str | None = None,
 ) -> SourceBundleResult:
     """Create immutable transcript and manifest members beneath a stable source folder."""
-    root = validate_youtube_attachment_root(youtube_attachment_root)
     vault_root = _vault_root(vault_context)
+    if youtube_attachment_root is None:
+        youtube_attachment_root = f"{get_vault_sources_dir_rel(vault_root)}/YouTube/_attachments"
+    root = validate_youtube_attachment_root(youtube_attachment_root)
     source_key = _source_key(candidate.item_ref)
     version_key = _version_key(candidate.content_identity, transcript.extensions.get("stage_version"))
     source_folder = (PurePosixPath(root) / source_key).as_posix()

--- a/app/settings/default-vault-layout.yaml
+++ b/app/settings/default-vault-layout.yaml
@@ -16,3 +16,4 @@ paths:
   system_dir_rel: "⚙️ System"
   inbox_dir_rel: "📥 Inbox"
   runtime_dir_rel: "⚙️ System/Runtime/Alpha"
+  sources_dir_rel: "Sources"

--- a/app/settings/mimer_scaffolder.py
+++ b/app/settings/mimer_scaffolder.py
@@ -8,6 +8,7 @@ from app.knowledge.write_ops import write_note_from_absolute
 from app.settings.default_vault_layout import load_default_vault_layout
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME
 from app.vault.layout import ensure_vault_layout_report
+from app.vault.paths import resolve_vault_sources_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
 
 # Bootstrap action asserted at the scaffold seam. It is a member of the write
@@ -46,6 +47,7 @@ class MimerScaffolder:
                 created.append(path)
             path.mkdir(parents=True, exist_ok=True)
 
+        sources_dir_rel = resolve_vault_sources_dir_rel(mimer_root_dir / "Mimer").value
         mimer_subdirs = [
             "Index",
             "Workspace",
@@ -53,7 +55,7 @@ class MimerScaffolder:
             "Projects",
             "Domains",
             "Corpus",
-            "Sources",
+            sources_dir_rel,
             "Ontology",
             "Taxonomy",
             "Canon",

--- a/app/vault/paths.py
+++ b/app/vault/paths.py
@@ -174,6 +174,34 @@ def _paths_data(vault_root: Path) -> Dict[str, str]:
     return _extract_paths(_read_system_settings(settings_path))
 
 
+def _configured_sources_dir_rel(vault_root: Path) -> str | None:
+    """Read the Sources setting strictly so malformed authority cannot fall back."""
+    settings_path = resolve_settings_file(
+        vault_root,
+        "system-settings.md",
+        legacy_paths=(LEGACY_SYSTEM_SETTINGS, LEGACY_COMPILED_DIR / "system-settings.yaml"),
+    )
+    if not settings_path.exists():
+        return None
+    try:
+        settings = read_settings_mapping(settings_path)
+    except Exception as exc:  # noqa: BLE001 - malformed authority must fail loud
+        raise ValueError(f"unable to read Sources path setting from {settings_path}") from exc
+
+    raw_paths = settings.get("paths")
+    if isinstance(raw_paths, dict) and "sources_dir_rel" in raw_paths:
+        value = raw_paths["sources_dir_rel"]
+        if not isinstance(value, str):
+            raise ValueError("paths.sources_dir_rel must be a string")
+        return value
+    if "sources_dir_rel" in settings:
+        value = settings["sources_dir_rel"]
+        if not isinstance(value, str):
+            raise ValueError("sources_dir_rel must be a string")
+        return value
+    return None
+
+
 def resolve_vault_inbox_dir_rel(vault_root: Path) -> VaultPathValue:
     env_value = (os.getenv("VAULT_INBOX_DIR_REL") or "").strip()
     if env_value:
@@ -222,9 +250,8 @@ def resolve_vault_sources_dir_rel(vault_root: Path) -> VaultPathValue:
             provenance="env:VAULT_SOURCES_DIR_REL",
         )
 
-    paths = _paths_data(vault_root)
-    if "sources_dir_rel" in paths:
-        configured = paths["sources_dir_rel"]
+    configured = _configured_sources_dir_rel(vault_root)
+    if configured is not None:
         return _validate_sources_dir_rel(
             configured,
             provenance="system-settings.yaml:paths.sources_dir_rel",

--- a/app/vault/paths.py
+++ b/app/vault/paths.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict
 
 import yaml
@@ -48,6 +48,9 @@ class NoVaultSelectedError(RuntimeError):
     CWD fallback must now branch on this explicit no-vault signal instead of
     reading or writing under the current working directory (#2384).
     """
+
+
+DEFAULT_SOURCES_DIR_REL = "Sources"
 
 
 class VaultPathResolver:
@@ -147,13 +150,17 @@ def _extract_paths(settings: Dict[str, Any]) -> Dict[str, str]:
     raw = settings.get("paths")
     if isinstance(raw, dict):
         for key, value in raw.items():
-            if isinstance(value, str) and value.strip():
+            if key == "sources_dir_rel" and isinstance(value, str):
                 out[key] = value.strip()
-    for key in ("inbox_dir_rel", "runtime_dir_rel", "system_dir_rel"):
+            elif isinstance(value, str) and value.strip():
+                out[key] = value.strip()
+    for key in ("inbox_dir_rel", "runtime_dir_rel", "system_dir_rel", "sources_dir_rel"):
         if key in out:
             continue
         value = settings.get(key)
-        if isinstance(value, str) and value.strip():
+        if key == "sources_dir_rel" and isinstance(value, str):
+            out[key] = value.strip()
+        elif isinstance(value, str) and value.strip():
             out[key] = value.strip()
     return out
 
@@ -184,6 +191,61 @@ def resolve_vault_inbox_dir_rel(vault_root: Path) -> VaultPathValue:
     raise ValueError(
         "inbox folder could not be resolved. Set VAULT_INBOX_DIR_REL, or ensure vault.layout.md has inbox_folder."
     )
+
+
+def _validate_sources_dir_rel(value: str, *, provenance: str) -> VaultPathValue:
+    raw = value.strip()
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or "\\" in raw
+        or "\x00" in raw
+        or path.is_absolute()
+        or path.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("sources_dir_rel must be a normalized vault-relative path")
+    return VaultPathValue(raw, provenance)
+
+
+def resolve_vault_sources_dir_rel(vault_root: Path) -> VaultPathValue:
+    """Resolve the selected vault's sensor/acquisition Sources root.
+
+    Explicit environment configuration wins, followed by the selected vault's
+    ``system-settings`` paths block, then the packaged default. Unlike the
+    legacy inbox resolver, the Sources root has a safe packaged default so
+    newly initialized vaults can use the acquisition writers immediately.
+    """
+    if "VAULT_SOURCES_DIR_REL" in os.environ:
+        return _validate_sources_dir_rel(
+            os.environ["VAULT_SOURCES_DIR_REL"],
+            provenance="env:VAULT_SOURCES_DIR_REL",
+        )
+
+    paths = _paths_data(vault_root)
+    if "sources_dir_rel" in paths:
+        configured = paths["sources_dir_rel"]
+        return _validate_sources_dir_rel(
+            configured,
+            provenance="system-settings.yaml:paths.sources_dir_rel",
+        )
+
+    try:
+        from app.settings.default_vault_layout import load_default_vault_layout
+
+        payload = load_default_vault_layout()
+        default_paths = payload.get("paths")
+        if isinstance(default_paths, dict):
+            packaged = default_paths.get("sources_dir_rel")
+            if isinstance(packaged, str) and packaged.strip():
+                return _validate_sources_dir_rel(
+                    packaged,
+                    provenance="default-vault-layout.yaml:paths.sources_dir_rel",
+                )
+    except Exception:
+        pass
+
+    return VaultPathValue(DEFAULT_SOURCES_DIR_REL, "packaged-default:Sources")
 
 
 def resolve_vault_system_dir_rel(vault_root: Path) -> VaultPathValue:
@@ -241,6 +303,11 @@ def resolve_vault_runtime_dir_rel(vault_root: Path) -> VaultPathValue:
 def get_vault_inbox_dir_rel(vault_root: Path | None = None) -> str:
     root = _resolve_vault_root(vault_root)
     return resolve_vault_inbox_dir_rel(root).value
+
+
+def get_vault_sources_dir_rel(vault_root: Path | None = None) -> str:
+    root = _resolve_vault_root(vault_root)
+    return resolve_vault_sources_dir_rel(root).value
 
 
 def get_vault_system_dir_rel(vault_root: Path | None = None) -> str:
@@ -306,9 +373,11 @@ __all__ = [
     "VaultPathResolver",
     "VaultPathValue",
     "get_vault_inbox_dir_rel",
+    "get_vault_sources_dir_rel",
     "get_vault_runtime_dir_rel",
     "get_vault_system_dir_rel",
     "resolve_vault_inbox_dir_rel",
+    "resolve_vault_sources_dir_rel",
     "resolve_vault_runtime_dir_rel",
     "resolve_vault_system_dir_rel",
     "resolve_vault_system_dir_rel_or_default",

--- a/docs/contracts/MIMER_CLIENT_CONTRACT.md
+++ b/docs/contracts/MIMER_CLIENT_CONTRACT.md
@@ -286,9 +286,10 @@ The owner has ruled that direct filesystem vault writes by external clients are 
 Sensor-captured material has its own vault zone, separate from the human's quick-capture inbox and
 from human-authored notes. The default relative root is `Sources/`, with user-relevant default
 subfolders `Sources/Voice memos/`, `Sources/Video & podcasts/`, and `Sources/Articles/`. These are
-**settings-resolved defaults**, not fixed paths: the setting key follows the existing
-`inbox_dir_rel` convention, and its concrete settings/UI enactment remains follow-on work. Clients
-and writers therefore must not hardcode the displayed names.
+**settings-resolved defaults**, not fixed paths: the root is resolved from `paths.sources_dir_rel`
+with the same selected-vault and environment precedence as `inbox_dir_rel` (and
+`VAULT_SOURCES_DIR_REL` is the one-release bootstrap override). The packaged default is `Sources/`.
+Clients and writers therefore must not hardcode the displayed names.
 
 Only Heimdal-side sensor/acquisition writers create material notes in this zone. App agents and the
 capture endpoint are excluded; human edits are allowed but never required. Sources notes are

--- a/docs/settings/default-vault-layout.yaml
+++ b/docs/settings/default-vault-layout.yaml
@@ -16,3 +16,4 @@ paths:
   system_dir_rel: "⚙️ System"
   inbox_dir_rel: "📥 Inbox"
   runtime_dir_rel: "⚙️ System/Runtime/Alpha"
+  sources_dir_rel: "Sources"

--- a/tests/knowledge_acquisition/test_sources_zone_resolution.py
+++ b/tests/knowledge_acquisition/test_sources_zone_resolution.py
@@ -106,3 +106,19 @@ def test_current_sources_producers_use_resolved_selected_vault_root(
     finally:
         reset_memory_observation_log()
         reset_memory_cursor_store()
+
+
+def test_malformed_sources_setting_denies_panel_agent_mutation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("VAULT_SOURCES_DIR_REL", raising=False)
+    settings_dir = tmp_path / "settings"
+    settings_dir.mkdir()
+    (settings_dir / "system-settings.md").write_text(
+        "---\npaths:\n  sources_dir_rel: []\n---\n",
+        encoding="utf-8",
+    )
+
+    assert watcher_panel_writeback_allowed(
+        "Sources/panel.md", vault_root=tmp_path
+    ) is False

--- a/tests/knowledge_acquisition/test_sources_zone_resolution.py
+++ b/tests/knowledge_acquisition/test_sources_zone_resolution.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.heimdal.candidate_projection import project_pending_candidates
+from app.heimdal.cursor_store import reset_memory_cursor_store
+from app.heimdal.observation_log import reset_memory_observation_log
+from app.heimdal.meeting_finalization import meetings_dir_rel
+from app.heimdal.publish import publish_observation
+from app.knowledge_acquisition.candidate_writeback import (
+    write_candidate_note,
+)
+from app.knowledge_acquisition.source_bundle import materialize_youtube_source_bundle
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+from tests.knowledge_acquisition.test_candidate_writeback import _assembled_candidate
+from tests.knowledge_acquisition.test_youtube_source_bundle import _source_material
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext("selected", "vault-test", "Vault Test", str(root))
+
+
+def _guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def test_current_sources_producers_use_resolved_selected_vault_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_SOURCES_DIR_REL", "ConfiguredSources")
+    vault = _vault(tmp_path / "vault")
+
+    candidate = _assembled_candidate()
+    note = write_candidate_note(candidate, vault_context=vault, write_guard=_guard())
+    assert note.artifact_path is not None
+    assert note.artifact_path.startswith("ConfiguredSources/")
+
+    _raw, transcript, bundle_candidate = _source_material(tmp_path)
+    bundle = materialize_youtube_source_bundle(
+        bundle_candidate,
+        transcript,
+        vault_context=vault,
+        write_guard=_guard(),
+    )
+    assert bundle.source_folder.startswith("ConfiguredSources/YouTube/_attachments/")
+    assert meetings_dir_rel(Path(vault.active_vault_path)) == "ConfiguredSources/Meetings"
+
+    reset_memory_observation_log()
+    reset_memory_cursor_store()
+    try:
+        publish_observation(
+            topic="heimdal.observation.published",
+            observation_id="obs-sources-zone",
+            payload={
+                "observation_id": "obs-sources-zone",
+                "episode_id": "episode-sources-zone",
+                "content": "Heimdal candidate",
+                "raw_ref": "raw:sources-zone",
+                "provenance": {
+                    "content_identity": "sha256:" + "a" * 64,
+                    "raw_ref": "raw:sources-zone",
+                    "capture_chain": ["test"],
+                },
+            },
+            source="test.sources-zone",
+            stage_versions={"test": "1"},
+        )
+        karakeep_id = "karakeep:sources-zone"
+        publish_observation(
+            topic="heimdal.observation.published",
+            observation_id=karakeep_id,
+            payload={
+                "observation_id": karakeep_id,
+                "episode_id": karakeep_id,
+                "content": "Karakeep candidate",
+                "raw_ref": "raw:karakeep:sources-zone",
+                "content_structure": {
+                    "karakeep": {
+                        "item_kind": "link",
+                        "source_item_identity": karakeep_id,
+                        "source_url": "https://example.com/sources-zone",
+                        "tombstone": False,
+                    }
+                },
+                "provenance": {
+                    "sensor": "karakeep_rest",
+                    "content_identity": "sha256:" + "b" * 64,
+                    "raw_ref": "raw:karakeep:sources-zone",
+                    "capture_chain": ["karakeep"],
+                },
+            },
+            source="test.sources-zone",
+            stage_versions={"test": "1"},
+        )
+        projected = project_pending_candidates(vault_context=vault, write_guard=_guard())
+        paths = {result.artifact_path for result in projected}
+        assert any(path and path.startswith("ConfiguredSources/Heimdal/") for path in paths)
+        assert any(path and path.startswith("ConfiguredSources/Reading/Karakeep/") for path in paths)
+        assert not (Path(vault.active_vault_path) / "Sources").exists()
+    finally:
+        reset_memory_observation_log()
+        reset_memory_cursor_store()

--- a/tests/knowledge_acquisition/test_sources_zone_resolution.py
+++ b/tests/knowledge_acquisition/test_sources_zone_resolution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from app.agents.panel_agent.policy import watcher_panel_writeback_allowed
 from app.heimdal.candidate_projection import project_pending_candidates
 from app.heimdal.cursor_store import reset_memory_cursor_store
 from app.heimdal.observation_log import reset_memory_observation_log
@@ -99,6 +100,9 @@ def test_current_sources_producers_use_resolved_selected_vault_root(
         assert any(path and path.startswith("ConfiguredSources/Heimdal/") for path in paths)
         assert any(path and path.startswith("ConfiguredSources/Reading/Karakeep/") for path in paths)
         assert not (Path(vault.active_vault_path) / "Sources").exists()
+        assert watcher_panel_writeback_allowed(
+            "ConfiguredSources/panel.md", vault_root=Path(vault.active_vault_path)
+        ) is False
     finally:
         reset_memory_observation_log()
         reset_memory_cursor_store()

--- a/tests/settings/test_mimer_scaffolder.py
+++ b/tests/settings/test_mimer_scaffolder.py
@@ -27,3 +27,12 @@ def test_scaffolder_writes_placeholder_via_knowledge_port(tmp_path: Path, monkey
     assert "settings/global.md" in writes
     assert "settings/system-settings.md" in writes
     assert result["created"]
+
+
+def test_scaffolder_uses_configured_sources_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_SOURCES_DIR_REL", "ConfiguredSources")
+
+    MimerScaffolder(root=tmp_path).scaffold()
+
+    assert (tmp_path / "Mimer" / "ConfiguredSources").is_dir()
+    assert not (tmp_path / "Mimer" / "Sources").exists()

--- a/tests/vault/test_paths.py
+++ b/tests/vault/test_paths.py
@@ -252,6 +252,14 @@ def test_sources_dir_rel_rejects_unsafe_values(
     with pytest.raises(ValueError, match="sources_dir_rel"):
         resolve_vault_sources_dir_rel(tmp_path)
 
+    settings_path = tmp_path / "_system" / "settings" / "system-settings.yaml"
+    settings_path.write_text(
+        settings_path.read_text(encoding="utf-8").replace("sources_dir_rel: ''", "sources_dir_rel: []"),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="sources_dir_rel"):
+        resolve_vault_sources_dir_rel(tmp_path)
+
 
 def test_paths_use_at_settings_when_present(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.delenv("VAULT_INBOX_DIR_REL", raising=False)

--- a/tests/vault/test_paths.py
+++ b/tests/vault/test_paths.py
@@ -11,8 +11,10 @@ from app.vault.paths import (
     VaultPathResolutionError,
     VaultPathResolver,
     get_vault_inbox_dir_rel,
+    get_vault_sources_dir_rel,
     get_vault_runtime_dir_rel,
     get_vault_system_dir_rel,
+    resolve_vault_sources_dir_rel,
     resolve_vault_system_dir_rel_or_default,
 )
 
@@ -71,6 +73,7 @@ def _write_settings(
     inbox: str,
     runtime: str,
     system: str,
+    sources: str | None = None,
     include_paths: bool = True,
     include_top_level: bool = False,
 ) -> None:
@@ -95,6 +98,8 @@ def _write_settings(
                 f"  system_dir_rel: {system}",
             ]
         )
+        if sources is not None:
+            lines.append(f"  sources_dir_rel: {sources!r}")
     if include_top_level:
         lines.extend(
             [
@@ -206,6 +211,46 @@ def test_paths_env_overrides_settings(monkeypatch, tmp_path: Path) -> None:
     assert get_vault_inbox_dir_rel(tmp_path) == "EnvInbox"
     assert get_vault_runtime_dir_rel(tmp_path) == "EnvRuntime"
     assert get_vault_system_dir_rel(tmp_path) == "EnvSystem"
+
+
+def test_sources_dir_rel_resolves_env_settings_and_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("VAULT_SOURCES_DIR_REL", raising=False)
+
+    assert get_vault_sources_dir_rel(tmp_path) == "Sources"
+
+    _write_settings(
+        tmp_path,
+        inbox="Inbox",
+        runtime="System/Runtime",
+        system="System",
+        sources="ConfiguredSources",
+    )
+    assert get_vault_sources_dir_rel(tmp_path) == "ConfiguredSources"
+
+    monkeypatch.setenv("VAULT_SOURCES_DIR_REL", "EnvSources")
+    assert get_vault_sources_dir_rel(tmp_path) == "EnvSources"
+
+
+def test_sources_dir_rel_rejects_unsafe_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    for unsafe in ("", "/tmp/escape", "../outside", "Sources/../outside", "Sources\\nested"):
+        monkeypatch.setenv("VAULT_SOURCES_DIR_REL", unsafe)
+        with pytest.raises(ValueError, match="sources_dir_rel"):
+            resolve_vault_sources_dir_rel(tmp_path)
+
+    monkeypatch.delenv("VAULT_SOURCES_DIR_REL")
+    _write_settings(
+        tmp_path,
+        inbox="Inbox",
+        runtime="System/Runtime",
+        system="System",
+        sources="",
+    )
+    with pytest.raises(ValueError, match="sources_dir_rel"):
+        resolve_vault_sources_dir_rel(tmp_path)
 
 
 def test_paths_use_at_settings_when_present(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5180

## Linked Issue
Closes #5180

## SBS Impact
- Primary subsystem: Product/Runtime WSP vault-path resolution
- Secondary subsystem(s): OEF/EBF sensor acquisition; HKA Sources artifacts; PDM filesystem persistence; watcher mutation policy
- Write class: authority-bearing path resolution at the production writer boundary
- Persistence impact: Durable acquisition artifacts remain selected-vault-relative
- Derived/rebuildable impact: Defaults and path provenance rebuild from checked-in settings and selected vault
- New or changed contract: sources_dir_rel is consumed by all enumerated shipped Sources producers and watcher policy
- Owner-doc impact: updated
- Transition debt impact: Removes the producer prerequisite blocking #3414
- Boundary risk: Invalid settings must fail before redirecting writes outside the selected vault; watcher mutation is denied

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Resolve the Sources landing zone from selected-vault settings and migrate enumerated production producers while preserving existing suffixes, writer semantics, and watcher mutation policy.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Implementation PR records the governed repo change; no separate BuilderOps record is required for this bounded slice.

## Notes
Initial review found two P1 issues: watcher policy was not using the configured root, and malformed settings could fall back to Sources. Both were repaired and regression-tested. ruff and mypy app are green; docs_guard passes with the repo-defined DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 because this change does not alter temporal current-state docs.
