### PR TITLE
Fix legacy-owner deployment convergence

### DIFF
--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -936,6 +936,7 @@ class InstanceStateBackup:
         ledger: OwnershipLedger,
         global_live_owners: Sequence[LegacyOwner],
         require_materialized_owner_roots: bool = True,
+        pending_legacy_owners: Sequence[LegacyOwner] = (),
     ) -> LedgerSnapshot:
         try:
             return ledger.require_registry_consistency(
@@ -968,6 +969,7 @@ class InstanceStateBackup:
                 ),
                 global_live_owners=global_live_owners,
                 require_materialized_roots=require_materialized_owner_roots,
+                pending_legacy_owners=pending_legacy_owners,
             )
         except LedgerError as exc:
             raise InstanceStatePreflightError(

--- a/app/instance/instance_state.py
+++ b/app/instance/instance_state.py
@@ -1061,28 +1061,23 @@ class InstanceStateBackup:
                 ancestor_identities = tuple(raw_ancestors)
             if not require_materialized_owner_roots and not binding_id:
                 # Deployment-finish verifies a host-produced receipt in a
-                # mount-blind scratch namespace. Recover a binding only from
-                # one exact normalized path match in the staged registry;
-                # aliases and ambiguity remain fail-closed.
+                # mount-blind scratch namespace. Prefer an exact normalized
+                # path match in the staged registry, but leave a foreign
+                # owner blank for the authenticated ledger resolver below;
+                # the receipt's host identity proof is its authority there.
                 normalized_root = raw_root
                 matches = [
                     registration.vault_binding_id
                     for registration in registry.registrations.values()
                     if str(registration.path) == normalized_root
                 ]
-                if not matches and skip_unadopted_owners:
-                    # A fresh channel volume may be verified before its
-                    # config-derived root has been adopted into the staged
-                    # registry.  Keep that candidate out of the consistency
-                    # set; the host-side inventory and later bootstrap still
-                    # govern whether it can claim ownership.
-                    continue
-                if len(matches) != 1:
+                if len(matches) > 1:
                     raise InstanceStatePreflightError(
                         "canonical global live-owner inventory is invalid: "
-                        f"owners[{index}].vault_binding_id is missing or path is ambiguous"
+                        f"owners[{index}].vault_binding_id path is ambiguous"
                     )
-                binding_id = matches[0]
+                if matches:
+                    binding_id = matches[0]
             # Owner-root materialization is not re-checked here (#4371): the
             # host-side inventory producer proved every root twice and the
             # receipt is digest-bound to the deployment lease, while this
@@ -1114,18 +1109,16 @@ class InstanceStateBackup:
                 )
             )
         try:
-            # Config-derived inventories (materialized-roots mode) may name
-            # candidates the ledger never adopted after legacy bootstrap
-            # completed; when such a root is also invisible to this process,
-            # the verifier cannot adjudicate it and the ledger holds no lease
-            # for it, so it is excluded from lease consistency. A lease-less
-            # owner whose root is locally materialized stays fail-closed, and
-            # lease-only payloads always carry binding ids.
+            # Config-derived inventories may name candidates the ledger never
+            # adopted after legacy bootstrap completed. The resolver first
+            # binds every adopted owner using the host receipt evidence; only
+            # an unadopted, mount-blind candidate can be excluded from lease
+            # consistency. A lease-less owner whose root is locally
+            # materialized stays fail-closed, and lease-only payloads always
+            # carry binding ids.
             resolved = ledger.resolve_live_owner_bindings(
                 owners,
-                skip_unadopted=(
-                    skip_unadopted_owners and require_materialized_owner_roots
-                ),
+                skip_unadopted=skip_unadopted_owners,
             )
         except LedgerError as exc:
             raise InstanceStatePreflightError(

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -424,6 +424,7 @@ class OwnershipLedger:
         transfer_lineage: Sequence[Mapping[str, str]],
         global_live_owners: Sequence[LegacyOwner],
         require_materialized_roots: bool = True,
+        pending_legacy_owners: Sequence[LegacyOwner] = (),
     ) -> LedgerSnapshot:
         """Authenticate one channel registry and the complete host-global ledger."""
 
@@ -456,6 +457,43 @@ class OwnershipLedger:
                     current,
                     key,
                     require_complete_legacy_chain=False,
