### PR TITLE
fix(standing-questions): enforce CAS on system updates

### DIFF
--- a/app/standing_questions/question_store.py
+++ b/app/standing_questions/question_store.py
@@ -320,8 +320,10 @@ class QuestionStore:
     def update_system_fields(
         self, question_id: str, updates: Mapping[str, Any]
     ) -> tuple[dict[str, Any], WriteReceipt]:
-        current = self.read_question(question_id)
-        return self._update_system_fields_from_current(question_id, current, updates)
+        current, expected_version = self.read_question_with_version(question_id)
+        return self._update_system_fields_from_current(
+            question_id, current, updates, expected_version=expected_version
+        )
 
     def update_system_fields_if_unchanged(
         self,

--- a/docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md
+++ b/docs/STANDING_QUESTIONS/STORE_QUESTION_NOTES_AND_PROJECTION.md
@@ -59,7 +59,9 @@ note-store+projection pattern (`docs/EPISODE_RESOLUTION_ENGINE/EPISODE_NOTE_STOR
    proposal-class default, a **newly created** Question note is written only via an already-confirmed
    registration (explicit human action, or an accepted capture-intent proposal per SQ-02) — there is
    no "proposed" Question-note state; the note either exists as an `open` question or it does not yet
-   exist.
+   exist. Every existing-note system-field rewrite carries the exact-byte version observed with the
+   note to the shared write seam. A concurrent human edit therefore conflicts before replacement and
+   leaves the latest note bytes intact; system writers still cannot mutate `text` or `status`.
 4. **Projection**: a rebuildable PG `standing_questions` projection (Alembic migration, forward-only,
    following the `decisions`/`episodes` projection precedent at `app/jobs/decisions_projection.py`) —
    vault notes are the SoR; the projection exists for query (open-question list, evidence-trail

--- a/tests/standing_questions/test_question_store.py
+++ b/tests/standing_questions/test_question_store.py
@@ -88,6 +88,57 @@ def test_engine_may_append_system_owned_fields_only(tmp_path: Path) -> None:
     assert updated["evidence"][0]["artifact_ref"] == "note:abc"
 
 
+def test_update_system_fields_refuses_concurrent_human_edit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text="Original question", scope="work", registered_via="explicit")
+    path = vault / "questions" / f"{note['question_id']}.md"
+    original_write = question_store_module.write_note_relative
+
+    def write_after_human_edit(*args: object, **kwargs: object) -> object:
+        human_edit = {**note, "text": "Human-edited question", "status": "closed"}
+        path.write_text(serialize_question_note(human_edit), encoding="utf-8")
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(question_store_module, "write_note_relative", write_after_human_edit)
+
+    with pytest.raises(KnowledgeWriteConflict):
+        store.update_system_fields(note["question_id"], {"last_refreshed_at": "2026-09-03T12:00:00Z"})
+
+    assert parse_question_note(path.read_text(encoding="utf-8"))["text"] == "Human-edited question"
+    assert parse_question_note(path.read_text(encoding="utf-8"))["status"] == "closed"
+
+
+def test_update_system_fields_preserves_human_owned_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _store(vault)
+    note, _ = store.create_question(text="Original question", scope="work", registered_via="explicit")
+    _observed, observed_version = store.read_question_with_version(note["question_id"])
+    expected_versions: list[str | None] = []
+    original_write = question_store_module.write_note_relative
+
+    def capture_expected_version(*args: object, **kwargs: object) -> object:
+        expected_versions.append(kwargs.get("expected_version"))
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(question_store_module, "write_note_relative", capture_expected_version)
+
+    updated, receipt = store.update_system_fields(
+        note["question_id"], {"last_refreshed_at": "2026-09-03T12:00:00Z"}
+    )
+
+    assert expected_versions == [observed_version]
+    assert receipt.operation == WRITE_ACTION
+    assert updated["text"] == note["text"]
+    assert updated["status"] == note["status"]
+
+
 def test_hashless_legacy_evidence_is_rejected_until_explicit_backfill() -> None:
     note = _minimal_valid_note(
         evidence=[


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [ ] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5135

## Linked Issue
Closes #5135

## SBS Impact
- Primary subsystem: Standing Questions note store
- Secondary subsystem(s): Vault multiwriter WriteGuard seam
- Write class: Guarded durable system-field rewrite
- Persistence impact: Existing Question-note bytes are compared before replacement; no schema change.
- Derived/rebuildable impact: Rebuildable standing_questions projection behavior is unchanged.
- New or changed contract: Existing-note system rewrites forward the exact observed byte version and fail on concurrent edits.
- Owner-doc impact: Standing Questions write discipline is corrected and enforced at its caller.
- Transition debt impact: None.
- Boundary risk: Concurrency conflict prevents a system writer from overwriting human-owned text or status.

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Pass the exact bytes observed for an existing Question note through the system-field write seam.
- Reject a concurrent human edit before replacement while preserving human-owned text and status.
- Document the enforced write discipline for existing-note system-field rewrites.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The Issue, claim receipt, independent review receipt, and PR carry the bounded delivery evidence; no separate BuilderOps record is needed.

## Notes
Validation on 6621a4333d76db8d5220078b82af5975ee251f9e: two exact AC tests passed; ruff check app tests passed; mypy app passed; docs guard passed with its documented DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 override because no high-risk temporal owner document is in scope. Independent concurrency/mechanism review: Issue comment 5531706041 (clean). Review-before-CI gate: satisfied for risk:concurrency. Claim receipt: dispatcher lease lease-8576f4af.
