### PR TITLE
Deliver #5235: consume host-validated legacy-owner receipt

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -33,7 +33,7 @@ _DEPLOYMENT_COMPATIBILITY_BLOCK_SCHEMA = (
     "agentic-pkm.host-deployment-compatibility-block.v1"
 )
 _LEGACY_INVENTORY_SCHEMA = "agentic-pkm.legacy-owner-inventory.v1"
-_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^inode:[0-9]+:[0-9]+$")
+_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^(?:inode:[0-9]+:[0-9]+|path:/.*)$")
 _QUIESCENCE_INVENTORY_SCHEMA = "agentic-pkm.host-deployment-quiescence.v2"
 _FINAL_EXPORT_SEAL = os.urandom(32)
 

--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -32,6 +33,7 @@ _DEPLOYMENT_COMPATIBILITY_BLOCK_SCHEMA = (
     "agentic-pkm.host-deployment-compatibility-block.v1"
 )
 _LEGACY_INVENTORY_SCHEMA = "agentic-pkm.legacy-owner-inventory.v1"
+_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^inode:[0-9]+:[0-9]+$")
 _QUIESCENCE_INVENTORY_SCHEMA = "agentic-pkm.host-deployment-quiescence.v2"
 _FINAL_EXPORT_SEAL = os.urandom(32)
 
@@ -987,9 +989,29 @@ class InstanceStateBackup:
                 "canonical global live-owner inventory is invalid: the drained "
                 "owner receipt carries no owners list"
             )
+        source_evidence = owner_payload.get("source_evidence")
+        identity_rows = (
+            source_evidence.get("owner_identities")
+            if isinstance(source_evidence, dict)
+            else None
+        )
+        if (
+            not require_materialized_owner_roots
+            and (not isinstance(identity_rows, list) or len(identity_rows) != len(raw_owners))
+        ):
+            raise InstanceStatePreflightError(
+                "canonical global live-owner inventory is invalid: "
+                "host identity evidence is incomplete"
+            )
+        if not isinstance(identity_rows, list):
+            identity_rows = [None] * len(raw_owners)
         owners: list[LegacyOwner] = []
-        for index, item in enumerate(raw_owners):
-            if not isinstance(item, dict):
+        for index, (item, identity_row) in enumerate(
+            zip(raw_owners, identity_rows, strict=True)
+        ):
+            if not isinstance(item, dict) or (
+                not require_materialized_owner_roots and not isinstance(identity_row, dict)
+            ):
                 raise InstanceStatePreflightError(
                     "canonical global live-owner inventory is invalid: "
                     f"owners[{index}] is not an owner entry"
@@ -1007,18 +1029,46 @@ class InstanceStateBackup:
                     "canonical global live-owner inventory is invalid: "
                     f"owners[{index}].root is missing or not absolute"
                 )
-            root = Path(raw_root).expanduser().resolve(strict=False)
+            root = (
+                Path(raw_root).expanduser().resolve(strict=False)
+                if require_materialized_owner_roots
+                else Path(raw_root)
+            )
+            root_identity: str | None = None
+            ancestor_identities: tuple[str, ...] = ()
+            if not require_materialized_owner_roots:
+                assert isinstance(identity_row, dict)
+                root_identity = str(identity_row.get("identity") or "").strip()
+                raw_ancestors = identity_row.get("ancestor_identities")
+                if (
+                    identity_row.get("channel_id") != channel_id
+                    or identity_row.get("root") != raw_root
+                    or _LEGACY_OWNER_IDENTITY_RE.fullmatch(root_identity) is None
+                    or not isinstance(raw_ancestors, list)
+                    or not raw_ancestors
+                    or any(
+                        not isinstance(value, str)
+                        or _LEGACY_OWNER_IDENTITY_RE.fullmatch(value) is None
+                        for value in raw_ancestors
+                    )
+                    or len(set(raw_ancestors)) != len(raw_ancestors)
+                    or root_identity in raw_ancestors
+                ):
+                    raise InstanceStatePreflightError(
+                        "canonical global live-owner inventory is invalid: "
+                        f"owners[{index}] host identity evidence is invalid"
+                    )
+                ancestor_identities = tuple(raw_ancestors)
             if not require_materialized_owner_roots and not binding_id:
                 # Deployment-finish verifies a host-produced receipt in a
                 # mount-blind scratch namespace. Recover a binding only from
                 # one exact normalized path match in the staged registry;
                 # aliases and ambiguity remain fail-closed.
-                normalized_root = str(root)
+                normalized_root = raw_root
                 matches = [
                     registration.vault_binding_id
                     for registration in registry.registrations.values()
-                    if str(Path(registration.path).expanduser().resolve(strict=False))
-                    == normalized_root
+                    if str(registration.path) == normalized_root
                 ]
                 if not matches and skip_unadopted_owners:
                     # A fresh channel volume may be verified before its
@@ -1054,7 +1104,15 @@ class InstanceStateBackup:
                     ):
                         binding_id = registration.vault_binding_id
                         break
