### PR TITLE
fix(deploy): keep acknowledged embedding cutovers deployable

### DIFF
--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -709,8 +709,13 @@ wait_json_required_ok() {
 
 health_gate() {
   wait_json_ok "http://127.0.0.1:${api_port}/healthz" || return 1
-  wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
-  wait_json_required_ok "http://127.0.0.1:${api_port}/api/health" || return 1
+  # The acknowledged rebuild smoke is the sole admission contract while the
+  # embedding index is rebuilding; ordinary deploys and every rollback remain
+  # bound to readiness and required-health predicates.
+  if [ "${action}" != "deploy" ] || [ "${ack_embedding_rebuild_required}" != "1" ]; then
+    wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
+    wait_json_required_ok "http://127.0.0.1:${api_port}/api/health" || return 1
+  fi
   wait_json_ok "http://127.0.0.1:${ui_port}/healthz" || return 1
 }
 

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -707,12 +707,110 @@ wait_json_required_ok() {
   return 1
 }
 
+wait_json_embedding_rebuild_transition() {
+  local url="$1" deadline body
+  deadline=$((SECONDS + health_timeout))
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    if body="$(curl -fsS --max-time 3 "${url}" 2>/dev/null)"; then
+      if "${PYTHON}" -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+checks = data.get("checks") if isinstance(data, dict) else None
+runtime = data.get("runtime") if isinstance(data, dict) else None
+required_failures = [
+    name
+    for name, raw_check in (checks or {}).items()
+    if isinstance(raw_check, dict)
+    and raw_check.get("required") is True
+    and raw_check.get("ok") is not True
+]
+embedding_check = (checks or {}).get("embedding_index") if isinstance(checks, dict) else None
+runtime_failures = [
+    name
+    for name, raw_status in (runtime or {}).items()
+    if not isinstance(raw_status, dict) or raw_status.get("ok") is not True
+]
+sys.exit(0 if (
+    isinstance(data, dict)
+    and data.get("required_ok") is False
+    and isinstance(checks, dict)
+    and all(isinstance(raw_check, dict) for raw_check in checks.values())
+    and required_failures == ["embedding_index"]
+    and isinstance(embedding_check, dict)
+    and embedding_check.get("status") == "rebuild_required"
+    and isinstance(runtime, dict)
+    and not runtime_failures
+) else 1)
+' <<<"${body}"; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+wait_product_readiness_usable() {
+  local url="$1" deadline body
+  deadline=$((SECONDS + health_timeout))
+  while [ "${SECONDS}" -lt "${deadline}" ]; do
+    if body="$(curl -fsS --max-time 3 "${url}" 2>/dev/null)"; then
+      if "${PYTHON}" -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+product_readiness = data.get("product_readiness") if isinstance(data, dict) else None
+sys.exit(0 if (
+    isinstance(data, dict)
+    and data.get("state") in {"running", "catch_up", "degraded"}
+    and isinstance(product_readiness, dict)
+    and product_readiness.get("ready") is True
+) else 1)
+' <<<"${body}"; then
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+readiness_http_503() {
+  local url="$1" status
+  status="$(curl -sS --max-time 3 -o /dev/null -w '%{http_code}' "${url}" 2>/dev/null)" || return 1
+  [ "${status}" = "503" ]
+}
+
+acknowledged_embedding_readiness_failure() {
+  wait_json_embedding_rebuild_transition \
+    "http://127.0.0.1:${api_port}/api/health" || return 1
+  wait_product_readiness_usable \
+    "http://127.0.0.1:${api_port}/status" || return 1
+}
+
 health_gate() {
   wait_json_ok "http://127.0.0.1:${api_port}/healthz" || return 1
-  # Product readiness remains a mandatory gate, including for an acknowledged
-  # embedding cutover. Only the exact embedding_index=rebuild_required
-  # functional-health transition is deferred to the later governed smoke.
-  wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
+  # Product readiness remains mandatory. An acknowledged cutover may defer a
+  # red /readyz only after the exact embedding-only transition is proven and
+  # the canonical status snapshot shows no independent readiness failure.
+  if ! wait_http_success "http://127.0.0.1:${api_port}/readyz"; then
+    if [ "${action}" != "deploy" ] || [ "${ack_embedding_rebuild_required}" != "1" ] \
+      || ! readiness_http_503 "http://127.0.0.1:${api_port}/readyz" \
+      || ! acknowledged_embedding_readiness_failure; then
+      return 1
+    fi
+  fi
   if [ "${action}" != "deploy" ] || [ "${ack_embedding_rebuild_required}" != "1" ]; then
     wait_json_required_ok "http://127.0.0.1:${api_port}/api/health" || return 1
   fi

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -709,11 +709,11 @@ wait_json_required_ok() {
 
 health_gate() {
   wait_json_ok "http://127.0.0.1:${api_port}/healthz" || return 1
-  # The acknowledged rebuild smoke is the sole admission contract while the
-  # embedding index is rebuilding; ordinary deploys and every rollback remain
-  # bound to readiness and required-health predicates.
+  # Product readiness remains a mandatory gate, including for an acknowledged
+  # embedding cutover. Only the exact embedding_index=rebuild_required
+  # functional-health transition is deferred to the later governed smoke.
+  wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
   if [ "${action}" != "deploy" ] || [ "${ack_embedding_rebuild_required}" != "1" ]; then
-    wait_http_success "http://127.0.0.1:${api_port}/readyz" || return 1
     wait_json_required_ok "http://127.0.0.1:${api_port}/api/health" || return 1
   fi
   wait_json_ok "http://127.0.0.1:${ui_port}/healthz" || return 1

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -332,7 +332,19 @@ case "$*" in
     fi
     printf '{"git_sha":"%s"}\\n' "${FAKE_VERSION_SHA:-$FAKE_SHA}"
     ;;
-  *"/api/health"*) printf '{"ok":true,"required_ok":true,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}" ;;
+  *"/api/health"*)
+    if [ "${FAKE_REQUIRED_HEALTH:-pass}" = "fail" ]; then
+      printf '{"ok":true,"required_ok":false,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}"
+    else
+      printf '{"ok":true,"required_ok":true,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}"
+    fi
+    ;;
+  *"/readyz"*)
+    if [ "${FAKE_READINESS:-pass}" = "fail" ]; then
+      exit 22
+    fi
+    printf '{"ok":true}\\n'
+    ;;
   *"/healthz"*)
     if [ "${FAKE_API_LIVENESS:-pass}" = "fail" ]; then
       if [ -n "${FAKE_REMOVE_SETTINGS_REBIND_RECEIPT:-}" ]; then
@@ -1514,13 +1526,43 @@ def test_acknowledged_embedding_cutover_stages_compose_before_transition_smoke(
     )
 
 
-def test_unacknowledged_deploy_keeps_strict_compose_startup(tmp_path: Path) -> None:
+def test_acknowledged_embedding_cutover_allows_transitional_health(tmp_path: Path) -> None:
     root, env, sha = _deploy_harness(tmp_path)
+    env["FAKE_READINESS"] = "fail"
+    env["FAKE_REQUIRED_HEALTH"] = "fail"
 
-    result = _run_deploy(root, env, sha)
+    result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
 
     assert result.returncode == 0, result.stdout + result.stderr
     events = _deploy_events(env)
+    assert any("/healthz" in event for event in events)
+    assert not any("/readyz" in event for event in events)
+
+
+@pytest.mark.parametrize(
+    ("action", "failure_env", "failed_endpoint"),
+    [
+        ("deploy", "FAKE_READINESS", "/readyz"),
+        ("deploy", "FAKE_REQUIRED_HEALTH", "/api/health"),
+        ("rollback", "FAKE_READINESS", "/readyz"),
+        ("rollback", "FAKE_REQUIRED_HEALTH", "/api/health"),
+    ],
+)
+def test_unacknowledged_deploy_keeps_strict_health_gates_for_deploy_and_rollback(
+    tmp_path: Path, action: str, failure_env: str, failed_endpoint: str
+) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    env[failure_env] = "fail"
+
+    if action == "deploy":
+        result = _run_deploy(root, env, sha)
+    else:
+        result = _run_rollback(root, env, sha)
+
+    assert result.returncode == 1
+    assert "health gate failed" in result.stderr
+    events = _deploy_events(env)
+    assert any(failed_endpoint in event for event in events)
     assert any(
         event.endswith(
             "up -d --force-recreate api worker watcher heimdal-capture-watch companion-ui"

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -334,12 +334,27 @@ case "$*" in
     ;;
   *"/api/health"*)
     if [ "${FAKE_REQUIRED_HEALTH:-pass}" = "fail" ]; then
-      printf '{"ok":true,"required_ok":false,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}"
+      printf '{"ok":false,"required_ok":false,"version":{"git_sha":"%s"},"checks":{"embedding_index":{"ok":false,"required":true,"status":"rebuild_required"}},"runtime":{"api":{"ok":true}}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}"
     else
       printf '{"ok":true,"required_ok":true,"version":{"git_sha":"%s"},"checks":{}}\\n' "${FAKE_HEALTH_VERSION_SHA:-$FAKE_SHA}"
     fi
     ;;
+  *"/status"*)
+    if [ "${FAKE_PRODUCT_READINESS:-pass}" = "fail" ]; then
+      printf '{"state":"running","product_readiness":{"ready":false,"state":"refused","reason":"product projection refused"}}\\n'
+    else
+      printf '{"state":"running","product_readiness":{"ready":true,"state":"ready","reason":"source-bound Product projection verified"}}\\n'
+    fi
+    ;;
   *"/readyz"*)
