### PR TITLE
fix(dev): bind bootstrap to canonical dev channel

### DIFF
--- a/scripts/dev_bootstrap.sh
+++ b/scripts/dev_bootstrap.sh
@@ -19,26 +19,40 @@ fi
 
 cd "$ROOT"
 
-docker compose up -d
+compose_args=(
+  -f docker-compose.yaml
+)
+if [ -n "${APP_CODE_BIND_COMPOSE:-}" ]; then
+  compose_args+=(
+    -f "$APP_CODE_BIND_COMPOSE"
+  )
+fi
+compose_args+=(
+  --env-file config/deploy/dev.env
+  -f docker-compose.dev.yml
+  -p pkm-dev
+)
+
+docker compose "${compose_args[@]}" up -d
 
 for attempt in $(seq 1 30); do
-  if curl -sf http://127.0.0.1:18000/healthz >/dev/null 2>&1; then
+  if curl -sf http://127.0.0.1:18001/healthz >/dev/null 2>&1; then
     break
   fi
   sleep 2
 done
 
-if ! curl -sf http://127.0.0.1:18000/healthz > /tmp/dev_bootstrap_health.json 2>/dev/null; then
-  echo "API did not become healthy on port 18000"
+if ! curl -sf http://127.0.0.1:18001/healthz > /tmp/dev_bootstrap_health.json 2>/dev/null; then
+  echo "API did not become healthy on port 18001"
   exit 1
 fi
 
-curl -sf http://127.0.0.1:18000/api/status > /tmp/dev_bootstrap_status.json || true
+curl -sf http://127.0.0.1:18001/api/status > /tmp/dev_bootstrap_status.json || true
 
 if [ "${RUN_SMOKE:-0}" != "0" ]; then
   cd "$ROOT"
   pytest tests/agents/test_panel_parser.py -q --maxfail=1
 fi
 
-echo "API healthy on 18000; db on 15432; worker running"
+echo "API healthy on 18001; db on 15433; worker running"
 cat /tmp/dev_bootstrap_status.json || true

--- a/tests/scripts/test_dev_bootstrap.py
+++ b/tests/scripts/test_dev_bootstrap.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "dev_bootstrap.sh"
+
+
+def test_dev_bootstrap_uses_canonical_dev_channel() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "--env-file config/deploy/dev.env" in text
+    assert "-f docker-compose.dev.yml" in text
+    assert "-p pkm-dev" in text
+    assert "127.0.0.1:18001/healthz" in text
+    assert "API healthy on 18001; db on 15433; worker running" in text
+
+
+def test_dev_bootstrap_has_no_prod_port_dependency() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "18000" not in text
+    assert "15432" not in text


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5266

## Linked Issue
Closes #5266

## SBS Impact
- Primary subsystem: Yggdrasil Platform and Operations System
- Secondary subsystem(s): Builder System / CES boundary
- Write class: mechanical bootstrap correction
- Persistence impact: dev database selection only; no migration or data rewrite
- Derived/rebuildable impact: none
- New or changed contract: none; align the legacy helper with the canonical dev contract
- Owner-doc impact: none
- Transition debt impact: reduces
- Boundary risk: the dev helper must not address or start the production fallback project/database

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- bind dev bootstrap to the pkm-dev Compose project, dev environment file, and dev overlay
- probe and report only the canonical dev API and database ports
- add regression coverage for the production bootstrap script path

## BuilderOps Routing
- Records/projections/receipts: GitHub claim receipt https://github.com/RasmusTho/agentic-pkm-mvp/issues/5266#issuecomment-5499784102
- Reason: No BuilderOps material was produced; this is a bounded dev bootstrap correction with its Issue and PR providing delivery traceability.

## Notes
Validation: pytest -q tests/scripts/test_dev_bootstrap.py; bash -n scripts/dev_bootstrap.sh; ruff check app tests companion-ui/companion-app; python3 scripts/docs_guard.py --language-only. No live environment action was run.