+                )
+
+            pending_lease_updates: dict[str, OwnershipLease] = {}
+            seen_pending_bindings: set[str] = set()
+            for owner in pending_legacy_owners:
+                binding_id = owner.vault_binding_id
+                if (
+                    owner.channel_id != channel_id
+                    or not binding_id
+                    or binding_id in seen_pending_bindings
+                ):
+                    raise LedgerError(
+                        "pending host receipt contains an invalid ownership binding"
+                    )
+                seen_pending_bindings.add(binding_id)
+                lease = current.leases.get(binding_id)
+                if (
+                    lease is None
+                    or lease.channel_id != channel_id
+                    or lease.vault_binding_id != binding_id
+                    or not self._matches_host_validated_identity(lease, owner, key)
+                ):
+                    raise LedgerError(
+                        "pending host receipt does not authenticate its ownership lease"
+                    )
+                if lease.state == "pending":
+                    pending_lease_updates[binding_id] = OwnershipLease(
+                        **(asdict(lease) | {"state": "active"})
+                    )
+                elif lease.state != "active":
+                    raise LedgerError(
+                        "pending host receipt targets an unrecoverable lease"
+                    )
+            if pending_lease_updates:
+                current = self._replace(
+                    current,
+                    leases={**current.leases, **pending_lease_updates},
                 )
 
             ledger_live_owners: set[tuple[str, str]] = set()
@@ -720,10 +758,11 @@ class OwnershipLedger:
                     raise LedgerError(
                         "registry/ledger consistency found an incompatible lineage fingerprint"
                     )
-            if needs_legacy_migration:
+            if needs_legacy_migration or pending_lease_updates:
                 self._write_ledger_locked(current, key)
-                self.rotation_path.unlink(missing_ok=True)
-                _fsync_directory(self.root)
+                if needs_legacy_migration:
+                    self.rotation_path.unlink(missing_ok=True)
+                    _fsync_directory(self.root)
             return current
 
     def recover_or_require_active(
@@ -765,13 +804,16 @@ class OwnershipLedger:
         owner: LegacyOwner,
         *,
         channel_id: str,
+        persist: bool = True,
         _capability: _StorageMutationCapability | None = None,
     ) -> OwnershipLease:
         """Recover a committed pending lease from opaque host receipt evidence.
 
         Deployment-finish may run without the host content-root mount.  This
         path therefore authenticates the receipt's identity fingerprints and
-        never opens, resolves, or checks ``owner.root``.
+        never opens, resolves, or checks ``owner.root``.  With ``persist=False``
+        it only validates and returns the candidate active lease; the caller
+        must persist that candidate only after its complete consistency check.
         """
 
         _require_storage_mutation_capability(_capability)
@@ -796,6 +838,8 @@ class OwnershipLedger:
             if lease.state != "pending":
                 raise LedgerError("registered binding ownership is not recoverable")
             active = OwnershipLease(**(asdict(lease) | {"state": "active"}))
+            if not persist:
+                return active
             leases = dict(current.leases)
             leases[owner.vault_binding_id] = active
             self._write_ledger_locked(self._replace(current, leases=leases), key)

--- a/app/instance/ownership_ledger.py
+++ b/app/instance/ownership_ledger.py
@@ -760,6 +760,47 @@ class OwnershipLedger:
             self._write_ledger_locked(self._replace(current, leases=leases), key)
             return active
 
