### PR TITLE
Make return orientation synthesis-safe

### DIFF
--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -50,6 +50,7 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
 )
 _ASK_LAST_ACTIVE_LOADED_ATTR = "_ask_recall_last_active_loaded"
 OrientationRole = Literal["active", "waiting", "supporting", "background"]
+_ORIENTATION_ROLES = frozenset({"active", "waiting", "supporting", "background"})
 
 _WAITING_SIGNAL = re.compile(r"\b(?:waiting|deferred|blocked|pending|on[ -]hold)\b")
 _ACTIVE_SIGNAL = re.compile(
@@ -60,7 +61,11 @@ _RETURN_ORIENTATION_INTENT = re.compile(
     r"\bafter\s+(?:an?\s+)?interruption\b|"
     r"\breturn(?:ing)?\s+(?:to|after)\b|"
     r"\bresum(?:e|ing)\s+(?:work|the|my|this|where)\b|"
-    r"\bpick\s+(?:up|back)\b"
+    r"\b(?:pick\s+up|pick\s+back(?:\s+up)?)\s+(?:"
+    r"where\s+i\s+left\s+off|"
+    r"after\s+(?:an?\s+)?(?:interruption|break)|"
+    r"(?:my|the|this)\s+(?:[\w-]+\s+){0,3}(?:thread|work|task|project)\s+again"
+    r")\b"
     r")"
 )
 
@@ -74,6 +79,9 @@ def is_return_orientation_query(query: str) -> bool:
 def orientation_of(payload: dict[str, Any], path: str | None, text: str | None = None) -> OrientationRole:
     """Derive orientation from situational signals, independent of admissibility metadata."""
 
+    explicit_orientation = payload.get("orientation")
+    if explicit_orientation in _ORIENTATION_ROLES:
+        return explicit_orientation
     normalized_path = (path or "").casefold()
     if "/sources/" in normalized_path or normalized_path.startswith("sources/"):
         return "supporting"
@@ -100,9 +108,13 @@ def is_background_orientation_evidence(
 
     ``evidence_role`` remains an independent admissibility dimension and is deliberately not
     consulted here. An active or waiting item may be background-admissible without disappearing
-    from a return-oriented read.
+    from a return-oriented read. A production vault note without an explicit orientation is also
+    retained: its neutral ``background`` display state is not sufficient evidence that the note
+    is disposable, and the indexed note body remains the citable read surface.
     """
 
+    if payload.get("source_role") == "vault_note" and payload.get("orientation") not in _ORIENTATION_ROLES:
+        return False
     return orientation_of(payload, path, text) == "background"
 
 

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -50,6 +50,19 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
 _ASK_LAST_ACTIVE_LOADED_ATTR = "_ask_recall_last_active_loaded"
 
 
+def is_return_orientation_query(query: str) -> bool:
+    """Identify the bounded return-after-interruption read path."""
+
+    normalized = query.casefold()
+    return "interrupt" in normalized or "returning" in normalized or "resume" in normalized
+
+
+def is_background_orientation_evidence(payload: dict[str, Any]) -> bool:
+    """Use the canonical indexed evidence role; never a fixture-only orientation flag."""
+
+    return payload.get("evidence_role") == "background"
+
+
 def _active_scope(state: AgentState) -> str | None:
     """This turn's active scope: the explicit per-request binding, else the ambient default.
 
@@ -139,6 +152,15 @@ def _rerank_node(state: AgentState, *, ask_settings) -> AgentState:
 
     top_k_llm = max(1, int(ask_settings.max_context_docs or 10))
     state.hits = sorted_hits[:top_k_llm]
+    if is_return_orientation_query(state.query):
+        # This must happen before recall/answer nodes assemble the ContextEnvelope,
+        # evaluate synthesis admission, or generate an answer. Keeping background
+        # material out of `state.hits` therefore also keeps source attribution aligned.
+        state.hits = [
+            hit
+            for hit in state.hits
+            if not is_background_orientation_evidence(hit.payload)
+        ]
     return state
 
 

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
-from typing import Any, Iterable, List, Optional
+from typing import Any, Iterable, List, Literal, Optional
 
 from langgraph.graph import END, START, StateGraph
 
@@ -48,19 +49,61 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
     "runtime/agent_memory/provisional_recall_receipts.jsonl"
 )
 _ASK_LAST_ACTIVE_LOADED_ATTR = "_ask_recall_last_active_loaded"
+OrientationRole = Literal["active", "waiting", "supporting", "background"]
+
+_WAITING_SIGNAL = re.compile(r"\b(?:waiting|deferred|blocked|pending|on[ -]hold)\b")
+_ACTIVE_SIGNAL = re.compile(
+    r"\b(?:active|current\s+focus|next\s+step|in\s+progress|underway)\b"
+)
+_RETURN_ORIENTATION_INTENT = re.compile(
+    r"(?:"
+    r"\bafter\s+(?:an?\s+)?interruption\b|"
+    r"\breturn(?:ing)?\s+(?:to|after)\b|"
+    r"\bresum(?:e|ing)\s+(?:work|the|my|this|where)\b|"
+    r"\bpick\s+(?:up|back)\b"
+    r")"
+)
 
 
 def is_return_orientation_query(query: str) -> bool:
     """Identify the bounded return-after-interruption read path."""
 
-    normalized = query.casefold()
-    return "interrupt" in normalized or "returning" in normalized or "resume" in normalized
+    return bool(_RETURN_ORIENTATION_INTENT.search(query.casefold()))
 
 
-def is_background_orientation_evidence(payload: dict[str, Any]) -> bool:
-    """Use the canonical indexed evidence role; never a fixture-only orientation flag."""
+def orientation_of(payload: dict[str, Any], path: str | None, text: str | None = None) -> OrientationRole:
+    """Derive orientation from situational signals, independent of admissibility metadata."""
 
-    return payload.get("evidence_role") == "background"
+    normalized_path = (path or "").casefold()
+    if "/sources/" in normalized_path or normalized_path.startswith("sources/"):
+        return "supporting"
+    searchable_text = " ".join(
+        str(payload.get(key) or "") for key in ("title", "text", "content")
+    )
+    if text:
+        searchable_text = f"{searchable_text} {text}"
+    searchable_text = searchable_text.casefold()
+    if _WAITING_SIGNAL.search(searchable_text):
+        return "waiting"
+    if _ACTIVE_SIGNAL.search(searchable_text) or payload.get("source_role") in {
+        "work_project",
+        "decision_record",
+    }:
+        return "active"
+    return "background"
+
+
+def is_background_orientation_evidence(
+    payload: dict[str, Any], path: str | None, text: str | None = None
+) -> bool:
+    """Return whether situational orientation marks a candidate as background.
+
+    ``evidence_role`` remains an independent admissibility dimension and is deliberately not
+    consulted here. An active or waiting item may be background-admissible without disappearing
+    from a return-oriented read.
+    """
+
+    return orientation_of(payload, path, text) == "background"
 
 
 def _active_scope(state: AgentState) -> str | None:
@@ -151,16 +194,17 @@ def _rerank_node(state: AgentState, *, ask_settings) -> AgentState:
             pass
 
     top_k_llm = max(1, int(ask_settings.max_context_docs or 10))
-    state.hits = sorted_hits[:top_k_llm]
     if is_return_orientation_query(state.query):
-        # This must happen before recall/answer nodes assemble the ContextEnvelope,
-        # evaluate synthesis admission, or generate an answer. Keeping background
-        # material out of `state.hits` therefore also keeps source attribution aligned.
-        state.hits = [
+        # Filter ranked candidates before taking the context-sized slice. This must happen before
+        # recall/answer nodes assemble the ContextEnvelope, evaluate synthesis admission, or
+        # generate an answer. Keeping background material out of `state.hits` therefore also keeps
+        # source attribution aligned.
+        sorted_hits = [
             hit
-            for hit in state.hits
-            if not is_background_orientation_evidence(hit.payload)
+            for hit in sorted_hits
+            if not is_background_orientation_evidence(hit.payload, hit.path, hit.text or hit.snippet)
         ]
+    state.hits = sorted_hits[:top_k_llm]
     return state
 
 

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -79,12 +79,12 @@ def is_return_orientation_query(query: str) -> bool:
 def orientation_of(payload: dict[str, Any], path: str | None, text: str | None = None) -> OrientationRole:
     """Derive orientation from situational signals, independent of admissibility metadata."""
 
-    explicit_orientation = payload.get("orientation")
-    if explicit_orientation in _ORIENTATION_ROLES:
-        return explicit_orientation
     normalized_path = (path or "").casefold()
     if "/sources/" in normalized_path or normalized_path.startswith("sources/"):
         return "supporting"
+    explicit_orientation = payload.get("orientation")
+    if explicit_orientation in _ORIENTATION_ROLES:
+        return explicit_orientation
     searchable_text = " ".join(
         str(payload.get(key) or "") for key in ("title", "text", "content")
     )

--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import AliasChoices, BaseModel, Field
 
-from app.agents.ask.graph import run_ask_graph
+from app.agents.ask.graph import is_background_orientation_evidence, run_ask_graph
 from app.agents.ask.utils import get_ask_settings
 from app.components.llm.fabric import LLMBackendTimeout
 from app.events.models import new_trace_id
@@ -186,9 +186,8 @@ def _capture_intent_suggestion(transcript: str) -> str | None:
 def _orientation_of(payload: dict[str, Any], path: str | None) -> Literal["active", "waiting", "supporting", "background"]:
     """Derive a bounded, read-only orientation label from retrieved evidence."""
 
-    declared = payload.get("orientation_role")
-    if declared in {"active", "waiting", "supporting", "background"}:
-        return declared
+    if is_background_orientation_evidence(payload):
+        return "background"
     normalized_path = (path or "").casefold()
     if "/sources/" in normalized_path or normalized_path.startswith("sources/"):
         return "supporting"
@@ -224,11 +223,6 @@ def _to_source(hit: Any) -> AskSource:
     )
 
 
-def _is_return_orientation_question(question: str) -> bool:
-    normalized = question.casefold()
-    return "interrupt" in normalized or "returning" in normalized or "resume" in normalized
-
-
 @router.post("/ask", response_model=AskResponse)
 async def ask(req: AskRequest, request: Request) -> AskResponse:
     if not _HYBRID_WARMED:
@@ -260,8 +254,6 @@ async def ask(req: AskRequest, request: Request) -> AskResponse:
     latency_ms = int((time.perf_counter() - start) * 1000)
     record_ask_query(float(latency_ms))
     sources = [_to_source(hit) for hit in top_hits]
-    if _is_return_orientation_question(req.question):
-        sources = [source for source in sources if source.orientation != "background"]
     recalled = [
         RecallAttribution(
             memory_id=exp.artifact_id,

--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import AliasChoices, BaseModel, Field
 
-from app.agents.ask.graph import is_background_orientation_evidence, run_ask_graph
+from app.agents.ask.graph import orientation_of, run_ask_graph
 from app.agents.ask.utils import get_ask_settings
 from app.components.llm.fabric import LLMBackendTimeout
 from app.events.models import new_trace_id
@@ -183,20 +183,6 @@ def _capture_intent_suggestion(transcript: str) -> str | None:
     return None
 
 
-def _orientation_of(payload: dict[str, Any], path: str | None) -> Literal["active", "waiting", "supporting", "background"]:
-    """Derive a bounded, read-only orientation label from retrieved evidence."""
-
-    if is_background_orientation_evidence(payload):
-        return "background"
-    normalized_path = (path or "").casefold()
-    if "/sources/" in normalized_path or normalized_path.startswith("sources/"):
-        return "supporting"
-    text = " ".join(str(payload.get(key) or "") for key in ("title", "text", "content")).casefold()
-    if any(token in text for token in ("waiting", "deferred", "blocked")):
-        return "waiting"
-    return "active"
-
-
 def _to_source(hit: Any) -> AskSource:
     raw: dict[str, Any]
     if hasattr(hit, "model_dump"):
@@ -219,7 +205,11 @@ def _to_source(hit: Any) -> AskSource:
         plane=plane,
         zone=zone,
         path=str(path) if path else None,
-        orientation=_orientation_of(payload, str(path) if path else None),
+        orientation=orientation_of(
+            payload,
+            str(path) if path else None,
+            str(raw.get("text") or raw.get("snippet") or ""),
+        ),
     )
 
 

--- a/tests/e2e/test_human_need_uat.py
+++ b/tests/e2e/test_human_need_uat.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+from app.agents.ask import graph as ask_graph
 from app.api.app import app
 from app.api.routes import ask as ask_route
 from app.retrieval.hybrid import get_store as get_hybrid_store
@@ -64,7 +65,13 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
                     "Atlas migration is the active project. Current focus: migrate the API gateway. "
                     "Next step: draft the migration checklist and schedule the rollout review."
                 ),
-                "payload": {"uuid": "atlas-active", "title": "Atlas Migration", "origin": "vault", "plane": "vault", "orientation_role": "active"},
+                "payload": {
+                    "uuid": "atlas-active",
+                    "title": "Atlas Migration",
+                    "origin": "vault",
+                    "plane": "vault",
+                    "evidence_role": "evidence",
+                },
             },
             {
                 "doc_id": "atlas-waiting",
@@ -73,24 +80,80 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
                     "Atlas migration waiting item. Blocked pending finance approval and vendor confirmation. "
                     "Do not treat this as the next action."
                 ),
