### PR TITLE
test(watcher): align quality-wave tests with resumable scan contract

### DIFF
--- a/tests/quality_wave/test_metamorphic_watcher.py
+++ b/tests/quality_wave/test_metamorphic_watcher.py
@@ -221,9 +221,14 @@ def test_max_scanned_files_caps_processing(
 
     summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_500.0)
 
-    assert summary["scanned_files"] == 10
-    assert summary["bad_tick"] is True
-    assert summary["bad_tick_reason"] == "too_many_files"
+    assert summary["scanned_files"] == max_scanned
+    assert summary["scan_progress_entries"] >= max_scanned
+    assert summary["scan_in_progress"] is True
+    assert summary["continuation_reason"] == "file_budget"
+    assert summary["observation_status"] == "catch-up"
+    assert summary["bad_tick"] is False
+    assert summary["bad_tick_reason"] is None
+    assert not cfg.stop_file.exists()
 
 
 def test_empty_vault_zero_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/quality_wave/test_watcher_registry_contracts.py
+++ b/tests/quality_wave/test_watcher_registry_contracts.py
@@ -132,24 +132,28 @@ def test_backoff_tick_short_circuits_scanning_until_expiry(tmp_path: Path, monke
 
 
 def test_bad_tick_resets_after_following_healthy_tick(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    _install_fake_emit(monkeypatch)
-    cfg, spec = _make_cfg(tmp_path, max_scanned=1)
-    one = cfg.vault_path / "Inbox" / "one.md"
-    two = cfg.vault_path / "Inbox" / "two.md"
-    _write_note(one, "one", mtime=1_700_003_000)
-    _write_note(two, "two", mtime=1_700_003_001)
+    cfg, spec = _make_cfg(tmp_path)
+    note = cfg.vault_path / "Inbox" / "note.md"
+    _write_note(note, "payload", mtime=1_700_003_000)
+
+    def boom(**kwargs: object) -> str:
+        raise RuntimeError("emit failed")
+
+    monkeypatch.setattr(registry, "_emit_watch_event", boom)
 
     state = WatcherState()
     bad = _run_tick(monkeypatch, cfg, spec, state, now=1_700_003_100.0)
     assert bad["bad_tick"] is True
+    assert bad["bad_tick_reason"] == "errors"
+    assert bad["observation_status"] == "degraded"
     assert state.bad_ticks == 1
 
-    two.unlink()
-    cfg.max_scanned_files_per_tick = 2
+    _install_fake_emit(monkeypatch)
     healthy = _run_tick(monkeypatch, cfg, spec, state, now=1_700_003_200.0)
 
     assert healthy["bad_tick"] is False
     assert healthy["bad_tick_reason"] is None
+    assert healthy["observation_status"] == "healthy-idle"
     assert state.bad_ticks == 0
     assert healthy["chosen_sleep_seconds"] == cfg.tick_sleep_seconds
     assert state.dynamic_sleep_seconds is None


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 0

Governing-Issue: #5300

## Linked Issue
Closes #5300

## SBS Impact
- Primary subsystem: Builder System / CI and fitness evidence
- Secondary subsystem(s): Product/Runtime watcher observation semantics
- Write class: Mechanical test-contract correction
- Persistence impact: None
- Derived/rebuildable impact: CI evidence now aligns with the delivered watcher contract
- New or changed contract: None; tests consume the contract delivered by #5211/#5217
- Owner-doc impact: None
- Transition debt impact: Reduces stale-test and red-baseline debt
- Boundary risk: Does not weaken the watcher safety stop or convert runtime failures into passing tests

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Aligns the max-scanned-files quality assertion with the resumable watcher catch-up contract.
- Uses a genuine emission failure before proving that a healthy tick resets degraded telemetry.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Mechanical test-contract correction produced no BuilderOps material or plan divergence.

## Notes
Validation: exact Verify targets (3 passed); affected quality-wave modules (24 passed); ruff check app tests; mypy app; git diff --check.
