### PR TITLE
fix: reject unauthenticated foreign legacy-owner bindings

### DIFF
--- a/app/instance/runtime.py
+++ b/app/instance/runtime.py
@@ -3039,7 +3039,19 @@ def _finish_instance_state_deployment_locked(
                         _capability=_STORAGE_MUTATION_CAPABILITY,
                     )
                     pending_legacy_owners.append(pending_owner)
-            owners = list(ledger.resolve_live_owner_bindings(owners, skip_unadopted=True))
+            # Foreign receipt owners are complete host-validated evidence,
+            # not this channel's mount-blind config candidates. Require each
+            # omitted foreign binding to resolve before the compatibility path
+            # below may skip a current-channel unadopted candidate.
+            foreign_owners_without_bindings = tuple(
+                owner
+                for owner in owners
+                if owner.channel_id != channel and not owner.vault_binding_id
+            )
+            ledger.resolve_live_owner_bindings(foreign_owners_without_bindings)
+            owners = list(
+                ledger.resolve_live_owner_bindings(owners, skip_unadopted=True)
+            )
         except (FilesystemIdentityError, LedgerError):
             recovery_failed = True
         if recovery_failed:

--- a/tests/ops/test_instance_state_volume_contract.py
+++ b/tests/ops/test_instance_state_volume_contract.py
@@ -5442,6 +5442,71 @@ def test_legacy_owner_inventory_resolves_foreign_binding_ids_before_collision_ch
     } == set(prod.ledger.load().leases)
 
 
+def test_deployment_finish_rejects_foreign_blank_binding_without_active_lease(
+    tmp_path,
+) -> None:
+    """#5250 AC1: every foreign receipt owner must resolve or fail closed."""
+
+    host_global_root = tmp_path / "host-global"
+    prod = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "prod-state", "prod"),
+        host_global_root,
+    )
+    dev = InstanceRegistryRuntime.for_paths(
+        InstanceStateLayout.for_channel(tmp_path / "dev-state", "dev"),
+        host_global_root,
+    )
+    prod_root = tmp_path / "prod-vault"
+    dev_root = tmp_path / "dev-vault"
+    prod_root.mkdir()
+    dev_root.mkdir()
+    prod_registration = prod.bootstrap_env_binding(
+        vault_root=prod_root, watcher_vault_path=prod_root
+    )
+    dev_registration = dev.bootstrap_env_binding(
+        vault_root=dev_root, watcher_vault_path=dev_root
+    )
+    prod.ledger.bootstrap_legacy_owners(
+        [],
+        inventory_complete=True,
+        writers_drained=True,
+        _capability=STORAGE_MUTATION_CAPABILITY,
+    )
+    ledger_payload = json.loads(prod.ledger.path.read_text(encoding="utf-8"))
+    del ledger_payload["leases"][dev_registration.vault_binding_id]
+    prod.ledger.path.write_text(json.dumps(ledger_payload), encoding="utf-8")
+    os.chmod(prod.ledger.path, 0o600)
+
+    proof, owner_receipt = _canonical_test_quiescence_authority(
+        layout=prod.layout,
+        host_global_root=host_global_root,
+        legacy_path=tmp_path / "missing-legacy.md",
+        owners=[
+            {"channel_id": "dev", "root": str(dev_root)},
+            {
+                "channel_id": "prod",
+                "vault_binding_id": prod_registration.vault_binding_id,
+                "root": str(prod_root),
+            },
+        ],
+    )
+
+    with pytest.raises(
+        InstanceStatePreflightError,
+        match="host-validated legacy-owner binding or lease recovery is invalid",
+    ):
+        _finish_instance_state_deployment(
+            channel="prod",
+            instance_state_root=prod.layout.root.parent,
+            host_global_root=host_global_root,
+            legacy_path=tmp_path / "missing-legacy.md",
+            inventory_path=owner_receipt,
+            backup_root=tmp_path / "backup",
+            restore_root=None,
+            quiescence_proof=proof,
+        )
+
+
 def test_deployment_finish_recovers_pending_legacy_owner_lease_before_consistency(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5250

## Linked Issue
Closes #5250

## SBS Impact
- Primary subsystem: instance-state legacy-owner deployment lifecycle
- Secondary subsystem(s): binding identity and ownership-ledger consistency
- Write class: runtime/deployment correctness
- Persistence impact: foreign receipt owners must remain represented by authenticated active leases before finalization
- Derived/rebuildable impact: foreign identity resolution remains receipt-derived and deterministic
- New or changed contract: foreign blank binding identities resolve against an active lease or deployment finalization fails closed
- Owner-doc impact: none; the bounded owner contract is unchanged
- Transition debt impact: repairs the P1 regression discovered after PR #5307 merged
- Boundary risk: host-only roots remain receipt-validated and unresolved foreign identity cannot clear the restart fence

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Reject a foreign legacy-owner receipt with a blank binding ID when no active lease authenticates it.
- Preserve the current-channel mount-blind unadopted-candidate path and add production-path regression coverage.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded P1 review repair satisfies the existing Issue contract without creating a new BuilderOps artifact.

## Notes
Convergence: a foreign receipt owner with a blank binding identity must resolve through exactly one active lease before deployment finalization; otherwise recovery fails and the restart fence remains. The strict foreign-only check is ordered before the existing mount-blind current-channel compatibility resolution. No new persistence writer or lock is introduced; the existing deployment and ledger transitions remain authoritative. Validation: focused volume-contract and writer-inventory suite 148 passed, 3 skipped; ruff check app tests; mypy app; git diff --check.