-                "payload": {"uuid": "atlas-waiting", "title": "Atlas Waiting", "origin": "vault", "plane": "vault", "orientation_role": "waiting"},
+                "payload": {
+                    "uuid": "atlas-waiting",
+                    "title": "Atlas Waiting",
+                    "origin": "vault",
+                    "plane": "vault",
+                    "evidence_role": "evidence",
+                },
             },
             {
                 "doc_id": "atlas-source",
                 "source_ref": str(source_note),
                 "text": "Vendor migration memo for Atlas. Confirms gateway deprecation window and required cutover steps.",
-                "payload": {"uuid": "atlas-source", "title": "Vendor Memo", "origin": "vault", "plane": "vault", "orientation_role": "supporting"},
+                "payload": {
+                    "uuid": "atlas-source",
+                    "title": "Vendor Memo",
+                    "origin": "vault",
+                    "plane": "vault",
+                    "evidence_role": "reference",
+                },
             },
             {
                 "doc_id": "unrelated-garden",
                 "source_ref": str(unrelated_note),
                 "text": "Garden seedlings note about watering tomatoes and spring soil temperature.",
-                "payload": {"uuid": "unrelated-garden", "title": "Seedlings", "origin": "vault", "plane": "vault", "orientation_role": "background"},
+                "payload": {
+                    "uuid": "unrelated-garden",
+                    "title": "Seedlings",
+                    "origin": "vault",
+                    "plane": "vault",
+                    "evidence_role": "background",
+                },
             },
         ]
     )
     ask_route._HYBRID_WARMED = True
     return {"active": active_note, "waiting": waiting_note, "source": source_note, "unrelated": unrelated_note}