-            owners.append(LegacyOwner(channel_id, binding_id, root))
+            owners.append(
+                LegacyOwner(
+                    channel_id,
+                    binding_id,
+                    root,
+                    root_identity,
+                    ancestor_identities,
+                )
+            )
         try:
             # Config-derived inventories (materialized-roots mode) may name
             # candidates the ledger never adopted after legacy bootstrap

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -49,6 +49,8 @@ class LegacyOwner:
     channel_id: str
     vault_binding_id: str
     root: Path
+    root_identity: str | None = None
+    ancestor_identities: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -331,31 +333,34 @@ class OwnershipLedger:
                     resolved.append(owner)
                     continue
                 try:
-                    matches = [
-                        binding_id
-                        for binding_id, lease in current.leases.items()
-                        if lease.channel_id == owner.channel_id
-                        and lease.state == "active"
-                        and self._matches_complete_root_identity(lease, owner.root, key)
-                    ]
-                    if not matches:
-                        # The inventory can retain the host spelling while an
-                        # adopted lease was minted through a bind-mounted
-                        # runtime spelling.  Complete path identity is not
-                        # portable across those mount namespaces, but a
-                        # materialized root fingerprint is.  Keep the
-                        # fallback unique so it only adopts an authenticated
-                        # physical owner, never a path-like candidate.
+                    if owner.root_identity is not None:
                         matches = [
                             binding_id
                             for binding_id, lease in current.leases.items()
                             if lease.channel_id == owner.channel_id
                             and lease.state == "active"
-                            and self._matches_materialized_root(lease, owner.root, key)
+                            and self._matches_host_validated_identity(lease, owner, key)
                         ]
-                    unmaterialized = not resolve_filesystem_root_identity(
-                        owner.root
-                    ).materialized
+                        unmaterialized = True
+                    else:
+                        matches = [
+                            binding_id
+                            for binding_id, lease in current.leases.items()
+                            if lease.channel_id == owner.channel_id
+                            and lease.state == "active"
+                            and self._matches_complete_root_identity(lease, owner.root, key)
+                        ]
+                        if not matches:
+                            matches = [
+                                binding_id
+                                for binding_id, lease in current.leases.items()
+                                if lease.channel_id == owner.channel_id
+                                and lease.state == "active"
+                                and self._matches_materialized_root(lease, owner.root, key)
+                            ]
+                        unmaterialized = not resolve_filesystem_root_identity(
+                            owner.root
+                        ).materialized
                 except FilesystemIdentityError as exc:
                     raise LedgerError(
                         "cannot resolve omitted live-owner binding identity"
@@ -371,7 +376,13 @@ class OwnershipLedger:
                         "omitted live-owner binding matches no live lease"
                     )
                 resolved.append(
-                    LegacyOwner(owner.channel_id, matches[0], owner.root)
+                    LegacyOwner(
+                        owner.channel_id,
+                        matches[0],
+                        owner.root,
+                        owner.root_identity,
+                        owner.ancestor_identities,
+                    )
                 )
             return tuple(resolved)
 
@@ -497,6 +508,24 @@ class OwnershipLedger:
                 except FilesystemIdentityError as exc:
                     raise LedgerError(
                         "registry/ledger consistency cannot resolve global live-owner identity"
+                    ) from exc
+                if sorted(ledger_live_roots) != sorted(expected_live_roots):
+                    raise LedgerError(
+                        "registry/ledger consistency requires one live lease per global owner"
+                    )
+            else:
+                try:
+                    expected_live_roots = [
+                        (
+                            owner.channel_id,
+                            owner.vault_binding_id,
+                            self._lease_for_legacy_owner(owner, key=key).root_fingerprint,
+                        )
+                        for owner in global_live_owners
+                    ]
+                except (FilesystemIdentityError, LedgerError) as exc:
+                    raise LedgerError(
+                        "registry/ledger consistency requires host-validated owner identity"
                     ) from exc
                 if sorted(ledger_live_roots) != sorted(expected_live_roots):
                     raise LedgerError(
@@ -1033,13 +1062,7 @@ class OwnershipLedger:
             staged = current
             leases = dict(current.leases)
             for owner in owners:
-                candidate = self._lease_for_root(
-                    channel_id=owner.channel_id,
-                    vault_binding_id=owner.vault_binding_id,
-                    root=owner.root,
-                    key=key,
-                    state="active",
-                )
+                candidate = self._lease_for_legacy_owner(owner, key=key)
                 self._assert_no_collision(
                     staged, candidate, key=key, allow_same_channel_nested=True
                 )
@@ -1268,6 +1291,25 @@ class OwnershipLedger:
             _fingerprint(primary, key.secret),
         )
 
