### PR TITLE
task: qualify a read-only Mac vault bridge boundary

### DIFF
--- a/docs/audits/YGGDRASIL_HOST_MULTIVAULT_SETTINGS_TARGET_ARCHITECTURE_2026-08-16.md
+++ b/docs/audits/YGGDRASIL_HOST_MULTIVAULT_SETTINGS_TARGET_ARCHITECTURE_2026-08-16.md
@@ -256,6 +256,12 @@ The bridge must pin served roots with `Keep Downloaded`, refuse placeholder/part
 
 The bridge cannot guarantee that an offline iPad has no unseen edit. Therefore the truthful model is eventual convergence plus detectable conflicts, not global serializability. Post-sync iCloud conflict copies and base mismatches must be quarantined and surfaced for resolution.
 
+#### Read-only bridge qualification (Issue #5253)
+
+The repository now carries `scripts/mac_vault_bridge_probe.py`, a standalone qualification adapter for one explicitly supplied root and a bounded set of normalized relative paths. It performs read/stat/identity observations only and emits versioned JSON with digest-only filesystem/content evidence, vault-marker status, bounded-read status, and explicit unknown reasons. The adapter is deliberately outside runtime selection, registry/settings/queue/watcher state, and any production bridge registration; it does not persist the supplied root or modify the target vault.
+
+This probe does not establish iCloud or File Provider hydration, placeholder completeness, atomic replacement, global serializability, or conflict-free convergence. A successful local read remains only a local observation. Before a write bridge decision, a live Mac-side qualification must still observe the relevant File Provider hydration/placeholder state, atomic replacement behavior, post-sync conflict behavior, and convergence across the external devices and the selected root. Those live observations are optional evidence for this slice and are not repository-test prerequisites. A Mac daemon/service, HTTP/RPC bridge, write queue, CAS writeback, merge engine, watcher rebind, and production registration remain explicit non-goals.
+
 ### 5.4 Backup authority
 
 iCloud is synchronization, not backup. Obsidian explicitly distinguishes the two. Choose one fully hydrated Mac as the vault backup source and create a one-way, versioned backup to storage outside the Proxmox SSD and outside the live iCloud root.

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -252,3 +252,9 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Diverged:** The initial implementation emitted inode-bound ancestor evidence while the existing ownership lease mechanism is path-bound, causing established multi-channel receipt validation to fail.
 **Upstream artifact:** `.codex/skills/issue-to-code/SKILL.md` and the issue/PR verification receipt contract
 **Compatibility fallback:** BuilderOps LearningSignal write unavailable: local CLI import failed because the `lingua` dependency is absent; convert this entry to a `LearningSignal` when the acknowledged BuilderOps store is reachable.
+
+## 2026-08-31 — #5253 (read-only Mac vault bridge qualification)
+**Source:** capture-learning after publish-pr gate invocation
+**Diverged:** The existing-PR review-before-CI gate was invoked without its required publication-mode flag, and the following shell command continued because the block lacked hard-exit behavior.
+**Upstream artifact:** `.codex/skills/publish-pr/SKILL.md :: Publication workflow`
+**Compatibility fallback:** BuilderOps LearningSignal write unavailable: local CLI import failed because the `lingua` dependency is absent; convert this entry to a `LearningSignal` when the acknowledged BuilderOps store is reachable.

