### PR TITLE
fix: reject invalid TARS channel qualification states

### DIFF
--- a/app/ops/product_tars_channel_topology.py
+++ b/app/ops/product_tars_channel_topology.py
@@ -8,6 +8,7 @@ local-workstation and Builder System VM-102 placement claims.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import re
 from typing import Any, Mapping
@@ -18,6 +19,8 @@ from jsonschema import Draft202012Validator, FormatChecker
 SCHEMA_VERSION = "product_tars_channel_topology.v1"
 SCHEMA_PATH = Path("config/platform/product_tars_channel_topology.v1.schema.json")
 CHANNELS = ("dev", "test", "prod")
+MAX_EVIDENCE_AGE = timedelta(hours=24)
+MAX_CLOCK_SKEW = timedelta(minutes=5)
 _ROOT = Path(__file__).resolve().parents[2]
 _SENSITIVE_KEY = re.compile(
     r"(?:password|token|credential|private[_-]?key|api[_-]?key|secret|authorization|dsn)",
@@ -34,7 +37,7 @@ _LOCAL_WORKSTATION = re.compile(
     r"\bloopback\b|docker-desktop|pkm-(?:dev|test|prod))",
     re.IGNORECASE,
 )
-_VM102 = re.compile(r"(?:vm[-_ ]?102|builder[-_ ]?system)", re.IGNORECASE)
+_VM102 = re.compile(r"(?:\btars-vm:102\b|\bvm[-_ ]?102\b|builder[-_ ]?system)", re.IGNORECASE)
 
 
 class ProductTarsChannelTopologyError(ValueError):
@@ -81,6 +84,21 @@ def _validate_schema(payload: Mapping[str, Any]) -> None:
         raise ProductTarsChannelTopologyError(errors[0].message)
 
 
+def _validate_observed_at(observed_at: str) -> None:
+    try:
+        observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ProductTarsChannelTopologyError("observed_at must be a valid timestamp") from exc
+    if observed.tzinfo is None:
+        raise ProductTarsChannelTopologyError("observed_at must include a timezone")
+    observed = observed.astimezone(timezone.utc)
+    now = datetime.now(timezone.utc)
+    if observed - now > MAX_CLOCK_SKEW:
+        raise ProductTarsChannelTopologyError("observed_at is too far in the future")
+    if now - observed > MAX_EVIDENCE_AGE:
+        raise ProductTarsChannelTopologyError("observed_at evidence is stale")
+
+
 def validate_product_tars_channel_topology(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Validate and return a copy of one redaction-safe topology input.
 
@@ -94,14 +112,21 @@ def validate_product_tars_channel_topology(payload: Mapping[str, Any]) -> dict[s
     candidate = dict(payload)
     _walk_forbidden(candidate)
     _validate_schema(candidate)
+    _validate_observed_at(candidate["observed_at"])
     channels = candidate["channels"]
     if {entry["channel"] for entry in channels} != set(CHANNELS):
         raise ProductTarsChannelTopologyError("topology input must cover dev, test, and prod exactly once")
+    vm_identities: set[str] = set()
     for entry in channels:
         if _VM102.search(entry["vm_identity"]):
             raise ProductTarsChannelTopologyError("Product Runtime cannot use Builder System VM 102")
         if _VM102.search(entry["engine_identity"]):
             raise ProductTarsChannelTopologyError("Product Runtime cannot use the Builder System engine")
+        vm_identity = entry["vm_identity"]
+        if vm_identity != "unknown" and vm_identity in vm_identities:
+            raise ProductTarsChannelTopologyError("Product Runtime channels must use distinct VM identities")
+        if vm_identity != "unknown":
+            vm_identities.add(vm_identity)
         identity_evidence = (
             entry["vm_identity"],
             entry["engine_identity"],

--- a/docs/deployment/profiles/TARS_PROXMOX.md
+++ b/docs/deployment/profiles/TARS_PROXMOX.md
@@ -32,6 +32,8 @@ Runtime `dev`, `test`, and `prod` channels. It does not invent channel VM identi
 residency. A fresh, redaction-safe `product_tars_channel_topology.v1` qualification input must bind
 each channel to its VM and engine identity, source/image identity, private ingress/auth class,
 health/version evidence, data/backup/rollback boundary, observed-at time, and explicit gaps/refusals.
+The validator accepts evidence no more than 24 hours old and allows at most five minutes of bounded
+future clock skew; older or farther-future evidence is rejected.
 Until that input and later operator acceptance exist, placement remains a repository contract only.
 
 Demerzel/Mac mini is a control, development, client, and operator computer, not a Product Runtime

--- a/tests/platform/test_product_tars_channel_topology.py
+++ b/tests/platform/test_product_tars_channel_topology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -17,11 +18,16 @@ FIXTURE = ROOT / "tests/fixtures/product_tars_channel_topology/valid.json"
 
 
 def _fixture() -> dict[str, object]:
-    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    payload["observed_at"] = datetime.now(timezone.utc).isoformat()
+    return payload
 
 
-def test_contract_binds_all_channels_to_explicit_identity_evidence_and_gaps() -> None:
-    validated = load_and_validate_product_tars_channel_topology(FIXTURE)
+def test_contract_binds_all_channels_to_explicit_identity_evidence_and_gaps(tmp_path: Path) -> None:
+    candidate = _fixture()
+    fixture_copy = tmp_path / "valid-test-copy.json"
+    fixture_copy.write_text(json.dumps(candidate), encoding="utf-8")
+    validated = load_and_validate_product_tars_channel_topology(fixture_copy)
 
     assert validated["schema_version"] == "product_tars_channel_topology.v1"
     assert {entry["channel"] for entry in validated["channels"]} == {"dev", "test", "prod"}
@@ -57,10 +63,6 @@ def test_contract_rejects_secret_local_and_cross_boundary_evidence() -> None:
     workstation["channels"][0]["ingress_auth_class"] = "loopback"
     cases.append(workstation)
 
-    vm102 = _fixture()
-    vm102["channels"][0]["vm_identity"] = "tars-vm:vm-102"
-    cases.append(vm102)
-
     missing_channel = _fixture()
     missing_channel["channels"] = missing_channel["channels"][:2]
     cases.append(missing_channel)
@@ -72,6 +74,41 @@ def test_contract_rejects_secret_local_and_cross_boundary_evidence() -> None:
     for candidate in cases:
         with pytest.raises(ProductTarsChannelTopologyError):
             validate_product_tars_channel_topology(candidate)
+
+
+def test_contract_rejects_builder_system_vm102_identity() -> None:
+    for field in ("vm_identity", "engine_identity"):
+        candidate = _fixture()
+        candidate["channels"][0][field] = "tars-vm:102" if field == "vm_identity" else "docker-engine:builder-system"
+        with pytest.raises(ProductTarsChannelTopologyError, match="Builder System"):
+            validate_product_tars_channel_topology(candidate)
+
+
+def test_contract_rejects_stale_or_future_observed_at() -> None:
+    stale = _fixture()
+    stale["observed_at"] = "2020-01-01T00:00:00Z"
+    with pytest.raises(ProductTarsChannelTopologyError, match="stale"):
+        validate_product_tars_channel_topology(stale)
+
+    future = _fixture()
+    future["observed_at"] = "2999-01-01T00:00:00Z"
+    with pytest.raises(ProductTarsChannelTopologyError, match="future"):
+        validate_product_tars_channel_topology(future)
+
+    bounded_skew = _fixture()
+    bounded_skew["observed_at"] = (datetime.now(timezone.utc) + timedelta(minutes=1)).isoformat()
+    assert validate_product_tars_channel_topology(bounded_skew)["observed_at"]
+
+
+def test_contract_rejects_duplicate_channel_vm_identity() -> None:
+    duplicate = _fixture()
+    duplicate["channels"][1]["vm_identity"] = duplicate["channels"][0]["vm_identity"] = "tars-vm:shared"
+    with pytest.raises(ProductTarsChannelTopologyError, match="distinct VM identities"):
+        validate_product_tars_channel_topology(duplicate)
+
+    unknowns = _fixture()
+    unknowns["channels"][0]["vm_identity"] = unknowns["channels"][1]["vm_identity"] = "unknown"
+    assert validate_product_tars_channel_topology(unknowns)["channels"][0]["vm_identity"] == "unknown"
 
 
 def test_contract_rejects_unresolved_evidence_without_gap_or_refusal() -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5272

## Linked Issue
Fixes #5272

## SBS Impact
- Primary subsystem: Platform and Operations System / Product Runtime deployment boundary
- Secondary subsystem(s): release channels and startup qualification
- Write class: runtime validation guard and regression tests
- Persistence impact: none
- Derived/rebuildable impact: qualification validation remains pure and rebuildable
- New or changed contract: Product Runtime qualification rejects VM-102 cross-boundary identities, stale/future evidence, and duplicate VM identities
- Owner-doc impact: Updated TARS deployment profile with precise freshness and clock-skew wording
- Transition debt impact: Reduces unsafe qualification ambiguity without claiming live deployment
- Boundary risk: no host, VM, network, deployment, credential, or Project operation

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reject Builder System VM-102 identities, stale/future qualification evidence, and duplicate non-unknown Product Runtime channel VM identities in the pure validator; add focused regression coverage.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No separate BuilderOps record or projection was produced; the bounded work is fully represented by Issue #5272, this PR, and the delivery receipt.

## Notes
Validation: pytest -q tests/platform/test_product_tars_channel_topology.py; ruff check app tests; mypy app; python3 scripts/docs_guard.py --language-only; git diff --check. TCD risk assessment completed; pure stateless validator, so mechanism convergence packet is not applicable. No live TARS/Proxmox or deployment evidence is claimed.