+    def recover_or_require_active_from_host_receipt(
+        self,
+        owner: LegacyOwner,
+        *,
+        channel_id: str,
+        _capability: _StorageMutationCapability | None = None,
+    ) -> OwnershipLease:
+        """Recover a committed pending lease from opaque host receipt evidence.
+
+        Deployment-finish may run without the host content-root mount.  This
+        path therefore authenticates the receipt's identity fingerprints and
+        never opens, resolves, or checks ``owner.root``.
+        """
+
+        _require_storage_mutation_capability(_capability)
+        if owner.channel_id != channel_id or not owner.vault_binding_id:
+            raise LedgerError("host-validated legacy-owner binding is invalid")
+        self._assert_existing_artifacts()
+        with self._locked():
+            key = self._load_or_create_key_locked(allow_create=False)
+            current = self._load_or_create_ledger_locked(key, allow_create=False)
+            lease = current.leases.get(owner.vault_binding_id)
+            if (
+                lease is None
+                or lease.channel_id != channel_id
+                or lease.vault_binding_id != owner.vault_binding_id
+                or not self._matches_host_validated_identity(lease, owner, key)
+            ):
+                raise LedgerError(
+                    "registered binding has no authenticated ownership reservation"
+                )
+            if lease.state == "active":
+                return lease
+            if lease.state != "pending":
+                raise LedgerError("registered binding ownership is not recoverable")
+            active = OwnershipLease(**(asdict(lease) | {"state": "active"}))
+            leases = dict(current.leases)
+            leases[owner.vault_binding_id] = active
+            self._write_ledger_locked(self._replace(current, leases=leases), key)
+            return active
+
     def recover_missing_active(
         self,
         *,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3002,6 +3002,8 @@ def _finish_instance_state_deployment_locked(
         quiescence_proof=quiescence_proof,
     )
     if established is not None and established.legacy_bootstrap_complete:
+        pending_legacy_owners: list[LegacyOwner] = []
+        recovery_failed = False
         try:
             # Only pending registrations need the recovery transition here.
             # Active leases must reach the canonical consistency check below
@@ -3033,15 +3035,19 @@ def _finish_instance_state_deployment_locked(
                     ledger.recover_or_require_active_from_host_receipt(
                         pending_owner,
                         channel_id=channel,
+                        persist=False,
                         _capability=_STORAGE_MUTATION_CAPABILITY,
                     )
+                    pending_legacy_owners.append(pending_owner)
             owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
         except (FilesystemIdentityError, LedgerError):
-            # deployment-finish must not expose a host-only path from a
-            # mount-blind recovery failure or its exception chain.
+            recovery_failed = True
+        if recovery_failed:
+            # Raise after leaving the handler so Python cannot retain a
+            # mount-only recovery exception in __context__.
             raise InstanceStatePreflightError(
                 "host-validated legacy-owner binding or lease recovery is invalid"
-            ) from None
+            )
     else:
         owners = [
             owner
@@ -3064,6 +3070,7 @@ def _finish_instance_state_deployment_locked(
             ledger=ledger,
             global_live_owners=tuple(owners),
             require_materialized_owner_roots=False,
+            pending_legacy_owners=tuple(pending_legacy_owners),
         )
     except InstanceStatePreflightError as exc:
         if established is not None and established.legacy_bootstrap_complete:

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -2648,8 +2648,6 @@ def _load_legacy_owner_inventory(
                 ancestor_identities,
             )
         )
-    if len({owner.vault_binding_id for owner in owners}) != len(owners):
-        raise InstanceStatePreflightError("legacy-owner inventory repeats a binding identity")
     represented = {owner.vault_binding_id for owner in owners if owner.channel_id == channel}
     missing_bindings = set(registry.registrations) - represented
     if missing_bindings:
@@ -3004,10 +3002,17 @@ def _finish_instance_state_deployment_locked(
     )
     if established is not None and established.legacy_bootstrap_complete:
         try:
+            for registration in registry.registrations.values():
+                ledger.recover_or_require_active(
+                    registration.vault_binding_id,
+                    channel_id=channel,
+                    root=Path(registration.path),
+                    _capability=_STORAGE_MUTATION_CAPABILITY,
+                )
             owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
         except LedgerError as exc:
             raise InstanceStatePreflightError(
-                "host-validated legacy-owner binding is invalid"
+                "host-validated legacy-owner binding or lease recovery is invalid"
             ) from exc
     else:
         owners = [
@@ -3023,6 +3028,8 @@ def _finish_instance_state_deployment_locked(
             )
             for owner in owners
         ]
+    if len({owner.vault_binding_id for owner in owners}) != len(owners):
+        raise InstanceStatePreflightError("legacy-owner inventory repeats a binding identity")
     try:
         ledger_snapshot = backup._require_registry_ledger_consistency(
             registry=registry,

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3002,13 +3002,25 @@ def _finish_instance_state_deployment_locked(
     )
     if established is not None and established.legacy_bootstrap_complete:
         try:
+            # Only pending registrations need the recovery transition here.
+            # Active leases must reach the canonical consistency check below
+            # first; otherwise a corrupted stored identity is misreported as
+            # generic recovery failure instead of the specific consistency
+            # failure that governs this finish path.
             for registration in registry.registrations.values():
-                ledger.recover_or_require_active(
-                    registration.vault_binding_id,
-                    channel_id=channel,
-                    root=Path(registration.path),
-                    _capability=_STORAGE_MUTATION_CAPABILITY,
+                registration_lease = established.leases.get(
+                    registration.vault_binding_id
                 )
+                if (
+                    registration_lease is not None
+                    and registration_lease.state == "pending"
+                ):
+                    ledger.recover_or_require_active(
+                        registration.vault_binding_id,
+                        channel_id=channel,
+                        root=Path(registration.path),
+                        _capability=_STORAGE_MUTATION_CAPABILITY,
+                    )
             owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
         except LedgerError as exc:
             raise InstanceStatePreflightError(

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from app.instance.vault_dimensions import VaultDimensionService
 
 from app.instance.filesystem_identity import (
+    FilesystemIdentityError,
     resolve_filesystem_root_identity,
     same_filesystem_root,
 )
@@ -3015,17 +3016,32 @@ def _finish_instance_state_deployment_locked(
                     registration_lease is not None
                     and registration_lease.state == "pending"
                 ):
-                    ledger.recover_or_require_active(
-                        registration.vault_binding_id,
+                    pending_owner = next(
+                        (
+                            owner
+                            for owner in owners
+                            if owner.channel_id == channel
+                            and owner.vault_binding_id
+                            == registration.vault_binding_id
+                        ),
+                        None,
+                    )
+                    if pending_owner is None:
+                        raise LedgerError(
+                            "pending registration has no host-validated owner receipt"
+                        )
+                    ledger.recover_or_require_active_from_host_receipt(
+                        pending_owner,
                         channel_id=channel,
-                        root=Path(registration.path),
                         _capability=_STORAGE_MUTATION_CAPABILITY,
                     )
             owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
-        except LedgerError as exc:
+        except (FilesystemIdentityError, LedgerError):
+            # deployment-finish must not expose a host-only path from a
+            # mount-blind recovery failure or its exception chain.
             raise InstanceStatePreflightError(
                 "host-validated legacy-owner binding or lease recovery is invalid"
-            ) from exc
+            ) from None
     else:
         owners = [
             owner

--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3001,8 +3001,8 @@ def _finish_instance_state_deployment_locked(
         channel=channel,
         quiescence_proof=quiescence_proof,
     )
+    pending_legacy_owners: list[LegacyOwner] = []
     if established is not None and established.legacy_bootstrap_complete:
-        pending_legacy_owners: list[LegacyOwner] = []
         recovery_failed = False
         try:
             # Only pending registrations need the recovery transition here.

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -5278,7 +5278,82 @@ def test_deployment_finish_redacts_pending_recovery_filesystem_identity_errors(
             quiescence_proof=proof,
         )
     assert raw_path not in str(excinfo.value)
-    assert raw_path not in repr(excinfo.value.__cause__)
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
+
+
+def test_deployment_finish_keeps_pending_lease_when_consistency_rejects_missing_lease(
+    tmp_path,
+) -> None:
+    """A failed consistency check must not commit pending lease activation."""
+
+    host_global_root = tmp_path / "host-global"
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod"),
+        host_global_root,
+    )
+    vault_root = tmp_path / "prod-vault"
+    vault_root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=vault_root, watcher_vault_path=vault_root
+    )
+    runtime.ledger.bootstrap_legacy_owners(
+        [],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger_payload = json.loads(runtime.ledger.path.read_text(encoding="utf-8"))
+    ledger_payload["leases"][registration.vault_binding_id]["state"] = "pending"
+    runtime.ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+    os.chmod(runtime.ledger.path, 0o600)
+
+    missing_root = tmp_path / "missing-registered-vault"
+    missing_root.mkdir()
+    runtime.registry.register(
+        VaultRegistration(
+            "missing-lease-binding",
+            f"path:{missing_root}",
+            str(missing_root),
+        ),
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=runtime.layout,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(vault_root),
+            },
+            {
+                "channel_id": "prod",
+                "vault_binding_id": "missing-lease-binding",
+                "root": str(missing_root),
+            },
+        ],
+    )
+    missing_root.rename(tmp_path / "missing-registered-vault-unmounted")
+
+    with pytest.raises(
+        InstanceStatePreflightError,
+        match="backup registry/ledger consistency verification failed",
+    ):
+        _finish_instance_state_deployment(
+            channel="prod",
+            instance_state_root=runtime.layout.root.parent,
+            host_global_root=host_global_root,
+            legacy_path=tmp_path / "missing-legacy.md",
+            inventory_path=owner_receipt,
+            backup_root=tmp_path / "backup",
+            restore_root=None,
+            quiescence_proof=proof,
+        )
+
+    assert runtime.ledger.load().leases[registration.vault_binding_id].state == "pending"
+    assert "missing-lease-binding" not in runtime.ledger.load().leases
 
 
 def test_staged_backup_binds_materialized_owner_after_root_leaves_scratch_view(

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -5085,6 +5085,133 @@ def test_staged_backup_preserves_adopted_active_lease_across_mount_namespace(
     assert dev_registration.vault_binding_id in prod.ledger.load().leases
 
 
+def test_legacy_owner_inventory_resolves_foreign_binding_ids_before_collision_check(
+    tmp_path,
+) -> None:
+    """#5250 AC1: the bound host receipt resolves foreign blank IDs first."""
+
+    host_global_root = tmp_path / "host-global"
+    prod = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod"),
+        host_global_root,
+    )
+    dev = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "dev-state", "dev"),
+        host_global_root,
+    )
+    test = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "test-state", "test"),
+        host_global_root,
+    )
+    prod_root = tmp_path / "prod-vault"
+    dev_root = tmp_path / "dev-vault"
+    test_root = tmp_path / "test-vault"
+    for root in (prod_root, dev_root, test_root):
+        root.mkdir()
+    prod_registration = prod.bootstrap_env_binding(
+        vault_root=prod_root, watcher_vault_path=prod_root
+    )
+    dev_registration = dev.bootstrap_env_binding(
+        vault_root=dev_root, watcher_vault_path=dev_root
+    )
+    test_registration = test.bootstrap_env_binding(
+        vault_root=test_root, watcher_vault_path=test_root
+    )
+    prod.ledger.bootstrap_legacy_owners(
+        [],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=prod.layout,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {"channel_id": "dev", "root": str(dev_root)},
+            {"channel_id": "test", "root": str(test_root)},
+            {
+                "channel_id": "prod",
+                "vault_binding_id": prod_registration.vault_binding_id,
+                "root": str(prod_root),
+            },
+        ],
+    )
+
+    result = _finish_instance_state_deployment(
+        channel="prod",
+        instance_state_root=prod.layout.root.parent,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        inventory_path=owner_receipt,
+        backup_root=tmp_path / "backup",
+        restore_root=None,
+        quiescence_proof=proof,
+    )
+
+    assert result["restart_fence_cleared"] is True
+    assert {
+        dev_registration.vault_binding_id,
+        test_registration.vault_binding_id,
+        prod_registration.vault_binding_id,
+    } == set(prod.ledger.load().leases)
+
+
+def test_deployment_finish_recovers_pending_legacy_owner_lease_before_consistency(
+    tmp_path,
+) -> None:
+    """#5250 AC2: a committed registration recovers its pending lease first."""
+
+    host_global_root = tmp_path / "host-global"
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod"),
+        host_global_root,
+    )
+    vault_root = tmp_path / "prod-vault"
+    vault_root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=vault_root, watcher_vault_path=vault_root
+    )
+    runtime.ledger.bootstrap_legacy_owners(
+        [],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger_payload = json.loads(runtime.ledger.path.read_text(encoding="utf-8"))
+    ledger_payload["leases"][registration.vault_binding_id]["state"] = "pending"
+    runtime.ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+    os.chmod(runtime.ledger.path, 0o600)
+
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=runtime.layout,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(vault_root),
+            }
+        ],
+    )
+
+    result = _finish_instance_state_deployment(
+        channel="prod",
+        instance_state_root=runtime.layout.root.parent,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        inventory_path=owner_receipt,
+        backup_root=tmp_path / "backup",
+        restore_root=None,
+        quiescence_proof=proof,
+    )
+
+    assert result["restart_fence_cleared"] is True
+    assert runtime.ledger.load().leases[registration.vault_binding_id].state == "active"
+
+
 def test_staged_backup_binds_materialized_owner_after_root_leaves_scratch_view(
     tmp_path,
 ) -> None:

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -30,7 +30,7 @@ from app.instance.instance_state import (
     validate_registry_disjoint_from_content,
 )
 from app.instance.ownership_ledger import LedgerCollisionError, LedgerError
