### PR TITLE
feat: diagnose mirror corruption

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -28,6 +28,7 @@ from app.cli.index_rebuild import index as index_cli
 from app.cli.llm_doctor import llm as llm_cli
 from app.cli import index_doctor  # noqa: F401 -- register index doctor command
 from app.cli.events_doctor import events_doctor
+from app.cli.rebuildability_doctor import rebuildability_doctor
 from app.cli.smoke import smoke as smoke_cli
 from app.cli.settings_validate import run_settings_validate
 from app.cli.settings_explain import build_settings_explain_payload, emit_settings_explain
@@ -320,6 +321,7 @@ def cli() -> None:
 cli.add_command(index_cli, name="index")
 cli.add_command(llm_cli)
 cli.add_command(events_doctor)
+cli.add_command(rebuildability_doctor)
 cli.add_command(smoke_cli, name="smoke")
 cli.add_command(builderops_cli, name="builderops")
 cli.add_command(vault_cli, name="vault")

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -1,0 +1,114 @@
+"""Read-only CLI adapter for explicitly supplied rebuildability snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import click
+
+from app.rebuildability.mirror_doctor import (
+    DurablePath,
+    DurablePathClass,
+    ProjectionRecord,
+    SourceRecord,
+    diagnose_mirror_corruption,
+)
+
+
+def _items(payload: Mapping[str, Any], key: str) -> Iterable[Mapping[str, Any]]:
+    value = payload.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, Mapping) for item in value):
+        raise click.ClickException(f"snapshot field {key!r} must be a list of objects")
+    return value
+
+
+def _text(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _flag(value: object) -> bool:
+    return value is True
+
+
+def _load_snapshot(path: Path):
+    """Parse one explicit operator-selected snapshot without discovering any state."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise click.ClickException("rebuildability snapshot is unreadable") from exc
+    if not isinstance(payload, Mapping):
+        raise click.ClickException("rebuildability snapshot must be an object")
+    inventory = [
+        DurablePath(
+            path=_text(item.get("path")) or "",
+            classification=(
+                DurablePathClass(value)
+                if (value := _text(item.get("classification"))) is not None
+                else None
+            ),
+            owner=_text(item.get("owner")),
+            rebuild_or_retention_source=_text(item.get("rebuild_or_retention_source")),
+            sole_meaning_authority=_flag(item.get("sole_meaning_authority")),
+            sole_action_authority=_flag(item.get("sole_action_authority")),
+        )
+        for item in _items(payload, "inventory")
+    ]
+    sources = [
+        SourceRecord(
+            identity=_text(item.get("identity")) or "",
+            generation=_text(item.get("generation")) or "",
+        )
+        for item in _items(payload, "sources")
+    ]
+    projections = [
+        ProjectionRecord(
+            projection_id=_text(item.get("projection_id")) or "",
+            source_identity=_text(item.get("source_identity")),
+            source_generation=_text(item.get("source_generation")),
+            recipe_version=_text(item.get("recipe_version")),
+            index_identity=_text(item.get("index_identity")),
+            expected_index_identity=_text(item.get("expected_index_identity")),
+            db_source_generation=_text(item.get("db_source_generation")),
+            sole_meaning_authority=_flag(item.get("sole_meaning_authority")),
+            sole_action_authority=_flag(item.get("sole_action_authority")),
+        )
+        for item in _items(payload, "projections")
+    ]
+    return inventory, sources, projections
+
+
+@click.command(
+    name="rebuildability-doctor",
+    help="Diagnose one explicitly supplied rebuildability snapshot without mutation or discovery.",
+)
+@click.option(
+    "--snapshot",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Explicit JSON snapshot from owner-native readers; never scanned or repaired by this command.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the redacted machine-readable report.")
+@click.option("--strict", is_flag=True, help="Exit 2 when the snapshot has typed findings.")
+def rebuildability_doctor(snapshot: Path, as_json: bool, strict: bool) -> None:
+    """Render a digest-only report from a caller-selected, read-only snapshot."""
+
+    inventory, sources, projections = _load_snapshot(snapshot)
+    report = diagnose_mirror_corruption(
+        inventory=inventory,
+        sources=sources,
+        projections=projections,
+    )
+    if as_json:
+        click.echo(json.dumps(report.as_dict(), sort_keys=True))
+    else:
+        click.echo("healthy" if report.healthy else "findings: " + ", ".join(
+            finding.code.value for finding in report.findings
+        ))
+    if strict and not report.healthy:
+        raise click.exceptions.Exit(2)
+
+
+__all__ = ["rebuildability_doctor"]

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -18,7 +18,9 @@ from app.rebuildability.mirror_doctor import (
 
 
 def _items(payload: Mapping[str, Any], key: str) -> Iterable[Mapping[str, Any]]:
-    value = payload.get(key, [])
+    if key not in payload:
+        raise click.ClickException(f"snapshot must include the {key!r} collection")
+    value = payload[key]
     if not isinstance(value, list) or not all(isinstance(item, Mapping) for item in value):
         raise click.ClickException(f"snapshot field {key!r} must be a list of objects")
     return value
@@ -30,6 +32,17 @@ def _text(value: object) -> str | None:
 
 def _flag(value: object) -> bool:
     return value is True
+
+
+def _classification(value: object) -> DurablePathClass | None:
+    """Treat an unknown owner classification as diagnosable, not a traceback."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        return DurablePathClass(value)
+    except ValueError:
+        return None
 
 
 def _load_snapshot(path: Path):
@@ -44,11 +57,7 @@ def _load_snapshot(path: Path):
     inventory = [
         DurablePath(
             path=_text(item.get("path")) or "",
-            classification=(
-                DurablePathClass(value)
-                if (value := _text(item.get("classification"))) is not None
-                else None
-            ),
+            classification=_classification(item.get("classification")),
             owner=_text(item.get("owner")),
             rebuild_or_retention_source=_text(item.get("rebuild_or_retention_source")),
             sole_meaning_authority=_flag(item.get("sole_meaning_authority")),

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -31,6 +31,8 @@ def _text(value: object) -> str | None:
 
 
 def _flag(value: object) -> bool:
+    if value is not None and not isinstance(value, bool):
+        raise click.ClickException("snapshot authority flags must be boolean")
     return value is True
 
 

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -86,7 +86,7 @@ def _load_snapshot(path: Path):
         )
         for item in _items(payload, "projections")
     ]
-    return inventory, sources, projections
+    return inventory, sources, projections, payload.get("complete") is True
 
 
 @click.command(
@@ -104,11 +104,12 @@ def _load_snapshot(path: Path):
 def rebuildability_doctor(snapshot: Path, as_json: bool, strict: bool) -> None:
     """Render a digest-only report from a caller-selected, read-only snapshot."""
 
-    inventory, sources, projections = _load_snapshot(snapshot)
+    inventory, sources, projections, snapshot_complete = _load_snapshot(snapshot)
     report = diagnose_mirror_corruption(
         inventory=inventory,
         sources=sources,
         projections=projections,
+        snapshot_complete=snapshot_complete,
     )
     if as_json:
         click.echo(json.dumps(report.as_dict(), sort_keys=True))

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -80,6 +80,7 @@ def _load_snapshot(path: Path):
             source_identity=_text(item.get("source_identity")),
             source_generation=_text(item.get("source_generation")),
             recipe_version=_text(item.get("recipe_version")),
+            expected_recipe_version=_text(item.get("expected_recipe_version")),
             index_identity=_text(item.get("index_identity")),
             expected_index_identity=_text(item.get("expected_index_identity")),
             db_source_generation=_text(item.get("db_source_generation")),

--- a/app/cli/rebuildability_doctor.py
+++ b/app/cli/rebuildability_doctor.py
@@ -80,7 +80,6 @@ def _load_snapshot(path: Path):
             source_identity=_text(item.get("source_identity")),
             source_generation=_text(item.get("source_generation")),
             recipe_version=_text(item.get("recipe_version")),
-            expected_recipe_version=_text(item.get("expected_recipe_version")),
             index_identity=_text(item.get("index_identity")),
             expected_index_identity=_text(item.get("expected_index_identity")),
             db_source_generation=_text(item.get("db_source_generation")),

--- a/app/rebuildability/__init__.py
+++ b/app/rebuildability/__init__.py
@@ -22,6 +22,16 @@ from .product_projection_rebuild import (
     load_durable_projection_work,
     rebuild_product_projections,
 )
+from .mirror_doctor import (
+    DurablePath,
+    DurablePathClass,
+    MirrorDoctorReport,
+    MirrorFinding,
+    MirrorFindingCode,
+    ProjectionRecord,
+    SourceRecord,
+    diagnose_mirror_corruption,
+)
 
 __all__ = [
     "DbOutboxProjectionQueue",
@@ -42,4 +52,12 @@ __all__ = [
     "RetainedProjectionSource",
     "load_durable_projection_work",
     "rebuild_product_projections",
+    "DurablePath",
+    "DurablePathClass",
+    "MirrorDoctorReport",
+    "MirrorFinding",
+    "MirrorFindingCode",
+    "ProjectionRecord",
+    "SourceRecord",
+    "diagnose_mirror_corruption",
 ]

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -42,6 +42,8 @@ class DurablePath:
     classification: DurablePathClass | None = None
     owner: str | None = None
     rebuild_or_retention_source: str | None = None
+    sole_meaning_authority: bool = False
+    sole_action_authority: bool = False
 
 
 @dataclass(frozen=True)
@@ -138,6 +140,10 @@ def diagnose_mirror_corruption(
             findings.append(
                 MirrorFinding(MirrorFindingCode.UNCLASSIFIED_PATH, _digest("path", path.path))
             )
+        if path.sole_meaning_authority or path.sole_action_authority:
+            findings.append(
+                MirrorFinding(MirrorFindingCode.HIDDEN_AUTHORITY, _digest("path", path.path))
+            )
 
     for projection in projections:
         subject = _digest("projection", projection.projection_id)
@@ -147,14 +153,17 @@ def diagnose_mirror_corruption(
             or _missing(projection.recipe_version)
         ):
             findings.append(MirrorFinding(MirrorFindingCode.MISSING_PROVENANCE, subject))
-        else:
+        if not _missing(projection.source_identity):
             source_identity = projection.source_identity
-            assert source_identity is not None  # narrowed by the provenance guard above
+            assert source_identity is not None
             source_generation = source_generations.get(source_identity)
             if source_generation is None:
                 findings.append(MirrorFinding(MirrorFindingCode.ORPHANED_PROJECTION, subject))
             else:
-                if projection.source_generation != source_generation:
+                if (
+                    not _missing(projection.source_generation)
+                    and projection.source_generation != source_generation
+                ):
                     findings.append(MirrorFinding(MirrorFindingCode.STALE_GENERATION, subject))
                 if (
                     not _missing(projection.db_source_generation)

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -35,6 +35,10 @@ class MirrorFindingCode(str, Enum):
     INCOMPLETE_SNAPSHOT = "incomplete_snapshot"
     CONFLICTING_SOURCE_GENERATION = "conflicting_source_generation"
     MISSING_IDENTITY = "missing_identity"
+    RECIPE_VERSION_MISMATCH = "recipe_version_mismatch"
+
+
+CURRENT_PRODUCT_RECIPE_VERSION = "product-object-replay-v1"
 
 
 @dataclass(frozen=True)
@@ -65,6 +69,7 @@ class ProjectionRecord:
     source_identity: str | None
     source_generation: str | None
     recipe_version: str | None
+    expected_recipe_version: str | None = None
     index_identity: str | None = None
     expected_index_identity: str | None = None
     db_source_generation: str | None = None
@@ -121,6 +126,7 @@ def diagnose_mirror_corruption(
     sources: Iterable[SourceRecord],
     projections: Iterable[ProjectionRecord],
     snapshot_complete: bool = True,
+    expected_recipe_version: str = CURRENT_PRODUCT_RECIPE_VERSION,
 ) -> MirrorDoctorReport:
     """Classify supplied mirrors without reading, writing, or authorizing state.
 
@@ -212,6 +218,12 @@ def diagnose_mirror_corruption(
             and projection.index_identity != projection.expected_index_identity
         ):
             findings.append(MirrorFinding(MirrorFindingCode.INDEX_IDENTITY_DRIFT, subject))
+        expected_recipe = projection.expected_recipe_version or expected_recipe_version
+        if (
+            not _missing(projection.recipe_version)
+            and projection.recipe_version != expected_recipe
+        ):
+            findings.append(MirrorFinding(MirrorFindingCode.RECIPE_VERSION_MISMATCH, subject))
         if projection.sole_meaning_authority or projection.sole_action_authority:
             findings.append(MirrorFinding(MirrorFindingCode.HIDDEN_AUTHORITY, subject))
 
@@ -219,6 +231,7 @@ def diagnose_mirror_corruption(
 
 
 __all__ = [
+    "CURRENT_PRODUCT_RECIPE_VERSION",
     "DurablePath",
     "DurablePathClass",
     "MirrorDoctorReport",

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Iterable
 
+from .product_total_loss import PRODUCT_REPLAY_RECIPE_VERSION
+
 
 class DurablePathClass(str, Enum):
     """The bounded inventory classes accepted by the rebuildability doctor."""
@@ -36,9 +38,6 @@ class MirrorFindingCode(str, Enum):
     CONFLICTING_SOURCE_GENERATION = "conflicting_source_generation"
     MISSING_IDENTITY = "missing_identity"
     RECIPE_VERSION_MISMATCH = "recipe_version_mismatch"
-
-
-CURRENT_PRODUCT_RECIPE_VERSION = "product-object-replay-v1"
 
 
 @dataclass(frozen=True)
@@ -218,7 +217,7 @@ def diagnose_mirror_corruption(
             findings.append(MirrorFinding(MirrorFindingCode.INDEX_IDENTITY_DRIFT, subject))
         if (
             not _missing(projection.recipe_version)
-            and projection.recipe_version != CURRENT_PRODUCT_RECIPE_VERSION
+            and projection.recipe_version != PRODUCT_REPLAY_RECIPE_VERSION
         ):
             findings.append(MirrorFinding(MirrorFindingCode.RECIPE_VERSION_MISMATCH, subject))
         if projection.sole_meaning_authority or projection.sole_action_authority:
@@ -228,7 +227,6 @@ def diagnose_mirror_corruption(
 
 
 __all__ = [
-    "CURRENT_PRODUCT_RECIPE_VERSION",
     "DurablePath",
     "DurablePathClass",
     "MirrorDoctorReport",

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -32,6 +32,7 @@ class MirrorFindingCode(str, Enum):
     INDEX_IDENTITY_DRIFT = "index_identity_drift"
     DB_SOURCE_MISMATCH = "db_source_mismatch"
     HIDDEN_AUTHORITY = "hidden_authority"
+    INCOMPLETE_SNAPSHOT = "incomplete_snapshot"
 
 
 @dataclass(frozen=True)
@@ -117,6 +118,7 @@ def diagnose_mirror_corruption(
     inventory: Iterable[DurablePath],
     sources: Iterable[SourceRecord],
     projections: Iterable[ProjectionRecord],
+    snapshot_complete: bool = True,
 ) -> MirrorDoctorReport:
     """Classify supplied mirrors without reading, writing, or authorizing state.
 
@@ -126,6 +128,8 @@ def diagnose_mirror_corruption(
     """
 
     findings: list[MirrorFinding] = []
+    if not snapshot_complete:
+        findings.append(MirrorFinding(MirrorFindingCode.INCOMPLETE_SNAPSHOT, _digest("snapshot")))
     source_generations: dict[str, str] = {}
     for source in sources:
         if not _missing(source.identity) and not _missing(source.generation):
@@ -151,6 +155,7 @@ def diagnose_mirror_corruption(
             _missing(projection.source_identity)
             or _missing(projection.source_generation)
             or _missing(projection.recipe_version)
+            or _missing(projection.db_source_generation)
         ):
             findings.append(MirrorFinding(MirrorFindingCode.MISSING_PROVENANCE, subject))
         if not _missing(projection.source_identity):

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -69,7 +69,6 @@ class ProjectionRecord:
     source_identity: str | None
     source_generation: str | None
     recipe_version: str | None
-    expected_recipe_version: str | None = None
     index_identity: str | None = None
     expected_index_identity: str | None = None
     db_source_generation: str | None = None
@@ -126,7 +125,6 @@ def diagnose_mirror_corruption(
     sources: Iterable[SourceRecord],
     projections: Iterable[ProjectionRecord],
     snapshot_complete: bool = True,
-    expected_recipe_version: str = CURRENT_PRODUCT_RECIPE_VERSION,
 ) -> MirrorDoctorReport:
     """Classify supplied mirrors without reading, writing, or authorizing state.
 
@@ -218,10 +216,9 @@ def diagnose_mirror_corruption(
             and projection.index_identity != projection.expected_index_identity
         ):
             findings.append(MirrorFinding(MirrorFindingCode.INDEX_IDENTITY_DRIFT, subject))
-        expected_recipe = projection.expected_recipe_version or expected_recipe_version
         if (
             not _missing(projection.recipe_version)
-            and projection.recipe_version != expected_recipe
+            and projection.recipe_version != CURRENT_PRODUCT_RECIPE_VERSION
         ):
             findings.append(MirrorFinding(MirrorFindingCode.RECIPE_VERSION_MISMATCH, subject))
         if projection.sole_meaning_authority or projection.sole_action_authority:

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -137,6 +137,8 @@ def diagnose_mirror_corruption(
 
     for path in inventory:
         if (
+            _missing(path.path)
+            or
             path.classification is None
             or _missing(path.owner)
             or _missing(path.rebuild_or_retention_source)

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -1,0 +1,184 @@
+"""Typed, read-only evidence for rebuildable Product mirror integrity.
+
+The doctor consumes caller-provided inventory and provenance snapshots.  It
+does not discover paths, open stores, or attempt repair: callers keep both
+environment selection and all mutation authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+
+class DurablePathClass(str, Enum):
+    """The bounded inventory classes accepted by the rebuildability doctor."""
+
+    DERIVED = "derived"
+    RUNTIME_DISCARDABLE = "runtime_discardable"
+    RECEIPT_TRACE = "receipt_trace"
+    OPERATIONAL_EXCEPTION = "operational_exception"
+
+
+class MirrorFindingCode(str, Enum):
+    """Stable, content-free finding codes for diagnostic callers."""
+
+    UNCLASSIFIED_PATH = "unclassified_path"
+    MISSING_PROVENANCE = "missing_provenance"
+    STALE_GENERATION = "stale_generation"
+    ORPHANED_PROJECTION = "orphaned_projection"
+    INDEX_IDENTITY_DRIFT = "index_identity_drift"
+    DB_SOURCE_MISMATCH = "db_source_mismatch"
+    HIDDEN_AUTHORITY = "hidden_authority"
+
+
+@dataclass(frozen=True)
+class DurablePath:
+    """A declared non-document durable path, never a filesystem path to scan."""
+
+    path: str
+    classification: DurablePathClass | None = None
+    owner: str | None = None
+    rebuild_or_retention_source: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    """Digest-bearing source authority supplied by an owner-native reader."""
+
+    identity: str
+    generation: str
+
+
+@dataclass(frozen=True)
+class ProjectionRecord:
+    """One caller-supplied projection provenance snapshot."""
+
+    projection_id: str
+    source_identity: str | None
+    source_generation: str | None
+    recipe_version: str | None
+    index_identity: str | None = None
+    expected_index_identity: str | None = None
+    db_source_generation: str | None = None
+    sole_meaning_authority: bool = False
+    sole_action_authority: bool = False
+
+
+@dataclass(frozen=True)
+class MirrorFinding:
+    """A stable typed observation with digest-only subject evidence."""
+
+    code: MirrorFindingCode
+    subject_digest: str
+
+    @property
+    def sort_key(self) -> tuple[str, str]:
+        return (self.code.value, self.subject_digest)
+
+    def as_dict(self) -> dict[str, str]:
+        return {"code": self.code.value, "subject_digest": self.subject_digest}
+
+
+@dataclass(frozen=True)
+class MirrorDoctorReport:
+    """Read-only report whose evidence deliberately excludes raw source content."""
+
+    findings: tuple[MirrorFinding, ...]
+
+    @property
+    def healthy(self) -> bool:
+        return not self.findings
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "healthy": self.healthy,
+            "findings": [finding.as_dict() for finding in self.findings],
+        }
+
+
+def _digest(*parts: object) -> str:
+    """Return a stable evidence digest without exposing caller-supplied values."""
+
+    material = "\x1f".join(str(part) for part in parts)
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _missing(value: str | None) -> bool:
+    return not value or not value.strip()
+
+
+def diagnose_mirror_corruption(
+    *,
+    inventory: Iterable[DurablePath],
+    sources: Iterable[SourceRecord],
+    projections: Iterable[ProjectionRecord],
+) -> MirrorDoctorReport:
+    """Classify supplied mirrors without reading, writing, or authorizing state.
+
+    Callers provide already-bounded snapshots from their owner-native seams. A
+    missing or inconsistent snapshot is a finding, never a reason to repair,
+    activate, restore, or infer a replacement source.
+    """
+
+    findings: list[MirrorFinding] = []
+    source_generations: dict[str, str] = {}
+    for source in sources:
+        if not _missing(source.identity) and not _missing(source.generation):
+            source_generations[source.identity] = source.generation
+
+    for path in inventory:
+        if (
+            path.classification is None
+            or _missing(path.owner)
+            or _missing(path.rebuild_or_retention_source)
+        ):
+            findings.append(
+                MirrorFinding(MirrorFindingCode.UNCLASSIFIED_PATH, _digest("path", path.path))
+            )
+
+    for projection in projections:
+        subject = _digest("projection", projection.projection_id)
+        if (
+            _missing(projection.source_identity)
+            or _missing(projection.source_generation)
+            or _missing(projection.recipe_version)
+        ):
+            findings.append(MirrorFinding(MirrorFindingCode.MISSING_PROVENANCE, subject))
+        else:
+            source_identity = projection.source_identity
+            assert source_identity is not None  # narrowed by the provenance guard above
+            source_generation = source_generations.get(source_identity)
+            if source_generation is None:
+                findings.append(MirrorFinding(MirrorFindingCode.ORPHANED_PROJECTION, subject))
+            else:
+                if projection.source_generation != source_generation:
+                    findings.append(MirrorFinding(MirrorFindingCode.STALE_GENERATION, subject))
+                if (
+                    not _missing(projection.db_source_generation)
+                    and projection.db_source_generation != source_generation
+                ):
+                    findings.append(MirrorFinding(MirrorFindingCode.DB_SOURCE_MISMATCH, subject))
+        if (
+            not _missing(projection.expected_index_identity)
+            and projection.index_identity != projection.expected_index_identity
+        ):
+            findings.append(MirrorFinding(MirrorFindingCode.INDEX_IDENTITY_DRIFT, subject))
+        if projection.sole_meaning_authority or projection.sole_action_authority:
+            findings.append(MirrorFinding(MirrorFindingCode.HIDDEN_AUTHORITY, subject))
+
+    return MirrorDoctorReport(tuple(sorted(set(findings), key=lambda finding: finding.sort_key)))
+
+
+__all__ = [
+    "DurablePath",
+    "DurablePathClass",
+    "MirrorDoctorReport",
+    "MirrorFinding",
+    "MirrorFindingCode",
+    "ProjectionRecord",
+    "SourceRecord",
+    "diagnose_mirror_corruption",
+]

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -135,15 +135,21 @@ def diagnose_mirror_corruption(
     source_generations: dict[str, str] = {}
     conflicting_source_identities: set[str] = set()
     for source in sources:
-        if not _missing(source.identity) and not _missing(source.generation):
-            if source.identity in conflicting_source_identities:
-                continue
-            previous_generation = source_generations.get(source.identity)
-            if previous_generation is not None and previous_generation != source.generation:
-                conflicting_source_identities.add(source.identity)
-                del source_generations[source.identity]
-            else:
-                source_generations[source.identity] = source.generation
+        source_subject = _digest("source", source.identity, source.generation)
+        if _missing(source.identity):
+            findings.append(MirrorFinding(MirrorFindingCode.MISSING_IDENTITY, source_subject))
+        if _missing(source.generation):
+            findings.append(MirrorFinding(MirrorFindingCode.MISSING_PROVENANCE, source_subject))
+        if _missing(source.identity) or _missing(source.generation):
+            continue
+        if source.identity in conflicting_source_identities:
+            continue
+        previous_generation = source_generations.get(source.identity)
+        if previous_generation is not None and previous_generation != source.generation:
+            conflicting_source_identities.add(source.identity)
+            del source_generations[source.identity]
+        else:
+            source_generations[source.identity] = source.generation
     for source_identity in conflicting_source_identities:
         findings.append(
             MirrorFinding(

--- a/app/rebuildability/mirror_doctor.py
+++ b/app/rebuildability/mirror_doctor.py
@@ -33,6 +33,8 @@ class MirrorFindingCode(str, Enum):
     DB_SOURCE_MISMATCH = "db_source_mismatch"
     HIDDEN_AUTHORITY = "hidden_authority"
     INCOMPLETE_SNAPSHOT = "incomplete_snapshot"
+    CONFLICTING_SOURCE_GENERATION = "conflicting_source_generation"
+    MISSING_IDENTITY = "missing_identity"
 
 
 @dataclass(frozen=True)
@@ -131,9 +133,24 @@ def diagnose_mirror_corruption(
     if not snapshot_complete:
         findings.append(MirrorFinding(MirrorFindingCode.INCOMPLETE_SNAPSHOT, _digest("snapshot")))
     source_generations: dict[str, str] = {}
+    conflicting_source_identities: set[str] = set()
     for source in sources:
         if not _missing(source.identity) and not _missing(source.generation):
-            source_generations[source.identity] = source.generation
+            if source.identity in conflicting_source_identities:
+                continue
+            previous_generation = source_generations.get(source.identity)
+            if previous_generation is not None and previous_generation != source.generation:
+                conflicting_source_identities.add(source.identity)
+                del source_generations[source.identity]
+            else:
+                source_generations[source.identity] = source.generation
+    for source_identity in conflicting_source_identities:
+        findings.append(
+            MirrorFinding(
+                MirrorFindingCode.CONFLICTING_SOURCE_GENERATION,
+                _digest("source", source_identity),
+            )
+        )
 
     for path in inventory:
         if (
@@ -153,6 +170,8 @@ def diagnose_mirror_corruption(
 
     for projection in projections:
         subject = _digest("projection", projection.projection_id)
+        if _missing(projection.projection_id):
+            findings.append(MirrorFinding(MirrorFindingCode.MISSING_IDENTITY, subject))
         if (
             _missing(projection.source_identity)
             or _missing(projection.source_generation)
@@ -161,22 +180,27 @@ def diagnose_mirror_corruption(
         ):
             findings.append(MirrorFinding(MirrorFindingCode.MISSING_PROVENANCE, subject))
         if not _missing(projection.source_identity):
-            source_identity = projection.source_identity
-            assert source_identity is not None
-            source_generation = source_generations.get(source_identity)
-            if source_generation is None:
-                findings.append(MirrorFinding(MirrorFindingCode.ORPHANED_PROJECTION, subject))
+            projection_source_identity = projection.source_identity
+            assert projection_source_identity is not None
+            if projection_source_identity in conflicting_source_identities:
+                findings.append(
+                    MirrorFinding(MirrorFindingCode.CONFLICTING_SOURCE_GENERATION, subject)
+                )
             else:
-                if (
-                    not _missing(projection.source_generation)
-                    and projection.source_generation != source_generation
-                ):
-                    findings.append(MirrorFinding(MirrorFindingCode.STALE_GENERATION, subject))
-                if (
-                    not _missing(projection.db_source_generation)
-                    and projection.db_source_generation != source_generation
-                ):
-                    findings.append(MirrorFinding(MirrorFindingCode.DB_SOURCE_MISMATCH, subject))
+                source_generation = source_generations.get(projection_source_identity)
+                if source_generation is None:
+                    findings.append(MirrorFinding(MirrorFindingCode.ORPHANED_PROJECTION, subject))
+                else:
+                    if (
+                        not _missing(projection.source_generation)
+                        and projection.source_generation != source_generation
+                    ):
+                        findings.append(MirrorFinding(MirrorFindingCode.STALE_GENERATION, subject))
+                    if (
+                        not _missing(projection.db_source_generation)
+                        and projection.db_source_generation != source_generation
+                    ):
+                        findings.append(MirrorFinding(MirrorFindingCode.DB_SOURCE_MISMATCH, subject))
         if (
             not _missing(projection.expected_index_identity)
             and projection.index_identity != projection.expected_index_identity

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -703,6 +703,7 @@ Use `python -m app.cli <command> --help` for the full, current argument list. Th
 | `canvas open|edit|close` | Operate the bounded canvas co-authoring surface when `CANVAS_ENABLED=1`. |
 | `llm check` | Probe LLM/embedding endpoint reachability. |
 | `index rebuild|doctor|reconcile` | Rebuild derived vectors, diagnose drift read-only, or explicitly reconcile stale/mixed rows. |
+| `rebuildability-doctor --snapshot <path> [--json] [--strict]` | Diagnose one explicit owner-native rebuildability snapshot with digest-only findings; it never discovers host state, repairs, restores, activates, or authorizes effects. |
 | `pipe <note.md>` | Run ingest for a note/path outside the watcher loop. |
 | `pkm-alpha-ingest`, `vault-alpha-ingest` | Compatibility aliases for legacy startup and ingest callers; prefer the neutral ingest commands for new scripts. |
 | `make verify-runtime` | Check container health plus in-container runtime health/status for the live Docker stack. |

--- a/docs/REBUILDABLE_SYSTEM_CONTINUITY/DIAGNOSE_MIRROR_CORRUPTION.md
+++ b/docs/REBUILDABLE_SYSTEM_CONTINUITY/DIAGNOSE_MIRROR_CORRUPTION.md
@@ -25,8 +25,11 @@ Output is redacted or digest-only where content is sensitive.
 
 ## Concretely
 
-Production-command tests inspect healthy, stale, corrupt, orphaned, and unclassified isolated
-fixtures and compare canonical typed results while asserting no filesystem/database mutation.
+The `rebuildability-doctor` Product command consumes one explicit JSON snapshot supplied by
+owner-native readers; it performs no path discovery, host scan, repair, activation, restore, or
+authority creation. Production-command tests inspect healthy, stale, corrupt, orphaned, and
+unclassified isolated fixtures and compare canonical typed results while asserting no
+filesystem/database mutation.
 
 ## Why This Matters
 

--- a/docs/REBUILDABLE_SYSTEM_CONTINUITY/DIAGNOSE_MIRROR_CORRUPTION.md
+++ b/docs/REBUILDABLE_SYSTEM_CONTINUITY/DIAGNOSE_MIRROR_CORRUPTION.md
@@ -27,7 +27,9 @@ Output is redacted or digest-only where content is sensitive.
 
 The `rebuildability-doctor` Product command consumes one explicit JSON snapshot supplied by
 owner-native readers; it performs no path discovery, host scan, repair, activation, restore, or
-authority creation. Production-command tests inspect healthy, stale, corrupt, orphaned, and
+authority creation. The snapshot must include an owner-native `complete: true` attestation; without
+it the command reports a typed incomplete-snapshot finding instead of claiming a healthy empty
+surface. Production-command tests inspect healthy, stale, corrupt, orphaned, and
 unclassified isolated fixtures and compare canonical typed results while asserting no
 filesystem/database mutation.
 

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -174,3 +174,42 @@ def test_rebuildability_doctor_command_is_read_only_and_redacted(tmp_path) -> No
     assert "must-not-be-rendered" not in result.output
     assert "queue owner" not in result.output
     assert json.loads(result.output)["healthy"] is False
+
+
+def test_rebuildability_doctor_rejects_incomplete_snapshot(tmp_path) -> None:
+    snapshot = tmp_path / "incomplete.json"
+    snapshot.write_text("{}", encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["rebuildability-doctor", "--snapshot", str(snapshot)])
+
+    assert result.exit_code == 1
+    assert "must include the 'inventory' collection" in result.output
+
+
+def test_rebuildability_doctor_reports_unknown_classification(tmp_path) -> None:
+    snapshot = tmp_path / "unknown-classification.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "inventory": [
+                    {
+                        "path": "skewed-path",
+                        "classification": "from-a-newer-owner",
+                        "owner": "owner",
+                        "rebuild_or_retention_source": "source",
+                    }
+                ],
+                "sources": [],
+                "projections": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["rebuildability-doctor", "--snapshot", str(snapshot), "--json", "--strict"],
+    )
+
+    assert result.exit_code == 2
+    assert json.loads(result.output)["findings"][0]["code"] == "unclassified_path"

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -8,7 +8,6 @@ from click.testing import CliRunner
 
 from app.cli import cli
 from app.rebuildability.mirror_doctor import (
-    CURRENT_PRODUCT_RECIPE_VERSION,
     DurablePath,
     DurablePathClass,
     MirrorFindingCode,
@@ -16,6 +15,7 @@ from app.rebuildability.mirror_doctor import (
     SourceRecord,
     diagnose_mirror_corruption,
 )
+from app.rebuildability.product_total_loss import PRODUCT_REPLAY_RECIPE_VERSION
 
 
 def _inventory() -> list[DurablePath]:
@@ -44,7 +44,7 @@ def _projection(**changes: object) -> ProjectionRecord:
         "projection_id": "object-row-1",
         "source_identity": "Notes/product.md",
         "source_generation": "source-generation",
-        "recipe_version": "product-object-replay-v1",
+        "recipe_version": PRODUCT_REPLAY_RECIPE_VERSION,
         "index_identity": "test:test-model:3",
         "expected_index_identity": "test:test-model:3",
         "db_source_generation": "source-generation",
@@ -125,7 +125,7 @@ def test_doctor_rejects_unsupported_recipe_version_but_accepts_current() -> None
         projections=[_projection(recipe_version="product-object-replay-v0")],
     )
 
-    assert CURRENT_PRODUCT_RECIPE_VERSION == "product-object-replay-v1"
+    assert PRODUCT_REPLAY_RECIPE_VERSION == "product-object-replay-v1"
     assert healthy.healthy is True
     assert {finding.code for finding in stale.findings} == {
         MirrorFindingCode.RECIPE_VERSION_MISMATCH

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -270,6 +270,22 @@ def test_doctor_reports_missing_projection_identity() -> None:
     assert MirrorFindingCode.MISSING_IDENTITY in {finding.code for finding in report.findings}
 
 
+def test_doctor_reports_unreferenced_malformed_source_records() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=_inventory(),
+        sources=[
+            SourceRecord(identity=" ", generation="generation"),
+            SourceRecord(identity="Notes/product.md", generation=" "),
+        ],
+        projections=[],
+    )
+
+    assert {finding.code for finding in report.findings} == {
+        MirrorFindingCode.MISSING_IDENTITY,
+        MirrorFindingCode.MISSING_PROVENANCE,
+    }
+
+
 def test_doctor_reports_missing_path_identity() -> None:
     report = diagnose_mirror_corruption(
         inventory=[

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -132,6 +132,24 @@ def test_doctor_rejects_unsupported_recipe_version_but_accepts_current() -> None
     }
 
 
+def test_snapshot_cannot_self_bless_unsupported_recipe_version() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=_inventory(),
+        sources=[_source()],
+        projections=[
+            _projection(
+                recipe_version="product-object-replay-v0",
+                # A snapshot must not choose the version that validates it.
+            )
+        ],
+    )
+
+    assert report.healthy is False
+    assert MirrorFindingCode.RECIPE_VERSION_MISMATCH in {
+        finding.code for finding in report.findings
+    }
+
+
 def test_doctor_is_redacted_and_non_mutating() -> None:
     inventory = [
         *_inventory(),

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
+from click.testing import CliRunner
+
+from app.cli import cli
 from app.rebuildability.mirror_doctor import (
     DurablePath,
     DurablePathClass,
@@ -66,7 +71,12 @@ def test_doctor_detects_projection_corruption_and_drift() -> None:
         inventory=_inventory(),
         sources=[_source()],
         projections=[
-            _projection(projection_id="missing-provenance", recipe_version=""),
+            _projection(
+                projection_id="missing-provenance",
+                recipe_version="",
+                source_generation="old-generation",
+                db_source_generation="db-old-generation",
+            ),
             _projection(projection_id="stale", source_generation="old-generation"),
             _projection(projection_id="orphan", source_identity="Notes/missing.md"),
             _projection(
@@ -87,26 +97,80 @@ def test_doctor_detects_projection_corruption_and_drift() -> None:
         MirrorFindingCode.DB_SOURCE_MISMATCH,
         MirrorFindingCode.HIDDEN_AUTHORITY,
     }
+    missing_subject = next(
+        finding.subject_digest
+        for finding in report.findings
+        if finding.code is MirrorFindingCode.MISSING_PROVENANCE
+    )
+    assert {
+        finding.code
+        for finding in report.findings
+        if finding.subject_digest == missing_subject
+    } == {
+        MirrorFindingCode.MISSING_PROVENANCE,
+        MirrorFindingCode.STALE_GENERATION,
+        MirrorFindingCode.DB_SOURCE_MISMATCH,
+    }
     assert tuple(report.findings) == tuple(sorted(report.findings, key=lambda item: item.sort_key))
 
 
 def test_doctor_is_redacted_and_non_mutating() -> None:
-    inventory = _inventory()
-    sources = [_source()]
-    projections = [
-        _projection(
-            source_generation="secret-source-generation",
-            db_source_generation="secret-db-generation",
-            recipe_version="secret-recipe",
-        )
+    inventory = [
+        *_inventory(),
+        DurablePath(
+            path="queue",
+            classification=DurablePathClass.OPERATIONAL_EXCEPTION,
+            owner="queue owner",
+            rebuild_or_retention_source="owner-native queue receipt",
+            sole_action_authority=True,
+        ),
     ]
-    before = (list(inventory), list(sources), list(projections))
-
-    report = diagnose_mirror_corruption(inventory=inventory, sources=sources, projections=projections)
+    report = diagnose_mirror_corruption(
+        inventory=inventory,
+        sources=[_source()],
+        projections=[
+            _projection(
+                source_generation="secret-source-generation",
+                db_source_generation="secret-db-generation",
+                recipe_version="secret-recipe",
+            )
+        ],
+    )
 
     assert report.healthy is False
-    assert (inventory, sources, projections) == before
+    assert MirrorFindingCode.HIDDEN_AUTHORITY in {finding.code for finding in report.findings}
     rendered = repr(report) + repr(report.as_dict())
     for secret in ("secret-source-generation", "secret-db-generation", "secret-recipe", "Notes/product.md"):
         assert secret not in rendered
     assert all(len(finding.subject_digest) == 64 for finding in report.findings)
+
+
+def test_rebuildability_doctor_command_is_read_only_and_redacted(tmp_path) -> None:
+    snapshot = tmp_path / "snapshot.json"
+    payload = {
+        "inventory": [
+            {
+                "path": "queue",
+                "classification": "operational_exception",
+                "owner": "queue owner",
+                "rebuild_or_retention_source": "owner-native queue receipt",
+                "sole_action_authority": True,
+            }
+        ],
+        "sources": [],
+        "projections": [],
+        "secret": "must-not-be-rendered",
+    }
+    snapshot.write_text(json.dumps(payload), encoding="utf-8")
+    before = snapshot.read_bytes()
+
+    result = CliRunner().invoke(
+        cli,
+        ["rebuildability-doctor", "--snapshot", str(snapshot), "--json", "--strict"],
+    )
+
+    assert result.exit_code == 2
+    assert snapshot.read_bytes() == before
+    assert "must-not-be-rendered" not in result.output
+    assert "queue owner" not in result.output
+    assert json.loads(result.output)["healthy"] is False

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -241,3 +241,48 @@ def test_doctor_requires_db_generation_evidence() -> None:
     )
 
     assert {finding.code for finding in report.findings} == {MirrorFindingCode.MISSING_PROVENANCE}
+
+
+def test_doctor_reports_missing_path_identity() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=[
+            DurablePath(
+                path=" ",
+                classification=DurablePathClass.DERIVED,
+                owner="owner",
+                rebuild_or_retention_source="source",
+            )
+        ],
+        sources=[],
+        projections=[],
+    )
+
+    assert report.findings[0].code is MirrorFindingCode.UNCLASSIFIED_PATH
+
+
+def test_rebuildability_doctor_rejects_malformed_authority_flag(tmp_path) -> None:
+    snapshot = tmp_path / "malformed-flag.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "complete": True,
+                "inventory": [
+                    {
+                        "path": "queue",
+                        "classification": "operational_exception",
+                        "owner": "owner",
+                        "rebuild_or_retention_source": "source",
+                        "sole_action_authority": "true",
+                    }
+                ],
+                "sources": [],
+                "projections": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["rebuildability-doctor", "--snapshot", str(snapshot)])
+
+    assert result.exit_code == 1
+    assert "authority flags must be boolean" in result.output

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -148,6 +148,7 @@ def test_doctor_is_redacted_and_non_mutating() -> None:
 def test_rebuildability_doctor_command_is_read_only_and_redacted(tmp_path) -> None:
     snapshot = tmp_path / "snapshot.json"
     payload = {
+        "complete": True,
         "inventory": [
             {
                 "path": "queue",
@@ -191,6 +192,7 @@ def test_rebuildability_doctor_reports_unknown_classification(tmp_path) -> None:
     snapshot.write_text(
         json.dumps(
             {
+                "complete": True,
                 "inventory": [
                     {
                         "path": "skewed-path",
@@ -213,3 +215,29 @@ def test_rebuildability_doctor_reports_unknown_classification(tmp_path) -> None:
 
     assert result.exit_code == 2
     assert json.loads(result.output)["findings"][0]["code"] == "unclassified_path"
+
+
+def test_rebuildability_doctor_reports_incomplete_empty_snapshot(tmp_path) -> None:
+    snapshot = tmp_path / "empty.json"
+    snapshot.write_text(
+        json.dumps({"inventory": [], "sources": [], "projections": []}),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["rebuildability-doctor", "--snapshot", str(snapshot), "--json", "--strict"],
+    )
+
+    assert result.exit_code == 2
+    assert json.loads(result.output)["findings"][0]["code"] == "incomplete_snapshot"
+
+
+def test_doctor_requires_db_generation_evidence() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=_inventory(),
+        sources=[_source()],
+        projections=[_projection(db_source_generation=None)],
+    )
+
+    assert {finding.code for finding in report.findings} == {MirrorFindingCode.MISSING_PROVENANCE}

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -1,0 +1,112 @@
+"""RSC-04 acceptance coverage for the read-only rebuildability doctor."""
+
+from __future__ import annotations
+
+from app.rebuildability.mirror_doctor import (
+    DurablePath,
+    DurablePathClass,
+    MirrorFindingCode,
+    ProjectionRecord,
+    SourceRecord,
+    diagnose_mirror_corruption,
+)
+
+
+def _inventory() -> list[DurablePath]:
+    return [
+        DurablePath(
+            path="product-object-projection",
+            classification=DurablePathClass.DERIVED,
+            owner="Product StorePort",
+            rebuild_or_retention_source="retained Product note",
+        ),
+        DurablePath(
+            path="governance-receipt-log",
+            classification=DurablePathClass.RECEIPT_TRACE,
+            owner="governance receipts",
+            rebuild_or_retention_source="vault receipt log",
+        ),
+    ]
+
+
+def _source() -> SourceRecord:
+    return SourceRecord(identity="Notes/product.md", generation="source-generation")
+
+
+def _projection(**changes: object) -> ProjectionRecord:
+    values: dict[str, object] = {
+        "projection_id": "object-row-1",
+        "source_identity": "Notes/product.md",
+        "source_generation": "source-generation",
+        "recipe_version": "product-object-replay-v1",
+        "index_identity": "test:test-model:3",
+        "expected_index_identity": "test:test-model:3",
+        "db_source_generation": "source-generation",
+    }
+    values.update(changes)
+    return ProjectionRecord(**values)  # type: ignore[arg-type]
+
+
+def test_inventory_requires_owner_and_rebuild_or_retention_source() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=[*_inventory(), DurablePath(path="unknown-cache")],
+        sources=[_source()],
+        projections=[_projection()],
+    )
+
+    assert report.healthy is False
+    assert [finding.code for finding in report.findings] == [
+        MirrorFindingCode.UNCLASSIFIED_PATH,
+    ]
+    assert report.findings[0].subject_digest
+
+
+def test_doctor_detects_projection_corruption_and_drift() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=_inventory(),
+        sources=[_source()],
+        projections=[
+            _projection(projection_id="missing-provenance", recipe_version=""),
+            _projection(projection_id="stale", source_generation="old-generation"),
+            _projection(projection_id="orphan", source_identity="Notes/missing.md"),
+            _projection(
+                projection_id="index-drift",
+                index_identity="test:wrong-model:3",
+            ),
+            _projection(projection_id="db-mismatch", db_source_generation="db-old-generation"),
+            _projection(projection_id="hidden-authority", sole_meaning_authority=True),
+        ],
+    )
+
+    assert report.healthy is False
+    assert {finding.code for finding in report.findings} == {
+        MirrorFindingCode.MISSING_PROVENANCE,
+        MirrorFindingCode.STALE_GENERATION,
+        MirrorFindingCode.ORPHANED_PROJECTION,
+        MirrorFindingCode.INDEX_IDENTITY_DRIFT,
+        MirrorFindingCode.DB_SOURCE_MISMATCH,
+        MirrorFindingCode.HIDDEN_AUTHORITY,
+    }
+    assert tuple(report.findings) == tuple(sorted(report.findings, key=lambda item: item.sort_key))
+
+
+def test_doctor_is_redacted_and_non_mutating() -> None:
+    inventory = _inventory()
+    sources = [_source()]
+    projections = [
+        _projection(
+            source_generation="secret-source-generation",
+            db_source_generation="secret-db-generation",
+            recipe_version="secret-recipe",
+        )
+    ]
+    before = (list(inventory), list(sources), list(projections))
+
+    report = diagnose_mirror_corruption(inventory=inventory, sources=sources, projections=projections)
+
+    assert report.healthy is False
+    assert (inventory, sources, projections) == before
+    rendered = repr(report) + repr(report.as_dict())
+    for secret in ("secret-source-generation", "secret-db-generation", "secret-recipe", "Notes/product.md"):
+        assert secret not in rendered
+    assert all(len(finding.subject_digest) == 64 for finding in report.findings)

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from app.cli import cli
 from app.rebuildability.mirror_doctor import (
+    CURRENT_PRODUCT_RECIPE_VERSION,
     DurablePath,
     DurablePathClass,
     MirrorFindingCode,
@@ -112,6 +113,23 @@ def test_doctor_detects_projection_corruption_and_drift() -> None:
         MirrorFindingCode.DB_SOURCE_MISMATCH,
     }
     assert tuple(report.findings) == tuple(sorted(report.findings, key=lambda item: item.sort_key))
+
+
+def test_doctor_rejects_unsupported_recipe_version_but_accepts_current() -> None:
+    healthy = diagnose_mirror_corruption(
+        inventory=_inventory(), sources=[_source()], projections=[_projection()]
+    )
+    stale = diagnose_mirror_corruption(
+        inventory=_inventory(),
+        sources=[_source()],
+        projections=[_projection(recipe_version="product-object-replay-v0")],
+    )
+
+    assert CURRENT_PRODUCT_RECIPE_VERSION == "product-object-replay-v1"
+    assert healthy.healthy is True
+    assert {finding.code for finding in stale.findings} == {
+        MirrorFindingCode.RECIPE_VERSION_MISMATCH
+    }
 
 
 def test_doctor_is_redacted_and_non_mutating() -> None:

--- a/tests/ops/test_rebuildability_doctor.py
+++ b/tests/ops/test_rebuildability_doctor.py
@@ -243,6 +243,33 @@ def test_doctor_requires_db_generation_evidence() -> None:
     assert {finding.code for finding in report.findings} == {MirrorFindingCode.MISSING_PROVENANCE}
 
 
+def test_doctor_rejects_conflicting_source_generations_order_independently() -> None:
+    sources = [
+        SourceRecord(identity="Notes/product.md", generation="generation-a"),
+        SourceRecord(identity="Notes/product.md", generation="generation-b"),
+    ]
+    first = diagnose_mirror_corruption(
+        inventory=_inventory(), sources=sources, projections=[_projection()]
+    )
+    reversed_sources = diagnose_mirror_corruption(
+        inventory=_inventory(), sources=list(reversed(sources)), projections=[_projection()]
+    )
+
+    assert first.healthy is False
+    assert first == reversed_sources
+    assert {
+        finding.code for finding in first.findings
+    } == {MirrorFindingCode.CONFLICTING_SOURCE_GENERATION}
+
+
+def test_doctor_reports_missing_projection_identity() -> None:
+    report = diagnose_mirror_corruption(
+        inventory=_inventory(), sources=[_source()], projections=[_projection(projection_id=" ")]
+    )
+
+    assert MirrorFindingCode.MISSING_IDENTITY in {finding.code for finding in report.findings}
+
+
 def test_doctor_reports_missing_path_identity() -> None:
     report = diagnose_mirror_corruption(
         inventory=[


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5292

## Linked Issue
Closes #5292

## SBS Impact
- Primary subsystem: Product/Runtime PDM and DRI rebuildability boundary
- Secondary subsystem(s): OEF and StorePort diagnostic surfaces
- Write class: Bounded read-only runtime diagnostic and isolated tests
- Persistence impact: None; caller snapshots and test fixtures only
- Derived/rebuildable impact: Reports projection provenance and consistency without treating mirrors as authority
- New or changed contract: Typed read-only corruption and hidden-authority findings
- Owner-doc impact: Governing continuity task and Operations documents updated with the bounded command interface
- Transition debt impact: Makes the existing fail-closed rebuild posture observable without repair authority
- Boundary risk: The diagnostic must not activate, restore, repair, or authorize effects

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a typed, caller-supplied read-only mirror-corruption doctor for Product rebuildability.
- Report digest-only inventory, provenance, generation, index, DB/source, and hidden-authority findings without repair or activation authority.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No plan divergence, operational record, or authority crossing was produced; the governing Issue and PR retain the delivery evidence.

## Notes
Validation: pytest -q tests/ops/test_rebuildability_doctor.py tests/integration/test_projection_rebuild.py tests/integration/test_product_total_loss.py; ruff check app tests; mypy app; python3 scripts/docs_guard.py. Repair: P1 review comments 3908849746 and 3908849754 plus P2 comment 3908849759 are addressed on the next head; fresh independent review is required before merge.
