### PR TITLE
fix: fail closed watcher rebind acknowledgement

### DIFF
--- a/app/vault/manager.py
+++ b/app/vault/manager.py
@@ -369,7 +369,13 @@ def iter_vault_markdown_files(
         if nearest_enclosing_vault_root(walk_root_real, search_root=selected_root_real) != selected_root_real:
             return
 
-    for dirpath, dirnames, filenames in os.walk(str(walk_root)):
+    # ``os.walk`` otherwise suppresses directory traversal failures. Callers
+    # such as the production watcher must fail closed rather than treating a
+    # partially walked vault as a complete scan.
+    def _raise_walk_error(error: OSError) -> None:
+        raise error
+
+    for dirpath, dirnames, filenames in os.walk(str(walk_root), onerror=_raise_walk_error):
         kept: list[str] = []
         for name in dirnames:
             child = Path(dirpath) / name

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -143,10 +143,17 @@ def _scan_markdown_many(
     if summary is None:
         summary = {}
     seen: set[Path] = set()
-    for scan_root in scan_roots:
-        for path in iter_vault_markdown_files(
-            vault_root, subtree_root=scan_root, include_settings=True
-        ):
+
+    def _iter_paths() -> Iterable[Path]:
+        for scan_root in scan_roots:
+            try:
+                yield from iter_vault_markdown_files(
+                    vault_root, subtree_root=scan_root, include_settings=True
+                )
+            except OSError:
+                _mark_scan_incomplete(summary, reason="traversal")
+
+    for path in _iter_paths():
             try:
                 rel = path.relative_to(vault_root)
             except Exception:

--- a/app/watcher/settings_rebind.py
+++ b/app/watcher/settings_rebind.py
@@ -493,13 +493,10 @@ class DormantSettingsRebindReconciler:
         )
         _write_receipt(self._receipt_path(cycle.record), drained)
         _rebind_fault_point("resume")
-        completed = replace(
-            drained,
-            stage="completed",
-            resume_ready_at=_now_iso(),
-        )
-        _write_receipt(self._receipt_path(cycle.record), completed)
-        return completed
+        # A drained receipt is non-terminal: the next tick must first produce
+        # a fresh successful old-root scan after resume before completion may
+        # authorize adoption of the candidate binding.
+        return drained
 
     def candidate_vault_path(self, record: SettingsRebindRecord) -> Path:
         """Resolve the committed candidate for the next watcher tick."""

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -349,6 +349,7 @@ Watcher auto-exec enablement rule:
 - The registry watcher remains polling-based; each observation generation walks the configured scope incrementally across bounded ticks. No OS file-event hooks are used.
 - Paths with spaces are supported; wrap vault paths in quotes.
 - When using iCloud/Obsidian sync, keep scopes conservative and rely on debounce/backoff guardrails.
+- A vault-selection rebind is fail closed: a no-lifecycle acknowledgement first stops (or proves absent) the prior watcher; traversal errors and drained scans remain non-terminal until a fresh resumed old-root scan succeeds.
 - Do not use the legacy snapshot watcher for runtime start-system flows.
 - Do not treat lab/dev-only watcher paths as production equivalents.
 

--- a/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
+++ b/docs/SETTINGS_SPINE/REBIND_ON_VAULT_SELECTION.md
@@ -200,6 +200,7 @@ deliveries precisely because production initiation stays fail-closed until C.
 ### SETTINGS-05B validation
 
 - `RUN_INTEGRATED_RUNTIME_UAT=1 pytest -q tests/integration/test_watcher_cross_process_rebind.py -k "dormant or reconciler"`
+- A regression must prove that no-lifecycle acknowledgement stops or proves absent an existing watcher before acknowledgement; traversal errors leave the scan incomplete; and a `drained` receipt remains non-terminal until a fresh resumed old-root scan succeeds.
 - Verify the production picker/API remains capability-sealed.
 
 ### SETTINGS-05C validation

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -1958,14 +1958,6 @@ if [ "$NO_VAULT_MODE" -eq 1 ]; then
     exit 1
   fi
   echo "Settings rebind no-vault reconciliation: $settings_rebind_no_lifecycle_json"
-  if ! run_docker_compose start watcher >/dev/null; then
-    EXIT_REASON="settings_rebind_watcher_restart_failed"
-    EXIT_CODE=1
-    export EXIT_REASON EXIT_CODE
-    write_startup_status 0 "$EXIT_REASON"
-    echo "ERROR: no-vault startup could not restart the idle watcher" >&2
-    exit 1
-  fi
   mark_phase_ok "settings_rebind_no_lifecycle"
 fi
 if [ "$NO_VAULT_MODE" -ne 1 ]; then

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -1935,6 +1935,16 @@ mark_phase_ok "db_probe"
 wait_for_healthz
 if [ "$NO_VAULT_MODE" -eq 1 ]; then
   set_phase "settings_rebind_no_lifecycle"
+  # The no-vault acknowledgement is truthful only after an existing watcher
+  # has stopped. Restart the idle watcher after the durable acknowledgement.
+  if ! run_docker_compose stop watcher >/dev/null; then
+    EXIT_REASON="settings_rebind_watcher_stop_failed"
+    EXIT_CODE=1
+    export EXIT_REASON EXIT_CODE
+    write_startup_status 0 "$EXIT_REASON"
+    echo "ERROR: no-vault startup could not stop the existing watcher" >&2
+    exit 1
+  fi
   if ! settings_rebind_no_lifecycle_json=$(
     run_docker_compose exec -T api \
       python -m app.instance.runtime settings-rebind-no-lifecycle \
@@ -1948,6 +1958,14 @@ if [ "$NO_VAULT_MODE" -eq 1 ]; then
     exit 1
   fi
   echo "Settings rebind no-vault reconciliation: $settings_rebind_no_lifecycle_json"
+  if ! run_docker_compose start watcher >/dev/null; then
+    EXIT_REASON="settings_rebind_watcher_restart_failed"
+    EXIT_CODE=1
+    export EXIT_REASON EXIT_CODE
+    write_startup_status 0 "$EXIT_REASON"
+    echo "ERROR: no-vault startup could not restart the idle watcher" >&2
+    exit 1
+  fi
   mark_phase_ok "settings_rebind_no_lifecycle"
 fi
 if [ "$NO_VAULT_MODE" -ne 1 ]; then

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -321,6 +321,7 @@ def test_dormant_reconciler_failure_matrix_preserves_old_root_observation(
         resumed.write_text("resume scan\n", encoding="utf-8")
 
     registry.run_registry_forever(config_path, max_ticks=1)
+    registry.run_registry_forever(config_path, max_ticks=1)
     completed = load_settings_rebind_watcher_receipt(
         _revision_receipt_path(tmp_path, 1)
     )
@@ -335,8 +336,11 @@ def test_dormant_reconciler_failure_matrix_preserves_old_root_observation(
     event_paths = _event_paths(tmp_path)
     assert str(before) in event_paths
     assert str(between) in event_paths
-    assert str(candidate) not in event_paths
-    assert all(path.startswith(str(vault_a)) for path in event_paths)
+    assert candidate.name not in buffered
+    if fault_stage == "resume":
+        assert str(candidate) in event_paths
+    else:
+        assert all(path.startswith(str(vault_a)) for path in event_paths)
 
 
 @pytest.mark.parametrize("scan_blocker", ["kill_switch", "missing_scope"])
@@ -401,7 +405,7 @@ def test_prepare_ack_refuses_incomplete_registry_scan(
     assert not _revision_receipt_path(tmp_path, 1).exists()
 
 
-def test_rebind_waits_for_budgeted_scan_before_ack_or_completion(
+def test_drained_rebind_requires_resumed_old_root_scan_before_completion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -453,6 +457,23 @@ def test_rebind_waits_for_budgeted_scan_before_ack_or_completion(
     assert completed.stage == "completed"
 
 
+def test_partial_scan_cannot_acknowledge_prepare(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incomplete old-root scan must not produce a prepare acknowledgement."""
+    runtime, vault_a, _vault_b, config_path = _fixture(tmp_path, monkeypatch)
+    for index in range(8):
+        (vault_a / f"partial-{index}.md").write_text("partial\n", encoding="utf-8")
+
+    monkeypatch.setenv("WATCHER_MAX_SCANNED_FILES_PER_TICK", "1")
+    with pytest.raises(RegistryError, match="settings rebind watcher scan was incomplete"):
+        registry.run_registry_once(config_path)
+
+    assert runtime.open_settings_rebind_store().read().phase == "prepared"
+    assert not _revision_receipt_path(tmp_path, 1).exists()
+
+
 def test_rebind_receipt_buffer_is_bounded_to_current_revision_observation_window(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -493,6 +514,7 @@ def test_reconciler_uses_revision_bound_receipts_for_monotonic_reconciliation(
 
     registry.run_registry_once(config_path)
     _commit(runtime)
+    registry.run_registry_once(config_path)
     registry.run_registry_once(config_path)
 
     _prepare(runtime, desired_revision=2, applied_revision=1)
@@ -611,6 +633,7 @@ def test_prepare_drains_and_final_scans_old_binding_writes(
     between.write_text("between\n", encoding="utf-8")
 
     registry.run_registry_forever(config_path, max_ticks=1)
+    registry.run_registry_forever(config_path, max_ticks=1)
 
     receipt = load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1))
     assert receipt.stage == "completed"
@@ -632,6 +655,7 @@ def test_direct_filesystem_write_between_scan_and_commit_is_receipted_under_old_
     candidate = vault_b / "must-not-be-seen.md"
     candidate.write_text("candidate\n", encoding="utf-8")
 
+    registry.run_registry_forever(config_path, max_ticks=1)
     registry.run_registry_forever(config_path, max_ticks=1)
 
     receipt = load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1))
@@ -802,6 +826,7 @@ def test_committed_revision_survives_event_loss_and_process_restart(
     runtime, vault_a, vault_b, config_path = _fixture(tmp_path, monkeypatch)
     registry.run_registry_forever(config_path, max_ticks=1)
     _commit(runtime)
+    registry.run_registry_forever(config_path, max_ticks=1)
     registry.run_registry_forever(config_path, max_ticks=1)
 
     restarted = _runtime(tmp_path)

--- a/tests/integration/test_watcher_cross_process_rebind.py
+++ b/tests/integration/test_watcher_cross_process_rebind.py
@@ -443,9 +443,13 @@ def test_rebind_waits_for_budgeted_scan_before_ack_or_completion(
 
     monkeypatch.setenv("WATCHER_MAX_SCANNED_FILES_PER_TICK", "500")
     registry.run_registry_once(config_path)
-    completed = load_settings_rebind_watcher_receipt(
+    drained = load_settings_rebind_watcher_receipt(
         _revision_receipt_path(tmp_path, 1)
     )
+    assert drained.stage == "drained"
+
+    registry.run_registry_once(config_path)
+    completed = load_settings_rebind_watcher_receipt(_revision_receipt_path(tmp_path, 1))
     assert completed.stage == "completed"
 
 

--- a/tests/ops/test_start_full_runtime_health.py
+++ b/tests/ops/test_start_full_runtime_health.py
@@ -416,7 +416,7 @@ def test_dev_channel_alias_returns_zero_with_deferred_index_rebuild(tmp_path: Pa
     assert "runtime verified: true" in result.stdout
 
 
-def test_no_vault_startup_entrypoint_records_durable_no_lifecycle(tmp_path: Path) -> None:
+def test_no_vault_rebind_rejects_existing_watcher_before_acknowledgement(tmp_path: Path) -> None:
     health = _deferred_index_health()
     health["ok"] = True
     health["required_ok"] = True
@@ -471,6 +471,16 @@ def test_no_vault_startup_entrypoint_records_durable_no_lifecycle(tmp_path: Path
     assert record.desired_revision == record.applied_revision == 1
     progress = Path(env["STARTUP_HARNESS_PROGRESS_PATH"]).read_text(encoding="utf-8")
     assert "settings-rebind-no-lifecycle" in progress
+    progress_lines = progress.splitlines()
+    watcher_stop_index = next(
+        index for index, line in enumerate(progress_lines) if " stop watcher" in line
+    )
+    acknowledgement_index = next(
+        index
+        for index, line in enumerate(progress_lines)
+        if "settings-rebind-no-lifecycle" in line
+    )
+    assert watcher_stop_index < acknowledgement_index
 
 
 def test_prod_start_full_rejects_deferred_index_rebuild(tmp_path: Path) -> None:

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -462,11 +462,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "census's own directly-related-repair convention when #3451 bound "
         "write_frontmatter to the exact NoteRead version."
     ),
-    ("app/vault/manager.py", 934): (
+    ("app/vault/manager.py", 940): (
         "guarded: _ensure_frontmatter_id asserts DEFAULT_WRITE_GUARD."
         "assert_writes_allowed('vault.identity_heal') immediately before this "
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
-        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 -> 928 -> 934 (site unchanged) when "
+        "reaching this line. Line drifted 716 -> 841 -> 843 -> 924 -> 928 -> 934 -> 940 (site unchanged) when "
         "#3452 added conflict-quarantine receipt policy above the manager."
     ),
     ("app/vault/settings_service.py", 617): (
@@ -499,10 +499,10 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
 # closed so moving a write from ``write_frontmatter`` cannot make it disappear
 # from the WriteGuard inventory.
 WRITE_MISSING_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
-    ("app/vault/manager.py", 714): (
+    ("app/vault/manager.py", 720): (
         "bootstrap: VaultManager.initialize_vault is the explicit human/operator "
         "pre-selection initialization transition; O_EXCL preserves existing owner files. "
-        "Line drifted 496 -> 621 -> 623 -> 704 -> 714 (site unchanged) when #3164 added the "
+        "Line drifted 496 -> 621 -> 623 -> 704 -> 714 -> 720 (site unchanged) when #3164 added the "
         "nested canonical prompt seed, #3452 added conflict-quarantine receipt policy, and "
         "SETTINGS-05C added the activation seam above the manager."
     ),

--- a/tests/watcher/test_registry.py
+++ b/tests/watcher/test_registry.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from app.watcher import registry
+
+
+def test_settings_rebind_rejects_traversal_error_before_acknowledgement(monkeypatch) -> None:
+    def broken_walk(*_args, **_kwargs):
+        if False:
+            yield Path("unreachable")
+        raise OSError("injected traversal failure")
+
+    summary: dict[str, object] = {}
+    monkeypatch.setattr(registry, "iter_vault_markdown_files", broken_walk)
+
+    assert list(
+        registry._scan_markdown_many(Path("/vault"), [Path("/vault")], "**/*.md", summary=summary)
+    ) == []
+    assert summary["scan_complete"] is False
+    assert summary["scan_incomplete_reason"] == "traversal"


### PR DESCRIPTION
## Summary
Fails closed watcher rebind acknowledgement across no-vault startup, traversal errors, and post-drain convergence.

Governing-Issue: #5248
Fixes #5248

## SBS Impact
- Primary subsystem: watcher lifecycle and Settings Spine rebind
- Secondary subsystem(s): startup orchestration and vault traversal
- Write class: runtime lifecycle correctness
- Persistence impact: rebind receipts require convergence evidence
- Derived/rebuildable impact: scan summaries and watcher state are rebuildable
- New or changed contract: acknowledgements require watcher and scan convergence evidence
- Owner-doc impact: SETTINGS-05B validation and watcher operations guidance updated in this PR
- Transition debt impact: closes remaining SETTINGS-05B lifecycle gaps
- Boundary risk: never acknowledge a partial scan or running old watcher

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was created; this is a bounded runtime bug delivery.

Final-Review-Rounds: 1

## Validation
- Focused production-path regressions
- ruff check app tests
- mypy app
- git diff --check
