### PR TITLE
governance: remove action subtype when unblocking dependents

### DIFF
--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -659,10 +659,13 @@ that fallback. Never infer either mode from an earlier lease, database existence
 After merging and delivering work, scan for issues blocked by the delivered Issue. Before unblocking
 each dependent, re-read its live Issue body, state, labels, and dependency evidence; do not unblock
 an Issue carrying `agent:needs-human`; form the prospective post-unblock label set by replacing
-`agent:blocked` with `agent:ready`; run the strict issue-readiness validation against that current
-body and prospective label set; and verify that this delivery actually satisfied the named
-dependency. Only then make the explicit lifecycle mutation and read it back. Do not unblock from a
-stale dependency graph, an earlier readiness report, or a successful merge alone.
+`agent:blocked` with `agent:ready` and removing every `action:*` label; run the strict
+issue-readiness validation against that current body and prospective label set; and verify that this
+delivery actually satisfied the named dependency. Only then make the explicit lifecycle mutation,
+remove the action subtype, and read both changes back. The previous `blocker_action.v1` comment
+remains immutable historical evidence; it does not authorize retaining an action label on ready
+work. Do not unblock from a stale dependency graph, an earlier readiness report, or a successful
+merge alone.
 
 ## Optional Project Projection
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -659,13 +659,14 @@ that fallback. Never infer either mode from an earlier lease, database existence
 After merging and delivering work, scan for issues blocked by the delivered Issue. Before unblocking
 each dependent, re-read its live Issue body, state, labels, and dependency evidence; do not unblock
 an Issue carrying `agent:needs-human`; form the prospective post-unblock label set by replacing
-`agent:blocked` with `agent:ready` and removing every `action:*` label; run the strict
-issue-readiness validation against that current body and prospective label set; and verify that this
-delivery actually satisfied the named dependency. Only then make the explicit lifecycle mutation,
-remove the action subtype, and read both changes back. The previous `blocker_action.v1` comment
-remains immutable historical evidence; it does not authorize retaining an action label on ready
-work. Do not unblock from a stale dependency graph, an earlier readiness report, or a successful
-merge alone.
+`agent:blocked` with `agent:ready` and remove every `action:*` label from that prospective set; run
+the strict issue-readiness validation against that current
+body and prospective label set; and verify that this delivery actually satisfied the named
+dependency. Only then make the explicit lifecycle mutation and read it back. The mutation must
+remove the action subtype as well as change the lifecycle label. The previous `blocker_action.v1`
+comment remains immutable historical evidence; it does not authorize retaining an action label on
+ready work. Do not unblock from a stale dependency graph, an earlier readiness report, or a
+successful merge alone.
 
 ## Optional Project Projection
 

--- a/docs/development/PR_ESCALATION_PATHS.md
+++ b/docs/development/PR_ESCALATION_PATHS.md
@@ -42,7 +42,9 @@ Use when local HEAD, the tracked remote branch, and the PR head SHA do not match
 Use after merge or after verification when the delivered work unblocks other issues.
 
 - scan for issues that explicitly depend on the delivered issue
-- remove `agent:blocked` and add `agent:ready` only when the dependency is truly satisfied
+- remove `agent:blocked` and every `action:*` label, then add `agent:ready`, only when the dependency
+  is truly satisfied and the prospective label set passes strict readiness validation; preserve the
+  prior `blocker_action.v1` comment as immutable historical evidence
 - do not unblock issues whose real dependency is still missing
 
 ## 5) Owner-Doc Check


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): none
- Write class: governance
- Persistence impact: none
- Derived/rebuildable impact: none
- New or changed contract: clarifies existing blocker-action transition contract
- Owner-doc impact: PR escalation reference updated
- Transition debt impact: removes one stale coarse-label instruction
- Boundary risk: low

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make dependent-Issue unblocking remove the stale action subtype as required by the canonical blocker action contract.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Tier 1 governance correction; no BuilderOps material was routed.

## Notes
Validation: docs_guard, skills consistency lint, skill quick validation, and 131 focused governance/BuilderOps tests passed. The first hosted head exposed one governed wording-anchor regression; current head preserves the anchor and the new action-removal rule.