### PR TITLE
fix(review-gate): allow governing Issue identity for new PR publication

### DIFF
--- a/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
+++ b/docs/development/AUTONOMOUS_REVIEW_REPAIR_GATE_CONTRACTS.md
@@ -433,6 +433,9 @@ foreign, stale, malformed, or partial evidence fails closed. The executable gate
 authority only against the canonical `origin/main...HEAD` selectors; workflow-risk analysis may use
 alternate selectors only when it is not issuing publication authority. Publication invokes the gate
 with an explicit `new` or `existing` mode, and scope revalidation is valid only in `existing` mode.
+For an issue-backed `new` publication, the governing Issue identity is valid publication authority,
+but it is not existing-PR scope-revalidation evidence. A new publication must reject a caller-supplied
+PR number or revalidation receipt.
 `existing` derives a unique open PR whose base repository
 and ref match the publication base and whose head repository and ref match the authenticated current
 branch, then requires the supplied PR identity and scope

--- a/scripts/review_before_ci_gate.py
+++ b/scripts/review_before_ci_gate.py
@@ -1398,6 +1398,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             raise ReviewBeforeCiGateError(
                 "publication requires explicit --publication-mode existing"
             )
+        elif args.governing_issue is not None:
+            raise ReviewBeforeCiGateError(
+                "governing Issue identity requires explicit --publication-mode new or existing"
+            )
         if args.pr_scope_revalidation:
             if (
                 args.pr_number is None

--- a/scripts/review_before_ci_gate.py
+++ b/scripts/review_before_ci_gate.py
@@ -1386,6 +1386,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 raise ReviewBeforeCiGateError(
                     "new-PR publication requires GitHub repository identity"
                 )
+            if args.pr_number is not None or args.contract_revalidation_receipt:
+                raise ReviewBeforeCiGateError(
+                    "new-PR publication cannot supply existing-PR identity or revalidation receipt"
+                )
             if _current_branch_has_open_pr(args.github_repository):
                 raise ReviewBeforeCiGateError(
                     "new-PR publication found an existing open PR for the current branch"
@@ -1438,7 +1442,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             value is not None
             for value in (
                 args.pr_number,
-                args.governing_issue,
                 args.contract_revalidation_receipt,
             )
         ) or (args.github_repository is not None and args.publication_mode != "new"):

--- a/scripts/review_before_ci_gate.py
+++ b/scripts/review_before_ci_gate.py
@@ -1386,7 +1386,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 raise ReviewBeforeCiGateError(
                     "new-PR publication requires GitHub repository identity"
                 )
-            if args.pr_number is not None or args.contract_revalidation_receipt:
+            if args.pr_number is not None or args.contract_revalidation_receipt is not None:
                 raise ReviewBeforeCiGateError(
                     "new-PR publication cannot supply existing-PR identity or revalidation receipt"
                 )

--- a/tests/ops/test_review_before_ci_gate.py
+++ b/tests/ops/test_review_before_ci_gate.py
@@ -1463,7 +1463,11 @@ def test_new_publication_rejects_scope_revalidation(
 
 @pytest.mark.parametrize(
     ("argument", "value"),
-    (("--pr-number", "4029"), ("--contract-revalidation-receipt", "receipt.json")),
+    (
+        ("--pr-number", "4029"),
+        ("--contract-revalidation-receipt", "receipt.json"),
+        ("--contract-revalidation-receipt", ""),
+    ),
 )
 def test_new_publication_rejects_existing_pr_evidence(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/ops/test_review_before_ci_gate.py
+++ b/tests/ops/test_review_before_ci_gate.py
@@ -1503,6 +1503,39 @@ def test_new_publication_rejects_existing_pr_evidence(
     assert "cannot supply existing-PR identity or revalidation receipt" in capsys.readouterr().err
 
 
+def test_modeless_governing_issue_requires_publication_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate.workflow_risk_evidence_from_git",
+        lambda *args, **kwargs: SimpleNamespace(risks=[], head_sha="a" * 40),
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._github_repository_from_origin", lambda: "octo/repo"
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._current_branch_has_open_pr", lambda repository: False
+    )
+
+    assert review_before_ci_main(
+        [
+            "--lane",
+            "governance",
+            "--changed-file",
+            "scripts/review_before_ci_gate.py",
+            "--risk-assessment-complete",
+            "--risk-surface",
+            "state-machine",
+            "--review-gate-complete",
+            "--github-repository",
+            "octo/repo",
+            "--governing-issue",
+            "5319",
+        ]
+    ) == 2
+    assert "requires explicit --publication-mode new or existing" in capsys.readouterr().err
+
+
 def test_pr_scope_revalidation_rejects_unbound_governing_issue_or_review() -> None:
     responses, api = _live_pr_review_api()
     responses["repos/octo/repo/pulls/4029"]["body"] = "Governing-Issue: #9999\n\nFixes #9999\n"  # type: ignore[index]

--- a/tests/ops/test_review_before_ci_gate.py
+++ b/tests/ops/test_review_before_ci_gate.py
@@ -1400,6 +1400,109 @@ def test_new_publication_mode_requires_repository_identity() -> None:
     assert "requires GitHub repository identity" in result.stderr
 
 
+def test_new_publication_accepts_governing_issue_without_scope_revalidation(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate.workflow_risk_evidence_from_git",
+        lambda *args, **kwargs: SimpleNamespace(risks=[], head_sha="a" * 40),
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._github_repository_from_origin", lambda: "octo/repo"
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._current_branch_has_open_pr", lambda repository: False
+    )
+
+    assert review_before_ci_main(
+        [
+            "--lane",
+            "governance",
+            "--changed-file",
+            "scripts/review_before_ci_gate.py",
+            "--risk-assessment-complete",
+            "--risk-surface",
+            "state-machine",
+            "--review-gate-complete",
+            "--publication-mode",
+            "new",
+            "--github-repository",
+            "octo/repo",
+            "--governing-issue",
+            "5319",
+        ]
+    ) == 0
+    assert '"ok": true' in capsys.readouterr().out
+
+
+def test_new_publication_rejects_scope_revalidation(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate.workflow_risk_evidence_from_git",
+        lambda *args, **kwargs: SimpleNamespace(risks=[], head_sha="a" * 40),
+    )
+
+    assert review_before_ci_main(
+        [
+            "--lane",
+            "governance",
+            "--changed-file",
+            "scripts/review_before_ci_gate.py",
+            "--risk-assessment-complete",
+            "--risk-surface",
+            "state-machine",
+            "--review-gate-complete",
+            "--publication-mode",
+            "new",
+            "--pr-scope-revalidation",
+        ]
+    ) == 2
+    assert "only valid with --publication-mode existing" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    (("--pr-number", "4029"), ("--contract-revalidation-receipt", "receipt.json")),
+)
+def test_new_publication_rejects_existing_pr_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argument: str,
+    value: str,
+) -> None:
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate.workflow_risk_evidence_from_git",
+        lambda *args, **kwargs: SimpleNamespace(risks=[], head_sha="a" * 40),
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._github_repository_from_origin", lambda: "octo/repo"
+    )
+    monkeypatch.setattr(
+        "scripts.review_before_ci_gate._current_branch_has_open_pr", lambda repository: False
+    )
+
+    assert review_before_ci_main(
+        [
+            "--lane",
+            "governance",
+            "--changed-file",
+            "scripts/review_before_ci_gate.py",
+            "--risk-assessment-complete",
+            "--risk-surface",
+            "state-machine",
+            "--review-gate-complete",
+            "--publication-mode",
+            "new",
+            "--github-repository",
+            "octo/repo",
+            argument,
+            value,
+        ]
+    ) == 2
+    assert "cannot supply existing-PR identity or revalidation receipt" in capsys.readouterr().err
+
+
 def test_pr_scope_revalidation_rejects_unbound_governing_issue_or_review() -> None:
     responses, api = _live_pr_review_api()
     responses["repos/octo/repo/pulls/4029"]["body"] = "Governing-Issue: #9999\n\nFixes #9999\n"  # type: ignore[index]


