### PR TITLE
dispatcher: automatically reclaim stale leases during next

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -191,11 +191,26 @@ def _cmd_queue(args: argparse.Namespace, store: SqliteStore) -> int:
 
 
 def _cmd_next(args: argparse.Namespace, store: SqliteStore) -> int:
-    task = queue_module.next(store, agent_id=args.agent)
+    task, reclaimed_count = queue_module.select_next(store, agent_id=args.agent)
     if task is None:
-        _emit({"ok": True, "task": None, "empty": True}, args.json)
+        _emit(
+            {
+                "ok": True,
+                "task": None,
+                "empty": True,
+                "leases_reclaimed": reclaimed_count,
+            },
+            args.json,
+        )
     else:
-        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        _emit(
+            {
+                "ok": True,
+                "task": _compact_task(task),
+                "leases_reclaimed": reclaimed_count,
+            },
+            args.json,
+        )
     return 0
 
 

--- a/app/dispatcher/leases.py
+++ b/app/dispatcher/leases.py
@@ -670,7 +670,12 @@ def _reclaim_one(
             conn.rollback()
             return None
 
-        next_status = "blocked" if task_row["blocked_reason"] is not None else "ready"
+        if task_row["status"] in {"completed", "done"}:
+            # A legacy/manual update can leave a terminal task lease-linked.
+            # Clear that stale ownership without resurrecting terminal work.
+            next_status = task_row["status"]
+        else:
+            next_status = "blocked" if task_row["blocked_reason"] is not None else "ready"
         cleared = conn.execute(
             """
             UPDATE dispatcher_tasks

--- a/app/dispatcher/queue.py
+++ b/app/dispatcher/queue.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from app.dispatcher.leases import reclaim_expired_leases
 from app.dispatcher.models import EventRecord, TaskRecord
 from app.dispatcher.store import SqliteStore
+
+
+logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> str:
@@ -21,11 +26,28 @@ def _make_event_id() -> str:
     return f"evt-{uuid.uuid4().hex[:8]}"
 
 
-def next(store: SqliteStore, agent_id: str) -> TaskRecord | None:
-    """Return the next ready, unblocked, unleased task.
+def select_next(
+    store: SqliteStore,
+    agent_id: str,
+) -> tuple[TaskRecord | None, int]:
+    """Reclaim stale leases, then return the next eligible task and count.
 
-    Tasks are ordered by priority first, then by creation/update time (age).
+    Expired task-linked leases are reclaimed at the shared queue-selection
+    boundary, immediately before eligibility is evaluated. The existing
+    atomic lease reclaimer fences each mutation on its observed lease ID, so a
+    concurrent stale takeover cannot be erased by this sweep.
+
+    Returns the selected task and the number of leases reclaimed during this
+    selection. ``agent_id`` remains part of the selection API for callers that
+    identify the requesting agent; selection itself does not claim a task.
     """
+    reclaimed = reclaim_expired_leases(store)
+    reclaimed_count = len(reclaimed)
+    logger.info(
+        "dispatcher queue selection reclaimed %d expired lease(s)",
+        reclaimed_count,
+    )
+
     with store._connect() as conn:
         row = conn.execute(
             """
@@ -48,10 +70,18 @@ def next(store: SqliteStore, agent_id: str) -> TaskRecord | None:
             """
         ).fetchone()
 
-    if row is None:
-        return None
+    task = None if row is None else _row_to_task(row)
+    return task, reclaimed_count
 
-    return _row_to_task(row)
+
+def next(store: SqliteStore, agent_id: str) -> TaskRecord | None:
+    """Return the next ready, unblocked, unleased task.
+
+    Expired task-linked leases are reclaimed automatically before selection.
+    Tasks are ordered by priority first, then by creation/update time (age).
+    """
+    task, _ = select_next(store, agent_id)
+    return task
 
 
 def block(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -624,6 +624,18 @@ The new claim event remains the receipt. Its payload contains `ttl_minutes` and,
 the opt-in flag, an expired lease remains a claim rejection and the error directs the agent to
 `--takeover-stale`.
 
+Automatic recovery runs at the narrowest shared lifecycle boundary: every `next` queue-selection
+call invokes `reclaim_expired_leases` immediately before selecting an eligible task. The JSON CLI
+receipt reports this as `leases_reclaimed`, and the dispatcher logger records the same count. This
+boundary is safe because it runs on the existing selection path, requires no daemon or coordination
+store, and the reclaimer rechecks the captured task-linked lease's ownership, unreleased state, and
+expiry inside its SQLite write transaction. A concurrent stale takeover therefore wins its lease-ID
+fence, while repeated selections are harmless. Only unreleased, expired leases still referenced by
+a dispatcher task are eligible; orphan lease rows are intentionally left for separate maintenance.
+This path reads and mutates only dispatcher SQLite state and emits the existing `task.released`
+expiry event; it does not query or mutate GitHub Issues, labels, Projects, Kanban, or any external
+API.
+
 Design boundary:
 - This extends the minimal shared lease boundary from #561 and `docs/development/GITHUB_GOVERNANCE_SETUP.md` but does not absorb #561's git-hygiene scope.
 

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -631,7 +631,8 @@ boundary is safe because it runs on the existing selection path, requires no dae
 store, and the reclaimer rechecks the captured task-linked lease's ownership, unreleased state, and
 expiry inside its SQLite write transaction. A concurrent stale takeover therefore wins its lease-ID
 fence, while repeated selections are harmless. Only unreleased, expired leases still referenced by
-a dispatcher task are eligible; orphan lease rows are intentionally left for separate maintenance.
+a dispatcher task are eligible; terminal `completed`/`done` status is preserved while clearing a
+stray lease, and orphan lease rows are intentionally left for separate maintenance.
 This path reads and mutates only dispatcher SQLite state and emits the existing `task.released`
 expiry event; it does not query or mutate GitHub Issues, labels, Projects, Kanban, or any external
 API.

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -7,6 +7,7 @@ No GitHub API access required.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -107,6 +108,35 @@ def test_next_compact_output_with_task(tmp_env, store):
     assert "title" in task
     assert "status" in task
     assert "sync_state" not in task
+
+
+def test_next_reclaims_expired_lease_and_reports_count(tmp_env, store):
+    from app.dispatcher.leases import claim
+    from tests.dispatcher.helpers import seed_tasks
+
+    ready = next(task for task in seed_tasks(store) if task.status == "ready")
+    _claimed_task, lease = claim(store, ready.task_id, "departed-agent")
+    old_lease = store.get_lease(lease.lease_id)
+    assert old_lease is not None
+    past_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    old_lease.acquired_at = past_time
+    old_lease.expires_at = past_time
+    old_lease.heartbeat_at = past_time
+    store.upsert_lease(old_lease)
+
+    code, data = _run(["next", "--agent", "replacement-agent", "--json"])
+
+    assert code == 0
+    assert data["ok"] is True
+    assert data["leases_reclaimed"] == 1
+    assert data["task"]["task_id"] == ready.task_id
+    assert data["task"]["status"] == "ready"
+    assert data["task"]["lease_id"] is None
+
+    code, repeated = _run(["next", "--agent", "replacement-agent", "--json"])
+    assert code == 0
+    assert repeated["leases_reclaimed"] == 0
+    assert len(store.list_events(ready.task_id)) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dispatcher/test_leases.py
+++ b/tests/dispatcher/test_leases.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -16,7 +16,7 @@ from app.dispatcher.leases import (
     reclaim_expired_leases,
     release,
 )
-from app.dispatcher.models import TaskRecord
+from app.dispatcher.models import LeaseRecord, TaskRecord
 from app.dispatcher.store import SqliteStore
 
 
@@ -213,7 +213,6 @@ def test_release_emits_event(store: SqliteStore) -> None:
 
 
 def test_expired_lease_reclaim(store: SqliteStore) -> None:
-    from app.dispatcher.models import LeaseRecord
     from datetime import datetime, timezone, timedelta
 
     task = _task()
@@ -242,6 +241,29 @@ def test_expired_lease_reclaim(store: SqliteStore) -> None:
     assert refetched.lease_id is None
     assert refetched.claimed_by is None
     assert refetched.status == "ready"
+
+
+def test_reclaim_ignores_expired_orphan_lease(store: SqliteStore) -> None:
+    past_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(
+        timespec="microseconds"
+    )
+    orphan = LeaseRecord(
+        lease_id="orphan-lease",
+        resource="issue:999",
+        holder="departed-agent",
+        ttl_seconds=60,
+        acquired_at=past_time,
+        expires_at=past_time,
+        heartbeat_at=past_time,
+    )
+    store.upsert_lease(orphan)
+
+    reclaimed = reclaim_expired_leases(store, actor="dispatcher-gc")
+
+    assert reclaimed == []
+    persisted = store.get_lease(orphan.lease_id)
+    assert persisted is not None
+    assert persisted.released_at is None
 
 
 def _expire_lease(store: SqliteStore, lease_id: str) -> str:

--- a/tests/dispatcher/test_queue.py
+++ b/tests/dispatcher/test_queue.py
@@ -167,6 +167,28 @@ def test_next_excludes_non_ready_tasks(store: SqliteStore) -> None:
     assert result is None
 
 
+def test_next_gc_does_not_resurrect_completed_task_with_expired_lease(
+    store: SqliteStore,
+) -> None:
+    from app.dispatcher.services import update_task
+
+    task = _task()
+    store.upsert_task(task)
+    _claimed_task, lease = claim(store, task.task_id, "departed-agent")
+    update_task(store, task.task_id, "completed", None, "operator")
+    _expire_lease(store, lease.lease_id)
+
+    selected, reclaimed_count = select_next(store, agent_id="replacement-agent")
+
+    assert selected is None
+    assert reclaimed_count == 1
+    completed = store.get_task(task.task_id)
+    assert completed is not None
+    assert completed.status == "completed"
+    assert completed.claimed_by is None
+    assert completed.lease_id is None
+
+
 def test_queue_ordering_priority_then_age(store: SqliteStore) -> None:
     from app.dispatcher.leases import claim
 

--- a/tests/dispatcher/test_queue.py
+++ b/tests/dispatcher/test_queue.py
@@ -167,15 +167,17 @@ def test_next_excludes_non_ready_tasks(store: SqliteStore) -> None:
     assert result is None
 
 
-def test_next_gc_does_not_resurrect_completed_task_with_expired_lease(
+@pytest.mark.parametrize("terminal_status", ["completed", "done"])
+def test_next_gc_does_not_resurrect_terminal_task_with_expired_lease(
     store: SqliteStore,
+    terminal_status: str,
 ) -> None:
     from app.dispatcher.services import update_task
 
     task = _task()
     store.upsert_task(task)
     _claimed_task, lease = claim(store, task.task_id, "departed-agent")
-    update_task(store, task.task_id, "completed", None, "operator")
+    update_task(store, task.task_id, terminal_status, None, "operator")
     _expire_lease(store, lease.lease_id)
 
     selected, reclaimed_count = select_next(store, agent_id="replacement-agent")
@@ -184,7 +186,7 @@ def test_next_gc_does_not_resurrect_completed_task_with_expired_lease(
     assert reclaimed_count == 1
     completed = store.get_task(task.task_id)
     assert completed is not None
-    assert completed.status == "completed"
+    assert completed.status == terminal_status
     assert completed.claimed_by is None
     assert completed.lease_id is None
 

--- a/tests/dispatcher/test_queue.py
+++ b/tests/dispatcher/test_queue.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from app.dispatcher.events import JsonlEventWriter
-from app.dispatcher.models import TaskRecord
-from app.dispatcher.queue import block, next, unblock
+from app.dispatcher.leases import claim
+from app.dispatcher.models import LeaseRecord, TaskRecord
+from app.dispatcher.queue import block, next, select_next, unblock
 from app.dispatcher.store import SqliteStore
 
 
@@ -36,6 +38,25 @@ def store(tmp_path: Path) -> SqliteStore:
     return s
 
 
+def _expire_lease(store: SqliteStore, lease_id: str) -> None:
+    lease = store.get_lease(lease_id)
+    assert lease is not None
+    past_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(
+        timespec="microseconds"
+    )
+    store.upsert_lease(
+        LeaseRecord(
+            lease_id=lease.lease_id,
+            resource=lease.resource,
+            holder=lease.holder,
+            ttl_seconds=lease.ttl_seconds,
+            acquired_at=past_time,
+            expires_at=past_time,
+            heartbeat_at=past_time,
+        )
+    )
+
+
 def test_next_returns_ready_unblocked_unleased(store: SqliteStore) -> None:
     task = _task()
     store.upsert_task(task)
@@ -59,6 +80,83 @@ def test_next_excludes_claimed_tasks(store: SqliteStore) -> None:
 
     result = next(store, agent_id="test-agent")
     assert result is None
+
+
+def test_next_reclaims_expired_task_lease_before_selection(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+    _claimed_task, lease = claim(store, task.task_id, "departed-agent")
+    _expire_lease(store, lease.lease_id)
+
+    selected, reclaimed_count = select_next(store, agent_id="replacement-agent")
+
+    assert reclaimed_count == 1
+    assert selected is not None
+    assert selected.task_id == task.task_id
+    reclaimed_task = store.get_task(task.task_id)
+    assert reclaimed_task is not None
+    assert reclaimed_task.status == "ready"
+    assert reclaimed_task.claimed_by is None
+    assert reclaimed_task.lease_id is None
+    events = store.list_events(task.task_id)
+    assert events[-1].event_type == "task.released"
+    assert events[-1].payload == {"reason": "expired"}
+
+
+def test_next_preserves_unexpired_task_lease(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+    _claimed_task, lease = claim(store, task.task_id, "active-agent")
+
+    selected, reclaimed_count = select_next(store, agent_id="replacement-agent")
+
+    assert selected is None
+    assert reclaimed_count == 0
+    current_task = store.get_task(task.task_id)
+    assert current_task is not None
+    assert current_task.status == "claimed"
+    assert current_task.claimed_by == "active-agent"
+    assert current_task.lease_id == lease.lease_id
+    current_lease = store.get_lease(lease.lease_id)
+    assert current_lease is not None
+    assert current_lease.released_at is None
+
+
+def test_next_reclaims_expired_blocked_task_but_keeps_it_blocked(
+    store: SqliteStore,
+) -> None:
+    task = _task()
+    store.upsert_task(task)
+    _claimed_task, lease = claim(store, task.task_id, "departed-agent")
+    block(store, task.task_id, "waiting for dependency", "dispatcher")
+    _expire_lease(store, lease.lease_id)
+
+    selected, reclaimed_count = select_next(store, agent_id="replacement-agent")
+
+    assert selected is None
+    assert reclaimed_count == 1
+    reclaimed_task = store.get_task(task.task_id)
+    assert reclaimed_task is not None
+    assert reclaimed_task.status == "blocked"
+    assert reclaimed_task.blocked_reason == "waiting for dependency"
+    assert reclaimed_task.claimed_by is None
+    assert reclaimed_task.lease_id is None
+
+
+def test_repeated_next_gc_is_harmless(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+    _claimed_task, lease = claim(store, task.task_id, "departed-agent")
+    _expire_lease(store, lease.lease_id)
+
+    first, first_count = select_next(store, agent_id="replacement-agent")
+    second, second_count = select_next(store, agent_id="replacement-agent")
+
+    assert first is not None
+    assert second is not None
+    assert first_count == 1
+    assert second_count == 0
+    assert len(store.list_events(task.task_id)) == 2
 
 
 def test_next_excludes_non_ready_tasks(store: SqliteStore) -> None:


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Bounded immediate dispatcher repair that wires the existing atomic expired-lease reclaimer into the shared queue-selection boundary.
Validation: Focused dispatcher lease/queue/CLI tests; agent-loop and dispatcher architecture tests; ruff check app tests; mypy app.
Issue required: no

## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System dispatcher lease and queue coordination
- Secondary subsystem(s): Dispatcher CLI, lease lifecycle tests, dispatcher contract
- Write class: Durable dispatcher SQLite operational-state mutation only
- Persistence impact: Reuses existing task, lease, and event rows; no schema or coordination-store change
- Derived/rebuildable impact: None
- New or changed contract: next selection now automatically reclaims expired task-linked leases; next receipts expose leases_reclaimed
- Owner-doc impact: Updated docs/AGENT_ISSUE_DISPATCHER.md
- Transition debt impact: None
- Boundary risk: Concurrency-safe local dispatcher recovery; GitHub Issues/labels and Project projections unchanged

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Automatically reclaim expired task-linked dispatcher leases during queue selection.
- Preserve live leases and stale takeover races while reporting reclaimed counts.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded dispatcher direct repair; no BuilderOps operational record, projection, or promotion was created.

## Notes
No GitHub Project/Kanban or external API calls are introduced. Expired orphan lease rows remain outside automatic task-linked recovery.