+
+
+def test_human_uat_orientation_classifies_production_indexed_background(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reset_runtime_state(monkeypatch)
+    paths = _seed_orientation_pack(tmp_path)
+
+    response = TestClient(app).post("/api/ask", json={"question": "What indexed material is available?"})
+    assert response.status_code == 200, response.text
+
+    sources_by_path = {source["path"]: source for source in response.json()["sources"]}
+    assert sources_by_path[str(paths["unrelated"])]["orientation"] == "background"
+
+
+def test_human_uat_orientation_filters_background_before_synthesis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reset_runtime_state(monkeypatch)
+    paths = _seed_orientation_pack(tmp_path)
+    captured: dict[str, str] = {}
+
+    def _fake_llm_answer(question: str, context: str, _ask_settings: object) -> tuple[str, dict[str, str]]:
+        captured["context"] = context
+        return "Synthesized orientation.", {"provider": "mock"}
+
+    monkeypatch.setattr(ask_graph, "llm_answer", _fake_llm_answer)
+    response = TestClient(app).post(
+        "/api/ask",
+        json={"question": "I am returning to the Atlas migration after interruption. What was I doing?"},
+    )
+    assert response.status_code == 200, response.text
+
+    payload = response.json()
+    returned_source_ids = {source["uuid"] for source in payload["sources"]}
+    assert str(paths["unrelated"]) not in {source["path"] for source in payload["sources"]}
+    assert "Seedlings" not in captured["context"]
+    assert set(payload["synthesis_source_ids"]).issubset(returned_source_ids)
 
 
 def test_human_uat_return_after_interruption_orientation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/test_human_need_uat.py
+++ b/tests/e2e/test_human_need_uat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 from pathlib import Path
 from uuid import uuid4
 
@@ -70,7 +71,7 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
                     "title": "Atlas Migration",
                     "origin": "vault",
                     "plane": "vault",
-                    "evidence_role": "evidence",
+                    "evidence_role": "background",
                 },
             },
             {
@@ -85,7 +86,7 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
                     "title": "Atlas Waiting",
                     "origin": "vault",
                     "plane": "vault",
-                    "evidence_role": "evidence",
+                    "evidence_role": "background",
                 },
             },
             {
@@ -154,6 +155,44 @@ def test_human_uat_orientation_filters_background_before_synthesis(
     assert str(paths["unrelated"]) not in {source["path"] for source in payload["sources"]}
     assert "Seedlings" not in captured["context"]
     assert set(payload["synthesis_source_ids"]).issubset(returned_source_ids)
+
+
+def test_human_uat_orientation_filters_before_context_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ask_graph, "get_reranker", lambda: None)
+    state = ask_graph.AgentState(
+        query="I am returning to the Atlas migration after interruption.",
+        hits=[
+            ask_graph.RetrievedHit(
+                object_id="background-first",
+                score=1.0,
+                ask_score=1.0,
+                path="Garden/seedlings.md",
+                payload={"title": "Seedlings", "evidence_role": "background"},
+            ),
+            ask_graph.RetrievedHit(
+                object_id="active-second",
+                score=0.5,
+                ask_score=0.5,
+                path="Projects/atlas.md",
+                payload={"title": "Atlas", "text": "Current focus: migrate the API gateway."},
+            ),
+        ],
+    )
+
+    result = ask_graph._rerank_node(state, ask_settings=SimpleNamespace(max_context_docs=1))
+    assert [hit.object_id for hit in result.hits] == ["active-second"]
+
+
+def test_human_uat_orientation_does_not_filter_ordinary_ask_substrings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for question in ("Please summarize my resume.", "Explain interrupt handling."):
+        _reset_runtime_state(monkeypatch)
+        paths = _seed_orientation_pack(tmp_path / question.replace(" ", "-"))
+
+        response = TestClient(app).post("/api/ask", json={"question": question})
+        assert response.status_code == 200, response.text
+        assert str(paths["unrelated"]) in {source["path"] for source in response.json()["sources"]}
 
 
 def test_human_uat_return_after_interruption_orientation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/e2e/test_human_need_uat.py
+++ b/tests/e2e/test_human_need_uat.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -55,6 +55,7 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
 
     active_note = tmp_path / "Projects" / "atlas-migration.md"
     waiting_note = tmp_path / "Projects" / "atlas-waiting.md"
+    neutral_note = tmp_path / "Projects" / "atlas-plan.md"
     source_note = tmp_path / "Sources" / "vendor-memo.md"
     unrelated_note = tmp_path / "Garden" / "seedlings.md"
     get_hybrid_store().set_documents(
@@ -90,6 +91,19 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
                 },
             },
             {
+                "doc_id": "atlas-plan",
+                "source_ref": str(neutral_note),
+                "text": "Atlas migration plan; migrate the gateway.",
+                "payload": {
+                    "uuid": "atlas-plan",
+                    "title": "Atlas Migration Plan",
+                    "origin": "vault",
+                    "plane": "vault",
+                    "source_role": "vault_note",
+                    "evidence_role": "background",
+                },
+            },
+            {
                 "doc_id": "atlas-source",
                 "source_ref": str(source_note),
                 "text": "Vendor migration memo for Atlas. Confirms gateway deprecation window and required cutover steps.",
@@ -116,7 +130,13 @@ def _seed_orientation_pack(tmp_path: Path) -> dict[str, Path]:
         ]
     )
     ask_route._HYBRID_WARMED = True
