### PR TITLE
fix(deploy): enforce readiness and functional health gates

### DIFF
--- a/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
+++ b/docs/deployment/DEPLOYMENT_AND_ENVIRONMENTS.md
@@ -129,13 +129,13 @@ for the environment-selection contract these values implement.
 | Shared renderer | `render_index_html` | `render_index_html` | `render_index_html` |
 | Vault mount → container `/app/vault` | none (no-vault posture) | Bifröst | Midgård |
 | Runtime env / deploy-pin source | `config/deploy/dev.env` + compose env | `config/deploy/test.env` + compose env | generated `tmp/runtime.env` + `config/deploy/prod.env` placeholder pin |
-| Container app code source | baked local image `pkm-app:dev-local` | `workspace-app` with shared host checkout bind-mounted at `/app` | `workspace-app` with shared host checkout bind-mounted at `/app` |
+| Container app code source | baked local image `pkm-app:dev-local` (app bind overlay opt-in) | pinned image (app bind overlay opt-in) | pinned image (app bind overlay opt-in) |
 | Startup wrappers | `make dev-up` / `make dev-ui` (`scripts/dev/start_niflheim_ui.sh`) | `make test-up` / `make test-ui` (`scripts/test/start_bifrost_ui.sh`) | `make prod-up` / `make prod-ui` (`scripts/prod/start_midgard_ui.sh`) |
 
 Anchors for the values above: ports/DBs in `docker-compose.{dev,test,prod}.yml`; the 2026-07-06 host recon recorded in #3124 / `docs/deployment/PINNED_IMAGE_CUTOVER/README.md`; gateway ports `_DEFAULT_PORT = 8111` (`serve_dev_page.py`) and `_PRODUCTION_PORT = 8113` (`serve_production_page.py`, with test 8112 set via the `PORT` env); vault names per `reference_three_vaults` (names are operator-owned and **never hardcoded**).
 
 Notes on the current model:
-- `test` and `prod` still bind-mount the **same host checkout** at `/app`. That repo bind-mount is what removes code isolation: a `git checkout` in the one host tree changes the code under both channels' containers at once. `dev` differs only by running the baked local `pkm-app:dev-local` image, not by running a promoted GHCR SHA pin.
+- The repo app bind mount is opt-in through `docker-compose.app-bind.yml`; the standard dev, test, and prod Compose/deploy paths omit it. When explicitly enabled for a local hot-reload or exact-worktree UAT session, it mounts the selected checkout at `/app` and therefore is not code-isolated from changes in that checkout. `dev` otherwise runs the baked local `pkm-app:dev-local` image, while test and prod use their channel image pins.
 - Companion UI gateways are now declared as managed compose units in the repo, but the running fleet has not yet adopted the pinned-image model. The cutover guard therefore checks gateway-unit participation in the recreate set before #2698 can treat a channel as ready.
 - Production Compose fixes Companion's publish to `127.0.0.1:8113` and passes the matching explicit
   declaration `COMPANION_UI_BIND_HOST=127.0.0.1` into the gateway as one canonical producer pair;

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -681,8 +681,36 @@ wait_json_ok() {
   return 1
 }
 
+wait_http_success() {
+  local url="$1" deadline
+  deadline=$((SECONDS + health_timeout))
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    if curl -fsS --max-time 3 "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+wait_json_required_ok() {
+  local url="$1" deadline body
+  deadline=$((SECONDS + health_timeout))
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    if body="$(curl -fsS --max-time 3 "${url}" 2>/dev/null)"; then
+      if "${PYTHON}" -c 'import json,sys; data=json.load(sys.stdin); sys.exit(0 if isinstance(data, dict) and data.get("required_ok") is True else 1)' <<<"${body}"; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  return 1
+}
+
 health_gate() {
   wait_json_ok "http://127.0.0.1:${api_port}/healthz" || return 1
+  wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
+  wait_json_required_ok "http://127.0.0.1:${api_port}/api/health" || return 1
   wait_json_ok "http://127.0.0.1:${ui_port}/healthz" || return 1
 }
 

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -151,17 +151,40 @@ def test_pin_write_preserves_channel_runtime_env() -> None:
     assert 'mv "${tmp_file}" "${file}"' in write_pin
 
 