--- a/scripts/mac_vault_bridge_probe.py
+++ b/scripts/mac_vault_bridge_probe.py
@@ -138,8 +138,16 @@ def _open_relative(root_fd: int, relative_path: str) -> tuple[int, os.stat_resul
             if not final:
                 flags |= getattr(os, "O_DIRECTORY", 0)
             try:
-                if stat.S_ISLNK(os.lstat(component, dir_fd=current_fd).st_mode):
+                entry_metadata = os.lstat(component, dir_fd=current_fd)
+                if stat.S_ISLNK(entry_metadata.st_mode):
                     raise ProbeAccessError("symlink_component_rejected")
+                if final and not (
+                    stat.S_ISREG(entry_metadata.st_mode)
+                    or stat.S_ISDIR(entry_metadata.st_mode)
+                ):
+                    raise ProbeAccessError("unsupported_special_file")
+                if not final and not stat.S_ISDIR(entry_metadata.st_mode):
+                    raise ProbeAccessError("target_not_directory")
                 next_fd = os.open(component, flags, dir_fd=current_fd)
             except ProbeAccessError:
                 raise
@@ -322,6 +330,7 @@ def main(argv: list[str] | None = None) -> int:
     return (
         0
         if report["root"]["valid"]
+        and report["marker"]["status"] == "present"
         and all(item["status"] == "observed" for item in report["observations"])
         else 2
     )

--- a/scripts/mac_vault_bridge_probe.py
+++ b/scripts/mac_vault_bridge_probe.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Qualify one explicitly supplied vault root without mutating it.
+
+This is a diagnostic boundary adapter, not a runtime vault selector.  It uses
+descriptor-relative, no-follow filesystem operations so that a bounded probe
+cannot follow a symlink out of the supplied root.  iCloud/File Provider
+hydration and convergence are deliberately reported as unknown: a successful
+local read is not evidence for those properties.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import os
+import platform
+import stat
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+PROBE_VERSION = "mac-vault-bridge-probe.v1"
+MARKER_PATH = "settings/vault.md"
+DEFAULT_PATHS = (MARKER_PATH,)
+MAX_PATHS = 32
+MAX_RELATIVE_PATH_BYTES = 240
+MAX_READ_BYTES = 64 * 1024
+
+UNKNOWN_REASONS = (
+    "icloud_hydration_not_observable",
+    "file_provider_state_not_observable",
+    "atomic_replacement_not_observable",
+    "global_serializability_not_provable",
+    "conflict_free_convergence_not_provable",
+)
+
+
+class ProbeInputError(ValueError):
+    """Raised for an unsafe or unbounded probe input."""
+
+
+class ProbeAccessError(OSError):
+    """Raised when a bounded target cannot be observed safely."""
+
+
+def _digest(*parts: object) -> str:
+    payload = "\x1f".join(str(part) for part in parts).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _file_digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _identity_digest(metadata: os.stat_result) -> str:
+    """Return identity evidence without exposing a path or raw inode values."""
+
+    return _digest(
+        "filesystem-identity-v1",
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+    )
+
+
+def _validate_relative_path(value: str) -> str:
+    if not value or "\x00" in value:
+        raise ProbeInputError("relative path is empty or contains NUL")
+    if len(value.encode("utf-8")) > MAX_RELATIVE_PATH_BYTES:
+        raise ProbeInputError("relative path exceeds the bounded length")
+    if value.startswith("/") or value.startswith("\\"):
+        raise ProbeInputError("absolute paths are not accepted")
+    if "\\" in value:
+        raise ProbeInputError("backslash path separators are not accepted")
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ProbeInputError("path must be a normalized relative path")
+    return "/".join(parts)
+
+
+def _bounded_paths(paths: Iterable[str]) -> tuple[str, ...]:
+    result: list[str] = []
+    for raw_path in paths:
+        path = _validate_relative_path(raw_path)
+        if path not in result:
+            result.append(path)
+    if len(result) > MAX_PATHS:
+        raise ProbeInputError(f"at most {MAX_PATHS} paths may be probed")
+    return tuple(result)
+
+
+def _no_follow_flag() -> int:
+    return getattr(os, "O_NOFOLLOW", 0)
+
+
+def _open_root(root: Path) -> tuple[int, os.stat_result]:
+    try:
+        root_lstat = os.lstat(root)
+    except FileNotFoundError as exc:
+        raise ProbeAccessError("root_missing") from exc
+    except OSError as exc:
+        raise ProbeAccessError("root_unreadable") from exc
+    if stat.S_ISLNK(root_lstat.st_mode):
+        raise ProbeAccessError("root_symlink_rejected")
+    if not stat.S_ISDIR(root_lstat.st_mode):
+        raise ProbeAccessError("root_not_directory")
+    if root_lstat.st_mode & 0o555 == 0:
+        raise ProbeAccessError("root_unreadable")
+
+    try:
+        fd = os.open(
+            root,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | _no_follow_flag(),
+        )
+    except FileNotFoundError as exc:
+        raise ProbeAccessError("root_missing") from exc
+    except OSError as exc:
+        raise ProbeAccessError("root_unreadable") from exc
+    try:
+        metadata = os.fstat(fd)
+    except OSError:
+        os.close(fd)
+        raise ProbeAccessError("root_unreadable")
+    return fd, metadata
+
+
+def _open_relative(root_fd: int, relative_path: str) -> tuple[int, os.stat_result]:
+    components = relative_path.split("/")
+    current_fd = os.dup(root_fd)
+    try:
+        for index, component in enumerate(components):
+            final = index == len(components) - 1
+            flags = os.O_RDONLY | _no_follow_flag()
+            if not final:
+                flags |= getattr(os, "O_DIRECTORY", 0)
+            try:
+                if stat.S_ISLNK(os.lstat(component, dir_fd=current_fd).st_mode):
+                    raise ProbeAccessError("symlink_component_rejected")
+                next_fd = os.open(component, flags, dir_fd=current_fd)
+            except ProbeAccessError:
+                raise
+            except FileNotFoundError as exc:
+                raise ProbeAccessError("target_missing") from exc
+            except PermissionError as exc:
+                raise ProbeAccessError("target_unreadable") from exc
+            except OSError as exc:
+                if exc.errno == errno.ELOOP:
+                    raise ProbeAccessError("symlink_component_rejected") from exc
+                raise ProbeAccessError("target_unreadable") from exc
+            os.close(current_fd)
+            current_fd = next_fd
+        metadata = os.fstat(current_fd)
+        if metadata.st_mode & 0o444 == 0:
+            raise ProbeAccessError("target_unreadable")
+        return current_fd, metadata
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _read_descriptor(fd: int, metadata: os.stat_result) -> tuple[bytes, bool]:
+    if not stat.S_ISREG(metadata.st_mode):
+        return b"", False
+    chunks: list[bytes] = []
+    remaining = MAX_READ_BYTES + 1
+    while remaining:
+        chunk = os.read(fd, min(16 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    return data[:MAX_READ_BYTES], len(data) > MAX_READ_BYTES
+
+
+def _unknown_observation(path: str, reason: str) -> dict[str, Any]:
+    status = "missing" if reason == "target_missing" else "unknown"
+    return {
+        "relative_path": path,
+        "status": status,
+        "reason": reason,
+        "hydration": {"status": "unknown", "reason": UNKNOWN_REASONS[0]},
+    }
+
+
+def _observe_path(root_fd: int, path: str) -> dict[str, Any]:
+    try:
+        fd, metadata = _open_relative(root_fd, path)
+    except ProbeAccessError as exc:
+        return _unknown_observation(path, str(exc))
+
+    try:
+        result: dict[str, Any] = {
+            "relative_path": path,
+            "status": "observed",
+            "kind": (
+                "file"
+                if stat.S_ISREG(metadata.st_mode)
+                else "directory"
+                if stat.S_ISDIR(metadata.st_mode)
+                else "other"
+            ),
+            "filesystem_identity_digest": _identity_digest(metadata),
+            "hydration": {"status": "unknown", "reason": UNKNOWN_REASONS[0]},
+            "file_provider_state": {"status": "unknown", "reason": UNKNOWN_REASONS[1]},
+        }
+        if stat.S_ISREG(metadata.st_mode):
+            try:
+                data, truncated = _read_descriptor(fd, metadata)
+            except OSError:
+                return _unknown_observation(path, "target_read_failed")
+            result.update(
+                {
+                    "bytes_read": len(data),
+                    "truncated": truncated,
+                    "content_digest": _file_digest(data),
+                }
+            )
+        else:
+            result["bytes_read"] = 0
+            result["truncated"] = False
+        return result
+    finally:
+        os.close(fd)
+
+
+def _invalid_report(reason: str, paths: tuple[str, ...], *, platform_status: str) -> dict[str, Any]:
+    return {
+        "probe_version": PROBE_VERSION,
+        "read_only": True,
+        "runtime_selector": False,
+        "platform": {
+            "name": platform.system().lower(),
+            "status": platform_status,
+            "reason": None if platform_status == "supported" else "mac_only_observations_unsupported",
+        },
+        "root": {"valid": False, "reason": reason},
+        "valid_root": {"status": "false", "reason": reason},
+        "marker": {"relative_path": MARKER_PATH, "status": "unknown", "reason": reason},
+        "observations": [_unknown_observation(path, reason) for path in paths],
+        "unknown_reasons": [reason, *UNKNOWN_REASONS],
+    }
+
+
+def probe(root: Path | str, paths: Iterable[str] = DEFAULT_PATHS) -> dict[str, Any]:
+    """Return a redacted report for one root and bounded relative paths."""
+
+    bounded_paths = _bounded_paths(paths)
+    platform_status = "supported" if platform.system() == "Darwin" else "unsupported"
+    root_path = Path(root).expanduser()
+    try:
+        root_fd, root_metadata = _open_root(root_path)
+    except ProbeAccessError as exc:
+        return _invalid_report(str(exc), bounded_paths, platform_status=platform_status)
+
+    try:
+        marker = _observe_path(root_fd, MARKER_PATH)
+        marker_status = (
+            "present"
+            if marker["status"] == "observed" and marker.get("kind") == "file"
+            else marker["status"]
+        )
+        report: dict[str, Any] = {
+            "probe_version": PROBE_VERSION,
+            "read_only": True,
+            "runtime_selector": False,
+            "platform": {
+                "name": platform.system().lower(),
+                "status": platform_status,
+                "reason": None if platform_status == "supported" else "mac_only_observations_unsupported",
+            },
+            "root": {
+                "valid": True,
+                "identity_digest": _identity_digest(root_metadata),
+            },
+            "valid_root": {"status": "true"},
+            "marker": {
+                "relative_path": MARKER_PATH,
+                "status": marker_status,
+                **(
+                    {"reason": marker["reason"]}
+                    if marker_status != "present" and "reason" in marker
+                    else {}
+                ),
+            },
+            "observations": [_observe_path(root_fd, path) for path in bounded_paths],
+            "unknown_reasons": list(UNKNOWN_REASONS),
+        }
+        return report
+    finally:
+        os.close(root_fd)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only qualification probe for one explicit vault root."
+    )
+    parser.add_argument("--root", required=True, type=Path, help="explicit root to inspect")
+    parser.add_argument(
+        "--path",
+        action="append",
+        dest="paths",
+        metavar="RELATIVE_PATH",
+        help="bounded normalized relative path; may be repeated",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        paths = _bounded_paths(args.paths or DEFAULT_PATHS)
+        report = probe(args.root, paths)
+    except ProbeInputError as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, sort_keys=True))
+    return (
+        0
+        if report["root"]["valid"]
+        and all(item["status"] == "observed" for item in report["observations"])
+        else 2
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_mac_vault_bridge_probe.py
+++ b/tests/scripts/test_mac_vault_bridge_probe.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "mac_vault_bridge_probe.py"
+
+
+def _run(root: Path, *paths: str) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(SCRIPT), "--root", str(root)]
+    for path in paths:
+        command.extend(("--path", path))
+    return subprocess.run(command, cwd=REPO_ROOT, capture_output=True, text=True)
+
+
+def _report(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    return json.loads(result.stdout)
+
+
+def _make_vault(root: Path) -> None:
+    (root / "settings").mkdir(parents=True)
+    (root / "settings" / "vault.md").write_text(
+        "---\nvaultId: test-vault\n---\n# marker\n", encoding="utf-8"
+    )
+    (root / "Notes").mkdir()
+    (root / "Notes" / "secret.md").write_bytes(b"private note content\n")
+
+
+def test_probe_emits_redacted_read_only_report(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _make_vault(vault)
+
+    result = _run(vault, "Notes/secret.md")
+
+    assert result.returncode == 0, result.stderr
+    report = _report(result)
+    assert report["probe_version"] == "mac-vault-bridge-probe.v1"
+    assert report["read_only"] is True
+    assert report["root"]["valid"] is True
+    assert report["valid_root"]["status"] == "true"
+    assert report["marker"]["status"] == "present"
+    assert report["platform"]["status"] in {"supported", "unsupported"}
+    observation = report["observations"][0]
+    assert observation["status"] == "observed"
+    assert observation["relative_path"] == "Notes/secret.md"
+    assert observation["bytes_read"] == len(b"private note content\n")
+    assert observation["filesystem_identity_digest"].startswith("sha256:")
+    assert "private note content" not in result.stdout
+    assert str(vault) not in result.stdout
+    assert observation["content_digest"] == "sha256:" + hashlib.sha256(b"private note content\n").hexdigest()
+    assert report["unknown_reasons"]
+
+    large = vault / "large.md"
+    large.write_bytes(b"x" * (64 * 1024 + 3))
+    bounded = _run(vault, "large.md")
+    assert bounded.returncode == 0, bounded.stderr
+    bounded_observation = _report(bounded)["observations"][0]
+    assert bounded_observation["bytes_read"] == 64 * 1024
+    assert bounded_observation["truncated"] is True
+
+
+def test_probe_rejects_invalid_or_escaping_targets(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _make_vault(vault)
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (vault / "escape.md").symlink_to(outside)
+
+    missing = _run(tmp_path / "missing", "Notes/secret.md")
+    assert missing.returncode != 0
+    assert _report(missing)["root"]["reason"] == "root_missing"
+
+    escaping = _run(vault, "../outside.md")
+    assert escaping.returncode != 0
+    assert "outside" not in escaping.stdout
+
+    symlink = _run(vault, "escape.md")
+    assert symlink.returncode != 0
+    symlink_report = _report(symlink)
+    assert symlink_report["observations"][0]["status"] == "unknown"
+    assert "symlink" in symlink_report["observations"][0]["reason"]
+
+    unreadable = vault / "unreadable.md"
+    unreadable.write_text("not observable", encoding="utf-8")
+    unreadable.chmod(0)
+    try:
+        unreadable_result = _run(vault, "unreadable.md")
+    finally:
+        unreadable.chmod(0o600)
+    assert unreadable_result.returncode != 0
+    assert _report(unreadable_result)["observations"][0]["reason"] == "target_unreadable"
+
+    unreadable_root = tmp_path / "unreadable-root"
+    unreadable_root.mkdir()
+    unreadable_root.chmod(0)
+    try:
+        unreadable_root_result = _run(unreadable_root)
+    finally:
+        unreadable_root.chmod(0o700)
+    assert unreadable_root_result.returncode != 0
+    assert _report(unreadable_root_result)["root"]["reason"] == "root_unreadable"
+
+    regular_file = tmp_path / "not-a-root"
+    regular_file.write_text("not a directory", encoding="utf-8")
+    non_directory = _run(regular_file)
+    assert non_directory.returncode != 0
+    assert _report(non_directory)["root"]["reason"] == "root_not_directory"
+
+    root_link = tmp_path / "root-link"
+    root_link.symlink_to(vault, target_is_directory=True)
+    linked_root = _run(root_link)
+    assert linked_root.returncode != 0
+    assert _report(linked_root)["root"]["reason"] == "root_symlink_rejected"
+
+
+def test_probe_is_read_only_and_not_a_runtime_selector(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _make_vault(vault)
+    before = {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()}
+
+    result = _run(vault, "Notes/secret.md", "settings/vault.md")
+
+    assert result.returncode == 0, result.stderr
+    after = {path.relative_to(vault): path.read_bytes() for path in vault.rglob("*") if path.is_file()}
+    assert after == before
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "write_text" not in source
+    assert "write_bytes" not in source
+    assert "mkdir" not in source
+    assert "unlink" not in source
+    assert "rename" not in source
+    assert "registry" not in source.lower()
+    assert "settings" in _report(result)["marker"]["relative_path"]
+
+
+def test_probe_has_no_production_vault_selection_seam() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "VAULT_ROOT" not in source
+    assert "activeVault" not in source
+    assert "active_vault" not in source
+    assert "resolve_vault_root" not in source
+    assert "from app." not in source

--- a/tests/scripts/test_mac_vault_bridge_probe.py
+++ b/tests/scripts/test_mac_vault_bridge_probe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -111,6 +112,20 @@ def test_probe_rejects_invalid_or_escaping_targets(tmp_path: Path) -> None:
     non_directory = _run(regular_file)
     assert non_directory.returncode != 0
     assert _report(non_directory)["root"]["reason"] == "root_not_directory"
+
+    no_marker = tmp_path / "no-marker"
+    no_marker.mkdir()
+    (no_marker / "note.md").write_text("local", encoding="utf-8")
+    custom_without_marker = _run(no_marker, "note.md")
+    assert custom_without_marker.returncode != 0
+    assert _report(custom_without_marker)["marker"]["status"] == "missing"
+
+    if hasattr(os, "mkfifo"):
+        special = vault / "pipe"
+        os.mkfifo(special)
+        special_result = _run(vault, "pipe")
+        assert special_result.returncode != 0
+        assert _report(special_result)["observations"][0]["reason"] == "unsupported_special_file"
 
     root_link = tmp_path / "root-link"
     root_link.symlink_to(vault, target_is_directory=True)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5253

## Linked Issue
Closes #5253

## SBS Impact
- Primary subsystem: EBF qualification adapter / Platform and Operations boundary
- Secondary subsystem(s): WSP/MVR identity and context; GOV/HKA/PDM concurrency seams
- Write class: none; read-only qualification tooling and documentation
- Persistence impact: none; no registry, vault, queue, or receipt-store mutation
- Derived/rebuildable impact: probe output is derived diagnostic evidence only
- New or changed contract: versioned redacted probe report and explicit boundary/non-goal contract; no production service contract
- Owner-doc impact: referenced advisory audit updated in this PR; no shipped-runtime claim
- Transition debt impact: reduces uncertainty; does not claim MVR completion
- Boundary risk: the probe must not become a second selector/authority or silently grant write access

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a standalone read-only probe for one explicit vault root with bounded no-follow observations and digest-only JSON output.
- Add deterministic temporary-vault coverage for redaction, invalid roots, unreadable targets, symlink escape, immutability, and the absence of a runtime selection seam.
- Document the probe boundary, explicit unknown iCloud/File Provider states, remaining live observations, and non-goals in the advisory architecture audit.

## BuilderOps Routing
- Records/projections/receipts: docs/learning-log.md compatibility fallback entry for #5253
- Reason: BuilderOps LearningSignal write was unavailable because the local CLI import chain lacks lingua; the required compatibility fallback records the process divergence and must be converted when the acknowledged store is reachable.

## Notes
Validation: focused #5253 tests, ruff check app tests, mypy app, docs_guard language-only, py_compile, --help, and git diff --check all pass. The fallback entry is operational BuilderOps compatibility evidence, not Product/Runtime authority.