-    return {"active": active_note, "waiting": waiting_note, "source": source_note, "unrelated": unrelated_note}
+    return {
+        "active": active_note,
+        "waiting": waiting_note,
+        "neutral": neutral_note,
+        "source": source_note,
+        "unrelated": unrelated_note,
+    }
 
 
 def test_human_uat_orientation_classifies_production_indexed_background(
@@ -193,6 +213,35 @@ def test_human_uat_orientation_does_not_filter_ordinary_ask_substrings(
         response = TestClient(app).post("/api/ask", json={"question": question})
         assert response.status_code == 200, response.text
         assert str(paths["unrelated"]) in {source["path"] for source in response.json()["sources"]}
+
+
+def test_human_uat_orientation_preserves_unmarked_production_vault_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reset_runtime_state(monkeypatch)
+    paths = _seed_orientation_pack(tmp_path)
+
+    response = TestClient(app).post(
+        "/api/ask",
+        json={"question": "I am returning to the Atlas migration after interruption."},
+    )
+    assert response.status_code == 200, response.text
+
+    sources_by_path = {source["path"]: source for source in response.json()["sources"]}
+    assert str(paths["neutral"]) in sources_by_path
+    assert sources_by_path[str(paths["neutral"])]["orientation"] == "background"
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("Where can I pick up my prescription?", False),
+        ("I need to pick up where I left off after interruption.", True),
+        ("I need to pick up the migration work again.", True),
+    ],
+)
+def test_human_uat_orientation_pickup_requires_resumption_context(question: str, expected: bool) -> None:
+    assert ask_graph.is_return_orientation_query(question) is expected
 
 
 def test_human_uat_return_after_interruption_orientation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Governing-Issue: #5228

Fixes #5228

Final-Review-Rounds: 0

## Summary
Classify orientation background from the canonical indexed `evidence_role` instead of fixture-only metadata.
Filter background hits before ASK builds its envelope, synthesis context, attribution, or returned sources for return-after-interruption queries.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded repair follows an authoritative GitHub Issue; no workflow divergence or operational BuilderOps material was produced.

## Notes
Validation: the three governing human-UAT Verify tests passed; focused ASK API/synthesis/envelope tests passed (19); `ruff check app tests` and `mypy app` passed. The broader suggested `tests/retrieval tests/api` collection is locally blocked by the pre-existing missing `lingua` dependency through unrelated Companion imports. No owner UAT claimed.

Pickup receipt: `pickup-claim-complete issue=5228 branch=codex/issue-5228-return-orientation-20260830 worktree=/Users/rasmusthornberg/.codex/worktrees/issue-5228-return-orientation coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-5228 lease_id=lease-d66e6ee5 holder=codex-slice-5228 evidence=verified-dispatcher-lease`
---