### PR TITLE
fix: restore Settings Spine architecture gates

### DIFF
--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -12,6 +12,7 @@ from app.instance._storage_boundary import (
     RegistryError,
     _StorageMutationCapability,
 )
+from app.settings.env_defaults import env_str
 
 if TYPE_CHECKING:
     from app.instance.vault_registry import KnownVaultRef, VaultRegistryStore
@@ -382,7 +383,7 @@ class SettingsRebindActivation:
     def from_environment(cls, registry: VaultRegistryStore) -> "SettingsRebindActivation":
         state_dir_raw = os.getenv("WATCHER_STATE_DIR", "").strip()
         state_dir = Path(state_dir_raw).expanduser() if state_dir_raw else None
-        enabled_raw = os.getenv("WATCHER_ENABLE", "").strip().lower()
+        enabled_raw = env_str("WATCHER_ENABLE").strip().lower()
         watcher_path = os.getenv("WATCHER_VAULT_PATH", "").strip()
         requested = enabled_raw in {"1", "true", "yes", "on"}
         enabled = requested and bool(watcher_path)

--- a/app/instance/settings_rebind.py
+++ b/app/instance/settings_rebind.py
@@ -12,7 +12,6 @@ from app.instance._storage_boundary import (
     RegistryError,
     _StorageMutationCapability,
 )
-from app.settings.env_defaults import env_str
 
 if TYPE_CHECKING:
     from app.instance.vault_registry import KnownVaultRef, VaultRegistryStore
@@ -383,9 +382,12 @@ class SettingsRebindActivation:
     def from_environment(cls, registry: VaultRegistryStore) -> "SettingsRebindActivation":
         state_dir_raw = os.getenv("WATCHER_STATE_DIR", "").strip()
         state_dir = Path(state_dir_raw).expanduser() if state_dir_raw else None
-        enabled_raw = env_str("WATCHER_ENABLE").strip().lower()
+        enabled_raw = os.getenv("WATCHER_ENABLE")
         watcher_path = os.getenv("WATCHER_VAULT_PATH", "").strip()
-        requested = enabled_raw in {"1", "true", "yes", "on"}
+        requested = (
+            enabled_raw is not None
+            and enabled_raw.strip().lower() in {"1", "true", "yes", "on"}
+        )
         enabled = requested and bool(watcher_path)
         return cls(
             registry,

--- a/app/watcher/config.py
+++ b/app/watcher/config.py
@@ -1,7 +1,7 @@
 """Watcher runtime configuration.
 
-HTTP-vs-background binding rationale (#2476, #3119, SETTINGS-05C)
------------------------------------------------------------------
+HTTP-vs-background split and binding rationale (#2476, #3119, SETTINGS-05C)
+---------------------------------------------------------------------------
 The watcher remains a separately deployed process and ``WATCHER_VAULT_PATH``
 remains its bootstrap adapter.  The old "document the split, do not converge"
 posture is superseded for the one compatibility lifecycle by SETTINGS-05C:

--- a/tests/watcher/test_ingest_binding_follows_selection.py
+++ b/tests/watcher/test_ingest_binding_follows_selection.py
@@ -64,6 +64,31 @@ def _heartbeat(path: Path, vault: Path) -> None:
     )
 
 
+def test_from_environment_uses_registered_watcher_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    initialize_test_vault(vault_a)
+    initialize_test_vault(vault_b)
+    registry = _registry(tmp_path, vault_a, vault_b)
+    monkeypatch.delenv("WATCHER_ENABLE", raising=False)
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_a))
+
+    from app.instance.settings_rebind import SettingsRebindActivation
+
+    activation = SettingsRebindActivation.from_environment(registry)
+
+    assert activation.watcher_requested is True
+    assert activation.watcher_enabled is True
+
+    monkeypatch.delenv("WATCHER_VAULT_PATH", raising=False)
+    idle_activation = SettingsRebindActivation.from_environment(registry)
+
+    assert idle_activation.watcher_requested is True
+    assert idle_activation.watcher_enabled is False
+
+
 def test_selection_rebinds_ingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     vault_a = tmp_path / "vault-a"
     vault_b = tmp_path / "vault-b"

--- a/tests/watcher/test_ingest_binding_follows_selection.py
+++ b/tests/watcher/test_ingest_binding_follows_selection.py
@@ -64,7 +64,7 @@ def _heartbeat(path: Path, vault: Path) -> None:
     )
 
 
-def test_from_environment_uses_registered_watcher_default(
+def test_from_environment_preserves_deliberate_unset_distinction(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault_a = tmp_path / "vault-a"
@@ -79,8 +79,14 @@ def test_from_environment_uses_registered_watcher_default(
 
     activation = SettingsRebindActivation.from_environment(registry)
 
-    assert activation.watcher_requested is True
-    assert activation.watcher_enabled is True
+    assert activation.watcher_requested is False
+    assert activation.watcher_enabled is False
+
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    enabled_activation = SettingsRebindActivation.from_environment(registry)
+
+    assert enabled_activation.watcher_requested is True
+    assert enabled_activation.watcher_enabled is True
 
     monkeypatch.delenv("WATCHER_VAULT_PATH", raising=False)
     idle_activation = SettingsRebindActivation.from_environment(registry)


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5263

## Linked Issue
Closes #5263

## SBS Impact
- Primary subsystem: WSP
- Secondary subsystem(s): Builder System / CES architecture fitness
- Write class: Runtime configuration read plus module-contract clarification
- Persistence impact: None
- Derived/rebuildable impact: None
- New or changed contract: None; restores accepted SETTINGS-05C and SET-4 contracts
- Owner-doc impact: None
- Transition debt impact: Removes two post-merge architecture-gate regressions
- Boundary risk: Must preserve deliberate raw-unset, explicit-on, and no-vault-idle behavior

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Restore the canonical watcher split marker while retaining the SETTINGS-05C rationale.
- Remove the duplicated WATCHER_ENABLE fallback while preserving the deliberate raw-unset, explicit-on, and no-vault-idle behavior.

## BuilderOps Routing
- Records/projections/receipts: dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-5263; lease lease-bcde0ec0
- Reason: Bounded current-state regression repair; no new BuilderOps material was created.

## Notes
Review finding 3898541856 is classified P1 and repaired by preserving the watcher CLI's deliberate raw-unset contract. Focused Verify targets, the complete watcher rebind test file, Ruff, and mypy pass locally.
