### PR TITLE
feat: activate Settings Spine vault selection rebind

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -177,21 +177,24 @@ class VaultIdentityState(BaseModel):
 
 
 class IngestBindingResponse(BaseModel):
-    """Whether the watcher/worker are actually bound to the selected vault (#3119).
+    """Whether the watcher/worker are actually bound to the selected vault (#4969).
 
-    Vault *selection* (this API process's in-process ``VaultManager`` state)
-    and vault *ingest binding* (the watcher/worker's own boot-time
-    ``WATCHER_VAULT_PATH``) are independent by design (#2476). This surfaces
-    that divergence instead of leaving it silent: ``state`` is one of
-    ``"bound"`` (watcher confirmed on the same vault), ``"diverged"`` (watcher
-    alive but bound elsewhere), ``"unbound"`` (no fresh watcher heartbeat), or
-    ``"unknown"`` (no vault selected yet to compare against).
+    The watcher is separately deployed, but its compatibility binding now
+    follows the durable SETTINGS-05C prepare/commit/resume transaction. The
+    rebind fields expose that protected phase and revision alongside the
+    heartbeat comparison; display fields never choose a binding.
     """
 
     state: str
     bound: bool
     detail: str
     watcher_vault_path: str | None = None
+    rebind_schema: str | None = None
+    rebind_phase: str | None = None
+    rebind_desired_revision: int | None = None
+    rebind_applied_revision: int | None = None
+    rebind_lifecycle_posture: str | None = None
+    rebind_failure_posture: str | None = None
 
 
 class CompanionTTSRequest(BaseModel):
@@ -1990,6 +1993,12 @@ def _ingest_binding_state(vault_root: Path) -> IngestBindingResponse:
         bound=status.is_bound,
         detail=status.detail,
         watcher_vault_path=status.watcher_vault_path,
+        rebind_schema=status.rebind_schema,
+        rebind_phase=status.rebind_phase,
+        rebind_desired_revision=status.rebind_desired_revision,
+        rebind_applied_revision=status.rebind_applied_revision,
+        rebind_lifecycle_posture=status.rebind_lifecycle_posture,
+        rebind_failure_posture=status.rebind_failure_posture,
     )
 
 

--- a/app/api/routes/ingest_binding.py
+++ b/app/api/routes/ingest_binding.py
@@ -70,6 +70,12 @@ class IngestBindingStatus:
     watcher_heartbeat_seen: bool
     watcher_heartbeat_fresh: bool
     detail: str
+    rebind_schema: str | None = None
+    rebind_phase: str | None = None
+    rebind_desired_revision: int | None = None
+    rebind_applied_revision: int | None = None
+    rebind_lifecycle_posture: str | None = None
+    rebind_failure_posture: str | None = None
 
     @property
     def is_bound(self) -> bool:
@@ -84,6 +90,41 @@ def _read_watcher_heartbeat(heartbeat_path: Path) -> dict[str, object] | None:
     except Exception:
         return None
     return raw if isinstance(raw, dict) else None
+
+
+def _rebind_status() -> dict[str, object | None]:
+    """Read durable rebind truth without making health depend on it."""
+
+    registry_value = os.getenv("INSTANCE_VAULT_REGISTRY_PATH", "").strip()
+    if not registry_value:
+        return {}
+    try:
+        registry_path = Path(registry_value).expanduser()
+        if not registry_path.is_file():
+            return {}
+        from app.instance.settings_rebind import SettingsRebindRecord
+        from app.instance.vault_registry import VaultRegistryStore
+
+        snapshot = VaultRegistryStore(registry_path).load()
+        if snapshot.settings_rebind is None:
+            return {}
+        record = SettingsRebindRecord.from_payload(snapshot.settings_rebind)
+        return {
+            "rebind_schema": record.as_payload()["schema"],
+            "rebind_phase": record.phase,
+            "rebind_desired_revision": record.desired_revision,
+            "rebind_applied_revision": record.applied_revision,
+            "rebind_lifecycle_posture": record.lifecycle_posture,
+            "rebind_failure_posture": (
+                "awaiting_watcher"
+                if record.phase == "prepared"
+                else "awaiting_resume"
+                if record.phase == "committed"
+                else "none"
+            ),
+        }
+    except Exception:
+        return {"rebind_failure_posture": "invalid_record"}
 
 
 def ingest_binding_status(
@@ -113,6 +154,7 @@ def ingest_binding_status(
     stale_after = stale_seconds if stale_seconds is not None else _env_float(
         "WATCHER_HEARTBEAT_STALE_SECONDS", _DEFAULT_STALE_SECONDS
     )
+    rebind = _rebind_status()
 
     selected_norm = _normalized(selected_vault_path)
     if selected_norm is None:
@@ -123,6 +165,7 @@ def ingest_binding_status(
             watcher_heartbeat_seen=False,
             watcher_heartbeat_fresh=False,
             detail="no vault is selected",
+            **rebind,
         )
 
     raw = _read_watcher_heartbeat(resolved_heartbeat_path)
@@ -137,6 +180,7 @@ def ingest_binding_status(
                 "watcher has not reported a heartbeat yet; captures to this "
                 "vault will not be ingested until the watcher/worker are bound"
             ),
+            **rebind,
         )
 
     watcher_vault_path = raw.get("vault_path")
@@ -160,6 +204,7 @@ def ingest_binding_status(
                 "watcher heartbeat is stale; captures to this vault may not "
                 "be ingested until the watcher/worker are confirmed running"
             ),
+            **rebind,
         )
 
     watcher_norm = _normalized(watcher_vault_path)
@@ -176,6 +221,7 @@ def ingest_binding_status(
                 "indexed, or made findable until the watcher/worker are "
                 "rebound to this vault"
             ),
+            **rebind,
         )
 
     return IngestBindingStatus(
@@ -185,6 +231,7 @@ def ingest_binding_status(
         watcher_heartbeat_seen=True,
         watcher_heartbeat_fresh=True,
         detail="watcher/worker are bound to the selected vault",
+        **rebind,
     )
 
 

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import time
 from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import TYPE_CHECKING, Mapping
 
 from app.instance._storage_boundary import (
@@ -11,7 +14,7 @@ from app.instance._storage_boundary import (
 )
 
 if TYPE_CHECKING:
-    from app.instance.vault_registry import VaultRegistryStore
+    from app.instance.vault_registry import KnownVaultRef, VaultRegistryStore
 
 
 SETTINGS_REBIND_SCHEMA = "settings_rebind.v1"
@@ -160,11 +163,12 @@ def provisional_binding_id(value: object) -> str | None:
 
 
 class SettingsRebindStore:
-    """Narrow facade for the durable dormant SETTINGS-05 record.
+    """Narrow facade for the durable SETTINGS-05 compatibility record.
 
-    SETTINGS-05B may only consume an existing revision or acknowledge that no
-    watcher lifecycle exists.  It cannot prepare a revision, choose a binding,
-    or commit a candidate binding.
+    The watcher owns acknowledgement/drain.  The foreground activation owner
+    owns prepare and the one locked selection+binding commit.  Keeping those
+    operations here prevents a caller from composing two independent registry
+    writes and accidentally exposing a new selection before its rebind phase.
     """
 
     def __init__(self, registry: VaultRegistryStore) -> None:
@@ -175,6 +179,60 @@ class SettingsRebindStore:
         if value is None:
             raise RegistryError("settings rebind record is not installed")
         return SettingsRebindRecord.from_payload(value)
+
+    def prepare(self, *, candidate_binding_id: str | None) -> SettingsRebindRecord:
+        """Prepare the next monotonic compatibility revision.
+
+        The current candidate is the only durable prior binding.  A prepared
+        or committed revision cannot be replaced underneath its watcher; the
+        caller must wait for that revision to finish and retry from its durable
+        result.
+        """
+
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        snapshot = self._registry.load()
+        current = self.read()
+        if current.phase == "prepared":
+            if current.candidate_binding_id == candidate_binding_id:
+                return current
+            raise RegistryError("settings rebind already has a prepared revision")
+        if current.phase == "committed":
+            raise RegistryError("settings rebind committed revision is awaiting watcher completion")
+        prior = current.candidate_binding_id
+        if prior == candidate_binding_id:
+            return current
+        prepared = SettingsRebindRecord(
+            desired_revision=max(current.desired_revision, current.applied_revision) + 1,
+            applied_revision=current.applied_revision,
+            phase="prepared",
+            lifecycle_posture="watcher",
+            prior_binding_id=prior,
+            candidate_binding_id=candidate_binding_id,
+        )
+        updated = self._registry.set_settings_rebind_state(
+            prepared.as_payload(),
+            expected_revision=snapshot.revision,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        return SettingsRebindRecord.from_payload(updated.settings_rebind)
+
+    def commit_selection(
+        self,
+        *,
+        desired_revision: int,
+        selection: KnownVaultRef,
+    ) -> SettingsRebindRecord:
+        """Atomically commit the prepared binding and compatibility selection."""
+
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        snapshot = self._registry.commit_settings_rebind_selection(
+            desired_revision=desired_revision,
+            selection=selection,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        return SettingsRebindRecord.from_payload(snapshot.settings_rebind)
 
     def acknowledge_no_lifecycle(
         self,
@@ -225,6 +283,149 @@ class SettingsRebindStore:
         raise RegistryError(
             "absent watcher cannot reconcile a committed settings rebind revision"
         )
+
+
+def _activation_fault_point(stage: str) -> None:
+    """Test seam for foreground crash recovery; production is a no-op."""
+
+    del stage
+
+
+class SettingsRebindActivation:
+    """Production choose/open transaction for the compatibility binding.
+
+    The API never calls the watcher helper directly.  It records ``prepared``
+    and waits for the separately running watcher to publish its durable
+    acknowledgement.  The watcher-disabled posture is explicit
+    ``no_lifecycle``.  After the locked selection commit, the API waits for a
+    completed watcher receipt when a watcher exists, then reloads through the
+    existing SETTINGS-01 ingestion entrypoint.
+    """
+
+    def __init__(
+        self,
+        registry: VaultRegistryStore,
+        *,
+        watcher_state_dir: Path | None = None,
+        watcher_enabled: bool | None = None,
+        wait_timeout_seconds: float | None = None,
+        poll_seconds: float = 0.05,
+    ) -> None:
+        self.store = SettingsRebindStore(registry)
+        self._watcher_state_dir = watcher_state_dir
+        self._watcher_enabled_override = watcher_enabled
+        self._wait_timeout_seconds = (
+            wait_timeout_seconds
+            if wait_timeout_seconds is not None
+            else float(os.getenv("SETTINGS_REBIND_WAIT_TIMEOUT_SECONDS", "5"))
+        )
+        self._poll_seconds = max(poll_seconds, 0.01)
+
+    @classmethod
+    def from_environment(cls, registry: VaultRegistryStore) -> "SettingsRebindActivation":
+        state_dir_raw = os.getenv("WATCHER_STATE_DIR", "").strip()
+        state_dir = Path(state_dir_raw).expanduser() if state_dir_raw else None
+        enabled_raw = os.getenv("WATCHER_ENABLE", "").strip().lower()
+        watcher_path = os.getenv("WATCHER_VAULT_PATH", "").strip()
+        enabled = enabled_raw in {"1", "true", "yes", "on"} and bool(watcher_path)
+        return cls(registry, watcher_state_dir=state_dir, watcher_enabled=enabled)
+
+    def activate(
+        self,
+        *,
+        selection: KnownVaultRef,
+        candidate_binding_id: str,
+        candidate_root: Path,
+    ) -> SettingsRebindRecord:
+        current = self.store.read()
+        if current.phase == "dormant" and current.candidate_binding_id == candidate_binding_id:
+            return current
+
+        _activation_fault_point("prepare")
+        prepared = self.store.prepare(candidate_binding_id=candidate_binding_id)
+        if prepared.phase != "prepared":
+            return prepared
+
+        if self.watcher_enabled:
+            _activation_fault_point("acknowledge")
+            self._wait_for_stage(prepared, required_stage="acknowledged")
+        else:
+            _activation_fault_point("acknowledge")
+            prepared = self.store.acknowledge_no_lifecycle(
+                desired_revision=prepared.desired_revision
+            )
+
+        _activation_fault_point("commit")
+        committed = self.store.commit_selection(
+            desired_revision=prepared.desired_revision,
+            selection=selection,
+        )
+
+        # This is deliberately the existing production SETTINGS-01 call site,
+        # not a second settings loader.  A malformed source leaves the durable
+        # commit visible and is surfaced by the ingestion health state.
+        from app.settings.ingestion import ingest_settings
+
+        _activation_fault_point("reload")
+        ingest_settings(
+            reason="vault_selection_rebind",
+            vault_root=candidate_root,
+            publish_signal=False,
+        )
+
+        if self.watcher_enabled:
+            _activation_fault_point("resume")
+            self._wait_for_stage(committed, required_stage="completed")
+        return committed
+
+    @property
+    def watcher_enabled(self) -> bool:
+        if self._watcher_enabled_override is not None:
+            return self._watcher_enabled_override
+        return bool(os.getenv("WATCHER_VAULT_PATH", "").strip())
+
+    def _wait_for_stage(
+        self,
+        record: SettingsRebindRecord,
+        *,
+        required_stage: str,
+    ) -> None:
+        if self._watcher_state_dir is None:
+            raise RegistryError("enabled settings rebind watcher has no state directory")
+        from app.watcher.settings_rebind import (
+            load_settings_rebind_watcher_receipt,
+            settings_rebind_watcher_receipt_path,
+        )
+
+        receipt_path = settings_rebind_watcher_receipt_path(
+            self._watcher_state_dir,
+            record.desired_revision,
+        )
+        deadline = time.monotonic() + max(self._wait_timeout_seconds, 0.0)
+        while True:
+            try:
+                receipt = load_settings_rebind_watcher_receipt(receipt_path)
+            except FileNotFoundError:
+                receipt = None
+            if receipt is not None:
+                if (
+                    receipt.desired_revision != record.desired_revision
+                    or receipt.prior_binding_id != record.prior_binding_id
+                    or receipt.candidate_binding_id != record.candidate_binding_id
+                ):
+                    raise RegistryError(
+                        "settings rebind watcher receipt does not match durable authority"
+                    )
+                if required_stage == "acknowledged" or receipt.stage == "completed":
+                    return
+                if receipt.stage in {"acknowledged", "drained"} and required_stage == "completed":
+                    pass
+            if time.monotonic() >= deadline:
+                raise RegistryError(
+                    "settings rebind watcher did not reach "
+                    f"{required_stage} for revision {record.desired_revision}"
+                )
+            time.sleep(self._poll_seconds)
 
 
 def _install_dormant_settings_rebind(

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -354,12 +354,15 @@ class SettingsRebindActivation:
             # only success receipt the losing request may return.
             observed = self.store.read()
             if (
-                observed.phase == "committed"
+                observed.phase in {"prepared", "committed"}
                 and observed.candidate_binding_id == candidate_binding_id
             ):
-                self._wait_for_completed_if_enabled(observed)
-                return observed
-            raise
+                if observed.phase == "committed":
+                    self._wait_for_completed_if_enabled(observed)
+                    return observed
+                prepared = observed
+            else:
+                raise
         if prepared.phase != "prepared":
             return prepared
 

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -6,7 +6,7 @@ import os
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Callable, Mapping
 
 from app.instance._storage_boundary import (
     RegistryError,
@@ -284,25 +284,19 @@ class SettingsRebindStore:
         )
         return SettingsRebindRecord.from_payload(updated.settings_rebind)
 
-    def mark_reload_completed(self, *, desired_revision: int) -> SettingsRebindRecord:
-        """Durably mark the SETTINGS-01 reload for one committed revision."""
+    def reload_once(
+        self,
+        *,
+        desired_revision: int,
+        reload_callback: Callable[[], object],
+    ) -> SettingsRebindRecord:
+        """Run and durably record one SETTINGS-01 reload under the store lock."""
 
         from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
 
-        snapshot = self._registry.load()
-        current = self.read()
-        if current.desired_revision != desired_revision:
-            raise RegistryError("settings rebind reload revision does not match durable authority")
-        if current.phase not in {"committed", "no_lifecycle"}:
-            raise RegistryError("settings rebind reload requires a committed revision")
-        if current.reload_revision == desired_revision:
-            return current
-        if current.reload_revision not in {None, 0}:
-            raise RegistryError("settings rebind reload revision cannot advance from an unexpected value")
-        updated = replace(current, reload_revision=desired_revision)
-        stored = self._registry.set_settings_rebind_state(
-            updated.as_payload(),
-            expected_revision=snapshot.revision,
+        stored = self._registry.complete_settings_rebind_reload(
+            desired_revision=desired_revision,
+            reload_callback=reload_callback,
             _capability=_STORAGE_MUTATION_CAPABILITY,
         )
         return SettingsRebindRecord.from_payload(stored.settings_rebind)
@@ -436,9 +430,8 @@ class SettingsRebindActivation:
         # binding and roll forward, matching the watcher transaction seam.
         _activation_fault_point("commit")
 
-        committed = self._reload_if_needed(committed, candidate_root)
-
         self._wait_for_completed_if_enabled(committed)
+        committed = self._reload_if_needed(committed, candidate_root)
         return committed
 
     def _wait_for_completed_if_enabled(self, record: SettingsRebindRecord) -> None:
@@ -462,17 +455,21 @@ class SettingsRebindActivation:
         if record.reload_revision == record.desired_revision:
             return record
         # This is deliberately the existing production SETTINGS-01 call site,
-        # not a second settings loader.  A malformed source leaves the durable
-        # commit visible and is surfaced by the ingestion health state.
+        # not a second settings loader.  The registry lock serializes this
+        # side effect with same-target callers and records completion durably.
         from app.settings.ingestion import ingest_settings
 
         _activation_fault_point("reload")
-        ingest_settings(
-            reason="vault_selection_rebind",
-            vault_root=candidate_root,
-            publish_signal=False,
+        completed = self.store.reload_once(
+            desired_revision=record.desired_revision,
+            reload_callback=lambda: ingest_settings(
+                reason="vault_selection_rebind",
+                vault_root=candidate_root,
+                publish_signal=False,
+            ),
         )
-        return self.store.mark_reload_completed(desired_revision=record.desired_revision)
+        _activation_fault_point("reload_complete")
+        return completed
 
     @property
     def watcher_enabled(self) -> bool:

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -31,8 +31,10 @@ _FIELDS = {
     "lifecyclePosture",
     "priorBindingId",
     "candidateBindingId",
+    "reloadRevision",
     "checksum",
 }
+_LEGACY_FIELDS = _FIELDS - {"reloadRevision"}
 _PHASE_POSTURES = {
     "dormant": "dormant",
     "prepared": "watcher",
@@ -74,6 +76,7 @@ class SettingsRebindRecord:
     lifecycle_posture: str = "dormant"
     prior_binding_id: str | None = None
     candidate_binding_id: str | None = None
+    reload_revision: int | None = 0
 
     @classmethod
     def dormant(cls, *, binding_id: str | None = None) -> SettingsRebindRecord:
@@ -89,13 +92,14 @@ class SettingsRebindRecord:
             "lifecyclePosture": self.lifecycle_posture,
             "priorBindingId": self.prior_binding_id,
             "candidateBindingId": self.candidate_binding_id,
+            "reloadRevision": self.reload_revision,
         }
         payload["checksum"] = _checksum(payload)
         return payload
 
     @classmethod
     def from_payload(cls, value: object) -> SettingsRebindRecord:
-        if not isinstance(value, dict) or set(value) != _FIELDS:
+        if not isinstance(value, dict) or set(value) not in (_FIELDS, _LEGACY_FIELDS):
             raise RegistryError("settings rebind record has an invalid shape")
         if value.get("schema") != SETTINGS_REBIND_SCHEMA:
             raise RegistryError("settings rebind record has an invalid schema")
@@ -120,6 +124,14 @@ class SettingsRebindRecord:
             raise RegistryError("completed settings rebind revisions must match")
         prior = _binding(value.get("priorBindingId"), name="prior binding")
         candidate = _binding(value.get("candidateBindingId"), name="candidate binding")
+        if "reloadRevision" not in value:
+            # Records written before reload completion became durable are
+            # intentionally treated as unknown and replayed once on retry.
+            reload_revision = None
+        else:
+            reload_revision = _revision(value.get("reloadRevision"), name="reload revision")
+            if reload_revision > applied:
+                raise RegistryError("settings rebind reload revision exceeds applied revision")
         supplied_checksum = value.get("checksum")
         if (
             not isinstance(supplied_checksum, str)
@@ -135,6 +147,7 @@ class SettingsRebindRecord:
             lifecycle_posture=posture,
             prior_binding_id=prior,
             candidate_binding_id=candidate,
+            reload_revision=reload_revision,
         )
 
 
@@ -209,6 +222,7 @@ class SettingsRebindStore:
             lifecycle_posture="watcher",
             prior_binding_id=prior,
             candidate_binding_id=candidate_binding_id,
+            reload_revision=0,
         )
         updated = self._registry.set_settings_rebind_state(
             prepared.as_payload(),
@@ -269,6 +283,29 @@ class SettingsRebindStore:
             _capability=_STORAGE_MUTATION_CAPABILITY,
         )
         return SettingsRebindRecord.from_payload(updated.settings_rebind)
+
+    def mark_reload_completed(self, *, desired_revision: int) -> SettingsRebindRecord:
+        """Durably mark the SETTINGS-01 reload for one committed revision."""
+
+        from app.instance._storage_boundary import _STORAGE_MUTATION_CAPABILITY
+
+        snapshot = self._registry.load()
+        current = self.read()
+        if current.desired_revision != desired_revision:
+            raise RegistryError("settings rebind reload revision does not match durable authority")
+        if current.phase not in {"committed", "no_lifecycle"}:
+            raise RegistryError("settings rebind reload requires a committed revision")
+        if current.reload_revision == desired_revision:
+            return current
+        if current.reload_revision not in {None, 0}:
+            raise RegistryError("settings rebind reload revision cannot advance from an unexpected value")
+        updated = replace(current, reload_revision=desired_revision)
+        stored = self._registry.set_settings_rebind_state(
+            updated.as_payload(),
+            expected_revision=snapshot.revision,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
+        return SettingsRebindRecord.from_payload(stored.settings_rebind)
 
     def reconcile_no_lifecycle(self) -> SettingsRebindRecord:
         """Converge an absent watcher without preparing or committing a revision."""
@@ -340,10 +377,12 @@ class SettingsRebindActivation:
         current = self.store.read()
         if current.candidate_binding_id == candidate_binding_id:
             if current.phase in {"dormant", "no_lifecycle"}:
+                if current.phase == "no_lifecycle":
+                    return self._reload_if_needed(current, candidate_root)
                 return current
             if current.phase == "committed":
                 self._wait_for_completed_if_enabled(current)
-                return current
+                return self._reload_if_needed(current, candidate_root)
 
         _activation_fault_point("prepare")
         try:
@@ -359,7 +398,7 @@ class SettingsRebindActivation:
             ):
                 if observed.phase == "committed":
                     self._wait_for_completed_if_enabled(observed)
-                    return observed
+                    return self._reload_if_needed(observed, candidate_root)
                 prepared = observed
             else:
                 raise
@@ -391,12 +430,37 @@ class SettingsRebindActivation:
                 and observed.desired_revision == prepared.desired_revision
             ):
                 self._wait_for_completed_if_enabled(observed)
-                return observed
+                return self._reload_if_needed(observed, candidate_root)
             raise
         # A commit fault is post-commit: recovery must observe the durable B
         # binding and roll forward, matching the watcher transaction seam.
         _activation_fault_point("commit")
 
+        committed = self._reload_if_needed(committed, candidate_root)
+
+        self._wait_for_completed_if_enabled(committed)
+        return committed
+
+    def _wait_for_completed_if_enabled(self, record: SettingsRebindRecord) -> None:
+        if self.watcher_enabled:
+            _activation_fault_point("resume")
+            self._wait_for_stage(record, required_stage="completed")
+
+    def _reload_if_needed(
+        self,
+        record: SettingsRebindRecord,
+        candidate_root: Path,
+    ) -> SettingsRebindRecord:
+        # Re-read after any watcher wait or commit race.  A concurrent winner
+        # may have completed the reload while this caller was waiting.
+        current = self.store.read()
+        if (
+            current.desired_revision == record.desired_revision
+            and current.candidate_binding_id == record.candidate_binding_id
+        ):
+            record = current
+        if record.reload_revision == record.desired_revision:
+            return record
         # This is deliberately the existing production SETTINGS-01 call site,
         # not a second settings loader.  A malformed source leaves the durable
         # commit visible and is surfaced by the ingestion health state.
@@ -408,14 +472,7 @@ class SettingsRebindActivation:
             vault_root=candidate_root,
             publish_signal=False,
         )
-
-        self._wait_for_completed_if_enabled(committed)
-        return committed
-
-    def _wait_for_completed_if_enabled(self, record: SettingsRebindRecord) -> None:
-        if self.watcher_enabled:
-            _activation_fault_point("resume")
-            self._wait_for_stage(record, required_stage="completed")
+        return self.store.mark_reload_completed(desired_revision=record.desired_revision)
 
     @property
     def watcher_enabled(self) -> bool:

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -338,11 +338,28 @@ class SettingsRebindActivation:
         candidate_root: Path,
     ) -> SettingsRebindRecord:
         current = self.store.read()
-        if current.phase == "dormant" and current.candidate_binding_id == candidate_binding_id:
-            return current
+        if current.candidate_binding_id == candidate_binding_id:
+            if current.phase in {"dormant", "no_lifecycle"}:
+                return current
+            if current.phase == "committed":
+                self._wait_for_completed_if_enabled(current)
+                return current
 
         _activation_fault_point("prepare")
-        prepared = self.store.prepare(candidate_binding_id=candidate_binding_id)
+        try:
+            prepared = self.store.prepare(candidate_binding_id=candidate_binding_id)
+        except RegistryError:
+            # Another foreground request may have committed this exact target
+            # between the read above and prepare.  Its durable commit is the
+            # only success receipt the losing request may return.
+            observed = self.store.read()
+            if (
+                observed.phase == "committed"
+                and observed.candidate_binding_id == candidate_binding_id
+            ):
+                self._wait_for_completed_if_enabled(observed)
+                return observed
+            raise
         if prepared.phase != "prepared":
             return prepared
 
@@ -355,10 +372,24 @@ class SettingsRebindActivation:
                 desired_revision=prepared.desired_revision
             )
 
-        committed = self.store.commit_selection(
-            desired_revision=prepared.desired_revision,
-            selection=selection,
-        )
+        try:
+            committed = self.store.commit_selection(
+                desired_revision=prepared.desired_revision,
+                selection=selection,
+            )
+        except RegistryError:
+            # A same-target request can win the lock after both callers have
+            # observed the prepared revision.  Do not report API success until
+            # that winner's commit and watcher resume are durable.
+            observed = self.store.read()
+            if (
+                observed.phase == "committed"
+                and observed.candidate_binding_id == candidate_binding_id
+                and observed.desired_revision == prepared.desired_revision
+            ):
+                self._wait_for_completed_if_enabled(observed)
+                return observed
+            raise
         # A commit fault is post-commit: recovery must observe the durable B
         # binding and roll forward, matching the watcher transaction seam.
         _activation_fault_point("commit")
@@ -375,10 +406,13 @@ class SettingsRebindActivation:
             publish_signal=False,
         )
 
+        self._wait_for_completed_if_enabled(committed)
+        return committed
+
+    def _wait_for_completed_if_enabled(self, record: SettingsRebindRecord) -> None:
         if self.watcher_enabled:
             _activation_fault_point("resume")
-            self._wait_for_stage(committed, required_stage="completed")
-        return committed
+            self._wait_for_stage(record, required_stage="completed")
 
     @property
     def watcher_enabled(self) -> bool:

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -92,7 +92,7 @@ class SettingsRebindRecord:
             "lifecyclePosture": self.lifecycle_posture,
             "priorBindingId": self.prior_binding_id,
             "candidateBindingId": self.candidate_binding_id,
-            "reloadRevision": self.reload_revision,
+            "reloadRevision": 0 if self.reload_revision is None else self.reload_revision,
         }
         payload["checksum"] = _checksum(payload)
         return payload

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -211,7 +211,13 @@ class SettingsRebindStore:
                 return current
             raise RegistryError("settings rebind already has a prepared revision")
         if current.phase == "committed":
-            raise RegistryError("settings rebind committed revision is awaiting watcher completion")
+            if current.reload_revision != current.desired_revision:
+                raise RegistryError(
+                    "settings rebind committed revision is awaiting reload completion"
+                )
+            # The activation owner checks the watcher receipt before starting
+            # the next transition. Once the foreground reload marker is
+            # durable, a later selection may prepare the next revision.
         prior = current.candidate_binding_id
         if prior == candidate_binding_id:
             return current
@@ -378,6 +384,12 @@ class SettingsRebindActivation:
                 self._wait_for_completed_if_enabled(current)
                 return self._reload_if_needed(current, candidate_root)
 
+        if current.phase == "committed":
+            # A completed committed record is the normal steady state while the
+            # watcher remains deployed. Quiesce that prior transition before
+            # allowing a new candidate to replace it.
+            self._wait_for_completed_if_enabled(current)
+
         _activation_fault_point("prepare")
         try:
             prepared = self.store.prepare(candidate_binding_id=candidate_binding_id)
@@ -457,16 +469,24 @@ class SettingsRebindActivation:
         # This is deliberately the existing production SETTINGS-01 call site,
         # not a second settings loader.  The registry lock serializes this
         # side effect with same-target callers and records completion durably.
-        from app.settings.ingestion import ingest_settings
+        from app.settings.ingestion import STATE_OK, ingest_settings
+
+        def reload_selected_settings() -> None:
+            state = ingest_settings(
+                reason="vault_selection_rebind",
+                vault_root=candidate_root,
+                publish_signal=False,
+            )
+            if state.state != STATE_OK:
+                raise RegistryError(
+                    "SETTINGS-01 reload did not complete successfully: "
+                    f"state={state.state} error={state.error or 'unknown'}"
+                )
 
         _activation_fault_point("reload")
         completed = self.store.reload_once(
             desired_revision=record.desired_revision,
-            reload_callback=lambda: ingest_settings(
-                reason="vault_selection_rebind",
-                vault_root=candidate_root,
-                publish_signal=False,
-            ),
+            reload_callback=reload_selected_settings,
         )
         _activation_fault_point("reload_complete")
         return completed

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -322,6 +322,24 @@ class SettingsRebindStore:
         )
 
 
+def validate_settings_rebind_candidate_root(candidate_root: Path) -> Path:
+    """Validate the candidate vault before any watcher adoption receipt."""
+
+    from app.vault.manager import VaultManager
+
+    manager = VaultManager()
+    context = manager.validate_vault(candidate_root)
+    if context.status != "selected":
+        raise RegistryError(
+            "settings rebind candidate watcher root is not a selected vault"
+        )
+    if not manager.permissions_for_context(context).enable_vault_watcher:
+        raise RegistryError(
+            "settings rebind candidate watcher root is disabled by local settings"
+        )
+    return candidate_root
+
+
 def _activation_fault_point(stage: str) -> None:
     """Test seam for foreground crash recovery; production is a no-op."""
 
@@ -345,12 +363,14 @@ class SettingsRebindActivation:
         *,
         watcher_state_dir: Path | None = None,
         watcher_enabled: bool | None = None,
+        watcher_requested: bool | None = None,
         wait_timeout_seconds: float | None = None,
         poll_seconds: float = 0.05,
     ) -> None:
         self.store = SettingsRebindStore(registry)
         self._watcher_state_dir = watcher_state_dir
         self._watcher_enabled_override = watcher_enabled