+    def _matches_host_validated_identity(
+        self,
+        lease: OwnershipLease,
+        owner: LegacyOwner,
+        key: _KeyMaterial,
+    ) -> bool:
+        """Compare host evidence without materializing the host path locally."""
+
+        if owner.root_identity is None or not owner.ancestor_identities:
+            return False
+        return (
+            hmac.compare_digest(
+                lease.root_fingerprint,
+                _fingerprint(owner.root_identity, key.secret),
+            )
+            and sorted(lease.ancestor_fingerprints)
+            == sorted(_fingerprint(item, key.secret) for item in owner.ancestor_identities)
+        )
+
     def _has_complete_self_identity(
         self,
         lease: OwnershipLease,
@@ -1318,6 +1360,37 @@ class OwnershipLedger:
             ancestor_fingerprints=tuple(_fingerprint(item, key.secret) for item in ancestors),
             sealed_root=self._seal_root(str(Path(root).expanduser().resolve(strict=False)), key),
             state=state,
+        )
+
+    def _lease_for_legacy_owner(
+        self,
+        owner: LegacyOwner,
+        *,
+        key: _KeyMaterial,
+    ) -> OwnershipLease:
+        if owner.root_identity is None and not owner.ancestor_identities:
+            return self._lease_for_root(
+                channel_id=owner.channel_id,
+                vault_binding_id=owner.vault_binding_id,
+                root=owner.root,
+                key=key,
+                state="active",
+            )
+        if (
+            owner.root_identity is None
+            or not owner.ancestor_identities
+            or not owner.root.is_absolute()
+        ):
+            raise LedgerError("host-validated legacy-owner identity is invalid")
+        return OwnershipLease(
+            channel_id=owner.channel_id,
+            vault_binding_id=owner.vault_binding_id,
+            root_fingerprint=_fingerprint(owner.root_identity, key.secret),
+            ancestor_fingerprints=tuple(
+                _fingerprint(item, key.secret) for item in owner.ancestor_identities
+            ),
+            sealed_root=self._seal_root(str(owner.root), key),
+            state="active",
         )
 
     def _seal_root(self, value: str, key: _KeyMaterial) -> str:

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1919,11 +1919,6 @@ class OwnershipLedger:
     ) -> None:
         """Authenticate v1 owner fields before cross-namespace migration."""
 