-def test_health_gate_blocks_and_triggers_rollback() -> None:
+def test_health_gate_requires_liveness_readiness_and_functional_health() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
-    assert "health_gate" in text
-    assert "http://127.0.0.1:${api_port}/healthz" in text
-    assert "http://127.0.0.1:${ui_port}/healthz" in text
-    assert 'wait_json_ok "http://127.0.0.1:${ui_port}/healthz"' in text
+    health_gate = text.split("health_gate() {", 1)[1].split("\n}\n", 1)[0]
+    readiness_wait = text.split("wait_http_success() {", 1)[1].split("\n}\n", 1)[0]
+    functional_health_wait = text.split("wait_json_required_ok() {", 1)[1].split(
+        "\n}\n", 1
+    )[0]
+
+    assert 'wait_json_ok "http://127.0.0.1:${api_port}/healthz"' in health_gate
+    assert 'wait_http_success "http://127.0.0.1:${api_port}/readyz"' in health_gate
+    assert 'wait_json_required_ok "http://127.0.0.1:${api_port}/api/health"' in health_gate
+    assert 'wait_json_ok "http://127.0.0.1:${ui_port}/healthz"' in health_gate
+    assert 'curl -fsS --max-time 3 "${url}"' in readiness_wait
+    assert 'data.get("required_ok") is True' in functional_health_wait
     assert "isinstance(data, dict)" in text
     assert 'run_postmutation_gate "health gate failed"' in text
     run_block = text.split('echo "deploy plan:', 1)[1]
     assert run_block.index("recreate_channel_services") < run_block.index("health_gate")
     assert run_block.index("health_gate") < run_block.index("version_gate")
+
+
+def test_embedding_rebuild_path_preserves_deferred_readiness_exception() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    recreate = text.split("recreate_channel_services() {", 1)[1].split(
+        "\n}\n\nscalar_rollback_gateway_auth_gate", 1
+    )[0]
+    acknowledged_path = recreate.split(
+        'if [ "${action}" = "deploy" ] && [ "${ack_embedding_rebuild_required}" = "1" ]; then',
+        1,
+    )[1].split("  fi\n\n  compose up", 1)[0]
+
+    assert 'wait_json_ok "http://127.0.0.1:${api_port}/healthz"' in acknowledged_path
+    assert "/readyz must stay red" in acknowledged_path
+    assert 'run_postmutation_gate "health gate failed" health_gate' in text
 
 
 def test_rollback_uses_previous_pin_and_skips_forward_only_reversal() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5265

## Linked Issue
Closes #5265

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Yggdrasil Platform and Operations System; Product deployment envelope
- Write class: mechanical deployment guard plus current-state docs correction
- Persistence impact: none
- Derived/rebuildable impact: deployment receipts remain rebuildable evidence
- New or changed contract: ordinary deployment admission requires liveness, HTTP readiness, and required functional health
- Owner-doc impact: updated
- Transition debt impact: reduces
- Boundary risk: the acknowledged embedding-rebuild transition retains deferred readiness until its governed rebuild/smoke gate

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Require API readiness and required functional health before an ordinary deploy or rollback passes the health gate.
- Keep the acknowledged embedding-rebuild transition on its explicit deferred-readiness path.
- Correct the local Compose fallback matrix to describe the app bind overlay as opt-in.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260831224716_aa5ccf05
- Reason: The prior readiness-semantics divergence was already captured; this PR applies it at the production deploy call site.

## Notes
Validation: pytest deploy script/deploy suite; bash -n scripts/deploy_channel.sh; docs language guard; ruff check app tests companion-ui/companion-app. No live channel operation was performed.