-from app.instance.filesystem_identity import FilesystemRootIdentity
+from app.instance.filesystem_identity import FilesystemIdentityError, FilesystemRootIdentity
 from app.instance.runtime import (
     InstanceRegistryRuntime,
     _begin_instance_state_deployment,
@@ -5196,6 +5196,7 @@ def test_deployment_finish_recovers_pending_legacy_owner_lease_before_consistenc
             }
         ],
     )
+    vault_root.rename(tmp_path / "prod-vault-unmounted")
 
     result = _finish_instance_state_deployment(
         channel="prod",
@@ -5210,6 +5211,74 @@ def test_deployment_finish_recovers_pending_legacy_owner_lease_before_consistenc
 
     assert result["restart_fence_cleared"] is True
     assert runtime.ledger.load().leases[registration.vault_binding_id].state == "active"
+
+
+def test_deployment_finish_redacts_pending_recovery_filesystem_identity_errors(
+    tmp_path, monkeypatch
+) -> None:
+    """Mount-blind pending recovery must expose only the governed diagnostic."""
+
+    host_global_root = tmp_path / "host-global"
+    runtime = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod"),
+        host_global_root,
+    )
+    vault_root = tmp_path / "prod-vault"
+    vault_root.mkdir()
+    registration = runtime.bootstrap_env_binding(
+        vault_root=vault_root, watcher_vault_path=vault_root
+    )
+    runtime.ledger.bootstrap_legacy_owners(
+        [],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger_payload = json.loads(runtime.ledger.path.read_text(encoding="utf-8"))
+    ledger_payload["leases"][registration.vault_binding_id]["state"] = "pending"
+    runtime.ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+    os.chmod(runtime.ledger.path, 0o600)
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=runtime.layout,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {
+                "channel_id": "prod",
+                "vault_binding_id": registration.vault_binding_id,
+                "root": str(vault_root),
+            }
+        ],
+    )
+    raw_path = str(vault_root)
+
+    def raise_raw_path_error(*args, **kwargs):
+        del args, kwargs
+        raise FilesystemIdentityError(
+            f"cannot resolve filesystem identity for {raw_path}"
+        )
+
+    monkeypatch.setattr(
+        ownership_ledger_module.OwnershipLedger,
+        "recover_or_require_active_from_host_receipt",
+        raise_raw_path_error,
+    )
+    with pytest.raises(
+        InstanceStatePreflightError,
+        match="host-validated legacy-owner binding or lease recovery is invalid",
+    ) as excinfo:
+        _finish_instance_state_deployment(
+            channel="prod",
+            instance_state_root=runtime.layout.root.parent,
+            host_global_root=host_global_root,
+            legacy_path=tmp_path / "missing-legacy.md",
+            inventory_path=owner_receipt,
+            backup_root=tmp_path / "backup",
+            restore_root=None,
+            quiescence_proof=proof,
+        )
+    assert raw_path not in str(excinfo.value)
+    assert raw_path not in repr(excinfo.value.__cause__)
 
 
 def test_staged_backup_binds_materialized_owner_after_root_leaves_scratch_view(


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5250

## Linked Issue
Closes #5250

## SBS Impact
- Primary subsystem: instance-state legacy-owner deployment lifecycle
- Secondary subsystem(s): binding identity and lease recovery
- Write class: runtime/deployment correctness
- Persistence impact: committed registration and lease state converge before completion
- Derived/rebuildable impact: foreign identities remain receipt-derived and collision checks remain deterministic
- New or changed contract: strict consistency never proceeds with an unresolved foreign identity or recoverable pending lease
- Owner-doc impact: none; the bounded contract wording is unchanged
- Transition debt impact: closes the remaining #5235 convergence gaps
- Boundary risk: host-only roots remain receipt-validated; no raw path or untrusted identity becomes authority

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Resolve blank foreign legacy-owner binding IDs through the bound host receipt and authenticated ledger before duplicate checks.
- Recover a committed registration's pending lease before strict registry/ledger consistency validation.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260902052516_ec301134
- Reason: The Issue retained a removed source-doc path; the runtime owner authority remained clear and the drift was recorded for upstream repair.

## Notes
Mechanism convergence: `legacy-owner deployment finish` admits only a bound host receipt and a committed registry. Foreign blank IDs resolve from authenticated host identity against active ledger leases before duplicate detection; unresolved/ambiguous identities fail closed, while the existing mount-blind unadopted-candidate behavior remains limited to records with no active lease. A pending lease may transition only to active through `recover_or_require_active` after the committed registration exists and while deployment admission plus producer-transition locks are held; malformed, contradictory, or non-recoverable evidence fails closed. Focused production-path proofs: the two #5250 tests cover foreign resolution and pending recovery; writer inventory redaction coverage remains green. Validation: 132 passed, 3 skipped in focused volume-contract and writer-inventory modules; `ruff check app tests`; `mypy app`; `git diff --check`.