### PR DESCRIPTION
## Change Lane
- [ ] Docs authoring lane
- [x] Governance lane

Final-Review-Rounds: 1

Governing-Issue: #5319

## Linked Issue
Closes #5319

## SBS Impact
- Primary subsystem: Builder System / CES publication governance
- Secondary subsystem(s): issue-to-code, publish-pr, verification-and-closure
- Write class: governance/process enforcement
- Persistence impact: none; gate evaluation and test/owner-contract evidence only
- Derived/rebuildable impact: publication eligibility remains derived from authenticated local Git and GitHub state
- New or changed contract: governing Issue identity is valid authority for a new issue-backed PR; existing-PR scope-revalidation evidence remains existing-PR-only
- Owner-doc impact: updated in this PR
- Transition debt impact: removes a false pre-PR deadlock in governed delivery
- Boundary risk: must not weaken existing-PR scope authentication or allow caller-supplied PR history

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Allow governing Issue identity for new PR publication while keeping existing-PR scope revalidation fail-closed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No separate BuilderOps records apply; this governance repair is tracked by Issue #5319 and its review receipts.

## Notes
Independent mechanism-convergence ACCEPT on exact candidate 52e6d75a8dbab8f52e8aa8e168faf47fb9e8d307. Focused gate tests, ruff, docs guard, and diff check pass. Current-SHA CI and governed merge/closure remain pending.