+    if [[ "$*" == *"-w"* ]]; then
+      if [ "${FAKE_READINESS:-pass}" = "fail" ]; then
+        printf '503'
+      else
+        printf '200'
+      fi
+      exit 0
+    fi
     if [ "${FAKE_READINESS:-pass}" = "fail" ]; then
       exit 22
     fi
@@ -1528,6 +1543,7 @@ def test_acknowledged_embedding_cutover_stages_compose_before_transition_smoke(
 
 def test_acknowledged_embedding_cutover_allows_transitional_health(tmp_path: Path) -> None:
     root, env, sha = _deploy_harness(tmp_path)
+    env["FAKE_READINESS"] = "fail"
     env["FAKE_REQUIRED_HEALTH"] = "fail"
 
     result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
@@ -1545,6 +1561,7 @@ def test_acknowledged_embedding_cutover_keeps_independent_readiness_failure_bloc
     root, env, sha = _deploy_harness(tmp_path)
     env["FAKE_READINESS"] = "fail"
     env["FAKE_REQUIRED_HEALTH"] = "fail"
+    env["FAKE_PRODUCT_READINESS"] = "fail"
 
     result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
 

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -1528,7 +1528,6 @@ def test_acknowledged_embedding_cutover_stages_compose_before_transition_smoke(
 
 def test_acknowledged_embedding_cutover_allows_transitional_health(tmp_path: Path) -> None:
     root, env, sha = _deploy_harness(tmp_path)
-    env["FAKE_READINESS"] = "fail"
     env["FAKE_REQUIRED_HEALTH"] = "fail"
 
     result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
@@ -1536,7 +1535,23 @@ def test_acknowledged_embedding_cutover_allows_transitional_health(tmp_path: Pat
     assert result.returncode == 0, result.stdout + result.stderr
     events = _deploy_events(env)
     assert any("/healthz" in event for event in events)
-    assert not any("/readyz" in event for event in events)
+    assert any("/readyz" in event for event in events)
+    assert any("/api/health" in event for event in events)
+
+
+def test_acknowledged_embedding_cutover_keeps_independent_readiness_failure_blocking(
+    tmp_path: Path,
+) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    env["FAKE_READINESS"] = "fail"
+    env["FAKE_REQUIRED_HEALTH"] = "fail"
+
+    result = _run_deploy(root, env, sha, "--ack-embedding-rebuild-required")
+
+    assert result.returncode == 1
+    assert "health gate failed" in result.stderr
+    events = _deploy_events(env)
+    assert any("/readyz" in event for event in events)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5302

## Linked Issue
Closes #5302

## SBS Impact
- Primary subsystem: Platform and Operations System / deployment channel lifecycle
- Secondary subsystem(s): Product Runtime readiness and embedding-rebuild transition
- Write class: mechanical deployment guard and regression tests
- Persistence impact: deploy pins and receipts retain their existing semantics
- Derived/rebuildable impact: none
- New or changed contract: the acknowledged embedding-rebuild exception is admitted only by its bounded transitional smoke contract
- Owner-doc impact: none; existing deployment wording already states the transitional-smoke boundary
- Transition debt impact: reduces an acknowledged deploy-transition false failure
- Boundary risk: the exception must not weaken ordinary deploy/rollback health gates or authorize an unverified runtime

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Admit the acknowledged embedding-index rebuild transition through its existing post-deploy smoke while retaining API and gateway liveness.
- Keep readiness and required-health checks fail-closed for ordinary deploys and all rollbacks, with focused deploy-harness coverage.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No plan divergence or durable BuilderOps material was produced; this is a bounded regression repair.

## Notes
Validation: pytest -q tests/deploy/test_deploy_channel.py -k 'acknowledged_embedding_cutover or unacknowledged_deploy_keeps_strict'; bash -n scripts/deploy_channel.sh; ruff check app tests; mypy app; git diff --check; python3 scripts/docs_guard.py --language-only. No live deploy, Docker/Compose, rollback, or production operation was run.
