### PR TITLE
fix: stabilize sealed GOV boundary digest

### DIFF
--- a/app/instance/gov_revocation_inventory.py
+++ b/app/instance/gov_revocation_inventory.py
@@ -12,12 +12,13 @@ from typing import Any, Mapping
 
 GOV_REVOCATION_INVENTORY_SCHEMA = "agentic-pkm.gov-revocation-producers.v1"
 _CANONICAL_BOUNDARY_DEFINITION_DIGESTS = {
-    "_KnownBinding": "f18a5e2845440bf446103154e5026afa12bfd044a3146580ac01c386f8313f8b",
-    "RegistryBindingAuthorizer.__setattr__": "82735f84d023d6fa7579b01b314d84eca1413f05c29fdd2f8e5468f6b6c2a5c0",
-    "RegistryBindingAuthorizer.__init__": "3bbb4bb8ff2adf8790bd7730685e0f0e2a28ba5420c91ebbabc7d4a65cb55cbc",
-    "RegistryBindingAuthorizer.set_binding": "d2692318e9fc1b22f5401059a49547a70f452e89910752faeea2f13056c280ca",
-    "RegistryBindingAuthorizer.authorize": "b7b0e7cd424fab2c465f9816e7a3b2048379ce5e8cb98947997fc326a93db3ba",
+    "_KnownBinding": "e84b127bd9688a215f802a37b5f3abb0cd8995f768ab3070c5ec6a003f8ab4b7",
+    "RegistryBindingAuthorizer.__setattr__": "fb8b9b77d47f3d463676fa1eb93e7cd0bacd114c09a403677c9db55cf99e2f93",
+    "RegistryBindingAuthorizer.__init__": "8ceeab00291883c9a819ee7accc8ad404aa25764ce4ed057a5b773f3feed5be1",
+    "RegistryBindingAuthorizer.set_binding": "993a6d3de3c4151030ede5b209373cbe693fe6708c8a927d8256521cc184ade6",
+    "RegistryBindingAuthorizer.authorize": "388fa8918d08304e157cfb6b772e109966cd30c3e7eeeb4e900edd4201a26ca0",
 }
+_AST_METADATA_FIELDS = frozenset({"kind", "type_comment"})
 
 
 @dataclass(frozen=True)
@@ -46,13 +47,37 @@ def _canonical_boundary_definitions(tree: ast.Module) -> dict[str, list[ast.AST]
     return definitions
 
 
+def _canonical_ast_shape(node: ast.AST) -> Any:
+    """Return an AST shape independent of minor-version dump formatting."""
+
+    fields: dict[str, Any] = {}
+    for field in sorted(node._fields):
+        if field in _AST_METADATA_FIELDS:
+            continue
+        value = getattr(node, field, None)
+        if value is None or value == [] or value == () or value == {}:
+            continue
+        fields[field] = _canonical_ast_value(value)
+    return [type(node).__name__, fields]
+
+
+def _canonical_ast_value(value: Any) -> Any:
+    if isinstance(value, ast.AST):
+        return _canonical_ast_shape(value)
+    if isinstance(value, (list, tuple)):
+        return [_canonical_ast_value(item) for item in value]
+    return value
+
+
 def _canonical_boundary_shape_is_exact(tree: ast.Module) -> bool:
     definitions = _canonical_boundary_definitions(tree)
     for name, expected_digest in _CANONICAL_BOUNDARY_DEFINITION_DIGESTS.items():
         nodes = definitions[name]
         if len(nodes) != 1:
             return False
-        digest = hashlib.sha256(ast.dump(nodes[0], include_attributes=False).encode()).hexdigest()
+        shape = _canonical_ast_shape(nodes[0])
+        material = json.dumps(shape, ensure_ascii=True, separators=(",", ":"))
+        digest = hashlib.sha256(material.encode()).hexdigest()
         if digest != expected_digest:
             return False
     return True

--- a/tests/architecture/test_multi_vault_projection_inventory.py
+++ b/tests/architecture/test_multi_vault_projection_inventory.py
@@ -39,6 +39,8 @@ Source anchors:
 
 from __future__ import annotations
 
+import ast
+import copy
 import json
 import operator
 import re
@@ -54,6 +56,7 @@ from app.governance.binding_authority import (
     RevocationCapabilityError,
 )
 from app.instance.gov_revocation_inventory import (
+    _canonical_boundary_shape_is_exact,
     discover_gov_revocation_producer_evidence,
     discover_gov_revocation_producers,
     load_gov_revocation_inventory,
@@ -112,6 +115,44 @@ def _substantial_sentences(reason: str) -> list[str]:
         for sentence in re.split(r"(?<=[.!?])\s+", reason)
         if len(sentence.split()) >= 10
     ]
+
+
+def test_canonical_boundary_digest_is_python_minor_stable_and_semantic() -> None:
+    source = (REPO_ROOT / "app" / "governance" / "binding_authority.py").read_text(
+        encoding="utf-8"
+    )
+    canonical_tree = ast.parse(source)
+    assert _canonical_boundary_shape_is_exact(canonical_tree)
+
+    minor_variant = copy.deepcopy(canonical_tree)
+    for node in ast.walk(minor_variant):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if hasattr(node, "type_params"):
+                node.type_params = []
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and hasattr(
+                node, "type_comment"
+            ):
+                node.type_comment = "minor-version metadata"
+        if isinstance(node, ast.Constant) and hasattr(node, "kind"):
+            node.kind = "minor-version metadata"
+    assert _canonical_boundary_shape_is_exact(minor_variant)
+
+    semantic_variant = copy.deepcopy(canonical_tree)
+    authorizer = next(
+        node
+        for node in semantic_variant.body
+        if isinstance(node, ast.ClassDef) and node.name == "RegistryBindingAuthorizer"
+    )
+    authorize = next(
+        node
+        for node in authorizer.body
+        if isinstance(node, ast.FunctionDef) and node.name == "authorize"
+    )
+    for node in ast.walk(authorize):
+        if isinstance(node, ast.Constant) and node.value == "allow":
+            node.value = "changed"
+            break
+    assert not _canonical_boundary_shape_is_exact(semantic_variant)
 
 
 RELATIONS_INIT_SQL = REPO_ROOT / "app" / "db" / "sql" / "relations_init.sql"


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5268

## Linked Issue
Closes #5268

## SBS Impact
- Primary subsystem: GOV
- Secondary subsystem(s): Builder System / OEF fitness boundary
- Write class: none
- Persistence impact: none
- Derived/rebuildable impact: Stabilizes a derived static source-shape proof across supported Python minors.
- New or changed contract: Version-neutral semantic canonicalization for the sealed GOV boundary fitness check.
- Owner-doc impact: none
- Transition debt impact: reduces false-positive local validation
- Boundary risk: Canonicalization must not hide semantic revocation or authority-boundary changes.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Canonicalize guarded GOV boundary AST shapes with version-neutral semantic fields.
- Add regression coverage for Python-minor metadata stability and semantic mutation rejection.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No separate BuilderOps record is needed; the bounded implementation, validation, and delivery evidence are fully represented by Issue #5268 and its PR.

## Notes
Validation: Python 3.12 exact acceptance target passed; semantic regression passed; focused architecture module 20 passed; ruff and mypy passed; direct Python 3.12/3.14 canonical digest comparison matched. The exact Python 3.14 pytest command could not run because that interpreter has no pytest module.

Claim receipt: verified dispatcher lease for github-RasmusTho--agentic-pkm-mvp-issue-5268, holder codex-luna-5268, lease lease-9d6de0f1.
