### PR TITLE
fix(watcher): coalesce settings source reloads

### DIFF
--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1501,6 +1501,47 @@ def _next_incremental_markdown(
     return None, True
 
 
+def _capture_settings_source_snapshot(
+    *,
+    vault_root: Path,
+    scan_roots: Iterable[Path],
+    state: WatcherState,
+) -> dict[str, tuple[float, str] | None]:
+    """Capture every physical settings source before a shared bundle reload."""
+
+    snapshot: dict[str, tuple[float, str] | None] = {}
+    source_root_names = {SETTINGS_SOURCE_DIR_NAME, LEGACY_COMPILED_DIR.name}
+    for scan_root in scan_roots:
+        try:
+            root_rel = scan_root.relative_to(vault_root)
+        except ValueError:
+            continue
+        if len(root_rel.parts) != 1 or root_rel.parts[0] not in source_root_names:
+            continue
+        if not scan_root.exists():
+            continue
+        for path in sorted(scan_root.rglob("*.md"), key=str):
+            try:
+                rel = path.relative_to(vault_root)
+                if not is_settings_source_path(rel):
+                    continue
+                mtime = path.stat().st_mtime
+                hashed = _hash_file(path)
+            except (OSError, ValueError):
+                continue
+            if hashed is not None:
+                snapshot[str(rel)] = (mtime, hashed[0])
+
+    # A source already known to the watcher may be absent at snapshot time. Keep
+    # that absence distinguishable from a path that could not be snapshotted so
+    # a deletion observed after reload start remains retryable.
+    for rel_str in state.file_paths():
+        rel = Path(rel_str)
+        if is_settings_source_path(rel):
+            snapshot.setdefault(rel_str, None)
+    return snapshot
+
+
 def _collect_changed_entries(
     cfg: RegistryConfig,
     spec: WatcherSpec,
@@ -1510,7 +1551,7 @@ def _collect_changed_entries(
     scan_roots: Iterable[Path],
     states: Mapping[str, WatcherState],
     handled_settings_sources: set[Path] | None = None,
-    settings_source_reload_results: dict[str, bool | float] | None = None,
+    settings_source_reload_results: dict[str, object] | None = None,
 ) -> tuple[list[ChangedEntry], list[str]]:
     changed_entries: list[ChangedEntry] = []
     scanned_paths: list[str] = []
@@ -1629,17 +1670,28 @@ def _collect_changed_entries(
             # physical path is observed; on failure none are advanced, keeping
             # every source retryable on the next scan generation.
             if "full_bundle" in settings_source_reload_results:
-                reload_started_at = settings_source_reload_results.get(
-                    "full_bundle_started_at"
+                source_snapshot = settings_source_reload_results.get(
+                    "full_bundle_snapshot"
+                )
+                expected_observation = (
+                    source_snapshot.get(rel_str)
+                    if isinstance(source_snapshot, dict)
+                    else None
                 )
                 if (
                     settings_source_reload_results["full_bundle"] is True
-                    and isinstance(reload_started_at, float)
-                    and mtime <= reload_started_at
+                    and isinstance(expected_observation, tuple)
+                    and expected_observation == (mtime, digest)
                 ):
                     state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
                 continue
-            settings_source_reload_results["full_bundle_started_at"] = time.time()
+            settings_source_reload_results["full_bundle_snapshot"] = (
+                _capture_settings_source_snapshot(
+                    vault_root=cfg.vault_path,
+                    scan_roots=roots,
+                    state=state,
+                )
+            )
             source_delta = handle_settings_source_delta(
                 rel_path=rel,
                 vault_root=cfg.vault_path,
@@ -1968,7 +2020,7 @@ def _run_spec_tick(
     states: Mapping[str, WatcherState] | None = None,
     process_panel_notes_inline: bool = False,
     handled_settings_sources: set[Path] | None = None,
-    settings_source_reload_results: dict[str, bool | float] | None = None,
+    settings_source_reload_results: dict[str, object] | None = None,
     retain_unemitted_observations: int | None = None,
 ) -> dict[str, object]:
     tick_start = now
@@ -2164,8 +2216,14 @@ def _run_spec_tick(
             removed_settings_sources
         )
         if "full_bundle" not in settings_source_reload_results:
-            if handled_settings_sources is not None:
-                handled_settings_sources.add(removed_settings_sources[0])
+            if "full_bundle_snapshot" not in settings_source_reload_results:
+                settings_source_reload_results["full_bundle_snapshot"] = (
+                    _capture_settings_source_snapshot(
+                        vault_root=cfg.vault_path,
+                        scan_roots=scan_roots,
+                        state=state,
+                    )
+                )
             removed_delta = handle_settings_source_delta(
                 rel_path=removed_settings_sources[0],
                 vault_root=cfg.vault_path,
@@ -2181,9 +2239,19 @@ def _run_spec_tick(
                 summary["settings_source_errors_in_tick"] = len(
                     removed_delta.errors
                 )
-                pending_settings_source_deletions.add(
-                    str(removed_settings_sources[0])
-                )
+        else:
+            source_reload_succeeded = settings_source_reload_results["full_bundle"] is True
+
+        source_snapshot = settings_source_reload_results.get("full_bundle_snapshot")
+        for removed_source in removed_settings_sources:
+            rel_str = str(removed_source)
+            snapshot_includes_absence = (
+                isinstance(source_snapshot, dict)
+                and rel_str in source_snapshot
+                and source_snapshot[rel_str] is None
+            )
+            if not source_reload_succeeded or not snapshot_includes_absence:
+                pending_settings_source_deletions.add(rel_str)
 
     if scan_completed and state.scan_scope_matched_files == 0:
         # The scope glob's directory exists, but the tick matched zero
@@ -2423,7 +2491,7 @@ def run_registry_once(
     }
     now = time.time()
     handled_settings_sources: set[Path] = set()
-    settings_source_reload_results: dict[str, bool | float] = {}
+    settings_source_reload_results: dict[str, object] = {}
     summaries = {
         spec.name: _run_spec_tick(
             cfg,
@@ -2519,7 +2587,7 @@ def run_registry_forever(
         )
         now = time.time()
         handled_settings_sources: set[Path] = set()
-        settings_source_reload_results: dict[str, bool | float] = {}
+        settings_source_reload_results: dict[str, object] = {}
         summaries = {
             spec.name: _run_spec_tick(
                 cfg,

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1510,7 +1510,7 @@ def _collect_changed_entries(
     scan_roots: Iterable[Path],
     states: Mapping[str, WatcherState],
     handled_settings_sources: set[Path] | None = None,
-    settings_source_reload_results: dict[str, bool] | None = None,
+    settings_source_reload_results: dict[str, bool | float] | None = None,
 ) -> tuple[list[ChangedEntry], list[str]]:
     changed_entries: list[ChangedEntry] = []
     scanned_paths: list[str] = []
@@ -1629,9 +1629,17 @@ def _collect_changed_entries(
             # physical path is observed; on failure none are advanced, keeping
             # every source retryable on the next scan generation.
             if "full_bundle" in settings_source_reload_results:
-                if settings_source_reload_results["full_bundle"]:
+                reload_started_at = settings_source_reload_results.get(
+                    "full_bundle_started_at"
+                )
+                if (
+                    settings_source_reload_results["full_bundle"] is True
+                    and isinstance(reload_started_at, float)
+                    and mtime <= reload_started_at
+                ):
                     state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
                 continue
+            settings_source_reload_results["full_bundle_started_at"] = time.time()
             source_delta = handle_settings_source_delta(
                 rel_path=rel,
                 vault_root=cfg.vault_path,
@@ -1960,7 +1968,7 @@ def _run_spec_tick(
     states: Mapping[str, WatcherState] | None = None,
     process_panel_notes_inline: bool = False,
     handled_settings_sources: set[Path] | None = None,
-    settings_source_reload_results: dict[str, bool] | None = None,
+    settings_source_reload_results: dict[str, bool | float] | None = None,
     retain_unemitted_observations: int | None = None,
 ) -> dict[str, object]:
     tick_start = now
@@ -2415,7 +2423,7 @@ def run_registry_once(
     }
     now = time.time()
     handled_settings_sources: set[Path] = set()
-    settings_source_reload_results: dict[str, bool] = {}
+    settings_source_reload_results: dict[str, bool | float] = {}
     summaries = {
         spec.name: _run_spec_tick(
             cfg,
@@ -2511,7 +2519,7 @@ def run_registry_forever(
         )
         now = time.time()
         handled_settings_sources: set[Path] = set()
-        settings_source_reload_results: dict[str, bool] = {}
+        settings_source_reload_results: dict[str, bool | float] = {}
         summaries = {
             spec.name: _run_spec_tick(
                 cfg,

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1510,10 +1510,16 @@ def _collect_changed_entries(
     scan_roots: Iterable[Path],
     states: Mapping[str, WatcherState],
     handled_settings_sources: set[Path] | None = None,
+    settings_source_reload_results: dict[str, bool] | None = None,
 ) -> tuple[list[ChangedEntry], list[str]]:
     changed_entries: list[ChangedEntry] = []
     scanned_paths: list[str] = []
     errors_before_root_normalization = state.errors
+    settings_source_reload_results = (
+        settings_source_reload_results
+        if settings_source_reload_results is not None
+        else {}
+    )
     roots = _normalized_scan_roots(cfg.vault_path, scan_roots, state=state)
     preflight_generation_error = state.errors > errors_before_root_normalization
     _begin_or_resume_scan(
@@ -1617,17 +1623,21 @@ def _collect_changed_entries(
             continue
         if is_settings_source_path(rel):
             # Settings markdown is runtime control input, never ordinary vault
-            # content. Reload it only once per registry tick, and advance each
-            # spec's observation only after that reload succeeds. A failed
-            # reload must remain retryable on the next scan generation.
-            if handled_settings_sources is not None and rel in handled_settings_sources:
-                state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
+            # content. Every source path maps to one full effective bundle, so
+            # a tick attempts that reload at most once even when canonical and
+            # legacy roots both contain source markdown. On success each
+            # physical path is observed; on failure none are advanced, keeping
+            # every source retryable on the next scan generation.
+            if "full_bundle" in settings_source_reload_results:
+                if settings_source_reload_results["full_bundle"]:
+                    state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
                 continue
             source_delta = handle_settings_source_delta(
                 rel_path=rel,
                 vault_root=cfg.vault_path,
             )
             source_reload_succeeded = source_delta.reloaded and not source_delta.errors
+            settings_source_reload_results["full_bundle"] = source_reload_succeeded
             if source_reload_succeeded:
                 summary["settings_source_reloads_in_tick"] = (
                     int(summary.get("settings_source_reloads_in_tick", 0)) + 1
@@ -1950,10 +1960,16 @@ def _run_spec_tick(
     states: Mapping[str, WatcherState] | None = None,
     process_panel_notes_inline: bool = False,
     handled_settings_sources: set[Path] | None = None,
+    settings_source_reload_results: dict[str, bool] | None = None,
     retain_unemitted_observations: int | None = None,
 ) -> dict[str, object]:
     tick_start = now
     handled_settings_sources = handled_settings_sources if handled_settings_sources is not None else set()
+    settings_source_reload_results = (
+        settings_source_reload_results
+        if settings_source_reload_results is not None
+        else {}
+    )
     state.ticks_run += 1
     errors_before = state.errors
 
@@ -2051,6 +2067,7 @@ def _run_spec_tick(
         scan_roots=scan_roots,
         states=active_states,
         handled_settings_sources=handled_settings_sources,
+        settings_source_reload_results=settings_source_reload_results,
     )
     if state.scan_generation_had_error:
         _mark_scan_incomplete(summary, reason="scan")
@@ -2138,14 +2155,16 @@ def _run_spec_tick(
         summary["settings_source_deletions_in_tick"] = len(
             removed_settings_sources
         )
-        if not handled_settings_sources:
+        if "full_bundle" not in settings_source_reload_results:
             if handled_settings_sources is not None:
                 handled_settings_sources.add(removed_settings_sources[0])
             removed_delta = handle_settings_source_delta(
                 rel_path=removed_settings_sources[0],
                 vault_root=cfg.vault_path,
             )
-            if removed_delta.reloaded:
+            source_reload_succeeded = removed_delta.reloaded and not removed_delta.errors
+            settings_source_reload_results["full_bundle"] = source_reload_succeeded
+            if source_reload_succeeded:
                 summary["settings_source_reloads_in_tick"] = (
                     int(summary.get("settings_source_reloads_in_tick", 0)) + 1
                 )
@@ -2396,6 +2415,7 @@ def run_registry_once(
     }
     now = time.time()
     handled_settings_sources: set[Path] = set()
+    settings_source_reload_results: dict[str, bool] = {}
     summaries = {
         spec.name: _run_spec_tick(
             cfg,
@@ -2405,6 +2425,7 @@ def run_registry_once(
             states=states,
             process_panel_notes_inline=True,
             handled_settings_sources=handled_settings_sources,
+            settings_source_reload_results=settings_source_reload_results,
             retain_unemitted_observations=rebind_observation_revision,
         )
         for spec in cfg.specs
@@ -2490,6 +2511,7 @@ def run_registry_forever(
         )
         now = time.time()
         handled_settings_sources: set[Path] = set()
+        settings_source_reload_results: dict[str, bool] = {}
         summaries = {
             spec.name: _run_spec_tick(
                 cfg,
@@ -2498,6 +2520,7 @@ def run_registry_forever(
                 now=now,
                 states=states,
                 handled_settings_sources=handled_settings_sources,
+                settings_source_reload_results=settings_source_reload_results,
                 retain_unemitted_observations=rebind_observation_revision,
             )
             for spec in cfg.specs

--- a/tests/settings/test_ingestion_startup.py
+++ b/tests/settings/test_ingestion_startup.py
@@ -10,6 +10,7 @@ Source: docs/SETTINGS_SPINE/WIRE_SETTINGS_INGESTION.md
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import time
 
@@ -464,5 +465,71 @@ def test_registry_watcher_coalesces_canonical_and_legacy_source_reload(
 
     assert len(attempted_paths) == 2
     assert recovered.get("settings_source_reloads_in_tick") == 1
+    assert state.file_entry("settings/global.md") is not None
+    assert state.file_entry("@Settings/global.md") is not None
+
+
+def test_registry_watcher_retries_source_changed_during_coalesced_reload(
+    sandbox_sources: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source changed after reload start is not acknowledged by that reload."""
+    vault_root = sandbox_sources.parent
+    initialize_test_vault(vault_root)
+    (vault_root / "settings" / "global.md").write_text(
+        _source_md("ERROR"), encoding="utf-8"
+    )
+    legacy_source = sandbox_sources / "global.md"
+    legacy_source.write_text(_source_md("DEBUG"), encoding="utf-8")
+    (vault_root / "Notes").mkdir()
+    config_path = tmp_path / "watchers.yaml"
+    config_path.write_text(
+        "watchers:\n  - name: panel\n    scope_glob: 'Notes/**'\n    emit_event: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "Notes/**")
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "watcher-state"))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "outbox.jsonl"))
+    cfg = registry.load_registry_config(config_path)
+    state = WatcherState()
+    attempted_paths: list[Path] = []
+    reload_clock = [100.0]
+    changed_rel: Path | None = None
+
+    monkeypatch.setattr(registry.time, "time", lambda: reload_clock[0])
+
+    def reload_settings(
+        *, rel_path: Path, vault_root: Path | None = None
+    ) -> SettingsSourceDeltaResult:
+        assert vault_root == sandbox_sources.parent
+        attempted_paths.append(rel_path)
+        if len(attempted_paths) == 1:
+            changed_source = (
+                sandbox_sources.parent / "settings" / "global.md"
+                if rel_path.parts[0] == "@Settings"
+                else legacy_source
+            )
+            changed_source.write_text(_source_md("WARNING"), encoding="utf-8")
+            os.utime(changed_source, (150.0, 150.0))
+            nonlocal changed_rel
+            changed_rel = changed_source.relative_to(sandbox_sources.parent)
+        return SettingsSourceDeltaResult(is_source=True, reloaded=True)
+
+    monkeypatch.setattr(registry, "handle_settings_source_delta", reload_settings)
+
+    first = registry._run_spec_tick(cfg, cfg.specs[0], state, now=0.0)
+
+    assert first.get("settings_source_reloads_in_tick") == 1
+    assert changed_rel is not None
+    assert state.file_entry(str(changed_rel)) is None
+
+    reload_clock[0] = 200.0
+    second = registry._run_spec_tick(cfg, cfg.specs[0], state, now=1.0)
+
+    assert len(attempted_paths) == 2
+    assert second.get("settings_source_reloads_in_tick") == 1
     assert state.file_entry("settings/global.md") is not None
     assert state.file_entry("@Settings/global.md") is not None

--- a/tests/settings/test_ingestion_startup.py
+++ b/tests/settings/test_ingestion_startup.py
@@ -480,6 +480,9 @@ def test_registry_watcher_retries_source_changed_during_coalesced_reload(
     )
     legacy_source = sandbox_sources / "global.md"
     legacy_source.write_text(_source_md("DEBUG"), encoding="utf-8")
+    snapshot_mtime = 50.0
+    for source_path in (vault_root / "settings" / "global.md", legacy_source):
+        os.utime(source_path, (snapshot_mtime, snapshot_mtime))
     (vault_root / "Notes").mkdir()
     config_path = tmp_path / "watchers.yaml"
     config_path.write_text(
@@ -513,7 +516,7 @@ def test_registry_watcher_retries_source_changed_during_coalesced_reload(
                 else legacy_source
             )
             changed_source.write_text(_source_md("WARNING"), encoding="utf-8")
-            os.utime(changed_source, (150.0, 150.0))
+            os.utime(changed_source, (snapshot_mtime, snapshot_mtime))
             nonlocal changed_rel
             changed_rel = changed_source.relative_to(sandbox_sources.parent)
         return SettingsSourceDeltaResult(is_source=True, reloaded=True)

--- a/tests/settings/test_ingestion_startup.py
+++ b/tests/settings/test_ingestion_startup.py
@@ -24,7 +24,7 @@ from app.settings.ingestion import (
     reset_settings_ingestion_state,
 )
 from app.settings.reload_signal import publish_reload_signal
-from app.watcher.settings_delta import handle_settings_source_delta
+from app.watcher.settings_delta import SettingsSourceDeltaResult, handle_settings_source_delta
 from app.watcher.state import WatcherState
 import app.watcher.registry as registry
 from tests.helpers.vault_settings import initialize_test_vault
@@ -409,3 +409,60 @@ def test_registry_watcher_does_not_emit_settings_sources_as_vault_content(
     assert summary.get("settings_source_reloads_in_tick") == 1
     assert summary["changed_in_tick"] == 0
     assert summary["emitted_in_tick"] == 0
+
+
+def test_registry_watcher_coalesces_canonical_and_legacy_source_reload(
+    sandbox_sources: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One bundle reload observes both source roots and preserves retry on failure."""
+    vault_root = sandbox_sources.parent
+    initialize_test_vault(vault_root)
+    (vault_root / "settings" / "global.md").write_text(
+        _source_md("ERROR"), encoding="utf-8"
+    )
+    (sandbox_sources / "global.md").write_text(_source_md("DEBUG"), encoding="utf-8")
+    (vault_root / "Notes").mkdir()
+    config_path = tmp_path / "watchers.yaml"
+    config_path.write_text(
+        "watchers:\n  - name: panel\n    scope_glob: 'Notes/**'\n    emit_event: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "Notes/**")
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "watcher-state"))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "outbox.jsonl"))
+    cfg = registry.load_registry_config(config_path)
+    state = WatcherState()
+    attempted_paths: list[Path] = []
+
+    def reload_settings(
+        *, rel_path: Path, vault_root: Path | None = None
+    ) -> SettingsSourceDeltaResult:
+        assert vault_root == sandbox_sources.parent
+        attempted_paths.append(rel_path)
+        if len(attempted_paths) == 1:
+            return SettingsSourceDeltaResult(
+                is_source=True,
+                reloaded=False,
+                errors=("temporary settings ingest failure",),
+            )
+        return SettingsSourceDeltaResult(is_source=True, reloaded=True)
+
+    monkeypatch.setattr(registry, "handle_settings_source_delta", reload_settings)
+
+    failed = registry._run_spec_tick(cfg, cfg.specs[0], state, now=time.time())
+
+    assert len(attempted_paths) == 1
+    assert failed.get("settings_source_reloads_in_tick") is None
+    assert state.file_entry("settings/global.md") is None
+    assert state.file_entry("@Settings/global.md") is None
+
+    recovered = registry._run_spec_tick(cfg, cfg.specs[0], state, now=time.time())
+
+    assert len(attempted_paths) == 2
+    assert recovered.get("settings_source_reloads_in_tick") == 1
+    assert state.file_entry("settings/global.md") is not None
+    assert state.file_entry("@Settings/global.md") is not None

--- a/tests/watcher/test_daemon_memory_bound.py
+++ b/tests/watcher/test_daemon_memory_bound.py
@@ -186,7 +186,7 @@ def test_scoped_daemon_updates_heartbeat(tmp_path: Path, monkeypatch: pytest.Mon
         states=None,
         process_panel_notes_inline: bool = False,
         handled_settings_sources: set[Path] | None = None,
-        settings_source_reload_results: dict[str, bool | float] | None = None,
+        settings_source_reload_results: dict[str, object] | None = None,
         retain_unemitted_observations: bool = False,
     ) -> dict[str, object]:
         del (

--- a/tests/watcher/test_daemon_memory_bound.py
+++ b/tests/watcher/test_daemon_memory_bound.py
@@ -186,6 +186,7 @@ def test_scoped_daemon_updates_heartbeat(tmp_path: Path, monkeypatch: pytest.Mon
         states=None,
         process_panel_notes_inline: bool = False,
         handled_settings_sources: set[Path] | None = None,
+        settings_source_reload_results: dict[str, bool | float] | None = None,
         retain_unemitted_observations: bool = False,
     ) -> dict[str, object]:
         del (
@@ -194,6 +195,7 @@ def test_scoped_daemon_updates_heartbeat(tmp_path: Path, monkeypatch: pytest.Mon
             states,
             process_panel_notes_inline,
             handled_settings_sources,
+            settings_source_reload_results,
             retain_unemitted_observations,
         )
         state_arg.ticks_run += 1


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5288

## Linked Issue
Closes #5288

## SBS Impact
- Primary subsystem: WSP (settings resolution and watcher-fed ingestion)
- Secondary subsystem(s): OEF (watcher health/summary), DRI (effective settings bundle projection)
- Write class: mechanical runtime observation and rebuildable settings projection
- Persistence impact: per-source watcher observation/retry state remains durable; no new durable store
- Derived/rebuildable impact: one effective bundle ingestion per tick; watcher summary remains derived telemetry
- New or changed contract: canonical and compatibility settings source paths may both be observed, but coalesce to one logical full-bundle reload per registry-spec tick
- Owner-doc impact: none
- Transition debt impact: reduces canonical/legacy reload duplication without retiring compatibility
- Boundary risk: a failed source ingest remains retryable and never silently falls back to code defaults or erases a last-valid bundle

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Coalesce canonical and legacy settings-source observations to one effective full-bundle reload per registry tick.
- Preserve per-source observation/retry state, canonical precedence, legacy compatibility, and zero-match watcher health.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps material was produced; the GitHub claim fallback receipt remains on Issue #5288.

## Notes
Validation: focused settings/watcher regression targets and scoped non-PG tests passed; ruff, mypy, and settings-validate passed. The repo-wide non-PG host-lease run completed without an observable terminal transport receipt, so current-head CI remains the full-suite authority.