### PR TITLE
fix: make closed-Issue label cleanup idempotent

### DIFF
--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -25,23 +25,31 @@ jobs:
             const actionLabels = labels.filter(name => name.startsWith("action:"));
             const blockedActions = new Set(["action:repair-contract", "action:wait-dependency", "action:restore-environment", "action:wait-external", "action:review-at"]);
             const humanActions = new Set(["action:human-decision", "action:human-authorization", "action:human-access", "action:human-operation", "action:human-acceptance"]);
-            if (agentLabels.length > 1) {
-              core.setFailed(`Issue must not carry more than one agent label at once: ${agentLabels.join(", ")}`);
-              return;
-            }
-            if (issue.state === "closed" && agentLabels.length) {
-              for (const name of agentLabels) {
+            const removeIssueLabel = async (name) => {
+              try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
                   name,
                 });
+              } catch (error) {
+                if (error && error.status === 404) return;
+                throw error;
+              }
+            };
+            if (agentLabels.length > 1) {
+              core.setFailed(`Issue must not carry more than one agent label at once: ${agentLabels.join(", ")}`);
+              return;
+            }
+            if (issue.state === "closed" && agentLabels.length) {
+              for (const name of agentLabels) {
+                await removeIssueLabel(name);
               }
             }
             if (issue.state === "closed" && actionLabels.length) {
               for (const name of actionLabels) {
-                await github.rest.issues.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, name});
+                await removeIssueLabel(name);
               }
               return;
             }

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -231,6 +231,33 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
     assert text.index("if (isDirectRepair) {") < text.index("const docsAuthoringPattern =")
 
 
+def test_closed_issue_label_cleanup_is_idempotent() -> None:
+    """The production cleanup path tolerates only the known absent-label race."""
+    text = _read(".github/workflows/issue-pr-governance.yml")
+    cleanup = text.split("  issue-agent-labels:", 1)[1].split(
+        "  issue-shape:", 1
+    )[0]
+
+    assert "const removeIssueLabel = async (name) => {" in cleanup
+    assert "if (error && error.status === 404) return;" in cleanup
+    assert "throw error;" in cleanup
+    assert "await github.rest.issues.removeLabel" in cleanup
+
+
+def test_closed_issue_label_cleanup_removes_present_labels() -> None:
+    """Both active-label collections use the production cleanup helper."""
+    text = _read(".github/workflows/issue-pr-governance.yml")
+    cleanup = text.split("  issue-agent-labels:", 1)[1].split(
+        "  issue-shape:", 1
+    )[0]
+
+    assert cleanup.count("await removeIssueLabel(name);") == 2
+    assert "for (const name of agentLabels)" in cleanup
+    assert "for (const name of actionLabels)" in cleanup
+    assert "issue.state === \"closed\" && agentLabels.length" in cleanup
+    assert "issue.state === \"closed\" && actionLabels.length" in cleanup
+
+
 def test_pr_template_includes_builderops_routing_receipt() -> None:
     text = _read(".github/pull_request_template.md")
 


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5291

## Linked Issue
Closes #5291

## SBS Impact
- Primary subsystem: Builder System / GitHub Issue and PR governance
- Secondary subsystem(s): none
- Write class: mechanical lifecycle cleanup of governance-bearing labels
- Persistence impact: durable labels; cleanup is rebuildable from live Issue state
- Derived/rebuildable impact: none
- New or changed contract: closed-Issue label cleanup tolerates only already-absent-label 404s and fails on unexpected API errors
- Owner-doc impact: none; existing lifecycle truth is unchanged
- Transition debt impact: reduces Builder System lifecycle-state drift
- Boundary risk: do not broaden the tolerated error beyond the known 404 race

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Make closed-Issue agent/action label cleanup tolerate the known already-absent-label 404 race while rethrowing unexpected API errors.
- Add production-path contract coverage for absent-label idempotence and present-label removal.
- Validation: focused pytest, Ruff, existing workflow-governance pytest, and actionlint.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No separate BuilderOps record was created; the bounded governance bug and its lifecycle evidence are fully represented by Issue #5291 and this PR.

## Notes
Fixes #5291

Owner-doc resolution: none; lifecycle truth remains unchanged.
SBS impact: Builder System governance only; no product/runtime, Project, deployment, credential, or sibling-Issue changes.
