### PR TITLE
docs: reconcile continuity authority

### DIFF
--- a/docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md
@@ -8,6 +8,8 @@ Authority: Defines the eventual authority cutover and Product separation boundar
 
 Activate one BuilderOps PostgreSQL authority without reintroducing Product ownership, a second writer, or a data-rewind rollback path.
 
+This owner contract follows the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): BuilderOps operational state is rebuildable from declared repository, image, configuration, and secret-custody sources; its journals, leases, epochs, and fences are operational safety state; and any missing lineage starts an inactive new fenced bootstrap with GitHub readback before activation. Diagnostic dumps and optional backups are evidence/ergonomics only, never semantic authority or a mandatory restore proof. The historical July 2026 restore-first/WAL proposal is superseded and not an active capability; no generalized backup/restore is shipped by this contract.
+
 ## Builder-system authority activation
 
 Before a live activation, the operator must prove an immutable source/image candidate, separate BuilderOps Docker engine/project, VM-local secret references, loopback API, Tailscale Serve private HTTPS without Funnel, scoped bearer authentication, schema/migrations, authority epoch/fencing, no dual writer, health/readiness, local disk/WAL guardrails, and a rebuild receipt. The BuilderOps database is rebuildable operational state: a failed deployment is rebuilt from repository, attested images, configuration, and secret custody. Backup or restore evidence is not an activation gate.

--- a/docs/BUILDEROPS_CONTROL_PLANE/README.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/README.md
@@ -17,6 +17,8 @@ BCP task names and historical file paths remain for traceability.
 This specification does not transfer product or delivery authority. GitHub Issues, PR head SHA,
 required CI, review gates, repository protection, and GitHub merge results remain authoritative.
 
+The BuilderOps specification follows the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts and document-backed governance receipts remain authority, BuilderOps machine state is rebuildable operational state, and its journals/leases/fences protect effects rather than human meaning. Missing lineage uses an inactive new fenced bootstrap and GitHub readback. Diagnostic dumps and optional backups are evidence/ergonomics only, never semantic authority or a mandatory restore proof. The historical restore-first/WAL proposal is superseded and not an active capability; deployment and total-loss recovery remain target-state unless their own receipts exist.
+
 ## Delivery status
 
 BCP-01 is implemented in the development baseline by #3792/PR #3852 with the independent

--- a/docs/CONCEPTS/MACHINE_MIRROR_AND_DB_AUTHORITY_CONTRACT.md
+++ b/docs/CONCEPTS/MACHINE_MIRROR_AND_DB_AUTHORITY_CONTRACT.md
@@ -14,6 +14,8 @@ The system runs on Postgres, pgvector, indexes, and caches. These are essential 
 
 It is the Layer 6 detail for `docs/SEMANTIC_SYSTEM_ARCHITECTURE.md` and the mirror-row detail for `docs/SEMANTIC_AUTHORITY_MATRIX.md`.
 