+        self._watcher_requested_override = watcher_requested
         self._wait_timeout_seconds = (
             wait_timeout_seconds
             if wait_timeout_seconds is not None
@@ -364,8 +384,14 @@ class SettingsRebindActivation:
         state_dir = Path(state_dir_raw).expanduser() if state_dir_raw else None
         enabled_raw = os.getenv("WATCHER_ENABLE", "").strip().lower()
         watcher_path = os.getenv("WATCHER_VAULT_PATH", "").strip()
-        enabled = enabled_raw in {"1", "true", "yes", "on"} and bool(watcher_path)
-        return cls(registry, watcher_state_dir=state_dir, watcher_enabled=enabled)
+        requested = enabled_raw in {"1", "true", "yes", "on"}
+        enabled = requested and bool(watcher_path)
+        return cls(
+            registry,
+            watcher_state_dir=state_dir,
+            watcher_enabled=enabled,
+            watcher_requested=requested,
+        )
 
     def activate(
         self,
@@ -415,6 +441,8 @@ class SettingsRebindActivation:
             _activation_fault_point("acknowledge")
             self._wait_for_stage(prepared, required_stage="acknowledged")
         else:
+            if self.watcher_requested:
+                validate_settings_rebind_candidate_root(candidate_root)
             _activation_fault_point("acknowledge")
             prepared = self.store.acknowledge_no_lifecycle(
                 desired_revision=prepared.desired_revision
@@ -496,6 +524,12 @@ class SettingsRebindActivation:
         if self._watcher_enabled_override is not None:
             return self._watcher_enabled_override
         return bool(os.getenv("WATCHER_VAULT_PATH", "").strip())
+
+    @property
+    def watcher_requested(self) -> bool:
+        if self._watcher_requested_override is not None:
+            return self._watcher_requested_override
+        return self.watcher_enabled
 
     def _wait_for_stage(
         self,

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -355,11 +355,13 @@ class SettingsRebindActivation:
                 desired_revision=prepared.desired_revision
             )
 
-        _activation_fault_point("commit")
         committed = self.store.commit_selection(
             desired_revision=prepared.desired_revision,
             selection=selection,
         )
+        # A commit fault is post-commit: recovery must observe the durable B
+        # binding and roll forward, matching the watcher transaction seam.
+        _activation_fault_point("commit")
 
         # This is deliberately the existing production SETTINGS-01 call site,
         # not a second settings loader.  A malformed source leaves the durable

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -505,9 +505,15 @@ class VaultRegistryStore:
                 and requested.applied_revision == existing.applied_revision
                 and requested != existing
             ):
-                raise RegistryError(
-                    "settings rebind state cannot change without a revision advance"
+                reload_only_advance = (
+                    requested.reload_revision == requested.desired_revision
+                    and requested.reload_revision != existing.reload_revision
+                    and replace(requested, reload_revision=existing.reload_revision) == existing
                 )
+                if not reload_only_advance:
+                    raise RegistryError(
+                        "settings rebind state cannot change without a revision advance"
+                    )
             if requested == existing:
                 return current
             self._validate_settings_rebind_binding(current, requested.prior_binding_id)

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -805,6 +805,99 @@ class VaultRegistryStore:
             self._write_locked(updated)
             return updated
 
+    def commit_settings_rebind_selection(
+        self,
+        *,
+        desired_revision: int,
+        selection: KnownVaultRef,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Commit rebind state and last-active selection in one registry generation.
+
+        This is the SETTINGS-05C foreground commit seam.  The watcher has
+        already acknowledged the prepared revision (or the caller has
+        durably recorded ``no_lifecycle``); neither the compatibility binding
+        nor the picker history may be advanced independently afterward.
+        """
+
+        _require_storage_mutation_capability(_capability)
+        from app.instance.settings_rebind import SettingsRebindRecord
+
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            if current.settings_rebind is None:
+                raise RegistryError("settings rebind record is not installed")
+            rebind = SettingsRebindRecord.from_payload(current.settings_rebind)
+            if rebind.phase not in {"prepared", "no_lifecycle"} or rebind.desired_revision != desired_revision:
+                raise RegistryError(
+                    "settings rebind selection commit requires the matching prepared/no_lifecycle revision"
+                )
+            candidate_id = rebind.candidate_binding_id
+            if candidate_id is None:
+                raise RegistryError("settings rebind selection commit has no candidate binding")
+            registration = current.registrations.get(candidate_id)
+            if registration is None:
+                raise RegistryError("settings rebind candidate binding is not registered")
+            try:
+                selection_path = Path(selection.path).expanduser().resolve(strict=True)
+                registration_path = Path(registration.path).expanduser().resolve(strict=True)
+            except OSError as exc:
+                raise RegistryError("settings rebind candidate path is unavailable") from exc
+            if (
+                selection.ref != registration.ref
+                or selection_path != registration_path
+                or (
+                    registration.vault_id is not None
+                    and selection.vault_id not in (None, registration.vault_id)
+                )
+                or (
+                    registration.local_instance_id is not None
+                    and selection.local_instance_id
+                    not in (None, registration.local_instance_id)
+                )
+            ):
+                raise RegistryError("settings rebind selection identity does not match candidate")
+            registrations = copy.deepcopy(current.registrations)
+            registrations[candidate_id] = VaultRegistration(
+                vault_binding_id=registration.vault_binding_id,
+                ref=registration.ref,
+                path=registration.path,
+                vault_id=registration.vault_id,
+                local_instance_id=registration.local_instance_id,
+                vault_name=selection.vault_name,
+                last_opened_at=selection.last_opened_at,
+                extensions=copy.deepcopy(registration.extensions),
+            )
+            committed = replace(
+                rebind,
+                applied_revision=rebind.desired_revision,
+                phase="no_lifecycle" if rebind.phase == "no_lifecycle" else "committed",
+                lifecycle_posture=(
+                    "no_lifecycle" if rebind.phase == "no_lifecycle" else "watcher"
+                ),
+            )
+            next_revision = current.revision + 1
+            extensions = copy.deepcopy(current.extensions)
+            if current.authority == REGISTRY_AUTHORITY_ACTIVE:
+                scalar_floor = extensions.get("scalarRollback")
+                if not isinstance(scalar_floor, dict):
+                    raise RegistryError("active registry scalar rollback floor is invalid")
+                extensions["scalarRollback"] = {
+                    **scalar_floor,
+                    "forkRegistryRevision": next_revision,
+                }
+            updated = replace(
+                current,
+                revision=next_revision,
+                last_active_vault_ref=registration.ref,
+                registrations=registrations,
+                settings_rebind=committed.as_payload(),
+                extensions=extensions,
+            )
+            self._write_locked(updated)
+            return updated
+
     def remove_registration(
         self,
         vault_binding_id: str,

--- a/app/instance/vault_registry.py
+++ b/app/instance/vault_registry.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Protocol, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, Protocol, cast
 from uuid import uuid4
 
 import yaml
@@ -534,6 +534,55 @@ class VaultRegistryStore:
                 current,
                 revision=next_revision,
                 settings_rebind=requested.as_payload(),
+                extensions=extensions,
+            )
+            self._write_locked(updated)
+            return updated
+
+    def complete_settings_rebind_reload(
+        self,
+        *,
+        desired_revision: int,
+        reload_callback: Callable[[], object],
+        _capability: _StorageMutationCapability | None = None,
+    ) -> RegistrySnapshot:
+        """Run one reload under the registry lock and durably record completion."""
+
+        _require_storage_mutation_capability(_capability)
+        with self._locked():
+            self._assert_no_scalar_rollback_session_locked()
+            current = self._read_current_locked(recover=True)
+            if current.settings_rebind is None:
+                raise RegistryError("settings rebind record is not installed")
+            rebind = SettingsRebindRecord.from_payload(current.settings_rebind)
+            if rebind.desired_revision != desired_revision:
+                raise RegistryError("settings rebind reload revision does not match durable authority")
+            if rebind.phase not in {"committed", "no_lifecycle"}:
+                raise RegistryError("settings rebind reload requires a committed revision")
+            if rebind.reload_revision == desired_revision:
+                return current
+            if rebind.reload_revision not in {None, 0}:
+                raise RegistryError("settings rebind reload revision cannot advance from an unexpected value")
+
+            # The lock prevents concurrent same-target callers from repeating
+            # the side effect.  If the process dies in the callback, the marker
+            # remains pending and a later caller retries from durable truth.
+            reload_callback()
+            completed = replace(rebind, reload_revision=desired_revision)
+            next_revision = current.revision + 1
+            extensions = copy.deepcopy(current.extensions)
+            if current.authority == REGISTRY_AUTHORITY_ACTIVE:
+                scalar_floor = extensions.get("scalarRollback")
+                if not isinstance(scalar_floor, dict):
+                    raise RegistryError("active registry scalar rollback floor is invalid")
+                extensions["scalarRollback"] = {
+                    **scalar_floor,
+                    "forkRegistryRevision": next_revision,
+                }
+            updated = replace(
+                current,
+                revision=next_revision,
+                settings_rebind=completed.as_payload(),
                 extensions=extensions,
             )
             self._write_locked(updated)

--- a/app/vault/manager.py
+++ b/app/vault/manager.py
@@ -547,9 +547,13 @@ class VaultManager:
             registration = runtime.production_register(vault_path, producer="picker")
             snapshot = registry.load()
         current_record = SettingsRebindActivation(registry).store.read()
-        if current_record.candidate_binding_id == registration.vault_binding_id:
-            # The durable watcher already follows this binding.  Persisting
-            # last-active metadata remains a normal compatibility write.
+        if (
+            current_record.candidate_binding_id == registration.vault_binding_id
+            and current_record.phase in {"dormant", "no_lifecycle"}
+        ):
+            # A stable record needs only the ordinary compatibility write.  A
+            # prepared or committed same-target record must still flow through
+            # activation so this request waits for commit and watcher resume.
             return None
         known = KnownVaultRef(
             ref=registration.ref,

--- a/app/vault/manager.py
+++ b/app/vault/manager.py
@@ -479,10 +479,91 @@ class VaultManager:
         previous = self._context
         context = self.validate_vault(vault_path)
         if remember and context.status in {"selected", "uninitialized", "invalid", "missing"}:
-            self._remember_context(context, vault_path)
+            rebind_selection = self._settings_rebind_selection(context, vault_path)
+            if rebind_selection is None:
+                self._remember_context(context, vault_path)
+            else:
+                activation, registration, known = rebind_selection
+                activation.activate(
+                    selection=known,
+                    candidate_binding_id=registration.vault_binding_id,
+                    candidate_root=Path(registration.path),
+                )
         self._context = context
         self._emit_changed(previous, context)
         return context
+
+    def _settings_rebind_selection(
+        self,
+        context: VaultContext,
+        vault_path: Path,
+    ) -> tuple[Any, Any, KnownVaultRef] | None:
+        """Return the SETTINGS-05C activation inputs when the floor is installed."""
+
+        if context.status != "selected":
+            return None
+        registry_value = os.getenv("INSTANCE_VAULT_REGISTRY_PATH", "").strip()
+        if not registry_value:
+            return None
+        from app.instance.filesystem_identity import (
+            resolve_filesystem_root_identity,
+            same_filesystem_root,
+        )
+        from app.instance.settings_rebind import SettingsRebindActivation
+        from app.instance.vault_registry import VaultRegistryStore
+
+        registry = VaultRegistryStore(Path(registry_value).expanduser().resolve(strict=False))
+        snapshot = registry.load()
+        if snapshot.settings_rebind is None:
+            return None
+        target_identity = resolve_filesystem_root_identity(vault_path)
+        registration = next(
+            (
+                item
+                for item in snapshot.registrations.values()
+                if same_filesystem_root(
+                    resolve_filesystem_root_identity(item.path), target_identity
+                )
+            ),
+            None,
+        )
+        if registration is None:
+            if snapshot.authority != "active":
+                raise ValueError(
+                    "SETTINGS-05C cannot select an unregistered vault before registry authority cutover"
+                )
+            ownership_value = os.getenv("INSTANCE_OWNERSHIP_ROOT", "").strip()
+            if not ownership_value:
+                raise ValueError(
+                    "SETTINGS-05C requires INSTANCE_OWNERSHIP_ROOT to register a selected vault"
+                )
+            from app.instance.runtime import _load_active_registry_runtime
+
+            runtime = _load_active_registry_runtime(
+                registry_path=registry.path,
+                ownership_root=Path(ownership_value).expanduser().resolve(strict=False),
+                channel=os.getenv("PKM_ENVIRONMENT", "dev"),
+            )
+            registration = runtime.production_register(vault_path, producer="picker")
+            snapshot = registry.load()
+        current_record = SettingsRebindActivation(registry).store.read()
+        if current_record.candidate_binding_id == registration.vault_binding_id:
+            # The durable watcher already follows this binding.  Persisting
+            # last-active metadata remains a normal compatibility write.
+            return None
+        known = KnownVaultRef(
+            ref=registration.ref,
+            path=registration.path,
+            vault_id=registration.vault_id or context.active_vault_id,
+            vault_name=context.active_vault_name,
+            local_instance_id=registration.local_instance_id or context.local_instance_id,
+            last_opened_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        )
+        return (
+            SettingsRebindActivation.from_environment(registry),
+            registration,
+            known,
+        )
 
     def validate_vault(self, vault_path: Path) -> VaultContext:
         # Lazy import: see the constructor's comment on the write_guard cycle.

--- a/app/vault/manager.py
+++ b/app/vault/manager.py
@@ -549,7 +549,13 @@ class VaultManager:
         current_record = SettingsRebindActivation(registry).store.read()
         if (
             current_record.candidate_binding_id == registration.vault_binding_id
-            and current_record.phase in {"dormant", "no_lifecycle"}
+            and (
+                current_record.phase == "dormant"
+                or (
+                    current_record.phase == "no_lifecycle"
+                    and current_record.reload_revision == current_record.desired_revision
+                )
+            )
         ):
             # A stable record needs only the ordinary compatibility write.  A
             # prepared or committed same-target record must still flow through

--- a/app/watcher/config.py
+++ b/app/watcher/config.py
@@ -1,28 +1,20 @@
 """Watcher runtime configuration.
 
-HTTP-vs-background split rationale (#2476)
-------------------------------------------
-The watcher resolves its vault via ``WATCHER_VAULT_PATH`` (not ``VAULT_ROOT``)
-and builds a throwaway ``VaultManager`` to validate the path.  This is an
-*intentional* HTTP-vs-background split, not a split-brain bug:
+HTTP-vs-background binding rationale (#2476, #3119, SETTINGS-05C)
+-----------------------------------------------------------------
+The watcher remains a separately deployed process and ``WATCHER_VAULT_PATH``
+remains its bootstrap adapter.  The old "document the split, do not converge"
+posture is superseded for the one compatibility lifecycle by SETTINGS-05C:
+the picker writes a protected ``settings_rebind.v1`` prepare, the watcher
+acknowledges a healthy old-root scan, and only the locked commit lets the
+watcher adopt the candidate binding.  This avoids sharing the HTTP process's
+in-memory ``VaultManager`` state while making the two processes follow one
+durable binding.  The watcher changes its in-memory root only after its
+post-commit drain/resume receipt; no multi-active lifecycle is implied.
 
-1. The watcher is a background process with an independent lifecycle — it does
-   not participate in the HTTP vault-selection state machine managed by
-   ``VaultManager`` singleton + ``AppLocalSettingsStore``.
-2. ``WATCHER_VAULT_PATH`` lets operators bind the watcher to a vault
-   independently of the user-facing ``VAULT_ROOT`` / selection flow (e.g. a
-   fixed mount path inside a container).
-3. Converging onto ``resolve_active_vault_root`` (the HTTP-path canonical
-   resolver) would require the watcher to call back into the FastAPI process or
-   share the in-memory singleton — coupling a background daemon to an HTTP
-   runtime boundary that it must not own.
-4. Converging onto ``resolve_optional_vault_root`` would remove the
-   ``WATCHER_VAULT_PATH`` override capability and the VaultManager validation
-   step that checks settings-level ``enable_vault_watcher``.
-
-Verdict: document the split, do not converge.  The watcher vault binding is
-governed by ``WATCHER_VAULT_PATH``; the HTTP path is governed by
-``VAULT_ROOT`` + selection.  Both read from independent source-binding slots.
+Health reads the durable phase/revision and heartbeat together.  A missing,
+invalid, or incomplete handoff remains visibly degraded; a display-only
+runtime settings field never selects a vault.
 """
 
 from __future__ import annotations

--- a/app/watcher/config.py
+++ b/app/watcher/config.py
@@ -9,8 +9,11 @@ the picker writes a protected ``settings_rebind.v1`` prepare, the watcher
 acknowledges a healthy old-root scan, and only the locked commit lets the
 watcher adopt the candidate binding.  This avoids sharing the HTTP process's
 in-memory ``VaultManager`` state while making the two processes follow one
-durable binding.  The watcher changes its in-memory root only after its
-post-commit drain/resume receipt; no multi-active lifecycle is implied.
+ durable binding.  The watcher changes its in-memory root only after its
+ post-commit drain/resume receipt; an explicitly enabled watcher with no
+ bootstrap path remains idle until the picker commits its first durable
+ candidate, which it then adopts after revalidating the candidate vault's
+ local watcher permission. No multi-active lifecycle is implied.
 
 Health reads the durable phase/revision and heartbeat together.  A missing,
 invalid, or incomplete handoff remains visibly degraded; a display-only

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -802,6 +802,31 @@ def load_registry_config(config_path: Path) -> RegistryConfig:
     return RegistryConfig.from_env(specs, config_path=config_path)
 
 
+def _adopt_idle_selected_binding(
+    cfg: RegistryConfig,
+    reconciler: DormantSettingsRebindReconciler | None,
+) -> None:
+    """Start an explicitly enabled watcher after its initial idle selection.
+
+    ``WATCHER_ENABLE=1`` with no bootstrap path is a supported running-idle
+    posture. The first picker selection is committed as ``no_lifecycle``
+    because no old root exists to bracket; the long-lived watcher then adopts
+    that durable candidate. ``WATCHER_ENABLE=0`` remains disabled.
+    """
+
+    if cfg.enable or reconciler is None:
+        return
+    if not _as_bool(env_str("WATCHER_ENABLE")):
+        return
+    if (os.getenv("WATCHER_VAULT_PATH") or "").strip():
+        return
+    record = reconciler.current_record()
+    if record.phase != "no_lifecycle" or record.candidate_binding_id is None:
+        return
+    cfg.vault_path = reconciler.candidate_vault_path(record)
+    cfg.enable = True
+
+
 def _state_path(state_dir: Path, name: str) -> Path:
     safe = "".join([c if c.isalnum() or c in {"-", "_"} else "_" for c in name])
     return state_dir / f"watcher_state_{safe}.json"
@@ -2355,6 +2380,7 @@ def run_registry_once(
 ) -> dict[str, dict[str, object]]:
     cfg = _loaded_config or load_registry_config(config_path)
     reconciler = DormantSettingsRebindReconciler.from_config(cfg)
+    _adopt_idle_selected_binding(cfg, reconciler)
     rebind_cycle = reconciler.begin_cycle(cfg) if reconciler is not None else None
     if rebind_cycle is not None and rebind_cycle.mode == "stable":
         cfg.vault_path = reconciler.candidate_vault_path(rebind_cycle.record)
@@ -2421,6 +2447,7 @@ def run_registry_forever(
 ) -> None:
     cfg = _loaded_config or load_registry_config(config_path)
     reconciler = DormantSettingsRebindReconciler.from_config(cfg)
+    _adopt_idle_selected_binding(cfg, reconciler)
     startup_rebind_cycle = reconciler.begin_cycle(cfg) if reconciler is not None else None
     if startup_rebind_cycle is not None and startup_rebind_cycle.mode == "stable":
         # A fresh watcher process may still boot from the old environment
@@ -2448,6 +2475,8 @@ def run_registry_forever(
 
     tick = 0
     while True:
+        if tick != 0:
+            _adopt_idle_selected_binding(cfg, reconciler)
         rebind_cycle = (
             startup_rebind_cycle
             if tick == 0

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -2356,6 +2356,8 @@ def run_registry_once(
     cfg = _loaded_config or load_registry_config(config_path)
     reconciler = DormantSettingsRebindReconciler.from_config(cfg)
     rebind_cycle = reconciler.begin_cycle(cfg) if reconciler is not None else None
+    if rebind_cycle is not None and rebind_cycle.mode == "stable":
+        cfg.vault_path = reconciler.candidate_vault_path(rebind_cycle.record)
     rebind_observation_revision = (
         rebind_cycle.record.desired_revision
         if rebind_cycle is not None
@@ -2419,6 +2421,12 @@ def run_registry_forever(
 ) -> None:
     cfg = _loaded_config or load_registry_config(config_path)
     reconciler = DormantSettingsRebindReconciler.from_config(cfg)
+    startup_rebind_cycle = reconciler.begin_cycle(cfg) if reconciler is not None else None
+    if startup_rebind_cycle is not None and startup_rebind_cycle.mode == "stable":
+        # A fresh watcher process may still boot from the old environment
+        # binding.  Resolve the completed durable candidate before startup
+        # ingestion or the first scan, so restart cannot observe old-root work.
+        cfg.vault_path = reconciler.candidate_vault_path(startup_rebind_cycle.record)
     # `watcher run` is the production entrypoint.  Compile its bound vault at
     # boot just as API and worker do; the registry config is authoritative for
     # this process and need not depend on VAULT_ROOT being set separately.
@@ -2440,7 +2448,11 @@ def run_registry_forever(
 
     tick = 0
     while True:
-        rebind_cycle = reconciler.begin_cycle(cfg) if reconciler is not None else None
+        rebind_cycle = (
+            startup_rebind_cycle
+            if tick == 0
+            else (reconciler.begin_cycle(cfg) if reconciler is not None else None)
+        )
         rebind_observation_revision = (
             rebind_cycle.record.desired_revision
             if rebind_cycle is not None

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -2388,11 +2388,13 @@ def run_registry_once(
     )
     summaries["journal_review"] = _run_journal_review_tick(cfg)
     if reconciler is not None and rebind_cycle is not None:
-        reconciler.finish_cycle(
+        receipt = reconciler.finish_cycle(
             rebind_cycle,
             summaries=summaries,
             states=states,
         )
+        if receipt is not None and receipt.stage == "completed":
+            cfg.vault_path = reconciler.candidate_vault_path(rebind_cycle.record)
     enqueue_failures_total = sum(state.enqueue_failures_total for state in states.values())
     write_registry_heartbeat(
         path=cfg.heartbeat_path,
@@ -2466,11 +2468,13 @@ def run_registry_forever(
         )
         summaries["journal_review"] = _run_journal_review_tick(cfg)
         if reconciler is not None and rebind_cycle is not None:
-            reconciler.finish_cycle(
+            receipt = reconciler.finish_cycle(
                 rebind_cycle,
                 summaries=summaries,
                 states=states,
             )
+            if receipt is not None and receipt.stage == "completed":
+                cfg.vault_path = reconciler.candidate_vault_path(rebind_cycle.record)
         enqueue_failures_total = sum(state.enqueue_failures_total for state in states.values())
         write_registry_heartbeat(
             path=cfg.heartbeat_path,

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -371,9 +371,9 @@ class DormantSettingsRebindReconciler:
                 receipt=None,
             )
         self._validate_record_bindings(record)
-        self._validate_old_root(snapshot, record, cfg)
-        receipt = self._load_matching_receipt(record)
         if record.phase == "prepared":
+            self._validate_old_root(snapshot, record, cfg)
+            receipt = self._load_matching_receipt(record)
             if receipt is not None and receipt.stage != "acknowledged":
                 raise RegistryError(
                     "prepared settings rebind has an invalid watcher receipt stage"
@@ -381,10 +381,17 @@ class DormantSettingsRebindReconciler:
             return RebindCycle(record=record, mode="prepared", receipt=receipt)
         if record.phase != "committed":
             raise RegistryError("settings rebind watcher phase is unsupported")
+        receipt = self._load_matching_receipt(record)
         if receipt is None:
             raise RegistryError(
                 "committed settings rebind has no durable watcher acknowledgement"
             )
+        if receipt.stage == "completed":
+            # The foreground loop updates cfg.vault_path to the candidate after
+            # completing a transition.  A completed receipt is stable state,
+            # not another old-root transition to validate on the next tick.
+            return RebindCycle(record=record, mode="stable", receipt=receipt)
+        self._validate_old_root(snapshot, record, cfg)
         _rebind_fault_point("commit")
         return RebindCycle(record=record, mode="committed", receipt=receipt)
 

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -335,6 +335,11 @@ class DormantSettingsRebindReconciler:
         self._store = SettingsRebindStore(self._registry)
         self.state_dir = state_dir
 
+    def current_record(self) -> SettingsRebindRecord:
+        """Read the current durable rebind authority for loop reconciliation."""
+
+        return self._store.read()
+
     @classmethod
     def from_config(
         cls,
@@ -498,7 +503,22 @@ class DormantSettingsRebindReconciler:
         registration = self._registry.load().registrations.get(candidate)
         if registration is None:
             raise RegistryError("settings rebind candidate watcher binding is missing")
-        return Path(registration.path)
+        candidate_path = Path(registration.path)
+        # Registration proves identity, not watcher permission. Revalidate the
+        # candidate at the adoption seam immediately before changing roots.
+        from app.vault.manager import VaultManager
+
+        manager = VaultManager()
+        context = manager.validate_vault(candidate_path)
+        if context.status != "selected":
+            raise RegistryError(
+                "settings rebind candidate watcher root is not a selected vault"
+            )
+        if not manager.permissions_for_context(context).enable_vault_watcher:
+            raise RegistryError(
+                "settings rebind candidate watcher root is disabled by local settings"
+            )
+        return candidate_path
 
     def _receipt_path(self, record: SettingsRebindRecord) -> Path:
         return settings_rebind_watcher_receipt_path(

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -481,6 +481,18 @@ class DormantSettingsRebindReconciler:
         _write_receipt(self._receipt_path(cycle.record), completed)
         return completed
 
+    def candidate_vault_path(self, record: SettingsRebindRecord) -> Path:
+        """Resolve the committed candidate for the next watcher tick."""
+
+        candidate = self._required_binding(
+            record.candidate_binding_id,
+            name="candidate",
+        )
+        registration = self._registry.load().registrations.get(candidate)
+        if registration is None:
+            raise RegistryError("settings rebind candidate watcher binding is missing")
+        return Path(registration.path)
+
     def _receipt_path(self, record: SettingsRebindRecord) -> Path:
         return settings_rebind_watcher_receipt_path(
             self.state_dir,

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -410,6 +410,10 @@ class DormantSettingsRebindReconciler:
         if cycle.mode not in {"prepared", "committed"}:
             return cycle.receipt
         self._assert_scan_success(summaries)
+        # Validate policy before acknowledging or completing the handoff. A
+        # completed receipt is an API-visible resume authority, so it must not
+        # be written for a candidate the watcher is forbidden to adopt.
+        self.candidate_vault_path(cycle.record)
         observations = self._observations(
             summaries,
             states=states,

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -23,7 +23,11 @@ from app.instance.filesystem_identity import (
     resolve_filesystem_root_identity,
     same_filesystem_root,
 )
-from app.instance.settings_rebind import SettingsRebindRecord, SettingsRebindStore
+from app.instance.settings_rebind import (
+    SettingsRebindRecord,
+    SettingsRebindStore,
+    validate_settings_rebind_candidate_root,
+)
 from app.instance.vault_registry import RegistrySnapshot, VaultRegistryStore
 
 if TYPE_CHECKING:
@@ -507,22 +511,9 @@ class DormantSettingsRebindReconciler:
         registration = self._registry.load().registrations.get(candidate)
         if registration is None:
             raise RegistryError("settings rebind candidate watcher binding is missing")
-        candidate_path = Path(registration.path)
         # Registration proves identity, not watcher permission. Revalidate the
         # candidate at the adoption seam immediately before changing roots.
-        from app.vault.manager import VaultManager
-
-        manager = VaultManager()
-        context = manager.validate_vault(candidate_path)
-        if context.status != "selected":
-            raise RegistryError(
-                "settings rebind candidate watcher root is not a selected vault"
-            )
-        if not manager.permissions_for_context(context).enable_vault_watcher:
-            raise RegistryError(
-                "settings rebind candidate watcher root is disabled by local settings"
-            )
-        return candidate_path
+        return validate_settings_rebind_candidate_root(Path(registration.path))
 
     def _receipt_path(self, record: SettingsRebindRecord) -> Path:
         return settings_rebind_watcher_receipt_path(

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -175,15 +175,15 @@ Writing the host path into the container's `VAULT_ROOT` is what made `resolve_va
 
 A **third** independent binding slot exists alongside the two above, and it is the one most likely to silently diverge from the human's expectation: the **watcher/worker's own boot-time binding**, governed by `WATCHER_VAULT_PATH` (`app/watcher/config.py`), not by `VAULT_ROOT` and not by the API process's in-process `VaultManager` selection.
 
-This split is **deliberate, documented architecture**, not a bug: the watcher is a background daemon with an independent lifecycle, and converging it onto the HTTP process's in-memory `VaultManager` singleton would couple a background daemon to an HTTP runtime boundary it must not own (`app/watcher/config.py` module docstring, #2476 — "document the split, do not converge"). Three binding slots, three sources:
+The watcher is still a separately deployed daemon and `WATCHER_VAULT_PATH` is still its bootstrap adapter. The former #2476 posture ("document the split, do not converge") is superseded for the one compatibility lifecycle by SETTINGS-05C: the picker and watcher do not share the HTTP process's in-memory `VaultManager`, but they do converge through the protected, checksummed `settings_rebind.v1` transaction. Three inputs remain distinct:
 
 - **API vault selection** — `VaultManager` in-process state (`app/vault/manager.py`), set by `POST /api/companion/vault/select` / `/vault/initialize`. This is what "vault selected through the Companion UI" means.
 - **`VAULT_ROOT` runtime binding** — the API process's own env/boot pointer (§Vault terminology above), read by `resolve_vault_root()` / `resolve_optional_vault_root()`.
-- **Watcher/worker ingest binding** — `WATCHER_VAULT_PATH`, read once at watcher boot (`RegistryConfig.from_env` / `WatcherConfig.from_env`) and frozen for the process lifetime; there is no live rebind on a later API-side selection.
+- **Watcher/worker ingest binding** — `WATCHER_VAULT_PATH` at boot, then the durable SETTINGS-05C candidate after prepare, old-root acknowledgement, commit, drain, and resume. The watcher changes its in-memory root only after the committed receipt; this is one compatibility lifecycle, not multi-active support.
 
-**The gap this creates.** A vault chosen or initialized entirely through the Companion UI picker (the primary new-user path, #3102) — with no prior `VAULT_HOST_ROOT`/`WATCHER_VAULT_PATH` binding — sets only the first of these three. The watcher/worker continue watching whatever (if anything) `WATCHER_VAULT_PATH` pointed to at container boot. A capture can therefore write successfully to disk while remaining permanently invisible to ingest/embed/retrieval, with no error surfaced anywhere (#3119).
+**The pre-SETTINGS-05C gap.** A vault chosen or initialized entirely through the Companion UI picker (the primary new-user path, #3102) could set only the first slot. That was the #3119 failure: capture could write successfully while remaining invisible to ingest/embed/retrieval. The activated path now holds compatibility mutation ingress closed during the handoff and returns success only after the durable commit.
 
-**Resolution: make the divergence visible, not silently self-healing.** Rather than restructuring the watcher's boot-time-frozen config/tick loop to support live rebind (a materially larger change to an intentionally independent daemon), the API compares its selected vault path against the path the watcher last self-reported via its heartbeat file (`app/watcher/heartbeat.py :: write_registry_heartbeat`, which already carries a `vault_path` field every tick). This comparison lives in `app.api.routes.ingest_binding.ingest_binding_status()` and reports one of four states:
+**Resolution: durable rebind plus visible phase truth.** The API writes the protected transaction; the separate watcher consumes it and reports its root through the heartbeat. `app.api.routes.ingest_binding.ingest_binding_status()` compares the heartbeat to the selected path and also exposes the rebind schema, phase, desired/applied revisions, lifecycle posture, and failure posture. It reports one of four binding states:
 
 - `"bound"` — the watcher's fresh heartbeat confirms the same vault path.
 - `"diverged"` — the watcher is alive but bound to a *different* vault.
@@ -192,7 +192,7 @@ This split is **deliberate, documented architecture**, not a bug: the watcher is
 
 This status is surfaced on two paths: `GET /api/companion/workspace`'s `runtime.ingest` block (consumed by the Companion UI shell as an `workspace-ingest-unbound-banner`, independent of the existing vault-unreachable banner), and `POST /api/companion/capture`'s `ingest_warning` field (an advisory string alongside the `written` acknowledgement — the write itself is never gated or delayed by this check). Both degrade to a visible warning rather than raising, so a heartbeat-read failure cannot itself become a new outage.
 
-Full live propagation (watcher automatically rebinding without restart) remains out of scope here — see #2143 (multi-vault registry) for where that would eventually live.
+The watcher may continue in its current process after a completed handoff, but only one compatibility root is active at a time. Generic multi-vault request/session selection and multi-active background lifecycle remain out of scope; MVR-06B owns the later supervisor handoff.
 
 ### Full-host access for in-process vault selection (#2310)
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -49,12 +49,13 @@ explain payload reports the effective identity and origin.
 Vault selection and the separately deployed watcher use the protected
 `settings_rebind.v1` compatibility transaction. A picker change is prepared,
 the old watcher root is acknowledged and drained, and selection plus binding
-are committed in one registry generation before the Settings Spine reloads.
-The watcher then resumes on the candidate root. `WATCHER_VAULT_PATH` remains a
-startup/bootstrap input, while health reads the durable phase and desired /
-applied revisions; compiled display fields never choose a binding. Only one
-compatibility watcher root is active at a time. Generic multi-vault lifecycle
-supervision remains owned by the later MVR handoff.
+are committed in one registry generation. The watcher then resumes on the
+candidate root, after which the Settings Spine reloads exactly once for the
+committed revision. `WATCHER_VAULT_PATH` remains a startup/bootstrap input,
+while health reads the durable phase and desired / applied / reload revisions;
+compiled display fields never choose a binding. Only one compatibility watcher
+root is active at a time. Generic multi-vault lifecycle supervision remains
+owned by the later MVR handoff.
 
 Settings tiering guidance (operator-facing vs dev/lab-only), inventory, and migration targets are described below.
 Runtime profile switch for tier enforcement: `PKM_SETTINGS_PROFILE=operator|lab` (default `operator`).

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -51,8 +51,11 @@ Vault selection and the separately deployed watcher use the protected
 the old watcher root is acknowledged and drained, and selection plus binding
 are committed in one registry generation. The watcher then resumes on the
 candidate root, after which the Settings Spine reloads exactly once for the
-committed revision. `WATCHER_VAULT_PATH` remains a startup/bootstrap input,
-while health reads the durable phase and desired / applied / reload revisions;
+committed revision after durable completion. If a process dies after the
+idempotent reload callback but before its completion marker is written,
+recovery may replay that callback; the marker prevents a second reload after
+completion. `WATCHER_VAULT_PATH` remains a startup/bootstrap input, while
+health reads the durable phase and desired / applied / reload revisions;
 compiled display fields never choose a binding. Only one compatibility watcher
 root is active at a time. Generic multi-vault lifecycle supervision remains
 owned by the later MVR handoff.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -44,6 +44,18 @@ the compiled provider. `llm_routing.timeout_seconds` and `.temperature` feed the
 same route; `LLM_TIMEOUT` and `LLM_TEMPERATURE` remain bootstrap overrides. The
 explain payload reports the effective identity and origin.
 
+## Authority
+
+Vault selection and the separately deployed watcher use the protected
+`settings_rebind.v1` compatibility transaction. A picker change is prepared,
+the old watcher root is acknowledged and drained, and selection plus binding
+are committed in one registry generation before the Settings Spine reloads.
+The watcher then resumes on the candidate root. `WATCHER_VAULT_PATH` remains a
+startup/bootstrap input, while health reads the durable phase and desired /
+applied revisions; compiled display fields never choose a binding. Only one
+compatibility watcher root is active at a time. Generic multi-vault lifecycle
+supervision remains owned by the later MVR handoff.
+
 Settings tiering guidance (operator-facing vs dev/lab-only), inventory, and migration targets are described below.
 Runtime profile switch for tier enforcement: `PKM_SETTINGS_PROFILE=operator|lab` (default `operator`).
 

--- a/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
+++ b/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
@@ -77,6 +77,13 @@ GET  /api/health -> watcher.ingest_binding.status == "bound"
 # a new file under the committed binding is ingested without a container restart
 ```
 
+When the watcher is explicitly enabled but has no bootstrap path, it stays
+running-idle until the picker commits the first selection. That initial
+selection is allowed to use the durable `no_lifecycle` posture because there
+is no old root to bracket; the watcher then adopts the committed candidate
+from the protected registry and revalidates the candidate vault's local
+watcher permission at the adoption seam.
+
 ## Why This Matters
 
 Selection can be the compatibility source of truth only when the independently deployed watcher

--- a/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
+++ b/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
@@ -56,7 +56,10 @@ Those substrate and registry responsibilities are owned by MVR-01:
 - Activates the production compatibility picker transaction only after the durable record and watcher
   reconciler are proven. The picker closes and drains compatibility-mutation ingress, prepares the
   revision, waits for watcher quiescence (or durable `no_lifecycle`), commits selection and binding,
-  then resumes the watcher and invokes the SETTINGS-01 reload path exactly once. `VaultChangedEvent`
+  then resumes the watcher and invokes the SETTINGS-01 reload path exactly once after durable
+  completion. If a process dies after the idempotent reload callback but before the completion
+  marker is written, recovery may replay that same callback; the durable marker prevents a second
+  reload after completion. `VaultChangedEvent`
   remains an optional same-process wake-up hint, never cross-process delivery authority.
 - Recovers pre-commit failure by cancelling and resuming A before ingress reopens. Post-commit recovery
   rolls forward while ingress remains blocked until the old-root scan/buffer drain and resume finish.

--- a/docs/testing/invariant-tests.md
+++ b/docs/testing/invariant-tests.md
@@ -90,6 +90,24 @@ declarative-schema-impossible and therefore live here as the source of truth.
   `docs/SETTINGS_SPINE/CANONICALIZE_SETTINGS_LOCATION.md`.
 - **Related issues:** #3156, #3161.
 
+### vault_selection_rebinds_consumers
+
+- **Purpose:** The legacy compatibility picker and separately deployed watcher follow one
+  protected `settings_rebind.v1` prepare/acknowledge/commit/drain/resume transaction.
+- **Protected principle:** No candidate-root effect before commit; no success before the
+  durable commit; the watcher changes roots only after its post-commit receipt.
+- **Expected failure mode:** stale or malformed phase/revision, unhealthy A scan, lost watcher
+  receipt, or a reload failure is visible and never silently redirects work to B.
+- **Current enforcement:** runtime tests in
+  `tests/watcher/test_ingest_binding_follows_selection.py` and
+  `tests/integration/test_watcher_cross_process_rebind.py`; health exposes phase and revisions.
+- **Runtime test path:** `tests/watcher/test_ingest_binding_follows_selection.py`;
+  `tests/integration/test_watcher_cross_process_rebind.py`.
+- **Related docs / contracts / ADRs:** `docs/SETTINGS.md :: Authority`;
+  `docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md`;
+  `docs/MULTI_VAULT_RUNTIME/BIND_BACKGROUND_LIFECYCLES.md :: Compatibility lifecycle`.
+- **Related issues:** #3156, #3163, #4969.
+
 ### inv_ef1_public_private_seam
 
 - **Purpose:** The public repository carries no secret-shaped values, and every retained personal binding has an owned, per-artifact INV-EF1 register row rather than an unreviewed baseline exception.

--- a/tests/integration/test_settings_rebind_record.py
+++ b/tests/integration/test_settings_rebind_record.py
@@ -9,6 +9,7 @@ from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
 from app.instance.settings_rebind import (
     SettingsRebindRecord,
+    _checksum,
     _install_dormant_settings_rebind,
 )
 from app.instance.vault_registry import VaultRegistration
@@ -135,3 +136,24 @@ def test_delayed_writer_cannot_regress_durable_rebind_revision(tmp_path: Path) -
             _capability=STORAGE_MUTATION_CAPABILITY,
         )
     assert store.read() == committed
+
+
+def test_markerless_legacy_record_normalizes_reload_revision_before_write() -> None:
+    legacy = SettingsRebindRecord(
+        desired_revision=1,
+        applied_revision=1,
+        phase="no_lifecycle",
+        lifecycle_posture="no_lifecycle",
+        prior_binding_id="binding-a",
+        candidate_binding_id="binding-b",
+    ).as_payload()
+    legacy.pop("reloadRevision")
+    legacy.pop("checksum")
+    legacy["checksum"] = _checksum(legacy)
+
+    parsed = SettingsRebindRecord.from_payload(legacy)
+
+    assert parsed.reload_revision is None
+    normalized = parsed.as_payload()
+    assert normalized["reloadRevision"] == 0
+    assert SettingsRebindRecord.from_payload(normalized).reload_revision == 0

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -895,6 +895,56 @@ def test_candidate_watcher_permission_is_revalidated_at_adoption(
         reconciler.candidate_vault_path(record)
 
 
+def test_disabled_candidate_cannot_complete_api_rebind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Candidate policy failure leaves the API transition prepared, not complete."""
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    runtime, _vault_a, vault_b, config_path = _fixture(
+        tmp_path, monkeypatch, enabled=True, prepare=False
+    )
+    local_path = vault_b / "settings" / "local.md"
+    settings_store = MarkdownSettingsStore()
+    local_doc = settings_store.read(local_path)
+    frontmatter = dict(local_doc.frontmatter)
+    frontmatter["enableVaultWatcher"] = False
+    settings_store.write_frontmatter(local_path, frontmatter, body=local_doc.body)
+    registration = runtime.registry.load().registrations["binding-b"]
+    selection = KnownVaultRef(
+        ref=registration.ref,
+        path=registration.path,
+        vault_id=registration.vault_id,
+        vault_name=registration.vault_name,
+        local_instance_id=registration.local_instance_id,
+        last_opened_at="2026-08-30T00:00:00Z",
+    )
+
+    def run_watcher_for_ack(
+        _activation: SettingsRebindActivation,
+        _record: SettingsRebindRecord,
+        *,
+        required_stage: str,
+    ) -> None:
+        assert required_stage == "acknowledged"
+        registry.run_registry_once(config_path)
+
+    monkeypatch.setattr(SettingsRebindActivation, "_wait_for_stage", run_watcher_for_ack)
+    with pytest.raises(RegistryError, match="disabled by local settings"):
+        SettingsRebindActivation(
+            runtime.registry,
+            watcher_state_dir=tmp_path / "watcher-state",
+            watcher_enabled=True,
+        ).activate(
+            selection=selection,
+            candidate_binding_id="binding-b",
+            candidate_root=vault_b,
+        )
+
+    assert runtime.open_settings_rebind_store().read().phase == "prepared"
+    assert not (tmp_path / "watcher-state" / "settings-rebind-watcher-r1.json").exists()
+
+
 def test_same_target_prepared_selection_finishes_durable_commit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -152,6 +152,7 @@ def _fixture(
     monkeypatch: pytest.MonkeyPatch,
     *,
     enabled: bool = True,
+    prepare: bool = True,
 ) -> tuple[InstanceRegistryRuntime, Path, Path, Path]:
     vault_a = tmp_path / "vault-a"
     vault_b = tmp_path / "vault-b"
@@ -180,7 +181,8 @@ def _fixture(
     outbox_path = tmp_path / "index-outbox.jsonl"
     if outbox_path.exists():
         outbox_path.unlink()
-    _prepare(runtime)
+    if prepare:
+        _prepare(runtime)
     return runtime, vault_a, vault_b, config_path
 
 
@@ -709,7 +711,18 @@ def test_settings05_parent_acceptance(
     """The production API seam and the separate watcher converge end-to-end."""
     from app.vault.manager import VaultManager
 
-    runtime, _vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    runtime, _vault_a, vault_b, config_path = _fixture(
+        tmp_path,
+        monkeypatch,
+        prepare=False,
+    )
+    # This acceptance test exercises the production picker as the prepare
+    # producer, so begin from the durable A binding rather than the prepared
+    # B revision used by the watcher-only scenarios above.
+    monkeypatch.setenv(
+        "WATCHER_STATE_DIR",
+        str(tmp_path / "acceptance-watcher-state"),
+    )
     monkeypatch.setenv("SETTINGS_REBIND_WAIT_TIMEOUT_SECONDS", "15")
     monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
     monkeypatch.setattr(

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -11,6 +11,8 @@ import time
 
 import pytest
 
+from app.settings.ingestion import SettingsIngestionState
+from app.vault.markdown_settings import MarkdownSettingsStore
 from app.instance._storage_boundary import RegistryError
 from app.instance.instance_state import InstanceStateLayout
 from app.instance.runtime import InstanceRegistryRuntime
@@ -23,6 +25,7 @@ from app.instance.vault_registry import KnownVaultRef
 from app.api.routes.ingest_binding import ingest_binding_status
 from app.watcher import registry
 from app.watcher.settings_rebind import (
+    DormantSettingsRebindReconciler,
     _write_receipt,
     SettingsRebindWatcherReceipt,
     load_settings_rebind_watcher_receipt,
@@ -32,6 +35,19 @@ from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILIT
 from tests.helpers.vault_settings import initialize_test_vault
 
 pytestmark = pytest.mark.not_pg
+
+
+def _successful_reload(**kwargs: object) -> SettingsIngestionState:
+    del kwargs
+    return SettingsIngestionState(state="ok", source="vault")
+
+
+def _record_reload(reloads: list[Path]):
+    def callback(**kwargs: object) -> SettingsIngestionState:
+        reloads.append(Path(kwargs["vault_root"]))
+        return _successful_reload()
+
+    return callback
 
 
 def _runtime(root: Path) -> InstanceRegistryRuntime:
@@ -646,7 +662,7 @@ def test_prepare_commit_resume_is_failure_atomic(
     reloads: list[Path] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+        _record_reload(reloads),
     )
 
     def fail_once(stage: str) -> None:
@@ -725,7 +741,7 @@ def test_reload_callback_success_before_marker_allows_one_idempotent_replay(
     reloads: list[Path] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+        _record_reload(reloads),
     )
     registration = runtime.registry.load().registrations["binding-b"]
     selection = KnownVaultRef(
@@ -834,6 +850,51 @@ def test_disabled_watcher_is_durable_no_lifecycle(
     assert record.desired_revision == record.applied_revision == 1
 
 
+def test_enabled_idle_watcher_adopts_first_durable_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """WATCHER_ENABLE=1 without a path idles, then adopts the first selection."""
+    from app.vault.manager import VaultManager
+
+    runtime, _vault_a, vault_b, config_path = _fixture(
+        tmp_path, monkeypatch, enabled=False
+    )
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.delenv("WATCHER_VAULT_PATH")
+    VaultManager().select_vault(vault_b)
+
+    registry.run_registry_once(config_path)
+
+    heartbeat = json.loads(
+        (tmp_path / "watcher-heartbeat.json").read_text(encoding="utf-8")
+    )
+    assert heartbeat["vault_path"] == str(vault_b)
+    assert runtime.open_settings_rebind_store().read().phase == "no_lifecycle"
+
+
+def test_candidate_watcher_permission_is_revalidated_at_adoption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A registered candidate with watcher disabled cannot become a scan root."""
+    runtime, _vault_a, vault_b, _config_path = _fixture(
+        tmp_path, monkeypatch, enabled=False, prepare=False
+    )
+    local_path = vault_b / "settings" / "local.md"
+    settings_store = MarkdownSettingsStore()
+    local_doc = settings_store.read(local_path)
+    frontmatter = dict(local_doc.frontmatter)
+    frontmatter["enableVaultWatcher"] = False
+    settings_store.write_frontmatter(local_path, frontmatter, body=local_doc.body)
+    record = _commit(runtime)
+    reconciler = DormantSettingsRebindReconciler(
+        registry_path=runtime.registry.path,
+        state_dir=tmp_path / "watcher-state",
+    )
+
+    with pytest.raises(RegistryError, match="disabled by local settings"):
+        reconciler.candidate_vault_path(record)
+
+
 def test_same_target_prepared_selection_finishes_durable_commit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -846,7 +907,7 @@ def test_same_target_prepared_selection_finishes_durable_commit(
     reloads: list[Path] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+        _record_reload(reloads),
     )
 
     selected = VaultManager().select_vault(vault_b)
@@ -873,7 +934,7 @@ def test_concurrent_same_target_callers_wait_for_commit_and_resume(
     reloads: list[Path] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+        _record_reload(reloads),
     )
     registration = runtime.registry.load().registrations["binding-b"]
     selection = KnownVaultRef(
@@ -962,7 +1023,7 @@ def test_settings05_parent_acceptance(
     monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **_kwargs: None,
+        _successful_reload,
     )
     process_env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[2]

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -753,6 +753,8 @@ def test_settings05_parent_acceptance(
             if record.phase == "committed" and str(post_commit) in _event_paths(tmp_path):
                 break
             time.sleep(0.05)
+        if process.poll() is None:
+            process.terminate()
         stdout, stderr = process.communicate(timeout=30)
     finally:
         if process.poll() is None:

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -760,7 +760,10 @@ def test_settings05_parent_acceptance(
         if process.poll() is None:
             process.kill()
             process.communicate(timeout=5)
-    assert process.returncode == 0, stdout + stderr
+    # The long-lived child is intentionally terminated after the durable
+    # commit/event observation; a naturally exhausted max-ticks run is also
+    # accepted.
+    assert process.returncode in {0, -15}, stdout + stderr
     record = runtime.open_settings_rebind_store().read()
     assert record.phase == "committed"
     assert record.desired_revision == record.applied_revision == 1

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -872,6 +872,30 @@ def test_enabled_idle_watcher_adopts_first_durable_selection(
     assert runtime.open_settings_rebind_store().read().phase == "no_lifecycle"
 
 
+def test_idle_enabled_watcher_rejects_disabled_first_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The idle-enabled API path validates watcher policy before no_lifecycle commit."""
+    from app.vault.manager import VaultManager
+
+    runtime, _vault_a, vault_b, _config_path = _fixture(
+        tmp_path, monkeypatch, enabled=False
+    )
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.delenv("WATCHER_VAULT_PATH")
+    local_path = vault_b / "settings" / "local.md"
+    settings_store = MarkdownSettingsStore()
+    local_doc = settings_store.read(local_path)
+    frontmatter = dict(local_doc.frontmatter)
+    frontmatter["enableVaultWatcher"] = False
+    settings_store.write_frontmatter(local_path, frontmatter, body=local_doc.body)
+
+    with pytest.raises(RegistryError, match="disabled by local settings"):
+        VaultManager().select_vault(vault_b)
+
+    assert runtime.open_settings_rebind_store().read().phase == "prepared"
+
+
 def test_candidate_watcher_permission_is_revalidated_at_adoption(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -664,11 +664,13 @@ def test_prepare_commit_resume_is_failure_atomic(
         )
 
     record = runtime.open_settings_rebind_store().read()
-    assert record.candidate_binding_id == "binding-a"
-    assert runtime.registry.load().last_active_vault_ref is None
     if fault_stage == "prepare":
+        assert record.candidate_binding_id == "binding-a"
+        assert runtime.registry.load().last_active_vault_ref is None
         assert record.phase == "dormant"
     else:
+        assert record.candidate_binding_id == "binding-b"
+        assert runtime.registry.load().last_active_vault_ref == registration.ref
         assert record.phase == "no_lifecycle"
 
 
@@ -707,6 +709,7 @@ def test_settings05_parent_acceptance(
     from app.vault.manager import VaultManager
 
     runtime, _vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    monkeypatch.setenv("SETTINGS_REBIND_WAIT_TIMEOUT_SECONDS", "15")
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
         lambda **_kwargs: None,
@@ -728,7 +731,7 @@ def test_settings05_parent_acceptance(
             "--config",
             str(config_path),
             "--max-ticks",
-            "6",
+            "100",
         ],
         cwd=repo_root,
         env=process_env,

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -702,6 +702,79 @@ def test_prepare_commit_resume_is_failure_atomic(
         assert reloads == [vault_b]
 
 
+def test_reload_callback_success_before_marker_allows_one_idempotent_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker-write crash replays once, then durable completion suppresses retries."""
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    runtime = _runtime(tmp_path)
+    _register(runtime, binding_id="binding-a", vault_root=vault_a)
+    _register(runtime, binding_id="binding-b", vault_root=vault_b)
+    _install_dormant_settings_rebind(
+        runtime.registry,
+        binding_id="binding-a",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+    )
+    registration = runtime.registry.load().registrations["binding-b"]
+    selection = KnownVaultRef(
+        ref=registration.ref,
+        path=registration.path,
+        vault_id=registration.vault_id,
+        vault_name=registration.vault_name,
+        local_instance_id=registration.local_instance_id,
+        last_opened_at="2026-08-30T00:00:00Z",
+    )
+    activation = SettingsRebindActivation.from_environment(runtime.registry)
+    original_write_locked = runtime.registry._write_locked
+    tripped = False
+
+    def fail_marker_write(snapshot: object) -> None:
+        nonlocal tripped
+        payload = getattr(snapshot, "settings_rebind", None)
+        if isinstance(payload, dict) and payload.get("reloadRevision") == 1 and not tripped:
+            tripped = True
+            raise RuntimeError("simulated marker write crash")
+        original_write_locked(snapshot)
+
+    monkeypatch.setattr(runtime.registry, "_write_locked", fail_marker_write)
+    with pytest.raises(RuntimeError, match="simulated marker write crash"):
+        activation.activate(
+            selection=selection,
+            candidate_binding_id="binding-b",
+            candidate_root=vault_b,
+        )
+    assert reloads == [vault_b]
+    assert runtime.open_settings_rebind_store().read().reload_revision == 0
+
+    monkeypatch.setattr(runtime.registry, "_write_locked", original_write_locked)
+    activation.activate(
+        selection=selection,
+        candidate_binding_id="binding-b",
+        candidate_root=vault_b,
+    )
+    assert reloads == [vault_b, vault_b]
+    assert runtime.open_settings_rebind_store().read().reload_revision == 1
+
+    activation.activate(
+        selection=selection,
+        candidate_binding_id="binding-b",
+        candidate_root=vault_b,
+    )
+    assert reloads == [vault_b, vault_b]
+
+
 def test_committed_revision_survives_event_loss_and_process_restart(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -681,7 +681,7 @@ def test_committed_revision_survives_event_loss_and_process_restart(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    runtime, _vault_a, _vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    runtime, vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
     registry.run_registry_forever(config_path, max_ticks=1)
     _commit(runtime)
     registry.run_registry_forever(config_path, max_ticks=1)
@@ -689,6 +689,38 @@ def test_committed_revision_survives_event_loss_and_process_restart(
     restarted = _runtime(tmp_path)
     assert restarted.open_settings_rebind_store().read().phase == "committed"
     assert load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1)).stage == "completed"
+
+    after_restart = vault_b / "after-restart.md"
+    after_restart.write_text("candidate remains authoritative after restart\n", encoding="utf-8")
+    process_env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    existing_pythonpath = process_env.get("PYTHONPATH")
+    process_env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(repo_root), existing_pythonpath) if part
+    )
+    process_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "app.cli",
+            "watcher",
+            "run",
+            "--config",
+            str(config_path),
+            "--max-ticks",
+            "1",
+        ],
+        cwd=repo_root,
+        env=process_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert process.returncode == 0, process.stdout + process.stderr
+    assert str(after_restart) in _event_paths(tmp_path)
+    assert all(path == "" or path.startswith(str(vault_b)) for path in _event_paths(tmp_path))
+    assert str(vault_a) not in _event_paths(tmp_path)
 
 
 def test_disabled_watcher_is_durable_no_lifecycle(
@@ -701,6 +733,26 @@ def test_disabled_watcher_is_durable_no_lifecycle(
     registry.run_registry_once(config_path)
     record = runtime.open_settings_rebind_store().read()
     assert record.phase == "no_lifecycle"
+    assert record.desired_revision == record.applied_revision == 1
+
+
+def test_same_target_prepared_selection_finishes_durable_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A picker racing an existing prepared target must not bypass activation."""
+    from app.vault.manager import VaultManager
+
+    runtime, _vault_a, vault_b, _config_path = _fixture(tmp_path, monkeypatch)
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    monkeypatch.setattr("app.settings.ingestion.ingest_settings", lambda **_kwargs: None)
+
+    selected = VaultManager().select_vault(vault_b)
+
+    record = runtime.open_settings_rebind_store().read()
+    assert selected.active_vault_path == str(vault_b)
+    assert record.phase == "no_lifecycle"
+    assert record.candidate_binding_id == "binding-b"
     assert record.desired_revision == record.applied_revision == 1
 
 

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -710,6 +711,7 @@ def test_settings05_parent_acceptance(
 
     runtime, _vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
     monkeypatch.setenv("SETTINGS_REBIND_WAIT_TIMEOUT_SECONDS", "15")
+    monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
         lambda **_kwargs: None,
@@ -731,7 +733,7 @@ def test_settings05_parent_acceptance(
             "--config",
             str(config_path),
             "--max-ticks",
-            "100",
+            "600",
         ],
         cwd=repo_root,
         env=process_env,
@@ -739,11 +741,18 @@ def test_settings05_parent_acceptance(
         stderr=subprocess.PIPE,
         text=True,
     )
+    stdout = stderr = ""
     try:
         selected = VaultManager().select_vault(vault_b)
         assert selected.active_vault_path == str(vault_b)
         post_commit = vault_b / "post-commit.md"
         post_commit.write_text("visible after the durable commit\n", encoding="utf-8")
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            record = runtime.open_settings_rebind_store().read()
+            if record.phase == "committed" and str(post_commit) in _event_paths(tmp_path):
+                break
+            time.sleep(0.05)
         stdout, stderr = process.communicate(timeout=30)
     finally:
         if process.poll() is None:

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -621,7 +621,7 @@ def test_direct_filesystem_write_between_scan_and_commit_is_receipted_under_old_
     assert all(path.startswith(str(vault_a)) for path in _event_paths(tmp_path))
 
 
-@pytest.mark.parametrize("fault_stage", ["prepare", "commit", "reload"])
+@pytest.mark.parametrize("fault_stage", ["prepare", "commit", "reload", "reload_complete"])
 def test_prepare_commit_resume_is_failure_atomic(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -682,14 +682,18 @@ def test_prepare_commit_resume_is_failure_atomic(
         assert record.candidate_binding_id == "binding-b"
         assert runtime.registry.load().last_active_vault_ref == registration.ref
         assert record.phase == "no_lifecycle"
-        assert record.reload_revision == 0
-        activation.activate(
-            selection=selection,
-            candidate_binding_id="binding-b",
-            candidate_root=vault_b,
-        )
-        assert reloads == [vault_b]
-        assert runtime.open_settings_rebind_store().read().reload_revision == 1
+        if fault_stage == "reload_complete":
+            assert record.reload_revision == 1
+            assert reloads == [vault_b]
+        else:
+            assert record.reload_revision == 0
+            activation.activate(
+                selection=selection,
+                candidate_binding_id="binding-b",
+                candidate_root=vault_b,
+            )
+            assert reloads == [vault_b]
+            assert runtime.open_settings_rebind_store().read().reload_revision == 1
         activation.activate(
             selection=selection,
             candidate_binding_id="binding-b",
@@ -766,7 +770,11 @@ def test_same_target_prepared_selection_finishes_durable_commit(
 
     runtime, _vault_a, vault_b, _config_path = _fixture(tmp_path, monkeypatch)
     monkeypatch.setenv("WATCHER_ENABLE", "0")
-    monkeypatch.setattr("app.settings.ingestion.ingest_settings", lambda **_kwargs: None)
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+    )
 
     selected = VaultManager().select_vault(vault_b)
 
@@ -789,7 +797,11 @@ def test_concurrent_same_target_callers_wait_for_commit_and_resume(
         monkeypatch,
         prepare=False,
     )
-    monkeypatch.setattr("app.settings.ingestion.ingest_settings", lambda **_kwargs: None)
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+    )
     registration = runtime.registry.load().registrations["binding-b"]
     selection = KnownVaultRef(
         ref=registration.ref,
@@ -851,6 +863,7 @@ def test_concurrent_same_target_callers_wait_for_commit_and_resume(
     assert not errors
     assert len(results) == 2
     assert {result.phase for result in results} == {"committed"}
+    assert reloads == [vault_b]
 
 
 def test_settings05_parent_acceptance(

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import threading
 import time
 
 import pytest
@@ -754,6 +755,82 @@ def test_same_target_prepared_selection_finishes_durable_commit(
     assert record.phase == "no_lifecycle"
     assert record.candidate_binding_id == "binding-b"
     assert record.desired_revision == record.applied_revision == 1
+
+
+def test_concurrent_same_target_callers_wait_for_commit_and_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both same-target callers remain blocked until the protected transition resumes."""
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    runtime, _vault_a, vault_b, _config_path = _fixture(
+        tmp_path,
+        monkeypatch,
+        prepare=False,
+    )
+    monkeypatch.setattr("app.settings.ingestion.ingest_settings", lambda **_kwargs: None)
+    registration = runtime.registry.load().registrations["binding-b"]
+    selection = KnownVaultRef(
+        ref=registration.ref,
+        path=registration.path,
+        vault_id=registration.vault_id,
+        vault_name=registration.vault_name,
+        local_instance_id=registration.local_instance_id,
+        last_opened_at="2026-08-30T00:00:00Z",
+    )
+    acknowledge_barrier = threading.Barrier(2)
+    resume_event = threading.Event()
+    results: list[SettingsRebindRecord] = []
+    errors: list[BaseException] = []
+
+    def wait_for_stage(
+        _activation: SettingsRebindActivation,
+        _record: SettingsRebindRecord,
+        *,
+        required_stage: str,
+    ) -> None:
+        if required_stage == "acknowledged":
+            acknowledge_barrier.wait(timeout=5)
+        else:
+            assert resume_event.wait(timeout=5)
+
+    monkeypatch.setattr(SettingsRebindActivation, "_wait_for_stage", wait_for_stage)
+
+    def run_activation() -> None:
+        try:
+            result = SettingsRebindActivation(
+                runtime.registry,
+                watcher_state_dir=tmp_path / "watcher-state",
+                watcher_enabled=True,
+            ).activate(
+                selection=selection,
+                candidate_binding_id="binding-b",
+                candidate_root=vault_b,
+            )
+            results.append(result)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run_activation) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if runtime.open_settings_rebind_store().read().phase == "committed":
+                break
+            time.sleep(0.01)
+        assert runtime.open_settings_rebind_store().read().phase == "committed"
+        assert results == []
+    finally:
+        resume_event.set()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert not errors
+    assert len(results) == 2
+    assert {result.phase for result in results} == {"committed"}
 
 
 def test_settings05_parent_acceptance(

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -17,6 +17,8 @@ from app.instance.settings_rebind import (
     _install_dormant_settings_rebind,
 )
 from app.instance.vault_registry import VaultRegistration
+from app.instance.vault_registry import KnownVaultRef
+from app.api.routes.ingest_binding import ingest_binding_status
 from app.watcher import registry
 from app.watcher.settings_rebind import (
     _write_receipt,
@@ -570,3 +572,188 @@ def test_dormant_no_lifecycle_reconciles_without_unsealing_picker(
     )
     assert "settings-rebind-initiate" not in picker_sources
     assert "set_settings_rebind_state(" not in picker_sources
+
+
+def test_prepare_drains_and_final_scans_old_binding_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, vault_a, _vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    before = vault_a / "before-final-scan.md"
+    between = vault_a / "between-final-scans.md"
+    before.write_text("before\n", encoding="utf-8")
+    registry.run_registry_forever(config_path, max_ticks=1)
+    _commit(runtime)
+    between.write_text("between\n", encoding="utf-8")
+
+    registry.run_registry_forever(config_path, max_ticks=1)
+
+    receipt = load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1))
+    assert receipt.stage == "completed"
+    assert {item.relative_path for item in receipt.buffer} >= {
+        "before-final-scan.md",
+        "between-final-scans.md",
+    }
+
+
+def test_direct_filesystem_write_between_scan_and_commit_is_receipted_under_old_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    registry.run_registry_forever(config_path, max_ticks=1)
+    between = vault_a / "direct-between-scan-and-commit.md"
+    between.write_text("old root remains authoritative\n", encoding="utf-8")
+    _commit(runtime)
+    candidate = vault_b / "must-not-be-seen.md"
+    candidate.write_text("candidate\n", encoding="utf-8")
+
+    registry.run_registry_forever(config_path, max_ticks=1)
+
+    receipt = load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1))
+    assert receipt.stage == "completed"
+    assert any(item.relative_path == between.name for item in receipt.buffer)
+    assert candidate.name not in {item.relative_path for item in receipt.buffer}
+    assert all(path.startswith(str(vault_a)) for path in _event_paths(tmp_path))
+
+
+@pytest.mark.parametrize("fault_stage", ["prepare", "commit"])
+def test_prepare_commit_resume_is_failure_atomic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault_stage: str,
+) -> None:
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    runtime = _runtime(tmp_path)
+    _register(runtime, binding_id="binding-a", vault_root=vault_a)
+    _register(runtime, binding_id="binding-b", vault_root=vault_b)
+    _install_dormant_settings_rebind(
+        runtime.registry,
+        binding_id="binding-a",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    tripped = False
+
+    def fail_once(stage: str) -> None:
+        nonlocal tripped
+        if stage == fault_stage and not tripped:
+            tripped = True
+            raise RuntimeError(f"injected {stage} fault")
+
+    monkeypatch.setattr("app.instance.settings_rebind._activation_fault_point", fail_once)
+    registration = runtime.registry.load().registrations["binding-b"]
+    activation = SettingsRebindActivation.from_environment(runtime.registry)
+    with pytest.raises(RuntimeError, match=f"injected {fault_stage} fault"):
+        activation.activate(
+            selection=KnownVaultRef(
+                ref=registration.ref,
+                path=registration.path,
+                vault_id=registration.vault_id,
+                vault_name=registration.vault_name,
+                local_instance_id=registration.local_instance_id,
+                last_opened_at="2026-08-30T00:00:00Z",
+            ),
+            candidate_binding_id="binding-b",
+            candidate_root=vault_b,
+        )
+
+    record = runtime.open_settings_rebind_store().read()
+    assert record.candidate_binding_id == "binding-a"
+    assert runtime.registry.load().last_active_vault_ref is None
+    if fault_stage == "prepare":
+        assert record.phase == "dormant"
+    else:
+        assert record.phase == "no_lifecycle"
+
+
+def test_committed_revision_survives_event_loss_and_process_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _vault_a, _vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    registry.run_registry_forever(config_path, max_ticks=1)
+    _commit(runtime)
+    registry.run_registry_forever(config_path, max_ticks=1)
+
+    restarted = _runtime(tmp_path)
+    assert restarted.open_settings_rebind_store().read().phase == "committed"
+    assert load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1)).stage == "completed"
+
+
+def test_disabled_watcher_is_durable_no_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, _vault_a, _vault_b, config_path = _fixture(
+        tmp_path, monkeypatch, enabled=False
+    )
+    registry.run_registry_once(config_path)
+    record = runtime.open_settings_rebind_store().read()
+    assert record.phase == "no_lifecycle"
+    assert record.desired_revision == record.applied_revision == 1
+
+
+def test_settings05_parent_acceptance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production API seam and the separate watcher converge end-to-end."""
+    from app.vault.manager import VaultManager
+
+    runtime, _vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **_kwargs: None,
+    )
+    process_env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[2]
+    existing_pythonpath = process_env.get("PYTHONPATH")
+    process_env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(repo_root), existing_pythonpath) if part
+    )
+    process_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "app.cli",
+            "watcher",
+            "run",
+            "--config",
+            str(config_path),
+            "--max-ticks",
+            "6",
+        ],
+        cwd=repo_root,
+        env=process_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        selected = VaultManager().select_vault(vault_b)
+        assert selected.active_vault_path == str(vault_b)
+        post_commit = vault_b / "post-commit.md"
+        post_commit.write_text("visible after the durable commit\n", encoding="utf-8")
+        stdout, stderr = process.communicate(timeout=30)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.communicate(timeout=5)
+    assert process.returncode == 0, stdout + stderr
+    record = runtime.open_settings_rebind_store().read()
+    assert record.phase == "committed"
+    assert record.desired_revision == record.applied_revision == 1
+    assert str(post_commit) in _event_paths(tmp_path)
+    status = ingest_binding_status(
+        selected_vault_path=str(vault_b),
+        heartbeat_path=tmp_path / "watcher-heartbeat.json",
+    )
+    assert status.rebind_phase == "committed"
+    assert status.rebind_desired_revision == status.rebind_applied_revision == 1

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -621,7 +621,7 @@ def test_direct_filesystem_write_between_scan_and_commit_is_receipted_under_old_
     assert all(path.startswith(str(vault_a)) for path in _event_paths(tmp_path))
 
 
-@pytest.mark.parametrize("fault_stage", ["prepare", "commit"])
+@pytest.mark.parametrize("fault_stage", ["prepare", "commit", "reload"])
 def test_prepare_commit_resume_is_failure_atomic(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -643,6 +643,11 @@ def test_prepare_commit_resume_is_failure_atomic(
     )
     monkeypatch.setenv("WATCHER_ENABLE", "0")
     tripped = False
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+    )
 
     def fail_once(stage: str) -> None:
         nonlocal tripped
@@ -652,17 +657,18 @@ def test_prepare_commit_resume_is_failure_atomic(
 
     monkeypatch.setattr("app.instance.settings_rebind._activation_fault_point", fail_once)
     registration = runtime.registry.load().registrations["binding-b"]
+    selection = KnownVaultRef(
+        ref=registration.ref,
+        path=registration.path,
+        vault_id=registration.vault_id,
+        vault_name=registration.vault_name,
+        local_instance_id=registration.local_instance_id,
+        last_opened_at="2026-08-30T00:00:00Z",
+    )
     activation = SettingsRebindActivation.from_environment(runtime.registry)
     with pytest.raises(RuntimeError, match=f"injected {fault_stage} fault"):
         activation.activate(
-            selection=KnownVaultRef(
-                ref=registration.ref,
-                path=registration.path,
-                vault_id=registration.vault_id,
-                vault_name=registration.vault_name,
-                local_instance_id=registration.local_instance_id,
-                last_opened_at="2026-08-30T00:00:00Z",
-            ),
+            selection=selection,
             candidate_binding_id="binding-b",
             candidate_root=vault_b,
         )
@@ -676,6 +682,20 @@ def test_prepare_commit_resume_is_failure_atomic(
         assert record.candidate_binding_id == "binding-b"
         assert runtime.registry.load().last_active_vault_ref == registration.ref
         assert record.phase == "no_lifecycle"
+        assert record.reload_revision == 0
+        activation.activate(
+            selection=selection,
+            candidate_binding_id="binding-b",
+            candidate_root=vault_b,
+        )
+        assert reloads == [vault_b]
+        assert runtime.open_settings_rebind_store().read().reload_revision == 1
+        activation.activate(
+            selection=selection,
+            candidate_binding_id="binding-b",
+            candidate_root=vault_b,
+        )
+        assert reloads == [vault_b]
 
 
 def test_committed_revision_survives_event_loss_and_process_restart(

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -499,12 +499,12 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
 # closed so moving a write from ``write_frontmatter`` cannot make it disappear
 # from the WriteGuard inventory.
 WRITE_MISSING_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
-    ("app/vault/manager.py", 704): (
+    ("app/vault/manager.py", 714): (
         "bootstrap: VaultManager.initialize_vault is the explicit human/operator "
         "pre-selection initialization transition; O_EXCL preserves existing owner files. "
-        "Line drifted 496 -> 621 -> 623 -> 704 (site unchanged) when #3164 added the "
-        "nested canonical prompt seed and #3452 added "
-        "conflict-quarantine receipt policy above the manager."
+        "Line drifted 496 -> 621 -> 623 -> 704 -> 714 (site unchanged) when #3164 added the "
+        "nested canonical prompt seed, #3452 added conflict-quarantine receipt policy, and "
+        "SETTINGS-05C added the activation seam above the manager."
     ),
     ("app/vault/settings_service.py", 696): (
         "guarded: _scaffold_missing_settings_file asserts DEFAULT_WRITE_GUARD."

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -462,11 +462,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "census's own directly-related-repair convention when #3451 bound "
         "write_frontmatter to the exact NoteRead version."
     ),
-    ("app/vault/manager.py", 924): (
+    ("app/vault/manager.py", 928): (
         "guarded: _ensure_frontmatter_id asserts DEFAULT_WRITE_GUARD."
         "assert_writes_allowed('vault.identity_heal') immediately before this "
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
-        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 (site unchanged) when "
+        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 -> 928 (site unchanged) when "
         "#3452 added conflict-quarantine receipt policy above the manager."
     ),
     ("app/vault/settings_service.py", 617): (

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -462,11 +462,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "census's own directly-related-repair convention when #3451 bound "
         "write_frontmatter to the exact NoteRead version."
     ),
-    ("app/vault/manager.py", 843): (
+    ("app/vault/manager.py", 924): (
         "guarded: _ensure_frontmatter_id asserts DEFAULT_WRITE_GUARD."
         "assert_writes_allowed('vault.identity_heal') immediately before this "
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
-        "reaching this line. Line drifted 716 -> 841 -> 843 (site unchanged) when "
+        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 (site unchanged) when "
         "#3452 added conflict-quarantine receipt policy above the manager."
     ),
     ("app/vault/settings_service.py", 617): (
@@ -478,30 +478,18 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2745): (
+    ("app/instance/vault_registry.py", 2838): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2745 "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2745 -> 2838 "
         "(site unchanged); re-pinned after directly related SETTINGS-05A (#4967) inserted "
         "the durable dormant-rebind schema and producers earlier in vault_registry.py. "
         "SETTINGS-05A adds no new "
         "write_frontmatter site: like MVR-02/MVR-04, it writes the registry through "
         "_atomic_private_write, "
         "not the vault-content seam."
-    ),
-    ("app/instance/vault_registry.py", 2838): (
-        "out_of_scope: AppLocalSettingsStore persists the app-local device "
-        "registry outside the vault content plane Sigma, not a Human Knowledge "
-        "Artifact. Line drifted after SETTINGS-05C added the durable selection "
-        "activation path above this existing app-local write."
-    ),
-    ("app/vault/manager.py", 924): (
-        "guarded: _ensure_frontmatter_id asserts the vault.identity_heal "
-        "write guard immediately before this call. Line drifted after "
-        "SETTINGS-05C added the selection activation path above the existing "
-        "identity-heal write."
     ),
 }
 

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -491,6 +491,18 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "_atomic_private_write, "
         "not the vault-content seam."
     ),
+    ("app/instance/vault_registry.py", 2838): (
+        "out_of_scope: AppLocalSettingsStore persists the app-local device "
+        "registry outside the vault content plane Sigma, not a Human Knowledge "
+        "Artifact. Line drifted after SETTINGS-05C added the durable selection "
+        "activation path above this existing app-local write."
+    ),
+    ("app/vault/manager.py", 924): (
+        "guarded: _ensure_frontmatter_id asserts the vault.identity_heal "
+        "write guard immediately before this call. Line drifted after "
+        "SETTINGS-05C added the selection activation path above the existing "
+        "identity-heal write."
+    ),
 }
 
 # ``MarkdownSettingsStore.write_missing`` is a distinct O_EXCL vault-write

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -462,11 +462,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "census's own directly-related-repair convention when #3451 bound "
         "write_frontmatter to the exact NoteRead version."
     ),
-    ("app/vault/manager.py", 928): (
+    ("app/vault/manager.py", 934): (
         "guarded: _ensure_frontmatter_id asserts DEFAULT_WRITE_GUARD."
         "assert_writes_allowed('vault.identity_heal') immediately before this "
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
-        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 -> 928 (site unchanged) when "
+        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 -> 928 -> 934 (site unchanged) when "
         "#3452 added conflict-quarantine receipt policy above the manager."
     ),
     ("app/vault/settings_service.py", 617): (
@@ -478,12 +478,12 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/instance/vault_registry.py", 2838): (
+    ("app/instance/vault_registry.py", 2893): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact. "
-        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2745 -> 2838 "
+        "Line drifted 1373 -> 1394 -> 1403 -> 1953 -> 2266 -> 2330 -> 2357 -> 2496 -> 2503 -> 2745 -> 2838 -> 2893 "
         "(site unchanged); re-pinned after directly related SETTINGS-05A (#4967) inserted "
         "the durable dormant-rebind schema and producers earlier in vault_registry.py. "
         "SETTINGS-05A adds no new "

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -499,10 +499,10 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
 # closed so moving a write from ``write_frontmatter`` cannot make it disappear
 # from the WriteGuard inventory.
 WRITE_MISSING_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
-    ("app/vault/manager.py", 623): (
+    ("app/vault/manager.py", 704): (
         "bootstrap: VaultManager.initialize_vault is the explicit human/operator "
         "pre-selection initialization transition; O_EXCL preserves existing owner files. "
-        "Line drifted 496 -> 621 -> 623 (site unchanged) when #3164 added the "
+        "Line drifted 496 -> 621 -> 623 -> 704 (site unchanged) when #3164 added the "
         "nested canonical prompt seed and #3452 added "
         "conflict-quarantine receipt policy above the manager."
     ),

--- a/tests/watcher/test_ingest_binding_follows_selection.py
+++ b/tests/watcher/test_ingest_binding_follows_selection.py
@@ -1,0 +1,154 @@
+"""SETTINGS-05C foreground activation and durable health truth."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from app.api.routes.ingest_binding import ingest_binding_status
+from app.instance.settings_rebind import (
+    SettingsRebindStore,
+    _install_dormant_settings_rebind,
+)
+from app.instance.vault_registry import KnownVaultRef, VaultRegistration, VaultRegistryStore
+from app.vault.manager import VaultManager
+from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILITY
+from tests.helpers.vault_settings import initialize_test_vault
+
+pytestmark = pytest.mark.not_pg
+
+
+def _registry(tmp_path: Path, vault_a: Path, vault_b: Path) -> VaultRegistryStore:
+    registry = VaultRegistryStore(tmp_path / "instance-state" / "vault-registry.md")
+    registry.register(
+        VaultRegistration("binding-a", "path:" + str(vault_a), str(vault_a)),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    registry.register(
+        VaultRegistration("binding-b", "path:" + str(vault_b), str(vault_b)),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    _install_dormant_settings_rebind(
+        registry,
+        binding_id="binding-a",
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    return registry
+
+
+def _selection(registration: VaultRegistration) -> KnownVaultRef:
+    return KnownVaultRef(
+        ref=registration.ref,
+        path=registration.path,
+        vault_id=registration.vault_id,
+        vault_name=registration.vault_name,
+        local_instance_id=registration.local_instance_id,
+        last_opened_at="2026-08-30T00:00:00Z",
+    )
+
+
+def _heartbeat(path: Path, vault: Path) -> None:
+    path.write_text(
+        json.dumps({"ts": time.time(), "vault_path": str(vault)}),
+        encoding="utf-8",
+    )
+
+
+def test_selection_rebinds_ingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+    )
+    manager = VaultManager()
+    context = manager.select_vault(vault_b)
+
+    record = SettingsRebindStore(registry).read()
+    assert context.active_vault_path == str(vault_b)
+    assert record.phase == "no_lifecycle"
+    assert record.desired_revision == record.applied_revision == 1
+    assert registry.load().last_active_vault_ref == "path:" + str(vault_b)
+    assert reloads == [vault_b]
+
+
+def test_switch_is_clean_and_truthful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    heartbeat = tmp_path / "heartbeat.json"
+    _heartbeat(heartbeat, vault_a)
+
+    prepared = SettingsRebindStore(registry).prepare(candidate_binding_id="binding-b")
+    status = ingest_binding_status(
+        selected_vault_path=str(vault_b), heartbeat_path=heartbeat
+    )
+
+    assert prepared.phase == "prepared"
+    assert prepared.desired_revision == 1
+    assert prepared.applied_revision == 0
+    assert status.rebind_phase == "prepared"
+    assert status.rebind_desired_revision == 1
+    assert status.rebind_applied_revision == 0
+    assert status.rebind_failure_posture == "awaiting_watcher"
+    assert status.watcher_vault_path == str(vault_a)
+
+
+def test_rebind_reloads_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: calls.append(kwargs["reason"]),
+    )
+
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    activation = SettingsRebindActivation.from_environment(registry)
+    registration = registry.load().registrations["binding-b"]
+    activation.activate(
+        selection=_selection(registration),
+        candidate_binding_id="binding-b",
+        candidate_root=vault_b,
+    )
+
+    assert calls == ["vault_selection_rebind"]
+    assert SettingsRebindStore(registry).read().applied_revision == 1
+
+
+def test_novault_transitions_truthful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    heartbeat = tmp_path / "heartbeat.json"
+    _heartbeat(heartbeat, vault_a)
+
+    status = ingest_binding_status(selected_vault_path=None, heartbeat_path=heartbeat)
+
+    assert status.state == "unknown"
+    assert status.rebind_schema == "settings_rebind.v1"
+    assert status.rebind_phase == "dormant"
+    assert status.rebind_desired_revision == 0
+    assert status.rebind_applied_revision == 0

--- a/tests/watcher/test_ingest_binding_follows_selection.py
+++ b/tests/watcher/test_ingest_binding_follows_selection.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from app.instance._storage_boundary import RegistryError
+from app.settings.ingestion import SettingsIngestionState
 from app.api.routes.ingest_binding import ingest_binding_status
 from app.instance.settings_rebind import (
     SettingsRebindStore,
@@ -19,6 +21,11 @@ from tests.helpers.instance_storage_capability import STORAGE_MUTATION_CAPABILIT
 from tests.helpers.vault_settings import initialize_test_vault
 
 pytestmark = pytest.mark.not_pg
+
+
+def _successful_reload(**kwargs: object) -> SettingsIngestionState:
+    del kwargs
+    return SettingsIngestionState(state="ok", source="vault")
 
 
 def _registry(tmp_path: Path, vault_a: Path, vault_b: Path) -> VaultRegistryStore:
@@ -69,7 +76,7 @@ def test_selection_rebinds_ingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     reloads: list[Path] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: reloads.append(Path(kwargs["vault_root"])),
+        lambda **kwargs: (reloads.append(Path(kwargs["vault_root"])), _successful_reload())[1],
     )
     manager = VaultManager()
     context = manager.select_vault(vault_b)
@@ -118,7 +125,7 @@ def test_rebind_reloads_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     calls: list[str] = []
     monkeypatch.setattr(
         "app.settings.ingestion.ingest_settings",
-        lambda **kwargs: calls.append(kwargs["reason"]),
+        lambda **kwargs: (calls.append(kwargs["reason"]), _successful_reload())[1],
     )
 
     from app.instance.settings_rebind import SettingsRebindActivation
@@ -133,6 +140,60 @@ def test_rebind_reloads_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     assert calls == ["vault_selection_rebind"]
     assert SettingsRebindStore(registry).read().applied_revision == 1
+
+
+def test_completed_no_lifecycle_revision_allows_next_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A completed foreground rebind can start the next monotonic revision."""
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    reloads: list[Path] = []
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **kwargs: (reloads.append(Path(kwargs["vault_root"])), _successful_reload())[1],
+    )
+
+    manager = VaultManager()
+    manager.select_vault(vault_b)
+    manager.select_vault(vault_a)
+
+    record = SettingsRebindStore(registry).read()
+    assert record.phase == "no_lifecycle"
+    assert record.desired_revision == record.applied_revision == 2
+    assert record.candidate_binding_id == "binding-a"
+    assert reloads == [vault_b, vault_a]
+
+
+def test_failed_settings_reload_remains_retryable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A degraded SETTINGS-01 result cannot advance the durable reload marker."""
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.setenv("INSTANCE_VAULT_REGISTRY_PATH", str(registry.path))
+    monkeypatch.setenv("WATCHER_ENABLE", "0")
+    monkeypatch.setattr(
+        "app.settings.ingestion.ingest_settings",
+        lambda **_kwargs: SettingsIngestionState(
+            state="degraded_last_valid", source="vault", error="invalid source"
+        ),
+    )
+
+    with pytest.raises(RegistryError, match="SETTINGS-01 reload did not complete successfully"):
+        VaultManager().select_vault(vault_b)
+
+    record = SettingsRebindStore(registry).read()
+    assert record.phase == "no_lifecycle"
+    assert record.reload_revision == 0
 
 
 def test_novault_transitions_truthful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Governing-Issue: #4969
Final-Review-Rounds: 1

Fixes #4969

## Summary
- activate protected settings_rebind.v1 prepare/acknowledge/commit/resume flow for production vault selection
- atomically commit compatibility selection and binding, reload SETTINGS-01 once, and expose durable phase/revision health
- switch watcher root only after old-root drain and add SETTINGS-05C integration/invariant documentation and tests

## Verification
- Verify: `tests/watcher/test_ingest_binding_follows_selection.py::test_selection_rebinds_ingest`
- Verify: `tests/watcher/test_ingest_binding_follows_selection.py::test_switch_is_clean_and_truthful`
- Verify: `tests/watcher/test_ingest_binding_follows_selection.py::test_rebind_reloads_settings`
- Verify: `tests/watcher/test_ingest_binding_follows_selection.py::test_novault_transitions_truthful`
- Verify: `tests/integration/test_watcher_cross_process_rebind.py::test_prepare_drains_and_final_scans_old_binding_writes`
- Verify: `tests/integration/test_watcher_cross_process_rebind.py::test_direct_filesystem_write_between_scan_and_commit_is_receipted_under_old_binding`
- Verify: `tests/integration/test_watcher_cross_process_rebind.py::test_prepare_commit_resume_is_failure_atomic`
- Verify: `tests/integration/test_watcher_cross_process_rebind.py::test_settings05_parent_acceptance`
- Verify: `ruff check app tests`

## BuilderOps Routing
- Records/projections/receipts: Issue #4969 claim/lease, PR #5241 delivery, CI and verification receipts; no ProjectV2 mutation.
- Reason: SETTINGS-05C bounded child delivery and parent-ledger handoff.

Full integrated watcher execution is included in the required CI/UAT path.