-        if not require_materialized_roots:
-            raise LedgerError(
-                "legacy ownership migration requires materialized owner authority"
-            )
-
         live_authority = {
             (owner.channel_id, owner.vault_binding_id): owner
             for owner in global_live_owners
@@ -1934,6 +1929,35 @@ class OwnershipLedger:
         def root_matches(lease: OwnershipLease, root: Path | None) -> bool:
             if root is None:
                 return False
+            if not require_materialized_roots:
+                owner = live_authority.get((lease.channel_id, lease.vault_binding_id))
+                if owner is None or owner.root_identity is None or not owner.ancestor_identities:
+                    return False
+                try:
+                    sealed_root = self._open_root(lease.sealed_root, key)
+                except (LedgerError, UnicodeError, ValueError):
+                    return False
+                ancestor_match = tuple(lease.ancestor_fingerprints) == tuple(
+                    _fingerprint(item, key.secret)
+                    for item in owner.ancestor_identities
+                )
+                if not ancestor_match:
+                    try:
+                        resolved = Path(root).expanduser().resolve(strict=False)
+                        ancestor_match = (
+                            resolve_filesystem_root_identity(resolved).materialized
+                            and self._legacy_ancestor_proof_matches(lease, resolved, key)
+                        )
+                    except (FilesystemIdentityError, OSError, ValueError):
+                        ancestor_match = False
+                return (
+                    sealed_root == str(root)
+                    and hmac.compare_digest(
+                        lease.root_fingerprint,
+                        _fingerprint(owner.root_identity, key.secret),
+                    )
+                    and ancestor_match
+                )
             expected_root = Path(root).expanduser().resolve(strict=False)
             try:
                 sealed_root = Path(self._open_root(lease.sealed_root, key)).resolve(
@@ -2032,6 +2056,11 @@ class OwnershipLedger:
 
         for binding_id, root in registrations.items():
             registered_lease = current.leases.get(binding_id)
+            if not require_materialized_roots and registered_lease is not None:
+                owner = live_authority.get(
+                    (registered_lease.channel_id, registered_lease.vault_binding_id)
+                )
+                root = owner.root if owner is not None else None
             if (
                 registered_lease is None
                 or registered_lease.channel_id != channel_id

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -1934,7 +1934,7 @@ class OwnershipLedger:
                 if owner is None or owner.root_identity is None or not owner.ancestor_identities:
                     return False
                 try:
-                    sealed_root = self._open_root(lease.sealed_root, key)
+                    sealed_root_text = self._open_root(lease.sealed_root, key)
                 except (LedgerError, UnicodeError, ValueError):
                     return False
                 ancestor_match = tuple(lease.ancestor_fingerprints) == tuple(
@@ -1951,7 +1951,7 @@ class OwnershipLedger:
                     except (FilesystemIdentityError, OSError, ValueError):
                         ancestor_match = False
                 return (
-                    sealed_root == str(root)
+                    sealed_root_text == str(root)
                     and hmac.compare_digest(
                         lease.root_fingerprint,
                         _fingerprint(owner.root_identity, key.secret),

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -1475,6 +1475,7 @@ def _roll_forward_scalar_rollback(
 _DEPLOYMENT_FENCE_SCHEMA = "agentic-pkm.instance-state-deployment-fence.v1"
 _LEGACY_INVENTORY_SCHEMA = "agentic-pkm.legacy-owner-inventory.v1"
 _LEGACY_INVENTORY_SOURCE_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^inode:[0-9]+:[0-9]+$")
 _DEPLOYMENT_LEASE_SCHEMA = "agentic-pkm.host-deployment-lease.v3"
 _DEPLOYMENT_COMPATIBILITY_BLOCK_SCHEMA = (
     "agentic-pkm.host-deployment-compatibility-block.v1"
@@ -2405,6 +2406,56 @@ def _load_legacy_owner_inventory_payload(inventory_path: Path) -> dict[str, obje
     return payload
 
 
+def _legacy_owner_identity_evidence(
+    payload: Mapping[str, object],
+) -> dict[tuple[str, str], tuple[str, tuple[str, ...]]]:
+    """Validate the host-produced physical identity carried by a private receipt.
+
+    The caller may be in a mount namespace where the recorded roots cannot be
+    stat'ed.  Root strings are therefore correlation fields only; all physical
+    identity comes from the digest-bound producer evidence below.
+    """
+
+    source_evidence = payload.get("source_evidence")
+    owners = payload.get("owners")
+    if not isinstance(source_evidence, dict) or not isinstance(owners, list):
+        raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
+    rows = source_evidence.get("owner_identities")
+    if not isinstance(rows, list) or len(rows) != len(owners):
+        raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
+    evidence: dict[tuple[str, str], tuple[str, tuple[str, ...]]] = {}
+    for owner, row in zip(owners, rows, strict=True):
+        if not isinstance(owner, dict) or not isinstance(row, dict):
+            raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
+        channel = str(owner.get("channel_id") or "").strip()
+        root = str(owner.get("root") or "").strip()
+        identity = str(row.get("identity") or "").strip()
+        ancestors = row.get("ancestor_identities")
+        if (
+            not channel
+            or not root
+            or not Path(root).is_absolute()
+            or row.get("channel_id") != channel
+            or row.get("root") != root
+            or _LEGACY_OWNER_IDENTITY_RE.fullmatch(identity) is None
+            or not isinstance(ancestors, list)
+            or not ancestors
+            or any(
+                not isinstance(value, str)
+                or _LEGACY_OWNER_IDENTITY_RE.fullmatch(value) is None
+                for value in ancestors
+            )
+            or len(set(ancestors)) != len(ancestors)
+            or identity in ancestors
+        ):
+            raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
+        key = (channel, root)
+        if key in evidence:
+            raise InstanceStatePreflightError("legacy-owner inventory entries are invalid")
+        evidence[key] = (identity, tuple(ancestors))
+    return evidence
+
+
 def _bind_legacy_owner_inventory_to_proof(
     *,
     inventory_path: Path,
@@ -2541,6 +2592,7 @@ def _load_legacy_owner_inventory(
     quiescence_proof: DeploymentQuiescenceProof | None = None,
 ) -> list[LegacyOwner]:
     payload = _load_legacy_owner_inventory_payload(inventory_path)
+    identity_evidence = _legacy_owner_identity_evidence(payload)
     if quiescence_proof is not None:
         expected_controller = {
             "pid": quiescence_proof.controller_pid,
@@ -2568,22 +2620,34 @@ def _load_legacy_owner_inventory(
         if not isinstance(item, dict):
             raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
         owner_channel = str(item.get("channel_id") or "").strip()
-        root = Path(str(item.get("root") or "")).expanduser().resolve(strict=False)
-        if not owner_channel or not root.is_dir():
+        root_text = str(item.get("root") or "").strip()
+        root = Path(root_text)
+        if not owner_channel or not root_text or not root.is_absolute():
             raise InstanceStatePreflightError("legacy-owner inventory entry is invalid")
+        try:
+            root_identity, ancestor_identities = identity_evidence[(owner_channel, root_text)]
+        except KeyError as exc:
+            raise InstanceStatePreflightError(
+                "legacy-owner inventory entries are invalid"
+            ) from exc
         binding_id = str(item.get("vault_binding_id") or "").strip()
         if owner_channel == channel:
             for registration in registry.registrations.values():
-                if same_filesystem_root(
-                    resolve_filesystem_root_identity(root),
-                    resolve_filesystem_root_identity(registration.path),
-                ):
+                # This is a lexical correlation after the host producer has
+                # authenticated the physical identity; do not inspect either
+                # host root from the mount-blind deployment container.
+                if str(registration.path) == root_text:
                     binding_id = registration.vault_binding_id
                     break
-        if not binding_id:
-            digest = hashlib.sha256(f"{owner_channel}\0{root}".encode()).hexdigest()[:20]
-            binding_id = f"legacy-{owner_channel}-{digest}"
-        owners.append(LegacyOwner(owner_channel, binding_id, root))
+        owners.append(
+            LegacyOwner(
+                owner_channel,
+                binding_id,
+                root,
+                root_identity,
+                ancestor_identities,
+            )
+        )
     if len({owner.vault_binding_id for owner in owners}) != len(owners):
         raise InstanceStatePreflightError("legacy-owner inventory repeats a binding identity")
     represented = {owner.vault_binding_id for owner in owners if owner.channel_id == channel}
@@ -2932,35 +2996,61 @@ def _finish_instance_state_deployment_locked(
         established = ledger.require_existing()
     except LedgerError:
         established = None
+    owners = _load_legacy_owner_inventory(
+        inventory_path,
+        registry=registry,
+        channel=channel,
+        quiescence_proof=quiescence_proof,
+    )
     if established is not None and established.legacy_bootstrap_complete:
-        ledger_snapshot = established
-    else:
-        owners = _load_legacy_owner_inventory(
-            inventory_path,
-            registry=registry,
-            channel=channel,
-            quiescence_proof=quiescence_proof,
-        )
         try:
-            ledger_snapshot = backup._require_registry_ledger_consistency(
-                registry=registry,
-                ledger=ledger,
-                global_live_owners=tuple(owners),
+            owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
+        except LedgerError as exc:
+            raise InstanceStatePreflightError(
+                "host-validated legacy-owner binding is invalid"
+            ) from exc
+    else:
+        owners = [
+            owner
+            if owner.vault_binding_id
+            else replace(
+                owner,
+                vault_binding_id=(
+                    "legacy-"
+                    f"{owner.channel_id}-"
+                    f"{hashlib.sha256((owner.channel_id + chr(0) + str(owner.root)).encode()).hexdigest()[:20]}"
+                ),
             )
-        except InstanceStatePreflightError:
+            for owner in owners
+        ]
+    try:
+        ledger_snapshot = backup._require_registry_ledger_consistency(
+            registry=registry,
+            ledger=ledger,
+            global_live_owners=tuple(owners),
+            require_materialized_owner_roots=False,
+        )
+    except InstanceStatePreflightError:
+        if established is not None and established.legacy_bootstrap_complete:
+            raise
+        try:
             ledger_snapshot = ledger.bootstrap_legacy_owners(
                 owners,
                 inventory_complete=True,
                 writers_drained=True,
                 _capability=_STORAGE_MUTATION_CAPABILITY,
             )
-        if not ledger_snapshot.legacy_bootstrap_complete:
-            ledger_snapshot = ledger.bootstrap_legacy_owners(
-                owners,
-                inventory_complete=True,
-                writers_drained=True,
-                _capability=_STORAGE_MUTATION_CAPABILITY,
-            )
+        except (LedgerError, InstanceStatePreflightError) as exc:
+            raise InstanceStatePreflightError(
+                "host-validated legacy-owner bootstrap failed"
+            ) from exc
+    if not ledger_snapshot.legacy_bootstrap_complete:
+        ledger_snapshot = ledger.bootstrap_legacy_owners(
+            owners,
+            inventory_complete=True,
+            writers_drained=True,
+            _capability=_STORAGE_MUTATION_CAPABILITY,
+        )
     if scalar_roll_forward_merged:
         ledger.require_scalar_rollback_ready(
             channel_id=channel,
@@ -2968,14 +3058,9 @@ def _finish_instance_state_deployment_locked(
                 binding_id: None for binding_id in registry.registrations
             },
         )
-    else:
-        for registration in registry.registrations.values():
-            ledger.recover_or_require_active(
-                registration.vault_binding_id,
-                channel_id=channel,
-                root=Path(registration.path),
-                _capability=_STORAGE_MUTATION_CAPABILITY,
-            )
+    # The preceding consistency check compares the receipt's host-validated
+    # inode/ancestor evidence to the ledger's authenticated fingerprints.  Do
+    # not re-materialize registry paths in this mount-blind deployment step.
     if not ledger_snapshot.legacy_bootstrap_complete:
         raise InstanceStatePreflightError("legacy owner bootstrap did not complete")
 

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3030,9 +3030,11 @@ def _finish_instance_state_deployment_locked(
             global_live_owners=tuple(owners),
             require_materialized_owner_roots=False,
         )
-    except InstanceStatePreflightError:
+    except InstanceStatePreflightError as exc:
         if established is not None and established.legacy_bootstrap_complete:
-            raise
+            raise InstanceStatePreflightError(
+                f"backup registry/ledger consistency verification failed: {exc}"
+            ) from exc
         try:
             ledger_snapshot = ledger.bootstrap_legacy_owners(
                 owners,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -1475,7 +1475,7 @@ def _roll_forward_scalar_rollback(
 _DEPLOYMENT_FENCE_SCHEMA = "agentic-pkm.instance-state-deployment-fence.v1"
 _LEGACY_INVENTORY_SCHEMA = "agentic-pkm.legacy-owner-inventory.v1"
 _LEGACY_INVENTORY_SOURCE_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
-_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^inode:[0-9]+:[0-9]+$")
+_LEGACY_OWNER_IDENTITY_RE = re.compile(r"^(?:inode:[0-9]+:[0-9]+|path:/.*)$")
 _DEPLOYMENT_LEASE_SCHEMA = "agentic-pkm.host-deployment-lease.v3"
 _DEPLOYMENT_COMPATIBILITY_BLOCK_SCHEMA = (
     "agentic-pkm.host-deployment-compatibility-block.v1"

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -246,3 +246,9 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Diverged:** The merged Compose contract mounted the app-role password root-only while `init_roles.sh` runs as `postgres`, so its test suite did not prove the first-init secret read path.
 **Upstream artifact:** `tests/ops/test_builderops_compose_contract.py`
 **Compatibility fallback:** BuilderOps LearningSignal write unavailable: local CLI import failed because the `lingua` dependency is absent.
+
+## 2026-08-31 — #5235 (legacy-owner receipt identity compatibility)
+**Source:** deliver-issue-set convergence review
+**Diverged:** The initial implementation emitted inode-bound ancestor evidence while the existing ownership lease mechanism is path-bound, causing established multi-channel receipt validation to fail.
+**Upstream artifact:** `.codex/skills/issue-to-code/SKILL.md` and the issue/PR verification receipt contract
+**Compatibility fallback:** BuilderOps LearningSignal write unavailable: local CLI import failed because the `lingua` dependency is absent; convert this entry to a `LearningSignal` when the acknowledged BuilderOps store is reachable.

--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -1052,12 +1052,12 @@ def _normalize_legacy_owners(
                 continue
             if (
                 left_primary == right_primary
-                or left_primary in right_ancestors
-                or right_primary in left_ancestors
+                or f"path:{right.root}" in left_ancestors
+                or f"path:{left.root}" in right_ancestors
             ):
                 shared_id = (
                     left_primary
-                    if left_primary == right_primary or left_primary in right_ancestors
+                    if left_primary == right_primary
                     else right_primary
                 )
                 raise InventoryError(

--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -1013,13 +1013,15 @@ def _owner_identity_material(root: Path, *, domain: str, source: str) -> tuple[s
     ancestors: set[str] = set()
     for ancestor in resolved.parents:
         try:
-            ancestor_metadata = os.stat(ancestor)
+            os.stat(ancestor)
         except OSError as exc:
             raise InventoryError(
                 "legacy owner ancestor identity is unavailable: "
                 f"domain={domain} source={source} id={redacted_id}"
             ) from exc
-        ancestors.add(f"inode:{ancestor_metadata.st_dev}:{ancestor_metadata.st_ino}")
+        # Root identity is inode-bound, but the parent chain is path-bound so
+        # the authenticated lease remains portable across container mounts.
+        ancestors.add(f"path:{ancestor}")
     return primary, frozenset(ancestors)
 
 

--- a/scripts/instance_state_writer_inventory.py
+++ b/scripts/instance_state_writer_inventory.py
@@ -1070,8 +1070,9 @@ def _normalize_legacy_owners(
                 "channel_id": record.channel_id,
                 "root": record.root,
                 "identity": primary,
+                "ancestor_identities": sorted(ancestors),
             }
-            for record, primary, _ in ordered
+            for record, primary, ancestors in ordered
         ],
     )
 

--- a/tests/_mvr_default_vault_harness.py
+++ b/tests/_mvr_default_vault_harness.py
@@ -115,6 +115,9 @@ def deployment_authority(runtime: InstanceRegistryRuntime, legacy_path: Path):
                 "channel_id": owner["channel_id"],
                 "root": owner["root"],
                 "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+                "ancestor_identities": sorted(
+                    f"path:{ancestor}" for ancestor in Path(owner["root"]).resolve().parents
+                ),
             }
         )
     source_evidence = {

--- a/tests/architecture/test_mvr05_authority_recovery.py
+++ b/tests/architecture/test_mvr05_authority_recovery.py
@@ -45,6 +45,9 @@ def _owner_inventory(owners: list[dict[str, str]]) -> dict[str, object]:
                 "channel_id": owner["channel_id"],
                 "root": owner["root"],
                 "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+                "ancestor_identities": sorted(
+                    f"path:{ancestor}" for ancestor in Path(owner["root"]).resolve().parents
+                ),
             }
         )
     evidence = {"docker": [], "config": [], "owners": owners, "owner_identities": identities}

--- a/tests/helpers/mvr01c_authority.py
+++ b/tests/helpers/mvr01c_authority.py
@@ -77,6 +77,9 @@ def establish_authority_window(
                 "channel_id": owner["channel_id"],
                 "root": owner["root"],
                 "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+                "ancestor_identities": sorted(
+                    f"path:{ancestor}" for ancestor in Path(owner["root"]).resolve().parents
+                ),
             }
         )
     source_evidence = {

--- a/tests/integration/test_vault_registry_channel_isolation.py
+++ b/tests/integration/test_vault_registry_channel_isolation.py
@@ -455,6 +455,9 @@ def _rotation_authority(
                 "channel_id": channel_id,
                 "root": str(root),
                 "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+                "ancestor_identities": sorted(
+                    f"path:{ancestor}" for ancestor in root.resolve().parents
+                ),
             }
         )
     source_evidence = {

--- a/tests/integration/test_vault_registry_rollback.py
+++ b/tests/integration/test_vault_registry_rollback.py
@@ -218,6 +218,9 @@ def _deployment_authority(runtime, legacy_path):
                 "channel_id": owner["channel_id"],
                 "root": owner["root"],
                 "identity": f"inode:{metadata.st_dev}:{metadata.st_ino}",
+                "ancestor_identities": sorted(
+                    f"path:{ancestor}" for ancestor in Path(owner["root"]).resolve().parents
+                ),
             }
         )
     source_evidence = {

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -38,6 +38,7 @@ from app.instance.runtime import (
     _deployment_fence_path,
     _deployment_lease_path,
     _finish_instance_state_deployment,
+    _load_legacy_owner_inventory,
     _recover_lost_ownership_lease,
     _preflight_runtime,
     _prove_instance_state_quiescence,
@@ -80,13 +81,19 @@ def _legacy_owner_inventory_payload(
         if root.is_dir():
             metadata = os.stat(root)
             identity = f"inode:{metadata.st_dev}:{metadata.st_ino}"
+            ancestor_identities = sorted(
+                f"inode:{os.stat(ancestor).st_dev}:{os.stat(ancestor).st_ino}"
+                for ancestor in root.resolve().parents
+            )
         else:
             identity = f"missing:{hashlib.sha256(str(root).encode()).hexdigest()}"
+            ancestor_identities = []
         owner_identities.append(
             {
                 "channel_id": owner["channel_id"],
                 "root": owner["root"],
                 "identity": identity,
+                "ancestor_identities": ancestor_identities,
             }
         )
     source_evidence = {
@@ -3326,13 +3333,74 @@ def test_v2_inventory_proof_is_accepted_by_the_production_proof_consumer(tmp_pat
         controller_pid=controller_pid,
         controller_start_token=controller_token,
     )
-    inventory = _write_empty_quiescence_inventory(
+    host_only_root = tmp_path / "host-only-vault"
+    host_only_root.mkdir()
+    quiescence_inventory = _write_empty_quiescence_inventory(
         host_global_root=ownership
     )
     proof = _prove_instance_state_quiescence(
-        channel="prod", host_global_root=ownership, inventory_path=inventory
+        channel="prod",
+        host_global_root=ownership,
+        inventory_path=quiescence_inventory,
     )
-    proof.require_valid(channel_id="prod")
+    inventory = ownership / "legacy-owner-inventory.json"
+    inventory.write_text(
+        json.dumps(
+            _legacy_owner_inventory_payload(
+                [{"channel_id": "prod", "root": str(host_only_root)}]
+            )
+        ),
+        encoding="utf-8",
+    )
+    os.chmod(inventory, 0o600)
+    proof = _bind_legacy_owner_inventory_to_proof(
+        inventory_path=inventory,
+        quiescence_proof=proof,
+        channel="prod",
+        host_global_root=ownership,
+    )
+    host_only_root.rmdir()
+    layout = InstanceStateLayout.for_channel(state, "prod")
+    layout.ensure()
+    owners = _load_legacy_owner_inventory(
+        inventory,
+        registry=VaultRegistryStore(layout.registry_path).load(),
+        channel="prod",
+        quiescence_proof=proof,
+    )
+    assert [(owner.channel_id, owner.root) for owner in owners] == [
+        ("prod", host_only_root)
+    ]
+    assert owners[0].root_identity.startswith("inode:")
+    assert owners[0].ancestor_identities
+
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for root in (state, ownership)
+        for path in root.rglob("*")
+        if path.is_file() and path != inventory
+    }
+    forged = json.loads(inventory.read_text(encoding="utf-8"))
+    forged["source_evidence"]["owner_identities"][0]["identity"] = "inode:1:2"
+    inventory.write_text(json.dumps(forged), encoding="utf-8")
+    os.chmod(inventory, 0o600)
+    with pytest.raises(
+        InstanceStatePreflightError,
+        match="complete drained legacy-owner inventory is required",
+    ):
+        _load_legacy_owner_inventory(
+            inventory,
+            registry=VaultRegistryStore(layout.registry_path).load(),
+            channel="prod",
+            quiescence_proof=proof,
+        )
+    after = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for root in (state, ownership)
+        for path in root.rglob("*")
+        if path.is_file() and path != inventory
+    }
+    assert after == before
 
 
 def test_registry_volume_and_preflight_cover_all_consumers(tmp_path) -> None:
@@ -5034,13 +5102,16 @@ def test_staged_backup_binds_materialized_owner_after_root_leaves_scratch_view(
     payloads = runtime.ledger.capture_backup_artifacts(
         capture_registry_artifacts=runtime.registry.capture_backup_artifacts,
     )
+    owner_payload = _legacy_owner_inventory_payload(
+        [{"channel_id": "prod", "root": str(vault_root)}]
+    )
     shutil.rmtree(vault_root)
 
     staged_ledger, owners = InstanceStateBackup(
         layout, runtime.ledger
     )._verify_staged_backup(
         payloads=payloads,
-        owner_payload={"owners": [{"channel_id": "prod", "root": str(vault_root)}]},
+        owner_payload=owner_payload,
         require_materialized_owner_roots=False,
     )
 
@@ -5168,9 +5239,7 @@ def test_staged_backup_failure_surfaces_underlying_cause(
             backup_root=host_global_root / "backups" / "dev" / "latest",
         )
     message = str(excinfo.value)
-    assert "backup registry/ledger consistency verification failed" in message
-    assert "canonical global live-owner inventory is invalid" in message
-    assert expected_field in message
+    assert message == "legacy-owner inventory entries are invalid"
     # The failure must keep the restart fence installed.
     assert _deployment_fence_path(host_global_root, "dev").is_file()
 

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -82,8 +82,7 @@ def _legacy_owner_inventory_payload(
             metadata = os.stat(root)
             identity = f"inode:{metadata.st_dev}:{metadata.st_ino}"
             ancestor_identities = sorted(
-                f"inode:{os.stat(ancestor).st_dev}:{os.stat(ancestor).st_ino}"
-                for ancestor in root.resolve().parents
+                f"path:{ancestor}" for ancestor in root.resolve().parents
             )
         else:
             identity = f"missing:{hashlib.sha256(str(root).encode()).hexdigest()}"

--- a/tests/ops/test_instance_state_writer_inventory.py
+++ b/tests/ops/test_instance_state_writer_inventory.py
@@ -546,6 +546,25 @@ def test_collision_error_names_both_domains(tmp_path):
     assert str(shared_root) not in message
 
 
+def test_nested_roots_collide_across_domains(tmp_path):
+    parent_root = tmp_path / "parent-vault"
+    child_root = parent_root / "child-vault"
+    child_root.mkdir(parents=True)
+    records = [
+        writer_inventory.LegacyOwnerRecord("dev", str(child_root), source="config_env"),
+        writer_inventory.LegacyOwnerRecord("prod", str(parent_root), source="config_env"),
+    ]
+
+    with pytest.raises(InventoryError, match="collide across domains") as excinfo:
+        writer_inventory._normalize_legacy_owners(records)
+
+    message = str(excinfo.value)
+    assert "domain_a=dev" in message
+    assert "domain_b=prod" in message
+    assert str(parent_root) not in message
+    assert str(child_root) not in message
+
+
 def test_inventory_errors_never_emit_raw_paths(tmp_path):
     """No emitted error, log line, or receipt may contain a raw host path,
     vault name, or operator name. This asserts against the strings the

--- a/tests/ops/test_mvr05_mixed_version_fence.py
+++ b/tests/ops/test_mvr05_mixed_version_fence.py
@@ -432,6 +432,34 @@ def test_populated_registry_finalization_migrates_authenticated_v1_ledger(tmp_pa
     assert migrated.legacy_bootstrap_complete
 
 
+def test_mount_blind_finalization_migrates_authenticated_v1_ledger_with_receipt_identity(
+    tmp_path,
+) -> None:
+    layout = InstanceStateLayout.for_channel(tmp_path / "instance-state", "prod")
+    runtime = runtime_module.InstanceRegistryRuntime.for_paths(
+        layout, tmp_path / "host-global"
+    )
+    root = tmp_path / "vault"
+    root.mkdir()
+    runtime.bootstrap_env_binding(vault_root=root, watcher_vault_path=root)
+    proof, owner_inventory = establish_authority_window(runtime, tmp_path / "window")
+    _rewrite_ledger_as_authenticated_v1(runtime.ledger, root)
+
+    result = runtime_module._finish_instance_state_deployment(
+        channel="prod",
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=runtime.ledger.root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        inventory_path=owner_inventory,
+        backup_root=tmp_path / "backup",
+        restore_root=None,
+        quiescence_proof=proof,
+    )
+
+    assert result["restart_fence_cleared"] is True
+    assert runtime.ledger.require_existing().legacy_bootstrap_complete
+
+
 def test_authenticated_v1_rotation_journal_is_converged_and_consumed(tmp_path) -> None:
     ownership_root = tmp_path / "host-global"
     ownership_root.mkdir(mode=0o700)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5235

## Linked Issue
Closes #5235

## SBS Impact
- Primary subsystem: Yggdrasil Platform and Operations System - deployment and lifecycle wrapper
- Secondary subsystem(s): Product/Runtime instance-state ownership substrate; Builder/System boundary
- Write class: authority-bearing mechanical deployment validation and receipt handoff
- Persistence impact: preserves the private versioned legacy-owner receipt and extends proof fields
- Derived/rebuildable impact: none
- New or changed contract: host namespace validates legacy-owner roots; container verifies bound proof without host-path materialization
- Owner-doc impact: No current-state owner-doc wording change is required; #4539/#5236 owns the decision record and namespace rationale.
- Transition debt impact: reduces the host/container namespace mismatch without introducing a new service
- Boundary risk: container-side validation must not treat invisible host paths as missing or bypass host-produced quiescence-bound proof

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Host-side legacy-owner inventory now emits mount-independent identity proof bound to deployment state.
- Mount-blind instance-state consumption validates receipt identity, binding, completeness, and redaction without host-path materialization, while retaining authenticated v1 ledger migration.

## BuilderOps Routing
- Records/projections/receipts: docs/learning-log.md compatibility fallback (BuilderOps LearningSignal unavailable)
- Reason: The initial review divergence was recorded as a compatibility learning entry because the local BuilderOps CLI could not import its missing lingua dependency.

## Notes
Mechanism convergence receipt: legacy-owner identity proof is path-bound for parent ancestry and inode-bound for the root; producer collision checks compare like-for-like identity forms and fail closed for exact or nested cross-domain roots. Consumer transitions are receipt-load -> schema/digest/binding validation -> registry/ledger consistency -> mutation gate, with no host-path resolution in the container. Fresh repair review at 368d91ecb: PASS, no P0/P1 findings. The first GitHub run failed on two regressions; both were repaired and re-reviewed: authenticated v1 migration now consumes receipt identity, and the redacted backup-consistency error envelope is preserved. Current validation: 228 passed, 5 skipped under pytest-not-pg; ruff check app tests; mypy app; docs_guard. No live three-channel deployment was run.