+The continuity classification is owned by [`RSC-01 continuity classification`](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts, companions, and document-backed governance receipts remain authority; machine mirrors remain rebuildable; diagnostics and optional backups remain evidence/ergonomics only; and missing operational lineage requires a new fenced bootstrap epoch. This contract does not claim a generalized restore program.
+
 ## Canonical authority
 
 The durable, authoritative set is the human-readable surface; machine mirrors sit beneath it.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -8,6 +8,8 @@ Authority: Practical dependency matrix for current code paths and environments; 
 - Watcher auto-run defaults on (`WATCHER_AUTO_EXEC=1`); set `WATCHER_AUTO_EXEC=0` for emit-only mode. LangGraph/Reasoning rollout remains opt-in.
 - See `docs/STATUS.md` and `docs/ARCHITECTURE.md` for the current baseline and forward line.
 
+This reference follows the [RSC-01 continuity classification](REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts, companions, and document-backed governance receipts are continuity authority; machine mirrors are rebuildable; and operational safety state is fenced when lineage is missing. Diagnostic JSONL, dumps, and optional backups are evidence/ergonomics only, never semantic authority and never a mandatory restore proof. They are not a scheduled disaster-recovery or readiness requirement.
+
 # Dependencies
 
 Overview of tools and libraries required in each environment.
@@ -60,7 +62,7 @@ runtime. These are **not** Python/pip dependencies; they load as ES modules.
 | --- | --- | --- | --- |
 | Local dev | `LLM_PROVIDER=mock` (or `ollama`), `STORE_BACKEND=memory`, `INDEX_OUTBOX_PATH=./tmp/index-outbox.jsonl` | Python venv, yt-dlp, ffmpeg, optional Ollama. | Health CLI proves ffmpeg/yt-dlp/outbox readiness; JSONL is audit only. |
 | CI smoke (`.github/workflows/ci-smoke.yaml`) | `LLM_PROVIDER=mock`, `STORE_BACKEND=memory`, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` | Installs ffmpeg via apt, pip installs requirements. | No Ollama; health runs in mock mode. |
-| “Prod” workstation | `LLM_PROVIDER=ollama`, `OLLAMA_HOST`, `LLM_MODEL`, `DATABASE_URL`, `STORE_BACKEND=pg`, `INDEX_OUTBOX_PATH` on persistent storage (e.g. `~/logs/index-outbox.jsonl`) | Same as local + Ollama daemon + Postgres when `STORE_BACKEND=pg`. | DB outbox is canonical in runtime; JSONL is audit-only. Add log rotation/backups for `INDEX_OUTBOX_PATH` (see `docs/OPERATIONS.md`). |
+| “Prod” workstation | `LLM_PROVIDER=ollama`, `OLLAMA_HOST`, `LLM_MODEL`, `DATABASE_URL`, `STORE_BACKEND=pg`, `INDEX_OUTBOX_PATH` on persistent storage (e.g. `~/logs/index-outbox.jsonl`) | Same as local + Ollama daemon + Postgres when `STORE_BACKEND=pg`. | DB outbox is canonical in runtime; JSONL is audit-only. Optional log rotation may retain diagnostic evidence; it is not a scheduled disaster-recovery or readiness requirement (see `docs/OPERATIONS.md`). |
 
 ## YouTube transcripts and anti-bot notes
 - yt-dlp may be rate limited (403/429). Health only checks imports—run `yt-dlp https://youtu.be/...` manually when debugging.

--- a/docs/GOVERNED_ARCHIVAL_FLOW/ADAPT_HUMAN_ARTIFACT_RECOVERY.md
+++ b/docs/GOVERNED_ARCHIVAL_FLOW/ADAPT_HUMAN_ARTIFACT_RECOVERY.md
@@ -17,6 +17,8 @@ can_parallelize_with: [Adapt Retained Source Artifacts, Govern Rebuildable Deriv
 Give durable human-authored and human-accepted artifacts a portable recovery path while preserving
 HKA as the authority for identity, generation, provenance, and governed writes.
 
+This is target-state recovery work and follows the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): HKA artifacts and document-backed receipts remain owner-native authority, while staged exports and machine representations are not authority until a governed write succeeds. Diagnostic dumps and optional backups are evidence/ergonomics only, never semantic authority or a mandatory restore proof. Historical restore-first material is superseded by this owner-native, conflict-safe posture. The adapter is not an active shipped capability until its bounded Issue and parent acceptance evidence are complete.
+
 ## What This Task Does
 
 - Implement an HKA recovery adapter under `app.archival.adapters` over the existing ArtifactContract

--- a/docs/GOVERNED_ARCHIVAL_FLOW/README.md
+++ b/docs/GOVERNED_ARCHIVAL_FLOW/README.md
@@ -30,6 +30,8 @@ authority; PDM owns storage mechanics; GOV owns access and policy decisions; SIP
 provenance; DRI owns rebuildable derivatives. Adapters map those owner-native contracts into the
 common flow without copying their truth into a central archive registry.
 
+This target-state specification follows the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts and document-backed receipts remain owner-native authority; derivatives and other machine projections are rebuildable; diagnostic dumps and optional backups are evidence/ergonomics only, never semantic authority or a mandatory restore proof. HKA recovery remains a bounded, blocked/target-state adapter until its own delivery and acceptance evidence exists; this directory is not a shipped general restore capability.
+
 ## Current-Main Reconciliation
 
 - Heimdal parent #3842 and HAR-01..05 (#3847–#3851) are closed. PR #5061 delivered HAR-05 at

--- a/docs/OBSERVABILITY_STABILIZATION/DEV_DB_SNAPSHOT_RESTORE.md
+++ b/docs/OBSERVABILITY_STABILIZATION/DEV_DB_SNAPSHOT_RESTORE.md
@@ -26,6 +26,8 @@ Give dev/test a fast snapshot/restore cycle for bug reproduction, and an on-dema
 forensic dump for prod incident investigation. This is explicitly dev-ergonomics and
 forensics — not scheduled disaster recovery.
 
+Snapshots and dumps follow the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): they are evidence/ergonomics only, never semantic authority and never a mandatory restore proof. They cannot establish readiness or replace the canonical worker queue, and this target-state task does not claim total-loss recovery.
+
 ## What This Task Does
 
 Adds three Makefile targets using `pg_dump` / `pg_restore`:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -172,6 +172,15 @@ created at runtime by the legacy bootstrap SQL, deleted by #4560) and changes it
 - JSONL outbox (`INDEX_OUTBOX_PATH`) is audit/diagnostic only and must not be used as the worker queue.
 - Registry watcher is the single runtime watcher (`configs/watchers.yaml` + `python -m app.cli watcher run`). Legacy snapshot watchers are dev-only.
 
+The operations playbook follows the [RSC-01 continuity classification](REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification).
+Retained human artifacts, companions, and document-backed governance receipts remain continuity
+authority; machine mirrors are rebuildable; operational journals, leases, ownership records, and
+fences are safety state. Diagnostic JSONL/dumps and optional backups are evidence/ergonomics only:
+they are never the worker queue, readiness, semantic authority, or a mandatory restore proof. If
+operational lineage is missing, the supported target posture is a new fenced bootstrap epoch with
+writers inactive until owner-native readback and convergence. Total-loss recovery is not claimed as
+shipped runtime capability here.
+
 ## Environment posture
 
 This document is primarily the `prod` operator entrypoint.
@@ -777,6 +786,10 @@ Quick issue routing:
 The vault (Obsidian iCloud) is the durable system-of-record; the database is a disposable projection.
 These Makefile targets are for bug-reproduction and incident investigation only.
 Do not use them as a prod DR restore path.
+
+Snapshots and dumps are evidence/ergonomics only: they are never semantic authority and never a
+mandatory restore proof. They cannot establish readiness, replace the DB outbox worker queue, or
+restore lost operational ownership/lineage. See the [RSC-01 continuity classification](REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification).
 
 Three targets are available:
 

--- a/docs/REBUILDABLE_SYSTEM_CONTINUITY/README.md
+++ b/docs/REBUILDABLE_SYSTEM_CONTINUITY/README.md
@@ -22,6 +22,24 @@ receipts, and activate only after convergence. The system never pretends that a 
 old ownership, and it never replays an effect solely because the lost local database cannot prove
 whether that effect happened.
 
+## RSC-01 continuity classification
+
+This is the shared classification for continuity and recovery owner docs:
+
+- Retained human artifacts, companions, and document-backed governance receipts are continuity
+  authority within their owner scope.
+- Machine mirrors and coordination projections are rebuildable from declared sources and recipes;
+  they never become semantic, governance, or action authority because they were retained.
+- Retained diagnostics, JSONL/dumps, and optional backups are evidence/ergonomics only. They are
+  never a worker queue, readiness gate, semantic authority, or a mandatory restore proof.
+- Journals, leases, ownership records, recovery fences, and epochs are operational safety state.
+  Missing lineage starts a new fenced bootstrap epoch, with writers inactive until owner-native or
+  external authority readback and convergence.
+
+Historical restore-first, WAL, and generalized backup proposals remain historical, superseded, or
+blocked unless a current owner contract explicitly promotes a bounded capability. This document
+does not claim that total-loss recovery or a generalized restore program is shipped.
+
 ## Cross-Task Invariants / Partial Failure Safety
 
 1. **Retained authority survives mirror loss.** Loss of a machine representation cannot alter

--- a/docs/REBUILDABLE_SYSTEM_CONTINUITY/RECONCILE_CONTINUITY_AUTHORITY.md
+++ b/docs/REBUILDABLE_SYSTEM_CONTINUITY/RECONCILE_CONTINUITY_AUTHORITY.md
@@ -2,7 +2,7 @@
 name: Reconcile Continuity Authority
 description: Align owner documents with retained authority, rebuildable mirrors, and fenced new-bootstrap recovery.
 task_id: RSC-01
-github_issue:
+github_issue: 5280
 source_anchor: "docs/audits/REBUILDABILITY_RECOVERY_AUTHORITY_AUDIT_2026-08-31.md :: 3. Anchored findings"
 parent_capability: Rebuildable System Continuity
 prerequisites: [DSP-01]

--- a/docs/SEMANTIC_AUTHORITY_MATRIX.md
+++ b/docs/SEMANTIC_AUTHORITY_MATRIX.md
@@ -14,6 +14,8 @@ This document is the per-entity authority detail for **Layer 4 (Governance/Autho
 
 It is a consolidation, not a new authority. Each flag's authoritative definition lives in an owner doc (named in the column legend); where a cell summarizes that owner, the owner wins on conflict and this matrix is updated to match.
 
+The matrix follows the [`RSC-01 continuity classification`](REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts, companions, and document-backed governance receipts are continuity authority; machine mirrors are rebuildable; diagnostics and optional backups are evidence/ergonomics only; and operational safety state with missing lineage starts a new fenced bootstrap epoch. These target-state continuity semantics do not claim that total-loss recovery is shipped.
+
 The accepted cross-plane Builder/PKM authority and provenance overlay is in
 `docs/architecture/INFORMATION_AUTHORITY_MODEL.md`. This matrix remains the owner of per-entity
 Product/Runtime authority flags; it adopts no replacement schema or local-contract semantics.

--- a/docs/audits/BUILDEROPS_CONTROL_PLANE_2026-07-15.md
+++ b/docs/audits/BUILDEROPS_CONTROL_PLANE_2026-07-15.md
@@ -1,4 +1,4 @@
-State: Advisory architecture audit snapshot, 2026-07-15. Structural evidence baseline: `origin/main` at `1e66c16120a9bbd0b1c91c3b50162be805d407c7`; lifecycle reconciliation refreshed through `origin/main` at `9e45e847b8cb8bfee847c9e7364cd8f16c793bdf` and live GitHub the same day. Subordinate to owner docs and ADRs. Executable handoff: `docs/BUILDEROPS_CONTROL_PLANE/`.
+State: Historical advisory architecture audit snapshot, 2026-07-15. Structural evidence baseline: `origin/main` at `1e66c16120a9bbd0b1c91c3b50162be805d407c7`; lifecycle reconciliation refreshed through `origin/main` at `9e45e847b8cb8bfee847c9e7364cd8f16c793bdf` and live GitHub the same day. Subordinate to owner docs and ADRs. Executable handoff: `docs/BUILDEROPS_CONTROL_PLANE/`.
 Doc role: Reference (architecture audit)
 Authority: Evidence and synthesis only. ADR-0010 owns the authority seam; accepted ADR-0062 owns the target decision; GitHub Issues own implementation work.
 Owner: BuilderOps governance / Architecture spine
@@ -249,3 +249,6 @@ only after the decision/spec contract is merged and each issue has resolvable `V
 No unresolved owner decision blocks that sequence. Authentication technology, ports, backup target
 and retention values, schema layout, and later source-repository extraction are bounded
 implementation/later-trigger decisions subject to the invariants above.
+
+The restore-first/WAL proposal in this historical audit is superseded by the current BuilderOps
+owner contracts and is not a current recovery requirement.

--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -11,6 +11,8 @@ Last verified against: `docker-compose.yaml`, `docker-compose.{dev,test,prod}.ym
 
 ## Why this document exists
 
+Deployment follows the [RSC-01 continuity classification](../REBUILDABLE_SYSTEM_CONTINUITY/README.md#rsc-01-continuity-classification): retained human artifacts, companions, and document-backed governance receipts remain continuity authority; machine mirrors and deployment projections are rebuildable; diagnostic dumps and optional backups are evidence/ergonomics only, never semantic authority or a mandatory restore proof. Deployment journals, leases, ownership records, and fences are operational safety state. Missing lineage requires a new inactive fenced bootstrap and owner-native/external readback before activation; this document does not claim shipped total-loss recovery.
+
 ## BuilderOps local rebuildable deployment contract
 
 The BuilderOps control plane is a separate deployment boundary from the Product channels. Its API

--- a/tests/architecture/test_rebuildability_authority_docs.py
+++ b/tests/architecture/test_rebuildability_authority_docs.py
@@ -1,0 +1,84 @@
+"""Static guards for the RSC-01 continuity-authority classification."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+CONTINUITY_README = ROOT / "docs/REBUILDABLE_SYSTEM_CONTINUITY/README.md"
+OWNER_DOCS = (
+    ROOT / "docs/CONCEPTS/MACHINE_MIRROR_AND_DB_AUTHORITY_CONTRACT.md",
+    ROOT / "docs/SEMANTIC_AUTHORITY_MATRIX.md",
+    ROOT / "docs/OPERATIONS.md",
+    ROOT / "docs/DEPENDENCIES.md",
+    ROOT / "docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md",
+    ROOT / "docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md",
+    ROOT / "docs/BUILDEROPS_CONTROL_PLANE/README.md",
+    ROOT / "docs/GOVERNED_ARCHIVAL_FLOW/README.md",
+    ROOT / "docs/GOVERNED_ARCHIVAL_FLOW/ADAPT_HUMAN_ARTIFACT_RECOVERY.md",
+)
+
+CLASSIFICATION_MARKER = "rsc-01 continuity classification"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(_read(path).lower().split())
+
+
+def test_owner_docs_share_one_continuity_classification() -> None:
+    canonical = _normalized(CONTINUITY_README)
+    assert CLASSIFICATION_MARKER in canonical
+    for phrase in (
+        "retained human artifacts, companions, and document-backed governance receipts",
+        "machine mirrors and coordination projections are rebuildable",
+        "optional backups are evidence/ergonomics only",
+        "operational safety state",
+        "new fenced bootstrap epoch",
+    ):
+        assert phrase in canonical
+
+    for path in OWNER_DOCS:
+        text = _read(path).lower()
+        assert CLASSIFICATION_MARKER in text, path
+
+
+def test_diagnostic_retention_is_not_recovery_authority() -> None:
+    canonical = _normalized(CONTINUITY_README)
+    operations = _normalized(ROOT / "docs/OPERATIONS.md")
+    dependencies = _normalized(ROOT / "docs/DEPENDENCIES.md")
+    snapshot_spec = _normalized(
+        ROOT / "docs/OBSERVABILITY_STABILIZATION/DEV_DB_SNAPSHOT_RESTORE.md"
+    )
+
+    for text in (canonical, operations, dependencies, snapshot_spec):
+        assert "evidence/ergonomics only" in text
+        assert "semantic authority" in text
+        assert "mandatory restore proof" in text
+    assert "must not be used as the worker queue" in operations
+    assert "not a scheduled disaster-recovery or readiness requirement" in dependencies
+
+
+def test_historical_recovery_material_cannot_claim_active_capability() -> None:
+    bcp_owner = _read(
+        ROOT / "docs/BUILDEROPS_CONTROL_PLANE/AUTHORITY_CUTOVER_PRODUCT_SEPARATION.md"
+    )
+    bcp_readme = _read(ROOT / "docs/BUILDEROPS_CONTROL_PLANE/README.md")
+    hka_recovery = _read(
+        ROOT / "docs/GOVERNED_ARCHIVAL_FLOW/ADAPT_HUMAN_ARTIFACT_RECOVERY.md"
+    )
+    historical = _read(ROOT / "docs/audits/BUILDEROPS_CONTROL_PLANE_2026-07-15.md")
+
+    for text in (bcp_owner, bcp_readme, hka_recovery):
+        assert "historical" in text.lower()
+        assert "superseded" in text.lower() or "blocked" in text.lower()
+        assert (
+            "not shipped" in text.lower()
+            or "not an active capability" in text.lower()
+            or "not an active shipped capability" in text.lower()
+        )
+    assert "historical" in historical.lower()
+    assert "superseded" in historical.lower()
+    assert "not a current recovery requirement" in historical


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5280

## Linked Issue
Closes #5280

## SBS Impact
- Primary subsystem: CES / Architecture boundary
- Secondary subsystem(s): HKA, SIP, GOV, PDM, DRI, WSP/MVR, Builder System, Platform/Ops
- Write class: governance/specification docs and static architecture tests
- Persistence impact: none; documentation and tests only, with no runtime or store mutation
- Derived/rebuildable impact: makes the retained-authority versus rebuildable-mirror classification explicit
- New or changed contract: owner-doc continuity classification and diagnostic-retention wording; no runtime contract
- Owner-doc impact: owner docs updated in this PR; no new registry or owner surface
- Transition debt impact: removes backup-as-authority and historical restore-first/WAL interpretations before runtime slices
- Boundary risk: target-state reconciliation must not be reported as shipped total-loss recovery capability

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Align continuity owner documents on retained authority, rebuildable machine mirrors, operational safety state, and the new fenced-bootstrap posture.
- Clarify diagnostic JSONL/dumps and optional backups as evidence/ergonomics only, and mark historical restore-first/WAL material as superseded without changing runtime behavior.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was produced; GitHub/dispatcher lifecycle receipts remain delivery coordination evidence, while this PR only changes repository docs and static guards.

## Notes
RSC-01 is a governance/docs slice. Validation is focused on the new architecture guards, docs index/archival contracts, docs language guard, ruff, mypy, and git diff hygiene. No runtime, database, backup, host, deployment, or historical-evidence deletion is in scope.
